### PR TITLE
fix(desktop): link unconfigured web search to settings

### DIFF
--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -768,6 +768,10 @@ fn tool_activity_from_call(call: ToolCallRecord) -> ChatToolActivitySnapshot {
     ChatToolActivitySnapshot {
         tool: crate::RendererToolName::from(call.name.as_str()),
         action: crate::preview::ToolActionPreview::build(&call.name, &call.arguments),
+        result: crate::preview::ToolResultPreview::from_stored_error(
+            &call.name,
+            call.error_code.as_deref(),
+        ),
         background_agent_run_id: (call.name == crate::agent_tools::SPAWN_SANDBOX_AGENT_TOOL)
             .then(|| crate::AgentRunId::sandbox_for_spawn_call(call.id)),
         status,

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -167,6 +167,9 @@ pub enum ToolResultPreview {
         stdout: String,
         stderr: String,
     },
+    /// Web search is available after the reader chooses and configures a
+    /// provider. Carries no model- or provider-authored text.
+    WebSearchProviderRequired,
     /// An external MCP tool that declared an MCP Apps view for its results.
     ///
     /// This is a *reference*, never markup: the renderer asks the server for
@@ -185,12 +188,18 @@ pub enum ToolResultPreview {
 impl ToolResultPreview {
     /// Project the result of a call from the tool's own output.
     ///
-    /// A tool opts in by putting the enumerated fields in
-    /// [`ToolOutput::data`], or — for an external MCP tool — by carrying the
-    /// host-side [`ToolOutput::ui_view`] declaration. Everything else the
-    /// output carries stays behind the boundary.
+    /// A tool opts in through an enumerated error category, by putting the
+    /// enumerated fields in [`ToolOutput::data`], or — for an external MCP
+    /// tool — by carrying the host-side [`ToolOutput::ui_view`] declaration.
+    /// Everything else the output carries stays behind the boundary.
     #[must_use]
     pub fn build(tool_name: &str, output: &ToolOutput) -> Option<Self> {
+        if output.is_error
+            && output.error_category == Some(crate::ToolErrorCategory::ConfigurationRequired)
+            && tool_name == crate::WEB_SEARCH_TOOL
+        {
+            return Some(Self::WebSearchProviderRequired);
+        }
         match tool_name {
             "exec" => {
                 let data = output.data.as_ref()?;
@@ -231,11 +240,28 @@ impl ToolResultPreview {
         }
     }
 
+    /// Rebuild a closed result from the stable failure code stored on a
+    /// terminal tool-call row.
+    ///
+    /// Arbitrary result text stays behind the renderer boundary. Only an exact
+    /// enumerated category for a known tool can recover a result here.
+    #[must_use]
+    pub fn from_stored_error(tool_name: &str, error_code: Option<&str>) -> Option<Self> {
+        if error_code == Some(crate::ToolErrorCategory::ConfigurationRequired.as_str())
+            && tool_name == crate::WEB_SEARCH_TOOL
+        {
+            Some(Self::WebSearchProviderRequired)
+        } else {
+            None
+        }
+    }
+
     /// Whether this result has any captured output to show.
     #[must_use]
     pub fn has_output(&self) -> bool {
         match self {
             Self::Exec { stdout, stderr, .. } => !stdout.is_empty() || !stderr.is_empty(),
+            Self::WebSearchProviderRequired => true,
             Self::McpApp { .. } => true,
         }
     }
@@ -550,6 +576,36 @@ mod tests {
         .unwrap();
         assert!(!json.contains("200"));
         assert!(!json.contains("done"));
+    }
+
+    #[test]
+    fn an_unconfigured_web_search_projects_only_a_typed_setup_signal() {
+        let output = crate::ToolOutput::failed(
+            crate::ToolErrorCategory::ConfigurationRequired,
+            "private diagnostic that must not cross",
+        );
+        let result = ToolResultPreview::build(crate::WEB_SEARCH_TOOL, &output);
+        assert_eq!(result, Some(ToolResultPreview::WebSearchProviderRequired));
+        assert_eq!(
+            serde_json::to_value(result.unwrap()).unwrap(),
+            serde_json::json!({"tool": "web_search_provider_required"})
+        );
+
+        assert_eq!(
+            ToolResultPreview::from_stored_error(
+                crate::WEB_SEARCH_TOOL,
+                Some(crate::ToolErrorCategory::ConfigurationRequired.as_str()),
+            ),
+            Some(ToolResultPreview::WebSearchProviderRequired)
+        );
+        assert_eq!(
+            ToolResultPreview::from_stored_error("exec", Some("configuration_required")),
+            None
+        );
+        assert_eq!(
+            ToolResultPreview::from_stored_error(crate::WEB_SEARCH_TOOL, Some("tool_failed")),
+            None
+        );
     }
 
     #[test]

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -74,8 +74,9 @@ pub struct ChatTranscriptSnapshot {
     pub refusals: Vec<ChatRefusalSnapshot>,
     /// Ordered renderer-safe sources keyed to their assistant message.
     pub citations: Vec<crate::AssistantCitationSnapshot>,
-    /// A renderer-safe historical projection. It contains fixed titles and
-    /// lifecycle timestamps only; canonical tool records never leave storage.
+    /// A renderer-safe historical projection. It contains fixed tool identity,
+    /// closed previews and lifecycle timestamps only; canonical tool records
+    /// never leave storage.
     pub tool_activity: Vec<ChatToolActivitySnapshot>,
     pub last_event_seq: i64,
 }
@@ -144,9 +145,9 @@ pub enum ChatToolActivityStatus {
     Cancelled,
 }
 
-/// A completed tool invocation with no results, tool identity, provider
-/// metadata, executor identity, lease, or diagnostic detail. The only arguments
-/// it can carry are the ones a tool explicitly projects for display.
+/// A completed tool invocation with no arbitrary result text, provider
+/// metadata, executor identity, lease, or diagnostic detail. The only action or
+/// result it can carry is one a tool explicitly projects through a closed type.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub struct ChatToolActivitySnapshot {
     /// Allowlisted renderer tool name, never a provider-supplied one.
@@ -166,6 +167,11 @@ pub struct ChatToolActivitySnapshot {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub action: Option<crate::preview::ToolActionPreview>,
+    /// Closed projection of an actionable result. Arbitrary result text is
+    /// never included.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub result: Option<crate::preview::ToolResultPreview>,
     // Present only for the fixed `spawn_sandbox_agent` renderer tool. It lets
     // the transcript attach the durable child status without exposing a
     // canonical tool record, delegated task, or executor identity.

--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -355,6 +355,8 @@ pub enum ToolErrorCategory {
     UserDeclined,
     /// The model named a tool this turn does not advertise.
     NotFound,
+    /// The capability is available after the reader configures it.
+    ConfigurationRequired,
     /// The tool ran and reported a failure of its own.
     ToolFailed,
 }
@@ -367,6 +369,7 @@ impl ToolErrorCategory {
             Self::UserCancelled => "user_cancelled",
             Self::UserDeclined => "user_declined",
             Self::NotFound => "not_found",
+            Self::ConfigurationRequired => "configuration_required",
             Self::ToolFailed => "tool_failed",
         }
     }
@@ -376,7 +379,10 @@ impl ToolErrorCategory {
     #[must_use]
     pub const fn is_product_failure(self) -> bool {
         match self {
-            Self::UserCancelled | Self::UserDeclined | Self::NotFound => false,
+            Self::UserCancelled
+            | Self::UserDeclined
+            | Self::NotFound
+            | Self::ConfigurationRequired => false,
             Self::ToolFailed => true,
         }
     }
@@ -731,6 +737,7 @@ mod tests {
             ToolErrorCategory::UserCancelled,
             ToolErrorCategory::UserDeclined,
             ToolErrorCategory::NotFound,
+            ToolErrorCategory::ConfigurationRequired,
         ] {
             assert!(!category.is_product_failure(), "{}", category.as_str());
         }
@@ -741,6 +748,7 @@ mod tests {
             ToolErrorCategory::UserCancelled,
             ToolErrorCategory::UserDeclined,
             ToolErrorCategory::NotFound,
+            ToolErrorCategory::ConfigurationRequired,
             ToolErrorCategory::ToolFailed,
         ]
         .map(ToolErrorCategory::as_str);

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -55,6 +55,31 @@ describe("terminal transcript presentation", () => {
     ]);
   });
 
+  it("retains an actionable web-search setup result after terminal hydration", () => {
+    const presented = presentChatTranscript({
+      messages: [],
+      tool_activity: [
+        {
+          tool: "web_search",
+          result: { tool: "web_search_provider_required" },
+          status: "failed",
+          started_at: "2026-07-27T12:00:00Z",
+          finished_at: "2026-07-27T12:00:01Z",
+        },
+      ],
+      last_event_seq: 4,
+    });
+
+    expect(presented.messages).toEqual([
+      expect.objectContaining({
+        role: "tool",
+        name: "web_search",
+        status: "failed",
+        result: { tool: "web_search_provider_required" },
+      }),
+    ]);
+  });
+
   it("replaces optimistic text with authoritative content and sources", async () => {
     const listChatMessages = vi.fn(async () => transcript);
     const presented = await loadCurrentTerminalTranscript(

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
@@ -41,6 +41,7 @@ export function presentChatTranscript(
             backgroundAgentRunId: entry.backgroundAgentRunId,
             status: entry.status,
             preview: entry.preview,
+            result: entry.result,
           } satisfies ChatMessage,
         ];
       }

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -6,6 +6,7 @@ import { ApprovalCard } from "./ApprovalCard";
 import { AppContextProvider, type AppContextValue } from "./AppContext";
 import type { ApiClient } from "./api";
 import { MessageBubble, MessageList, type ChatMessage } from "./MessageList";
+import { renderWithRouter } from "./test/router";
 
 const noop = () => undefined;
 
@@ -627,5 +628,48 @@ describe("mcp app views", () => {
     expect(
       await screen.findByTitle("MCP App view from gateway"),
     ).toBeInTheDocument();
+  });
+});
+
+describe("actionable tool results", () => {
+  it("takes an unconfigured web search directly to its settings section", async () => {
+    const user = userEvent.setup();
+    const { router } = await renderWithRouter(
+      <MessageList
+        messages={[
+          {
+            id: "web-search-1",
+            role: "tool",
+            callId: "call-1",
+            name: "web_search",
+            status: "failed",
+            result: { tool: "web_search_provider_required" },
+          },
+        ]}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Web search needs a provider" }),
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Configure web search" }),
+    );
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/settings/web-search");
+    });
   });
 });

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -31,6 +31,7 @@ import { UserQuestionsCard } from "./UserQuestionsCard";
 import type { TranscriptImageAttachment } from "./ImageAttachments";
 import { TranscriptImageAttachments } from "./TranscriptImageAttachments";
 import { BackgroundAgentList } from "./BackgroundAgentList";
+import { WebSearchProviderRequiredCard } from "./WebSearchProviderRequiredCard";
 import { useSourceNav } from "./panel/SourceNav";
 import { useStreamingTypewriter } from "./useStreamingTypewriter";
 import { Skeleton } from "./components/ui/skeleton";
@@ -522,6 +523,13 @@ function surfacedCards(
       continue;
     }
     if (entry.role !== "tool") continue;
+    if (
+      entry.result?.tool === "web_search_provider_required" &&
+      !parked.has(entry.callId)
+    ) {
+      cards.push(<WebSearchProviderRequiredCard key={entry.id} />);
+      continue;
+    }
     // An MCP App view is keyed on the *result*: the tool has no action
     // preview, and its card exists to show what the server's declared view
     // renders — inside the sandbox — not to restate arguments or output.

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -1,9 +1,10 @@
-import { parseToolActionPreview } from "./api";
+import { parseToolActionPreview, parseToolResultPreview } from "./api";
 import type {
   ChatMessage,
   ChatToolActivity,
   RendererRefusal,
   ToolActionPreview,
+  ToolResultPreview,
 } from "./api";
 import type { AssistantSource } from "./AssistantSources";
 import type { TranscriptImageAttachment } from "./ImageAttachments";
@@ -27,6 +28,7 @@ export type HydratedTranscriptEntry =
       /** Opaque child correlation for a historical sandbox spawn. */
       backgroundAgentRunId?: string;
       preview: ToolActionPreview | null;
+      result: ToolResultPreview | null;
       status: ToolCallStatus;
       createdAt: string;
     };
@@ -85,9 +87,10 @@ export function hydrateTranscriptHistory(
       name: activity.tool,
       backgroundAgentRunId: activity.background_agent_run_id,
       status: activity.status,
-      // History carries what the call did but not what it produced: results
-      // are not persisted, so a reloaded command card shows its command alone.
       preview: parseToolActionPreview(activity.action),
+      // Arbitrary result text stays server-side. A tool can retain only a
+      // closed renderer result such as an actionable configuration signal.
+      result: parseToolResultPreview(activity.result),
       createdAt: activity.started_at,
     })),
   ];

