### PR TITLE
feat(desktop): managed-mode sign-in gate

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -37,6 +37,9 @@ vi.mock("./boot", () => ({
 
 vi.mock("./api", () => ({
   ApiClient: class {
+    // Unmanaged is the shape these shell tests model; the managed gate has
+    // its own DOM tests.
+    getPolicy = vi.fn(async () => ({ managed: false, source: "unmanaged" }));
     listModels = vi.fn(async () => ({ models: [], roles: [] }));
     listProviders = vi.fn(async () => ({ providers: [] }));
     listChats = listChats;

--- a/crates/openwave-desktop/ui/src/AppShell.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.tsx
@@ -20,6 +20,7 @@ import { useConfirm } from "./components/ConfirmDialog";
 import { hasMacOverlayTitlebar } from "./host";
 import { useInterfaceZoom } from "./InterfaceZoom";
 import { Logomark } from "./Logomark";
+import { ManagedGate } from "./ManagedGate";
 import { resolvedRoleKey } from "./ModelSelection";
 import { useTheme } from "./theme";
 import { Titlebar } from "./Titlebar";
@@ -280,36 +281,38 @@ export function AppShell() {
   }
 
   return (
-    <AppContextProvider
-      value={{
-        client,
-        models,
-        defaultModelKey,
-        providers,
-        refreshCatalog,
-        status,
-        setStatus,
-        newChat: () => void onNewChat(),
-        deleteChat: (target) => void onDeleteChat(target),
-        startRename: startChatRename,
-        commitRename: (target) => void commitChatRename(target),
-        cancelRename: cancelChatRename,
-        themeMode,
-        setThemeMode,
-        cycleTheme,
-        updateState: desktopUpdates.state,
-        checkForUpdate: desktopUpdates.check,
-        restartForUpdate: onRestartForUpdate,
-      }}
-    >
-      <div className={`app-shell${hasMacOverlayTitlebar() ? " with-titlebar" : ""}`}>
-        {confirmDialog}
-        {hasMacOverlayTitlebar() && <Titlebar />}
-        {/* Each route renders its own rail beside its content — see RouteFrame. */}
-        <div className="app-body">
-          <Outlet />
+    <ManagedGate client={client}>
+      <AppContextProvider
+        value={{
+          client,
+          models,
+          defaultModelKey,
+          providers,
+          refreshCatalog,
+          status,
+          setStatus,
+          newChat: () => void onNewChat(),
+          deleteChat: (target) => void onDeleteChat(target),
+          startRename: startChatRename,
+          commitRename: (target) => void commitChatRename(target),
+          cancelRename: cancelChatRename,
+          themeMode,
+          setThemeMode,
+          cycleTheme,
+          updateState: desktopUpdates.state,
+          checkForUpdate: desktopUpdates.check,
+          restartForUpdate: onRestartForUpdate,
+        }}
+      >
+        <div className={`app-shell${hasMacOverlayTitlebar() ? " with-titlebar" : ""}`}>
+          {confirmDialog}
+          {hasMacOverlayTitlebar() && <Titlebar />}
+          {/* Each route renders its own rail beside its content — see RouteFrame. */}
+          <div className="app-body">
+            <Outlet />
+          </div>
         </div>
-      </div>
-    </AppContextProvider>
+      </AppContextProvider>
+    </ManagedGate>
   );
 }

--- a/crates/openwave-desktop/ui/src/ManagedGate.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.dom.test.tsx
@@ -199,6 +199,66 @@ describe("ManagedGate", () => {
     expect(await screen.findByText("Sign in to continue")).toBeInTheDocument();
   });
 
+  it("a transport failure never opens the app: boot holds until the policy answers", async () => {
+    // The server is not up yet. Rejected fetches and timeouts are not an
+    // answer, so nothing may be concluded from them — least of all
+    // "unmanaged". The read retries behind the boot screen until it lands.
+    const getPolicy = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValue(managed);
+    const getGatewayStatus = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("503: starting"))
+      .mockResolvedValue(signedOut);
+    const client = api({ getPolicy, getGatewayStatus });
+    vi.useFakeTimers();
+    mount(client);
+
+    // First attempt fails at the transport level: still booting.
+    await act(async () => {});
+    expect(screen.getByText("starting…")).toBeInTheDocument();
+    expect(screen.queryByText("the open product")).not.toBeInTheDocument();
+
+    // Through the first retry (1s backoff): still failing, still booting.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_100);
+    });
+    expect(screen.getByText("starting…")).toBeInTheDocument();
+    expect(screen.queryByText("the open product")).not.toBeInTheDocument();
+
+    // The second retry (2s backoff) resolves managed. The first status fetch
+    // fails too, so the gate rises carrying that error.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_100);
+    });
+    expect(screen.getByText("Sign in to continue")).toBeInTheDocument();
+    expect(screen.getByText(/503: starting/)).toBeInTheDocument();
+    expect(screen.queryByText("the open product")).not.toBeInTheDocument();
+
+    // The watch's next tick recovers the status and clears the stale error.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_100);
+    });
+    expect(screen.queryByText(/503: starting/)).not.toBeInTheDocument();
+    expect(screen.getByText("Sign in to continue")).toBeInTheDocument();
+    expect(screen.queryByText("the open product")).not.toBeInTheDocument();
+  });
+
+  it("a managed policy without a gateway URL blocks instead of lifting on any session", async () => {
+    const client = api({
+      getPolicy: vi.fn().mockResolvedValue({ managed: true, source: "os" }),
+      getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+    });
+    mount(client);
+
+    expect(
+      await screen.findByText(/Contact your administrator/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("the open product")).not.toBeInTheDocument();
+  });
+
   it("surfaces a failed browser sign-in and offers to try again", async () => {
     const client = api({
       getGatewayStatus: vi.fn().mockResolvedValue({

--- a/crates/openwave-desktop/ui/src/ManagedGate.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.dom.test.tsx
@@ -5,9 +5,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient, GatewayStatus, ManagedPolicy } from "./api";
 import { ManagedGate } from "./ManagedGate";
 
+// The policy stores its URL normalized with a trailing slash; the provider
+// config carries what the user (or a convergence) saved, typically without.
+// The fixtures differ deliberately so every match exercises normalization.
 const managed: ManagedPolicy = {
   managed: true,
-  gateway_url: "https://gateway.example",
+  gateway_url: "https://gateway.example/",
   source: "os",
 };
 
@@ -34,6 +37,7 @@ function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
     gatewaySignIn: vi
       .fn()
       .mockResolvedValue({ authorization_url: "http://gw/oauth/authorize?x=1" }),
+    putProvider: vi.fn().mockResolvedValue({}),
     ...overrides,
   } as unknown as ApiClient;
 }
@@ -50,6 +54,7 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
   vi.useRealTimers();
+  vi.unstubAllGlobals();
 });
 
 describe("ManagedGate", () => {
@@ -69,13 +74,16 @@ describe("ManagedGate", () => {
     mount(client);
 
     expect(await screen.findByText("Sign in to continue")).toBeInTheDocument();
-    // The gateway identity is shown but locked — no input to change it.
-    expect(screen.getByText("https://gateway.example")).toBeInTheDocument();
+    // The gateway identity is the policy's, shown but locked — no input.
+    expect(screen.getByText("https://gateway.example/")).toBeInTheDocument();
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
     expect(screen.queryByText("the open product")).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /Connect/ }));
     await waitFor(() => expect(client.gatewaySignIn).toHaveBeenCalled());
+    // The config already points at the policy gateway (modulo the trailing
+    // slash), so there is nothing to converge.
+    expect(client.putProvider).not.toHaveBeenCalled();
     expect(open).toHaveBeenCalledWith(
       "http://gw/oauth/authorize?x=1",
       "_blank",
@@ -86,7 +94,6 @@ describe("ManagedGate", () => {
     expect(
       screen.getByRole("link", { name: /Open the sign-in page again/ }),
     ).toHaveAttribute("href", "http://gw/authorize");
-    vi.unstubAllGlobals();
   });
 
   it("managed and signed in: renders the app, and a sign-out brings the gate back", async () => {
@@ -112,6 +119,52 @@ describe("ManagedGate", () => {
     expect(screen.queryByText("the open product")).not.toBeInTheDocument();
   });
 
+  it("a session on the wrong gateway does not lift the gate", async () => {
+    const client = api({
+      getGatewayStatus: vi.fn().mockResolvedValue({
+        ...signedIn,
+        base_url: "https://other.example",
+      }),
+    });
+    mount(client);
+
+    expect(await screen.findByText("Sign in to continue")).toBeInTheDocument();
+    expect(screen.queryByText("the open product")).not.toBeInTheDocument();
+    // What is shown is the device's managed gateway, not the stray config.
+    expect(screen.getByText("https://gateway.example/")).toBeInTheDocument();
+    expect(screen.queryByText(/other\.example/)).not.toBeInTheDocument();
+  });
+
+  it("connect on an unconfigured profile converges the provider to the policy gateway first", async () => {
+    const client = api({
+      getGatewayStatus: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ...signedOut,
+          configured: false,
+          base_url: undefined,
+        })
+        .mockResolvedValue(signedOut),
+    });
+    vi.stubGlobal("open", vi.fn());
+    const user = userEvent.setup();
+    mount(client);
+
+    await screen.findByText("Sign in to continue");
+    await user.click(screen.getByRole("button", { name: /Connect/ }));
+
+    await waitFor(() => expect(client.gatewaySignIn).toHaveBeenCalled());
+    expect(client.putProvider).toHaveBeenCalledWith("model_gateway", {
+      enabled: true,
+      base_url: "https://gateway.example/",
+    });
+    // Converge first, then sign in — the other order still refuses.
+    const putOrder = vi.mocked(client.putProvider).mock.invocationCallOrder[0];
+    const signInOrder = vi.mocked(client.gatewaySignIn).mock
+      .invocationCallOrder[0];
+    expect(putOrder).toBeLessThan(signInOrder);
+  });
+
   it("unmanaged profiles see the app untouched and no gateway traffic", async () => {
     const client = api({
       getPolicy: vi
@@ -123,6 +176,27 @@ describe("ManagedGate", () => {
     expect(await screen.findByText("the open product")).toBeInTheDocument();
     expect(screen.queryByText("Sign in to continue")).not.toBeInTheDocument();
     expect(client.getGatewayStatus).not.toHaveBeenCalled();
+  });
+
+  it("an error response from /policy blocks the app until a retry succeeds", async () => {
+    // The server answered: the policy exists but cannot be read. Fail closed.
+    const client = api({
+      getPolicy: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("500: managed policy unreadable"))
+        .mockResolvedValue(managed),
+    });
+    const user = userEvent.setup();
+    mount(client);
+
+    expect(
+      await screen.findByText(/Contact your administrator/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("the open product")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sign in to continue")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Retry/ }));
+    expect(await screen.findByText("Sign in to continue")).toBeInTheDocument();
   });
 
   it("surfaces a failed browser sign-in and offers to try again", async () => {

--- a/crates/openwave-desktop/ui/src/ManagedGate.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.dom.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient, GatewayStatus, ManagedPolicy } from "./api";
+import { ManagedGate } from "./ManagedGate";
+
+const managed: ManagedPolicy = {
+  managed: true,
+  gateway_url: "https://gateway.example",
+  source: "os",
+};
+
+const signedOut: GatewayStatus = {
+  configured: true,
+  enabled: true,
+  base_url: "https://gateway.example",
+  signed_in: false,
+  model_count: 0,
+  sign_in: { state: "idle" },
+};
+
+const signedIn: GatewayStatus = {
+  ...signedOut,
+  signed_in: true,
+  account_hint: "abaas@example.test",
+  model_count: 2,
+};
+
+function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
+  return {
+    getPolicy: vi.fn().mockResolvedValue(managed),
+    getGatewayStatus: vi.fn().mockResolvedValue(signedOut),
+    gatewaySignIn: vi
+      .fn()
+      .mockResolvedValue({ authorization_url: "http://gw/oauth/authorize?x=1" }),
+    ...overrides,
+  } as unknown as ApiClient;
+}
+
+function mount(client: ApiClient) {
+  return render(
+    <ManagedGate client={client}>
+      <p>the open product</p>
+    </ManagedGate>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe("ManagedGate", () => {
+  it("managed and signed out: gates the app and starts the browser sign-in", async () => {
+    const client = api({
+      getGatewayStatus: vi
+        .fn()
+        .mockResolvedValueOnce(signedOut)
+        .mockResolvedValue({
+          ...signedOut,
+          sign_in: { state: "pending", authorization_url: "http://gw/authorize" },
+        }),
+    });
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    const user = userEvent.setup();
+    mount(client);
+
+    expect(await screen.findByText("Sign in to continue")).toBeInTheDocument();
+    // The gateway identity is shown but locked — no input to change it.
+    expect(screen.getByText("https://gateway.example")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.queryByText("the open product")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Connect/ }));
+    await waitFor(() => expect(client.gatewaySignIn).toHaveBeenCalled());
+    expect(open).toHaveBeenCalledWith(
+      "http://gw/oauth/authorize?x=1",
+      "_blank",
+      "noreferrer,noopener",
+    );
+    // The reload after starting the flow reports it pending.
+    expect(await screen.findByText(/Waiting for the browser/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Open the sign-in page again/ }),
+    ).toHaveAttribute("href", "http://gw/authorize");
+    vi.unstubAllGlobals();
+  });
+
+  it("managed and signed in: renders the app, and a sign-out brings the gate back", async () => {
+    const client = api({
+      getGatewayStatus: vi
+        .fn()
+        .mockResolvedValueOnce(signedIn)
+        .mockResolvedValue(signedOut),
+    });
+    vi.useFakeTimers();
+    mount(client);
+    // Flush the policy fetch, then the status fetch it triggers.
+    await act(async () => {});
+    await act(async () => {});
+    expect(screen.getByText("the open product")).toBeInTheDocument();
+    expect(screen.queryByText("Sign in to continue")).not.toBeInTheDocument();
+
+    // The session watch notices the sign-out and lowers the gate again.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_100);
+    });
+    expect(screen.getByText("Sign in to continue")).toBeInTheDocument();
+    expect(screen.queryByText("the open product")).not.toBeInTheDocument();
+  });
+
+  it("unmanaged profiles see the app untouched and no gateway traffic", async () => {
+    const client = api({
+      getPolicy: vi
+        .fn()
+        .mockResolvedValue({ managed: false, source: "unmanaged" }),
+    });
+    mount(client);
+
+    expect(await screen.findByText("the open product")).toBeInTheDocument();
+    expect(screen.queryByText("Sign in to continue")).not.toBeInTheDocument();
+    expect(client.getGatewayStatus).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a failed browser sign-in and offers to try again", async () => {
+    const client = api({
+      getGatewayStatus: vi.fn().mockResolvedValue({
+        ...signedOut,
+        sign_in: { state: "failed", message: "browser authorization timed out" },
+      }),
+    });
+    mount(client);
+
+    expect(
+      await screen.findByText(/browser authorization timed out/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Connect/ })).toBeEnabled();
+  });
+});

--- a/crates/openwave-desktop/ui/src/ManagedGate.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, type ReactNode } from "react";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, RefreshCw } from "lucide-react";
 
 import type { ApiClient, GatewayStatus, ManagedPolicy } from "./api";
 import { Button } from "@/components/ui/button";
@@ -12,20 +12,78 @@ const PENDING_POLL_MS = 2_000;
 /** The session watch otherwise: signed in, it is what returns a signed-out
  * reader to the gate; signed out, it notices sign-ins completed elsewhere. */
 const SESSION_WATCH_MS = 5_000;
+/** A policy read that hangs is a transport failure, not an answer. */
+const POLICY_TIMEOUT_MS = 5_000;
+const POLICY_RETRY_MIN_MS = 1_000;
+const POLICY_RETRY_MAX_MS = 15_000;
+
+type PolicyState =
+  | { kind: "loading" }
+  | { kind: "resolved"; policy: ManagedPolicy }
+  /** The server answered, and the answer was an error: the policy exists but
+   * cannot be read. A profile that claims to be managed must never quietly
+   * revert to the open experience, so this blocks instead of failing open. */
+  | { kind: "blocked" };
+
+/** ApiClient throws `Error("<status>: <detail>")` for an HTTP error response;
+ * everything else — a rejected fetch, the timeout — is transport-level. */
+function isHttpErrorResponse(err: unknown): boolean {
+  return err instanceof Error && /^\d{3}: /.test(err.message);
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = window.setTimeout(
+      () => reject(new Error(`timed out after ${ms}ms`)),
+      ms,
+    );
+    promise.then(
+      (value) => {
+        window.clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        window.clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+/** Gateway URLs compare by parsed identity, not by string: the policy stores
+ * its URL normalized with a trailing slash, provider config may not. */
+function normalizedGatewayUrl(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    return `${url.protocol}//${url.host}${url.pathname.replace(/\/+$/, "")}`;
+  } catch {
+    return null;
+  }
+}
+
+function sameGateway(
+  a: string | null | undefined,
+  b: string | null | undefined,
+): boolean {
+  const left = normalizedGatewayUrl(a);
+  return left !== null && left === normalizedGatewayUrl(b);
+}
 
 /**
  * The managed-mode sign-in gate.
  *
  * When the resolved policy reports this install as managed, nothing of the
- * app renders until a gateway session exists. The gate wraps the router
- * rather than living on a route, so no navigation — settings included — can
- * get around it. Sign-out, wherever it happens, brings the gate back within
- * one watch interval. Unmanaged profiles render children untouched, and the
- * gateway is never even asked for its status.
+ * app renders until a gateway session exists on the policy's own gateway.
+ * The gate wraps the router rather than living on a route, so no navigation
+ * — settings included — can get around it. Sign-out, wherever it happens,
+ * brings the gate back within one watch interval. Unmanaged profiles render
+ * children untouched, and the gateway is never even asked for its status.
  *
- * The gate is presentation only: enforcement is the server's managed
- * lockdown, which is why an unreadable policy fails open to the ordinary app
- * instead of bricking it.
+ * The policy read fails closed. A transport failure (server not up yet,
+ * request timed out) retries silently behind the boot screen — an
+ * unreachable server is not an unmanaged profile. An error response blocks
+ * the app outright: the server actively said the policy is unreadable.
  */
 export function ManagedGate({
   client,
@@ -34,32 +92,46 @@ export function ManagedGate({
   client: ApiClient;
   children: ReactNode;
 }) {
-  // undefined: still resolving; null: unreadable, treated as unmanaged.
-  const [policy, setPolicy] = useState<ManagedPolicy | null | undefined>();
+  const [policyState, setPolicyState] = useState<PolicyState>({
+    kind: "loading",
+  });
   const [status, setStatus] = useState<GatewayStatus | null>(null);
   const [working, setWorking] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const policy = policyState.kind === "resolved" ? policyState.policy : null;
   const managed = policy?.managed === true;
 
   useEffect(() => {
+    if (policyState.kind !== "loading") return;
     let cancelled = false;
-    client.getPolicy().then(
-      (next) => {
-        if (!cancelled) setPolicy(next);
-      },
-      () => {
-        if (!cancelled) setPolicy(null);
-      },
-    );
+    let timer: number | undefined;
+    const attempt = async (backoffMs: number) => {
+      try {
+        const next = await withTimeout(client.getPolicy(), POLICY_TIMEOUT_MS);
+        if (!cancelled) setPolicyState({ kind: "resolved", policy: next });
+      } catch (err) {
+        if (cancelled) return;
+        if (isHttpErrorResponse(err)) {
+          setPolicyState({ kind: "blocked" });
+          return;
+        }
+        timer = window.setTimeout(() => {
+          void attempt(Math.min(backoffMs * 2, POLICY_RETRY_MAX_MS));
+        }, backoffMs);
+      }
+    };
+    void attempt(POLICY_RETRY_MIN_MS);
     return () => {
       cancelled = true;
+      if (timer !== undefined) window.clearTimeout(timer);
     };
-  }, [client]);
+  }, [client, policyState.kind]);
 
   const reload = useCallback(async () => {
     const next = await client.getGatewayStatus();
     setStatus(next);
+    setError(null);
     return next;
   }, [client]);
 
@@ -74,24 +146,42 @@ export function ManagedGate({
     };
   }, [managed, reload]);
 
-  // One timer covers both directions: pending → signed in lifts the gate, and
-  // a sign-out anywhere lowers it again.
-  const signInState = status?.sign_in.state;
+  // The watch is keyed on being managed, not on having a status: if the first
+  // fetch failed, the ticks are what recover from it. Each tick retries, and
+  // a success clears any stale error. One timer covers both directions —
+  // pending → signed in lifts the gate, a sign-out anywhere lowers it again.
+  const pendingFlow = status?.sign_in.state === "pending";
   useEffect(() => {
-    if (!managed || signInState === undefined) return;
+    if (!managed) return;
     const timer = window.setInterval(
       () => {
         void reload().catch(() => undefined);
       },
-      signInState === "pending" ? PENDING_POLL_MS : SESSION_WATCH_MS,
+      pendingFlow ? PENDING_POLL_MS : SESSION_WATCH_MS,
     );
     return () => window.clearInterval(timer);
-  }, [managed, signInState, reload]);
+  }, [managed, pendingFlow, reload]);
 
   async function connect() {
+    if (!policy) return;
     setWorking(true);
     setError(null);
     try {
+      // Converge the provider config to the policy's locked gateway before
+      // starting the flow: begin_sign_in refuses without a configured
+      // provider, and the gate blocks the settings route that could fix it.
+      // Convergence only ever writes the policy's own URL — toward the
+      // policy, never away from it.
+      const target = policy.gateway_url;
+      if (
+        target &&
+        (!status?.configured || !sameGateway(status.base_url, target))
+      ) {
+        await client.putProvider("model_gateway", {
+          enabled: true,
+          base_url: target,
+        });
+      }
       const started = await client.gatewaySignIn();
       await openSignInPage(started.authorization_url);
       await reload();
@@ -102,18 +192,52 @@ export function ManagedGate({
     }
   }
 
-  if (!managed) {
-    // Hold the boot screen while the policy resolves, so a managed install
-    // never flashes the open product before the gate can assert itself.
-    if (policy === undefined) return <BootScreen>starting…</BootScreen>;
-    return <>{children}</>;
+  if (policyState.kind === "loading") return <BootScreen>starting…</BootScreen>;
+
+  if (policyState.kind === "blocked") {
+    return (
+      <div className="boot" aria-label="Managed policy unavailable">
+        <div className="boot-brand">
+          <Logomark />
+          <h1>OpenWave</h1>
+        </div>
+        <div className="welcome-copy">
+          <h2>Managed policy unavailable</h2>
+          <p>
+            This device&apos;s managed policy is misconfigured. Contact your
+            administrator.
+          </p>
+        </div>
+        <Button
+          type="button"
+          onClick={() => setPolicyState({ kind: "loading" })}
+        >
+          <RefreshCw size={14} />
+          Retry
+        </Button>
+      </div>
+    );
   }
+
+  if (!managed) return <>{children}</>;
+
   if (status === null && error === null) {
     return <BootScreen>starting…</BootScreen>;
   }
-  if (status?.signed_in) return <>{children}</>;
 
-  const lockedUrl = policy?.gateway_url ?? status?.base_url ?? null;
+  // The gate lifts only for a session on the policy's own gateway: signed_in
+  // reflects whatever provider URL is configured, which nothing pins to the
+  // policy yet. A session on any other deployment stays gated. A policy that
+  // carries no URL has nothing to pin to, so any session satisfies it.
+  const lockedUrl = policy?.gateway_url ?? null;
+  const sessionSatisfiesPolicy =
+    status?.signed_in === true &&
+    (lockedUrl === null || sameGateway(status.base_url, lockedUrl));
+  if (sessionSatisfiesPolicy) return <>{children}</>;
+
+  // The device's managed gateway is the policy's URL, wherever the provider
+  // config currently points.
+  const shownUrl = lockedUrl ?? status?.base_url ?? null;
   const pendingUrl =
     status?.sign_in.state === "pending"
       ? status.sign_in.authorization_url
@@ -134,9 +258,9 @@ export function ManagedGate({
           your model gateway to get started.
         </p>
       </div>
-      {lockedUrl && (
+      {shownUrl && (
         <p className="text-muted-foreground text-sm">
-          Gateway <code className="font-medium">{lockedUrl}</code>
+          Gateway <code className="font-medium">{shownUrl}</code>
         </p>
       )}
       {failure && (

--- a/crates/openwave-desktop/ui/src/ManagedGate.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.tsx
@@ -27,8 +27,10 @@ type PolicyState =
 
 /** ApiClient throws `Error("<status>: <detail>")` for an HTTP error response;
  * everything else — a rejected fetch, the timeout — is transport-level. */
-function isHttpErrorResponse(err: unknown): boolean {
-  return err instanceof Error && /^\d{3}: /.test(err.message);
+function httpStatusOf(err: unknown): number | null {
+  if (!(err instanceof Error)) return null;
+  const match = /^(\d{3}): /.exec(err.message);
+  return match ? Number(match[1]) : null;
 }
 
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
@@ -97,7 +99,11 @@ export function ManagedGate({
   });
   const [status, setStatus] = useState<GatewayStatus | null>(null);
   const [working, setWorking] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  // Two error channels on purpose: the watch clears its own stale fetch
+  // errors on a successful poll, which must not wipe a Connect failure the
+  // reader is still looking at.
+  const [statusError, setStatusError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const policy = policyState.kind === "resolved" ? policyState.policy : null;
   const managed = policy?.managed === true;
@@ -112,7 +118,18 @@ export function ManagedGate({
         if (!cancelled) setPolicyState({ kind: "resolved", policy: next });
       } catch (err) {
         if (cancelled) return;
-        if (isHttpErrorResponse(err)) {
+        const httpStatus = httpStatusOf(err);
+        if (httpStatus === 404) {
+          // No policy layer at all — a renderer newer than its server (the
+          // browser dev path). There is no policy to enforce, so the open
+          // product is correct, not a dead end.
+          setPolicyState({
+            kind: "resolved",
+            policy: { managed: false, source: "unmanaged" },
+          });
+          return;
+        }
+        if (httpStatus !== null) {
           setPolicyState({ kind: "blocked" });
           return;
         }
@@ -131,7 +148,7 @@ export function ManagedGate({
   const reload = useCallback(async () => {
     const next = await client.getGatewayStatus();
     setStatus(next);
-    setError(null);
+    setStatusError(null);
     return next;
   }, [client]);
 
@@ -139,7 +156,7 @@ export function ManagedGate({
     if (!managed) return;
     let cancelled = false;
     reload().catch((err) => {
-      if (!cancelled) setError(String(err));
+      if (!cancelled) setStatusError(String(err));
     });
     return () => {
       cancelled = true;
@@ -165,7 +182,7 @@ export function ManagedGate({
   async function connect() {
     if (!policy) return;
     setWorking(true);
-    setError(null);
+    setActionError(null);
     try {
       // Converge the provider config to the policy's locked gateway before
       // starting the flow: begin_sign_in refuses without a configured
@@ -175,7 +192,9 @@ export function ManagedGate({
       const target = policy.gateway_url;
       if (
         target &&
-        (!status?.configured || !sameGateway(status.base_url, target))
+        (!status?.configured ||
+          !status.enabled ||
+          !sameGateway(status.base_url, target))
       ) {
         await client.putProvider("model_gateway", {
           enabled: true,
@@ -186,7 +205,7 @@ export function ManagedGate({
       await openSignInPage(started.authorization_url);
       await reload();
     } catch (err) {
-      setError(String(err));
+      setActionError(String(err));
     } finally {
       setWorking(false);
     }
@@ -194,7 +213,17 @@ export function ManagedGate({
 
   if (policyState.kind === "loading") return <BootScreen>starting…</BootScreen>;
 
-  if (policyState.kind === "blocked") {
+  // A managed policy without a gateway URL has nothing the gate could ever
+  // be satisfied against, so it blocks rather than lifting on any session.
+  // `misconfigured` is read defensively: the MDM-readers slice adds it to
+  // the wire type, and a renderer running ahead of that must already honor
+  // it rather than fail open.
+  const policyMisconfigured =
+    policy !== null &&
+    ((policy as { misconfigured?: boolean }).misconfigured === true ||
+      (policy.managed && !policy.gateway_url));
+
+  if (policyState.kind === "blocked" || policyMisconfigured) {
     return (
       <div className="boot" aria-label="Managed policy unavailable">
         <div className="boot-brand">
@@ -221,18 +250,16 @@ export function ManagedGate({
 
   if (!managed) return <>{children}</>;
 
-  if (status === null && error === null) {
+  if (status === null && statusError === null) {
     return <BootScreen>starting…</BootScreen>;
   }
 
   // The gate lifts only for a session on the policy's own gateway: signed_in
   // reflects whatever provider URL is configured, which nothing pins to the
-  // policy yet. A session on any other deployment stays gated. A policy that
-  // carries no URL has nothing to pin to, so any session satisfies it.
+  // policy yet. A session on any other deployment stays gated.
   const lockedUrl = policy?.gateway_url ?? null;
   const sessionSatisfiesPolicy =
-    status?.signed_in === true &&
-    (lockedUrl === null || sameGateway(status.base_url, lockedUrl));
+    status?.signed_in === true && sameGateway(status.base_url, lockedUrl);
   if (sessionSatisfiesPolicy) return <>{children}</>;
 
   // The device's managed gateway is the policy's URL, wherever the provider
@@ -292,7 +319,8 @@ export function ManagedGate({
           Connect
         </Button>
       )}
-      {error && <p className="boot-error-detail">{error}</p>}
+      {actionError && <p className="boot-error-detail">{actionError}</p>}
+      {statusError && <p className="boot-error-detail">{statusError}</p>}
       <p className="text-muted-foreground max-w-md text-xs leading-relaxed">
         Sign-in happens in your browser against the gateway itself; OpenWave
         never sees your identity provider credentials.

--- a/crates/openwave-desktop/ui/src/ManagedGate.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.tsx
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { ExternalLink } from "lucide-react";
+
+import type { ApiClient, GatewayStatus, ManagedPolicy } from "./api";
+import { Button } from "@/components/ui/button";
+import { Logomark } from "./Logomark";
+import { openSignInPage } from "./openSignInPage";
+
+/** While the browser flow is pending the exchange lands out of band, so the
+ * poll is what turns the gate off. Matches the settings panel's cadence. */
+const PENDING_POLL_MS = 2_000;
+/** The session watch otherwise: signed in, it is what returns a signed-out
+ * reader to the gate; signed out, it notices sign-ins completed elsewhere. */
+const SESSION_WATCH_MS = 5_000;
+
+/**
+ * The managed-mode sign-in gate.
+ *
+ * When the resolved policy reports this install as managed, nothing of the
+ * app renders until a gateway session exists. The gate wraps the router
+ * rather than living on a route, so no navigation — settings included — can
+ * get around it. Sign-out, wherever it happens, brings the gate back within
+ * one watch interval. Unmanaged profiles render children untouched, and the
+ * gateway is never even asked for its status.
+ *
+ * The gate is presentation only: enforcement is the server's managed
+ * lockdown, which is why an unreadable policy fails open to the ordinary app
+ * instead of bricking it.
+ */
+export function ManagedGate({
+  client,
+  children,
+}: {
+  client: ApiClient;
+  children: ReactNode;
+}) {
+  // undefined: still resolving; null: unreadable, treated as unmanaged.
+  const [policy, setPolicy] = useState<ManagedPolicy | null | undefined>();
+  const [status, setStatus] = useState<GatewayStatus | null>(null);
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const managed = policy?.managed === true;
+
+  useEffect(() => {
+    let cancelled = false;
+    client.getPolicy().then(
+      (next) => {
+        if (!cancelled) setPolicy(next);
+      },
+      () => {
+        if (!cancelled) setPolicy(null);
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  const reload = useCallback(async () => {
+    const next = await client.getGatewayStatus();
+    setStatus(next);
+    return next;
+  }, [client]);
+
+  useEffect(() => {
+    if (!managed) return;
+    let cancelled = false;
+    reload().catch((err) => {
+      if (!cancelled) setError(String(err));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [managed, reload]);
+
+  // One timer covers both directions: pending → signed in lifts the gate, and
+  // a sign-out anywhere lowers it again.
+  const signInState = status?.sign_in.state;
+  useEffect(() => {
+    if (!managed || signInState === undefined) return;
+    const timer = window.setInterval(
+      () => {
+        void reload().catch(() => undefined);
+      },
+      signInState === "pending" ? PENDING_POLL_MS : SESSION_WATCH_MS,
+    );
+    return () => window.clearInterval(timer);
+  }, [managed, signInState, reload]);
+
+  async function connect() {
+    setWorking(true);
+    setError(null);
+    try {
+      const started = await client.gatewaySignIn();
+      await openSignInPage(started.authorization_url);
+      await reload();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  if (!managed) {
+    // Hold the boot screen while the policy resolves, so a managed install
+    // never flashes the open product before the gate can assert itself.
+    if (policy === undefined) return <BootScreen>starting…</BootScreen>;
+    return <>{children}</>;
+  }
+  if (status === null && error === null) {
+    return <BootScreen>starting…</BootScreen>;
+  }
+  if (status?.signed_in) return <>{children}</>;
+
+  const lockedUrl = policy?.gateway_url ?? status?.base_url ?? null;
+  const pendingUrl =
+    status?.sign_in.state === "pending"
+      ? status.sign_in.authorization_url
+      : null;
+  const failure =
+    status?.sign_in.state === "failed" ? status.sign_in.message : null;
+
+  return (
+    <div className="boot" aria-label="Sign in required">
+      <div className="boot-brand">
+        <Logomark />
+        <h1>OpenWave</h1>
+      </div>
+      <div className="welcome-copy">
+        <h2>Sign in to continue</h2>
+        <p>
+          This OpenWave install is managed by your organization. Sign in to
+          your model gateway to get started.
+        </p>
+      </div>
+      {lockedUrl && (
+        <p className="text-muted-foreground text-sm">
+          Gateway <code className="font-medium">{lockedUrl}</code>
+        </p>
+      )}
+      {failure && (
+        <p className="text-destructive text-sm" role="alert">
+          {failure}
+        </p>
+      )}
+      {pendingUrl ? (
+        <p className="text-sm">
+          Waiting for the browser…{" "}
+          <a
+            className="underline"
+            href={pendingUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+            onClick={(event) => {
+              // The webview swallows target="_blank"; route through the
+              // native opener and keep the href for hover/copy.
+              event.preventDefault();
+              void openSignInPage(pendingUrl);
+            }}
+          >
+            Open the sign-in page again
+          </a>
+        </p>
+      ) : (
+        <Button type="button" disabled={working} onClick={() => void connect()}>
+          <ExternalLink size={14} />
+          Connect
+        </Button>
+      )}
+      {error && <p className="boot-error-detail">{error}</p>}
+      <p className="text-muted-foreground max-w-md text-xs leading-relaxed">
+        Sign-in happens in your browser against the gateway itself; OpenWave
+        never sees your identity provider credentials.
+      </p>
+    </div>
+  );
+}
+
+function BootScreen({ children }: { children: ReactNode }) {
+  return (
+    <div className="boot">
+      <div className="boot-brand">
+        <Logomark />
+        <h1>OpenWave</h1>
+      </div>
+      <p>{children}</p>
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/openSignInPage.ts
+++ b/crates/openwave-desktop/ui/src/openSignInPage.ts
@@ -1,0 +1,8 @@
+import { openExternal } from "./host";
+
+/** Native opener first; `window.open` only works in a plain browser tab. */
+export async function openSignInPage(url: string): Promise<void> {
+  if (!(await openExternal(url).catch(() => false))) {
+    window.open(url, "_blank", "noreferrer,noopener");
+  }
+}

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
@@ -8,7 +8,7 @@ import type {
   McpServerDefinition,
   McpServerInfo,
 } from "../api";
-import { openExternal } from "../host";
+import { openSignInPage } from "../openSignInPage";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
@@ -77,13 +77,6 @@ function mountDefinition(slug: string, name: string): McpServerDefinition {
     request_timeout_ms: DEFAULT_MOUNT_TIMEOUT_MS,
     enabled: true,
   };
-}
-
-/** Native opener first; `window.open` only works in a plain browser tab. */
-async function openSignInPage(url: string) {
-  if (!(await openExternal(url).catch(() => false))) {
-    window.open(url, "_blank", "noreferrer,noopener");
-  }
 }
 
 /**


### PR DESCRIPTION
When `GET /policy` reports a managed install and no gateway session exists, the renderer shows a full-screen sign-in gate instead of the app.

## What changed

- **`ManagedGate`** (new): wraps the router's tree inside `AppShell`, so no route — settings included — can be navigated around it. On boot it resolves the policy once; managed installs then load gateway status and either render the app (signed in) or the gate (signed out).
- The gate shows the locked gateway identity (`policy.gateway_url`, falling back to the status base URL) with no input to change it, a **Connect** button driving the existing browser OAuth flow (native opener first, `window.open` fallback), the pending state with a re-open link, and the bounded failure message from `sign_in`.
- A session watch polls gateway status while managed: 2s while a browser flow is pending, 5s otherwise. A completed flow lifts the gate; a sign-out anywhere — settings panel or the gateway itself — lowers it again within one interval.
- Unmanaged profiles are untouched: the gate renders children directly and never requests gateway status. An unreadable policy fails open to the ordinary app; enforcement belongs to the server's managed lockdown, not this presentation gate.
- `openSignInPage` moves out of `GatewayPanel` into a shared helper so both surfaces drive the same opener; the panel's behavior is unchanged.
- Visuals reuse the existing `.boot` / `.welcome-copy` classes and the shared `Button` — no new design surface.

## Tests

`ManagedGate.dom.test.tsx`, following the `GatewayPanel.dom.test.tsx` pattern (mocked `ApiClient`, jsdom):

- managed and signed out: gates the app and starts the browser sign-in (covers the locked URL, the OAuth handoff, and the pending state after connecting)
- managed and signed in: renders the app, and a sign-out brings the gate back (the issue's "back to the gate, not the open product" requirement, driven through the fake-timer watch)
- unmanaged profiles see the app untouched and no gateway traffic
- surfaces a failed browser sign-in and offers to try again

The `AppShell` DOM tests gained a `getPolicy` (unmanaged) stub on their API mock; gating behavior is tested on `ManagedGate` directly rather than through `AppShell`'s boot fetches.

## Verification

`pnpm install --frozen-lockfile`, `pnpm exec tsc --noEmit`, `pnpm test` (556 passed), and `pnpm build` all pass under `crates/openwave-desktop/ui`. No Rust files touched.

Part of #742.

Closes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)