### PR TITLE
fix(desktop): hide unavailable providers from the composer model picker

### DIFF
--- a/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
@@ -1,6 +1,11 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { ModelMenu, ReasoningEffortMenu, reasoningEffortOptions } from "./ModelMenu";
+import {
+  ModelMenu,
+  ReasoningEffortMenu,
+  reasoningEffortOptions,
+  visibleModelGroups,
+} from "./ModelMenu";
 import { ProviderIcon } from "./ProviderIcons";
 import type { ModelInfo } from "./api";
 
@@ -72,6 +77,44 @@ describe("ModelMenu", () => {
       <ModelMenu models={MODELS} value={null} disabled onChange={() => {}} />,
     );
     expect(markup).toContain("disabled");
+  });
+});
+
+describe("visibleModelGroups", () => {
+  const withAvailability = (available: {
+    anthropic: boolean;
+    openai: boolean;
+  }): ModelInfo[] =>
+    MODELS.map((model) => ({
+      ...model,
+      available: available[model.provider as "anthropic" | "openai"],
+    }));
+
+  it("hides a provider whose models are all unavailable", () => {
+    const groups = visibleModelGroups(
+      withAvailability({ anthropic: true, openai: false }),
+      null,
+    );
+    expect(groups.map((group) => group.provider)).toEqual(["anthropic"]);
+  });
+
+  it("keeps the group holding the current selection even when unavailable", () => {
+    const groups = visibleModelGroups(
+      withAvailability({ anthropic: true, openai: false }),
+      "openai::gpt-4o",
+    );
+    expect(groups.map((group) => group.provider)).toEqual(["anthropic", "openai"]);
+  });
+
+  it("keeps a partially available provider intact", () => {
+    const models = withAvailability({ anthropic: true, openai: true }).map(
+      (model, index) => ({ ...model, available: index === 0 }),
+    );
+    const anthropic = visibleModelGroups(
+      [...models, { ...models[0], key: "anthropic::claude-haiku", id: "claude-haiku", available: false }],
+      null,
+    ).find((group) => group.provider === "anthropic");
+    expect(anthropic?.models).toHaveLength(2);
   });
 });
 

--- a/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
@@ -107,13 +107,16 @@ describe("visibleModelGroups", () => {
   });
 
   it("keeps a partially available provider intact", () => {
-    const models = withAvailability({ anthropic: true, openai: true }).map(
-      (model, index) => ({ ...model, available: index === 0 }),
+    const [sonnet] = MODELS;
+    const haiku = {
+      ...sonnet,
+      key: "anthropic::claude-haiku" as const,
+      id: "claude-haiku",
+      available: false,
+    };
+    const anthropic = visibleModelGroups([sonnet, haiku], null).find(
+      (group) => group.provider === "anthropic",
     );
-    const anthropic = visibleModelGroups(
-      [...models, { ...models[0], key: "anthropic::claude-haiku", id: "claude-haiku", available: false }],
-      null,
-    ).find((group) => group.provider === "anthropic");
     expect(anthropic?.models).toHaveLength(2);
   });
 });

--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -47,6 +47,26 @@ function groupByProvider(
 }
 
 /**
+ * The groups the composer picker actually shows: providers with at least one
+ * model that can run, plus — whatever its availability — the group holding the
+ * current selection, so an active override never vanishes from the menu that
+ * set it. A provider with nothing usable renders as no group at all rather
+ * than a run of disabled rows; discovery of the full registry belongs to the
+ * settings Models surface, not here.
+ */
+export function visibleModelGroups(
+  models: readonly ModelInfo[],
+  selectedKey: string | null,
+): { provider: ProviderKind; models: ModelInfo[] }[] {
+  return groupByProvider(models).filter(
+    (group) =>
+      group.models.some((model) => model.available) ||
+      (selectedKey !== null &&
+        group.models.some((model) => model.key === selectedKey)),
+  );
+}
+
+/**
  * The row that reads as a mode rather than another model.
  *
  * A picker that offers "default" as one more entry never says what picking it
@@ -179,7 +199,7 @@ export function ModelMenu({
             }}
           />
 
-          {groupByProvider(models).map((group) => (
+          {visibleModelGroups(models, canonical).map((group) => (
             <div key={group.provider}>
               <DropdownMenuSeparator />
               {group.models.map((model) => {


### PR DESCRIPTION
The composer model picker rendered every curated provider group, marking rows for unconfigured providers merely `disabled` — so a user with one configured provider scrolled past several dead groups, and the dropdown read as broken rather than filtered (#683).

This filters at the group level, renderer-side only (no wire change — the server already computes `available`):

- `visibleModelGroups` hides provider groups whose models are **all** unavailable; a partially available group still renders whole, its unavailable rows disabled as before.
- The group holding the current selection always renders, even if its provider became unavailable, so an active override never vanishes from the menu that set it.
- A selection the catalog cannot resolve keeps the existing "unavailable legacy selection" row.
- The settings Models surface is untouched and still shows the full registry.

The filter is an exported pure function with three focused tests — issue #659's picker redesign is explicitly at risk of re-introducing the disabled groups, which makes this a decision worth pinning.

Verified under `crates/openwave-desktop/ui`: `tsc --noEmit` clean, vitest (new tests pass; the only failures are 2 pre-existing `AppShell.dom.test.tsx` failures already broken on `main`, unrelated to this change), and a production `vite build`.

Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)