### PR TITLE
fix(desktop): settle a rejected folder mutation on real broker state

### DIFF
--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -10267,6 +10267,10 @@ async fn delete_chat_erases_quiesced_history_and_fails_closed_for_live_work_or_r
     );
     assert!(store.get_chat(rooted.id).await.unwrap().is_some());
 
+    // The store still refuses an unknown broker observation, even though the
+    // desktop no longer records one: a rejected mutation now settles on the
+    // state the broker reports. This keeps the gate honest for a row written by
+    // an older build, which nothing will ever re-drive.
     let ambiguous = sample_chat();
     store.create_chat(&ambiguous).await.unwrap();
     let change = BeginRootAttachmentChange {

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -118,6 +118,10 @@ pub enum DeleteChatOutcome {
     /// A root is still projected into the conversation's broker context.
     RootsAttached,
     /// Broker history cannot conclusively prove every detached root is gone.
+    ///
+    /// Every terminal change records what the broker held when it settled, so in
+    /// practice this means a change is still in flight — transient, and worth
+    /// retrying — rather than a permanently unknowable observation.
     RootAttachmentStateUnresolved,
 }
 

--- a/crates/openwave-desktop/src/client_execution/product_sync.rs
+++ b/crates/openwave-desktop/src/client_execution/product_sync.rs
@@ -533,10 +533,20 @@ fn attachment_receipt_terminal(
                 }))
             }
         }
+        // As in the server-owned path: a rejected attach still knows what the
+        // broker holds now, and recording that instead of "unknown" is what keeps
+        // this change conclusive rather than permanently unresolvable.
+        RootAttachmentMutationReceipt::Failed {
+            currently_attached: true,
+            ..
+        } => Ok(Some(RootAttachmentChangeTerminal::Completed {
+            broker_changed: false,
+            broker_currently_attached: true,
+        })),
         RootAttachmentMutationReceipt::Failed { .. } => {
             Ok(Some(RootAttachmentChangeTerminal::Failed {
-                broker_changed: None,
-                broker_currently_attached: None,
+                broker_changed: Some(false),
+                broker_currently_attached: Some(false),
                 failure: RootAttachmentChangeFailure {
                     code: "broker_attachment_failed".to_owned(),
                     message: "The host broker could not complete this folder attachment."
@@ -717,17 +727,49 @@ mod tests {
                     message: "private broker detail".to_owned(),
                     retryable: true,
                 },
+                currently_attached: false,
             },
             root_id,
         )
         .unwrap()
         .unwrap();
-        let RootAttachmentChangeTerminal::Failed { failure, .. } = terminal else {
+        let RootAttachmentChangeTerminal::Failed {
+            broker_currently_attached,
+            failure,
+            ..
+        } = terminal
+        else {
             panic!("expected failed product terminal")
         };
+        // Conclusive, not unknown: nothing re-drives a terminal change, so an
+        // unknown observation would keep the conversation undeletable for good.
+        assert_eq!(broker_currently_attached, Some(false));
         assert_eq!(failure.code, "broker_attachment_failed");
         assert!(!failure.message.contains("private broker detail"));
         assert!(!failure.retryable);
+
+        // Rejected, yet the folder is attached anyway: the product keeps it
+        // rather than rolling back authority the host is still granting.
+        let attached = attachment_receipt_terminal(
+            RootAttachmentMutationReceipt::Failed {
+                error: ErrorResponse {
+                    code: ErrorCode::HostIo,
+                    message: "private broker detail".to_owned(),
+                    retryable: true,
+                },
+                currently_attached: true,
+            },
+            root_id,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(matches!(
+            attached,
+            RootAttachmentChangeTerminal::Completed {
+                broker_currently_attached: true,
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -783,6 +825,7 @@ mod tests {
                         message: "unknown root".to_owned(),
                         retryable: false,
                     },
+                    currently_attached: false,
                 },
                 root_id,
             )

--- a/crates/openwave-desktop/src/client_execution/root_attachment_reconciliation.rs
+++ b/crates/openwave-desktop/src/client_execution/root_attachment_reconciliation.rs
@@ -676,16 +676,27 @@ fn mutation_terminal(
                 }))
             }
         }
-        RootAttachmentMutationReceipt::Failed { .. } => {
-            Ok(Some(RootAttachmentChangeTerminal::Failed {
-                broker_changed: None,
-                broker_currently_attached: None,
-                failure: safe_failure(
-                    "broker_attachment_failed",
-                    "The host broker could not complete this folder attachment change.",
-                ),
-            }))
-        }
+        // A rejected mutation still has a knowable outcome: what the broker is
+        // attached to now. Recording that rather than "unknown" is what keeps
+        // this change conclusive — an unknown observation can never be revisited,
+        // because nothing re-drives a terminal change, and it leaves the
+        // conversation permanently undeletable.
+        RootAttachmentMutationReceipt::Failed {
+            currently_attached, ..
+        } if currently_attached == desired => Ok(Some(RootAttachmentChangeTerminal::Completed {
+            broker_changed: false,
+            broker_currently_attached: currently_attached,
+        })),
+        RootAttachmentMutationReceipt::Failed {
+            currently_attached, ..
+        } => Ok(Some(RootAttachmentChangeTerminal::Failed {
+            broker_changed: Some(false),
+            broker_currently_attached: Some(currently_attached),
+            failure: safe_failure(
+                "broker_attachment_failed",
+                "The host broker could not complete this folder attachment change.",
+            ),
+        })),
         _ => Err("host broker returned an unsupported attachment receipt".to_owned()),
     }
 }
