### PR TITLE
fix(desktop): state both provider timeouts in seconds

### DIFF
--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
@@ -68,7 +68,7 @@ describe("CodeExecutionPanel", () => {
       target: { value: "daytona-secret" },
     });
     fireEvent.change(screen.getByLabelText(/Execution timeout/), {
-      target: { value: "30000" },
+      target: { value: "30" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
 
@@ -129,7 +129,7 @@ describe("CodeExecutionPanel", () => {
     render(<CodeExecutionPanel client={client} />);
 
     fireEvent.change(await screen.findByLabelText(/Execution timeout/), {
-      target: { value: "500000" },
+      target: { value: "500" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
 

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
@@ -7,18 +7,21 @@ import type {
   CodeExecutionProviderKind,
 } from "../api";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { ActiveProviderField, ProviderCredentialField } from "./ProviderFields";
+import {
+  ActiveProviderField,
+  ProviderCredentialField,
+  TimeoutSecondsField,
+  timeoutMsFromSeconds,
+} from "./ProviderFields";
 import {
   SettingsError,
-  SettingsField,
   SettingsPanel,
   SettingsSection,
   SettingsStatus,
 } from "./primitives";
 
-const MIN_CODE_EXECUTION_TIMEOUT_MS = 1_000;
-const MAX_CODE_EXECUTION_TIMEOUT_MS = 120_000;
+const MIN_CODE_EXECUTION_TIMEOUT_SECONDS = 1;
+const MAX_CODE_EXECUTION_TIMEOUT_SECONDS = 120;
 
 /** The local sandbox needs no credential, so it never appears in the key list. */
 const LOCAL_PROVIDER: CodeExecutionProviderKind = "local";
@@ -29,7 +32,7 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
     CodeExecutionCredentialReadiness[]
   >([]);
   const [provider, setProvider] = useState<CodeExecutionProviderKind | "">("");
-  const [timeoutMs, setTimeoutMs] = useState("");
+  const [timeoutSeconds, setTimeoutSeconds] = useState("");
   // One draft key per managed provider, so E2B and Daytona can be configured
   // together and switching the active provider discards neither.
   const [apiKeys, setApiKeys] = useState<
@@ -56,7 +59,7 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
         setConfig(nextConfig);
         setCredentials(nextCredentials.credentials);
         setProvider(nextConfig.provider ?? "");
-        setTimeoutMs(String(nextConfig.timeout_ms));
+        setTimeoutSeconds(String(nextConfig.timeout_ms / 1000));
       } catch (err) {
         if (!cancelled) setError(String(err));
       } finally {
@@ -72,15 +75,13 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
   const state = codeExecutionState(config);
 
   async function save() {
-    const parsedTimeout = Number(timeoutMs);
-    if (
-      !Number.isInteger(parsedTimeout) ||
-      parsedTimeout < MIN_CODE_EXECUTION_TIMEOUT_MS ||
-      parsedTimeout > MAX_CODE_EXECUTION_TIMEOUT_MS
-    ) {
-      setError(
-        `Timeout must be a whole number between ${MIN_CODE_EXECUTION_TIMEOUT_MS.toLocaleString()} and ${MAX_CODE_EXECUTION_TIMEOUT_MS.toLocaleString()} ms.`,
-      );
+    const timeout = timeoutMsFromSeconds(
+      timeoutSeconds,
+      MIN_CODE_EXECUTION_TIMEOUT_SECONDS,
+      MAX_CODE_EXECUTION_TIMEOUT_SECONDS,
+    );
+    if ("error" in timeout) {
+      setError(timeout.error);
       return;
     }
 
@@ -97,13 +98,13 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
       }
       const nextConfig = await client.putCodeExecutionConfig({
         provider: provider || null,
-        timeout_ms: parsedTimeout,
+        timeout_ms: timeout.timeoutMs,
       });
       const nextCredentials = await client.listCodeExecutionCredentials();
       setConfig(nextConfig);
       setCredentials(nextCredentials.credentials);
       setProvider(nextConfig.provider ?? "");
-      setTimeoutMs(String(nextConfig.timeout_ms));
+      setTimeoutSeconds(String(nextConfig.timeout_ms / 1000));
       toast.success("Saved code-execution settings");
     } catch (err) {
       setError(String(err));
@@ -195,21 +196,14 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
               ]}
             />
 
-            <SettingsField
-              label="Execution timeout (ms)"
-              hint={`Between ${MIN_CODE_EXECUTION_TIMEOUT_MS.toLocaleString()} and ${MAX_CODE_EXECUTION_TIMEOUT_MS.toLocaleString()} ms.`}
-            >
-              <Input
-                type="number"
-                inputMode="numeric"
-                min={MIN_CODE_EXECUTION_TIMEOUT_MS}
-                max={MAX_CODE_EXECUTION_TIMEOUT_MS}
-                step="1000"
-                value={timeoutMs}
-                disabled={working}
-                onChange={(event) => setTimeoutMs(event.target.value)}
-              />
-            </SettingsField>
+            <TimeoutSecondsField
+              label="Execution timeout"
+              minSeconds={MIN_CODE_EXECUTION_TIMEOUT_SECONDS}
+              maxSeconds={MAX_CODE_EXECUTION_TIMEOUT_SECONDS}
+              value={timeoutSeconds}
+              disabled={working}
+              onChange={setTimeoutSeconds}
+            />
           </SettingsSection>
 
           {/* One save for the whole surface: it stores every key typed above

--- a/crates/openwave-desktop/ui/src/settings/ProviderFields.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProviderFields.tsx
@@ -29,6 +29,69 @@ export type ProviderOption<Kind extends string> = {
 };
 
 /**
+ * The host-enforced bound on one provider request. Both surfaces persist a
+ * millisecond policy, and both read and write it in seconds — the unit the
+ * bounds are actually reasoned about in, and the only one worth typing.
+ */
+export function TimeoutSecondsField({
+  label,
+  minSeconds,
+  maxSeconds,
+  value,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  minSeconds: number;
+  maxSeconds: number;
+  value: string;
+  disabled?: boolean;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <SettingsField
+      label={`${label} (seconds)`}
+      hint={`Between ${minSeconds} and ${maxSeconds} seconds.`}
+    >
+      <Input
+        type="number"
+        inputMode="numeric"
+        min={minSeconds}
+        max={maxSeconds}
+        step="1"
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    </SettingsField>
+  );
+}
+
+/**
+ * Convert what the user typed into the millisecond policy the wire carries, or
+ * report why it cannot be sent. Bounds are checked here so an out-of-range
+ * timeout never reaches the server, which enforces the same range itself.
+ */
+export function timeoutMsFromSeconds(
+  value: string,
+  minSeconds: number,
+  maxSeconds: number,
+): { timeoutMs: number } | { error: string } {
+  const seconds = Number(value);
+  if (
+    value.trim() === "" ||
+    !Number.isFinite(seconds) ||
+    seconds < minSeconds ||
+    seconds > maxSeconds
+  ) {
+    return {
+      error: `Timeout must be between ${minSeconds} and ${maxSeconds} seconds.`,
+    };
+  }
+  return { timeoutMs: Math.round(seconds * 1000) };
+}
+
+/**
  * The single provider a host-owned tool runs through, alongside an explicit
  * Disabled choice — the safe state, and the only way to take the tool out of
  * service without discarding what is configured.

--- a/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
@@ -7,14 +7,14 @@ import type {
   WebSearchProviderKind,
 } from "../api";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   ActiveProviderField,
   ProviderCredentialField,
+  TimeoutSecondsField,
+  timeoutMsFromSeconds,
 } from "./ProviderFields";
 import {
   SettingsError,
-  SettingsField,
   SettingsPanel,
   SettingsSection,
   SettingsStatus,
@@ -68,16 +68,13 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
   const state = webSearchState(config);
 
   async function save() {
-    const seconds = Number(timeoutSeconds);
-    if (
-      !Number.isFinite(seconds) ||
-      timeoutSeconds.trim() === "" ||
-      seconds < MIN_WEB_SEARCH_TIMEOUT_SECONDS ||
-      seconds > MAX_WEB_SEARCH_TIMEOUT_SECONDS
-    ) {
-      setError(
-        `Timeout must be between ${MIN_WEB_SEARCH_TIMEOUT_SECONDS} and ${MAX_WEB_SEARCH_TIMEOUT_SECONDS} seconds.`,
-      );
+    const timeout = timeoutMsFromSeconds(
+      timeoutSeconds,
+      MIN_WEB_SEARCH_TIMEOUT_SECONDS,
+      MAX_WEB_SEARCH_TIMEOUT_SECONDS,
+    );
+    if ("error" in timeout) {
+      setError(timeout.error);
       return;
     }
 
@@ -94,7 +91,7 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
       }
       const nextConfig = await client.putWebSearchConfig({
         provider: provider || null,
-        timeout_ms: Math.round(seconds * 1000),
+        timeout_ms: timeout.timeoutMs,
       });
       const nextCredentials = await client.listWebSearchCredentials();
       setConfig(nextConfig);
@@ -186,21 +183,14 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
               }))}
             />
 
-            <SettingsField
-              label="Request timeout (seconds)"
-              hint={`Between ${MIN_WEB_SEARCH_TIMEOUT_SECONDS} and ${MAX_WEB_SEARCH_TIMEOUT_SECONDS} seconds.`}
-            >
-              <Input
-                type="number"
-                inputMode="numeric"
-                min={MIN_WEB_SEARCH_TIMEOUT_SECONDS}
-                max={MAX_WEB_SEARCH_TIMEOUT_SECONDS}
-                step="1"
-                value={timeoutSeconds}
-                disabled={working}
-                onChange={(event) => setTimeoutSeconds(event.target.value)}
-              />
-            </SettingsField>
+            <TimeoutSecondsField
+              label="Request timeout"
+              minSeconds={MIN_WEB_SEARCH_TIMEOUT_SECONDS}
+              maxSeconds={MAX_WEB_SEARCH_TIMEOUT_SECONDS}
+              value={timeoutSeconds}
+              disabled={working}
+              onChange={setTimeoutSeconds}
+            />
           </SettingsSection>
 
           {/* One save for the whole surface: it stores every key typed above


### PR DESCRIPTION
Follow-on to #785, which left one unit difference between the two panels: web search took its request timeout in seconds (1–60) and code execution took its execution timeout in milliseconds (1,000–120,000). Both persist `timeout_ms`, so the split was presentation only — and milliseconds are the wrong unit to type, which is why that field stepped by 1,000.

Both panels now read and write seconds. The control and the bounds check move into the shared provider fields:

- `TimeoutSecondsField` — the labelled number input, with the unit and the "Between X and Y seconds" hint owned by the control rather than restated per panel.
- `timeoutMsFromSeconds` — parses, bounds-checks, and converts to the millisecond wire in one place, returning either the value or the message to show.

Code execution keeps its 1–120 second range and web search its 1–60; only the unit the user sees and the place the conversion happens changed. Code execution's old rule also demanded a whole number of milliseconds; in seconds it now accepts a fractional value the way web search always has, which the server's millisecond range accepts unchanged.

Tests: the existing code-execution panel tests move to seconds (typing `30` must still send `timeout_ms: 30000`, and an out-of-range value must not reach the server). No new tests — this is one control behind two existing assertions.

`tsc`, `pnpm test` (556) and `pnpm build` are green. UI-only, so the Rust lanes will skip.

Closes #793