### PR TITLE
feat(desktop): mount the toaster and confirm settings saves

### DIFF
--- a/crates/openwave-desktop/ui/src/main.tsx
+++ b/crates/openwave-desktop/ui/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "@tanstack/react-router";
+import { Toaster } from "@/components/ui/sonner";
 import { ErrorBoundary } from "./ErrorBoundary";
 import { refuseStrayFileDrops } from "./ImageAttachments";
 import { startImportQueue } from "./ImportQueueStore";
@@ -16,6 +17,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <ErrorBoundary>
       <RouterProvider router={router} />
+      <Toaster richColors />
     </ErrorBoundary>
   </React.StrictMode>,
 );

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import type {
   ApiClient,
   CodeExecutionConfigInfo,
@@ -73,6 +74,7 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
       setConfig(nextConfig);
       setProvider(nextConfig.provider ?? "");
       setTimeoutMs(String(nextConfig.timeout_ms));
+      toast.success("Saved code-execution configuration");
     } catch (err) {
       setError(String(err));
     } finally {

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 import { ExternalLink, LogOut, RefreshCw } from "lucide-react";
 import type { ApiClient, GatewayApps, GatewayStatus } from "../api";
 import { openExternal } from "../host";
@@ -117,6 +118,7 @@ export function GatewayPanel({
       setDirty(false);
       dirtyRef.current = false;
       onChanged();
+      toast.success("Saved gateway settings");
     });
   }
 
@@ -202,6 +204,7 @@ export function GatewayPanel({
                   void run(async () => {
                     await client.syncGatewayModels();
                     onChanged();
+                    toast.success("Refreshed entitled models");
                   })
                 }
               >
@@ -216,6 +219,7 @@ export function GatewayPanel({
                   void run(async () => {
                     await client.gatewaySignOut();
                     onChanged();
+                    toast.success("Disconnected from the gateway");
                   })
                 }
               >

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type ReactNode } from "react";
+import { toast } from "sonner";
 import { Plus, RefreshCw, Trash2 } from "lucide-react";
 import type {
   ApiClient,
@@ -113,6 +114,7 @@ export function McpPanel({ client }: { client: ApiClient }) {
       const result = await client.putMcpServers(servers.map(definition));
       setServers(result.servers);
       setDirty(false);
+      toast.success("Saved MCP servers");
     } catch (err) {
       setError(String(err));
     } finally {

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { toast } from "sonner";
 import type {
   ApiClient,
   CustomModelConfig,
@@ -98,6 +99,7 @@ function ProviderRow({
       setKey("");
       setServiceAccountJson("");
       onChanged();
+      toast.success(`Saved ${providerLabel(info.kind)} settings`);
     } catch (err) {
       setError(String(err));
     } finally {
@@ -111,6 +113,7 @@ function ProviderRow({
     try {
       await client.deleteCredential(info.kind as ProviderKind);
       onChanged();
+      toast.success(`Removed the saved ${providerLabel(info.kind)} credential`);
     } catch (err) {
       setError(String(err));
     } finally {

--- a/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import type {
   ApiClient,
   WebSearchConfigInfo,
@@ -97,6 +98,7 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
       });
       setConfig(nextConfig);
       setTimeoutMs(String(nextConfig.timeout_ms));
+      toast.success("Saved web-search configuration");
     } catch (err) {
       setError(String(err));
     } finally {
@@ -112,6 +114,7 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
       await client.putWebSearchCredential(activeProvider, apiKey.trim());
       setApiKey("");
       await refresh();
+      toast.success("Saved the API key");
     } catch (err) {
       setError(String(err));
     } finally {
@@ -126,6 +129,7 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
     try {
       await client.deleteWebSearchCredential(activeProvider);
       await refresh();
+      toast.success("Removed the saved API key");
     } catch (err) {
       setError(String(err));
     } finally {


### PR DESCRIPTION
The settings panels saved credentials and configuration without any confirmation, so a successful save looked identical to a no-op. The `Toaster` component already existed but nothing mounted it and nothing called `toast()`.

- Mount `<Toaster richColors />` once at the app root, alongside the router inside the error boundary.
- Raise a success toast when a provider, gateway, MCP, web-search, or code-execution save (or credential removal) completes.

Form-scoped validation and load errors keep their existing inline `SettingsError` surface — the toasts complement it with page-independent confirmation for actions that previously succeeded silently.

Closes #687