### PR TITLE
feat(desktop): rename or delete the open chat from its header

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatHeaderTitle.tsx
+++ b/crates/openwave-desktop/ui/src/ChatHeaderTitle.tsx
@@ -1,0 +1,94 @@
+import { Ellipsis, Pencil, Trash2 } from "lucide-react";
+
+import type { Chat } from "./api";
+import { useApp } from "./AppContext";
+import { useChatListStore } from "./ChatListStore";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+/**
+ * The open conversation's title, made actable from where it is shown.
+ *
+ * Rename and delete used to live only on the sidebar's chat row, out of reach
+ * whenever the rail was collapsed. Clicking the title here swaps it for an edit
+ * field, and the menu beside it offers the same two actions — both wired to the
+ * shell's existing orchestration, so a deletion of the open chat lands home the
+ * same way it does from the rail. The rename draft is the shared one, so the
+ * two entry points cannot disagree about what is being typed.
+ */
+export function ChatHeaderTitle({ chat }: { chat: Chat }) {
+  const { startRename, commitRename, cancelRename, deleteChat } = useApp();
+  const renaming = useChatListStore((state) => state.renamingChatId === chat.id);
+  const renameDraft = useChatListStore((state) => state.renameChatDraft);
+  const savingTitle = useChatListStore((state) => state.savingTitle);
+  const setRenameDraft = useChatListStore((state) => state.setRenameDraft);
+  const deletingChatId = useChatListStore((state) => state.deletingChatId);
+  const title = chat.title?.trim() || "New chat";
+
+  if (renaming) {
+    return (
+      <input
+        className="min-w-0 max-w-sm flex-1 rounded-md border border-input bg-background px-2 py-1 text-center text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        autoFocus
+        aria-label="Chat title"
+        value={renameDraft}
+        disabled={savingTitle}
+        onChange={(event) => setRenameDraft(event.target.value)}
+        onBlur={() => commitRename(chat)}
+        onKeyDown={(event) => {
+          // Enter commits through the same blur the field would fire on losing
+          // focus; Escape flags the pending blur to skip so it does not patch.
+          if (event.key === "Enter") {
+            event.preventDefault();
+            event.currentTarget.blur();
+          }
+          if (event.key === "Escape") {
+            event.preventDefault();
+            cancelRename();
+          }
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className="flex min-w-0 max-w-sm flex-1 items-center justify-center gap-1">
+      <button
+        type="button"
+        className="min-w-0 cursor-pointer truncate rounded-md px-2 py-1 text-center text-sm font-medium transition-colors hover:bg-muted"
+        title="Rename chat"
+        onClick={() => startRename(chat)}
+      >
+        {title}
+      </button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="shrink-0 cursor-pointer rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+            aria-label={`Actions for ${title}`}
+            disabled={deletingChatId !== null}
+          >
+            <Ellipsis size={15} />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="center">
+          <DropdownMenuItem onSelect={() => startRename(chat)}>
+            <Pencil />
+            Rename
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive" onSelect={() => deleteChat(chat)}>
+            <Trash2 />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -9,6 +9,7 @@ import type {
 } from "./api";
 import { useApp } from "./AppContext";
 import { AssistantSourceMarkerStreamScrubber } from "./AssistantSourceMarkerStream";
+import { ChatHeaderTitle } from "./ChatHeaderTitle";
 import { reconcilePendingApprovalCards } from "./ApprovalHistory";
 import { loadChatApprovalHydration } from "./ChatApprovalHydration";
 import { useChatListStore } from "./ChatListStore";
@@ -440,9 +441,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     <div className="mr-2 flex min-h-0 min-w-0 flex-1 flex-col">
       <header className="mt-2 flex h-9 w-full shrink-0 items-center justify-between gap-2 px-1">
         <div className="w-24" />
-        <h1 className="min-w-0 max-w-sm flex-1 truncate text-center text-sm font-medium">
-          {chat.title?.trim() || "New chat"}
-        </h1>
+        <ChatHeaderTitle chat={chat} />
         <div className="flex w-24 items-center justify-end">
           <span className="truncate text-xs text-muted-foreground" title={status}>
             {status}


### PR DESCRIPTION
The chat header showed the conversation's title as an inert heading; renaming and deleting were only reachable from the sidebar's chat row, which disappears when the rail is collapsed.

The title is now click-to-edit — clicking swaps it for an input that commits on Enter or blur and cancels on Escape — and a small menu beside it offers Rename and Delete. Both entry points reuse the shell's existing rename and delete orchestration and share the same rename draft as the sidebar row, so deleting the open chat lands home the way it already did from the rail, and the two places can't disagree about what is being typed.

Closes #696