### PR TITLE
fix(connectors): style the loopback sign-in callback page

### DIFF
--- a/crates/openwave-connectors/src/gateway.rs
+++ b/crates/openwave-connectors/src/gateway.rs
@@ -732,12 +732,75 @@ async fn callback(
         .into_response()
 }
 
+/// One-shot page served by the ephemeral loopback listener; it must stay
+/// fully self-contained (inline CSS, no external assets).
 fn callback_page(heading: &str, message: &str) -> String {
     format!(
-        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">\
-         <meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">\
-         <title>{heading}</title></head><body><main><h1>{heading}</h1>\
-         <p>{message}</p></main></body></html>"
+        r#"<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{heading}</title>
+<style>
+  :root {{
+    color-scheme: light dark;
+    --bg: #f4f4f5;
+    --card: #ffffff;
+    --border: #e4e4e7;
+    --text: #18181b;
+    --muted: #52525b;
+  }}
+  @media (prefers-color-scheme: dark) {{
+    :root {{
+      --bg: #18181b;
+      --card: #232326;
+      --border: #3f3f46;
+      --text: #fafafa;
+      --muted: #a1a1aa;
+    }}
+  }}
+  body {{
+    margin: 0;
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    background: var(--bg);
+    color: var(--text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+      "Helvetica Neue", Arial, sans-serif;
+  }}
+  main {{
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 2.5rem 3rem;
+    margin: 1rem;
+    max-width: 24rem;
+    text-align: center;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  }}
+  .product {{
+    font-size: 0.8125rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin: 0 0 1rem;
+  }}
+  h1 {{
+    font-size: 1.375rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem;
+  }}
+  p {{
+    color: var(--muted);
+    font-size: 0.9375rem;
+    line-height: 1.5;
+    margin: 0;
+  }}
+</style></head><body><main>
+<p class="product">OpenWave</p>
+<h1>{heading}</h1>
+<p>{message}</p>
+</main></body></html>"#
     )
 }
 


### PR DESCRIPTION
The one-shot page served by the ephemeral loopback listener after gateway sign-in was skeleton HTML with no CSS — browser-default serif in the top-left corner, rendered immediately after the gateway's branded authorize page. All three variants (signed in, denied, state mismatch) read as broken at exactly the moment sign-in succeeded.

This styles `callback_page` as a centered card on a neutral background: product name, status heading, and the close-this-window line, using a system font stack and dark mode via `prefers-color-scheme`. The page stays fully self-contained (inline CSS, no external assets), as required for a one-shot response from the localhost listener; the markup structure and all three heading/message variants are unchanged.

Verified with `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace` (all green, no lock diff).

Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)