### PR TITLE
fix(connectors): treat a gateway session for a different deployment as absent

### DIFF
--- a/crates/openwave-connectors/src/gateway.rs
+++ b/crates/openwave-connectors/src/gateway.rs
@@ -630,9 +630,19 @@ impl GatewayConnection {
     }
 
     /// Whether stored credentials were minted against this connection's
-    /// configured gateway.
+    /// configured gateway. Trailing slashes are normalized the same way
+    /// [`GatewayAuth::endpoint`] does, so a subpath deployment retyped with
+    /// or without one never reads as a different gateway.
     fn matches_deployment(&self, credentials: &GatewayCredentials) -> bool {
-        reqwest::Url::parse(&credentials.base_url).is_ok_and(|url| url == self.auth.config.base_url)
+        fn normalized(url: &reqwest::Url) -> String {
+            let mut base = url.to_string();
+            if !base.ends_with('/') {
+                base.push('/');
+            }
+            base
+        }
+        reqwest::Url::parse(&credentials.base_url)
+            .is_ok_and(|url| normalized(&url) == normalized(&self.auth.config.base_url))
     }
 
     /// The stored (offline) identity, if signed in to this connection's

--- a/crates/openwave-connectors/src/gateway.rs
+++ b/crates/openwave-connectors/src/gateway.rs
@@ -629,9 +629,22 @@ impl GatewayConnection {
             .await
     }
 
-    /// The stored (offline) identity, if signed in.
+    /// Whether stored credentials were minted against this connection's
+    /// configured gateway.
+    fn matches_deployment(&self, credentials: &GatewayCredentials) -> bool {
+        reqwest::Url::parse(&credentials.base_url).is_ok_and(|url| url == self.auth.config.base_url)
+    }
+
+    /// The stored (offline) identity, if signed in to this connection's
+    /// configured gateway. A session minted against a different deployment
+    /// reads as absent: reporting it would assert an identity that is simply
+    /// wrong for the configured base URL.
     pub async fn stored_credentials(&self) -> Result<Option<GatewayCredentials>> {
-        self.vault.load().await
+        Ok(self
+            .vault
+            .load()
+            .await?
+            .filter(|credentials| self.matches_deployment(credentials)))
     }
 
     /// A fresh access token for `resource`, from cache when possible and via
