### PR TITLE
feat(desktop): open a source document in a panel

### DIFF
--- a/crates/openwave-desktop/src/documents.rs
+++ b/crates/openwave-desktop/src/documents.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tauri::{AppHandle, DragDropEvent, Emitter, Manager, State, WindowEvent};
 use tauri_plugin_dialog::DialogExt;
+use tokio::io::AsyncWriteExt;
 use tokio::sync::oneshot;
 use tokio_util::io::ReaderStream;
 use unicode_general_category::{get_general_category, GeneralCategory};
@@ -340,6 +341,11 @@ pub(crate) struct LibraryDocumentRequest {
     document_id: Uuid,
 }
 
+#[derive(Debug, Deserialize)]
+struct DocumentTitle {
+    title: Option<String>,
+}
+
 #[tauri::command]
 pub(crate) async fn list_library_documents(
     state: State<'_, Arc<AppState>>,
@@ -595,6 +601,187 @@ pub(crate) async fn import_dropped_library_documents(
         )
         .await,
     ))
+}
+
+/// Save one source's original bytes wherever the reader chooses.
+///
+/// The renderer names the document by id and nothing else. The suggested
+/// filename is derived from the stored title here, the destination is chosen
+/// through the native dialog, and neither the path nor the bytes are ever
+/// handed back across the boundary. Returns false when the dialog was
+/// dismissed without picking a destination.
+#[tauri::command]
+pub(crate) async fn export_library_document(
+    app: AppHandle,
+    app_state: State<'_, Arc<AppState>>,
+    host_access: State<'_, HostAccess>,
+    request: LibraryDocumentRequest,
+) -> Result<bool, String> {
+    let (chat_id, document_id) =
+        resolve_document_scope(&host_access, request.chat_id, request.document_id).await?;
+    let _picker = host_access
+        .picker
+        .try_lock()
+        .map_err(|_| "A file or folder picker is already open".to_owned())?;
+    let info = wait_server_info(app_state.inner()).await?;
+    let response = native_auth(
+        local_client().get(format!(
+            "{}{}",
+            info.base_url,
+            document_path(chat_id, document_id)
+        )),
+        &info,
+    )
+    .send()
+    .await
+    .map_err(|_| "Could not open that source".to_owned())?;
+    if !response.status().is_success() {
+        return Err("Could not open that source".to_owned());
+    }
+    let detail = response
+        .json::<DocumentTitle>()
+        .await
+        .map_err(|_| "That source returned an invalid response".to_owned())?;
+
+    let Some(destination) = pick_export_path(
+        &app,
+        "Save source",
+        &export_file_name(detail.title.as_deref()),
+    )
+    .await?
+    else {
+        return Ok(false);
+    };
+    // The dialog may stay open long enough for the conversation to be deleted.
+    // Revalidate before the one host write the reader authorized.
+    let (chat_id, document_id) =
+        resolve_document_scope(&host_access, request.chat_id, request.document_id).await?;
+    let response = native_auth(
+        streaming_local_client().get(format!(
+            "{}{}",
+            info.base_url,
+            document_file_content_path(chat_id, document_id)
+        )),
+        &info,
+    )
+    .send()
+    .await
+    .map_err(|_| "Could not read that source".to_owned())?;
+    if !response.status().is_success() {
+        return Err("Could not read that source".to_owned());
+    }
+    write_exported_document(&destination, response).await?;
+    Ok(true)
+}
+
+/// Stream a response body into `destination`, replacing it only once complete.
+///
+/// The bytes go straight from the loopback response to disk rather than being
+/// buffered: a source is whatever the reader imported, and some of them are
+/// far larger than a copy we would want to hold in memory. The write lands in
+/// a sibling temporary first, so an interrupted save cannot leave a truncated
+/// file where a whole one used to be.
+async fn write_exported_document(
+    destination: &Path,
+    mut response: reqwest::Response,
+) -> Result<(), String> {
+    if !destination.is_absolute() {
+        return Err("The save destination is invalid".to_owned());
+    }
+    let parent = destination
+        .parent()
+        .ok_or_else(|| "The save destination is invalid".to_owned())?;
+    let filename = destination
+        .file_name()
+        .ok_or_else(|| "The save destination is invalid".to_owned())?;
+    let directory = Dir::open_ambient_dir(parent, ambient_authority())
+        .map_err(|_| "Could not open the selected folder".to_owned())?;
+    let permissions = match directory.symlink_metadata(filename) {
+        Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => {
+            Some(metadata.permissions())
+        }
+        Ok(_) => return Err("The selected destination is not a regular file".to_owned()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(_) => return Err("Could not inspect the selected destination".to_owned()),
+    };
+    let temporary = format!(".openwave-export-{}.tmp", Uuid::new_v4());
+    let result =
+        stream_into_temporary(&directory, &temporary, filename, permissions, &mut response).await;
+    if result.is_err() {
+        let _ = directory.remove_file(&temporary);
+    }
+    result
+}
+
+async fn stream_into_temporary(
+    directory: &Dir,
+    temporary: &str,
+    filename: &std::ffi::OsStr,
+    permissions: Option<cap_std::fs::Permissions>,
+    response: &mut reqwest::Response,
+) -> Result<(), String> {
+    let mut options = OpenOptions::new();
+    options
+        .write(true)
+        .create_new(true)
+        .follow(FollowSymlinks::No);
+    #[cfg(unix)]
+    {
+        use cap_std::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let file = directory
+        .open_with(temporary, &options)
+        .map_err(|_| "Could not save that source".to_owned())?;
+    if let Some(permissions) = permissions {
+        file.set_permissions(permissions)
+            .map_err(|_| "Could not save that source".to_owned())?;
+    }
+    let mut file = tokio::fs::File::from_std(file.into_std());
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|_| "Could not read that source".to_owned())?
+    {
+        file.write_all(&chunk)
+            .await
+            .map_err(|_| "Could not save that source".to_owned())?;
+    }
+    file.sync_all()
+        .await
+        .map_err(|_| "Could not save that source".to_owned())?;
+    drop(file);
+    directory
+        .rename(temporary, directory, filename)
+        .map_err(|_| "Could not save that source".to_owned())?;
+    #[cfg(unix)]
+    directory
+        .open(".")
+        .and_then(|handle| handle.sync_all())
+        .map_err(|_| "Could not save that source".to_owned())?;
+    Ok(())
+}
+
+/// A filename to suggest in the save dialog, derived from the stored title.
+///
+/// Only a name, never a path: separators and anything that could climb out of
+/// the folder the reader picks are dropped rather than escaped, and a title
+/// that survives none of that falls back to a fixed name.
+fn export_file_name(title: Option<&str>) -> String {
+    let cleaned = title
+        .unwrap_or_default()
+        .chars()
+        .filter(|character| {
+            is_safe_title_char(*character) && !matches!(*character, '/' | '\\' | ':' | '\0')
+        })
+        .take(200)
+        .collect::<String>();
+    let cleaned = cleaned.trim().trim_start_matches('.').trim();
+    if cleaned.is_empty() {
+        "document".to_owned()
+    } else {
+        cleaned.to_owned()
+    }
 }
 
 /// Turn native drag events into a small renderer-safe state signal while
@@ -946,6 +1133,10 @@ fn streamed_raw_documents_path(chat_id: ChatId) -> String {
     format!("{}/raw-stream", documents_path(chat_id))
 }
 
+fn document_file_content_path(chat_id: ChatId, document_id: DocumentId) -> String {
+    format!("{}/file-content", document_path(chat_id, document_id))
+}
+
 fn search_path(chat_id: ChatId) -> String {
     format!("/chats/{chat_id}/search")
 }
@@ -1013,6 +1204,34 @@ pub(crate) async fn pick_documents(app: &AppHandle) -> Result<Option<Vec<PathBuf
         })
         .transpose()
         .map_err(|_| "The document picker returned an invalid file".to_owned())
