### PR TITLE
fix(desktop): make starting a chat the rail's one solid control

### DIFF
--- a/crates/openwave-desktop/ui/src/sidebar/NewChatButton.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/NewChatButton.tsx
@@ -5,9 +5,10 @@ import { SidebarButton, useSidebarWidth } from "./primitives";
 
 /**
  * Starting a chat is the rail's primary action, so an expanded rail gives it a
- * prominent full-width button rather than another nav row. A compact rail has
- * no room for that, so it falls back to the icon-only row with its label in a
- * tooltip — the same treatment every other compact control gets.
+ * filled full-width button rather than another nav row — the one solid control
+ * in a rail of quiet ones. A compact rail has no room for that, so it falls
+ * back to the icon-only row with its label in a tooltip, the same treatment
+ * every other compact control gets.
  */
 export function NewChatButton({
   onClick,
@@ -32,9 +33,8 @@ export function NewChatButton({
 
   return (
     <Button
-      variant="outline"
       size="sm"
-      className="w-full justify-start gap-2"
+      className="w-full gap-2"
       onClick={onClick}
       disabled={disabled}
     >


### PR DESCRIPTION
The New chat button was an outline button sitting in a rail of outline and ghost controls, so the rail's primary action carried no more visual weight than the theme toggle. In the reference app the equivalent is the one filled control in the rail.

It is filled now and its content is centered, rather than left-aligned against a column of nav labels it isn't part of. The compact rail is unchanged — it still falls back to the icon row with a tooltip.