### PR TITLE
ci: run the durable vector store lane on main only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,7 +321,12 @@ jobs:
   vectors:
     name: durable vector store
     needs: changes
-    if: ${{ needs.changes.outputs.rust == 'true' }}
+    # LanceDB is ~330 crates nobody else compiles, and it is the most expensive
+    # lane we run. While the durable store is parked, pay for it once per merge
+    # instead of once per push to every open PR: post-merge is late signal, but
+    # the feature is off by default in shipped builds. See #760 to restore the
+    # pull-request run when durable vectors come back into active development.
+    if: ${{ needs.changes.outputs.rust == 'true' && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
@@ -510,7 +515,6 @@ jobs:
               test "$LINT_RESULT" = success
               test "$DESKTOP_RESULT" = success
               test "$TEST_RESULT" = success
-              test "$VECTORS_RESULT" = success
               test "$POSTGRES_RESULT" = success
               ;;
             false)
@@ -518,7 +522,6 @@ jobs:
               test "$LINT_RESULT" = skipped
               test "$DESKTOP_RESULT" = skipped
               test "$TEST_RESULT" = skipped
-              test "$VECTORS_RESULT" = skipped
               test "$POSTGRES_RESULT" = skipped
               ;;
             *)
@@ -526,3 +529,16 @@ jobs:
               exit 1
               ;;
           esac
+
+          # The durable vector store is deliberately not a pull-request gate
+          # (see the job's own comment and #760). Assert the exemption rather
+          # than dropping the lane from the gate, so a silent regression on main
+          # still fails here.
+          if test "$EVENT_NAME" = pull_request; then
+            test "$VECTORS_RESULT" = skipped
+          else
+            case "$RUST_CHANGED" in
+              true) test "$VECTORS_RESULT" = success ;;
+              false) test "$VECTORS_RESULT" = skipped ;;
+            esac
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,14 +115,21 @@ is the whole rule, and it is coarse on purpose:
 - Any changed file outside `*.md`, `docs/`, `assets/`, `LICENSE`, `NOTICE`, and
   `crates/openwave-desktop/ui/` marks the change **Rust** — including
   `Cargo.toml` and `Cargo.lock`. That runs rustfmt, clippy (`--all-targets
-  -D warnings`), the desktop tests, the headless workspace tests, the
-  LanceDB-backed lane, and the PostgreSQL turn-state lane. Every cargo
-  invocation passes `--locked`, so a lockfile drift fails there too.
+  -D warnings`), the desktop tests, the headless workspace tests, and the
+  PostgreSQL turn-state lane. Every cargo invocation passes `--locked`, so a
+  lockfile drift fails there too.
 - Any file under `crates/openwave-desktop/ui/` marks it **UI**, which runs
   `pnpm test` and `pnpm build`.
 - The aggregate `fmt · clippy · build · test` check asserts each lane either
   succeeded or was legitimately skipped, and branch protection requires it. A
   lane is skipped only when the change could not have affected it.
+- **One exception, and it is a real coverage gap:** the `durable vector store`
+  lane no longer runs on pull requests. LanceDB is the most expensive thing in
+  CI and the durable store is parked, so it runs only on merges to `main` and on
+  `workflow_dispatch`. If you touch `openwave-retrieval`, the `vec-lance`
+  feature, or the release guard in `openwave-server`'s build script, run
+  `cargo test -p openwave-retrieval --features vec-lance` locally — a PR going
+  green says nothing about it. Tracked in #760.
 
 So a scoped skip is not a coverage hole, and duplicating those lanes locally is
 wasted time. Run a cheap subset for fast feedback on what you actually touched —


### PR DESCRIPTION
The `vectors` lane is the only job that compiles LanceDB — roughly 330 crates no
other lane builds, plus its own protobuf toolchain — which makes it the most
expensive thing in CI by a wide margin. Durable vectors are parked and
`vec-lance` is off by default in shipped builds, so paying for that lane on every
push to every open PR is not buying signal proportional to its cost.

It now runs on merges to `main` and on `workflow_dispatch`.

## The gate asserts the exemption rather than forgetting the lane

Dropping `VECTORS_RESULT` from the `fmt · clippy · build · test` gate would have
been the small edit, but it would also let a genuine break on `main` pass the
required check. Instead the gate expects `skipped` on `pull_request` and still
requires `success` on `main`:

| event | rust changed | vectors | gate |
| --- | --- | --- | --- |
| `pull_request` | yes | skipped | pass |
| `pull_request` | no | skipped | pass |
| `push` to main | yes | success | pass |
| `push` to main | yes | skipped | **fail** |
| `push` to main | yes | failure | **fail** |
| `pull_request` | yes | success | **fail** |

That last row is deliberate. Re-enabling the lane on PRs without also updating
the gate fails loudly, which keeps the two halves of #760's fix from landing
half-done.

## This is a real coverage gap

Everything else in that gate is a scoped skip — a lane skips only when the change
could not have affected it. This one is different: a PR touching
`openwave-retrieval`, the `vec-lance` feature, or the release guard in
`openwave-server`'s build script now goes green having verified none of it, and a
break surfaces as red `main` after the merge. `CLAUDE.md` calls that out
explicitly next to the change-scope rule rather than leaving it to be discovered,
and points at the local command to run instead.

## Verification

`actionlint` is clean. The gate's shell was extracted and run against all six
event/result combinations in the table above; each produced the listed outcome.
Because this PR edits `ci.yml`, the change detector marks it both Rust and UI, so
its own run is the end-to-end check that the remaining lanes still satisfy the
gate.

Follows up in #760.