+}
+
+/// Ask the reader where to write a file the app is handing back to them.
+///
+/// `filename` is only a suggestion the dialog opens on; the destination the
+/// reader confirms is what gets written.
+pub(crate) async fn pick_export_path(
+    app: &AppHandle,
+    dialog_title: &str,
+    filename: &str,
+) -> Result<Option<PathBuf>, String> {
+    let (tx, rx) = oneshot::channel();
+    let mut picker = app
+        .dialog()
+        .file()
+        .set_title(dialog_title)
+        .set_file_name(filename);
+    if let Some(window) = app.get_webview_window("main") {
+        picker = picker.set_parent(&window);
+    }
+    picker.save_file(move |path| {
+        let _ = tx.send(path);
+    });
+    rx.await
+        .map_err(|_| "The save dialog closed unexpectedly".to_owned())?
+        .map(tauri_plugin_dialog::FilePath::into_path)
+        .transpose()
+        .map_err(|_| "The save dialog returned an invalid destination".to_owned())
 }
 
 fn import_display_name(path: &Path) -> Result<String, String> {
@@ -1384,12 +1603,27 @@ mod tests {
             search_path(standalone.id),
             format!("/chats/{}/search", standalone.id)
         );
+        // Original bytes are reachable only through the owning conversation.
+        let document_id = DocumentId::new();
+        assert_eq!(
+            document_file_content_path(standalone.id, document_id),
+            format!(
+                "/chats/{}/documents/{document_id}/file-content",
+                standalone.id
+            )
+        );
 
         let injected = serde_json::json!({
             "chatId": standalone.id,
             "projectId": project.id,
         });
         assert!(serde_json::from_value::<LibraryRequest>(injected).is_err());
+        let injected_document = serde_json::json!({
+            "chatId": standalone.id,
+            "documentId": Uuid::new_v4(),
+            "projectId": project.id,
+        });
+        assert!(serde_json::from_value::<LibraryDocumentRequest>(injected_document).is_err());
         let injected_search = serde_json::json!({
             "chatId": standalone.id,
             "projectId": project.id,
@@ -1402,6 +1636,28 @@ mod tests {
             "projectId": project.id,
         });
         assert!(serde_json::from_value::<LibraryDocumentRequest>(injected_document).is_err());
+    }
+
+    #[test]
+    fn export_file_name_suggests_a_name_and_never_a_path() {
+        assert_eq!(
+            export_file_name(Some("Quarterly report.pdf")),
+            "Quarterly report.pdf"
+        );
+        // A title is stored text, not a filename. Anything that could steer the
+        // save dialog out of the folder the reader picked is dropped outright,
+        // as are the characters filtered everywhere else on this boundary.
+        assert_eq!(
+            export_file_name(Some("../../.ssh/authorized_keys")),
+            "sshauthorized_keys"
+        );
+        assert_eq!(
+            export_file_name(Some("C:\\Windows\\system32")),
+            "CWindowssystem32"
+        );
+        assert_eq!(export_file_name(Some("plan\u{202e}.md")), "plan.md");
+        assert_eq!(export_file_name(Some("  ..  ")), "document");
+        assert_eq!(export_file_name(None), "document");
     }
 
     #[test]

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -182,6 +182,7 @@ pub fn run() {
             documents::search_library_documents,
             documents::delete_library_document,
             documents::retry_library_document,
+            documents::export_library_document,
             deliverables::list_deliverables,
             deliverables::read_deliverable,
             deliverables::export_deliverable,

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -398,7 +398,6 @@ export function ChatRoute({ chatId }: { chatId: string }) {
           <PanelFrame position={side} spaceBetween>
             <DocumentsView
               chatId={chatId}
-              documentId={panel.documentId}
               onOpen={(documentId) => openPanel({ type: "sources", documentId })}
             />
           </PanelFrame>

--- a/crates/openwave-desktop/ui/src/DocumentsView.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentsView.tsx
@@ -46,7 +46,7 @@ export function DocumentsView({
   apis = defaultApis,
 }: {
   chatId: string;
-  /** URL-selected source identity. The detail viewer lands in #543. */
+  /** URL-selected source identity, highlighted when this catalog is visible. */
   documentId?: string;
   /** Navigate to the existing `sources.{documentId}` panel contract. */
   onOpen?: (documentId: string) => void;

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -46,6 +46,7 @@ import {
   type ToolApprovalKind,
   type ToolResultPreview as WireToolResultPreview,
 } from "./generated/wire";
+import type { DocumentProcessingStatus } from "./documents";
 
 export type {
   ApprovalClass,
@@ -68,6 +69,16 @@ export type AgentEvent = RendererAgentEvent;
 
 /** Generated from `ToolApprovalKind`. */
 export type RendererApprovalKind = ToolApprovalKind;
+
+export type DocumentDetail = {
+  document_id: string;
+  media_type: string;
+  title: string | null;
+  processing_status: DocumentProcessingStatus;
+  searchable: boolean;
+  updated_at: string;
+  content: string;
+};
 
 /** Connection details from the Tauri host (`server_info` command). */
 export type ServerInfo = {
@@ -642,15 +653,11 @@ export class ApiClient {
     });
   }
 
-  async getChatImageAttachment(
-    chatId: string,
-    attachmentId: string,
-    signal?: AbortSignal,
-  ): Promise<Blob> {
-    const response = await fetch(
-      `${this.baseUrl}/chats/${encodeURIComponent(chatId)}/attachments/images/${encodeURIComponent(attachmentId)}`,
-      { headers: this.headers(), signal },
-    );
+  private async blob(path: string, signal?: AbortSignal): Promise<Blob> {
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      headers: this.headers(),
+      signal,
+    });
     if (!response.ok) {
       let detail = response.statusText;
       try {
@@ -662,6 +669,17 @@ export class ApiClient {
       throw new Error(`${response.status}: ${detail}`);
     }
     return response.blob();
+  }
+
+  getChatImageAttachment(
+    chatId: string,
+    attachmentId: string,
+    signal?: AbortSignal,
+  ): Promise<Blob> {
+    return this.blob(
+      `/chats/${encodeURIComponent(chatId)}/attachments/images/${encodeURIComponent(attachmentId)}`,
+      signal,
+    );
   }
 
   /**
@@ -690,6 +708,32 @@ export class ApiClient {
       throw new Error(`${response.status}: ${detail}`);
     }
     return new Uint8Array(await response.arrayBuffer());
+  }
+
+  /** One source's extracted text and catalog metadata. */
+  getChatDocument(chatId: string, documentId: string): Promise<DocumentDetail> {
+    return this.json(
+      `/chats/${encodeURIComponent(chatId)}/documents/${encodeURIComponent(documentId)}`,
+      { headers: this.headers() },
+    );
+  }
+
+  /**
+   * The original bytes of one source, exactly as they were imported.
+   *
+   * Bytes are addressed by document id and never by a host path, so a viewer
+   * can show the file the reader gave us without the renderer learning where
+   * on disk it came from.
+   */
+  getChatDocumentFile(
+    chatId: string,
+    documentId: string,
+    signal?: AbortSignal,
+  ): Promise<Blob> {
+    return this.blob(
+      `/chats/${encodeURIComponent(chatId)}/documents/${encodeURIComponent(documentId)}/file-content`,
+      signal,
+    );
   }
 
   patchChatTitle(chatId: string, title: string | null): Promise<Chat> {

--- a/crates/openwave-desktop/ui/src/components/document/document-details.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/document-details.tsx
@@ -1,0 +1,130 @@
+import type { DocumentDetail } from "@/api";
+import { useApp } from "@/AppContext";
+import {
+  DocumentViewer,
+  hasOriginalViewer,
+} from "@/document/DocumentViewer";
+import { DocumentError } from "./error";
+import { ImageViewer } from "./image-viewer";
+import { MarkdownViewer, type HighlightRange } from "./markdown-viewer";
+
+/** Which of a document's two views is on screen. */
+export type DocumentView = "extracted_text" | "original_doc";
+
+/**
+ * A media type reduced to `type/subtype`: lowercased, parameters dropped.
+ * Sources are typed by sniffing their bytes, so the stored value can carry a
+ * charset that no viewer wants to match on.
+ */
+export function baseMediaType(mediaType: string): string {
+  return mediaType.split(";")[0]?.trim().toLowerCase() ?? "";
+}
+
+/**
+ * Whether any viewer can draw this format's original bytes.
+ *
+ * A format with no viewer is not refused: its panel drops the original view
+ * and opens on the extracted text alone, which is a better floor than
+ * declining to open the document at all. Keep this in step with the dispatch
+ * below — a type listed here must reach a viewer there.
+ */
+export function isDocumentRenderable(mediaType: string): boolean {
+  const type = baseMediaType(mediaType);
+  return (
+    type.startsWith("image/") ||
+    type.startsWith("text/") ||
+    type === "application/json" ||
+    type === "application/xml" ||
+    hasOriginalViewer(type)
+  );
+}
+
+type DocumentDetailsProps = {
+  chatId: string;
+  info: DocumentDetail;
+  view: DocumentView;
+  hasOriginalDocumentTab?: boolean;
+  /** Character range in the original to reveal, when opened from a citation. */
+  highlightRange?: HighlightRange;
+};
+
+/**
+ * The two ways a source is shown, and which viewer draws each format.
+ *
+ * The original is whatever the reader imported, dispatched on media type. The
+ * extracted text is what OpenWave actually read out of it — the text of record
+ * that searches and citations index into — and every source has one, which is
+ * why it is the view a format with no viewer falls back to.
+ *
+ * Adding a format is a branch here plus a case in {@link isDocumentRenderable}.
+ */
+export function DocumentDetails({
+  chatId,
+  info,
+  view,
+  hasOriginalDocumentTab,
+  highlightRange,
+}: DocumentDetailsProps) {
+  const { client } = useApp();
+  const type = baseMediaType(info.media_type);
+
+  return (
+    <div className="flex min-h-0 grow flex-col overflow-hidden">
+      {hasOriginalDocumentTab && view === "original_doc" && (
+        <>
+          {hasOriginalViewer(type) ? (
+            <DocumentViewer
+              client={client}
+              documentId={info.document_id}
+              mediaType={type}
+              className="grow"
+            />
+          ) : type.startsWith("image/") ? (
+            <ImageViewer chatId={chatId} documentID={info.document_id} className="grow" />
+          ) : (
+            <MarkdownViewer
+              chatId={chatId}
+              documentID={info.document_id}
+              highlightRange={highlightRange}
+              markdown={type === "text/markdown"}
+              className="grow"
+            />
+          )}
+        </>
+      )}
+      {view === "extracted_text" && <ExtractedText info={info} />}
+    </div>
+  );
+}
+
+/**
+ * The text of record, rendered as one contiguous run rather than paginated.
+ *
+ * That is deliberate: citation offsets index into this exact string, so the
+ * day a citation has to be scrolled to and highlighted there is a single text
+ * node to find the offset in.
+ */
+function ExtractedText({ info }: { info: DocumentDetail }) {
+  if (info.content.length === 0) {
+    switch (info.processing_status) {
+      case "failed":
+        return <DocumentError>Failed to process document</DocumentError>;
+      case "ready":
+        return (
+          <DocumentError>
+            No text could be read out of this document
+          </DocumentError>
+        );
+      default:
+        return <DocumentError>This document is still being prepared</DocumentError>;
+    }
+  }
+
+  return (
+    <div className="min-h-0 grow overflow-auto p-6">
+      <pre className="mx-auto max-w-4xl font-sans text-sm leading-relaxed break-words whitespace-pre-wrap">
+        {info.content}
+      </pre>
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/components/document/error.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/error.tsx
@@ -1,0 +1,11 @@
+import { CircleAlertIcon } from "lucide-react";
+import type { PropsWithChildren } from "react";
+
+export function DocumentError(props: PropsWithChildren) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-10 font-bold text-muted-foreground">
+      <CircleAlertIcon className="size-4" />
+      {props.children}
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/components/document/image-viewer.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/image-viewer.tsx
@@ -1,0 +1,69 @@
+import { Loader2Icon } from "lucide-react";
+import type { HTMLAttributes } from "react";
+import { useEffect, useState } from "react";
+
+import { cn } from "@/lib/utils";
+import { useFileDownload } from "./useFileDownload";
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  chatId: string;
+  documentID: string;
+}
+
+export function ImageViewer({ chatId, documentID, className, ...restProps }: Props) {
+  const [imageError, setImageError] = useState(false);
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const fileDownload = useFileDownload(chatId, documentID, { parseAs: "blob" });
+
+  useEffect(() => {
+    if (!fileDownload.data) return;
+    const url = URL.createObjectURL(fileDownload.data);
+    setImageUrl(url);
+    // An object URL outlives its blob, so a panel left open through a session
+    // of clicking around would otherwise leak every image it drew.
+    return () => URL.revokeObjectURL(url);
+  }, [fileDownload.data]);
+
+  // Reset error state on document change
+  useEffect(() => {
+    setImageError(false);
+  }, [documentID]);
+
+  if (fileDownload.isLoading) {
+    return (
+      <div className={cn("relative overflow-auto", className)} {...restProps}>
+        <div className="flex h-64 items-center justify-center text-muted-foreground">
+          <div className="flex flex-col items-center gap-2">
+            <Loader2Icon className="size-6 animate-spin" />
+            <p>Loading image…</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (fileDownload.isError || imageError) {
+    return (
+      <div className={cn("relative overflow-auto", className)} {...restProps}>
+        <div className="flex h-64 items-center justify-center text-muted-foreground">
+          <p>Failed to load image</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("relative overflow-auto", className)} {...restProps}>
+      <div className="flex justify-center p-4">
+        {imageUrl && (
+          <img
+            src={imageUrl}
+            alt="Document image"
+            className="max-w-full shadow-lg"
+            onError={() => setImageError(true)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/components/document/markdown-viewer.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/markdown-viewer.tsx
@@ -1,0 +1,217 @@
+import { FileIcon, Loader2Icon } from "lucide-react";
+import type { HTMLAttributes } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { cn } from "@/lib/utils";
+import { MessageMarkdown } from "@/MessageMarkdown";
+import { useFileDownload } from "./useFileDownload";
+
+/** A character range in the raw file, as a citation reports it. */
+export type HighlightRange = { start: number; end: number };
+
+// Each chunk is rendered as a separate markdown block. 50K chars is
+// comfortably fast for the parser to handle in one pass.
+const CHUNK_SIZE_CHARS = 50_000;
+
+// How many chunks to render on initial mount
+const INITIAL_CHUNK_COUNT = 2;
+
+/**
+ * Find a safe content split point at or before `pos`.
+ * Prefers paragraph boundaries (\n\n), falls back to any line break,
+ * then to the raw position.
+ */
+function findSplitPoint(text: string, pos: number): number {
+  const para = text.lastIndexOf("\n\n", pos);
+  if (para >= 0) return para + 2;
+  const line = text.lastIndexOf("\n", pos);
+  if (line >= 0) return line + 1;
+  return Math.max(0, pos);
+}
+
+/** Split text into chunks at paragraph/line boundaries. */
+export function splitIntoChunks(text: string, chunkSize: number): string[] {
+  if (text.length <= chunkSize) return [text];
+
+  const chunks: string[] = [];
+  let pos = 0;
+  while (pos < text.length) {
+    if (pos + chunkSize >= text.length) {
+      chunks.push(text.slice(pos));
+      break;
+    }
+    const splitPos = findSplitPoint(text, pos + chunkSize);
+    // Guard against no progress (e.g. a single enormous line with no breaks)
+    const end = splitPos <= pos ? pos + chunkSize : splitPos;
+    chunks.push(text.slice(pos, end));
+    pos = end;
+  }
+  return chunks;
+}
+
+/**
+ * Find which chunk a character offset falls in, and the offset of that chunk's
+ * start within the full text.
+ */
+export function findChunkForOffset(
+  chunks: string[],
+  offset: number,
+): { index: number; chunkStart: number } | null {
+  let chunkStart = 0;
+  for (let i = 0; i < chunks.length; i++) {
+    if (offset < chunkStart + chunks[i]!.length) {
+      return { index: i, chunkStart };
+    }
+    chunkStart += chunks[i]!.length;
+  }
+  return null;
+}
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  chatId: string;
+  documentID: string;
+  /**
+   * Character range in the raw file to reveal, as a citation reports it. The
+   * range decides which chunk is rendered first and what is scrolled to;
+   * drawing the highlight itself is not implemented yet.
+   */
+  highlightRange?: HighlightRange;
+  /** Render the file as markdown rather than as the text it literally is. */
+  markdown?: boolean;
+}
+
+/** Text-shaped originals: markdown rendered, everything else as written. */
+export function MarkdownViewer({
+  chatId,
+  documentID,
+  highlightRange,
+  markdown = false,
+  className,
+  ...props
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const fileDownload = useFileDownload(chatId, documentID, { parseAs: "text" });
+  const fullContent = fileDownload.data ?? "";
+
+  // Split into render-friendly chunks at paragraph boundaries
+  const chunks = useMemo(
+    () => splitIntoChunks(fullContent, CHUNK_SIZE_CHARS),
+    [fullContent],
+  );
+
+  // For citation mode: locate the chunk containing the highlight
+  const citationInfo = useMemo(() => {
+    if (!highlightRange || !fullContent) return null;
+    const hit = findChunkForOffset(chunks, highlightRange.start);
+    return hit ? { chunkIndex: hit.index } : null;
+  }, [highlightRange, fullContent, chunks]);
+
+  // In citation mode, skip the chunks before it rather than parsing megabytes
+  // of text the reader has not asked to see yet.
+  const startChunkIndex =
+    citationInfo != null ? Math.max(0, citationInfo.chunkIndex - 1) : 0;
+  const maxRenderableChunks = chunks.length - startChunkIndex;
+  const initialCount = Math.min(INITIAL_CHUNK_COUNT, maxRenderableChunks);
+
+  const [renderedCount, setRenderedCount] = useState(initialCount);
+
+  // Reset when content or citation changes
+  useEffect(() => {
+    setRenderedCount(initialCount);
+  }, [initialCount]);
+
+  // Load more chunks as the reader scrolls near the bottom
+  useEffect(() => {
+    if (renderedCount >= maxRenderableChunks) return;
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          setRenderedCount((prev) => Math.min(prev + 2, maxRenderableChunks));
+        }
+      },
+      { rootMargin: "600px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [renderedCount, maxRenderableChunks]);
+
+  // Scroll to the citation anchor after it renders
+  useEffect(() => {
+    if (!citationInfo) return;
+    requestAnimationFrame(() => {
+      const container = containerRef.current;
+      const anchor = anchorRef.current;
+      if (!container || !anchor) return;
+      const containerRect = container.getBoundingClientRect();
+      const anchorRect = anchor.getBoundingClientRect();
+      const scrollTarget = anchorRect.top - containerRect.top + container.scrollTop;
+      container.scrollTo({ top: Math.max(0, scrollTarget - 40), behavior: "instant" });
+    });
+  }, [citationInfo]);
+
+  if (fileDownload.isError) {
+    return (
+      <div className={cn("relative overflow-auto", className)} {...props}>
+        <div className="flex h-64 items-center justify-center text-muted-foreground">
+          <p>Failed to download document</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (fileDownload.isLoading) {
+    return (
+      <div className={cn("flex items-center justify-center", className)} {...props}>
+        <Loader2Icon className="size-6 animate-spin" />
+      </div>
+    );
+  }
+
+  // Binary files sniffed as text-adjacent can't be rendered as text
+  if (fileDownload.contentType === "application/octet-stream") {
+    return (
+      <div className={cn("flex items-center justify-center", className)} {...props}>
+        <div className="flex flex-col items-center gap-2 text-muted-foreground">
+          <FileIcon className="size-8" />
+          <p>No preview available for this file type</p>
+        </div>
+      </div>
+    );
+  }
+
+  const hasMoreChunks = renderedCount < maxRenderableChunks;
+  const visibleChunks = chunks.slice(startChunkIndex, startChunkIndex + renderedCount);
+
+  return (
+    <div className={cn("relative flex min-h-0 flex-1 flex-col", className)} {...props}>
+      <div ref={containerRef} className="min-h-0 flex-1 overflow-auto p-6">
+        <div className="mx-auto max-w-4xl">
+          <div ref={anchorRef} />
+          {visibleChunks.map((chunk, i) =>
+            markdown ? (
+              <MessageMarkdown key={startChunkIndex + i}>{chunk}</MessageMarkdown>
+            ) : (
+              <pre
+                key={startChunkIndex + i}
+                className="font-mono text-xs break-words whitespace-pre-wrap"
+              >
+                {chunk}
+              </pre>
+            ),
+          )}
+          {hasMoreChunks && (
+            <div ref={sentinelRef} className="flex items-center justify-center py-8">
+              <Loader2Icon className="size-5 animate-spin text-muted-foreground" />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/components/document/useFileDownload.ts
+++ b/crates/openwave-desktop/ui/src/components/document/useFileDownload.ts
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+
+import { useApp } from "@/AppContext";
+
+export type ParseAsType = "text" | "blob";
+
+type ParsedData<T extends ParseAsType> = T extends "text" ? string : Blob;
+
+interface UseFileDownloadOptions<T extends ParseAsType> {
+  /**
+   * How to parse the downloaded bytes.
+   * - "blob": the bytes as they were stored (default)
+   * - "text": decoded as UTF-8
+   */
+  parseAs?: T;
+  /** Whether to download at all. Default: true. */
+  enabled?: boolean;
+}
+
+export interface FileDownloadResult<T extends ParseAsType> {
+  data: ParsedData<T> | null;
+  isLoading: boolean;
+  isError: boolean;
+  /** The stored media type, once the response has arrived. */
+  contentType: string | null;
+}
+
+/**
+ * Download one source's original bytes.
+ *
+ * The file is addressed by document id inside its conversation, never by a
+ * host path, so a viewer can draw the file the reader imported without the
+ * renderer learning where on disk it came from. The download is deferred
+ * behind `enabled` — opening a large source to read its extracted text should
+ * not pull the whole file across first.
+ */
+export function useFileDownload<T extends ParseAsType = "blob">(
+  chatId: string,
+  documentID: string,
+  options: UseFileDownloadOptions<T> = {},
+): FileDownloadResult<T> {
+  const { parseAs = "blob" as T, enabled = true } = options;
+  const { client } = useApp();
+  const [result, setResult] = useState<FileDownloadResult<T>>(idle);
+
+  useEffect(() => {
+    if (!enabled) {
+      setResult(idle);
+      return;
+    }
+    const controller = new AbortController();
+    setResult({ data: null, isLoading: true, isError: false, contentType: null });
+    void client
+      .getChatDocumentFile(chatId, documentID, controller.signal)
+      .then(async (blob) => {
+        const data = (parseAs === "text" ? await blob.text() : blob) as ParsedData<T>;
+        if (controller.signal.aborted) return;
+        setResult({
+          data,
+          isLoading: false,
+          isError: false,
+          contentType: blob.type || null,
+        });
+      })
+      .catch(() => {
+        if (controller.signal.aborted) return;
+        setResult({ data: null, isLoading: false, isError: true, contentType: null });
+      });
+    return () => controller.abort();
+  }, [client, chatId, documentID, parseAs, enabled]);
+
+  return result;
+}
+
+const idle = {
+  data: null,
+  isLoading: false,
+  isError: false,
+  contentType: null,
+} as const;

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailHeader.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailHeader.tsx
@@ -1,0 +1,91 @@
+import { AlignLeft, Download, FileText } from "lucide-react";
+
+import { PanelBreadcrumb } from "@/components/PanelHeader";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { WithTooltip } from "@/components/ui/tooltip";
+import type { DocumentView } from "@/components/document/document-details";
+
+/**
+ * The panel's header, in the two slots {@link PanelFrame} exposes: the trail
+ * back to the list on the left, the view switch and actions on the right.
+ */
+
+export function DocumentDetailBreadcrumb({
+  documentName,
+  onBackToSources,
+}: {
+  documentName?: string;
+  onBackToSources: () => void;
+}) {
+  return (
+    <PanelBreadcrumb
+      firstPart={
+        <button
+          type="button"
+          className="cursor-pointer hover:underline"
+          onClick={onBackToSources}
+        >
+          Sources
+        </button>
+      }
+      currentItem={documentName}
+    />
+  );
+}
+
+export function DocumentDetailActions({
+  view,
+  onViewChange,
+  showOriginalView = true,
+  canDownload,
+  downloading,
+  onDownload,
+}: {
+  view: DocumentView;
+  onViewChange: (view: DocumentView) => void;
+  /** Hidden for a format no viewer can draw; its panel is the extracted text. */
+  showOriginalView?: boolean;
+  canDownload?: boolean;
+  downloading?: boolean;
+  onDownload: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      {canDownload && (
+        <WithTooltip label="Download">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            disabled={downloading}
+            onClick={onDownload}
+          >
+            <Download className="size-4" />
+            <span className="sr-only">Download</span>
+          </Button>
+        </WithTooltip>
+      )}
+      {showOriginalView && (
+        <Tabs
+          value={view}
+          onValueChange={(value) => onViewChange(value as DocumentView)}
+        >
+          <TabsList className="rounded-lg bg-muted p-1">
+            <WithTooltip label="Extracted text">
+              <TabsTrigger value="extracted_text" className="h-7 w-7 px-0">
+                <AlignLeft className="size-4" />
+                <span className="sr-only">Extracted text</span>
+              </TabsTrigger>
+            </WithTooltip>
+            <WithTooltip label="Original document">
+              <TabsTrigger value="original_doc" className="h-7 w-7 px-0">
+                <FileText className="size-4" />
+                <span className="sr-only">Original document</span>
+              </TabsTrigger>
+            </WithTooltip>
+          </TabsList>
+        </Tabs>
+      )}
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { ApiClient, DocumentDetail } from "@/api";
+import { AppContextProvider, type AppContextValue } from "@/AppContext";
+import { renderWithRouter } from "../test/router";
+import { DocumentDetailRoot } from "./DocumentDetailRoot";
+
+afterEach(cleanup);
+
+beforeAll(() => {
+  // jsdom implements neither half of the object-URL API the image viewer uses.
+  URL.createObjectURL = vi.fn(() => "blob:document");
+  URL.revokeObjectURL = vi.fn();
+});
+
+function detail(overrides: Partial<DocumentDetail> = {}): DocumentDetail {
+  return {
+    document_id: "doc-1",
+    media_type: "image/png",
+    title: "Floor plan.png",
+    processing_status: "ready",
+    searchable: false,
+    updated_at: "2026-07-24T00:00:00Z",
+    content: "",
+    ...overrides,
+  };
+}
+
+async function openPanel(info: DocumentDetail, download = vi.fn()) {
+  const client = {
+    getChatDocument: vi.fn().mockResolvedValue(info),
+    getChatDocumentFile: vi.fn().mockResolvedValue(new Blob(["bytes"])),
+  };
+  const rendered = await renderWithRouter(
+    <AppContextProvider value={{ client } as unknown as AppContextValue}>
+      <DocumentDetailRoot
+        chatId="chat-1"
+        documentID="doc-1"
+        position="left"
+        download={download}
+        canDownload
+      />
+    </AppContextProvider>,
+    { initialUrl: "/c/chat-1?left=sources.doc-1&right=chat" },
+  );
+  return { ...rendered, client: client as unknown as ApiClient & typeof client, download };
+}
+
+describe("DocumentDetailRoot", () => {
+  it("draws the original, saves it, and leads back to the list", async () => {
+    const user = userEvent.setup();
+    const { client, download, router } = await openPanel(detail());
+
+    expect(await screen.findByAltText("Document image")).toHaveAttribute(
+      "src",
+      "blob:document",
+    );
+    expect(client.getChatDocumentFile).toHaveBeenCalledWith(
+      "chat-1",
+      "doc-1",
+      expect.anything(),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Download" }));
+    await waitFor(() => expect(download).toHaveBeenCalledWith("chat-1", "doc-1"));
+
+    await user.click(screen.getByRole("button", { name: "Sources" }));
+    await waitFor(() =>
+      expect(router.state.location.search).toEqual({ left: "sources", right: "chat" }),
+    );
+  });
+
+  it("opens a format it cannot draw on the extracted text alone", async () => {
+    const { client } = await openPanel(
+      detail({
+        media_type: "application/vnd.ms-outlook",
+        title: "Mailbox.pst",
+        content: "Subject: quarterly numbers",
+        searchable: true,
+      }),
+    );
+
+    expect(await screen.findByText("Subject: quarterly numbers")).toBeVisible();
+    expect(screen.queryByRole("tab", { name: "Original document" })).toBeNull();
+    // Nothing is going to draw those bytes, so nothing should pull them over.
+    expect(client.getChatDocumentFile).not.toHaveBeenCalled();
+  });
+});

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from "react";
+
+import type { DocumentDetail } from "@/api";
+import { useApp } from "@/AppContext";
+import {
+  DocumentDetails,
+  isDocumentRenderable,
+  type DocumentView,
+} from "@/components/document/document-details";
+import { DocumentError } from "@/components/document/error";
+import { exportLibraryDocument } from "@/documents";
+import { hasNativeHost } from "@/host";
+import { PanelFrame } from "@/panel/PanelFrame";
+import type { PanelPosition } from "@/panel/panelTypes";
+import { usePanelNav } from "@/panel/usePanelNav";
+import {
+  DocumentDetailActions,
+  DocumentDetailBreadcrumb,
+} from "./DocumentDetailHeader";
+
+type Props = {
+  chatId: string;
+  documentID: string;
+  position: PanelPosition;
+  /** Resolves false when the reader dismissed the save dialog. */
+  download?: (chatId: string, documentID: string) => Promise<boolean>;
+  canDownload?: boolean;
+};
+
+/** One source, opened in a panel addressed as `sources.{documentId}`. */
+export function DocumentDetailRoot({
+  chatId,
+  documentID,
+  position,
+  download = exportLibraryDocument,
+  canDownload = hasNativeHost(),
+}: Props) {
+  const { client } = useApp();
+  const { openPanel } = usePanelNav();
+  const [info, setInfo] = useState<DocumentDetail | null>(null);
+  const [loadError, setLoadError] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setInfo(null);
+    setLoadError(false);
+    setDownloadError(null);
+    void client
+      .getChatDocument(chatId, documentID)
+      .then((next) => {
+        if (!cancelled) setInfo(next);
+      })
+      .catch(() => {
+        if (!cancelled) setLoadError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client, chatId, documentID]);
+
+  const hasOriginalDocumentTab =
+    info != null && info.processing_status !== "failed" && isDocumentRenderable(info.media_type);
+
+  const [view, setView] = useState<DocumentView>("original_doc");
+
+  // Reset the view when the document changes. A format with no viewer has only
+  // the extracted text to land on.
+  useEffect(() => {
+    setView(hasOriginalDocumentTab ? "original_doc" : "extracted_text");
+  }, [documentID, hasOriginalDocumentTab]);
+
+  const documentName = info ? documentTitle(info) : undefined;
+
+  async function onDownload() {
+    if (downloading) return;
+    setDownloading(true);
+    setDownloadError(null);
+    try {
+      await download(chatId, documentID);
+    } catch (caught) {
+      setDownloadError(friendlyDownloadError(caught));
+    } finally {
+      setDownloading(false);
+    }
+  }
+
+  return (
+    <PanelFrame
+      position={position}
+      breadcrumb={
+        <DocumentDetailBreadcrumb
+          documentName={documentName}
+          onBackToSources={() => openPanel({ type: "sources" })}
+        />
+      }
+      headerRightSlot={
+        <DocumentDetailActions
+          view={view}
+          onViewChange={setView}
+          showOriginalView={hasOriginalDocumentTab}
+          canDownload={canDownload && info != null}
+          downloading={downloading}
+          onDownload={() => void onDownload()}
+        />
+      }
+    >
+      {loadError ? (
+        <DocumentError>The document is no longer available.</DocumentError>
+      ) : info ? (
+        <DocumentDetails
+          chatId={chatId}
+          info={info}
+          view={view}
+          hasOriginalDocumentTab={hasOriginalDocumentTab}
+        />
+      ) : (
+        <p className="p-6 text-sm text-muted-foreground" role="status">
+          Loading this source…
+        </p>
+      )}
+      {downloadError && (
+        <p className="shrink-0 px-6 pb-2 text-sm text-critical" role="alert">
+          {downloadError}
+        </p>
+      )}
+    </PanelFrame>
+  );
+}
+
+function documentTitle(info: DocumentDetail): string {
+  return info.title?.trim() || `Source ${info.document_id.slice(0, 8)}`;
+}
+
+function friendlyDownloadError(error: unknown): string {
+  const message = String(error).replace(/^Error:\s*/, "").trim();
+  return message && message.length <= 240 ? message : "Could not save that source.";
+}

--- a/crates/openwave-desktop/ui/src/documents.ts
+++ b/crates/openwave-desktop/ui/src/documents.ts
@@ -116,6 +116,22 @@ export async function importDroppedLibraryDocuments(
   );
 }
 
+/**
+ * Write one source's original bytes wherever the reader chooses.
+ *
+ * Resolves false when the save dialog was dismissed. The bytes never pass
+ * through the renderer: the host reads them and writes the file itself, so
+ * neither the destination nor the size of the source is a renderer concern.
+ */
+export async function exportLibraryDocument(
+  chatId: string,
+  documentId: string,
+): Promise<boolean> {
+  return (await invoke("export_library_document", {
+    request: { chatId, documentId },
+  })) as boolean;
+}
+
 export async function listenForLibraryImportProgress(
   listener: (progress: LibraryImportProgress) => void,
 ): Promise<() => void> {


### PR DESCRIPTION
Clicking a source opened nothing: the list could point at
`sources.{documentId}`, and #666 landed a viewer dispatcher and a PDF viewer,
but no panel connected the two.

A source now opens in a panel addressed as `sources.{documentId}`, with a
breadcrumb back to the list. Each document is shown two ways — the original
file, drawn by whichever viewer the dispatcher selects, and the extracted text
OpenWave read out of it, which every source has. A format no viewer can draw
is not refused: its panel drops the original view and opens on the extracted
text alone, which is a better floor than declining to open the source at all.
The original wins whenever it can be drawn, because a reader who opens a
source usually means "show me my document".

Two viewers join the dispatcher rather than starting a second one: images, and
text/markdown. The text viewer splits its content at paragraph boundaries and
renders it a couple of chunks at a time — a source is whatever the reader
imported, and a multi-megabyte log laid out in one element locks the window
long enough to look like a crash. It also accepts a `highlightRange`, which
decides the chunk it starts on and the position it scrolls to; drawing the
highlight itself is not implemented here.

`getDocumentFileContent` moves to the conversation-scoped route. The unscoped
one it used deliberately serves only documents belonging to no chat and no
project, so it answers 404 for every source the desktop imports; the
conversation is threaded through the dispatcher and the PDF viewer with it.

Downloading is the one part that has to be native. `export_library_document`
resolves the document inside its conversation, derives a suggested filename
from the stored title — a name, never a path — opens the save dialog, and
streams the response straight to a sibling temporary before renaming it into
place. An interrupted save cannot truncate an existing file, a large source is
never buffered in memory, and neither the destination nor the bytes cross back
into the webview.

Closes #543