### PR TITLE
feat(desktop): scroll affordances that match the design — jump-to-bottom, follow on growth, turn pinning, edge fades, skeleton

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatScroll.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatScroll.test.ts
@@ -8,14 +8,14 @@ import {
 } from "./ChatScroll";
 
 describe("chat scroll behavior", () => {
-  it("only follows new activity near the bottom", () => {
+  it("only follows new activity within a hair of the bottom", () => {
     expect(
-      isNearBottom({ scrollTop: 828, clientHeight: 100, scrollHeight: 1_000 }),
+      isNearBottom({ scrollTop: 870, clientHeight: 100, scrollHeight: 1_000 }),
     ).toBe(true);
     expect(
-      isNearBottom({ scrollTop: 827, clientHeight: 100, scrollHeight: 1_000 }),
+      isNearBottom({ scrollTop: 869, clientHeight: 100, scrollHeight: 1_000 }),
     ).toBe(false);
-    expect(AUTO_SCROLL_THRESHOLD_PX).toBe(72);
+    expect(AUTO_SCROLL_THRESHOLD_PX).toBe(30);
   });
 
   it("scrolls to the latest item when explicitly requested", () => {

--- a/crates/openwave-desktop/ui/src/ChatScroll.ts
+++ b/crates/openwave-desktop/ui/src/ChatScroll.ts
@@ -1,4 +1,4 @@
-export const AUTO_SCROLL_THRESHOLD_PX = 72;
+export const AUTO_SCROLL_THRESHOLD_PX = 30;
 
 type ScrollMetrics = {
   scrollTop: number;

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -96,20 +97,121 @@ export function ChatView({
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const followsLatestRef = useRef(true);
+  const isProgrammaticRef = useRef(false);
   const visibleContinuationCallIdsRef = useRef<Set<string>>(new Set());
-  const [hasUnreadActivity, setHasUnreadActivity] = useState(false);
+  const scrollObserverRef = useRef<ResizeObserver | null>(null);
+  const contentObserverRef = useRef<ResizeObserver | null>(null);
+  const [scrolledAway, setScrolledAway] = useState(false);
+  const [maskClass, setMaskClass] = useState<string | null>(null);
+  // True once the reader has sent in this mounted session. Gates the turn pin so
+  // a freshly loaded history reads normally, then the just-sent turn is held tall
+  // enough to land near the top of the viewport.
+  const [pinLastTurn, setPinLastTurn] = useState(false);
+
+  // Reflect where the scroll sits onto the edge-fade masks: fade the top once
+  // there is content above, the bottom while there is content below.
+  const updateEdges = useCallback(() => {
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+    const fromTop = scroll.scrollTop > 0;
+    const fromBottom =
+      scroll.scrollHeight - scroll.scrollTop - scroll.clientHeight > 1;
+    setMaskClass(
+      fromTop && fromBottom
+        ? "is-faded-both"
+        : fromTop
+          ? "is-faded-top"
+          : fromBottom
+            ? "is-faded-bottom"
+            : null,
+    );
+  }, []);
+
+  // Jump to the latest message. Marked programmatic so the resulting scroll
+  // events don't read as the reader deliberately scrolling away.
+  const scrollToBottom = useCallback((behavior: ScrollBehavior) => {
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+    isProgrammaticRef.current = true;
+    scrollToLatest(scroll, behavior);
+    if (behavior === "smooth") {
+      let timeout: ReturnType<typeof setTimeout>;
+      const done = () => {
+        clearTimeout(timeout);
+        isProgrammaticRef.current = false;
+      };
+      scroll.addEventListener("scrollend", done, { once: true });
+      timeout = setTimeout(() => {
+        scroll.removeEventListener("scrollend", done);
+        isProgrammaticRef.current = false;
+      }, 800);
+    } else {
+      requestAnimationFrame(() => {
+        isProgrammaticRef.current = false;
+      });
+    }
+  }, []);
+
+  const handleScroll = useCallback(() => {
+    updateEdges();
+    if (isProgrammaticRef.current) return;
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+    const away = !isNearBottom(scroll);
+    setScrolledAway(away);
+    // Drifting away disarms follow; re-arming is deliberate (the button, or a
+    // send), never a side effect of scrolling back toward the bottom.
+    if (away && followsLatestRef.current) followsLatestRef.current = false;
+  }, [updateEdges]);
+
+  // Track the scroll viewport height in a CSS variable so a pinned turn can
+  // reserve roughly a screenful, and keep the edge fades honest across resizes.
+  const attachScrollRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      scrollObserverRef.current?.disconnect();
+      scrollRef.current = element;
+      if (!element) return;
+      const observer = new ResizeObserver(() => {
+        element.style.setProperty(
+          "--transcript-viewport",
+          `${element.clientHeight}px`,
+        );
+        updateEdges();
+      });
+      observer.observe(element);
+      scrollObserverRef.current = observer;
+    },
+    [updateEdges],
+  );
+
+  // Follow asynchronous layout growth (image loads, markdown reflow) that no
+  // React state change announces, so a following reader stays pinned to the end.
+  const attachContentRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      contentObserverRef.current?.disconnect();
+      if (!element) return;
+      const observer = new ResizeObserver(() => {
+        if (!transcriptVisible) return;
+        if (followsLatestRef.current) scrollToBottom("auto");
+        const scroll = scrollRef.current;
+        if (scroll) setScrolledAway(!isNearBottom(scroll));
+        updateEdges();
+      });
+      observer.observe(element);
+      contentObserverRef.current = observer;
+    },
+    [transcriptVisible, scrollToBottom, updateEdges],
+  );
 
   useEffect(() => {
-    const scroll = scrollRef.current;
     // Scrolling a transcript that has been expanded away does nothing, so this
     // also runs on the way back to put a following reader at the latest message.
-    if (!scroll || !transcriptVisible) return;
+    if (!transcriptVisible) return;
     if (followsLatestRef.current) {
-      scrollToLatest(scroll, followScrollBehavior(busy));
-    } else {
-      setHasUnreadActivity(true);
+      scrollToBottom(followScrollBehavior(busy));
     }
-  }, [messages, busy, transcriptVisible]);
+    updateEdges();
+  }, [messages, busy, transcriptVisible, scrollToBottom, updateEdges]);
 
   useEffect(() => {
     const next = new Set([
@@ -122,18 +224,27 @@ export function ChatView({
     );
     visibleContinuationCallIdsRef.current = next;
     if (!gainedRequest) return;
-    const scroll = scrollRef.current;
-    if (!scroll) return;
-    if (followsLatestRef.current) {
-      scrollToLatest(scroll, followScrollBehavior(false));
-    } else {
-      setHasUnreadActivity(true);
-    }
+    if (followsLatestRef.current) scrollToBottom(followScrollBehavior(false));
   }, [
     folderAccess.requests,
     outputWritebacks.requests,
     userQuestions.requests,
+    scrollToBottom,
   ]);
+
+  const jumpToLatest = useCallback(() => {
+    followsLatestRef.current = true;
+    setScrolledAway(false);
+    scrollToBottom(followScrollBehavior(false));
+  }, [scrollToBottom]);
+
+  const handleSend = useCallback(async () => {
+    followsLatestRef.current = true;
+    setScrolledAway(false);
+    setPinLastTurn(true);
+    await onSend();
+    scrollToBottom(followScrollBehavior(false));
+  }, [onSend, scrollToBottom]);
 
   return (
     <section className="chat-pane">
@@ -160,12 +271,11 @@ export function ChatView({
           onRetryBackgroundAgentRuns={agentRuns.refresh}
           busy={busy}
           reasoningActive={reasoningActive}
-          scrollRef={scrollRef}
-          onScroll={(event) => {
-            const followsLatest = isNearBottom(event.currentTarget);
-            followsLatestRef.current = followsLatest;
-            if (followsLatest) setHasUnreadActivity(false);
-          }}
+          scrollRef={attachScrollRef}
+          contentRef={attachContentRef}
+          maskClass={maskClass}
+          pinLastTurn={pinLastTurn}
+          onScroll={handleScroll}
           onApproval={approvals.decide}
           onFolderAccessDecision={folderAccess.decide}
           onFolderAccessCancel={folderAccess.cancel}
@@ -179,22 +289,16 @@ export function ChatView({
           hydrated={hydrated}
           imageClient={client}
         />
-        {hasUnreadActivity && (
-          <button
-            type="button"
-            className="new-activity"
-            onClick={() => {
-              followsLatestRef.current = true;
-              setHasUnreadActivity(false);
-              if (scrollRef.current) {
-                scrollToLatest(scrollRef.current, followScrollBehavior(false));
-              }
-            }}
-          >
-            New activity
-            <ArrowDown size={13} />
-          </button>
-        )}
+        <button
+          type="button"
+          className={`scroll-to-latest${scrolledAway ? " is-visible" : ""}`}
+          aria-label="Scroll to latest"
+          aria-hidden={!scrolledAway}
+          tabIndex={scrolledAway ? 0 : -1}
+          onClick={jumpToLatest}
+        >
+          <ArrowDown size={16} />
+        </button>
       </div>
 
       <Composer
@@ -222,7 +326,7 @@ export function ChatView({
           turnControls.clearSteerFeedback();
           onDraftChange(value);
         }}
-        onSend={onSend}
+        onSend={handleSend}
         onSteer={turnControls.steer}
         onStop={turnControls.cancel}
         resetKey={chat.id}

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -1,5 +1,5 @@
-import { memo, useMemo } from "react";
-import type { ReactNode, RefObject, UIEvent } from "react";
+import { Fragment, memo, useMemo } from "react";
+import type { ReactNode, Ref, RefCallback, UIEvent } from "react";
 import type {
   ApprovalGrantRung,
   ApiClient,
@@ -32,6 +32,7 @@ import type { TranscriptImageAttachment } from "./ImageAttachments";
 import { TranscriptImageAttachments } from "./TranscriptImageAttachments";
 import { BackgroundAgentList } from "./BackgroundAgentList";
 import { useSourceNav } from "./panel/SourceNav";
+import { Skeleton } from "./components/ui/skeleton";
 
 export type ChatMessage =
   | {
@@ -106,7 +107,14 @@ type MessageListProps = {
   onRetryBackgroundAgentRuns?: () => void;
   busy: boolean;
   reasoningActive?: boolean;
-  scrollRef: RefObject<HTMLDivElement | null>;
+  scrollRef: Ref<HTMLDivElement>;
+  /** Attached to the transcript content column so growth can drive auto-follow. */
+  contentRef?: RefCallback<HTMLDivElement>;
+  /** Extra classes for the scroll container — used for the scroll-edge fades. */
+  maskClass?: string | null;
+  /** Lift the trailing exchange into a pinned wrapper so a just-sent message
+   *  lands near the top with room below for its streaming reply. */
+  pinLastTurn?: boolean;
   onScroll: (event: UIEvent<HTMLDivElement>) => void;
   onApproval: (
     callId: string,
@@ -156,6 +164,9 @@ export function MessageList({
   busy,
   reasoningActive = false,
   scrollRef,
+  contentRef,
+  maskClass,
+  pinLastTurn = false,
   onScroll,
   onApproval,
   onFolderAccessDecision,
@@ -174,7 +185,7 @@ export function MessageList({
     () => ({ decidingApprovalCalls, approvalErrors }),
     [decidingApprovalCalls, approvalErrors],
   );
-  const messageItems = groupMessageItems(
+  const { items: messageItems, lastTurnStart } = groupMessageItems(
     messages,
     busy,
     onApproval,
@@ -207,59 +218,120 @@ export function MessageList({
     );
   }
 
-  return (
-    <div className="messages" ref={scrollRef} onScroll={onScroll}>
-      <div className="messages-column">
-        {messageItems}
-        {folderAccessRequests.map((request) => (
-          <FolderAccessCard
-            key={request.callId}
-            request={request}
-            nativeHost={nativeHost}
-            nativeBusy={nativeBusy}
-            working={resolvingFolderCalls.has(request.callId)}
-            error={folderAccessErrors[request.callId]}
-            onDecision={(decision) =>
-              onFolderAccessDecision(request.callId, decision)
-            }
-            onCancel={() => onFolderAccessCancel(request.callId, request.turnId)}
-          />
-        ))}
-        {outputWritebackRequests.map((request) => (
-          <OutputWritebackCard
-            key={request.callId}
-            request={request}
-            nativeHost={nativeHost}
-            working={resolvingOutputWritebackCalls.has(request.callId)}
-            error={outputWritebackErrors[request.callId]}
-            onDecision={(decision) =>
-              onOutputWritebackDecision(request.callId, decision)
-            }
-            onCancel={() =>
-              onOutputWritebackCancel(request.callId, request.turnId)
-            }
-          />
-        ))}
-        {userQuestionRequests.map((request) => (
-          <UserQuestionsCard
-            key={request.callId}
-            request={request}
-            working={answeringQuestionCalls.has(request.callId)}
-            error={userQuestionErrors[request.callId]}
-            onAnswer={(answers) =>
-              onAnswerUserQuestions(request.callId, answers)
-            }
-            onCancel={() => onUserQuestionsCancel(request.turnId)}
-          />
-        ))}
-        {shouldShowAssistantWorking(
-          messages,
-          busy,
-          folderAccessRequests.length +
-            outputWritebackRequests.length +
-            userQuestionRequests.length,
-        ) && <AssistantWorkingIndicator thinking={reasoningActive} />}
+  // A conversation that hasn't hydrated yet is transiently empty; a skeleton
+  // holds the shape of a transcript so the pane doesn't flash blank before the
+  // history lands.
+  if (!hydrated && messages.length === 0) {
+    return (
+      <div
+        className={`messages${maskClass ? ` ${maskClass}` : ""}`}
+        ref={scrollRef}
+        onScroll={onScroll}
+      >
+        <div className="messages-column">
+          <TranscriptSkeleton />
+        </div>
       </div>
+    );
+  }
+
+  // The continuation cards and the working indicator belong to the turn in
+  // flight, so when the trailing turn is pinned they ride inside its wrapper.
+  const trailing = (
+    <>
+      {folderAccessRequests.map((request) => (
+        <FolderAccessCard
+          key={request.callId}
+          request={request}
+          nativeHost={nativeHost}
+          nativeBusy={nativeBusy}
+          working={resolvingFolderCalls.has(request.callId)}
+          error={folderAccessErrors[request.callId]}
+          onDecision={(decision) =>
+            onFolderAccessDecision(request.callId, decision)
+          }
+          onCancel={() => onFolderAccessCancel(request.callId, request.turnId)}
+        />
+      ))}
+      {outputWritebackRequests.map((request) => (
+        <OutputWritebackCard
+          key={request.callId}
+          request={request}
+          nativeHost={nativeHost}
+          working={resolvingOutputWritebackCalls.has(request.callId)}
+          error={outputWritebackErrors[request.callId]}
+          onDecision={(decision) =>
+            onOutputWritebackDecision(request.callId, decision)
+          }
+          onCancel={() =>
+            onOutputWritebackCancel(request.callId, request.turnId)
+          }
+        />
+      ))}
+      {userQuestionRequests.map((request) => (
+        <UserQuestionsCard
+          key={request.callId}
+          request={request}
+          working={answeringQuestionCalls.has(request.callId)}
+          error={userQuestionErrors[request.callId]}
+          onAnswer={(answers) => onAnswerUserQuestions(request.callId, answers)}
+          onCancel={() => onUserQuestionsCancel(request.turnId)}
+        />
+      ))}
+      {shouldShowAssistantWorking(
+        messages,
+        busy,
+        folderAccessRequests.length +
+          outputWritebackRequests.length +
+          userQuestionRequests.length,
+      ) && <AssistantWorkingIndicator thinking={reasoningActive} />}
+    </>
+  );
+
+  const pin = pinLastTurn && lastTurnStart >= 0;
+
+  return (
+    <div
+      className={`messages${maskClass ? ` ${maskClass}` : ""}`}
+      ref={scrollRef}
+      onScroll={onScroll}
+    >
+      <div className="messages-column" ref={contentRef}>
+        {pin ? (
+          <>
+            {messageItems.slice(0, lastTurnStart)}
+            <div className="message-turn is-pinned">
+              {messageItems.slice(lastTurnStart)}
+              {trailing}
+            </div>
+          </>
+        ) : (
+          <>
+            {messageItems}
+            {trailing}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Placeholder rows that echo the transcript's shape while history hydrates. */
+function TranscriptSkeleton() {
+  return (
+    <div className="flex w-full flex-col gap-4" aria-hidden="true">
+      {[0, 1, 2, 3].map((row) => (
+        <Fragment key={row}>
+          <Skeleton className="h-9 w-1/2 self-start rounded-xl" />
+          <div className="flex flex-col gap-2.5 py-2">
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-5/6" />
+            <Skeleton className="h-3 w-1/3" />
+          </div>
+        </Fragment>
+      ))}
     </div>
   );
 }
@@ -294,6 +366,10 @@ export function groupMessageItems(
   } = { runs: [], loading: false, error: null, retry: () => undefined },
 ) {
   const items: ReactNode[] = [];
+  // The item index at which the trailing turn opens (its user message). Lets the
+  // caller lift the last exchange into a pinned wrapper without re-deriving the
+  // turn boundary. Stays -1 for a transcript that opens on activity alone.
+  let lastTurnStart = -1;
   let index = 0;
   let groupIndex = 0;
   let streamingAssistantId: string | undefined;
@@ -318,6 +394,7 @@ export function groupMessageItems(
     const message = messages[index];
 
     if (!isActivityMessage(message)) {
+      if (message.role === "user") lastTurnStart = items.length;
       items.push(
         <MessageBubble
           key={message.id}
@@ -396,7 +473,7 @@ export function groupMessageItems(
     groupIndex += 1;
   }
 
-  return items;
+  return { items, lastTurnStart };
 }
 
 /**

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -792,26 +792,83 @@ body {
   }
 }
 
-.new-activity {
+/* An icon-only affordance centered just above the composer. It stays mounted
+   and fades on opacity so scrolling away and back doesn't pop it in and out. */
+.scroll-to-latest {
   position: absolute;
   z-index: 1;
-  right: clamp(1rem, 7vw, 7rem);
-  bottom: 1rem;
+  left: 50%;
+  bottom: 0.75rem;
+  transform: translateX(-50%);
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
+  justify-content: center;
   border: 1px solid var(--line);
   border-radius: 999px;
-  padding: 0.38rem 0.7rem 0.38rem 0.85rem;
+  padding: 0.5rem;
   color: var(--ink);
   background: var(--bg-elevated);
   box-shadow: var(--shadow);
-  font-size: 0.78rem;
-  font-weight: 500;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 150ms ease, background-color 120ms ease;
 }
 
-.new-activity:hover {
-  background: var(--accent);
+.scroll-to-latest.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.scroll-to-latest:hover {
+  background: var(--muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scroll-to-latest {
+    transition: none;
+  }
+}
+
+/* The trailing exchange, held at least a screenful tall on send so the
+   just-sent message rises near the top with room below for its reply, rather
+   than being nudged up a line at a time as the answer streams in. */
+.message-turn {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.message-turn:not(:first-child) {
+  margin-top: 1rem;
+}
+
+.message-turn.is-pinned {
+  min-height: calc(var(--transcript-viewport, 100dvh) - 8rem);
+}
+
+/* Scroll-edge fades: soften whichever edges have more content beyond them, so
+   the transcript reads as continuing past the frame rather than clipped. */
+.messages.is-faded-top {
+  mask-image: linear-gradient(180deg, transparent, #000 2rem, #000);
+}
+
+.messages.is-faded-bottom {
+  mask-image: linear-gradient(
+    180deg,
+    #000,
+    #000 calc(100% - 2rem),
+    transparent
+  );
+}
+
+.messages.is-faded-both {
+  mask-image: linear-gradient(
+    180deg,
+    transparent,
+    #000 2rem,
+    #000 calc(100% - 2rem),
+    transparent
+  );
 }
 
 .message {


### PR DESCRIPTION
Reworks the transcript's scroll behavior so it tracks the intended design.

- **Jump-to-bottom affordance**: an icon-only round button now appears whenever the reader is scrolled away from the bottom (past a ~30px threshold), centered just above the composer and fading in and out on opacity. Clicking it re-arms follow and returns to the latest message. Previously it only appeared after new activity arrived.
- **Follow on growth**: auto-follow is now driven by a `ResizeObserver` on the transcript content column, so asynchronous layout growth (image loads, markdown reflow) keeps a following reader pinned to the end instead of landing just shy of the bottom.
- **Deliberate arming**: drifting away from the bottom disarms follow; it re-arms only through the button or on send, never as a side effect of scrolling back down. The disarm threshold is aligned to ~30px.
- **Turn pinning**: on send, the trailing exchange is held at least a screenful tall (via a viewport height tracked in a CSS variable), so the just-sent message rises near the top with room below for its streaming reply rather than being nudged up a line at a time.
- **Edge fades**: the transcript now fades whichever edges have more content beyond them (top, bottom, or both), reusing the existing gradient-mask trick.
- **Hydration skeleton**: a transcript skeleton (alternating a short left-aligned bubble bar and a multi-line paragraph block) fills the pane while history hydrates, instead of a blank flash.

`ChatScroll.test.ts` is updated for the new threshold. The scroll behavior itself is driven by real scroll geometry and `ResizeObserver`, which jsdom does not model, so the visual pinning/fade behavior is best confirmed in the running app.

Closes #690