### PR TITLE
feat(execution): add Daytona sandbox provider

### DIFF
--- a/crates/openwave-code-execution/Cargo.toml
+++ b/crates/openwave-code-execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openwave-code-execution"
-description = "OpenWave code execution: a bounded provider contract with local and E2B sandboxes."
+description = "OpenWave code execution: one bounded contract for local and managed sandboxes."
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/openwave-code-execution/src/credential.rs
+++ b/crates/openwave-code-execution/src/credential.rs
@@ -1,0 +1,57 @@
+use std::sync::Arc;
+
+use openwave_core::SecretProvider;
+use sha2::{Digest, Sha256};
+
+use crate::CodeExecutionError;
+
+/// Shared storage and redaction primitive for managed-provider credentials.
+#[derive(Clone)]
+pub(crate) struct SecretCredential(Arc<str>);
+
+impl std::fmt::Debug for SecretCredential {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_tuple("SecretCredential")
+            .field(&"***")
+            .finish()
+    }
+}
+
+impl SecretCredential {
+    pub(crate) fn parse(
+        provider: &str,
+        value: impl Into<String>,
+    ) -> Result<Self, CodeExecutionError> {
+        let value = value.into();
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(CodeExecutionError::InvalidRequest(format!(
+                "{provider} API key must not be empty"
+            )));
+        }
+        Ok(Self(Arc::from(trimmed)))
+    }
+
+    pub(crate) async fn load(
+        secrets: &dyn SecretProvider,
+        key: &str,
+        provider: &str,
+    ) -> Result<Option<Self>, CodeExecutionError> {
+        let value = secrets.get_secret(key).await.map_err(|_| {
+            CodeExecutionError::Unavailable(format!("{provider} credential storage is unavailable"))
+        })?;
+        value
+            .filter(|value| !value.trim().is_empty())
+            .map(|value| Self::parse(provider, value))
+            .transpose()
+    }
+
+    pub(crate) fn expose(&self) -> &str {
+        &self.0
+    }
+
+    pub(crate) fn fingerprint(&self) -> [u8; 32] {
+        Sha256::digest(self.0.as_bytes()).into()
+    }
+}

