### PR TITLE
feat(desktop): view spreadsheets and word documents

### DIFF
--- a/crates/openwave-desktop/ui/package.json
+++ b/crates/openwave-desktop/ui/package.json
@@ -25,8 +25,14 @@
     "@radix-ui/react-tooltip": "1.2.13",
     "@tanstack/react-router": "1.170.18",
     "@tauri-apps/api": "2.11.1",
+    "@univerjs/core": "0.25.1",
+    "@univerjs/preset-docs-core": "0.25.1",
+    "@univerjs/preset-sheets-core": "0.25.1",
+    "@univerjs/presets": "0.25.1",
+    "@univerjs/sheets": "0.25.1",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
+    "jszip": "3.10.1",
     "lucide-react": "1.25.0",
     "pdfjs-dist": "4.8.69",
     "react": "19.2.7",
@@ -40,6 +46,7 @@
     "sonner": "2.0.7",
     "tailwind-merge": "3.6.0",
     "tailwindcss-animate": "1.0.7",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zustand": "5.0.14"
   },
   "devDependencies": {

--- a/crates/openwave-desktop/ui/package.json
+++ b/crates/openwave-desktop/ui/package.json
@@ -29,7 +29,6 @@
     "@univerjs/preset-docs-core": "0.25.1",
     "@univerjs/preset-sheets-core": "0.25.1",
     "@univerjs/presets": "0.25.1",
-    "@univerjs/sheets": "0.25.1",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "jszip": "3.10.1",

--- a/crates/openwave-desktop/ui/pnpm-lock.yaml
+++ b/crates/openwave-desktop/ui/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       '@univerjs/presets':
         specifier: 0.25.1
         version: 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
-      '@univerjs/sheets':
-        specifier: 0.25.1
-        version: 0.25.1(react@19.2.7)(rxjs@7.8.2)
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -3441,7 +3438,7 @@ packages:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
-    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
+    resolution: {integrity: sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==, tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
     version: 0.20.3
     engines: {node: '>=0.8'}
     hasBin: true

--- a/crates/openwave-desktop/ui/pnpm-lock.yaml
+++ b/crates/openwave-desktop/ui/pnpm-lock.yaml
@@ -44,12 +44,30 @@ importers:
       '@tauri-apps/api':
         specifier: 2.11.1
         version: 2.11.1
+      '@univerjs/core':
+        specifier: 0.25.1
+        version: 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-docs-core':
+        specifier: 0.25.1
+        version: 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-sheets-core':
+        specifier: 0.25.1
+        version: 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/presets':
+        specifier: 0.25.1
+        version: 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets':
+        specifier: 0.25.1
+        version: 0.25.1(react@19.2.7)(rxjs@7.8.2)
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
       clsx:
         specifier: 2.1.1
         version: 2.1.1
+      jszip:
+        specifier: 3.10.1
+        version: 3.10.1
       lucide-react:
         specifier: 1.25.0
         version: 1.25.0(react@19.2.7)
@@ -89,13 +107,16 @@ importers:
       tailwindcss-animate:
         specifier: 1.0.7
         version: 1.0.7(tailwindcss@4.3.3)
+      xlsx:
+        specifier: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
+        version: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
       zustand:
         specifier: 5.0.14
         version: 5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     devDependencies:
       '@tailwindcss/vite':
         specifier: 4.3.3
-        version: 4.3.3(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 4.3.3(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0))
       '@testing-library/jest-dom':
         specifier: 7.0.0
         version: 7.0.0(@testing-library/dom@10.4.1)
@@ -113,10 +134,10 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: 4.7.0
-        version: 4.7.0(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 4.7.0(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0))
       jsdom:
         specifier: 29.1.1
-        version: 29.1.1(canvas@3.2.3)
+        version: 29.1.1(@noble/hashes@2.2.0)(canvas@3.2.3)
       tailwindcss:
         specifier: 4.3.3
         version: 4.3.3
@@ -125,10 +146,10 @@ importers:
         version: 5.8.3
       vite:
         specifier: 7.3.6
-        version: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+        version: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0)
       vitest:
         specifier: 3.2.7
-        version: 3.2.7(@types/debug@4.1.13)(jiti@2.7.0)(jsdom@29.1.1(canvas@3.2.3))(lightningcss@1.32.0)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.1.2)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.3))(lightningcss@1.32.0)
 
 packages:
 
@@ -442,6 +463,9 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@flatten-js/interval-tree@1.1.3':
+    resolution: {integrity: sha512-xhFWUBoHJFF77cJO1D6REjdgJEMRf2Y2Z+eKEPav8evGKcLSnj1ud5pLXQSbGuxF3VSvT1rWhMfVpXEKJLTL+A==}
+
   '@floating-ui/core@1.8.0':
     resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
 
