### PR TITLE
fix(desktop): dock the home composer and give new chat its intended weight

### DIFF
--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -52,9 +52,11 @@ export function HomeRoute() {
 
   return (
     <RouteFrame sidebar={<HomeSidebar />}>
-      <div className="content-container flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden">
-        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-[clamp(0.5rem,4%,5rem)]">
-          <div className="mx-auto flex w-full min-h-0 max-w-3xl flex-1 flex-col gap-8 py-10">
+      <div className="content-container flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden px-[clamp(0.5rem,4%,5rem)]">
+        {/* The greeting and the list of past chats scroll together and stay
+            centred while there is room; the composer below does not move. */}
+        <div className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto">
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 py-10">
             <div className="space-y-2 text-center">
               <p className="text-3xl font-normal text-foreground">
                 What are we working on?
@@ -64,30 +66,31 @@ export function HomeRoute() {
               </p>
             </div>
 
-            {/* The composer leads, because starting something is what this
-                page is for; the list below is for returning to something. */}
-            <div>
-              {error && <p className="pb-2 text-sm text-critical">{error}</p>}
-              <Composer
-                activeTurnId={null}
-                busy={false}
-                cancelError={null}
-                cancelPending={false}
-                disabled={creatingChat}
-                draft={draft}
-                resetKey="home"
-                steerError={null}
-                steerPending={false}
-                steerStatus={null}
-                onDraftChange={setDraft}
-                onSend={startChat}
-                onSteer={async () => {}}
-                onStop={async () => {}}
-              />
-            </div>
-
             {chatsLoaded && <ChatExplorer />}
           </div>
+        </div>
+
+        {/* Docked at the foot of the page: the composer here starts a chat
+            rather than posting into one, but it stays put while the list above
+            scrolls, the way it does inside a conversation. */}
+        <div className="z-10 mx-auto w-full max-w-3xl pb-2">
+          {error && <p className="pb-2 text-sm text-critical">{error}</p>}
+          <Composer
+            activeTurnId={null}
+            busy={false}
+            cancelError={null}
+            cancelPending={false}
+            disabled={creatingChat}
+            draft={draft}
+            resetKey="home"
+            steerError={null}
+            steerPending={false}
+            steerStatus={null}
+            onDraftChange={setDraft}
+            onSend={startChat}
+            onSteer={async () => {}}
+            onStop={async () => {}}
+          />
         </div>
       </div>
     </RouteFrame>

--- a/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
@@ -5,7 +5,6 @@ import {
   FolderOpen,
   Library,
   Shapes,
-  SquarePen,
 } from "lucide-react";
 
 import type { Chat } from "@/api";
@@ -14,6 +13,7 @@ import { useChatAttention } from "@/ChatAttention";
 import { useChatListStore } from "@/ChatListStore";
 import type { PanelType } from "@/panel/panelTypes";
 import { usePanelNav } from "@/panel/usePanelNav";
+import { NewChatButton } from "./NewChatButton";
 import { SidebarButton, SidebarSectionTitle } from "./primitives";
 import { SidebarFrame } from "./SidebarFrame";
 
@@ -64,13 +64,11 @@ export function ChatSidebar({ chat }: { chat: Chat }) {
         )}
       </SidebarButton>
 
-      <SidebarButton
+      <NewChatButton
         onClick={newChat}
         disabled={creatingChat || deletingChatId !== null}
-      >
-        <SquarePen />
-        <span>{creatingChat ? "Starting…" : "New chat"}</span>
-      </SidebarButton>
+        creating={creatingChat}
+      />
 
       <SidebarSectionTitle className="mt-4">
         {chat.title?.trim() || "New chat"}

--- a/crates/openwave-desktop/ui/src/sidebar/HomeSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/HomeSidebar.tsx
@@ -1,11 +1,11 @@
 import { useNavigate } from "@tanstack/react-router";
-import { SquarePen } from "lucide-react";
 
 import { useApp } from "@/AppContext";
 import { useChatAttention } from "@/ChatAttention";
 import { useChatListStore } from "@/ChatListStore";
+import { NewChatButton } from "./NewChatButton";
 import { RecentChatRow } from "./RecentChatRow";
-import { SidebarButton, SidebarSectionTitle, useSidebarWidth } from "./primitives";
+import { SidebarSectionTitle, useSidebarWidth } from "./primitives";
 import { SidebarFrame } from "./SidebarFrame";
 
 /** How many conversations the rail shows before deferring to the home list. */
@@ -39,13 +39,11 @@ export function HomeSidebar() {
 
   return (
     <SidebarFrame>
-      <SidebarButton
+      <NewChatButton
         onClick={newChat}
         disabled={creatingChat || deletingChatId !== null}
-      >
-        <SquarePen />
-        <span>{creatingChat ? "Starting…" : "New chat"}</span>
-      </SidebarButton>
+        creating={creatingChat}
+      />
 
       {recentChats.length > 0 && (
         <SidebarSectionTitle className="mt-4">Recent</SidebarSectionTitle>

--- a/crates/openwave-desktop/ui/src/sidebar/NewChatButton.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/NewChatButton.tsx
@@ -1,0 +1,45 @@
+import { SquarePen } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { SidebarButton, useSidebarWidth } from "./primitives";
+
+/**
+ * Starting a chat is the rail's primary action, so an expanded rail gives it a
+ * prominent full-width button rather than another nav row. A compact rail has
+ * no room for that, so it falls back to the icon-only row with its label in a
+ * tooltip — the same treatment every other compact control gets.
+ */
+export function NewChatButton({
+  onClick,
+  disabled,
+  creating,
+}: {
+  onClick: () => void;
+  disabled: boolean;
+  creating: boolean;
+}) {
+  const isCompact = useSidebarWidth() === "compact";
+  const label = creating ? "Starting…" : "New chat";
+
+  if (isCompact) {
+    return (
+      <SidebarButton aria-label={label} onClick={onClick} disabled={disabled}>
+        <SquarePen />
+        <span>{label}</span>
+      </SidebarButton>
+    );
+  }
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="w-full justify-start gap-2"
+      onClick={onClick}
+      disabled={disabled}
+    >
+      <SquarePen />
+      <span>{label}</span>
+    </Button>
+  );
+}


### PR DESCRIPTION
Three adjustments to the home screen:

- **Docked composer.** The greeting, past-chat list, and composer used to scroll together in one column. The page now splits: the greeting and chat explorer share a scrollable region that stays vertically centred while there is room, and the composer sits in a non-scrolling section docked at the foot of the viewport — the same relationship the composer has inside a conversation.
- **New chat gets its weight back.** In both the home and in-chat rails, an expanded sidebar now renders "New chat" as a prominent full-width outline button rather than another plain nav row. A compact rail keeps the icon-only row with its label in a tooltip, like every other compact control. The two rails share one `NewChatButton` so the treatment stays identical.

The welcome greeting already matches the intended `text-3xl` scale, so no typography change was needed; the chat empty state is left as is.

Closes #695