--- a/crates/openwave-code-execution/src/daytona.rs
+++ b/crates/openwave-code-execution/src/daytona.rs
@@ -1,0 +1,765 @@
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use openwave_core::SecretProvider;
+use reqwest::{Client, Response, StatusCode, Url};
+use serde::{Deserialize, Serialize};
+
+use crate::credential::SecretCredential;
+use crate::http::decode_bounded_json;
+use crate::output::{Capture, StreamKind};
+use crate::remote::{
+    execute_remote, RemoteSandboxAdapter, RemoteSession, RemoteSessionError, RemoteSessionPool,
+};
+use crate::{
+    CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest,
+    CodeExecutionResponse,
+};
+
+const DAYTONA_API_BASE: &str = "https://app.daytona.io/api";
+const DAYTONA_IDLE_MINUTES: u32 = 5;
+const DAYTONA_START_TIMEOUT: Duration = Duration::from_secs(60);
+const DAYTONA_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const DAYTONA_TRANSPORT_GRACE: Duration = Duration::from_secs(10);
+const MAX_DAYTONA_RESPONSE_BYTES: usize = 1024 * 1024;
+
+/// Fixed key for Daytona credentials in OpenWave's host secret store.
+pub const DAYTONA_CREDENTIAL_KEY: &str = "code_execution.daytona.api_key";
+
+/// Non-serializable, redacted Daytona API credential.
+#[derive(Clone)]
+pub struct DaytonaCredential(SecretCredential);
+
+impl std::fmt::Debug for DaytonaCredential {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_tuple("DaytonaCredential")
+            .field(&"***")
+            .finish()
+    }
+}
+
+impl DaytonaCredential {
+    pub fn parse(value: impl Into<String>) -> Result<Self, CodeExecutionError> {
+        SecretCredential::parse("Daytona", value).map(Self)
+    }
+
+    /// Resolve the credential without exposing it through serializable config.
+    pub async fn load(secrets: &dyn SecretProvider) -> Result<Option<Self>, CodeExecutionError> {
+        SecretCredential::load(secrets, DAYTONA_CREDENTIAL_KEY, "Daytona")
+            .await
+            .map(|credential| credential.map(Self))
+    }
+
+    fn as_str(&self) -> &str {
+        self.0.expose()
+    }
+
+    fn fingerprint(&self) -> [u8; 32] {
+        self.0.fingerprint()
+    }
+}
+
+/// Direct-command adapter for Daytona's managed sandbox service.
+pub struct DaytonaExecutionProvider {
+    credential: DaytonaCredential,
+    timeout: Duration,
+    pool: RemoteSessionPool,
+    client: Client,
+    endpoints: DaytonaEndpoints,
+}
+
+#[derive(Clone)]
+struct DaytonaEndpoints {
+    api_base: String,
+    allow_insecure_toolbox: bool,
+}
+
+impl Default for DaytonaEndpoints {
+    fn default() -> Self {
+        Self {
+            api_base: DAYTONA_API_BASE.into(),
+            allow_insecure_toolbox: false,
+        }
+    }
+}
+
+impl DaytonaExecutionProvider {
+    pub fn new(
+        credential: DaytonaCredential,
+        timeout: Duration,
+    ) -> Result<Self, CodeExecutionError> {
+        Self::with_session_pool(credential, timeout, RemoteSessionPool::default())
+    }
+
+    pub fn with_session_pool(
+        credential: DaytonaCredential,
+        timeout: Duration,
+        pool: RemoteSessionPool,
+    ) -> Result<Self, CodeExecutionError> {
+        Self::with_endpoints(credential, timeout, pool, DaytonaEndpoints::default())
+    }
+
+    fn with_endpoints(
+        credential: DaytonaCredential,
+        timeout: Duration,
+        pool: RemoteSessionPool,
+        endpoints: DaytonaEndpoints,
+    ) -> Result<Self, CodeExecutionError> {
+        if timeout.is_zero() {
+            return Err(CodeExecutionError::InvalidRequest(
+                "execution timeout must be positive".into(),
+            ));
+        }
+        let client = Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(timeout.saturating_add(DAYTONA_TRANSPORT_GRACE))
+            .build()
+            .map_err(|_| {
+                CodeExecutionError::Unavailable("could not configure Daytona transport".into())
+            })?;
+        Ok(Self {
+            credential,
+            timeout,
+            pool,
+            client,
+            endpoints,
+        })
+    }
+
+    async fn create_sandbox(
+        &self,
+        workspace_id: &str,
+    ) -> Result<RemoteSession, CodeExecutionError> {
+        let response = self
+            .client
+            .post(self.api_url("/sandbox"))
+            .bearer_auth(self.credential.as_str())
+            .json(&CreateSandboxRequest {
+                labels: HashMap::from([
+                    ("openwave_workspace_id", workspace_id),
+                    ("code-toolbox-language", "python"),
+                ]),
+                network_block_all: false,
+                auto_stop_interval: DAYTONA_IDLE_MINUTES,
+                // Delete once the idle stop happens. A later command creates a
+                // fresh chat workspace instead of leaving stopped resources.
+                auto_delete_interval: 0,
+            })
+            .send()
+            .await
+            .map_err(|_| CodeExecutionError::Unavailable("could not reach Daytona".into()))?;
+        let sandbox = self.decode_sandbox(response).await?;
+        self.wait_until_started(sandbox, true)
+            .await?
+            .ok_or_else(|| {
+                CodeExecutionError::Unavailable(
+                    "Daytona sandbox disappeared while it was starting".into(),
+                )
+            })
+    }
+
+    async fn reconnect_sandbox(
+        &self,
+        sandbox_id: &str,
+    ) -> Result<Option<RemoteSession>, CodeExecutionError> {
+        validate_sandbox_id(sandbox_id)?;
+        let response = self
+            .client
+            .get(self.api_url(&format!("/sandbox/{sandbox_id}")))
+            .bearer_auth(self.credential.as_str())
+            .send()
+            .await
+            .map_err(|_| CodeExecutionError::Unavailable("could not reach Daytona".into()))?;
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let sandbox = self.decode_sandbox(response).await?;
+        self.wait_until_started(sandbox, true).await
+    }
+
+    async fn wait_until_started(
+        &self,
+        mut sandbox: DaytonaSandbox,
+        start_if_stopped: bool,
+    ) -> Result<Option<RemoteSession>, CodeExecutionError> {
+        let deadline = Instant::now() + DAYTONA_START_TIMEOUT;
+        let mut requested_start = false;
+        loop {
+            match sandbox.state.as_deref() {
+                Some("started") => {
+                    return sandbox
+                        .into_session(self.endpoints.allow_insecure_toolbox)
+                        .map(Some);
+                }
+                Some("destroyed" | "destroying") => return Ok(None),
+                Some("error" | "build_failed") => {
+                    return Err(CodeExecutionError::Unavailable(
+                        "Daytona sandbox failed to start".into(),
+                    ));
+                }
+                Some("stopped" | "paused" | "archived") if start_if_stopped && !requested_start => {
+                    let response = self
+                        .client
+                        .post(self.api_url(&format!("/sandbox/{}/start", sandbox.id)))
+                        .bearer_auth(self.credential.as_str())
+                        .send()
+                        .await
+                        .map_err(|_| {
+                            CodeExecutionError::Unavailable("could not reach Daytona".into())
+                        })?;
+                    if response.status() == StatusCode::NOT_FOUND {
+                        return Ok(None);
+                    }
+                    sandbox = self.decode_sandbox(response).await?;
+                    requested_start = true;
+                    continue;
+                }
+                Some(
+                    "creating" | "restoring" | "starting" | "pending_build" | "building_snapshot"
+                    | "pulling_snapshot" | "resuming",
+                ) => {}
+                Some("stopped" | "paused" | "archived") => {
+                    return Err(CodeExecutionError::Unavailable(
+                        "Daytona sandbox did not start".into(),
+                    ));
+                }
+                _ => {
+                    return Err(CodeExecutionError::Unavailable(
+                        "Daytona returned an unknown sandbox state".into(),
+                    ));
+                }
+            }
+            if Instant::now() >= deadline {
+                return Err(CodeExecutionError::Unavailable(
+                    "Daytona sandbox did not start before its deadline".into(),
+                ));
+            }
+            tokio::time::sleep(DAYTONA_POLL_INTERVAL).await;
+            let response = self
+                .client
+                .get(self.api_url(&format!("/sandbox/{}", sandbox.id)))
+                .bearer_auth(self.credential.as_str())
+                .send()
+                .await
+                .map_err(|_| CodeExecutionError::Unavailable("could not reach Daytona".into()))?;
+            if response.status() == StatusCode::NOT_FOUND {
+                return Ok(None);
+            }
+            sandbox = self.decode_sandbox(response).await?;
+        }
+    }
+
+    async fn run_daytona_command(
+        &self,
+        session: &RemoteSession,
+        request: &CodeExecutionRequest,
+    ) -> Result<CodeExecutionResponse, RemoteSessionError> {
+        validate_sandbox_id(&session.sandbox_id)?;
+        let endpoint = session.endpoint.as_deref().ok_or_else(|| {
+            CodeExecutionError::Unavailable("Daytona toolbox endpoint is unavailable".into())
+        })?;
+        let url = toolbox_execute_url(
+            endpoint,
+            &session.sandbox_id,
+            self.endpoints.allow_insecure_toolbox,
+        )?;
+        let started = Instant::now();
+        let response = self
+            .client
+            .post(url)
+            .bearer_auth(self.credential.as_str())
+            .json(&ExecuteRequest {
+                command: direct_command(request),
+                cwd: &request.cwd,
+                timeout: timeout_seconds(self.timeout),
+            })
+            .send()
+            .await
+            .map_err(|_| CodeExecutionError::AmbiguousExecution)?;
+        if matches!(
+            response.status(),
+            StatusCode::NOT_FOUND | StatusCode::GONE | StatusCode::BAD_GATEWAY
+        ) {
+            return Err(RemoteSessionError::Missing);
+        }
+        if response.status() == StatusCode::REQUEST_TIMEOUT {
+            return Ok(Capture::default().response(
+                CodeExecutionProviderKind::Daytona,
+                started,
+                None,
+                true,
+            ));
+        }
+        if !response.status().is_success() {
+            let status = response.status();
+            let error = decode_bounded_json::<DaytonaErrorResponse>(
+                response,
+                "Daytona",
+                MAX_DAYTONA_RESPONSE_BYTES,
+            )
+            .await
+            .ok();
+            if error
+                .and_then(|body| body.code)
+                .is_some_and(|code| code == "PROCESS_EXECUTION_TIMEOUT")
+            {
+                return Ok(Capture::default().response(
+                    CodeExecutionProviderKind::Daytona,
+                    started,
+                    None,
+                    true,
+                ));
+            }
+            return Err(provider_status_error(status).into());
+        }
+        let body =
+            decode_bounded_json::<ExecuteResponse>(response, "Daytona", MAX_DAYTONA_RESPONSE_BYTES)
+                .await?;
+        let mut capture = Capture::default();
+        capture.append(body.result.as_bytes(), StreamKind::Stdout);
+        Ok(capture.response(
+            CodeExecutionProviderKind::Daytona,
+            started,
+            body.exit_code,
+            false,
+        ))
+    }
+
+    async fn decode_sandbox(
+        &self,
+        response: Response,
+    ) -> Result<DaytonaSandbox, CodeExecutionError> {
+        if !response.status().is_success() {
+            return Err(provider_status_error(response.status()));
+        }
+        let sandbox: DaytonaSandbox =
+            decode_bounded_json(response, "Daytona", MAX_DAYTONA_RESPONSE_BYTES).await?;
+        validate_sandbox_id(&sandbox.id)?;
+        Ok(sandbox)
+    }
+
+    fn api_url(&self, path: &str) -> String {
+        format!("{}{}", self.endpoints.api_base.trim_end_matches('/'), path)
+    }
+}
+
+#[async_trait]
+impl RemoteSandboxAdapter for DaytonaExecutionProvider {
+    fn kind(&self) -> CodeExecutionProviderKind {
+        CodeExecutionProviderKind::Daytona
+    }
+
+    fn credential_fingerprint(&self) -> [u8; 32] {
+        self.credential.fingerprint()
+    }
+
+    async fn create_session(
+        &self,
+        workspace_id: &str,
+    ) -> Result<RemoteSession, CodeExecutionError> {
+        self.create_sandbox(workspace_id).await
+    }
+
+    async fn reconnect_session(
+        &self,
+        session: &RemoteSession,
+    ) -> Result<Option<RemoteSession>, CodeExecutionError> {
+        self.reconnect_sandbox(&session.sandbox_id).await
+    }
+
+    async fn run_command(
+        &self,
+        session: &RemoteSession,
+        request: &CodeExecutionRequest,
+    ) -> Result<CodeExecutionResponse, RemoteSessionError> {
+        self.run_daytona_command(session, request).await
+    }
+}
+
+#[async_trait]
+impl CodeExecutionProvider for DaytonaExecutionProvider {
+    async fn execute(
+        &self,
+        request: CodeExecutionRequest,
+    ) -> Result<CodeExecutionResponse, CodeExecutionError> {
+        execute_remote(self, &self.pool, request).await
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateSandboxRequest<'a> {
+    labels: HashMap<&'static str, &'a str>,
+    network_block_all: bool,
+    auto_stop_interval: u32,
+    auto_delete_interval: u32,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DaytonaSandbox {
+    id: String,
+    state: Option<String>,
+    toolbox_proxy_url: String,
+}
+
+impl DaytonaSandbox {
+    fn into_session(self, allow_insecure: bool) -> Result<RemoteSession, CodeExecutionError> {
+        validate_toolbox_base(&self.toolbox_proxy_url, allow_insecure)?;
+        Ok(RemoteSession {
+            sandbox_id: self.id,
+            endpoint: Some(self.toolbox_proxy_url),
+            access_token: None,
+        })
+    }
+}
+
+#[derive(Serialize)]
+struct ExecuteRequest<'a> {
+    command: String,
+    cwd: &'a str,
+    timeout: u32,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExecuteResponse {
+    exit_code: Option<i32>,
+    result: String,
+}
+
+#[derive(Deserialize)]
+struct DaytonaErrorResponse {
+    code: Option<String>,
+}
+
+/// Preserve the provider-neutral direct argv contract over Daytona's shell-text
+/// transport. Quoting every element keeps metacharacters as argument data; the
+/// shell is only the protocol bridge and is replaced by the requested process.
+fn direct_command(request: &CodeExecutionRequest) -> String {
+    std::iter::once(request.command.as_str())
+        .chain(request.arguments.iter().map(String::as_str))
+        .map(shell_quote)
+        .fold(String::from("exec"), |mut command, argument| {
+            command.push(' ');
+            command.push_str(&argument);
+            command
+        })
+}
+
+fn shell_quote(value: &str) -> String {
+    let mut quoted = String::with_capacity(value.len() + 2);
+    quoted.push('\'');
+    for (index, part) in value.split('\'').enumerate() {
+        if index > 0 {
+            quoted.push_str("'\"'\"'");
+        }
+        quoted.push_str(part);
+    }
+    quoted.push('\'');
+    quoted
+}
+
+fn timeout_seconds(timeout: Duration) -> u32 {
+    u32::try_from(timeout.as_millis().saturating_add(999) / 1_000)
+        .unwrap_or(u32::MAX)
+        .max(1)
+}
+
+fn toolbox_execute_url(
+    endpoint: &str,
+    sandbox_id: &str,
+    allow_insecure: bool,
+) -> Result<Url, CodeExecutionError> {
+    validate_sandbox_id(sandbox_id)?;
+    let mut url = validate_toolbox_base(endpoint, allow_insecure)?;
+    let path = format!(
+        "{}/{sandbox_id}/process/execute",
+        url.path().trim_end_matches('/')
+    );
+    url.set_path(&path);
+    Ok(url)
+}
+
+fn validate_toolbox_base(endpoint: &str, allow_insecure: bool) -> Result<Url, CodeExecutionError> {
+    let url = Url::parse(endpoint).map_err(|_| {
+        CodeExecutionError::Unavailable("Daytona returned an invalid toolbox endpoint".into())
+    })?;
+    let host = url.host_str().unwrap_or_default();
+    let cloud_endpoint =
+        url.scheme() == "https" && (host == "daytona.io" || host.ends_with(".daytona.io"));
+    let test_endpoint = allow_insecure
+        && url.scheme() == "http"
+        && matches!(host, "127.0.0.1" | "localhost" | "::1");
+    if (!cloud_endpoint && !test_endpoint)
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(CodeExecutionError::Unavailable(
+            "Daytona returned an invalid toolbox endpoint".into(),
+        ));
+    }
+    Ok(url)
+}
+
+fn validate_sandbox_id(value: &str) -> Result<(), CodeExecutionError> {
+    if value.is_empty()
+        || value.len() > 128
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(CodeExecutionError::Unavailable(
+            "Daytona returned an invalid sandbox identity".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn provider_status_error(status: StatusCode) -> CodeExecutionError {
+    match status {
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+            CodeExecutionError::Unavailable("Daytona credential was rejected".into())
+        }
+        StatusCode::TOO_MANY_REQUESTS => {
+            CodeExecutionError::Unavailable("Daytona rate limit exceeded".into())
+        }
+        _ => CodeExecutionError::Unavailable(format!(
+            "Daytona request failed with status {}",
+            status.as_u16()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex, OnceLock};
+
+    use axum::extract::{Path, State};
+    use axum::http::{HeaderMap, StatusCode};
+    use axum::routing::{get, post};
+    use axum::{Json, Router};
+    use serde_json::{json, Value};
+
+    use super::*;
+    use crate::{ExecutionId, ExecutionWorkspaceId};
+
+    #[derive(Clone, Default)]
+    struct MockState {
+        base: Arc<OnceLock<String>>,
+        requests: Arc<Mutex<Vec<(String, HeaderMap, Value)>>>,
+    }
+
+    async fn spawn_mock() -> (String, MockState, tokio::task::JoinHandle<()>) {
+        let state = MockState::default();
+        let app = Router::new()
+            .route("/api/sandbox", post(create_sandbox))
+            .route("/api/sandbox/{id}", get(get_sandbox))
+            .route("/toolbox/{id}/process/execute", post(execute))
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        state
+            .base
+            .set(format!("http://{address}"))
+            .expect("mock base is set once");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{address}"), state, server)
+    }
+
+    async fn create_sandbox(
+        State(state): State<MockState>,
+        headers: HeaderMap,
+        Json(body): Json<Value>,
+    ) -> Json<Value> {
+        state
+            .requests
+            .lock()
+            .unwrap()
+            .push(("create".into(), headers, body));
+        Json(json!({
+            "id": "sandbox-123",
+            "state": "started",
+            "toolboxProxyUrl": format!("{}/toolbox", state.base.get().unwrap()),
+        }))
+    }
+
+    async fn get_sandbox(
+        State(state): State<MockState>,
+        Path(id): Path<String>,
+        headers: HeaderMap,
+    ) -> Json<Value> {
+        state
+            .requests
+            .lock()
+            .unwrap()
+            .push(("get".into(), headers, json!({"id": id})));
+        Json(json!({
+            "id": "sandbox-123",
+            "state": "started",
+            "toolboxProxyUrl": format!("{}/toolbox", state.base.get().unwrap()),
+        }))
+    }
+
+    async fn execute(
+        State(state): State<MockState>,
+        Path(id): Path<String>,
+        headers: HeaderMap,
+        Json(body): Json<Value>,
+    ) -> (StatusCode, Json<Value>) {
+        let timed_out = body["command"] == "exec 'slow'";
+        state.requests.lock().unwrap().push((
+            "execute".into(),
+            headers,
+            json!({"id": id, "request": body}),
+        ));
+        if timed_out {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "code": "PROCESS_EXECUTION_TIMEOUT",
+                    "message": "command exceeded its timeout",
+                })),
+            )
+        } else {
+            (
+                StatusCode::OK,
+                Json(json!({"exitCode": 0, "result": "ok\n"})),
+            )
+        }
+    }
+
+    fn request(execution_id: &str) -> CodeExecutionRequest {
+        CodeExecutionRequest::new(
+            ExecutionId::parse(execution_id).unwrap(),
+            ExecutionWorkspaceId::parse("chat-123").unwrap(),
+            "printf",
+            vec![
+                "%s".into(),
+                "a; touch /tmp/not-openwave".into(),
+                "single'quote".into(),
+            ],
+            ".",
+        )
+        .unwrap()
+    }
+
+    fn timeout_request() -> CodeExecutionRequest {
+        CodeExecutionRequest::new(
+            ExecutionId::parse("call-timeout").unwrap(),
+            ExecutionWorkspaceId::parse("chat-timeout").unwrap(),
+            "slow",
+            Vec::new(),
+            ".",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn direct_argv_is_quoted_before_crossing_daytonas_shell_api() {
+        assert_eq!(
+            direct_command(&request("call-123")),
+            "exec 'printf' '%s' 'a; touch /tmp/not-openwave' 'single'\"'\"'quote'"
+        );
+    }
+
+    #[tokio::test]
+    async fn daytona_reuses_the_chat_sandbox_and_replays_an_exact_execution() {
+        let (base, state, server) = spawn_mock().await;
+        let provider = DaytonaExecutionProvider::with_endpoints(
+            DaytonaCredential::parse("test-daytona-key").unwrap(),
+            Duration::from_secs(5),
+            RemoteSessionPool::default(),
+            DaytonaEndpoints {
+                api_base: format!("{base}/api"),
+                allow_insecure_toolbox: true,
+            },
+        )
+        .unwrap();
+
+        let first = provider.execute(request("call-123")).await.unwrap();
+        let second = provider.execute(request("call-456")).await.unwrap();
+        let replay = provider.execute(request("call-456")).await.unwrap();
+        assert_eq!(first.provider, CodeExecutionProviderKind::Daytona);
+        assert_eq!(first.stdout, "ok\n");
+        assert_eq!(second, replay);
+
+        let requests = state.requests.lock().unwrap();
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|(path, _, _)| path == "create")
+                .count(),
+            1
+        );
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|(path, _, _)| path == "execute")
+                .count(),
+            2
+        );
+        assert_eq!(
+            requests.iter().filter(|(path, _, _)| path == "get").count(),
+            1
+        );
+        for (_, headers, _) in requests
+            .iter()
+            .filter(|(path, _, _)| matches!(path.as_str(), "create" | "get" | "execute"))
+        {
+            assert_eq!(
+                headers
+                    .get("authorization")
+                    .and_then(|value| value.to_str().ok()),
+                Some("Bearer test-daytona-key")
+            );
+        }
+        let create_body = requests
+            .iter()
+            .find(|(path, _, _)| path == "create")
+            .map(|(_, _, body)| body)
+            .unwrap();
+        assert_eq!(create_body["networkBlockAll"], false);
+        assert_eq!(create_body["autoStopInterval"], DAYTONA_IDLE_MINUTES);
+        assert_eq!(create_body["autoDeleteInterval"], 0);
+        assert_eq!(create_body["labels"]["openwave_workspace_id"], "chat-123");
+        let execute_body = requests
+            .iter()
+            .find(|(path, _, _)| path == "execute")
+            .map(|(_, _, body)| &body["request"])
+            .unwrap();
+        assert_eq!(
+            execute_body["command"],
+            "exec 'printf' '%s' 'a; touch /tmp/not-openwave' 'single'\"'\"'quote'"
+        );
+        assert_eq!(execute_body["cwd"], ".");
+        assert_eq!(execute_body["timeout"], 5);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn daytona_normalizes_the_toolbox_timeout_error() {
+        let (base, _state, server) = spawn_mock().await;
+        let provider = DaytonaExecutionProvider::with_endpoints(
+            DaytonaCredential::parse("test-daytona-key").unwrap(),
+            Duration::from_secs(5),
+            RemoteSessionPool::default(),
+            DaytonaEndpoints {
+                api_base: format!("{base}/api"),
+                allow_insecure_toolbox: true,
+            },
+        )
+        .unwrap();
+
+        let response = provider.execute(timeout_request()).await.unwrap();
+        assert!(response.timed_out);
+        assert_eq!(response.exit_code, None);
+        server.abort();
+    }
+}

