### PR TITLE
fix(desktop): disconnect a chat's folders when deleting it

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.tsx
@@ -11,7 +11,11 @@ import {
 } from "./api";
 import { AppContextProvider } from "./AppContext";
 import { resolveServerInfo } from "./boot";
-import { prependReplacementChat } from "./ChatDeletion";
+import {
+  deletionDescription,
+  detachChatFolders,
+  prependReplacementChat,
+} from "./ChatDeletion";
 import { useChatListStore } from "./ChatListStore";
 import { useConfirm } from "./components/ConfirmDialog";
 import { hasMacOverlayTitlebar } from "./host";
@@ -154,9 +158,19 @@ export function AppShell() {
   async function onDeleteChat(target: Chat) {
     if (!client || deletionInFlightRef.current || creationInFlightRef.current) return;
     const label = target.title?.trim() || "this chat";
+    // The listed chat carries the folders it had at the last refresh, which
+    // predates anything connected since. The server refuses the delete on its
+    // own count, so ask it what is attached before promising to detach it.
+    let current: Chat;
+    try {
+      current = await client.getChat(target.id);
+    } catch (err) {
+      chatListActions.setChatsError(`Could not delete chat: ${String(err)}`);
+      return;
+    }
     const confirmed = await confirm({
       title: `Delete ${label}?`,
-      description: "This cannot be undone.",
+      description: deletionDescription(current.root_attachments.length),
       confirmLabel: "Delete chat",
       destructive: true,
     });
@@ -169,6 +183,7 @@ export function AppShell() {
     // by the time the request lands this is no longer the route we are on.
     const deletingOpenChat = openChatId === target.id;
     try {
+      await detachChatFolders(current);
       await client.deleteChat(target.id);
       let refreshed = await client.listChats();
       if (!deletingOpenChat) {

--- a/crates/openwave-desktop/ui/src/ChatDeletion.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatDeletion.test.ts
@@ -1,6 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Chat } from "./api";
-import { prependReplacementChat } from "./ChatDeletion";
+import {
+  deletionDescription,
+  detachChatFolders,
+  prependReplacementChat,
+} from "./ChatDeletion";
+import { disconnectFolder, hasNativeHost } from "./host";
+
+vi.mock("./host", () => ({
+  disconnectFolder: vi.fn(async () => true),
+  hasNativeHost: vi.fn(() => true),
+}));
 
 function chat(id: string, projectId: string | null): Chat {
   return {
@@ -15,6 +25,16 @@ function chat(id: string, projectId: string | null): Chat {
   };
 }
 
+function withFolders(target: Chat, rootIds: string[]): Chat {
+  return {
+    ...target,
+    root_attachments: rootIds.map((root_id) => ({
+      root_id,
+      origin: "conversation" as const,
+    })),
+  };
+}
+
 describe("chat deletion replacement", () => {
   it("puts a new loose replacement ahead of the chats that remain", () => {
     const projectChat = chat("project-chat", "project-1");
@@ -24,5 +44,39 @@ describe("chat deletion replacement", () => {
       replacement,
       projectChat,
     ]);
+  });
+});
+
+describe("connected folders on delete", () => {
+  beforeEach(() => {
+    vi.mocked(disconnectFolder).mockClear();
+    vi.mocked(hasNativeHost).mockReturnValue(true);
+  });
+
+  // The server refuses to delete a chat that still holds a root, so a folder
+  // left attached here is the 409 the reader was shown instead of a delete.
+  it("disconnects every folder the chat holds", async () => {
+    const target = withFolders(chat("chat-1", null), ["root-a", "root-b"]);
+    await detachChatFolders(target);
+    expect(vi.mocked(disconnectFolder).mock.calls.map((call) => call[1])).toEqual([
+      "root-a",
+      "root-b",
+    ]);
+  });
+
+  it("has nothing to disconnect without a native host", async () => {
+    vi.mocked(hasNativeHost).mockReturnValue(false);
+    await detachChatFolders(withFolders(chat("chat-1", null), ["root-a"]));
+    expect(disconnectFolder).not.toHaveBeenCalled();
+  });
+
+  it("says what confirming also disconnects", () => {
+    expect(deletionDescription(0)).toBe("This cannot be undone.");
+    expect(deletionDescription(1)).toBe(
+      "Disconnects 1 connected folder first. This cannot be undone.",
+    );
+    expect(deletionDescription(2)).toBe(
+      "Disconnects 2 connected folders first. This cannot be undone.",
+    );
   });
 });

--- a/crates/openwave-desktop/ui/src/ChatDeletion.ts
+++ b/crates/openwave-desktop/ui/src/ChatDeletion.ts
@@ -1,6 +1,34 @@
 import type { Chat } from "./api";
+import { disconnectFolder, hasNativeHost } from "./host";
 
 /** Retain every refreshed chat when a new loose replacement is required. */
 export function prependReplacementChat(chats: Chat[], replacement: Chat): Chat[] {
   return [replacement, ...chats];
+}
+
+/**
+ * Disconnect every folder a chat holds, so the chat can then be deleted.
+ *
+ * `DELETE /chats/{id}` refuses a conversation with roots still attached: a
+ * connected folder is native authority held by the host broker, not a row, so
+ * the server deliberately never revokes it as a side effect of deletion. The
+ * renderer is the one caller that can drive both halves, so it detaches first
+ * rather than handing the reader a conflict to go resolve by hand.
+ *
+ * Detaching is sequential because each change is a compare-and-set against the
+ * chat's attachment revision; concurrent detaches would lose the race and fail.
+ */
+export async function detachChatFolders(chat: Chat): Promise<void> {
+  if (!hasNativeHost()) return;
+  for (const attachment of chat.root_attachments) {
+    await disconnectFolder(chat, attachment.root_id);
+  }
+}
+
+/** How the delete confirmation describes what else goes with the chat. */
+export function deletionDescription(folderCount: number): string {
+  if (folderCount < 1) return "This cannot be undone.";
+  const folders =
+    folderCount === 1 ? "1 connected folder" : `${folderCount} connected folders`;
+  return `Disconnects ${folders} first. This cannot be undone.`;
 }

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -704,6 +704,10 @@ export class ApiClient {
     return this.json("/chats", { headers: this.headers() });
   }
 
+  getChat(chatId: string): Promise<Chat> {
+    return this.json(`/chats/${chatId}`, { headers: this.headers() });
+  }
+
   async listPendingChatPrompts(): Promise<PendingChatPrompt[]> {
     const body = await this.json<unknown>("/chats/pending-prompts", {
       headers: this.headers(),


### PR DESCRIPTION
Deleting a conversation with a folder still connected handed the reader the server's conflict text:

```
Could not delete chat: Error: 409: detach connected folders before deleting this conversation
```

`DELETE /chats/{id}` is fail-closed on purpose: a connected root is native authority held by the host broker, not an ordinary row, so the server never revokes it as a side effect of a delete. But the renderer already drives detachment through `disconnect_folder`, and it is the only caller that can drive both halves — so it now detaches the chat's roots itself and then deletes, instead of leaving the reader to go clear the Folders panel by hand.

The confirmation says what confirming also does ("Disconnects 2 connected folders first. This cannot be undone."), so nothing is destroyed without the count being on screen first.

Detaching is sequential: each change is a compare-and-set against the chat's attachment revision, so concurrent detaches would lose the race and fail.

One wrinkle worth naming — the chat in the sidebar carries the `root_attachments` from the last `GET /chats`, which predates any folder connected since, and connecting a folder does not refresh that list. Deciding what to detach from the stale copy would reproduce the same 409 in the exact case that provokes it, so this reads the chat first, which is what `getChat` is added for.

Not covered here: the sibling `chat_root_attachment_unresolved` conflict, which the renderer cannot resolve — it clears when the native recovery loop finishes — and still surfaces as raw server text.

Tests: one reproduction of the bug (every held root is disconnected, in order), plus the no-native-host case and the dialog wording. `tsc` clean; the 545 UI tests pass.

Closes #766