### PR TITLE
fix(desktop): retire the brand yellow from the UI

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatExplorer.tsx
+++ b/crates/openwave-desktop/ui/src/ChatExplorer.tsx
@@ -91,7 +91,7 @@ export function ChatExplorer() {
                     <span className="min-w-0 truncate">{title}</span>
                     {chatIdsWithPendingPrompts.has(chat.id) && (
                       <span
-                        className="ml-auto shrink-0 text-amber-600 dark:text-amber-400"
+                        className="text-warning ml-auto shrink-0"
                         aria-label={`${title} needs attention`}
                         title="Needs attention"
                       >

--- a/crates/openwave-desktop/ui/src/WebSearchProviderRequiredCard.tsx
+++ b/crates/openwave-desktop/ui/src/WebSearchProviderRequiredCard.tsx
@@ -1,10 +1,17 @@
 import { useId } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { Globe } from "lucide-react";
 
+import { AttentionCard } from "./AttentionCard";
 import { Button } from "@/components/ui/button";
 
-/** An actionable, renderer-owned explanation of an unconfigured web search. */
+/**
+ * An actionable, renderer-owned explanation of an unconfigured web search.
+ *
+ * It wears the shared attention-card chrome, so a result that needs a decision
+ * reads the same as a consent prompt or a clarifying question. The tool group
+ * above already names and labels the search, so the card carries no icon of its
+ * own.
+ */
 export function WebSearchProviderRequiredCard() {
   const titleId = useId();
   const navigate = useNavigate();
@@ -13,32 +20,20 @@ export function WebSearchProviderRequiredCard() {
   const settingsPath: string = "/settings/web-search";
 
   return (
-    <section
-      className="bg-background flex max-w-prose items-start gap-3 rounded-lg border p-4"
-      aria-labelledby={titleId}
+    <AttentionCard
+      title="Web search needs a provider"
+      titleId={titleId}
+      subtitle="Choose a web search provider and add its API key in Settings."
     >
-      <Globe
-        className="text-muted-foreground mt-0.5 size-5 shrink-0"
-        aria-hidden="true"
-      />
-      <div className="flex min-w-0 flex-1 flex-col items-start gap-3">
-        <div className="space-y-1">
-          <h2 id={titleId} className="text-sm font-medium">
-            Web search needs a provider
-          </h2>
-          <p className="text-muted-foreground text-sm">
-            Choose a web search provider and add its API key in Settings.
-          </p>
-        </div>
+      <div className="flex flex-wrap gap-2">
         <Button
           type="button"
-          variant="primary"
           size="sm"
           onClick={() => void navigate({ to: settingsPath })}
         >
           Configure web search
         </Button>
       </div>
-    </section>
+    </AttentionCard>
   );
 }

--- a/crates/openwave-desktop/ui/src/components/ui/button.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/button.tsx
@@ -17,8 +17,6 @@ const buttonVariants = cva(
           "border border-border bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        primary:
-          "bg-openwave hover:bg-openwave/80 active:bg-openwave dark:text-black",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },

--- a/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
@@ -55,7 +55,7 @@ export function ChatSidebar({ chat }: { chat: Chat }) {
         <span>All chats</span>
         {elsewhereNeedsAttention && (
           <span
-            className="ml-auto shrink-0 text-amber-600 dark:text-amber-400"
+            className="text-warning ml-auto shrink-0"
             aria-label="Another chat needs attention"
             title="Another chat needs attention"
           >

--- a/crates/openwave-desktop/ui/src/sidebar/RecentChatRow.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/RecentChatRow.tsx
@@ -82,7 +82,7 @@ export function RecentChatRow({
       </button>
       {needsAttention && (
         <span
-          className="shrink-0 text-amber-600 dark:text-amber-400"
+          className="text-warning shrink-0"
           aria-label={`${title} needs attention`}
           title="Needs attention"
         >

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -38,9 +38,6 @@
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.984 0.003 247.858);
 
-  --color-openwave: oklch(0.87 0.2 102);
-  --color-openwave-light: oklch(0.966 0.155 102);
-
   /* Semantic status */
   --success: oklch(0.627 0.194 149.214);
   --success-foreground: oklch(0.393 0.095 152.535);
@@ -140,9 +137,6 @@
   --destructive: oklch(0.68 0.22 27.325);
   --destructive-foreground: oklch(0.95 0.005 247.858);
 
-  --color-openwave: oklch(0.87 0.2 102);
-  --color-openwave-light: oklch(0.68 0.14 102);
-
   /* Semantic status — dark */
   --success: oklch(0.792 0.209 151.711);
   --success-foreground: oklch(0.962 0.044 156.743);
@@ -176,9 +170,6 @@
 }
 
 @theme inline {
-  --color-openwave: var(--color-openwave);
-  --color-openwave-light: var(--color-openwave-light);
-
   --color-page-background: var(--page-background);
   --color-border: var(--border);
   --color-input: var(--input);
@@ -750,7 +741,7 @@ body {
 }
 
 .welcome-prompt:hover svg {
-  color: var(--color-openwave);
+  color: var(--ink);
 }
 
 @media (max-width: 720px) {
@@ -2088,9 +2079,9 @@ body {
   justify-content: space-between;
   gap: 1rem;
   padding: 0.75rem 0.9rem;
-  border: 1px solid color-mix(in srgb, var(--color-openwave) 48%, var(--line));
+  border: 1px solid var(--line);
   border-radius: 8px;
-  background: color-mix(in srgb, var(--color-openwave) 7%, var(--bg-elevated));
+  background: var(--bg-elevated);
   font-size: 0.84rem;
 }
 
@@ -2142,7 +2133,7 @@ body {
 }
 
 .document-search input:focus {
-  outline: 2px solid color-mix(in srgb, var(--color-openwave) 40%, transparent);
+  outline: 2px solid var(--ring);
   outline-offset: 1px;
 }
 
@@ -2245,7 +2236,7 @@ body {
 }
 
 .document-catalog-toolbar input:focus {
-  outline: 2px solid color-mix(in srgb, var(--color-openwave) 40%, transparent);
+  outline: 2px solid var(--ring);
   outline-offset: 1px;
 }
 
@@ -2319,7 +2310,7 @@ body {
 }
 
 .document-table tbody tr[aria-current="true"] {
-  background: color-mix(in srgb, var(--color-openwave) 6%, transparent);
+  background: var(--accent);
 }
 
 .document-title-button {
@@ -2411,7 +2402,7 @@ body {
 .document-action {
   border: 0;
   padding: 0.15rem 0.2rem;
-  color: var(--color-openwave);
+  color: var(--ink);
   background: transparent;
   font-size: 0.72rem;
   font-weight: 600;
@@ -2918,8 +2909,8 @@ body {
   justify-content: center;
   gap: 0.45rem;
   pointer-events: none;
-  border: 3px dashed color-mix(in srgb, var(--color-openwave) 72%, var(--line));
-  background: color-mix(in srgb, var(--color-openwave) 12%, transparent);
+  border: 3px dashed color-mix(in srgb, var(--ink) 40%, var(--line));
+  background: color-mix(in srgb, var(--ink) 8%, transparent);
   color: var(--ink);
   text-align: center;
 }


### PR DESCRIPTION
## Summary

The unconfigured-web-search card from #740 leads with a brand-yellow button and
is a hand-rolled panel rather than the shared attention-card shell #737
established. It now wears that shell, so it reads as the same kind of thing as
the approval, folder-consent, and clarifying-question cards it sits beside —
same border, spacing, `h3` title and muted subtitle. Its globe icon is gone: the
tool group directly above already names the search with one, and the second
copy pushed the title off the card's grid.

That action was the only consumer of the `primary` button variant, and so the
only consumer of `bg-openwave`. With the variant removed, the token's remaining
uses were all in the document views and the welcome prompts, where the yellow
was standing in for whatever the site actually meant:

| site | was | now |
| --- | --- | --- |
| `.welcome-prompt:hover svg` | yellow | `--ink` |
| `.document-notice` border + fill | yellow tint | `--line` / `--bg-elevated` |
| document search + catalog `input:focus` | yellow outline | `--ring` |
| `.document-table tr[aria-current]` | yellow tint | `--accent` |
| `.document-retry` / `.document-action` | yellow text | `--ink` |
| `.document-drop-target` | yellow dashed border + fill | neutral `--ink` mix |

`.document-error` and the drop target's reject state still override to danger, so
the two states that were red stay red. With no consumers left,
`--color-openwave` is retired, along with `--color-openwave-light`, which nothing
ever used.

Separately, the three "needs attention" indicators reached past the theme into
raw `text-amber-600 dark:text-amber-400`. They use the semantic `warning` token
now, which is what the indicator means and what light and dark are already tuned
for.

No tests added or removed: this is a token and chrome change, and the card's
existing behavioral test — heading present, button routes to
`/settings/web-search` — covers the rebuild without caring how it is painted.

## Testing

- `pnpm exec tsc --noEmit`
- `pnpm test` (535 tests)
- `pnpm build`

I did not drive the running app, so the rendered card is unverified visually.

Closes #746