### PR TITLE
fix(desktop): align dialog, dropdown, tooltip, select, scrollbar, and status tokens with the design system

### DIFF
--- a/crates/openwave-desktop/ui/src/components/ui/badge.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/badge.tsx
@@ -15,12 +15,12 @@ const badgeVariants = cva(
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
         outline: "text-muted-foreground",
         success:
-          "border-transparent bg-success-background text-success-foreground",
+          "border-transparent bg-success-background text-success-foreground-muted",
         warning:
-          "border-transparent bg-warning-background text-warning-foreground",
+          "border-transparent bg-warning-background text-warning-foreground-muted",
         critical:
-          "border-transparent bg-critical-background text-critical-foreground",
-        info: "border-transparent bg-info-background text-info-foreground",
+          "border-transparent bg-critical-background text-critical-foreground-muted",
+        info: "border-transparent bg-info-background text-info-foreground-muted",
       },
       size: {
         default: "px-2.5 py-0.5 font-semibold",

--- a/crates/openwave-desktop/ui/src/components/ui/card.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/card.tsx
@@ -8,7 +8,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "bg-card text-card-foreground flex flex-col gap-6 rounded-md p-6",
+      "bg-card text-card-foreground flex flex-col gap-6 rounded-md p-6 transition-colors [&[role=button]]:hover:bg-card/50 [&[role=button]]:cursor-default",
       className,
     )}
     {...props}

--- a/crates/openwave-desktop/ui/src/components/ui/dialog.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/dialog.tsx
@@ -17,7 +17,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/60 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/80 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -45,7 +45,7 @@ const DialogContent = React.forwardRef<
       {children}
       {withCloseButton && (
         <DialogPrimitive.Close asChild>
-          <Button variant="ghost" size="icon-sm" className="absolute top-2 right-2">
+          <Button variant="ghost" size="icon" className="absolute top-2 right-2">
             <X className="size-4" />
             <span className="sr-only">Close</span>
           </Button>

--- a/crates/openwave-desktop/ui/src/components/ui/dropdown-menu.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/dropdown-menu.tsx
@@ -18,7 +18,7 @@ const DropdownMenuContent = React.forwardRef<
       sideOffset={sideOffset}
       onCloseAutoFocus={(e) => e.preventDefault()}
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[9rem] overflow-hidden rounded-md border p-1 shadow-lg",
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-lg",
         className,
       )}
       {...props}
@@ -28,7 +28,7 @@ const DropdownMenuContent = React.forwardRef<
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 const dropdownMenuItemVariants = cva(
-  "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0",
+  "relative flex cursor-default items-center gap-4 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -61,7 +61,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn("bg-border -mx-1 my-1 h-px", className)}
+    className={cn("bg-muted -mx-1 my-1 h-px", className)}
     {...props}
   />
 ));

--- a/crates/openwave-desktop/ui/src/components/ui/select.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/select.tsx
@@ -15,7 +15,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className,
     )}
     {...props}

