### PR TITLE
feat(desktop): managed-mode policy state and resolution

### DIFF
--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -22,6 +22,7 @@ import {
   type SignInProgress,
   type McpServerInfo as WireMcpServerInfo,
   type ManagedPolicy as WireManagedPolicy,
+  type ManagedPolicySource as WireManagedPolicySource,
   type McpServersInfo as WireMcpServersInfo,
   type ModelInfo as WireModelInfo,
   type ModelRole as WireModelRole,
@@ -162,6 +163,7 @@ export type McpServersInfo = WireMcpServersInfo;
 
 /** The resolved managed-mode policy; read-only for the renderer. */
 export type ManagedPolicy = WireManagedPolicy;
+export type ManagedPolicySource = WireManagedPolicySource;
 
 export type Chat = WireChat;
 

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -21,6 +21,7 @@ import {
   type GatewayStatus as WireGatewayStatus,
   type SignInProgress,
   type McpServerInfo as WireMcpServerInfo,
+  type ManagedPolicy as WireManagedPolicy,
   type McpServersInfo as WireMcpServersInfo,
   type ModelInfo as WireModelInfo,
   type ModelRole as WireModelRole,
@@ -158,6 +159,9 @@ export type McpServerDefinition = WireMcpServerDefinition;
 export type McpServerInfo = WireMcpServerInfo;
 
 export type McpServersInfo = WireMcpServersInfo;
+
+/** The resolved managed-mode policy; read-only for the renderer. */
+export type ManagedPolicy = WireManagedPolicy;
 
 export type Chat = WireChat;
 
@@ -613,6 +617,10 @@ export class ApiClient {
       headers: this.headers(true),
       body: JSON.stringify({ uri }),
     });
+  }
+
+  getPolicy(): Promise<ManagedPolicy> {
+    return this.json("/policy", { headers: this.headers() });
   }
 
   getGatewayStatus(): Promise<GatewayStatus> {

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -332,6 +332,17 @@ export type HostRootId = string;
 export type InputModality = "text" | "image";
 
 /**
+ * Renderer-safe resolved policy. Carries only what surfaces need to render
+ * managed state: the verdict, the locked gateway URL, and its authority.
+ */
+export type ManagedPolicy = { managed: boolean, gateway_url?: string, source: ManagedPolicySource, };
+
+/**
+ * Which authority asserted the active policy.
+ */
+export type ManagedPolicySource = "os" | "provisioned" | "unmanaged";
+
+/**
  * Renderer-safe connection lifecycle.
  */
 export type McpHealth = "initializing" | "healthy" | "degraded" | "reconnecting" | "disabled";

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -578,16 +578,16 @@ mod tests {
         runtime.sign_out().await.unwrap();
         let status = runtime.status().await.unwrap();
         assert!(!status.signed_in);
-        let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
-            .await
-            .unwrap();
-        assert!(policy.managed);
         assert_eq!(status.model_count, 0);
         assert!(status.account_hint.is_none());
         let config = providers::read_config(&*store, ProviderKind::ModelGateway)
             .await
             .unwrap();
         assert!(config.models.is_empty());
+        let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
+            .await
+            .unwrap();
+        assert!(policy.managed, "sign-out must not deprovision the profile");
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -569,9 +569,19 @@ mod tests {
         assert!(!json.contains("mg_at_"));
         assert!(!json.contains("mg_rt_"));
 
+        // Managed policy is a separate layer with a separate lifecycle:
+        // disconnecting the session must never deprovision the profile.
+        crate::managed_policy::provision(&*store, &base)
+            .await
+            .unwrap();
+
         runtime.sign_out().await.unwrap();
         let status = runtime.status().await.unwrap();
         assert!(!status.signed_in);
+        let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
+            .await
+            .unwrap();
+        assert!(policy.managed);
         assert_eq!(status.model_count, 0);
         assert!(status.account_hint.is_none());
         let config = providers::read_config(&*store, ProviderKind::ModelGateway)

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -29,6 +29,7 @@ mod event_projection;
 mod extract;
 mod foreground_prompt;
 mod gateway_runtime;
+mod managed_policy;
 mod mcp_config;
 mod model_registry;
 mod model_roles;
@@ -297,6 +298,7 @@ pub fn app(state: AppState) -> Router {
             "/chats/{chat_id}/calls/{call_id}/mcp-app-payload",
             get(routes::get_mcp_app_payload),
         )
+        .route("/policy", get(routes::get_policy))
         .route("/gateway/status", get(routes::get_gateway_status))
         .route("/gateway/apps", get(routes::get_gateway_apps))
         .route("/gateway/sign-in", post(routes::post_gateway_sign_in))

--- a/crates/openwave-server/src/managed_policy.rs
+++ b/crates/openwave-server/src/managed_policy.rs
@@ -1,0 +1,182 @@
+//! Managed-mode policy: whether this profile is provisioned by a model
+//! gateway, and on whose authority.
+//!
+//! Policy and session are separate layers with separate lifecycles: the
+//! gateway session (keychain) comes and goes with sign-in, while the policy
+//! (this module) persists across restarts and sign-out. Resolution honors a
+//! fixed precedence — an OS-managed source (MDM) over sticky provisioned
+//! state over the open default — so a device-management assertion can never
+//! be shadowed by local state.
+//!
+//! Nothing here changes behavior yet. Lockdown of the BYOK and MCP write
+//! paths, the settings surfaces, and the sign-in gate all read this policy
+//! in follow-up slices. The provisioning write path is crate-internal by
+//! design: its only intended callers are the deep-link pairing flow and
+//! tests — it is deliberately not reachable from any renderer-writable
+//! route, which is what makes the state sticky rather than a setting.
+
+use openwave_core::{AgentError, Result, Store};
+use serde::{Deserialize, Serialize};
+
+const SETTING_KEY: &str = "managed_policy_v1";
+
+/// Which authority asserted the active policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ManagedPolicySource {
+    /// OS-managed device policy (MDM); not removable by the user in place.
+    Os,
+    /// Sticky state written when the app was paired with a gateway.
+    Provisioned,
+    /// No policy: the open, bring-your-own-key experience.
+    Unmanaged,
+}
+
+/// Renderer-safe resolved policy. Carries only what surfaces need to render
+/// managed state: the verdict, the locked gateway URL, and its authority.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
+pub(crate) struct ManagedPolicy {
+    pub(crate) managed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub(crate) gateway_url: Option<String>,
+    pub(crate) source: ManagedPolicySource,
+}
+
+/// An OS-managed policy reader. Platform implementations (macOS managed
+/// preferences, Windows registry policy, Linux `/etc/openwave/`) arrive in a
+/// follow-up slice; the seam exists now so the precedence order is fixed and
+/// testable before any reader ships.
+pub(crate) trait OsPolicySource: Send + Sync {
+    /// The OS-asserted gateway base URL, when the platform declares one.
+    fn gateway_url(&self) -> Option<String>;
+}
+
+/// The default source on every platform until a reader ships.
+pub(crate) struct NoOsPolicy;
+
+impl OsPolicySource for NoOsPolicy {
+    fn gateway_url(&self) -> Option<String> {
+        None
+    }
+}
+
+/// The durable provisioned state, stored as one setting.
+#[derive(Serialize, Deserialize)]
+struct ProvisionedPolicy {
+    gateway_url: String,
+}
+
+/// Resolve the active policy: OS-managed over provisioned over unmanaged.
+///
+/// A present-but-unreadable provisioned value is an error, not silently
+/// unmanaged: a profile that claims to be managed must never quietly revert
+/// to the open experience on a decode failure.
+pub(crate) async fn resolve(
+    store: &dyn Store,
+    os_policy: &dyn OsPolicySource,
+) -> Result<ManagedPolicy> {
+    if let Some(gateway_url) = os_policy.gateway_url() {
+        return Ok(ManagedPolicy {
+            managed: true,
+            gateway_url: Some(gateway_url),
+            source: ManagedPolicySource::Os,
+        });
+    }
+    if let Some(value) = store.get_setting(SETTING_KEY).await? {
+        let saved: ProvisionedPolicy = serde_json::from_value(value)
+            .map_err(|_| AgentError::config("saved managed policy is unreadable"))?;
+        return Ok(ManagedPolicy {
+            managed: true,
+            gateway_url: Some(saved.gateway_url),
+            source: ManagedPolicySource::Provisioned,
+        });
+    }
+    Ok(ManagedPolicy {
+        managed: false,
+        gateway_url: None,
+        source: ManagedPolicySource::Unmanaged,
+    })
+}
+
+/// Persist sticky provisioned state for `gateway_url`.
+///
+/// The URL is held to the same contract as a configured gateway base URL —
+/// http/https, no embedded credentials — so a pairing payload cannot smuggle
+/// an invalid or credentialed origin into durable policy.
+// The deep-link pairing flow is the intended production caller; until that
+// slice lands, only tests exercise this write path.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) async fn provision(store: &dyn Store, gateway_url: &str) -> Result<()> {
+    let validated = openwave_connectors::GatewayAuthConfig::new(gateway_url)?;
+    store
+        .set_setting(
+            SETTING_KEY,
+            &serde_json::to_value(ProvisionedPolicy {
+                gateway_url: validated.base_url().to_string(),
+            })?,
+        )
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use openwave_core::DbStore;
+
+    use super::*;
+
+    struct OsAsserted(&'static str);
+
+    impl OsPolicySource for OsAsserted {
+        fn gateway_url(&self) -> Option<String> {
+            Some(self.0.to_string())
+        }
+    }
+
+    async fn test_store() -> (Arc<dyn Store>, tempfile::TempDir) {
+        let directory = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("policy.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        (store, directory)
+    }
+
+    #[tokio::test]
+    async fn resolution_prefers_os_policy_over_provisioned_over_open() {
+        let (store, _directory) = test_store().await;
+
+        let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
+        assert!(!policy.managed);
+        assert_eq!(policy.source, ManagedPolicySource::Unmanaged);
+        assert!(policy.gateway_url.is_none());
+
+        provision(&*store, "https://gw.example").await.unwrap();
+        let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
+        assert!(policy.managed);
+        assert_eq!(policy.source, ManagedPolicySource::Provisioned);
+        assert_eq!(policy.gateway_url.as_deref(), Some("https://gw.example/"));
+
+        let policy = resolve(&*store, &OsAsserted("https://mdm.example/"))
+            .await
+            .unwrap();
+        assert_eq!(policy.source, ManagedPolicySource::Os);
+        assert_eq!(policy.gateway_url.as_deref(), Some("https://mdm.example/"));
+    }
+
+    #[tokio::test]
+    async fn provisioning_holds_the_url_to_the_gateway_contract() {
+        let (store, _directory) = test_store().await;
+        for url in ["ftp://gw", "not a url", "http://user:pw@gw.example"] {
+            assert!(provision(&*store, url).await.is_err(), "{url}");
+        }
+        // A rejected write leaves the profile unmanaged.
+        assert!(!resolve(&*store, &NoOsPolicy).await.unwrap().managed);
+    }
+}

--- a/crates/openwave-server/src/managed_policy.rs
+++ b/crates/openwave-server/src/managed_policy.rs
@@ -69,9 +69,12 @@ struct ProvisionedPolicy {
 
 /// Resolve the active policy: OS-managed over provisioned over unmanaged.
 ///
-/// A present-but-unreadable provisioned value is an error, not silently
-/// unmanaged: a profile that claims to be managed must never quietly revert
-/// to the open experience on a decode failure.
+/// A present-but-invalid policy is an error, not silently unmanaged: a
+/// profile that claims to be managed must never quietly revert to the open
+/// experience on a decode or validation failure. Both authorities pass
+/// through [`validated_gateway_url`], so consumers always see one URL shape
+/// regardless of which authority asserted it — no platform reader has to
+/// remember to validate.
 pub(crate) async fn resolve(
     store: &dyn Store,
     os_policy: &dyn OsPolicySource,
@@ -79,7 +82,7 @@ pub(crate) async fn resolve(
     if let Some(gateway_url) = os_policy.gateway_url() {
         return Ok(ManagedPolicy {
             managed: true,
-            gateway_url: Some(gateway_url),
+            gateway_url: Some(validated_gateway_url(&gateway_url)?),
             source: ManagedPolicySource::Os,
         });
     }
@@ -88,7 +91,7 @@ pub(crate) async fn resolve(
             .map_err(|_| AgentError::config("saved managed policy is unreadable"))?;
         return Ok(ManagedPolicy {
             managed: true,
-            gateway_url: Some(saved.gateway_url),
+            gateway_url: Some(validated_gateway_url(&saved.gateway_url)?),
             source: ManagedPolicySource::Provisioned,
         });
     }
@@ -99,22 +102,43 @@ pub(crate) async fn resolve(
     })
 }
 
+/// The one gateway-URL contract for every policy authority: http/https, no
+/// embedded credentials, normalized to the parsed form.
+fn validated_gateway_url(gateway_url: &str) -> Result<String> {
+    Ok(openwave_connectors::GatewayAuthConfig::new(gateway_url)?
+        .base_url()
+        .to_string())
+}
+
 /// Persist sticky provisioned state for `gateway_url`.
 ///
-/// The URL is held to the same contract as a configured gateway base URL —
-/// http/https, no embedded credentials — so a pairing payload cannot smuggle
-/// an invalid or credentialed origin into durable policy.
+/// A pairing payload cannot smuggle an invalid or credentialed origin into
+/// durable policy (the URL contract), and it cannot silently re-point an
+/// already-provisioned profile at a different gateway: re-provisioning the
+/// same gateway is idempotent, a conflicting one is refused. If re-pairing
+/// ever becomes a product flow, it belongs behind an explicit user
+/// confirmation in the deep-link slice, not in this write path.
 // The deep-link pairing flow is the intended production caller; until that
 // slice lands, only tests exercise this write path.
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) async fn provision(store: &dyn Store, gateway_url: &str) -> Result<()> {
-    let validated = openwave_connectors::GatewayAuthConfig::new(gateway_url)?;
+    let gateway_url = validated_gateway_url(gateway_url)?;
+    if let Some(value) = store.get_setting(SETTING_KEY).await? {
+        // Unreadable existing state is not honored as a conflict: this write
+        // path is its only repair.
+        if let Ok(existing) = serde_json::from_value::<ProvisionedPolicy>(value) {
+            if existing.gateway_url == gateway_url {
+                return Ok(());
+            }
+            return Err(AgentError::config(
+                "this profile is already provisioned to a different gateway",
+            ));
+        }
+    }
     store
         .set_setting(
             SETTING_KEY,
-            &serde_json::to_value(ProvisionedPolicy {
-                gateway_url: validated.base_url().to_string(),
-            })?,
+            &serde_json::to_value(ProvisionedPolicy { gateway_url })?,
         )
         .await
 }
@@ -163,20 +187,53 @@ mod tests {
         assert_eq!(policy.source, ManagedPolicySource::Provisioned);
         assert_eq!(policy.gateway_url.as_deref(), Some("https://gw.example/"));
 
-        let policy = resolve(&*store, &OsAsserted("https://mdm.example/"))
+        // The OS authority passes through the same validation and
+        // normalization as the provisioned one: no trailing slash in, one
+        // URL shape out.
+        let policy = resolve(&*store, &OsAsserted("https://mdm.example"))
             .await
             .unwrap();
         assert_eq!(policy.source, ManagedPolicySource::Os);
         assert_eq!(policy.gateway_url.as_deref(), Some("https://mdm.example/"));
+        assert!(resolve(&*store, &OsAsserted("http://user:pw@mdm.example"))
+            .await
+            .is_err());
     }
 
     #[tokio::test]
     async fn provisioning_holds_the_url_to_the_gateway_contract() {
         let (store, _directory) = test_store().await;
-        for url in ["ftp://gw", "not a url", "http://user:pw@gw.example"] {
-            assert!(provision(&*store, url).await.is_err(), "{url}");
-        }
-        // A rejected write leaves the profile unmanaged.
+        // The contract itself is asserted in the connectors crate; here only
+        // that a rejected write leaves the profile unmanaged.
+        assert!(provision(&*store, "http://user:pw@gw.example")
+            .await
+            .is_err());
         assert!(!resolve(&*store, &NoOsPolicy).await.unwrap().managed);
+    }
+
+    #[tokio::test]
+    async fn a_conflicting_re_provision_is_refused() {
+        let (store, _directory) = test_store().await;
+        provision(&*store, "https://corp.gateway").await.unwrap();
+        // Same gateway (modulo normalization): idempotent.
+        provision(&*store, "https://corp.gateway/").await.unwrap();
+        // Different gateway: refused, and the original pairing survives.
+        let error = provision(&*store, "https://evil.example")
+            .await
+            .err()
+            .unwrap();
+        assert!(error.to_string().contains("already provisioned"));
+        let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
+        assert_eq!(policy.gateway_url.as_deref(), Some("https://corp.gateway/"));
+    }
+
+    #[tokio::test]
+    async fn a_degenerate_stored_value_never_resolves_managed() {
+        let (store, _directory) = test_store().await;
+        store
+            .set_setting(SETTING_KEY, &serde_json::json!({ "gateway_url": "" }))
+            .await
+            .unwrap();
+        assert!(resolve(&*store, &NoOsPolicy).await.is_err());
     }
 }

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -143,6 +143,17 @@ fn mcp_app_payload_from_events(
     })
 }
 