--- a/crates/openwave-desktop/ui/src/WebSearchProviderRequiredCard.tsx
+++ b/crates/openwave-desktop/ui/src/WebSearchProviderRequiredCard.tsx
@@ -1,0 +1,44 @@
+import { useId } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { Globe } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+/** An actionable, renderer-owned explanation of an unconfigured web search. */
+export function WebSearchProviderRequiredCard() {
+  const titleId = useId();
+  const navigate = useNavigate();
+  // Settings sections are registered from a runtime table, so TanStack's
+  // generated route union contains `/settings` but not each literal child.
+  const settingsPath: string = "/settings/web-search";
+
+  return (
+    <section
+      className="bg-background flex max-w-prose items-start gap-3 rounded-lg border p-4"
+      aria-labelledby={titleId}
+    >
+      <Globe
+        className="text-muted-foreground mt-0.5 size-5 shrink-0"
+        aria-hidden="true"
+      />
+      <div className="flex min-w-0 flex-1 flex-col items-start gap-3">
+        <div className="space-y-1">
+          <h2 id={titleId} className="text-sm font-medium">
+            Web search needs a provider
+          </h2>
+          <p className="text-muted-foreground text-sm">
+            Choose a web search provider and add its API key in Settings.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="primary"
+          size="sm"
+          onClick={() => void navigate({ to: settingsPath })}
+        >
+          Configure web search
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -772,7 +772,13 @@ describe("sandbox agent cancellation", () => {
   });
 });
 
