### PR TITLE
feat(desktop): carry a citation's source and place to the renderer

### DIFF
--- a/crates/openwave-core/src/citation.rs
+++ b/crates/openwave-core/src/citation.rs
@@ -7,7 +7,7 @@
 use std::collections::HashSet;
 
 use crate::RetrievalEvidenceInput;
-use crate::{AssistantCitationId, MessageId};
+use crate::{AssistantCitationId, DocumentId, MessageId};
 
 const SOURCE_REFERENCE_PREFIX: &str = "[[ow-source:";
 const SOURCE_REFERENCE_SUFFIX: &str = "]]";
@@ -40,15 +40,39 @@ pub struct ParsedAssistantCitations {
 }
 
 /// Renderer-safe historical citation projected from immutable evidence.
+///
+/// The source identity and canonical-text span travel with the excerpt because
+/// a citation is a position in a document, not just a quotation of one: without
+/// them a reader can only be shown the words again, never where they came from.
+/// Neither is a capability — the document id already addresses the source panel,
+/// and the span only means anything against text the same client can already
+/// read.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, ts_rs::TS)]
 pub struct AssistantCitationSnapshot {
     pub id: AssistantCitationId,
     #[serde(skip)]
     pub message_id: MessageId,
     pub ordinal: u16,
+    /// The cited source, addressable as a document panel.
+    pub document_id: DocumentId,
+    /// Half-open byte range of the cited passage in that document's canonical
+    /// text, which is the text the extracted-text view renders.
+    pub span: CitationSpan,
     pub excerpt: String,
     pub heading: Option<String>,
     pub pages: Vec<u32>,
+}
+
+/// A citation's byte range, projected for the renderer.
+///
+/// [`crate::ByteSpan`] is `usize`, which is a host-width detail rather than part
+/// of a wire contract; canonical text is bounded well inside `u32`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, ts_rs::TS)]
+pub struct CitationSpan {
+    /// Inclusive start byte offset.
+    pub start: u32,
+    /// Exclusive end byte offset.
+    pub end: u32,
 }
 
 /// Produce the exact closed reference a search result gives to the model.

--- a/crates/openwave-core/src/db/ops/citation.rs
+++ b/crates/openwave-core/src/db/ops/citation.rs
@@ -6,7 +6,7 @@ use sea_orm::{
 };
 
 use crate::citation::{
-    parse_assistant_citations, AssistantCitationReference, AssistantCitationSnapshot,
+    parse_assistant_citations, AssistantCitationReference, AssistantCitationSnapshot, CitationSpan,
     MAX_ASSISTANT_CITATIONS, MAX_CITATION_EXCERPT_CHARS, MAX_CITATION_HEADING_CHARS,
     MAX_CITATION_PAGES,
 };
@@ -383,11 +383,19 @@ where
                 .take(MAX_CITATION_HEADING_CHARS)
                 .collect()
         });
