### PR TITLE
feat(desktop): expand folders and zip archives on import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6721,6 +6721,7 @@ dependencies = [
  "unicode-general-category",
  "uuid",
  "windows-sys 0.61.2",
+ "zip",
 ]
 
 [[package]]
@@ -12205,6 +12206,7 @@ checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
+ "flate2",
  "indexmap 2.14.0",
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,5 @@ base64 = "=0.22.1"
 libc = "=0.2.186"
 async-stream = "=0.3.6"
 axum = { version = "=0.8.9", features = ["ws"] }
+tempfile = "=3.27.0"
+zip = { version = "=4.6.1", default-features = false, features = ["deflate-flate2"] }

--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -52,10 +52,11 @@ tokio = { workspace = true, features = ["io-util", "process", "rt-multi-thread",
 tokio-util = { workspace = true }
 unicode-general-category = { workspace = true }
 uuid = { workspace = true }
+tempfile.workspace = true
+zip.workspace = true
 
 [dev-dependencies]
 chrono = { workspace = true }
-tempfile = "=3.27.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "linux", windows))'.dependencies]
 tauri-plugin-single-instance = "=2.4.3"

--- a/crates/openwave-desktop/src/documents.rs
+++ b/crates/openwave-desktop/src/documents.rs
@@ -7,6 +7,7 @@
 use std::collections::HashMap;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -28,6 +29,8 @@ use uuid::Uuid;
 
 use crate::host_access::HostAccess;
 use crate::{wait_server_info, AppState};
+
+mod expansion;
 
 const MAX_SEARCH_QUERY_CHARS: usize = 500;
 const MAX_RENDERER_SNIPPET_CHARS: usize = 4_000;
@@ -251,8 +254,19 @@ struct LibraryImportDropState {
 
 struct PendingDocumentImport {
     import_id: Uuid,
-    path: PathBuf,
     display_name: String,
+    source: PendingDocumentSource,
+}
+
+enum PendingDocumentSource {
+    File(DocumentImportSource),
+    Failed(String),
+}
+
+#[derive(Clone)]
+enum DocumentImportSource {
+    Path(PathBuf),
+    Open(Arc<std::fs::File>),
 }
 
 struct PreparedDocumentImport {
@@ -265,6 +279,32 @@ struct PreparedDocumentImport {
 struct CompletedDocumentImport {
     document: ImportedDocument,
     already_present: bool,
+}
+
+struct CancelExpansionOnDrop {
+    cancelled: Arc<AtomicBool>,
+    armed: bool,
+}
+
+impl CancelExpansionOnDrop {
+    fn new(cancelled: Arc<AtomicBool>) -> Self {
+        Self {
+            cancelled,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for CancelExpansionOnDrop {
+    fn drop(&mut self) {
+        if self.armed {
+            self.cancelled.store(true, Ordering::Relaxed);
+        }
+    }
 }
 
 enum ImportFailure {
@@ -468,15 +508,22 @@ pub(crate) async fn import_library_document(
         &app,
         LibraryImportProgress {
             import_id: import_id.to_string(),
-            display_name,
+            display_name: display_name.clone(),
             status: LibraryImportProgressStatus::Queued,
             document_id: None,
             processing_status: None,
             message: None,
         },
     );
-    let completed =
-        import_selected_document(&app, app_state.inner(), chat_id, path, import_id).await?;
+    let completed = import_selected_document(
+        &app,
+        app_state.inner(),
+        chat_id,
+        DocumentImportSource::Path(path),
+        display_name,
+        import_id,
+    )
+    .await?;
     emit_import_progress(
         &app,
         completed_progress(
@@ -590,13 +637,15 @@ pub(crate) fn handle_window_drag_drop(app: &AppHandle, window_label: &str, event
 }
 
 fn drop_state(phase: LibraryImportDropPhase, paths: &[PathBuf]) -> LibraryImportDropState {
-    // The host accepts every regular file type. A folder (or a symlink, which
-    // is intentionally rejected later by the capability-safe opener) cannot
-    // be imported as a document and gets an immediate reject state instead.
+    // Folder contents are expanded natively after the drop is claimed. A
+    // symlink is never accepted as a shortcut to a file or directory.
     let accepted = !paths.is_empty()
         && paths.iter().all(|path| {
             std::fs::symlink_metadata(path)
-                .map(|metadata| metadata.file_type().is_file())
+                .map(|metadata| {
+                    let file_type = metadata.file_type();
+                    !file_type.is_symlink() && (file_type.is_file() || file_type.is_dir())
+                })
                 .unwrap_or(false)
         });
     LibraryImportDropState {
@@ -613,13 +662,63 @@ pub(crate) async fn import_document_paths(
     chat_id: Uuid,
     paths: Vec<PathBuf>,
 ) -> LibraryImportBatch {
-    let pending = paths
+    let root_names = paths
+        .iter()
+        .map(|path| import_display_name(path).unwrap_or_else(|_| "Selected source".to_owned()))
+        .collect::<Vec<_>>();
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let task_cancelled = Arc::clone(&cancelled);
+    let mut cancel_on_drop = CancelExpansionOnDrop::new(cancelled);
+    let expansion = tauri::async_runtime::spawn_blocking(move || {
+        expansion::expand_import_paths(paths, &|| task_cancelled.load(Ordering::Relaxed))
+    })
+    .await;
+    cancel_on_drop.disarm();
+    let (expanded, _temp_dir) = match expansion {
+        Ok(Ok(expanded)) => expanded.into_parts(),
+        Ok(Err(_)) => {
+            return LibraryImportBatch {
+                results: Vec::new(),
+            }
+        }
+        Err(_) => (
+            root_names
+                .into_iter()
+                .map(|display_name| expansion::ExpandedImportItem::Failure {
+                    display_name,
+                    message: "Could not inspect the selected source".to_owned(),
+                })
+                .collect(),
+            None,
+        ),
+    };
+    let pending = expanded
         .into_iter()
-        .map(|path| PendingDocumentImport {
-            import_id: Uuid::new_v4(),
-            display_name: import_display_name(&path)
-                .unwrap_or_else(|_| "Selected document".to_owned()),
-            path,
+        .map(|item| {
+            let import_id = Uuid::new_v4();
+            match item {
+                expansion::ExpandedImportItem::File {
+                    source,
+                    display_name,
+                } => PendingDocumentImport {
+                    import_id,
+                    display_name,
+                    source: PendingDocumentSource::File(match source {
+                        expansion::ExpandedFile::Path(path) => DocumentImportSource::Path(path),
+                        expansion::ExpandedFile::Open(file) => {
+                            DocumentImportSource::Open(Arc::new(file))
+                        }
+                    }),
+                },
+                expansion::ExpandedImportItem::Failure {
+                    display_name,
+                    message,
+                } => PendingDocumentImport {
+                    import_id,
+                    display_name,
+                    source: PendingDocumentSource::Failed(message),
+                },
+            }
         })
         .collect::<Vec<_>>();
     for import in &pending {
@@ -638,14 +737,29 @@ pub(crate) async fn import_document_paths(
 
     let mut results = stream::iter(pending.into_iter().enumerate().map(
         |(index, import)| async move {
+            let PendingDocumentImport {
+                import_id,
+                display_name,
+                source,
+            } = import;
+            let path = match source {
+                PendingDocumentSource::File(path) => path,
+                PendingDocumentSource::Failed(message) => {
+                    return (
+                        index,
+                        failed_import_result(app, import_id, display_name, message),
+                    )
+                }
+            };
             let result = match resolve_conversation_scope(host_access, chat_id).await {
                 Ok(chat_id) => {
                     match import_selected_document(
                         app,
                         app_state,
                         chat_id,
-                        import.path,
-                        import.import_id,
+                        path,
+                        display_name.clone(),
+                        import_id,
                     )
                     .await
                     {
@@ -653,7 +767,7 @@ pub(crate) async fn import_document_paths(
                             emit_import_progress(
                                 app,
                                 completed_progress(
-                                    import.import_id,
+                                    import_id,
                                     &completed.document,
                                     LibraryImportProgressStatus::AlreadyPresent,
                                 ),
@@ -666,7 +780,7 @@ pub(crate) async fn import_document_paths(
                             emit_import_progress(
                                 app,
                                 completed_progress(
-                                    import.import_id,
+                                    import_id,
                                     &completed.document,
                                     LibraryImportProgressStatus::Imported,
                                 ),
@@ -675,17 +789,10 @@ pub(crate) async fn import_document_paths(
                                 document: completed.document,
                             }
                         }
-                        Err(message) => failed_import_result(
-                            app,
-                            import.import_id,
-                            import.display_name,
-                            message,
-                        ),
+                        Err(message) => failed_import_result(app, import_id, display_name, message),
                     }
                 }
-                Err(message) => {
-                    failed_import_result(app, import.import_id, import.display_name, message)
-                }
+                Err(message) => failed_import_result(app, import_id, display_name, message),
             };
             (index, result)
         },
@@ -921,27 +1028,47 @@ fn import_display_name(path: &Path) -> Result<String, String> {
         .ok_or_else(|| "The selected document has an invalid name".to_owned())
 }
 
-fn prepare_selected_document(path: &Path) -> Result<PreparedDocumentImport, String> {
-    let display_name = import_display_name(path)?;
-    let parent = path
-        .parent()
-        .ok_or_else(|| "The document picker returned an invalid file".to_owned())?;
-    let file_name = path
-        .file_name()
-        .ok_or_else(|| "The document picker returned an invalid file".to_owned())?;
-    let directory = Dir::open_ambient_dir(parent, ambient_authority())
-        .map_err(|_| "Could not read the selected document".to_owned())?;
-    let mut options = OpenOptions::new();
-    options.read(true).follow(FollowSymlinks::No);
-    let mut file = directory
-        .open_with(file_name, &options)
-        .map_err(|_| "Could not read the selected document".to_owned())?;
+fn prepare_selected_document(
+    source: DocumentImportSource,
+    display_name: String,
+) -> Result<PreparedDocumentImport, String> {
+    if !is_safe_renderer_text(&display_name, 255, false) {
+        return Err("The selected document has an invalid name".to_owned());
+    }
+    // Extension policy is decided before any bytes are read or media-sniffed:
+    // an executable renamed to look like a PDF internally is still refused.
+    if expansion::has_blocked_import_extension(Path::new(&display_name)) {
+        return Err("This file type cannot be imported".to_owned());
+    }
+    let mut file = match source {
+        DocumentImportSource::Path(path) => {
+            let parent = path
+                .parent()
+                .ok_or_else(|| "The document picker returned an invalid file".to_owned())?;
+            let file_name = path
+                .file_name()
+                .ok_or_else(|| "The document picker returned an invalid file".to_owned())?;
+            let directory = Dir::open_ambient_dir(parent, ambient_authority())
+                .map_err(|_| "Could not read the selected document".to_owned())?;
+            let mut options = OpenOptions::new();
+            options.read(true).follow(FollowSymlinks::No);
+            directory
+                .open_with(file_name, &options)
+                .map_err(|_| "Could not read the selected document".to_owned())?
+                .into_std()
+        }
+        DocumentImportSource::Open(file) => file
+            .try_clone()
+            .map_err(|_| "Could not read the selected document".to_owned())?,
+    };
     let metadata = file
         .metadata()
         .map_err(|_| "Could not read the selected document".to_owned())?;
     if !metadata.is_file() {
         return Err("Choose a file to import".to_owned());
     }
+    file.seek(SeekFrom::Start(0))
+        .map_err(|_| "Could not read the selected document".to_owned())?;
     let mut digest = Sha256::new();
     let mut byte_len = 0_u64;
     let mut sniff_bytes = Vec::with_capacity(8_192);
@@ -967,10 +1094,13 @@ fn prepare_selected_document(path: &Path) -> Result<PreparedDocumentImport, Stri
         .map_err(|_| "Could not read the selected document".to_owned())?;
     let sha256: [u8; 32] = digest.finalize().into();
     Ok(PreparedDocumentImport {
+        media_type: crate::media_type::sniff_media_type_for_path(
+            &sniff_bytes,
+            Path::new(&display_name),
+        ),
         display_name,
-        media_type: crate::media_type::sniff_media_type_for_path(&sniff_bytes, path),
         source_blob: DocumentSourceBlob::from_digest(sha256, byte_len),
-        file: file.into_std(),
+        file,
     })
 }
 
@@ -978,7 +1108,8 @@ async fn import_selected_document(
     app: &AppHandle,
     app_state: &Arc<AppState>,
     chat_id: ChatId,
-    path: PathBuf,
+    source: DocumentImportSource,
+    display_name: String,
     import_id: Uuid,
 ) -> Result<CompletedDocumentImport, String> {
     for delay in IMPORT_RETRY_DELAYS
@@ -987,7 +1118,15 @@ async fn import_selected_document(
         .map(Some)
         .chain(std::iter::once(None))
     {
-        match import_selected_document_once(app, app_state, chat_id, path.clone(), import_id).await
+        match import_selected_document_once(
+            app,
+            app_state,
+            chat_id,
+            source.clone(),
+            display_name.clone(),
+            import_id,
+        )
+        .await
         {
             Ok(completed) => return Ok(completed),
             Err(ImportFailure::Retryable(_)) if delay.is_some() => {
@@ -1005,13 +1144,16 @@ async fn import_selected_document_once(
     app: &AppHandle,
     app_state: &Arc<AppState>,
     chat_id: ChatId,
-    path: PathBuf,
+    source: DocumentImportSource,
+    display_name: String,
     import_id: Uuid,
 ) -> Result<CompletedDocumentImport, ImportFailure> {
-    let prepared = tauri::async_runtime::spawn_blocking(move || prepare_selected_document(&path))
-        .await
-        .map_err(|_| ImportFailure::Permanent("Could not read the selected document".to_owned()))?
-        .map_err(ImportFailure::Permanent)?;
+    let prepared = tauri::async_runtime::spawn_blocking(move || {
+        prepare_selected_document(source, display_name)
+    })
+    .await
+    .map_err(|_| ImportFailure::Permanent("Could not read the selected document".to_owned()))?
+    .map_err(ImportFailure::Permanent)?;
     emit_import_progress(
         app,
         LibraryImportProgress {
@@ -1332,6 +1474,21 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn drop_state_accepts_directories_but_not_symbolic_links() {
+        use std::os::unix::fs::symlink;
+
+        let directory = tempfile::tempdir().unwrap();
+        let folder = directory.path().join("sources");
+        std::fs::create_dir(&folder).unwrap();
+        let link = directory.path().join("sources-link");
+        symlink(&folder, &link).unwrap();
+
+        assert!(drop_state(LibraryImportDropPhase::Enter, &[folder]).accepted);
+        assert!(!drop_state(LibraryImportDropPhase::Enter, &[link]).accepted);
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn selected_document_preparation_rejects_symlinks_and_keeps_large_files_streamable() {
         use std::os::unix::fs::symlink;
 
@@ -1340,18 +1497,39 @@ mod tests {
         std::fs::write(&target, "private").unwrap();
         let link = directory.path().join("link.md");
         symlink(&target, &link).unwrap();
-        assert!(prepare_selected_document(&link).is_err());
+        assert!(
+            prepare_selected_document(DocumentImportSource::Path(link), "link.md".to_owned())
+                .is_err()
+        );
 
         let large = directory.path().join("large.md");
         let file = std::fs::File::create(&large).unwrap();
         let large_len = 16 * 1024 * 1024 + 1;
         file.set_len(large_len).unwrap();
-        let prepared = prepare_selected_document(&large).unwrap();
+        let prepared =
+            prepare_selected_document(DocumentImportSource::Path(large), "large.md".to_owned())
+                .unwrap();
         assert_eq!(
             prepared.source_blob.byte_len, large_len,
             "preparation hashes the file but leaves its bytes on disk for the upload stream"
         );
         assert_eq!(prepared.file.metadata().unwrap().len(), large_len);
+    }
+
+    #[test]
+    fn executable_extension_is_rejected_before_pdf_bytes_are_sniffed() {
+        let directory = tempfile::tempdir().unwrap();
+        let disguised = directory.path().join("invoice.exe");
+        std::fs::write(&disguised, b"%PDF-1.7\nnot an executable").unwrap();
+        assert_eq!(
+            prepare_selected_document(
+                DocumentImportSource::Path(disguised),
+                "invoice.exe".to_owned(),
+            )
+            .err()
+            .unwrap(),
+            "This file type cannot be imported"
+        );
     }
 
     #[test]

--- a/crates/openwave-desktop/src/documents/expansion.rs
+++ b/crates/openwave-desktop/src/documents/expansion.rs
@@ -1,0 +1,958 @@
+//! Bounded, native-only expansion for folders and ZIP archives.
+//!
+//! The renderer never receives source paths. Folder traversal uses directory
+//! capabilities and never follows symlinks; archive entries are copied into
+//! isolated temporary directories rather than extracted by their supplied
+//! paths.
+
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt};
+use cap_std::ambient_authority;
+use cap_std::fs::{Dir, OpenOptions};
+use tempfile::{Builder as TempDirBuilder, TempDir};
+use zip::ZipArchive;
+
+use super::{import_display_name, is_safe_title_char};
+
+const MAX_DIRECTORY_DEPTH: usize = 8;
+const MAX_IMPORT_FILES: usize = 500;
+const MAX_IMPORT_RESULTS: usize = 1_000;
+const MAX_DIRECTORY_ENTRIES: usize = 10_000;
+const MAX_ZIP_ENTRIES: usize = 1_000;
+const MAX_ZIP_ENTRY_BYTES: u64 = 128 * 1024 * 1024;
+const MAX_ZIP_TOTAL_BYTES: u64 = 512 * 1024 * 1024;
+const COPY_BUFFER_BYTES: usize = 64 * 1024;
+
+const BLOCKED_IMPORT_EXTENSIONS: &[&str] = &[
+    "apk",
+    "app",
+    "appimage",
+    "appx",
+    "appxbundle",
+    "bat",
+    "bin",
+    "cmd",
+    "com",
+    "cpl",
+    "deb",
+    "dmg",
+    "exe",
+    "gadget",
+    "hta",
+    "img",
+    "ins",
+    "ipa",
+    "iso",
+    "jar",
+    "lnk",
+    "msi",
+    "msp",
+    "mst",
+    "pkg",
+    "qcow",
+    "qcow2",
+    "rpm",
+    "scr",
+    "sparsebundle",
+    "sparseimage",
+    "sys",
+    "vb",
+    "vbe",
+    "vbs",
+    "vhd",
+    "vhdx",
+    "wim",
+    "ws",
+    "wsc",
+    "wsf",
+    "wsh",
+];
+
+#[derive(Clone, Copy)]
+struct ExpansionLimits {
+    max_directory_depth: usize,
+    max_import_files: usize,
+    max_directory_entries: usize,
+    max_zip_entries: usize,
+    max_zip_entry_bytes: u64,
+    max_zip_total_bytes: u64,
+}
+
+impl Default for ExpansionLimits {
+    fn default() -> Self {
+        Self {
+            max_directory_depth: MAX_DIRECTORY_DEPTH,
+            max_import_files: MAX_IMPORT_FILES,
+            max_directory_entries: MAX_DIRECTORY_ENTRIES,
+            max_zip_entries: MAX_ZIP_ENTRIES,
+            max_zip_entry_bytes: MAX_ZIP_ENTRY_BYTES,
+            max_zip_total_bytes: MAX_ZIP_TOTAL_BYTES,
+        }
+    }
+}
+
+pub(super) enum ExpandedImportItem {
+    File {
+        source: ExpandedFile,
+        display_name: String,
+    },
+    Failure {
+        display_name: String,
+        message: String,
+    },
+}
+
+pub(super) enum ExpandedFile {
+    Path(PathBuf),
+    Open(File),
+}
+
+pub(super) struct ExpandedImports {
+    items: Vec<ExpandedImportItem>,
+    temp_dir: Option<TempDir>,
+}
+
+impl ExpandedImports {
+    pub(super) fn into_parts(self) -> (Vec<ExpandedImportItem>, Option<TempDir>) {
+        (self.items, self.temp_dir)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct ExpansionCancelled;
+
+pub(super) fn expand_import_paths(
+    paths: Vec<PathBuf>,
+    is_cancelled: &dyn Fn() -> bool,
+) -> Result<ExpandedImports, ExpansionCancelled> {
+    expand_import_paths_with_limits(paths, ExpansionLimits::default(), is_cancelled)
+}
+
+fn expand_import_paths_with_limits(
+    paths: Vec<PathBuf>,
+    limits: ExpansionLimits,
+    is_cancelled: &dyn Fn() -> bool,
+) -> Result<ExpandedImports, ExpansionCancelled> {
+    let mut expander = Expander {
+        limits,
+        is_cancelled,
+        items: Vec::new(),
+        temp_dir: None,
+        imported_files: 0,
+        visited_directory_entries: 0,
+        temp_file_sequence: 0,
+        stopped: false,
+        limit_reported: false,
+    };
+    for path in paths {
+        expander.check_cancelled()?;
+        if expander.stopped {
+            break;
+        }
+        expander.expand_root(path)?;
+    }
+    Ok(ExpandedImports {
+        items: expander.items,
+        temp_dir: expander.temp_dir,
+    })
+}
+
+struct Expander<'a> {
+    limits: ExpansionLimits,
+    is_cancelled: &'a dyn Fn() -> bool,
+    items: Vec<ExpandedImportItem>,
+    temp_dir: Option<TempDir>,
+    imported_files: usize,
+    visited_directory_entries: usize,
+    temp_file_sequence: usize,
+    stopped: bool,
+    limit_reported: bool,
+}
+
+impl Expander<'_> {
+    fn check_cancelled(&self) -> Result<(), ExpansionCancelled> {
+        if (self.is_cancelled)() {
+            Err(ExpansionCancelled)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn expand_root(&mut self, path: PathBuf) -> Result<(), ExpansionCancelled> {
+        let display_name =
+            import_display_name(&path).unwrap_or_else(|_| "Selected source".to_owned());
+        if path_component_is_skipped(&display_name) {
+            return Ok(());
+        }
+        let metadata = match std::fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(_) => {
+                self.push_failure(display_name, "Could not read the selected source");
+                return Ok(());
+            }
+        };
+        let file_type = metadata.file_type();
+        if file_type.is_symlink() {
+            self.push_failure(
+                display_name,
+                "Aliases and symbolic links cannot be imported",
+            );
+        } else if file_type.is_dir() {
+            match open_directory_nofollow(&path) {
+                Ok(directory) => self.walk_directory(&path, &directory, Path::new(""), 0)?,
+                Err(_) => self.push_failure(display_name, "Could not read the selected folder"),
+            }
+        } else if file_type.is_file() {
+            self.expand_path_file(path, display_name)?;
+        } else {
+            self.push_failure(display_name, "Choose a file or folder to import");
+        }
+        Ok(())
+    }
+
+    fn walk_directory(
+        &mut self,
+        root_path: &Path,
+        directory: &Dir,
+        relative_path: &Path,
+        depth: usize,
+    ) -> Result<(), ExpansionCancelled> {
+        self.check_cancelled()?;
+        let entries = match directory.entries() {
+            Ok(entries) => entries,
+            Err(_) => {
+                self.push_failure(
+                    directory_display_name(root_path, relative_path),
+                    "Could not read this folder",
+                );
+                return Ok(());
+            }
+        };
+        let mut entries = entries
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| {
+                let file_name = entry.file_name();
+                let sort_name = file_name.to_str()?.to_owned();
+                Some((sort_name, file_name, entry))
+            })
+            .collect::<Vec<_>>();
+        entries.sort_by(|left, right| left.0.cmp(&right.0));
+
+        for (name, os_name, entry) in entries {
+            self.check_cancelled()?;
+            if self.stopped {
+                break;
+            }
+            self.visited_directory_entries += 1;
+            if self.visited_directory_entries > self.limits.max_directory_entries {
+                self.stop_at_limit(
+                    directory_display_name(root_path, relative_path),
+                    format!(
+                        "Folder expansion is limited to {} entries",
+                        self.limits.max_directory_entries
+                    ),
+                );
+                break;
+            }
+            if path_component_is_skipped(&name) {
+                continue;
+            }
+            let child_relative = relative_path.join(&os_name);
+            let child_path = root_path.join(&child_relative);
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(_) => {
+                    self.push_failure(name, "Could not inspect this folder entry");
+                    continue;
+                }
+            };
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
+                if depth >= self.limits.max_directory_depth {
+                    self.push_failure(
+                        name,
+                        format!(
+                            "Folder nesting is limited to {} levels",
+                            self.limits.max_directory_depth
+                        ),
+                    );
+                    continue;
+                }
+                match directory.open_dir_nofollow(&os_name) {
+                    Ok(child) => {
+                        self.walk_directory(root_path, &child, &child_relative, depth + 1)?
+                    }
+                    Err(_) => self.push_failure(name, "Could not read this folder"),
+                }
+            } else if file_type.is_file() {
+                self.expand_directory_file(directory, Path::new(&os_name), child_path, name)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn expand_path_file(
+        &mut self,
+        path: PathBuf,
+        display_name: String,
+    ) -> Result<(), ExpansionCancelled> {
+        self.check_cancelled()?;
+        if path_component_is_skipped(&display_name)
+            || has_blocked_import_extension(Path::new(&display_name))
+        {
+            return Ok(());
+        }
+        if path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"))
+        {
+            match open_regular_file_nofollow(&path) {
+                Ok(file) => self.expand_zip(file, display_name),
+                Err(_) => {
+                    self.push_failure(display_name, "Could not read this archive");
+                    Ok(())
+                }
+            }
+        } else {
+            self.push_file(ExpandedFile::Path(path), display_name);
+            Ok(())
+        }
+    }
+
+    fn expand_directory_file(
+        &mut self,
+        directory: &Dir,
+        file_name: &Path,
+        path: PathBuf,
+        display_name: String,
+    ) -> Result<(), ExpansionCancelled> {
+        self.check_cancelled()?;
+        if path_component_is_skipped(&display_name)
+            || has_blocked_import_extension(Path::new(&display_name))
+        {
+            return Ok(());
+        }
+        let file = match open_directory_file_nofollow(directory, file_name) {
+            Ok(file) => file,
+            Err(_) => {
+                self.push_failure(display_name, "Could not read this document");
+                return Ok(());
+            }
+        };
+        if path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"))
+        {
+            self.expand_zip(file, display_name)
+        } else {
+            self.push_file(ExpandedFile::Open(file), display_name);
+            Ok(())
+        }
+    }
+
+    fn expand_zip(
+        &mut self,
+        archive_file: File,
+        archive_name: String,
+    ) -> Result<(), ExpansionCancelled> {
+        let fallback_file = match archive_file.try_clone() {
+            Ok(file) => file,
+            Err(_) => {
+                self.push_failure(archive_name, "Could not read this archive");
+                return Ok(());
+            }
+        };
+        let mut archive = match ZipArchive::new(archive_file) {
+            Ok(archive) => archive,
+            Err(_) => {
+                self.push_file(ExpandedFile::Open(fallback_file), archive_name);
+                return Ok(());
+            }
+        };
+        if archive.len() > self.limits.max_zip_entries {
+            self.push_file(ExpandedFile::Open(fallback_file), archive_name);
+            return Ok(());
+        }
+
+        let mut seen_names = HashSet::new();
+        let mut plans = Vec::new();
+        let mut declared_total = 0_u64;
+        for index in 0..archive.len() {
+            self.check_cancelled()?;
+            let file = match archive.by_index(index) {
+                Ok(file) => file,
+                Err(_) => continue,
+            };
+            if file.is_dir() || file.is_symlink() || file.encrypted() || file.size() == 0 {
+                continue;
+            }
+            let Some((normalized_path, display_name)) = safe_zip_entry_name(file.name()) else {
+                continue;
+            };
+            if !seen_names.insert(normalized_path.to_lowercase()) {
+                continue;
+            }
+            if has_blocked_import_extension(Path::new(&display_name)) {
+                continue;
+            }
+            if file.size() > self.limits.max_zip_entry_bytes {
+                plans.push(ArchivePlan::Failure {
+                    normalized_path,
+                    display_name,
+                    message: format!(
+                        "Archive entries are limited to {} MiB",
+                        self.limits.max_zip_entry_bytes / (1024 * 1024)
+                    ),
+                });
+                continue;
+            }
+            let Some(next_total) = declared_total.checked_add(file.size()) else {
+                self.push_file(ExpandedFile::Open(fallback_file), archive_name);
+                return Ok(());
+            };
+            if next_total > self.limits.max_zip_total_bytes {
+                self.push_file(ExpandedFile::Open(fallback_file), archive_name);
+                return Ok(());
+            }
+            declared_total = next_total;
+            plans.push(ArchivePlan::File {
+                normalized_path,
+                display_name,
+                index,
+                declared_size: file.size(),
+            });
+        }
+        if !plans
+            .iter()
+            .any(|plan| matches!(plan, ArchivePlan::File { .. }))
+        {
+            self.push_file(ExpandedFile::Open(fallback_file), archive_name);
+            return Ok(());
+        }
+        plans.sort_by(|left, right| left.normalized_path().cmp(right.normalized_path()));
+
+        let mut extracted_files = 0;
+        let mut extracted_bytes = 0_u64;
+        for plan in plans {
+            self.check_cancelled()?;
+            if self.stopped {
+                break;
+            }
+            match plan {
+                ArchivePlan::Failure {
+                    display_name,
+                    message,
+                    ..
+                } => self.push_failure(display_name, message),
+                ArchivePlan::File {
+                    display_name,
+                    index,
+                    declared_size,
+                    ..
+                } => {
+                    let output_path = match self.next_temp_path(&display_name) {
+                        Ok(path) => path,
+                        Err(message) => {
+                            self.push_failure(display_name, message);
+                            continue;
+                        }
+                    };
+                    let mut entry = match archive.by_index(index) {
+                        Ok(entry) => entry,
+                        Err(_) => {
+                            self.push_failure(display_name, "Could not read this archive entry");
+                            continue;
+                        }
+                    };
+                    match copy_archive_entry(
+                        &mut entry,
+                        &output_path,
+                        declared_size,
+                        self.limits.max_zip_entry_bytes,
+                        self.limits
+                            .max_zip_total_bytes
+                            .saturating_sub(extracted_bytes),
+                        self.is_cancelled,
+                    ) {
+                        Ok(copied) => {
+                            extracted_bytes += copied;
+                            self.push_file(ExpandedFile::Path(output_path), display_name);
+                            extracted_files += 1;
+                        }
+                        Err(CopyArchiveError::Cancelled) => return Err(ExpansionCancelled),
+                        Err(CopyArchiveError::Failed) => {
+                            self.push_failure(display_name, "Could not read this archive entry")
+                        }
+                    }
+                }
+            }
+        }
+        if extracted_files == 0 && !self.stopped {
+            self.push_file(ExpandedFile::Open(fallback_file), archive_name);
+        }
+        Ok(())
+    }
+
+    fn next_temp_path(&mut self, display_name: &str) -> Result<PathBuf, &'static str> {
+        if self.temp_dir.is_none() {
+            self.temp_dir = Some(
+                TempDirBuilder::new()
+                    .prefix("openwave-source-import-")
+                    .tempdir()
+                    .map_err(|_| "Could not prepare this archive")?,
+            );
+        }
+        let sequence = self.temp_file_sequence;
+        self.temp_file_sequence += 1;
+        let directory = self
+            .temp_dir
+            .as_ref()
+            .expect("temporary directory was initialized")
+            .path()
+            .join(format!("{sequence:08}"));
+        std::fs::create_dir(&directory).map_err(|_| "Could not prepare this archive")?;
+        let file_name = Path::new(display_name)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or("Could not prepare this archive")?;
+        Ok(directory.join(file_name))
+    }
+
+    fn push_file(&mut self, source: ExpandedFile, display_name: String) {
+        if self.imported_files >= self.limits.max_import_files
+            || self.items.len() >= MAX_IMPORT_RESULTS
+        {
+            self.stop_at_limit(
+                display_name,
+                format!(
+                    "One import is limited to {} files",
+                    self.limits.max_import_files
+                ),
+            );
+            return;
+        }
+        self.imported_files += 1;
+        self.items.push(ExpandedImportItem::File {
+            source,
+            display_name,
+        });
+    }
+
+    fn push_failure(&mut self, display_name: impl Into<String>, message: impl Into<String>) {
+        if self.items.len() < MAX_IMPORT_RESULTS {
+            self.items.push(ExpandedImportItem::Failure {
+                display_name: display_name.into(),
+                message: message.into(),
+            });
+        }
+    }
+
+    fn stop_at_limit(&mut self, display_name: String, message: String) {
+        if !self.limit_reported {
+            self.push_failure(display_name, message);
+            self.limit_reported = true;
+        }
+        self.stopped = true;
+    }
+}
+
+enum ArchivePlan {
+    File {
+        normalized_path: String,
+        display_name: String,
+        index: usize,
+        declared_size: u64,
+    },
+    Failure {
+        normalized_path: String,
+        display_name: String,
+        message: String,
+    },
+}
+
+impl ArchivePlan {
+    fn normalized_path(&self) -> &str {
+        match self {
+            Self::File {
+                normalized_path, ..
+            }
+            | Self::Failure {
+                normalized_path, ..
+            } => normalized_path,
+        }
+    }
+}
+
+enum CopyArchiveError {
+    Cancelled,
+    Failed,
+}
+
+fn copy_archive_entry(
+    source: &mut impl Read,
+    destination: &Path,
+    declared_size: u64,
+    max_entry_bytes: u64,
+    max_total_bytes: u64,
+    is_cancelled: &dyn Fn() -> bool,
+) -> Result<u64, CopyArchiveError> {
+    let mut destination = File::create_new(destination).map_err(|_| CopyArchiveError::Failed)?;
+    let mut copied = 0_u64;
+    let mut buffer = [0_u8; COPY_BUFFER_BYTES];
+    loop {
+        if is_cancelled() {
+            return Err(CopyArchiveError::Cancelled);
+        }
+        let read = source
+            .read(&mut buffer)
+            .map_err(|_| CopyArchiveError::Failed)?;
+        if read == 0 {
+            break;
+        }
+        copied = copied
+            .checked_add(u64::try_from(read).expect("copy buffer length fits u64"))
+            .ok_or(CopyArchiveError::Failed)?;
+        if copied > max_entry_bytes || copied > max_total_bytes {
+            return Err(CopyArchiveError::Failed);
+        }
+        destination
+            .write_all(&buffer[..read])
+            .map_err(|_| CopyArchiveError::Failed)?;
+    }
+    if copied != declared_size {
+        return Err(CopyArchiveError::Failed);
+    }
+    destination.flush().map_err(|_| CopyArchiveError::Failed)?;
+    Ok(copied)
+}
+
+fn safe_zip_entry_name(raw_name: &str) -> Option<(String, String)> {
+    if raw_name.is_empty()
+        || raw_name.starts_with('/')
+        || raw_name.contains('\\')
+        || raw_name.contains('\0')
+    {
+        return None;
+    }
+    let components = raw_name.split('/').collect::<Vec<_>>();
+    if components.is_empty()
+        || components
+            .iter()
+            .any(|component| zip_component_is_ambiguous(component))
+        || components
+            .iter()
+            .any(|component| path_component_is_skipped(component))
+    {
+        return None;
+    }
+    let normalized_path = components.join("/");
+    let display_name = if safe_display_name(&normalized_path) {
+        normalized_path.clone()
+    } else {
+        let file_name = components.last().copied()?;
+        safe_display_name(file_name).then(|| file_name.to_owned())?
+    };
+    Some((normalized_path, display_name))
+}
+
+fn zip_component_is_ambiguous(component: &str) -> bool {
+    if component.is_empty()
+        || matches!(component, "." | "..")
+        || component.contains(':')
+        || component.ends_with(' ')
+        || component.ends_with('.')
+    {
+        return true;
+    }
+    let stem = component
+        .split_once('.')
+        .map_or(component, |(stem, _)| stem)
+        .to_ascii_lowercase();
+    matches!(stem.as_str(), "con" | "prn" | "aux" | "nul")
+        || stem
+            .strip_prefix("com")
+            .or_else(|| stem.strip_prefix("lpt"))
+            .is_some_and(|number| number.len() == 1 && matches!(number.as_bytes()[0], b'1'..=b'9'))
+}
+
+fn path_component_is_skipped(component: &str) -> bool {
+    component.starts_with('.')
+        || component.starts_with("~$")
+        || component.eq_ignore_ascii_case("__MACOSX")
+}
+
+fn safe_display_name(name: &str) -> bool {
+    !name.is_empty() && name.chars().count() <= 255 && name.chars().all(is_safe_title_char)
+}
+
+fn directory_display_name(root_path: &Path, relative_path: &Path) -> String {
+    relative_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| safe_display_name(name))
+        .map(str::to_owned)
+        .or_else(|| import_display_name(root_path).ok())
+        .unwrap_or_else(|| "Selected folder".to_owned())
+}
+
+fn open_directory_nofollow(path: &Path) -> std::io::Result<Dir> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    Dir::open_ambient_dir(parent, ambient_authority())?.open_dir_nofollow(file_name)
+}
+
+fn open_regular_file_nofollow(path: &Path) -> std::io::Result<File> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    let directory = Dir::open_ambient_dir(parent, ambient_authority())?;
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let file = directory.open_with(file_name, &options)?;
+    if !file.metadata()?.is_file() {
+        return Err(std::io::Error::from(std::io::ErrorKind::InvalidInput));
+    }
+    Ok(file.into_std())
+}
+
+fn open_directory_file_nofollow(directory: &Dir, path: &Path) -> std::io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let file = directory.open_with(path, &options)?;
+    if !file.metadata()?.is_file() {
+        return Err(std::io::Error::from(std::io::ErrorKind::InvalidInput));
+    }
+    Ok(file.into_std())
+}
+
+pub(super) fn has_blocked_import_extension(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            BLOCKED_IMPORT_EXTENSIONS
+                .iter()
+                .any(|blocked| extension.eq_ignore_ascii_case(blocked))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+
+    use zip::write::SimpleFileOptions;
+    use zip::ZipWriter;
+
+    use super::*;
+
+    #[test]
+    fn folders_are_sorted_bounded_and_skip_non_documents_without_following_links() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("sources");
+        std::fs::create_dir(&root).unwrap();
+        std::fs::write(root.join("b.md"), "b").unwrap();
+        std::fs::write(root.join("a.md"), "a").unwrap();
+        std::fs::write(root.join(".hidden.md"), "hidden").unwrap();
+        std::fs::write(root.join("~$notes.docx"), "lock").unwrap();
+        std::fs::write(root.join("installer.EXE"), b"%PDF executable").unwrap();
+        std::fs::create_dir(root.join("__MACOSX")).unwrap();
+        std::fs::write(root.join("__MACOSX").join("metadata"), "metadata").unwrap();
+        std::fs::create_dir(root.join("nested")).unwrap();
+        std::fs::write(root.join("nested").join("c.txt"), "c").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(root.join("nested"), root.join("linked")).unwrap();
+
+        let expanded = expand_import_paths(vec![root.clone()], &|| false).unwrap();
+        assert_eq!(file_names(&expanded.items), ["a.md", "b.md", "c.txt"]);
+
+        std::fs::rename(root.join("a.md"), root.join("a-original.md")).unwrap();
+        std::fs::write(root.join("a.md"), "replacement").unwrap();
+        let original = expanded
+            .items
+            .iter()
+            .find_map(|item| match item {
+                ExpandedImportItem::File {
+                    source: ExpandedFile::Open(file),
+                    display_name,
+                } if display_name == "a.md" => Some(file),
+                _ => None,
+            })
+            .unwrap();
+        let mut original = original.try_clone().unwrap();
+        let mut contents = String::new();
+        original.read_to_string(&mut contents).unwrap();
+        assert_eq!(contents, "a");
+        std::fs::remove_file(root.join("a.md")).unwrap();
+        std::fs::rename(root.join("a-original.md"), root.join("a.md")).unwrap();
+
+        let limited = expand_import_paths_with_limits(
+            vec![root.clone()],
+            ExpansionLimits {
+                max_import_files: 2,
+                ..ExpansionLimits::default()
+            },
+            &|| false,
+        )
+        .unwrap();
+        assert_eq!(file_names(&limited.items), ["a.md", "b.md"]);
+        assert!(failures(&limited.items)
+            .iter()
+            .any(|(_, message)| message.contains("limited to 2 files")));
+
+        let depth_limited = expand_import_paths_with_limits(
+            vec![root],
+            ExpansionLimits {
+                max_directory_depth: 0,
+                ..ExpansionLimits::default()
+            },
+            &|| false,
+        )
+        .unwrap();
+        assert_eq!(file_names(&depth_limited.items), ["a.md", "b.md"]);
+        assert!(failures(&depth_limited.items)
+            .iter()
+            .any(|(_, message)| message.contains("limited to 0 levels")));
+    }
+
+    #[test]
+    fn zip_entries_are_safely_sorted_and_an_all_skipped_archive_is_retained() {
+        let directory = tempfile::tempdir().unwrap();
+        let archive_path = directory.path().join("sources.zip");
+        write_zip(
+            &archive_path,
+            &[
+                ("b.md", b"b"),
+                ("../escape.md", b"escape"),
+                ("folder\\ambiguous.md", b"ambiguous"),
+                ("__MACOSX/metadata", b"metadata"),
+                (".hidden.md", b"hidden"),
+                ("run.exe", b"%PDF executable"),
+                ("folder/a.md", b"a"),
+            ],
+            true,
+        );
+
+        let expanded = expand_import_paths(vec![archive_path], &|| false).unwrap();
+        assert_eq!(file_names(&expanded.items), ["b.md", "folder/a.md"]);
+        assert!(!directory.path().join("escape.md").exists());
+
+        let skipped_path = directory.path().join("skipped.zip");
+        write_zip(
+            &skipped_path,
+            &[(".hidden.md", b"hidden"), ("run.exe", b"binary")],
+            false,
+        );
+        let skipped = expand_import_paths(vec![skipped_path], &|| false).unwrap();
+        assert_eq!(file_names(&skipped.items), ["skipped.zip"]);
+    }
+
+    #[test]
+    fn zip_count_and_size_limits_retain_the_archive_or_report_partial_failure() {
+        let directory = tempfile::tempdir().unwrap();
+        let archive_path = directory.path().join("many.zip");
+        write_zip(
+            &archive_path,
+            &[("a.md", b"a"), ("b.md", b"bb"), ("c.md", b"ccc")],
+            false,
+        );
+        let count_limited = expand_import_paths_with_limits(
+            vec![archive_path.clone()],
+            ExpansionLimits {
+                max_zip_entries: 2,
+                ..ExpansionLimits::default()
+            },
+            &|| false,
+        )
+        .unwrap();
+        assert_eq!(file_names(&count_limited.items), ["many.zip"]);
+
+        let size_limited = expand_import_paths_with_limits(
+            vec![archive_path],
+            ExpansionLimits {
+                max_zip_entry_bytes: 1,
+                ..ExpansionLimits::default()
+            },
+            &|| false,
+        )
+        .unwrap();
+        assert_eq!(file_names(&size_limited.items), ["a.md"]);
+        assert_eq!(
+            failures(&size_limited.items)
+                .iter()
+                .map(|(name, _)| name.as_str())
+                .collect::<Vec<_>>(),
+            ["b.md", "c.md"]
+        );
+    }
+
+    #[test]
+    fn expansion_observes_cancellation_between_sorted_entries() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("sources");
+        std::fs::create_dir(&root).unwrap();
+        for name in ["a.md", "b.md", "c.md"] {
+            std::fs::write(root.join(name), name).unwrap();
+        }
+        let checks = std::cell::Cell::new(0);
+        let result = expand_import_paths(vec![root], &|| {
+            let next = checks.get() + 1;
+            checks.set(next);
+            next >= 4
+        });
+        assert_eq!(result.err(), Some(ExpansionCancelled));
+    }
+
+    fn write_zip(path: &Path, entries: &[(&str, &[u8])], include_symlink: bool) {
+        let file = File::create(path).unwrap();
+        let mut writer = ZipWriter::new(file);
+        for (name, bytes) in entries {
+            writer
+                .start_file(*name, SimpleFileOptions::default())
+                .unwrap();
+            writer.write_all(bytes).unwrap();
+        }
+        if include_symlink {
+            writer
+                .add_symlink("linked.md", "folder/a.md", SimpleFileOptions::default())
+                .unwrap();
+        }
+        writer.finish().unwrap();
+    }
+
+    fn file_names(items: &[ExpandedImportItem]) -> Vec<&str> {
+        items
+            .iter()
+            .filter_map(|item| match item {
+                ExpandedImportItem::File { display_name, .. } => Some(display_name.as_str()),
+                ExpandedImportItem::Failure { .. } => None,
+            })
+            .collect()
+    }
+
+    fn failures(items: &[ExpandedImportItem]) -> Vec<(&String, &String)> {
+        items
+            .iter()
+            .filter_map(|item| match item {
+                ExpandedImportItem::Failure {
+                    display_name,
+                    message,
+                } => Some((display_name, message)),
+                ExpandedImportItem::File { .. } => None,
+            })
+            .collect()
+    }
+}

--- a/crates/openwave-desktop/ui/src/DocumentDropTarget.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentDropTarget.dom.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DocumentDropTarget,
+  dropItemCountCopy,
+  parseDropState,
+} from "./DocumentDropTarget";
+
+const mocks = vi.hoisted(() => ({
+  handler: undefined as ((event: { payload: unknown }) => void) | undefined,
+  importDropped: vi.fn(),
+  stop: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async (_event: string, handler: (event: { payload: unknown }) => void) => {
+    mocks.handler = handler;
+    return mocks.stop;
+  }),
+}));
+
+vi.mock("./documents", () => ({
+  importDroppedLibraryDocuments: mocks.importDropped,
+}));
+
+vi.mock("./host", () => ({
+  hasNativeHost: () => true,
+}));
+
+describe("DocumentDropTarget", () => {
+  beforeEach(() => {
+    mocks.handler = undefined;
+    mocks.importDropped.mockReset();
+    mocks.importDropped.mockResolvedValue(null);
+    mocks.stop.mockReset();
+  });
+
+  it("offers native files and folders without claiming aliases", async () => {
+    render(<DocumentDropTarget chatId="chat-1" />);
+    await waitFor(() => expect(mocks.handler).toBeTypeOf("function"));
+
+    act(() => {
+      mocks.handler?.({
+        payload: { phase: "enter", accepted: true, fileCount: 1 },
+      });
+    });
+    expect(
+      screen.getByText("Add this file or folder to this conversation"),
+    ).toBeInTheDocument();
+    expect(dropItemCountCopy(3)).toBe("3 files or folders");
+
+    act(() => {
+      mocks.handler?.({
+        payload: { phase: "dropped", accepted: true, fileCount: 1 },
+      });
+    });
+    expect(mocks.importDropped).toHaveBeenCalledWith("chat-1");
+  });
+
+  it("cancels its native listener and ignores a stale drop after unmount", async () => {
+    const view = render(<DocumentDropTarget chatId="chat-1" />);
+    await waitFor(() => expect(mocks.handler).toBeTypeOf("function"));
+    view.unmount();
+    expect(mocks.stop).toHaveBeenCalledOnce();
+
+    act(() => {
+      mocks.handler?.({
+        payload: { phase: "dropped", accepted: true, fileCount: 1 },
+      });
+    });
+    expect(mocks.importDropped).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed drop projections", () => {
+    expect(parseDropState({ phase: "enter", accepted: true, fileCount: -1 })).toBeNull();
+    expect(parseDropState({ phase: "enter", accepted: true, fileCount: 2 })).toEqual({
+      phase: "enter",
+      accepted: true,
+      fileCount: 2,
+    });
+  });
+});

--- a/crates/openwave-desktop/ui/src/DocumentDropTarget.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentDropTarget.tsx
@@ -49,19 +49,19 @@ export function DocumentDropTarget({ chatId }: { chatId: string }) {
     >
       <strong>
         {state.accepted
-          ? `Add ${fileCountCopy(state.fileCount)} to this conversation`
-          : "Only files can be added as sources"}
+          ? `Add ${dropItemCountCopy(state.fileCount)} to this conversation`
+          : "Only files and folders can be added as sources"}
       </strong>
       <span>
         {state.accepted
-          ? "Release to add them in the background."
-          : "Drop files, not folders or aliases."}
+          ? "Release to add their documents in the background."
+          : "Aliases and unavailable items cannot be imported."}
       </span>
     </div>
   );
 }
 
-function parseDropState(value: unknown): DropState | null {
+export function parseDropState(value: unknown): DropState | null {
   if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
   const state = value as Record<string, unknown>;
   if (
@@ -80,6 +80,6 @@ function parseDropState(value: unknown): DropState | null {
   };
 }
 
-function fileCountCopy(count: number): string {
-  return count === 1 ? "this file" : `${count} files`;
+export function dropItemCountCopy(count: number): string {
+  return count === 1 ? "this file or folder" : `${count} files or folders`;
 }

--- a/crates/openwave-desktop/ui/src/DocumentsView.test.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentsView.test.tsx
@@ -10,7 +10,7 @@ describe("DocumentsView", () => {
 
     expect(markup).toContain(">Sources<");
     expect(markup).toContain(
-      "Add files for OpenWave to use in this conversation.",
+      "Add files, folders, or ZIP archives for OpenWave to use in this",
     );
     expect(markup).toContain("Conversation sources");
     expect(markup).toContain("Loading sources for this conversation");

--- a/crates/openwave-desktop/ui/src/DocumentsView.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentsView.tsx
@@ -272,8 +272,8 @@ export function DocumentsView({
         <div>
           <h1 id="documents-title">Sources</h1>
           <p>
-            Add files for OpenWave to use in this conversation. Supported sources
-            are prepared for search on this device.
+            Add files, folders, or ZIP archives for OpenWave to use in this
+            conversation. Supported sources are prepared for search on this device.
           </p>
         </div>
         <div className="documents-header-actions">
@@ -386,9 +386,10 @@ export function DocumentsView({
             <div className="document-empty">
               <strong>No sources yet</strong>
               <span>
-                Drop files of any type, up to 16 MB each. PDFs, Office documents,
-                Markdown, text, and supported images are prepared for search; other
-                formats remain available as conversation sources.
+                Drop files of any type, up to 16 MB each, or add folders and ZIP
+                archives. PDFs, Office documents, Markdown, text, and supported
+                images are prepared for search; other formats remain available as
+                conversation sources.
               </span>
               <span>This panel shows the newest 1,000 sources.</span>
             </div>

--- a/crates/openwave-desktop/ui/src/ImportQueueStore.test.ts
+++ b/crates/openwave-desktop/ui/src/ImportQueueStore.test.ts
@@ -82,4 +82,28 @@ describe("ImportQueueStore", () => {
       "streaming",
     ]);
   });
+
+  it("keeps an expanded archive's successes and failures independent", () => {
+    const store = createImportQueueStore();
+    store.getState().receive(queued);
+    store.getState().receive({
+      ...queued,
+      status: "imported",
+      documentId: "22222222-2222-4222-8222-222222222222",
+      processingStatus: "queued",
+    });
+    store.getState().receive({
+      ...queued,
+      importId: "55555555-5555-4555-8555-555555555555",
+      displayName: "oversized.pdf",
+      status: "failed",
+      message: "Archive entries are limited to 128 MiB",
+    });
+
+    expect(store.getState().entries).toHaveLength(2);
+    expect(sortedImportQueue(store.getState().entries).map((entry) => entry.status)).toEqual([
+      "failed",
+      "imported",
+    ]);
+  });
 });

--- a/crates/openwave-desktop/ui/src/documents.test.ts
+++ b/crates/openwave-desktop/ui/src/documents.test.ts
@@ -45,6 +45,16 @@ describe("document library renderer projections", () => {
         message: null,
       }),
     ).toThrow("Invalid document import progress");
+
+    expect(() =>
+      parseLibraryImportBatch({
+        results: Array.from({ length: 1_001 }, () => ({
+          status: "failed",
+          displayName: "entry.md",
+          message: "Could not import",
+        })),
+      }),
+    ).toThrow("Invalid document import response");
   });
 
   it("accepts the closed catalog and import shapes", () => {

--- a/crates/openwave-desktop/ui/src/documents.ts
+++ b/crates/openwave-desktop/ui/src/documents.ts
@@ -159,7 +159,11 @@ export function parseLibraryImportProgress(value: unknown): LibraryImportProgres
 
 export function parseLibraryImportBatch(value: unknown): LibraryImportBatch | null {
   if (value === null) return null;
-  if (!isExactRecord(value, ["results"]) || !Array.isArray(value.results)) {
+  if (
+    !isExactRecord(value, ["results"]) ||
+    !Array.isArray(value.results) ||
+    value.results.length > 1_000
+  ) {
     throw new Error("Invalid document import response");
   }
   return {


### PR DESCRIPTION
Refs #533
Refs #539

Adds bounded deterministic no-follow directory traversal and defensive ZIP expansion to the existing streamed/deduplicated import queue. Enforces skip/blocklist policy before sniffing, rejects ambiguous and malicious archive paths, supports cancellation and partial failure, and falls back to importing archives with no usable entries.

Validation: full locked workspace tests/check/clippy, formatting, 514 UI tests, UI production build, and targeted cap/order/skip/malicious/cancellation tests.