### PR TITLE
feat(provider): constrain model output with response formats and tool choice

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1203,6 +1203,7 @@ impl Agent {
                     temperature: self.config.temperature,
                     reasoning_effort: self.config.reasoning_effort,
                     images,
+                    ..Default::default()
                 };
 
                 progress.model_steps = step + 1;
@@ -3026,7 +3027,13 @@ impl Agent {
             // the set of models that can create a checkpoint.
             temperature: None,
             reasoning_effort: self.config.reasoning_effort,
+            // Constrain the answer to the payload schema. Without this the
+            // model's shape is a request, the parse below is a coin toss, and a
+            // lost toss abandons this prefix for the rest of the conversation —
+            // the boundary is fenced above before the call is made.
+            response_format: Some(ContextCheckpointPayloadV1::response_format()),
             images: ImageAttachments::new(),
+            ..Default::default()
         };
         let mut stream = self.provider.stream(request).await.ok()?;
         let mut content = String::new();
@@ -7618,6 +7625,21 @@ mod tests {
             .expect("one maintenance request");
         assert!(maintenance.tools.is_empty());
         assert!(maintenance.images.is_empty());
+        // The call constrains its own output, and the schema it sends has to
+        // survive the conversion every adapter runs it through — a payload field
+        // that cannot be expressed strictly would fail every checkpoint call
+        // rather than degrade to prose.
+        let Some(crate::provider::ResponseFormat::JsonSchema { name, schema }) =
+            &maintenance.response_format
+        else {
+            panic!("the checkpoint call asks for a constrained payload");
+        };
+        assert_eq!(name, "context_checkpoint");
+        assert!(
+            crate::tool::strict_json_schema(schema, crate::tool::OptionalProperties::AcceptNull)
+                .is_some(),
+            "the checkpoint payload schema has a strict form: {schema}"
+        );
         let maintenance_debug = format!("{:?}", maintenance.messages);
         assert!(maintenance_debug.contains("OLD PREFIX"));
         assert!(!maintenance_debug.contains("RECENT USER"));

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -143,7 +143,7 @@ pub use model::{
 pub use preview::{ToolActionPreview, ToolResultPreview};
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId,
-    RefusalDetails, RefusalOutcome, StopReason, Usage,
+    RefusalDetails, RefusalOutcome, ResponseFormat, StopReason, ToolChoice, Usage,
 };
 pub use renderer_tool::RendererToolName;
 pub use semantic_checkpoint::{
@@ -175,8 +175,8 @@ pub use storage::{
     MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
 };
 pub use tool::{
-    input_schema_for, ApprovalClass, Tool, ToolCtx, ToolErrorCategory, ToolOutput, ToolScratch,
-    ToolSpec, ToolUiView,
+    input_schema_for, strict_json_schema, ApprovalClass, OptionalProperties, Tool, ToolCtx,
+    ToolErrorCategory, ToolOutput, ToolScratch, ToolSpec, ToolUiView,
 };
 #[cfg(feature = "tools")]
 pub use tools::{CreateDeliverable, ListDir, ReadFile, WriteFile};

--- a/crates/openwave-core/src/provider.rs
+++ b/crates/openwave-core/src/provider.rs
@@ -94,8 +94,69 @@ impl ChatMessage {
     }
 }
 
-/// A request for one streamed model completion.
+/// A constraint on the shape of a completion's output.
+///
+/// This is a constraint, not a hint. An adapter either enforces it with the
+/// provider's native mechanism or fails the request; none of them sends an
+/// unconstrained completion and hopes. A caller that asked for JSON therefore
+/// never has to guess whether it got JSON — only whether the turn ran.
+///
+/// **Return channel.** Constrained output always arrives on
+/// [`ProviderEvent::TextDelta`], whatever mechanism the adapter used to obtain
+/// it. Providers disagree here — OpenAI and Gemini have a native JSON mode that
+/// streams as ordinary text, while Anthropic's form is a forced tool call whose
+/// arguments stream as [`ProviderEvent::ToolCallArgsDelta`] — and normalizing in
+/// the adapter is what keeps that disagreement out of every consumer. Both
+/// consumers of this event stream match exhaustively and reject a tool call
+/// they did not advertise, so the alternative would be a provider-conditional
+/// branch in each of them.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ResponseFormat {
+    /// The completion must be a single JSON value satisfying `schema`.
+    JsonSchema {
+        /// Short identifier for the schema, e.g. `context_checkpoint`.
+        ///
+        /// Providers surface it in errors, and the Anthropic adapter uses it as
+        /// the name of the tool it forces, so it must match
+        /// `^[a-zA-Z0-9_-]{1,64}$`.
+        name: String,
+        /// The JSON Schema (draft 2020-12) the output must satisfy.
+        ///
+        /// Providers accept only a strict subset — see
+        /// [`crate::tool::strict_json_schema`], which produces it.
+        schema: Value,
+    },
+}
+
+/// Whether the model may, must, or must not call a tool this turn.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ToolChoice {
+    /// The model decides. This is every provider's default.
+    Auto,
+    /// The model must call one of the advertised tools.
+    Required,
+    /// The model must not call a tool.
+    None,
+    /// The model must call exactly this tool.
+    Tool {
+        /// The name of the tool, which must be one the request advertises.
+        name: String,
+    },
+}
+
+/// A request for one streamed model completion.
+///
+/// The struct is constructed as a literal rather than through a builder, so it
+/// derives [`Default`] and callers spread `..Default::default()` over the
+/// controls they do not set. New request controls then reach the adapters
+/// without a mechanical edit at every construction site — and, more usefully,
+/// without the temptation to make the struct `#[non_exhaustive]`, which would
+/// hide from the compiler the one place that genuinely has to opt in.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ChatRequest {
     /// Explicit provider route selected by the host. Composite routers must
     /// honor this hint exactly and must not silently fall back to another
@@ -128,6 +189,17 @@ pub struct ChatRequest {
     /// control and ignore it otherwise.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_effort: Option<crate::model::ReasoningEffort>,
+    /// Constraint on the output's shape. Absent, the model writes prose.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<ResponseFormat>,
+    /// Whether the model may, must, or must not call a tool. Absent, the
+    /// provider's own default holds, which is always the automatic choice.
+    ///
+    /// A [`ResponseFormat`] overrides this on adapters that constrain output by
+    /// forcing a tool: there is only one tool-choice slot on the wire, and the
+    /// output constraint is the stronger promise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<ToolChoice>,
     /// Pixels for the [`ContentBlock::Image`] blocks in `messages`.
     ///
     /// Hydrated from the blob store for exactly this request. Skipped by serde
@@ -397,6 +469,7 @@ mod tests {
             temperature: None,
             reasoning_effort: None,
             images: ImageAttachments::new(),
+            ..Default::default()
         }))
         .unwrap();
         drop(provider);
