### PR TITLE
fix(desktop): scope the keychain service by build profile

### DIFF
--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -61,7 +61,14 @@ fn usage_error(message: &str) -> ! {
 
 /// Bind the server and run its accept loop, announcing where to reach it.
 async fn serve() -> Result<()> {
-    let config = Config::from_env()?;
+    #[cfg_attr(not(debug_assertions), allow(unused_mut))]
+    let mut config = Config::from_env()?;
+    // Debug builds keep their own keychain service, matching the desktop's
+    // dev/release split: a dev daemon must not mutate release secret state.
+    #[cfg(debug_assertions)]
+    {
+        config.keychain_service = Some("openwave.dev".into());
+    }
     let server = openwave_server::bind_configured(config).await?;
     // The address and token are the client's entry point: the parent process that
     // launched the daemon reads them from stdout to connect. The token is a secret,

--- a/crates/openwave-core/src/config.rs
+++ b/crates/openwave-core/src/config.rs
@@ -167,6 +167,12 @@ mod tests {
     }
 
     #[test]
+    fn legacy_config_without_keychain_service_defaults_to_none() {
+        let config = serde_json::from_str::<Config>(r#"{"data_dir":"/data"}"#).unwrap();
+        assert_eq!(config.keychain_service, None);
+    }
+
+    #[test]
     fn profile_defaults_to_desktop() {
         assert_eq!(Profile::default(), Profile::Desktop);
     }

--- a/crates/openwave-core/src/config.rs
+++ b/crates/openwave-core/src/config.rs
@@ -38,6 +38,13 @@ pub struct Config {
     pub profile: Profile,
     /// Directory holding the app's data (database, blobs, …).
     pub data_dir: PathBuf,
+    /// Keychain service name secrets are stored under; `None` uses the
+    /// default (`openwave`). Embedders whose builds must not share secret
+    /// state — a dev build running beside an installed release — set a
+    /// distinct service here, mirroring the app-identifier and data-dir
+    /// split.
+    #[serde(default)]
+    pub keychain_service: Option<String>,
 }
 
 impl Config {
@@ -46,6 +53,7 @@ impl Config {
         Self {
             profile: Profile::Desktop,
             data_dir: data_dir.into(),
+            keychain_service: None,
         }
     }
 
@@ -79,7 +87,11 @@ impl Config {
                 .map_err(|e| AgentError::config(format!("no working directory: {e}")))?
                 .join(".openwave"),
         };
-        Ok(Self { profile, data_dir })
+        Ok(Self {
+            profile,
+            data_dir,
+            keychain_service: None,
+        })
     }
 
     /// The default `Store` connection URL for this config.

--- a/crates/openwave-core/src/keychain.rs
+++ b/crates/openwave-core/src/keychain.rs
@@ -40,16 +40,16 @@ impl KeychainSecretProvider {
     /// call `use_mock` before `main`.
     #[must_use]
     pub fn new() -> Self {
-        if std::env::var("OPENWAVE_KEYCHAIN_MOCK").is_ok_and(|v| !v.is_empty()) {
-            Self::use_mock();
-        }
-        Self {
-            service: DEFAULT_SERVICE.to_string(),
-        }
+        Self::with_service(DEFAULT_SERVICE)
     }
 
     /// Use a custom service name (useful to isolate profiles or tests).
+    /// Honors [`use_mock`](Self::new) and `OPENWAVE_KEYCHAIN_MOCK` the same
+    /// way [`new`](Self::new) does.
     pub fn with_service(service: impl Into<String>) -> Self {
+        if std::env::var("OPENWAVE_KEYCHAIN_MOCK").is_ok_and(|v| !v.is_empty()) {
+            Self::use_mock();
+        }
         Self {
             service: service.into(),
         }

--- a/crates/openwave-core/src/keychain.rs
+++ b/crates/openwave-core/src/keychain.rs
@@ -44,8 +44,8 @@ impl KeychainSecretProvider {
     }
 
     /// Use a custom service name (useful to isolate profiles or tests).
-    /// Honors [`use_mock`](Self::new) and `OPENWAVE_KEYCHAIN_MOCK` the same
-    /// way [`new`](Self::new) does.
+    /// Honors [`use_mock`](Self::use_mock) and `OPENWAVE_KEYCHAIN_MOCK` the
+    /// same way [`new`](Self::new) does.
     pub fn with_service(service: impl Into<String>) -> Self {
         if std::env::var("OPENWAVE_KEYCHAIN_MOCK").is_ok_and(|v| !v.is_empty()) {
             Self::use_mock();

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -233,12 +233,19 @@ async fn boot_server(
     data_dir: PathBuf,
 ) -> Result<(), String> {
     let client_executor_id = app.state::<host_access::HostAccess>().client_executor_id();
-    let server = openwave_server::bind_configured_with_desktop_executor(
-        Config::desktop(data_dir),
-        client_executor_id,
-    )
-    .await
-    .map_err(|e| e.to_string())?;
+    #[cfg_attr(not(debug_assertions), allow(unused_mut))]
+    let mut config = Config::desktop(data_dir);
+    // Debug builds keep their own keychain service, completing the identifier
+    // and app-data split: dev and release must not share mutable secret state,
+    // and items created by a dev-signed binary fail the release app's keychain
+    // ACL check anyway.
+    #[cfg(debug_assertions)]
+    {
+        config.keychain_service = Some("openwave.dev".into());
+    }
+    let server = openwave_server::bind_configured_with_desktop_executor(config, client_executor_id)
+        .await
+        .map_err(|e| e.to_string())?;
     app.state::<host_access::HostAccess>()
         .initialize_store(server.store())?;
     let base_url = format!("http://{}", server.local_addr());

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -572,7 +572,10 @@ async fn bind_inner(
     // directory and its worker set.
     let instance_lock = InstanceLock::acquire(&config)?;
     let store = connect_store(&config).await?;
-    let secrets: Arc<dyn SecretProvider> = Arc::new(KeychainSecretProvider::new());
+    let secrets: Arc<dyn SecretProvider> = Arc::new(match &config.keychain_service {
+        Some(service) => KeychainSecretProvider::with_service(service),
+        None => KeychainSecretProvider::new(),
+    });
     // Pre-providers installs may only have an env/legacy key — enable Anthropic
     // so `KeyedResolver`'s enabled check doesn't fail-closed on upgrade.
     providers::migrate_legacy_anthropic(&*store, &*secrets).await?;


### PR DESCRIPTION
Dev and release builds shared the single keychain service `openwave` — the last shared surface after #643's identifier and data-dir split (#676). Consequences on a machine running both: keychain-password prompts in the release app (dev-signed items fail the release binary's ACL check), and cross-profile clobbering where sign-out/re-auth in one profile silently mutates the other's credentials — observed as a dev gateway session (`admin@development.invalid`) presenting as signed-in inside a release install.

Shape, as proposed on the issue:

- Boot `Config` grows `keychain_service: Option<String>` (serde-defaulted; `None` → the existing `openwave`). All construction flows through `Config::desktop` / `from_vars`, which set `None`.
- `bind_inner` feeds it to `KeychainSecretProvider::with_service` instead of hardcoding `::new()`; every secret (provider credentials and the gateway session alike) flows through this one switch.
- Debug desktop builds set `openwave.dev` in `boot_server`, mirroring the `io.brightwave.openwave.dev` identifier override; the debug CLI daemon gets the same split, since a dev `openwave serve` mutating release secret state is the same hazard.
- `with_service` now honors `OPENWAVE_KEYCHAIN_MOCK` the way `new()` does (`new` delegates to it), so mock-backed integration runs behave identically through either constructor.

As with the data-dir split, the first dev run after this lands sees an empty keychain and dev credentials are entered once — that separation is the point.

No new tests: which OS keychain service gets opened isn't observable from a test (the keyring mock is process-global), and the debug override is `cfg`-gated; the existing config round-trip test covers the new field's serde default.

Verified with `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace` (30 suites, all green, no lock diff).

Closes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)