### PR TITLE
feat(desktop): keyboard shortcuts for sidebar, new chat, and composer focus

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.tsx
@@ -19,8 +19,16 @@ import { Logomark } from "./Logomark";
 import { useTheme } from "./theme";
 import { useActiveChatId } from "./useActiveChatId";
 import { useChatPromptWatcher } from "./useChatPromptWatcher";
+import { useShellShortcuts } from "./ShellShortcuts";
 import { useUiStore } from "./UiStore";
 import { useDesktopUpdates } from "./updates";
+
+/** Move focus to whichever composer the current route has on screen. */
+function focusComposer(): void {
+  document
+    .querySelector<HTMLTextAreaElement>("[data-composer-input]")
+    ?.focus();
+}
 
 // Store actions are stable for the store's lifetime; these handles are for
 // calling actions only — never read state fields from them.
@@ -62,6 +70,15 @@ export function AppShell() {
   // Watched here rather than in the conversation, so that the agent parking a
   // turn on a question is noticed whatever screen the reader is on.
   useChatPromptWatcher(client, openChatId);
+
+  // Shell shortcuts live here because these actions outlive any one route:
+  // toggling the frame, starting a chat, and reaching the composer all work
+  // wherever the reader is.
+  useShellShortcuts({
+    "toggle-sidebar": () => useUiStore.getState().toggleSidebar(),
+    "new-chat": () => void onNewChat(),
+    "focus-composer": focusComposer,
+  });
 
   useEffect(() => {
     let cancelled = false;

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -324,6 +324,9 @@ export function Composer({
             active ? "Guide the active response…" : "Message OpenWave…"
           }
           aria-label="Message"
+          // A stable hook for the shell's focus-composer shortcut, which has to
+          // find the field without a ref threaded up through every route.
+          data-composer-input=""
           disabled={inputDisabled}
           onChange={onChange}
           onPaste={onPaste}

--- a/crates/openwave-desktop/ui/src/ShellShortcuts.test.ts
+++ b/crates/openwave-desktop/ui/src/ShellShortcuts.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+
+import {
+  isEditableTarget,
+  resolveShellShortcut,
+  type ShellShortcutAction,
+} from "./ShellShortcuts";
+
+function keyEvent(overrides: Partial<KeyboardEvent>): KeyboardEvent {
+  return {
+    key: "b",
+    metaKey: true,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    ...overrides,
+  } as KeyboardEvent;
+}
+
+describe("shell shortcut resolution", () => {
+  it("classifies text fields as editable and other elements as not", () => {
+    const input = document.createElement("input");
+    const textarea = document.createElement("textarea");
+    const editable = document.createElement("div");
+    editable.setAttribute("contenteditable", "true");
+    const plain = document.createElement("div");
+
+    expect(isEditableTarget(input)).toBe(true);
+    expect(isEditableTarget(textarea)).toBe(true);
+    expect(isEditableTarget(editable)).toBe(true);
+    expect(isEditableTarget(plain)).toBe(false);
+    expect(isEditableTarget(null)).toBe(false);
+  });
+
+  it("fires chorded shortcuts even while the composer has focus", () => {
+    // The whole point of mod-chorded combos: the reader can reach them without
+    // leaving the field they are typing in.
+    const cases: Array<[string, ShellShortcutAction]> = [
+      ["b", "toggle-sidebar"],
+      ["n", "new-chat"],
+      ["k", "focus-composer"],
+    ];
+    for (const [key, id] of cases) {
+      const resolved = resolveShellShortcut(keyEvent({ key }), {
+        editable: true,
+        modalOpen: false,
+      });
+      expect(resolved?.id).toBe(id);
+    }
+  });
+
+  it("stays out of the way of plain typing", () => {
+    const resolved = resolveShellShortcut(
+      keyEvent({ key: "n", metaKey: false, ctrlKey: false }),
+      { editable: true, modalOpen: false },
+    );
+    expect(resolved).toBeNull();
+  });
+
+  it("suppresses every shortcut while a modal dialog is open", () => {
+    const resolved = resolveShellShortcut(keyEvent({ key: "n" }), {
+      editable: false,
+      modalOpen: true,
+    });
+    expect(resolved).toBeNull();
+  });
+});

--- a/crates/openwave-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/openwave-desktop/ui/src/ShellShortcuts.ts
@@ -1,0 +1,139 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Shell-level keyboard shortcuts: the ones that act on the frame rather than on
+ * a single conversation, so they work from every route.
+ *
+ * The bindings live in one declarative table rather than scattered through
+ * component handlers, so a future shortcuts-help dialog can read the same list
+ * the listener acts on and stay honest about what the keys actually do.
+ */
+export type ShellShortcutAction = "toggle-sidebar" | "new-chat" | "focus-composer";
+
+export type ShellShortcutDef = {
+  id: ShellShortcutAction;
+  /** A single character, matched case-insensitively against `event.key`. */
+  key: string;
+  /** Requires the platform command modifier — Cmd on macOS, Ctrl elsewhere. */
+  mod: boolean;
+  /** Whether shift must be held (defaults to must-not). */
+  shift?: boolean;
+  /** What the shortcut does, phrased for a help dialog. */
+  description: string;
+  /**
+   * Whether the shortcut may fire while focus is in a text field. Chorded
+   * combos (mod+key) are safe there — they are not something a reader types —
+   * so the composer's own focus never swallows them.
+   */
+  allowInEditable: boolean;
+};
+
+export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
+  {
+    id: "toggle-sidebar",
+    key: "b",
+    mod: true,
+    description: "Show or hide the sidebar",
+    allowInEditable: true,
+  },
+  {
+    id: "new-chat",
+    key: "n",
+    mod: true,
+    description: "Start a new chat",
+    allowInEditable: true,
+  },
+  {
+    id: "focus-composer",
+    key: "k",
+    mod: true,
+    description: "Focus the message composer",
+    allowInEditable: true,
+  },
+];
+
+type ShortcutKeyEvent = Pick<
+  KeyboardEvent,
+  "key" | "metaKey" | "ctrlKey" | "shiftKey" | "altKey"
+>;
+
+/** Whether a key event is the combo a shortcut is bound to. */
+export function matchesShellShortcut(
+  event: ShortcutKeyEvent,
+  def: ShellShortcutDef,
+): boolean {
+  if (event.altKey) return false;
+  if (event.key.toLowerCase() !== def.key) return false;
+  if (event.shiftKey !== (def.shift ?? false)) return false;
+  const hasMod = event.metaKey || event.ctrlKey;
+  return def.mod ? hasMod : !hasMod;
+}
+
+/** Whether focus sits in a field the reader is typing into. */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (target.isContentEditable) return true;
+  // `isContentEditable` is layout-derived and unimplemented in some test DOMs;
+  // the attribute is the direct signal the shortcut layer actually cares about.
+  const editable = target.getAttribute("contenteditable");
+  return editable === "" || editable === "true";
+}
+
+/**
+ * The shortcut a key event should trigger, or `null` when none should.
+ *
+ * A modal dialog on screen suppresses every shell shortcut: the reader is
+ * mid-decision, and toggling the frame or starting a new chat behind the
+ * dialog would be a surprise. Kept pure so the guard is testable without a DOM.
+ */
+export function resolveShellShortcut(
+  event: ShortcutKeyEvent,
+  context: { editable: boolean; modalOpen: boolean },
+): ShellShortcutDef | null {
+  if (context.modalOpen) return null;
+  for (const def of SHELL_SHORTCUTS) {
+    if (!matchesShellShortcut(event, def)) continue;
+    if (context.editable && !def.allowInEditable) return null;
+    return def;
+  }
+  return null;
+}
+
+/** A radix dialog or alert dialog currently open on screen. */
+function hasOpenModalDialog(doc: Document): boolean {
+  return (
+    doc.querySelector(
+      '[role="dialog"][data-state="open"], [role="alertdialog"][data-state="open"]',
+    ) !== null
+  );
+}
+
+export type ShellShortcutHandlers = Record<ShellShortcutAction, () => void>;
+
+/**
+ * Bind the shell shortcuts to a single window listener for the app's lifetime.
+ *
+ * Handlers are read through a ref so the listener registers once and never has
+ * to be torn down and rebound as the callbacks change identity between renders.
+ */
+export function useShellShortcuts(handlers: ShellShortcutHandlers): void {
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.defaultPrevented) return;
+      const def = resolveShellShortcut(event, {
+        editable: isEditableTarget(event.target),
+        modalOpen: hasOpenModalDialog(document),
+      });
+      if (!def) return;
+      event.preventDefault();
+      handlersRef.current[def.id]();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+}


### PR DESCRIPTION
Adds a shell-level keyboard shortcut layer so the frame's actions are reachable from every route:

- **Cmd/Ctrl+B** toggles the sidebar.
- **Cmd/Ctrl+N** starts a new chat, reusing the shell's existing create-and-open action.
- **Cmd/Ctrl+K** moves focus to the message composer.

The bindings live in one declarative table (`ShellShortcuts.ts`) that a listener registered once in the shell reads, rather than being scattered through component handlers — a later shortcuts-help dialog can read the same list. Because the combos are all chorded they fire even while a text field has focus, but every shell shortcut is suppressed while a modal dialog is open. The composer is reached through a stable `data-composer-input` attribute so no ref has to be threaded up through the routes.

Closes #693