### PR TITLE
fix(desktop): publish pasted images from the host

### DIFF
--- a/crates/openwave-desktop/src/image_attachments.rs
+++ b/crates/openwave-desktop/src/image_attachments.rs
@@ -1,10 +1,16 @@
 //! Native image attachment bridge.
 //!
-//! Image bytes terminate here. The read and the upload happen in the host
-//! process; the webview receives an opaque attachment id and a few bounded
-//! numbers, and never sees the pixels or the path they came from. That is what
-//! keeps a compromised or merely buggy renderer from being able to exfiltrate
-//! the contents of a file the user only meant to show the model.
+//! Every image publish happens in the host process, and the webview receives an
+//! opaque attachment id and a few bounded numbers back. For a picked file that
+//! also means the pixels and the path never cross into the renderer at all,
+//! which is what keeps a compromised or merely buggy renderer from being able to
+//! exfiltrate the contents of a file the user only meant to show the model.
+//!
+//! A pasted or dropped image is the one case where the renderer already holds
+//! the bytes — it has no path to hand over, and it drew a preview from them — so
+//! it sends them here instead. The publish still has to happen in the host: in a
+//! native embedding the server mounts the publish endpoint behind the
+//! client-executor token, which the renderer deliberately does not have.
 //!
 //! Choosing the file is [`crate::attachments`]'s job, because one picker serves
 //! both images and documents and only the bytes can say which a file is.
@@ -13,11 +19,14 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
 use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
 use cap_std::ambient_authority;
 use cap_std::fs::{Dir, OpenOptions};
 use openwave_core::{ChatId, MAX_IMAGE_BYTES};
 use serde::{Deserialize, Serialize};
+use tauri::State;
 use uuid::Uuid;
 
 use crate::documents::resolve_conversation_scope;
@@ -42,8 +51,15 @@ pub(crate) struct AttachedImage {
     byte_len: u64,
 }
 