@@ -425,6 +498,7 @@ mod tests {
             temperature: None,
             reasoning_effort: None,
             images: ImageAttachments::new(),
+            ..Default::default()
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(!json.contains("system"), "{json}");

--- a/crates/openwave-core/src/semantic_checkpoint.rs
+++ b/crates/openwave-core/src/semantic_checkpoint.rs
@@ -7,11 +7,13 @@
 //! as untrusted historical context.
 
 use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{AgentError, Result};
 use crate::id::{ChatId, MessageId};
-use crate::provider::Usage;
+use crate::provider::{ResponseFormat, Usage};
+use crate::tool::input_schema_for;
 
 /// The only checkpoint payload format this build can read and write.
 ///
@@ -39,7 +41,7 @@ pub const MAX_CONTEXT_CHECKPOINT_ITEM_BYTES: usize = 1_024;
 /// capability, instruction, or attachment-bytes field: source/output values
 /// are identities only, and projection wraps the whole payload as untrusted
 /// historical context.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ContextCheckpointPayloadV1 {
     /// Payload schema version, independently explicit inside the stored JSON.
@@ -58,12 +60,38 @@ pub struct ContextCheckpointPayloadV1 {
     pub conclusions: Vec<String>,
 }
 
+/// Name the checkpoint's output constraint carries on the wire.
+///
+/// The Anthropic adapter turns it into a tool name, so it stays within
+/// `^[a-zA-Z0-9_-]{1,64}$`.
+const CONTEXT_CHECKPOINT_SCHEMA_NAME: &str = "context_checkpoint";
+
 impl ContextCheckpointPayloadV1 {
+    /// The output constraint the checkpoint's maintenance call sends.
+    ///
+    /// The system prompt still spells the shape out in prose. That is not
+    /// redundancy for its own sake: this adapter layer covers any
+    /// OpenAI-compatible endpoint, including local runtimes that accept
+    /// `response_format` and then ignore it, and the prompt is what those
+    /// runtimes have to go on.
+    pub(crate) fn response_format() -> ResponseFormat {
+        ResponseFormat::JsonSchema {
+            name: CONTEXT_CHECKPOINT_SCHEMA_NAME.to_owned(),
+            schema: input_schema_for::<Self>(),
+        }
+    }
+
     /// Parse untrusted model output and return canonical, bounded JSON.
     ///
     /// The producer fails open when this rejects an answer; it never stores a
     /// partial or vaguely-shaped summary merely because the model returned
     /// something readable.
+    ///
+    /// A constrained completion arrives as bare JSON, so the fence strip below
+    /// is dead weight against a provider that honored the schema. It stays for
+    /// the ones that do not — an OpenAI-compatible runtime that accepts
+    /// `response_format` and ignores it still answers the prompt, in a fenced
+    /// block, and there is no reason to throw that away.
     pub(crate) fn parse_and_canonicalize(content: &str) -> Result<String> {
         let content = strip_json_fence(content.trim());
         let payload: Self = serde_json::from_str(content).map_err(|error| {

--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -156,6 +156,183 @@ fn remove_schema_defaults(schema: &mut Value) {
     }
 }
 
+/// What to do with a property the schema does not require, when converting to
+/// the strict schema subset providers enforce.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OptionalProperties {
+    /// Widen the property to also accept `null`, then require it.
+    ///
+    /// Correct when the reader is a serde `Option`, which reads an explicit
+    /// `null` back as absent.
+    AcceptNull,
+    /// Refuse the conversion.
+    ///
+    /// Correct when the reader's handling of an absent value is unknown. A
+    /// hand-written tool schema whose optional property deserializes into a
+    /// `#[serde(default)]` field that is *not* an `Option` rejects the `null`
+    /// that widening invites, and would start failing every call.
+    Reject,
+}
+
+/// Keywords carried through a strict conversion unchanged.
+///
+/// Anything not listed here and not handled structurally below is refused
+/// rather than dropped. Silently discarding a constraint changes what the model
+/// was asked for, and strict mode is precisely the promise that it did not.
+const STRICT_PASSTHROUGH_KEYWORDS: &[&str] = &[
+    "description",
+    "enum",
+    "const",
+    "pattern",
+    "minLength",
+    "maxLength",
+    "minItems",
+    "maxItems",
+    "minimum",
+    "maximum",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+    "multipleOf",
+];
+
+/// `format` values providers recognize in a strict schema.
+///
+/// `format` is an annotation rather than a constraint, and generators emit
+/// Rust-shaped values (`uint16`, `float`) that a strict validator rejects
+/// outright. An unrecognized value is therefore dropped instead of refusing the
+/// whole schema: the `type` and the numeric bounds beside it still carry the
+/// constraint.
+const STRICT_FORMATS: &[&str] = &[
+    "date-time",
+    "time",
+    "date",
+    "duration",
+    "email",
+    "hostname",
+    "ipv4",
+    "ipv6",
+    "uuid",
+];
+
+/// Rewrite a draft 2020-12 schema into the strict subset providers enforce, or
+/// return `None` when it cannot be expressed there.
+///
+/// Strict mode narrows JSON Schema in two ways. Every object must close
+/// `additionalProperties` and must enumerate its properties — so a schema that
+/// declares no `properties` at all ("any object") has no strict form. And every
+/// declared property must appear in `required`, which is not safe in general;
+/// `optional` decides what happens when one does not.
+///
+/// Refusing rather than guessing is the point. A schema the provider rejects
+/// fails the whole turn, so a caller needs a definite answer: either a schema
+/// the provider will accept, or a signal to send the request unconstrained.
+#[must_use]
+pub fn strict_json_schema(schema: &Value, optional: OptionalProperties) -> Option<Value> {
+    let object = schema.as_object()?;
+    let mut strict = serde_json::Map::new();
+    for (keyword, value) in object {
+        match keyword.as_str() {
+            // Handled structurally below.
+            "type" | "properties" | "required" | "items" | "additionalProperties" | "anyOf" => {}
+            // Not a constraint on the value, so it neither survives nor blocks.
+            "title" => {}
+            "format" => {
+                if value.as_str().is_some_and(|f| STRICT_FORMATS.contains(&f)) {
+                    strict.insert(keyword.clone(), value.clone());
+                }
+            }
+            keyword if STRICT_PASSTHROUGH_KEYWORDS.contains(&keyword) => {
+                strict.insert(keyword.to_owned(), value.clone());
+            }
+            // `$ref`/`$defs`, `oneOf`, `allOf`, `not`, `if`/`then`,
+            // `patternProperties`, and whatever a later draft adds.
+            _ => return None,
+        }
+    }
+
+    if let Some(branches) = object.get("anyOf") {
+        let branches: Vec<Value> = branches
+            .as_array()
+            .filter(|branches| !branches.is_empty())?
+            .iter()
+            .map(|branch| strict_json_schema(branch, optional))
+            .collect::<Option<_>>()?;
+        strict.insert("anyOf".to_owned(), Value::Array(branches));
+    }
+
+    let types: Vec<&str> = match object.get("type") {
+        Some(Value::String(name)) => vec![name.as_str()],
+        Some(Value::Array(names)) => names
+            .iter()
+            .map(Value::as_str)
+            .collect::<Option<Vec<_>>>()
+            .filter(|names| !names.is_empty())?,
+        Some(_) => return None,
+        // Strict mode has no way to say "any value"; a branch schema carries
+        // its types inside the branches instead.
+        None if strict.contains_key("anyOf") => Vec::new(),
+        None => return None,
+    };
+
+    if types.contains(&"object") {
+        let properties = object.get("properties").and_then(Value::as_object)?;
+        let required: Vec<&str> = match object.get("required") {
+            Some(Value::Array(names)) => names.iter().map(Value::as_str).collect::<Option<_>>()?,
+            Some(_) => return None,
+            None => Vec::new(),
+        };
+        let mut strict_properties = serde_json::Map::new();
+        for (name, property) in properties {
+            let mut property = strict_json_schema(property, optional)?;
+            if !required.contains(&name.as_str()) {
+                if optional == OptionalProperties::Reject {
+                    return None;
+                }
+                property = accepting_null(property)?;
+            }
+            strict_properties.insert(name.clone(), property);
+        }
+        strict.insert(
+            "required".to_owned(),
+            Value::Array(properties.keys().cloned().map(Value::String).collect()),
+        );
+        strict.insert("properties".to_owned(), Value::Object(strict_properties));
+        strict.insert("additionalProperties".to_owned(), Value::Bool(false));
+    }
+    if types.contains(&"array") {
+        let items = strict_json_schema(object.get("items")?, optional)?;
+        strict.insert("items".to_owned(), items);
+    }
+    if let Some(declared) = object.get("type") {
+        strict.insert("type".to_owned(), declared.clone());
+    }
+    Some(Value::Object(strict))
+}
+
+/// Widen an already-strict property schema to also accept `null`.
+fn accepting_null(mut property: Value) -> Option<Value> {
+    let object = property.as_object_mut()?;
+    match object.get_mut("type") {
+        Some(Value::String(name)) if name != "null" => {
+            let widened = vec![
+                Value::String(name.clone()),
+                Value::String("null".to_owned()),
+            ];
+            object.insert("type".to_owned(), Value::Array(widened));
+        }
+        Some(Value::String(_)) => {}
+        Some(Value::Array(names)) => {
+            if !names.iter().any(|name| name.as_str() == Some("null")) {
+                names.push(Value::String("null".to_owned()));
+            }
+        }
+        // A branch schema has no single type to widen, and adding a `"null"`
+        // branch would need every sibling keyword re-checked against it.
+        _ => return None,
+    }
+    Some(property)
+}
+
 /// The result of executing a tool.
 ///
 /// `content` is the model-readable result folded back into the conversation;
@@ -479,6 +656,70 @@ mod tests {
                 "additionalProperties": false
             })
         );
+    }
+
+    #[test]
+    fn strict_mode_requires_every_property_or_refuses_to_convert() {
+        // The case the post-processor exists for: schemars leaves an `Option`
+        // field out of `required`, and strict mode has no optional properties.
+        let schema = input_schema_for::<DerivedArguments>();
+        assert_eq!(
+            strict_json_schema(&schema, OptionalProperties::AcceptNull).unwrap(),
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "optional": {
+                        "type": ["string", "null"],
+                        "description": "Optional text."
+                    }
+                },
+                "required": ["optional"],
+                "additionalProperties": false
+            })
+        );
+        // Widening invites a `null` the reader has to absorb, which only an
+        // `Option` reliably does. A hand-written tool schema cannot promise
+        // that, so the conversion is refused rather than quietly performed.
+        assert!(strict_json_schema(&schema, OptionalProperties::Reject).is_none());
+    }
+
+    #[test]
+    fn strict_mode_closes_objects_and_refuses_what_it_cannot_express() {
+        // Closing the object is the safe half of strict mode: readers ignore
+        // unknown keys, so forbidding them takes nothing away.
+        let open = serde_json::json!({
+            "type": "object",
+            "properties": { "path": { "type": "string" } },
+            "required": ["path"],
+        });
+        let strict = strict_json_schema(&open, OptionalProperties::Reject).unwrap();
+        assert_eq!(strict["additionalProperties"], serde_json::json!(false));
+
+        // A generator-shaped `format` is an annotation a strict validator
+        // rejects outright, so it goes while the real bound beside it stays.
+        let counted = serde_json::json!({
+            "type": "object",
+            "properties": { "n": { "type": "integer", "format": "uint16", "minimum": 0 } },
+            "required": ["n"],
+        });
+        let strict = strict_json_schema(&counted, OptionalProperties::Reject).unwrap();
+        assert_eq!(
+            strict["properties"]["n"],
+            serde_json::json!({ "type": "integer", "minimum": 0 })
+        );
+
+        // An object declaring no properties means "any object"; closing it would
+        // narrow it to `{}`. A `$ref` is a constraint we never translated.
+        for inexpressible in [
+            serde_json::json!({ "type": "object" }),
+            serde_json::json!({ "$ref": "#/$defs/Node" }),
+            serde_json::json!({ "description": "anything at all" }),
+        ] {
+            assert!(
+                strict_json_schema(&inexpressible, OptionalProperties::AcceptNull).is_none(),
+                "{inexpressible}"
+            );
+        }
     }
 
     #[test]

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -259,9 +259,9 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
     }
     // Extended thinking and a forced tool are mutually exclusive on the Messages
     // API: with thinking on, `tool_choice` may only be `auto` or `none`. The
