### PR TITLE
chore: restore rustfmt on main

### DIFF
--- a/crates/openwave-core/src/db/ops/chat_prompt.rs
+++ b/crates/openwave-core/src/db/ops/chat_prompt.rs
@@ -8,8 +8,8 @@ use crate::error::Result;
 use crate::model::{ToolCallExecution, ToolCallStatus, TurnClientWaitStatus, TurnRunStatus};
 use crate::storage::PendingChatPrompt;
 use crate::{
-    validate_request_folder_access_arguments, CallId, ChatId, ASK_USER_QUESTIONS_TOOL,
-    validate_write_output_to_connected_folder_arguments, REQUEST_FOLDER_ACCESS_TOOL,
+    validate_request_folder_access_arguments, validate_write_output_to_connected_folder_arguments,
+    CallId, ChatId, ASK_USER_QUESTIONS_TOOL, REQUEST_FOLDER_ACCESS_TOOL,
     WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
 };
 
@@ -127,9 +127,7 @@ pub(in crate::db) async fn list_pending_chat_prompts(
     }
 
     let writeback_calls = entities::tool_call::Entity::find()
-        .filter(
-            entities::tool_call::Column::Name.eq(WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL),
-        )
+        .filter(entities::tool_call::Column::Name.eq(WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL))
         .filter(entities::tool_call::Column::Execution.eq(ToolCallExecution::Client.as_str()))
         .filter(entities::tool_call::Column::Status.eq(ToolCallStatus::Pending.as_str()))
         .order_by_asc(entities::tool_call::Column::ChatId)

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -90,13 +90,13 @@ pub use client_tools::{
     validate_list_connected_folders_arguments, validate_list_folder_arguments,
     validate_read_connected_file_arguments, validate_request_folder_access_arguments,
     validate_write_output_to_connected_folder_arguments,
-    write_output_to_connected_folder_tool_spec,
-    ImportConnectedFileArgs, ImportConnectedFileResult, ListConnectedFoldersArgs, ListFolderArgs,
-    OutputWriteMode, ReadConnectedFileArgs, RequestFolderAccessArgs, RequestFolderAccessResult,
-    RequestedFolderCapability, RequestedFolderHint, IMPORT_CONNECTED_FILE_TOOL,
+    write_output_to_connected_folder_tool_spec, ImportConnectedFileArgs, ImportConnectedFileResult,
+    ListConnectedFoldersArgs, ListFolderArgs, OutputWriteMode, ReadConnectedFileArgs,
+    RequestFolderAccessArgs, RequestFolderAccessResult, RequestedFolderCapability,
+    RequestedFolderHint, WriteOutputToConnectedFolderArgs, IMPORT_CONNECTED_FILE_TOOL,
     LIST_CONNECTED_FOLDERS_TOOL, LIST_FOLDER_TOOL, MAX_CONNECTED_FOLDER_PATH_BYTES,
     MAX_FOLDER_ACCESS_REASON_CHARS, READ_CONNECTED_FILE_TOOL, REQUEST_FOLDER_ACCESS_TOOL,
-    WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL, WriteOutputToConnectedFolderArgs,
+    WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
 };
 pub use config::{Config, Profile};
 #[cfg(any(feature = "sqlite", feature = "postgres"))]

--- a/crates/openwave-desktop/src/client_execution/output_writeback.rs
+++ b/crates/openwave-desktop/src/client_execution/output_writeback.rs
@@ -9,8 +9,8 @@ use std::collections::HashSet;
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use openwave_core::{
-    CallId, ChatId, HostRootId, OutputWriteMode, ToolCallRecord,
-    WriteOutputToConnectedFolderArgs, WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
+    CallId, ChatId, HostRootId, OutputWriteMode, ToolCallRecord, WriteOutputToConnectedFolderArgs,
+    WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
 };
 use openwave_host_broker::{
     ErrorCode, OperationEnvelope, OperationRequest, OperationResult, RelativePath, RootId,
@@ -188,14 +188,13 @@ async fn recover_once(app: &AppHandle) -> bool {
                     continue;
                 }
             };
-            let claimed =
-                match canonical_arguments(&claim.call, summary.chat_id, call_id) {
-                    Ok(claimed) if claimed == arguments => claimed,
-                    _ => {
-                        failed = true;
-                        continue;
-                    }
-                };
+            let claimed = match canonical_arguments(&claim.call, summary.chat_id, call_id) {
+                Ok(claimed) if claimed == arguments => claimed,
+                _ => {
+                    failed = true;
+                    continue;
+                }
+            };
             let receipt =
                 match prepare_receipt(&state, claim.call, claim.lease_token, claimed, None).await {
                     Ok(receipt) => receipt,
@@ -207,10 +206,7 @@ async fn recover_once(app: &AppHandle) -> bool {
                         continue;
                     }
                 };
