### PR TITLE
feat(desktop): give code execution the same multi-provider settings shape

### DIFF
--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -584,6 +584,14 @@ export class ApiClient {
     });
   }
 
+  listCodeExecutionCredentials(): Promise<{
+    credentials: CodeExecutionCredentialReadiness[];
+  }> {
+    return this.json("/code-execution/credentials", {
+      headers: this.headers(),
+    });
+  }
+
   putCodeExecutionCredential(
     provider: CodeExecutionProviderKind,
     apiKey: string,

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  ApiClient,
+  CodeExecutionConfigInfo,
+  CodeExecutionCredentialReadiness,
+} from "../api";
+import { CodeExecutionPanel } from "./CodeExecutionPanel";
+
+function clientFor(
+  config: CodeExecutionConfigInfo,
+  credentials: CodeExecutionCredentialReadiness[] = [
+    { provider: "e2b", has_credential: false },
+    { provider: "daytona", has_credential: false },
+  ],
+) {
+  const putCodeExecutionConfig = vi.fn().mockResolvedValue(config);
+  const putCodeExecutionCredential = vi
+    .fn()
+    .mockImplementation((provider: string) =>
+      Promise.resolve({ provider, has_credential: true }),
+    );
+  const deleteCodeExecutionCredential = vi
+    .fn()
+    .mockImplementation((provider: string) =>
+      Promise.resolve({ provider, has_credential: false }),
+    );
+  return {
+    client: {
+      getCodeExecutionConfig: vi.fn().mockResolvedValue(config),
+      listCodeExecutionCredentials: vi.fn().mockResolvedValue({ credentials }),
+      putCodeExecutionConfig,
+      putCodeExecutionCredential,
+      deleteCodeExecutionCredential,
+    } as unknown as ApiClient,
+    putCodeExecutionConfig,
+    putCodeExecutionCredential,
+    deleteCodeExecutionCredential,
+  };
+}
+
+afterEach(cleanup);
+
+describe("CodeExecutionPanel", () => {
+  it("saves a key per managed provider before the active selection", async () => {
+    const { client, putCodeExecutionConfig, putCodeExecutionCredential } =
+      clientFor({
+        provider: "e2b",
+        timeout_ms: 20_000,
+        available: false,
+        has_credential: false,
+      });
+
+    render(<CodeExecutionPanel client={client} />);
+
+    fireEvent.change(await screen.findByLabelText(/E2B API key/), {
+      target: { value: "  e2b-secret  " },
+    });
+    fireEvent.change(screen.getByLabelText(/Daytona API key/), {
+      target: { value: "daytona-secret" },
+    });
+    fireEvent.change(screen.getByLabelText(/Execution timeout/), {
+      target: { value: "30000" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+
+    await waitFor(() =>
+      expect(putCodeExecutionCredential).toHaveBeenCalledWith(
+        "e2b",
+        "e2b-secret",
+      ),
+    );
+    expect(putCodeExecutionCredential).toHaveBeenCalledWith(
+      "daytona",
+      "daytona-secret",
+    );
+    expect(putCodeExecutionConfig).toHaveBeenCalledWith({
+      provider: "e2b",
+      timeout_ms: 30_000,
+    });
+    // A provider must not go active in a pass that failed to store its key.
+    expect(
+      putCodeExecutionCredential.mock.invocationCallOrder[0],
+    ).toBeLessThan(putCodeExecutionConfig.mock.invocationCallOrder[0]);
+  });
+
+  it("removes one provider's saved key without touching the other", async () => {
+    const { client, deleteCodeExecutionCredential } = clientFor(
+      {
+        provider: "e2b",
+        timeout_ms: 20_000,
+        available: true,
+        has_credential: true,
+      },
+      [
+        { provider: "e2b", has_credential: true },
+        { provider: "daytona", has_credential: true },
+      ],
+    );
+
+    render(<CodeExecutionPanel client={client} />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Remove saved Daytona key" }),
+    );
+
+    await waitFor(() =>
+      expect(deleteCodeExecutionCredential).toHaveBeenCalledWith("daytona"),
+    );
+    expect(deleteCodeExecutionCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a timeout outside the bounds before touching the server", async () => {
+    const { client, putCodeExecutionConfig } = clientFor({
+      provider: "local",
+      timeout_ms: 20_000,
+      available: true,
+      has_credential: false,
+    });
+
+    render(<CodeExecutionPanel client={client} />);
+
+    fireEvent.change(await screen.findByLabelText(/Execution timeout/), {
+      target: { value: "500000" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+
+    await screen.findByRole("alert");
+    expect(putCodeExecutionConfig).not.toHaveBeenCalled();
+  });
+});

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
@@ -3,84 +3,75 @@ import { toast } from "sonner";
 import type {
   ApiClient,
   CodeExecutionConfigInfo,
+  CodeExecutionCredentialReadiness,
   CodeExecutionProviderKind,
 } from "../api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { ActiveProviderField, ProviderCredentialField } from "./ProviderFields";
 import {
   SettingsError,
   SettingsField,
   SettingsPanel,
   SettingsSection,
+  SettingsStatus,
 } from "./primitives";
 
 const MIN_CODE_EXECUTION_TIMEOUT_MS = 1_000;
 const MAX_CODE_EXECUTION_TIMEOUT_MS = 120_000;
 
-// Radix Select reserves the empty string, so "Disabled" (no provider) rides on
-// a sentinel value the wire never carries.
-const NO_PROVIDER = "__disabled__";
+/** The local sandbox needs no credential, so it never appears in the key list. */
+const LOCAL_PROVIDER: CodeExecutionProviderKind = "local";
 
 export function CodeExecutionPanel({ client }: { client: ApiClient }) {
   const [config, setConfig] = useState<CodeExecutionConfigInfo | null>(null);
+  const [credentials, setCredentials] = useState<
+    CodeExecutionCredentialReadiness[]
+  >([]);
   const [provider, setProvider] = useState<CodeExecutionProviderKind | "">("");
   const [timeoutMs, setTimeoutMs] = useState("");
-  const [apiKey, setApiKey] = useState("");
+  // One draft key per managed provider, so E2B and Daytona can be configured
+  // together and switching the active provider discards neither.
+  const [apiKeys, setApiKeys] = useState<
+    Partial<Record<CodeExecutionProviderKind, string>>
+  >({});
   const [loading, setLoading] = useState(true);
-  const [savingConfig, setSavingConfig] = useState(false);
-  const [savingCredential, setSavingCredential] = useState(false);
-  const [removingCredential, setRemovingCredential] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [removing, setRemoving] = useState<CodeExecutionProviderKind | null>(
+    null,
+  );
   const [error, setError] = useState<string | null>(null);
-
-  async function refresh() {
-    const nextConfig = await client.getCodeExecutionConfig();
-    setConfig(nextConfig);
-    setProvider(nextConfig.provider ?? "");
-    setTimeoutMs(String(nextConfig.timeout_ms));
-  }
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    void client
-      .getCodeExecutionConfig()
-      .then((nextConfig) => {
+    void (async () => {
+      try {
+        const [nextConfig, nextCredentials] = await Promise.all([
+          client.getCodeExecutionConfig(),
+          client.listCodeExecutionCredentials(),
+        ]);
         if (cancelled) return;
         setConfig(nextConfig);
+        setCredentials(nextCredentials.credentials);
         setProvider(nextConfig.provider ?? "");
         setTimeoutMs(String(nextConfig.timeout_ms));
-      })
-      .catch((err) => {
+      } catch (err) {
         if (!cancelled) setError(String(err));
-      })
-      .finally(() => {
+      } finally {
         if (!cancelled) setLoading(false);
-      });
+      }
+    })();
     return () => {
       cancelled = true;
     };
   }, [client]);
 
+  const working = saving || removing !== null;
   const state = codeExecutionState(config);
-  const activeProvider = config?.provider;
-  const managedProvider =
-    activeProvider === "e2b" || activeProvider === "daytona"
-      ? activeProvider
-      : null;
-  const managedProviderLabel = managedProvider
-    ? codeExecutionProviderLabel(managedProvider)
-    : null;
-  const working = savingConfig || savingCredential || removingCredential;
 
-  async function saveConfig() {
+  async function save() {
     const parsedTimeout = Number(timeoutMs);
     if (
       !Number.isInteger(parsedTimeout) ||
@@ -93,59 +84,59 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
       return;
     }
 
-    setSavingConfig(true);
+    setSaving(true);
     setError(null);
     try {
+      // Keys go first so the newly active provider never lands
+      // selected-but-unusable when the caller supplied both in one pass.
+      for (const credential of credentials) {
+        const key = apiKeys[credential.provider]?.trim();
+        if (!key) continue;
+        await client.putCodeExecutionCredential(credential.provider, key);
+        setApiKeys((current) => ({ ...current, [credential.provider]: "" }));
+      }
       const nextConfig = await client.putCodeExecutionConfig({
         provider: provider || null,
         timeout_ms: parsedTimeout,
       });
+      const nextCredentials = await client.listCodeExecutionCredentials();
       setConfig(nextConfig);
+      setCredentials(nextCredentials.credentials);
       setProvider(nextConfig.provider ?? "");
       setTimeoutMs(String(nextConfig.timeout_ms));
-      toast.success("Saved code-execution configuration");
+      toast.success("Saved code-execution settings");
     } catch (err) {
       setError(String(err));
     } finally {
-      setSavingConfig(false);
+      setSaving(false);
     }
   }
 
-  async function saveCredential() {
-    if (!managedProvider || !managedProviderLabel || !apiKey.trim()) return;
-    setSavingCredential(true);
+  async function removeCredential(target: CodeExecutionProviderKind) {
+    setRemoving(target);
     setError(null);
     try {
-      await client.putCodeExecutionCredential(managedProvider, apiKey.trim());
-      setApiKey("");
-      await refresh();
-      toast.success(`Saved the ${managedProviderLabel} API key`);
+      await client.deleteCodeExecutionCredential(target);
+      const [nextConfig, nextCredentials] = await Promise.all([
+        client.getCodeExecutionConfig(),
+        client.listCodeExecutionCredentials(),
+      ]);
+      setConfig(nextConfig);
+      setCredentials(nextCredentials.credentials);
+      toast.success(
+        `Removed the saved ${codeExecutionProviderLabel(target)} API key`,
+      );
     } catch (err) {
       setError(String(err));
     } finally {
-      setSavingCredential(false);
-    }
-  }
-
-  async function removeCredential() {
-    if (!managedProvider || !managedProviderLabel) return;
-    setRemovingCredential(true);
-    setError(null);
-    try {
-      await client.deleteCodeExecutionCredential(managedProvider);
-      await refresh();
-      toast.success(`Removed the saved ${managedProviderLabel} API key`);
-    } catch (err) {
-      setError(String(err));
-    } finally {
-      setRemovingCredential(false);
+      setRemoving(null);
     }
   }
 
   return (
     <SettingsPanel
       title="Code execution"
-      description="Choose an isolated execution provider and a host-enforced timeout."
+      description="Configure as many cloud sandboxes as you like, choose where agents execute, and bound every run. Saved keys are never shown here."
       busy={loading}
     >
       {loading ? (
@@ -158,37 +149,51 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
         </p>
       ) : (
         <>
-          <div className={`web-search-state is-${state.kind}`} role="status">
-            <strong>{state.label}</strong>
-            <span>{state.description}</span>
-          </div>
+          <SettingsStatus
+            tone={state.kind}
+            label={state.label}
+            description={state.description}
+          />
 
-          <SettingsSection>
-            <SettingsField label="Provider">
-              <Select
-                value={provider === "" ? NO_PROVIDER : provider}
+          <SettingsSection
+            title="Cloud sandbox keys"
+            description="Give a key to every managed provider you want available. The local sandbox needs none."
+          >
+            {credentials.map((credential) => (
+              <ProviderCredentialField
+                key={credential.provider}
+                provider={codeExecutionProviderLabel(credential.provider)}
+                hasCredential={credential.has_credential}
+                value={apiKeys[credential.provider] ?? ""}
                 disabled={working}
-                onValueChange={(value) =>
-                  setProvider(
-                    value === NO_PROVIDER
-                      ? ""
-                      : (value as CodeExecutionProviderKind),
-                  )
+                removing={removing === credential.provider}
+                onChange={(value) =>
+                  setApiKeys((current) => ({
+                    ...current,
+                    [credential.provider]: value,
+                  }))
                 }
-              >
-                <SelectTrigger aria-label="Provider">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={NO_PROVIDER}>Disabled</SelectItem>
-                  <SelectItem value="local">Local native sandbox</SelectItem>
-                  <SelectItem value="e2b">E2B cloud sandbox</SelectItem>
-                  <SelectItem value="daytona">
-                    Daytona cloud sandbox
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-            </SettingsField>
+                onRemove={() => void removeCredential(credential.provider)}
+              />
+            ))}
+          </SettingsSection>
+
+          <SettingsSection
+            title="Active provider"
+            description="Agents execute in this one provider. The others stay configured and idle."
+          >
+            <ActiveProviderField
+              value={provider}
+              disabled={working}
+              onChange={setProvider}
+              options={[
+                { kind: LOCAL_PROVIDER, label: "Local native sandbox" },
+                ...credentials.map((credential) => ({
+                  kind: credential.provider,
+                  label: `${codeExecutionProviderLabel(credential.provider)} cloud sandbox`,
+                })),
+              ]}
+            />
 
             <SettingsField
               label="Execution timeout (ms)"
@@ -205,69 +210,16 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
                 onChange={(event) => setTimeoutMs(event.target.value)}
               />
             </SettingsField>
-
-            <Button
-              type="button"
-              className="self-start"
-              disabled={working}
-              onClick={() => void saveConfig()}
-            >
-              {savingConfig ? "Saving…" : "Save configuration"}
-            </Button>
           </SettingsSection>
 
-          {managedProvider && managedProviderLabel && (
-            <SettingsSection title={`${managedProviderLabel} credential`}>
-              <span className="text-xs text-muted-foreground">
-                {config.has_credential
-                  ? "credential saved"
-                  : "no credential saved"}
-              </span>
-              <SettingsField
-                label={config.has_credential ? "Replace API key" : "API key"}
-              >
-                <Input
-                  type="password"
-                  placeholder={`Paste a new ${managedProviderLabel} API key`}
-                  value={apiKey}
-                  maxLength={8_192}
-                  autoComplete="new-password"
-                  disabled={working}
-                  onChange={(event) => setApiKey(event.target.value)}
-                />
-              </SettingsField>
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  type="button"
-                  disabled={working || !apiKey.trim()}
-                  onClick={() => void saveCredential()}
-                >
-                  {savingCredential
-                    ? "Saving…"
-                    : config.has_credential
-                      ? "Update key"
-                      : "Save key"}
-                </Button>
-                {config.has_credential && (
-                  <Button
-                    type="button"
-                    variant="destructive"
-                    disabled={working}
-                    onClick={() => void removeCredential()}
-                  >
-                    {removingCredential ? "Removing…" : "Remove saved key"}
-                  </Button>
-                )}
-              </div>
-            </SettingsSection>
-          )}
-
-          {provider !== (activeProvider ?? "") && (
-            <p className="text-xs text-muted-foreground">
-              Save the provider configuration before managing that provider’s
-              key.
-            </p>
-          )}
+          {/* One save for the whole surface: it stores every key typed above
+              and the selection together, so a provider cannot go active in a
+              pass that failed to save its key. */}
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" disabled={working} onClick={() => void save()}>
+              {saving ? "Saving…" : "Save settings"}
+            </Button>
+          </div>
 
           <p className="text-sm leading-relaxed text-muted-foreground">
             Local execution blocks network and confines writes to private chat
@@ -300,12 +252,12 @@ function codeExecutionState(config: CodeExecutionConfigInfo | null): {
       kind: "ready",
       label: "Ready",
       description:
-        config.provider !== "local"
+        config.provider !== LOCAL_PROVIDER
           ? `${codeExecutionProviderLabel(config.provider)} is selected and has a saved credential.`
           : "The local native sandbox is available.",
     };
   }
-  if (config.provider !== "local" && !config.has_credential) {
+  if (config.provider !== LOCAL_PROVIDER && !config.has_credential) {
     return {
       kind: "not-configured",
       label: "Not configured",

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
@@ -17,6 +17,7 @@ import {
   SettingsField,
   SettingsPanel,
   SettingsSection,
+  SettingsStatus,
 } from "./primitives";
 
 const SIGN_IN_POLL_MS = 2_000;
@@ -295,15 +296,15 @@ export function GatewayPanel({
       <SettingsSection title="Connection">
         {status.signed_in ? (
           <>
-            <div className="web-search-state is-ready" role="status">
-              <strong>Signed in</strong>
-              <span>
-                {status.account_hint ?? "Connected"} ·{" "}
-                {status.model_count === 1
+            <SettingsStatus
+              tone="ready"
+              label="Signed in"
+              description={`${status.account_hint ?? "Connected"} · ${
+                status.model_count === 1
                   ? "1 model entitled"
-                  : `${status.model_count} models entitled`}
-              </span>
-            </div>
+                  : `${status.model_count} models entitled`
+              }`}
+            />
             {status.installation_id && (
               <p className="text-muted-foreground text-xs">
                 Installation {status.installation_id}
@@ -344,14 +345,15 @@ export function GatewayPanel({
           </>
         ) : (
           <>
-            <div className="web-search-state is-not-configured" role="status">
-              <strong>Not signed in</strong>
-              <span>
-                {status.configured
+            <SettingsStatus
+              tone="not-configured"
+              label="Not signed in"
+              description={
+                status.configured
                   ? "Connect to sign in with your browser."
-                  : "Save the gateway URL, then connect."}
-              </span>
-            </div>
+                  : "Save the gateway URL, then connect."
+              }
+            />
             {status.sign_in.state === "failed" && (
               <SettingsError>{status.sign_in.message}</SettingsError>
             )}

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
@@ -14,6 +14,7 @@ import {
   SettingsField,
   SettingsPanel,
   SettingsSection,
+  SettingsStatus,
 } from "./primitives";
 
 const DEFAULT_TIMEOUT_MS = 60_000;
@@ -181,18 +182,16 @@ export function McpPanel({ client }: { client: ApiClient }) {
               key={index}
               title={server.name || `Server ${index + 1}`}
             >
-              <div
-                className={`web-search-state is-${healthTone(server.health)}`}
-                role="status"
-              >
-                <strong>{healthLabel(server.health)}</strong>
-                <span>
-                  {server.health === "healthy"
+              <SettingsStatus
+                tone={healthTone(server.health)}
+                label={healthLabel(server.health)}
+                description={
+                  server.health === "healthy"
                     ? `${server.tool_count} tool${server.tool_count === 1 ? "" : "s"} available to new turns.`
                     : server.diagnostic ??
-                      "Save the configuration to verify this server."}
-                </span>
-              </div>
+                      "Save the configuration to verify this server."
+                }
+              />
 
               <div className="flex items-center justify-between gap-4">
                 <div className="flex-1">

--- a/crates/openwave-desktop/ui/src/settings/ProviderFields.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProviderFields.tsx
@@ -1,0 +1,132 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { SettingsField } from "./primitives";
+
+/**
+ * Web search and code execution both hold one credential per provider in a
+ * fixed keychain slot and run through one provider at a time. These are the two
+ * controls that shape gives every such panel: a key field per slot, and the
+ * choice of which provider is live.
+ */
+
+// Radix Select reserves the empty string, so "Disabled" (no provider) rides on
+// a sentinel value the wire never carries.
+const NO_PROVIDER = "__disabled__";
+
+/** Longest key the local credential endpoints accept. */
+const MAX_CREDENTIAL_LENGTH = 8_192;
+
+export type ProviderOption<Kind extends string> = {
+  kind: Kind;
+  label: string;
+};
+
+/**
+ * The single provider a host-owned tool runs through, alongside an explicit
+ * Disabled choice — the safe state, and the only way to take the tool out of
+ * service without discarding what is configured.
+ */
+export function ActiveProviderField<Kind extends string>({
+  options,
+  value,
+  disabled,
+  onChange,
+}: {
+  options: ProviderOption<Kind>[];
+  value: Kind | "";
+  disabled?: boolean;
+  onChange: (value: Kind | "") => void;
+}) {
+  return (
+    <SettingsField label="Provider">
+      <Select
+        value={value === "" ? NO_PROVIDER : value}
+        disabled={disabled}
+        onValueChange={(next) =>
+          onChange(next === NO_PROVIDER ? "" : (next as Kind))
+        }
+      >
+        <SelectTrigger aria-label="Provider">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={NO_PROVIDER}>Disabled</SelectItem>
+          {options.map((option) => (
+            <SelectItem key={option.kind} value={option.kind}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </SettingsField>
+  );
+}
+
+/**
+ * A write-only key field for one provider's credential slot, with the remove
+ * action beside it. A saved key is never read back, so the field reports only
+ * that one is there and stays empty until the user types a replacement.
+ */
+export function ProviderCredentialField({
+  provider,
+  hasCredential,
+  value,
+  disabled,
+  removing,
+  onChange,
+  onRemove,
+}: {
+  provider: string;
+  hasCredential: boolean;
+  value: string;
+  disabled?: boolean;
+  removing?: boolean;
+  onChange: (value: string) => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <SettingsField
+        label={`${provider} API key`}
+        hint={
+          hasCredential
+            ? "A key is already saved. Type a new one to replace it."
+            : undefined
+        }
+      >
+        <Input
+          type="password"
+          placeholder={
+            hasCredential
+              ? "Saved — leave blank to keep it"
+              : `Paste your ${provider} API key`
+          }
+          value={value}
+          maxLength={MAX_CREDENTIAL_LENGTH}
+          autoComplete="new-password"
+          disabled={disabled}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      </SettingsField>
+      {hasCredential && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="self-start"
+          disabled={disabled}
+          onClick={onRemove}
+        >
+          {removing ? "Removing…" : `Remove saved ${provider} key`}
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/settings/WebSearchPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/WebSearchPanel.dom.test.tsx
@@ -81,6 +81,10 @@ describe("WebSearchPanel", () => {
       provider: "exa",
       timeout_ms: 30_000,
     });
+    // A provider must not go active in a pass that failed to store its key.
+    expect(putWebSearchCredential.mock.invocationCallOrder[0]).toBeLessThan(
+      putWebSearchConfig.mock.invocationCallOrder[0],
+    );
   });
 
   it("removes one provider's saved key without touching the other", async () => {

--- a/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
@@ -9,25 +9,19 @@ import type {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  ActiveProviderField,
+  ProviderCredentialField,
+} from "./ProviderFields";
 import {
   SettingsError,
   SettingsField,
   SettingsPanel,
   SettingsSection,
+  SettingsStatus,
 } from "./primitives";
 
 const MIN_WEB_SEARCH_TIMEOUT_SECONDS = 1;
 const MAX_WEB_SEARCH_TIMEOUT_SECONDS = 60;
-
-// Radix Select reserves the empty string, so "Disabled" (no provider) rides on
-// a sentinel value the wire never carries.
-const NO_PROVIDER = "__disabled__";
 
 export function WebSearchPanel({ client }: { client: ApiClient }) {
   const [config, setConfig] = useState<WebSearchConfigInfo | null>(null);
@@ -149,59 +143,32 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
         </p>
       ) : (
         <>
-          <div className={`web-search-state is-${state.kind}`} role="status">
-            <strong>{state.label}</strong>
-            <span>{state.description}</span>
-          </div>
+          <SettingsStatus
+            tone={state.kind}
+            label={state.label}
+            description={state.description}
+          />
 
           <SettingsSection
             title="Providers"
             description="Give a key to every provider you want available. Each key is stored in the system keychain and never shown again."
           >
             {credentials.map((credential) => (
-              <div className="flex flex-col gap-1.5" key={credential.provider}>
-                <SettingsField
-                  label={`${providerLabel(credential.provider)} API key`}
-                  hint={
-                    credential.has_credential
-                      ? "A key is already saved. Type a new one to replace it."
-                      : undefined
-                  }
-                >
-                  <Input
-                    type="password"
-                    placeholder={
-                      credential.has_credential
-                        ? "Saved — leave blank to keep it"
-                        : `Paste your ${providerLabel(credential.provider)} API key`
-                    }
-                    value={apiKeys[credential.provider] ?? ""}
-                    maxLength={8_192}
-                    autoComplete="new-password"
-                    disabled={working}
-                    onChange={(event) =>
-                      setApiKeys((current) => ({
-                        ...current,
-                        [credential.provider]: event.target.value,
-                      }))
-                    }
-                  />
-                </SettingsField>
-                {credential.has_credential && (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    className="self-start"
-                    disabled={working}
-                    onClick={() => void removeCredential(credential.provider)}
-                  >
-                    {removing === credential.provider
-                      ? "Removing…"
-                      : `Remove saved ${providerLabel(credential.provider)} key`}
-                  </Button>
-                )}
-              </div>
+              <ProviderCredentialField
+                key={credential.provider}
+                provider={providerLabel(credential.provider)}
+                hasCredential={credential.has_credential}
+                value={apiKeys[credential.provider] ?? ""}
+                disabled={working}
+                removing={removing === credential.provider}
+                onChange={(value) =>
+                  setApiKeys((current) => ({
+                    ...current,
+                    [credential.provider]: value,
+                  }))
+                }
+                onRemove={() => void removeCredential(credential.provider)}
+              />
             ))}
           </SettingsSection>
 
@@ -209,34 +176,15 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
             title="Active provider"
             description="Agents search through this one provider. The others stay configured and idle."
           >
-            <SettingsField label="Provider">
-              <Select
-                value={provider === "" ? NO_PROVIDER : provider}
-                disabled={working}
-                onValueChange={(value) =>
-                  setProvider(
-                    value === NO_PROVIDER
-                      ? ""
-                      : (value as WebSearchProviderKind),
-                  )
-                }
-              >
-                <SelectTrigger aria-label="Provider">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={NO_PROVIDER}>Disabled</SelectItem>
-                  {credentials.map((credential) => (
-                    <SelectItem
-                      key={credential.provider}
-                      value={credential.provider}
-                    >
-                      {providerLabel(credential.provider)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </SettingsField>
+            <ActiveProviderField
+              value={provider}
+              disabled={working}
+              onChange={setProvider}
+              options={credentials.map((credential) => ({
+                kind: credential.provider,
+                label: providerLabel(credential.provider),
+              }))}
+            />
 
             <SettingsField
               label="Request timeout (seconds)"

--- a/crates/openwave-desktop/ui/src/settings/primitives.tsx
+++ b/crates/openwave-desktop/ui/src/settings/primitives.tsx
@@ -90,6 +90,29 @@ export function SettingsSection({
   );
 }
 
+/**
+ * The readiness line a settings surface leads with: a short verdict and the one
+ * sentence that says what to do about it. The tone carries the only colour —
+ * green for ready, red for something the user still has to supply — so a panel
+ * never has to reach for the class itself.
+ */
+export function SettingsStatus({
+  tone,
+  label,
+  description,
+}: {
+  tone: "ready" | "not-configured" | "disabled";
+  label: string;
+  description: ReactNode;
+}) {
+  return (
+    <div className={`settings-status is-${tone}`} role="status">
+      <strong>{label}</strong>
+      <span>{description}</span>
+    </div>
+  );
+}
+
 export function SettingsError({ children }: { children: ReactNode }) {
   return (
     <p className="text-sm text-destructive" role="alert">

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -1882,7 +1882,7 @@ body {
   color: var(--ink);
 }
 
-.web-search-state {
+.settings-status {
   display: grid;
   gap: 0.18rem;
   padding: 0.65rem 0.7rem;
@@ -1893,16 +1893,16 @@ body {
   font-size: 0.82rem;
 }
 
-.web-search-state strong {
+.settings-status strong {
   color: var(--ink);
   font-size: 0.84rem;
 }
 
-.web-search-state.is-ready {
+.settings-status.is-ready {
   border-color: color-mix(in srgb, var(--success) 55%, var(--line));
 }
 
-.web-search-state.is-not-configured {
+.settings-status.is-not-configured {
   border-color: color-mix(in srgb, var(--danger) 30%, var(--line));
 }
 

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -27,6 +27,14 @@ pub const DEFAULT_TIMEOUT_MS: u64 = 20_000;
 pub const MIN_TIMEOUT_MS: u64 = 1_000;
 pub const MAX_TIMEOUT_MS: u64 = 120_000;
 
+/// The fixed managed providers this host can hold a credential for. Local needs
+/// none. Keeping the allow-list here means a local API route can never turn an
+/// arbitrary path segment into a keychain key.
+const CREDENTIAL_PROVIDERS: [CodeExecutionProviderKind; 2] = [
+    CodeExecutionProviderKind::E2b,
+    CodeExecutionProviderKind::Daytona,
+];
+
 /// Non-secret host selection. Local is usable by default because its mandatory
 /// sandbox denies network and outside-workspace writes. `None` explicitly
 /// removes execution from service without changing the stable tool contract.
@@ -85,6 +93,13 @@ pub struct CodeExecutionConfigInfo {
 pub struct CodeExecutionCredentialReadiness {
     pub provider: CodeExecutionProviderKind,
     pub has_credential: bool,
+}
+
+/// Credential readiness for every managed provider this host supports, so the
+/// renderer can offer a key field per provider without selecting one first.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CodeExecutionCredentialsInfo {
+    pub credentials: Vec<CodeExecutionCredentialReadiness>,
 }
 
 /// Partial update accepted by `PUT /code-execution`. An explicit null disables
@@ -149,6 +164,19 @@ pub async fn config_info(
     })
 }
 
+/// Report readiness for every managed provider without reading or returning any
+/// key material.
+pub async fn credentials_info(secrets: &dyn SecretProvider) -> CodeExecutionCredentialsInfo {
+    let mut credentials = Vec::with_capacity(CREDENTIAL_PROVIDERS.len());
+    for provider in CREDENTIAL_PROVIDERS {
+        credentials.push(CodeExecutionCredentialReadiness {
+            provider,
+            has_credential: has_credential(secrets, provider).await,
+        });
+    }
+    CodeExecutionCredentialsInfo { credentials }
+}
+
 pub async fn update_config(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
@@ -200,13 +228,14 @@ pub async fn delete_credential(
 pub fn credential_provider(
     value: &str,
 ) -> std::result::Result<CodeExecutionProviderKind, ServerError> {
-    match value {
-        "e2b" => Ok(CodeExecutionProviderKind::E2b),
-        "daytona" => Ok(CodeExecutionProviderKind::Daytona),
-        _ => Err(ServerError::not_found(format!(
-            "unknown credentialed code execution provider kind: {value}"
-        ))),
-    }
+    CREDENTIAL_PROVIDERS
+        .into_iter()
+        .find(|provider| provider.as_str() == value)
+        .ok_or_else(|| {
+            ServerError::not_found(format!(
+                "unknown credentialed code execution provider kind: {value}"
+            ))
+        })
 }
 
 async fn has_credential(secrets: &dyn SecretProvider, provider: CodeExecutionProviderKind) -> bool {

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -273,6 +273,10 @@ pub fn app(state: AppState) -> Router {
                 .layer(DefaultBodyLimit::max(MAX_CODE_EXECUTION_CONFIG_BODY_BYTES)),
         )
         .route(
+            "/code-execution/credentials",
+            get(routes::get_code_execution_credentials),
+        )
+        .route(
             "/code-execution/credentials/{provider}",
             axum::routing::put(routes::put_code_execution_credential)
                 .delete(routes::delete_code_execution_credential)

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -27,6 +27,7 @@ use openwave_core::{
 use crate::auth::{offered_handshake_subprotocol, WS_HANDSHAKE_SUBPROTOCOL};
 use crate::code_execution::{
     self, CodeExecutionConfigInfo, CodeExecutionConfigUpdate, CodeExecutionCredentialReadiness,
+    CodeExecutionCredentialsInfo,
 };
 use crate::error::ServerError;
 use crate::event_projection::{RendererChatFrame, RendererChatMetadata, RendererSequencedEvent};
@@ -416,6 +417,14 @@ pub async fn put_code_execution_config(
     ))
 }
 
+/// `GET /code-execution/credentials` — readiness for the fixed E2B and Daytona
+/// credential slots. Local execution needs no credential and is absent here.
+pub async fn get_code_execution_credentials(
+    State(state): State<AppState>,
+) -> Json<CodeExecutionCredentialsInfo> {
+    Json(code_execution::credentials_info(&*state.secrets).await)
+}
+
 const MAX_CODE_EXECUTION_CREDENTIAL_BYTES: usize = 8 * 1024;
 
 /// Body of `PUT /code-execution/credentials/{provider}`. Debug output always
@@ -505,7 +514,7 @@ pub async fn put_web_search_credential(
     Path(provider): Path<String>,
     Json(body): Json<WebSearchCredentialUpdate>,
 ) -> Result<Json<WebSearchCredentialReadiness>, ServerError> {
-    let provider = parse_web_search_provider(&provider)?;
+    let provider = web_search::credential_provider(&provider)?;
     if body.api_key.len() > MAX_WEB_SEARCH_CREDENTIAL_BYTES {
         return Err(ServerError::bad_request(format!(
             "web search api_key must be at most {MAX_WEB_SEARCH_CREDENTIAL_BYTES} bytes"
@@ -528,22 +537,10 @@ pub async fn delete_web_search_credential(
     State(state): State<AppState>,
     Path(provider): Path<String>,
 ) -> Result<Json<WebSearchCredentialReadiness>, ServerError> {
-    let provider = parse_web_search_provider(&provider)?;
+    let provider = web_search::credential_provider(&provider)?;
     Ok(Json(
         web_search::delete_credential(&*state.secrets, provider).await?,
     ))
-}
-
-fn parse_web_search_provider(
-    value: &str,
-) -> std::result::Result<openwave_web_search::WebSearchProviderKind, ServerError> {
-    match value {
-        "exa" => Ok(openwave_web_search::WebSearchProviderKind::Exa),
-        "tavily" => Ok(openwave_web_search::WebSearchProviderKind::Tavily),
-        _ => Err(ServerError::not_found(format!(
-            "unknown web search provider kind: {value}"
-        ))),
-    }
 }
 
 /// The configured chat model, if any — the `chat` role's explicit selection.

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -574,6 +574,44 @@ async fn code_execution_config_route_is_authenticated_and_preserves_explicit_dis
     assert!(initial["available"].is_boolean());
     assert_eq!(initial["has_credential"], false);
 
+    let unauthenticated_credentials = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/code-execution/credentials")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        unauthenticated_credentials.status(),
+        StatusCode::UNAUTHORIZED
+    );
+
+    let credentials = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/code-execution/credentials")
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(credentials.status(), StatusCode::OK);
+    assert_eq!(
+        json_body::<serde_json::Value>(credentials).await,
+        serde_json::json!({
+            "credentials": [
+                {"provider": "e2b", "has_credential": false},
+                {"provider": "daytona", "has_credential": false}
+            ]
+        }),
+        "local execution needs no credential and has no slot to report"
+    );
+
     let disabled = router
         .clone()
         .oneshot(
@@ -762,6 +800,28 @@ async fn code_execution_config_route_is_authenticated_and_preserves_explicit_dis
             .as_deref(),
         Some(key),
         "managed providers retain separate fixed credential slots"
+    );
+
+    let credentials = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/code-execution/credentials")
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        json_body::<serde_json::Value>(credentials).await,
+        serde_json::json!({
+            "credentials": [
+                {"provider": "e2b", "has_credential": true},
+                {"provider": "daytona", "has_credential": true}
+            ]
+        }),
+        "readiness is reported per provider, not only for the selected one"
     );
 
     let ready = router

--- a/crates/openwave-server/src/web_search.rs
+++ b/crates/openwave-server/src/web_search.rs
@@ -175,6 +175,16 @@ pub async fn credentials_info(
     Ok(WebSearchCredentialsInfo { credentials })
 }
 
+/// Resolve a local API path segment to a provider that has a fixed credential
+/// slot. Deriving this from the allow-list keeps the set of addressable keychain
+/// entries in one place.
+pub fn credential_provider(value: &str) -> std::result::Result<WebSearchProviderKind, ServerError> {
+    CREDENTIAL_PROVIDERS
+        .into_iter()
+        .find(|provider| provider.as_str() == value)
+        .ok_or_else(|| ServerError::not_found(format!("unknown web search provider kind: {value}")))
+}
+
 /// Store a non-empty, already validated credential under the provider's fixed
 /// key. The provider kind is an enum rather than caller-controlled storage
 /// input, so this cannot address other application secrets.

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -17,6 +17,7 @@ The authenticated local API owns provider selection and timeout policy:
 | --- | --- |
 | `GET /code-execution` | Return the selected provider, timeout, and host readiness |
 | `PUT /code-execution` | Select a fixed provider or disable execution, and update the bounded timeout |
+| `GET /code-execution/credentials` | Read readiness for the fixed E2B and Daytona key slots |
 | `PUT /code-execution/credentials/{e2b\|daytona}` | Store that provider's API key in its fixed host-secret slot |
 | `DELETE /code-execution/credentials/{e2b\|daytona}` | Remove only that provider's saved API key |
 
@@ -40,9 +41,23 @@ disables execution; sending `{"provider": "local"}` enables the local adapter.
 their fixed credential slot is populated. No executable, endpoint, environment
 value, or secret reference is accepted by the non-secret settings surface.
 
+`GET /code-execution` reports `has_credential` for the selected provider only,
+while `GET /code-execution/credentials` reports readiness for both managed slots
+independently. Local execution needs no credential and has no slot to report.
+
 The `exec` tool remains registered with a stable schema while settings change.
 The host resolves the selected provider immediately before execution, so a
 configuration update takes effect without restarting OpenWave.
+
+## Desktop setup
+
+The desktop sidebar's **Code execution** panel drives this same local API. It
+offers a key field per managed slot, so E2B and Daytona can both hold a key and
+switching between them needs no retyping, and a separate choice of which
+provider agents execute in — the local sandbox, one of the managed ones, or
+disabled. Saving writes every key the user typed before it writes selection, so
+a provider cannot become active in a pass that failed to store its key. Saved
+keys are never displayed or read into the renderer.
 
 ## Provider contract
 

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -48,10 +48,13 @@ disabled selection fails closed: there is no provider to invoke.
 
 The desktop sidebar has a **Web search** panel for this same local API. It
 shows whether the saved configuration is disabled, ready, or missing the
-selected provider's key; lets the user choose Exa or Tavily (or disable search),
-set the bounded timeout, and save, replace, or remove a key. Existing keys are
-never displayed or read into the renderer. Saving a key and saving provider
-selection are deliberately separate actions, matching the API boundary above.
+selected provider's key; offers a key field per fixed slot, so Exa and Tavily
+can both hold a key and switching between them needs no retyping; and lets the
+user pick which provider is active (or disable search) and set the bounded
+timeout. Existing keys are never displayed or read into the renderer. Saving
+writes every key the user typed before it writes selection, so a provider cannot
+become active in a pass that failed to store its key. Removing a key stays a
+separate action against a single slot.
 
 ## Current boundary
 


### PR DESCRIPTION
Follow-on to #769. Code execution has the same underlying model web search does — one credential per managed provider in its own fixed keychain slot, one active selection — but its panel was a step behind: the key field appeared only for the provider *already saved* as active, so configuring Daytona meant saving the selection first, and holding both keys meant switching back and forth.

**Server.** `GET /code-execution/credentials` mirrors the web-search route and reports readiness for the E2B and Daytona slots independently. `GET /code-execution` still reports `has_credential` for the selection alone. Local execution needs no credential and has no slot to report. Both modules' credential path segments now resolve against the same allow-list constant that backs the readiness list, replacing a second `match` in the route layer — the set of addressable keychain entries lives in one place per module.

**Panel.** A key field per managed slot with its own remove action, an active-provider select covering local, both managed providers, and disabled, and one save that writes keys before selection. This drops the old "save the provider configuration before managing that provider's key" hop entirely.

**Shared, not duplicated.** The controls the two panels now have in common are shared code:

- `SettingsStatus` (primitives) for the readiness banner — Gateway and MCP adopt it too, which retires the `web-search-state` class they were borrowing in favour of `settings-status`.
- `ActiveProviderField` and `ProviderCredentialField` (new `settings/ProviderFields.tsx`) for the provider surface, including the Radix "Disabled" sentinel and the write-only key field that reports a saved key without reading it back.

Tests: extended the existing code-execution route test with the new endpoint's shape at both ends (empty, then both slots populated) rather than standing up a second fixture; added a `CodeExecutionPanel` DOM test for save-both-keys-then-selection, per-slot removal, and timeout bounds. Both panels now assert that credential writes precede the selection write, which is the invariant behind saving in one pass. `cargo check`/`clippy`/`fmt`, the server config tests, `tsc`, `pnpm test` (555) and `pnpm build` are green.

Docs: `docs/code-execution.md` gains the endpoint and a Desktop setup section; `docs/web-search.md`'s setup section is updated for the shape that landed in #769.

Closes #782