-#[derive(Debug, Deserialize)]
-struct PublishedImageAttachment {
+/// What the server said about one published image.
+///
+/// Deserialized from the server's snake_case wire shape and serialized back out
+/// in the camelCase every other host command uses, because for a renderer-held
+/// image this is the whole answer — there is no file name to add, the renderer
+/// named the paste itself.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all(serialize = "camelCase"))]
+pub(crate) struct PublishedImageAttachment {
     attachment_id: Uuid,
     media_type: String,
     width: u32,
@@ -106,7 +122,64 @@ pub(crate) async fn publish_image_at(
     let bytes = tauri::async_runtime::spawn_blocking(move || read_selected_image(&path))
         .await
         .map_err(|_| "Could not read the selected image".to_owned())??;
+    let published = publish_image_bytes(app_state, host_access, requested_chat, bytes).await?;
+    Ok(AttachedImage::new(published, file_name))
+}
 
+/// One image the renderer already holds, published from the host on its behalf.
+///
+/// Base64 rather than a raw IPC body so the bytes travel as one argument
+/// alongside the conversation they belong to. The renderer makes no claim about
+/// the format: the media type is derived here from the bytes, as it is for a
+/// picked file, so a renderer that lied could only mislabel its own paste.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct PublishImageRequest {
+    chat_id: Uuid,
+    content_base64: String,
+}
+
+/// Publish a pasted or dropped image, which arrives as bytes because it has no
+/// path for the host to read.
+#[tauri::command]
+pub(crate) async fn publish_chat_image(
+    app_state: State<'_, Arc<AppState>>,
+    host_access: State<'_, HostAccess>,
+    request: PublishImageRequest,
+) -> Result<PublishedImageAttachment, String> {
+    let bytes = decode_image_payload(&request.content_base64)?;
+    publish_image_bytes(app_state.inner(), &host_access, request.chat_id, bytes).await
+}
+
+/// The longest base64 payload that could still decode to an attachable image.
+///
+/// Checked before decoding so an oversized paste is refused without first
+/// allocating what it decodes to.
+const MAX_IMAGE_BASE64_CHARS: usize = (MAX_IMAGE_BYTES as usize).div_ceil(3) * 4;
+
+fn decode_image_payload(encoded: &str) -> Result<Vec<u8>, String> {
+    if encoded.len() > MAX_IMAGE_BASE64_CHARS {
+        return Err("Images must be 16 MB or smaller".to_owned());
+    }
+    let bytes = BASE64
+        .decode(encoded)
+        .map_err(|_| "Could not attach that image".to_owned())?;
+    if bytes.is_empty() {
+        return Err("That image file is empty".to_owned());
+    }
+    if bytes.len() as u64 > MAX_IMAGE_BYTES {
+        return Err("Images must be 16 MB or smaller".to_owned());
+    }
+    Ok(bytes)
+}
+
+/// Hand one image's bytes to the server and return what it minted for them.
+async fn publish_image_bytes(
+    app_state: &Arc<AppState>,
+    host_access: &HostAccess,
+    requested_chat: Uuid,
+    bytes: Vec<u8>,
+) -> Result<PublishedImageAttachment, String> {
     let chat_id = resolve_conversation_scope(host_access, requested_chat).await?;
     let info = wait_server_info(app_state).await?;
     // The declared type is derived from the bytes, not the file name, so the
@@ -135,11 +208,10 @@ pub(crate) async fn publish_image_at(
             .unwrap_or_default();
         return Err(refusal_message(&kind));
     }
-    let published = response
+    response
         .json::<PublishedImageAttachment>()
         .await
-        .map_err(|_| "Attaching the image returned an invalid response".to_owned())?;
-    Ok(AttachedImage::new(published, file_name))
+        .map_err(|_| "Attaching the image returned an invalid response".to_owned())
 }
 
 /// Whether this file should be attached as an image rather than imported as a
@@ -372,6 +444,26 @@ mod tests {
                 "a known refusal fell through to the generic message"
             );
         }
