### PR TITLE
test(desktop): update AppShell prompt mocks for output write-backs

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -27,6 +27,7 @@ const createChat = vi.fn(async () => chats[0]);
 const listPendingUserQuestions = vi.fn(async () => [] as unknown[]);
 const listPendingFolderAccessRequests = vi.fn(async () => [] as unknown[]);
 const listPendingChatPrompts = vi.fn(async () => [] as unknown[]);
+const listPendingOutputWritebackRequests = vi.fn(async () => [] as unknown[]);
 const requestUserAttention = vi.fn(async () => {});
 const postMessage = vi.fn(async () => {});
 
@@ -43,6 +44,7 @@ vi.mock("./api", () => ({
     listPendingUserQuestions = listPendingUserQuestions;
     listPendingFolderAccessRequests = listPendingFolderAccessRequests;
     listPendingChatPrompts = listPendingChatPrompts;
+    listPendingOutputWritebackRequests = listPendingOutputWritebackRequests;
     postMessage = postMessage;
     openEvents = vi.fn(() => ({ close: vi.fn() }));
   },
@@ -129,6 +131,8 @@ beforeEach(() => {
   listPendingFolderAccessRequests.mockResolvedValue([]);
   listPendingChatPrompts.mockReset();
   listPendingChatPrompts.mockResolvedValue([]);
+  listPendingOutputWritebackRequests.mockReset();
+  listPendingOutputWritebackRequests.mockResolvedValue([]);
   requestUserAttention.mockClear();
   postMessage.mockClear();
   usePendingPrompts.setState({ chatId: null, userQuestions: [], folderAccess: [] });
@@ -159,7 +163,12 @@ describe("app shell", () => {
 
   it("marks a parked conversation other than the one that is open", async () => {
     listPendingChatPrompts.mockResolvedValue([
-      { chatId: "chat-2", questionCallIds: ["call-parked"], folderAccessCallIds: [] },
+      {
+        chatId: "chat-2",
+        questionCallIds: ["call-parked"],
+        folderAccessCallIds: [],
+        outputWritebackCallIds: [],
+      },
     ]);
     await mountApp({ at: "/c/chat-1" });
 
@@ -325,7 +334,12 @@ describe("app shell", () => {
     // settings has no chat, and the one being returned to rehydrates its own.
     const readsBefore = listPendingChatPrompts.mock.calls.length;
     listPendingChatPrompts.mockResolvedValue([
-      { chatId: "chat-1", questionCallIds: ["call-1"], folderAccessCallIds: [] },
+      {
+        chatId: "chat-1",
+        questionCallIds: ["call-1"],
+        folderAccessCallIds: [],
+        outputWritebackCallIds: [],
+      },
     ]);
     useRefreshSignals.getState().signal("userQuestions");
 


### PR DESCRIPTION
The pending-prompt refresh gained `outputWritebackCallIds` and `listPendingOutputWritebackRequests` in #677, but the AppShell DOM test mocks were not updated, so the prompt refresh throws before `requestUserAttention` runs and two attention tests fail deterministically. It slipped past main because the commits that landed after it were docs-only, so the UI lane never ran.

Adds the missing method to the mock client and the missing field to the pending-prompt fixtures. All 14 AppShell DOM tests pass locally; this unblocks the UI lane for every open UI PR.