### PR TITLE
feat(desktop): rebuild the conversation sources panel

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -88,6 +88,7 @@ struct DocumentSummaryRow {
     source_uri: Option<String>,
     media_type: String,
     title: Option<String>,
+    source_byte_len: Option<i64>,
     content_revision: i64,
     processing_status: String,
     /// Emptiness of the canonical text, evaluated in the database so a listing
@@ -366,6 +367,7 @@ impl Store for DbStore {
                 entities::document::Column::SourceUri,
                 entities::document::Column::MediaType,
                 entities::document::Column::Title,
+                entities::document::Column::SourceByteLen,
                 entities::document::Column::ContentRevision,
                 entities::document::Column::ProcessingStatus,
                 entities::document::Column::IndexedRevision,
@@ -3773,6 +3775,13 @@ fn document_summary_from_row(row: DocumentSummaryRow) -> Result<DocumentSummaryR
         source_uri: row.source_uri,
         media_type: row.media_type,
         title: row.title,
+        source_byte_len: row
+            .source_byte_len
+            .map(u64::try_from)
+            .transpose()
+            .map_err(|_| {
+                AgentError::Store("stored document source length must be nonnegative".into())
+            })?,
         content_revision: row.content_revision,
         processing_status,
         searchable: processing_status == DocumentProcessingStatus::Ready && row.has_canonical_text,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1002,6 +1002,8 @@ pub struct DocumentSummaryRecord {
     pub media_type: String,
     /// Optional human-facing title.
     pub title: Option<String>,
+    /// Exact retained source byte length, when original bytes are available.
+    pub source_byte_len: Option<u64>,
     /// Current authoritative source revision.
     pub content_revision: i64,
     /// Processing lifecycle of the current authoritative revision.

--- a/crates/openwave-core/src/storage/tests.rs
+++ b/crates/openwave-core/src/storage/tests.rs
@@ -1982,6 +1982,7 @@ fn document_summary(document: &DocumentRecord) -> DocumentSummaryRecord {
         source_uri: document.source_uri.clone(),
         media_type: document.media_type.clone(),
         title: document.title.clone(),
+        source_byte_len: document.source_blob.as_ref().map(|blob| blob.byte_len),
         content_revision: document.content_revision,
         processing_status: document.processing_status,
         searchable: document.is_searchable(),

--- a/crates/openwave-desktop/src/documents.rs
+++ b/crates/openwave-desktop/src/documents.rs
@@ -14,7 +14,9 @@ use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
 use cap_std::ambient_authority;
 use cap_std::fs::{Dir, OpenOptions};
 use futures::{stream, StreamExt};
-use openwave_core::{ChatId, DocumentProcessingStatus, DocumentSourceBlob, Store};
+use openwave_core::{
+    ChatId, DocumentId, DocumentJobStatus, DocumentProcessingStatus, DocumentSourceBlob, Store,
+};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tauri::{AppHandle, DragDropEvent, Emitter, Manager, State, WindowEvent};
@@ -50,9 +52,18 @@ struct CatalogDocument {
     document_id: Uuid,
     title: Option<String>,
     media_type: String,
+    source_byte_len: Option<u64>,
+    content_revision: i64,
     processing_status: DocumentProcessingStatus,
     searchable: bool,
     updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct LibraryDocumentFailure {
+    message: &'static str,
+    retriable: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -61,8 +72,10 @@ pub(crate) struct LibraryDocument {
     document_id: String,
     title: Option<String>,
     media_type: String,
+    size_bytes: Option<u64>,
     processing_status: DocumentProcessingStatus,
     searchable: bool,
+    failure: Option<LibraryDocumentFailure>,
     updated_at: String,
 }
 
@@ -73,16 +86,18 @@ pub(crate) struct LibraryCatalog {
     truncated: bool,
 }
 
-impl From<CatalogDocument> for LibraryDocument {
-    fn from(document: CatalogDocument) -> Self {
+impl LibraryDocument {
+    fn from_catalog(document: CatalogDocument, failure: Option<LibraryDocumentFailure>) -> Self {
         Self {
             document_id: document.document_id.to_string(),
             title: document
                 .title
                 .and_then(|title| is_safe_renderer_text(&title, 255, false).then_some(title)),
             media_type: document.media_type,
+            size_bytes: document.source_byte_len,
             processing_status: document.processing_status,
             searchable: document.searchable,
+            failure,
             updated_at: document.updated_at,
         }
     }
@@ -278,6 +293,13 @@ pub(crate) struct LibraryRequest {
     chat_id: Uuid,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct LibraryDocumentRequest {
+    chat_id: Uuid,
+    document_id: Uuid,
+}
+
 #[tauri::command]
 pub(crate) async fn list_library_documents(
     state: State<'_, Arc<AppState>>,
@@ -287,6 +309,9 @@ pub(crate) async fn list_library_documents(
     let chat_id = resolve_conversation_scope(&host_access, request.chat_id).await?;
     let info = wait_server_info(state.inner()).await?;
     let http = local_client();
+    let store = host_access
+        .store()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())?;
     let path = documents_path(chat_id);
     let mut cursor: Option<String> = None;
     let mut documents = Vec::new();
@@ -309,7 +334,10 @@ pub(crate) async fn list_library_documents(
             .json::<CatalogPage>()
             .await
             .map_err(|_| "The source catalog returned an invalid response".to_owned())?;
-        documents.extend(page.documents.into_iter().map(LibraryDocument::from));
+        for document in page.documents {
+            let failure = library_document_failure(store.as_ref(), &document).await?;
+            documents.push(LibraryDocument::from_catalog(document, failure));
+        }
         cursor = page.next_cursor;
         if documents.len() >= MAX_LIBRARY_DOCUMENTS || cursor.is_none() {
             let overflowed = documents.len() > MAX_LIBRARY_DOCUMENTS;
@@ -322,6 +350,63 @@ pub(crate) async fn list_library_documents(
         documents,
         truncated,
     })
+}
+
+#[tauri::command]
+pub(crate) async fn delete_library_document(
+    state: State<'_, Arc<AppState>>,
+    host_access: State<'_, HostAccess>,
+    request: LibraryDocumentRequest,
+) -> Result<(), String> {
+    let (chat_id, document_id) =
+        resolve_document_scope(&host_access, request.chat_id, request.document_id).await?;
+    let info = wait_server_info(state.inner()).await?;
+    let response = native_auth(
+        local_client().delete(format!(
+            "{}{}",
+            info.base_url,
+            document_path(chat_id, document_id)
+        )),
+        &info,
+    )
+    .send()
+    .await
+    .map_err(|_| "Could not delete that source".to_owned())?;
+    if !response.status().is_success() {
+        return Err("Could not delete that source".to_owned());
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn retry_library_document(
+    state: State<'_, Arc<AppState>>,
+    host_access: State<'_, HostAccess>,
+    request: LibraryDocumentRequest,
+) -> Result<(), String> {
+    let (chat_id, document_id) =
+        resolve_document_scope(&host_access, request.chat_id, request.document_id).await?;
+    let info = wait_server_info(state.inner()).await?;
+    let response = native_auth(
+        local_client().post(format!(
+            "{}{}",
+            info.base_url,
+            retry_document_path(chat_id, document_id)
+        )),
+        &info,
+    )
+    .send()
+    .await
+    .map_err(|_| "Could not retry that source".to_owned())?;
+    if !response.status().is_success() {
+        return Err(if response.status() == reqwest::StatusCode::CONFLICT {
+            "This source can no longer be retried. Refresh sources for its current status."
+                .to_owned()
+        } else {
+            "Could not retry that source".to_owned()
+        });
+    }
+    Ok(())
 }
 
 #[tauri::command]
@@ -640,8 +725,110 @@ async fn resolve_conversation_scope_from_store(
     Ok(chat_id)
 }
 
+async fn resolve_document_scope(
+    host_access: &HostAccess,
+    chat_id: Uuid,
+    document_id: Uuid,
+) -> Result<(ChatId, DocumentId), String> {
+    let chat_id = resolve_conversation_scope(host_access, chat_id).await?;
+    if document_id.is_nil() {
+        return Err("Invalid source".to_owned());
+    }
+    let document_id = DocumentId::from(document_id);
+    let store = host_access
+        .store()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    let owned = store
+        .get_document(document_id)
+        .await
+        .map_err(|_| "Could not load that source".to_owned())?
+        .is_some_and(|document| document.chat_id == Some(chat_id) && document.project_id.is_none());
+    if !owned {
+        return Err("Source not found in this conversation".to_owned());
+    }
+    Ok((chat_id, document_id))
+}
+
+async fn library_document_failure(
+    store: &dyn Store,
+    document: &CatalogDocument,
+) -> Result<Option<LibraryDocumentFailure>, String> {
+    if document.processing_status != DocumentProcessingStatus::Failed {
+        return Ok(None);
+    }
+    let failed = store
+        .list_document_jobs(DocumentId::from(document.document_id))
+        .await
+        .map_err(|_| "Could not load this conversation's source status".to_owned())?
+        .into_iter()
+        .filter(|job| {
+            job.content_revision == document.content_revision
+                && job.status == DocumentJobStatus::Failed
+        })
+        .max_by_key(|job| job.updated_at);
+    Ok(Some(failure_projection(
+        failed
+            .as_ref()
+            .and_then(|job| job.last_error_code.as_deref()),
+    )))
+}
+
+fn failure_projection(code: Option<&str>) -> LibraryDocumentFailure {
+    let (message, retriable) = match code {
+        Some("embedding_failed") => (
+            "OpenWave could not prepare this source for search. Check the model connection, then retry.",
+            true,
+        ),
+        Some("vector_store_failed" | "index_failed") => (
+            "The local search index was unavailable. Retry preparing this source.",
+            true,
+        ),
+        Some("source_blob_read_failed") => (
+            "OpenWave could not read the stored file. Retry, or delete it and add it again if the problem continues.",
+            true,
+        ),
+        Some("pipeline_changed" | "lease_expired") => (
+            "Source processing changed before this file finished. Retry with the current setup.",
+            true,
+        ),
+        Some("parse_failed") => (
+            "OpenWave could not read this file. Delete it and add a supported, uncorrupted version.",
+            false,
+        ),
+        Some(
+            "source_blob_missing"
+            | "source_blob_length_mismatch"
+            | "source_blob_digest_mismatch",
+        ) => (
+            "The stored file is unavailable or damaged. Delete this source and add the file again.",
+            false,
+        ),
+        Some("dimension_mismatch" | "generation_conflict") => (
+            "This source no longer matches the current search index. Delete it and add the file again.",
+            false,
+        ),
+        Some("generation_fenced" | "activation_fenced" | "invalid_document_stage") => (
+            "This source was superseded while it was being prepared. Delete it and add the file again.",
+            false,
+        ),
+        Some(_) | None => (
+            "OpenWave could not prepare this source. Delete it and add the file again.",
+            false,
+        ),
+    };
+    LibraryDocumentFailure { message, retriable }
+}
+
 fn documents_path(chat_id: ChatId) -> String {
     format!("/chats/{chat_id}/documents")
+}
+
+fn document_path(chat_id: ChatId, document_id: DocumentId) -> String {
+    format!("{}/{document_id}", documents_path(chat_id))
+}
+
+fn retry_document_path(chat_id: ChatId, document_id: DocumentId) -> String {
+    format!("{}/retry", document_path(chat_id, document_id))
 }
 
 pub(crate) fn raw_documents_path(chat_id: ChatId) -> String {
@@ -1042,6 +1229,15 @@ mod tests {
             raw_documents_path(standalone.id),
             format!("/chats/{}/documents/raw", standalone.id)
         );
+        let document_id = DocumentId::new();
+        assert_eq!(
+            document_path(standalone.id, document_id),
+            format!("/chats/{}/documents/{document_id}", standalone.id)
+        );
+        assert_eq!(
+            retry_document_path(standalone.id, document_id),
+            format!("/chats/{}/documents/{document_id}/retry", standalone.id)
+        );
         assert_eq!(
             search_path(standalone.id),
             format!("/chats/{}/search", standalone.id)
@@ -1058,6 +1254,12 @@ mod tests {
             "query": "notes",
         });
         assert!(serde_json::from_value::<SearchLibraryRequest>(injected_search).is_err());
+        let injected_document = serde_json::json!({
+            "chatId": standalone.id,
+            "documentId": DocumentId::new(),
+            "projectId": project.id,
+        });
+        assert!(serde_json::from_value::<LibraryDocumentRequest>(injected_document).is_err());
     }
 
     #[test]
@@ -1176,14 +1378,19 @@ mod tests {
 
     #[test]
     fn renderer_catalog_projection_has_a_closed_safe_shape() {
-        let document = LibraryDocument::from(CatalogDocument {
-            document_id: Uuid::nil(),
-            title: Some("notes.md".to_owned()),
-            media_type: "text/markdown".to_owned(),
-            processing_status: DocumentProcessingStatus::Ready,
-            searchable: true,
-            updated_at: "2026-07-18T00:00:00Z".to_owned(),
-        });
+        let document = LibraryDocument::from_catalog(
+            CatalogDocument {
+                document_id: Uuid::nil(),
+                title: Some("notes.md".to_owned()),
+                media_type: "text/markdown".to_owned(),
+                source_byte_len: Some(42),
+                content_revision: 1,
+                processing_status: DocumentProcessingStatus::Ready,
+                searchable: true,
+                updated_at: "2026-07-18T00:00:00Z".to_owned(),
+            },
+            None,
+        );
         let json = serde_json::to_value(document).unwrap();
         let keys = json
             .as_object()
@@ -1195,9 +1402,11 @@ mod tests {
             keys,
             [
                 "documentId",
+                "failure",
                 "mediaType",
                 "processingStatus",
                 "searchable",
+                "sizeBytes",
                 "title",
                 "updatedAt"
             ]
@@ -1206,5 +1415,38 @@ mod tests {
         for forbidden in ["uri", "revision", "fingerprint", "content", "token", "path"] {
             assert!(!serialized.contains(forbidden));
         }
+    }
+
+    #[test]
+    fn failure_projection_offers_retry_only_for_recoverable_worker_failures() {
+        for code in [
+            "embedding_failed",
+            "vector_store_failed",
+            "index_failed",
+            "source_blob_read_failed",
+            "pipeline_changed",
+            "lease_expired",
+        ] {
+            let failure = failure_projection(Some(code));
+            assert!(failure.retriable, "{code}");
+            assert!(is_safe_renderer_text(failure.message, 500, false));
+        }
+        for code in [
+            "parse_failed",
+            "source_blob_missing",
+            "source_blob_length_mismatch",
+            "source_blob_digest_mismatch",
+            "dimension_mismatch",
+            "generation_conflict",
+            "generation_fenced",
+            "activation_fenced",
+            "invalid_document_stage",
+            "unknown",
+        ] {
+            let failure = failure_projection(Some(code));
+            assert!(!failure.retriable, "{code}");
+            assert!(is_safe_renderer_text(failure.message, 500, false));
+        }
+        assert!(!failure_projection(None).retriable);
     }
 }

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -178,6 +178,8 @@ pub fn run() {
             documents::import_dropped_library_documents,
             documents::list_library_documents,
             documents::search_library_documents,
+            documents::delete_library_document,
+            documents::retry_library_document,
             image_attachments::attach_chat_image,
             deliverables::list_deliverables,
             deliverables::read_deliverable,

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -87,7 +87,7 @@ const { signal: signalTurnLifecycle } = useTurnLifecycle.getState();
 export function ChatRoute({ chatId }: { chatId: string }) {
   const navigate = useNavigate();
   const { client, models, status, setStatus } = useApp();
-  const { layout } = usePanelNav();
+  const { layout, openPanel } = usePanelNav();
   const chats = useChatListStore((state) => state.chats);
   const deletingChatId = useChatListStore((state) => state.deletingChatId);
   const busy = useChatSessionStore((session) => session.busy);
@@ -386,7 +386,11 @@ export function ChatRoute({ chatId }: { chatId: string }) {
       case "sources":
         return (
           <PanelFrame position={side} spaceBetween>
-            <DocumentsView chatId={chatId} />
+            <DocumentsView
+              chatId={chatId}
+              documentId={panel.documentId}
+              onOpen={(documentId) => openPanel({ type: "sources", documentId })}
+            />
           </PanelFrame>
         );
       case "outputs":

--- a/crates/openwave-desktop/ui/src/DocumentsView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentsView.dom.test.tsx
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DocumentsView,
+  type DocumentsApis,
+} from "./DocumentsView";
+import type { LibraryDocument } from "./documents";
+
+afterEach(cleanup);
+
+const ids = {
+  alpha: "6c3df6af-bc62-4a66-a34e-29f327eaef41",
+  zeta: "dcf9cc51-465d-438a-bac4-8005c6c980d9",
+  queued: "295b4e3d-092e-48ab-9121-1a50c721d676",
+  retryable: "096c0f5a-e5f7-46c7-8e6a-d534793a585b",
+  permanent: "f079210a-f870-4030-b0b2-c628af729bb6",
+};
+
+describe("DocumentsView catalog", () => {
+  it("sorts and filters the source table and opens a row from the keyboard", async () => {
+    const onOpen = vi.fn();
+    const apis = sourceApis([
+      source({
+        documentId: ids.alpha,
+        title: "Alpha notes.md",
+        mediaType: "text/markdown",
+        sizeBytes: 1_024,
+        updatedAt: "2026-07-20T00:00:00Z",
+      }),
+      source({
+        documentId: ids.zeta,
+        title: "Zeta report.pdf",
+        mediaType: "application/pdf",
+        sizeBytes: 2_097_152,
+        updatedAt: "2026-07-24T00:00:00Z",
+      }),
+    ]);
+    const user = userEvent.setup();
+
+    render(<DocumentsView chatId="chat-1" onOpen={onOpen} apis={apis} />);
+    await screen.findByRole("table");
+    expect(openTitleOrder()).toEqual(["Open Zeta report.pdf", "Open Alpha notes.md"]);
+
+    await user.click(screen.getByRole("button", { name: "Title" }));
+    expect(screen.getByRole("columnheader", { name: /Title/ })).toHaveAttribute(
+      "aria-sort",
+      "ascending",
+    );
+    expect(openTitleOrder()).toEqual(["Open Alpha notes.md", "Open Zeta report.pdf"]);
+
+    await user.type(screen.getByRole("searchbox", { name: "Filter sources" }), "pdf");
+    expect(screen.queryByRole("button", { name: "Open Alpha notes.md" })).not.toBeInTheDocument();
+    const titleButton = screen.getByRole("button", { name: "Open Zeta report.pdf" });
+    titleButton.focus();
+    await user.keyboard("{Enter}");
+    expect(onOpen).toHaveBeenCalledWith(ids.zeta);
+    expect(screen.getByText("PDF")).toBeVisible();
+    expect(screen.getByText("2 MB")).toBeVisible();
+  });
+
+  it("renders authoritative lifecycle states and gates retry by the server projection", async () => {
+    const retryable = source({
+      documentId: ids.retryable,
+      title: "Retry me.pdf",
+      processingStatus: "failed",
+      searchable: false,
+      failure: {
+        message: "The local search index was unavailable. Retry preparing this source.",
+        retriable: true,
+      },
+    });
+    const permanent = source({
+      documentId: ids.permanent,
+      title: "Broken.pdf",
+      processingStatus: "failed",
+      searchable: false,
+      failure: {
+        message:
+          "OpenWave could not read this file. Delete it and add a supported, uncorrupted version.",
+        retriable: false,
+      },
+    });
+    const queued = source({
+      documentId: ids.queued,
+      title: "Preparing.md",
+      processingStatus: "processing",
+      searchable: false,
+    });
+    const ready = source({ documentId: ids.alpha, title: "Ready.md" });
+    const unsearchable = source({
+      documentId: ids.zeta,
+      title: "Scan.pdf",
+      searchable: false,
+    });
+    const afterRetry = {
+      ...retryable,
+      processingStatus: "queued" as const,
+      failure: null,
+    };
+    const apis = sourceApis([retryable, permanent, queued, ready, unsearchable]);
+    vi.mocked(apis.list)
+      .mockResolvedValueOnce({
+        documents: [retryable, permanent, queued, ready, unsearchable],
+        truncated: false,
+      })
+      .mockResolvedValue({
+        documents: [afterRetry, permanent, queued, ready, unsearchable],
+        truncated: false,
+      });
+    const user = userEvent.setup();
+
+    render(<DocumentsView chatId="chat-1" apis={apis} />);
+    expect(await screen.findByText("The local search index was unavailable. Retry preparing this source.")).toBeVisible();
+    expect(screen.getAllByRole("button", { name: "Retry" })).toHaveLength(1);
+    expect(screen.getByText(/Delete it and add a supported/)).toBeVisible();
+    expect(screen.getAllByText("Preparing")).toHaveLength(1);
+    expect(screen.getByText("Not searchable")).toBeVisible();
+    expect(screen.getByText("Ready")).toHaveClass("sr-only");
+
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() =>
+      expect(apis.retry).toHaveBeenCalledWith("chat-1", ids.retryable),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByText(
+          "The local search index was unavailable. Retry preparing this source.",
+        ),
+      ).not.toBeInTheDocument(),
+    );
+    expect(screen.getAllByText("Preparing").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("navigates open, confirms delete, and supports cancelling with Escape", async () => {
+    const onOpen = vi.fn();
+    const document = source({ documentId: ids.alpha, title: "Notes.md" });
+    const apis = sourceApis([document]);
+    const user = userEvent.setup();
+
+    render(<DocumentsView chatId="chat-1" onOpen={onOpen} apis={apis} />);
+    await screen.findByRole("table");
+
+    await user.click(screen.getByRole("button", { name: "Open Notes.md" }));
+    expect(onOpen).toHaveBeenCalledWith(ids.alpha);
+
+    await user.click(screen.getByRole("button", { name: "Delete Notes.md" }));
+    expect(await screen.findByRole("alertdialog")).toBeVisible();
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
+    expect(apis.delete).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Delete Notes.md" }));
+    await user.click(await screen.findByRole("button", { name: "Delete source" }));
+    await waitFor(() =>
+      expect(apis.delete).toHaveBeenCalledWith("chat-1", ids.alpha),
+    );
+    expect(screen.queryByRole("button", { name: "Open Notes.md" })).not.toBeInTheDocument();
+  });
+
+  it("ignores a stale catalog response after the conversation changes", async () => {
+    let resolveStale:
+      | ((catalog: { documents: LibraryDocument[]; truncated: boolean }) => void)
+      | undefined;
+    const stale = new Promise<{ documents: LibraryDocument[]; truncated: boolean }>(
+      (resolve) => {
+        resolveStale = resolve;
+      },
+    );
+    const apis = sourceApis([]);
+    vi.mocked(apis.list).mockImplementation((chatId) =>
+      chatId === "chat-1"
+        ? stale
+        : Promise.resolve({
+            documents: [source({ documentId: ids.zeta, title: "Current.pdf" })],
+            truncated: false,
+          }),
+    );
+    const view = render(<DocumentsView chatId="chat-1" apis={apis} />);
+    await waitFor(() => expect(apis.list).toHaveBeenCalledWith("chat-1"));
+
+    view.rerender(<DocumentsView chatId="chat-2" apis={apis} />);
+    expect(await screen.findByRole("button", { name: "Open Current.pdf" })).toBeVisible();
+    await act(async () => {
+      resolveStale?.({
+        documents: [source({ documentId: ids.alpha, title: "Stale.md" })],
+        truncated: false,
+      });
+    });
+    expect(screen.getByRole("button", { name: "Open Current.pdf" })).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Open Stale.md" })).not.toBeInTheDocument();
+  });
+
+  it("does not apply a pending delete confirmation to a different conversation", async () => {
+    const document = source({ documentId: ids.alpha, title: "Scoped.md" });
+    const apis = sourceApis([document]);
+    const user = userEvent.setup();
+    const view = render(<DocumentsView chatId="chat-1" apis={apis} />);
+    await screen.findByRole("button", { name: "Delete Scoped.md" });
+    await user.click(screen.getByRole("button", { name: "Delete Scoped.md" }));
+    expect(await screen.findByRole("alertdialog")).toBeVisible();
+
+    view.rerender(<DocumentsView chatId="chat-2" apis={apis} />);
+    await user.click(screen.getByRole("button", { name: "Delete source" }));
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument());
+    expect(apis.delete).not.toHaveBeenCalled();
+  });
+
+  it("states accepted file behavior and catalog limits when empty", async () => {
+    render(<DocumentsView chatId="chat-1" apis={sourceApis([])} />);
+    expect(await screen.findByText("No sources yet")).toBeVisible();
+    expect(screen.getByText(/files of any type, up to 16 MB each/i)).toBeVisible();
+    expect(screen.getByText(/newest 1,000 sources/i)).toBeVisible();
+  });
+});
+
+function openTitleOrder(): string[] {
+  return within(screen.getByRole("table"))
+    .getAllByRole("button")
+    .map((button) => button.getAttribute("aria-label"))
+    .filter((label): label is string => label?.startsWith("Open ") ?? false);
+}
+
+function source(overrides: Partial<LibraryDocument> = {}): LibraryDocument {
+  return {
+    documentId: ids.alpha,
+    title: "Source.md",
+    mediaType: "text/markdown",
+    sizeBytes: 512,
+    processingStatus: "ready",
+    searchable: true,
+    failure: null,
+    updatedAt: "2026-07-22T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function sourceApis(documents: LibraryDocument[]): DocumentsApis {
+  return {
+    list: vi.fn().mockResolvedValue({ documents, truncated: false }),
+    import: vi.fn().mockResolvedValue(null),
+    search: vi.fn().mockResolvedValue([]),
+    delete: vi.fn().mockResolvedValue(undefined),
+    retry: vi.fn().mockResolvedValue(undefined),
+  };
+}

--- a/crates/openwave-desktop/ui/src/DocumentsView.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentsView.tsx
@@ -1,11 +1,15 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { FileText } from "lucide-react";
 import {
+  deleteLibraryDocument,
   importLibraryDocuments,
   listLibraryDocuments,
+  retryLibraryDocument,
   searchLibraryDocuments,
   type ImportedDocument,
+  type LibraryCatalog,
   type LibraryDocument,
+  type LibraryImportBatch,
   type LibraryImportSuccess,
   type LibrarySearchResult,
 } from "./documents";
@@ -14,11 +18,39 @@ import {
   PICKER_HOLDERS,
   useNativePickerLatch,
 } from "./NativePickerLatch";
+import { useConfirm } from "./components/ConfirmDialog";
+
+type SortColumn = "title" | "type" | "size" | "date";
+type SortDirection = "ascending" | "descending";
+
+export type DocumentsApis = {
+  list: (chatId: string) => Promise<LibraryCatalog>;
+  import: (chatId: string) => Promise<LibraryImportBatch | null>;
+  search: (chatId: string, query: string) => Promise<LibrarySearchResult[]>;
+  delete: (chatId: string, documentId: string) => Promise<void>;
+  retry: (chatId: string, documentId: string) => Promise<void>;
+};
+
+const defaultApis: DocumentsApis = {
+  list: listLibraryDocuments,
+  import: importLibraryDocuments,
+  search: searchLibraryDocuments,
+  delete: deleteLibraryDocument,
+  retry: retryLibraryDocument,
+};
 
 export function DocumentsView({
   chatId,
+  documentId,
+  onOpen = () => {},
+  apis = defaultApis,
 }: {
   chatId: string;
+  /** URL-selected source identity. The detail viewer lands in #543. */
+  documentId?: string;
+  /** Navigate to the existing `sources.{documentId}` panel contract. */
+  onOpen?: (documentId: string) => void;
+  apis?: DocumentsApis;
 }) {
   const [documents, setDocuments] = useState<LibraryDocument[]>([]);
   const [catalogTruncated, setCatalogTruncated] = useState(false);
@@ -30,24 +62,37 @@ export function DocumentsView({
   const [searching, setSearching] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
   const [results, setResults] = useState<LibrarySearchResult[] | null>(null);
+  const [filter, setFilter] = useState("");
+  const [sort, setSort] = useState<{
+    column: SortColumn;
+    direction: SortDirection;
+  }>({ column: "date", direction: "descending" });
+  const [busyDocument, setBusyDocument] = useState<string | null>(null);
   const mountedRef = useRef(true);
+  const scopeRef = useRef(0);
   const catalogRequestRef = useRef(0);
   const searchRequestRef = useRef(0);
+  const { confirm, dialog: confirmDialog } = useConfirm();
+
+  function isCurrentScope(scope: number) {
+    return mountedRef.current && scope === scopeRef.current;
+  }
 
   async function refreshCatalog(showLoading = false) {
     const request = ++catalogRequestRef.current;
+    const scope = scopeRef.current;
     if (showLoading) setLoading(true);
     try {
-      const next = await listLibraryDocuments(chatId);
-      if (!mountedRef.current || request !== catalogRequestRef.current) return;
+      const next = await apis.list(chatId);
+      if (!isCurrentScope(scope) || request !== catalogRequestRef.current) return;
       setDocuments(next.documents);
       setCatalogTruncated(next.truncated);
       setError(null);
     } catch (err) {
-      if (!mountedRef.current || request !== catalogRequestRef.current) return;
+      if (!isCurrentScope(scope) || request !== catalogRequestRef.current) return;
       setError(friendlyError(err, "Could not load this conversation's sources."));
     } finally {
-      if (mountedRef.current && request === catalogRequestRef.current) {
+      if (isCurrentScope(scope) && request === catalogRequestRef.current) {
         setLoading(false);
       }
     }
@@ -55,6 +100,7 @@ export function DocumentsView({
 
   useEffect(() => {
     mountedRef.current = true;
+    scopeRef.current += 1;
     setDocuments([]);
     setCatalogTruncated(false);
     setError(null);
@@ -62,14 +108,17 @@ export function DocumentsView({
     setResults(null);
     setSearchError(null);
     setSearching(false);
+    setFilter("");
+    setBusyDocument(null);
     searchRequestRef.current += 1;
     void refreshCatalog(true);
     return () => {
       mountedRef.current = false;
+      scopeRef.current += 1;
       catalogRequestRef.current += 1;
       searchRequestRef.current += 1;
     };
-  }, [chatId]);
+  }, [chatId, apis]);
 
   const processing = documents.some((document) =>
     ["queued", "processing"].includes(document.processingStatus),
@@ -79,7 +128,7 @@ export function DocumentsView({
     if (!processing) return;
     const interval = window.setInterval(() => void refreshCatalog(), 2_000);
     return () => window.clearInterval(interval);
-  }, [processing]);
+  }, [processing, chatId, apis]);
 
   async function onImport() {
     if (importing) return;
@@ -87,22 +136,23 @@ export function DocumentsView({
       setError(PICKER_BUSY_MESSAGE);
       return;
     }
+    const scope = scopeRef.current;
     setImporting(true);
     setError(null);
     setImported(null);
     try {
-      const batch = await importLibraryDocuments(chatId);
+      const batch = await apis.import(chatId);
       const accepted = batch?.results.find(isImportedDocument);
-      if (!mountedRef.current || !accepted) return;
+      if (!isCurrentScope(scope) || !accepted) return;
       setImported(accepted.document);
       await refreshCatalog();
     } catch (err) {
-      if (mountedRef.current) {
+      if (isCurrentScope(scope)) {
         setError(friendlyError(err, "Could not add that source."));
       }
     } finally {
       useNativePickerLatch.getState().release(PICKER_HOLDERS.importSource);
-      if (mountedRef.current) setImporting(false);
+      if (isCurrentScope(scope)) setImporting(false);
     }
   }
 
@@ -111,25 +161,107 @@ export function DocumentsView({
     const normalized = query.trim();
     if (!normalized || searching) return;
     const request = ++searchRequestRef.current;
+    const scope = scopeRef.current;
     setSearching(true);
     setSearchError(null);
     try {
-      const next = await searchLibraryDocuments(chatId, normalized);
-      if (!mountedRef.current || request !== searchRequestRef.current) return;
+      const next = await apis.search(chatId, normalized);
+      if (!isCurrentScope(scope) || request !== searchRequestRef.current) return;
       setResults(next);
     } catch (err) {
-      if (!mountedRef.current || request !== searchRequestRef.current) return;
+      if (!isCurrentScope(scope) || request !== searchRequestRef.current) return;
       setSearchError(
         friendlyError(err, "Could not search this conversation's sources."),
       );
       setResults(null);
     } finally {
-      if (mountedRef.current && request === searchRequestRef.current) {
+      if (isCurrentScope(scope) && request === searchRequestRef.current) {
         setSearching(false);
       }
     }
   }
 
+  async function onDelete(document: LibraryDocument) {
+    const title = documentTitle(document);
+    const scope = scopeRef.current;
+    const accepted = await confirm({
+      title: `Delete ${title}?`,
+      description:
+        "This removes the source from this conversation and cannot be undone.",
+      confirmLabel: "Delete source",
+      destructive: true,
+    });
+    if (!accepted || !isCurrentScope(scope)) return;
+    catalogRequestRef.current += 1;
+    setBusyDocument(document.documentId);
+    setError(null);
+    try {
+      await apis.delete(chatId, document.documentId);
+      if (!isCurrentScope(scope)) return;
+      setDocuments((current) =>
+        current.filter((candidate) => candidate.documentId !== document.documentId),
+      );
+      setResults((current) =>
+        current?.filter((result) => result.documentId !== document.documentId) ?? null,
+      );
+    } catch (err) {
+      if (isCurrentScope(scope)) {
+        setError(friendlyError(err, "Could not delete that source."));
+      }
+    } finally {
+      if (isCurrentScope(scope)) setBusyDocument(null);
+    }
+  }
+
+  async function onRetry(document: LibraryDocument) {
+    if (!document.failure?.retriable) return;
+    const scope = scopeRef.current;
+    catalogRequestRef.current += 1;
+    setBusyDocument(document.documentId);
+    setError(null);
+    try {
+      await apis.retry(chatId, document.documentId);
+      if (!isCurrentScope(scope)) return;
+      setDocuments((current) =>
+        current.map((candidate) =>
+          candidate.documentId === document.documentId
+            ? {
+                ...candidate,
+                processingStatus: "queued",
+                searchable: false,
+                failure: null,
+              }
+            : candidate,
+        ),
+      );
+      void refreshCatalog();
+    } catch (err) {
+      if (isCurrentScope(scope)) {
+        setError(friendlyError(err, "Could not retry that source."));
+      }
+    } finally {
+      if (isCurrentScope(scope)) setBusyDocument(null);
+    }
+  }
+
+  function changeSort(column: SortColumn) {
+    setSort((current) => ({
+      column,
+      direction:
+        current.column === column
+          ? current.direction === "ascending"
+            ? "descending"
+            : "ascending"
+          : column === "date"
+            ? "descending"
+            : "ascending",
+    }));
+  }
+
+  const visibleDocuments = useMemo(
+    () => filterAndSortDocuments(documents, filter, sort.column, sort.direction),
+    [documents, filter, sort],
+  );
   const titles = new Map(
     documents.map((document) => [document.documentId, documentTitle(document)]),
   );
@@ -159,15 +291,17 @@ export function DocumentsView({
       <div className="documents-content">
         {imported && (
           <div className="document-notice" role="status">
-            <strong>{imported.displayName}</strong> was added to this conversation.
-            OpenWave is preparing it for search.
+            <span>
+              <strong>{imported.displayName}</strong> was added to this conversation.
+              OpenWave is preparing it for search.
+            </span>
           </div>
         )}
         {error && (
           <div className="document-error" role="alert">
             <span>{error}</span>
             <button type="button" className="btn" onClick={() => void refreshCatalog(true)}>
-              Try again
+              Refresh
             </button>
           </div>
         )}
@@ -179,7 +313,7 @@ export function DocumentsView({
           </div>
           <form onSubmit={(event) => void onSearch(event)}>
             <input
-              aria-label="Search sources"
+              aria-label="Search source contents"
               placeholder="What are you looking for?"
               maxLength={500}
               value={query}
@@ -223,9 +357,15 @@ export function DocumentsView({
           <div className="document-section-heading">
             <div>
               <h2 id="document-catalog-title">Conversation sources</h2>
-              <p>{documents.length} {documents.length === 1 ? "source" : "sources"}</p>
+              <p>
+                {documents.length} {documents.length === 1 ? "source" : "sources"}
+                {filter.trim() && ` · ${visibleDocuments.length} shown`}
+              </p>
               {catalogTruncated && (
-                <p>Showing the newest 1,000 sources.</p>
+                <p>
+                  Showing the newest 1,000 sources; sorting and filtering apply to
+                  these sources.
+                </p>
               )}
             </div>
             <button
@@ -245,54 +385,265 @@ export function DocumentsView({
           ) : documents.length === 0 && !error ? (
             <div className="document-empty">
               <strong>No sources yet</strong>
-              <span>Add a file to use it in this conversation.</span>
+              <span>
+                Drop files of any type, up to 16 MB each. PDFs, Office documents,
+                Markdown, text, and supported images are prepared for search; other
+                formats remain available as conversation sources.
+              </span>
+              <span>This panel shows the newest 1,000 sources.</span>
             </div>
           ) : (
-            <div className="document-list">
-              {documents.map((document) => (
-                <article className="document-row" key={document.documentId}>
-                  <div className="document-icon" aria-hidden="true">
-                    <FileText size={16} />
-                  </div>
-                  <div className="document-copy">
-                    <strong>{documentTitle(document)}</strong>
-                    <span>
-                      {mediaTypeLabel(document.mediaType)} · Updated {formatDate(document.updatedAt)}
-                    </span>
-                  </div>
-                  <DocumentStatus document={document} />
-                </article>
-              ))}
-            </div>
+            <>
+              <div className="document-catalog-toolbar">
+                <label>
+                  <span className="sr-only">Filter sources</span>
+                  <input
+                    type="search"
+                    aria-label="Filter sources"
+                    placeholder="Filter by title or type"
+                    value={filter}
+                    onChange={(event) => setFilter(event.target.value)}
+                  />
+                </label>
+              </div>
+              {visibleDocuments.length === 0 ? (
+                <div className="document-empty">
+                  <strong>No matching sources</strong>
+                  <span>Try another title or file type.</span>
+                  <button type="button" className="btn" onClick={() => setFilter("")}>
+                    Clear filter
+                  </button>
+                </div>
+              ) : (
+                <div className="document-table-wrap">
+                  <table className="document-table">
+                    <caption className="sr-only">
+                      Sources attached to this conversation
+                    </caption>
+                    <thead>
+                      <tr>
+                        <SortHeader
+                          label="Title"
+                          column="title"
+                          sortColumn={sort.column}
+                          direction={sort.direction}
+                          onSort={changeSort}
+                        />
+                        <SortHeader
+                          label="Type"
+                          column="type"
+                          sortColumn={sort.column}
+                          direction={sort.direction}
+                          onSort={changeSort}
+                        />
+                        <SortHeader
+                          label="Size"
+                          column="size"
+                          sortColumn={sort.column}
+                          direction={sort.direction}
+                          onSort={changeSort}
+                        />
+                        <SortHeader
+                          label="Date"
+                          column="date"
+                          sortColumn={sort.column}
+                          direction={sort.direction}
+                          onSort={changeSort}
+                        />
+                        <th scope="col">Status</th>
+                        <th scope="col">
+                          <span className="sr-only">Actions</span>
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {visibleDocuments.map((document) => {
+                        const title = documentTitle(document);
+                        const busy = busyDocument === document.documentId;
+                        return (
+                          <tr
+                            key={document.documentId}
+                            data-status={document.processingStatus}
+                            aria-current={
+                              document.documentId === documentId ? "true" : undefined
+                            }
+                          >
+                            <td>
+                              <button
+                                type="button"
+                                className="document-title-button"
+                                onClick={() => onOpen(document.documentId)}
+                                aria-label={`Open ${title}`}
+                              >
+                                <span className="document-icon" aria-hidden="true">
+                                  <FileText size={16} />
+                                </span>
+                                <strong>{title}</strong>
+                              </button>
+                            </td>
+                            <td>{mediaTypeLabel(document.mediaType)}</td>
+                            <td>{formatSize(document.sizeBytes)}</td>
+                            <td>
+                              <time dateTime={document.updatedAt}>
+                                {formatDate(document.updatedAt)}
+                              </time>
+                            </td>
+                            <td className="document-status-cell">
+                              <DocumentStatus
+                                document={document}
+                                busy={busy}
+                                onRetry={() => void onRetry(document)}
+                              />
+                            </td>
+                            <td>
+                              <div className="document-actions">
+                                <button
+                                  type="button"
+                                  className="document-action"
+                                  disabled={busy}
+                                  onClick={() => onOpen(document.documentId)}
+                                >
+                                  Open
+                                </button>
+                                <button
+                                  type="button"
+                                  className="document-action is-danger"
+                                  disabled={busy}
+                                  onClick={() => void onDelete(document)}
+                                  aria-label={`Delete ${title}`}
+                                >
+                                  Delete
+                                </button>
+                              </div>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </>
           )}
         </section>
       </div>
+      {confirmDialog}
     </section>
   );
 }
 
-function DocumentStatus({ document }: { document: LibraryDocument }) {
-  const { processingStatus: status, searchable } = document;
-  // A source can finish processing without producing anything to search — a
-  // scan without OCR, or a format whose parser is missing on this host. Saying
-  // "Available" there would promise a search that silently never matches.
-  if (status === "ready" && !searchable) {
+function SortHeader({
+  label,
+  column,
+  sortColumn,
+  direction,
+  onSort,
+}: {
+  label: string;
+  column: SortColumn;
+  sortColumn: SortColumn;
+  direction: SortDirection;
+  onSort: (column: SortColumn) => void;
+}) {
+  const active = column === sortColumn;
+  return (
+    <th scope="col" aria-sort={active ? direction : "none"}>
+      <button type="button" onClick={() => onSort(column)}>
+        {label}
+        <span aria-hidden="true">{active ? (direction === "ascending" ? " ↑" : " ↓") : ""}</span>
+      </button>
+    </th>
+  );
+}
+
+function DocumentStatus({
+  document,
+  busy,
+  onRetry,
+}: {
+  document: LibraryDocument;
+  busy: boolean;
+  onRetry: () => void;
+}) {
+  if (document.processingStatus === "ready" && document.searchable) {
+    return <span className="sr-only">Ready</span>;
+  }
+  if (document.processingStatus === "ready") {
     return (
-      <span
-        className="document-status is-unsearchable"
-        title="Stored in this conversation, but nothing in it can be searched."
-      >
+      <span className="document-unsearchable">
         Not searchable
+        <span>OpenWave stored this file, but found no searchable text.</span>
       </span>
     );
   }
-  const label =
-    status === "ready"
-      ? "Available"
-      : status === "failed"
-        ? "Needs attention"
-        : "Preparing";
-  return <span className={`document-status is-${status}`}>{label}</span>;
+  if (
+    document.processingStatus === "queued" ||
+    document.processingStatus === "processing"
+  ) {
+    return (
+      <span className="document-processing" role="status">
+        <span className="document-processing-pulse" aria-hidden="true" />
+        Preparing
+      </span>
+    );
+  }
+  const failure = document.failure;
+  return (
+    <span className="document-failure">
+      <span>{failure?.message ?? "OpenWave could not prepare this source."}</span>
+      {failure?.retriable && (
+        <button type="button" className="document-retry" disabled={busy} onClick={onRetry}>
+          {busy ? "Retrying…" : "Retry"}
+        </button>
+      )}
+    </span>
+  );
+}
+
+function filterAndSortDocuments(
+  documents: LibraryDocument[],
+  filter: string,
+  column: SortColumn,
+  direction: SortDirection,
+): LibraryDocument[] {
+  const normalized = filter.trim().toLocaleLowerCase();
+  const visible = normalized
+    ? documents.filter((document) =>
+        [documentTitle(document), mediaTypeLabel(document.mediaType), document.mediaType]
+          .join(" ")
+          .toLocaleLowerCase()
+          .includes(normalized),
+      )
+    : [...documents];
+  return visible.sort((left, right) => {
+    if (column === "size") {
+      if (left.sizeBytes === null) return right.sizeBytes === null ? tieBreak(left, right) : 1;
+      if (right.sizeBytes === null) return -1;
+    }
+    const comparison =
+      column === "title"
+        ? documentTitle(left).localeCompare(documentTitle(right), undefined, {
+            sensitivity: "base",
+          })
+        : column === "type"
+          ? mediaTypeLabel(left.mediaType).localeCompare(
+              mediaTypeLabel(right.mediaType),
+              undefined,
+              { sensitivity: "base" },
+            )
+          : column === "size"
+            ? (left.sizeBytes ?? 0) - (right.sizeBytes ?? 0)
+            : Date.parse(left.updatedAt) - Date.parse(right.updatedAt);
+    return comparison === 0
+      ? tieBreak(left, right)
+      : comparison * (direction === "ascending" ? 1 : -1);
+  });
+}
+
+function tieBreak(left: LibraryDocument, right: LibraryDocument): number {
+  return documentTitle(left)
+    .localeCompare(documentTitle(right), undefined, { sensitivity: "base" })
+    || left.documentId.localeCompare(right.documentId);
 }
 
 function documentTitle(document: LibraryDocument): string {
@@ -303,14 +654,33 @@ function mediaTypeLabel(mediaType: string): string {
   const base = mediaType.split(";")[0]?.trim().toLowerCase() ?? "";
   if (base === "application/pdf") return "PDF";
   if (base === "text/markdown") return "Markdown";
+  if (base.includes("wordprocessingml") || base === "application/msword") return "Word";
+  if (base.includes("spreadsheetml") || base === "application/vnd.ms-excel") return "Excel";
+  if (base.includes("presentationml") || base === "application/vnd.ms-powerpoint") {
+    return "PowerPoint";
+  }
+  if (base.startsWith("image/")) return "Image";
   if (base.startsWith("text/")) return "Text";
   return "File";
 }
 
+function formatSize(value: number | null): string {
+  if (value === null) return "—";
+  if (value < 1_024) return `${value} B`;
+  if (value < 1_048_576) return `${formatNumber(value / 1_024)} KB`;
+  return `${formatNumber(value / 1_048_576)} MB`;
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 }).format(value);
+}
+
 function formatDate(value: string): string {
-  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(
-    new Date(value),
-  );
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(new Date(value));
 }
 
 function isImportedDocument(

--- a/crates/openwave-desktop/ui/src/documents.test.ts
+++ b/crates/openwave-desktop/ui/src/documents.test.ts
@@ -55,8 +55,10 @@ describe("document library renderer projections", () => {
             documentId,
             title: "notes.md",
             mediaType: "text/markdown",
+            sizeBytes: 1_024,
             processingStatus: "processing",
             searchable: false,
+            failure: null,
             updatedAt: "2026-07-18T12:00:00Z",
           },
         ],
@@ -93,8 +95,10 @@ describe("document library renderer projections", () => {
           documentId,
           title: "scan.pdf",
           mediaType: "application/pdf",
+          sizeBytes: 2_048,
           processingStatus: "ready",
           searchable: false,
+          failure: null,
           updatedAt: "2026-07-18T12:00:00Z",
         },
       ],
@@ -111,8 +115,54 @@ describe("document library renderer projections", () => {
             documentId,
             title: "scan.pdf",
             mediaType: "application/pdf",
+            sizeBytes: 2_048,
             processingStatus: "ready",
+            failure: null,
             updatedAt: "2026-07-18T12:00:00Z",
+          },
+        ],
+        truncated: false,
+      }),
+    ).toThrow("Invalid document library response");
+  });
+
+  it("accepts only bounded renderer-safe failures tied to failed state", () => {
+    const failed = {
+      documentId,
+      title: "report.pdf",
+      mediaType: "application/pdf",
+      sizeBytes: 4_096,
+      processingStatus: "failed",
+      searchable: false,
+      failure: {
+        message: "The local search index was unavailable. Retry preparing this source.",
+        retriable: true,
+      },
+      updatedAt: "2026-07-18T12:00:00Z",
+    };
+    expect(
+      parseLibraryCatalog({ documents: [failed], truncated: false }).documents[0]
+        ?.failure?.retriable,
+    ).toBe(true);
+
+    expect(() =>
+      parseLibraryCatalog({
+        documents: [{ ...failed, processingStatus: "ready" }],
+        truncated: false,
+      }),
+    ).toThrow("Invalid document library response");
+    expect(() =>
+      parseLibraryCatalog({
+        documents: [{ ...failed, failure: null }],
+        truncated: false,
+      }),
+    ).toThrow("Invalid document library response");
+    expect(() =>
+      parseLibraryCatalog({
+        documents: [
+          {
+            ...failed,
+            failure: { message: `unsafe\u202e`, retriable: true },
           },
         ],
         truncated: false,
@@ -137,8 +187,10 @@ describe("document library renderer projections", () => {
               documentId,
               title: "notes.md",
               mediaType: "text/markdown",
+              sizeBytes: 42,
               processingStatus: "ready",
               searchable: true,
+              failure: null,
               updatedAt: "2026-07-18T12:00:00Z",
               [field]: "private",
             },

--- a/crates/openwave-desktop/ui/src/documents.ts
+++ b/crates/openwave-desktop/ui/src/documents.ts
@@ -11,10 +11,17 @@ export type LibraryDocument = {
   documentId: string;
   title: string | null;
   mediaType: string;
+  sizeBytes: number | null;
   processingStatus: DocumentProcessingStatus;
   /** Whether searching this conversation can actually match this source. */
   searchable: boolean;
+  failure: LibraryDocumentFailure | null;
   updatedAt: string;
+};
+
+export type LibraryDocumentFailure = {
+  message: string;
+  retriable: boolean;
 };
 
 export type ImportedDocument = {
@@ -67,6 +74,20 @@ export async function listLibraryDocuments(chatId: string): Promise<LibraryCatal
   return parseLibraryCatalog(
     await invoke("list_library_documents", { request: { chatId } }),
   );
+}
+
+export async function deleteLibraryDocument(
+  chatId: string,
+  documentId: string,
+): Promise<void> {
+  await invoke("delete_library_document", { request: { chatId, documentId } });
+}
+
+export async function retryLibraryDocument(
+  chatId: string,
+  documentId: string,
+): Promise<void> {
+  await invoke("retry_library_document", { request: { chatId, documentId } });
 }
 
 export async function importLibraryDocument(
@@ -260,8 +281,10 @@ function parseLibraryDocument(value: unknown): LibraryDocument {
       "documentId",
       "title",
       "mediaType",
+      "sizeBytes",
       "processingStatus",
       "searchable",
+      "failure",
       "updatedAt",
     ])
   ) {
@@ -275,8 +298,15 @@ function parseLibraryDocument(value: unknown): LibraryDocument {
     typeof value.mediaType !== "string" ||
     value.mediaType.length === 0 ||
     value.mediaType.length > 255 ||
+    (value.sizeBytes !== null &&
+      (typeof value.sizeBytes !== "number" ||
+        !Number.isSafeInteger(value.sizeBytes) ||
+        value.sizeBytes < 1 ||
+        value.sizeBytes > MAX_SOURCE_BYTES)) ||
     !isProcessingStatus(value.processingStatus) ||
     typeof value.searchable !== "boolean" ||
+    !isLibraryDocumentFailure(value.failure) ||
+    (value.processingStatus === "failed") !== (value.failure !== null) ||
     typeof value.updatedAt !== "string" ||
     !Number.isFinite(Date.parse(value.updatedAt))
   ) {
@@ -286,10 +316,25 @@ function parseLibraryDocument(value: unknown): LibraryDocument {
     documentId: value.documentId,
     title: value.title,
     mediaType: value.mediaType,
+    sizeBytes: value.sizeBytes,
     processingStatus: value.processingStatus,
     searchable: value.searchable,
+    failure: value.failure,
     updatedAt: value.updatedAt,
   };
+}
+
+function isLibraryDocumentFailure(
+  value: unknown,
+): value is LibraryDocumentFailure | null {
+  if (value === null) return true;
+  return (
+    isExactRecord(value, ["message", "retriable"]) &&
+    typeof value.message === "string" &&
+    value.message.length > 0 &&
+    isSafeRendererText(value.message, 500, false) &&
+    typeof value.retriable === "boolean"
+  );
 }
 
 function isProcessingStatus(value: unknown): value is DocumentProcessingStatus {
@@ -325,6 +370,7 @@ function isSafeRendererText(
 }
 
 const DISALLOWED_RENDERER_CATEGORY = /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u;
+const MAX_SOURCE_BYTES = 16 * 1024 * 1024;
 
 function isExactRecord(
   value: unknown,

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -2381,24 +2381,6 @@ body {
   opacity: 0.5;
 }
 
-.document-list {
-  display: grid;
-  border-top: 1px solid var(--line);
-}
-
-.document-row {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 0.75rem;
-  min-height: 4.25rem;
-  border-bottom: 1px solid var(--line);
-}
-
-.document-row:last-child {
-  border-bottom: 0;
-}
-
 .document-icon {
   display: grid;
   width: 2rem;
@@ -2410,23 +2392,217 @@ body {
   background: var(--page-background);
 }
 
-.document-copy {
-  display: grid;
-  min-width: 0;
-  gap: 0.15rem;
+.document-catalog-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.7rem 0;
+  border-top: 1px solid var(--line);
 }
 
-.document-copy strong {
+.document-catalog-toolbar label {
+  width: min(100%, 20rem);
+}
+
+.document-catalog-toolbar input {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  padding: 0.45rem 0.6rem;
+  background: var(--page-background);
+  font-size: 0.8rem;
+}
+
+.document-catalog-toolbar input:focus {
+  outline: 2px solid color-mix(in srgb, var(--color-openwave) 40%, transparent);
+  outline-offset: 1px;
+}
+
+.document-table-wrap {
+  max-width: 100%;
+  overflow-x: auto;
+  border-top: 1px solid var(--line);
+}
+
+.document-table {
+  width: 100%;
+  min-width: 58rem;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-size: 0.78rem;
+}
+
+.document-table th,
+.document-table td {
+  padding: 0.7rem 0.55rem;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+  vertical-align: middle;
+}
+
+.document-table th {
+  color: var(--muted-foreground);
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.document-table th:first-child {
+  width: 25%;
+}
+
+.document-table th:nth-child(2) {
+  width: 9%;
+}
+
+.document-table th:nth-child(3) {
+  width: 8%;
+}
+
+.document-table th:nth-child(4) {
+  width: 13%;
+}
+
+.document-table th:nth-child(5) {
+  width: 29%;
+}
+
+.document-table th:last-child {
+  width: 16%;
+}
+
+.document-table th button {
+  border: 0;
+  padding: 0.15rem 0;
+  color: inherit;
+  background: transparent;
+  font: inherit;
+}
+
+.document-table th button:hover,
+.document-table th button:focus-visible {
+  color: var(--ink);
+}
+
+.document-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.document-table tbody tr[aria-current="true"] {
+  background: color-mix(in srgb, var(--color-openwave) 6%, transparent);
+}
+
+.document-title-button {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  align-items: center;
+  gap: 0.55rem;
+  border: 0;
+  padding: 0;
+  color: var(--ink);
+  background: transparent;
+  text-align: left;
+}
+
+.document-title-button strong {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 0.86rem;
+  font-size: 0.82rem;
   font-weight: 590;
 }
 
-.document-copy span {
+.document-title-button:hover strong,
+.document-title-button:focus-visible strong {
+  text-decoration: underline;
+  text-underline-offset: 0.16rem;
+}
+
+.document-status-cell {
+  overflow-wrap: anywhere;
+}
+
+.document-processing {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  color: var(--warning-foreground);
+  font-weight: 570;
+}
+
+.document-processing-pulse {
+  width: 0.48rem;
+  height: 0.48rem;
+  border-radius: 999px;
+  background: currentColor;
+  animation: document-processing-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes document-processing-pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+    transform: scale(0.8);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .document-processing-pulse {
+    animation: none;
+  }
+}
+
+.document-failure,
+.document-unsearchable {
+  display: grid;
+  justify-items: start;
+  gap: 0.3rem;
+  color: var(--danger);
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
+.document-unsearchable {
   color: var(--muted-foreground);
-  font-size: 0.74rem;
+  font-weight: 570;
+}
+
+.document-unsearchable > span {
+  font-weight: 400;
+}
+
+.document-retry,
+.document-action {
+  border: 0;
+  padding: 0.15rem 0.2rem;
+  color: var(--color-openwave);
+  background: transparent;
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.document-retry:hover:not(:disabled),
+.document-retry:focus-visible,
+.document-action:hover:not(:disabled),
+.document-action:focus-visible {
+  text-decoration: underline;
+  text-underline-offset: 0.15rem;
+}
+
+.document-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.35rem;
+}
+
+.document-action.is-danger {
+  color: var(--danger);
 }
 
 /* A transcript phase whose row threw while rendering. Deliberately quiet: the
@@ -2436,37 +2612,6 @@ body {
   padding: 0.5rem 0.75rem;
   color: var(--muted-foreground);
   font-size: 0.82rem;
-}
-
-.document-status {
-  padding: 0.2rem 0.5rem;
-  border-radius: 999px;
-  color: var(--muted-foreground);
-  background: var(--muted);
-  font-size: 0.72rem;
-  font-weight: 570;
-}
-
-.document-status.is-ready {
-  color: var(--success-foreground);
-  background: var(--success-background);
-}
-
-.document-status.is-processing,
-.document-status.is-queued {
-  color: var(--warning-foreground);
-  background: var(--warning-background);
-}
-
-.document-status.is-failed {
-  color: var(--danger);
-  background: color-mix(in srgb, var(--danger) 9%, var(--page-background));
-}
-
-/* Stored but with nothing to search: neither a success nor a failure, so it
-   keeps the neutral base and only hints that an explanation is available. */
-.document-status.is-unsearchable {
-  cursor: help;
 }
 
 .document-empty,
@@ -2855,14 +3000,8 @@ body {
     max-height: 14rem;
   }
 
-  .document-row {
-    grid-template-columns: auto minmax(0, 1fr);
-  }
-
-  .document-status {
-    grid-column: 2;
-    justify-self: start;
-    margin-top: -0.5rem;
+  .document-catalog-toolbar label {
+    width: 100%;
   }
 }
 

--- a/crates/openwave-server/src/routes/document.rs
+++ b/crates/openwave-server/src/routes/document.rs
@@ -100,6 +100,8 @@ pub struct DocumentSummary {
     pub media_type: String,
     /// Optional human-facing title.
     pub title: Option<String>,
+    /// Exact retained source byte length, when original bytes are available.
+    pub source_byte_len: Option<u64>,
     /// Current authoritative source revision.
     pub content_revision: i64,
     /// Processing lifecycle of the current source revision.
@@ -131,6 +133,7 @@ impl From<DocumentSummaryRecord> for DocumentSummary {
             uri: document.source_uri,
             media_type: document.media_type,
             title: document.title,
+            source_byte_len: document.source_byte_len,
             content_revision: document.content_revision,
             processing_status: document.processing_status,
             searchable: document.searchable,
@@ -152,6 +155,7 @@ impl From<&DocumentRecord> for DocumentSummary {
             uri: document.source_uri.clone(),
             media_type: document.media_type.clone(),
             title: document.title.clone(),
+            source_byte_len: document.source_blob.as_ref().map(|source| source.byte_len),
             content_revision: document.content_revision,
             processing_status: document.processing_status,
             searchable: document.is_searchable(),

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -6697,6 +6697,10 @@ async fn document_catalog_pages_metadata_and_keeps_project_content_private() {
         .unwrap();
     assert_eq!(catalog_summary["uri"], "file:///catalog.txt");
     assert_eq!(catalog_summary["media_type"], "text/markdown");
+    assert_eq!(
+        catalog_summary["source_byte_len"],
+        serde_json::json!("# Catalog\n\nDurable source".len())
+    );
     assert_eq!(catalog_summary["content_revision"], 1);
     assert_eq!(catalog_summary["processing_status"], "queued");
     assert!(catalog_summary["indexed_revision"].is_null());


### PR DESCRIPTION
Refs #533
Refs #541

Rebuilds the Sources panel as an accessible searchable/sortable table backed by authoritative per-document state. Adds safe failure copy and retry gating, delete/retry actions, stale-request fencing, truthful limits, and URL navigation for open without duplicating the #543 viewer.

Validation: 509 UI tests, TypeScript and production build, formatting, full workspace clippy/tests, and targeted catalog/native/server tests.