### PR TITLE
feat: configurable model roles, with compaction on a utility model

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -347,6 +347,31 @@ Return JSON only, with exactly this shape:
 {"version":1,"confirmed_decisions":[],"unresolved_questions":[],"task_state":[],"source_identities":[],"output_identities":[],"conclusions":[]}
 Include only facts explicit in the supplied prefix. Preserve opaque source, citation, output, and revision identities exactly; never infer identities, permissions, capabilities, attachment bytes, or actions. Put at most 16 concise strings in each array, each at most 1024 UTF-8 bytes. Do not use markdown or add fields."#;
 
+/// The model background maintenance work runs on.
+///
+/// Maintenance work is work the user did not ask for — compacting a transcript,
+/// for instance — so it must not be billed at the model and effort the user
+/// chose for the conversation. The host resolves this from its own model
+/// configuration before the turn starts; the agent only carries it. An absent
+/// value means the host has no model for that work, and the work is skipped
+/// rather than quietly moved back onto the foreground model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UtilityModel {
+    /// Explicit provider route for this model.
+    pub provider: Option<crate::provider::ProviderId>,
+    /// Provider model identifier (e.g. `claude-haiku-4-5-20251001`).
+    pub model: String,
+    /// Whether this model uses the provider's reasoning request shape.
+    pub reasoning_model: bool,
+    /// Reasoning effort to request, already reconciled with what this model
+    /// accepts. `None` leaves the parameter off the request.
+    pub reasoning_effort: Option<crate::model::ReasoningEffort>,
+    /// This model's context window in tokens, which bounds a maintenance
+    /// request. It is not the foreground model's window: a cheaper maintenance
+    /// model usually holds less.
+    pub context_window: usize,
+}
+
 /// Per-turn tuning for an [`Agent`].
 #[derive(Debug, Clone)]
 pub struct AgentConfig {
@@ -377,6 +402,9 @@ pub struct AgentConfig {
     /// tools. It is derived by the embedding server and never persisted in a
     /// project or conversation.
     pub tool_scratch: Option<ToolScratch>,
+    /// Model for background maintenance calls this turn may make. `None` means
+    /// the host has none, and that work is skipped.
+    pub utility_model: Option<UtilityModel>,
 }
 
 /// Default context window: 200k tokens (Claude Opus/Sonnet).
@@ -396,6 +424,7 @@ impl Default for AgentConfig {
             max_tool_result_bytes: DEFAULT_MAX_TOOL_RESULT_BYTES,
             context_window: DEFAULT_CONTEXT_WINDOW,
             tool_scratch: None,
+            utility_model: None,
         }
     }
 }