-    // output constraint is the caller's explicit ask and reasoning is a quality
-    // preference, so the constraint wins and this request does not think.
-    if req.reasoning_model && req.response_format.is_none() && takes_adaptive_thinking(&req.model) {
+    // forcing is the caller's explicit ask and reasoning is a quality
+    // preference, so the ask wins and this request does not think.
+    if req.reasoning_model && !forces_a_tool(req) && takes_adaptive_thinking(&req.model) {
         // An omitted `thinking` means thinking is *off* on Opus 4.7 and later,
         // so a reasoning model only reasons when the request says so.
         //
@@ -275,6 +275,15 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         }
     }
     Ok(body)
+}
+
+/// Whether the request obliges the model to call a specific tool or any tool.
+fn forces_a_tool(req: &ChatRequest) -> bool {
+    req.response_format.is_some()
+        || matches!(
+            req.tool_choice,
+            Some(ToolChoice::Required | ToolChoice::Tool { .. })
+        )
 }
 
 fn anthropic_tool_choice(choice: &ToolChoice) -> Result<Value> {

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -15,8 +15,9 @@ use base64::Engine as _;
 use openwave_core::error::{AgentError, Result};
 use openwave_core::provider::{
     ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, RefusalDetails,
-    StopReason, Usage,
+    ResponseFormat, StopReason, ToolChoice, Usage,
 };
+use openwave_core::tool::{strict_json_schema, OptionalProperties};
 use openwave_core::{ImageAttachments, Role};
 
 use crate::sse::{classify_provider_error, drain_frames, frame_data, read_bounded_error_body};
@@ -24,6 +25,15 @@ use crate::sse::{classify_provider_error, drain_frames, frame_data, read_bounded
 const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
 const DEFAULT_MAX_TOKENS: u32 = 4096;
+
+/// Description for the synthetic tool that carries a constrained response.
+///
+/// The model is told what the call is for, because a forced tool with an opaque
+/// name reads to it as an unexplained side quest and it starts narrating around
+/// the call.
+const STRUCTURED_OUTPUT_TOOL_DESCRIPTION: &str =
+    "Return the result of this request. Call this once, with the whole answer in \
+     its arguments, and write nothing else.";
 
 fn provider_err(err: impl std::fmt::Display) -> AgentError {
     AgentError::Provider(err.to_string())
@@ -79,6 +89,11 @@ impl ModelProvider for AnthropicProvider {
 
     async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
         let body = build_request_json(&req)?;
+        // `build_request_json` has already rejected a format it cannot enforce.
+        let output_tool = match &req.response_format {
+            Some(ResponseFormat::JsonSchema { name, .. }) => Some(name.clone()),
+            _ => None,
+        };
         let url = format!("{}/v1/messages", self.base_url);
         let api_key = match &self.token_source {
             Some(source) => source.bearer_token().await?,
@@ -113,7 +128,7 @@ impl ModelProvider for AnthropicProvider {
             // Accumulate raw BYTES, not a String: a chunk may split a multi-byte
             // UTF-8 character, so we only decode once a whole frame is buffered.
             let mut buffer: Vec<u8> = Vec::new();
-            let mut state = StreamState::default();
+            let mut state = StreamState { output_tool, ..StreamState::default() };
             while let Some(chunk) = bytes.next().await {
                 // A mid-stream transport error must not read as a clean end:
                 // the accumulated tool-call arguments may be truncated
@@ -198,10 +213,55 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
                 .collect(),
         );
     }
+    match &req.response_format {
+        Some(ResponseFormat::JsonSchema { name, schema }) => {
+            // The Messages API constrains output through a forced tool call, so
+            // the schema becomes a tool nothing above the adapter ever sees: the
+            // stream re-reads its arguments as text (see `normalize`), which is
+            // the channel every other provider delivers structured output on.
+            let schema =
+                strict_json_schema(schema, OptionalProperties::AcceptNull).ok_or_else(|| {
+                    AgentError::Provider(format!(
+                        "response format {name} has no strict JSON Schema form"
+                    ))
+                })?;
+            let output_tool = json!({
+                "name": name,
+                "description": STRUCTURED_OUTPUT_TOOL_DESCRIPTION,
+                "input_schema": schema,
+            });
+            match body["tools"].as_array_mut() {
+                Some(tools) => tools.push(output_tool),
+                None => body["tools"] = json!([output_tool]),
+            }
+            // Forcing the output tool is what makes the constraint a
+            // constraint. It also takes the one tool-choice slot on the wire, so
+            // an explicit `tool_choice` loses to it — see
+            // `ChatRequest::tool_choice`.
+            body["tool_choice"] = json!({ "type": "tool", "name": name });
+        }
+        None => {
+            if let Some(choice) = &req.tool_choice {
+                body["tool_choice"] = anthropic_tool_choice(choice)?;
+            }
+        }
+        // `ResponseFormat` is open. A format this adapter has not learned must
+        // fail the request rather than stream an unconstrained answer that only
+        // looks like a success.
+        Some(other) => {
+            return Err(AgentError::Provider(format!(
+                "anthropic cannot enforce response format {other:?}"
+            )))
+        }
+    }
     if let Some(temperature) = req.temperature {
         body["temperature"] = json!(temperature);
     }
-    if req.reasoning_model && takes_adaptive_thinking(&req.model) {
+    // Extended thinking and a forced tool are mutually exclusive on the Messages
+    // API: with thinking on, `tool_choice` may only be `auto` or `none`. The
+    // output constraint is the caller's explicit ask and reasoning is a quality
+    // preference, so the constraint wins and this request does not think.
+    if req.reasoning_model && req.response_format.is_none() && takes_adaptive_thinking(&req.model) {
         // An omitted `thinking` means thinking is *off* on Opus 4.7 and later,
         // so a reasoning model only reasons when the request says so.
         //
@@ -215,6 +275,24 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         }
     }
     Ok(body)
+}
+
+fn anthropic_tool_choice(choice: &ToolChoice) -> Result<Value> {
+    Ok(match choice {
+        ToolChoice::Auto => json!({ "type": "auto" }),
+        ToolChoice::Required => json!({ "type": "any" }),
+        ToolChoice::None => json!({ "type": "none" }),
+        ToolChoice::Tool { name } => json!({ "type": "tool", "name": name }),
+        // `ToolChoice` is open so a provider-neutral mode can be added without
+        // a breaking change. Silently substituting the model's own judgement
+        // for a mode this adapter has not learned would turn "must not call a
+        // tool" into "may".
+        other => {
+            return Err(AgentError::Provider(format!(
+                "anthropic cannot express tool choice {other:?}"
+            )))
+        }
+    })
 }
 
 /// Whether `model` takes the adaptive-thinking request shape.
@@ -326,6 +404,13 @@ struct StreamState {
     input_tokens: u32,
     cache_read_input_tokens: u32,
     cache_creation_input_tokens: u32,
+    /// Name of the synthetic tool carrying a constrained response, when the
+    /// request set a [`ResponseFormat`].
+    output_tool: Option<String>,
+    /// Content-block index that tool occupied, once it starts.
+    output_block: Option<u32>,
+    /// Whether any *other* tool call was announced this stream.
+    saw_other_tool_call: bool,
 }
 
 fn u32_at(value: &Value, key: &str) -> u32 {
@@ -348,10 +433,19 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
             let block = data.get("content_block");
             if block.and_then(|b| b.get("type")).and_then(Value::as_str) == Some("tool_use") {
                 let block = block.unwrap();
+                let name = str_at(block, "name");
+                // The synthetic output tool is the request's own scaffolding.
+                // Announcing it as a tool call would hand consumers a call they
+                // never advertised and cannot answer.
+                if state.output_tool.as_deref() == Some(name.as_str()) {
+                    state.output_block = Some(index);
+                    return Vec::new();
+                }
+                state.saw_other_tool_call = true;
                 vec![ProviderEvent::ToolCallStarted {
                     index,
                     id: str_at(block, "id"),
-                    name: str_at(block, "name"),
+                    name,
                 }]
             } else {
                 Vec::new()
@@ -370,6 +464,14 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                 Some("thinking_delta") => vec![ProviderEvent::ReasoningDelta {
                     text: str_at(delta, "thinking"),
                 }],
+                // A constrained response is JSON in a tool call's arguments;
+                // every other provider streams it as text, so it becomes text
+                // here too and consumers stay provider-blind.
+                Some("input_json_delta") if state.output_block == Some(index) => {
+                    vec![ProviderEvent::TextDelta {
+                        text: str_at(delta, "partial_json"),
+                    }]
+                }
                 Some("input_json_delta") => vec![ProviderEvent::ToolCallArgsDelta {
                     index,
                     fragment: str_at(delta, "partial_json"),
@@ -392,7 +494,16 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                 .and_then(|d| d.get("stop_reason"))
                 .and_then(Value::as_str)
             {
-                let reason = map_stop_reason(reason);
+                let mut reason = map_stop_reason(reason);
+                // The forced output tool is not a tool call the consumer has to
+                // answer; the model said everything it had to say. Reporting
+                // `ToolUse` here would read as a turn waiting on a tool result.
+                if reason == StopReason::ToolUse
+                    && state.output_block.is_some()
+                    && !state.saw_other_tool_call
+                {
+                    reason = StopReason::EndTurn;
+                }
                 if reason == StopReason::Refusal {
                     let category = data
                         .get("delta")
@@ -456,6 +567,7 @@ mod tests {
             temperature: Some(0.5),
             reasoning_effort: None,
             images: ImageAttachments::new(),
+            ..Default::default()
         };
         let body = build_request_json(&req).unwrap();
         assert_eq!(body["model"], "claude-opus-4-8");
@@ -484,6 +596,7 @@ mod tests {
             temperature: None,
             reasoning_effort: effort,
             images: ImageAttachments::new(),
+            ..Default::default()
         }
     }
 
@@ -497,6 +610,67 @@ mod tests {
         assert_eq!(body["thinking"]["display"], "summarized");
         // Absent a per-chat override the provider's own effort default holds.
         assert!(body.get("output_config").is_none());
+    }
+
+    #[test]
+    fn a_constrained_response_is_a_forced_tool_read_back_as_text() {
+        let mut req = reasoning_request("claude-opus-5", Some(ReasoningEffort::Low));
+        req.response_format = Some(ResponseFormat::JsonSchema {
+            name: "note".into(),
+            schema: json!({
+                "type": "object",
+                "properties": { "body": { "type": "string" } },
+                "required": ["body"],
+            }),
+        });
+        let body = build_request_json(&req).unwrap();
+        assert_eq!(
+            body["tool_choice"],
+            json!({ "type": "tool", "name": "note" })
+        );
+        assert_eq!(body["tools"][0]["name"], "note");
+        assert_eq!(
+            body["tools"][0]["input_schema"]["additionalProperties"],
+            false
+        );
+        // With extended thinking on, this API accepts only `auto` or `none` for
+        // `tool_choice`, so a constrained request cannot also think.
+        assert!(body.get("thinking").is_none());
+
+        // The constrained value arrives on the text channel, and the turn ends
+        // rather than reading as one waiting on a tool result. Both consumers of
+        // this stream reject a tool call they never advertised.
+        let mut state = StreamState {
+            output_tool: Some("note".into()),
+            ..StreamState::default()
+        };
+        let events: Vec<ProviderEvent> = [
+            json!({
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": { "type": "tool_use", "id": "toolu_1", "name": "note" },
+            }),
+            json!({
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": { "type": "input_json_delta", "partial_json": "{\"body\":\"hi\"}" },
+            }),
+            json!({ "type": "message_delta", "delta": { "stop_reason": "tool_use" } }),
+        ]
+        .iter()
+        .flat_map(|frame| normalize(frame, &mut state))
+        .collect();
+        assert_eq!(
+            events,
+            vec![
+                ProviderEvent::TextDelta {
+                    text: "{\"body\":\"hi\"}".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ]
+        );
     }
 
     #[test]
@@ -733,6 +907,7 @@ mod tests {
             temperature: None,
             reasoning_effort: None,
             images,
+            ..Default::default()
         }
     }
 

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -20,8 +20,9 @@ use uuid::Uuid;
 use openwave_core::error::{AgentError, Result};
 use openwave_core::provider::{
     ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, RefusalDetails,
-    StopReason, Usage,
+    ResponseFormat, StopReason, ToolChoice, Usage,
 };
+use openwave_core::tool::{strict_json_schema, OptionalProperties};
 use openwave_core::{ImageAttachments, ReasoningEffort, Role};
 
 use crate::google_auth::{valid_resource_segment, valid_vertex_location};
@@ -276,6 +277,31 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         }
     }
 
+    match &req.response_format {
+        Some(ResponseFormat::JsonSchema { name, schema }) => {
+            // Gemini's native JSON mode streams the constrained value as
+            // ordinary text parts, so there is nothing to renormalize on the way
+            // back out.
+            let schema =
+                strict_json_schema(schema, OptionalProperties::AcceptNull).ok_or_else(|| {
+                    AgentError::Provider(format!(
+                        "response format {name} has no strict JSON Schema form"
+                    ))
+                })?;
+            generation_config["responseMimeType"] = json!("application/json");
+            generation_config["responseSchema"] = gemini_response_schema(&schema)?;
+        }
+        None => {}
+        // `ResponseFormat` is open. A format this adapter has not learned must
+        // fail the request rather than stream an unconstrained answer that only
+        // looks like a success.
+        Some(other) => {
+            return Err(AgentError::Provider(format!(
+                "gemini cannot enforce response format {other:?}"
+            )))
+        }
+    }
+
     let mut body = json!({
         "contents": gemini_contents(&req.messages, &req.images)?,
         "generationConfig": generation_config,
@@ -291,9 +317,172 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
                 "parameters": tool.input_schema,
             })).collect::<Vec<_>>(),
         }]);
-        body["toolConfig"] = json!({ "functionCallingConfig": { "mode": "AUTO" } });
+        body["toolConfig"] = json!({
+            "functionCallingConfig": gemini_function_calling_config(req.tool_choice.as_ref())?,
+        });
     }
     Ok(body)
+}
+
+fn gemini_function_calling_config(choice: Option<&ToolChoice>) -> Result<Value> {
+    Ok(match choice {
+        None | Some(ToolChoice::Auto) => json!({ "mode": "AUTO" }),
+        Some(ToolChoice::Required) => json!({ "mode": "ANY" }),
+        Some(ToolChoice::None) => json!({ "mode": "NONE" }),
+        Some(ToolChoice::Tool { name }) => {
+            json!({ "mode": "ANY", "allowedFunctionNames": [name] })
+        }
+        // `ToolChoice` is open so a provider-neutral mode can be added without
+        // a breaking change. Silently substituting the model's own judgement
+        // for a mode this adapter has not learned would turn "must not call a
+        // tool" into "may".
+        Some(other) => {
+            return Err(AgentError::Provider(format!(
+                "gemini cannot express tool choice {other:?}"
+            )))
+        }
+    })
+}
+
+/// Keywords `responseSchema` understands and that carry over unchanged.
+const GEMINI_SCHEMA_KEYWORDS: &[&str] = &[
+    "description",
+    "enum",
+    "pattern",
+    "minLength",
+    "maxLength",
+    "minItems",
+    "maxItems",
+    "minimum",
+    "maximum",
+];
+
+/// `format` values `responseSchema` recognizes.
+///
+/// Gemini's list is shorter than JSON Schema's, and it rejects a value it does
+/// not know. `format` is an annotation rather than a constraint, so an
+/// unrecognized one is dropped — the same trade [`strict_json_schema`] makes.
+const GEMINI_FORMATS: &[&str] = &[
+    "date-time",
+    "date",
+    "time",
+    "duration",
+    "enum",
+    "float",
+    "double",
+    "int32",
+    "int64",
+];
+
+/// Translate a strict draft 2020-12 schema into Gemini's `responseSchema`.
+///
+/// `responseSchema` is a subset of the OpenAPI 3.0 Schema object, not JSON
+/// Schema: type names are upper-case, nullability is a `nullable` flag rather
+/// than a `"null"` member of a type union, and `additionalProperties` does not
+/// exist — a Gemini object is closed already.
+///
+/// Anything outside the subset is an error rather than a dropped keyword, for
+/// the same reason as in [`strict_json_schema`]: a constraint we neither sent
+/// nor reported is a promise we quietly broke.
+fn gemini_response_schema(schema: &Value) -> Result<Value> {
+    let unsupported = |detail: &str| {
+        AgentError::Provider(format!("gemini responseSchema cannot express {detail}"))
+    };
+    let object = schema
+        .as_object()
+        .ok_or_else(|| unsupported("a non-object schema"))?;
+    let mut out = serde_json::Map::new();
+    for (keyword, value) in object {
+        match keyword.as_str() {
+            "type" | "properties" | "required" | "items" | "anyOf" => {}
+            // Gemini objects reject unknown properties on their own.
+            "additionalProperties" => {}
+            "format" => {
+                if value.as_str().is_some_and(|f| GEMINI_FORMATS.contains(&f)) {
+                    out.insert(keyword.clone(), value.clone());
+                }
+            }
+            keyword if GEMINI_SCHEMA_KEYWORDS.contains(&keyword) => {
+                out.insert(keyword.to_owned(), value.clone());
+            }
+            keyword => return Err(unsupported(&format!("the keyword `{keyword}`"))),
+        }
+    }
+
+    if let Some(branches) = object.get("anyOf").and_then(Value::as_array) {
+        let branches = branches
+            .iter()
+            .map(gemini_response_schema)
+            .collect::<Result<Vec<_>>>()?;
+        out.insert("anyOf".to_owned(), Value::Array(branches));
+    }
+
+    let mut nullable = false;
+    let mut declared: Option<&str> = None;
+    if let Some(value) = object.get("type") {
+        let names: Vec<&str> = match value {
+            Value::String(name) => vec![name.as_str()],
+            Value::Array(names) => names
+                .iter()
+                .map(Value::as_str)
+                .collect::<Option<_>>()
+                .ok_or_else(|| unsupported("a non-string type name"))?,
+            _ => return Err(unsupported("a non-string type")),
+        };
+        for name in names {
+            if name == "null" {
+                nullable = true;
+            } else if declared.replace(name).is_some() {
+                // OpenAPI 3.0 has one type per schema, so a genuine union has
+                // no representation here.
+                return Err(unsupported("a union of two concrete types"));
+            }
+        }
+    }
+
+    if let Some(name) = declared {
+        let gemini_type =
+            gemini_schema_type(name).ok_or_else(|| unsupported(&format!("the type `{name}`")))?;
+        out.insert("type".to_owned(), json!(gemini_type));
+        if name == "object" {
+            let properties = object
+                .get("properties")
+                .and_then(Value::as_object)
+                .ok_or_else(|| unsupported("an object with no declared properties"))?;
+            let translated = properties
+                .iter()
+                .map(|(name, property)| Ok((name.clone(), gemini_response_schema(property)?)))
+                .collect::<Result<serde_json::Map<_, _>>>()?;
+            out.insert("properties".to_owned(), Value::Object(translated));
+            if let Some(required) = object.get("required") {
+                out.insert("required".to_owned(), required.clone());
+            }
+        }
+        if name == "array" {
+            let items = object
+                .get("items")
+                .ok_or_else(|| unsupported("an array with no item schema"))?;
+            out.insert("items".to_owned(), gemini_response_schema(items)?);
+        }
+    } else if !out.contains_key("anyOf") {
+        return Err(unsupported("a schema with no type"));
+    }
+    if nullable {
+        out.insert("nullable".to_owned(), json!(true));
+    }
+    Ok(Value::Object(out))
+}
+
+fn gemini_schema_type(name: &str) -> Option<&'static str> {
+    match name {
+        "object" => Some("OBJECT"),
+        "array" => Some("ARRAY"),
+        "string" => Some("STRING"),
+        "integer" => Some("INTEGER"),
+        "number" => Some("NUMBER"),
+        "boolean" => Some("BOOLEAN"),
+        _ => None,
+    }
 }
 
 fn gemini_thinking_level(effort: ReasoningEffort) -> &'static str {
