### PR TITLE
fix(desktop): drop the tile behind the logomark

### DIFF
--- a/crates/openwave-desktop/ui/src/Logomark.tsx
+++ b/crates/openwave-desktop/ui/src/Logomark.tsx
@@ -1,7 +1,5 @@
 import type { ComponentPropsWithoutRef } from "react";
 
-import { cn } from "@/lib/utils";
-
 /** OpenWave mark geometry, shared with the packaged desktop app icon. */
 const LOGOMARK_VIEWBOX = "127 217 757 407";
 const LOGOMARK_PATH = `
@@ -12,31 +10,12 @@ const LOGOMARK_PATH = `
 `;
 
 /**
- * The boxed lockup — the mark on its tile, the same shape as the packaged app
- * icon and the form the brand is recognized in.
+ * The mark, drawn in the current text color.
  *
- * The bare mark is four thin chevrons; at rail size it reads as an ornament
- * rather than as the app. The tile is what makes it a logo, so anywhere the
- * logo stands for the app this is the one to use.
+ * No tile behind it and no color of its own: the mark takes the foreground,
+ * so it reads as ink on the page in the light theme and inverts with it in the
+ * dark one, the same way the app's other glyphs do.
  */
-export function BoxedLogomark({
-  className,
-  ...props
-}: ComponentPropsWithoutRef<"span">) {
-  return (
-    <span
-      className={cn(
-        "inline-flex size-6 shrink-0 items-center justify-center rounded-[7px] bg-foreground text-background",
-        className,
-      )}
-      {...props}
-    >
-      <Logomark width="15" height="8" />
-    </span>
-  );
-}
-
-/** The bare mark. Prefer {@link BoxedLogomark} where the logo stands alone. */
 export function Logomark(props: ComponentPropsWithoutRef<"svg">) {
   return (
     <svg

--- a/crates/openwave-desktop/ui/src/sidebar/SidebarFrame.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/SidebarFrame.tsx
@@ -12,7 +12,7 @@ import {
 
 import { useApp } from "@/AppContext";
 import { WithTooltip } from "@/components/ui/tooltip";
-import { BoxedLogomark } from "@/Logomark";
+import { Logomark } from "@/Logomark";
 import {
   Sidebar as SidebarRail,
   SidebarButton,
@@ -46,11 +46,11 @@ export function SidebarFrame({ children }: { children: ReactNode }) {
       <SidebarHeader>
         <button
           type="button"
-          className="inline-flex shrink-0 cursor-pointer items-center rounded-md p-1 transition-opacity hover:opacity-80"
+          className="inline-flex shrink-0 cursor-pointer items-center rounded-md p-1 text-foreground transition-opacity hover:opacity-70"
           aria-label="Home"
           onClick={() => void navigate({ to: "/" })}
         >
-          <BoxedLogomark />
+          <Logomark width="28" height="15" />
         </button>
         <span className="grow" />
         {!isCompact && (


### PR DESCRIPTION
The tile I put behind the rail's logomark in #764 reads as a border boxing the mark in rather than as the brand. Gone — the mark stands on its own as an inline SVG, a little larger to hold the space the tile was filling.

It takes `currentColor` from the header, so it is ink on the page in the light theme and inverts with it in the dark one, the same as every other glyph in the rail. No separate asset or theme branch to keep in sync.