### PR TITLE
feat(desktop): attach any file from one composer button

### DIFF
--- a/crates/openwave-desktop/src/attachments.rs
+++ b/crates/openwave-desktop/src/attachments.rs
@@ -1,0 +1,139 @@
+//! One attach gesture, routed by what the bytes actually are.
+//!
+//! The composer offers a single button for putting a file into a conversation.
+//! Underneath there are still two destinations, because they are two different
+//! capabilities: an image attachment reaches the model as pixels, while an
+//! imported document is parsed into text that can be searched and cited. A
+//! reader holding a screenshot should not have to know which of those the app
+//! will do before they can choose a button.
+//!
+//! The routing has to happen here rather than in the renderer. Picked paths are
+//! deliberately never serialized to the webview, so the renderer has nothing to
+//! decide on; it receives only the two sets of outcomes.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, State};
+use uuid::Uuid;
+
+use crate::documents::{import_document_paths, pick_documents, LibraryImportBatch};
+use crate::host_access::HostAccess;
+use crate::image_attachments::{is_attachable_image, publish_image_at, AttachedImage};
+use crate::AppState;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct AttachFilesRequest {
+    chat_id: Uuid,
+}
+
+/// What one mixed selection produced.
+///
+/// The two halves are reported separately because the composer shows them
+/// differently — images as removable chips it can preview, documents as the
+/// conversation's sources — and because a failure in one says nothing about
+/// the other.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AttachedFiles {
+    images: Vec<AttachedImage>,
+    /// Absent when the selection held no documents, which is not the same as a
+    /// selection whose documents all failed.
+    documents: Option<LibraryImportBatch>,
+    /// Images that could not be published, by file name. Documents carry their
+    /// own per-file outcome inside the batch; images have no such envelope, so
+    /// their failures are reported here rather than sinking the whole call.
+    failed_images: Vec<FailedImage>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct FailedImage {
+    file_name: String,
+    message: String,
+}
+
+/// Select any files and put each where it belongs.
+///
+/// One picker, unfiltered — the document picker never filtered either, so
+/// nothing the reader could previously choose is greyed out now.
+#[tauri::command]
+pub(crate) async fn attach_chat_files(
+    app: AppHandle,
+    app_state: State<'_, Arc<AppState>>,
+    host_access: State<'_, HostAccess>,
+    request: AttachFilesRequest,
+) -> Result<Option<AttachedFiles>, String> {
+    // Validated before the dialog and again after it, so a picker left open
+    // across a deletion cannot deposit into a conversation that is gone.
+    crate::documents::resolve_conversation_scope(&host_access, request.chat_id).await?;
+    let _picker = host_access
+        .picker
+        .try_lock()
+        .map_err(|_| "A file or folder picker is already open".to_owned())?;
+    let Some(paths) = pick_documents(&app).await? else {
+        return Ok(None);
+    };
+
+    let (image_paths, document_paths): (Vec<_>, Vec<_>) = paths
+        .into_iter()
+        .partition(|path| is_attachable_image(path));
+
+    let mut images = Vec::new();
+    let mut failed_images = Vec::new();
+    for path in image_paths {
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("image")
+            .to_owned();
+        // One bad image must not cost the reader the rest of the selection, so
+        // each is reported on its own terms — the same rule the document batch
+        // already follows.
+        match publish_image_at(app_state.inner(), &host_access, request.chat_id, path).await {
+            Ok(attached) => images.push(attached),
+            Err(message) => failed_images.push(FailedImage {
+                file_name: name,
+                message,
+            }),
+        }
+    }
+
+    let documents = if document_paths.is_empty() {
+        None
+    } else {
+        Some(
+            import_document_paths(
+                &app,
+                app_state.inner(),
+                &host_access,
+                request.chat_id,
+                document_paths,
+            )
+            .await,
+        )
+    };
+
+    Ok(Some(AttachedFiles {
+        images,
+        documents,
+        failed_images,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Moved here with the request it guards: `attach_chat_files` is now the
+    /// one command that carries a conversation id in from the renderer.
+    #[test]
+    fn a_renderer_cannot_widen_the_request_beyond_one_conversation() {
+        let injected = serde_json::json!({
+            "chatId": Uuid::nil(),
+            "projectId": Uuid::nil(),
+        });
+        assert!(serde_json::from_value::<AttachFilesRequest>(injected).is_err());
+    }
+}

--- a/crates/openwave-desktop/src/documents.rs
+++ b/crates/openwave-desktop/src/documents.rs
@@ -606,7 +606,7 @@ fn drop_state(phase: LibraryImportDropPhase, paths: &[PathBuf]) -> LibraryImport
     }
 }
 
-async fn import_document_paths(
+pub(crate) async fn import_document_paths(
     app: &AppHandle,
     app_state: &Arc<AppState>,
     host_access: &HostAccess,
@@ -887,7 +887,7 @@ async fn pick_document(app: &AppHandle) -> Result<Option<PathBuf>, String> {
         .map_err(|_| "The document picker returned an invalid file".to_owned())
 }
 
-async fn pick_documents(app: &AppHandle) -> Result<Option<Vec<PathBuf>>, String> {
+pub(crate) async fn pick_documents(app: &AppHandle) -> Result<Option<Vec<PathBuf>>, String> {
     let (tx, rx) = oneshot::channel();
     let mut picker = app.dialog().file().set_title("Import documents");
     if let Some(window) = app.get_webview_window("main") {

--- a/crates/openwave-desktop/src/image_attachments.rs
+++ b/crates/openwave-desktop/src/image_attachments.rs
@@ -1,10 +1,13 @@
 //! Native image attachment bridge.
 //!
-//! Image bytes terminate here. The picker, the read, and the upload all happen
-//! in the host process; the webview receives an opaque attachment id and a few
-//! bounded numbers, and never sees the pixels or the path they came from. That
-//! is what keeps a compromised or merely buggy renderer from being able to
-//! exfiltrate the contents of a file the user only meant to show the model.
+//! Image bytes terminate here. The read and the upload happen in the host
+//! process; the webview receives an opaque attachment id and a few bounded
+//! numbers, and never sees the pixels or the path they came from. That is what
+//! keeps a compromised or merely buggy renderer from being able to exfiltrate
+//! the contents of a file the user only meant to show the model.
+//!
+//! Choosing the file is [`crate::attachments`]'s job, because one picker serves
+//! both images and documents and only the bytes can say which a file is.
 
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -15,27 +18,11 @@ use cap_std::ambient_authority;
 use cap_std::fs::{Dir, OpenOptions};
 use openwave_core::{ChatId, MAX_IMAGE_BYTES};
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Manager, State};
-use tauri_plugin_dialog::DialogExt;
-use tokio::sync::oneshot;
 use uuid::Uuid;
 
 use crate::documents::resolve_conversation_scope;
 use crate::host_access::HostAccess;
 use crate::{wait_server_info, AppState};
-
-/// Extensions offered in the picker.
-///
-/// This is a convenience filter only, never a trust decision: the server sniffs
-/// the actual format from the bytes and refuses a file whose contents disagree
-/// with what its name claims.
-const IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "webp", "gif"];
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub(crate) struct AttachImageRequest {
-    chat_id: Uuid,
-}
 
 /// What the renderer learns about an attached image.
 ///
@@ -105,34 +92,23 @@ fn picked_image_name(path: &Path) -> Result<String, String> {
         .ok_or_else(|| "The selected image has an invalid name".to_owned())
 }
 
-/// Pick one image from disk and publish it for a conversation.
+/// Read one image off disk and publish it, returning what the renderer may see.
 ///
-/// Returns `None` when the user dismisses the picker, which is a normal outcome
-/// rather than a failure.
-#[tauri::command]
-pub(crate) async fn attach_chat_image(
-    app: AppHandle,
-    app_state: State<'_, Arc<AppState>>,
-    host_access: State<'_, HostAccess>,
-    request: AttachImageRequest,
-) -> Result<Option<AttachedImage>, String> {
-    // Validate before presenting native consent, then resolve again after the
-    // user returns so a long-lived picker cannot retain a deleted conversation.
-    resolve_conversation_scope(&host_access, request.chat_id).await?;
-    let _picker = host_access
-        .picker
-        .try_lock()
-        .map_err(|_| "A file or folder picker is already open".to_owned())?;
-    let Some(path) = pick_image(&app).await? else {
-        return Ok(None);
-    };
+/// Split out from the picker so a mixed selection can route a file here without
+/// opening a second dialog for it — see [`crate::attachments`].
+pub(crate) async fn publish_image_at(
+    app_state: &Arc<AppState>,
+    host_access: &HostAccess,
+    requested_chat: Uuid,
+    path: PathBuf,
+) -> Result<AttachedImage, String> {
     let file_name = picked_image_name(&path)?;
     let bytes = tauri::async_runtime::spawn_blocking(move || read_selected_image(&path))
         .await
         .map_err(|_| "Could not read the selected image".to_owned())??;
 
-    let chat_id = resolve_conversation_scope(&host_access, request.chat_id).await?;
-    let info = wait_server_info(app_state.inner()).await?;
+    let chat_id = resolve_conversation_scope(host_access, requested_chat).await?;
+    let info = wait_server_info(app_state).await?;
     // The declared type is derived from the bytes, not the file name, so the
     // server's sniff-versus-declared check stays a genuine cross-check of two
     // independent claims rather than a comparison of one value with itself.
@@ -163,7 +139,51 @@ pub(crate) async fn attach_chat_image(
         .json::<PublishedImageAttachment>()
         .await
         .map_err(|_| "Attaching the image returned an invalid response".to_owned())?;
-    Ok(Some(AttachedImage::new(published, file_name)))
+    Ok(AttachedImage::new(published, file_name))
+}
+
+/// Whether this file should be attached as an image rather than imported as a
+/// document, decided from its leading bytes and its size.
+///
+/// Both halves matter. An oversized PNG is a real image that cannot be an image
+/// attachment, and routing it here would refuse the file outright; treating it
+/// as a document instead keeps it usable, which is what the reader wanted from
+/// dropping it on the composer.
+pub(crate) fn is_attachable_image(path: &Path) -> bool {
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    let Some(file_name) = path.file_name() else {
+        return false;
+    };
+    let Ok(directory) = Dir::open_ambient_dir(parent, ambient_authority()) else {
+        return false;
+    };
+    let mut options = OpenOptions::new();
+    options.read(true).follow(FollowSymlinks::No);
+    let Ok(file) = directory.open_with(file_name, &options) else {
+        return false;
+    };
+    match file.metadata() {
+        Ok(metadata) if metadata.is_file() && metadata.len() <= MAX_IMAGE_BYTES => {}
+        _ => return false,
+    }
+    // Enough for the longest signature checked, and no more: this runs on every
+    // file in a selection, most of which are not images.
+    let mut header = [0u8; 12];
+    let mut read = 0;
+    let mut handle = file.take(12);
+    loop {
+        match handle.read(&mut header[read..]) {
+            Ok(0) => break,
+            Ok(count) => read += count,
+            Err(_) => return false,
+        }
+        if read == header.len() {
+            break;
+        }
+    }
+    declared_media_type(&header[..read]).is_some()
 }
 
 fn image_attachments_path(chat_id: ChatId) -> String {
@@ -216,26 +236,6 @@ fn declared_media_type(bytes: &[u8]) -> Option<&'static str> {
         return Some("image/webp");
     }
     None
-}
-
-async fn pick_image(app: &AppHandle) -> Result<Option<PathBuf>, String> {
-    let (tx, rx) = oneshot::channel();
-    let mut picker = app
-        .dialog()
-        .file()
-        .set_title("Attach an image")
-        .add_filter("Images", IMAGE_EXTENSIONS);
-    if let Some(window) = app.get_webview_window("main") {
-        picker = picker.set_parent(&window);
-    }
-    picker.pick_file(move |path| {
-        let _ = tx.send(path);
-    });
-    rx.await
-        .map_err(|_| "The image picker closed unexpectedly".to_owned())?
-        .map(tauri_plugin_dialog::FilePath::into_path)
-        .transpose()
-        .map_err(|_| "The image picker returned an invalid file".to_owned())
 }
 
 /// Read the picked file without following symlinks and without exceeding the
@@ -352,15 +352,6 @@ mod tests {
         assert!(picked_image_name(Path::new("/Users/private/bad\u{202e}gnp.png")).is_err());
         let overlong = format!("/Users/private/{}.png", "a".repeat(300));
         assert!(picked_image_name(Path::new(&overlong)).is_err());
-    }
-
-    #[test]
-    fn a_renderer_cannot_widen_the_request_beyond_one_conversation() {
-        let injected = serde_json::json!({
-            "chatId": Uuid::nil(),
-            "projectId": Uuid::nil(),
-        });
-        assert!(serde_json::from_value::<AttachImageRequest>(injected).is_err());
     }
 
     #[test]

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -14,6 +14,7 @@ use tokio::sync::watch;
 
 use openwave_core::Config;
 
+mod attachments;
 mod broker;
 mod client_execution;
 mod deliverables;
@@ -173,6 +174,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             server_info,
             request_user_attention,
+            attachments::attach_chat_files,
             documents::import_library_document,
             documents::import_library_documents,
             documents::import_dropped_library_documents,
@@ -180,7 +182,6 @@ pub fn run() {
             documents::search_library_documents,
             documents::delete_library_document,
             documents::retry_library_document,
-            image_attachments::attach_chat_image,
             deliverables::list_deliverables,
             deliverables::read_deliverable,
             deliverables::export_deliverable,

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -29,8 +29,8 @@ import { DeliverablesView } from "./DeliverablesView";
 import { DocumentsView } from "./DocumentsView";
 import { FoldersView } from "./FoldersView";
 import { hasNativeHost } from "./host";
+import { attachChatFiles } from "./attachments";
 import {
-  importLibraryDocuments,
   type ImportedDocument,
   type LibraryImportSuccess,
 } from "./documents";
@@ -93,9 +93,9 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   const busy = useChatSessionStore((session) => session.busy);
   const [hydrated, setHydrated] = useState(false);
   const [draft, setDraft] = useState("");
-  const [attachingSource, setAttachingSource] = useState(false);
+  const [attaching, setAttaching] = useState(false);
   const [recentSource, setRecentSource] = useState<ImportedDocument | null>(null);
-  const [sourceAttachmentError, setSourceAttachmentError] = useState<string | null>(null);
+  const [attachError, setAttachError] = useState<string | null>(null);
   const images = useImageAttachments(client, chatId);
   const handleEventRef = useRef<(event: SequencedEvent) => void>(() => {});
   const terminalHydrationGenerationRef = useRef(0);
@@ -289,23 +289,38 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     }
   }
 
-  async function onAddSource() {
-    if (attachingSource || deletingChatId !== null) return;
+  /**
+   * One picker for anything the reader wants to attach.
+   *
+   * Which of the two things each file becomes — pixels for the model, or a
+   * parsed and searchable source — is decided by the host from the bytes, so
+   * nothing here has to guess from a name or ask the reader to know first.
+   */
+  async function onAttach() {
+    if (attaching || deletingChatId !== null) return;
     if (!useNativePickerLatch.getState().claim(PICKER_HOLDERS.importSource)) {
-      setSourceAttachmentError(PICKER_BUSY_MESSAGE);
+      setAttachError(PICKER_BUSY_MESSAGE);
       return;
     }
-    setAttachingSource(true);
-    setSourceAttachmentError(null);
+    setAttaching(true);
+    setAttachError(null);
     try {
-      const batch = await importLibraryDocuments(chatId);
-      const source = batch?.results.find(isImportedDocument);
+      const attached = await attachChatFiles(chatId);
+      if (!attached) return;
+      images.adopt(attached.images);
+      const source = attached.documents?.results.find(isImportedDocument);
       if (source) setRecentSource(source.document);
+      // A file that could not be attached as an image is the reader's to fix,
+      // and saying nothing would read as a silent drop from the selection.
+      const [firstFailure] = attached.failedImages;
+      if (firstFailure) {
+        setAttachError(`${firstFailure.fileName}: ${firstFailure.message}`);
+      }
     } catch (err) {
-      setSourceAttachmentError(friendlySourceAttachmentError(err));
+      setAttachError(friendlyAttachError(err));
     } finally {
       useNativePickerLatch.getState().release(PICKER_HOLDERS.importSource);
-      setAttachingSource(false);
+      setAttaching(false);
     }
   }
 
@@ -337,18 +352,13 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             deletingChat={deletingChatId !== null}
             draft={draft}
             draftRef={draftRef}
-            attachingSource={attachingSource}
+            attaching={attaching}
             attachedSourceName={recentSource?.displayName ?? null}
-            sourceAttachmentError={sourceAttachmentError}
+            attachError={attachError}
             composerImages={{
               items: images.attachments,
-              // Drop and paste hand the composer the bytes directly; only the
-              // picker needs the host, so only it is withheld in a browser.
-              canPick: hasNativeHost(),
-              picking: images.attachingFromPicker,
               error: images.error,
               unsupportedModel: textOnlyModelLabel(models, chat!.model),
-              onPick: images.attachFromPicker,
               onAttachFiles: images.attachFiles,
               onRemove: images.remove,
               onRetry: images.retry,
@@ -372,7 +382,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
               </>
             }
             onDraftChange={setComposerDraft}
-            onAddSource={onAddSource}
+            onAttach={onAttach}
             onDismissAttachedSource={() => setRecentSource(null)}
             onSelectPrompt={setComposerDraft}
             onSend={onSend}
@@ -452,9 +462,9 @@ function textOnlyModelLabel(
   return model && !model.multimodal ? model.display_name : null;
 }
 
-function friendlySourceAttachmentError(error: unknown): string {
+function friendlyAttachError(error: unknown): string {
   const message = String(error).replace(/^Error:\s*/, "").trim();
-  return message && message.length <= 240 ? message : "Could not add that file.";
+  return message && message.length <= 240 ? message : "Could not attach that file.";
 }
 
 function isImportedDocument(

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -32,11 +32,8 @@ const client = {
 function noImages(): ComposerImages {
   return {
     items: [],
-    canPick: false,
-    picking: false,
     error: null,
     unsupportedModel: null,
-    onPick: vi.fn(),
     onAttachFiles: vi.fn(),
     onRemove: vi.fn(),
     onRetry: vi.fn(),
@@ -61,14 +58,14 @@ function DraftingChatView(overrides: Partial<ChatViewProps> = {}) {
       draftRef={draftRef}
       composerModelMenu={null}
       composerImages={noImages()}
-      attachingSource={false}
+      attaching={false}
       attachedSourceName={null}
-      sourceAttachmentError={null}
+      attachError={null}
       onDraftChange={(value) => {
         draftRef.current = value;
         setDraft(value);
       }}
-      onAddSource={vi.fn(async () => {})}
+      onAttach={vi.fn(async () => {})}
       onDismissAttachedSource={vi.fn()}
       onSelectPrompt={vi.fn()}
       onSend={vi.fn(async () => {})}
@@ -88,11 +85,11 @@ function renderChatView(overrides: Partial<ChatViewProps> = {}) {
     draftRef: { current: "" },
     composerModelMenu: null,
     composerImages: noImages(),
-    attachingSource: false,
+    attaching: false,
     attachedSourceName: null,
-    sourceAttachmentError: null,
+    attachError: null,
     onDraftChange: vi.fn(),
-    onAddSource: vi.fn(async () => {}),
+    onAttach: vi.fn(async () => {}),
     onDismissAttachedSource: vi.fn(),
     onSelectPrompt: vi.fn(),
     onSend: vi.fn(async () => {}),

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -30,11 +30,11 @@ export type ChatViewProps = {
   draftRef: RefObject<string>;
   composerModelMenu: ReactNode;
   composerImages: ComposerImages;
-  attachingSource: boolean;
+  attaching: boolean;
   attachedSourceName: string | null;
-  sourceAttachmentError: string | null;
+  attachError: string | null;
   onDraftChange: (value: string) => void;
-  onAddSource: () => Promise<void>;
+  onAttach: () => Promise<void>;
   onDismissAttachedSource: () => void;
   onSelectPrompt: (prompt: string) => void;
   onSend: () => Promise<void>;
@@ -57,11 +57,11 @@ export function ChatView({
   draftRef,
   composerModelMenu,
   composerImages,
-  attachingSource,
+  attaching,
   attachedSourceName,
-  sourceAttachmentError,
+  attachError,
   onDraftChange,
-  onAddSource,
+  onAttach,
   onDismissAttachedSource,
   onSelectPrompt,
   onSend,
@@ -195,11 +195,11 @@ export function ChatView({
         draft={draft}
         modelMenu={composerModelMenu}
         images={composerImages}
-        canAttachSource={nativeHost}
-        attachingSource={attachingSource}
+        canAttach={nativeHost}
+        attaching={attaching}
         attachedSourceName={attachedSourceName}
-        sourceAttachmentError={sourceAttachmentError}
-        onAddSource={onAddSource}
+        attachError={attachError}
+        onAttach={onAttach}
         onDismissAttachedSource={onDismissAttachedSource}
         // Typing retires the verdict on the last piece of guidance. Accepted
         // guidance clears the draft through the raw callback instead, so

--- a/crates/openwave-desktop/ui/src/Composer.test.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.test.tsx
@@ -23,11 +23,8 @@ const noop = async () => undefined;
 function images(overrides: Partial<ComposerImages> = {}): ComposerImages {
   return {
     items: [],
-    canPick: true,
-    picking: false,
     error: null,
     unsupportedModel: null,
-    onPick: vi.fn(),
     onAttachFiles: vi.fn(),
     onRemove: vi.fn(),
     onRetry: vi.fn(),
@@ -290,7 +287,7 @@ describe("Composer", () => {
     expect(markup).toContain('disabled=""');
   });
 
-  it("keeps source attachment inside the conversation composer", () => {
+  it("offers one attach control, and reports what it added", () => {
     const markup = renderToStaticMarkup(
       <Composer
         activeTurnId={null}
@@ -299,11 +296,11 @@ describe("Composer", () => {
         cancelPending={false}
         disabled={false}
         draft="Summarize this"
-        canAttachSource
-        attachingSource={false}
+        canAttach
+        attaching={false}
         attachedSourceName="brief.pdf"
-        sourceAttachmentError={null}
-        onAddSource={noop}
+        attachError={null}
+        onAttach={noop}
         onDismissAttachedSource={vi.fn()}
         onDraftChange={vi.fn()}
         onSend={noop}
@@ -316,7 +313,10 @@ describe("Composer", () => {
       />,
     );
 
-    expect(markup).toContain('aria-label="Add source"');
+    // One button for any file. Which of the two things it becomes is the
+    // host's decision from the bytes, not a choice put to the reader.
+    expect(markup).toContain('aria-label="Attach files"');
+    expect(markup).not.toContain('aria-label="Attach image"');
     expect(markup).toContain("brief.pdf");
     expect(markup).toContain("Added to this conversation");
     expect(markup).toContain('aria-label="Dismiss brief.pdf"');
@@ -399,14 +399,6 @@ describe("Composer", () => {
     expect(markup).toContain("Choose a model that");
     expect(markup).toContain("remove the attached image");
     expect(markup).toContain('aria-label="Send message" disabled=""');
-  });
-
-  it("offers the picker only where a host can open one", () => {
-    expect(composerWithImages({})).toContain('aria-label="Attach image"');
-    // Drop and paste still work in a browser; only the native picker does not.
-    expect(composerWithImages({ canPick: false })).not.toContain(
-      'aria-label="Attach image"',
-    );
   });
 
   it("explains why a turn carrying images is not sendable yet", () => {

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -98,16 +98,12 @@ function resizeComposerTextarea(textarea: HTMLTextAreaElement): void {
  */
 export type ComposerImages = {
   items: ImageAttachment[];
-  /** Whether the host can open a picker; drop and paste work regardless. */
-  canPick: boolean;
-  picking: boolean;
   error: string | null;
   /**
    * The selected model's label when it cannot read images, so the composer can
    * say so before the send that would be refused.
    */
   unsupportedModel: string | null;
-  onPick: () => void;
   onAttachFiles: (files: readonly File[]) => void;
   onRemove: (id: string) => void;
   onRetry: (id: string) => void;
@@ -135,11 +131,12 @@ export type ComposerProps = {
   draft: string;
   modelMenu?: ReactNode;
   images?: ComposerImages;
-  canAttachSource?: boolean;
-  attachingSource?: boolean;
+  /** Whether the host can open a picker; drop and paste work regardless. */
+  canAttach?: boolean;
+  attaching?: boolean;
   attachedSourceName?: string | null;
-  sourceAttachmentError?: string | null;
-  onAddSource?: () => Promise<void>;
+  attachError?: string | null;
+  onAttach?: () => Promise<void>;
   onDismissAttachedSource?: () => void;
   onDraftChange: (draft: string) => void;
   onSend: () => Promise<void>;
@@ -160,11 +157,11 @@ export function Composer({
   draft,
   modelMenu,
   images,
-  canAttachSource = false,
-  attachingSource = false,
+  canAttach = false,
+  attaching = false,
   attachedSourceName = null,
-  sourceAttachmentError = null,
-  onAddSource,
+  attachError = null,
+  onAttach,
   onDismissAttachedSource,
   onDraftChange,
   onSend,
@@ -338,31 +335,16 @@ export function Composer({
         />
         <div className="composer-actions">
           <div className="composer-actions-left">
-            {canAttachSource && onAddSource && (
-              <WithTooltip label={attachingSource ? "Adding source…" : "Add source"}>
+            {canAttach && onAttach && (
+              <WithTooltip label={attaching ? "Attaching…" : "Attach files"}>
                 <button
                   type="button"
                   className="composer-attach"
-                  aria-label={attachingSource ? "Adding source" : "Add source"}
-                  disabled={inputDisabled || attachingSource || busy}
-                  onClick={() => void onAddSource()}
+                  aria-label={attaching ? "Attaching" : "Attach files"}
+                  disabled={inputDisabled || attaching || busy}
+                  onClick={() => void onAttach()}
                 >
                   <Paperclip size={15} aria-hidden="true" />
-                </button>
-              </WithTooltip>
-            )}
-            {images?.canPick && (
-              <WithTooltip
-                label={images.picking ? "Choosing image…" : "Attach image"}
-              >
-                <button
-                  type="button"
-                  className="composer-attach"
-                  aria-label={images.picking ? "Choosing image" : "Attach image"}
-                  disabled={inputDisabled || images.picking}
-                  onClick={images.onPick}
-                >
-                  <ImageIcon size={15} aria-hidden="true" />
                 </button>
               </WithTooltip>
             )}
@@ -437,9 +419,9 @@ export function Composer({
             Guidance contains an unsupported character.
           </span>
         )}
-        {sourceAttachmentError && (
+        {attachError && (
           <span className="composer-turn-error" role="alert">
-            Couldn’t add source: {sourceAttachmentError}
+            Couldn’t attach: {attachError}
           </span>
         )}
         {images?.error && (

--- a/crates/openwave-desktop/ui/src/ImageAttachments.ts
+++ b/crates/openwave-desktop/ui/src/ImageAttachments.ts
@@ -1,4 +1,3 @@
-import { invoke } from "@tauri-apps/api/core";
 
 /**
  * Composer image attachments: what one is, how it moves between states, and the
@@ -497,15 +496,6 @@ function refusalFromBody(body: string): string {
     /* An unparseable body is just an unknown refusal. */
   }
   return imageAttachmentRefusal("");
-}
-
-/** Pick one image through the host's native picker and publish it. */
-export async function attachChatImage(
-  chatId: string,
-): Promise<PickedImage | null> {
-  return parseAttachedImage(
-    await invoke("attach_chat_image", { request: { chatId } }),
-  );
 }
 
 /**

--- a/crates/openwave-desktop/ui/src/attachments.ts
+++ b/crates/openwave-desktop/ui/src/attachments.ts
@@ -1,0 +1,64 @@
+import { invoke } from "@tauri-apps/api/core";
+
+import { parseLibraryImportBatch, type LibraryImportBatch } from "./documents";
+import { parseAttachedImage, type PickedImage } from "./ImageAttachments";
+
+/** One file the host could not attach as an image, named so it can be reported. */
+export type FailedImage = {
+  fileName: string;
+  message: string;
+};
+
+/**
+ * What one mixed selection produced.
+ *
+ * Images and documents are separated because the composer shows them
+ * differently, and because a failure in one says nothing about the other. The
+ * renderer does no routing of its own: picked paths never cross the boundary,
+ * so the host has already decided what each file was.
+ */
+export type AttachedFiles = {
+  images: PickedImage[];
+  documents: LibraryImportBatch | null;
+  failedImages: FailedImage[];
+};
+
+/** Attach any files through one native picker. `null` if the reader dismissed it. */
+export async function attachChatFiles(chatId: string): Promise<AttachedFiles | null> {
+  return parseAttachedFiles(await invoke("attach_chat_files", { request: { chatId } }));
+}
+
+export function parseAttachedFiles(value: unknown): AttachedFiles | null {
+  if (value === null) return null;
+  if (!isRecord(value)) throw new Error("Invalid attachment response");
+  const { images, documents, failedImages } = value;
+  if (!Array.isArray(images) || !Array.isArray(failedImages)) {
+    throw new Error("Invalid attachment response");
+  }
+  return {
+    images: images.map((image) => {
+      const parsed = parseAttachedImage(image);
+      // Only the top-level result is nullable; a null inside the list would
+      // mean the host emitted an entry for an image it did not attach.
+      if (!parsed) throw new Error("Invalid attachment response");
+      return parsed;
+    }),
+    documents: documents === null ? null : parseLibraryImportBatch(documents),
+    failedImages: failedImages.map(parseFailedImage),
+  };
+}
+
+function parseFailedImage(value: unknown): FailedImage {
+  if (
+    !isRecord(value) ||
+    typeof value.fileName !== "string" ||
+    typeof value.message !== "string"
+  ) {
+    throw new Error("Invalid attachment response");
+  }
+  return { fileName: value.fileName, message: value.message };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/crates/openwave-desktop/ui/src/useImageAttachments.ts
+++ b/crates/openwave-desktop/ui/src/useImageAttachments.ts
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from "react";
 
 import type { ApiClient } from "./api";
 import {
-  attachChatImage,
   imageAttachmentName,
   imageAttachmentRejection,
   queuedImageAttachment,
@@ -14,22 +13,16 @@ import {
   withUploadPublished,
   withUploadStarted,
   withoutAttachment,
-  MAX_IMAGE_ATTACHMENTS,
   type ImageAttachment,
+  type PickedImage,
 } from "./ImageAttachments";
-import {
-  PICKER_BUSY_MESSAGE,
-  PICKER_HOLDERS,
-  useNativePickerLatch,
-} from "./NativePickerLatch";
 
 export type ImageAttachmentControls = {
   attachments: ImageAttachment[];
-  /** The native picker is open, so a second one would be refused by the host. */
-  attachingFromPicker: boolean;
   /** Why the last attach was refused outright, before any bytes moved. */
   error: string | null;
-  attachFromPicker: () => void;
+  /** Take images the host has already published, from the composer's picker. */
+  adopt: (published: readonly PickedImage[]) => void;
   attachFiles: (files: readonly File[]) => void;
   remove: (id: string) => void;
   retry: (id: string) => void;
@@ -56,7 +49,6 @@ export function useImageAttachments(
   chatId: string,
 ): ImageAttachmentControls {
   const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
-  const [attachingFromPicker, setAttachingFromPicker] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const attachmentsRef = useRef<ImageAttachment[]>([]);
   const filesRef = useRef(new Map<string, File>());
@@ -148,39 +140,21 @@ export function useImageAttachments(
     for (const attachment of queued) void upload(attachment.id);
   }
 
-  async function openPicker() {
-    if (attachingFromPicker) return;
-    if (attachmentsRef.current.length >= MAX_IMAGE_ATTACHMENTS) {
-      setError(`A message can carry at most ${MAX_IMAGE_ATTACHMENTS} images.`);
-      return;
-    }
-    if (!useNativePickerLatch.getState().claim(PICKER_HOLDERS.attachImage)) {
-      setError(PICKER_BUSY_MESSAGE);
-      return;
-    }
-    setAttachingFromPicker(true);
+  function adopt(published: readonly PickedImage[]) {
+    if (published.length === 0) return;
     setError(null);
-    try {
-      const published = await attachChatImage(chatId);
-      // Dismissing the picker is a normal outcome, not a failure.
-      if (!published) return;
-      update((current) => [
-        ...current,
-        readyImageAttachment(crypto.randomUUID(), published),
-      ]);
-    } catch (err) {
-      if (mountedRef.current) setError(failureText(err));
-    } finally {
-      useNativePickerLatch.getState().release(PICKER_HOLDERS.attachImage);
-      if (mountedRef.current) setAttachingFromPicker(false);
-    }
+    update((current) => [
+      ...current,
+      ...published.map((image) =>
+        readyImageAttachment(crypto.randomUUID(), image),
+      ),
+    ]);
   }
 
   return {
     attachments,
-    attachingFromPicker,
     error,
-    attachFromPicker: () => void openPicker(),
+    adopt,
     attachFiles,
     remove: (id) => {
       forget(id);


### PR DESCRIPTION
The composer had two attach buttons side by side: a paperclip that imported a document and an image icon that attached an image. A reader with a file in hand had to know which of the two kinds the app considered it before they could pick a button, and nothing about the file told them.

There is one button now.

## Two destinations, still

Underneath there are still two capabilities, and they are worth keeping apart. An attached **image** reaches the model as pixels in a provider-native multimodal block. An imported **document** is parsed into text that can be searched and cited — `liteparse_image_parser` already claims PNG/JPEG/WebP/GIF/TIFF, so an image sent that way becomes extracted text. Ask what is wrong in a diagram and the first gives the model the picture, the second gives it OCR output. Collapsing the button should not collapse that.

## Routing is the host's

It has to be. `pick_document` deliberately never serializes paths to the webview, so the renderer has nothing to decide on. The new `attach_chat_files` command opens one unfiltered picker — the document picker never filtered either, so nothing previously choosable is greyed out — sniffs each selection's leading bytes, and sends a supported image within the attachment limits to the image path and everything else to the library import.

Size is part of the test, not just the signature. An oversized PNG is a real image that cannot be an image attachment; treating it as a document keeps it usable instead of refusing it outright.

Failures stay per-file in both halves. One bad image does not cost the reader the rest of the selection, which is the rule the document batch already followed; images have no per-file envelope of their own, so they get one.

## Removed

`attach_chat_image`, its dedicated picker, and the extension filter go with the button they served. The guard that a renderer cannot widen the request beyond one conversation moves to `attach_chat_files`, now the one command carrying a chat id in from the renderer.

## Not in this change

- **Drop and paste routing.** A dropped file still goes to the library whatever it is; the same split belongs in `import_dropped_library_documents`.
- **Pasted images fail in the packaged app** — #658. A paste has no path, so it uploads over `XMLHttpRequest` from the renderer rather than through the host. That request returns `201` in a browser against a real server and fails inside the app with the generic transport error. Cause unconfirmed; it wants the Tauri app running to pin down, and I did not want to guess at a fix.

Closes #657