+        let span = CitationSpan {
+            start: u32::try_from(evidence.evidence.span.start)
+                .map_err(|_| AgentError::Store("citation span exceeds the wire range".into()))?,
+            end: u32::try_from(evidence.evidence.span.end)
+                .map_err(|_| AgentError::Store("citation span exceeds the wire range".into()))?,
+        };
         snapshots.push(AssistantCitationSnapshot {
             id: AssistantCitationId(row.id),
             message_id: MessageId(row.message_id),
             ordinal: u16::try_from(row.ordinal)
                 .map_err(|_| AgentError::Store("invalid assistant citation ordinal".into()))?,
+            document_id: evidence.evidence.document_id,
+            span,
             excerpt: evidence
                 .evidence
                 .snippet

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -80,7 +80,7 @@ pub use blob::FsBlobStore;
 pub use cancel::{CancelToken, Cancelled};
 pub use citation::{
     format_source_reference, parse_assistant_citations, AssistantCitationReference,
-    AssistantCitationSnapshot, ParsedAssistantCitations, MAX_ASSISTANT_CITATIONS,
+    AssistantCitationSnapshot, CitationSpan, ParsedAssistantCitations, MAX_ASSISTANT_CITATIONS,
     MAX_CITATION_EXCERPT_CHARS, MAX_CITATION_HEADING_CHARS, MAX_CITATION_PAGES,
 };
 pub use client_tools::{

--- a/crates/openwave-desktop/ui/src/AssistantSources.test.tsx
+++ b/crates/openwave-desktop/ui/src/AssistantSources.test.tsx
@@ -6,6 +6,8 @@ function source(overrides: Partial<AssistantSource> = {}): AssistantSource {
   return {
     id: "private-source-id",
     ordinal: 1,
+    documentId: "document-1",
+    span: { start: 0, end: 26 },
     excerpt: "A short supporting excerpt.",
     heading: "Project notes",
     pages: [2, 3],

--- a/crates/openwave-desktop/ui/src/AssistantSources.tsx
+++ b/crates/openwave-desktop/ui/src/AssistantSources.tsx
@@ -3,6 +3,13 @@ import { ChevronRight } from "lucide-react";
 export type AssistantSource = Readonly<{
   id: string;
   ordinal: number;
+  /** The cited source, which is the document panel this row opens. */
+  documentId: string;
+  /**
+   * Half-open byte range of the cited passage in the document's canonical
+   * text — the position the source panel highlights and scrolls to.
+   */
+  span: Readonly<{ start: number; end: number }>;
   excerpt: string;
   heading: string | null;
   pages: number[];
@@ -10,6 +17,11 @@ export type AssistantSource = Readonly<{
 
 type AssistantSourcesProps = {
   sources: readonly AssistantSource[];
+  /**
+   * Open the cited place in the source panel. Omitted where there is no panel
+   * to open into, which leaves the list exactly as it reads today.
+   */
+  onOpenSource?: (source: AssistantSource) => void;
 };
 
 // Matches the server's MAX_ASSISTANT_CITATIONS contract. Keeping the guard in
@@ -20,11 +32,19 @@ const MAX_EXCERPT_CHARACTERS = 600;
 const MAX_PAGE_REFERENCES = 8;
 
 /**
- * A closed, presentation-only view of evidence attached to an assistant
- * response. It intentionally has no navigation callbacks: source identity,
- * storage paths, and retrieval tokens stay outside the rendered surface.
+ * Evidence attached to an assistant response, as a list of places rather than a
+ * list of quotations: a row opens the document it came from at the passage it
+ * quoted.
+ *
+ * What a row carries is still closed. Storage paths, retrieval tokens, and the
+ * call the evidence came from stay outside the rendered surface; the document
+ * id and the cited span are here because they are the address, and neither is
+ * useful without the source panel that already resolves them.
  */
-export function AssistantSources({ sources }: AssistantSourcesProps) {
+export function AssistantSources({
+  sources,
+  onOpenSource,
+}: AssistantSourcesProps) {
   const visibleSources = [...sources]
     .map((source, inputIndex) => ({ source, inputIndex }))
     .sort(
@@ -71,19 +91,50 @@ export function AssistantSources({ sources }: AssistantSourcesProps) {
             <span className="assistant-source-number" aria-hidden="true">
               {source.ordinal}
             </span>
-            <div className="assistant-source-copy">
-              {boundedText(source.heading, MAX_HEADING_CHARACTERS) ? (
-                <strong>
-                  {boundedText(source.heading, MAX_HEADING_CHARACTERS)}
-                </strong>
-              ) : null}
-              <p>{boundedText(source.excerpt, MAX_EXCERPT_CHARACTERS)}</p>
-              <PageReferences pages={source.pages} />
-            </div>
+            <SourceCopy source={source} onOpen={onOpenSource} />
           </li>
         ))}
       </ol>
     </details>
+  );
+}
+
+/**
+ * The row's text, as a button wherever it can be opened.
+ *
+ * A citation whose document id did not survive the round trip is still worth
+ * reading, so it degrades to the plain excerpt rather than to a control that
+ * goes nowhere.
+ */
+function SourceCopy({
+  source,
+  onOpen,
+}: {
+  source: AssistantSource;
+  onOpen?: (source: AssistantSource) => void;
+}) {
+  const heading = boundedText(source.heading, MAX_HEADING_CHARACTERS);
+  const body = (
+    <>
+      {heading ? <strong>{heading}</strong> : null}
+      <p>{boundedText(source.excerpt, MAX_EXCERPT_CHARACTERS)}</p>
+      <PageReferences pages={source.pages} />
+    </>
+  );
+
+  if (!onOpen || !source.documentId) {
+    return <div className="assistant-source-copy">{body}</div>;
+  }
+
+  return (
+    <button
+      type="button"
+      className="assistant-source-copy assistant-source-open"
+      aria-label={`Open source ${source.ordinal}`}
+      onClick={() => onOpen(source)}
+    >
+      {body}
+    </button>
   );
 }
 

--- a/crates/openwave-desktop/ui/src/AssistantWorkingIndicator.test.tsx
+++ b/crates/openwave-desktop/ui/src/AssistantWorkingIndicator.test.tsx
@@ -60,6 +60,8 @@ describe("AssistantWorkingIndicator", () => {
               {
                 id: "source",
                 ordinal: 1,
+                documentId: "document-1",
+                span: { start: 0, end: 16 },
                 excerpt: "Visible evidence",
                 heading: null,
                 pages: [],

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -52,6 +52,7 @@ import { PanelFrame } from "./panel/PanelFrame";
 import { PanelLayout } from "./panel/PanelLayout";
 import type { PanelContent } from "./panel/panelTypes";
 import { usePanelNav } from "./panel/usePanelNav";
+import { SourceNavProvider, useStableSourceNav } from "./panel/SourceNav";
 import { PanelBreadcrumb } from "./components/PanelHeader";
 import { RouteFrame } from "./RouteFrame";
 import { ChatSidebar } from "./sidebar/ChatSidebar";
@@ -88,6 +89,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   const navigate = useNavigate();
   const { client, models, status, setStatus } = useApp();
   const { layout, openPanel } = usePanelNav();
+  const sourceNav = useStableSourceNav(openPanel);
   const chats = useChatListStore((state) => state.chats);
   const deletingChatId = useChatListStore((state) => state.deletingChatId);
   const busy = useChatSessionStore((session) => session.busy);
@@ -435,7 +437,11 @@ export function ChatRoute({ chatId }: { chatId: string }) {
           </span>
         </div>
       </header>
-      <PanelLayout layout={layout} renderPanel={renderPanel} />
+      {/* Citations live in the transcript but open into the panel beside it,
+          so the way there is provided above both slots. */}
+      <SourceNavProvider value={sourceNav}>
+        <PanelLayout layout={layout} renderPanel={renderPanel} />
+      </SourceNavProvider>
       <ImportQueue />
       <DocumentDropTarget chatId={chatId} />
     </div>

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -17,6 +17,8 @@ const transcript: ChatTranscript = {
         {
           id: "citation-private-id",
           ordinal: 1,
+          document_id: "document-1",
+          span: { start: 0, end: 22 },
           excerpt: "Bounded source excerpt",
           heading: null,
           pages: [],
@@ -72,6 +74,8 @@ describe("terminal transcript presentation", () => {
           {
             id: "citation-private-id",
             ordinal: 1,
+            documentId: "document-1",
+            span: { start: 0, end: 22 },
             excerpt: "Bounded source excerpt",
             heading: null,
             pages: [],
@@ -162,6 +166,8 @@ describe("terminal transcript presentation", () => {
             {
               id: "citation-second",
               ordinal: 2,
+              document_id: "document-2",
+              span: { start: 30, end: 52 },
               excerpt: "Second bounded excerpt",
               heading: "Heading",
               pages: [4],
@@ -181,6 +187,8 @@ describe("terminal transcript presentation", () => {
           {
             id: "citation-private-id",
             ordinal: 1,
+            documentId: "document-1",
+            span: { start: 0, end: 22 },
             excerpt: "Bounded source excerpt",
             heading: null,
             pages: [],
@@ -188,6 +196,8 @@ describe("terminal transcript presentation", () => {
           {
             id: "citation-second",
             ordinal: 2,
+            documentId: "document-2",
+            span: { start: 30, end: 52 },
             excerpt: "Second bounded excerpt",
             heading: "Heading",
             pages: [4],

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -267,6 +267,8 @@ describe("MessageBubble", () => {
           {
             id: "private-citation-id",
             ordinal: 1,
+            documentId: "document-1",
+            span: { start: 0, end: 20 },
             excerpt: "First source excerpt",
             heading: "First source",
             pages: [4],

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -26,6 +26,7 @@ import { UserQuestionsCard } from "./UserQuestionsCard";
 import type { TranscriptImageAttachment } from "./ImageAttachments";
 import { TranscriptImageAttachments } from "./TranscriptImageAttachments";
 import { BackgroundAgentList } from "./BackgroundAgentList";
+import { useSourceNav } from "./panel/SourceNav";
 
 export type ChatMessage =
   | {
@@ -464,6 +465,8 @@ function MessageBubbleImpl({
   imageClient?: Pick<ApiClient, "getChatImageAttachment">;
   chatId?: string;
 }) {
+  const sourceNav = useSourceNav();
+
   if (message.role === "assistant") {
     if (!message.text && message.sources.length === 0) return null;
 
@@ -481,7 +484,18 @@ function MessageBubbleImpl({
     return (
       <article className="message message-assistant" aria-label="Assistant">
         {message.text && <MessageMarkdown>{message.text}</MessageMarkdown>}
-        <AssistantSources sources={message.sources} />
+        <AssistantSources
+          sources={message.sources}
+          onOpenSource={
+            sourceNav
+              ? (source) =>
+                  sourceNav.openCitation({
+                    documentId: source.documentId,
+                    citationId: source.id,
+                  })
+              : undefined
+          }
+        />
         <MessageFooter
           role="assistant"
           text={message.text}

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
@@ -156,6 +156,8 @@ describe("hydrateTranscriptHistory", () => {
             {
               id: "citation-1",
               ordinal: 1,
+              document_id: "document-1",
+              span: { start: 0, end: 12 },
               excerpt: "safe excerpt",
               heading: "Safe heading",
               pages: [2],

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -60,9 +60,11 @@ export function hydrateTranscriptHistory(
       sources:
         message.role === "assistant"
           ? (message.citations ?? []).map(
-              ({ id, ordinal, excerpt, heading, pages }) => ({
+              ({ id, ordinal, document_id, span, excerpt, heading, pages }) => ({
                 id,
                 ordinal,
+                documentId: document_id,
+                span: { start: span.start, end: span.end },
                 excerpt,
                 heading,
                 pages,

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -87,8 +87,24 @@ export type AssistantCitationId = string;
 
 /**
  * Renderer-safe historical citation projected from immutable evidence.
+ *
+ * The source identity and canonical-text span travel with the excerpt because
+ * a citation is a position in a document, not just a quotation of one: without
+ * them a reader can only be shown the words again, never where they came from.
+ * Neither is a capability — the document id already addresses the source panel,
+ * and the span only means anything against text the same client can already
+ * read.
  */
-export type AssistantCitationSnapshot = { id: AssistantCitationId, ordinal: number, excerpt: string, heading: string | null, pages: Array<number>, };
+export type AssistantCitationSnapshot = { id: AssistantCitationId, ordinal: number, 
+/**
+ * The cited source, addressable as a document panel.
+ */
+document_id: DocumentId, 
+/**
+ * Half-open byte range of the cited passage in that document's canonical
+ * text, which is the text the extracted-text view renders.
+ */
+span: CitationSpan, excerpt: string, heading: string | null, pages: Array<number>, };
 
 /**
  * Identifies one tool call, stable across its request/approval/result.
@@ -209,6 +225,22 @@ export type ChatTranscript = { messages: Array<ChatMessageSnapshot>,
 tool_activity: Array<ChatToolActivitySnapshot>, last_event_seq: number, };
 
 /**
+ * A citation's byte range, projected for the renderer.
+ *
+ * [`crate::ByteSpan`] is `usize`, which is a host-width detail rather than part
+ * of a wire contract; canonical text is bounded well inside `u32`.
+ */
+export type CitationSpan = { 
+/**
+ * Inclusive start byte offset.
+ */
+start: number, 
+/**
+ * Exclusive end byte offset.
+ */
+end: number, };
+
+/**
  * Renderer-safe configuration and readiness.
  */
 export type CodeExecutionConfigInfo = { provider?: CodeExecutionProviderKind, timeout_ms: number, available: boolean, };
@@ -239,6 +271,14 @@ context_window: number,
  * Maximum output sent to the endpoint.
  */
 max_output_tokens: number, };
+
+/**
+ * Identifies an authoritative source document.
+ *
+ * Usually minted fresh with [`DocumentId::new`], but [`DocumentId::derive`]
+ * preserves the existing stable URI identity used by retrieval ingestion.
+ */
+export type DocumentId = string;
 
 /**
  * One entitled connected app, with the slugs of the MCP endpoints that

--- a/crates/openwave-desktop/ui/src/panel/SourceNav.tsx
+++ b/crates/openwave-desktop/ui/src/panel/SourceNav.tsx
@@ -1,0 +1,54 @@
+import { createContext, useContext, useMemo, useRef } from "react";
+
+import type { PanelContent } from "./panelTypes";
+
+/** Where a citation points: one place inside one source. */
+export type CitationTarget = {
+  documentId: string;
+  citationId: string;
+};
+
+export type SourceNav = {
+  openCitation: (target: CitationTarget) => void;
+};
+
+const SourceNavContext = createContext<SourceNav | null>(null);
+
+export const SourceNavProvider = SourceNavContext.Provider;
+
+/**
+ * How a citation reaches the source panel beside it, or `null` where there is
+ * no panel to reach.
+ *
+ * A citation is rendered several components below the route that owns the
+ * layout, and most of what sits in between has no business knowing about
+ * panels — so this is read where the citation is rather than threaded through
+ * each of them. Read outside a provider it is `null`, and a citation renders as
+ * it always has.
+ */
+export function useSourceNav(): SourceNav | null {
+  return useContext(SourceNavContext);
+}
+
+/**
+ * A `SourceNav` whose identity survives a re-render.
+ *
+ * The transcript re-renders on every streamed token, and a context value that
+ * changed with it would re-render every settled message alongside the live one,
+ * defeating the memoization that keeps streaming cheap. Only the latest way to
+ * navigate is needed, and only at the moment of a click, so it is read through
+ * a ref instead of captured.
+ */
+export function useStableSourceNav(
+  openPanel: (panel: PanelContent) => void,
+): SourceNav {
+  const latest = useRef(openPanel);
+  latest.current = openPanel;
+  return useMemo(
+    () => ({
+      openCitation: ({ documentId, citationId }: CitationTarget) =>
+        latest.current({ type: "sources", documentId, citationId }),
+    }),
+    [],
+  );
+}

--- a/crates/openwave-desktop/ui/src/panel/panelTypes.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelTypes.ts
@@ -6,7 +6,12 @@
  */
 export type PanelContent =
   | { type: "chat" }
-  | { type: "sources"; documentId?: string }
+  /**
+   * `citationId` is where in the document to open: the citation it names
+   * carries the cited span and page. It only means anything alongside the
+   * document it points into, so it is never set without `documentId`.
+   */
+  | { type: "sources"; documentId?: string; citationId?: string }
   | { type: "outputs"; outputId?: string }
   | { type: "folders" };
 

--- a/crates/openwave-desktop/ui/src/panel/panelUrl.test.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelUrl.test.ts
@@ -23,6 +23,21 @@ describe("parsePanelSegment", () => {
     });
   });
 
+  it("reads the citation a source panel should open at", () => {
+    expect(parsePanelSegment("sources.0e5b1c3a.7f21b904")).toEqual({
+      type: "sources",
+      documentId: "0e5b1c3a",
+      citationId: "7f21b904",
+    });
+  });
+
+  it("rejects a citation target that addresses nothing", () => {
+    // Half an address, or one segment more than the grammar has.
+    expect(parsePanelSegment("sources..7f21b904")).toBeNull();
+    expect(parsePanelSegment("sources.0e5b1c3a.")).toBeNull();
+    expect(parsePanelSegment("sources.0e5b1c3a.7f21b904.extra")).toBeNull();
+  });
+
   it("carries an opaque output identity", () => {
     expect(
       parsePanelSegment("outputs.550062d4-2528-5cc6-90f8-a788e119bf36"),
@@ -47,6 +62,7 @@ describe("parsePanelSegment", () => {
       { type: "chat" },
       { type: "sources" },
       { type: "sources", documentId: "doc-1" },
+      { type: "sources", documentId: "doc-1", citationId: "cite-1" },
       { type: "outputs" },
       {
         type: "outputs",

--- a/crates/openwave-desktop/ui/src/panel/panelUrl.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelUrl.ts
@@ -10,17 +10,21 @@ import {
  * and linked at — which is what a citation needs in order to point at a place
  * inside a document rather than just at the app.
  *
- * The grammar is `{type}` or `{type}.{id}`:
+ * The grammar is `{type}` or `{type}.{id}`, with one source panel taking a
+ * second identifier:
  *
  *   chat
  *   sources
  *   sources.{documentId}
+ *   sources.{documentId}.{citationId}
  *   outputs
  *   outputs.{outputId}
  *   folders
  *
- * Only the first separator is significant. Output navigation carries the
- * durable opaque output identity rather than display filename.
+ * Only the first separator picks the panel type; what follows is read by that
+ * panel and nothing else. Output navigation carries the durable opaque output
+ * identity rather than a display filename. A source identifier is followed by
+ * the citation to open it at, when the reader arrived from one.
  */
 export function parsePanelSegment(segment: string): PanelContent | null {
   const separator = segment.indexOf(".");
@@ -33,12 +37,26 @@ export function parsePanelSegment(segment: string): PanelContent | null {
     case "folders":
       return id ? null : { type: "folders" };
     case "sources":
-      return id ? { type: "sources", documentId: id } : { type: "sources" };
+      return parseSourcesTarget(id);
     case "outputs":
       return id ? { type: "outputs", outputId: id } : { type: "outputs" };
     default:
       return null;
   }
+}
+
+function parseSourcesTarget(id: string): PanelContent | null {
+  if (!id) return { type: "sources" };
+
+  const separator = id.indexOf(".");
+  if (separator === -1) return { type: "sources", documentId: id };
+
+  const documentId = id.slice(0, separator);
+  const citationId = id.slice(separator + 1);
+  // A citation is a position inside one document, so neither half addresses
+  // anything alone, and a third segment is not part of the grammar.
+  if (!documentId || !citationId || citationId.includes(".")) return null;
+  return { type: "sources", documentId, citationId };
 }
 
 export function encodePanelSegment(panel: PanelContent): string {
@@ -48,7 +66,10 @@ export function encodePanelSegment(panel: PanelContent): string {
     case "folders":
       return "folders";
     case "sources":
-      return panel.documentId ? `sources.${panel.documentId}` : "sources";
+      if (!panel.documentId) return "sources";
+      return panel.citationId
+        ? `sources.${panel.documentId}.${panel.citationId}`
+        : `sources.${panel.documentId}`;
     case "outputs":
       return panel.outputId ? `outputs.${panel.outputId}` : "outputs";
   }

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -986,6 +986,28 @@ body {
   gap: 0.18rem;
 }
 
+.assistant-source-open {
+  margin: -0.2rem -0.3rem;
+  border: 0;
+  border-radius: 6px;
+  padding: 0.2rem 0.3rem;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  background: none;
+}
+
+.assistant-source-open:hover,
+.assistant-source-open:focus-visible {
+  background: color-mix(in srgb, var(--accent) 58%, transparent);
+}
+
+.assistant-source-open:hover strong,
+.assistant-source-open:focus-visible strong {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
 .assistant-source-copy strong {
   overflow-wrap: anywhere;
   color: var(--ink);

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -51,6 +51,8 @@ fn transcript_citation_json_is_closed_and_renderer_bounded() {
             id: openwave_core::AssistantCitationId::derive(message_id, 1),
             message_id,
             ordinal: 1,
+            document_id: openwave_core::DocumentId::new(),
+            span: openwave_core::CitationSpan { start: 0, end: 8 },
             excerpt: "x".repeat(openwave_core::MAX_CITATION_EXCERPT_CHARS),
             heading: Some("h".repeat(openwave_core::MAX_CITATION_HEADING_CHARS)),
             pages: (1..=u32::try_from(openwave_core::MAX_CITATION_PAGES).unwrap()).collect(),
@@ -67,20 +69,29 @@ fn transcript_citation_json_is_closed_and_renderer_bounded() {
             .keys()
             .cloned()
             .collect::<std::collections::BTreeSet<_>>(),
-        ["excerpt", "heading", "id", "ordinal", "pages"]
-            .into_iter()
-            .map(str::to_owned)
-            .collect()
+        [
+            "document_id",
+            "excerpt",
+            "heading",
+            "id",
+            "ordinal",
+            "pages",
+            "span"
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect()
     );
+    // The source and the place in it are what make a citation navigable. What
+    // stays behind are the retrieval mechanics: the token the model was given,
+    // the call it came from, the ranking, and the generation fencing.
     let encoded = serde_json::to_string(&json).unwrap();
     for private in [
-        "document_id",
         "source_token",
         "call_id",
         "rank",
         "revision",
         "generation",
-        "span",
         "chunk",
         "source_uri",
         "tool",


### PR DESCRIPTION
A citation is a position in a document, and the transcript could not express one. Evidence arrives with a document id, a byte span into that document's canonical text, and the pages the span came from; `list_snapshots_on` read all three and projected only the pages, so a citation could say which page it came from and never take a reader there.

## What the renderer now receives

`AssistantCitationSnapshot` gains `document_id` and `span`. Pages already survived and are unchanged.

The span is projected as a `CitationSpan` of `u32` rather than reusing `ByteSpan`, whose `usize` is a host-width detail rather than part of a wire contract; canonical text is bounded well inside `u32`, and the conversion fails loudly rather than truncating.

`transcript_citation_json_is_closed_and_renderer_bounded` asserted, as an explicit invariant, that neither field ever reaches a client. That invariant is what this change reverses, so the test now names the closed set including them, and keeps asserting the rest: the token the model was handed, the call the evidence came from, the ranking, the generation fence, the source URI. The document id is already the address the source panel is opened by, and the span only means anything against text the same client can already read.

The generated wire types were regenerated from the same definitions.

## The address

The panel grammar gains `sources.{documentId}.{citationId}`, so the place a citation points at is part of the URL and survives a reload, a back button, and a copied link — the extension the file's own comment anticipated.

Only the source panel reads a second identifier. Outputs still take the whole remainder after the panel name, because the two panels want opposite things from what follows it, and a source identifier is a UUID that cannot contain a separator. A segment naming half an address, or one more than the grammar has, parses to nothing and lands the reader on the conversation rather than on an error.

## The click

A citation row is now a control that opens its source with the conversation still beside it. A row whose document id did not survive the round trip degrades to the excerpt it always was, rather than to a control that goes nowhere.

The route owns the layout; the citation is rendered several components below it, and most of what sits between has no business knowing about panels. So the way to the panel is provided above both slots and read where the citation is. It is read through a ref: the transcript re-renders on every streamed token, and a context value that changed with it would re-render every settled message alongside the live one, defeating the memoization that keeps streaming cheap.

## What this does not do yet

The panel that `sources.{documentId}.{citationId}` resolves to does not act on the citation part: the extracted-text view does not yet highlight the span, and the PDF viewer does not yet open at the recorded page. That is #674, which is now unblocked — it has a target to consume and a document panel (#665) to consume it in.

## Tests

Two added to the URL grammar, which is the contract a shared link rests on: one for a citation target, one for the targets that address nothing. The round-trip case gains the citation panel. Everything else is fixture updates for the two new fields.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace`, and `cargo check --workspace --locked` with no lockfile movement. Under `ui`: `tsc` and 516 vitest tests.

Part of #545, which stays open for #674.