@@ -949,6 +960,7 @@ mod tests {
                     message: "/private/secret/path".to_owned(),
                     retryable: true,
                 },
+                currently_attached: true,
             },
             root_id,
             RootAttachmentChangeAction::Detach,
@@ -960,5 +972,47 @@ mod tests {
         };
         assert!(!failure.message.contains("secret"));
         assert!(!failure.retryable);
+    }
+
+    /// A terminal change is never re-driven, so an unknown broker observation is
+    /// unknown forever — and the delete gate reads exactly that field, which is
+    /// how a rejected attach used to leave a conversation undeletable. Every
+    /// rejected mutation must settle on what the broker actually holds.
+    #[test]
+    fn a_rejected_mutation_settles_on_the_state_the_broker_reports() {
+        let root_id = RootId::new();
+        let rejected = |action| {
+            mutation_terminal(
+                RootAttachmentMutationReceipt::Failed {
+                    error: ErrorResponse {
+                        code: ErrorCode::Denied,
+                        message: "denied".to_owned(),
+                        retryable: false,
+                    },
+                    currently_attached: false,
+                },
+                root_id,
+                action,
+            )
+            .unwrap()
+            .unwrap()
+        };
+
+        assert!(matches!(
+            rejected(RootAttachmentChangeAction::Attach),
+            RootAttachmentChangeTerminal::Failed {
+                broker_currently_attached: Some(false),
+                ..
+            }
+        ));
+        // Nothing is attached and nothing was wanted, so the world already
+        // matches the intent however the operation itself ended.
+        assert!(matches!(
+            rejected(RootAttachmentChangeAction::Detach),
+            RootAttachmentChangeTerminal::Completed {
+                broker_currently_attached: false,
+                ..
+            }
+        ));
     }
 }

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -775,6 +775,11 @@ impl Controller {
             }) if attachment_lookup_matches(existing, &expected) => {
                 RootAttachmentMutationReceipt::Failed {
                     error: error.clone(),
+                    currently_attached: has_root_attachment(
+                        &state,
+                        request.conversation_id,
+                        request.root_id,
+                    ),
                 }
             }
             Some(_) => return Err(error_response(BrokerError::OperationIdConflict)),

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -1492,7 +1492,62 @@ fn failed_attachment_mutation_is_durable_and_cannot_widen_authority() {
             },
         )
         .unwrap(),
-        RootAttachmentMutationReceipt::Failed { error } if error == first
+        RootAttachmentMutationReceipt::Failed { error, currently_attached: false }
+            if error == first
+    ));
+}
+
+/// A rejected mutation changed nothing, but the broker still knows what it
+/// holds. Saying so is what lets a caller tell "nothing is attached" apart from
+/// "cannot say" — the product records that observation durably, and an
+/// unknowable one can never be settled afterwards.
+#[test]
+fn a_failed_mutation_reports_the_attachment_it_could_not_change() {
+    let (_temp, broker, path) = setup();
+    let conversation = Uuid::new_v4();
+    let owner = GrantSubject::project(Uuid::new_v4()).unwrap();
+    let registered = register(
+        &broker.controller(),
+        owner,
+        conversation,
+        path,
+        OperationId::new(),
+    );
+    let root_id = registered.root.root_id;
+
+    // The conversation itself holds no grant on this root, so detaching under
+    // that subject is denied while the attachment plainly still exists.
+    let ungranted = GrantSubject::conversation(conversation).unwrap();
+    let operation_id = OperationId::new();
+    assert_eq!(
+        mutate_attachment(
+            &broker.controller(),
+            operation_id,
+            ungranted,
+            conversation,
+            root_id,
+            RootAttachmentMutationKind::Detach,
+        )
+        .unwrap_err()
+        .code,
+        ErrorCode::Denied
+    );
+    assert!(matches!(
+        lookup_attachment_receipt(
+            &broker.controller(),
+            LookupRootAttachmentReceiptRequest {
+                operation_id,
+                subject: ungranted,
+                conversation_id: conversation,
+                root_id,
+                mutation: RootAttachmentMutationKind::Detach,
+            },
+        )
+        .unwrap(),
+        RootAttachmentMutationReceipt::Failed {
+            currently_attached: true,
+            ..
+        }
     ));
 }
 