+    }
+
+    #[test]
+    fn a_pasted_payload_is_bounded_before_it_is_decoded() {
+        // The ceiling is checked on the encoded string, so a renderer cannot
+        // make the host allocate 100 MB to find out the image was too large.
+        let oversized = "A".repeat(MAX_IMAGE_BASE64_CHARS + 1);
+        assert_eq!(
+            decode_image_payload(&oversized).unwrap_err(),
+            "Images must be 16 MB or smaller"
+        );
+        assert_eq!(
+            decode_image_payload("").unwrap_err(),
+            "That image file is empty"
+        );
+        assert!(decode_image_payload("not base64!").is_err());
+        assert_eq!(
+            decode_image_payload(&BASE64.encode(b"PNG")).unwrap(),
+            b"PNG"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -183,6 +183,7 @@ pub fn run() {
             server_info,
             request_user_attention,
             attachments::attach_chat_files,
+            image_attachments::publish_chat_image,
             documents::import_library_document,
             documents::import_library_documents,
             documents::import_dropped_library_documents,

--- a/crates/openwave-desktop/ui/src/ImageAttachments.ts
+++ b/crates/openwave-desktop/ui/src/ImageAttachments.ts
@@ -301,7 +301,11 @@ export function describeImageAttachment(attachment: ImageAttachment): string {
     case "queued":
       return "Waiting to upload";
     case "uploading":
-      return `Uploading ${imageUploadPercent(attachment)}%`;
+      // A host publish moves the bytes over IPC in one step and has no progress
+      // to report, so quoting 0% would read as a stall rather than as work.
+      return attachment.uploadedBytes === 0
+        ? "Uploading"
+        : `Uploading ${imageUploadPercent(attachment)}%`;
     case "ready":
       return attachment.width && attachment.height
         ? `${attachment.width} × ${attachment.height}`
@@ -467,7 +471,7 @@ export function uploadImageAttachment(
     };
     request.onload = () => {
       if (request.status !== 201) {
-        reject(new Error(refusalFromBody(request.responseText)));
+        reject(new Error(refusalFromBody(request.status, request.responseText)));
         return;
       }
       try {
@@ -486,7 +490,7 @@ export function uploadImageAttachment(
   });
 }
 
-function refusalFromBody(body: string): string {
+function refusalFromBody(status: number, body: string): string {
   try {
     const parsed: unknown = JSON.parse(body);
     if (isRecord(parsed) && typeof parsed.kind === "string") {
@@ -494,6 +498,13 @@ function refusalFromBody(body: string): string {
     }
   } catch {
     /* An unparseable body is just an unknown refusal. */
+  }
+  // The auth middleware answers with a bare status and no body, so this is the
+  // one refusal that carries no `kind` to explain itself. Saying so is what
+  // separates "this build cannot publish from the renderer" from a dead
+  // network — the two used to arrive as the same sentence.
+  if (status === 401 || status === 403) {
+    return "This build cannot attach images from the composer";
   }
   return imageAttachmentRefusal("");
 }
@@ -546,6 +557,34 @@ function isSafeRendererText(value: string, maxCodePoints: number): boolean {
   return characters.every(
     (character) => !/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u.test(character),
   );
+}
+
+/**
+ * The host's publish result for an image the renderer already held.
+ *
+ * Same five numbers as the endpoint's own answer, in the camelCase every host
+ * command uses. There is no file name here: the renderer named the paste before
+ * any bytes moved, and the host has no better name to offer for one.
+ */
+export function parseHostPublishedImage(value: unknown): PublishedImage {
+  if (
+    !isExactRecord(value, [
+      "attachmentId",
+      "mediaType",
+      "width",
+      "height",
+      "byteLen",
+    ])
+  ) {
+    throw new Error("Invalid image attachment response");
+  }
+  return checkedPublishedImage({
+    attachmentId: value.attachmentId,
+    mediaType: value.mediaType,
+    width: value.width,
+    height: value.height,
+    byteLen: value.byteLen,
+  });
 }
 
 /** The publish endpoint's result, which uses the server's snake_case shape. */

--- a/crates/openwave-desktop/ui/src/attachments.ts
+++ b/crates/openwave-desktop/ui/src/attachments.ts
@@ -1,7 +1,12 @@
 import { invoke } from "@tauri-apps/api/core";
 
 import { parseLibraryImportBatch, type LibraryImportBatch } from "./documents";
-import { parseAttachedImage, type PickedImage } from "./ImageAttachments";
+import {
+  parseAttachedImage,
+  parseHostPublishedImage,
+  type PickedImage,
+  type PublishedImage,
+} from "./ImageAttachments";
 
 /** One file the host could not attach as an image, named so it can be reported. */
 export type FailedImage = {
@@ -26,6 +31,40 @@ export type AttachedFiles = {
 /** Attach any files through one native picker. `null` if the reader dismissed it. */
 export async function attachChatFiles(chatId: string): Promise<AttachedFiles | null> {
   return parseAttachedFiles(await invoke("attach_chat_files", { request: { chatId } }));
+}
+
+/**
+ * Publish an image the renderer is already holding, from the host.
+ *
+ * A pasted or dropped image has no path, so it cannot go through the picker
+ * route — but it cannot go straight to the server either. Under a native host
+ * the publish endpoint is mounted behind the client-executor token, which the
+ * renderer does not have, and a bearer-authenticated POST from here comes back
+ * `401` with an empty body. So the bytes take the same last mile as every other
+ * attachment: the host posts them and hands back the identity it was given.
+ */
+export async function publishChatImage(
+  chatId: string,
+  file: Blob,
+): Promise<PublishedImage> {
+  const contentBase64 = encodeBase64(await file.arrayBuffer());
+  return parseHostPublishedImage(
+    await invoke("publish_chat_image", { request: { chatId, contentBase64 } }),
+  );
+}
+
+/**
+ * Base64 in chunks, because spreading 16 MB of bytes into one call to
+ * `String.fromCharCode` overflows the argument stack.
+ */
+function encodeBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+  }
+  return btoa(binary);
 }
 
 export function parseAttachedFiles(value: unknown): AttachedFiles | null {

--- a/crates/openwave-desktop/ui/src/useImageAttachments.test.ts
+++ b/crates/openwave-desktop/ui/src/useImageAttachments.test.ts
@@ -63,12 +63,26 @@ class FakeUpload {
 
 const client = { baseUrl: "http://127.0.0.1:9", token: "t" } as ApiClient;
 
+const hasNativeHost = vi.hoisted(() => vi.fn(() => false));
+const publishChatImage = vi.hoisted(() => vi.fn());
+
+vi.mock("./host", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./host")>()),
+  hasNativeHost,
+}));
+vi.mock("./attachments", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./attachments")>()),
+  publishChatImage,
+}));
+
 function png(name = "chart.png"): File {
   return new File([new Uint8Array([1, 2, 3, 4])], name, { type: "image/png" });
 }
 
 beforeEach(() => {
   FakeUpload.opened = [];
+  hasNativeHost.mockReturnValue(false);
+  publishChatImage.mockReset();
   vi.stubGlobal("XMLHttpRequest", FakeUpload);
   URL.createObjectURL = vi.fn((): string => "blob:preview");
   URL.revokeObjectURL = vi.fn();
@@ -170,6 +184,32 @@ describe("useImageAttachments", () => {
     expect(result.current.error).toMatch(/PNG, JPEG, WebP, or GIF/);
     expect(result.current.attachments).toEqual([]);
     expect(FakeUpload.opened).toHaveLength(0);
+  });
+
+  // Regression: the packaged app has no bearer for the publish endpoint, so a
+  // pasted image posted from the renderer came back 401 with an empty body and
+  // reached the reader as the generic "Could not attach that image".
+  it("publishes through the host rather than the renderer when there is one", async () => {
+    hasNativeHost.mockReturnValue(true);
+    publishChatImage.mockResolvedValue({
+      attachmentId: ATTACHMENT_ID,
+      mediaType: "image/png",
+      width: 800,
+      height: 600,
+      byteLen: 4,
+    });
+    const { result } = renderHook(() => useImageAttachments(client, "chat-1"));
+
+    act(() => result.current.attachFiles([png()]));
+    await waitFor(() =>
+      expect(result.current.attachments[0]).toMatchObject({
+        status: "ready",
+        attachmentId: ATTACHMENT_ID,
+        width: 800,
+      }),
+    );
+    expect(FakeUpload.opened).toHaveLength(0);
+    expect(publishChatImage).toHaveBeenCalledWith("chat-1", expect.any(File));
   });
 
   it("forgets everything once a turn has carried it", async () => {

--- a/crates/openwave-desktop/ui/src/useImageAttachments.ts
+++ b/crates/openwave-desktop/ui/src/useImageAttachments.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 
 import type { ApiClient } from "./api";
+import { publishChatImage } from "./attachments";
+import { hasNativeHost } from "./host";
 import {
   imageAttachmentName,
   imageAttachmentRejection,
@@ -93,6 +95,32 @@ export function useImageAttachments(
     filesRef.current.delete(id);
   }
 
+  /**
+   * Move one file's bytes, by whichever route this build has.
+   *
+   * Under a native host the server mounts the image publish endpoint behind the
+   * client-executor token, so the renderer cannot post to it and the bytes go
+   * over IPC for the host to publish. In a browser — `pnpm dev`, and the UI
+   * tests — the same endpoint sits on the renderer's own bearer, and posting it
+   * directly is what gives the chip real byte progress.
+   */
+  async function publish(id: string, file: File, signal: AbortSignal) {
+    if (!hasNativeHost()) {
+      return uploadImageAttachment(client, chatId, file, {
+        onProgress: (uploadedBytes) =>
+          update((current) => withUploadProgress(current, id, uploadedBytes)),
+        signal,
+      });
+    }
+    // One IPC call with no cancellation seam, so a removal mid-flight is
+    // honoured on the way out instead of interrupting it. The bytes are
+    // published by then, but nothing references them, so the server's orphan
+    // sweep reclaims them.
+    const published = await publishChatImage(chatId, file);
+    if (signal.aborted) throw new DOMException("Upload cancelled", "AbortError");
+    return published;
+  }
+
   async function upload(id: string) {
     const file = filesRef.current.get(id);
     if (!file) return;
@@ -100,11 +128,7 @@ export function useImageAttachments(
     abortsRef.current.set(id, controller);
     update((current) => withUploadStarted(current, id));
     try {
-      const published = await uploadImageAttachment(client, chatId, file, {
-        onProgress: (uploadedBytes) =>
-          update((current) => withUploadProgress(current, id, uploadedBytes)),
-        signal: controller.signal,
-      });
+      const published = await publish(id, file, controller.signal);
       update((current) => withUploadPublished(current, id, published));
     } catch (err) {
       // A cancelled upload belongs to an attachment the reader already removed,


### PR DESCRIPTION
Pasting an image into the composer showed its chip and then failed with the generic "Could not attach that image", retryable only into the same failure. Closes #658.

## Cause

Not a transport problem, and not CORS. A paste has no path, so `uploadImageAttachment` posted the `File` to `POST /chats/{id}/attachments/images` straight from the renderer — and in a native embedding that endpoint is not on the renderer's bearer. In `server::router`, `document_api` (raw document ingest plus image publication) is merged into `client_executor_api` when `root_attachment_routes_enabled`, which is gated by `require_client_executor_token`. A bearer-authenticated POST from the webview got a `401`.

That `401` is `StatusCode::UNAUTHORIZED.into_response()` — a bare status with no body — so there was no `kind` for `refusalFromBody` to map and the composer fell through to its fallback sentence. Under `pnpm dev` the server is a headless embedding, the same route sits on the primary bearer, and the paste works; hence "only in the packaged app".

The issue's leading suspicion (a cross-origin XHR carrying a `File` from a custom-scheme origin) is not what is happening. The `201` observed by hand came from a request carrying the client-executor token.

## Change

The pasted bytes now take the same last mile as every other attachment. A new `publish_chat_image` command carries them over IPC and the host posts them, deriving the media type from the bytes as the picker path already does, so the server's sniff-versus-declared check stays a cross-check of two independent claims. `publish_image_at` and the new command share one `publish_image_bytes` tail.

The renderer keeps its direct POST for a browser, where it *is* the authenticated caller and `XMLHttpRequest` can report real byte progress. Choice of route is `hasNativeHost()`.

A host publish has no progress to report, so `describeImageAttachment` says "Uploading" rather than "Uploading 0%" while `uploadedBytes` is still zero — which also covers the moment before the first progress event on the browser path.

Separately: a bodyless `401`/`403` now gets its own sentence. It was the one refusal indistinguishable from a dead network, and that is what made this read as a transport failure.

## Tests

- `useImageAttachments.test.ts` — one added: with a native host present, no `XMLHttpRequest` is opened and the chip goes ready from the host's answer. This is the reproduction; the bug was precisely that the renderer posted it itself.
- `image_attachments.rs` — one added, covering `decode_image_payload`: the size ceiling is enforced on the encoded string before decoding, so an oversized paste cannot make the host allocate what it decodes to, plus the empty and malformed cases.

## Not verified

I did not drive the packaged app. The diagnosis is read off the router and auth middleware and matches every observation in the issue, including the two that looked contradictory. Worth a paste in a packaged build before this is called closed.