### PR TITLE
feat(desktop): zoom the interface in and out

### DIFF
--- a/crates/openwave-desktop/capabilities/default.json
+++ b/crates/openwave-desktop/capabilities/default.json
@@ -14,6 +14,7 @@
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",
+    "core:webview:allow-set-webview-zoom",
     "shell:allow-open"
   ]
 }

--- a/crates/openwave-desktop/ui/src/AppShell.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.tsx
@@ -15,6 +15,7 @@ import { prependReplacementChat } from "./ChatDeletion";
 import { useChatListStore } from "./ChatListStore";
 import { useConfirm } from "./components/ConfirmDialog";
 import { hasMacOverlayTitlebar } from "./host";
+import { useInterfaceZoom } from "./InterfaceZoom";
 import { Logomark } from "./Logomark";
 import { resolvedRoleKey } from "./ModelSelection";
 import { useTheme } from "./theme";
@@ -67,18 +68,22 @@ export function AppShell() {
   const { confirm, dialog: confirmDialog } = useConfirm();
   const { mode: themeMode, cycle: cycleTheme, setMode: setThemeMode } = useTheme();
   const desktopUpdates = useDesktopUpdates();
+  const zoom = useInterfaceZoom();
 
   // Watched here rather than in the conversation, so that the agent parking a
   // turn on a question is noticed whatever screen the reader is on.
   useChatPromptWatcher(client, openChatId);
 
   // Shell shortcuts live here because these actions outlive any one route:
-  // toggling the frame, starting a chat, and reaching the composer all work
-  // wherever the reader is.
+  // toggling the frame, starting a chat, reaching the composer, and scaling the
+  // window all work wherever the reader is.
   useShellShortcuts({
     "toggle-sidebar": () => useUiStore.getState().toggleSidebar(),
     "new-chat": () => void onNewChat(),
     "focus-composer": focusComposer,
+    "zoom-in": zoom.zoomIn,
+    "zoom-out": zoom.zoomOut,
+    "zoom-reset": zoom.resetZoom,
   });
 
   useEffect(() => {

--- a/crates/openwave-desktop/ui/src/InterfaceZoom.test.ts
+++ b/crates/openwave-desktop/ui/src/InterfaceZoom.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_ZOOM, ZOOM_STEPS, nextZoom } from "./InterfaceZoom";
+
+describe("nextZoom", () => {
+  it("stops at both ends rather than running off the steps", () => {
+    const smallest = ZOOM_STEPS[0] as number;
+    const largest = ZOOM_STEPS[ZOOM_STEPS.length - 1] as number;
+
+    expect(nextZoom(smallest, "out")).toBe(smallest);
+    expect(nextZoom(largest, "in")).toBe(largest);
+  });
+
+  it("moves one step from a level that is not on the steps", () => {
+    // A level restored from an older set of steps, or one the platform rounded,
+    // still has to move by a single press instead of jumping to an end.
+    const above = nextZoom(1.02, "in");
+    const below = nextZoom(1.02, "out");
+
+    expect(above).toBeGreaterThan(DEFAULT_ZOOM);
+    expect(below).toBeLessThan(DEFAULT_ZOOM);
+    expect(ZOOM_STEPS.indexOf(above) - ZOOM_STEPS.indexOf(below)).toBe(2);
+  });
+});

--- a/crates/openwave-desktop/ui/src/InterfaceZoom.ts
+++ b/crates/openwave-desktop/ui/src/InterfaceZoom.ts
@@ -1,0 +1,123 @@
+import { useEffect, useRef } from "react";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+
+import { hasNativeHost } from "./host";
+
+const ZOOM_KEY = "openwave.zoom";
+
+/**
+ * The scales the interface offers.
+ *
+ * Discrete steps rather than a free multiplier: each press has to be a visible
+ * change, and both ends have to stop somewhere the layout still works. The rail
+ * and the composer have fixed minimum widths, so a scale far past 2 leaves the
+ * transcript with nothing to occupy.
+ */
+export const ZOOM_STEPS: readonly number[] = [
+  0.7, 0.8, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2,
+];
+
+export const DEFAULT_ZOOM = 1;
+
+function stepIndexNearest(level: number): number {
+  let nearest = 0;
+  for (let index = 1; index < ZOOM_STEPS.length; index += 1) {
+    const candidate = ZOOM_STEPS[index] as number;
+    const best = ZOOM_STEPS[nearest] as number;
+    if (Math.abs(candidate - level) < Math.abs(best - level)) nearest = index;
+  }
+  return nearest;
+}
+
+/**
+ * The scale one press away from where the interface sits.
+ *
+ * Snapping to the nearest step first means a level restored from an older set
+ * of steps — or one the platform rounded — still moves by one press rather than
+ * jumping somewhere unrelated.
+ */
+export function nextZoom(level: number, direction: "in" | "out"): number {
+  const from = stepIndexNearest(level);
+  const to = direction === "in" ? from + 1 : from - 1;
+  const clamped = Math.min(ZOOM_STEPS.length - 1, Math.max(0, to));
+  return ZOOM_STEPS[clamped] as number;
+}
+
+/** A stored level, snapped onto the steps, or the default if there is none. */
+export function readStoredZoom(): number {
+  try {
+    const stored = window.localStorage.getItem(ZOOM_KEY);
+    if (stored === null) return DEFAULT_ZOOM;
+    const level = Number.parseFloat(stored);
+    if (!Number.isFinite(level)) return DEFAULT_ZOOM;
+    return ZOOM_STEPS[stepIndexNearest(level)] as number;
+  } catch {
+    return DEFAULT_ZOOM;
+  }
+}
+
+function storeZoom(level: number): void {
+  try {
+    window.localStorage.setItem(ZOOM_KEY, String(level));
+  } catch {
+    // Preference persistence is best-effort.
+  }
+}
+
+/**
+ * Scale the interface.
+ *
+ * The webview's own zoom is what's wanted rather than a CSS transform: it
+ * scales text, layout, and images the way the platform's own zoom does, and
+ * leaves the renderer's own measurements — the composer's line height, the
+ * transcript's scroll positions — in the units they were written in.
+ *
+ * Outside the native host there is no webview to ask, so the document carries
+ * it. That path is the browser dev server, not the shipped app.
+ */
+async function applyZoom(level: number): Promise<void> {
+  if (hasNativeHost()) {
+    try {
+      await getCurrentWebview().setZoom(level);
+      return;
+    } catch {
+      // Fall through: better a scaled document than a shortcut that does
+      // nothing if the host refuses the call.
+    }
+  }
+  document.documentElement.style.zoom = String(level);
+}
+
+export type InterfaceZoom = {
+  zoomIn: () => void;
+  zoomOut: () => void;
+  resetZoom: () => void;
+};
+
+/**
+ * Interface scale, restored on launch and persisted as it changes.
+ *
+ * The level is held in a ref rather than in state because nothing renders it —
+ * the webview holds the truth, and a re-render on every press would be a
+ * re-render for nothing.
+ */
+export function useInterfaceZoom(): InterfaceZoom {
+  const levelRef = useRef(readStoredZoom());
+
+  useEffect(() => {
+    if (levelRef.current !== DEFAULT_ZOOM) void applyZoom(levelRef.current);
+  }, []);
+
+  function moveTo(level: number) {
+    if (level === levelRef.current) return;
+    levelRef.current = level;
+    storeZoom(level);
+    void applyZoom(level);
+  }
+
+  return {
+    zoomIn: () => moveTo(nextZoom(levelRef.current, "in")),
+    zoomOut: () => moveTo(nextZoom(levelRef.current, "out")),
+    resetZoom: () => moveTo(DEFAULT_ZOOM),
+  };
+}

--- a/crates/openwave-desktop/ui/src/ShellShortcuts.test.ts
+++ b/crates/openwave-desktop/ui/src/ShellShortcuts.test.ts
@@ -50,6 +50,23 @@ describe("shell shortcut resolution", () => {
     }
   });
 
+  it("reaches zoom whether or not shift is held for the key", () => {
+    // Cmd+= and Cmd+Shift+= are the same intent on a US keyboard, and the
+    // reader has no way to know which one the app is listening for.
+    for (const [key, shiftKey] of [
+      ["=", false],
+      ["+", true],
+      ["-", false],
+      ["_", true],
+    ] as Array<[string, boolean]>) {
+      const resolved = resolveShellShortcut(keyEvent({ key, shiftKey }), {
+        editable: true,
+        modalOpen: false,
+      });
+      expect(resolved?.id).toBe(key === "=" || key === "+" ? "zoom-in" : "zoom-out");
+    }
+  });
+
   it("stays out of the way of plain typing", () => {
     const resolved = resolveShellShortcut(
       keyEvent({ key: "n", metaKey: false, ctrlKey: false }),

--- a/crates/openwave-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/openwave-desktop/ui/src/ShellShortcuts.ts
@@ -8,16 +8,29 @@ import { useEffect, useRef } from "react";
  * component handlers, so a future shortcuts-help dialog can read the same list
  * the listener acts on and stay honest about what the keys actually do.
  */
-export type ShellShortcutAction = "toggle-sidebar" | "new-chat" | "focus-composer";
+export type ShellShortcutAction =
+  | "toggle-sidebar"
+  | "new-chat"
+  | "focus-composer"
+  | "zoom-in"
+  | "zoom-out"
+  | "zoom-reset";
 
 export type ShellShortcutDef = {
   id: ShellShortcutAction;
-  /** A single character, matched case-insensitively against `event.key`. */
-  key: string;
+  /**
+   * The characters that trigger it, matched case-insensitively against
+   * `event.key`. More than one because a keyboard can reach the same intent
+   * through more than one glyph — zooming in is `=` unshifted and `+` shifted.
+   */
+  keys: readonly string[];
   /** Requires the platform command modifier — Cmd on macOS, Ctrl elsewhere. */
   mod: boolean;
-  /** Whether shift must be held (defaults to must-not). */
-  shift?: boolean;
+  /**
+   * Whether shift must be held (defaults to must-not). `"any"` for shortcuts
+   * whose key is reachable both ways.
+   */
+  shift?: boolean | "any";
   /** What the shortcut does, phrased for a help dialog. */
   description: string;
   /**
@@ -31,23 +44,46 @@ export type ShellShortcutDef = {
 export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
   {
     id: "toggle-sidebar",
-    key: "b",
+    keys: ["b"],
     mod: true,
     description: "Show or hide the sidebar",
     allowInEditable: true,
   },
   {
     id: "new-chat",
-    key: "n",
+    keys: ["n"],
     mod: true,
     description: "Start a new chat",
     allowInEditable: true,
   },
   {
     id: "focus-composer",
-    key: "k",
+    keys: ["k"],
     mod: true,
     description: "Focus the message composer",
+    allowInEditable: true,
+  },
+  {
+    id: "zoom-in",
+    keys: ["=", "+"],
+    mod: true,
+    shift: "any",
+    description: "Make the interface larger",
+    allowInEditable: true,
+  },
+  {
+    id: "zoom-out",
+    keys: ["-", "_"],
+    mod: true,
+    shift: "any",
+    description: "Make the interface smaller",
+    allowInEditable: true,
+  },
+  {
+    id: "zoom-reset",
+    keys: ["0"],
+    mod: true,
+    description: "Reset the interface size",
     allowInEditable: true,
   },
 ];
@@ -63,8 +99,8 @@ export function matchesShellShortcut(
   def: ShellShortcutDef,
 ): boolean {
   if (event.altKey) return false;
-  if (event.key.toLowerCase() !== def.key) return false;
-  if (event.shiftKey !== (def.shift ?? false)) return false;
+  if (!def.keys.includes(event.key.toLowerCase())) return false;
+  if (def.shift !== "any" && event.shiftKey !== (def.shift ?? false)) return false;
   const hasMod = event.metaKey || event.ctrlKey;
   return def.mod ? hasMod : !hasMod;
 }


### PR DESCRIPTION
There was no way to change the interface scale. On a large display the transcript is small enough that people go looking for one, and the window has no browser chrome to fall back on.

Cmd/Ctrl with `+`, `-`, and `0` now step the webview's own zoom through a bounded set of scales. Going through the webview rather than a CSS transform matters: text, layout, and images scale the way the platform's own zoom does, and the renderer's own measurements — the composer's line height, the transcript's scroll offsets — stay in the units they were written in. Outside the native host (the browser dev server) the document carries it instead, which is also the fallback if the host refuses the call.

Levels are discrete steps from 0.7 to 2, so each press is a visible change and both ends stop somewhere the layout still works — the rail and composer have fixed minimum widths, and past 2 the transcript has nothing left to occupy. The level persists, and a stored level that isn't on the steps snaps to the nearest one so it still moves by a single press.

Zooming in is reachable as both an unshifted `=` and a shifted `+`; the shortcut table couldn't express that, so a definition now carries the set of keys it accepts rather than one key. The three existing shortcuts are unchanged in behavior.

Needs `core:webview:allow-set-webview-zoom` in the window capability.

Not verified in the running app.

Closes #758