-            if state
-                .receipts
-                .save_output_writeback(&receipt)
-                .is_err()
+            if state.receipts.save_output_writeback(&receipt).is_err()
                 || execute_receipt(app, &state, receipt).await.is_err()
             {
                 failed = true;
@@ -358,12 +354,7 @@ async fn execute_receipt(
         let output = output.clone();
         let revision = revision.clone();
         tauri::async_runtime::spawn_blocking(move || {
-            read_output_revision_bytes(
-                &scratch_root,
-                receipt.chat_id,
-                &output,
-                &revision,
-            )
+            read_output_revision_bytes(&scratch_root, receipt.chat_id, &output, &revision)
         })
         .await
         .map_err(|_| "could not read immutable output revision".to_owned())??
@@ -376,7 +367,9 @@ async fn execute_receipt(
         OutputWriteMode::Create => WriteFileMode::Create,
         OutputWriteMode::Replace => WriteFileMode::Replace,
     };
-    let approval = receipt.approval_id.map(|approval_id| WriteApproval { approval_id });
+    let approval = receipt
+        .approval_id
+        .map(|approval_id| WriteApproval { approval_id });
 
     client
         .heartbeat(receipt.chat_id, receipt.call_id, receipt.lease_token)

--- a/crates/openwave-desktop/src/client_execution/receipt_store.rs
+++ b/crates/openwave-desktop/src/client_execution/receipt_store.rs
@@ -13,8 +13,8 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use chrono::{DateTime, Utc};
 use openwave_core::{
     validate_deliverable_name, CallId, ChatId, HostRootId, OutputId, OutputRevisionId,
-    OutputWriteMode, RootAttachmentChangeId, MAX_ATTACHMENT_REVISION, MAX_DELIVERABLE_BYTES,
-    MAX_CONNECTED_FOLDER_PATH_BYTES,
+    OutputWriteMode, RootAttachmentChangeId, MAX_ATTACHMENT_REVISION,
+    MAX_CONNECTED_FOLDER_PATH_BYTES, MAX_DELIVERABLE_BYTES,
 };
 use openwave_host_broker::GrantSubject;
 use openwave_host_broker::OperationId;
@@ -684,8 +684,7 @@ impl OutputWritebackReceipt {
             || matches!(self.mode, OutputWriteMode::Create) && self.approval_id.is_some()
             || matches!(self.mode, OutputWriteMode::Replace)
                 && self.approval_id.is_none_or(|id| id.is_nil())
-            || self.resolution.is_some()
-                && self.phase != FolderOperationPhase::DispatchStarted
+            || self.resolution.is_some() && self.phase != FolderOperationPhase::DispatchStarted
         {
             return Err(invalid_data("invalid output-writeback receipt"));
         }
@@ -901,10 +900,7 @@ impl ReceiptStore {
         write_atomically(&self.directory, &path, &bytes)
     }
 
-    pub(super) fn save_output_writeback(
-        &self,
-        receipt: &OutputWritebackReceipt,
-    ) -> io::Result<()> {
+    pub(super) fn save_output_writeback(&self, receipt: &OutputWritebackReceipt) -> io::Result<()> {
         receipt.validate()?;
         let bytes = serde_json::to_vec(receipt).map_err(invalid_data)?;
         if bytes.len() > MAX_RECEIPT_BYTES {
@@ -913,7 +909,11 @@ impl ReceiptStore {
         let path = self.output_writeback_receipt_path(receipt.call_id);
         match fs::symlink_metadata(&path) {
             Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => {}
-            Ok(_) => return Err(invalid_data("output-writeback receipt is not a regular file")),
+            Ok(_) => {
+                return Err(invalid_data(
+                    "output-writeback receipt is not a regular file",
+                ))
+            }
             Err(error) if error.kind() == io::ErrorKind::NotFound => {
                 if self.load_output_writebacks()?.len() >= MAX_RECEIPTS {
                     return Err(invalid_data("too many durable output-writeback receipts"));

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -907,8 +907,7 @@ impl Operator {
                     Ok(result)
                 }
                 OperationRequest::WriteFile(request) => {
-                    let (result, authorized_by) =
-                        self.write_file(envelope.context, request)?;
+                    let (result, authorized_by) = self.write_file(envelope.context, request)?;
                     grant_id = authorized_by;
                     Ok(OperationResult::WriteFile(result))
                 }
@@ -1052,12 +1051,7 @@ impl Operator {
             .try_clone()?;
 
         let terminal = if recovering {
-            if destination_matches(
-                &directory,
-                &request.path,
-                request.bytes,
-                request.sha256,
-            ) {
+            if destination_matches(&directory, &request.path, request.bytes, request.sha256) {
                 Ok(WriteFileResult {
                     operation_id: request.operation_id,
                     bytes: request.bytes,
@@ -1269,11 +1263,9 @@ fn error_response(error: BrokerError) -> ErrorResponse {
             "write destination does not exist",
             false,
         ),
-        BrokerError::ReplacementApprovalRequired | BrokerError::InvalidWriteContent => (
-            ErrorCode::InvalidRequest,
-            "write request is invalid",
-            false,
-        ),
+        BrokerError::ReplacementApprovalRequired | BrokerError::InvalidWriteContent => {
+            (ErrorCode::InvalidRequest, "write request is invalid", false)
+        }
         BrokerError::AmbiguousWrite => (
             ErrorCode::AmbiguousWrite,
             "write outcome is ambiguous and will not be replayed",
@@ -1652,9 +1644,7 @@ fn atomic_write_connected_file(
     match directory.symlink_metadata(&filename) {
         Ok(metadata) => match mode {
             WriteFileMode::Create => return Err(BrokerError::DestinationExists),
-            WriteFileMode::Replace
-                if !metadata.is_file() || metadata.file_type().is_symlink() =>
-            {
+            WriteFileMode::Replace if !metadata.is_file() || metadata.file_type().is_symlink() => {
                 return Err(BrokerError::NotRegularFile);
             }
             WriteFileMode::Replace => {}
@@ -1709,12 +1699,7 @@ fn atomic_write_connected_file(
     result
 }
 
-fn destination_matches(
-    root: &Dir,
-    path: &RelativePath,
-    byte_len: usize,
-    sha256: [u8; 32],
-) -> bool {
+fn destination_matches(root: &Dir, path: &RelativePath, byte_len: usize, sha256: [u8; 32]) -> bool {
     if byte_len == 0 || byte_len > MAX_WRITE_FILE_BYTES {
         return false;
     }
@@ -1724,9 +1709,7 @@ fn destination_matches(
     let Ok(metadata) = directory.symlink_metadata(&filename) else {
         return false;
     };
-    if !metadata.is_file()
-        || metadata.file_type().is_symlink()
-        || metadata.len() != byte_len as u64
+    if !metadata.is_file() || metadata.file_type().is_symlink() || metadata.len() != byte_len as u64
     {
         return false;
     }

--- a/crates/openwave-host-broker/src/broker/state_file.rs
+++ b/crates/openwave-host-broker/src/broker/state_file.rs
@@ -438,10 +438,9 @@ pub(super) fn validate_loaded_state(state: &State) -> Result<(), BrokerError> {
             } if result.bytes != request.byte_len
                 || result.replaced != matches!(request.mode, crate::WriteFileMode::Replace) =>
             {
-                return Err(invalid_data(
-                    "successful write receipt does not match its request",
-                )
-                .into());
+                return Err(
+                    invalid_data("successful write receipt does not match its request").into(),
+                );
             }
             MutationRecord::Write {
                 outcome: super::MutationOutcome::Pending,

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -2612,12 +2612,7 @@ fn replacement_requires_native_approval_and_fails_closed_on_symlinks_and_revoke(
         );
     }
 
-    revoke(
-        &broker.controller(),
-        OperationId::new(),
-        subject,
-        root_id,
-    );
+    revoke(&broker.controller(), OperationId::new(), subject, root_id);
     assert!(matches!(
         operate(
             &broker.operator(),

--- a/crates/openwave-host-broker/src/capability.rs
+++ b/crates/openwave-host-broker/src/capability.rs
@@ -225,19 +225,15 @@ pub enum GrantError {
 fn validate_capability_scope(capability: Capability, scope: &Scope) -> Result<(), GrantError> {
     match (capability, scope) {
         (Capability::ListRoots, Scope::Subject)
-        | (Capability::ReadFiles | Capability::WriteFiles, Scope::Root { .. }) => {
+        | (Capability::ReadFiles | Capability::WriteFiles, Scope::Root { .. }) => Ok(()),
+        (Capability::ReadFiles | Capability::WriteFiles, Scope::PathSubtree { relative, .. })
+            if !relative.is_root() =>
+        {
             Ok(())
         }
-        (
-            Capability::ReadFiles | Capability::WriteFiles,
-            Scope::PathSubtree { relative, .. },
-        ) if !relative.is_root() => {
-            Ok(())
+        (Capability::ReadFiles | Capability::WriteFiles, Scope::PathSubtree { .. }) => {
+            Err(GrantError::EmptySubtree)
         }
-        (
-            Capability::ReadFiles | Capability::WriteFiles,
-            Scope::PathSubtree { .. },
-        ) => Err(GrantError::EmptySubtree),
         _ => Err(GrantError::InvalidCapabilityScope),
     }
 }

--- a/crates/openwave-host-broker/src/lib.rs
+++ b/crates/openwave-host-broker/src/lib.rs
@@ -37,8 +37,7 @@ pub use protocol::{
     OperationResponseEnvelope, OperationResult, PathRequest, ReadFileBinaryResult, ReadFileResult,
     RegisterRootReceipt, RegisterRootRequest, RegisterRootResult, Response, ResponseEnvelope,
     RevokeRootRequest, RevokeRootResult, RootAttachmentMutationKind, RootAttachmentMutationReceipt,
-    RootAttachmentMutationRequest, RootAttachmentMutationResult, RootSummary,
-    WriteApproval, WriteFileMode, WriteFileRequest, WriteFileResult, MAX_READ_FILE_BINARY_BYTES,
-    PROTOCOL_VERSION,
+    RootAttachmentMutationRequest, RootAttachmentMutationResult, RootSummary, WriteApproval,
+    WriteFileMode, WriteFileRequest, WriteFileResult, MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
 };
 pub use relative_path::{RelativePath, RelativePathError};

--- a/crates/openwave-host-broker/src/sidecar.rs
+++ b/crates/openwave-host-broker/src/sidecar.rs
@@ -10,8 +10,7 @@ use crate::{
 };
 
 /// Enough for one base64-encoded maximum output write plus strict envelope overhead.
-pub const MAX_REQUEST_BYTES: usize =
-    4 * crate::broker::MAX_WRITE_FILE_BYTES / 3 + 128 * 1024;
+pub const MAX_REQUEST_BYTES: usize = 4 * crate::broker::MAX_WRITE_FILE_BYTES / 3 + 128 * 1024;
 
 /// Enough for a base64 [`crate::protocol::MAX_READ_FILE_BINARY_BYTES`] payload
 /// plus envelope overhead. Binary reads are the only response that approaches

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -64,9 +64,8 @@ use openwave_core::{
     request_folder_access_tool_spec, validate_ask_user_questions_arguments,
     validate_import_connected_file_arguments, validate_list_connected_folders_arguments,
     validate_list_folder_arguments, validate_read_connected_file_arguments,
-    validate_request_folder_access_arguments, AgentConfig, AgentError, Config, CreateDeliverable,
-    validate_write_output_to_connected_folder_arguments,
-    write_output_to_connected_folder_tool_spec,
+    validate_request_folder_access_arguments, validate_write_output_to_connected_folder_arguments,
+    write_output_to_connected_folder_tool_spec, AgentConfig, AgentError, Config, CreateDeliverable,
     KeychainSecretProvider, ListDir, Profile, ReadFile, Result, SecretProvider, Store, Tool,
     ToolRegistry, WriteFile,
 };

--- a/crates/openwave-server/src/routes/client_execution.rs
+++ b/crates/openwave-server/src/routes/client_execution.rs
@@ -12,9 +12,9 @@ use serde::{Deserialize, Serialize};
 
 use chrono::{Duration, Utc};
 use openwave_core::{
-    CallId, ChatId, ClaimClientToolCallOutcome, HeartbeatClientToolCallOutcome,
-    OutputWriteMode, RequestFolderAccessArgs, RequestedFolderHint, ResolveToolCallOutcome,
-    ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnId, TurnRunStatus,
+    CallId, ChatId, ClaimClientToolCallOutcome, HeartbeatClientToolCallOutcome, OutputWriteMode,
+    RequestFolderAccessArgs, RequestedFolderHint, ResolveToolCallOutcome, ToolCallExecution,
+    ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnId, TurnRunStatus,
     WriteOutputToConnectedFolderArgs, REQUEST_FOLDER_ACCESS_TOOL,
     WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
 };

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -564,12 +564,11 @@ mod tests {
             folder_hint: Some(openwave_core::RequestedFolderHint::Documents),
             claimed: true,
         };
-        let output_writeback =
-            crate::routes::client_execution::PendingOutputWritebackRequest {
-                call_id: openwave_core::CallId(id(6)),
-                turn_id: openwave_core::TurnId(id(7)),
-                claimed: false,
-            };
+        let output_writeback = crate::routes::client_execution::PendingOutputWritebackRequest {
+            call_id: openwave_core::CallId(id(6)),
+            turn_id: openwave_core::TurnId(id(7)),
+            claimed: false,
+        };
 
         vec![
             (


### PR DESCRIPTION
`cargo fmt --all --check` fails on `main` as of 710e3d8, across 13 files in
`openwave-core`, `openwave-desktop`, `openwave-host-broker`, and
`openwave-server`. Every PR opened since inherits the red lane.

This is the output of `cargo fmt --all`, nothing else — reflowed match arms and
import lists, no logic touched.

The formatting arrived with #677. Its post-merge run is worth a look: `rustfmt`,
`clippy`, and `test` all report `skipping` while the required aggregate
`fmt · clippy · build · test` reports `fail` — that check exists precisely to
catch a lane being skipped when the change scope says it should have run, and it
did catch it, after the merge rather than before.