### PR TITLE
fix(desktop): square off the composer's controls

### DIFF
--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from "react";
 import {
-  ArrowUp,
+  ArrowUpRight,
   FileText,
   Image as ImageIcon,
   Paperclip,
@@ -376,7 +376,7 @@ export function Composer({
                     disabled={disabled || cancelPending}
                     onClick={() => void onStop()}
                   >
-                    <Square size={15} fill="currentColor" strokeWidth={0} />
+                    <Square size={14} fill="currentColor" strokeWidth={0} />
                   </button>
                 </WithTooltip>
               </>
@@ -388,7 +388,7 @@ export function Composer({
                   aria-label="Send message"
                   disabled={!canSubmit}
                 >
-                  <ArrowUp size={18} />
+                  <ArrowUpRight size={16} />
                 </button>
               </WithTooltip>
             )}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -1431,7 +1431,7 @@ body {
 .composer {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.25rem;
   max-width: 48rem;
   margin: 0 auto;
   border: 1px solid var(--line);
@@ -1495,7 +1495,7 @@ body {
   height: 2rem;
   flex: 0 0 auto;
   border: 1px solid var(--line);
-  border-radius: 999px;
+  border-radius: 6px;
   padding: 0;
   color: var(--muted-foreground);
   background: transparent;
@@ -1718,7 +1718,7 @@ body {
   gap: 0.3rem;
   max-width: 14rem;
   border: 1px solid var(--line);
-  border-radius: 999px;
+  border-radius: 6px;
   padding: 0.25rem 0.6rem;
   background: transparent;
   color: var(--muted-foreground);
@@ -1760,6 +1760,8 @@ body {
   overflow-y: auto;
 }
 
+/* A rounded square rather than a circle: the same footprint as the icon
+   buttons everywhere else in the app, so the action row reads as one set. */
 .composer-icon-btn {
   display: inline-flex;
   align-items: center;
@@ -1768,7 +1770,7 @@ body {
   height: 2rem;
   flex: 0 0 auto;
   border: 0;
-  border-radius: 999px;
+  border-radius: 6px;
   padding: 0;
   transition: background-color 120ms ease, opacity 120ms ease;
 }


### PR DESCRIPTION
Side by side with the reference app, the composer reads as a different control. Most of that is shape: send and stop were circles, attach was a circular paperclip, and the model trigger was a full pill, none of which match the 6px rounded squares the rest of the app's icon buttons use. Send also pointed straight up where the reference points up and out.

All four are rounded squares now, the send arrow is `ArrowUpRight`, and the gap between the field and the action row is tightened to match.

Visual only — no behavior changed, so the existing composer tests cover it. The control layout question (whether model, effort, and attach fold behind one plus menu) stays in #705, and the mode switchers that belong in that row are #752 and #756.

Closes #759