### PR TITLE
docs: add a one-command desktop dev launcher

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,10 @@ design before large changes.
 ## Development
 
 ```sh
+# Run the desktop app: installs the UI dependencies, then opens the window.
+# Arguments are forwarded to `cargo tauri dev`.
+scripts/dev.sh
+
 # Build everything
 cargo build --workspace
 

--- a/crates/openwave-desktop/README.md
+++ b/crates/openwave-desktop/README.md
@@ -38,7 +38,15 @@ picker is a normal decline, and paths remain confined to app-private native stat
 
 ## Run locally (native window)
 
-From this directory:
+From anywhere in the repo:
+
+```sh
+scripts/dev.sh
+```
+
+That installs the UI dependencies and opens the window. Arguments are forwarded
+to `cargo tauri dev`, so `scripts/dev.sh --features vec-lance` works. The long
+way, from this directory, is the same two steps:
 
 ```sh
 pnpm --dir ui install

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Install the desktop UI dependencies and open the app in a native window.
+#
+# Running the desktop app takes two commands from a directory that is not the
+# one you are usually in, and forgetting the first leaves Vite serving a stale
+# dependency tree. This does both, from anywhere in the repo.
+#
+#   scripts/dev.sh                      # the usual dev build
+#   scripts/dev.sh --features vec-lance # keep the document index across restarts
+#
+# Every argument is forwarded to `cargo tauri dev`.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(dirname "$script_dir")"
+desktop_dir="$repo_root/crates/openwave-desktop"
+ui_dir="$desktop_dir/ui"
+
+missing=()
+command -v pnpm >/dev/null || missing+=("pnpm — https://pnpm.io/installation")
+cargo tauri --version >/dev/null 2>&1 ||
+  missing+=("Tauri CLI 2 — cargo install tauri-cli --version \"^2\"")
+
+if ((${#missing[@]})); then
+  echo "Missing prerequisites:" >&2
+  printf '  - %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+
+echo "==> Installing UI dependencies"
+pnpm --dir "$ui_dir" install
+
+echo "==> Starting the desktop app"
+# tauri.conf.json lives here, and its before-dev hook stages the broker sidecar
+# and starts Vite.
+cd "$desktop_dir"
+exec cargo tauri dev "$@"


### PR DESCRIPTION
Running the desktop app takes two commands from `crates/openwave-desktop`, and
forgetting the first leaves Vite serving a stale dependency tree after anyone
touches `package.json`. `scripts/dev.sh` does both from anywhere in the repo:

```sh
scripts/dev.sh
scripts/dev.sh --features vec-lance
```

It resolves the repo from the script's own location rather than the working
directory, checks for pnpm and the Tauri CLI up front and names what is missing
along with how to install it, installs the UI dependencies, and then execs
`cargo tauri dev` from the directory holding `tauri.conf.json`. Every argument
is forwarded, so the existing flags still work.

The long way stays documented in the desktop README for anyone who wants to run
the steps separately.