@@ -696,6 +885,7 @@ mod tests {
             temperature: Some(0.2),
             reasoning_effort: Some(ReasoningEffort::High),
             images: ImageAttachments::new(),
+            ..Default::default()
         }
     }
 
@@ -715,6 +905,51 @@ mod tests {
         assert_eq!(body["toolConfig"]["functionCallingConfig"]["mode"], "AUTO");
         assert!(body.get("temperature").is_none());
         assert!(body["generationConfig"].get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn a_constrained_request_translates_the_schema_to_the_openapi_subset() {
+        let mut req = request(vec![ChatMessage::text(Role::User, "hi")]);
+        req.tools.clear();
+        req.response_format = Some(ResponseFormat::JsonSchema {
+            name: "note".into(),
+            schema: json!({
+                "type": "object",
+                "properties": {
+                    "items": { "type": "array", "items": { "type": "string" } },
+                    "note": { "type": "string", "description": "Optional note." },
+                    "count": { "type": "integer", "format": "uint16", "minimum": 0 },
+                },
+                "required": ["items", "count"],
+            }),
+        });
+        let body = build_request_json(&req).unwrap();
+        assert_eq!(
+            body["generationConfig"]["responseMimeType"],
+            "application/json"
+        );
+        // Upper-case type names, `nullable` in place of a `"null"` type member,
+        // no `additionalProperties`, and no generator-shaped `format`.
+        assert_eq!(
+            body["generationConfig"]["responseSchema"],
+            json!({
+                "type": "OBJECT",
+                "properties": {
+                    "items": { "type": "ARRAY", "items": { "type": "STRING" } },
+                    "note": {
+                        "type": "STRING",
+                        "nullable": true,
+                        "description": "Optional note.",
+                    },
+                    "count": { "type": "INTEGER", "minimum": 0 },
+                },
+                "required": ["count", "items", "note"],
+            })
+        );
+
+        // OpenAPI 3.0 schemas carry one concrete type, so a genuine union has no
+        // translation and must not go out as an unconstrained request.
+        assert!(gemini_response_schema(&json!({ "type": ["string", "integer"] })).is_err());
     }
 
     #[test]

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -16,8 +16,10 @@ use serde_json::{json, Value};
 
 use openwave_core::error::{AgentError, Result};
 use openwave_core::provider::{
-    ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, StopReason, Usage,
+    ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, ResponseFormat,
+    StopReason, ToolChoice, Usage,
 };
+use openwave_core::tool::{strict_json_schema, OptionalProperties};
 use openwave_core::{ImageAttachments, Role};
 
 use crate::sse::{classify_provider_error, drain_frames, frame_data, read_bounded_error_body};
@@ -197,26 +199,82 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
     }
 
     if !req.tools.is_empty() {
-        body["tools"] = Value::Array(
-            req.tools
-                .iter()
-                .map(|tool| {
-                    json!({
-                        "type": "function",
-                        "function": {
-                            "name": tool.name,
-                            "description": tool.description,
-                            "parameters": tool.input_schema,
-                        }
-                    })
-                })
-                .collect(),
-        );
+        body["tools"] = Value::Array(req.tools.iter().map(openai_tool).collect());
+    }
+    if let Some(choice) = &req.tool_choice {
+        body["tool_choice"] = openai_tool_choice(choice)?;
+    }
+    match &req.response_format {
+        Some(ResponseFormat::JsonSchema { name, schema }) => {
+            // Without `strict` the schema is a strong suggestion; with it the
+            // provider constrains decoding. Refuse the turn rather than send the
+            // loose form: a caller that asked for a shape it can parse would
+            // otherwise get prose back and no way to tell why.
+            let schema =
+                strict_json_schema(schema, OptionalProperties::AcceptNull).ok_or_else(|| {
+                    AgentError::Provider(format!(
+                        "response format {name} has no strict JSON Schema form"
+                    ))
+                })?;
+            body["response_format"] = json!({
+                "type": "json_schema",
+                "json_schema": { "name": name, "strict": true, "schema": schema },
+            });
+        }
+        None => {}
+        // `ResponseFormat` is open. A format this adapter has not learned must
+        // fail the request rather than stream an unconstrained answer that only
+        // looks like a success.
+        Some(other) => {
+            return Err(AgentError::Provider(format!(
+                "openai-compat cannot enforce response format {other:?}"
+            )))
+        }
     }
     if let Some(temperature) = req.temperature {
         body["temperature"] = json!(temperature);
     }
     Ok(body)
+}
+
+/// Shape one advertised tool as a Chat Completions function tool.
+///
+/// `strict` is what makes the arguments conform to `parameters` rather than
+/// merely resemble it, but it is only offered for a schema that already
+/// enumerates every property as required. Widening an optional property to
+/// accept `null` — the usual way to satisfy strict mode — would start feeding
+/// `null` to tools whose argument types take a `#[serde(default)]` non-`Option`
+/// field, turning working calls into deserialization errors. A schema that needs
+/// widening therefore goes out unconstrained, exactly as it does today.
+fn openai_tool(tool: &openwave_core::tool::ToolSpec) -> Value {
+    let mut function = json!({
+        "name": tool.name,
+        "description": tool.description,
+        "parameters": tool.input_schema,
+    });
+    if let Some(schema) = strict_json_schema(&tool.input_schema, OptionalProperties::Reject) {
+        function["parameters"] = schema;
+        function["strict"] = json!(true);
+    }
+    json!({ "type": "function", "function": function })
+}
+
+fn openai_tool_choice(choice: &ToolChoice) -> Result<Value> {
+    Ok(match choice {
+        ToolChoice::Auto => json!("auto"),
+        ToolChoice::Required => json!("required"),
+        ToolChoice::None => json!("none"),
+        ToolChoice::Tool { name } => json!({ "type": "function", "function": { "name": name } }),
+        // `ToolChoice` is open so a provider-neutral mode can be added without
+        // a breaking change. Silently substituting the model's own judgement
+        // for a mode this adapter has not learned would turn "must not call a
+        // tool" into "may".
+        other => {
+            return Err(AgentError::Provider(format!(
+                "openai-compat cannot express tool choice {other:?}"
+            )))
+        }
+    })
 }
 
 /// Append one normalized message as one or more OpenAI Chat Completions messages.