--- a/crates/openwave-desktop/ui/src/components/ui/tooltip.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/tooltip.tsx
@@ -9,14 +9,14 @@ const TooltipTrigger = TooltipPrimitive.Trigger;
 const TooltipContent = React.forwardRef<
   React.ComponentRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 6, children, ...props }, ref) => (
+>(({ className, sideOffset = 4, children, ...props }, ref) => (
   <TooltipPrimitive.Portal>
     <TooltipPrimitive.Content
       ref={ref}
       hideWhenDetached
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-w-xs rounded-md bg-neutral-900 px-2.5 py-1.5 text-xs font-medium text-neutral-50 shadow-md select-none dark:bg-neutral-100 dark:text-neutral-900 data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-[state=closed]:zoom-out-95",
+        "z-50 max-w-xs rounded-lg bg-neutral-900 px-3 py-2.5 text-sm font-medium text-neutral-50 shadow-lg select-none dark:bg-neutral-100 dark:text-neutral-900 data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-[state=closed]:zoom-out-95",
         className,
       )}
       {...props}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -43,16 +43,24 @@
   /* Semantic status */
   --success: oklch(0.627 0.194 149.214);
   --success-foreground: oklch(0.393 0.095 152.535);
+  --success-foreground-muted: color-mix(in oklch, var(--success-foreground) 75%, transparent);
   --success-background: oklch(0.962 0.044 156.743);
+  --success-border: oklch(0.393 0.095 152.535);
   --warning: oklch(0.666 0.179 58.318);
   --warning-foreground: oklch(0.414 0.112 45.904);
+  --warning-foreground-muted: color-mix(in oklch, var(--warning-foreground) 75%, transparent);
   --warning-background: oklch(0.962 0.059 95.617);
+  --warning-border: oklch(0.414 0.112 45.904);
   --critical: oklch(0.577 0.245 27.325);
   --critical-foreground: oklch(0.396 0.141 25.723);
+  --critical-foreground-muted: color-mix(in oklch, var(--critical-foreground) 75%, transparent);
   --critical-background: oklch(0.936 0.032 17.717);
+  --critical-border: oklch(0.396 0.141 25.723);
   --info: oklch(0.588 0.158 241.966);
   --info-foreground: oklch(0.391 0.09 240.876);
+  --info-foreground-muted: color-mix(in oklch, var(--info-foreground) 75%, transparent);
   --info-background: oklch(0.951 0.026 236.824);
+  --info-border: oklch(0.391 0.09 240.876);
 
   --radius: 0.5rem;
 
@@ -137,16 +145,24 @@
   /* Semantic status — dark */
   --success: oklch(0.792 0.209 151.711);
   --success-foreground: oklch(0.962 0.044 156.743);
+  --success-foreground-muted: color-mix(in oklch, var(--success-foreground) 75%, transparent);
   --success-background: oklch(0.393 0.095 152.535);
+  --success-border: oklch(0.792 0.209 151.711);
   --warning: oklch(0.828 0.189 84.429);
   --warning-foreground: oklch(0.962 0.059 95.617);
+  --warning-foreground-muted: color-mix(in oklch, var(--warning-foreground) 75%, transparent);
   --warning-background: oklch(0.414 0.112 45.904);
+  --warning-border: oklch(0.828 0.189 84.429);
   --critical: oklch(0.704 0.191 22.216);
   --critical-foreground: oklch(0.936 0.032 17.717);
+  --critical-foreground-muted: color-mix(in oklch, var(--critical-foreground) 75%, transparent);
   --critical-background: oklch(0.396 0.141 25.723);
+  --critical-border: oklch(0.704 0.191 22.216);
   --info: oklch(0.746 0.16 232.661);
   --info-foreground: oklch(0.951 0.026 236.824);
+  --info-foreground-muted: color-mix(in oklch, var(--info-foreground) 75%, transparent);
   --info-background: oklch(0.391 0.09 240.876);
+  --info-border: oklch(0.746 0.16 232.661);
 
   --shadow-sm: 0 0px 8px 0px oklch(0 0 0 / 0.24);
   --shadow: 0 0px 8px 0px oklch(0 0 0 / 0.28);
@@ -192,19 +208,27 @@
 
   --color-success: var(--success);
   --color-success-foreground: var(--success-foreground);
+  --color-success-foreground-muted: var(--success-foreground-muted);
   --color-success-background: var(--success-background);
+  --color-success-border: var(--success-border);
 
   --color-warning: var(--warning);
   --color-warning-foreground: var(--warning-foreground);
+  --color-warning-foreground-muted: var(--warning-foreground-muted);
   --color-warning-background: var(--warning-background);
+  --color-warning-border: var(--warning-border);
 
   --color-critical: var(--critical);
   --color-critical-foreground: var(--critical-foreground);
+  --color-critical-foreground-muted: var(--critical-foreground-muted);
   --color-critical-background: var(--critical-background);
+  --color-critical-border: var(--critical-border);
 
   --color-info: var(--info);
   --color-info-foreground: var(--info-foreground);
+  --color-info-foreground-muted: var(--info-foreground-muted);
   --color-info-background: var(--info-background);
+  --color-info-border: var(--info-border);
 
   --shadow-2xs: var(--shadow-sm);
   --shadow-xs: var(--shadow-sm);
@@ -3100,10 +3124,40 @@ body {
 
 } /* @layer components */
 
-/* Scrollbar styling */
+/* Scrollbar styling. The thumb rests dim and brightens on hover; scoping the
+   color to scrollable containers keeps it from painting on every element.
+   These rules must stay unlayered to override Tailwind v4's unlayered
+   `* { scrollbar-color: initial }` reset. */
 * {
-  scrollbar-color: var(--muted-foreground) transparent;
   scrollbar-width: thin;
+}
+
+.overflow-auto,
+.overflow-scroll,
+.overflow-x-auto,
+.overflow-x-scroll,
+.overflow-y-auto,
+.overflow-y-scroll {
+  scrollbar-color: var(--muted) transparent;
+  transition: scrollbar-color 300ms;
+}
+
+.overflow-auto:hover,
+.overflow-scroll:hover,
+.overflow-x-auto:hover,
+.overflow-x-scroll:hover,
+.overflow-y-auto:hover,
+.overflow-y-scroll:hover {
+  scrollbar-color: var(--color-zinc-400) transparent;
+}
+
+.dark .overflow-auto:hover,
+.dark .overflow-scroll:hover,
+.dark .overflow-x-auto:hover,
+.dark .overflow-x-scroll:hover,
+.dark .overflow-y-auto:hover,
+.dark .overflow-y-scroll:hover {
+  scrollbar-color: var(--ring) transparent;
 }
 
 /* ---------- Window chrome ---------- */


### PR DESCRIPTION
Several shared UI primitives had drifted from the design system. This brings them back in line:

- **Dialog** — overlay darkens to `bg-black/80` (matching `AlertDialog`) and the close button uses the `icon` size so it aligns with other icon buttons.
- **Dropdown menu** — items space icon and label at `gap-4`, content rests at the standard `min-w-[8rem]`, and the separator uses the `muted` token.
- **Tooltip** — larger padding, text, radius, and shadow (`px-3 py-2.5 text-sm rounded-lg shadow-lg`), sitting closer to its trigger (`sideOffset` 4).
- **Select** — the trigger is `h-10` so it aligns with inputs and default buttons in mixed form rows.
- **Scrollbar** — the global thumb now rests dim (`--muted`) and brightens on hover with a `300ms` transition, scoped to scrollable containers rather than painting on every element.
- **Status tokens** — success/warning/critical/info gain `-foreground-muted` (a 75% mix toward transparent) and `-border` variants in both themes, wired through `@theme inline`; status badges switch to the muted foreground for softer text on their tinted backgrounds.
- **Card** — gains a hover treatment when it acts as a button (`[&[role=button]]`).

Closes #686