### PR TITLE
fix(desktop): confirm folder disconnect, allow dismissing failed imports, add type icons and download

### DIFF
--- a/crates/openwave-desktop/ui/src/DeliverablesView.tsx
+++ b/crates/openwave-desktop/ui/src/DeliverablesView.tsx
@@ -8,6 +8,7 @@ import {
   type DeliverablesCatalog,
   type OutputExportResult,
 } from "./deliverables";
+import { documentIcon } from "./documentIcon";
 import { MessageMarkdown } from "./MessageMarkdown";
 import {
   PICKER_BUSY_MESSAGE,
@@ -240,7 +241,9 @@ export function DeliverablesView({
                 </div>
               </div>
               <div className="deliverables-list">
-                {catalog.deliverables.map((item) => (
+                {catalog.deliverables.map((item) => {
+                  const Icon = documentIcon(item.mediaType);
+                  return (
                   <button
                     type="button"
                     className={`deliverable-row${selected === item.outputId ? " is-selected" : ""}`}
@@ -249,7 +252,7 @@ export function DeliverablesView({
                     onClick={() => setSelected(item.outputId)}
                   >
                     <span className="deliverable-icon" aria-hidden="true">
-                      <FileOutput size={16} />
+                      <Icon size={16} />
                     </span>
                     <span className="deliverable-copy">
                       <strong>{item.filename}</strong>
@@ -262,7 +265,8 @@ export function DeliverablesView({
                       </small>
                     </span>
                   </button>
-                ))}
+                  );
+                })}
               </div>
             </section>
 

--- a/crates/openwave-desktop/ui/src/DocumentsView.tsx
+++ b/crates/openwave-desktop/ui/src/DocumentsView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { FileText } from "lucide-react";
 import {
   deleteLibraryDocument,
+  exportLibraryDocument,
   importLibraryDocuments,
   listLibraryDocuments,
   retryLibraryDocument,
@@ -13,6 +13,8 @@ import {
   type LibraryImportSuccess,
   type LibrarySearchResult,
 } from "./documents";
+import { documentIcon } from "./documentIcon";
+import { hasNativeHost } from "./host";
 import {
   PICKER_BUSY_MESSAGE,
   PICKER_HOLDERS,
@@ -73,6 +75,7 @@ export function DocumentsView({
   const catalogRequestRef = useRef(0);
   const searchRequestRef = useRef(0);
   const { confirm, dialog: confirmDialog } = useConfirm();
+  const nativeHost = hasNativeHost();
 
   function isCurrentScope(scope: number) {
     return mountedRef.current && scope === scopeRef.current;
@@ -241,6 +244,17 @@ export function DocumentsView({
       }
     } finally {
       if (isCurrentScope(scope)) setBusyDocument(null);
+    }
+  }
+
+  async function onDownload(document: LibraryDocument) {
+    const scope = scopeRef.current;
+    try {
+      await exportLibraryDocument(chatId, document.documentId);
+    } catch (err) {
+      if (isCurrentScope(scope)) {
+        setError(friendlyError(err, "Could not save that source."));
+      }
     }
   }
 
@@ -461,6 +475,7 @@ export function DocumentsView({
                       {visibleDocuments.map((document) => {
                         const title = documentTitle(document);
                         const busy = busyDocument === document.documentId;
+                        const Icon = documentIcon(document.mediaType);
                         return (
                           <tr
                             key={document.documentId}
@@ -477,7 +492,7 @@ export function DocumentsView({
                                 aria-label={`Open ${title}`}
                               >
                                 <span className="document-icon" aria-hidden="true">
-                                  <FileText size={16} />
+                                  <Icon size={16} />
                                 </span>
                                 <strong>{title}</strong>
                               </button>
@@ -506,6 +521,17 @@ export function DocumentsView({
                                 >
                                   Open
                                 </button>
+                                {nativeHost && (
+                                  <button
+                                    type="button"
+                                    className="document-action"
+                                    disabled={busy}
+                                    onClick={() => void onDownload(document)}
+                                    aria-label={`Download ${title}`}
+                                  >
+                                    Download
+                                  </button>
+                                )}
                                 <button
                                   type="button"
                                   className="document-action is-danger"

--- a/crates/openwave-desktop/ui/src/FoldersView.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersView.tsx
@@ -13,6 +13,7 @@ import {
   PICKER_HOLDERS,
   useNativePickerLatch,
 } from "./NativePickerLatch";
+import { useConfirm } from "./components/ConfirmDialog";
 
 /**
  * A chat's connected folders: the directories the native host may read on this
@@ -27,6 +28,7 @@ export function FoldersView({ chat }: { chat: Chat }) {
   const [working, setWorking] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const refreshGeneration = useRef(0);
+  const { confirm, dialog: confirmDialog } = useConfirm();
   const connectedIds = new Set(folders.map((folder) => folder.rootId));
   const availableFolders = approvedFolders.filter(
     (folder) => !connectedIds.has(folder.rootId),
@@ -95,11 +97,18 @@ export function FoldersView({ chat }: { chat: Chat }) {
     );
   }
 
-  async function removeFolder(rootId: string) {
+  async function removeFolder(folder: ConnectedFolder) {
+    const accepted = await confirm({
+      title: `Disconnect ${folder.displayName}?`,
+      description: "The agent loses access to this folder.",
+      confirmLabel: "Disconnect",
+      destructive: true,
+    });
+    if (!accepted) return;
     setWorking(true);
     setError(null);
     try {
-      await disconnectFolder(chat, rootId);
+      await disconnectFolder(chat, folder.rootId);
       await refresh();
     } catch (err) {
       setError(String(err));
@@ -159,7 +168,7 @@ export function FoldersView({ chat }: { chat: Chat }) {
                     type="button"
                     className="btn"
                     disabled={working}
-                    onClick={() => void removeFolder(folder.rootId)}
+                    onClick={() => void removeFolder(folder)}
                   >
                     Disconnect
                   </button>
@@ -195,6 +204,7 @@ export function FoldersView({ chat }: { chat: Chat }) {
           </div>
         )}
       </div>
+      {confirmDialog}
     </section>
   );
 }

--- a/crates/openwave-desktop/ui/src/ImportQueue.tsx
+++ b/crates/openwave-desktop/ui/src/ImportQueue.tsx
@@ -6,7 +6,7 @@ import {
 
 export function ImportQueue() {
   const entries = useImportQueueStore((state) => state.entries);
-  const dismissCleanRun = useImportQueueStore((state) => state.dismissCleanRun);
+  const dismiss = useImportQueueStore((state) => state.dismiss);
   if (entries.length === 0) return null;
 
   const sorted = sortedImportQueue(entries);
@@ -22,8 +22,8 @@ export function ImportQueue() {
           </h2>
           <p>{active ? "OpenWave is preparing your files for this conversation." : null}</p>
         </div>
-        {!active && !failed && (
-          <button type="button" className="btn" onClick={dismissCleanRun}>
+        {!active && (
+          <button type="button" className="btn" onClick={dismiss}>
             Dismiss
           </button>
         )}

--- a/crates/openwave-desktop/ui/src/ImportQueueStore.test.ts
+++ b/crates/openwave-desktop/ui/src/ImportQueueStore.test.ts
@@ -34,7 +34,7 @@ describe("ImportQueueStore", () => {
     ]);
   });
 
-  it("only dismisses a completed run with no failures", () => {
+  it("automatically dismisses only a completed run with no failures", () => {
     const store = createImportQueueStore();
     store.getState().receive({ ...queued, status: "streaming" });
     store.getState().dismissCleanRun();
@@ -57,6 +57,22 @@ describe("ImportQueueStore", () => {
     });
     clean.getState().dismissCleanRun();
     expect(clean.getState().entries).toEqual([]);
+  });
+
+  it("lets the reader manually dismiss a finished run even after a failure", () => {
+    const store = createImportQueueStore();
+    store.getState().receive({ ...queued, status: "streaming" });
+    // Nothing to dismiss while the run is still working.
+    store.getState().dismiss();
+    expect(store.getState().entries).toHaveLength(1);
+
+    store.getState().receive({
+      ...queued,
+      status: "failed",
+      message: "The file is empty",
+    });
+    store.getState().dismiss();
+    expect(store.getState().entries).toEqual([]);
   });
 
   it("puts failures before active and completed imports", () => {

--- a/crates/openwave-desktop/ui/src/ImportQueueStore.ts
+++ b/crates/openwave-desktop/ui/src/ImportQueueStore.ts
@@ -13,6 +13,17 @@ export type ImportQueueEntry = LibraryImportProgress & {
 export type ImportQueueStore = {
   entries: ImportQueueEntry[];
   receive: (progress: LibraryImportProgress) => void;
+  /**
+   * Manual dismissal, from the reader clicking away the widget. Clears the run
+   * once it is no longer active — failures and all, because a reader who has
+   * read the failure and asks to close it should be obeyed.
+   */
+  dismiss: () => void;
+  /**
+   * Automatic dismissal, for a caller clearing the widget on the reader's
+   * behalf. A clean completed run goes; a run with a failure stays put until
+   * the reader has seen it and dismissed it themselves.
+   */
   dismissCleanRun: () => void;
 };
 
@@ -28,6 +39,12 @@ export function createImportQueueStore() {
         entries[index] = next;
         return { entries };
       }),
+    dismiss: () =>
+      set((state) =>
+        state.entries.some((entry) => importIsActive(entry.status))
+          ? state
+          : { entries: [] },
+      ),
     // A failed run stays visible until its reader has seen and resolved it.
     dismissCleanRun: () =>
       set((state) =>

--- a/crates/openwave-desktop/ui/src/documentIcon.ts
+++ b/crates/openwave-desktop/ui/src/documentIcon.ts
@@ -1,0 +1,49 @@
+import {
+  File,
+  FileAudio,
+  FileImage,
+  FileJson,
+  FileSpreadsheet,
+  FileText,
+  FileType,
+  Presentation,
+  type LucideIcon,
+} from "lucide-react";
+
+/**
+ * A lucide icon for a document's media-type family, shared by every list that
+ * shows sources or outputs. Grouped by family rather than exact type — every
+ * spreadsheet shares one glyph, every image another — and the generic fallback
+ * covers anything unrecognised, so a caller always has an icon to draw.
+ */
+export function documentIcon(mediaType: string | null | undefined): LucideIcon {
+  const type = (mediaType ?? "").split(";")[0]?.trim().toLowerCase() ?? "";
+
+  if (type === "application/pdf") return FileText;
+  if (type.includes("wordprocessingml") || type === "application/msword") {
+    return FileType;
+  }
+  if (
+    type.includes("spreadsheetml") ||
+    type === "application/vnd.ms-excel" ||
+    type === "text/csv"
+  ) {
+    return FileSpreadsheet;
+  }
+  if (type.includes("presentationml") || type === "application/vnd.ms-powerpoint") {
+    return Presentation;
+  }
+  if (
+    type === "application/json" ||
+    type.endsWith("+json") ||
+    type === "application/xml" ||
+    type === "text/xml" ||
+    type.endsWith("+xml")
+  ) {
+    return FileJson;
+  }
+  if (type.startsWith("image/")) return FileImage;
+  if (type.startsWith("audio/")) return FileAudio;
+  if (type.startsWith("text/")) return FileText;
+  return File;
+}


### PR DESCRIPTION
A cluster of fixes across the connected-folders and source panels.

- Folder disconnect now asks first. "Disconnect" ran `removeFolder` immediately with no way back; it now goes through the shared confirmation dialog with destructive styling, so an accidental click no longer silently revokes the agent's access to a folder.
- A failed import can be dismissed again. A batch with any failed entry could never be cleared: the store's clean-run dismissal no-ops on failure and the Dismiss button only rendered for a clean run, so the corner widget was stuck until reload. Manual dismissal is now available whenever the run is no longer active; only the automatic clean-run dismissal still holds a failure on screen until the reader has seen it.
- Type-aware icons. The sources list drew one file-text glyph for every source and the outputs list one glyph for every output, regardless of media type. Both now draw from a shared `documentIcon` helper that maps a media type to a per-family lucide icon (PDF, word processor, spreadsheet, presentation, text/markdown, JSON/XML, image, audio, generic fallback).
- Download a source. `exportLibraryDocument` was fully implemented but had no caller from the catalog. Added a Download row action, shown only where a native host can receive the save, wired to it.

Closes #698