--- a/crates/openwave-host-broker/src/protocol.rs
+++ b/crates/openwave-host-broker/src/protocol.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// Current pre-v1 broker protocol. Bump this for incompatible wire changes.
-pub const PROTOCOL_VERSION: u32 = 6;
+pub const PROTOCOL_VERSION: u32 = 7;
 
 /// Largest file the broker returns as opaque bytes.
 ///
@@ -401,6 +401,11 @@ pub enum RootAttachmentMutationReceipt {
     },
     Failed {
         error: ErrorResponse,
+        /// Live state now, which a failed mutation does not describe. A rejected
+        /// attach usually leaves nothing attached, and a caller that cannot tell
+        /// that apart from "unknown" has to keep treating the folder as though
+        /// authority might still exist.
+        currently_attached: bool,
     },
 }
 

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1335,7 +1335,7 @@ pub async fn delete_chat(
         )),
         DeleteChatOutcome::RootAttachmentStateUnresolved => Err(ServerError::conflict_kind(
             "chat_root_attachment_unresolved",
-            "reconcile connected-folder changes before deleting this conversation",
+            "a connected-folder change is still finishing; try deleting again in a moment",
         )),
     }
 }


### PR DESCRIPTION
Follow-up to #771, which left the sibling conflict in place. Deleting a chat could still fail with:

```
409: reconcile connected-folder changes before deleting this conversation
```

and unlike the other one, that state was **permanent**.

## What was wrong

When the host broker rejected an attach or detach, the renderer recorded the change as terminal with `broker_currently_attached: None` — "cannot say". Both mapping paths did it: `mutation_terminal` for server-owned changes and `attachment_receipt_terminal` for manual picker connects.

Nothing ever revisits a terminal change; the recovery loop only picks up `awaiting_broker`. And `delete_chat` reads exactly that field — the latest change per root must say `Some(false)` or the delete is refused. So one rejected attach made a conversation undeletable for good, and the message asked the reader to reconcile something they had no way to reach.

## The fix

The broker knew the answer all along. It already calls `has_root_attachment(conversation_id, root_id)` to fill `currently_attached` on a `Completed` receipt; the `Failed` variant just didn't carry it. So:

- `RootAttachmentMutationReceipt::Failed` gains `currently_attached`, filled from the same state lookup. `PROTOCOL_VERSION` 6 → 7; both sides pin the version exactly and reject a mismatched peer at the handshake, so there is no cross-version pairing to support. The persisted state version is separate and untouched — approved folders survive.
- Both terminal mappings apply the rule the completed path already used: if the broker's live state matches the intent, the change **completes** (`broker_changed: false` — this operation changed nothing); otherwise it **fails** with the observed state recorded. The symmetry is the point — a rejected operation and a superseded one are the same question about the same field.

`RootAttachmentStateUnresolved` now means only that a change is genuinely in flight, which is transient, so the server says that instead: *"a connected-folder change is still finishing; try deleting again in a moment."* A conclusively-still-attached root can't reach that gate — the projection keeps the root in every such case, so `RootsAttached` fires first and #771 detaches it.

## Deliberately not repaired

I checked both live app databases (`io.brightwave.openwave` and `.dev`) read-only: every `root_attachment_change` row is a clean `completed` attach, no unknown observations. So this is prevention, and there is nothing to backfill — an observation we never made can't be reconstructed. The store keeps failing closed on such a row for an older build's data, with a comment on that test saying why it is no longer reachable from the app.

Also left alone: the two cleanup paths that work around the missing field by falling back to the *registration* receipt to infer detachment (`cleanup_receipt_outcome`, `confirm_registration_disconnected`). They can now ask directly, but their fallback is sound and that is a separate simplification.

## Tests

- Broker: a rejected mutation reports the attachment it could not change. Uses the discriminating case — a detach denied under a subject holding no grant, while the attachment plainly exists — so the field must be read from state rather than defaulted.
- Desktop: a rejected mutation settles on what the broker reports, both directions; and on the manual-connect path, a rejected attach that nonetheless left the folder attached keeps it rather than rolling back authority the host still grants.
- Updated the four existing constructions of the receipt. One asserted a safe bounded failure message for a rejected *detach*; it now passes `currently_attached: true`, which is the shape that still fails.

Broker (86) and desktop (82) suites pass; workspace `cargo check --all-targets --locked` clean, no lock drift; clippy and rustfmt clean.

I have not driven the app through a broker rejection to watch this happen live.

Closes #787