--- a/crates/openwave-code-execution/src/e2b.rs
+++ b/crates/openwave-code-execution/src/e2b.rs
@@ -1,20 +1,22 @@
 use std::collections::HashMap;
 use std::path::{Component, Path};
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use base64::Engine as _;
 use futures::StreamExt as _;
 use openwave_core::SecretProvider;
 use reqwest::{Client, Response, StatusCode};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use sha2::{Digest, Sha256};
-use tokio::sync::Mutex;
+use serde::{Deserialize, Serialize};
 
+use crate::credential::SecretCredential;
+use crate::http::decode_bounded_json;
+use crate::output::{Capture, StreamKind};
+use crate::remote::{
+    execute_remote, RemoteSandboxAdapter, RemoteSession, RemoteSessionError, RemoteSessionPool,
+};
 use crate::{
     CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest,
-    CodeExecutionResponse, MAX_CAPTURE_BYTES,
+    CodeExecutionResponse,
 };
 
 const E2B_API_BASE: &str = "https://api.e2b.app";
@@ -34,7 +36,7 @@ pub const E2B_CREDENTIAL_KEY: &str = "code_execution.e2b.api_key";
 
 /// Non-serializable, redacted E2B API credential.
 #[derive(Clone)]
-pub struct E2BCredential(String);
+pub struct E2BCredential(SecretCredential);
 
 impl std::fmt::Debug for E2BCredential {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -47,160 +49,22 @@ impl std::fmt::Debug for E2BCredential {
 
 impl E2BCredential {
     pub fn parse(value: impl Into<String>) -> Result<Self, CodeExecutionError> {
-        let value = value.into();
-        let trimmed = value.trim();
-        if trimmed.is_empty() {
-            return Err(CodeExecutionError::InvalidRequest(
-                "E2B API key must not be empty".into(),
-            ));
-        }
-        Ok(Self(trimmed.to_owned()))
+        SecretCredential::parse("E2B", value).map(Self)
     }
 
     /// Resolve the credential without exposing it through serializable config.
     pub async fn load(secrets: &dyn SecretProvider) -> Result<Option<Self>, CodeExecutionError> {
-        let value = secrets.get_secret(E2B_CREDENTIAL_KEY).await.map_err(|_| {
-            CodeExecutionError::Unavailable("E2B credential storage is unavailable".into())
-        })?;
-        value
-            .filter(|value| !value.trim().is_empty())
-            .map(Self::parse)
-            .transpose()
+        SecretCredential::load(secrets, E2B_CREDENTIAL_KEY, "E2B")
+            .await
+            .map(|credential| credential.map(Self))
     }
 
     fn as_str(&self) -> &str {
-        &self.0
+        self.0.expose()
     }
 
     fn fingerprint(&self) -> [u8; 32] {
-        Sha256::digest(self.0.as_bytes()).into()
-    }
-}
-
-/// Shared process-local E2B sessions and idempotency receipts.
-///
-/// A configured host keeps one pool for its lifetime, while individual adapter
-/// values can still be rebuilt when timeout policy or credentials change.
-#[derive(Clone, Default)]
-pub struct E2BSessionPool {
-    state: Arc<Mutex<PoolState>>,
-}
-
-#[derive(Default)]
-struct PoolState {
-    sessions: HashMap<SessionKey, Arc<Mutex<Option<E2BSession>>>>,
-    receipts: HashMap<String, ExecutionReceipt>,
-}
-
-#[derive(Clone, PartialEq, Eq, Hash)]
-struct SessionKey {
-    credential: [u8; 32],
-    workspace_id: String,
-}
-
-#[derive(Clone)]
-struct E2BSession {
-    sandbox_id: String,
-    access_token: String,
-}
-
-#[derive(Clone)]
-enum ExecutionReceipt {
-    Running {
-        fingerprint: String,
-    },
-    Completed {
-        fingerprint: String,
-        response: CodeExecutionResponse,
-    },
-    Failed {
-        fingerprint: String,
-        message: String,
-    },
-}
-
-enum BeginExecution {
-    Started,
-    Cached(CodeExecutionResponse),
-}
-
-impl E2BSessionPool {
-    async fn begin_execution(
-        &self,
-        request: &CodeExecutionRequest,
-    ) -> Result<BeginExecution, CodeExecutionError> {
-        let fingerprint = request_fingerprint(request)?;
-        let mut state = self.state.lock().await;
-        match state.receipts.get(request.execution_id.as_str()) {
-            None => {
-                state.receipts.insert(
-                    request.execution_id.as_str().to_owned(),
-                    ExecutionReceipt::Running { fingerprint },
-                );
-                Ok(BeginExecution::Started)
-            }
-            Some(ExecutionReceipt::Running {
-                fingerprint: existing,
-            }) => {
-                ensure_same_fingerprint(existing, &fingerprint)?;
-                Err(CodeExecutionError::AmbiguousExecution)
-            }
-            Some(ExecutionReceipt::Completed {
-                fingerprint: existing,
-                response,
-            }) => {
-                ensure_same_fingerprint(existing, &fingerprint)?;
-                Ok(BeginExecution::Cached(response.clone()))
-            }
-            Some(ExecutionReceipt::Failed {
-                fingerprint: existing,
-                message,
-            }) => {
-                ensure_same_fingerprint(existing, &fingerprint)?;
-                Err(CodeExecutionError::Unavailable(message.clone()))
-            }
-        }
-    }
-
-    async fn finish_execution(
-        &self,
-        request: &CodeExecutionRequest,
-        outcome: &Result<CodeExecutionResponse, CodeExecutionError>,
-    ) -> Result<(), CodeExecutionError> {
-        let fingerprint = request_fingerprint(request)?;
-        let receipt = match outcome {
-            Ok(response) => ExecutionReceipt::Completed {
-                fingerprint,
-                response: response.clone(),
-            },
-            Err(error) => ExecutionReceipt::Failed {
-                fingerprint,
-                message: error.to_string(),
-            },
-        };
-        self.state
-            .lock()
-            .await
-            .receipts
-            .insert(request.execution_id.as_str().to_owned(), receipt);
-        Ok(())
-    }
-
-    async fn session(
-        &self,
-        credential: &E2BCredential,
-        workspace_id: &str,
-    ) -> Arc<Mutex<Option<E2BSession>>> {
-        let key = SessionKey {
-            credential: credential.fingerprint(),
-            workspace_id: workspace_id.to_owned(),
-        };
-        let mut state = self.state.lock().await;
-        state
-            .sessions
-            .entry(key)
-            .or_insert_with(|| Arc::new(Mutex::new(None)))
-            .clone()
+        self.0.fingerprint()
     }
 }
 
@@ -208,7 +72,7 @@ impl E2BSessionPool {
 pub struct E2BExecutionProvider {
     credential: E2BCredential,
     timeout: Duration,
-    pool: E2BSessionPool,
+    pool: RemoteSessionPool,
     client: Client,
     endpoints: E2BEndpoints,
 }
@@ -230,13 +94,13 @@ impl Default for E2BEndpoints {
 
 impl E2BExecutionProvider {
     pub fn new(credential: E2BCredential, timeout: Duration) -> Result<Self, CodeExecutionError> {
-        Self::with_session_pool(credential, timeout, E2BSessionPool::default())
+        Self::with_session_pool(credential, timeout, RemoteSessionPool::default())
     }
 
     pub fn with_session_pool(
         credential: E2BCredential,
         timeout: Duration,
-        pool: E2BSessionPool,
+        pool: RemoteSessionPool,
     ) -> Result<Self, CodeExecutionError> {
         Self::with_endpoints(credential, timeout, pool, E2BEndpoints::default())
     }
@@ -244,7 +108,7 @@ impl E2BExecutionProvider {
     fn with_endpoints(
         credential: E2BCredential,
         timeout: Duration,
-        pool: E2BSessionPool,
+        pool: RemoteSessionPool,
         endpoints: E2BEndpoints,
     ) -> Result<Self, CodeExecutionError> {
         if timeout.is_zero() {
@@ -271,41 +135,10 @@ impl E2BExecutionProvider {
         })
     }
 
-    async fn execute_uncached(
+    async fn create_sandbox(
         &self,
-        request: &CodeExecutionRequest,
-    ) -> Result<CodeExecutionResponse, CodeExecutionError> {
-        let session = self
-            .pool
-            .session(&self.credential, request.workspace_id.as_str())
-            .await;
-        // Commands for one chat are serialized so workspace mutations have a
-        // deterministic order and session replacement cannot race execution.
-        let mut session = session.lock().await;
-        let active = match session.as_ref() {
-            Some(existing) => match self.connect_sandbox(&existing.sandbox_id).await {
-                Ok(connected) => connected,
-                Err(ManagementError::NotFound) => {
-                    self.create_sandbox(request.workspace_id.as_str()).await?
-                }
-                Err(ManagementError::Provider(error)) => return Err(error),
-            },
-            None => self.create_sandbox(request.workspace_id.as_str()).await?,
-        };
-        *session = Some(active.clone());
-
-        let result = self.run_command(&active, request).await;
-        if matches!(
-            result,
-            Err(CodeExecutionError::Unavailable(ref message))
-                if message == "E2B sandbox is no longer available"
-        ) {
-            *session = None;
-        }
-        result
-    }
-
-    async fn create_sandbox(&self, workspace_id: &str) -> Result<E2BSession, CodeExecutionError> {
+        workspace_id: &str,
+    ) -> Result<RemoteSession, CodeExecutionError> {
         let url = format!(
             "{}/sandboxes",
             self.endpoints.api_base.trim_end_matches('/')
@@ -327,8 +160,11 @@ impl E2BExecutionProvider {
         decode_session(response).await
     }
 
-    async fn connect_sandbox(&self, sandbox_id: &str) -> Result<E2BSession, ManagementError> {
-        validate_sandbox_id(sandbox_id).map_err(ManagementError::Provider)?;
+    async fn connect_sandbox(
+        &self,
+        sandbox_id: &str,
+    ) -> Result<Option<RemoteSession>, CodeExecutionError> {
+        validate_sandbox_id(sandbox_id)?;
         let url = format!(
             "{}/sandboxes/{sandbox_id}/connect",
             self.endpoints.api_base.trim_end_matches('/')
@@ -342,25 +178,22 @@ impl E2BExecutionProvider {
             })
             .send()
             .await
-            .map_err(|_| {
-                ManagementError::Provider(CodeExecutionError::Unavailable(
-                    "could not reach the E2B API".into(),
-                ))
-            })?;
+            .map_err(|_| CodeExecutionError::Unavailable("could not reach the E2B API".into()))?;
         if response.status() == StatusCode::NOT_FOUND {
-            return Err(ManagementError::NotFound);
+            return Ok(None);
         }
-        decode_session(response)
-            .await
-            .map_err(ManagementError::Provider)
+        decode_session(response).await.map(Some)
     }
 
-    async fn run_command(
+    async fn run_e2b_command(
         &self,
-        session: &E2BSession,
+        session: &RemoteSession,
         request: &CodeExecutionRequest,
-    ) -> Result<CodeExecutionResponse, CodeExecutionError> {
+    ) -> Result<CodeExecutionResponse, RemoteSessionError> {
         validate_sandbox_id(&session.sandbox_id)?;
+        let access_token = session.access_token.as_deref().ok_or_else(|| {
+            CodeExecutionError::Unavailable("E2B sandbox token is unavailable".into())
+        })?;
         let started = Instant::now();
         let request_json = serde_json::to_vec(&StartRequest {
             process: ProcessConfig {
@@ -388,7 +221,7 @@ impl E2BExecutionProvider {
             .header("Connect-Timeout-Ms", timeout_ms)
             .header("E2b-Sandbox-Id", &session.sandbox_id)
             .header("E2b-Sandbox-Port", E2B_ENVD_PORT)
-            .header("X-Access-Token", &session.access_token)
+            .header("X-Access-Token", access_token)
             .body(body)
             .send()
             .await
@@ -396,15 +229,48 @@ impl E2BExecutionProvider {
         if response.status() == StatusCode::NOT_FOUND
             || response.status() == StatusCode::BAD_GATEWAY
         {
-            return Err(CodeExecutionError::Unavailable(
-                "E2B sandbox is no longer available".into(),
-            ));
+            return Err(RemoteSessionError::Missing);
         }
         if !response.status().is_success() {
-            return Err(provider_status_error(response.status()));
+            return Err(provider_status_error(response.status()).into());
         }
 
-        decode_command_response(response, started).await
+        decode_command_response(response, started)
+            .await
+            .map_err(RemoteSessionError::Provider)
+    }
+}
+
+#[async_trait]
+impl RemoteSandboxAdapter for E2BExecutionProvider {
+    fn kind(&self) -> CodeExecutionProviderKind {
+        CodeExecutionProviderKind::E2b
+    }
+
+    fn credential_fingerprint(&self) -> [u8; 32] {
+        self.credential.fingerprint()
+    }
+
+    async fn create_session(
+        &self,
+        workspace_id: &str,
+    ) -> Result<RemoteSession, CodeExecutionError> {
+        self.create_sandbox(workspace_id).await
+    }
+
+    async fn reconnect_session(
+        &self,
+        session: &RemoteSession,
+    ) -> Result<Option<RemoteSession>, CodeExecutionError> {
+        self.connect_sandbox(&session.sandbox_id).await
+    }
+
+    async fn run_command(
+        &self,
+        session: &RemoteSession,
+        request: &CodeExecutionRequest,
+    ) -> Result<CodeExecutionResponse, RemoteSessionError> {
+        self.run_e2b_command(session, request).await
     }
 }
 
@@ -414,20 +280,8 @@ impl CodeExecutionProvider for E2BExecutionProvider {
         &self,
         request: CodeExecutionRequest,
     ) -> Result<CodeExecutionResponse, CodeExecutionError> {
-        request.validate()?;
-        match self.pool.begin_execution(&request).await? {
-            BeginExecution::Cached(response) => return Ok(response),
-            BeginExecution::Started => {}
-        }
-        let outcome = self.execute_uncached(&request).await;
-        self.pool.finish_execution(&request, &outcome).await?;
-        outcome
+        execute_remote(self, &self.pool, request).await
     }
-}
-
-enum ManagementError {
-    NotFound,
-    Provider(CodeExecutionError),
 }
 
 #[derive(Serialize)]
@@ -453,11 +307,13 @@ struct SandboxResponse {
     access_token: Option<String>,
 }
 
-async fn decode_session(response: Response) -> Result<E2BSession, CodeExecutionError> {
+async fn decode_session(response: Response) -> Result<RemoteSession, CodeExecutionError> {
     if !response.status().is_success() {
         return Err(provider_status_error(response.status()));
     }
-    let body = decode_bounded_json::<SandboxResponse>(response).await?;
+    let body =
+        decode_bounded_json::<SandboxResponse>(response, "E2B", MAX_MANAGEMENT_RESPONSE_BYTES)
+            .await?;
     validate_sandbox_id(&body.sandbox_id)?;
     let access_token = body
         .access_token
@@ -465,30 +321,11 @@ async fn decode_session(response: Response) -> Result<E2BSession, CodeExecutionE
         .ok_or_else(|| {
             CodeExecutionError::Unavailable("E2B did not return a secure sandbox token".into())
         })?;
-    Ok(E2BSession {
+    Ok(RemoteSession {
         sandbox_id: body.sandbox_id,
-        access_token,
+        endpoint: None,
+        access_token: Some(access_token),
     })
-}
-
-async fn decode_bounded_json<T: DeserializeOwned>(
-    response: Response,
-) -> Result<T, CodeExecutionError> {
-    let mut bytes = Vec::new();
-    let mut stream = response.bytes_stream();
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|_| {
-            CodeExecutionError::Unavailable("E2B returned an incomplete response".into())
-        })?;
-        if bytes.len().saturating_add(chunk.len()) > MAX_MANAGEMENT_RESPONSE_BYTES {
-            return Err(CodeExecutionError::Unavailable(
-                "E2B returned an oversized response".into(),
-            ));
-        }
-        bytes.extend_from_slice(&chunk);
-    }
-    serde_json::from_slice(&bytes)
-        .map_err(|_| CodeExecutionError::Unavailable("E2B returned an invalid response".into()))
 }
 
 fn provider_status_error(status: StatusCode) -> CodeExecutionError {
@@ -622,10 +459,10 @@ async fn decode_command_response(
             };
             if let Some(data) = event.data {
                 if let Some(stdout) = data.stdout {
-                    capture.append_base64(&stdout, StreamKind::Stdout)?;
+                    capture.append_base64(&stdout, StreamKind::Stdout, "E2B")?;
                 }
                 if let Some(stderr) = data.stderr {
-                    capture.append_base64(&stderr, StreamKind::Stderr)?;
+                    capture.append_base64(&stderr, StreamKind::Stderr, "E2B")?;
                 }
             }
             if let Some(end) = event.end {
@@ -656,15 +493,12 @@ fn command_response(
     exit_code: Option<i32>,
     timed_out: bool,
 ) -> CodeExecutionResponse {
-    CodeExecutionResponse {
-        provider: CodeExecutionProviderKind::E2b,
+    capture.response(
+        CodeExecutionProviderKind::E2b,
+        started,
         exit_code,
-        stdout: String::from_utf8_lossy(&capture.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&capture.stderr).into_owned(),
         timed_out,
-        output_truncated: capture.truncated,
-        duration_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
-    }
+    )
 }
 
 #[derive(Default)]
@@ -770,69 +604,17 @@ struct ConnectStreamError {
     code: String,
 }
 
-#[derive(Clone, Copy)]
-enum StreamKind {
-    Stdout,
-    Stderr,
-}
-
-#[derive(Default)]
-struct Capture {
-    stdout: Vec<u8>,
-    stderr: Vec<u8>,
-    total: usize,
-    truncated: bool,
-}
-
-impl Capture {
-    fn append_base64(&mut self, value: &str, kind: StreamKind) -> Result<(), CodeExecutionError> {
-        let decoded = base64::engine::general_purpose::STANDARD
-            .decode(value)
-            .map_err(|_| {
-                CodeExecutionError::Unavailable("E2B returned invalid command output".into())
-            })?;
-        self.append(&decoded, kind);
-        Ok(())
-    }
-
-    fn append(&mut self, value: &[u8], kind: StreamKind) {
-        let available = MAX_CAPTURE_BYTES.saturating_sub(self.total);
-        let kept = available.min(value.len());
-        let target = match kind {
-            StreamKind::Stdout => &mut self.stdout,
-            StreamKind::Stderr => &mut self.stderr,
-        };
-        target.extend_from_slice(&value[..kept]);
-        self.total += kept;
-        self.truncated |= kept < value.len();
-    }
-}
-
-fn request_fingerprint(request: &CodeExecutionRequest) -> Result<String, CodeExecutionError> {
-    let bytes = serde_json::to_vec(request)
-        .map_err(|_| CodeExecutionError::InvalidRequest("request is not serializable".into()))?;
-    let digest = Sha256::digest(bytes);
-    Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
-}
-
-fn ensure_same_fingerprint(existing: &str, expected: &str) -> Result<(), CodeExecutionError> {
-    if existing == expected {
-        Ok(())
-    } else {
-        Err(CodeExecutionError::IdentityConflict)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Mutex as StdMutex;
+    use std::sync::{Arc, Mutex as StdMutex};
 
     use axum::body::Bytes;
     use axum::extract::{Path as AxumPath, State};
     use axum::http::{header, HeaderMap};
     use axum::routing::post;
     use axum::{Json, Router};
+    use base64::Engine as _;
     use serde_json::{json, Value};
 
     use super::*;
@@ -893,7 +675,7 @@ mod tests {
         let provider = E2BExecutionProvider::with_endpoints(
             E2BCredential::parse("test-e2b-key").unwrap(),
             Duration::from_secs(2),
-            E2BSessionPool::default(),
+            RemoteSessionPool::default(),
             E2BEndpoints {
                 api_base: base.clone(),
                 sandbox_base: base,

--- a/crates/openwave-code-execution/src/http.rs
+++ b/crates/openwave-code-execution/src/http.rs
@@ -1,0 +1,29 @@
+use futures::StreamExt as _;
+use reqwest::Response;
+use serde::de::DeserializeOwned;
+
+use crate::CodeExecutionError;
+
+/// Bound JSON returned by managed-provider control and command APIs.
+pub(crate) async fn decode_bounded_json<T: DeserializeOwned>(
+    response: Response,
+    provider: &str,
+    max_bytes: usize,
+) -> Result<T, CodeExecutionError> {
+    let mut bytes = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|_| {
+            CodeExecutionError::Unavailable(format!("{provider} returned an incomplete response"))
+        })?;
+        if bytes.len().saturating_add(chunk.len()) > max_bytes {
+            return Err(CodeExecutionError::Unavailable(format!(
+                "{provider} returned an oversized response"
+            )));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    serde_json::from_slice(&bytes).map_err(|_| {
+        CodeExecutionError::Unavailable(format!("{provider} returned an invalid response"))
+    })
+}

--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -7,16 +7,24 @@
 //! provider credentials or host paths to the model.
 //!
 //! [`LocalExecutionProvider`] runs directly on macOS under the native Seatbelt
-//! sandbox. [`E2BExecutionProvider`] runs the same direct command contract in a
-//! managed E2B sandbox and reuses one live remote workspace per chat.
+//! sandbox. Managed providers run the same direct command contract in a remote
+//! sandbox and share session, idempotency, and bounded-output primitives.
 
+mod credential;
+mod daytona;
 mod e2b;
+mod http;
 mod local;
+mod output;
+mod receipt;
+mod remote;
 mod tool;
 mod types;
 
-pub use e2b::{E2BCredential, E2BExecutionProvider, E2BSessionPool, E2B_CREDENTIAL_KEY};
+pub use daytona::{DaytonaCredential, DaytonaExecutionProvider, DAYTONA_CREDENTIAL_KEY};
+pub use e2b::{E2BCredential, E2BExecutionProvider, E2B_CREDENTIAL_KEY};
 pub use local::LocalExecutionProvider;
+pub use remote::RemoteSessionPool;
 pub use tool::{ExecTool, EXEC_TOOL_NAME};
 pub use types::{
     CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest,

--- a/crates/openwave-code-execution/src/local.rs
+++ b/crates/openwave-code-execution/src/local.rs
@@ -14,18 +14,19 @@ use std::time::Duration;
 use std::time::Instant;
 
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 #[cfg(target_os = "macos")]
 use tokio::io::{AsyncRead, AsyncReadExt};
 #[cfg(target_os = "macos")]
 use tokio::process::Command;
 
+#[cfg(target_os = "macos")]
+use crate::output::{Capture, StreamKind};
+use crate::receipt::{request_fingerprint, BeginExecution, ExecutionReceipt};
+#[cfg(target_os = "macos")]
+use crate::CodeExecutionProviderKind;
 use crate::{
     CodeExecutionError, CodeExecutionProvider, CodeExecutionRequest, CodeExecutionResponse,
 };
-#[cfg(target_os = "macos")]
-use crate::{CodeExecutionProviderKind, MAX_CAPTURE_BYTES};
 
 const SANDBOX_EXEC: &str = "/usr/bin/sandbox-exec";
 const RECEIPT_DIR: &str = ".code-execution-receipts";
@@ -146,31 +147,8 @@ impl CodeExecutionProvider for LocalExecutionProvider {
     }
 }
 
-enum BeginExecution {
-    Started,
-    Cached(CodeExecutionResponse),
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "state", rename_all = "snake_case")]
-enum ExecutionReceipt {
-    Running {
-        fingerprint: String,
-    },
-    Completed {
-        fingerprint: String,
-        response: CodeExecutionResponse,
-    },
-    Failed {
-        fingerprint: String,
-        message: String,
-    },
-}
-
 fn begin_execution(path: &Path, fingerprint: &str) -> Result<BeginExecution, CodeExecutionError> {
-    let receipt = ExecutionReceipt::Running {
-        fingerprint: fingerprint.into(),
-    };
+    let receipt = ExecutionReceipt::running(fingerprint);
     let bytes = serde_json::to_vec(&receipt)
         .map_err(|_| CodeExecutionError::Sandbox("could not encode receipt".into()))?;
     begin_execution_with_persistence(path, fingerprint, |file| {
@@ -203,28 +181,7 @@ fn begin_execution_with_persistence(
         }
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
             let receipt = read_receipt(path)?;
-            match receipt {
-                ExecutionReceipt::Running {
-                    fingerprint: existing,
-                } => {
-                    ensure_same_fingerprint(&existing, fingerprint)?;
-                    Err(CodeExecutionError::AmbiguousExecution)
-                }
-                ExecutionReceipt::Completed {
-                    fingerprint: existing,
-                    response,
-                } => {
-                    ensure_same_fingerprint(&existing, fingerprint)?;
-                    Ok(BeginExecution::Cached(response))
-                }
-                ExecutionReceipt::Failed {
-                    fingerprint: existing,
-                    message,
-                } => {
-                    ensure_same_fingerprint(&existing, fingerprint)?;
-                    Err(CodeExecutionError::Sandbox(message))
-                }
-            }
+            receipt.replay(fingerprint, CodeExecutionError::Sandbox)
         }
         Err(_) => Err(CodeExecutionError::Sandbox(
             "could not create execution receipt".into(),
@@ -245,14 +202,6 @@ fn discard_unstarted_receipt(path: &Path, parent: &Path) -> Result<(), CodeExecu
     sync_dir(parent).map_err(|_| {
         CodeExecutionError::Sandbox("could not clean up incomplete execution receipt".into())
     })
-}
-
-fn ensure_same_fingerprint(existing: &str, expected: &str) -> Result<(), CodeExecutionError> {
-    if existing == expected {
-        Ok(())
-    } else {
-        Err(CodeExecutionError::IdentityConflict)
-    }
 }
 
 fn read_receipt(path: &Path) -> Result<ExecutionReceipt, CodeExecutionError> {
@@ -327,13 +276,6 @@ fn secure_dir(path: &Path) -> Result<(), CodeExecutionError> {
         CodeExecutionError::Sandbox("could not secure private receipt storage".into())
     })?;
     Ok(())
-}
-
-fn request_fingerprint(request: &CodeExecutionRequest) -> Result<String, CodeExecutionError> {
-    let bytes = serde_json::to_vec(request)
-        .map_err(|_| CodeExecutionError::InvalidRequest("request is not serializable".into()))?;
-    let digest = Sha256::digest(bytes);
-    Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
 }
 
 #[cfg(target_os = "macos")]
@@ -418,16 +360,13 @@ async fn run_native(
     finish_reader(stdout_reader).await;
     finish_reader(stderr_reader).await;
 
-    let capture = capture.lock().unwrap();
-    Ok(CodeExecutionResponse {
-        provider: CodeExecutionProviderKind::Local,
-        exit_code: status.code(),
-        stdout: String::from_utf8_lossy(&capture.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&capture.stderr).into_owned(),
+    let capture = std::mem::take(&mut *capture.lock().unwrap());
+    Ok(capture.response(
+        CodeExecutionProviderKind::Local,
+        started,
+        status.code(),
         timed_out,
-        output_truncated: capture.truncated,
-        duration_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
-    })
+    ))
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -484,22 +423,6 @@ fn signal_group(group: i32, signal: i32) {
 }
 
 #[cfg(target_os = "macos")]
-#[derive(Clone, Copy)]
-enum StreamKind {
-    Stdout,
-    Stderr,
-}
-
-#[cfg(target_os = "macos")]
-#[derive(Default)]
-struct Capture {
-    stdout: Vec<u8>,
-    stderr: Vec<u8>,
-    total: usize,
-    truncated: bool,
-}
-
-#[cfg(target_os = "macos")]
 async fn drain_output<R>(mut reader: R, capture: Arc<Mutex<Capture>>, kind: StreamKind)
 where
     R: AsyncRead + Unpin,
@@ -511,15 +434,7 @@ where
             Ok(read) => read,
         };
         let mut capture = capture.lock().unwrap();
-        let available = MAX_CAPTURE_BYTES.saturating_sub(capture.total);
-        let kept = available.min(read);
-        let target = match kind {
-            StreamKind::Stdout => &mut capture.stdout,
-            StreamKind::Stderr => &mut capture.stderr,
-        };
-        target.extend_from_slice(&chunk[..kept]);
-        capture.total += kept;
-        capture.truncated |= kept < read;
+        capture.append(&chunk[..read], kind);
     }
 }
 

--- a/crates/openwave-code-execution/src/output.rs
+++ b/crates/openwave-code-execution/src/output.rs
@@ -1,0 +1,70 @@
+use std::time::Instant;
+
+use base64::Engine as _;
+
+use crate::{
+    CodeExecutionError, CodeExecutionProviderKind, CodeExecutionResponse, MAX_CAPTURE_BYTES,
+};
+
+#[derive(Clone, Copy)]
+pub(crate) enum StreamKind {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Default)]
+pub(crate) struct Capture {
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    total: usize,
+    truncated: bool,
+}
+
+impl Capture {
+    pub(crate) fn append(&mut self, bytes: &[u8], kind: StreamKind) {
+        let available = MAX_CAPTURE_BYTES.saturating_sub(self.total);
+        let kept = available.min(bytes.len());
+        let target = match kind {
+            StreamKind::Stdout => &mut self.stdout,
+            StreamKind::Stderr => &mut self.stderr,
+        };
+        target.extend_from_slice(&bytes[..kept]);
+        self.total += kept;
+        self.truncated |= kept < bytes.len();
+    }
+
+    pub(crate) fn append_base64(
+        &mut self,
+        value: &str,
+        kind: StreamKind,
+        provider: &str,
+    ) -> Result<(), CodeExecutionError> {
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(value)
+            .map_err(|_| {
+                CodeExecutionError::Unavailable(format!(
+                    "{provider} returned invalid encoded output"
+                ))
+            })?;
+        self.append(&decoded, kind);
+        Ok(())
+    }
+
+    pub(crate) fn response(
+        self,
+        provider: CodeExecutionProviderKind,
+        started: Instant,
+        exit_code: Option<i32>,
+        timed_out: bool,
+    ) -> CodeExecutionResponse {
+        CodeExecutionResponse {
+            provider,
+            exit_code,
+            stdout: String::from_utf8_lossy(&self.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&self.stderr).into_owned(),
+            timed_out,
+            output_truncated: self.truncated,
+            duration_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+        }
+    }
+}

--- a/crates/openwave-code-execution/src/receipt.rs
+++ b/crates/openwave-code-execution/src/receipt.rs
@@ -1,0 +1,95 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{CodeExecutionError, CodeExecutionRequest, CodeExecutionResponse};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub(crate) enum ExecutionReceipt {
+    Running {
+        fingerprint: String,
+    },
+    Completed {
+        fingerprint: String,
+        response: CodeExecutionResponse,
+    },
+    Failed {
+        fingerprint: String,
+        message: String,
+    },
+}
+
+pub(crate) enum BeginExecution {
+    Started,
+    Cached(CodeExecutionResponse),
+}
+
+impl ExecutionReceipt {
+    pub(crate) fn running(fingerprint: impl Into<String>) -> Self {
+        Self::Running {
+            fingerprint: fingerprint.into(),
+        }
+    }
+
+    pub(crate) fn from_outcome(
+        fingerprint: String,
+        outcome: &Result<CodeExecutionResponse, CodeExecutionError>,
+    ) -> Self {
+        match outcome {
+            Ok(response) => Self::Completed {
+                fingerprint,
+                response: response.clone(),
+            },
+            Err(error) => Self::Failed {
+                fingerprint,
+                message: error.to_string(),
+            },
+        }
+    }
+
+    pub(crate) fn replay(
+        &self,
+        fingerprint: &str,
+        failed_error: fn(String) -> CodeExecutionError,
+    ) -> Result<BeginExecution, CodeExecutionError> {
+        match self {
+            Self::Running {
+                fingerprint: existing,
+            } => {
+                ensure_same_fingerprint(existing, fingerprint)?;
+                Err(CodeExecutionError::AmbiguousExecution)
+            }
+            Self::Completed {
+                fingerprint: existing,
+                response,
+            } => {
+                ensure_same_fingerprint(existing, fingerprint)?;
+                Ok(BeginExecution::Cached(response.clone()))
+            }
+            Self::Failed {
+                fingerprint: existing,
+                message,
+            } => {
+                ensure_same_fingerprint(existing, fingerprint)?;
+                Err(failed_error(message.clone()))
+            }
+        }
+    }
+}
+
+pub(crate) fn request_fingerprint(
+    request: &CodeExecutionRequest,
+) -> Result<String, CodeExecutionError> {
+    let bytes = serde_json::to_vec(request)
+        .map_err(|_| CodeExecutionError::InvalidRequest("request is not serializable".into()))?;
+    let digest = Sha256::digest(bytes);
+    Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+fn ensure_same_fingerprint(existing: &str, expected: &str) -> Result<(), CodeExecutionError> {
+    if existing == expected {
+        Ok(())
+    } else {
+        Err(CodeExecutionError::IdentityConflict)
+    }
+}

--- a/crates/openwave-code-execution/src/remote.rs
+++ b/crates/openwave-code-execution/src/remote.rs
@@ -1,0 +1,193 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use crate::receipt::{request_fingerprint, BeginExecution, ExecutionReceipt};
+use crate::{
+    CodeExecutionError, CodeExecutionProviderKind, CodeExecutionRequest, CodeExecutionResponse,
+};
+
+/// Shared process-local sessions and idempotency receipts for managed sandboxes.
+#[derive(Clone, Default)]
+pub struct RemoteSessionPool {
+    state: Arc<Mutex<PoolState>>,
+}
+
+#[derive(Default)]
+struct PoolState {
+    sessions: HashMap<SessionKey, Arc<Mutex<Option<RemoteSession>>>>,
+    receipts: HashMap<ReceiptKey, ExecutionReceipt>,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct SessionKey {
+    provider: CodeExecutionProviderKind,
+    credential: [u8; 32],
+    workspace_id: String,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct ReceiptKey {
+    provider: CodeExecutionProviderKind,
+    execution_id: String,
+}
+
+#[derive(Clone)]
+pub(crate) struct RemoteSession {
+    pub(crate) sandbox_id: String,
+    pub(crate) endpoint: Option<String>,
+    pub(crate) access_token: Option<String>,
+}
+
+pub(crate) enum RemoteSessionError {
+    Missing,
+    Provider(CodeExecutionError),
+}
+
+impl From<CodeExecutionError> for RemoteSessionError {
+    fn from(error: CodeExecutionError) -> Self {
+        Self::Provider(error)
+    }
+}
+
+#[async_trait]
+pub(crate) trait RemoteSandboxAdapter: Send + Sync {
+    fn kind(&self) -> CodeExecutionProviderKind;
+    fn credential_fingerprint(&self) -> [u8; 32];
+
+    async fn create_session(&self, workspace_id: &str)
+        -> Result<RemoteSession, CodeExecutionError>;
+
+    async fn reconnect_session(
+        &self,
+        session: &RemoteSession,
+    ) -> Result<Option<RemoteSession>, CodeExecutionError>;
+
+    async fn run_command(
+        &self,
+        session: &RemoteSession,
+        request: &CodeExecutionRequest,
+    ) -> Result<CodeExecutionResponse, RemoteSessionError>;
+}
+
+impl RemoteSessionPool {
+    async fn begin_execution(
+        &self,
+        provider: CodeExecutionProviderKind,
+        request: &CodeExecutionRequest,
+    ) -> Result<BeginExecution, CodeExecutionError> {
+        let fingerprint = request_fingerprint(request)?;
+        let key = ReceiptKey {
+            provider,
+            execution_id: request.execution_id.as_str().to_owned(),
+        };
+        let mut state = self.state.lock().await;
+        match state.receipts.get(&key) {
+            None => {
+                state
+                    .receipts
+                    .insert(key, ExecutionReceipt::running(fingerprint));
+                Ok(BeginExecution::Started)
+            }
+            Some(receipt) => receipt.replay(&fingerprint, CodeExecutionError::Unavailable),
+        }
+    }
+
+    async fn finish_execution(
+        &self,
+        provider: CodeExecutionProviderKind,
+        request: &CodeExecutionRequest,
+        outcome: &Result<CodeExecutionResponse, CodeExecutionError>,
+    ) -> Result<(), CodeExecutionError> {
+        let key = ReceiptKey {
+            provider,
+            execution_id: request.execution_id.as_str().to_owned(),
+        };
+        let receipt = ExecutionReceipt::from_outcome(request_fingerprint(request)?, outcome);
+        self.state.lock().await.receipts.insert(key, receipt);
+        Ok(())
+    }
+
+    async fn session(
+        &self,
+        provider: CodeExecutionProviderKind,
+        credential: [u8; 32],
+        workspace_id: &str,
+    ) -> Arc<Mutex<Option<RemoteSession>>> {
+        let key = SessionKey {
+            provider,
+            credential,
+            workspace_id: workspace_id.to_owned(),
+        };
+        let mut state = self.state.lock().await;
+        state
+            .sessions
+            .entry(key)
+            .or_insert_with(|| Arc::new(Mutex::new(None)))
+            .clone()
+    }
+}
+
+pub(crate) async fn execute_remote(
+    adapter: &dyn RemoteSandboxAdapter,
+    pool: &RemoteSessionPool,
+    request: CodeExecutionRequest,
+) -> Result<CodeExecutionResponse, CodeExecutionError> {
+    request.validate()?;
+    let provider = adapter.kind();
+    match pool.begin_execution(provider, &request).await? {
+        BeginExecution::Cached(response) => return Ok(response),
+        BeginExecution::Started => {}
+    }
+    let outcome = execute_uncached(adapter, pool, &request).await;
+    pool.finish_execution(provider, &request, &outcome).await?;
+    outcome
+}
+
+async fn execute_uncached(
+    adapter: &dyn RemoteSandboxAdapter,
+    pool: &RemoteSessionPool,
+    request: &CodeExecutionRequest,
+) -> Result<CodeExecutionResponse, CodeExecutionError> {
+    let provider = adapter.kind();
+    let session = pool
+        .session(
+            provider,
+            adapter.credential_fingerprint(),
+            request.workspace_id.as_str(),
+        )
+        .await;
+    // Commands for one chat are serialized so workspace mutations have a
+    // deterministic order and session replacement cannot race execution.
+    let mut session = session.lock().await;
+    let active = match session.as_ref() {
+        Some(existing) => match adapter.reconnect_session(existing).await? {
+            Some(connected) => connected,
+            None => {
+                adapter
+                    .create_session(request.workspace_id.as_str())
+                    .await?
+            }
+        },
+        None => {
+            adapter
+                .create_session(request.workspace_id.as_str())
+                .await?
+        }
+    };
+    *session = Some(active.clone());
+
+    match adapter.run_command(&active, request).await {
+        Ok(response) => Ok(response),
+        Err(RemoteSessionError::Missing) => {
+            *session = None;
+            Err(CodeExecutionError::Unavailable(format!(
+                "{} sandbox is no longer available",
+                provider
+            )))
+        }
+        Err(RemoteSessionError::Provider(error)) => Err(error),
+    }
+}

--- a/crates/openwave-code-execution/src/types.rs
+++ b/crates/openwave-code-execution/src/types.rs
@@ -25,6 +25,8 @@ pub enum CodeExecutionProviderKind {
     Local,
     /// A managed E2B cloud sandbox.
     E2b,
+    /// A managed Daytona cloud sandbox.
+    Daytona,
 }
 
 impl CodeExecutionProviderKind {
@@ -33,6 +35,7 @@ impl CodeExecutionProviderKind {
         match self {
             Self::Local => "local",
             Self::E2b => "e2b",
+            Self::Daytona => "daytona",
         }
     }
 }

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -145,7 +145,7 @@ export type CodeExecutionProviderKind = WireCodeExecutionProviderKind;
 /** Non-secret code-execution selection, timeout policy, and host readiness. */
 export type CodeExecutionConfigInfo = WireCodeExecutionConfigInfo;
 
-/** Readiness only: the API never returns the saved E2B key. */
+/** Readiness only: the API never returns a saved managed-provider key. */
 export type CodeExecutionCredentialReadiness =
   WireCodeExecutionCredentialReadiness;
 

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -251,14 +251,14 @@ end: number, };
 export type CodeExecutionConfigInfo = { provider?: CodeExecutionProviderKind, timeout_ms: number, available: boolean, has_credential: boolean, };
 
 /**
- * Renderer-safe readiness for E2B's fixed credential slot.
+ * Renderer-safe readiness for one managed provider's fixed credential slot.
  */
 export type CodeExecutionCredentialReadiness = { provider: CodeExecutionProviderKind, has_credential: boolean, };
 
 /**
  * A configured code-execution backend.
  */
-export type CodeExecutionProviderKind = "local" | "e2b";
+export type CodeExecutionProviderKind = "local" | "e2b" | "daytona";
 
 /**
  * Conservative, user-inspectable capabilities for one model served by an

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
@@ -71,6 +71,13 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
 
   const state = codeExecutionState(config);
   const activeProvider = config?.provider;
+  const managedProvider =
+    activeProvider === "e2b" || activeProvider === "daytona"
+      ? activeProvider
+      : null;
+  const managedProviderLabel = managedProvider
+    ? codeExecutionProviderLabel(managedProvider)
+    : null;
   const working = savingConfig || savingCredential || removingCredential;
 
   async function saveConfig() {
@@ -105,14 +112,14 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
   }
 
   async function saveCredential() {
-    if (activeProvider !== "e2b" || !apiKey.trim()) return;
+    if (!managedProvider || !managedProviderLabel || !apiKey.trim()) return;
     setSavingCredential(true);
     setError(null);
     try {
-      await client.putCodeExecutionCredential("e2b", apiKey.trim());
+      await client.putCodeExecutionCredential(managedProvider, apiKey.trim());
       setApiKey("");
       await refresh();
-      toast.success("Saved the E2B API key");
+      toast.success(`Saved the ${managedProviderLabel} API key`);
     } catch (err) {
       setError(String(err));
     } finally {
@@ -121,13 +128,13 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
   }
 
   async function removeCredential() {
-    if (activeProvider !== "e2b") return;
+    if (!managedProvider || !managedProviderLabel) return;
     setRemovingCredential(true);
     setError(null);
     try {
-      await client.deleteCodeExecutionCredential("e2b");
+      await client.deleteCodeExecutionCredential(managedProvider);
       await refresh();
-      toast.success("Removed the saved E2B API key");
+      toast.success(`Removed the saved ${managedProviderLabel} API key`);
     } catch (err) {
       setError(String(err));
     } finally {
@@ -176,6 +183,9 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
                   <SelectItem value={NO_PROVIDER}>Disabled</SelectItem>
                   <SelectItem value="local">Local native sandbox</SelectItem>
                   <SelectItem value="e2b">E2B cloud sandbox</SelectItem>
+                  <SelectItem value="daytona">
+                    Daytona cloud sandbox
+                  </SelectItem>
                 </SelectContent>
               </Select>
             </SettingsField>
@@ -206,8 +216,8 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
             </Button>
           </SettingsSection>
 
-          {activeProvider === "e2b" && (
-            <SettingsSection title="E2B credential">
+          {managedProvider && managedProviderLabel && (
+            <SettingsSection title={`${managedProviderLabel} credential`}>
               <span className="text-xs text-muted-foreground">
                 {config.has_credential
                   ? "credential saved"
@@ -218,7 +228,7 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
               >
                 <Input
                   type="password"
-                  placeholder="Paste a new E2B API key"
+                  placeholder={`Paste a new ${managedProviderLabel} API key`}
                   value={apiKey}
                   maxLength={8_192}
                   autoComplete="new-password"
@@ -261,9 +271,10 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
 
           <p className="text-sm leading-relaxed text-muted-foreground">
             Local execution blocks network and confines writes to private chat
-            scratch. E2B runs commands in a managed cloud sandbox, reuses its
-            workspace while the sandbox is alive, and allows internet access.
-            Both providers retain the execution consent boundary.
+            scratch. E2B and Daytona run commands in managed cloud sandboxes,
+            reuse their workspace while the sandbox is alive, and allow internet
+            access. Every provider retains the same direct-command, bounded
+            output, idempotency, and execution-consent contract.
           </p>
         </>
       )}
@@ -289,16 +300,16 @@ function codeExecutionState(config: CodeExecutionConfigInfo | null): {
       kind: "ready",
       label: "Ready",
       description:
-        config.provider === "e2b"
-          ? "E2B is selected and has a saved credential."
+        config.provider !== "local"
+          ? `${codeExecutionProviderLabel(config.provider)} is selected and has a saved credential.`
           : "The local native sandbox is available.",
     };
   }
-  if (config.provider === "e2b" && !config.has_credential) {
+  if (config.provider !== "local" && !config.has_credential) {
     return {
       kind: "not-configured",
       label: "Not configured",
-      description: "E2B is selected but needs an API key.",
+      description: `${codeExecutionProviderLabel(config.provider)} is selected but needs an API key.`,
     };
   }
   return {
@@ -306,4 +317,17 @@ function codeExecutionState(config: CodeExecutionConfigInfo | null): {
     label: "Unavailable",
     description: "The selected execution provider is unavailable.",
   };
+}
+
+function codeExecutionProviderLabel(
+  provider: CodeExecutionProviderKind,
+): string {
+  switch (provider) {
+    case "local":
+      return "Local";
+    case "e2b":
+      return "E2B";
+    case "daytona":
+      return "Daytona";
+  }
 }

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -3,8 +3,8 @@
 //! The model cannot select a provider or timeout. The foreground `exec` tool
 //! calls [`ConfiguredCodeExecutionProvider`], which reads the current host
 //! setting at the last possible boundary and delegates to the selected adapter.
-//! Local and E2B adapters implement the same provider contract without changing
-//! the tool schema or persisted tool-call arguments.
+//! Local and managed adapters implement the same provider contract without
+//! changing the tool schema or persisted tool-call arguments.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -13,8 +13,9 @@ use std::time::Duration;
 use async_trait::async_trait;
 use openwave_code_execution::{
     CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest,
-    CodeExecutionResponse, E2BCredential, E2BExecutionProvider, E2BSessionPool,
-    LocalExecutionProvider, E2B_CREDENTIAL_KEY,
+    CodeExecutionResponse, DaytonaCredential, DaytonaExecutionProvider, E2BCredential,
+    E2BExecutionProvider, LocalExecutionProvider, RemoteSessionPool, DAYTONA_CREDENTIAL_KEY,
+    E2B_CREDENTIAL_KEY,
 };
 use openwave_core::{Result, SecretProvider, Store};
 use serde::{Deserialize, Serialize};
@@ -79,7 +80,7 @@ pub struct CodeExecutionConfigInfo {
     pub has_credential: bool,
 }
 
-/// Renderer-safe readiness for E2B's fixed credential slot.
+/// Renderer-safe readiness for one managed provider's fixed credential slot.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub struct CodeExecutionCredentialReadiness {
     pub provider: CodeExecutionProviderKind,
@@ -130,12 +131,13 @@ pub async fn config_info(
     secrets: &dyn SecretProvider,
 ) -> Result<CodeExecutionConfigInfo> {
     let config = read_config(store).await?;
-    let e2b_has_credential = E2BCredential::load(secrets).await.ok().flatten().is_some();
-    let has_credential =
-        matches!(config.provider, Some(CodeExecutionProviderKind::E2b)) && e2b_has_credential;
+    let has_credential = match config.provider {
+        Some(provider) => has_credential(secrets, provider).await,
+        None => false,
+    };
     let available = match config.provider {
         Some(CodeExecutionProviderKind::Local) => LocalExecutionProvider::is_supported(),
-        Some(CodeExecutionProviderKind::E2b) => e2b_has_credential,
+        Some(CodeExecutionProviderKind::E2b | CodeExecutionProviderKind::Daytona) => has_credential,
         None => false,
         _ => false,
     };
@@ -166,29 +168,72 @@ pub async fn update_config(
 
 pub async fn write_credential(
     secrets: &dyn SecretProvider,
+    provider: CodeExecutionProviderKind,
     api_key: &str,
 ) -> std::result::Result<CodeExecutionCredentialReadiness, ServerError> {
+    let (key, label) = credential_spec(provider)?;
     secrets
-        .set_secret(E2B_CREDENTIAL_KEY, api_key)
+        .set_secret(key, api_key)
         .await
-        .map_err(|_| ServerError::internal("E2B credential storage is unavailable"))?;
+        .map_err(|_| ServerError::internal(format!("{label} credential storage is unavailable")))?;
     Ok(CodeExecutionCredentialReadiness {
-        provider: CodeExecutionProviderKind::E2b,
+        provider,
         has_credential: true,
     })
 }
 
 pub async fn delete_credential(
     secrets: &dyn SecretProvider,
+    provider: CodeExecutionProviderKind,
 ) -> std::result::Result<CodeExecutionCredentialReadiness, ServerError> {
+    let (key, label) = credential_spec(provider)?;
     secrets
-        .delete_secret(E2B_CREDENTIAL_KEY)
+        .delete_secret(key)
         .await
-        .map_err(|_| ServerError::internal("E2B credential storage is unavailable"))?;
+        .map_err(|_| ServerError::internal(format!("{label} credential storage is unavailable")))?;
     Ok(CodeExecutionCredentialReadiness {
-        provider: CodeExecutionProviderKind::E2b,
+        provider,
         has_credential: false,
     })
+}
+
+pub fn credential_provider(
+    value: &str,
+) -> std::result::Result<CodeExecutionProviderKind, ServerError> {
+    match value {
+        "e2b" => Ok(CodeExecutionProviderKind::E2b),
+        "daytona" => Ok(CodeExecutionProviderKind::Daytona),
+        _ => Err(ServerError::not_found(format!(
+            "unknown credentialed code execution provider kind: {value}"
+        ))),
+    }
+}
+
+async fn has_credential(secrets: &dyn SecretProvider, provider: CodeExecutionProviderKind) -> bool {
+    match provider {
+        CodeExecutionProviderKind::E2b => {
+            E2BCredential::load(secrets).await.ok().flatten().is_some()
+        }
+        CodeExecutionProviderKind::Daytona => DaytonaCredential::load(secrets)
+            .await
+            .ok()
+            .flatten()
+            .is_some(),
+        CodeExecutionProviderKind::Local => false,
+        _ => false,
+    }
+}
+
+fn credential_spec(
+    provider: CodeExecutionProviderKind,
+) -> std::result::Result<(&'static str, &'static str), ServerError> {
+    match provider {
+        CodeExecutionProviderKind::E2b => Ok((E2B_CREDENTIAL_KEY, "E2B")),
+        CodeExecutionProviderKind::Daytona => Ok((DAYTONA_CREDENTIAL_KEY, "Daytona")),
+        _ => Err(ServerError::not_found(format!(
+            "unknown credentialed code execution provider kind: {provider}"
+        ))),
+    }
 }
 
 /// Late-binding provider used by the stable foreground tool registration.
@@ -196,7 +241,7 @@ pub struct ConfiguredCodeExecutionProvider {
     store: Arc<dyn Store>,
     secrets: Arc<dyn SecretProvider>,
     scratch_root: PathBuf,
-    e2b_sessions: E2BSessionPool,
+    remote_sessions: RemoteSessionPool,
 }
 
 impl ConfiguredCodeExecutionProvider {
@@ -210,7 +255,7 @@ impl ConfiguredCodeExecutionProvider {
             store,
             secrets,
             scratch_root: scratch_root.into(),
-            e2b_sessions: E2BSessionPool::default(),
+            remote_sessions: RemoteSessionPool::default(),
         }
     }
 }
@@ -242,7 +287,18 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
                 let provider = E2BExecutionProvider::with_session_pool(
                     credential,
                     Duration::from_millis(config.timeout_ms),
-                    self.e2b_sessions.clone(),
+                    self.remote_sessions.clone(),
+                )?;
+                provider.execute(request).await
+            }
+            CodeExecutionProviderKind::Daytona => {
+                let credential = DaytonaCredential::load(&*self.secrets)
+                    .await?
+                    .ok_or(CodeExecutionError::NotConfigured)?;
+                let provider = DaytonaExecutionProvider::with_session_pool(
+                    credential,
+                    Duration::from_millis(config.timeout_ms),
+                    self.remote_sessions.clone(),
                 )?;
                 provider.execute(request).await
             }

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -407,8 +407,8 @@ pub async fn put_code_execution_config(
 
 const MAX_CODE_EXECUTION_CREDENTIAL_BYTES: usize = 8 * 1024;
 
-/// Body of `PUT /code-execution/credentials/e2b`. Debug output always redacts
-/// the credential.
+/// Body of `PUT /code-execution/credentials/{provider}`. Debug output always
+/// redacts the credential.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CodeExecutionCredentialUpdate {
@@ -424,46 +424,38 @@ impl std::fmt::Debug for CodeExecutionCredentialUpdate {
     }
 }
 
-/// Store E2B's key in its fixed host-secret slot without changing selection.
+/// Store a managed provider key in its fixed slot without changing selection.
 pub async fn put_code_execution_credential(
     State(state): State<AppState>,
     Path(provider): Path<String>,
     Json(body): Json<CodeExecutionCredentialUpdate>,
 ) -> Result<Json<CodeExecutionCredentialReadiness>, ServerError> {
-    require_e2b_provider(&provider)?;
+    let provider = code_execution::credential_provider(&provider)?;
     if body.api_key.len() > MAX_CODE_EXECUTION_CREDENTIAL_BYTES {
         return Err(ServerError::bad_request(format!(
-            "E2B api_key must be at most {MAX_CODE_EXECUTION_CREDENTIAL_BYTES} bytes"
+            "{provider} api_key must be at most {MAX_CODE_EXECUTION_CREDENTIAL_BYTES} bytes"
         )));
     }
     let api_key = body.api_key.trim();
     if api_key.is_empty() {
-        return Err(ServerError::bad_request("E2B api_key must not be empty"));
+        return Err(ServerError::bad_request(format!(
+            "{provider} api_key must not be empty"
+        )));
     }
     Ok(Json(
-        code_execution::write_credential(&*state.secrets, api_key).await?,
+        code_execution::write_credential(&*state.secrets, provider, api_key).await?,
     ))
 }
 
-/// Remove only E2B's fixed credential; provider selection remains unchanged.
+/// Remove only the requested provider's credential; selection remains unchanged.
 pub async fn delete_code_execution_credential(
     State(state): State<AppState>,
     Path(provider): Path<String>,
 ) -> Result<Json<CodeExecutionCredentialReadiness>, ServerError> {
-    require_e2b_provider(&provider)?;
+    let provider = code_execution::credential_provider(&provider)?;
     Ok(Json(
-        code_execution::delete_credential(&*state.secrets).await?,
+        code_execution::delete_credential(&*state.secrets, provider).await?,
     ))
-}
-
-fn require_e2b_provider(value: &str) -> std::result::Result<(), ServerError> {
-    if value == "e2b" {
-        Ok(())
-    } else {
-        Err(ServerError::not_found(format!(
-            "unknown credentialed code execution provider kind: {value}"
-        )))
-    }
 }
 
 /// Maximum API-key size accepted by the local credential endpoint. This is

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -682,6 +682,7 @@ async fn code_execution_config_route_is_authenticated_and_preserves_explicit_dis
     );
 
     let ready = router
+        .clone()
         .oneshot(
             Request::builder()
                 .uri("/code-execution")
@@ -693,6 +694,88 @@ async fn code_execution_config_route_is_authenticated_and_preserves_explicit_dis
         .unwrap();
     let ready: serde_json::Value = json_body(ready).await;
     assert_eq!(ready["provider"], "e2b");
+    assert_eq!(ready["available"], true);
+    assert_eq!(ready["has_credential"], true);
+
+    let daytona = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/code-execution")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "provider": "daytona",
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(daytona.status(), StatusCode::OK);
+    let daytona: serde_json::Value = json_body(daytona).await;
+    assert_eq!(daytona["provider"], "daytona");
+    assert_eq!(daytona["available"], false);
+    assert_eq!(daytona["has_credential"], false);
+
+    let daytona_key = "test-daytona-key";
+    let saved = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/code-execution/credentials/daytona")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"api_key": daytona_key}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(saved.status(), StatusCode::OK);
+    let saved_body = to_bytes(saved.into_body(), usize::MAX).await.unwrap();
+    assert!(!std::str::from_utf8(&saved_body)
+        .unwrap()
+        .contains(daytona_key));
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&saved_body).unwrap(),
+        serde_json::json!({"provider": "daytona", "has_credential": true})
+    );
+    assert_eq!(
+        secrets
+            .get_secret(openwave_code_execution::DAYTONA_CREDENTIAL_KEY)
+            .await
+            .unwrap()
+            .as_deref(),
+        Some(daytona_key)
+    );
+    assert_eq!(
+        secrets
+            .get_secret(openwave_code_execution::E2B_CREDENTIAL_KEY)
+            .await
+            .unwrap()
+            .as_deref(),
+        Some(key),
+        "managed providers retain separate fixed credential slots"
+    );
+
+    let ready = router
+        .oneshot(
+            Request::builder()
+                .uri("/code-execution")
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let ready: serde_json::Value = json_body(ready).await;
+    assert_eq!(ready["provider"], "daytona");
     assert_eq!(ready["available"], true);
     assert_eq!(ready["has_credential"], true);
 }

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -2,8 +2,8 @@
 
 OpenWave exposes one foreground `exec` tool through a provider-neutral command
 execution contract. The first provider is a native local sandbox. A managed
-provider such as E2B can implement the same contract later without changing the
-model-facing tool schema.
+provider can implement the same contract without changing the model-facing tool
+schema; E2B and Daytona are the current managed adapters.
 
 This capability is separate from a sandbox *agent*. A sandbox agent is a
 depth-one model run with a constrained tool budget. A code-execution sandbox is
@@ -17,6 +17,8 @@ The authenticated local API owns provider selection and timeout policy:
 | --- | --- |
 | `GET /code-execution` | Return the selected provider, timeout, and host readiness |
 | `PUT /code-execution` | Select a fixed provider or disable execution, and update the bounded timeout |
+| `PUT /code-execution/credentials/{e2b\|daytona}` | Store that provider's API key in its fixed host-secret slot |
+| `DELETE /code-execution/credentials/{e2b\|daytona}` | Remove only that provider's saved API key |
 
 The initial state is:
 
@@ -24,7 +26,8 @@ The initial state is:
 {
   "provider": "local",
   "timeout_ms": 20000,
-  "available": true
+  "available": true,
+  "has_credential": false
 }
 ```
 
@@ -33,8 +36,9 @@ the current host. The example above is the supported macOS state; it is false
 when execution is disabled or unsupported.
 Timeouts must be between 1 and 120 seconds. Sending `{"provider": null}`
 disables execution; sending `{"provider": "local"}` enables the local adapter.
-No executable, endpoint, environment value, or secret reference is accepted by
-this settings surface.
+`e2b` and `daytona` select the managed adapters, which become available once
+their fixed credential slot is populated. No executable, endpoint, environment
+value, or secret reference is accepted by the non-secret settings surface.
 
 The `exec` tool remains registered with a stable schema while settings change.
 The host resolves the selected provider immediately before execution, so a
@@ -52,7 +56,9 @@ CodeExecutionProvider::execute
     |
     +-- LocalExecutionProvider
     |
-    `-- future managed provider (for example E2B)
+    +-- E2BExecutionProvider --------+
+    |                                |
+    `-- DaytonaExecutionProvider ----+-- shared remote session + receipt layer
 ```
 
 A request contains:
@@ -64,8 +70,8 @@ A request contains:
 
 The execution ID is a provider idempotency key. Reusing it with different
 arguments is an identity conflict. The workspace ID lets local execution map a
-chat to private scratch and gives a future managed provider a stable key for a
-remote session or staged workspace.
+chat to private scratch and lets managed providers map the same chat identity to
+a reusable remote sandbox.
 
 Every provider returns the same bounded shape: provider kind, optional exit
 code, stdout, stderr, timeout and truncation flags, and duration. Provider-native
@@ -94,7 +100,7 @@ The initial adapter is deliberately fail-closed and macOS-first:
 
 This is a defense-in-depth boundary for OpenWave's single-user local runtime,
 not a VM-grade multi-tenant boundary. Hostile or remotely supplied workloads
-should use a managed isolation provider once one is available.
+should use a managed isolation provider.
 
 The executable receives its arguments directly. A model that truly needs a
 shell must invoke one explicitly, such as `/bin/sh` with `["-c", "..."]`.
@@ -110,18 +116,25 @@ model-visible chat scratch directory.
 approval/standing-grant boundary. Native confinement limits what an approved
 command can do; it does not replace user consent for command execution.
 
-## Adding E2B or another managed provider
+## Managed sandboxes
 
-A managed adapter should preserve the same invariants:
+E2B and Daytona share one process-local session pool, request fingerprint and
+receipt state machine, bounded capture primitive, response decoder, and
+credential primitive. Both serialize commands within a chat workspace and
+reconcile the remote sandbox before each new execution. An exact retry returns
+the cached normalized response; a changed request is rejected; an ambiguous
+dispatch is never started a second time.
 
-1. Treat the execution ID as an idempotency/reconciliation key.
-2. Map the opaque workspace ID to a bounded remote sandbox lifecycle.
-3. Keep credentials and endpoint selection host-owned.
-4. Enforce host-selected time, output, file, concurrency, and network policy.
-5. Normalize terminal results before they enter model context.
-6. Fail conservatively after an ambiguous dispatch instead of starting a second
-   remote job.
+The provider adapters own only their control-plane and command transports:
 
-Provider-specific configuration and credentials can be added beside the current
-host-owned selection once a second adapter exists. They should not become
-`exec` arguments.
+- E2B sends the executable and argv directly through envd's process protocol.
+- Daytona's toolbox accepts shell text, so its adapter quotes every executable
+  and argv element before dispatch and prefixes the result with `exec`. Shell
+  metacharacters therefore remain argument data. A caller that deliberately
+  needs a shell must still name `/bin/sh` and `-c` explicitly.
+
+Managed credentials remain in the OS secret store and never enter configuration,
+tool arguments, logs, or renderer responses. Remote API endpoints are fixed by
+the build; Daytona toolbox URLs returned by the control plane are restricted to
+HTTPS Daytona origins. Both managed providers allow internet access inside the
+sandbox, unlike the local native provider.


### PR DESCRIPTION
## Summary

- add Daytona as a host-selected managed sandbox provider with fixed secret storage and desktop settings support
- extract shared credential, receipt, bounded-output, bounded-HTTP, and remote-session primitives used by local, E2B, and Daytona execution
- preserve the direct argv contract over Daytona shell transport with per-argument quoting, timeout normalization, and bounded responses
- reuse one Daytona sandbox per chat while it is live, with a five-minute idle stop and immediate cleanup

## Verification

- cargo test -p openwave-code-execution --locked
- cargo test -p openwave-server --locked code_execution_config_route_is_authenticated_and_preserves_explicit_disable
- cargo test -p openwave-server --locked wire_types::tests::the_generated_bindings_are_current
- cargo clippy -p openwave-code-execution --all-targets --no-deps --locked -- -D warnings
- cargo clippy -p openwave-server --lib --no-deps --locked -- -D warnings
- pnpm exec tsc --noEmit
- pnpm build
- gitleaks git . --log-opts=origin/main..HEAD --redact --verbose --timeout 60

Closes #744