### PR TITLE
fix(desktop): give the titlebar navigation and a title

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 import { Outlet, useNavigate } from "@tanstack/react-router";
-import { PanelLeftClose, PanelLeftOpen } from "lucide-react";
 
 import {
   ApiClient,
@@ -18,6 +17,7 @@ import { hasMacOverlayTitlebar } from "./host";
 import { Logomark } from "./Logomark";
 import { resolvedRoleKey } from "./ModelSelection";
 import { useTheme } from "./theme";
+import { Titlebar } from "./Titlebar";
 import { useActiveChatId } from "./useActiveChatId";
 import { useChatPromptWatcher } from "./useChatPromptWatcher";
 import { useShellShortcuts } from "./ShellShortcuts";
@@ -57,7 +57,6 @@ export function AppShell() {
   const [defaultModelKey, setDefaultModelKey] = useState<string | null>(null);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
   const [status, setStatus] = useState("starting…");
-  const sidebarCollapsed = useUiStore((state) => state.sidebarCollapsed);
   const openChatId = useActiveChatId();
   const savingTitle = useChatListStore((state) => state.savingTitle);
   const renameChatDraft = useChatListStore((state) => state.renameChatDraft);
@@ -285,19 +284,7 @@ export function AppShell() {
     >
       <div className={`app-shell${hasMacOverlayTitlebar() ? " with-titlebar" : ""}`}>
         {confirmDialog}
-        {hasMacOverlayTitlebar() && (
-          <div className="titlebar" data-tauri-drag-region>
-            <button
-              type="button"
-              className="titlebar-panel-toggle"
-              aria-label={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
-              title={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
-              onClick={() => useUiStore.getState().toggleSidebar()}
-            >
-              {sidebarCollapsed ? <PanelLeftOpen size={15} /> : <PanelLeftClose size={15} />}
-            </button>
-          </div>
-        )}
+        {hasMacOverlayTitlebar() && <Titlebar />}
         {/* Each route renders its own rail beside its content — see RouteFrame. */}
         <div className="app-body">
           <Outlet />

--- a/crates/openwave-desktop/ui/src/DesktopNavigation.test.ts
+++ b/crates/openwave-desktop/ui/src/DesktopNavigation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { nextNavigationReach } from "./DesktopNavigation";
+
+describe("nextNavigationReach", () => {
+  it("keeps forward live after going back, and kills it once a push replaces the entries ahead", () => {
+    let reach = { index: 0, furthest: 0 };
+    reach = nextNavigationReach(reach, "PUSH", 1);
+    reach = nextNavigationReach(reach, "PUSH", 2);
+    expect(reach).toEqual({ index: 2, furthest: 2 });
+
+    reach = nextNavigationReach(reach, "BACK", 1);
+    expect(reach.index).toBeLessThan(reach.furthest);
+
+    // Navigating somewhere new from a back entry discards what was ahead, so
+    // forward has to go dead even though the stack is no shorter than before.
+    reach = nextNavigationReach(reach, "PUSH", 2);
+    expect(reach).toEqual({ index: 2, furthest: 2 });
+  });
+});

--- a/crates/openwave-desktop/ui/src/DesktopNavigation.ts
+++ b/crates/openwave-desktop/ui/src/DesktopNavigation.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import { useRouter } from "@tanstack/react-router";
+import type { HistoryLocation } from "@tanstack/react-router";
+
+/** The move that produced a location, as the history reports it. */
+type NavigationAction = "PUSH" | "REPLACE" | "FORWARD" | "BACK" | "GO";
+
+/**
+ * Where the reader sits in the history stack, and how far ahead of them it
+ * still reaches.
+ *
+ * The history API reports whether there is anything behind the current entry
+ * but not whether there is anything ahead — the browser deliberately hides
+ * that. Tracking the furthest entry the session has reached recovers it, which
+ * is what a forward button needs to know whether it is live or dead.
+ */
+export type NavigationReach = { index: number; furthest: number };
+
+/**
+ * Fold one navigation into the reach.
+ *
+ * A push from anywhere but the end of the stack discards every entry ahead of
+ * it, so the furthest reachable entry becomes wherever the push landed. Every
+ * other move walks entries that already exist and leaves the far end alone.
+ */
+export function nextNavigationReach(
+  reach: NavigationReach,
+  action: NavigationAction,
+  index: number,
+): NavigationReach {
+  if (action === "PUSH") return { index, furthest: index };
+  return { index, furthest: Math.max(reach.furthest, index) };
+}
+
+function entryIndex(location: HistoryLocation): number {
+  return location.state.__TSR_index ?? 0;
+}
+
+export type DesktopNavigation = {
+  canGoBack: boolean;
+  canGoForward: boolean;
+  goBack: () => void;
+  goForward: () => void;
+};
+
+/**
+ * Back and forward for the app's own history, for the titlebar to drive.
+ *
+ * The window has no browser chrome of its own, so without this the reader has
+ * no way back from a screen they reached by following something — the rail only
+ * offers the places it lists.
+ */
+export function useDesktopNavigation(): DesktopNavigation {
+  const history = useRouter().history;
+  const [reach, setReach] = useState<NavigationReach>(() => {
+    const index = entryIndex(history.location);
+    return { index, furthest: index };
+  });
+
+  useEffect(
+    () =>
+      history.subscribe(({ location, action }) => {
+        setReach((current) =>
+          nextNavigationReach(current, action.type, entryIndex(location)),
+        );
+      }),
+    [history],
+  );
+
+  return {
+    canGoBack: reach.index > 0,
+    canGoForward: reach.index < reach.furthest,
+    goBack: () => history.back(),
+    goForward: () => history.forward(),
+  };
+}

--- a/crates/openwave-desktop/ui/src/Logomark.tsx
+++ b/crates/openwave-desktop/ui/src/Logomark.tsx
@@ -1,5 +1,7 @@
 import type { ComponentPropsWithoutRef } from "react";
 
+import { cn } from "@/lib/utils";
+
 /** OpenWave mark geometry, shared with the packaged desktop app icon. */
 const LOGOMARK_VIEWBOX = "127 217 757 407";
 const LOGOMARK_PATH = `
@@ -9,7 +11,32 @@ const LOGOMARK_PATH = `
   M6860 2005l-115-116 345-341c190-188 460-456 602-596l256-254 10 3c5 2 159 150 341 328l331 324v22l-745 745h-910l-115-115z
 `;
 
-/** Logomark only — used in the shell chrome. */
+/**
+ * The boxed lockup — the mark on its tile, the same shape as the packaged app
+ * icon and the form the brand is recognized in.
+ *
+ * The bare mark is four thin chevrons; at rail size it reads as an ornament
+ * rather than as the app. The tile is what makes it a logo, so anywhere the
+ * logo stands for the app this is the one to use.
+ */
+export function BoxedLogomark({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"span">) {
+  return (
+    <span
+      className={cn(
+        "inline-flex size-6 shrink-0 items-center justify-center rounded-[7px] bg-foreground text-background",
+        className,
+      )}
+      {...props}
+    >
+      <Logomark width="15" height="8" />
+    </span>
+  );
+}
+
+/** The bare mark. Prefer {@link BoxedLogomark} where the logo stands alone. */
 export function Logomark(props: ComponentPropsWithoutRef<"svg">) {
   return (
     <svg

--- a/crates/openwave-desktop/ui/src/Titlebar.tsx
+++ b/crates/openwave-desktop/ui/src/Titlebar.tsx
@@ -1,0 +1,48 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import { WithTooltip } from "@/components/ui/tooltip";
+import { useDesktopNavigation } from "./DesktopNavigation";
+
+/**
+ * The macOS overlay titlebar: the strip the traffic lights sit in, which the
+ * app has to furnish itself because the system chrome is hidden.
+ *
+ * It carries navigation and the app's name and nothing else. The rail's own
+ * collapse control stays in the rail — it acts on the rail, and putting a
+ * second copy up here left two buttons for one job on adjacent rows.
+ */
+export function Titlebar() {
+  const navigation = useDesktopNavigation();
+
+  return (
+    <div className="titlebar" data-tauri-drag-region>
+      <div className="titlebar-nav">
+        <WithTooltip label="Back" side="bottom">
+          <button
+            type="button"
+            className="titlebar-nav-btn"
+            aria-label="Back"
+            disabled={!navigation.canGoBack}
+            onClick={navigation.goBack}
+          >
+            <ChevronLeft size={16} />
+          </button>
+        </WithTooltip>
+        <WithTooltip label="Forward" side="bottom">
+          <button
+            type="button"
+            className="titlebar-nav-btn"
+            aria-label="Forward"
+            disabled={!navigation.canGoForward}
+            onClick={navigation.goForward}
+          >
+            <ChevronRight size={16} />
+          </button>
+        </WithTooltip>
+      </div>
+      <span className="titlebar-title" data-tauri-drag-region>
+        OpenWave
+      </span>
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/sidebar/SidebarFrame.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/SidebarFrame.tsx
@@ -12,7 +12,7 @@ import {
 
 import { useApp } from "@/AppContext";
 import { WithTooltip } from "@/components/ui/tooltip";
-import { Logomark } from "@/Logomark";
+import { BoxedLogomark } from "@/Logomark";
 import {
   Sidebar as SidebarRail,
   SidebarButton,
@@ -46,12 +46,11 @@ export function SidebarFrame({ children }: { children: ReactNode }) {
       <SidebarHeader>
         <button
           type="button"
-          className="inline-flex min-w-0 cursor-pointer items-center gap-2 rounded-md p-1 transition-colors hover:bg-muted"
+          className="inline-flex shrink-0 cursor-pointer items-center rounded-md p-1 transition-opacity hover:opacity-80"
           aria-label="Home"
           onClick={() => void navigate({ to: "/" })}
         >
-          <Logomark />
-          {!isCompact && <span className="truncate text-sm font-medium">OpenWave</span>}
+          <BoxedLogomark />
         </button>
         <span className="grow" />
         {!isCompact && (

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -2974,8 +2974,8 @@ body {
 }
 
 
-/* macOS overlay titlebar: one strip carries the traffic lights, panel
-   toggle, brand, and theme control, and drags the window. */
+/* macOS overlay titlebar: one strip carries the traffic lights, back and
+   forward, the app's name, and drags the window. */
 .app-shell.with-titlebar {
   flex-direction: column;
 }
@@ -2984,35 +2984,53 @@ body {
   flex: 0 0 52px;
   display: flex;
   align-items: center;
-  gap: 0.55rem;
+  gap: 0.5rem;
   padding-left: 84px;
-  padding-right: 0.6rem;
+  padding-right: 1rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.titlebar-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.1rem;
+}
+
+.titlebar-nav-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 6px;
+  color: var(--muted-foreground);
+}
+
+.titlebar-nav-btn:hover:not(:disabled) {
+  color: var(--ink);
+  background: color-mix(in srgb, var(--ink) 8%, transparent);
+}
+
+.titlebar-nav-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.titlebar-title {
+  min-width: 0;
+  color: var(--muted-foreground);
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* The strip already provides top breathing room; keep the sidebar header
    tight beneath it. */
 .app-shell.with-titlebar .sidebar {
   padding-top: 0;
-}
-
-.app-shell.with-titlebar .sidebar-brand {
-  margin-bottom: 0.4rem;
-}
-
-.titlebar-panel-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.7rem;
-  height: 1.7rem;
-  margin-top: -10px;
-  border-radius: 6px;
-  color: var(--muted-foreground);
-}
-
-.titlebar-panel-toggle:hover {
-  color: var(--ink);
-  background: color-mix(in srgb, var(--ink) 8%, transparent);
 }
 
 .app-body {


### PR DESCRIPTION
The overlay titlebar carried a sidebar toggle and nothing else, with a second copy of the same control in the sidebar header one row below it — two buttons for one job. And there was no way back from a screen reached by following something: the window has no browser chrome, and the rail only offers the places it lists.

The strip now carries back and forward and the app's name, matching the reference app. The collapse control stays in the rail, where it acts on the rail.

Forward is the interesting part. The history API reports whether anything sits behind the current entry but deliberately not whether anything sits ahead, so `useDesktopNavigation` tracks the furthest entry the session has reached and compares. A push from a back entry discards every entry ahead of it, so that case resets the far end — otherwise the forward button stays lit pointing at history that no longer exists. That's the one case the new test covers.

The rail's header now shows the boxed lockup, the same shape as the packaged app icon, rather than the bare mark beside an "OpenWave" wordmark that the titlebar now carries anyway.

Not verified in the running app: the titlebar is macOS-overlay-only, so it renders under `hasMacOverlayTitlebar()` and does not appear in the browser dev server.

Closes #757