### PR TITLE
fix(desktop): themed settings controls, confirmed credential removal, visible app version

### DIFF
--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
@@ -8,7 +8,13 @@ import type {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
-  SETTINGS_SELECT_CLASS,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   SettingsError,
   SettingsField,
   SettingsPanel,
@@ -17,6 +23,10 @@ import {
 
 const MIN_CODE_EXECUTION_TIMEOUT_MS = 1_000;
 const MAX_CODE_EXECUTION_TIMEOUT_MS = 120_000;
+
+// Radix Select reserves the empty string, so "Disabled" (no provider) rides on
+// a sentinel value the wire never carries.
+const NO_PROVIDER = "__disabled__";
 
 export function CodeExecutionPanel({ client }: { client: ApiClient }) {
   const [config, setConfig] = useState<CodeExecutionConfigInfo | null>(null);
@@ -105,19 +115,25 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
 
           <SettingsSection>
             <SettingsField label="Provider">
-              <select
-                className={SETTINGS_SELECT_CLASS}
-                value={provider}
+              <Select
+                value={provider === "" ? NO_PROVIDER : provider}
                 disabled={saving}
-                onChange={(event) =>
+                onValueChange={(value) =>
                   setProvider(
-                    event.target.value as CodeExecutionProviderKind | "",
+                    value === NO_PROVIDER
+                      ? ""
+                      : (value as CodeExecutionProviderKind),
                   )
                 }
               >
-                <option value="">Disabled</option>
-                <option value="local">Local native sandbox</option>
-              </select>
+                <SelectTrigger aria-label="Provider">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={NO_PROVIDER}>Disabled</SelectItem>
+                  <SelectItem value="local">Local native sandbox</SelectItem>
+                </SelectContent>
+              </Select>
             </SettingsField>
 
             <SettingsField

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
@@ -5,6 +5,7 @@ import type { ApiClient, GatewayApps, GatewayStatus } from "../api";
 import { openExternal } from "../host";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import {
   SettingsError,
   SettingsField,
@@ -140,15 +141,21 @@ export function GatewayPanel({
       busy={working}
     >
       <SettingsSection>
-        <label className="flex items-center gap-2 text-sm font-medium">
-          <input
-            type="checkbox"
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex-1">
+            <p className="text-sm font-bold">Use Model Gateway</p>
+            <p className="text-xs text-muted-foreground">
+              Route models and governed tools through a signed-in gateway. Off,
+              OpenWave stays fully local.
+            </p>
+          </div>
+          <Switch
+            aria-label="Use Model Gateway"
             checked={status.enabled}
             disabled={working}
-            onChange={(event) => void save(event.target.checked)}
+            onCheckedChange={(checked) => void save(checked)}
           />
-          Use Model Gateway
-        </label>
+        </div>
 
         <SettingsField
           label="Gateway URL"

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
@@ -8,6 +8,7 @@ import type {
 } from "../api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import {
   SettingsError,
   SettingsField,
@@ -189,17 +190,22 @@ export function McpPanel({ client }: { client: ApiClient }) {
                 </span>
               </div>
 
-              <label className="flex items-center gap-2 text-sm font-medium">
-                <input
-                  type="checkbox"
+              <div className="flex items-center justify-between gap-4">
+                <div className="flex-1">
+                  <p className="text-sm font-bold">Enabled</p>
+                  <p className="text-xs text-muted-foreground">
+                    Off keeps the server configured but out of new turns.
+                  </p>
+                </div>
+                <Switch
+                  aria-label="Enabled"
                   checked={server.enabled}
                   disabled={working}
-                  onChange={(event) =>
-                    update(index, { enabled: event.target.checked })
+                  onCheckedChange={(checked) =>
+                    update(index, { enabled: checked })
                   }
                 />
-                Enabled
-              </label>
+              </div>
 
               <SettingsField
                 label="Namespace"

--- a/crates/openwave-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import type { ApiClient, ModelInfo } from "../api";
 import { ModelsPanel } from "./ModelsPanel";
@@ -45,25 +46,39 @@ describe("ModelsPanel", () => {
       has_api_key: true,
     });
     const client = { getSettings, putSettings } as unknown as ApiClient;
+    const user = userEvent.setup();
 
     render(<ModelsPanel client={client} models={models} />);
 
-    const provider = await screen.findByLabelText("Provider");
-    await waitFor(() => expect(provider).toHaveValue("openai"));
-    const model = screen.getAllByRole("combobox")[1];
-    expect(model).toHaveValue("openai::gpt-4o");
-    expect(screen.getByText("GPT-4o")).toBeInTheDocument();
+    // The saved bare id resolves to its provider and canonical model.
+    const provider = await screen.findByRole("combobox", { name: "Provider" });
+    await waitFor(() => expect(provider).toHaveTextContent("OpenAI"));
+    expect(
+      screen.getByRole("combobox", { name: "Model" }),
+    ).toHaveTextContent("GPT-4o");
 
-    fireEvent.change(provider, { target: { value: "anthropic" } });
+    // Switching provider alone must not persist anything.
+    await user.click(provider);
+    await user.click(
+      screen.getByRole("option", { name: "Anthropic — unavailable" }),
+    );
     expect(putSettings).not.toHaveBeenCalled();
-    const unavailable = screen.getByRole("option", {
-      name: "Claude Opus 4.8 — unavailable",
-    });
-    expect(unavailable).toBeDisabled();
 
-    fireEvent.change(model, {
-      target: { value: "" },
-    });
-    await waitFor(() => expect(putSettings).toHaveBeenCalledWith({ model: null }));
+    // That provider's only model is unavailable and cannot be chosen.
+    await user.click(screen.getByRole("combobox", { name: "Model" }));
+    expect(
+      screen.getByRole("option", { name: "Claude Opus 4.8 — unavailable" }),
+    ).toHaveAttribute("aria-disabled", "true");
+    await user.keyboard("{Escape}");
+
+    // Choosing a model — here the server default over the migrated GPT-4o —
+    // is what persists.
+    await user.click(provider);
+    await user.click(screen.getByRole("option", { name: "OpenAI" }));
+    await user.click(screen.getByRole("combobox", { name: "Model" }));
+    await user.click(screen.getByRole("option", { name: "Server default" }));
+    await waitFor(() =>
+      expect(putSettings).toHaveBeenCalledWith({ model: null }),
+    );
   });
 });

--- a/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
@@ -11,12 +11,23 @@ import {
   providerLabel,
 } from "../ModelSelection";
 import {
-  SETTINGS_SELECT_CLASS,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   SettingsError,
   SettingsField,
   SettingsPanel,
   SettingsSection,
 } from "./primitives";
+
+// Radix Select reserves the empty string for its placeholder, so the
+// "Server default" choice needs a sentinel that no catalog key can collide
+// with (keys are always `provider::id`).
+const SERVER_DEFAULT = "__server_default__";
 
 export function ModelsPanel({
   client,
@@ -102,55 +113,63 @@ export function ModelsPanel({
         <>
           <SettingsSection title="Default model">
             <SettingsField label="Provider">
-              <select
-                className={SETTINGS_SELECT_CLASS}
+              <Select
                 value={provider ?? ""}
                 disabled={saving || providers.length === 0}
-                onChange={(event) =>
-                  setProvider((event.target.value || null) as ProviderKind | null)
+                onValueChange={(value) =>
+                  setProvider((value || null) as ProviderKind | null)
                 }
               >
-                {providers.length === 0 && (
-                  <option value="">No providers configured</option>
-                )}
-                {providers.map((kind) => {
-                  const usable = models.some(
-                    (model) => model.provider === kind && model.available,
-                  );
-                  return (
-                    <option key={kind} value={kind}>
-                      {providerLabel(kind)}
-                      {usable ? "" : " — unavailable"}
-                    </option>
-                  );
-                })}
-              </select>
+                <SelectTrigger aria-label="Provider">
+                  <SelectValue placeholder="No providers configured" />
+                </SelectTrigger>
+                <SelectContent>
+                  {providers.map((kind) => {
+                    const usable = models.some(
+                      (model) => model.provider === kind && model.available,
+                    );
+                    return (
+                      <SelectItem key={kind} value={kind}>
+                        {providerLabel(kind)}
+                        {usable ? "" : " — unavailable"}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
             </SettingsField>
             <SettingsField
               label="Model"
               hint="Unavailable models remain visible for clarity but cannot be selected until their provider is enabled and credentialed."
             >
-              <select
-                className={SETTINGS_SELECT_CLASS}
-                value={selectedValue}
+              <Select
+                value={selectedValue === "" ? SERVER_DEFAULT : selectedValue}
                 disabled={saving || provider === null}
-                onChange={(event) => {
-                  const value = event.target.value as ModelSelectionKey | "";
-                  void save(value || null);
+                onValueChange={(value) => {
+                  void save(
+                    value === SERVER_DEFAULT
+                      ? null
+                      : (value as ModelSelectionKey),
+                  );
                 }}
               >
-                <option value="">Server default</option>
-                {providerModels.map((model) => (
-                  <option
-                    key={model.key}
-                    value={model.key}
-                    disabled={!model.available}
-                  >
-                    {model.display_name}
-                    {model.available ? "" : " — unavailable"}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger aria-label="Model">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={SERVER_DEFAULT}>Server default</SelectItem>
+                  {providerModels.map((model) => (
+                    <SelectItem
+                      key={model.key}
+                      value={model.key}
+                      disabled={!model.available}
+                    >
+                      {model.display_name}
+                      {model.available ? "" : " — unavailable"}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </SettingsField>
             {legacyUnavailable && (
               <SettingsError>

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -8,6 +8,8 @@ import type {
 } from "../api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { useConfirm } from "../components/ConfirmDialog";
 import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
 import { providerLabel } from "../ModelSelection";
 
@@ -58,6 +60,7 @@ function ProviderRow({
   const [models, setModels] = useState<CustomModelConfig[]>(info.models);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { confirm, dialog } = useConfirm();
 
   async function save(enabled: boolean) {
     setSaving(true);
@@ -108,6 +111,15 @@ function ProviderRow({
   }
 
   async function clearCredential() {
+    const accepted = await confirm({
+      title: "Remove the saved credential?",
+      description: `This deletes the stored ${providerLabel(
+        info.kind,
+      )} credential from this machine's keychain. You can add it again at any time.`,
+      confirmLabel: "Remove credential",
+      destructive: true,
+    });
+    if (!accepted) return;
     setSaving(true);
     setError(null);
     try {
@@ -123,20 +135,19 @@ function ProviderRow({
 
   return (
     <SettingsSection title={providerLabel(info.kind)}>
-      <div className="flex items-center justify-between gap-3">
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            className="size-4 accent-[var(--primary)]"
-            checked={info.enabled}
-            disabled={saving}
-            onChange={(e) => void save(e.target.checked)}
-          />
-          Enabled
-        </label>
-        <span className="text-xs text-muted-foreground">
-          {info.has_credential ? "credential set" : "no credential"}
-        </span>
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex-1">
+          <p className="text-sm font-bold">Enabled</p>
+          <p className="text-xs text-muted-foreground">
+            {info.has_credential ? "Credential set" : "No credential"}
+          </p>
+        </div>
+        <Switch
+          aria-label="Enabled"
+          checked={info.enabled}
+          disabled={saving}
+          onCheckedChange={(checked) => void save(checked)}
+        />
       </div>
       {info.kind === "openai_compatible" && (
         <>
@@ -348,7 +359,7 @@ function ProviderRow({
         {info.has_credential && (
           <Button
             type="button"
-            variant="outline"
+            variant="destructive"
             disabled={saving}
             onClick={() => void clearCredential()}
           >
@@ -357,6 +368,7 @@ function ProviderRow({
         )}
       </div>
       {error && <SettingsError>{error}</SettingsError>}
+      {dialog}
     </SettingsSection>
   );
 }

--- a/crates/openwave-desktop/ui/src/settings/UpdatesPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/UpdatesPanel.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from "react";
+import { getVersion } from "@tauri-apps/api/app";
 import { RefreshCw, RotateCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ClipboardCopyButton } from "../ClipboardCopyButton";
+import { hasNativeHost } from "../host";
 import type { DesktopUpdateState } from "../updates";
 import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
 
@@ -34,7 +37,23 @@ export function UpdatesPanel({
   onRestart: () => Promise<void>;
 }) {
   const [manualResult, setManualResult] = useState<string | null>(null);
+  const [version, setVersion] = useState<string | null>(null);
   const busy = state.status === "checking" || state.status === "downloading";
+
+  // Only the packaged desktop host can report its version; a browser dev build
+  // has none, so the line falls back to a plain note there.
+  useEffect(() => {
+    if (!hasNativeHost()) return;
+    let cancelled = false;
+    void getVersion()
+      .then((value) => {
+        if (!cancelled) setVersion(value);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (busy || state.status === "ready" || state.error) {
@@ -86,6 +105,25 @@ export function UpdatesPanel({
                   ? "Downloading…"
                   : "Check for updates"}
             </Button>
+          )}
+        </div>
+      </SettingsSection>
+
+      <SettingsSection title="About">
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-sm text-muted-foreground">
+            {version
+              ? `OpenWave ${version}`
+              : "Version is reported by the desktop app."}
+          </p>
+          {version && (
+            <ClipboardCopyButton
+              value={version}
+              label="Copy version"
+              copiedAnnouncement="Version copied to clipboard."
+              failedAnnouncement="Version could not be copied."
+              className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden"
+            />
           )}
         </div>
       </SettingsSection>

--- a/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
@@ -9,7 +9,13 @@ import type {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
-  SETTINGS_SELECT_CLASS,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   SettingsError,
   SettingsField,
   SettingsPanel,
@@ -18,6 +24,10 @@ import {
 
 const MIN_WEB_SEARCH_TIMEOUT_MS = 1_000;
 const MAX_WEB_SEARCH_TIMEOUT_MS = 60_000;
+
+// Radix Select reserves the empty string, so "Disabled" (no provider) rides on
+// a sentinel value the wire never carries.
+const NO_PROVIDER = "__disabled__";
 
 export function WebSearchPanel({ client }: { client: ApiClient }) {
   const [config, setConfig] = useState<WebSearchConfigInfo | null>(null);
@@ -160,18 +170,26 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
 
           <SettingsSection>
             <SettingsField label="Provider">
-              <select
-                className={SETTINGS_SELECT_CLASS}
-                value={provider}
+              <Select
+                value={provider === "" ? NO_PROVIDER : provider}
                 disabled={working}
-                onChange={(event) =>
-                  setProvider(event.target.value as WebSearchProviderKind | "")
+                onValueChange={(value) =>
+                  setProvider(
+                    value === NO_PROVIDER
+                      ? ""
+                      : (value as WebSearchProviderKind),
+                  )
                 }
               >
-                <option value="">Disabled</option>
-                <option value="exa">Exa</option>
-                <option value="tavily">Tavily</option>
-              </select>
+                <SelectTrigger aria-label="Provider">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={NO_PROVIDER}>Disabled</SelectItem>
+                  <SelectItem value="exa">Exa</SelectItem>
+                  <SelectItem value="tavily">Tavily</SelectItem>
+                </SelectContent>
+              </Select>
             </SettingsField>
 
             <SettingsField

--- a/crates/openwave-desktop/ui/src/settings/primitives.tsx
+++ b/crates/openwave-desktop/ui/src/settings/primitives.tsx
@@ -1,9 +1,5 @@
 import type { ReactNode } from "react";
 
-/** Shared styling for the native <select> elements used across settings. */
-export const SETTINGS_SELECT_CLASS =
-  "flex h-10 w-full rounded-md border border-border bg-background px-3 text-sm ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
-
 /**
  * A single settings surface: a titled, optionally described column of fields.
  * The surrounding container owns scrolling and chrome, so this stays layout-only

--- a/crates/openwave-desktop/ui/src/test/setup.ts
+++ b/crates/openwave-desktop/ui/src/test/setup.ts
@@ -12,6 +12,24 @@ if (
   Element.prototype.scrollTo = () => {};
 }
 
+// jsdom implements none of the Pointer Capture API nor scrollIntoView, which
+// Radix's Select and other pointer-driven primitives call while opening. Stubs
+// keep those components interactive under test.
+if (typeof Element !== "undefined") {
+  if (typeof Element.prototype.hasPointerCapture !== "function") {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (typeof Element.prototype.setPointerCapture !== "function") {
+    Element.prototype.setPointerCapture = () => {};
+  }
+  if (typeof Element.prototype.releasePointerCapture !== "function") {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (typeof Element.prototype.scrollIntoView !== "function") {
+    Element.prototype.scrollIntoView = () => {};
+  }
+}
+
 // jsdom has no ResizeObserver. A stub that never reports a size is as good as
 // no stub for anything that lays out from measurements, so this one answers
 // once per observed element with a plausible viewport-sized box.


### PR DESCRIPTION
The settings panels mixed raw HTML controls with the app's themed component set — native checkboxes for toggles and native `<select>` elements for the provider and model pickers. This brings them onto the shared primitives and tightens two rough edges.

- **Themed toggles.** The provider *Enabled*, *Use Model Gateway*, and MCP server *Enabled* toggles now use the shared `Switch`, laid out as a labelled row with a short description beside the control.
- **Themed selects.** The provider, model, web-search, and code-execution pickers use the Radix `Select` instead of a native element, so they match the rest of the UI in the dark theme. The now-unused `SETTINGS_SELECT_CLASS` is removed.
- **Confirmed credential removal.** Clearing a provider credential deletes it from the keychain, so it is now a destructive action gated behind a confirmation dialog.
- **Visible app version.** Settings shows the running app version with a copy-to-clipboard control, read from the desktop host and hidden where no host reports one.

Test setup gains Pointer Capture / `scrollIntoView` stubs so Radix's pointer-driven `Select` is interactive under jsdom, and the ModelsPanel DOM test drives the new control instead of a native `<select>`.


Closes #688