@@ -456,6 +480,15 @@ packages:
 
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.8.1':
+    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -472,6 +505,47 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@noble/ciphers@2.2.0':
+    resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/ed25519@3.1.0':
+    resolution: {integrity: sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@radix-ui/number@1.1.3':
     resolution: {integrity: sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==}
@@ -699,6 +773,19 @@ packages:
 
   '@radix-ui/react-focus-scope@1.1.16':
     resolution: {integrity: sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.23':
+    resolution: {integrity: sha512-H8qONfZd3ltrU3+jHCIgITbWo6e1iTKvP9DHdrvYbX48ooRM5FjEDTn16AMwdfuOGkWdZEhpl3PLL/Wk/AnHDQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1449,6 +1536,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@26.1.2':
+    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1465,6 +1555,548 @@ packages:
 
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
+
+  '@univerjs-pro/collaboration-client-ui@0.25.1':
+    resolution: {integrity: sha512-cpHvRNCWeYAPibzzy2s3FwWBiNiVP52/QZMO4BhYj+Ft2OYVrrpcu6EtKSTXUiuyqVtbFobOu71atJGYc+12xw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs-pro/collaboration-client@0.25.1':
+    resolution: {integrity: sha512-QZ1WHsAlb618i0Ta3tVpZJFjjY3aBmTQXwdrFp0thJI/aNZ+Mpug1dkHe25bt+dRmv7BMpb2yg+UFG6aGw4AZg==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs-pro/collaboration@0.25.1':
+    resolution: {integrity: sha512-54aiegetXmkr5TgucrvHAuziw5O9+6fw0oHAdo86yfhAJRCinM+DHyH4BiIej8q5UfhHCv841MBjwT3Pm5YRpA==}
+
+  '@univerjs-pro/docs-exchange-client@0.25.1':
+    resolution: {integrity: sha512-9AzGATwSvisQ2PpkEDIZehqbeuKhBFqMRVyVDmhw7hRUzGackiEojxRw0BZCLp3Dxot5rvH7T3EtJaYB9ogHUA==}
+
+  '@univerjs-pro/docs-print@0.25.1':
+    resolution: {integrity: sha512-HlxPHGP3Wl0HLsQcupkGMCCgPyb9gE0uNkhv4ZQVFlZZMwmfh1bNQhHSA8xGwhP6IC33QA51trhO7oCHZTzWpQ==}
+
+  '@univerjs-pro/edit-history-loader@0.25.1':
+    resolution: {integrity: sha512-pK5TtIYwv9YZl35r8hm3bVvsvsNDFyOdB8t82zNVO4vm/f1Rbz1LEzyVet8LuYD5/+q/z29w7LeyJFL72oqINw==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs-pro/edit-history-viewer@0.25.1':
+    resolution: {integrity: sha512-U9NHs9kI1vaIRIDKHjU5oFCvmsYTrF6L5R2DOXCaYh0FkzW72Z83A5DwWkNTsQ7cdF5ilfjHeiYxMo04yBOdhA==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs-pro/engine-chart@0.25.1':
+    resolution: {integrity: sha512-o9RZh6hzBq4Wh/IuK4ai5E99TUvuw+XI6oL3iBtSSW2EDFH0IvsePtAaJR/1o1YxSDySPCB0tBFNWPUx4uVCcQ==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs-pro/engine-formula@0.25.1':
+    resolution: {integrity: sha512-oPREHYb4Jk+L4FiAht3+g4TGQSILHSN7dfG2XOyAGJRktN9ApNDIACaOnHxIzw6LQKUqpsstZjrcxR01nypxVg==}
+
+  '@univerjs-pro/engine-pivot@0.25.1':
+    resolution: {integrity: sha512-Dk5FbO1lhKESUeY5i8Qc/eFJzXunfPk8rsndIvG5w7c4DQgwjFryd8wZk9NIvwW+YrAX5J/NX7HmgSKreODt7g==}
+
+  '@univerjs-pro/engine-shape@0.25.1':
+    resolution: {integrity: sha512-U0i0STMYc0W9MHIetiP4nvEFZjsVlmzcpRrcEEPTkj83KW9FpQV8xE6wER/0cSSbuvBfKbiHpZC8YoEgZVQaaw==}
+
+  '@univerjs-pro/exchange-client@0.25.1':
+    resolution: {integrity: sha512-UgZTUOk+9VCRrODyIWplhesa4tOaXEr1OOuBXxmUi2NkMjJVteBRJacQBGR7cqUQUmhM7vqYiAeP8B5EjCsTEQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs-pro/license@0.25.1':
+    resolution: {integrity: sha512-pXK47oWmDZWtCYzXam0EHAqi2zuE0+uR3HVolfFU5aP3k0GdHidOF1ZugOSBzkuV34rRU0g+/gXln+Xw6KkRQg==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs-pro/print@0.25.1':
+    resolution: {integrity: sha512-VPIK197YPFnDb/CsF/2Euaw72rC4BRvZNFhFNi62kx44tp8ppJ1kBOZwLSoudt51eNk4139yiWsGI7p5vsWmzw==}
+
+  '@univerjs-pro/sheets-chart-ui@0.25.1':
+    resolution: {integrity: sha512-0hxQEQwpaceANnzfU+eN/ktvfj6UXFOlupXGq8+ivI6MS4oAB7njI4W6q3mfo2VOi6btMUYfRT6E9cvtXdlyMw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs-pro/sheets-chart@0.25.1':
+    resolution: {integrity: sha512-YqufhKXIJD2dQcRJDGsqCN77k5Ii6/7qXeDC6+8sc3UCuUJXymmPPkEhqK09ofqu6u32z72Zri5jyUdrLsCa4A==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs-pro/sheets-exchange-client@0.25.1':
+    resolution: {integrity: sha512-gtSXuneb/wcn/8r7+2sbQUtN6GeaVeARZwIidixHT8/vPOpajbZlYYVpybyR6EP0qkZr7ufLgtNfeNP8PXGVsg==}
+
+  '@univerjs-pro/sheets-outline-ui@0.25.1':
+    resolution: {integrity: sha512-e5tv6FhbjFiZJ3b10aGIaJ3cI0gRSMS+s7MnKJVRzDFadMrULLHCFaX/XiqfB4atHEKwXgOBO7CbeLVcU7pJlw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs-pro/sheets-outline@0.25.1':
+    resolution: {integrity: sha512-LFfkrvel33khqEbYrhWXsQY6LwSGXd22JXRjleirJoWIVw+vVX6yDKkHVHhLHmG/RcJEqrNIgGsq7cBpSQKcgA==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs-pro/sheets-pivot-ui@0.25.1':
+    resolution: {integrity: sha512-VDbmWSJaCzeEImfhtNWSaU+mFKvlfjhDBuzkvKLxNvtRc1uJXzohYvCNlE2CBdq1zasA6UENrRc+ES5dRZa/Kw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs-pro/sheets-pivot@0.25.1':
+    resolution: {integrity: sha512-VZ9rewAX/JK0j7W58u2rPgC3ONQ9JYrg8+jFtR+3ma5DZ2P1iicvVr1WG92MbaUaZi1C3zGWM/7nrPzSmuHIBQ==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs-pro/sheets-print@0.25.1':
+    resolution: {integrity: sha512-RXU9Cnc++H5ZF/bDpTOuXjuDLkpjVDQzQRHbeF0Zd5MrEQxgmdBUny1UqunfDTki788CB21NeBcvLjqKQ4FS3g==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs-pro/sheets-shape-ui@0.25.1':
+    resolution: {integrity: sha512-GfIFKWsqM5NpcZBbkl20l8oB1dHPzEa2dBMeMw1nerUCP7rvgOY2QbXoKL76IgqqD0srnAeWxXeT33L56O+czw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs-pro/sheets-shape@0.25.1':
+    resolution: {integrity: sha512-84I8/IS1nzgXpzr8que6fHPFkPuF4PnIIGJjQ/IOhn22oL8MPm8Km15cM52oLPqOGiq+4hs0E6Vjyb7AOXyyng==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+
+  '@univerjs-pro/sheets-sparkline-ui@0.25.1':
+    resolution: {integrity: sha512-NBD5Trimk6JEggDgtJDLokyaD+0rbtD44oLkmCb0jzzI5j+XZlm4YVlYxDab6O9TElxgLpW5D6jATC/JCDXqFQ==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs-pro/sheets-sparkline@0.25.1':
+    resolution: {integrity: sha512-+2eq/n/QeyVBNxDifnayr+z5QpcNJMl7mYzVIddjgHrrHHp+lJHw89vesA8NlQSZEVkgz/wdghN0wBHqCcAgDQ==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs-pro/thread-comment-datasource@0.25.1':
+    resolution: {integrity: sha512-Bbfu4Mb3O/5zO1jft3HaUAC3owSaG8sk7eFiT0J85EKLJsy9Pp3U/D88Q5JSvHwJENRrWMBYdo2TDbxnkGBo1Q==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/core@0.25.1':
+    resolution: {integrity: sha512-0FQjuL1HdPtl8NsU5muT8HNtuA4yMEvbBLgewyqUVQmT5oks89a3jdqxi5/dvHYDRvW7wssVjZitfbL79el3Jg==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/data-validation@0.25.1':
+    resolution: {integrity: sha512-MLSOXYpQWNgwFnVXcdh5YbVjDFRYs9WZy1YwvN3aUDVYgy6dDoU2N52IE+IbDhTi33TZI0JdVLu5000bmv+bcQ==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/design@0.25.1':
+    resolution: {integrity: sha512-tqKzxh/HhUiHsZZzkFUHGBTEsRfOsSNgIGAjY6PTvbucpLJTYzijrQxEZfgOMC/tEQykUFJUo/WDRTXZEHMPXg==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+
+  '@univerjs/docs-drawing-ui@0.25.1':
+    resolution: {integrity: sha512-dNolVFpRKpDXAmFQ64rkzkNDDu7mpXgqQWGOndpHs/hPrIbOUgPuCk5t+dzejravAw89edDYs7qVJLqjW44i5Q==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/docs-drawing@0.25.1':
+    resolution: {integrity: sha512-xkDGZ/dcwpH6Q/+iYhVKQy8RsxXfLqmO9I9iJXMiZB5ZKZlWSHBKcMp/d09hf/n37ajkwtNCcxNayOAEnRyQXQ==}
+
+  '@univerjs/docs-hyper-link-ui@0.25.1':
+    resolution: {integrity: sha512-k2rZU9d6md4yn3mmT2B+UwcK0ZKGmYymW9qt5X1YiQB8Cc5atDH9uM/BkiEigD1gFwzy0IXC2ONaV9b5p7/vuA==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/docs-hyper-link@0.25.1':
+    resolution: {integrity: sha512-8EAQmyusCPD3z7P1b4romx3f490T/mn7rkDOtlqpmVMk1ojA2mPjOKP+HURsBr+f65wLbbhHdX/JYqlxvJplMw==}
+
+  '@univerjs/docs-thread-comment-ui@0.25.1':
+    resolution: {integrity: sha512-eiamay2YqODtv2eQQHVLNeDbjqgClP7PdTNoIeeDxATjhJBwwmY+NT3gpaKFx6bcwV9VIK3RBtfFaNGwuvs++g==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/docs-ui@0.25.1':
+    resolution: {integrity: sha512-Oy5iPjf+gJlijUe3pQj5iIAILR/4YzCvOVtGy4FPyksXXrYYy1oMZ5JnEP3U7AUKhQ4yTNIFoaTYT6LwbshG+A==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/docs@0.25.1':
+    resolution: {integrity: sha512-U85iZNLBxRCaiU3++N8rCBgUMTpFGsm1G0U6UcsZxAy0XGhRjD+vhtvgQNis25sNjksmy/25kXtYqWMrk/XWbw==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/drawing-ui@0.25.1':
+    resolution: {integrity: sha512-SqctH5TFOpH9JILi9awe72uMS+VWkEtS4WhUkiN3hjLKZajzGrRBYjr0Sy2ix+AxiEG8tSc8K43FJHRBvuBxGQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/drawing@0.25.1':
+    resolution: {integrity: sha512-ZS+YpSo/RWoh21zZAHM0Hg57FyqqW/9P5zoQ8hL1vGoEN3ZhbZA8jwiQHv1PFqlzXPzKWO0bysc4yB8BtJW8Pg==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/engine-formula@0.25.1':
+    resolution: {integrity: sha512-ZNx8ndlz7d8zASwoE/pK1csreW553tSxoYJmEgHSAiCHtSYkdk6OiynkFjyDIUCMe56n5pdQo9uHfynMBbOY7A==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/engine-render@0.25.1':
+    resolution: {integrity: sha512-CDbIjOQTbEwwVe8+l6NEQGxegsbRjVXWJ6Qrm91Z1gzwKzrl9P1mOaDsXGYgbp5ujTJBxOVePPuU2QuS/9iMeA==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/find-replace@0.25.1':
+    resolution: {integrity: sha512-Xa+pkCqogQ0AHcIzUGpmqbb6driQJ0i4nqT6XPS/RYh/u0encY9/an7z3ly9b5Z24PChyPGTfrvrbFAnmON3WA==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/icons@1.4.0':
+    resolution: {integrity: sha512-ohBfPk+EyLuSc+1Rvz06jiMDgEydwc6lLUOQyUjS/W3zBKYLhbXaEP4qq7/YQH8OhzkTsRQGvsTgYSg1roRXgg==}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+
+  '@univerjs/network@0.25.1':
+    resolution: {integrity: sha512-5sqyI9qKyn/fb+IMIoW6nQPJHlpJr1/WscCyDG4PmMtpMm/ipN/CZu31FIyMyM1jLOeJX1uMeldflviEq4iorA==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-docs-advanced@0.25.1':
+    resolution: {integrity: sha512-Es/BlOdMYM9jPRkQSF5JQXC8UHWxVdSLM0mYYubSD1Un+PSoKDMle9k4J8QT6wANWVqRTGeAP4EVlyyFEd0ENA==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-docs-collaboration@0.25.1':
+    resolution: {integrity: sha512-ZU6LIAxRfh72cR2Nyy9Sd56+GSPB+ugP5+fy8sjiSn2vOh10ZrQI7I1YNN9gB3CI4GRGtqEmbAV32VQDdfYcCQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-docs-core@0.25.1':
+    resolution: {integrity: sha512-V98oGWbMa2NjvHZEMFyHvVu0DXp8h4i/soJilAdK+mV+Ja0i2Eofj/Wsmoj9LT++nC1pXfGfNzpezy04uR/EVw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-docs-drawing@0.25.1':
+    resolution: {integrity: sha512-j6pYAGWSdNUhFWoydH0Cp4lpiKPjnXwQSByZhsK8yr51vkMe5AqBab0atPJYmYzu89Qth6e9Tnofe5qHUdu1aA==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-docs-hyper-link@0.25.1':
+    resolution: {integrity: sha512-kN2vGhAgY7QBIynQasdwBOUxtimNufn29pJXSEmDeKpASNtcPFQI+VqfhPBuG6L5fJqYW9mYqnXIWes5wca3Ww==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-docs-node-core@0.25.1':
+    resolution: {integrity: sha512-alB/hLdIDMnd2/W8ZK1z9YrQI6zxqpt9jyXGXqo2aMz+eYuxJ9W2peKC04Iz8DAFlZnQmpcgxQzZ5tlxVV4lOQ==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-docs-thread-comment@0.25.1':
+    resolution: {integrity: sha512-2SRYv/byKi5DYIo1+n6kxG6x4S6Iy+PEr2TXimkTlg5lnlMyNUaaFSaisnsXKdAjPkhF82S81L5U57bSuzh6Rw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-sheets-advanced@0.25.1':
+    resolution: {integrity: sha512-+bkHUk3W0ui6+ZvW+Alo0vf+qBaj1S1o3FgBEGmKhdqxKKv5CLAhuRD6zQm755EV9tQGXqAZ1heGGggOBPK1/w==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-sheets-collaboration@0.25.1':
+    resolution: {integrity: sha512-R/X0ZwkMWc5um8DE7kqNvb6gGt29IgCdq5qeJC+fU8BC4vgXpJhCEGsGk4HDPOnHH2rnZk9rPr1VzcUMThgFUA==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-sheets-conditional-formatting@0.25.1':
+    resolution: {integrity: sha512-MsbzZEw6Z6L7UHpNxF1B1ua/aM0we1u9GRBf7ExZlPAzZbEicd5DM2n0yvO/5a7SmzFuFQZshX1JY5xSNLJvhw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-sheets-core@0.25.1':
+    resolution: {integrity: sha512-hCxvFUcWBZLEUf1SUOmqHvf3MN/17LW7AQYLcWIJIGQP2laa0XIrW1kXrTfmh8G0BTwDes286FIPf5y70SC0YA==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-sheets-data-validation@0.25.1':
+    resolution: {integrity: sha512-9K3XOzmfjxJ39iR9GQCH9FGrLdMqc0FOFv1BLfMyWwwh2N3sWaz+Ae1sKjpKPLDuOn8uYH6QRRAxif8UK1V49A==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-sheets-drawing@0.25.1':
+    resolution: {integrity: sha512-QLTWlzCx/K2eVq4TXTiGH8aIYBuTNEaPLLdzgguPJIqxCLjcmLwWAsTKgoSq058st+JOPVR9GCnx2VhEx9HBkQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-sheets-filter@0.25.1':
+    resolution: {integrity: sha512-ox6OAUFetC9Al1XY7eb4JNPvNwto7ZWZBXiD5nNGzeK6R8LKrN31Yhu69RgCTpuymVlv7rNROtDKeXxroJzUbg==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-sheets-find-replace@0.25.1':
+    resolution: {integrity: sha512-eao9xoiPsnn3qfk9pRVEip7Yte36RgBWpdZ72xj0WtX7r0pKOsCWHLpluQwO2tR8YR6BBTB009qarxDMTeQw3g==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-sheets-hyper-link@0.25.1':
+    resolution: {integrity: sha512-nKROwzxzYadnetwlGVAGtpuMP8Cn2qdiJiWQjXjPI217TUtojYKXIRdOhK909/BFAR/l7oalX4x+fKLWSdU5ag==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-sheets-node-core@0.25.1':
+    resolution: {integrity: sha512-AtHLj63zdM3SdT8Ya2kDsQ2N20Dp+RPEubXv5d4jA4aSZXJTzHRA4MOTMmlosowd5KQwoJO5/ewqM6ZKBgwrcQ==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-sheets-note@0.25.1':
+    resolution: {integrity: sha512-Lo0lhMfHHzSPJaAxUQ5F9TANtXwL7xIjoNdVPLDMz5dumPCPHKH3j7fewI4pOrSVqvcVyWvmDxwUQqMDYSk8SQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-sheets-sort@0.25.1':
+    resolution: {integrity: sha512-xebD11RrtJ+JY6Tn3pYoQf28jMuLAlOEAoDYqB8Rh4mzKLimBcB/emmXNg+KfNbbXFelFRvjr8uaLL5P41R5WQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-sheets-table@0.25.1':
+    resolution: {integrity: sha512-ycZlK/ZgyRXgsw0pYulFpUa++mJIGNX4D37M9Vg1pNOmdJWygPF8Q4zEZUK9bARYMalIdUommQ+93rl1jNiXWw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/preset-sheets-thread-comment@0.25.1':
+    resolution: {integrity: sha512-/zlzXHNWVQkp9fr+d6kSeGEwtb5nnGhKbCmF0y+JSHpws6MPWBVjBD1MbzsGvT99P7OhLXtdFrbrQUMBsFduOg==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/presets@0.25.1':
+    resolution: {integrity: sha512-AHZyR0KTd9Z43A3ybFkGGH8PBT8NDsJa7xY4PMq8ZDHdxUZIVjqoIJlqUq+DAFxGAWInr27SXu6KaBpfZ1U43Q==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/protocol@0.25.1':
+    resolution: {integrity: sha512-RHkNl/Gm8T5VyrXGj3dnJ4CGgB12/oqP7BVUZ4DcfxezFh1vq/nIHD0fIqL8DZslZV6CGK/sxcNeGn3E/S3Xnw==}
+
+  '@univerjs/rpc-node@0.25.1':
+    resolution: {integrity: sha512-573sHGgLVPzQa4alglAhTDxdEAh7XhlYIpYGhK1ueqjvn60g4/8HBAjq3yza0jW+rykHevkSg6tdatxn/0RyUg==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/rpc@0.25.1':
+    resolution: {integrity: sha512-cwQJ+faKb983QRAGG/hkisASzb3HgjlWm4JMf6w1gVO/oYbLm6ObACu7zVHU+xhw8EKRFN3Kxl6SH0KTqFLOVQ==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-conditional-formatting-ui@0.25.1':
+    resolution: {integrity: sha512-/DZRAhClo1T9v3S8h6W7shSemckIeLvYYwygl3vlWe1opcUFraUt2A8iS/SToQeIgIstVEGGq3EZh5yeDJDvAQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-conditional-formatting@0.25.1':
+    resolution: {integrity: sha512-+3q3WS6+m3qNDyyv4LuppxqNQdOFT99fQHpkrc2WIi1pSgO/HnCXm348KP1RhpYoVwcHOV8eoFDTqK9Q1DrdOg==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-data-validation-ui@0.25.1':
+    resolution: {integrity: sha512-jg40+G3S0gwtQILvfzB0bFnigLNHxUEcnuAGHwgdS+GRHxGb+GbtY2qy5Fob7tGCMlgIiL4vZBZ5LCRVq2ciLg==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-data-validation@0.25.1':
+    resolution: {integrity: sha512-I2NkLoiRJs9+zyijsa+wLnFviJNurqxJ77wAnh+ZZe6OLWmh1ErCsmu20sljvaPZgIKBqeXYi/sRYv9f4xY+2w==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-drawing-ui@0.25.1':
+    resolution: {integrity: sha512-GL9uteQK3xtkcJke0FJEfj+bfSilE0MJVF2BFAAa3x0iYSL0eUFAbqIG4TJ7zoHTzr4gToLk0xEma2zKT7NDVw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-drawing@0.25.1':
+    resolution: {integrity: sha512-b1UknaJAgQ7687+ZN4QLo38ql1z+yEh0/a0Xng4K5pY+snDj2vaJAtyn6cj5fiQcXIaQoJdvnyAd7dPz5URNcQ==}
+
+  '@univerjs/sheets-filter-ui@0.25.1':
+    resolution: {integrity: sha512-VROeSot8Fu/wUqeUuGaCgNHLllzOqrmnyeZO8oARlUZNaNSwZl1LfOxu35xR63HS1HuC7amaFspCdo5u4D1nsg==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-filter@0.25.1':
+    resolution: {integrity: sha512-pQl8KcHhR6Qj+VQQogKeaGbJ1yes39lfmTrCd5JUgXMXJwE2nrZsCBDXM4B3I4shMbE0vLvJVkHXxLV0ApVQvA==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-find-replace@0.25.1':
+    resolution: {integrity: sha512-AdpmCl1Y7hqSMgTvCI9NOCjcAS+mutPCkmVyxoNHNtdguob6hbP0FQxcOkHd2feSLptcK/EvRZu3BfquMqAGmw==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-formula-ui@0.25.1':
+    resolution: {integrity: sha512-iMDZZutB5mcwBGn1kL2QfsQoiOJKJhyLtzp3oRv0bEhbScGDPyoADuAoOCQjDnnUKTp3cTAvc0ACn3Gj3vOvRQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-formula@0.25.1':
+    resolution: {integrity: sha512-5zDcLfzAhO0H1gwYeCY0JYgZIxcKAhA02jS0wXRpOa+dVWs2/zcKy4CjDCbINIsA/aLrICAd9O8Q3VbU/G3rEg==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-graphics@0.25.1':
+    resolution: {integrity: sha512-TBdA+5ab2ZiX+FUhdx4vA+h12uAKk0TIEOJurXSOk42NC3ZJcyOIbl5snY8dDTzfdPh2SOoQmsq1hzXmZoFKTg==}
+
+  '@univerjs/sheets-hyper-link-ui@0.25.1':
+    resolution: {integrity: sha512-grb7WsYlbzKOzZeEXKYv1IkrdwXcykpfWYKix6MNdAsg9EIIm2N85JAxdmz/gUO4Skh5YW8sfUiQx/1IKe/W7A==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-hyper-link@0.25.1':
+    resolution: {integrity: sha512-hr9YkCeGZzy1ZStbRoyt3zS0HUa2PxzfeasaTQyAf0o82Patq2jyKVSplp/iOOMUTgtYRZHv+NntQ2/dm/c9vA==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-note-ui@0.25.1':
+    resolution: {integrity: sha512-TSYVH9WEv+5p9lwwXXWKXJuG2G2Vb9ZcB/ptLUKR48XE3AB4aNUr+Nw01E57aYp0/Q64a5pmYZwlhTWalZQi7Q==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-note@0.25.1':
+    resolution: {integrity: sha512-mGKYGJwI3HB4ySRlOyqFwZTzYP7IYdedt/rF6OIQCwHSiEqliokRVqSh5zcHw46HhbBc36BqnBLImXGr/ib9pQ==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-numfmt-ui@0.25.1':
+    resolution: {integrity: sha512-L8MzmnjYiWq/M/X+lv69ryOqiS0WTazv4CYTv10hO5mqmHsGVDx59ECkLhd3L8gN4CM9Wet7eU1Qf27H5i8RhA==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-numfmt@0.25.1':
+    resolution: {integrity: sha512-yLuOfgFa8t+uDnBvCs+PjCjYBq6iJ+tIUEj7ana5YCnxUdKmDed4M8woSffgDRaMXcV8sY9SOexA2iwMLo9ioQ==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-sort-ui@0.25.1':
+    resolution: {integrity: sha512-KJPaD5Y+WqrlZncJYDggVhBG9T0DwpT00LNESZYdv55lbKUbH2Lc/ilUQ7xpVkkUml4UZtr/s/JB22m5++Gj6g==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-sort@0.25.1':
+    resolution: {integrity: sha512-xVKhNrdT5q7v3HIwx0Jp9gKkZWIEq/wQAIMPZkRZdtkGSMJ3wSvCXrWiiEalP2YOccfzxKzT58IiuqUpSgu82Q==}
+
+  '@univerjs/sheets-table-ui@0.25.1':
+    resolution: {integrity: sha512-NufPBswZi8TtfxazeY313/MBHBP8sSM1cMD7AFMYeM+1wag6440qj3NRLBes8NmwVuZ1bdiWo1wleiAYjKl42Q==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-table@0.25.1':
+    resolution: {integrity: sha512-439D8+q1E7EotM2W02yREi67ZK0OBmJwJ0/0LIIn4h1+C2MbJtZfrn1Q9AKE4BCQF8jBTrLuVKiyGjdhtcVQFQ==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-thread-comment-ui@0.25.1':
+    resolution: {integrity: sha512-jjyGo7QRY/rLjlvV8wrJyUzH+FjAuO2SJojoRlR8U1zfyQGF7LDhCIkhmf5366hPUqvkzfz2Hkk+CAEp5zeg5g==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-thread-comment@0.25.1':
+    resolution: {integrity: sha512-Kw3V/hAXJwx0TpJ/JewwPgwcSZhXEbhjz4ocREY2KzxPzIqzgNOGz5ZgyY1F0HwvQgr5ZpPXMFVAQpUenKcidg==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets-ui@0.25.1':
+    resolution: {integrity: sha512-iCzUfuVc78iRYXCs4kzJKb7wdFQ05irvxxvMeeu5OfOMRef1z1Hr8fvChXfOfjDv6HzQ4nfTO7iGNzD59eE78g==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/sheets@0.25.1':
+    resolution: {integrity: sha512-VcHtHgCOStJZO4XLstvV6oWHxBwhGCpArKJaEe22EmKNY1lfsibOrvwIjEW/Xpm9Ago9ybTvmuIvByrCd60pew==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/telemetry@0.25.1':
+    resolution: {integrity: sha512-eAGiFs2OUAIBrC0g3gASRAvr7++KkmnPS49yAoa95gd6TW8R8o0YASOXyrahysMhDriBXmFGN7hHNLXRo9UlGw==}
+
+  '@univerjs/themes@0.25.1':
+    resolution: {integrity: sha512-21iH3Z3Ai9pRV+l2weuHJu2V8XB3T5Hr8VEPlOyctFbqOJMTNRC5peYJdn7Ra5kMdO+Wa7uWsZf6qurHouswmg==}
+
+  '@univerjs/thread-comment-ui@0.25.1':
+    resolution: {integrity: sha512-cCTPxMLjSzdLRXmdfFv4LtjBZFDG5VeCnqm6o9+XYPIVbZ7UAYRKGPOzv1204lDJu1XJgYgTnMJr4Ms2Yh2bUg==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
+
+  '@univerjs/thread-comment@0.25.1':
+    resolution: {integrity: sha512-TL7Pj5oCA0rD+EjmRIjoTG7tHgRVIBewTL27Ow79JkbJDUAMqaxGAyZc1BpuIM/Fvjp6+hcPO+9FribwRgj+6A==}
+    peerDependencies:
+      rxjs: '>=7.0.0'
+
+  '@univerjs/ui@0.25.1':
+    resolution: {integrity: sha512-DapFtWHIcidxE+vfueIL/sDQeVnf5MRY4MzrK1ag+VHuN6/bU4jwFXDEmyGi1otL03cYg8PFJja2lkV73cbYJA==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.9.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      rxjs: '>=7.0.0'
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -1501,8 +2133,20 @@ packages:
   '@vitest/utils@3.2.7':
     resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
+  '@wendellhu/redi@1.1.1':
+    resolution: {integrity: sha512-y2fuAgHJ2n8sI8Pe/1QtAuPQ6ZbZ9/Dn3uVQI8cctVqLZzp/0OpLM7DSMOU6vmGYXNsIQwsquR91WcxZ4jrRvA==}
+    peerDependencies:
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
   ansi-styles@5.2.0:
@@ -1523,6 +2167,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  async-lock@1.4.1:
+    resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -1586,12 +2233,30 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  cjk-regex@3.4.0:
+    resolution: {integrity: sha512-m+gbmlIP6gAG7tDvo2kpeSPAz/uh5wY5/zx10ymjdpbbiTHNTNoYnP2lCiyqtmbLxwhEdq8/lsVbsy4GTc9oUw==}
+    engines: {node: '>=16'}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -1601,6 +2266,9 @@ packages:
 
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -1663,8 +2331,14 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+
   electron-to-chromium@1.5.389:
     resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -1710,6 +2384,9 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1718,6 +2395,12 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.9:
+    resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
+
+  franc-min@6.2.0:
+    resolution: {integrity: sha512-1uDIEUSlUZgvJa2AKYR/dmJC66v/PvGQ9mWfI9nOr/kPpMFyvswK0gPXOwpYJYiYD008PpHLkGfG58SPjQJFxw==}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -1730,6 +2413,10 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
@@ -1767,6 +2454,9 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
@@ -1789,6 +2479,10 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
@@ -1798,6 +2492,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
   isbot@5.2.1:
     resolution: {integrity: sha512-dJ+LpKyClQZ7NG+j3OensC/mAZkGpukE9YUrgPYvAZj2doVL0edfDgywTUh5CXa0o+nW9a1V9e5+CJTX8+SxRw==}
@@ -1831,6 +2528,18 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  kdbush@4.1.0:
+    resolution: {integrity: sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==}
+
+  lie@3.1.1:
+    resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1901,6 +2610,18 @@ packages:
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
+
+  localforage@1.10.0:
+    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -2100,9 +2821,17 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  n-gram@2.0.2:
+    resolution: {integrity: sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==}
+
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.11:
+    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   napi-build-utils@2.0.0:
@@ -2119,8 +2848,28 @@ packages:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
 
+  numfmt@3.2.6:
+    resolution: {integrity: sha512-MXc2KP3j+2usdHTY5/ENUc2S+3BRF/cJqnR6RHeq6LBqKoIZOAQ62DQw974nnaZOencbfkmkTPyTmMnlkCpjzg==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  opentype.js@2.0.0:
+    resolution: {integrity: sha512-kCyjv6xdDY1W/jLWZ/L3QhhTlKUqDZMQ5+Jdlw12b3dXkKNpYBqqlMMj0YDQPShWFTMwgZI1hG14kN3XUDSg/A==}
+    hasBin: true
+
+  ot-json1@1.0.2:
+    resolution: {integrity: sha512-IhxkqVWQqlkWULoi/Q2AdzKk0N5vQRbUMUwubFXFCPcY4TsOZjmp2YKrk0/z1TeiECPadWEK060sdFdQ3Grokg==}
+
+  ot-text-unicode@4.0.0:
+    resolution: {integrity: sha512-W7ZLU8QXesY2wagYFv47zErXud3E93FGImmSGJsQnBzE+idcPPyo2u2KMilIrTwBh4pbCizy71qRjmmV6aDhcQ==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
@@ -2164,8 +2913,18 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -2173,6 +2932,12 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
+
+  rbush@4.0.1:
+    resolution: {integrity: sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -2188,6 +2953,9 @@ packages:
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -2248,9 +3016,18 @@ packages:
       '@types/react':
         optional: true
 
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -2259,6 +3036,10 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  regexp-util@2.0.3:
+    resolution: {integrity: sha512-GP6h9OgJmhAZpb3dbNbXTfRWVnGcoMhWRZv/HxgM4/qCVqs1P9ukQdYxaUhjWBSAs9oJ/uPXUUvGT1VMe0Bs0Q==}
+    engines: {node: '>=16'}
 
   rehype-highlight@7.0.2:
     resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
@@ -2275,6 +3056,10 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -2283,6 +3068,12 @@ packages:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -2313,6 +3104,9 @@ packages:
     resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -2341,11 +3135,22 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -2366,6 +3171,9 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tailwind-merge@2.6.0:
+    resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
 
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
@@ -2429,6 +3237,9 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  trigram-utils@2.0.1:
+    resolution: {integrity: sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ==}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -2446,9 +3257,19 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
+
+  unicode-regex@4.2.0:
+    resolution: {integrity: sha512-fEYz7CCnvHDAdrb8OYAP7qlQCWzXBO5cHXQ3XI+HoZaBpiAwyC6b2nixMGl91yrDYEIRm7NDskgTvnLZ7mqrKQ==}
+    engines: {node: '>=16'}
+
+  unicount@1.1.0:
+    resolution: {integrity: sha512-RlwWt1ywVW4WErPGAVHw/rIuJ2+MxvTME0siJ6lk9zBhpDfExDbspe6SRlWT3qU6AucNjotPl9qAJRVjP7guCQ==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -2504,6 +3325,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -2608,8 +3433,18 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
+    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
+    version: 0.20.3
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -2618,8 +3453,20 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
 
   zustand@5.0.14:
     resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
@@ -2886,7 +3733,11 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@exodus/bytes@1.15.1': {}
+  '@exodus/bytes@1.15.1(@noble/hashes@2.2.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.2.0
+
+  '@flatten-js/interval-tree@1.1.3': {}
 
   '@floating-ui/core@1.8.0':
     dependencies:
@@ -2904,6 +3755,18 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
 
   '@floating-ui/utils@0.2.12': {}
+
+  '@grpc/grpc-js@1.14.4':
+    dependencies:
+      '@grpc/proto-loader': 0.8.1
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.8.1':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.5
+      yargs: 17.7.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2923,6 +3786,34 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@noble/ciphers@2.2.0': {}
+
+  '@noble/ed25519@3.1.0': {}
+
+  '@noble/hashes@2.2.0': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
 
   '@radix-ui/number@1.1.3': {}
 
@@ -3136,6 +4027,23 @@ snapshots:
       '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-hover-card@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
@@ -3697,12 +4605,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
 
-  '@tailwindcss/vite@4.3.3(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@tailwindcss/vite@4.3.3(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
-      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0)
 
   '@tanstack/history@1.162.0': {}
 
@@ -3818,6 +4726,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@26.1.2':
+    dependencies:
+      undici-types: 8.3.0
+
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
@@ -3832,7 +4744,1417 @@ snapshots:
 
   '@ungap/structured-clone@1.3.3': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@univerjs-pro/collaboration-client-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/collaboration': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/collaboration-client': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/network': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/protocol': 0.25.1
+      '@univerjs/rpc': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs-pro/collaboration-client@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@noble/ciphers': 2.2.0
+      '@univerjs-pro/collaboration': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/license': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/network': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/protocol': 0.25.1
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/telemetry': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs-pro/collaboration@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/license': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-outline': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/data-validation': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/protocol': 0.25.1
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-conditional-formatting': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-filter': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-hyper-link': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/thread-comment': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      uuid: 14.0.1
+    transitivePeerDependencies:
+      - react
+      - rxjs
+
+  '@univerjs-pro/docs-exchange-client@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/exchange-client': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+      - rxjs
+
+  '@univerjs-pro/docs-print@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/license': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/print': 0.25.1
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/network': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+      - rxjs
+
+  '@univerjs-pro/edit-history-loader@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/collaboration': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/collaboration-client': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/collaboration-client-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/edit-history-viewer': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/license': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-chart': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-chart-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-pivot': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-shape': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-shape-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-sparkline': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-sparkline-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/data-validation': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/network': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/rpc': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-conditional-formatting': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-conditional-formatting-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-data-validation': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-data-validation-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-drawing-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-filter': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-filter-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-formula-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-hyper-link': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-hyper-link-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-numfmt': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-table': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+
+  '@univerjs-pro/edit-history-viewer@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/collaboration': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/collaboration-client': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/collaboration-client-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-chart': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-pivot': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-shape': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-sparkline': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/data-validation': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/network': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/protocol': 0.25.1
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-conditional-formatting': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-data-validation': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-filter': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-table': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs-pro/engine-chart@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs-pro/engine-formula@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/license': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - react
+      - rxjs
+
+  '@univerjs-pro/engine-pivot@0.25.1': {}
+
+  '@univerjs-pro/engine-shape@0.25.1': {}
+
+  '@univerjs-pro/exchange-client@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/collaboration': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/license': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/network': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/protocol': 0.25.1
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      fflate: 0.4.9
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs-pro/license@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@noble/ed25519': 3.1.0
+      '@noble/hashes': 2.2.0
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs-pro/print@0.25.1': {}
+
+  '@univerjs-pro/sheets-chart-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/engine-chart': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-chart': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-drawing-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-formula-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs-pro/sheets-chart@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/engine-chart': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/license': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs-pro/sheets-exchange-client@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/exchange-client': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+      - rxjs
+
+  '@univerjs-pro/sheets-outline-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/sheets-outline': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs-pro/sheets-outline@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/license': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs-pro/sheets-pivot-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/engine-pivot': 0.25.1
+      '@univerjs-pro/sheets-pivot': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/docs-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-formula-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs-pro/sheets-pivot@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/engine-pivot': 0.25.1
+      '@univerjs-pro/license': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/rpc': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-filter': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs-pro/sheets-print@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/collaboration-client': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/license': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/print': 0.25.1
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/network': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs-pro/sheets-shape-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/engine-shape': 0.25.1
+      '@univerjs-pro/sheets-shape': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-drawing-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs-pro/sheets-shape@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/engine-shape': 0.25.1
+      '@univerjs-pro/license': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - react
+      - rxjs
+
+  '@univerjs-pro/sheets-sparkline-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/sheets-sparkline': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-formula-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-graphics': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs-pro/sheets-sparkline@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/license': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs-pro/thread-comment-datasource@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/collaboration-client': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/license': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/network': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/protocol': 0.25.1
+      '@univerjs/thread-comment': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/thread-comment-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+
+  '@univerjs/core@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/protocol': 0.25.1
+      '@univerjs/themes': 0.25.1
+      '@wendellhu/redi': 1.1.1(react@19.2.7)
+      async-lock: 1.4.1
+      fast-diff: 1.3.0
+      kdbush: 4.1.0
+      lodash-es: 4.18.1
+      nanoid: 5.1.11
+      numfmt: 3.2.6
+      ot-json1: 1.0.2
+      rbush: 4.0.1
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/data-validation@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/design@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dropdown-menu': 2.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-hover-card': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-popover': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-separator': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      class-variance-authority: 0.7.1
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-transition-group: 4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      sonner: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      tailwind-merge: 2.6.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/docs-drawing-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/docs-drawing@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - react
+      - rxjs
+
+  '@univerjs/docs-hyper-link-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-hyper-link': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/docs-hyper-link@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - react
+      - rxjs
+
+  '@univerjs/docs-thread-comment-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/thread-comment': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/thread-comment-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/docs-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/docs@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/drawing-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/drawing@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      ot-json1: 1.0.2
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/engine-formula@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@flatten-js/interval-tree': 1.1.3
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/rpc': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      decimal.js: 10.6.0
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/engine-render@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      '@floating-ui/utils': 0.2.12
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      cjk-regex: 3.4.0
+      franc-min: 6.2.0
+      opentype.js: 2.0.0
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/find-replace@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/icons@1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@univerjs/network@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/preset-docs-advanced@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/docs-exchange-client': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/docs-print': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/exchange-client': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/license': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-docs-collaboration@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/collaboration': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/collaboration-client': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/collaboration-client-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-docs-core@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/network': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-docs-drawing@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/docs-drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-drawing-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-docs-hyper-link@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/docs-hyper-link': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-hyper-link-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-docs-node-core@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-hyper-link': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/rpc-node': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/thread-comment': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/preset-docs-thread-comment@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/docs-thread-comment-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/thread-comment': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/thread-comment-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-sheets-advanced@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/engine-chart': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/engine-shape': 0.25.1
+      '@univerjs-pro/exchange-client': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/license': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-chart': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-chart-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-exchange-client': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-outline': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-outline-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-pivot': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-pivot-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-print': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-shape': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-shape-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-sparkline': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/sheets-sparkline-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-graphics': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-sheets-collaboration@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs-pro/collaboration': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/collaboration-client': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/collaboration-client-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/edit-history-loader': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/edit-history-viewer': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs-pro/thread-comment-datasource': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-sheets-advanced': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-sheets-conditional-formatting@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/sheets-conditional-formatting': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-conditional-formatting-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-sheets-core@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/network': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/rpc': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-formula-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-numfmt': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-numfmt-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-sheets-data-validation@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/data-validation': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-data-validation': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-data-validation-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-sheets-drawing@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/docs-drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-drawing-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-sheets-filter@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/sheets-filter': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-filter-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-sheets-find-replace@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/find-replace': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-find-replace': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-sheets-hyper-link@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/sheets-hyper-link': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-hyper-link-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-sheets-node-core@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/rpc-node': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-data-validation': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-filter': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-hyper-link': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-numfmt': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-sort': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-thread-comment': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/thread-comment': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/preset-sheets-note@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/sheets-note': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-note-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-sheets-sort@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/sheets-sort': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-sort-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-sheets-table@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/sheets-table': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-table-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/preset-sheets-thread-comment@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/sheets-thread-comment': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-thread-comment-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/thread-comment': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/thread-comment-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/presets@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-docs-advanced': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-docs-collaboration': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-docs-core': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-docs-drawing': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-docs-hyper-link': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-docs-node-core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-docs-thread-comment': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-sheets-advanced': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-sheets-collaboration': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-sheets-conditional-formatting': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-sheets-core': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-sheets-data-validation': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-sheets-drawing': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-sheets-filter': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-sheets-find-replace': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-sheets-hyper-link': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-sheets-node-core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-sheets-note': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-sheets-sort': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-sheets-table': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/preset-sheets-thread-comment': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@univerjs/protocol@0.25.1':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+
+  '@univerjs/rpc-node@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/rpc': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/rpc@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/sheets-conditional-formatting-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-conditional-formatting': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-formula-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/sheets-conditional-formatting@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/sheets-data-validation-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/data-validation': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-data-validation': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-formula-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-numfmt': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/sheets-data-validation@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/data-validation': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/protocol': 0.25.1
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/sheets-drawing-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/docs-drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/sheets-drawing@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/drawing': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - react
+      - rxjs
+
+  '@univerjs/sheets-filter-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/rpc': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-filter': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/sheets-filter@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/rpc': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/sheets-find-replace@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/find-replace': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+
+  '@univerjs/sheets-formula-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/sheets-formula@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/rpc': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/sheets-graphics@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react
+      - react-dom
+      - rxjs
+
+  '@univerjs/sheets-hyper-link-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-data-validation': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-formula-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-hyper-link': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/sheets-hyper-link@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/sheets-note-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-note': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/sheets-note@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/sheets-numfmt-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-numfmt': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/sheets-numfmt@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/sheets-sort-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-sort': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/sheets-sort@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - react
+      - rxjs
+
+  '@univerjs/sheets-table-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-formula-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-sort': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-table': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/sheets-table@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/sheets-thread-comment-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-thread-comment': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/thread-comment': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/thread-comment-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/sheets-thread-comment@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/thread-comment': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/sheets-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/docs': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/docs-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/protocol': 0.25.1
+      '@univerjs/sheets': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/telemetry': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/sheets@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-formula': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/protocol': 0.25.1
+      '@univerjs/rpc': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/telemetry@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+    transitivePeerDependencies:
+      - react
+      - rxjs
+
+  '@univerjs/themes@0.25.1': {}
+
+  '@univerjs/thread-comment-ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/docs-ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/thread-comment': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/ui': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)
+      react: 19.2.7
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - react-dom
+
+  '@univerjs/thread-comment@0.25.1(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react
+
+  '@univerjs/ui@0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rxjs@7.8.2)':
+    dependencies:
+      '@univerjs/core': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/design': 0.25.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@univerjs/engine-render': 0.25.1(react@19.2.7)(rxjs@7.8.2)
+      '@univerjs/icons': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@wendellhu/redi': 1.1.1(react@19.2.7)
+      localforage: 1.10.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  '@vitejs/plugin-react@4.7.0(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -3840,7 +6162,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3852,13 +6174,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.7(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@vitest/mocker@3.2.7(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 3.2.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@3.2.7':
     dependencies:
@@ -3886,7 +6208,15 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@wendellhu/redi@1.1.1(react@19.2.7)':
+    optionalDependencies:
+      react: 19.2.7
+
   ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
 
@@ -3901,6 +6231,8 @@ snapshots:
   aria-query@5.3.2: {}
 
   assertion-error@2.0.1: {}
+
+  async-lock@1.4.1: {}
 
   bail@2.0.2: {}
 
@@ -3967,17 +6299,38 @@ snapshots:
   chownr@1.1.4:
     optional: true
 
+  cjk-regex@3.4.0:
+    dependencies:
+      regexp-util: 2.0.3
+      unicode-regex: 4.2.0
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   clsx@2.1.1: {}
+
+  collapse-white-space@2.1.0: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
 
   comma-separated-tokens@2.0.3: {}
 
   convert-source-map@2.0.0: {}
 
   cookie-es@3.1.1: {}
+
+  core-util-is@1.0.3: {}
 
   css-tree@3.2.1:
     dependencies:
@@ -3988,10 +6341,10 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  data-urls@7.0.0:
+  data-urls@7.0.0(@noble/hashes@2.2.0):
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -4029,7 +6382,14 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      csstype: 3.2.3
+
   electron-to-chromium@1.5.389: {}
+
+  emoji-regex@8.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -4091,9 +6451,17 @@ snapshots:
 
   extend@3.0.2: {}
 
+  fast-diff@1.3.0: {}
+
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  fflate@0.4.9: {}
+
+  franc-min@6.2.0:
+    dependencies:
+      trigram-utils: 2.0.1
 
   fs-constants@1.0.0:
     optional: true
@@ -4102,6 +6470,8 @@ snapshots:
     optional: true
 
   gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-nonce@1.0.1: {}
 
@@ -4147,9 +6517,9 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
-  html-encoding-sniffer@6.0.0:
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.1
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -4158,10 +6528,11 @@ snapshots:
   ieee754@1.2.1:
     optional: true
 
+  immediate@3.0.6: {}
+
   indent-string@4.0.0: {}
 
-  inherits@2.0.4:
-    optional: true
+  inherits@2.0.4: {}
 
   ini@1.3.8:
     optional: true
@@ -4177,11 +6548,15 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-hexadecimal@2.0.1: {}
 
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  isarray@1.0.0: {}
 
   isbot@5.2.1: {}
 
@@ -4191,17 +6566,17 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  jsdom@29.1.1(canvas@3.2.3):
+  jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.3):
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
       '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
-      '@exodus/bytes': 1.15.1
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
       css-tree: 3.2.1
-      data-urls: 7.0.0
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
       decimal.js: 10.6.0
-      html-encoding-sniffer: 6.0.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.5.2
       parse5: 8.0.1
@@ -4212,7 +6587,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
       xml-name-validator: 5.0.0
     optionalDependencies:
       canvas: 3.2.3
@@ -4222,6 +6597,23 @@ snapshots:
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
+
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
+  kdbush@4.1.0: {}
+
+  lie@3.1.1:
+    dependencies:
+      immediate: 3.0.6
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -4271,6 +6663,16 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  localforage@1.10.0:
+    dependencies:
+      lie: 3.1.1
+
+  lodash-es@4.18.1: {}
+
+  lodash.camelcase@4.3.0: {}
+
+  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -4671,7 +7073,11 @@ snapshots:
 
   ms@2.1.3: {}
 
+  n-gram@2.0.2: {}
+
   nanoid@3.3.16: {}
+
+  nanoid@5.1.11: {}
 
   napi-build-utils@2.0.0:
     optional: true
@@ -4686,10 +7092,26 @@ snapshots:
 
   node-releases@2.0.51: {}
 
+  numfmt@3.2.6: {}
+
+  object-assign@4.1.1: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
     optional: true
+
+  opentype.js@2.0.0: {}
+
+  ot-json1@1.0.2:
+    dependencies:
+      ot-text-unicode: 4.0.0
+
+  ot-text-unicode@4.0.0:
+    dependencies:
+      unicount: 1.1.0
+
+  pako@1.0.11: {}
 
   parse-entities@4.0.2:
     dependencies:
@@ -4749,7 +7171,29 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  process-nextick-args@2.0.1: {}
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   property-information@7.2.0: {}
+
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 26.1.2
+      long: 5.3.2
 
   pump@3.0.4:
     dependencies:
@@ -4758,6 +7202,12 @@ snapshots:
     optional: true
 
   punycode@2.3.1: {}
+
+  quickselect@3.0.0: {}
+
+  rbush@4.0.1:
+    dependencies:
+      quickselect: 3.0.0
 
   rc@1.2.8:
     dependencies:
@@ -4776,6 +7226,8 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
+
+  react-is@16.13.1: {}
 
   react-is@17.0.2: {}
 
@@ -4846,7 +7298,26 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  react-transition-group@4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   react@19.2.7: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   readable-stream@3.6.2:
     dependencies:
@@ -4859,6 +7330,8 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
+
+  regexp-util@2.0.3: {}
 
   rehype-highlight@7.0.2:
     dependencies:
@@ -4902,6 +7375,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
 
   rollup@4.62.2:
@@ -4935,6 +7410,12 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1:
     optional: true
 
@@ -4954,6 +7435,8 @@ snapshots:
       seroval: 1.5.6
 
   seroval@1.5.6: {}
+
+  setimmediate@1.0.5: {}
 
   siginfo@2.0.0: {}
 
@@ -4980,6 +7463,16 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -4989,6 +7482,10 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-indent@3.0.0:
     dependencies:
@@ -5010,6 +7507,8 @@ snapshots:
       inline-style-parser: 0.2.7
 
   symbol-tree@3.2.4: {}
+
+  tailwind-merge@2.6.0: {}
 
   tailwind-merge@3.6.0: {}
 
@@ -5069,6 +7568,11 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  trigram-utils@2.0.1:
+    dependencies:
+      collapse-white-space: 2.1.0
+      n-gram: 2.0.2
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -5082,7 +7586,15 @@ snapshots:
 
   typescript@5.8.3: {}
 
+  undici-types@8.3.0: {}
+
   undici@7.28.0: {}
+
+  unicode-regex@4.2.0:
+    dependencies:
+      regexp-util: 2.0.3
+
+  unicount@1.1.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -5147,8 +7659,9 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  util-deprecate@1.0.2:
-    optional: true
+  util-deprecate@1.0.2: {}
+
+  uuid@14.0.1: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -5160,13 +7673,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(jiti@2.7.0)(lightningcss@1.32.0):
+  vite-node@3.2.4(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5181,7 +7694,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0):
+  vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
@@ -5190,15 +7703,16 @@ snapshots:
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 26.1.2
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
 
-  vitest@3.2.7(@types/debug@4.1.13)(jiti@2.7.0)(jsdom@29.1.1(canvas@3.2.3))(lightningcss@1.32.0):
+  vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.1.2)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0)(canvas@3.2.3))(lightningcss@1.32.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
-      '@vitest/mocker': 3.2.7(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitest/mocker': 3.2.7(vite@7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0))
       '@vitest/pretty-format': 3.2.7
       '@vitest/runner': 3.2.7
       '@vitest/snapshot': 3.2.7
@@ -5216,12 +7730,13 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
-      vite-node: 3.2.4(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.6(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite-node: 3.2.4(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13
-      jsdom: 29.1.1(canvas@3.2.3)
+      '@types/node': 26.1.2
+      jsdom: 29.1.1(@noble/hashes@2.2.0)(canvas@3.2.3)
     transitivePeerDependencies:
       - jiti
       - less
@@ -5248,9 +7763,9 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1:
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
     dependencies:
-      '@exodus/bytes': 1.15.1
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
@@ -5261,14 +7776,36 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2:
     optional: true
+
+  xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz: {}
 
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   zustand@5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
     optionalDependencies:

--- a/crates/openwave-desktop/ui/src/document/DocumentViewer.tsx
+++ b/crates/openwave-desktop/ui/src/document/DocumentViewer.tsx
@@ -8,6 +8,31 @@ import type { ApiClient } from "@/api";
 const PdfViewer = lazy(() =>
   import("@/document/PdfViewer").then((m) => ({ default: m.PdfViewer })),
 );
+// The spreadsheet and word-document engines are larger still, and split apart
+// so that opening a workbook does not also fetch the document renderer.
+const UniverSpreadsheetViewer = lazy(
+  () => import("@/document/UniverSpreadsheetViewer"),
+);
+const UniverDocumentViewer = lazy(
+  () => import("@/document/UniverDocumentViewer"),
+);
+
+const SPREADSHEET_MEDIA_TYPES = new Set([
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-excel",
+]);
+
+/**
+ * Delimited text is a spreadsheet with one sheet and no styling — the same
+ * viewer renders it, with the workbook style pass skipped.
+ */
+const DELIMITED_TEXT_MEDIA_TYPES = new Set([
+  "text/csv",
+  "text/tab-separated-values",
+]);
+
+const WORD_DOCUMENT_MEDIA_TYPE =
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 
 /**
  * Which viewer renders a source in its original form, chosen by media type.
@@ -18,7 +43,13 @@ const PdfViewer = lazy(() =>
  * extracted text, which is a better floor than refusing to open the source.
  */
 export function hasOriginalViewer(mediaType: string): boolean {
-  return normalizeMediaType(mediaType) === "application/pdf";
+  const type = normalizeMediaType(mediaType);
+  return (
+    type === "application/pdf" ||
+    type === WORD_DOCUMENT_MEDIA_TYPE ||
+    SPREADSHEET_MEDIA_TYPES.has(type) ||
+    DELIMITED_TEXT_MEDIA_TYPES.has(type)
+  );
 }
 
 interface DocumentViewerProps {
@@ -37,27 +68,63 @@ export function DocumentViewer({
   targetPage,
   className,
 }: DocumentViewerProps) {
-  switch (normalizeMediaType(mediaType)) {
-    case "application/pdf":
-      return (
-        <Suspense
-          fallback={
-            <div className="flex grow items-center justify-center">
-              <Loader2Icon className="size-6 animate-spin text-muted-foreground" />
-            </div>
-          }
-        >
-          <PdfViewer
-            client={client}
-            documentId={documentId}
-            targetPage={targetPage}
-            className={className}
-          />
-        </Suspense>
-      );
-    default:
-      return null;
+  const type = normalizeMediaType(mediaType);
+
+  if (type === "application/pdf") {
+    return (
+      <ViewerBoundary>
+        <PdfViewer
+          client={client}
+          documentId={documentId}
+          targetPage={targetPage}
+          className={className}
+        />
+      </ViewerBoundary>
+    );
   }
+
+  if (SPREADSHEET_MEDIA_TYPES.has(type) || DELIMITED_TEXT_MEDIA_TYPES.has(type)) {
+    return (
+      <ViewerBoundary>
+        <UniverSpreadsheetViewer
+          key={documentId}
+          client={client}
+          documentId={documentId}
+          isCsv={DELIMITED_TEXT_MEDIA_TYPES.has(type)}
+          className={className}
+        />
+      </ViewerBoundary>
+    );
+  }
+
+  if (type === WORD_DOCUMENT_MEDIA_TYPE) {
+    return (
+      <ViewerBoundary>
+        <UniverDocumentViewer
+          key={documentId}
+          client={client}
+          documentId={documentId}
+          className={className}
+        />
+      </ViewerBoundary>
+    );
+  }
+
+  return null;
+}
+
+function ViewerBoundary({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex grow items-center justify-center">
+          <Loader2Icon className="size-6 animate-spin text-muted-foreground" />
+        </div>
+      }
+    >
+      {children}
+    </Suspense>
+  );
 }
 
 /** Media types arrive with parameters (`application/pdf; charset=binary`). */

--- a/crates/openwave-desktop/ui/src/document/SpreadsheetShortcutsInfo.tsx
+++ b/crates/openwave-desktop/ui/src/document/SpreadsheetShortcutsInfo.tsx
@@ -1,0 +1,27 @@
+import { Button } from "@/components/ui/button";
+
+/**
+ * The strip above the grid. Column widths stored in a workbook are frequently
+ * narrower than the text they hold, so autofit is the one control worth having
+ * within reach of a viewer that otherwise cannot be edited.
+ */
+export function SpreadsheetShortcutsInfoBar({
+  onAutofit,
+}: {
+  onAutofit?: () => void;
+}) {
+  if (!onAutofit) return null;
+
+  return (
+    <div className="text-muted-foreground flex items-center gap-1 border-b px-2 py-1 text-xs">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="text-muted-foreground hover:text-foreground h-6 px-1.5 text-[11px]"
+        onClick={onAutofit}
+      >
+        Autofit all columns
+      </Button>
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/document/UniverDocumentViewer.tsx
+++ b/crates/openwave-desktop/ui/src/document/UniverDocumentViewer.tsx
@@ -1,0 +1,174 @@
+import { UniverDocsCorePreset } from "@univerjs/preset-docs-core";
+import docsCoreEnUS from "@univerjs/preset-docs-core/locales/en-US";
+import "@univerjs/preset-docs-core/lib/index.css";
+import type { FUniver } from "@univerjs/presets";
+import { createUniver, LocaleType } from "@univerjs/presets";
+import { Loader2Icon } from "lucide-react";
+import type { HTMLAttributes } from "react";
+import { useEffect, useRef, useState } from "react";
+
+import type { ApiClient } from "@/api";
+import { cn } from "@/lib/utils";
+import { docxToUniver } from "./docx-to-univer";
+import { useFileDownload } from "./useFileDownload";
+
+// The MODERN flavor hardcodes page width to 595/0.75 ≈ 793px. To fill the
+// container we CSS-scale the render canvas so its pixel width matches the
+// container width. The document component adds 20px of left page margin.
+const UNIVER_MODERN_PAGE_WIDTH = 595 / 0.75;
+const UNIVER_PAGE_MARGIN_LEFT = 20;
+const UNIVER_EFFECTIVE_WIDTH = UNIVER_MODERN_PAGE_WIDTH + UNIVER_PAGE_MARGIN_LEFT;
+
+// Hide the heading outline sidebar and its toggle button.
+const UNIVER_VIEWER_STYLES = `
+.univer-doc-viewer [id^="univer-side-menu-"],
+.univer-doc-viewer .univer-min-w-\\[180px\\].univer-pt-14,
+.univer-doc-viewer .univer-left-5.univer-top-4.univer-z-\\[100\\] {
+    display: none !important;
+}
+`;
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  client: Pick<ApiClient, "getDocumentFileContent">;
+  documentId: string;
+}
+
+/**
+ * The word-document viewer: a docx rendered in the app.
+ *
+ * Rendering the file rather than converting it means office formats do not
+ * depend on a converter being installed on the host, which is the whole point
+ * of viewing one locally.
+ */
+export default function UniverDocumentViewer({
+  client,
+  documentId,
+  className,
+  ...restProps
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const univerRef = useRef<FUniver | null>(null);
+  const [errorType, setErrorType] = useState<"parse" | "load" | null>(null);
+  const [isReady, setIsReady] = useState(false);
+
+  const fileDownload = useFileDownload(client, documentId);
+
+  // Parse the docx, then mount Univer on the result.
+  useEffect(() => {
+    if (!fileDownload.data || !containerRef.current) return;
+
+    if (univerRef.current) {
+      univerRef.current.dispose();
+      univerRef.current = null;
+    }
+
+    setIsReady(false);
+    setErrorType(null);
+
+    let cancelled = false;
+    const container = containerRef.current;
+
+    docxToUniver(fileDownload.data)
+      .then((documentData) => {
+        if (cancelled) return;
+
+        const { univerAPI } = createUniver({
+          locale: LocaleType.EN_US,
+          locales: { [LocaleType.EN_US]: docsCoreEnUS },
+          presets: [
+            UniverDocsCorePreset({
+              container,
+              toolbar: false,
+              contextMenu: false,
+            }),
+          ],
+        });
+
+        univerRef.current = univerAPI;
+        univerAPI.createUniverDoc(documentData);
+
+        // The MODERN flavor renders at a fixed ~793px, so apply a uniform CSS
+        // scale to stretch the page to the container without distorting text.
+        const containerWidth = container.clientWidth;
+        if (containerWidth && containerWidth !== UNIVER_EFFECTIVE_WIDTH) {
+          const scale = containerWidth / UNIVER_EFFECTIVE_WIDTH;
+          const wrapper = container.firstElementChild;
+          if (wrapper instanceof HTMLElement) {
+            wrapper.style.transform = `scale(${scale})`;
+            wrapper.style.transformOrigin = "left top";
+            wrapper.style.width = `${100 / scale}%`;
+            wrapper.style.height = `${100 / scale}%`;
+          }
+        }
+
+        // Block editing commands while preserving scrolling and selection.
+        univerAPI.addEvent(univerAPI.Event.BeforeCommandExecute, (event) => {
+          if (
+            event.id.startsWith("doc.command.") ||
+            event.id.startsWith("doc.mutation.")
+          ) {
+            event.cancel = true;
+          }
+        });
+
+        setIsReady(true);
+      })
+      .catch(() => {
+        if (!cancelled) setErrorType("parse");
+      });
+
+    return () => {
+      cancelled = true;
+      if (univerRef.current) {
+        univerRef.current.dispose();
+        univerRef.current = null;
+      }
+    };
+  }, [fileDownload.data, documentId]);
+
+  useEffect(() => {
+    if (fileDownload.error) setErrorType("load");
+  }, [fileDownload.error]);
+
+  if (errorType) {
+    return (
+      <div className={cn("relative overflow-auto", className)} {...restProps}>
+        <div className="text-muted-foreground flex h-64 items-center justify-center">
+          <p>
+            {errorType === "parse"
+              ? "This document could not be read."
+              : "This document could not be loaded."}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const isLoading = fileDownload.isLoading || !isReady;
+
+  return (
+    <div
+      className={cn("univer-doc-viewer relative flex flex-col", className)}
+      {...restProps}
+    >
+      <style dangerouslySetInnerHTML={{ __html: UNIVER_VIEWER_STYLES }} />
+      {isLoading && (
+        <div className="bg-background/80 absolute inset-0 z-10 flex items-center justify-center">
+          <div className="text-muted-foreground flex flex-col items-center gap-2">
+            <Loader2Icon className="size-6 animate-spin" />
+            <p>
+              {fileDownload.isLoading
+                ? "Loading document…"
+                : "Reading document…"}
+            </p>
+          </div>
+        </div>
+      )}
+      <div
+        ref={containerRef}
+        className="min-h-0 grow"
+        style={{ width: "100%", height: "100%" }}
+      />
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/document/UniverSpreadsheetViewer.tsx
+++ b/crates/openwave-desktop/ui/src/document/UniverSpreadsheetViewer.tsx
@@ -1,0 +1,485 @@
+import { ICommandService } from "@univerjs/core";
+import {
+  CalculationMode,
+  type ISequenceNode,
+  sequenceNodeType,
+  UniverSheetsCorePreset,
+} from "@univerjs/preset-sheets-core";
+import sheetsCoreEnUS from "@univerjs/preset-sheets-core/locales/en-US";
+import "@univerjs/preset-sheets-core/lib/index.css";
+import type { FUniver, IWorkbookData, Univer } from "@univerjs/presets";
+import { createUniver, LocaleType } from "@univerjs/presets";
+import { Loader2Icon } from "lucide-react";
+import type { HTMLAttributes, ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { ApiClient } from "@/api";
+import { useApp } from "@/AppContext";
+import { cn } from "@/lib/utils";
+import { resolveTheme } from "@/theme";
+import UniverFormulaWorker from "@/workers/univer-formula.worker?worker&inline";
+import { SpreadsheetShortcutsInfoBar } from "./SpreadsheetShortcutsInfo";
+import { parseCellAddress } from "./spreadsheet";
+import { useFileDownload } from "./useFileDownload";
+import { useUniverWorker } from "./useUniverWorker";
+
+/** A cell range a citation points at, resolved against a named or indexed sheet. */
+export interface SheetHighlightRange {
+  startCell: string | null | undefined;
+  endCell: string | null | undefined;
+  sheetName: string | null | undefined;
+  sheetIndex: number | null | undefined;
+}
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  client: Pick<ApiClient, "getDocumentFileContent">;
+  documentId: string;
+  highlightRange?: SheetHighlightRange;
+  /** When true, skip the XLSX-only style pass — a CSV has none. */
+  isCsv?: boolean;
+}
+
+/** Mutable state for a mounted Univer instance, stored in a single ref. */
+interface UniverInstance {
+  core: Univer;
+  api: FUniver;
+  workbookData: IWorkbookData;
+  canvasReady: boolean;
+}
+
+/**
+ * The spreadsheet viewer: an xlsx, xls, or csv rendered with its sheet tabs,
+ * formulas, and cell selection intact.
+ *
+ * Read-only. Univer is a full editor, so rather than trusting the absence of a
+ * toolbar the viewer cancels every editing command before it executes, letting
+ * navigation, selection, and the formula engine's own writes through.
+ */
+export default function UniverSpreadsheetViewer({
+  client,
+  documentId,
+  highlightRange,
+  isCsv,
+  className,
+  ...restProps
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const univerInstanceRef = useRef<UniverInstance | null>(null);
+  const highlightRangeRef = useRef(highlightRange);
+  highlightRangeRef.current = highlightRange;
+  const [errorType, setErrorType] = useState<"parse" | "load" | null>(null);
+  const univerWorker = useUniverWorker();
+  const { themeMode } = useApp();
+  const resolvedTheme = resolveTheme(themeMode);
+  const resolvedThemeRef = useRef(resolvedTheme);
+  resolvedThemeRef.current = resolvedTheme;
+
+  // Sync dark mode with Univer.
+  useEffect(() => {
+    univerInstanceRef.current?.api.toggleDarkMode(resolvedTheme === "dark");
+  }, [resolvedTheme]);
+
+  // Keep a trackpad horizontal swipe from triggering back/forward navigation
+  // while the spreadsheet is mounted. The webview processes that gesture at the
+  // compositor level, before JS wheel events, so the only reliable opt-out is
+  // overscroll-behavior-x on the root element.
+  useEffect(() => {
+    const html = document.documentElement;
+    const previous = html.style.overscrollBehaviorX;
+    html.style.overscrollBehaviorX = "none";
+    return () => {
+      html.style.overscrollBehaviorX = previous;
+    };
+  }, []);
+
+  const fileDownload = useFileDownload(client, documentId);
+
+  // Shortcuts the canvas does not handle itself.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const instance = univerInstanceRef.current;
+      if (!instance) return;
+      const univerAPI = instance.api;
+
+      // --- Trace precedents: Ctrl+[ ---
+      if (e.ctrlKey && e.key === "[") {
+        const workbook = univerAPI.getActiveWorkbook();
+        const sheet = workbook?.getActiveSheet();
+        if (!workbook || !sheet) return;
+
+        const range = sheet.getSelection()?.getActiveRange();
+        if (!range) return;
+
+        const formula = sheet
+          .getRange(range.getRow(), range.getColumn())
+          .getFormula();
+        if (!formula) return;
+
+        const nodes = univerAPI.getFormula().sequenceNodesBuilder(formula);
+        if (!nodes) return;
+
+        const refs = nodes.filter(
+          (n): n is ISequenceNode =>
+            typeof n !== "string" && n.nodeType === sequenceNodeType.REFERENCE,
+        );
+        if (refs.length === 0) return;
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        const { token } = refs[0]!;
+
+        let targetSheetName: string | null = null;
+        let cellRef = token;
+        const bangIdx = token.indexOf("!");
+        if (bangIdx !== -1) {
+          targetSheetName = token
+            .substring(0, bangIdx)
+            .replace(/^'|'$/g, "")
+            .replace(/''/g, "'");
+          cellRef = token.substring(bangIdx + 1);
+        }
+
+        const colonIdx = cellRef.indexOf(":");
+        if (colonIdx !== -1) cellRef = cellRef.substring(0, colonIdx);
+        cellRef = cellRef.replace(/\$/g, "");
+
+        const target = parseCellAddress(cellRef);
+        if (!target) return;
+
+        if (targetSheetName) {
+          workbook.getSheetByName(targetSheetName)?.activate();
+        }
+
+        const activeSheet = workbook.getActiveSheet();
+        if (!activeSheet) return;
+
+        activeSheet.getRange(target.row, target.col).activate();
+        activeSheet.scrollToCell(
+          Math.max(0, target.row - 5),
+          Math.max(0, target.col - 2),
+          200,
+        );
+        return;
+      }
+
+      // --- Switch sheet tabs: Ctrl+PageDown / Ctrl+PageUp ---
+      if (e.ctrlKey && (e.key === "PageDown" || e.key === "PageUp")) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const workbook = univerAPI.getActiveWorkbook();
+        if (!workbook) return;
+
+        const sheets = workbook.getSheets();
+        const activeSheet = workbook.getActiveSheet();
+        if (!activeSheet || sheets.length <= 1) return;
+
+        const currentIdx = sheets.findIndex(
+          (s) => s.getSheetId() === activeSheet.getSheetId(),
+        );
+        if (currentIdx === -1) return;
+
+        const nextIdx =
+          e.key === "PageDown"
+            ? Math.min(currentIdx + 1, sheets.length - 1)
+            : Math.max(currentIdx - 1, 0);
+
+        if (nextIdx !== currentIdx) sheets[nextIdx]!.activate();
+      }
+    };
+
+    container.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () => {
+      container.removeEventListener("keydown", handleKeyDown, {
+        capture: true,
+      });
+    };
+  }, [fileDownload.data]);
+
+  // Parse the workbook in the worker, then mount Univer on the result.
+  useEffect(() => {
+    if (!fileDownload.data || !containerRef.current) return;
+
+    setErrorType(null);
+    let disposed = false;
+
+    univerWorker
+      .parseWorkbook(fileDownload.data, documentId, { isCsv })
+      .then(({ workbookData }) => {
+        if (disposed || !containerRef.current) return;
+
+        const corePreset = UniverSheetsCorePreset({
+          container: containerRef.current,
+          toolbar: false,
+          contextMenu: false,
+          workerURL: new UniverFormulaWorker(),
+          formula: { initialFormulaComputing: CalculationMode.WHEN_EMPTY },
+          sheets: {
+            disableForceStringAlert: true,
+            disableForceStringMark: true,
+          },
+          footer: { zoomSlider: false },
+        });
+
+        const { univer, univerAPI } = createUniver({
+          locale: LocaleType.EN_US,
+          locales: { [LocaleType.EN_US]: sheetsCoreEnUS },
+          presets: [corePreset],
+        });
+
+        univerInstanceRef.current = {
+          core: univer,
+          api: univerAPI,
+          workbookData,
+          canvasReady: false,
+        };
+        univerAPI.toggleDarkMode(resolvedThemeRef.current === "dark");
+        univerAPI.createWorkbook(workbookData);
+
+        // Disable editing while preserving keyboard navigation: block the cell
+        // editor from opening and block text insertion, but leave
+        // set-activate-cell-edit alone because arrow-key navigation uses it
+        // internally. The formula engine writes its computed values through
+        // mutations, so those are let through by name.
+        const formulaAllowlist = new Set([
+          "sheet.mutation.set-range-values",
+          "sheet.mutation.toggle-gridlines",
+          "sheet.mutation.set-worksheet-col-width",
+          "sheet.mutation.set-worksheet-col-auto-width",
+          "sheet.mutation.set-worksheet-row-height",
+          "sheet.mutation.set-worksheet-row-auto-height",
+        ]);
+        univerAPI.addEvent(univerAPI.Event.BeforeCommandExecute, (event) => {
+          if (
+            event.id === "sheet.operation.set-cell-edit-visible" ||
+            event.id === "sheet.operation.set-cell-edit-visible-arrow" ||
+            event.id === "doc.command.insert-text" ||
+            event.id === "sheet.command.set-range-values" ||
+            (event.id.startsWith("sheet.mutation.") &&
+              !formulaAllowlist.has(event.id))
+          ) {
+            event.cancel = true;
+          }
+        });
+
+        // Univer creates its canvas asynchronously, and its appearance is the
+        // most reliable "the renderer is up" signal available. Poll for it, and
+        // use it to gate a highlight that arrived before the mount finished.
+        const MAX_CANVAS_POLL_ATTEMPTS = 25; // ~5s total
+        window.setTimeout(() => {
+          if (disposed || !containerRef.current) return;
+          let attempts = 0;
+          const findSpreadsheetCanvas = () => {
+            if (disposed || !containerRef.current) return;
+            attempts++;
+
+            const canvases = containerRef.current.querySelectorAll("canvas");
+            let bigCanvas: HTMLCanvasElement | null = null;
+            canvases.forEach((c) => {
+              if (c.offsetWidth > 100 && c.offsetHeight > 100) bigCanvas = c;
+            });
+
+            if (bigCanvas) {
+              const instance = univerInstanceRef.current;
+              if (instance) {
+                instance.canvasReady = true;
+                const pending = highlightRangeRef.current;
+                if (pending?.startCell) applyHighlight(instance, pending);
+              }
+            } else if (attempts < MAX_CANVAS_POLL_ATTEMPTS) {
+              window.setTimeout(findSpreadsheetCanvas, 200);
+            }
+          };
+          findSpreadsheetCanvas();
+        }, 100);
+      })
+      .catch(() => {
+        if (!disposed) setErrorType("parse");
+      });
+
+    return () => {
+      disposed = true;
+      // Dispose both the core runtime and the facade so the formula engine's
+      // state cannot leak into the next workbook opened in this window.
+      if (univerInstanceRef.current) {
+        univerInstanceRef.current.core.dispose();
+        univerInstanceRef.current.api.dispose();
+        univerInstanceRef.current = null;
+      }
+    };
+  }, [fileDownload.data, documentId, isCsv, univerWorker]);
+
+  // Apply a highlight that arrives after the canvas is up; one that arrives
+  // before it is applied by the canvas poll above.
+  useEffect(() => {
+    const instance = univerInstanceRef.current;
+    if (!instance || !instance.canvasReady || !highlightRange) return;
+    applyHighlight(instance, highlightRange);
+  }, [highlightRange]);
+
+  useEffect(() => {
+    if (fileDownload.error) setErrorType("load");
+  }, [fileDownload.error]);
+
+  const handleAutofit = useCallback(() => {
+    const instance = univerInstanceRef.current;
+    if (!instance) return;
+
+    const sheet = instance.api.getActiveWorkbook()?.getActiveSheet();
+    if (!sheet) return;
+
+    const maxRow = sheet.getLastRow();
+    const maxCol = sheet.getLastColumn();
+    if (maxRow <= 0 || maxCol <= 0) return;
+
+    const ranges = [
+      { startRow: 0, endRow: maxRow - 1, startColumn: 0, endColumn: maxCol - 1 },
+    ];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const injector = (instance.api as any)._injector;
+    const commandService = injector.get(ICommandService) as ICommandService;
+
+    const colCmd = "sheet.command.set-col-is-auto-width";
+    const rowCmd = "sheet.command.set-row-is-auto-height";
+    if (
+      !commandService.hasCommand(colCmd) ||
+      !commandService.hasCommand(rowCmd)
+    ) {
+      return;
+    }
+
+    void commandService.executeCommand(colCmd, { ranges });
+    void commandService.executeCommand(rowCmd, { ranges });
+  }, []);
+
+  if (fileDownload.isLoading) {
+    return (
+      <div className={cn("relative overflow-auto", className)} {...restProps}>
+        <ViewerMessage spinner>Loading spreadsheet…</ViewerMessage>
+      </div>
+    );
+  }
+
+  if (errorType) {
+    return (
+      <div className={cn("relative overflow-auto", className)} {...restProps}>
+        <ViewerMessage>
+          {errorType === "parse"
+            ? "This spreadsheet could not be read."
+            : "This spreadsheet could not be loaded."}
+        </ViewerMessage>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("relative flex flex-col", className)} {...restProps}>
+      {univerWorker.isProcessing && (
+        <div className="bg-background/80 absolute inset-0 z-10 flex items-center justify-center">
+          <ViewerMessage spinner>Reading spreadsheet…</ViewerMessage>
+        </div>
+      )}
+      <SpreadsheetShortcutsInfoBar onAutofit={handleAutofit} />
+      <style>{`
+        [data-u-comp="slide-tab-item"] {
+            color: var(--muted-foreground) !important;
+            background-color: transparent !important;
+            font-weight: 500 !important;
+            box-shadow: none !important;
+        }
+        [data-u-comp="slide-tab-item"]:hover {
+            background-color: var(--muted) !important;
+        }
+        [data-u-comp="slide-tab-item"].univer-bg-white,
+        [data-u-comp="slide-tab-item"].univer-font-bold {
+            color: var(--foreground) !important;
+            background-color: var(--muted) !important;
+            font-weight: 700 !important;
+        }
+        .univerjs-icon-dropdown-icon {
+            color: var(--muted-foreground) !important;
+        }
+      `}</style>
+      <div
+        ref={containerRef}
+        className="min-h-0 grow"
+        style={{ width: "100%", height: "100%" }}
+      />
+    </div>
+  );
+}
+
+function ViewerMessage({
+  spinner,
+  children,
+}: {
+  spinner?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div className="text-muted-foreground flex h-64 items-center justify-center">
+      <div className="flex flex-col items-center gap-2">
+        {spinner && <Loader2Icon className="size-6 animate-spin" />}
+        <p>{children}</p>
+      </div>
+    </div>
+  );
+}
+
+function applyHighlight(
+  instance: UniverInstance,
+  highlightRange: SheetHighlightRange,
+) {
+  if (!highlightRange.startCell) return;
+
+  const start = parseCellAddress(highlightRange.startCell);
+  if (!start) return;
+
+  const end = highlightRange.endCell
+    ? parseCellAddress(highlightRange.endCell)
+    : start;
+  if (!end) return;
+
+  const { api: univerAPI, workbookData } = instance;
+  const activeWorkbook = univerAPI.getActiveWorkbook();
+  if (!activeWorkbook) return;
+
+  let targetSheetName = highlightRange.sheetName;
+  if (
+    !targetSheetName &&
+    highlightRange.sheetIndex !== null &&
+    highlightRange.sheetIndex !== undefined
+  ) {
+    const sheetId = workbookData.sheetOrder[highlightRange.sheetIndex];
+    if (sheetId) targetSheetName = workbookData.sheets[sheetId]?.name ?? null;
+  }
+
+  if (targetSheetName) {
+    activeWorkbook.getSheetByName(targetSheetName)?.activate();
+  }
+
+  const activeSheet = activeWorkbook.getActiveSheet();
+  if (!activeSheet) return;
+
+  activeSheet
+    .getRange(
+      start.row,
+      start.col,
+      end.row - start.row + 1,
+      end.col - start.col + 1,
+    )
+    .activate();
+
+  // Offset the scroll target so the cell lands roughly in the middle of the
+  // viewport instead of in the top-left corner.
+  activeSheet.scrollToCell(
+    Math.max(0, start.row - 5),
+    Math.max(0, start.col - 2),
+    200,
+  );
+}

--- a/crates/openwave-desktop/ui/src/document/docx-to-univer.ts
+++ b/crates/openwave-desktop/ui/src/document/docx-to-univer.ts
@@ -1,0 +1,1259 @@
+import type {
+    ICustomRange,
+    ICustomTable,
+    IDocumentData,
+    IDocumentStyle,
+    ILists,
+    INumberUnit,
+    IParagraph,
+    IParagraphStyle,
+    ISectionBreak,
+    ITable,
+    ITableCell,
+    ITableCellBorder,
+    ITableCellMargin,
+    ITableColumn,
+    ITableRow,
+    ITextRun,
+    ITextStyle,
+    ITables,
+} from "@univerjs/presets";
+import {
+    BaselineOffset,
+    BooleanNumber,
+    BulletAlignment,
+    CustomRangeType,
+    DashStyleType,
+    DocumentFlavor,
+    HorizontalAlign,
+    ListGlyphType,
+    NamedStyleType,
+    NumberUnitType,
+    ObjectRelativeFromH,
+    ObjectRelativeFromV,
+    TableAlignmentType,
+    TableLayoutType,
+    TableRowHeightRule,
+    TableSizeType,
+    TableTextWrapType,
+    VerticalAlignmentType,
+} from "@univerjs/presets";
+import JSZip from "jszip";
+
+/**
+ * Direct DOCX (OOXML) → Univer IDocumentData converter.
+ *
+ * Parses the raw XML from word/document.xml and word/styles.xml to build
+ * Univer's position-based document model without an intermediate HTML step.
+ *
+ * OOXML reference: https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/
+ * Key mappings:
+ *   w:p        → paragraph (dataStream \r)
+ *   w:r        → text run with inline styling
+ *   w:rPr      → ITextStyle (bold, italic, underline, font, size, color)
+ *   w:pPr      → IParagraphStyle (alignment, spacing, indentation)
+ *   w:pStyle   → heading/list detection
+ *   w:tbl      → styled text table with paragraph borders
+ *   w:hyperlink → ICustomRange with HYPERLINK type
+ *   w:br       → line/page break
+ */
+
+// DataStream table markers (verified from @univerjs/core runtime bundle)
+const TABLE_START = "\x1A";
+const TABLE_ROW_START = "\x1B";
+const TABLE_CELL_START = "\x1C";
+const TABLE_CELL_END = "\x1D";
+const TABLE_ROW_END = "\x0E";
+const TABLE_END = "\x0F";
+
+// Map common DOCX fonts to web-safe equivalents
+const FONT_MAP: Record<string, string> = {
+    Calibri: "Calibri, Trebuchet MS, sans-serif",
+    "Calibri Light": "Calibri, Trebuchet MS, sans-serif",
+    Aptos: "Aptos, Calibri, Trebuchet MS, sans-serif",
+    "Aptos Display": "Aptos, Calibri, Trebuchet MS, sans-serif",
+    Cambria: "Cambria, Georgia, serif",
+    "Times New Roman": "Times New Roman, Times, serif",
+    Arial: "Arial, Helvetica, sans-serif",
+    "Arial Black": "Arial Black, Arial, sans-serif",
+    Verdana: "Verdana, Geneva, sans-serif",
+    Tahoma: "Tahoma, Geneva, sans-serif",
+    "Courier New": "Courier New, Courier, monospace",
+    "Lucida Console": "Lucida Console, Monaco, monospace",
+    Consolas: "Consolas, Courier New, monospace",
+    Georgia: "Georgia, Times, serif",
+    Palatino: "Palatino Linotype, Palatino, serif",
+    "Book Antiqua": "Book Antiqua, Palatino, serif",
+    Garamond: "Garamond, Georgia, serif",
+    "Trebuchet MS": "Trebuchet MS, sans-serif",
+    "Comic Sans MS": "Comic Sans MS, cursive",
+    Impact: "Impact, sans-serif",
+    "Century Gothic": "Century Gothic, sans-serif",
+    "Segoe UI": "Segoe UI, Helvetica, Arial, sans-serif",
+};
+
+// Map OOXML paragraph style IDs to Univer NamedStyleType
+const HEADING_STYLE_IDS: Record<string, NamedStyleType> = {
+    Title: NamedStyleType.TITLE,
+    Heading1: NamedStyleType.HEADING_1,
+    Heading2: NamedStyleType.HEADING_2,
+    Heading3: NamedStyleType.HEADING_3,
+    Heading4: NamedStyleType.HEADING_4,
+    Heading5: NamedStyleType.HEADING_5,
+    // Common alternate IDs
+    heading1: NamedStyleType.HEADING_1,
+    heading2: NamedStyleType.HEADING_2,
+    heading3: NamedStyleType.HEADING_3,
+    heading4: NamedStyleType.HEADING_4,
+    heading5: NamedStyleType.HEADING_5,
+};
+
+// Default font sizes for headings (points)
+const HEADING_FONT_SIZES: Partial<Record<NamedStyleType, number>> = {
+    [NamedStyleType.TITLE]: 28,
+    [NamedStyleType.HEADING_1]: 24,
+    [NamedStyleType.HEADING_2]: 20,
+    [NamedStyleType.HEADING_3]: 16,
+    [NamedStyleType.HEADING_4]: 14,
+    [NamedStyleType.HEADING_5]: 12,
+};
+
+// Map OOXML alignment values to Univer HorizontalAlign
+const ALIGNMENT_MAP: Record<string, HorizontalAlign> = {
+    left: HorizontalAlign.LEFT,
+    center: HorizontalAlign.CENTER,
+    right: HorizontalAlign.RIGHT,
+    both: HorizontalAlign.JUSTIFIED,
+    justify: HorizontalAlign.JUSTIFIED,
+};
+
+interface BuilderState {
+    dataStream: string;
+    textRuns: ITextRun[];
+    paragraphs: IParagraph[];
+    customRanges: ICustomRange[];
+    tables: ICustomTable[];
+    tableSource: ITables;
+    lists: ILists;
+}
+
+interface StyleInfo {
+    headingLevel?: NamedStyleType;
+    defaultRunProps?: ITextStyle;
+}
+
+const W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+
+/**
+ * Convert a DOCX ArrayBuffer to Univer IDocumentData by parsing OOXML directly.
+ */
+export async function docxToUniver(
+    arrayBuffer: ArrayBuffer,
+): Promise<IDocumentData> {
+    const zip = await JSZip.loadAsync(arrayBuffer);
+
+    // Parse main document
+    const docXml = await zip.file("word/document.xml")?.async("string");
+    if (!docXml) {
+        throw new Error("Invalid DOCX: missing word/document.xml");
+    }
+
+    // Parse styles (optional)
+    const stylesXml = await zip.file("word/styles.xml")?.async("string");
+    const styleMap = stylesXml
+        ? parseStyles(stylesXml)
+        : new Map<string, StyleInfo>();
+
+    // Parse relationships for hyperlinks
+    const relsXml = await zip
+        .file("word/_rels/document.xml.rels")
+        ?.async("string");
+    const relsMap = relsXml
+        ? parseRelationships(relsXml)
+        : new Map<string, string>();
+
+    // Parse page/section properties from document XML
+    const pageStyle = parseDocumentPageStyle(docXml);
+
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(docXml, "application/xml");
+
+    const body = doc.getElementsByTagNameNS(W_NS, "body")[0];
+    if (!body) {
+        throw new Error("Invalid DOCX: missing w:body element");
+    }
+
+    const state: BuilderState = {
+        dataStream: "",
+        textRuns: [],
+        paragraphs: [],
+        customRanges: [],
+        tables: [],
+        tableSource: {},
+        lists: {},
+    };
+
+    // In MODERN flavor, Univer overrides pageSize/margins to:
+    //   width = 595/0.75 = 793.33, marginLeft = marginRight = 50/0.75 = 66.67
+    // So effective content width = 793.33 - 66.67*2 = 660
+    const UNIVER_MODERN_CONTENT_WIDTH = 595 / 0.75 - 2 * (50 / 0.75);
+    const contentWidth =
+        pageStyle.documentFlavor === DocumentFlavor.MODERN
+            ? UNIVER_MODERN_CONTENT_WIDTH
+            : (pageStyle.pageSize?.width ?? 595.28) -
+              (pageStyle.marginLeft ?? 72) -
+              (pageStyle.marginRight ?? 72);
+    processBody(body, state, styleMap, relsMap, contentWidth);
+
+    // Ensure document ends with \r\n
+    if (!state.dataStream.endsWith("\r\n")) {
+        if (!state.dataStream.endsWith("\r")) {
+            state.paragraphs.push({ startIndex: state.dataStream.length });
+            state.dataStream += "\r";
+        }
+        state.dataStream += "\n";
+    }
+
+    const sectionBreaks: ISectionBreak[] = [
+        { startIndex: state.dataStream.length - 1 },
+    ];
+
+    const result: IDocumentData = {
+        id: `doc-${Date.now()}`,
+        body: {
+            dataStream: state.dataStream,
+            textRuns: state.textRuns,
+            paragraphs: state.paragraphs,
+            sectionBreaks,
+            customRanges:
+                state.customRanges.length > 0 ? state.customRanges : undefined,
+            tables: state.tables.length > 0 ? state.tables : undefined,
+        },
+        documentStyle: pageStyle,
+    };
+
+    if (Object.keys(state.tableSource).length > 0) {
+        result.tableSource = state.tableSource;
+    }
+
+    if (Object.keys(state.lists).length > 0) {
+        result.lists = state.lists;
+    }
+
+    return result;
+}
+
+function parseStyles(xml: string): Map<string, StyleInfo> {
+    const map = new Map<string, StyleInfo>();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(xml, "application/xml");
+
+    const styles = doc.getElementsByTagNameNS(W_NS, "style");
+    for (const style of Array.from(styles)) {
+        const styleId = style.getAttribute("w:styleId");
+        if (!styleId) continue;
+
+        const info: StyleInfo = {};
+
+        // Check if it's a heading style
+        const headingLevel = HEADING_STYLE_IDS[styleId];
+        if (headingLevel !== undefined) {
+            info.headingLevel = headingLevel;
+        }
+
+        // Check for basedOn reference to heading styles
+        const basedOn = style.getElementsByTagNameNS(W_NS, "basedOn")[0];
+        if (basedOn) {
+            const basedOnId = basedOn.getAttribute("w:val");
+            if (basedOnId && HEADING_STYLE_IDS[basedOnId] !== undefined) {
+                info.headingLevel = HEADING_STYLE_IDS[basedOnId];
+            }
+        }
+
+        // Extract default run properties from style
+        const rPr = style.getElementsByTagNameNS(W_NS, "rPr")[0];
+        if (rPr) {
+            info.defaultRunProps = extractRunProperties(rPr);
+        }
+
+        map.set(styleId, info);
+    }
+
+    return map;
+}
+
+function parseRelationships(xml: string): Map<string, string> {
+    const map = new Map<string, string>();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(xml, "application/xml");
+
+    const rels = doc.getElementsByTagName("Relationship");
+    for (const rel of Array.from(rels)) {
+        const id = rel.getAttribute("Id");
+        const target = rel.getAttribute("Target");
+        const targetMode = rel.getAttribute("TargetMode");
+        if (id && target && targetMode === "External") {
+            map.set(id, target);
+        }
+    }
+
+    return map;
+}
+
+function parseDocumentPageStyle(xml: string): IDocumentStyle {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(xml, "application/xml");
+
+    // Default A4 dimensions in points
+    let width = 595.28;
+    let height = 841.89;
+    let marginTop = 72;
+    let marginBottom = 72;
+    let marginLeft = 72;
+    let marginRight = 72;
+
+    // Look for w:sectPr (section properties) — usually the last child of w:body
+    const sectPrs = doc.getElementsByTagNameNS(W_NS, "sectPr");
+    if (sectPrs.length > 0) {
+        const sectPr = sectPrs[sectPrs.length - 1]!;
+
+        const pgSz = sectPr.getElementsByTagNameNS(W_NS, "pgSz")[0];
+        if (pgSz) {
+            // OOXML uses twips (1/20 of a point)
+            const w = pgSz.getAttribute("w:w");
+            const h = pgSz.getAttribute("w:h");
+            if (w) width = parseInt(w, 10) / 20;
+            if (h) height = parseInt(h, 10) / 20;
+        }
+
+        const pgMar = sectPr.getElementsByTagNameNS(W_NS, "pgMar")[0];
+        if (pgMar) {
+            const top = pgMar.getAttribute("w:top");
+            const bottom = pgMar.getAttribute("w:bottom");
+            const left = pgMar.getAttribute("w:left");
+            const right = pgMar.getAttribute("w:right");
+            if (top) marginTop = parseInt(top, 10) / 20;
+            if (bottom) marginBottom = parseInt(bottom, 10) / 20;
+            if (left) marginLeft = parseInt(left, 10) / 20;
+            if (right) marginRight = parseInt(right, 10) / 20;
+        }
+    }
+
+    return {
+        pageSize: { width, height },
+        documentFlavor: DocumentFlavor.MODERN,
+        marginTop: Math.min(marginTop, 36),
+        marginBottom: Math.min(marginBottom, 36),
+        marginLeft: Math.min(marginLeft, 36),
+        marginRight: Math.min(marginRight, 36),
+    };
+}
+
+function processBody(
+    body: Element,
+    state: BuilderState,
+    styleMap: Map<string, StyleInfo>,
+    relsMap: Map<string, string>,
+    contentWidth: number,
+): void {
+    for (const child of Array.from(body.children)) {
+        const localName = child.localName;
+        if (localName === "p") {
+            processParagraph(child, state, styleMap, relsMap);
+        } else if (localName === "tbl") {
+            processTable(child, state, styleMap, relsMap, contentWidth);
+        }
+        // Skip w:sectPr and other non-content elements
+    }
+}
+
+function processParagraph(
+    pEl: Element,
+    state: BuilderState,
+    styleMap: Map<string, StyleInfo>,
+    relsMap: Map<string, string>,
+): void {
+    const pPr = getFirstChild(pEl, "pPr");
+    const paragraphStyle: IParagraphStyle = {};
+    let isListItem = false;
+    let listLevel = 0;
+    let listNumId = "0";
+    let resolvedStyleInfo: StyleInfo | undefined;
+
+    if (pPr) {
+        // Paragraph style reference
+        const pStyle = getFirstChild(pPr, "pStyle");
+        if (pStyle) {
+            const styleId = pStyle.getAttribute("w:val");
+            if (styleId) {
+                resolvedStyleInfo = styleMap.get(styleId);
+                if (resolvedStyleInfo?.headingLevel) {
+                    paragraphStyle.namedStyleType =
+                        resolvedStyleInfo.headingLevel;
+                }
+                // Also check directly against known heading IDs
+                const headingLevel = HEADING_STYLE_IDS[styleId];
+                if (headingLevel !== undefined) {
+                    paragraphStyle.namedStyleType = headingLevel;
+                }
+            }
+        }
+
+        // Paragraph-level run properties (w:rPr inside w:pPr) — these apply to all runs
+        const pRPr = getFirstChild(pPr, "rPr");
+        if (pRPr) {
+            const pRunProps = extractRunProperties(pRPr);
+            if (Object.keys(pRunProps).length > 0) {
+                if (!resolvedStyleInfo) {
+                    resolvedStyleInfo = {};
+                }
+                // Merge: style defaults < paragraph rPr
+                resolvedStyleInfo = {
+                    ...resolvedStyleInfo,
+                    defaultRunProps: {
+                        ...(resolvedStyleInfo.defaultRunProps ?? {}),
+                        ...pRunProps,
+                    },
+                };
+            }
+        }
+
+        // Alignment
+        const jc = getFirstChild(pPr, "jc");
+        if (jc) {
+            const align = jc.getAttribute("w:val");
+            if (align && ALIGNMENT_MAP[align] !== undefined) {
+                paragraphStyle.horizontalAlign = ALIGNMENT_MAP[align];
+            }
+        }
+
+        // Indentation
+        const ind = getFirstChild(pPr, "ind");
+        if (ind) {
+            const left = ind.getAttribute("w:left");
+            const firstLine = ind.getAttribute("w:firstLine");
+            const hanging = ind.getAttribute("w:hanging");
+            if (left) {
+                paragraphStyle.indentStart = {
+                    v: parseInt(left, 10) / 20,
+                    u: NumberUnitType.POINT,
+                };
+            }
+            if (firstLine) {
+                paragraphStyle.indentFirstLine = {
+                    v: parseInt(firstLine, 10) / 20,
+                    u: NumberUnitType.POINT,
+                };
+            }
+            if (hanging) {
+                paragraphStyle.hanging = {
+                    v: parseInt(hanging, 10) / 20,
+                    u: NumberUnitType.POINT,
+                };
+            }
+        }
+
+        // Spacing
+        const spacing = getFirstChild(pPr, "spacing");
+        if (spacing) {
+            const before = spacing.getAttribute("w:before");
+            const after = spacing.getAttribute("w:after");
+            const line = spacing.getAttribute("w:line");
+            if (before) {
+                paragraphStyle.spaceAbove = {
+                    v: parseInt(before, 10) / 20,
+                    u: NumberUnitType.POINT,
+                };
+            }
+            if (after) {
+                paragraphStyle.spaceBelow = {
+                    v: parseInt(after, 10) / 20,
+                    u: NumberUnitType.POINT,
+                };
+            }
+            if (line) {
+                // Line spacing in twips; 240 twips = single spacing
+                paragraphStyle.lineSpacing = parseInt(line, 10) / 240;
+            }
+        }
+
+        // List detection (w:numPr)
+        const numPr = getFirstChild(pPr, "numPr");
+        if (numPr) {
+            isListItem = true;
+            const ilvl = getFirstChild(numPr, "ilvl");
+            const numId = getFirstChild(numPr, "numId");
+            if (ilvl) {
+                listLevel = parseInt(ilvl.getAttribute("w:val") ?? "0", 10);
+            }
+            if (numId) {
+                listNumId = numId.getAttribute("w:val") ?? "0";
+            }
+        }
+    }
+
+    // Process runs within this paragraph
+    processRunsInParagraph(
+        pEl,
+        state,
+        styleMap,
+        relsMap,
+        paragraphStyle,
+        resolvedStyleInfo,
+    );
+
+    // Add paragraph marker
+    const entry: IParagraph = {
+        startIndex: state.dataStream.length,
+    };
+
+    if (Object.keys(paragraphStyle).length > 0) {
+        entry.paragraphStyle = paragraphStyle;
+    }
+
+    if (isListItem) {
+        const listKey = `list-${listNumId}`;
+
+        // Register list definition so Univer can resolve the bullet
+        if (!state.lists[listKey]) {
+            state.lists[listKey] = {
+                listType: listKey,
+                nestingLevel: Array.from({ length: 9 }, (_, level) => ({
+                    bulletAlignment: BulletAlignment.START,
+                    glyphFormat: "%0",
+                    startNumber: 1,
+                    glyphType: ListGlyphType.BULLET,
+                    glyphSymbol: "\u25CF",
+                    paragraphProperties: {
+                        indentStart: {
+                            v: 18 * (level + 1),
+                        },
+                    },
+                })),
+            };
+        }
+
+        entry.bullet = {
+            listType: listKey,
+            listId: listKey,
+            nestingLevel: listLevel,
+            textStyle: {},
+        };
+    }
+
+    state.paragraphs.push(entry);
+    state.dataStream += "\r";
+}
+
+function processRunsInParagraph(
+    pEl: Element,
+    state: BuilderState,
+    styleMap: Map<string, StyleInfo>,
+    relsMap: Map<string, string>,
+    paragraphStyle: IParagraphStyle,
+    paragraphStyleInfo?: StyleInfo,
+): void {
+    // Build inherited run defaults from paragraph style
+    const inheritedRunProps: ITextStyle = {};
+
+    // Apply style-level run properties (e.g., heading color/font from styles.xml)
+    if (paragraphStyleInfo?.defaultRunProps) {
+        Object.assign(inheritedRunProps, paragraphStyleInfo.defaultRunProps);
+    }
+
+    // Apply heading defaults (font size + bold)
+    const namedStyleType = paragraphStyle.namedStyleType;
+    const headingFontSize = namedStyleType
+        ? HEADING_FONT_SIZES[namedStyleType]
+        : undefined;
+    if (headingFontSize) {
+        if (!inheritedRunProps.fs) inheritedRunProps.fs = headingFontSize;
+        if (!inheritedRunProps.bl) inheritedRunProps.bl = BooleanNumber.TRUE;
+    }
+
+    for (const child of Array.from(pEl.children)) {
+        const localName = child.localName;
+
+        if (localName === "r") {
+            processRun(child, state, styleMap, inheritedRunProps);
+        } else if (localName === "hyperlink") {
+            processHyperlink(
+                child,
+                state,
+                styleMap,
+                relsMap,
+                inheritedRunProps,
+            );
+        }
+        // Skip w:pPr, w:bookmarkStart, etc.
+    }
+}
+
+function processRun(
+    rEl: Element,
+    state: BuilderState,
+    styleMap: Map<string, StyleInfo>,
+    inheritedRunProps: ITextStyle,
+): void {
+    const rPr = getFirstChild(rEl, "rPr");
+    const explicitStyle = rPr ? extractRunProperties(rPr) : {};
+
+    // Build final style: inherited defaults < rStyle defaults < explicit properties
+    const runStyle: ITextStyle = { ...inheritedRunProps };
+
+    // Merge rStyle reference defaults
+    if (rPr) {
+        const rStyle = getFirstChild(rPr, "rStyle");
+        if (rStyle) {
+            const styleId = rStyle.getAttribute("w:val");
+            if (styleId) {
+                const info = styleMap.get(styleId);
+                if (info?.defaultRunProps) {
+                    Object.assign(runStyle, info.defaultRunProps);
+                }
+            }
+        }
+    }
+
+    // Explicit properties always win
+    Object.assign(runStyle, explicitStyle);
+
+    for (const child of Array.from(rEl.children)) {
+        const localName = child.localName;
+
+        if (localName === "t") {
+            // Text content
+            const text = child.textContent ?? "";
+            if (text.length === 0) continue;
+
+            const st = state.dataStream.length;
+            state.dataStream += text;
+            const ed = state.dataStream.length;
+
+            if (Object.keys(runStyle).length > 0) {
+                state.textRuns.push({ st, ed, ts: { ...runStyle } });
+            }
+        } else if (localName === "br") {
+            // Break element
+            const type = child.getAttribute("w:type");
+            if (type === "page") {
+                // Page break: \f in Univer
+                state.dataStream += "\f";
+            } else {
+                // Line break within paragraph — just add newline text
+                state.dataStream += "\n";
+            }
+        } else if (localName === "tab") {
+            state.dataStream += "\t";
+        } else if (localName === "cr") {
+            // Carriage return
+            state.dataStream += "\n";
+        }
+    }
+}
+
+function processHyperlink(
+    hlEl: Element,
+    state: BuilderState,
+    styleMap: Map<string, StyleInfo>,
+    relsMap: Map<string, string>,
+    inheritedRunProps: ITextStyle,
+): void {
+    const rId = hlEl.getAttribute("r:id");
+    const url = rId ? relsMap.get(rId) : undefined;
+
+    const rangeStart = state.dataStream.length;
+
+    // Add custom range start marker
+    state.dataStream += "\x1F";
+    const contentStart = state.dataStream.length;
+
+    // Process child runs
+    for (const child of Array.from(hlEl.children)) {
+        if (child.localName === "r") {
+            processRun(child, state, styleMap, inheritedRunProps);
+        }
+    }
+
+    const contentEnd = state.dataStream.length;
+
+    // Add custom range end marker
+    state.dataStream += "\x1E";
+
+    if (url) {
+        state.customRanges.push({
+            startIndex: rangeStart,
+            endIndex: contentEnd,
+            rangeId: `link-${state.customRanges.length}`,
+            rangeType: CustomRangeType.HYPERLINK,
+            properties: { url },
+        });
+
+        // Style the hyperlink text (blue + underline)
+        if (contentStart < contentEnd) {
+            state.textRuns.push({
+                st: contentStart,
+                ed: contentEnd,
+                ts: {
+                    cl: { rgb: "#0563C1" },
+                    ul: { s: BooleanNumber.TRUE },
+                },
+            });
+        }
+    }
+}
+
+// OOXML border style → Univer DashStyleType
+const BORDER_DASH_MAP: Record<string, DashStyleType> = {
+    single: DashStyleType.SOLID,
+    thick: DashStyleType.SOLID,
+    double: DashStyleType.SOLID,
+    dotted: DashStyleType.DOT,
+    dashed: DashStyleType.DASH,
+    dashSmallGap: DashStyleType.DASH,
+    dotDash: DashStyleType.DASH,
+    dotDotDash: DashStyleType.DASH,
+    nil: DashStyleType.DASH_STYLE_UNSPECIFIED,
+    none: DashStyleType.DASH_STYLE_UNSPECIFIED,
+};
+
+// OOXML table alignment → Univer TableAlignmentType
+const TABLE_ALIGN_MAP: Record<string, TableAlignmentType> = {
+    start: TableAlignmentType.START,
+    left: TableAlignmentType.START,
+    center: TableAlignmentType.CENTER,
+    end: TableAlignmentType.END,
+    right: TableAlignmentType.END,
+};
+
+// OOXML vertical alignment → Univer VerticalAlignmentType
+const VALIGN_MAP: Record<string, VerticalAlignmentType> = {
+    top: VerticalAlignmentType.TOP,
+    center: VerticalAlignmentType.CENTER,
+    bottom: VerticalAlignmentType.BOTTOM,
+};
+
+function parseBorderElement(
+    borderEl: Element | null,
+): ITableCellBorder | undefined {
+    if (!borderEl) return undefined;
+    const val = borderEl.getAttribute("w:val");
+    if (!val || val === "nil" || val === "none") return undefined;
+
+    const color = borderEl.getAttribute("w:color");
+    const sz = borderEl.getAttribute("w:sz");
+    // w:sz is in eighth-points (1/8 pt)
+    const widthPt = sz ? parseInt(sz, 10) / 8 : 1;
+
+    return {
+        color: { rgb: color && color !== "auto" ? `#${color}` : "#000000" },
+        width: { v: widthPt },
+        dashStyle: BORDER_DASH_MAP[val] ?? DashStyleType.SOLID,
+    };
+}
+
+function parseCellMargin(
+    marginEl: Element | null,
+): ITableCellMargin | undefined {
+    if (!marginEl) return undefined;
+    const top = getFirstChild(marginEl, "top");
+    const bottom = getFirstChild(marginEl, "bottom");
+    const start =
+        getFirstChild(marginEl, "start") ?? getFirstChild(marginEl, "left");
+    const end =
+        getFirstChild(marginEl, "end") ?? getFirstChild(marginEl, "right");
+
+    const parse = (el: Element | null): INumberUnit => {
+        if (!el) return { v: 0 };
+        const w = el.getAttribute("w:w");
+        return { v: w ? parseInt(w, 10) / 20 : 0 };
+    };
+
+    return {
+        top: parse(top),
+        bottom: parse(bottom),
+        start: parse(start),
+        end: parse(end),
+    };
+}
+
+function processTable(
+    tblEl: Element,
+    state: BuilderState,
+    styleMap: Map<string, StyleInfo>,
+    relsMap: Map<string, string>,
+    contentWidth: number,
+): void {
+    const tableId = `table-${Object.keys(state.tableSource).length}`;
+    const rows = getDirectChildren(tblEl, "tr");
+    const tableRows: ITableRow[] = [];
+    const columnWidths: number[] = [];
+
+    // Parse table properties
+    const tblPr = getFirstChild(tblEl, "tblPr");
+
+    // Parse table grid for column widths
+    const tblGrid = getFirstChild(tblEl, "tblGrid");
+    if (tblGrid) {
+        for (const col of getDirectChildren(tblGrid, "gridCol")) {
+            const w = col.getAttribute("w:w");
+            columnWidths.push(w ? parseInt(w, 10) / 20 : 100);
+        }
+    }
+
+    // Parse table-level borders (used as defaults for cells)
+    const tblBorders = tblPr ? getFirstChild(tblPr, "tblBorders") : null;
+    const defaultBorders = tblBorders
+        ? {
+              top: parseBorderElement(getFirstChild(tblBorders, "top")),
+              bottom: parseBorderElement(getFirstChild(tblBorders, "bottom")),
+              left: parseBorderElement(getFirstChild(tblBorders, "left")),
+              right: parseBorderElement(getFirstChild(tblBorders, "right")),
+              insideH: parseBorderElement(getFirstChild(tblBorders, "insideH")),
+              insideV: parseBorderElement(getFirstChild(tblBorders, "insideV")),
+          }
+        : null;
+
+    // Parse table-level cell margin defaults
+    const tblCellMar = tblPr ? getFirstChild(tblPr, "tblCellMar") : null;
+    const defaultCellMargin = parseCellMargin(tblCellMar);
+
+    // Parse table alignment
+    const tblJc = tblPr ? getFirstChild(tblPr, "jc") : null;
+    const tableAlign =
+        TABLE_ALIGN_MAP[tblJc?.getAttribute("w:val") ?? ""] ??
+        TableAlignmentType.START;
+
+    // Parse explicit table width
+    const tblW = tblPr ? getFirstChild(tblPr, "tblW") : null;
+    const explicitTableWidth = tblW?.getAttribute("w:w");
+
+    const tableStartIndex = state.dataStream.length;
+    state.dataStream += TABLE_START;
+
+    const totalRows = rows.length;
+    for (let rowIdx = 0; rowIdx < totalRows; rowIdx++) {
+        const row = rows[rowIdx]!;
+        state.dataStream += TABLE_ROW_START;
+
+        const cells = getDirectChildren(row, "tc");
+        const totalCells = cells.length;
+        const rowCells: ITableCell[] = [];
+
+        for (let cellIdx = 0; cellIdx < totalCells; cellIdx++) {
+            const cell = cells[cellIdx]!;
+            state.dataStream += TABLE_CELL_START;
+
+            const cellDef: ITableCell = {};
+
+            // Parse cell properties
+            const tcPr = getFirstChild(cell, "tcPr");
+            if (tcPr) {
+                // Cell width
+                const tcW = getFirstChild(tcPr, "tcW");
+                if (tcW) {
+                    const w = tcW.getAttribute("w:w");
+                    if (w) {
+                        cellDef.size = {
+                            type: TableSizeType.SPECIFIED,
+                            width: { v: parseInt(w, 10) / 20 },
+                        };
+                    }
+                }
+
+                // Column span
+                const gridSpan = getFirstChild(tcPr, "gridSpan");
+                if (gridSpan) {
+                    const span = parseInt(
+                        gridSpan.getAttribute("w:val") ?? "1",
+                        10,
+                    );
+                    if (span > 1) cellDef.columnSpan = span;
+                }
+
+                // Row span (vMerge)
+                const vMerge = getFirstChild(tcPr, "vMerge");
+                if (vMerge) {
+                    const mergeVal = vMerge.getAttribute("w:val");
+                    if (mergeVal === "restart") {
+                        // Count how many rows this spans
+                        let spanCount = 1;
+                        for (let ri = rowIdx + 1; ri < totalRows; ri++) {
+                            const nextCells = getDirectChildren(
+                                rows[ri]!,
+                                "tc",
+                            );
+                            if (cellIdx < nextCells.length) {
+                                const nextTcPr = getFirstChild(
+                                    nextCells[cellIdx]!,
+                                    "tcPr",
+                                );
+                                const nextVMerge = nextTcPr
+                                    ? getFirstChild(nextTcPr, "vMerge")
+                                    : null;
+                                if (
+                                    nextVMerge &&
+                                    nextVMerge.getAttribute("w:val") !==
+                                        "restart"
+                                ) {
+                                    spanCount++;
+                                } else {
+                                    break;
+                                }
+                            }
+                        }
+                        if (spanCount > 1) cellDef.rowSpan = spanCount;
+                    }
+                }
+
+                // Cell borders (override table-level defaults)
+                const tcBorders = getFirstChild(tcPr, "tcBorders");
+                const cellBorderTop =
+                    parseBorderElement(
+                        tcBorders ? getFirstChild(tcBorders, "top") : null,
+                    ) ??
+                    (rowIdx === 0
+                        ? defaultBorders?.top
+                        : defaultBorders?.insideH);
+                const cellBorderBottom =
+                    parseBorderElement(
+                        tcBorders ? getFirstChild(tcBorders, "bottom") : null,
+                    ) ??
+                    (rowIdx === totalRows - 1
+                        ? defaultBorders?.bottom
+                        : defaultBorders?.insideH);
+                const cellBorderLeft =
+                    parseBorderElement(
+                        tcBorders ? getFirstChild(tcBorders, "left") : null,
+                    ) ??
+                    (cellIdx === 0
+                        ? defaultBorders?.left
+                        : defaultBorders?.insideV);
+                const cellBorderRight =
+                    parseBorderElement(
+                        tcBorders ? getFirstChild(tcBorders, "right") : null,
+                    ) ??
+                    (cellIdx === totalCells - 1
+                        ? defaultBorders?.right
+                        : defaultBorders?.insideV);
+
+                if (cellBorderTop) cellDef.borderTop = cellBorderTop;
+                if (cellBorderBottom) cellDef.borderBottom = cellBorderBottom;
+                if (cellBorderLeft) cellDef.borderLeft = cellBorderLeft;
+                if (cellBorderRight) cellDef.borderRight = cellBorderRight;
+
+                // Cell background color
+                const shd = getFirstChild(tcPr, "shd");
+                if (shd) {
+                    const fill = shd.getAttribute("w:fill");
+                    if (fill && fill !== "auto") {
+                        cellDef.backgroundColor = { rgb: `#${fill}` };
+                    }
+                }
+
+                // Cell vertical alignment
+                const vAlignEl = getFirstChild(tcPr, "vAlign");
+                if (vAlignEl) {
+                    const va = VALIGN_MAP[vAlignEl.getAttribute("w:val") ?? ""];
+                    if (va !== undefined) cellDef.vAlign = va;
+                }
+
+                // Cell margins (override table defaults)
+                const tcMar = getFirstChild(tcPr, "tcMar");
+                const margin = parseCellMargin(tcMar) ?? defaultCellMargin;
+                if (margin) cellDef.margin = margin;
+            } else if (defaultCellMargin) {
+                cellDef.margin = defaultCellMargin;
+            }
+
+            // Apply table-level default borders if cell has no tcPr
+            if (!tcPr && defaultBorders) {
+                const bt =
+                    rowIdx === 0 ? defaultBorders.top : defaultBorders.insideH;
+                const bb =
+                    rowIdx === totalRows - 1
+                        ? defaultBorders.bottom
+                        : defaultBorders.insideH;
+                const bl =
+                    cellIdx === 0
+                        ? defaultBorders.left
+                        : defaultBorders.insideV;
+                const br =
+                    cellIdx === totalCells - 1
+                        ? defaultBorders.right
+                        : defaultBorders.insideV;
+                if (bt) cellDef.borderTop = bt;
+                if (bb) cellDef.borderBottom = bb;
+                if (bl) cellDef.borderLeft = bl;
+                if (br) cellDef.borderRight = br;
+            }
+
+            // Process cell content — each cell must have at least one paragraph (\r)
+            const cellParagraphs = getDirectChildren(cell, "p");
+            if (cellParagraphs.length > 0) {
+                for (const p of cellParagraphs) {
+                    processParagraph(p, state, styleMap, relsMap);
+                }
+            } else {
+                // Empty cell still needs a paragraph marker
+                state.paragraphs.push({ startIndex: state.dataStream.length });
+                state.dataStream += "\r";
+            }
+
+            rowCells.push(cellDef);
+            // Each cell must end with a section break before CELL_END
+            // so that the parser can attach paragraphs to the cell node
+            state.dataStream += "\n";
+            state.dataStream += TABLE_CELL_END;
+        }
+
+        // Parse row height
+        const trPr = getFirstChild(row, "trPr");
+        const trHeight = trPr ? getFirstChild(trPr, "trHeight") : null;
+        const rowHeightVal = trHeight?.getAttribute("w:val");
+        const rowHeight = rowHeightVal ? parseInt(rowHeightVal, 10) / 20 : 20;
+        const hRuleVal = trHeight?.getAttribute("w:hRule");
+        const hRule: TableRowHeightRule =
+            hRuleVal === "exact"
+                ? TableRowHeightRule.EXACT
+                : hRuleVal === "atLeast"
+                  ? TableRowHeightRule.AT_LEAST
+                  : TableRowHeightRule.AUTO;
+
+        tableRows.push({
+            tableCells: rowCells,
+            trHeight: { val: { v: rowHeight }, hRule },
+            isFirstRow: rowIdx === 0 ? BooleanNumber.TRUE : BooleanNumber.FALSE,
+        });
+
+        state.dataStream += TABLE_ROW_END;
+    }
+
+    state.dataStream += TABLE_END;
+    const tableEndIndex = state.dataStream.length;
+
+    // Build column definitions, scaling to fill content width
+    const numCols =
+        columnWidths.length > 0
+            ? columnWidths.length
+            : rows[0]
+              ? getDirectChildren(rows[0], "tc").length
+              : 1;
+
+    // Determine target table width
+    const tblWType = tblW?.getAttribute("w:type");
+    let targetWidth: number;
+    if (explicitTableWidth && tblWType === "dxa") {
+        targetWidth = parseInt(explicitTableWidth, 10) / 20;
+    } else if (explicitTableWidth && tblWType === "pct") {
+        // Percentage of page width (value is in 1/50ths of a percent)
+        targetWidth = (parseInt(explicitTableWidth, 10) / 5000) * contentWidth;
+    } else {
+        // Auto or unspecified — use content width
+        targetWidth = contentWidth;
+    }
+
+    const rawTotal = columnWidths.reduce((s, w) => s + w, 0);
+    const scale = rawTotal > 0 ? targetWidth / rawTotal : 1;
+
+    const tableColumns: ITableColumn[] = [];
+    for (let i = 0; i < numCols; i++) {
+        const raw = columnWidths[i] ?? targetWidth / numCols;
+        tableColumns.push({
+            size: { type: TableSizeType.SPECIFIED, width: { v: raw * scale } },
+        });
+    }
+
+    const totalWidth = targetWidth;
+
+    // Scale cell widths to match column scaling
+    if (scale !== 1) {
+        for (const row of tableRows) {
+            for (const cell of row.tableCells) {
+                if (cell.size) {
+                    cell.size.width.v *= scale;
+                }
+            }
+        }
+    }
+
+    const tableDef: ITable = {
+        tableId,
+        tableRows,
+        tableColumns,
+        align: tableAlign,
+        indent: { v: 0 },
+        textWrap: TableTextWrapType.NONE,
+        position: {
+            positionH: { relativeFrom: ObjectRelativeFromH.PAGE },
+            positionV: { relativeFrom: ObjectRelativeFromV.PAGE },
+        },
+        dist: { distT: 0, distB: 0, distL: 0, distR: 0 },
+        size: { type: TableSizeType.SPECIFIED, width: { v: totalWidth } },
+        layout: TableLayoutType.FIXED,
+    };
+
+    if (defaultCellMargin) {
+        tableDef.cellMargin = defaultCellMargin;
+    }
+
+    // Parse table indent
+    const tblInd = tblPr ? getFirstChild(tblPr, "tblInd") : null;
+    if (tblInd) {
+        const indW = tblInd.getAttribute("w:w");
+        if (indW) tableDef.indent = { v: parseInt(indW, 10) / 20 };
+    }
+
+    state.tableSource[tableId] = tableDef;
+
+    // The Univer parser registers tables on the \r AFTER TABLE_END.
+    // It matches body.tables entries where endIndex === table_node.endIndex + 1.
+    // Add a paragraph after the table for proper registration.
+    state.paragraphs.push({ startIndex: state.dataStream.length });
+    state.dataStream += "\r";
+
+    state.tables.push({
+        startIndex: tableStartIndex,
+        endIndex: tableEndIndex,
+        tableId,
+    });
+}
+
+function getDirectChildren(parent: Element, localName: string): Element[] {
+    const result: Element[] = [];
+    for (const child of Array.from(parent.children)) {
+        if (child.localName === localName) {
+            result.push(child);
+        }
+    }
+    return result;
+}
+
+/**
+ * Extract Univer ITextStyle properties from a w:rPr element.
+ */
+function extractRunProperties(rPr: Element): ITextStyle {
+    const style: ITextStyle = {};
+
+    // Bold: w:b or w:bCs
+    if (hasToggleProperty(rPr, "b")) {
+        style.bl = BooleanNumber.TRUE;
+    }
+
+    // Italic: w:i or w:iCs
+    if (hasToggleProperty(rPr, "i")) {
+        style.it = BooleanNumber.TRUE;
+    }
+
+    // Underline: w:u
+    const u = getFirstChild(rPr, "u");
+    if (u) {
+        const val = u.getAttribute("w:val");
+        if (val && val !== "none") {
+            style.ul = { s: BooleanNumber.TRUE };
+        }
+    }
+
+    // Strikethrough: w:strike
+    if (hasToggleProperty(rPr, "strike")) {
+        style.st = { s: BooleanNumber.TRUE };
+    }
+
+    // Font size: w:sz (in half-points)
+    const sz = getFirstChild(rPr, "sz");
+    if (sz) {
+        const val = sz.getAttribute("w:val");
+        if (val) {
+            style.fs = parseInt(val, 10) / 2; // Convert half-points to points
+        }
+    }
+
+    // Font family: w:rFonts
+    const rFonts = getFirstChild(rPr, "rFonts");
+    if (rFonts) {
+        const ff =
+            rFonts.getAttribute("w:ascii") ??
+            rFonts.getAttribute("w:hAnsi") ??
+            rFonts.getAttribute("w:cs");
+        if (ff) {
+            style.ff = FONT_MAP[ff] ?? ff;
+        }
+    }
+
+    // Font color: w:color
+    const color = getFirstChild(rPr, "color");
+    if (color) {
+        const val = color.getAttribute("w:val");
+        if (val && val !== "auto") {
+            style.cl = { rgb: `#${val}` };
+        }
+    }
+
+    // Superscript/subscript: w:vertAlign
+    const vertAlign = getFirstChild(rPr, "vertAlign");
+    if (vertAlign) {
+        const val = vertAlign.getAttribute("w:val");
+        if (val === "superscript") {
+            style.va = BaselineOffset.SUPERSCRIPT;
+        } else if (val === "subscript") {
+            style.va = BaselineOffset.SUBSCRIPT;
+        }
+    }
+
+    // Highlight/background color: w:highlight or w:shd
+    const highlight = getFirstChild(rPr, "highlight");
+    if (highlight) {
+        const val = highlight.getAttribute("w:val");
+        if (val && val !== "none") {
+            const highlightColor = HIGHLIGHT_COLORS[val];
+            if (highlightColor) {
+                style.bg = { rgb: highlightColor };
+            }
+        }
+    }
+
+    return style;
+}
+
+// Common highlight color names → hex values
+const HIGHLIGHT_COLORS: Record<string, string> = {
+    yellow: "#FFFF00",
+    green: "#00FF00",
+    cyan: "#00FFFF",
+    magenta: "#FF00FF",
+    blue: "#0000FF",
+    red: "#FF0000",
+    darkBlue: "#00008B",
+    darkCyan: "#008B8B",
+    darkGreen: "#006400",
+    darkMagenta: "#8B008B",
+    darkRed: "#8B0000",
+    darkYellow: "#808000",
+    darkGray: "#A9A9A9",
+    lightGray: "#D3D3D3",
+    black: "#000000",
+    white: "#FFFFFF",
+};
+
+/**
+ * Check if a toggle property (like w:b, w:i, w:strike) is enabled.
+ * In OOXML, presence of the element means true unless w:val="false" or w:val="0".
+ */
+function hasToggleProperty(parent: Element, name: string): boolean {
+    const el = getFirstChild(parent, name);
+    if (!el) return false;
+    const val = el.getAttribute("w:val");
+    return val !== "false" && val !== "0";
+}
+
+/**
+ * Get the first child element with the given local name in the w: namespace.
+ */
+function getFirstChild(parent: Element, localName: string): Element | null {
+    for (const child of Array.from(parent.children)) {
+        if (child.localName === localName) {
+            return child;
+        }
+    }
+    return null;
+}

--- a/crates/openwave-desktop/ui/src/document/sheetjs-to-univer.ts
+++ b/crates/openwave-desktop/ui/src/document/sheetjs-to-univer.ts
@@ -1,0 +1,510 @@
+import type {
+    ICellData,
+    IWorkbookData,
+    IWorksheetData,
+    IStyleData,
+    IColumnData,
+    IRowData,
+    IRange,
+} from "@univerjs/presets";
+import {
+    BooleanNumber,
+    BorderStyleTypes,
+    CellValueType,
+    HorizontalAlign,
+    LocaleType,
+    VerticalAlign,
+    WrapStrategy,
+} from "@univerjs/presets";
+import type { WorkBook, WorkSheet } from "xlsx";
+import * as XLSX from "xlsx";
+
+import type {
+    ParsedBorderSide,
+    ParsedCellStyle,
+    ParsedFreezePane,
+    XlsxCellStyleMap,
+} from "./xlsx-styles-parser";
+
+// ── Style mapping helpers ────────────────────────────────────────────────────
+
+function mapHorizontalAlign(align: string): HorizontalAlign | undefined {
+    switch (align) {
+        case "left":
+            return HorizontalAlign.LEFT;
+        case "center":
+        case "centerContinuous":
+            return HorizontalAlign.CENTER;
+        case "right":
+            return HorizontalAlign.RIGHT;
+        case "justify":
+        case "distributed":
+            return HorizontalAlign.JUSTIFIED;
+        default:
+            return undefined;
+    }
+}
+
+function mapVerticalAlign(align: string): VerticalAlign | undefined {
+    switch (align) {
+        case "top":
+            return VerticalAlign.TOP;
+        case "center":
+            return VerticalAlign.MIDDLE;
+        case "bottom":
+            return VerticalAlign.BOTTOM;
+        default:
+            return undefined;
+    }
+}
+
+// Map common non-web-safe fonts to their closest web-safe equivalents so
+// the canvas renders the right family even when the original font isn't
+// installed (e.g. Calibri isn't available on macOS).
+const FONT_SUBSTITUTIONS: Record<string, string> = {
+    calibri: "Arial",
+    cambria: "Georgia",
+    "calibri light": "Arial",
+    "cambria math": "Georgia",
+    consolas: "Courier New",
+    candara: "Trebuchet MS",
+    constantia: "Palatino Linotype",
+    corbel: "Verdana",
+};
+
+/** Resolve a font name to a web-safe equivalent when necessary */
+function resolveFont(name: string): string {
+    return FONT_SUBSTITUTIONS[name.toLowerCase()] ?? name;
+}
+
+const OOXML_BORDER_STYLE_MAP: Record<string, BorderStyleTypes> = {
+    thin: BorderStyleTypes.THIN,
+    hair: BorderStyleTypes.HAIR,
+    dotted: BorderStyleTypes.DOTTED,
+    dashed: BorderStyleTypes.DASHED,
+    dashDot: BorderStyleTypes.DASH_DOT,
+    dashDotDot: BorderStyleTypes.DASH_DOT_DOT,
+    double: BorderStyleTypes.DOUBLE,
+    medium: BorderStyleTypes.MEDIUM,
+    mediumDashed: BorderStyleTypes.MEDIUM_DASHED,
+    mediumDashDot: BorderStyleTypes.MEDIUM_DASH_DOT,
+    mediumDashDotDot: BorderStyleTypes.MEDIUM_DASH_DOT_DOT,
+    slantDashDot: BorderStyleTypes.SLANT_DASH_DOT,
+    thick: BorderStyleTypes.THICK,
+};
+
+function mapBorderSide(
+    side: ParsedBorderSide | undefined,
+): { s: BorderStyleTypes; cl: { rgb: string } } | undefined {
+    if (!side) return undefined;
+    const s = OOXML_BORDER_STYLE_MAP[side.style];
+    if (s === undefined) return undefined;
+    return {
+        s,
+        cl: { rgb: side.color ? `#${side.color}` : "#000000" },
+    };
+}
+
+/**
+ * Converts a SheetJS WorkBook to Univer IWorkbookData format.
+ * Optionally accepts font styles extracted directly from XLSX XML
+ * (bypassing SheetJS CE's limited style support).
+ */
+export function sheetjsToUniver(
+    workbook: WorkBook,
+    fontStyles?: XlsxCellStyleMap,
+    freezePanes?: Map<string, ParsedFreezePane>,
+): IWorkbookData {
+    const styles: Record<string, IStyleData> = {};
+    let styleCounter = 0;
+    const styleCache = new Map<string, string>();
+
+    function getOrCreateStyleId(style: IStyleData): string {
+        const key = JSON.stringify(style);
+        const existing = styleCache.get(key);
+        if (existing) return existing;
+        const id = `s${styleCounter++}`;
+        styles[id] = style;
+        styleCache.set(key, id);
+        return id;
+    }
+
+    // Build a default style from the workbook's default font (font index 0)
+    let defaultStyleId: string | undefined;
+    const defaultFont = fontStyles?.defaultFont;
+    if (defaultFont) {
+        const defaultStyle: IStyleData = {};
+        if (defaultFont.size) defaultStyle.fs = defaultFont.size;
+        if (defaultFont.name) defaultStyle.ff = resolveFont(defaultFont.name);
+        if (defaultFont.bold) defaultStyle.bl = BooleanNumber.TRUE;
+        if (defaultFont.italic) defaultStyle.it = BooleanNumber.TRUE;
+        if (Object.keys(defaultStyle).length > 0) {
+            defaultStyleId = getOrCreateStyleId(defaultStyle);
+        }
+    }
+
+    const sheets: Record<string, Partial<IWorksheetData>> = {};
+    const sheetOrder: string[] = [];
+
+    for (const sheetName of workbook.SheetNames) {
+        const worksheet = workbook.Sheets[sheetName];
+        if (!worksheet) continue;
+
+        const sheetId = `sheet-${sheetOrder.length}`;
+        sheetOrder.push(sheetId);
+
+        const sheetFontStyles = fontStyles?.get(sheetName);
+        const freezePane = freezePanes?.get(sheetName);
+
+        sheets[sheetId] = convertSheet(
+            worksheet,
+            sheetName,
+            sheetId,
+            getOrCreateStyleId,
+            sheetFontStyles,
+            defaultStyleId,
+            defaultFont,
+            freezePane,
+        );
+    }
+
+    return {
+        id: "workbook-1",
+        name: workbook.Props?.Title ?? "Workbook",
+        appVersion: "1.0.0",
+        locale: LocaleType.EN_US,
+        styles,
+        sheetOrder,
+        sheets,
+    };
+}
+
+function convertSheet(
+    ws: WorkSheet,
+    name: string,
+    id: string,
+    getOrCreateStyleId: (style: IStyleData) => string,
+    sheetFontStyles?: Map<string, ParsedCellStyle>,
+    defaultStyleId?: string,
+    defaultFont?: ParsedCellStyle,
+    freezePane?: ParsedFreezePane,
+): Partial<IWorksheetData> {
+    const refString = ws["!ref"] || "A1";
+    const range = XLSX.utils.decode_range(refString);
+
+    const rowCount = range.e.r + 1;
+    const columnCount = range.e.c + 1;
+
+    // Convert cells
+    const cellData: Record<number, Record<number, ICellData>> = {};
+
+    const cellAddresses = Object.keys(ws).filter((k) => !k.startsWith("!"));
+    for (const addr of cellAddresses) {
+        const cell = ws[addr];
+        if (!cell) continue;
+
+        const { r, c } = XLSX.utils.decode_cell(addr);
+        if (!cellData[r]) cellData[r] = {};
+
+        const univerCell: ICellData = {};
+
+        // Value
+        if (cell.v !== undefined && cell.v !== null) {
+            univerCell.v = cell.v;
+        }
+
+        // Type
+        if (cell.t === "n") {
+            univerCell.t = CellValueType.NUMBER;
+        } else if (cell.t === "b") {
+            univerCell.t = CellValueType.BOOLEAN;
+        } else if (cell.t === "s" || cell.t === "z") {
+            univerCell.t = CellValueType.STRING;
+        }
+
+        // Formula
+        if (cell.f) {
+            univerCell.f = `=${cell.f}`;
+        }
+
+        // Style — combine SheetJS numfmt with custom-parsed style data
+        const numFmt = cell.z;
+        const fontData = sheetFontStyles?.get(addr);
+
+        const style: IStyleData = {};
+        let hasStyle = false;
+
+        // Number format (from SheetJS)
+        if (numFmt && numFmt !== "General") {
+            style.n = { pattern: numFmt };
+            hasStyle = true;
+        }
+
+        // Custom-parsed cell styles (fills, borders, alignment, fonts)
+        if (fontData) {
+            // Background fill color
+            if (fontData.bg) {
+                style.bg = { rgb: `#${fontData.bg}` };
+                hasStyle = true;
+            }
+
+            // Font properties
+            if (fontData.color) {
+                style.cl = { rgb: `#${fontData.color}` };
+                hasStyle = true;
+            }
+            if (fontData.bold) {
+                style.bl = BooleanNumber.TRUE;
+                hasStyle = true;
+            }
+            if (fontData.italic) {
+                style.it = BooleanNumber.TRUE;
+                hasStyle = true;
+            }
+            if (fontData.size) {
+                style.fs = fontData.size;
+                hasStyle = true;
+            }
+            if (fontData.name) {
+                style.ff = resolveFont(fontData.name);
+                hasStyle = true;
+            }
+            if (fontData.underline) {
+                style.ul = { s: BooleanNumber.TRUE };
+                hasStyle = true;
+            }
+            if (fontData.strike) {
+                style.st = { s: BooleanNumber.TRUE };
+                hasStyle = true;
+            }
+
+            // Borders
+            const bl = mapBorderSide(fontData.borderLeft);
+            const br = mapBorderSide(fontData.borderRight);
+            const bt = mapBorderSide(fontData.borderTop);
+            const bb = mapBorderSide(fontData.borderBottom);
+            if (bl || br || bt || bb) {
+                style.bd = {};
+                if (bt) style.bd.t = bt;
+                if (bb) style.bd.b = bb;
+                if (bl) style.bd.l = bl;
+                if (br) style.bd.r = br;
+                hasStyle = true;
+            }
+
+            // Alignment
+            if (fontData.horizontalAlign) {
+                const ht = mapHorizontalAlign(fontData.horizontalAlign);
+                if (ht !== undefined) {
+                    style.ht = ht;
+                    hasStyle = true;
+                }
+            }
+            if (fontData.verticalAlign) {
+                const vt = mapVerticalAlign(fontData.verticalAlign);
+                if (vt !== undefined) {
+                    style.vt = vt;
+                    hasStyle = true;
+                }
+            }
+
+            // Text wrapping
+            if (fontData.wrapText) {
+                style.tb = WrapStrategy.WRAP;
+                hasStyle = true;
+            }
+            if (fontData.textRotation !== undefined || fontData.verticalText) {
+                style.tr = {
+                    a: fontData.textRotation ?? 0,
+                    ...(fontData.verticalText ? { v: BooleanNumber.TRUE } : {}),
+                };
+                hasStyle = true;
+            }
+        }
+
+        // Fill in workbook default font properties wherever the cell-level
+        // style didn't set them. Cells with fontId 0 that have fills/borders
+        // produce a fontData entry but no font properties — without this
+        // fallback those cells would get Univer's built-in serif default.
+        if (defaultFont) {
+            if (!style.bl && defaultFont.bold) {
+                style.bl = BooleanNumber.TRUE;
+                hasStyle = true;
+            }
+            if (!style.it && defaultFont.italic) {
+                style.it = BooleanNumber.TRUE;
+                hasStyle = true;
+            }
+            if (!style.fs && defaultFont.size) {
+                style.fs = defaultFont.size;
+                hasStyle = true;
+            }
+            if (!style.ff && defaultFont.name) {
+                style.ff = resolveFont(defaultFont.name);
+                hasStyle = true;
+            }
+        }
+
+        // Fall back to SheetJS bg color if custom parser didn't find one
+        if (!fontData?.bg) {
+            const bgColor = cell.s?.fill?.fgColor?.rgb || cell.s?.fgColor?.rgb;
+            if (bgColor) {
+                style.bg = { rgb: `#${bgColor}` };
+                hasStyle = true;
+            }
+        }
+
+        if (hasStyle) {
+            univerCell.s = getOrCreateStyleId(style);
+        }
+
+        cellData[r][c] = univerCell;
+    }
+
+    // Merged cells
+    const mergeData: IRange[] = (ws["!merges"] ?? []).map((m: XLSX.Range) => ({
+        startRow: m.s.r,
+        startColumn: m.s.c,
+        endRow: m.e.r,
+        endColumn: m.e.c,
+    }));
+
+    // Row data (hidden state + explicit heights)
+    const rowData: Record<number, Partial<IRowData>> = {};
+    if (ws["!rows"]) {
+        ws["!rows"].forEach((row: XLSX.RowInfo, idx: number) => {
+            if (!row) return;
+            const data: Partial<IRowData> = {};
+            if (row.hidden) data.hd = BooleanNumber.TRUE;
+            const height = row.hpx ?? (row.hpt ? row.hpt * 1.33 : undefined);
+            if (height) data.h = height * 1.2;
+            if (Object.keys(data).length > 0) rowData[idx] = data;
+        });
+    }
+
+    // Column data (widths — scaled by 1.3x because SheetJS
+    // character-unit-to-pixel conversion underestimates vs. Excel)
+    const columnData: Record<number, Partial<IColumnData>> = {};
+    if (ws["!cols"]) {
+        ws["!cols"].forEach((col: XLSX.ColInfo, idx: number) => {
+            if (!col) return;
+            const data: Partial<IColumnData> = {};
+            if (col.wpx) data.w = col.wpx * 1.3;
+            else if (col.wch) data.w = col.wch * 9.1;
+            if (col.hidden) data.hd = BooleanNumber.TRUE;
+            if (Object.keys(data).length > 0) columnData[idx] = data;
+        });
+    }
+
+    const sheetData: Partial<IWorksheetData> = {
+        id,
+        name,
+        tabColor: "",
+        hidden: BooleanNumber.FALSE,
+        freeze: freezePane
+            ? {
+                  xSplit: freezePane.xSplit,
+                  ySplit: freezePane.ySplit,
+                  startRow: freezePane.ySplit > 0 ? freezePane.ySplit : -1,
+                  startColumn: freezePane.xSplit > 0 ? freezePane.xSplit : -1,
+              }
+            : { xSplit: 0, ySplit: 0, startRow: -1, startColumn: -1 },
+        rowCount: Math.max(rowCount, 100),
+        columnCount: Math.max(columnCount, 26),
+        defaultColumnWidth: 88,
+        defaultRowHeight: 24,
+        mergeData,
+        cellData,
+        rowData,
+        columnData,
+        rowHeader: { width: 46 },
+        columnHeader: { height: 20 },
+        showGridlines: BooleanNumber.TRUE,
+        rightToLeft: BooleanNumber.FALSE,
+        zoomRatio: 1,
+        scrollTop: 0,
+        scrollLeft: 0,
+    };
+
+    if (defaultStyleId) {
+        sheetData.defaultStyle = defaultStyleId;
+    }
+
+    return sheetData;
+}
+
+/**
+ * Converts Univer workbook data back to a SheetJS WorkBook for export.
+ */
+export function univerToSheetjs(workbookData: IWorkbookData): WorkBook {
+    const wb = XLSX.utils.book_new();
+
+    for (const sheetId of workbookData.sheetOrder) {
+        const sheetData = workbookData.sheets[sheetId];
+        if (!sheetData) continue;
+
+        const ws: WorkSheet = {};
+        const cellMatrix = sheetData.cellData;
+
+        let maxRow = 0;
+        let maxCol = 0;
+
+        if (cellMatrix) {
+            for (const rowStr of Object.keys(cellMatrix)) {
+                const r = Number(rowStr);
+                const row = cellMatrix[r];
+                if (!row) continue;
+                for (const colStr of Object.keys(row)) {
+                    const c = Number(colStr);
+                    const cell = row[c];
+                    if (!cell) continue;
+
+                    maxRow = Math.max(maxRow, r);
+                    maxCol = Math.max(maxCol, c);
+
+                    const addr = XLSX.utils.encode_cell({ r, c });
+                    const sheetCell: XLSX.CellObject = {
+                        v: cell.v ?? "",
+                        t:
+                            cell.t === CellValueType.NUMBER
+                                ? "n"
+                                : cell.t === CellValueType.BOOLEAN
+                                  ? "b"
+                                  : "s",
+                    };
+
+                    if (cell.f) {
+                        // Strip leading = since SheetJS stores without it
+                        sheetCell.f = cell.f.startsWith("=")
+                            ? cell.f.slice(1)
+                            : cell.f;
+                    }
+
+                    ws[addr] = sheetCell;
+                }
+            }
+        }
+
+        ws["!ref"] = XLSX.utils.encode_range({
+            s: { r: 0, c: 0 },
+            e: { r: maxRow, c: maxCol },
+        });
+
+        // Merged cells
+        if (sheetData.mergeData && sheetData.mergeData.length > 0) {
+            ws["!merges"] = sheetData.mergeData.map((m) => ({
+                s: { r: m.startRow, c: m.startColumn },
+                e: { r: m.endRow, c: m.endColumn },
+            }));
+        }
+
+        XLSX.utils.book_append_sheet(
+            wb,
+            ws,
+            sheetData.name ??
+                `Sheet${workbookData.sheetOrder.indexOf(sheetId) + 1}`,
+        );
+    }
+
+    return wb;
+}

--- a/crates/openwave-desktop/ui/src/document/spreadsheet.ts
+++ b/crates/openwave-desktop/ui/src/document/spreadsheet.ts
@@ -1,0 +1,106 @@
+/**
+ * Represents a range of merged cells in a spreadsheet.
+ * Coordinates are 0-indexed (row 0 is Excel row 1, col 0 is Excel column A).
+ */
+export interface MergedCellRange {
+    start: { row: number; col: number };
+    end: { row: number; col: number };
+}
+
+/**
+ * Determines if a hex color is dark using perceived brightness calculation.
+ * Uses the weighted RGB formula that accounts for human perception.
+ *
+ * @param hexColor - Hex color string (with or without #, e.g., "FF0000" or "#FF0000")
+ * @returns true if the color is dark (white text should be used), false if light (black text should be used)
+ *
+ * @example
+ * isColorDark("000000") // true - black background, use white text
+ * isColorDark("FFFFFF") // false - white background, use black text
+ * isColorDark("0066CC") // true - dark blue background, use white text
+ * isColorDark("FFA500") // false - orange background, use black text
+ * isColorDark("228B22") // true - forest green background, use white text
+ */
+export function isColorDark(hexColor: string): boolean {
+    // Remove # if present
+    let hex = hexColor.replace("#", "");
+
+    // Handle 3-digit hex colors (e.g., "F00" -> "FF0000")
+    if (hex.length === 3) {
+        hex = hex
+            .split("")
+            .map((char) => char + char)
+            .join("");
+    }
+
+    // Validate hex color (should be 6 or 8 characters)
+    if (hex.length !== 6 && hex.length !== 8) {
+        console.warn(
+            `[isColorDark] Invalid hex color: ${hexColor}, defaulting to light`,
+        );
+        return false; // Default to light (black text)
+    }
+
+    // Parse RGB values (ignore alpha channel if present)
+    const r = parseInt(hex.substring(0, 2), 16);
+    const g = parseInt(hex.substring(2, 4), 16);
+    const b = parseInt(hex.substring(4, 6), 16);
+
+    // Validate parsed values
+    if (isNaN(r) || isNaN(g) || isNaN(b)) {
+        console.warn(
+            `[isColorDark] Failed to parse hex color: ${hexColor}, defaulting to light`,
+        );
+        return false;
+    }
+
+    // Calculate perceived brightness using weighted RGB formula
+    // This accounts for human eye sensitivity (more sensitive to green, less to blue)
+    // Formula: (R × 299 + G × 587 + B × 114) / 1000
+    const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+
+    // If brightness < 128 (out of 255), it's dark
+    return brightness < 128;
+}
+
+/**
+ * Gets the appropriate text color (white or black) for a given background color.
+ *
+ * @param hexColor - Hex color string (with or without #)
+ * @returns "#FFFFFF" for dark backgrounds, "#000000" for light backgrounds
+ */
+export function getContrastTextColor(hexColor: string): string {
+    return isColorDark(hexColor) ? "#FFFFFF" : "#000000";
+}
+
+/** Parse an Excel cell address (e.g. "A1", "B5", "AA10") into 0-based row/col indices. */
+export function parseCellAddress(
+    address: string,
+): { row: number; col: number } | null {
+    const match = address.match(/^([A-Z]+)(\d+)$/);
+    if (!match?.[1] || !match[2]) return null;
+
+    const colLetters = match[1];
+    const rowNum = parseInt(match[2], 10);
+
+    let col = 0;
+    for (let i = 0; i < colLetters.length; i++) {
+        col = col * 26 + (colLetters.charCodeAt(i) - 65 + 1);
+    }
+    col -= 1;
+
+    return { row: rowNum - 1, col };
+}
+
+// Convert column number to Excel-style letter (0 -> A, 1 -> B, 25 -> Z, 26 -> AA, etc.)
+export function columnToLetter(column: number): string {
+    let temp: number;
+    let letter = "";
+    let col = column;
+    while (col >= 0) {
+        temp = col % 26;
+        letter = String.fromCharCode(temp + 65) + letter;
+        col = Math.floor(col / 26) - 1;
+    }
+    return letter;
+}

--- a/crates/openwave-desktop/ui/src/document/useFileDownload.ts
+++ b/crates/openwave-desktop/ui/src/document/useFileDownload.ts
@@ -1,0 +1,76 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import type { ApiClient } from "@/api";
+
+/**
+ * A source document's original bytes, held for the life of the process.
+ *
+ * A document's content is immutable once imported — replacing a file produces a
+ * new document with a new id — so a cache hit can never be stale, and reopening
+ * a workbook costs nothing.
+ */
+const byteCache = new Map<string, Uint8Array>();
+
+export type FileDownload = {
+  /** A fresh copy each time the bytes change: the parsers take ownership. */
+  data: ArrayBuffer | null;
+  isLoading: boolean;
+  error: Error | null;
+};
+
+export function useFileDownload(
+  client: Pick<ApiClient, "getDocumentFileContent">,
+  documentId: string,
+): FileDownload {
+  const [bytes, setBytes] = useState<Uint8Array | null>(
+    () => byteCache.get(documentId) ?? null,
+  );
+  const [error, setError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState(!byteCache.has(documentId));
+  const requestRef = useRef(0);
+
+  useEffect(() => {
+    const request = ++requestRef.current;
+    const cached = byteCache.get(documentId);
+    if (cached) {
+      setBytes(cached);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setBytes(null);
+    setError(null);
+    setIsLoading(true);
+
+    void (async () => {
+      try {
+        const downloaded = await client.getDocumentFileContent(
+          documentId,
+          controller.signal,
+        );
+        if (request !== requestRef.current) return;
+        byteCache.set(documentId, downloaded);
+        setBytes(downloaded);
+      } catch (err) {
+        if (controller.signal.aborted || request !== requestRef.current) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        if (request === requestRef.current) setIsLoading(false);
+      }
+    })();
+
+    return () => controller.abort();
+  }, [client, documentId]);
+
+  const data = useMemo(() => {
+    if (!bytes) return null;
+    return bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength,
+    ) as ArrayBuffer;
+  }, [bytes]);
+
+  return { data, isLoading, error };
+}

--- a/crates/openwave-desktop/ui/src/document/useUniverWorker.ts
+++ b/crates/openwave-desktop/ui/src/document/useUniverWorker.ts
@@ -1,0 +1,131 @@
+import type { IWorkbookData } from "@univerjs/presets";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import UniverParserWorker from "@/workers/univer-parser.worker?worker&inline";
+
+// Singleton worker instance (persists across component unmounts to preserve cache)
+let globalWorker: Worker | null = null;
+
+function getWorkerInstance(): Worker {
+  if (!globalWorker) {
+    globalWorker = new UniverParserWorker();
+  }
+  return globalWorker;
+}
+
+export interface WorkerParseResult {
+  workbookData: IWorkbookData;
+}
+
+/**
+ * Parse a workbook off the main thread.
+ *
+ * A spreadsheet of any size takes long enough to read that doing it inline
+ * freezes the window; the worker keeps the app responsive and caches parsed
+ * workbooks so reopening a source is instant.
+ */
+export function useUniverWorker() {
+  const workerRef = useRef<Worker | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const pendingOpsRef = useRef(
+    new Map<
+      string,
+      {
+        resolve: (result: WorkerParseResult) => void;
+        reject: (error: Error) => void;
+      }
+    >(),
+  );
+
+  useEffect(() => {
+    workerRef.current = getWorkerInstance();
+    const worker = workerRef.current;
+    const pendingOps = pendingOpsRef.current;
+
+    const handleMessage = (e: MessageEvent) => {
+      const message = e.data;
+      const opId = message.opId;
+
+      switch (message.type) {
+        case "cache-miss": {
+          if (!pendingOps.has(opId)) break;
+          setIsProcessing(true);
+          break;
+        }
+
+        case "result": {
+          const pending = pendingOps.get(opId);
+          if (pending) {
+            pending.resolve({ workbookData: message.workbookData });
+            pendingOps.delete(opId);
+            if (pendingOps.size === 0) setIsProcessing(false);
+          }
+          break;
+        }
+
+        case "error": {
+          const pending = pendingOps.get(opId);
+          if (pending) {
+            pending.reject(new Error(message.error));
+            pendingOps.delete(opId);
+            if (pendingOps.size === 0) setIsProcessing(false);
+          }
+          break;
+        }
+      }
+    };
+
+    const handleError = (event: ErrorEvent) => {
+      const err = new Error(event.message || "the spreadsheet parser stopped");
+      pendingOps.forEach((pending) => pending.reject(err));
+      pendingOps.clear();
+      setIsProcessing(false);
+    };
+
+    worker.addEventListener("message", handleMessage);
+    worker.addEventListener("error", handleError);
+
+    return () => {
+      worker.removeEventListener("message", handleMessage);
+      worker.removeEventListener("error", handleError);
+    };
+  }, []);
+
+  const parseWorkbook = useCallback(
+    (
+      data: ArrayBuffer,
+      documentId: string,
+      options?: { isCsv?: boolean },
+    ): Promise<WorkerParseResult> => {
+      return new Promise((resolve, reject) => {
+        if (!workerRef.current) {
+          reject(new Error("the spreadsheet parser is not running"));
+          return;
+        }
+
+        const opId = `univer:${documentId}:${Date.now()}`;
+        pendingOpsRef.current.set(opId, { resolve, reject });
+
+        const clonedData = data.slice(0);
+        workerRef.current.postMessage(
+          {
+            type: "parse",
+            data: clonedData,
+            documentId,
+            opId,
+            isCsv: options?.isCsv,
+          },
+          [clonedData],
+        );
+      });
+    },
+    [],
+  );
+
+  const clearCache = useCallback((documentId: string) => {
+    workerRef.current?.postMessage({ type: "clear-cache", documentId });
+  }, []);
+
+  return { parseWorkbook, clearCache, isProcessing };
+}

--- a/crates/openwave-desktop/ui/src/document/xlsx-styles-parser.ts
+++ b/crates/openwave-desktop/ui/src/document/xlsx-styles-parser.ts
@@ -1,0 +1,702 @@
+import JSZip from "jszip";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface ParsedBorderSide {
+    style: string; // OOXML border style name (thin, medium, thick, etc.)
+    color?: string; // Resolved RGB hex without # (e.g. "FF0000")
+}
+
+export interface ParsedCellStyle {
+    color?: string; // Resolved RGB hex without # (e.g. "FF0000")
+    bold?: boolean;
+    italic?: boolean;
+    size?: number;
+    name?: string;
+    underline?: boolean;
+    strike?: boolean;
+    // Cell-level styles (parsed from cellXfs fills, borders, alignment)
+    bg?: string; // Background fill color hex without #
+    borderLeft?: ParsedBorderSide;
+    borderRight?: ParsedBorderSide;
+    borderTop?: ParsedBorderSide;
+    borderBottom?: ParsedBorderSide;
+    horizontalAlign?: string;
+    verticalAlign?: string;
+    wrapText?: boolean;
+    textRotation?: number;
+    verticalText?: boolean;
+}
+
+export interface ParsedFreezePane {
+    xSplit: number; // Number of frozen columns
+    ySplit: number; // Number of frozen rows
+}
+
+/** Map<sheetName, Map<cellAddress, ParsedCellStyle>> */
+export type XlsxCellStyleMap = Map<string, Map<string, ParsedCellStyle>> & {
+    defaultFont?: ParsedCellStyle;
+};
+
+// ── Regex-based XML helpers (web-worker-safe, no DOMParser) ──────────────────
+
+/** Find all occurrences of a tag, returning {tag, inner} for body tags and {tag, inner:""} for self-closing */
+function findTags(
+    xml: string,
+    tagName: string,
+): { tag: string; inner: string }[] {
+    // Self-closing FIRST (with lazy [^>]*? so the / before > isn't consumed),
+    // then body tags.  The old regex used greedy [^>]* which ate the trailing /
+    // in self-closing tags, making them unmatchable; the body alternative then
+    // swallowed them + the next closing tag, shifting every subsequent index.
+    const pattern = new RegExp(
+        `<${tagName}\\b[^>]*?\\/>|<${tagName}\\b[^>]*?>([\\s\\S]*?)<\\/${tagName}>`,
+        "g",
+    );
+    const results: { tag: string; inner: string }[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = pattern.exec(xml)) !== null) {
+        results.push({ tag: m[0], inner: m[1] ?? "" });
+    }
+    return results;
+}
+
+/** Get inner content between opening and closing tags */
+function getInner(xml: string, tagName: string): string | null {
+    const m = xml.match(
+        new RegExp(`<${tagName}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${tagName}>`),
+    );
+    return m ? m[1]! : null;
+}
+
+/** Get attribute value from a tag string */
+function getAttr(tag: string, attr: string): string | null {
+    const m = tag.match(new RegExp(`${attr}="([^"]*)"`));
+    return m ? m[1]! : null;
+}
+
+/** Check if a flag element exists and isn't explicitly val="0" */
+function hasFlag(xml: string, tagName: string): boolean {
+    const m = xml.match(new RegExp(`<${tagName}(?:\\s[^>]*)?\\/?>`, "i"));
+    if (!m) return false;
+    const val = getAttr(m[0], "val");
+    return val !== "0" && val !== "false";
+}
+
+/** Get the val attribute from a child element */
+function childAttrVal(xml: string, tagName: string): string | null {
+    const m = xml.match(new RegExp(`<${tagName}\\s[^>]*?\\/?>`));
+    if (!m) return null;
+    return getAttr(m[0], "val");
+}
+
+// ── Theme color parsing ─────────────────────────────────────────────────────
+
+// OOXML theme indices are swapped for the first two pairs:
+// dk1→index 1, lt1→index 0, dk2→index 3, lt2→index 2, accent1-6→indices 4-9
+const THEME_INDEX_MAP: Record<number, number> = {
+    0: 1, // dk1
+    1: 0, // lt1
+    2: 3, // dk2
+    3: 2, // lt2
+};
+
+const DEFAULT_THEME_COLORS: Record<number, string> = {
+    0: "000000", // dk1
+    1: "FFFFFF", // lt1
+    2: "44546A", // dk2
+    3: "E7E6E6", // lt2
+    4: "4472C4", // accent1
+    5: "ED7D31", // accent2
+    6: "A5A5A5", // accent3
+    7: "FFC000", // accent4
+    8: "5B9BD5", // accent5
+    9: "70AD47", // accent6
+};
+
+function parseThemeColors(themeXml: string): string[] {
+    const colors: string[] = [];
+
+    const themeElements = getInner(themeXml, "a:themeElements");
+    if (!themeElements) return colors;
+
+    const clrScheme = getInner(themeElements, "a:clrScheme");
+    if (!clrScheme) return colors;
+
+    // Parse color elements in order: dk1, lt1, dk2, lt2, accent1-6
+    const colorTags = [
+        "a:dk1",
+        "a:lt1",
+        "a:dk2",
+        "a:lt2",
+        "a:accent1",
+        "a:accent2",
+        "a:accent3",
+        "a:accent4",
+        "a:accent5",
+        "a:accent6",
+    ];
+
+    for (const tag of colorTags) {
+        const inner = getInner(clrScheme, tag);
+        if (!inner) {
+            colors.push("");
+            continue;
+        }
+
+        // Try srgbClr first, then sysClr lastClr
+        const srgb = inner.match(/<a:srgbClr\s[^>]*?val="([^"]+)"/);
+        if (srgb) {
+            colors.push(srgb[1]!);
+            continue;
+        }
+
+        const sys = inner.match(/<a:sysClr\s[^>]*?lastClr="([^"]+)"/);
+        if (sys) {
+            colors.push(sys[1]!);
+            continue;
+        }
+
+        colors.push("");
+    }
+
+    return colors;
+}
+
+function resolveThemeColor(
+    themeIndex: number,
+    themeColors: string[],
+): string | null {
+    const mappedIndex = THEME_INDEX_MAP[themeIndex] ?? themeIndex;
+    const color = themeColors[mappedIndex];
+    if (color) return color;
+    return DEFAULT_THEME_COLORS[themeIndex] ?? null;
+}
+
+// ── Color tint helpers ──────────────────────────────────────────────────────
+
+function applyTint(hex: string, tint: number): string {
+    const r = parseInt(hex.substring(0, 2), 16);
+    const g = parseInt(hex.substring(2, 4), 16);
+    const b = parseInt(hex.substring(4, 6), 16);
+
+    const apply = (c: number) => {
+        if (tint < 0) return Math.round(c * (1 + tint));
+        return Math.round(c + (255 - c) * tint);
+    };
+
+    const clamp = (v: number) => Math.min(255, Math.max(0, v));
+
+    return [clamp(apply(r)), clamp(apply(g)), clamp(apply(b))]
+        .map((v) => v.toString(16).padStart(2, "0").toUpperCase())
+        .join("");
+}
+
+/** Resolve color from a tag like <color rgb="..." /> or <color theme="..." tint="..." /> */
+function resolveColor(
+    colorTag: string,
+    themeColors: string[],
+): string | undefined {
+    const rgb = getAttr(colorTag, "rgb");
+    if (rgb) {
+        const hex = rgb.length === 8 ? rgb.slice(2) : rgb;
+        const tint = getAttr(colorTag, "tint");
+        return tint ? applyTint(hex, parseFloat(tint)) : hex;
+    }
+
+    const theme = getAttr(colorTag, "theme");
+    if (theme !== null) {
+        const resolved = resolveThemeColor(parseInt(theme, 10), themeColors);
+        if (resolved) {
+            const tint = getAttr(colorTag, "tint");
+            return tint ? applyTint(resolved, parseFloat(tint)) : resolved;
+        }
+    }
+
+    return undefined;
+}
+
+// ── Font parsing ────────────────────────────────────────────────────────────
+
+interface FontDef {
+    color?: string;
+    bold?: boolean;
+    italic?: boolean;
+    size?: number;
+    name?: string;
+    underline?: boolean;
+    strike?: boolean;
+}
+
+function parseFonts(stylesXml: string, themeColors: string[]): FontDef[] {
+    const fontsBlock = getInner(stylesXml, "fonts");
+    if (!fontsBlock) return [];
+
+    const fontTags = findTags(fontsBlock, "font");
+    const fonts: FontDef[] = [];
+
+    for (const { inner } of fontTags) {
+        const font: FontDef = {};
+
+        const colorMatch = inner.match(/<color\s[^>]*?\/?>/);
+        if (colorMatch) {
+            const resolved = resolveColor(colorMatch[0], themeColors);
+            if (resolved) font.color = resolved;
+        }
+
+        if (hasFlag(inner, "b")) font.bold = true;
+        if (hasFlag(inner, "i")) font.italic = true;
+        if (hasFlag(inner, "u")) font.underline = true;
+        if (hasFlag(inner, "strike")) font.strike = true;
+
+        const sz = childAttrVal(inner, "sz");
+        if (sz) font.size = parseFloat(sz);
+
+        const nameVal = childAttrVal(inner, "name");
+        if (nameVal) font.name = nameVal;
+
+        fonts.push(font);
+    }
+
+    return fonts;
+}
+
+// ── Fill parsing ─────────────────────────────────────────────────────────────
+
+interface FillDef {
+    color?: string; // Resolved RGB hex for solid fills
+}
+
+function parseFills(stylesXml: string, themeColors: string[]): FillDef[] {
+    const fillsBlock = getInner(stylesXml, "fills");
+    if (!fillsBlock) return [];
+
+    const fillTags = findTags(fillsBlock, "fill");
+    const fills: FillDef[] = [];
+
+    for (const { inner } of fillTags) {
+        const fill: FillDef = {};
+
+        const patternFillMatch = inner.match(/<patternFill[^>]*>/);
+        if (patternFillMatch) {
+            const patternType = getAttr(patternFillMatch[0], "patternType");
+            if (patternType === "solid") {
+                const fgColorMatch = inner.match(/<fgColor\s[^>]*?\/?>/);
+                if (fgColorMatch) {
+                    fill.color = resolveColor(fgColorMatch[0], themeColors);
+                }
+            }
+        }
+
+        fills.push(fill);
+    }
+
+    return fills;
+}
+
+// ── Border parsing ───────────────────────────────────────────────────────────
+
+interface BorderSideDef {
+    style: string;
+    color?: string;
+}
+
+interface BorderDef {
+    left?: BorderSideDef;
+    right?: BorderSideDef;
+    top?: BorderSideDef;
+    bottom?: BorderSideDef;
+}
+
+function parseBorderSide(
+    borderXml: string,
+    sideTag: string,
+    themeColors: string[],
+): ParsedBorderSide | undefined {
+    const found = findTags(borderXml, sideTag);
+    if (found.length === 0) return undefined;
+
+    const { tag } = found[0]!;
+    const style = getAttr(tag, "style");
+    if (!style || style === "none") return undefined;
+
+    const side: ParsedBorderSide = { style };
+
+    const colorMatch = tag.match(/<color\s[^>]*?\/?>/);
+    if (colorMatch) {
+        side.color = resolveColor(colorMatch[0], themeColors);
+    }
+
+    return side;
+}
+
+function parseBorders(stylesXml: string, themeColors: string[]): BorderDef[] {
+    const bordersBlock = getInner(stylesXml, "borders");
+    if (!bordersBlock) return [];
+
+    const borderTags = findTags(bordersBlock, "border");
+    const borders: BorderDef[] = [];
+
+    for (const { inner } of borderTags) {
+        borders.push({
+            left: parseBorderSide(inner, "left", themeColors),
+            right: parseBorderSide(inner, "right", themeColors),
+            top: parseBorderSide(inner, "top", themeColors),
+            bottom: parseBorderSide(inner, "bottom", themeColors),
+        });
+    }
+
+    return borders;
+}
+
+// ── cellXfs parsing (cell format → font/fill/border/alignment mapping) ──────
+
+interface CellXf {
+    fontId: number;
+    fillId: number;
+    borderId: number;
+    alignment?: {
+        horizontal?: string;
+        vertical?: string;
+        wrapText?: boolean;
+        textRotation?: number;
+        verticalText?: boolean;
+    };
+}
+
+function parseCellXfs(stylesXml: string): CellXf[] {
+    const cellXfsBlock = getInner(stylesXml, "cellXfs");
+    if (!cellXfsBlock) return [];
+
+    const xfTags = findTags(cellXfsBlock, "xf");
+    return xfTags.map(({ tag, inner }) => {
+        const fontId = getAttr(tag, "fontId");
+        const fillId = getAttr(tag, "fillId");
+        const borderId = getAttr(tag, "borderId");
+
+        const xf: CellXf = {
+            fontId: fontId ? parseInt(fontId, 10) : 0,
+            fillId: fillId ? parseInt(fillId, 10) : 0,
+            borderId: borderId ? parseInt(borderId, 10) : 0,
+        };
+
+        const alignMatch = inner.match(/<alignment\s[^>]*?\/?>/);
+        if (alignMatch) {
+            const horizontal = getAttr(alignMatch[0], "horizontal");
+            const vertical = getAttr(alignMatch[0], "vertical");
+            const wrapText = getAttr(alignMatch[0], "wrapText");
+            const textRotation = getAttr(alignMatch[0], "textRotation");
+            const parsedTextRotation = textRotation
+                ? Number.parseInt(textRotation, 10)
+                : null;
+            const validTextRotation = Number.isFinite(parsedTextRotation)
+                ? parsedTextRotation
+                : null;
+
+            if (
+                horizontal ||
+                vertical ||
+                wrapText === "1" ||
+                wrapText === "true" ||
+                validTextRotation !== null
+            ) {
+                xf.alignment = {};
+                if (horizontal) xf.alignment.horizontal = horizontal;
+                if (vertical) xf.alignment.vertical = vertical;
+                if (wrapText === "1" || wrapText === "true")
+                    xf.alignment.wrapText = true;
+                if (validTextRotation === 255) {
+                    xf.alignment.verticalText = true;
+                } else if (validTextRotation !== null) {
+                    xf.alignment.textRotation = validTextRotation;
+                }
+            }
+        }
+
+        return xf;
+    });
+}
+
+// ── Sheet path resolution ───────────────────────────────────────────────────
+
+interface SheetInfo {
+    name: string;
+    rId: string;
+}
+
+function parseWorkbookSheets(workbookXml: string): SheetInfo[] {
+    const sheets: SheetInfo[] = [];
+    const sheetPattern = /<sheet\s[^>]*?\/?>/g;
+    let m: RegExpExecArray | null;
+    while ((m = sheetPattern.exec(workbookXml)) !== null) {
+        const name = getAttr(m[0], "name");
+        const rId = m[0].match(/r:id="([^"]+)"/)?.[1];
+        if (name && rId) sheets.push({ name, rId });
+    }
+    return sheets;
+}
+
+function parseWorkbookRels(relsXml: string): Map<string, string> {
+    const map = new Map<string, string>();
+    const relPattern = /<Relationship\s[^>]*?\/?>/g;
+    let m: RegExpExecArray | null;
+    while ((m = relPattern.exec(relsXml)) !== null) {
+        const id = getAttr(m[0], "Id");
+        const target = getAttr(m[0], "Target");
+        if (id && target) map.set(id, target);
+    }
+    return map;
+}
+
+// ── Per-sheet cell → font extraction ────────────────────────────────────────
+
+function parseSheetCells(
+    sheetXml: string,
+    cellXfs: CellXf[],
+    fonts: FontDef[],
+    fills: FillDef[],
+    borders: BorderDef[],
+): Map<string, ParsedCellStyle> {
+    const cellMap = new Map<string, ParsedCellStyle>();
+
+    // Match <c> tags with r (reference) and s (style index) attributes
+    const cellPattern = /<c\s[^>]*?\/?>/g;
+    let m: RegExpExecArray | null;
+    while ((m = cellPattern.exec(sheetXml)) !== null) {
+        const ref = getAttr(m[0], "r");
+        const styleIdx = getAttr(m[0], "s");
+        if (!ref || styleIdx === null) continue;
+
+        const xfIndex = parseInt(styleIdx, 10);
+        const xf = cellXfs[xfIndex];
+        if (!xf) continue;
+
+        const parsed: ParsedCellStyle = {};
+        let hasData = false;
+
+        // Font properties (skip fontId 0 = default font, handled separately)
+        if (xf.fontId !== 0) {
+            const fontDef = fonts[xf.fontId];
+            if (fontDef) {
+                if (fontDef.color) {
+                    parsed.color = fontDef.color;
+                    hasData = true;
+                }
+                if (fontDef.bold) {
+                    parsed.bold = true;
+                    hasData = true;
+                }
+                if (fontDef.italic) {
+                    parsed.italic = true;
+                    hasData = true;
+                }
+                if (fontDef.size) {
+                    parsed.size = fontDef.size;
+                    hasData = true;
+                }
+                if (fontDef.name) {
+                    parsed.name = fontDef.name;
+                    hasData = true;
+                }
+                if (fontDef.underline) {
+                    parsed.underline = true;
+                    hasData = true;
+                }
+                if (fontDef.strike) {
+                    parsed.strike = true;
+                    hasData = true;
+                }
+            }
+        }
+
+        // Background fill color (skip white — solid white fill is visually
+        // identical to no-fill in Excel but renders differently in Univer)
+        const fillDef = fills[xf.fillId];
+        if (fillDef?.color && fillDef.color.toUpperCase() !== "FFFFFF") {
+            parsed.bg = fillDef.color;
+            hasData = true;
+        }
+
+        // Borders
+        if (xf.borderId > 0) {
+            const borderDef = borders[xf.borderId];
+            if (borderDef) {
+                if (borderDef.left) {
+                    parsed.borderLeft = borderDef.left;
+                    hasData = true;
+                }
+                if (borderDef.right) {
+                    parsed.borderRight = borderDef.right;
+                    hasData = true;
+                }
+                if (borderDef.top) {
+                    parsed.borderTop = borderDef.top;
+                    hasData = true;
+                }
+                if (borderDef.bottom) {
+                    parsed.borderBottom = borderDef.bottom;
+                    hasData = true;
+                }
+            }
+        }
+
+        // Alignment
+        if (xf.alignment) {
+            if (xf.alignment.horizontal) {
+                parsed.horizontalAlign = xf.alignment.horizontal;
+                hasData = true;
+            }
+            if (xf.alignment.vertical) {
+                parsed.verticalAlign = xf.alignment.vertical;
+                hasData = true;
+            }
+            if (xf.alignment.wrapText) {
+                parsed.wrapText = true;
+                hasData = true;
+            }
+            if (xf.alignment.textRotation !== undefined) {
+                parsed.textRotation = xf.alignment.textRotation;
+                hasData = true;
+            }
+            if (xf.alignment.verticalText) {
+                parsed.verticalText = true;
+                hasData = true;
+            }
+        }
+
+        if (hasData) cellMap.set(ref, parsed);
+    }
+
+    return cellMap;
+}
+
+// ── Freeze pane extraction ───────────────────────────────────────────────────
+
+function parseSheetFreezePane(sheetXml: string): ParsedFreezePane | null {
+    // Look for <pane> inside <sheetViews> → <sheetView>
+    const paneMatch = sheetXml.match(/<pane\s[^>]*?\/?>/);
+    if (!paneMatch) return null;
+
+    const paneTag = paneMatch[0];
+    const state = getAttr(paneTag, "state");
+    if (state !== "frozen" && state !== "frozenSplit") return null;
+
+    const xSplit = getAttr(paneTag, "xSplit");
+    const ySplit = getAttr(paneTag, "ySplit");
+    const x = xSplit ? parseInt(xSplit, 10) : 0;
+    const y = ySplit ? parseInt(ySplit, 10) : 0;
+
+    if (x === 0 && y === 0) return null;
+    return { xSplit: x, ySplit: y };
+}
+
+// ── Main entry point ────────────────────────────────────────────────────────
+
+export interface XlsxMetadata {
+    fontStyles: XlsxCellStyleMap;
+    freezePanes: Map<string, ParsedFreezePane>;
+}
+
+/**
+ * Extracts font styles and freeze pane configuration from XLSX XML
+ * in a single zip pass. SheetJS CE doesn't expose either of these,
+ * so we parse the raw XML directly (web-worker-safe, no DOMParser).
+ */
+export async function extractXlsxMetadata(
+    data: ArrayBuffer,
+): Promise<XlsxMetadata> {
+    const fontStyles: XlsxCellStyleMap = new Map();
+    const freezePanes = new Map<string, ParsedFreezePane>();
+
+    try {
+        const zip = await JSZip.loadAsync(data);
+
+        // Parse theme colors
+        let themeColors: string[] = [];
+        const themeFile = zip.file("xl/theme/theme1.xml");
+        if (themeFile) {
+            const themeXml = await themeFile.async("text");
+            themeColors = parseThemeColors(themeXml);
+        }
+
+        // Parse styles
+        const stylesFile = zip.file("xl/styles.xml");
+        let fonts: FontDef[] = [];
+        let cellXfs: CellXf[] = [];
+        let fills: FillDef[] = [];
+        let borders: BorderDef[] = [];
+
+        if (stylesFile) {
+            const stylesXml = await stylesFile.async("text");
+            fonts = parseFonts(stylesXml, themeColors);
+            fills = parseFills(stylesXml, themeColors);
+            borders = parseBorders(stylesXml, themeColors);
+            cellXfs = parseCellXfs(stylesXml);
+
+            // Expose the default font (index 0) so the converter can set
+            // it as the workbook/sheet default style in Univer.
+            const defaultFontDef = fonts[0];
+            if (defaultFontDef) {
+                const df: ParsedCellStyle = {};
+                if (defaultFontDef.size) df.size = defaultFontDef.size;
+                if (defaultFontDef.name) df.name = defaultFontDef.name;
+                if (defaultFontDef.bold) df.bold = true;
+                if (defaultFontDef.italic) df.italic = true;
+                if (defaultFontDef.color) df.color = defaultFontDef.color;
+                if (Object.keys(df).length > 0) fontStyles.defaultFont = df;
+            }
+        }
+
+        const hasStyleData = cellXfs.length > 0;
+
+        // Resolve sheet paths
+        const workbookFile = zip.file("xl/workbook.xml");
+        const workbookRelsFile = zip.file("xl/_rels/workbook.xml.rels");
+        if (!workbookFile || !workbookRelsFile) {
+            return { fontStyles, freezePanes };
+        }
+
+        const workbookXml = await workbookFile.async("text");
+        const workbookRelsXml = await workbookRelsFile.async("text");
+
+        const sheets = parseWorkbookSheets(workbookXml);
+        const rels = parseWorkbookRels(workbookRelsXml);
+
+        // Parse each sheet for font styles and freeze panes
+        for (const sheet of sheets) {
+            const target = rels.get(sheet.rId);
+            if (!target) continue;
+
+            const sheetPath = target.startsWith("/")
+                ? target.slice(1)
+                : `xl/${target}`;
+
+            const sheetFile = zip.file(sheetPath);
+            if (!sheetFile) continue;
+
+            const sheetXml = await sheetFile.async("text");
+
+            if (hasStyleData) {
+                const cellMap = parseSheetCells(
+                    sheetXml,
+                    cellXfs,
+                    fonts,
+                    fills,
+                    borders,
+                );
+                if (cellMap.size > 0) {
+                    fontStyles.set(sheet.name, cellMap);
+                }
+            }
+
+            const freeze = parseSheetFreezePane(sheetXml);
+            if (freeze) {
+                freezePanes.set(sheet.name, freeze);
+            }
+        }
+    } catch (e) {
+        console.error("[xlsx-metadata] Error extracting XLSX metadata:", e);
+    }
+
+    return { fontStyles, freezePanes };
+}

--- a/crates/openwave-desktop/ui/src/useStreamingTypewriter.ts
+++ b/crates/openwave-desktop/ui/src/useStreamingTypewriter.ts
@@ -15,7 +15,10 @@ export function useStreamingTypewriter(text: string, live: boolean): string {
   const targetRef = useRef(text);
   const liveRef = useRef(live);
   const mountedRef = useRef(false);
-  const timerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
+  // Spelled out rather than inferred from `window.setTimeout`: a dependency
+  // that references Node's types puts a competing `setTimeout` declaration in
+  // scope, and the inferred return type then picks the wrong one.
+  const timerRef = useRef<number | null>(null);
 
   const showImmediately = useCallback((value: string) => {
     displayedRef.current = value;

--- a/crates/openwave-desktop/ui/src/workers/univer-formula.worker.ts
+++ b/crates/openwave-desktop/ui/src/workers/univer-formula.worker.ts
@@ -1,0 +1,11 @@
+import sheetsCoreEnUS from "@univerjs/preset-sheets-core/locales/en-US";
+import { UniverSheetsCoreWorkerPreset } from "@univerjs/preset-sheets-core/worker";
+import { createUniver, LocaleType } from "@univerjs/presets";
+
+createUniver({
+    locale: LocaleType.EN_US,
+    locales: {
+        [LocaleType.EN_US]: sheetsCoreEnUS,
+    },
+    presets: [UniverSheetsCoreWorkerPreset()],
+});

--- a/crates/openwave-desktop/ui/src/workers/univer-parser.worker.ts
+++ b/crates/openwave-desktop/ui/src/workers/univer-parser.worker.ts
@@ -1,0 +1,136 @@
+import type { IWorkbookData } from "@univerjs/presets";
+import * as XLSX from "xlsx";
+
+import { sheetjsToUniver } from "@/document/sheetjs-to-univer";
+import { extractXlsxMetadata } from "@/document/xlsx-styles-parser";
+
+// LRU cache for parsed workbook data (keyed by documentId)
+const MAX_CACHE_SIZE = 5;
+const workbookCache = new Map<string, { workbookData: IWorkbookData }>();
+
+function lruGet<K, V>(cache: Map<K, V>, key: K): V | undefined {
+  const value = cache.get(key);
+  if (value !== undefined) {
+    cache.delete(key);
+    cache.set(key, value);
+  }
+  return value;
+}
+
+function lruSet<K, V>(cache: Map<K, V>, key: K, value: V, maxSize: number) {
+  if (cache.size >= maxSize && !cache.has(key)) {
+    const firstKey = cache.keys().next().value;
+    if (firstKey !== undefined) {
+      cache.delete(firstKey);
+    }
+  }
+  cache.delete(key);
+  cache.set(key, value);
+}
+
+// ── Message types ────────────────────────────────────────────────────────────
+
+interface ParseMessage {
+  type: "parse";
+  data: ArrayBuffer;
+  documentId: string;
+  opId: string;
+  isCsv?: boolean;
+}
+
+interface ClearCacheMessage {
+  type: "clear-cache";
+  documentId: string;
+}
+
+interface CacheMissMessage {
+  type: "cache-miss";
+  opId: string;
+}
+
+interface ResultMessage {
+  type: "result";
+  workbookData: IWorkbookData;
+  opId: string;
+}
+
+interface ErrorMessage {
+  type: "error";
+  error: string;
+  opId: string;
+}
+
+interface CacheClearedMessage {
+  type: "cache-cleared";
+  documentId: string;
+}
+
+type WorkerRequest = ParseMessage | ClearCacheMessage;
+
+// ── Message handler ──────────────────────────────────────────────────────────
+
+self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
+  if (e.data.type === "clear-cache") {
+    const { documentId } = e.data;
+    workbookCache.delete(documentId);
+    self.postMessage({
+      type: "cache-cleared",
+      documentId,
+    } satisfies CacheClearedMessage);
+    return;
+  }
+
+  const { opId, documentId, data, isCsv } = e.data;
+
+  try {
+    const cached = lruGet(workbookCache, documentId);
+    if (cached) {
+      self.postMessage({
+        type: "result",
+        workbookData: cached.workbookData,
+        opId,
+      } satisfies ResultMessage);
+      return;
+    }
+
+    self.postMessage({
+      type: "cache-miss",
+      opId,
+    } satisfies CacheMissMessage);
+
+    const workbook = XLSX.read(data, {
+      type: "array",
+      cellStyles: !isCsv,
+      cellFormula: true,
+      cellNF: true,
+    });
+
+    let workbookData: IWorkbookData;
+
+    if (isCsv) {
+      workbookData = sheetjsToUniver(workbook);
+    } else {
+      const metadata = await extractXlsxMetadata(data);
+      workbookData = sheetjsToUniver(
+        workbook,
+        metadata.fontStyles,
+        metadata.freezePanes,
+      );
+    }
+
+    lruSet(workbookCache, documentId, { workbookData }, MAX_CACHE_SIZE);
+
+    self.postMessage({
+      type: "result",
+      workbookData,
+      opId,
+    } satisfies ResultMessage);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    self.postMessage({
+      type: "error",
+      error: errorMessage,
+      opId,
+    } satisfies ErrorMessage);
+  }
+};

--- a/crates/openwave-desktop/ui/vite.config.ts
+++ b/crates/openwave-desktop/ui/vite.config.ts
@@ -9,6 +9,10 @@ const host = process.env.TAURI_DEV_HOST;
 
 export default defineConfig(async () => ({
   plugins: [react(), tailwindcss()],
+  // The spreadsheet and word-document viewers parse off the main thread, and
+  // their workers are large enough to be split into chunks themselves — which
+  // the default IIFE worker format cannot express.
+  worker: { format: "es" as const },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
Two more branches on the document dispatcher: spreadsheets and word documents now render in their original form rather than falling back to extracted text.

## The spreadsheet viewer

`xlsx`, `xls`, and `csv`, with sheet tabs, formulas, and cell selection. Selecting a cell shows what is actually in it, formula and all, which is the difference between reading a model and reading a screenshot of one. `Ctrl+[` follows a formula to the first cell it references, switching sheets if the reference crosses one; `Ctrl+PageDown` / `Ctrl+PageUp` move between sheet tabs. Column widths stored in a workbook are frequently narrower than the text they hold, so there is an autofit control above the grid.

Delimited text is a spreadsheet with one sheet and no styling, so `csv` and `tsv` go through the same viewer with the workbook style pass skipped.

## The word-document viewer

`docx`, rendered in the app. Converting to PDF first would put office formats at the mercy of whatever the host happens to have installed, which is the opposite of what a local-first app should do with a file the user already has on disk.

## Read-only, deliberately

The engine behind both viewers is a full editor. Hiding the toolbar is not a guarantee, so the viewers cancel every editing command before it executes and allow through only what read-only use needs: navigation, selection, and the formula engine writing its own computed values. That inversion — deny by default, allow by name — is what keeps a viewer from becoming an accidental editor as the engine gains commands.

## Parsing off the main thread

A workbook of any size takes long enough to read that doing it inline freezes the window, so parsing happens in a worker, which also keeps an LRU of parsed workbooks so reopening a source is instant. The formula engine runs in a second worker of its own. Splitting workers out of the entry chunk requires the ES worker format; the default is IIFE, which cannot be code-split.

## Bundle

Everything here is fetched on first use. The two engines together are several times the size of the rest of the renderer, and a conversation that never opens a workbook should not pay for one.

Nothing reaches the dispatcher until #543 lands the panel that calls it, so today's build is unchanged. Measured with the dispatcher forced reachable:

- Entry chunk 1,013 kB → 1,030 kB. That 17 kB is the lazy-import shims for every viewer the dispatcher knows about, PDF included.
- Spreadsheet viewer: a 6.3 MB chunk, fetched when a workbook is opened.
- Word-document viewer: 113 kB on top of a 3.4 MB engine chunk shared with the spreadsheet viewer.

The word-document renderer also ships per-language hyphenation patterns as separate dynamic chunks. They sit unloaded in the app bundle and are fetched only for the language a document is actually in.

## Deliberately not included

The viewers this is ported from also carry cell comments as sheet notes, an embedded-chart overlay, and cell-level citation highlighting. The first two would add dependencies for behaviour nothing in the app asks for yet; the third has no citation plumbing to attach to. The spreadsheet viewer keeps its highlight-a-range entry point so cell citations have somewhere to land when they exist. Worth a follow-up issue rather than speculative weight now.

## Tests

None added. The behaviour worth testing here is whether a real workbook renders, which needs the engine, a canvas, and a fixture file — a test that would cost more on every build than the regressions it could plausibly catch. The dispatcher's media-type mapping is a one-line table; a test over it would assert that the code exists.

## Two notes on the toolchain

`useStreamingTypewriter` now spells out its timer type instead of inferring it from `window.setTimeout`. One of the new dependencies references Node's types, which puts a competing `setTimeout` declaration in scope and left the inferred return type ambiguous.

SheetJS publishes from its own CDN rather than the npm registry, and a lockfile entry for a remote tarball carries no integrity hash — `--frozen-lockfile` refuses to install one. The digest is recorded in the lockfile so the download is verified on every install like any other dependency.

## Verification

Under `crates/openwave-desktop/ui`: `tsc`, 515 vitest tests, a production build, and `pnpm install --frozen-lockfile` against an empty store. No Rust changed.

Closes #546