@@ -2933,10 +2962,13 @@ impl Agent {
     /// Create the next semantic checkpoint immediately before a model-specific
     /// fit would discard its eligible raw prefix.
     ///
-    /// The call is maintenance work: it receives no foreground tools or
+    /// The call is maintenance work: it runs on the host's utility model rather
+    /// than the conversation's, it receives no foreground tools or
     /// capabilities, its usage is stored on the checkpoint rather than added
     /// to the turn, and every failure returns `None` so deterministic context
-    /// reduction remains available.
+    /// reduction remains available. With no utility model configured there is
+    /// nothing to compact with, and the turn proceeds on deterministic
+    /// reduction alone rather than spending the user's conversation model here.
     async fn maybe_create_context_checkpoint(
         &self,
         chat_id: ChatId,
@@ -2946,6 +2978,7 @@ impl Agent {
         reduction_level: u32,
         attempted_boundary: &mut Option<usize>,
     ) -> Option<ContextCheckpoint> {
+        let utility = self.config.utility_model.clone()?;
         let foreground_budget = context::compute_message_budget(
             self.config.context_window,
             reduction_level,
@@ -2990,8 +3023,10 @@ impl Agent {
         // maintenance call on the same raw prefix.
         *attempted_boundary = Some(candidate.provider_boundary);
 
+        // Budgeted against the utility model's own window, which is typically
+        // smaller than the conversation model's.
         let summary_budget = context::compute_message_budget(
-            self.config.context_window,
+            utility.context_window,
             0,
             Some(CONTEXT_CHECKPOINT_SYSTEM_PROMPT),
             &[],
@@ -3015,9 +3050,9 @@ impl Agent {
         }
 
         let request = ChatRequest {
-            provider: self.config.provider.clone(),
-            model: self.config.model.clone(),
-            reasoning_model: self.config.reasoning_model,
+            provider: utility.provider.clone(),
+            model: utility.model.clone(),
+            reasoning_model: utility.reasoning_model,
             system: Some(CONTEXT_CHECKPOINT_SYSTEM_PROMPT.into()),
             messages: summary_messages,
             tools: Vec::new(),
@@ -3026,7 +3061,7 @@ impl Agent {
             // strict schema/validator provides determinism without narrowing
             // the set of models that can create a checkpoint.
             temperature: None,
-            reasoning_effort: self.config.reasoning_effort,
+            reasoning_effort: utility.reasoning_effort,
             // Constrain the answer to the payload schema. Without this the
             // model's shape is a request, the parse below is a coin toss, and a
             // lost toss abandons this prefix for the rest of the conversation —
@@ -7509,6 +7544,19 @@ mod tests {
         }
     }
 
+    /// What the host resolves for maintenance work. Deliberately not the
+    /// conversation model, so a maintenance request is identifiable by its
+    /// model alone.
+    fn test_utility_model() -> UtilityModel {
+        UtilityModel {
+            provider: None,
+            model: "utility-model".into(),
+            reasoning_model: false,
+            reasoning_effort: None,
+            context_window: 3_000,
+        }
+    }
+
     async fn append_semantic_checkpoint_history(
         store: &Arc<dyn Store>,
         chat_id: ChatId,
@@ -7577,6 +7625,7 @@ mod tests {
             AgentConfig {
                 model: "small-context-model".into(),
                 context_window: 3_000,
+                utility_model: Some(test_utility_model()),
                 ..Default::default()
             },
         );
@@ -7701,6 +7750,7 @@ mod tests {
             AgentConfig {
                 model: "small-context-model".into(),
                 context_window: 3_000,
+                utility_model: Some(test_utility_model()),
                 ..Default::default()
             },
         );
@@ -7743,6 +7793,7 @@ mod tests {
             AgentConfig {
                 model: "large-context-model".into(),
                 context_window: 50_000,
+                utility_model: Some(test_utility_model()),
                 ..Default::default()
             },
         );
@@ -7775,6 +7826,7 @@ mod tests {
             AgentConfig {
                 model: "small-context-model".into(),
                 context_window: 3_000,
+                utility_model: Some(test_utility_model()),
                 ..Default::default()
             },
         );
@@ -7788,7 +7840,8 @@ mod tests {
         assert_eq!(small_summary_calls.load(Ordering::SeqCst), 1);
         assert_eq!(
             small_requests.lock().unwrap()[0].model,
-            "small-context-model"
+            "utility-model",
+            "maintenance runs on the utility model, not the conversation's"
         );
         assert_eq!(
             store

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -56,7 +56,7 @@ pub mod user_questions;
 
 pub use agent::{
     Agent, AgentConfig, AgentTurnOutcome, ClaimedAgentEvent, ForegroundAgentWaitRequest,
-    SandboxAgentSpawnRequest, ToolRegistry,
+    SandboxAgentSpawnRequest, ToolRegistry, UtilityModel,
 };
 pub use agent_tools::{
     sandbox_read_delegated_file_tool_spec, sandbox_web_search_tool_spec,

--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -37,7 +37,7 @@ vi.mock("./boot", () => ({
 
 vi.mock("./api", () => ({
   ApiClient: class {
-    listModels = vi.fn(async () => ({ models: [] }));
+    listModels = vi.fn(async () => ({ models: [], roles: [] }));
     listProviders = vi.fn(async () => ({ providers: [] }));
     listChats = listChats;
     createChat = createChat;

--- a/crates/openwave-desktop/ui/src/AppShell.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.tsx
@@ -16,6 +16,7 @@ import { useChatListStore } from "./ChatListStore";
 import { useConfirm } from "./components/ConfirmDialog";
 import { hasMacOverlayTitlebar } from "./host";
 import { Logomark } from "./Logomark";
+import { resolvedRoleKey } from "./ModelSelection";
 import { useTheme } from "./theme";
 import { useActiveChatId } from "./useActiveChatId";
 import { useChatPromptWatcher } from "./useChatPromptWatcher";
@@ -110,7 +111,7 @@ export function AppShell() {
         ]);
         if (cancelled) return;
         setModels(catalog.models);
-        setDefaultModelKey(catalog.default_key);
+        setDefaultModelKey(resolvedRoleKey(catalog.roles, "chat"));
         setProviders(providerList.providers);
         chatListActions.setChats(existingChats);
       } catch (err) {
@@ -129,7 +130,7 @@ export function AppShell() {
       client.listProviders(),
     ]);
     setModels(catalog.models);
-    setDefaultModelKey(catalog.default_key);
+    setDefaultModelKey(resolvedRoleKey(catalog.roles, "chat"));
     setProviders(providerList.providers);
   }
 

--- a/crates/openwave-desktop/ui/src/ModelSelection.ts
+++ b/crates/openwave-desktop/ui/src/ModelSelection.ts
@@ -1,5 +1,7 @@
 import type {
   ModelInfo,
+  ModelRole,
+  ModelRoleInfo,
   ModelSelectionKey,
   ProviderKind,
 } from "./api";
@@ -45,4 +47,17 @@ export function providerLabel(provider: ProviderKind): string {
     case "model_gateway":
       return "Model Gateway";
   }
+}
+
+/**
+ * What `role` resolves to right now, as the server reports it.
+ *
+ * `null` when the server could not name a model for the role, which a client
+ * must present as "nothing" rather than guessing at one.
+ */
+export function resolvedRoleKey(
+  roles: ModelRoleInfo[],
+  role: ModelRole,
+): string | null {
+  return roles.find((entry) => entry.role === role)?.resolved_key ?? null;
 }

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -22,6 +22,8 @@ import {
   type McpServerInfo as WireMcpServerInfo,
   type McpServersInfo as WireMcpServersInfo,
   type ModelInfo as WireModelInfo,
+  type ModelRole as WireModelRole,
+  type ModelRoleInfo as WireModelRoleInfo,
   type Project as WireProject,
   type ProviderInfo as WireProviderInfo,
   type ProviderKind as WireProviderKind,
@@ -108,6 +110,17 @@ export type CustomModelConfig = WireCustomModelConfig;
  */
 export type ModelInfo = Omit<WireModelInfo, "key"> & {
   key: ModelSelectionKey;
+};
+
+export type ModelRole = WireModelRole;
+
+/** A named model role, its pinned selection, and what it resolves to now. */
+export type ModelRoleInfo = WireModelRoleInfo;
+
+/** The catalog plus what each role resolves to (`GET /models`). */
+export type ModelCatalog = {
+  models: ModelInfo[];
+  roles: ModelRoleInfo[];
 };
 
 /** Global runtime settings (`GET/PUT /settings`). */
@@ -449,12 +462,27 @@ export class ApiClient {
   }
 
   /**
-   * The selectable catalog, plus the key a turn falls back to when its chat
-   * carries no override — which is the only way a client can name what
-   * "default" means.
+   * The selectable catalog, plus one row per model role: what the user pinned
+   * it to, and what it resolves to right now — the only way a client can name
+   * what "default" or "automatic" means for a role.
    */
-  listModels(): Promise<{ models: ModelInfo[]; default_key: string | null }> {
+  listModels(): Promise<ModelCatalog> {
     return this.json("/models", { headers: this.headers() });
+  }
+
+  /**
+   * Pin a model role to one model, or pass `null` to return it to automatic
+   * resolution against the role's ordered defaults.
+   */
+  putModelRole(
+    role: ModelRole,
+    selection: ModelSelectionKey | null,
+  ): Promise<ModelRoleInfo> {
+    return this.json(`/models/roles/${role}`, {
+      method: "PUT",
+      headers: this.headers(true),
+      body: JSON.stringify({ selection }),
+    });
   }
 
   getSettings(): Promise<RuntimeSettings> {

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -442,6 +442,38 @@ reasoning_efforts: Array<ReasoningEffort>,
 multimodal: boolean, };
 
 /**
+ * The roles the product resolves a model for.
+ *
+ * `#[non_exhaustive]` so a new role can land without breaking wire clients that
+ * match on the string form.
+ */
+export type ModelRole = "chat" | "utility";
+
+/**
+ * One named model role and what it resolves to right now.
+ */
+export type ModelRoleInfo = { 
+/**
+ * The role this row describes.
+ */
+role: ModelRole, 
+/**
+ * The catalog key the user selected for this role, or `None` when the role
+ * is left automatic.
+ */
+selection: string | null, 
+/**
+ * The catalog key this role resolves to right now, selection or not.
+ *
+ * A selector that offers "automatic" as a choice can only say what that
+ * choice means if the server says which model it lands on. `None` when the
+ * role resolves to nothing the catalog can name, which leaves the client
+ * with nothing to promise rather than a guess — and, for `utility`, means
+ * the work that depends on it is skipped.
+ */
+resolved_key: string | null, };
+
+/**
  * Closed renderer-safe pending approval projection. Canonical arguments,
  * model-authored summaries, and unknown tool names never cross this boundary;
  * only a tool's own closed preview of the action under review does.

--- a/crates/openwave-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
@@ -3,7 +3,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import type { ApiClient, ModelInfo } from "../api";
+import type { ApiClient, ModelInfo, ModelRoleInfo } from "../api";
 import { ModelsPanel } from "./ModelsPanel";
 
 const models: ModelInfo[] = [
@@ -33,52 +33,97 @@ const models: ModelInfo[] = [
     reasoning_efforts: [],
     multimodal: false,
   },
+  {
+    key: "openai::gpt-4o-mini",
+    id: "gpt-4o-mini",
+    display_name: "GPT-4o mini",
+    provider: "openai",
+    available: true,
+    context_window: 128_000,
+    max_output_tokens: 16_384,
+    input_modalities: ["text"],
+    supports_reasoning: false,
+    reasoning_efforts: [],
+    multimodal: false,
+  },
+];
+
+const roles: ModelRoleInfo[] = [
+  // A legacy bare id, which the panel migrates to its provider-qualified key.
+  { role: "chat", selection: "gpt-4o", resolved_key: "openai::gpt-4o" },
+  { role: "utility", selection: null, resolved_key: "openai::gpt-4o-mini" },
 ];
 
 describe("ModelsPanel", () => {
-  it("shows provider-first typed selection and never saves a provider alone", async () => {
-    const getSettings = vi.fn().mockResolvedValue({
-      model: "gpt-4o", // legacy bare id migrates in the view
-      has_api_key: true,
-    });
-    const putSettings = vi.fn().mockResolvedValue({
-      model: null,
-      has_api_key: true,
-    });
-    const client = { getSettings, putSettings } as unknown as ApiClient;
+  it("picks a model per role and names what automatic resolves to", async () => {
+    const listModels = vi.fn().mockResolvedValue({ models, roles });
+    const putModelRole = vi
+      .fn()
+      .mockImplementation(async (role: string, selection: string | null) => ({
+        role,
+        selection,
+        resolved_key: selection ?? "openai::gpt-4o-mini",
+      }));
+    const onChanged = vi.fn();
+    const client = { listModels, putModelRole } as unknown as ApiClient;
     const user = userEvent.setup();
 
-    render(<ModelsPanel client={client} models={models} />);
+    render(
+      <ModelsPanel client={client} models={models} onChanged={onChanged} />,
+    );
 
-    // The saved bare id resolves to its provider and canonical model.
-    const provider = await screen.findByRole("combobox", { name: "Provider" });
-    await waitFor(() => expect(provider).toHaveTextContent("OpenAI"));
+    // The chat row opens on the provider owning its saved (legacy) id, resolved
+    // to that provider's canonical model.
+    const chatProvider = await screen.findByRole("combobox", {
+      name: "Chat provider",
+    });
+    await waitFor(() => expect(chatProvider).toHaveTextContent("OpenAI"));
     expect(
-      screen.getByRole("combobox", { name: "Model" }),
+      screen.getByRole("combobox", { name: "Chat model" }),
     ).toHaveTextContent("GPT-4o");
 
-    // Switching provider alone must not persist anything.
-    await user.click(provider);
+    // The automatic choice says which model it lands on, per role.
+    const utilityModel = screen.getByRole("combobox", {
+      name: "Background work model",
+    });
+    expect(utilityModel).toHaveTextContent("Automatic — GPT-4o mini");
+
+    // Switching a provider alone must not persist anything, and that provider's
+    // only model cannot be chosen while it is unavailable.
+    const utilityProvider = screen.getByRole("combobox", {
+      name: "Background work provider",
+    });
+    await user.click(utilityProvider);
     await user.click(
       screen.getByRole("option", { name: "Anthropic — unavailable" }),
     );
-    expect(putSettings).not.toHaveBeenCalled();
-
-    // That provider's only model is unavailable and cannot be chosen.
-    await user.click(screen.getByRole("combobox", { name: "Model" }));
+    expect(putModelRole).not.toHaveBeenCalled();
+    await user.click(utilityModel);
     expect(
       screen.getByRole("option", { name: "Claude Opus 4.8 — unavailable" }),
     ).toHaveAttribute("aria-disabled", "true");
     await user.keyboard("{Escape}");
 
-    // Choosing a model — here the server default over the migrated GPT-4o —
-    // is what persists.
-    await user.click(provider);
+    // Choosing a model for one role pins that role.
+    await user.click(utilityProvider);
     await user.click(screen.getByRole("option", { name: "OpenAI" }));
-    await user.click(screen.getByRole("combobox", { name: "Model" }));
-    await user.click(screen.getByRole("option", { name: "Server default" }));
+    await user.click(utilityModel);
+    await user.click(screen.getByRole("option", { name: "GPT-4o mini" }));
     await waitFor(() =>
-      expect(putSettings).toHaveBeenCalledWith({ model: null }),
+      expect(putModelRole).toHaveBeenCalledWith(
+        "utility",
+        "openai::gpt-4o-mini",
+      ),
+    );
+    expect(onChanged).toHaveBeenCalled();
+
+    // Back to automatic clears the pin rather than writing a model.
+    await user.click(utilityModel);
+    await user.click(
+      screen.getByRole("option", { name: "Automatic — GPT-4o mini" }),
+    );
+    await waitFor(() =>
+      expect(putModelRole).toHaveBeenCalledWith("utility", null),
     );
   });
 });

--- a/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useState } from "react";
 import type {
   ApiClient,
   ModelInfo,
+  ModelRole,
+  ModelRoleInfo,
   ModelSelectionKey,
   ProviderKind,
 } from "../api";
@@ -25,32 +27,42 @@ import {
 } from "./primitives";
 
 // Radix Select reserves the empty string for its placeholder, so the
-// "Server default" choice needs a sentinel that no catalog key can collide
-// with (keys are always `provider::id`).
-const SERVER_DEFAULT = "__server_default__";
+// "automatic" choice needs a sentinel that no catalog key can collide with
+// (keys are always `provider::id`).
+const AUTOMATIC = "__automatic__";
+
+/**
+ * The roles a reader can choose a model for, in the order they matter to them:
+ * the conversation first, then the work the app does on its own.
+ *
+ * A new role is an entry here, matching the server's role list.
+ */
+const ROLES: { role: ModelRole; title: string; hint: string }[] = [
+  {
+    role: "chat",
+    title: "Chat",
+    hint: "New conversations start on this model, and each one can still override it.",
+  },
+  {
+    role: "utility",
+    title: "Background work",
+    hint: "Work OpenWave does on its own — compacting a long conversation, for instance — runs here, so it is not billed at your conversation model. Left automatic, it picks the cheapest model your configured providers serve; with none available, that work is skipped rather than moved onto your chat model.",
+  },
+];
 
 export function ModelsPanel({
   client,
   models,
+  onChanged,
 }: {
   client: ApiClient;
   models: ModelInfo[];
+  onChanged?: () => void;
 }) {
-  const [defaultModel, setDefaultModel] = useState<string | null>(null);
-  const [provider, setProvider] = useState<ProviderKind | null>(null);
+  const [roles, setRoles] = useState<ModelRoleInfo[]>([]);
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
+  const [saving, setSaving] = useState<ModelRole | null>(null);
   const [error, setError] = useState<string | null>(null);
-
-  const providers = useMemo(
-    () =>
-      [...new Set(models.map((model) => model.provider))] as ProviderKind[],
-    [models],
-  );
-  const selected = modelForSelection(models, defaultModel);
-  const providerModels = provider
-    ? models.filter((model) => model.provider === provider)
-    : [];
 
   useEffect(() => {
     let cancelled = false;
@@ -58,18 +70,8 @@ export function ModelsPanel({
     setError(null);
     void (async () => {
       try {
-        const settings = await client.getSettings();
-        if (cancelled) return;
-        setDefaultModel(settings.model);
-        const resolved = modelForSelection(models, settings.model);
-        setProvider(
-          resolved?.provider ??
-            providers.find((kind) =>
-              models.some((model) => model.provider === kind && model.available),
-            ) ??
-            providers[0] ??
-            null,
-        );
+        const catalog = await client.listModels();
+        if (!cancelled) setRoles(catalog.roles);
       } catch (err) {
         if (!cancelled) setError(String(err));
       } finally {
@@ -79,105 +81,51 @@ export function ModelsPanel({
     return () => {
       cancelled = true;
     };
-  }, [client, models, providers]);
+  }, [client]);
 
-  async function save(model: ModelSelectionKey | null) {
-    setSaving(true);
+  async function save(role: ModelRole, selection: ModelSelectionKey | null) {
+    setSaving(role);
     setError(null);
     try {
-      const next = await client.putSettings({ model });
-      setDefaultModel(next.model);
-      const resolved = modelForSelection(models, next.model);
-      if (resolved) setProvider(resolved.provider);
+      const next = await client.putModelRole(role, selection);
+      setRoles((current) =>
+        current.map((entry) => (entry.role === role ? next : entry)),
+      );
+      // The composer names its own default from the shell's catalog, which is
+      // now a step behind.
+      onChanged?.();
     } catch (err) {
       setError(String(err));
     } finally {
-      setSaving(false);
+      setSaving(null);
     }
   }
-
-  const canonical = canonicalModelSelection(models, defaultModel);
-  const selectedValue =
-    selected?.provider === provider ? (canonical ?? "") : "";
-  const legacyUnavailable = defaultModel !== null && selected === null;
 
   return (
     <SettingsPanel
       title="Models"
-      description="Choose the provider first, then a model that provider is configured to serve. New chats inherit this default; each conversation can still override it."
+      description="Choose the provider first, then a model that provider is configured to serve. A role left automatic is resolved against whatever you have credentialed."
       busy={loading}
     >
       {loading ? (
         <p className="text-sm text-muted-foreground">Loading model settings…</p>
       ) : (
         <>
-          <SettingsSection title="Default model">
-            <SettingsField label="Provider">
-              <Select
-                value={provider ?? ""}
-                disabled={saving || providers.length === 0}
-                onValueChange={(value) =>
-                  setProvider((value || null) as ProviderKind | null)
-                }
-              >
-                <SelectTrigger aria-label="Provider">
-                  <SelectValue placeholder="No providers configured" />
-                </SelectTrigger>
-                <SelectContent>
-                  {providers.map((kind) => {
-                    const usable = models.some(
-                      (model) => model.provider === kind && model.available,
-                    );
-                    return (
-                      <SelectItem key={kind} value={kind}>
-                        {providerLabel(kind)}
-                        {usable ? "" : " — unavailable"}
-                      </SelectItem>
-                    );
-                  })}
-                </SelectContent>
-              </Select>
-            </SettingsField>
-            <SettingsField
-              label="Model"
-              hint="Unavailable models remain visible for clarity but cannot be selected until their provider is enabled and credentialed."
-            >
-              <Select
-                value={selectedValue === "" ? SERVER_DEFAULT : selectedValue}
-                disabled={saving || provider === null}
-                onValueChange={(value) => {
-                  void save(
-                    value === SERVER_DEFAULT
-                      ? null
-                      : (value as ModelSelectionKey),
-                  );
-                }}
-              >
-                <SelectTrigger aria-label="Model">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={SERVER_DEFAULT}>Server default</SelectItem>
-                  {providerModels.map((model) => (
-                    <SelectItem
-                      key={model.key}
-                      value={model.key}
-                      disabled={!model.available}
-                    >
-                      {model.display_name}
-                      {model.available ? "" : " — unavailable"}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </SettingsField>
-            {legacyUnavailable && (
-              <SettingsError>
-                The saved legacy model “{defaultModel}” is not uniquely registered.
-                Add it under the OpenAI-compatible provider, then choose it here.
-              </SettingsError>
-            )}
-          </SettingsSection>
+          {ROLES.map((entry) => {
+            const info = roles.find((row) => row.role === entry.role);
+            if (!info) return null;
+            return (
+              <ModelRoleRow
+                key={entry.role}
+                title={entry.title}
+                hint={entry.hint}
+                models={models}
+                info={info}
+                saving={saving === entry.role}
+                onSelect={(selection) => void save(entry.role, selection)}
+              />
+            );
+          })}
           {models.length === 0 && (
             <p className="text-sm text-muted-foreground">
               No models are registered yet. Configure a provider first.
@@ -188,4 +136,133 @@ export function ModelsPanel({
       {error && <SettingsError>{error}</SettingsError>}
     </SettingsPanel>
   );
+}
+
+/** One role's provider-then-model picker, plus what automatic resolves to. */
+function ModelRoleRow({
+  title,
+  hint,
+  models,
+  info,
+  saving,
+  onSelect,
+}: {
+  title: string;
+  hint: string;
+  models: ModelInfo[];
+  info: ModelRoleInfo;
+  saving: boolean;
+  onSelect: (selection: ModelSelectionKey | null) => void;
+}) {
+  const providers = useMemo(
+    () => [...new Set(models.map((model) => model.provider))] as ProviderKind[],
+    [models],
+  );
+  const selected = modelForSelection(models, info.selection);
+  const [provider, setProvider] = useState<ProviderKind | null>(null);
+
+  // Open on the pinned model's provider, else on one that can actually serve
+  // this role, so the list beneath is never a dead end.
+  useEffect(() => {
+    setProvider(
+      selected?.provider ??
+        providers.find((kind) =>
+          models.some((model) => model.provider === kind && model.available),
+        ) ??
+        providers[0] ??
+        null,
+    );
+  }, [selected?.provider, providers, models]);
+
+  const providerModels = provider
+    ? models.filter((model) => model.provider === provider)
+    : [];
+  const canonical = canonicalModelSelection(models, info.selection);
+  const selectedValue =
+    selected?.provider === provider ? (canonical ?? "") : "";
+  const unresolvedSelection = info.selection !== null && selected === null;
+
+  return (
+    <SettingsSection title={title}>
+      <p className="text-sm text-muted-foreground">{hint}</p>
+      <SettingsField label="Provider">
+        <Select
+          value={provider ?? ""}
+          disabled={saving || providers.length === 0}
+          onValueChange={(value) =>
+            setProvider((value || null) as ProviderKind | null)
+          }
+        >
+          {/* Both rows carry the same visible labels, so the accessible name
+              names the role as well. */}
+          <SelectTrigger aria-label={`${title} provider`}>
+            <SelectValue placeholder="No providers configured" />
+          </SelectTrigger>
+          <SelectContent>
+            {providers.map((kind) => {
+              const usable = models.some(
+                (model) => model.provider === kind && model.available,
+              );
+              return (
+                <SelectItem key={kind} value={kind}>
+                  {providerLabel(kind)}
+                  {usable ? "" : " — unavailable"}
+                </SelectItem>
+              );
+            })}
+          </SelectContent>
+        </Select>
+      </SettingsField>
+      <SettingsField
+        label="Model"
+        hint="Unavailable models remain visible for clarity but cannot be selected until their provider is enabled and credentialed."
+      >
+        <Select
+          value={selectedValue === "" ? AUTOMATIC : selectedValue}
+          disabled={saving || provider === null}
+          onValueChange={(value) => {
+            onSelect(value === AUTOMATIC ? null : (value as ModelSelectionKey));
+          }}
+        >
+          <SelectTrigger aria-label={`${title} model`}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={AUTOMATIC}>
+              {automaticLabel(models, info)}
+            </SelectItem>
+            {providerModels.map((model) => (
+              <SelectItem
+                key={model.key}
+                value={model.key}
+                disabled={!model.available}
+              >
+                {model.display_name}
+                {model.available ? "" : " — unavailable"}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </SettingsField>
+      {unresolvedSelection && (
+        <SettingsError>
+          The saved model “{info.selection}” is not uniquely registered. Add it
+          under the OpenAI-compatible provider, then choose it here.
+        </SettingsError>
+      )}
+    </SettingsSection>
+  );
+}
+
+/**
+ * What "automatic" currently means, named rather than implied.
+ *
+ * Only the server can say which model the choice lands on — it resolves a role
+ * against provider readiness — including that it lands on nothing at all.
+ */
+function automaticLabel(models: ModelInfo[], info: ModelRoleInfo): string {
+  const resolved = modelForSelection(models, info.resolved_key);
+  if (resolved) return `Automatic — ${resolved.display_name}`;
+  if (info.resolved_key) return `Automatic — ${info.resolved_key}`;
+  return "Automatic — none available";
 }

--- a/crates/openwave-desktop/ui/src/settings/sections.tsx
+++ b/crates/openwave-desktop/ui/src/settings/sections.tsx
@@ -42,8 +42,14 @@ function GatewaySection() {
 }
 
 function ModelsSection() {
-  const { client, models } = useApp();
-  return <ModelsPanel client={client} models={models} />;
+  const { client, models, refreshCatalog } = useApp();
+  return (
+    <ModelsPanel
+      client={client}
+      models={models}
+      onChanged={() => void refreshCatalog()}
+    />
+  );
 }
 
 function WebSearchSection() {

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -30,6 +30,7 @@ mod foreground_prompt;
 mod gateway_runtime;
 mod mcp_config;
 mod model_registry;
+mod model_roles;
 mod provider;
 mod providers;
 mod resolver;
@@ -254,6 +255,10 @@ pub fn app(state: AppState) -> Router {
                 )),
         )
         .route("/models", get(routes::list_models))
+        .route(
+            "/models/roles/{role}",
+            axum::routing::put(routes::put_model_role),
+        )
         .route(
             "/web-search",
             get(routes::get_web_search_config).put(routes::put_web_search_config),
@@ -662,6 +667,7 @@ async fn bind_inner(
     let turn_worker = turn_worker::TurnWorker::new(
         state.store.clone(),
         state.resolver.clone(),
+        state.secrets.clone(),
         state.tools.clone(),
         state.approvals.clone(),
         state.events.clone(),

--- a/crates/openwave-server/src/model_roles.rs
+++ b/crates/openwave-server/src/model_roles.rs
@@ -1,0 +1,252 @@
+//! Named model roles.
+//!
+//! A role names a job the product needs a model for, so "use something cheap
+//! for this" has somewhere to live. [`ModelRole::Chat`] is the model a
+//! foreground turn runs on — the user's choice, unchanged by this module.
+//! [`ModelRole::Utility`] is for work the user did not ask for: compacting a
+//! transcript today, and other maintenance later. Two roles is deliberate;
+//! adding a third is an entry in the tables below rather than a refactor.
+//!
+//! Each role's explicit selection is stored under `model.<role>`, matching the
+//! `provider.<kind>` convention — except `chat`, whose selection has lived under
+//! a bare `model` key since before roles existed and keeps it.
+//!
+//! A role also carries an ordered list of curated defaults, where order is both
+//! preference and failover: [`resolve`] walks it and takes the first entry whose
+//! provider is enabled and credentialed, so an Anthropic-only install and an
+//! OpenAI-only install each get a sensible model without configuring one.
+//! Resolution reads settings and credentials on every call rather than at boot,
+//! so enabling a provider takes effect on the next turn instead of the next
+//! launch. And it degrades instead of failing: no resolvable model means the
+//! caller skips its work, never that a turn blocks or fails.
+
+use serde::{Deserialize, Serialize};
+
+use openwave_core::{
+    AgentError, ProviderId, ReasoningEffort, Result, SecretProvider, Store, UtilityModel,
+};
+
+use crate::providers::{self, ResolvedModelPolicy};
+
+/// The roles the product resolves a model for.
+///
+/// `#[non_exhaustive]` so a new role can land without breaking wire clients that
+/// match on the string form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ModelRole {
+    /// The model a foreground turn runs on.
+    Chat,
+    /// The model background work the user did not ask for runs on.
+    Utility,
+}
+
+/// The `utility` role's ordered defaults.
+///
+/// One entry per provider that serves curated models, each that provider's
+/// cheapest current row. Anthropic leads because it is the provider the product
+/// defaults to for chat, so the common single-provider install resolves on the
+/// first step; the rest follow so an install credentialed elsewhere still gets
+/// a utility model. Any of the three is a good answer for a multi-provider
+/// install, so the order only has to be stable and explainable.
+const UTILITY_DEFAULTS: &[&str] = &[
+    "anthropic::claude-haiku-4-5-20251001",
+    "openai::gpt-5.4-nano",
+    "gemini::gemini-3.5-flash-lite",
+];
+
+impl ModelRole {
+    /// All roles, in display order.
+    pub const ALL: &'static [ModelRole] = &[ModelRole::Chat, ModelRole::Utility];
+
+    /// Wire/path form (`chat`, `utility`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ModelRole::Chat => "chat",
+            ModelRole::Utility => "utility",
+        }
+    }
+
+    /// Parse a path segment into a role.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "chat" => Some(Self::Chat),
+            "utility" => Some(Self::Utility),
+            _ => None,
+        }
+    }
+
+    /// Store setting key holding this role's explicit selection.
+    pub fn setting_key(self) -> &'static str {
+        match self {
+            // Pre-roles key, kept so existing installs keep their default.
+            ModelRole::Chat => "model",
+            ModelRole::Utility => "model.utility",
+        }
+    }
+
+    /// Ordered preference list of curated selection keys for this role.
+    ///
+    /// Empty for `chat`: a conversation runs on what the user picked, and its
+    /// last resort is the model this process launched with — process state no
+    /// registry list can name. Silently moving a foreground turn to another
+    /// provider is exactly what we don't want there.
+    pub fn defaults(self) -> &'static [&'static str] {
+        match self {
+            ModelRole::Chat => &[],
+            ModelRole::Utility => UTILITY_DEFAULTS,
+        }
+    }
+
+    /// The reasoning effort work in this role asks for, before the model's own
+    /// accepted range clamps it.
+    ///
+    /// `None` for `chat`, where effort is the user's per-chat choice rather than
+    /// a property of the role.
+    pub fn reasoning_effort(self) -> Option<ReasoningEffort> {
+        match self {
+            ModelRole::Chat => None,
+            // Compaction is summarization of text already written: buy speed,
+            // not thought. Models that reject the level clamp up or drop it.
+            ModelRole::Utility => Some(ReasoningEffort::None),
+        }
+    }
+}
+
+impl std::fmt::Display for ModelRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The explicit selection stored for `role`, if the user set one.
+pub async fn read_selection(store: &dyn Store, role: ModelRole) -> Result<Option<String>> {
+    Ok(store
+        .get_setting(role.setting_key())
+        .await?
+        .and_then(|value| value.as_str().map(str::to_owned)))
+}
+
+/// Persist `selection` for `role`. `None` clears it back to automatic, stored as
+/// JSON null so [`read_selection`] reads it back as unset.
+pub async fn write_selection(
+    store: &dyn Store,
+    role: ModelRole,
+    selection: Option<&str>,
+) -> Result<()> {
+    let value = selection.map_or(serde_json::Value::Null, |key| serde_json::json!(key));
+    store.set_setting(role.setting_key(), &value).await
+}
+
+/// Resolve the model `role` runs on right now: the user's selection when its
+/// provider can serve it, else the first usable entry in the role's ordered
+/// defaults.
+///
+/// `None` means this install has no model for the role. Callers skip the work.
+pub async fn resolve(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+    role: ModelRole,
+) -> Result<Option<ResolvedModelPolicy>> {
+    if let Some(selection) = read_selection(store, role).await? {
+        // A selection whose provider has since been disabled or lost its
+        // credential falls through to the defaults rather than issuing a
+        // request that would fail.
+        if let Some(policy) = usable_policy(store, secrets, &selection).await? {
+            return Ok(Some(policy));
+        }
+    }
+    for key in role.defaults() {
+        if let Some(policy) = usable_policy(store, secrets, key).await? {
+            return Ok(Some(policy));
+        }
+    }
+    Ok(None)
+}
+
+/// Resolve `selection` only if its provider is enabled and credentialed.
+async fn usable_policy(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+    selection: &str,
+) -> Result<Option<ResolvedModelPolicy>> {
+    let Some(policy) = providers::resolve_model_policy(store, selection, false).await? else {
+        return Ok(None);
+    };
+    Ok(
+        providers::provider_is_usable(store, secrets, policy.provider)
+            .await?
+            .then_some(policy),
+    )
+}
+
+/// Resolve the `utility` role into the shape the agent carries for one turn.
+///
+/// `None` means there is no utility model, and the agent skips maintenance work
+/// instead of billing it to the conversation's model.
+pub async fn resolve_utility_model(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+) -> Result<Option<UtilityModel>> {
+    let role = ModelRole::Utility;
+    let Some(policy) = resolve(store, secrets, role).await? else {
+        return Ok(None);
+    };
+    Ok(Some(UtilityModel {
+        provider: Some(ProviderId::new(policy.provider.as_str())),
+        model: policy.id.clone(),
+        reasoning_model: policy.supports_reasoning,
+        // Same reconciliation `apply_model_policy` performs for a foreground
+        // turn: a level this model does not accept degrades to the nearest one
+        // it does, or is dropped when it exposes no effort control.
+        reasoning_effort: role
+            .reasoning_effort()
+            .and_then(|effort| effort.clamp_to(&policy.reasoning_efforts)),
+        context_window: usize::try_from(policy.context_window)
+            .map_err(|_| AgentError::config("model context window is unsupported"))?,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model_registry;
+    use crate::providers::ProviderKind;
+
+    #[test]
+    fn every_role_default_names_a_curated_model() {
+        for &role in ModelRole::ALL {
+            for key in role.defaults() {
+                let (provider, id) = model_registry::parse_selection_key(key)
+                    .unwrap_or_else(|| panic!("{role}'s default `{key}` is not a selection key"));
+                assert!(
+                    model_registry::find_for(provider, id).is_some(),
+                    "{role}'s default `{key}` is not in the model registry",
+                );
+            }
+        }
+    }
+
+    /// A user credentialed on one provider must still get a utility model, or
+    /// the work that depends on it silently stops happening for them.
+    #[test]
+    fn the_utility_defaults_cover_every_provider_that_serves_curated_models() {
+        for &provider in ProviderKind::ALL {
+            if model_registry::models_for(provider).next().is_none() {
+                // Providers whose models come from their own configuration — a
+                // custom compatible endpoint, the gateway — have nothing a
+                // curated list can name. Those installs point `model.utility`
+                // at one of the models they configured.
+                continue;
+            }
+            assert!(
+                ModelRole::Utility.defaults().iter().any(|key| {
+                    model_registry::parse_selection_key(key)
+                        .is_some_and(|(kind, _)| kind == provider)
+                }),
+                "a user credentialed only on {provider} has no default utility model",
+            );
+        }
+    }
+}

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -30,6 +30,7 @@ use crate::error::ServerError;
 use crate::event_projection::RendererSequencedEvent;
 use crate::extract::{Json, Path, Query};
 use crate::mcp_config::{McpServersConfig, McpServersInfo};
+use crate::model_roles::{self, ModelRole};
 use crate::providers::{self, ProviderCredential, ProviderInfo, ProviderKind, ProviderUpdate};
 use crate::state::AppState;
 use crate::web_search::{
@@ -285,9 +286,6 @@ fn mcp_request_error(error: AgentError) -> ServerError {
     }
 }
 
-/// The store-settings key for the selected model.
-const MODEL_SETTING: &str = "model";
-
 /// Product-facing project names stay compact across desktop and API clients.
 pub const MAX_PROJECT_TITLE_CHARS: usize = 120;
 /// Project metadata requests need only a compact JSON object.
@@ -343,23 +341,16 @@ pub async fn put_settings(
     match body.model {
         // Absent: leave the model unchanged.
         None => {}
-        // Explicit null: reset to the server default (stored as JSON null, which
-        // `read_model` reads back as "unset").
+        // Explicit null: reset to the server default.
         Some(None) => {
-            state
-                .store
-                .set_setting(MODEL_SETTING, &serde_json::Value::Null)
-                .await?;
+            model_roles::write_selection(&*state.store, ModelRole::Chat, None).await?;
         }
         // A value: reject empty (it would break every turn), else set it.
         Some(Some(model)) => {
             if model.is_empty() {
                 return Err(ServerError::bad_request("model must not be empty"));
             }
-            state
-                .store
-                .set_setting(MODEL_SETTING, &serde_json::json!(model))
-                .await?;
+            model_roles::write_selection(&*state.store, ModelRole::Chat, Some(&model)).await?;
         }
     }
     Ok(Json(Settings {
@@ -484,12 +475,20 @@ fn parse_web_search_provider(
     }
 }
 
-/// The configured model, if any.
+/// The configured chat model, if any — the `chat` role's explicit selection.
 async fn read_model(store: &dyn Store) -> openwave_core::Result<Option<String>> {
-    Ok(store
-        .get_setting(MODEL_SETTING)
+    model_roles::read_selection(store, ModelRole::Chat).await
+}
+
+/// The `chat` role's model with no conversation in hand: the global selection,
+/// else the model this process launched with.
+///
+/// The boot default is process state, which is why the chat role has no
+/// registry-backed default list of its own the way `utility` does.
+async fn chat_role_model(store: &dyn Store, boot_default: &str) -> openwave_core::Result<String> {
+    Ok(read_model(store)
         .await?
-        .and_then(|value| value.as_str().map(str::to_owned)))
+        .unwrap_or_else(|| boot_default.to_owned()))
 }
 
 /// Resolve which model a new execution in `chat` should use.
@@ -505,9 +504,7 @@ pub(crate) async fn resolve_chat_model(
 ) -> openwave_core::Result<String> {
     match chat.model.clone() {
         Some(model) => Ok(model),
-        None => Ok(read_model(store)
-            .await?
-            .unwrap_or_else(|| boot_default.to_owned())),
+        None => chat_role_model(store, boot_default).await,
     }
 }
 
@@ -682,19 +679,31 @@ pub struct ModelInfo {
     pub multimodal: bool,
 }
 
+/// One named model role and what it resolves to right now.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct ModelRoleInfo {
+    /// The role this row describes.
+    pub role: ModelRole,
+    /// The catalog key the user selected for this role, or `None` when the role
+    /// is left automatic.
+    pub selection: Option<String>,
+    /// The catalog key this role resolves to right now, selection or not.
+    ///
+    /// A selector that offers "automatic" as a choice can only say what that
+    /// choice means if the server says which model it lands on. `None` when the
+    /// role resolves to nothing the catalog can name, which leaves the client
+    /// with nothing to promise rather than a guess — and, for `utility`, means
+    /// the work that depends on it is skipped.
+    pub resolved_key: Option<String>,
+}
+
 /// Response for `GET /models`.
 #[derive(Debug, Serialize)]
 pub struct ModelCatalog {
     /// The models a client can select from.
     pub models: Vec<ModelInfo>,
-    /// The catalog key a turn runs against when its chat carries no override —
-    /// the global default, else the one this server booted with.
-    ///
-    /// A selector that offers "default" as a choice can only say what that
-    /// choice means if the server says which model it lands on. `None` when the
-    /// fallback resolves to nothing the catalog can name, which leaves the
-    /// client with nothing to promise rather than a guess.
-    pub default_key: Option<String>,
+    /// Every named role, its selection, and what it currently resolves to.
+    pub roles: Vec<ModelRoleInfo>,
 }
 
 /// `GET /models` — the catalog a chat's model selector chooses from.
@@ -702,15 +711,16 @@ pub struct ModelCatalog {
 /// All typed registry rows plus current availability. Clients may explain
 /// unavailable rows, but must never offer them as usable selections.
 pub async fn list_models(State(state): State<AppState>) -> Result<Json<ModelCatalog>, ServerError> {
-    // The same order `POST /chats/{id}/turns` resolves a new turn with, minus
-    // the chat override, so the label a client shows for "default" is the model
-    // the next turn actually gets.
-    let fallback = read_model(&*state.store)
-        .await?
-        .unwrap_or_else(|| state.agent_config.model.clone());
-    let default_key = providers::resolve_model_policy(&*state.store, &fallback, true)
-        .await?
-        .map(|policy| policy.key);
+    let mut roles = Vec::with_capacity(ModelRole::ALL.len());
+    for &role in ModelRole::ALL {
+        let selection = model_roles::read_selection(&*state.store, role).await?;
+        let resolved_key = resolved_role_key(&state, role, selection.as_deref()).await?;
+        roles.push(ModelRoleInfo {
+            role,
+            selection,
+            resolved_key,
+        });
+    }
     let models = providers::catalog_models(&*state.store, &*state.secrets)
         .await?
         .into_iter()
@@ -731,10 +741,71 @@ pub async fn list_models(State(state): State<AppState>) -> Result<Json<ModelCata
                 .contains(&crate::model_registry::InputModality::Image),
         })
         .collect();
-    Ok(Json(ModelCatalog {
-        models,
-        default_key,
+    Ok(Json(ModelCatalog { models, roles }))
+}
+
+/// Body of `PUT /models/roles/{role}`. An explicit `null` selection returns the
+/// role to automatic resolution.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ModelRoleUpdate {
+    /// The catalog key to pin this role to, or `null` for automatic.
+    #[serde(default)]
+    pub selection: Option<String>,
+}
+
+/// `PUT /models/roles/{role}` — pin a role to one model, or clear it back to
+/// automatic resolution.
+///
+/// A selection must be a registered model whose provider is currently usable, so
+/// a role cannot be pinned to something that could not run. For `chat` this
+/// writes the same setting as `PUT /settings`.
+pub async fn put_model_role(
+    State(state): State<AppState>,
+    Path(role): Path<String>,
+    Json(body): Json<ModelRoleUpdate>,
+) -> Result<Json<ModelRoleInfo>, ServerError> {
+    let role = ModelRole::parse(&role)
+        .ok_or_else(|| ServerError::not_found(format!("unknown model role: {role}")))?;
+    let selection = match body.selection {
+        Some(selection) => Some(validate_model_selection(&state, &selection, false).await?),
+        None => None,
+    };
+    model_roles::write_selection(&*state.store, role, selection.as_deref()).await?;
+    let resolved_key = resolved_role_key(&state, role, selection.as_deref()).await?;
+    Ok(Json(ModelRoleInfo {
+        role,
+        selection,
+        resolved_key,
     }))
+}
+
+/// The catalog key `role` resolves to right now, given its stored `selection`.
+async fn resolved_role_key(
+    state: &AppState,
+    role: ModelRole,
+    selection: Option<&str>,
+) -> Result<Option<String>, ServerError> {
+    match role {
+        // The chat role goes through the same seam a new execution does, minus
+        // the per-chat override there is no chat here to read — so the label a
+        // client shows for "default" is what the next turn actually gets. Its
+        // last resort is the boot default, which no role's list can name.
+        ModelRole::Chat => {
+            let fallback = match selection {
+                Some(selection) => selection.to_owned(),
+                None => chat_role_model(&*state.store, &state.agent_config.model).await?,
+            };
+            Ok(
+                providers::resolve_model_policy(&*state.store, &fallback, true)
+                    .await?
+                    .map(|policy| policy.key),
+            )
+        }
+        _ => Ok(model_roles::resolve(&*state.store, &*state.secrets, role)
+            .await?
+            .map(|policy| policy.key)),
+    }
 }
 
 /// Body of `POST /projects`.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -2152,6 +2152,7 @@ fn spawn_turn_worker_with_config(state: &AppState, config: turn_worker::TurnWork
     let worker = turn_worker::TurnWorker::new(
         state.store.clone(),
         state.resolver.clone(),
+        state.secrets.clone(),
         state.tools.clone(),
         state.approvals.clone(),
         state.events.clone(),

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1049,6 +1049,183 @@ async fn configured_router_canonicalizes_typed_models_and_rejects_wrong_or_unava
     }
 }
 
+/// Roles resolve on read, against whatever the user has credentialed: the
+/// ordered defaults skip providers that cannot serve a request, a pin overrides
+/// them, and enabling a provider changes the answer without a restart.
+#[tokio::test]
+async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("model-roles.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(resolver::ConfiguredResolver::new(
+            store.clone(),
+            secrets.clone(),
+            crate::gateway_runtime::GatewayRuntime::new(store.clone(), secrets.clone()),
+        )),
+        secrets,
+        Arc::new(ToolRegistry::new()),
+        retrieval,
+        AgentConfig {
+            model: "gpt-5.6-sol".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let bearer = format!("Bearer {}", state.token);
+    let router = app(state);
+
+    let configure_provider = |kind: &'static str, body: serde_json::Value| {
+        let router = router.clone();
+        let bearer = bearer.clone();
+        async move {
+            let response = router
+                .oneshot(
+                    Request::builder()
+                        .method("PUT")
+                        .uri(format!("/providers/{kind}"))
+                        .header(header::AUTHORIZATION, &bearer)
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(body.to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+    };
+    let put_role = |role: &'static str, body: serde_json::Value| {
+        let router = router.clone();
+        let bearer = bearer.clone();
+        async move {
+            router
+                .oneshot(
+                    Request::builder()
+                        .method("PUT")
+                        .uri(format!("/models/roles/{role}"))
+                        .header(header::AUTHORIZATION, &bearer)
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(body.to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+        }
+    };
+    let role_rows = || {
+        let router = router.clone();
+        let bearer = bearer.clone();
+        async move {
+            let response = router
+                .oneshot(
+                    Request::builder()
+                        .uri("/models")
+                        .header(header::AUTHORIZATION, &bearer)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let catalog: serde_json::Value = json_body(response).await;
+            catalog["roles"].clone()
+        }
+    };
+    let role_row = |roles: &serde_json::Value, role: &str| {
+        roles
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["role"] == role)
+            .cloned()
+            .unwrap_or_else(|| panic!("the catalog reports the {role} role"))
+    };
+
+    // Nothing credentialed: no utility model, so its consumers skip their work
+    // rather than borrowing the conversation's model.
+    let roles = role_rows().await;
+    assert_eq!(
+        role_row(&roles, "utility")["resolved_key"],
+        serde_json::Value::Null
+    );
+
+    configure_provider(
+        "openai",
+        serde_json::json!({
+            "enabled": true,
+            "credential": {"type": "api_key", "key": "sk-openai"}
+        }),
+    )
+    .await;
+
+    // No restart between the two reads: credentialing OpenAI is enough for the
+    // ordered defaults to land on its cheapest row.
+    let roles = role_rows().await;
+    let utility = role_row(&roles, "utility");
+    assert_eq!(utility["selection"], serde_json::Value::Null);
+    assert_eq!(utility["resolved_key"], "openai::gpt-5.4-nano");
+    // The chat role is unchanged: its last resort is still the boot default.
+    assert_eq!(
+        role_row(&roles, "chat")["resolved_key"],
+        "openai::gpt-5.6-sol"
+    );
+
+    // A pin wins over the defaults, and only a model that could actually run is
+    // accepted.
+    let pinned = put_role(
+        "utility",
+        serde_json::json!({"selection": "openai::gpt-5.4-mini"}),
+    )
+    .await;
+    assert_eq!(pinned.status(), StatusCode::OK);
+    let pinned: serde_json::Value = json_body(pinned).await;
+    assert_eq!(pinned["resolved_key"], "openai::gpt-5.4-mini");
+    assert_eq!(
+        role_row(&role_rows().await, "utility")["selection"],
+        "openai::gpt-5.4-mini"
+    );
+
+    let unavailable = put_role(
+        "utility",
+        serde_json::json!({"selection": "anthropic::claude-haiku-4-5-20251001"}),
+    )
+    .await;
+    assert_eq!(unavailable.status(), StatusCode::CONFLICT);
+
+    let unknown_role = put_role("titling", serde_json::json!({"selection": null})).await;
+    assert_eq!(unknown_role.status(), StatusCode::NOT_FOUND);
+
+    // Cleared, then OpenAI turned off and Gemini turned on: the walk moves to
+    // the next entry it can serve.
+    let cleared = put_role("utility", serde_json::json!({"selection": null})).await;
+    assert_eq!(cleared.status(), StatusCode::OK);
+    configure_provider("openai", serde_json::json!({"enabled": false})).await;
+    configure_provider(
+        "gemini",
+        serde_json::json!({
+            "enabled": true,
+            "credential": {"type": "api_key", "key": "gemini-key"}
+        }),
+    )
+    .await;
+    assert_eq!(
+        role_row(&role_rows().await, "utility")["resolved_key"],
+        "gemini::gemini-3.5-flash-lite"
+    );
+}
+
 #[tokio::test]
 async fn custom_models_live_under_openai_compatible_with_conservative_capabilities() {
     let (router, token, _store, _dir) = test_app().await;

--- a/crates/openwave-server/src/tests/image_attachment.rs
+++ b/crates/openwave-server/src/tests/image_attachment.rs
@@ -127,6 +127,7 @@ fn spawn_turn_worker_with_image_blobs(state: &AppState) {
     let worker = crate::turn_worker::TurnWorker::new(
         state.store.clone(),
         state.resolver.clone(),
+        state.secrets.clone(),
         state.tools.clone(),
         state.approvals.clone(),
         state.events.clone(),

--- a/crates/openwave-server/src/tests/workers.rs
+++ b/crates/openwave-server/src/tests/workers.rs
@@ -824,6 +824,7 @@ async fn worker_renews_a_near_expiry_ambiguous_claim_before_execution() {
     let worker = turn_worker::TurnWorker::new(
         state.store.clone(),
         state.resolver.clone(),
+        state.secrets.clone(),
         state.tools.clone(),
         state.approvals.clone(),
         state.events.clone(),
@@ -919,6 +920,7 @@ async fn worker_heartbeats_while_event_journaling_is_blocked() {
     let worker = turn_worker::TurnWorker::new(
         state.store.clone(),
         state.resolver.clone(),
+        state.secrets.clone(),
         state.tools.clone(),
         state.approvals.clone(),
         state.events.clone(),

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -19,9 +19,9 @@ use openwave_core::{
     AgentRunWaitSetCheckpointRequest, AgentTurnOutcome, BlobStore, CheckpointSandboxSpawnOutcome,
     ClaimedAgentEvent, CompleteTurnRunOutcome, ForegroundAgentWaitRequest, MessageId,
     ParkTurnForAgentRunWaitSetOutcome, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
-    Result, SandboxAgentSpawnRequest, SandboxSpawnCheckpointRequest, SequencedEvent, Store,
-    ToolRegistry, ToolScratch, TurnCheckpointProgress, TurnFailureRetry, TurnId, TurnRun,
-    TurnRunStatus, SPAWN_SANDBOX_AGENT_TOOL, WAIT_FOR_AGENTS_TOOL,
+    Result, SandboxAgentSpawnRequest, SandboxSpawnCheckpointRequest, SecretProvider,
+    SequencedEvent, Store, ToolRegistry, ToolScratch, TurnCheckpointProgress, TurnFailureRetry,
+    TurnId, TurnRun, TurnRunStatus, SPAWN_SANDBOX_AGENT_TOOL, WAIT_FOR_AGENTS_TOOL,
 };
 use tokio::sync::Notify;
 
@@ -71,6 +71,7 @@ pub(crate) enum TurnWorkerOutcome {
 pub(crate) struct TurnWorker {
     store: Arc<dyn Store>,
     resolver: Arc<dyn ProviderResolver>,
+    secrets: Arc<dyn SecretProvider>,
     tools: Arc<ToolRegistry>,
     blobs: Option<Arc<dyn BlobStore>>,
     mcp: Option<Arc<McpRuntime>>,
@@ -272,6 +273,7 @@ impl TurnWorker {
     pub(crate) fn new(
         store: Arc<dyn Store>,
         resolver: Arc<dyn ProviderResolver>,
+        secrets: Arc<dyn SecretProvider>,
         tools: Arc<ToolRegistry>,
         approvals: Arc<ApprovalBroker>,
         events: Arc<EventBus>,
@@ -290,6 +292,7 @@ impl TurnWorker {
         Self {
             store,
             resolver,
+            secrets,
             tools,
             blobs: None,
             mcp: None,
@@ -486,6 +489,14 @@ impl TurnWorker {
                 )
                 .await;
         }
+        // Resolved per turn, not at boot, so enabling a provider takes effect on
+        // the next turn. `None` is not a failure: background maintenance is
+        // skipped rather than run on the model the user picked for talking.
+        let utility_model = if self.resolver.enforces_model_registry() {
+            crate::model_roles::resolve_utility_model(&*self.store, &*self.secrets).await?
+        } else {
+            None
+        };
         let active = loop {
             if let Some(active) = self.signals.register(turn.chat_id, turn.id, lease_token) {
                 break active;
@@ -546,6 +557,7 @@ impl TurnWorker {
                 config.model = turn.model.clone();
                 config.reasoning_effort = chat.reasoning_effort;
             }
+            config.utility_model = utility_model.clone();
             config.max_steps = remaining_steps;
             config.tool_scratch = self.private_scratch_root.as_deref().and_then(|root| {
                 match private_chat_scratch(root, chat.id) {

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -330,6 +330,7 @@ mod tests {
         // renderer importing from a single place.
         generate::collect_from::<crate::routes::Settings>(&cfg, &mut out);
         generate::collect_from::<crate::routes::ModelInfo>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::ModelRoleInfo>(&cfg, &mut out);
         generate::collect_from::<crate::routes::ChatTranscript>(&cfg, &mut out);
         generate::collect_from::<crate::providers::ProviderInfo>(&cfg, &mut out);
         generate::collect_from::<crate::web_search::WebSearchConfigInfo>(&cfg, &mut out);

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -149,6 +149,19 @@ by both `GET /models` and model-to-provider routing. The host applies that
 metadata to the runtime request; clients cannot override token or capability
 policy.
 
+Models are chosen per *role*, not once globally. `chat` is the model a
+foreground turn runs on: the chat's override, then the global default, then the
+boot default. `utility` is the model for background work the user did not ask
+for, such as compacting a long transcript, so maintenance is not billed at the
+model and reasoning effort chosen for the conversation. Each role can be pinned
+to one model (`PUT /models/roles/{role}`, stored under `model.<role>`); left
+automatic, it resolves against an ordered list of curated defaults and takes the
+first entry whose provider is enabled and credentialed. That happens on read, so
+enabling a provider changes the answer without a restart, and it degrades rather
+than fails: when nothing resolves for `utility`, the work that would have used
+it is skipped instead of falling back to the conversation's model. `GET /models`
+reports what each role resolves to so a client can label the automatic choice.
+
 OpenAI-compatible endpoints can register custom model IDs and their context and
 output limits in provider settings. Those models enter the same catalog with
 conservative text-only, non-reasoning capabilities. Existing unqualified model


### PR DESCRIPTION
Every model decision in the product resolved to one of three answers, and two of them were wrong. A foreground turn resolves properly. The context checkpoint inherited the chat's model *and* reasoning effort verbatim — compacting a transcript is maintenance work, but it was billed at whatever the user picked for conversation, at whatever effort they picked.

Model choice becomes per role.

- `chat` is what exists today — the chat override, the global `model` setting, then the boot default — and does not change.
- `utility` is new: the model for background work the user did not ask for.

Two roles is deliberate. A third is an entry in the tables in `model_roles.rs`, not a refactor.

## The mechanism

A role stores an explicit selection under `model.<role>`, matching the existing `provider.<kind>` convention. `chat` keeps the bare `model` key it has always used, so existing installs keep their default and `PUT /settings` keeps working unchanged.

Left automatic, a role resolves against an ordered list of curated defaults where order is both preference and failover. Resolution walks it and takes the first entry whose provider is enabled and credentialed:

1. `anthropic::claude-haiku-4-5-20251001`
2. `openai::gpt-5.4-nano`
3. `gemini::gemini-3.5-flash-lite`

One entry per provider that serves curated models, each that provider's cheapest current row, so an Anthropic-only install gets Haiku 4.5, an OpenAI-only install nano, and a Gemini-only install Flash-Lite. Anthropic leads because it is the provider the product defaults to for chat, so the common single-provider install resolves on the first step. A provider whose models come from its own configuration — a custom OpenAI-compatible endpoint, the gateway — has nothing a curated list can name; those installs pin `model.utility` to one of the models they configured.

Resolution reads settings and credentials on every call rather than at boot, so enabling a provider takes effect on the next turn instead of the next launch. And it degrades rather than fails: no resolvable model means the caller skips its work. It can never block or fail a turn.

The role carries a default reasoning effort — `none` for `utility`, since compaction is summarization of text already written. `apply_model_policy`'s clamping rules apply, so the level comes up to `low` on Anthropic's adaptive-thinking rows and is dropped entirely on Haiku 4.5, which rejects the parameter.

## The first consumer

The context checkpoint moves onto the role, which is the cost win on its own. It runs on the utility model at the role's effort, and is budgeted against *that* model's context window rather than the conversation model's — a cheaper model usually holds less, and the old code would have overrun it. With no utility model resolvable it skips the call entirely; deterministic context reduction already covers that path, and the alternative would be spending the user's conversation model on maintenance again.

The utility model is resolved once per turn in the turn worker and carried on `AgentConfig`, so `openwave-core` stays unaware of providers and registries.

## Surface

`GET /models` now returns one row per role — the pinned selection and what the role resolves to right now — replacing the single `default_key`. The `chat` row goes through the same seam a new execution does (`resolve_chat_model` from #731, minus the per-chat override there is no chat to read here), so it still carries exactly what `default_key` did, including the boot-default last resort that no role list can name. `PUT /models/roles/{role}` pins or clears a role through the same validation `PUT /settings` uses, so a role cannot be pinned to a model whose provider could not serve it.

The Models settings panel grows a row per role, reusing its provider-then-model two-step picker. The automatic option names its outcome ("Automatic — Claude Haiku 4.5") instead of leaving the reader to guess, including the case where it resolves to nothing and the background work is skipped. Both rows save through the role route, and a save refreshes the shell's catalog so the composer's default label no longer goes stale — it did before this change.

## Tests

Two unit tests that would tell us something we would act on: every key in a role's default list exists in `MODEL_REGISTRY`, and the list covers every provider that serves curated models, so no credentialed user is left without a utility model. Adding a curated provider without a utility entry fails the second one.

One end-to-end test through the HTTP surface for the mechanism itself: nothing credentialed resolves to nothing, credentialing OpenAI alone lands on nano with no restart between the reads, a pin overrides the defaults and an unusable one is refused, and disabling OpenAI while enabling Gemini moves the walk to Flash-Lite.

An existing core test asserted the maintenance request's model; it now asserts that model is the utility one rather than the conversation's, which is the behavior change stated directly. The panel's dom test covers a row per role rather than one picker.

## Not ported from Brightwave

Deliberately absent: the Redis circuit breaker and per-model health scoring, the cross-cloud service-provider routing layer, and the feature-flag layer its config reads through. All three exist to run a fleet.

## Notes

- Rebased onto `main` after #731 landed. The `subagent` case #731 settled by freezing the origin turn's model at admission is untouched here; if it ever becomes a role, it resolves at admission rather than in the worker, which the ordered-list mechanism supports without change.
- #735 was the settings-panel slice and merged into this branch before this one landed, so it arrives as one squash commit rather than two.

## Not verified

The app was not driven for this. Checkpoint creation is covered by the core agent tests against a fake provider, role resolution by the HTTP test, and the panel by its dom test; what is unverified is a real Haiku call producing a well-formed checkpoint payload for a transcript compacted from an Opus conversation.

Closes #714