### PR TITLE
feat(desktop): configure several web-search providers, select one active

### DIFF
--- a/crates/openwave-desktop/ui/src/settings/WebSearchPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/WebSearchPanel.dom.test.tsx
@@ -8,39 +8,49 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ApiClient, WebSearchConfigInfo } from "../api";
+import type {
+  ApiClient,
+  WebSearchConfigInfo,
+  WebSearchCredentialReadiness,
+} from "../api";
 import { WebSearchPanel } from "./WebSearchPanel";
 
-function clientFor(config: WebSearchConfigInfo) {
+function clientFor(
+  config: WebSearchConfigInfo,
+  credentials: WebSearchCredentialReadiness[] = [
+    { provider: "exa", has_credential: false },
+    { provider: "tavily", has_credential: false },
+  ],
+) {
   const putWebSearchConfig = vi.fn().mockResolvedValue(config);
-  const putWebSearchCredential = vi.fn().mockResolvedValue({
-    provider: "exa",
-    has_credential: true,
-  });
-  const credentials = {
-    credentials: [
-      {
-        provider: config.provider ?? "exa",
-        has_credential: config.has_credential,
-      },
-    ],
-  };
+  const putWebSearchCredential = vi
+    .fn()
+    .mockImplementation((provider: string) =>
+      Promise.resolve({ provider, has_credential: true }),
+    );
+  const deleteWebSearchCredential = vi
+    .fn()
+    .mockImplementation((provider: string) =>
+      Promise.resolve({ provider, has_credential: false }),
+    );
   return {
     client: {
       getWebSearchConfig: vi.fn().mockResolvedValue(config),
-      listWebSearchCredentials: vi.fn().mockResolvedValue(credentials),
+      listWebSearchCredentials: vi.fn().mockResolvedValue({ credentials }),
       putWebSearchConfig,
       putWebSearchCredential,
+      deleteWebSearchCredential,
     } as unknown as ApiClient,
     putWebSearchConfig,
     putWebSearchCredential,
+    deleteWebSearchCredential,
   };
 }
 
 afterEach(cleanup);
 
 describe("WebSearchPanel", () => {
-  it("saves the key and the configuration in one pass, in seconds", async () => {
+  it("saves a key per provider and the active selection in one pass, in seconds", async () => {
     const { client, putWebSearchConfig, putWebSearchCredential } = clientFor({
       provider: "exa",
       has_credential: false,
@@ -49,8 +59,12 @@ describe("WebSearchPanel", () => {
 
     render(<WebSearchPanel client={client} />);
 
-    const key = await screen.findByLabelText(/API key/);
-    fireEvent.change(key, { target: { value: "  exa-secret  " } });
+    fireEvent.change(await screen.findByLabelText(/Exa API key/), {
+      target: { value: "  exa-secret  " },
+    });
+    fireEvent.change(screen.getByLabelText(/Tavily API key/), {
+      target: { value: "tavily-secret" },
+    });
     fireEvent.change(screen.getByLabelText(/Request timeout/), {
       target: { value: "30" },
     });
@@ -59,10 +73,35 @@ describe("WebSearchPanel", () => {
     await waitFor(() =>
       expect(putWebSearchCredential).toHaveBeenCalledWith("exa", "exa-secret"),
     );
+    expect(putWebSearchCredential).toHaveBeenCalledWith(
+      "tavily",
+      "tavily-secret",
+    );
     expect(putWebSearchConfig).toHaveBeenCalledWith({
       provider: "exa",
       timeout_ms: 30_000,
     });
+  });
+
+  it("removes one provider's saved key without touching the other", async () => {
+    const { client, deleteWebSearchCredential } = clientFor(
+      { provider: "exa", has_credential: true, timeout_ms: 20_000 },
+      [
+        { provider: "exa", has_credential: true },
+        { provider: "tavily", has_credential: true },
+      ],
+    );
+
+    render(<WebSearchPanel client={client} />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Remove saved Tavily key" }),
+    );
+
+    await waitFor(() =>
+      expect(deleteWebSearchCredential).toHaveBeenCalledWith("tavily"),
+    );
+    expect(deleteWebSearchCredential).toHaveBeenCalledTimes(1);
   });
 
   it("rejects a timeout outside the bounds before touching the server", async () => {

--- a/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
@@ -34,10 +34,14 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
   const [credentials, setCredentials] = useState<WebSearchCredentialReadiness[]>([]);
   const [provider, setProvider] = useState<WebSearchProviderKind | "">("");
   const [timeoutSeconds, setTimeoutSeconds] = useState("");
-  const [apiKey, setApiKey] = useState("");
+  // One draft key per provider: a pass can add Exa's key and Tavily's key
+  // together, and switching the active provider must not discard either.
+  const [apiKeys, setApiKeys] = useState<
+    Partial<Record<WebSearchProviderKind, string>>
+  >({});
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [removingCredential, setRemovingCredential] = useState(false);
+  const [removing, setRemoving] = useState<WebSearchProviderKind | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -66,13 +70,7 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
     };
   }, [client]);
 
-  // Keyed to the provider in the dropdown, not the saved one: picking a
-  // provider has to offer its key field in the same pass that selects it.
-  const selectedHasCredential = provider
-    ? (credentials.find((credential) => credential.provider === provider)
-        ?.has_credential ?? false)
-    : false;
-  const working = saving || removingCredential;
+  const working = saving || removing !== null;
   const state = webSearchState(config);
 
   async function save() {
@@ -92,11 +90,13 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
     setSaving(true);
     setError(null);
     try {
-      // The key goes first so a provider never lands selected-but-unusable
-      // when the caller supplied both in one pass.
-      if (provider && apiKey.trim()) {
-        await client.putWebSearchCredential(provider, apiKey.trim());
-        setApiKey("");
+      // Keys go first so the newly active provider never lands
+      // selected-but-unusable when the caller supplied both in one pass.
+      for (const credential of credentials) {
+        const key = apiKeys[credential.provider]?.trim();
+        if (!key) continue;
+        await client.putWebSearchCredential(credential.provider, key);
+        setApiKeys((current) => ({ ...current, [credential.provider]: "" }));
       }
       const nextConfig = await client.putWebSearchConfig({
         provider: provider || null,
@@ -114,30 +114,29 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
     }
   }
 
-  async function removeCredential() {
-    if (!provider) return;
-    setRemovingCredential(true);
+  async function removeCredential(target: WebSearchProviderKind) {
+    setRemoving(target);
     setError(null);
     try {
-      await client.deleteWebSearchCredential(provider);
+      await client.deleteWebSearchCredential(target);
       const [nextConfig, nextCredentials] = await Promise.all([
         client.getWebSearchConfig(),
         client.listWebSearchCredentials(),
       ]);
       setConfig(nextConfig);
       setCredentials(nextCredentials.credentials);
-      toast.success("Removed the saved API key");
+      toast.success(`Removed the saved ${providerLabel(target)} API key`);
     } catch (err) {
       setError(String(err));
     } finally {
-      setRemovingCredential(false);
+      setRemoving(null);
     }
   }
 
   return (
     <SettingsPanel
       title="Web search"
-      description="Choose the provider agents may use, give it a key, and bound every request. Saved keys are never shown here."
+      description="Configure as many providers as you like, choose the one agents search through, and bound every request. Saved keys are never shown here."
       busy={loading}
     >
       {loading ? (
@@ -155,55 +154,89 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
             <span>{state.description}</span>
           </div>
 
-          <SettingsSection>
+          <SettingsSection
+            title="Providers"
+            description="Give a key to every provider you want available. Each key is stored in the system keychain and never shown again."
+          >
+            {credentials.map((credential) => (
+              <div className="flex flex-col gap-1.5" key={credential.provider}>
+                <SettingsField
+                  label={`${providerLabel(credential.provider)} API key`}
+                  hint={
+                    credential.has_credential
+                      ? "A key is already saved. Type a new one to replace it."
+                      : undefined
+                  }
+                >
+                  <Input
+                    type="password"
+                    placeholder={
+                      credential.has_credential
+                        ? "Saved — leave blank to keep it"
+                        : `Paste your ${providerLabel(credential.provider)} API key`
+                    }
+                    value={apiKeys[credential.provider] ?? ""}
+                    maxLength={8_192}
+                    autoComplete="new-password"
+                    disabled={working}
+                    onChange={(event) =>
+                      setApiKeys((current) => ({
+                        ...current,
+                        [credential.provider]: event.target.value,
+                      }))
+                    }
+                  />
+                </SettingsField>
+                {credential.has_credential && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="self-start"
+                    disabled={working}
+                    onClick={() => void removeCredential(credential.provider)}
+                  >
+                    {removing === credential.provider
+                      ? "Removing…"
+                      : `Remove saved ${providerLabel(credential.provider)} key`}
+                  </Button>
+                )}
+              </div>
+            ))}
+          </SettingsSection>
+
+          <SettingsSection
+            title="Active provider"
+            description="Agents search through this one provider. The others stay configured and idle."
+          >
             <SettingsField label="Provider">
               <Select
                 value={provider === "" ? NO_PROVIDER : provider}
                 disabled={working}
-                onValueChange={(value) => {
+                onValueChange={(value) =>
                   setProvider(
                     value === NO_PROVIDER
                       ? ""
                       : (value as WebSearchProviderKind),
-                  );
-                  setApiKey("");
-                }}
+                  )
+                }
               >
                 <SelectTrigger aria-label="Provider">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value={NO_PROVIDER}>Disabled</SelectItem>
-                  <SelectItem value="exa">Exa</SelectItem>
-                  <SelectItem value="tavily">Tavily</SelectItem>
+                  {credentials.map((credential) => (
+                    <SelectItem
+                      key={credential.provider}
+                      value={credential.provider}
+                    >
+                      {providerLabel(credential.provider)}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </SettingsField>
-
-            {provider && (
-              <SettingsField
-                label="API key"
-                hint={
-                  selectedHasCredential
-                    ? "A key is already saved. Type a new one to replace it."
-                    : "Stored in the system keychain, never shown again."
-                }
-              >
-                <Input
-                  type="password"
-                  placeholder={
-                    selectedHasCredential
-                      ? "Saved — leave blank to keep it"
-                      : `Paste your ${providerLabel(provider)} API key`
-                  }
-                  value={apiKey}
-                  maxLength={8_192}
-                  autoComplete="new-password"
-                  disabled={working}
-                  onChange={(event) => setApiKey(event.target.value)}
-                />
-              </SettingsField>
-            )}
 
             <SettingsField
               label="Request timeout (seconds)"
@@ -220,27 +253,16 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
                 onChange={(event) => setTimeoutSeconds(event.target.value)}
               />
             </SettingsField>
-
-            <div className="flex flex-wrap gap-2">
-              <Button
-                type="button"
-                disabled={working}
-                onClick={() => void save()}
-              >
-                {saving ? "Saving…" : "Save settings"}
-              </Button>
-              {provider && selectedHasCredential && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={working}
-                  onClick={() => void removeCredential()}
-                >
-                  {removingCredential ? "Removing…" : "Remove saved key"}
-                </Button>
-              )}
-            </div>
           </SettingsSection>
+
+          {/* One save for the whole surface: it stores every key typed above
+              and the selection together, so a provider cannot go active in a
+              pass that failed to save its key. */}
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" disabled={working} onClick={() => void save()}>
+              {saving ? "Saving…" : "Save settings"}
+            </Button>
+          </div>
 
           <p className="text-sm leading-relaxed text-muted-foreground">
             Foreground and background agents can request configured search.


### PR DESCRIPTION
Moving web search from Exa to Tavily used to mean pasting a key you had already saved: the settings panel only rendered a key field for the provider that was currently selected. The host was never the limitation — it stores a credential per provider under its own fixed keychain key and keeps the active selection in a separate setting, so this is a UI-only change.

- A **Providers** section with a key field per provider the credentials endpoint advertises, each with its own "Remove saved … key" action.
- An **Active provider** section for the selection agents actually search through, with the request timeout beside it.
- One save for the whole surface. It stores every key typed and then the selection, keys first, so a provider cannot land selected-but-unusable in a pass that failed to store its key.
- The select's items come from the server's provider list instead of a hardcoded Exa/Tavily pair, so the allow-list lives in one place.

Tests: the existing save-in-one-pass test now types a key for both providers and asserts both credential writes plus the selection; added one covering that removing Tavily's key leaves Exa's alone, which is the failure mode the per-provider remove buttons introduce. `pnpm test` (543 passing) and `tsc` are green.

Closes #768