@@ -518,6 +576,7 @@ mod tests {
             temperature: Some(0.2),
             reasoning_effort: Some(ReasoningEffort::High),
             images: ImageAttachments::new(),
+            ..Default::default()
         };
         let body = build_request_json(&req).unwrap();
         assert_eq!(body["model"], "gpt-4o");
@@ -535,6 +594,70 @@ mod tests {
     }
 
     #[test]
+    fn strict_is_offered_only_where_the_schema_already_allows_it() {
+        let req = ChatRequest {
+            model: "gpt-4o".into(),
+            messages: vec![ChatMessage::text(Role::User, "hi")],
+            tools: vec![
+                ToolSpec {
+                    name: "write_file".into(),
+                    description: "write a file".into(),
+                    input_schema: json!({
+                        "type": "object",
+                        "properties": { "path": { "type": "string" } },
+                        "required": ["path"],
+                    }),
+                },
+                ToolSpec {
+                    name: "read_source".into(),
+                    description: "read a source".into(),
+                    input_schema: json!({
+                        "type": "object",
+                        "properties": {
+                            "document_id": { "type": "string" },
+                            "offset": { "type": "integer", "minimum": 0 },
+                        },
+                        "required": ["document_id"],
+                    }),
+                },
+            ],
+            response_format: Some(ResponseFormat::JsonSchema {
+                name: "note".into(),
+                schema: json!({
+                    "type": "object",
+                    "properties": { "body": { "type": "string" } },
+                    "required": ["body"],
+                }),
+            }),
+            ..Default::default()
+        };
+        let body = build_request_json(&req).unwrap();
+        let format = &body["response_format"];
+        assert_eq!(format["type"], "json_schema");
+        assert_eq!(format["json_schema"]["name"], "note");
+        assert_eq!(format["json_schema"]["strict"], true);
+        assert_eq!(
+            format["json_schema"]["schema"]["additionalProperties"],
+            false
+        );
+
+        // A schema that already requires every property is constrained.
+        assert_eq!(body["tools"][0]["function"]["strict"], true);
+        assert_eq!(
+            body["tools"][0]["function"]["parameters"]["additionalProperties"],
+            false
+        );
+        // One with an optional property is not: strict mode would require it,
+        // and the `null` that makes that safe for the model is not safe for
+        // every argument type on our side. It goes out as it does today.
+        assert!(body["tools"][1]["function"].get("strict").is_none());
+        assert_eq!(
+            body["tools"][1]["function"]["parameters"],
+            req.tools[1].input_schema
+        );
+    }
+
+    #[test]
     fn reasoning_models_use_max_completion_tokens() {
         let req = ChatRequest {
             provider: Some(ProviderId::new("openai")),
@@ -547,6 +670,7 @@ mod tests {
             temperature: None,
             reasoning_effort: None,
             images: ImageAttachments::new(),
+            ..Default::default()
         };
         let body = build_request_json(&req).unwrap();
         assert_eq!(body["max_completion_tokens"], 1024);
@@ -568,6 +692,7 @@ mod tests {
             temperature: None,
             reasoning_effort: Some(ReasoningEffort::Low),
             images: ImageAttachments::new(),
+            ..Default::default()
         };
         let body = build_request_json(&req).unwrap();
         assert_eq!(body["reasoning_effort"], "low");

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -605,6 +605,7 @@ mod tests {
                 temperature: None,
                 reasoning_effort: None,
                 images: ImageAttachments::new(),
+                ..Default::default()
             })
             .await;
         match result {

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -978,6 +978,7 @@ async fn sandbox_request(
         // Sandbox runs replay text and tool blocks from checkpoints; no path
         // puts an image block in this transcript.
         images: openwave_core::ImageAttachments::new(),
+        ..Default::default()
     })
 }
 
