### PR TITLE
fix(server): run sandbox subagents on the chat's model

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -412,6 +412,7 @@ pub mod agent_run {
         pub depth: i16,
         pub status: String,
         pub input: Option<String>,
+        pub model: Option<String>,
         pub attempt_count: i32,
         pub max_attempts: i32,
         pub claim_count: i32,

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -32,7 +32,51 @@ impl MigratorTrait for Migrator {
             Box::new(AddContextCheckpoints),
             Box::new(AddStandingToolGrants),
             Box::new(AddContextCheckpointUsage),
+            Box::new(AddAgentRunModel),
         ]
+    }
+}
+
+/// Records the model a sandbox run executes against.
+///
+/// The column is nullable because runs admitted before this migration have no
+/// recorded selection, and because foreground coordinators carry their model on
+/// each turn instead.
+struct AddAgentRunModel;
+
+impl MigrationName for AddAgentRunModel {
+    fn name(&self) -> &str {
+        "m20260728_000019_add_agent_run_model"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddAgentRunModel {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(AgentRun::Table)
+                    .add_column(
+                        ColumnDef::new(AgentRun::Model)
+                            .string_len(crate::model::AgentRun::MAX_MODEL_LEN as u32),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(AgentRun::Table)
+                    .drop_column(AgentRun::Model)
+                    .to_owned(),
+            )
+            .await?;
+        Ok(())
     }
 }
 
@@ -6115,6 +6159,7 @@ enum AgentRun {
     Depth,
     Status,
     Input,
+    Model,
     AttemptCount,
     MaxAttempts,
     ClaimCount,

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use sea_orm::{
     sea_query::ExprTrait, ActiveModelTrait, ColumnTrait, Condition, DatabaseBackend, EntityTrait,
-    QueryFilter, QueryOrder, QuerySelect, Set, Statement, TransactionTrait,
+    NotSet, QueryFilter, QueryOrder, QuerySelect, Set, Statement, TransactionTrait,
 };
 
 use crate::agent_tools::SandboxAgentFileResource;
@@ -59,6 +59,9 @@ where
         depth: Set(0),
         status: Set(AgentRunStatus::Active.as_str().into()),
         input: Set(None),
+        // A foreground coordinator carries no model of its own; each of its
+        // turns records the selection it ran.
+        model: NotSet,
         attempt_count: Set(0),
         max_attempts: Set(0),
         claim_count: Set(0),
@@ -189,6 +192,9 @@ pub(in crate::db) async fn accept_agent_run(
         depth: Set(depth),
         status: Set(status.as_str().into()),
         input: Set(input.map(ToOwned::to_owned)),
+        // Only turn-bound sandbox admission records a model, and this path
+        // rejects sandbox execution outright.
+        model: NotSet,
         attempt_count: Set(0),
         max_attempts: Set(match execution {
             AgentRunExecution::Foreground => 0,
@@ -459,6 +465,11 @@ where
         depth: Set(i16::from(AgentRun::MAX_DEPTH)),
         status: Set(AgentRunStatus::Queued.as_str().into()),
         input: Set(Some(input.into())),
+        // Inherit the origin turn's frozen selection inside the same
+        // transaction that admits the child. A sandbox executor can then run
+        // the conversation's model without re-resolving mutable settings, and
+        // the row records what it ran against.
+        model: Set(Some(turn.model.clone())),
         attempt_count: Set(0),
         max_attempts: Set(AgentRun::DEFAULT_MAX_ATTEMPTS),
         claim_count: Set(0),
@@ -2426,6 +2437,7 @@ pub(in crate::db) fn agent_run_from_model(model: entities::agent_run::Model) -> 
             .map_err(|_| AgentError::Store("invalid negative agent-run depth".into()))?,
         status,
         input: model.input,
+        model: model.model,
         attempt_count: model.attempt_count,
         max_attempts: model.max_attempts,
         claim_count: model.claim_count,
@@ -2999,6 +3011,16 @@ fn validate_stored_shape(
     if model.id.is_nil() || model.updated_at < model.created_at {
         return Err(AgentError::Store(
             "invalid persisted agent-run identity or timestamp".into(),
+        ));
+    }
+    // A recorded model is optional — rows admitted before it was persisted have
+    // none — but a stored one must be a usable selection.
+    if model.model.as_ref().is_some_and(|selection| {
+        let len = selection.chars().count();
+        len == 0 || len > AgentRun::MAX_MODEL_LEN
+    }) {
+        return Err(AgentError::Store(
+            "invalid persisted agent-run model".into(),
         ));
     }
     let valid = match execution {

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -243,6 +243,10 @@ async fn sandbox_spawn_and_foreground_checkpoint_commit_as_one_exact_transition(
         Some(AgentRunId::foreground_for_chat(chat.id))
     );
     assert_eq!(parked.0.status, AgentRunStatus::Queued);
+    // The child inherits the origin turn's model in the same transaction, so its
+    // executor never has to fall back to a boot default and the row records what
+    // the run used.
+    assert_eq!(parked.0.model.as_deref(), Some("gpt-5"));
     assert_eq!(parked.1.status, TurnRunStatus::WaitingForAgentRun);
     assert_eq!(parked.1.lease_token, None);
     assert_eq!(parked.2.turn_id, running.id);
@@ -1161,6 +1165,7 @@ async fn agent_run_schema_rejects_cross_chat_parentage() {
         depth: Set(1),
         status: Set(AgentRunStatus::Queued.as_str().into()),
         input: Set(Some("cross-chat raw insert".into())),
+        model: Set(None),
         attempt_count: Set(0),
         max_attempts: Set(crate::model::AgentRun::DEFAULT_MAX_ATTEMPTS),
         claim_count: Set(0),
@@ -1207,6 +1212,7 @@ async fn scheduler_never_claims_a_sandbox_row_without_an_admission_receipt() {
         depth: Set(1),
         status: Set(AgentRunStatus::Queued.as_str().into()),
         input: Set(Some("receiptless corruption".into())),
+        model: Set(None),
         attempt_count: Set(0),
         max_attempts: Set(AgentRun::DEFAULT_MAX_ATTEMPTS),
         claim_count: Set(0),

--- a/crates/openwave-core/src/db/tests/message_attachment.rs
+++ b/crates/openwave-core/src/db/tests/message_attachment.rs
@@ -71,22 +71,23 @@ async fn m0014_upgrades_an_existing_store_and_orders_deletion_behind_its_foreign
     let store = DbStore { conn: conn.clone() };
     let chat = sample_chat();
     store.create_chat(&chat).await.unwrap();
-    let pre_upgrade_turn = TurnId::new();
+    // The fixture starts before attachment persistence (and therefore before
+    // standing-grant and agent-run model persistence). Upgrade before calling
+    // current lifecycle code: its durable projections legitimately expect
+    // columns that did not exist in this historical schema.
+    migration::Migrator::up(&conn, None).await.unwrap();
+    let pre_attachment_turn = TurnId::new();
     store
-        .accept_turn(pre_upgrade_turn, chat.id, "gpt-5", "before the upgrade")
+        .accept_turn(pre_attachment_turn, chat.id, "gpt-5", "before any image")
         .await
         .unwrap();
-    // The fixture starts before attachment persistence (and therefore before
-    // standing-grant persistence). Upgrade before calling current lifecycle
-    // code: its durable tool-call projection legitimately expects columns that
-    // did not exist in this historical schema.
-    migration::Migrator::up(&conn, None).await.unwrap();
     store
-        .request_turn_cancellation_and_append_event(pre_upgrade_turn, Utc::now())
+        .request_turn_cancellation_and_append_event(pre_attachment_turn, Utc::now())
         .await
         .unwrap();
 
-    // History written before the upgrade survives and simply has no images.
+    // A conversation created before attachment persistence keeps its history and
+    // simply has no images.
     assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 1);
     assert!(store
         .list_message_attachments(chat.id)

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1330,6 +1330,12 @@ pub struct AgentRun {
     pub status: AgentRunStatus,
     /// Exact delegated task for a sandbox run. Foreground runs have no task.
     pub input: Option<String>,
+    /// Model selection frozen when a sandbox run was admitted, inherited from
+    /// its origin turn so the child cannot silently execute against a different
+    /// model than the conversation that delegated it. Foreground coordinators
+    /// carry the selection on their turns instead, and runs admitted before this
+    /// was persisted read back as absent.
+    pub model: Option<String>,
     /// Failure attempts already started. Reclaiming an expired lease starts a
     /// new attempt; later continuation resumptions will not.
     pub attempt_count: i32,
@@ -1365,6 +1371,8 @@ impl AgentRun {
     pub const MAX_DEPTH: u8 = 1;
     /// Maximum persisted delegated task length.
     pub const MAX_INPUT_LEN: usize = 65_536;
+    /// Maximum persisted model identifier length.
+    pub const MAX_MODEL_LEN: usize = TurnRun::MAX_MODEL_LEN;
     /// Default failure-attempt budget for sandboxed work.
     pub const DEFAULT_MAX_ATTEMPTS: i32 = 3;
     /// Default wall-clock budget for one sandbox run.

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -485,11 +485,30 @@ fn parse_web_search_provider(
 }
 
 /// The configured model, if any.
-async fn read_model(store: &dyn Store) -> Result<Option<String>, ServerError> {
+async fn read_model(store: &dyn Store) -> openwave_core::Result<Option<String>> {
     Ok(store
         .get_setting(MODEL_SETTING)
         .await?
         .and_then(|value| value.as_str().map(str::to_owned)))
+}
+
+/// Resolve which model a new execution in `chat` should use.
+///
+/// The order is the chat's override, then the global `model` setting, then the
+/// boot default. A foreground turn freezes the result when its message is
+/// accepted; a sandbox child inherits its origin turn's frozen selection and
+/// only falls back here when it was admitted before that was recorded.
+pub(crate) async fn resolve_chat_model(
+    store: &dyn Store,
+    chat: &openwave_core::Chat,
+    boot_default: &str,
+) -> openwave_core::Result<String> {
+    match chat.model.clone() {
+        Some(model) => Ok(model),
+        None => Ok(read_model(store)
+            .await?
+            .unwrap_or_else(|| boot_default.to_owned())),
+    }
 }
 
 /// Resolve, canonicalize, and availability-check a model selection before it
@@ -1767,13 +1786,7 @@ pub async fn post_message(
         }
         existing.model
     } else {
-        // New-turn resolution order: chat override, global default, boot default.
-        let selected = match chat.model.clone() {
-            Some(model) => model,
-            None => read_model(&*state.store)
-                .await?
-                .unwrap_or_else(|| state.agent_config.model.clone()),
-        };
+        let selected = resolve_chat_model(&*state.store, &chat, &state.agent_config.model).await?;
         validate_model_selection(&state, &selected, true).await?
     };
     let images = resolve_message_attachments(&state, &body.attachments).await?;

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -466,31 +466,44 @@ impl SandboxAgentRunWorker {
             .store
             .list_sandbox_tool_calls_for_agent_run(run.id)
             .await?;
+        let chat = self.store.get_chat(run.chat_id).await?.ok_or_else(|| {
+            AgentError::msg(format!("claimed sandbox agent run {} has no chat", run.id))
+        })?;
         let delegated_file_available = if self.config.delegated_file_executor_enabled {
-            match (
-                self.store.get_sandbox_agent_admission(run.id).await?,
-                self.store.get_chat(run.chat_id).await?,
-            ) {
-                (Some(admission), Some(chat)) => {
-                    delegated_file_admission_matches(&run, &admission, &chat)
-                }
-                _ => false,
+            match self.store.get_sandbox_agent_admission(run.id).await? {
+                Some(admission) => delegated_file_admission_matches(&run, &admission, &chat),
+                None => false,
             }
         } else {
             false
         };
+        // A sandbox child runs the conversation's model, not the boot default.
+        // Admission froze the origin turn's selection on the run; only a run
+        // admitted before that was recorded resolves the chat's model here.
+        let model = match run.model.clone() {
+            Some(model) => model,
+            None => {
+                crate::routes::resolve_chat_model(&*self.store, &chat, &self.agent_config.model)
+                    .await?
+            }
+        };
         let mut agent_config = self.agent_config.clone();
-        if let Some(policy) = if self.resolver.enforces_model_registry() {
-            crate::providers::resolve_model_policy(&*self.store, &agent_config.model, true).await?
+        if self.resolver.enforces_model_registry() {
+            let Some(policy) =
+                crate::providers::resolve_model_policy(&*self.store, &model, true).await?
+            else {
+                return Err(AgentError::config(
+                    "sandbox model is not registered for its provider",
+                ));
+            };
+            crate::providers::apply_model_policy(
+                &mut agent_config,
+                &policy,
+                chat.reasoning_effort,
+            )?;
         } else {
-            None
-        } {
-            let reasoning_effort = agent_config.reasoning_effort;
-            crate::providers::apply_model_policy(&mut agent_config, &policy, reasoning_effort)?;
-        } else if self.resolver.enforces_model_registry() {
-            return Err(AgentError::config(
-                "sandbox model is not registered for its provider",
-            ));
+            agent_config.model = model;
+            agent_config.reasoning_effort = chat.reasoning_effort;
         }
         let request = sandbox_request(
             &agent_config,
@@ -1170,8 +1183,8 @@ mod tests {
     use futures::stream::{self, BoxStream};
     use openwave_core::{
         AcceptTurnOutcome, AgentRunInboxStatus, CallId, Chat, ChatId, ChatRequest, DbStore,
-        ModelProvider, ProviderId, Role, Store, ToolCallResolution, TurnCheckpointProgress, TurnId,
-        TurnRunStatus, Usage,
+        ModelProvider, ProviderId, ReasoningEffort, Role, Store, ToolCallResolution,
+        TurnCheckpointProgress, TurnId, TurnRunStatus, Usage,
     };
 
     use super::*;
@@ -1594,6 +1607,67 @@ mod tests {
             )]
         );
         assert_eq!(requests[0].system.as_deref(), Some(SANDBOX_SYSTEM_PROMPT));
+    }
+
+    /// Regression: a sandbox child used to run the boot default model and never
+    /// carried the chat's reasoning effort, so a conversation on a cheaper model
+    /// was silently billed for the default one.
+    #[tokio::test]
+    async fn sandbox_run_inherits_the_chat_model_and_reasoning_effort() {
+        let (worker, store, provider, _fixture_chat, _dir) = fixture().await;
+        let chat = Chat {
+            model: Some("chat-cheap-model".into()),
+            reasoning_effort: Some(ReasoningEffort::Low),
+            ..sandbox_chat()
+        };
+        store.create_chat(&chat).await.unwrap();
+
+        // Mirror message acceptance: the turn freezes the chat's resolved model.
+        let selected = crate::routes::resolve_chat_model(&*store, &chat, "boot-default-model")
+            .await
+            .unwrap();
+        assert_eq!(selected, "chat-cheap-model");
+        let turn_id = TurnId::new();
+        store
+            .accept_turn(turn_id, chat.id, &selected, "delegate")
+            .await
+            .unwrap();
+        let lease = uuid::Uuid::new_v4();
+        let now = Utc::now();
+        store
+            .claim_turn_run(lease, now, now + chrono::Duration::hours(1))
+            .await
+            .unwrap()
+            .turn
+            .expect("the delegating turn should claim");
+
+        let run = admit_sandbox(
+            &store,
+            chat.id,
+            CallId::new(),
+            "Investigate this in isolation.",
+        )
+        .await;
+        assert_eq!(run.model.as_deref(), Some("chat-cheap-model"));
+
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            SandboxAgentRunWorkerOutcome::Completed(run.id)
+        );
+        assert_eq!(
+            store
+                .get_agent_run(run.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .model
+                .as_deref(),
+            Some("chat-cheap-model")
+        );
+        let requests = provider.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].model, "chat-cheap-model");
+        assert_eq!(requests[0].reasoning_effort, Some(ReasoningEffort::Low));
     }
 
     #[tokio::test]


### PR DESCRIPTION
A sandbox agent run built its config from the boot `AgentConfig`, so every subagent executed against `OPENWAVE_MODEL` or the compiled-in default regardless of what the user had selected. Choosing a model in Settings, or overriding it on a single chat, changed the foreground turn and nothing else — the child still ran the default. That silently bills a deliberately cheaper conversation for the expensive model, and leaves someone with no Anthropic credentials holding a subagent that cannot resolve a provider. `reasoning_effort` had the same hole from the other direction: it came from the boot config, which never carries one, so a chat's effort override never reached a child.

## What changed

- **Sandbox admission freezes the origin turn's model on the child.** All three admission paths funnel through `admit_sandbox_agent_run_on`, which already holds the locked turn row, so the child inherits `turn.model` in the same transaction that admits it. The turn's selection is itself the result of the chat-override / global-setting / boot-default order applied when the message was accepted, so the child runs the conversation's model without re-resolving mutable settings mid-run and cannot drift from its parent across retries or a web-search checkpoint resumption.
- **The worker runs that model with the chat's reasoning effort**, mirroring `turn_worker`: resolve the registry policy for the run's model and apply it with `chat.reasoning_effort`, or set both directly when the resolver does not enforce the registry. It now loads the chat unconditionally (it previously did so only for delegated-file admission).
- **`agent_run` gains a nullable `model` column** recording what a run executed against, matching `turn_run`. Foreground coordinators leave it unset — their turns carry the selection instead — and runs admitted before the column existed read back as absent.
- **The `post_message` resolution order moved into `resolve_chat_model`**, which the worker's fallback for those pre-column runs also calls. This is the small shared-helper extraction; `validate_model_selection` and the catalog are untouched.

A long-running background agent is arguably its own model role, but that is a separate question from this bug: a user who picks a model expects their subagents to use it, so the child inherits the conversation's selection. Nothing here forecloses a future named role.

## Migration

`m20260728_000019_add_agent_run_model` adds one nullable `agent_run.model` column bounded by `AgentRun::MAX_MODEL_LEN`; `down` drops it. Nothing backfills, so pre-upgrade rows keep the fallback path. The domain shape check rejects a stored selection that is empty or over the bound.

Because the column is on a table that early lifecycle code reads, the m0014 attachment-upgrade fixture can no longer accept a turn while the schema is pinned at step 13 — its `accept_turn` now runs after the upgrade, alongside the tool-call projection calls that were already ordered that way for the same reason. The chat is still created on the historical schema and the deletion-ordering coverage is unchanged.

## Tests

- `sandbox_run_inherits_the_chat_model_and_reasoning_effort` drives a real run end to end: a chat overriding the model and effort, a turn accepted through `resolve_chat_model`, an admitted child, and the request the provider actually received. Before this change it would see the boot default and no effort.
- One assertion added to the existing spawn-checkpoint transaction test that the admitted child records the origin turn's model.

Not verified: I did not drive the desktop app, so the end-to-end Settings-to-subagent path is unconfirmed outside these tests. The PostgreSQL turn-state lane and the migration run in CI.

Closes #716