### PR TITLE
fix(desktop): open a source document in the sources panel instead of ignoring the selection

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -26,6 +26,7 @@ import {
 import { useFirstMessage } from "./FirstMessage";
 import { ChatView } from "./ChatView";
 import { DeliverablesView } from "./DeliverablesView";
+import { DocumentDetailRoot } from "./document-detail/DocumentDetailRoot";
 import { DocumentsView } from "./DocumentsView";
 import { FoldersView } from "./FoldersView";
 import { hasNativeHost } from "./host";
@@ -400,7 +401,15 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     const side = position === "right" ? "right" : "left";
     switch (panel.type) {
       case "sources":
-        return (
+        // A document id turns the list into the reader for that one source; the
+        // breadcrumb's way back clears the id and lands on the catalog again.
+        return panel.documentId ? (
+          <DocumentDetailRoot
+            chatId={chatId}
+            documentID={panel.documentId}
+            position={side}
+          />
+        ) : (
           <PanelFrame position={side} spaceBetween>
             <DocumentsView
               chatId={chatId}

--- a/crates/openwave-desktop/ui/src/components/document/document-details.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/document-details.tsx
@@ -77,17 +77,21 @@ export function DocumentDetails({
               client={client}
               documentId={info.document_id}
               mediaType={type}
-              className="grow"
+              className="bg-page-background grow p-4 pt-2"
             />
           ) : type.startsWith("image/") ? (
-            <ImageViewer chatId={chatId} documentID={info.document_id} className="grow" />
+            <ImageViewer
+              chatId={chatId}
+              documentID={info.document_id}
+              className="bg-page-background grow"
+            />
           ) : (
             <MarkdownViewer
               chatId={chatId}
               documentID={info.document_id}
               highlightRange={highlightRange}
               markdown={type === "text/markdown"}
-              className="grow"
+              className="bg-page-background grow"
             />
           )}
         </>

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
@@ -89,6 +89,7 @@ export function DocumentDetailRoot({
   return (
     <PanelFrame
       position={position}
+      showBorder
       breadcrumb={
         <DocumentDetailBreadcrumb
           documentName={documentName}

--- a/crates/openwave-desktop/ui/src/panel/PanelFrame.tsx
+++ b/crates/openwave-desktop/ui/src/panel/PanelFrame.tsx
@@ -17,12 +17,14 @@ export function PanelFrame({
   breadcrumb,
   headerRightSlot,
   spaceBetween,
+  showBorder,
   children,
 }: {
   position: PanelPosition;
   breadcrumb?: ReactNode;
   headerRightSlot?: ReactNode;
   spaceBetween?: boolean;
+  showBorder?: boolean;
   children: ReactNode;
 }) {
   const { layout, closePanel, toggleFullscreen } = usePanelNav();
@@ -36,6 +38,7 @@ export function PanelFrame({
           breadcrumb={breadcrumb}
           rightSlot={headerRightSlot}
           spaceBetween={spaceBetween}
+          showBorder={showBorder}
           isFullscreen={isFullscreen}
           onToggleFullscreen={() => toggleFullscreen(position)}
           onClose={() => closePanel(position)}


### PR DESCRIPTION
The sources panel could address a specific document (`sources.{documentId}` in the URL, set by the document row's Open action and by citations), but the panel body always rendered the catalog list and ignored that id. `DocumentDetailRoot` — the viewer that dispatches to the PDF, spreadsheet, image, and markdown viewers — had no production call site, so opening a source only changed URL state while the list stayed on screen.

- Branch the sources panel on `documentId`: render `DocumentDetailRoot` for a selected source and keep `DocumentsView` for the catalog. The breadcrumb's way back clears the id and returns to the list.
- Restore the viewer framing that had been dropped: the PDF, image, spreadsheet, and markdown viewers now carry the `page-background` surface (and the PDF viewer its intended padding) rather than a bare `grow`.
- Give `PanelFrame` a `showBorder` passthrough to its header and set it for the document reader, so the reader's header shows its bottom border.

Closes #697