@@ -1680,6 +1681,7 @@ mod tests {
             temperature: None,
             reasoning_effort: None,
             images: openwave_core::ImageAttachments::new(),
+            ..Default::default()
         };
         for events in [
             vec![
@@ -1757,6 +1759,7 @@ mod tests {
             temperature: None,
             reasoning_effort: None,
             images: openwave_core::ImageAttachments::new(),
+            ..Default::default()
         };
 
         let bare = match complete_sandbox_task(
@@ -2731,6 +2734,7 @@ mod tests {
             temperature: Some(0.0),
             reasoning_effort: None,
             images: openwave_core::ImageAttachments::new(),
+            ..Default::default()
         };
         let provider = Arc::new(EventProvider(vec![
             ProviderEvent::ToolCallStarted {


### PR DESCRIPTION
The provider layer had no way to constrain what a model produced. Where we needed structured data we asked for JSON in the prompt and parsed whatever came back — which is why the context checkpoint carries a fence-stripping helper, and why a malformed answer there throws a paid-for completion away for good: the boundary is fenced before the call, so that prefix never gets a second attempt.

`ChatRequest` now carries `response_format` and `tool_choice`, and each adapter turns them into its provider's native mechanism.

## What each adapter sends

- **OpenAI-compatible** — `response_format: {type: "json_schema", json_schema: {name, strict: true, schema}}`, and `tool_choice` as `"auto" | "required" | "none" | {type: "function", …}`.
- **Gemini** — `generationConfig.responseMimeType` plus `responseSchema`, and `toolConfig.functionCallingConfig.mode` (`AUTO`/`ANY`/`NONE`, with `allowedFunctionNames` for a named tool). `responseSchema` is an OpenAPI 3.0 subset rather than JSON Schema, so it needs translating: upper-case type names, `nullable` in place of a `"null"` member of a type union, no `additionalProperties`.
- **Anthropic** — a synthetic tool holding the schema, with `tool_choice` forced to it.

## Design decisions worth arguing about

**The return channel is always `TextDelta`.** OpenAI's and Gemini's native JSON modes stream as ordinary text; Anthropic's tool-based form streams as `ToolCallArgsDelta`. Rather than push that split up to consumers — both of which match the event stream exhaustively and reject a tool call they never advertised (`agent.rs`, `sandbox_agent_run_worker.rs`) — the Anthropic adapter re-reads the forced tool's argument fragments as `TextDelta`, suppresses its `ToolCallStarted`, and maps `stop_reason: tool_use` to `EndTurn` when the only call was that one. A consumer of structured output is provider-blind.

**Anthropic gets the forced tool rather than the newer `output_format`.** The forced-tool form works on every Claude model without a beta header, and I can't exercise the native structured-outputs path against the live API from here. Worth revisiting as its own change.

**An Anthropic request that forces a tool does not think.** With extended thinking enabled the Messages API accepts only `auto` or `none` for `tool_choice`, so a forced tool and a `thinking` block cannot both go out — that covers a `response_format` and an explicit `tool_choice` of `Required` or `Tool`. The forcing is the caller's explicit ask and reasoning is a quality preference, so the ask wins and the adapter drops `thinking`. This is the one behavior change to an existing path: the checkpoint's maintenance call no longer reasons on a Claude reasoning model.

**`strict_json_schema` refuses instead of guessing.** Strict mode narrows JSON Schema in two ways: every object must close `additionalProperties`, which is always safe (our readers ignore unknown keys), and every property must appear in `required`, which is not. The converter takes an `OptionalProperties` policy — `AcceptNull` widens an optional property's type to include `"null"` and requires it, `Reject` refuses the conversion — and returns `None` for anything else it did not translate (`$ref`, `oneOf`, an object declaring no `properties`, an unknown keyword). A schema the provider rejects fails the whole turn, so the caller needs a definite answer rather than a hopeful one. The one exception is `format`: it is an annotation, generators emit Rust-shaped values (`uint16`) that strict validators reject outright, and the `type` and bounds beside it carry the real constraint, so an unrecognized value is dropped.

**OpenAI function tools get `strict: true` only where the schema already requires every property.** This is the issue's "arguably worse" item, and it needs care: `read_source`'s `offset` deserializes into a `#[serde(default)] usize`, so the null-widening that satisfies strict mode would turn every call into a deserialization error. Tools whose schemas already require everything (`read_file`, `write_file`, …) get constrained arguments; the rest go out exactly as they do today. The residual risk is third-party OpenAI-compatible runtimes that choke on the `strict` key itself rather than ignoring it — it is only sent where it applies, and it is easy to back out if a local runtime complains.

## First consumer

The context checkpoint. `ContextCheckpointPayloadV1` derives `JsonSchema`, and the maintenance call sends `input_schema_for::<Self>()` as its response format under the name `context_checkpoint`. The system prompt still spells the shape out in prose, and `strip_json_fence` stays: this adapter covers any OpenAI-compatible endpoint, including local runtimes that accept `response_format` and then ignore it, and for those the prompt is all there is.

`ChatRequest` also derives `Default` now, with the construction sites spreading `..Default::default()` — one added line each — so the next request control reaches the adapters without a mechanical edit at every call site.

## Not in scope

Validating incoming tool arguments against `input_schema` — the always-true client-tool predicates and the `validate_remote_tool` gap in `openwave-mcp`. That needs a JSON-schema validation crate and is separate work.

## Tests

Five, plus one assertion on an existing end-to-end test:

- the strict converter's two halves: required-widening under `AcceptNull` versus refusal under `Reject`, and object-closing / `format`-dropping / refusal of what it cannot express;
- the Gemini translation, asserted through `build_request_json` so the wiring and the translation are covered once, including the union it must refuse;
- the Anthropic forced tool and its `TextDelta` renormalization — this is the test that pins the return-channel decision;
- OpenAI's `response_format` alongside one strict-eligible and one strict-ineligible tool;
- and `creates_projects_and_deduplicates_a_structured_semantic_checkpoint` now asserts the checkpoint call carries the constraint and that its payload schema has a strict form, so a payload field that cannot be expressed strictly fails here rather than failing every checkpoint call at runtime.

No new dependencies; `Cargo.lock` is unchanged. I have not driven the running app or hit a live provider — the wire shapes are covered by request-shaping tests only.

Closes #713