-describe("parseToolResultPreview mcp_app references", () => {
+describe("parseToolResultPreview closed results", () => {
+  it("accepts only the closed web-search setup signal", () => {
+    expect(
+      parseToolResultPreview({ tool: "web_search_provider_required" }),
+    ).toEqual({ tool: "web_search_provider_required" });
+  });
+
   it("accepts a validated reference and remaps it to the app shape", () => {
     expect(
       parseToolResultPreview({

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -230,6 +230,10 @@ export type ToolResultPreview =
       stderr: string;
     }
   | {
+      /** Web search is available after the reader configures a provider. */
+      tool: "web_search_provider_required";
+    }
+  | {
       /** A reference to an MCP Apps view — never markup. The document is
        * fetched separately and rendered only inside the sandboxed frame. */
       tool: "mcp_app";
@@ -1371,6 +1375,9 @@ export function parseToolResultPreview(
 ): ToolResultPreview | null {
   if (value === undefined || value === null) return null;
   if (!isRecord(value)) return null;
+  if (value.tool === "web_search_provider_required") {
+    return { tool: "web_search_provider_required" };
+  }
   if (value.tool === "mcp_app") {
     const { server, resource_uri }: UncheckedMcpAppResult = value;
     if (

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -182,9 +182,9 @@ root_id: HostRootId,
 origin: RootAttachmentOrigin, };
 
 /**
- * A completed tool invocation with no results, tool identity, provider
- * metadata, executor identity, lease, or diagnostic detail. The only arguments
- * it can carry are the ones a tool explicitly projects for display.
+ * A completed tool invocation with no arbitrary result text, provider
+ * metadata, executor identity, lease, or diagnostic detail. The only action or
+ * result it can carry is one a tool explicitly projects through a closed type.
  */
 export type ChatToolActivitySnapshot = { 
 /**
@@ -205,7 +205,12 @@ tool: RendererToolName,
  * from the arguments it ran with, so history describes the same action
  * the live stream did.
  */
-action?: ToolActionPreview, background_agent_run_id?: AgentRunId, status: ChatToolActivityStatus, started_at: string, finished_at: string | null, };
+action?: ToolActionPreview, 
+/**
+ * Closed projection of an actionable result. Arbitrary result text is
+ * never included.
+ */
+result?: ToolResultPreview, background_agent_run_id?: AgentRunId, status: ChatToolActivityStatus, started_at: string, finished_at: string | null, };
 
 /**
  * Fixed lifecycle vocabulary exposed for a historical tool card.
@@ -695,7 +700,7 @@ timed_out: boolean,
 /**
  * Whether the provider dropped output past its capture limit.
  */
-output_truncated: boolean, stdout: string, stderr: string, } | { "tool": "mcp_app", 
+output_truncated: boolean, stdout: string, stderr: string, } | { "tool": "web_search_provider_required" } | { "tool": "mcp_app", 
 /**
  * The configured MCP server namespace that serves the view.
  */

--- a/crates/openwave-desktop/ui/src/test/router.tsx
+++ b/crates/openwave-desktop/ui/src/test/router.tsx
@@ -36,9 +36,23 @@ export async function renderWithRouter(
     path: "/",
     component: () => <>{ui}</>,
   });
+  const settingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/settings",
+    component: () => <>{ui}</>,
+  });
+  const webSearchSettingsRoute = createRoute({
+    getParentRoute: () => settingsRoute,
+    path: "web-search",
+    component: () => <>{ui}</>,
+  });
 
   const router = createRouter({
-    routeTree: rootRoute.addChildren([homeRoute, chatRoute]),
+    routeTree: rootRoute.addChildren([
+      homeRoute,
+      chatRoute,
+      settingsRoute.addChildren([webSearchSettingsRoute]),
+    ]),
     history: createMemoryHistory({ initialEntries: [initialUrl] }),
   });
 

--- a/crates/openwave-server/src/tests/conversations.rs
+++ b/crates/openwave-server/src/tests/conversations.rs
@@ -807,6 +807,48 @@ async fn transcript_tool_activity_is_allowlisted_and_redacts_canonical_tool_data
         openwave_core::ResolveToolCallOutcome::Resolved
     );
 
+    // A known, actionable failure may retain only its closed renderer signal.
+    // Its model-facing result and durable error code still stay server-side.
+    let configuration_call_id = CallId::new();
+    let configuration_private_result = "private host configuration detail";
+    store
+        .accept_tool_call(&ToolCallRecord {
+            id: configuration_call_id,
+            chat_id: chat.id,
+            turn_id: turn.id,
+            provider_id: "provider-web-search".into(),
+            name: openwave_core::WEB_SEARCH_TOOL.into(),
+            arguments: serde_json::json!({"query": "private web query"}),
+            execution: ToolCallExecution::Server,
+            status: ToolCallStatus::Pending,
+            result: None,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
+            created_at: started_at + chrono::Duration::milliseconds(4),
+            resolved_at: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .resolve_server_tool_call(
+                configuration_call_id,
+                &ToolCallResolution::Failed {
+                    result: configuration_private_result.into(),
+                    error_code: openwave_core::ToolErrorCategory::ConfigurationRequired
+                        .as_str()
+                        .into(),
+                    error_detail: None,
+                },
+                started_at + chrono::Duration::seconds(1),
+            )
+            .await
+            .unwrap(),
+        openwave_core::ResolveToolCallOutcome::Resolved
+    );
+
     // An approval-in-flight call must stay on the event journal. Including it
     // in this durable snapshot could race its corresponding live event.
     store
@@ -891,12 +933,13 @@ async fn transcript_tool_activity_is_allowlisted_and_redacts_canonical_tool_data
         "/private/ignored",
         "declined by the user",
         "pending secret query",
+        configuration_private_result,
+        "configuration_required",
         "private_error_code",
         "private diagnostic detail",
         call_id_text.as_str(),
         "mcp__private_server__read_sensitive_path",
         "arguments",
-        "result",
         "provider_id",
         "execution",
         "error_code",
@@ -911,7 +954,7 @@ async fn transcript_tool_activity_is_allowlisted_and_redacts_canonical_tool_data
     }
     let transcript: serde_json::Value = serde_json::from_str(&body).unwrap();
     let activity = transcript["tool_activity"].as_array().unwrap();
-    assert_eq!(activity.len(), 3);
+    assert_eq!(activity.len(), 4);
     assert!(activity.iter().any(|card| {
         card["tool"] == "other"
             && card["status"] == "failed"
@@ -927,6 +970,11 @@ async fn transcript_tool_activity_is_allowlisted_and_redacts_canonical_tool_data
                 == serde_json::json!(openwave_core::AgentRunId::sandbox_for_spawn_call(
                     spawn_call_id
                 ))
+    }));
+    assert!(activity.iter().any(|card| {
+        card["tool"] == "web_search"
+            && card["status"] == "failed"
+            && card["result"] == serde_json::json!({"tool": "web_search_provider_required"})
     }));
 }
 

--- a/crates/openwave-web-search/src/tool.rs
+++ b/crates/openwave-web-search/src/tool.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use openwave_core::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec, WebSearchArgs};
+use openwave_core::{
+    ApprovalClass, Tool, ToolCtx, ToolErrorCategory, ToolOutput, ToolSpec, WebSearchArgs,
+};
 use serde_json::Value;
 use thiserror::Error;
 
@@ -75,7 +77,8 @@ impl Tool for WebSearchTool {
         let provider = match self.resolver.resolve().await {
             Ok(Some(provider)) => provider,
             Ok(None) => {
-                return Ok(ToolOutput::error(
+                return Ok(ToolOutput::failed(
+                    ToolErrorCategory::ConfigurationRequired,
                     "Web search is not configured for this host.",
                 ))
             }
@@ -209,6 +212,10 @@ mod tests {
         assert_eq!(
             output.content,
             "Web search is not configured for this host."
+        );
+        assert_eq!(
+            output.error_category,
+            Some(ToolErrorCategory::ConfigurationRequired)
         );
     }
 


### PR DESCRIPTION
## Summary

- classify an unconfigured foreground web search as a typed configuration-required result
- preserve the closed setup signal across terminal transcript hydration without exposing arbitrary result text or diagnostics
- show an actionable desktop card that opens the Web search settings section

## Testing

- `cargo test -p openwave-web-search --locked`
- `cargo test -p openwave-core an_unconfigured_web_search_projects_only_a_typed_setup_signal --locked`
- `cargo test -p openwave-core a_reader_choice_is_not_recorded_as_a_product_failure --locked`
- `cargo test -p openwave-server transcript_tool_activity_is_allowlisted_and_redacts_canonical_tool_data --locked`
- `cargo test -p openwave-server wire_types::tests::the_generated_bindings_are_current --locked`
- `pnpm exec tsc --noEmit`
- `pnpm test` (535 tests)

Closes #738