@@ -641,6 +654,13 @@ impl GatewayConnection {
         let Some(mut credentials) = self.vault.load().await? else {
             return Err(sign_in_required("no gateway session is stored"));
         };
+        // Refuse early rather than let installation pinning fail downstream:
+        // "sign-in required" is actionable, a provider 500 is not.
+        if !self.matches_deployment(&credentials) {
+            return Err(sign_in_required(
+                "the stored gateway session belongs to a different gateway deployment",
+            ));
+        }
         if let Some(cached) = credentials.access_tokens.get(resource) {
             if cached.is_fresh() {
                 return Ok(cached.token.clone());

--- a/crates/openwave-connectors/tests/gateway_flow.rs
+++ b/crates/openwave-connectors/tests/gateway_flow.rs
@@ -387,6 +387,30 @@ async fn a_stale_refresh_token_reads_as_signed_out() {
 }
 
 #[tokio::test]
+async fn a_session_for_a_different_deployment_reads_as_signed_out() {
+    let (_gateway, connection) = signed_in_connection().await;
+    let stored = connection.stored_credentials().await.unwrap().unwrap();
+
+    // The same vault contents viewed by a connection configured for a
+    // different deployment — the settings URL was edited after sign-in.
+    let vault = CredentialVault::new(Arc::new(MockSecrets::default()));
+    vault.save(&stored).await.unwrap();
+    let other = GatewayConnection::new(
+        GatewayAuth::new(GatewayAuthConfig::new("http://127.0.0.1:9").unwrap()).unwrap(),
+        vault,
+    );
+
+    assert!(other.stored_credentials().await.unwrap().is_none());
+    // Refused before any refresh attempt: the failure must read as
+    // "sign-in required", not as a provider error downstream.
+    let error = other
+        .access_token(RESOURCE_CONTROL)
+        .await
+        .expect_err("a mismatched session must not mint tokens");
+    assert!(is_sign_in_required(&error), "{error}");
+}
+
+#[tokio::test]
 async fn a_state_mismatch_never_reaches_the_token_endpoint() {
     let gateway = Arc::new(FakeGateway::default());
     gateway.corrupt_state.store(true, Ordering::SeqCst);

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -261,13 +261,13 @@ impl GatewayRuntime {
         Ok(Some(connection))
     }
 
-    /// A router token source, when the provider is configured and a session is
-    /// stored. `None` keeps the gateway route out of the router entirely.
+    /// A router token source, when the provider is configured and a session
+    /// for that deployment is stored. `None` keeps the gateway route out of
+    /// the router entirely — including when the stored session belongs to a
+    /// different gateway than the configured base URL.
     pub(crate) async fn route_token_source(&self) -> Option<Arc<dyn BearerTokenSource>> {
-        if !openwave_connectors::has_stored_credentials(&*self.secrets).await {
-            return None;
-        }
         let connection = self.connection().await.ok().flatten()?;
+        connection.stored_credentials().await.ok().flatten()?;
         Some(Arc::new(GatewayTokenSource(connection)))
     }
 
@@ -578,6 +578,33 @@ mod tests {
             .await
             .unwrap();
         assert!(config.models.is_empty());
+    }
+
+    #[tokio::test]
+    async fn a_session_for_a_different_gateway_reads_signed_out() {
+        let address = serve(Arc::new(FakeGateway::default())).await;
+        let base = format!("http://{address}");
+        let (runtime, store, _directory) = signed_in_runtime(&base).await;
+
+        // Repoint the provider at a different deployment; the stored session
+        // (minted against `base`) stays in the vault untouched.
+        let mut config = providers::read_config(&*store, ProviderKind::ModelGateway)
+            .await
+            .unwrap();
+        config.base_url = Some("http://127.0.0.1:9".to_string());
+        providers::write_config(&*store, ProviderKind::ModelGateway, &config)
+            .await
+            .unwrap();
+
+        let status = runtime.status().await.unwrap();
+        assert!(status.configured);
+        assert!(
+            !status.signed_in,
+            "a foreign session must not read signed-in"
+        );
+        assert!(status.account_hint.is_none());
+        assert!(status.installation_id.is_none());
+        assert!(runtime.route_token_source().await.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
`GatewayRuntime::status()` set `signed_in: credentials.is_some()` without checking that the stored session's `base_url` matches the configured gateway, so signing in to gateway A and then pointing the URL at gateway B still showed **Signed in** with A's account and installation id — and the first real request surfaced as `500: provider authentication failed` instead of a sign-in prompt (#679).

The check lives in `GatewayConnection`, which knows both sides:

- `matches_deployment` compares the stored `base_url` (parsed) against the configured one.
- `stored_credentials()` filters through it, so `status()` reports signed-out for a foreign session with no account hint or installation id, and the renderer's existing signed-out state offers sign-in. No wire change.
- `access_token()` refuses a mismatched session up front with the existing sign-in-required error — the issue's optional hardening, so the failure reads as "sign-in required" rather than a provider error after installation pinning rejects it downstream.
- `route_token_source()` now derives from the connection's filtered credentials instead of raw `has_stored_credentials`, keeping the gateway route out of the router entirely.

`providers::has_credential` still treats any stored session as the gateway credential (it has no access to the configured URL at that seam); with token minting refusing early, its worst case is now an explicit sign-in-required rather than a 500. Left as-is to keep this slice small.

Two tests, both crossing a boundary: a connectors integration test that a vault viewed by a differently-configured connection reads signed-out and refuses to mint (`is_sign_in_required`), and a server test reproducing the issue verbatim — sign in against one deployment, repoint the config, assert signed-out status and no route.

Verified with `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, and `cargo test --workspace` (1391 passed, 0 failed, no lock diff).

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)