+/// `GET /policy` — the resolved managed-mode policy. Read-only by design:
+/// provisioning has no renderer-writable route, which is what keeps the
+/// state sticky.
+pub async fn get_policy(
+    State(state): State<AppState>,
+) -> Result<Json<crate::managed_policy::ManagedPolicy>, ServerError> {
+    Ok(Json(
+        crate::managed_policy::resolve(&*state.store, &*state.os_policy).await?,
+    ))
+}
+
 /// `GET /gateway/status` — renderer-safe model-gateway connection state.
 pub async fn get_gateway_status(
     State(state): State<AppState>,

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -46,6 +46,10 @@ pub struct AppState {
     /// this with the resolver's instance — refresh rotation is serialized
     /// per instance, so routes and resolver must share one.
     pub(crate) gateway: Arc<crate::gateway_runtime::GatewayRuntime>,
+    /// The OS-managed policy reader for managed-mode resolution. The default
+    /// asserts nothing; platform readers are installed by the embedding once
+    /// they exist.
+    pub(crate) os_policy: Arc<dyn crate::managed_policy::OsPolicySource>,
     /// The retrieval pipeline used by the durable document worker and the
     /// agent's shared `search` tool.
     pub retrieval: Arc<Retriever>,
@@ -144,6 +148,7 @@ impl AppState {
             tools,
             mcp,
             gateway,
+            os_policy: Arc::new(crate::managed_policy::NoOsPolicy),
             retrieval,
             document_job_wake: Arc::new(Notify::new()),
             turn_job_wake: Arc::new(Notify::new()),

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -47,8 +47,8 @@ pub struct AppState {
     /// per instance, so routes and resolver must share one.
     pub(crate) gateway: Arc<crate::gateway_runtime::GatewayRuntime>,
     /// The OS-managed policy reader for managed-mode resolution. The default
-    /// asserts nothing; platform readers are installed by the embedding once
-    /// they exist.
+    /// asserts nothing; the platform-readers slice selects the real source
+    /// here when it lands.
     pub(crate) os_policy: Arc<dyn crate::managed_policy::OsPolicySource>,
     /// The retrieval pipeline used by the durable document worker and the
     /// agent's shared `search` tool.

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -346,6 +346,7 @@ mod tests {
         generate::collect_from::<crate::mcp_config::McpServerDefinition>(&cfg, &mut out);
         generate::collect_from::<crate::routes::McpViewSession>(&cfg, &mut out);
         generate::collect_from::<crate::gateway_runtime::GatewayStatus>(&cfg, &mut out);
+        generate::collect_from::<crate::managed_policy::ManagedPolicy>(&cfg, &mut out);
         generate::collect_from::<crate::gateway_runtime::GatewayApps>(&cfg, &mut out);
         generate::collect_from::<openwave_core::Project>(&cfg, &mut out);
         generate::collect_from::<openwave_core::Chat>(&cfg, &mut out);


### PR DESCRIPTION
## What

The durable managed-mode policy layer for #742, with no behavior change:
resolution in fixed precedence (OS-managed source → sticky provisioned state
→ open default), a crate-internal provisioning write path, and a read-only
`GET /policy` projection. Lockdown slices (BYOK/MCP write paths, settings
surfaces, sign-in gate) build on this.

Closes #750. Second slice of #742.

## How

- `managed_policy.rs`: `ManagedPolicy { managed, gateway_url, source }`
  resolved from an `OsPolicySource` trait (platform MDM readers are a
  follow-up slice; the seam fixes the precedence now) and the
  `managed_policy_v1` store key. A present-but-unreadable provisioned value
  is an error, never silently unmanaged.
- `provision()` validates the URL against the gateway base-URL contract
  (http/https, no embedded credentials) and is not reachable from any
  renderer-writable route — the only intended callers are the deep-link
  pairing flow (future slice) and tests. That is what makes the state
  sticky rather than a setting.
- Sign-out does not clear policy: session state (keychain) and policy state
  (store) are separate layers. Asserted in the existing sign-out test —
  this is a decision that would be easy to reverse by accident.
- `GET /policy` + generated wire type + `ApiClient.getPolicy()` for the
  surfaces that will render managed state.

## Tests

- Resolution precedence (OS over provisioned over open) and the URL
  contract on the write path.
- Sign-out invariant folded into the existing gateway sign-out test.

Verified locally: `cargo fmt --check`, `cargo clippy --workspace
--all-targets --locked -D warnings`, `cargo test --workspace`,
`cargo check --workspace --locked` (no lock diff); UI: `tsc`, vitest
(541 passing), production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
