### PR TITLE
fix(desktop): explain the empty composer picker and land the toggle in render order

### DIFF
--- a/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
@@ -1,6 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import {
+  firstAvailableModel,
   ModelMenu,
   ReasoningEffortMenu,
   reasoningEffortOptions,
@@ -118,6 +119,22 @@ describe("visibleModelGroups", () => {
       (group) => group.provider === "anthropic",
     );
     expect(anthropic?.models).toHaveLength(2);
+  });
+});
+
+describe("firstAvailableModel", () => {
+  it("lands in render order, not catalog order", () => {
+    // OpenAI first in the catalog, but Anthropic renders first — the toggle
+    // must land where the reader sees the check appear.
+    const [sonnet, gpt] = MODELS;
+    expect(firstAvailableModel([gpt, sonnet], null)?.key).toBe(
+      "anthropic::claude-sonnet-4",
+    );
+  });
+
+  it("is null when nothing can run", () => {
+    const nothing = MODELS.map((model) => ({ ...model, available: false }));
+    expect(firstAvailableModel(nothing, null)).toBeNull();
   });
 });
 

--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -67,6 +67,23 @@ export function visibleModelGroups(
 }
 
 /**
+ * The model turning the Default switch off should land on: the first
+ * available row *as the menu renders them*, so the selection visibly lands
+ * at the top of the list rather than on whatever the catalog happened to
+ * order first. `null` when nothing can run.
+ */
+export function firstAvailableModel(
+  models: readonly ModelInfo[],
+  selectedKey: string | null,
+): ModelInfo | null {
+  return (
+    visibleModelGroups(models, selectedKey)
+      .flatMap((group) => group.models)
+      .find((model) => model.available) ?? null
+  );
+}
+
+/**
  * The row that reads as a mode rather than another model.
  *
  * A picker that offers "default" as one more entry never says what picking it
@@ -136,6 +153,7 @@ export function ModelMenu({
   const canonical = canonicalModelSelection(models, value);
   const isDefault = value === null;
   const resolvedDefault = modelForSelection(models, defaultKey);
+  const anyAvailable = models.some((model) => model.available);
 
   const label = isDefault ? "Default" : (known?.display_name ?? `${value} (unavailable)`);
   // The pill names the default's resolution too: the reader is hovering the
@@ -186,18 +204,31 @@ export function ModelMenu({
           <DefaultRow
             isDefault={isDefault}
             tooltip={defaultTooltip}
-            disabled={Boolean(disabled)}
+            // With nothing available, turning the default off has nowhere to
+            // land — freeze the switch instead of letting it snap back;
+            // flipping back *to* the default must always stay possible.
+            disabled={Boolean(disabled) || (isDefault && !anyAvailable)}
             onToggle={(useDefault) => {
               if (useDefault) {
                 void onChange(null);
                 return;
               }
               // Turning the default off has to land on something; the first
-              // model that can actually run is the only sane candidate.
-              const first = models.find((model) => model.available);
+              // model as the menu renders them, so the check appears at the
+              // top of the list rather than mid-scroll.
+              const first = firstAvailableModel(models, canonical);
               if (first) void onChange(first.key);
             }}
           />
+
+          {!anyAvailable && (
+            <div>
+              <DropdownMenuSeparator />
+              <p className="text-muted-foreground px-2 py-2 text-sm">
+                Configure a provider in Settings to choose a model.
+              </p>
+            </div>
+          )}
 
           {visibleModelGroups(models, canonical).map((group) => (
             <div key={group.provider}>


### PR DESCRIPTION
Follow-up to #694, closing the two gaps its review deferred (#706):

- **Empty state.** With no provider configured, the picker now shows "Configure a provider in Settings to choose a model." instead of a bare Default row, and the Default switch is frozen while there is nothing to land on — turning it *off* had silently no-oped and snapped back. Flipping back **to** the default remains possible whenever an override is active, so nobody gets stuck.
- **Toggle-off landing order.** `firstAvailableModel` walks `visibleModelGroups` in render order rather than `models.find` in catalog order, so the selection lands on the top visible row — the reader sees the check appear where they're looking.

Two focused tests on the new pure function: render-order-not-catalog-order, and null when nothing can run. The empty-state markup itself is not tested — a DOM test through Radix's open-menu state would be setup-heavy scaffolding around a static line of copy.

Verified under `crates/openwave-desktop/ui`: `tsc --noEmit` clean, vitest 526/526, production `vite build` clean.

Closes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)