### PR TITLE
feat(desktop): pair with a gateway via openwave:// deep link

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2965,6 +2965,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "dom_query"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6714,6 +6723,7 @@ dependencies = [
  "sha2 0.11.0",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
@@ -6877,6 +6887,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -8238,6 +8258,16 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
 
 [[package]]
 name = "rust-stemmers"
@@ -9936,6 +9966,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.19",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10007,6 +10058,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri",
+ "tauri-plugin-deep-link",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -11518,6 +11570,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]

--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -42,6 +42,7 @@ openwave-server = { path = "../openwave-server" }
 reqwest = { workspace = true }
 sha2 = { workspace = true }
 tauri = { version = "=2.11.5", features = [] }
+tauri-plugin-deep-link = "=2.4.9"
 tauri-plugin-dialog = "=2.7.2"
 tauri-plugin-shell = "=2.3.5"
 tauri-plugin-updater = "=2.10.1"
@@ -59,7 +60,7 @@ zip.workspace = true
 chrono = { workspace = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "linux", windows))'.dependencies]
-tauri-plugin-single-instance = "=2.4.3"
+tauri-plugin-single-instance = { version = "=2.4.3", features = ["deep-link"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }

--- a/crates/openwave-desktop/capabilities/default.json
+++ b/crates/openwave-desktop/capabilities/default.json
@@ -13,6 +13,8 @@
   },
   "permissions": [
     "core:default",
+    "core:event:deny-emit",
+    "core:event:deny-emit-to",
     "core:window:allow-start-dragging",
     "core:webview:allow-set-webview-zoom",
     "shell:allow-open"

--- a/crates/openwave-desktop/src/deep_link.rs
+++ b/crates/openwave-desktop/src/deep_link.rs
@@ -10,14 +10,22 @@
 //! Windows/Linux is picked up from the plugin's recorded launch URL right
 //! after the listener is registered.
 //!
-//! Provisioning itself lives server-side ([`openwave_server::pair_with_gateway`]):
-//! the shell calls it directly on the embedded server's store, so no HTTP
-//! route — authenticated or otherwise — can reach the policy write path.
+//! A deep link is an unauthenticated remote trigger — any page the user
+//! visits can raise one — so a valid provision link never writes anything by
+//! itself: a native dialog names the gateway origin and the consequence, and
+//! only an explicit confirmation runs the pairing. Provisioning itself lives
+//! server-side ([`openwave_server::pair_with_gateway`]): the shell calls it
+//! directly on the embedded server's store, so no HTTP route — authenticated
+//! or otherwise — can reach the policy write path. The webview cannot reach
+//! it either: the main window's capability denies `core:event:emit`, so a
+//! compromised renderer cannot forge the plugin's open-URL event.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use tauri::Manager;
 use tauri_plugin_deep_link::DeepLinkExt;
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use tokio::sync::watch;
 
 use openwave_core::Store;
@@ -27,21 +35,38 @@ use openwave_core::Store;
 /// app, so the handler awaits this instead of racing the boot task.
 pub(crate) struct PairingStore {
     rx: watch::Receiver<Option<Arc<dyn Store>>>,
+    /// One pairing at a time. While a confirmation dialog is up or a probe
+    /// is in flight, further provision links are dropped with a log line
+    /// instead of stacking dialogs and long-timeout probes.
+    in_flight: AtomicBool,
 }
 
 impl PairingStore {
     pub(crate) fn new(rx: watch::Receiver<Option<Arc<dyn Store>>>) -> Self {
-        Self { rx }
+        Self {
+            rx,
+            in_flight: AtomicBool::new(false),
+        }
     }
+}
+
+/// A validated provision link: the gateway URL to pair with, and its origin
+/// — the only form of it that user-facing text and logs ever carry.
+#[derive(Debug, PartialEq, Eq)]
+struct ProvisionLink {
+    gateway_url: String,
+    origin: String,
 }
 
 /// Register the open-URL listener and pick up a launch link.
 pub(crate) fn install(app: &tauri::AppHandle) {
-    // Dev builds and portable installs have no installer run to write the
-    // scheme registration; best-effort runtime registration keeps the link
-    // working there. Not available on macOS, where the bundle's Info.plist
-    // (generated from the deep-link config) is the only registration path.
-    #[cfg(any(windows, target_os = "linux"))]
+    // Dev builds have no installer run to write the scheme registration, so
+    // register at runtime. Debug-only: in a release build this would write
+    // a per-user registration for whatever path the binary runs from,
+    // shadowing the installer's registration. Not available on macOS, where
+    // the bundle's Info.plist (generated from the deep-link config) is the
+    // only registration path.
+    #[cfg(all(debug_assertions, any(windows, target_os = "linux")))]
     if let Err(error) = app.deep_link().register_all() {
         eprintln!("openwave-desktop: deep-link scheme registration failed: {error}");
     }
@@ -57,17 +82,17 @@ pub(crate) fn install(app: &tauri::AppHandle) {
     }
 }
 
-/// Handle every `openwave://` URL in one delivery: surface the window, then
-/// pair for each well-formed provision link. A malformed link is logged
-/// (bounded, without echoing the link) and changes nothing.
+/// Handle every URL in one delivery. Only a link that parses as a provision
+/// link surfaces the window and starts the (confirmation-gated) pairing; a
+/// malformed link is logged bounded — never echoing the link — and changes
+/// nothing.
 fn handle_deep_link_urls(app: &tauri::AppHandle, urls: &[tauri::Url]) {
     for url in urls {
-        if url.scheme() != "openwave" {
-            continue;
-        }
-        focus_main_window(app);
-        match provision_gateway_url(url) {
-            Ok(gateway_url) => spawn_pairing(app.clone(), gateway_url),
+        match provision_link(url) {
+            Ok(link) => {
+                focus_main_window(app);
+                spawn_pairing(app.clone(), link);
+            }
             Err(reason) => log_pairing(app, &format!("ignored a deep link: {reason}")),
         }
     }
@@ -83,19 +108,30 @@ pub(crate) fn focus_main_window(app: &tauri::AppHandle) {
     }
 }
 
-/// Extract the gateway URL from a provision link.
+/// Parse and validate a provision link.
 ///
-/// The contract is strict — scheme `openwave`, action `provision`, exactly
-/// one query parameter named `gateway` — so a malformed link is refused
-/// whole rather than partially honored. The gateway URL value itself is held
-/// to the gateway contract server-side, before anything is written.
-fn provision_gateway_url(url: &tauri::Url) -> Result<String, String> {
+/// The contract is strict — scheme `openwave`, action `provision` with no
+/// userinfo, port, or extra path, exactly one query parameter named
+/// `gateway`, and a gateway value that is an http(s) URL with no query or
+/// fragment — so a malformed or hostile link is refused whole rather than
+/// partially honored. Near-miss gateway values matter: the conflict check on
+/// the write path compares normalized URL strings, so accepting a decorated
+/// variant would mint a distinct, permanently conflicting policy value. The
+/// gateway URL is additionally held to the connectors contract server-side.
+fn provision_link(url: &tauri::Url) -> Result<ProvisionLink, String> {
     if url.scheme() != "openwave" {
         return Err("not an openwave:// link".into());
     }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err("the link must not carry credentials".into());
+    }
+    if url.port().is_some() {
+        return Err("the link must not carry a port".into());
+    }
     // `openwave://provision` parses the action as a host; a bare
     // `openwave:provision` parses it as the path. Anything left over in the
-    // other position means a different link shape.
+    // other position means a different link shape. The host is opaque for a
+    // custom scheme, so a percent-encoded spelling does not match.
     let action = match (url.host_str(), url.path().trim_matches('/')) {
         (Some(host), "") => host.to_string(),
         (None, path) => path.to_string(),
@@ -117,25 +153,100 @@ fn provision_gateway_url(url: &tauri::Url) -> Result<String, String> {
     if value.is_empty() {
         return Err("the provision link carries an empty gateway URL".into());
     }
-    Ok(value.into_owned())
+    let gateway =
+        tauri::Url::parse(&value).map_err(|_| "the gateway URL is invalid".to_string())?;
+    if !matches!(gateway.scheme(), "http" | "https") {
+        return Err("the gateway URL must use http or https".into());
+    }
+    if gateway.query().is_some() || gateway.fragment().is_some() {
+        return Err("the gateway URL must not carry a query or fragment".into());
+    }
+    Ok(ProvisionLink {
+        origin: gateway.origin().ascii_serialization(),
+        gateway_url: value.into_owned(),
+    })
 }
 
-fn spawn_pairing(app: tauri::AppHandle, gateway_url: String) {
+fn spawn_pairing(app: tauri::AppHandle, link: ProvisionLink) {
+    if app
+        .state::<PairingStore>()
+        .in_flight
+        .swap(true, Ordering::SeqCst)
+    {
+        log_pairing(
+            &app,
+            "a pairing is already awaiting confirmation; ignored another provision link",
+        );
+        return;
+    }
     tauri::async_runtime::spawn(async move {
-        match pair(&app, &gateway_url).await {
-            Ok(base_url) => log_pairing(&app, &format!("provisioned to {base_url}")),
+        let origin = link.origin.clone();
+        let confirm_app = app.clone();
+        let pair_app = app.clone();
+        let outcome = pair_after_confirmation(
+            link,
+            move |origin| confirm_pairing(&confirm_app, origin),
+            move |gateway_url| pair(pair_app, gateway_url),
+        )
+        .await;
+        match outcome {
+            Ok(Some(())) => log_pairing(&app, &format!("provisioned to {origin}")),
+            Ok(None) => log_pairing(&app, &format!("pairing with {origin} declined")),
             Err(reason) => log_pairing(&app, &format!("pairing failed: {reason}")),
         }
+        app.state::<PairingStore>()
+            .in_flight
+            .store(false, Ordering::SeqCst);
     });
+}
+
+/// The confirmation gate, separated from the dialog and the store so the
+/// decision path is testable without a GUI: `confirm` sees only the gateway
+/// origin, and nothing runs `pair` but a confirming answer.
+async fn pair_after_confirmation<C, P, F>(
+    link: ProvisionLink,
+    confirm: C,
+    pair: P,
+) -> Result<Option<()>, String>
+where
+    C: FnOnce(&str) -> bool,
+    P: FnOnce(String) -> F,
+    F: std::future::Future<Output = Result<(), String>>,
+{
+    if !confirm(&link.origin) {
+        return Ok(None);
+    }
+    pair(link.gateway_url).await.map(Some)
+}
+
+/// Ask the user — in a native dialog, before anything is probed or written —
+/// whether this device should become managed by `origin`. Blocking is fine
+/// here: the pairing task runs on the async runtime's worker pool, never the
+/// main thread.
+fn confirm_pairing(app: &tauri::AppHandle, origin: &str) -> bool {
+    app.dialog()
+        .message(format!(
+            "Pair OpenWave with {origin}?\n\nThis device will become managed by that gateway: \
+             it will control which models are available, and the pairing cannot be undone from \
+             within OpenWave."
+        ))
+        .title("Pair with a model gateway")
+        .kind(MessageDialogKind::Warning)
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Pair".to_string(),
+            "Cancel".to_string(),
+        ))
+        .blocking_show()
 }
 
 /// Validate, probe, and provision — all server-side. The sign-in gate is a
 /// separate surface: once policy flips to managed it presents itself on its
 /// next poll, so pairing does not drive the renderer.
-async fn pair(app: &tauri::AppHandle, gateway_url: &str) -> Result<String, String> {
-    let store = wait_store(app).await?;
-    openwave_server::pair_with_gateway(&*store, gateway_url)
+async fn pair(app: tauri::AppHandle, gateway_url: String) -> Result<(), String> {
+    let store = wait_store(&app).await?;
+    openwave_server::pair_with_gateway(&*store, &gateway_url)
         .await
+        .map(|_| ())
         .map_err(|error| error.to_string())
 }
 
@@ -152,8 +263,9 @@ async fn wait_store(app: &tauri::AppHandle) -> Result<Arc<dyn Store>, String> {
 }
 
 /// One bounded, secret-free line per pairing attempt: stderr for terminal
-/// launches, `pairing.log` under app-data for GUI launches. Gateway errors
-/// already strip URLs and token material; the raw link is never echoed.
+/// launches, `pairing.log` under app-data for GUI launches. Only the gateway
+/// origin is ever named — never the full link or URL — and gateway errors
+/// already strip URLs and token material.
 fn log_pairing(app: &tauri::AppHandle, message: &str) {
     use std::io::Write;
     eprintln!("openwave-desktop: gateway pairing: {message}");
@@ -170,7 +282,9 @@ fn log_pairing(app: &tauri::AppHandle, message: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::provision_gateway_url;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::{pair_after_confirmation, provision_link, ProvisionLink};
 
     #[test]
     fn provision_links_are_held_to_the_contract() {
@@ -190,7 +304,7 @@ mod tests {
                 Some("https://gw.example"),
             ),
             // Wrong action, missing/empty/duplicated/unknown parameters,
-            // trailing path, foreign scheme: all refused whole.
+            // trailing path, foreign scheme: refused whole.
             ("openwave://settings?gateway=https://gw.example", None),
             ("openwave://provision", None),
             ("openwave://provision?gateway=", None),
@@ -207,14 +321,75 @@ mod tests {
                 None,
             ),
             ("https://provision?gateway=https://gw.example", None),
+            // Hostile decoration of the link itself: userinfo, an explicit
+            // port, a percent-encoded action host.
+            (
+                "openwave://user:pw@provision?gateway=https://gw.example",
+                None,
+            ),
+            ("openwave://provision:9999?gateway=https://gw.example", None),
+            ("openwave://pro%76ision?gateway=https://gw.example", None),
+            // Near-miss gateway values: not a URL, wrong scheme, or carrying
+            // a query or fragment (which would also leak into any log that
+            // echoed them, and would mint a permanently conflicting policy
+            // value under the string-equality conflict check).
+            ("openwave://provision?gateway=notaurl", None),
+            ("openwave://provision?gateway=ftp://gw.example", None),
+            (
+                "openwave://provision?gateway=https://gw.example/?token=x",
+                None,
+            ),
+            (
+                "openwave://provision?gateway=https%3A%2F%2Fgw.example%2F%23frag",
+                None,
+            ),
         ];
         for (link, expected) in cases {
-            let url = tauri::Url::parse(link).expect(link);
+            let parsed = tauri::Url::parse(link)
+                .ok()
+                .and_then(|url| provision_link(&url).ok());
             assert_eq!(
-                provision_gateway_url(&url).ok().as_deref(),
+                parsed.as_ref().map(|link| link.gateway_url.as_str()),
                 *expected,
                 "{link}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn only_a_confirmed_pairing_reaches_the_write_path() {
+        let link = || ProvisionLink {
+            gateway_url: "https://gw.example".to_string(),
+            origin: "https://gw.example".to_string(),
+        };
+
+        // Declined: the pairing action is never invoked.
+        let paired = AtomicBool::new(false);
+        let outcome = pair_after_confirmation(
+            link(),
+            |_| false,
+            |_| {
+                paired.store(true, Ordering::SeqCst);
+                async { Ok(()) }
+            },
+        )
+        .await;
+        assert_eq!(outcome, Ok(None));
+        assert!(!paired.load(Ordering::SeqCst));
+
+        // Confirmed: the dialog sees the origin, the pairing action the URL.
+        let outcome = pair_after_confirmation(
+            link(),
+            |origin| {
+                assert_eq!(origin, "https://gw.example");
+                true
+            },
+            |gateway_url| async move {
+                assert_eq!(gateway_url, "https://gw.example");
+                Ok(())
+            },
+        )
+        .await;
+        assert_eq!(outcome, Ok(Some(())));
     }
 }

--- a/crates/openwave-desktop/src/deep_link.rs
+++ b/crates/openwave-desktop/src/deep_link.rs
@@ -1,0 +1,220 @@
+//! `openwave://` deep-link handling: gateway pairing.
+//!
+//! One link shape is recognized: `openwave://provision?gateway=<url>`. macOS
+//! delivers opened URLs through the runtime's opened-URL events, which the
+//! deep-link plugin re-emits; on Windows and Linux the OS launches a second
+//! app instance with the link as its only argument, and the single-instance
+//! plugin (via its `deep-link` feature) forwards those arguments to the
+//! deep-link plugin in the primary process. Every warm path therefore
+//! funnels into the one open-URL listener registered here; a cold start on
+//! Windows/Linux is picked up from the plugin's recorded launch URL right
+//! after the listener is registered.
+//!
+//! Provisioning itself lives server-side ([`openwave_server::pair_with_gateway`]):
+//! the shell calls it directly on the embedded server's store, so no HTTP
+//! route — authenticated or otherwise — can reach the policy write path.
+
+use std::sync::Arc;
+
+use tauri::Manager;
+use tauri_plugin_deep_link::DeepLinkExt;
+use tokio::sync::watch;
+
+use openwave_core::Store;
+
+/// Where the pairing handler waits for the embedded server's store: filled
+/// once boot has bound the server. A provision link commonly *launches* the
+/// app, so the handler awaits this instead of racing the boot task.
+pub(crate) struct PairingStore {
+    rx: watch::Receiver<Option<Arc<dyn Store>>>,
+}
+
+impl PairingStore {
+    pub(crate) fn new(rx: watch::Receiver<Option<Arc<dyn Store>>>) -> Self {
+        Self { rx }
+    }
+}
+
+/// Register the open-URL listener and pick up a launch link.
+pub(crate) fn install(app: &tauri::AppHandle) {
+    // Dev builds and portable installs have no installer run to write the
+    // scheme registration; best-effort runtime registration keeps the link
+    // working there. Not available on macOS, where the bundle's Info.plist
+    // (generated from the deep-link config) is the only registration path.
+    #[cfg(any(windows, target_os = "linux"))]
+    if let Err(error) = app.deep_link().register_all() {
+        eprintln!("openwave-desktop: deep-link scheme registration failed: {error}");
+    }
+    let handle = app.clone();
+    app.deep_link().on_open_url(move |event| {
+        handle_deep_link_urls(&handle, &event.urls());
+    });
+    // Windows/Linux cold start: the launch link was recorded by the plugin
+    // before this listener existed. macOS delivers the launch link as an
+    // opened-URL event after setup, so it reaches the listener instead.
+    if let Ok(Some(urls)) = app.deep_link().get_current() {
+        handle_deep_link_urls(app, &urls);
+    }
+}
+
+/// Handle every `openwave://` URL in one delivery: surface the window, then
+/// pair for each well-formed provision link. A malformed link is logged
+/// (bounded, without echoing the link) and changes nothing.
+fn handle_deep_link_urls(app: &tauri::AppHandle, urls: &[tauri::Url]) {
+    for url in urls {
+        if url.scheme() != "openwave" {
+            continue;
+        }
+        focus_main_window(app);
+        match provision_gateway_url(url) {
+            Ok(gateway_url) => spawn_pairing(app.clone(), gateway_url),
+            Err(reason) => log_pairing(app, &format!("ignored a deep link: {reason}")),
+        }
+    }
+}
+
+/// Bring the main window to the user: pairing was asked for from outside the
+/// app (a browser or terminal), and its outcome shows in the app.
+pub(crate) fn focus_main_window(app: &tauri::AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
+/// Extract the gateway URL from a provision link.
+///
+/// The contract is strict — scheme `openwave`, action `provision`, exactly
+/// one query parameter named `gateway` — so a malformed link is refused
+/// whole rather than partially honored. The gateway URL value itself is held
+/// to the gateway contract server-side, before anything is written.
+fn provision_gateway_url(url: &tauri::Url) -> Result<String, String> {
+    if url.scheme() != "openwave" {
+        return Err("not an openwave:// link".into());
+    }
+    // `openwave://provision` parses the action as a host; a bare
+    // `openwave:provision` parses it as the path. Anything left over in the
+    // other position means a different link shape.
+    let action = match (url.host_str(), url.path().trim_matches('/')) {
+        (Some(host), "") => host.to_string(),
+        (None, path) => path.to_string(),
+        (Some(host), path) => format!("{host}/{path}"),
+    };
+    if action != "provision" {
+        return Err("not a provision link".into());
+    }
+    let mut pairs = url.query_pairs();
+    let Some((key, value)) = pairs.next() else {
+        return Err("the provision link carries no gateway parameter".into());
+    };
+    if pairs.next().is_some() {
+        return Err("the provision link must carry exactly one parameter".into());
+    }
+    if key != "gateway" {
+        return Err("the provision link carries an unrecognized parameter".into());
+    }
+    if value.is_empty() {
+        return Err("the provision link carries an empty gateway URL".into());
+    }
+    Ok(value.into_owned())
+}
+
+fn spawn_pairing(app: tauri::AppHandle, gateway_url: String) {
+    tauri::async_runtime::spawn(async move {
+        match pair(&app, &gateway_url).await {
+            Ok(base_url) => log_pairing(&app, &format!("provisioned to {base_url}")),
+            Err(reason) => log_pairing(&app, &format!("pairing failed: {reason}")),
+        }
+    });
+}
+
+/// Validate, probe, and provision — all server-side. The sign-in gate is a
+/// separate surface: once policy flips to managed it presents itself on its
+/// next poll, so pairing does not drive the renderer.
+async fn pair(app: &tauri::AppHandle, gateway_url: &str) -> Result<String, String> {
+    let store = wait_store(app).await?;
+    openwave_server::pair_with_gateway(&*store, gateway_url)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+async fn wait_store(app: &tauri::AppHandle) -> Result<Arc<dyn Store>, String> {
+    let mut rx = app.state::<PairingStore>().rx.clone();
+    loop {
+        if let Some(store) = rx.borrow().clone() {
+            return Ok(store);
+        }
+        rx.changed()
+            .await
+            .map_err(|_| "the embedded server did not start".to_string())?;
+    }
+}
+
+/// One bounded, secret-free line per pairing attempt: stderr for terminal
+/// launches, `pairing.log` under app-data for GUI launches. Gateway errors
+/// already strip URLs and token material; the raw link is never echoed.
+fn log_pairing(app: &tauri::AppHandle, message: &str) {
+    use std::io::Write;
+    eprintln!("openwave-desktop: gateway pairing: {message}");
+    let Ok(dir) = crate::data_dir(app) else {
+        return;
+    };
+    let line = format!("{} {message}\n", chrono::Local::now().to_rfc3339());
+    let _ = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dir.join("pairing.log"))
+        .and_then(|mut file| file.write_all(line.as_bytes()));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::provision_gateway_url;
+
+    #[test]
+    fn provision_links_are_held_to_the_contract() {
+        let cases: &[(&str, Option<&str>)] = &[
+            // Well-formed, including the trailing-slash and encoded forms
+            // real browsers and MDM tooling produce.
+            (
+                "openwave://provision?gateway=https://gw.example",
+                Some("https://gw.example"),
+            ),
+            (
+                "openwave://provision/?gateway=https%3A%2F%2Fgw.example%2F",
+                Some("https://gw.example/"),
+            ),
+            (
+                "openwave:provision?gateway=https://gw.example",
+                Some("https://gw.example"),
+            ),
+            // Wrong action, missing/empty/duplicated/unknown parameters,
+            // trailing path, foreign scheme: all refused whole.
+            ("openwave://settings?gateway=https://gw.example", None),
+            ("openwave://provision", None),
+            ("openwave://provision?gateway=", None),
+            (
+                "openwave://provision?gateway=https://a.example&gateway=https://b.example",
+                None,
+            ),
+            (
+                "openwave://provision?gateway=https://gw.example&extra=1",
+                None,
+            ),
+            (
+                "openwave://provision/extra?gateway=https://gw.example",
+                None,
+            ),
+            ("https://provision?gateway=https://gw.example", None),
+        ];
+        for (link, expected) in cases {
+            let url = tauri::Url::parse(link).expect(link);
+            assert_eq!(
+                provision_gateway_url(&url).ok().as_deref(),
+                *expected,
+                "{link}"
+            );
+        }
+    }
+}

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -17,6 +17,7 @@ use openwave_core::Config;
 mod attachments;
 mod broker;
 mod client_execution;
+mod deep_link;
 mod deliverables;
 mod documents;
 mod host_access;
@@ -161,22 +162,28 @@ pub fn run() {
 
     let (info_tx, info_rx) = watch::channel(None);
     let state = Arc::new(AppState { info_rx });
+    // Filled once the embedded server binds; the deep-link pairing handler
+    // waits on it, because a provision link often launches the app.
+    let (store_tx, store_rx) = watch::channel(None);
 
     let builder = tauri::Builder::default();
     #[cfg(desktop)]
     let builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
-        if let Some(window) = app.get_webview_window("main") {
-            let _ = window.unminimize();
-            let _ = window.show();
-            let _ = window.set_focus();
-        }
+        // On Windows and Linux an `openwave://` link opens a second instance
+        // with the link as its argument. The plugin's `deep-link` feature has
+        // already forwarded `_args` to the deep-link plugin (raising the same
+        // open-URL event macOS delivers natively) before this callback runs,
+        // so the callback itself only surfaces the window.
+        deep_link::focus_main_window(app);
     }));
 
     let app = builder
+        .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(state)
+        .manage(deep_link::PairingStore::new(store_rx))
         .manage(documents::PendingLibraryDrop::default())
         .manage(updater::UpdateManager::default())
         .invoke_handler(tauri::generate_handler![
@@ -209,6 +216,7 @@ pub fn run() {
         .setup(move |app| {
             let handle = app.handle().clone();
             point_pdfium_at_bundle(&handle);
+            deep_link::install(&handle);
             updater::spawn_update_loop(handle.clone());
             let data = data_dir(&handle)?;
             let home = home_dir(&handle)?;
@@ -216,7 +224,7 @@ pub fn run() {
             app.manage(host_access);
 
             tauri::async_runtime::spawn(async move {
-                if let Err(error) = boot_server(handle, &info_tx, data.clone()).await {
+                if let Err(error) = boot_server(handle, &info_tx, store_tx, data.clone()).await {
                     // stderr for terminal launches, the app-data log for
                     // GUI launches, and the watch channel for the window.
                     eprintln!("openwave-desktop: {error}");
@@ -257,6 +265,7 @@ fn log_boot_failure(data_dir: &Path, error: &str) {
 async fn boot_server(
     app: tauri::AppHandle,
     info_tx: &watch::Sender<Option<BootOutcome>>,
+    store_tx: watch::Sender<Option<Arc<dyn openwave_core::Store>>>,
     data_dir: PathBuf,
 ) -> Result<(), String> {
     let client_executor_id = app.state::<host_access::HostAccess>().client_executor_id();
@@ -275,6 +284,8 @@ async fn boot_server(
         .map_err(|e| e.to_string())?;
     app.state::<host_access::HostAccess>()
         .initialize_store(server.store())?;
+    // Unblock any pairing task parked on a deep link that arrived pre-boot.
+    let _ = store_tx.send(Some(server.store()));
     let base_url = format!("http://{}", server.local_addr());
     let token = server.token().to_string();
     let executor_token = server.client_executor_token().to_string();

--- a/crates/openwave-desktop/tauri.conf.json
+++ b/crates/openwave-desktop/tauri.conf.json
@@ -38,6 +38,11 @@
     }
   },
   "plugins": {
+    "deep-link": {
+      "desktop": {
+        "schemes": ["openwave"]
+      }
+    },
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEUyRjM1NjZGOTQxRUFBNwpSV1NuNmtINVpqVXZEaXY4cVFWZ0RrbThUbHlEZFB1RnVtT01MSGcwRElhcjdtUUpJckJzM2ZjTAo=",
       "endpoints": [

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -33,6 +33,7 @@ mod managed_policy;
 mod mcp_config;
 mod model_registry;
 mod model_roles;
+mod pairing;
 mod provider;
 mod providers;
 mod resolver;
@@ -82,6 +83,7 @@ use openwave_retrieval::{
 use resolver::KeyedResolver;
 
 pub use error::ServerError;
+pub use pairing::pair_with_gateway;
 pub use state::AppState;
 
 const MAX_RAW_DOCUMENT_BYTES: usize = 16 * 1024 * 1024;

--- a/crates/openwave-server/src/managed_policy.rs
+++ b/crates/openwave-server/src/managed_policy.rs
@@ -118,9 +118,6 @@ fn validated_gateway_url(gateway_url: &str) -> Result<String> {
 /// same gateway is idempotent, a conflicting one is refused. If re-pairing
 /// ever becomes a product flow, it belongs behind an explicit user
 /// confirmation in the deep-link slice, not in this write path.
-// The deep-link pairing flow is the intended production caller; until that
-// slice lands, only tests exercise this write path.
-#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) async fn provision(store: &dyn Store, gateway_url: &str) -> Result<()> {
     let gateway_url = validated_gateway_url(gateway_url)?;
     if let Some(value) = store.get_setting(SETTING_KEY).await? {

--- a/crates/openwave-server/src/managed_policy.rs
+++ b/crates/openwave-server/src/managed_policy.rs
@@ -120,17 +120,13 @@ fn validated_gateway_url(gateway_url: &str) -> Result<String> {
 /// confirmation in the deep-link slice, not in this write path.
 pub(crate) async fn provision(store: &dyn Store, gateway_url: &str) -> Result<()> {
     let gateway_url = validated_gateway_url(gateway_url)?;
-    if let Some(value) = store.get_setting(SETTING_KEY).await? {
-        // Unreadable existing state is not honored as a conflict: this write
-        // path is its only repair.
-        if let Ok(existing) = serde_json::from_value::<ProvisionedPolicy>(value) {
-            if existing.gateway_url == gateway_url {
-                return Ok(());
-            }
-            return Err(AgentError::config(
-                "this profile is already provisioned to a different gateway",
-            ));
+    if let Some(existing) = provisioned_url(store).await? {
+        if existing == gateway_url {
+            return Ok(());
         }
+        return Err(AgentError::config(
+            "this profile is already provisioned to a different gateway",
+        ));
     }
     store
         .set_setting(
@@ -138,6 +134,19 @@ pub(crate) async fn provision(store: &dyn Store, gateway_url: &str) -> Result<()
             &serde_json::to_value(ProvisionedPolicy { gateway_url })?,
         )
         .await
+}
+
+/// The provisioned gateway URL currently on record, if readable.
+///
+/// Unreadable stored state reads as `None`, not as an error: [`provision`]
+/// treats it as repairable rather than honoring it as a conflict, and the
+/// pairing pre-check must agree with that judgment.
+pub(crate) async fn provisioned_url(store: &dyn Store) -> Result<Option<String>> {
+    Ok(store
+        .get_setting(SETTING_KEY)
+        .await?
+        .and_then(|value| serde_json::from_value::<ProvisionedPolicy>(value).ok())
+        .map(|saved| saved.gateway_url))
 }
 
 #[cfg(test)]

--- a/crates/openwave-server/src/pairing.rs
+++ b/crates/openwave-server/src/pairing.rs
@@ -1,0 +1,173 @@
+//! Deep-link pairing: validate a gateway, then provision this profile.
+//!
+//! The desktop shell's `openwave://provision` handler lands here. The gateway
+//! is probed (`GET /api/v1/meta`) before anything is written, so a mistyped
+//! or unreachable URL never becomes durable policy; only then does the
+//! managed-policy write path run and the ModelGateway provider config get
+//! pointed at the gateway. This function is exported for native embedders
+//! only — pairing changes policy, and policy must never be reachable from a
+//! renderer-writable route.
+
+use openwave_connectors::{GatewayAuth, GatewayAuthConfig};
+use openwave_core::{Result, Store};
+use tokio::sync::Mutex;
+
+use crate::managed_policy;
+use crate::providers::{self, ProviderKind};
+
+/// Serializes pairing end to end. [`managed_policy::provision`] is a
+/// check-then-write over the settings store, and the [`Store`] API offers no
+/// cross-call transaction to make it atomic; two links decoded concurrently
+/// could otherwise both pass the conflict check and the second would
+/// overwrite the first. One desktop process owns the store (the server's
+/// instance lock guarantees it), so a process-local mutex is enough to make
+/// the check-then-write effectively atomic.
+static PAIRING: Mutex<()> = Mutex::const_new(());
+
+/// Validate `gateway_url`, probe the gateway, and provision this profile.
+///
+/// Returns the normalized gateway base URL on success. Nothing is written
+/// unless the URL passes the gateway contract and the deployment answers
+/// `GET /api/v1/meta`; a conflicting re-provision is refused inside
+/// [`managed_policy::provision`] and leaves both the policy and the provider
+/// configuration untouched. Success also points the ModelGateway provider at
+/// the gateway and enables it, dropping any model snapshot synced from a
+/// previously configured base URL — sign-in resyncs the entitled set.
+pub async fn pair_with_gateway(store: &dyn Store, gateway_url: &str) -> Result<String> {
+    let config = GatewayAuthConfig::new(gateway_url)?;
+    let base_url = config.base_url().to_string();
+    GatewayAuth::new(config)?.meta().await?;
+    let _guard = PAIRING.lock().await;
+    managed_policy::provision(store, &base_url).await?;
+    let mut provider = providers::read_config(store, ProviderKind::ModelGateway).await?;
+    if provider.base_url.as_deref() != Some(base_url.as_str()) {
+        // A model snapshot synced from a previously configured gateway does
+        // not describe this one.
+        provider.models = Vec::new();
+        provider.base_url = Some(base_url.clone());
+    }
+    provider.enabled = true;
+    providers::write_config(store, ProviderKind::ModelGateway, &provider).await?;
+    Ok(base_url)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::routing::get;
+    use axum::Json;
+    use openwave_core::DbStore;
+    use serde_json::json;
+
+    use super::*;
+    use crate::managed_policy::{resolve, NoOsPolicy};
+
+    async fn test_store() -> (Arc<dyn Store>, tempfile::TempDir) {
+        let directory = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("pairing.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        (store, directory)
+    }
+
+    /// A gateway that answers only the unauthenticated identity probe.
+    async fn serve_meta() -> String {
+        let app = axum::Router::new().route(
+            "/api/v1/meta",
+            get(|| async {
+                Json(json!({
+                    "api_version": "v1",
+                    "installation_id": "install-1",
+                    "gateway_version": "1.0.0",
+                    "public_url": "http://gateway.test",
+                    "auth_mode": "oidc",
+                }))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{address}")
+    }
+
+    #[tokio::test]
+    async fn pairing_provisions_policy_and_points_the_provider() {
+        let (store, _directory) = test_store().await;
+        let base = serve_meta().await;
+
+        // A stale snapshot from a manually configured endpoint must not
+        // survive as this gateway's model set.
+        providers::write_config(
+            &*store,
+            ProviderKind::ModelGateway,
+            &providers::ProviderConfig {
+                enabled: false,
+                base_url: Some("http://old.gateway.test".into()),
+                vertex_location: None,
+                models: vec![providers::CustomModelConfig {
+                    id: "stale-model".into(),
+                    display_name: None,
+                    context_window: 32_768,
+                    max_output_tokens: 4_096,
+                }],
+            },
+        )
+        .await
+        .unwrap();
+
+        let normalized = pair_with_gateway(&*store, &base).await.unwrap();
+        assert_eq!(normalized, format!("{base}/"));
+
+        let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
+        assert!(policy.managed);
+        assert_eq!(policy.gateway_url.as_deref(), Some(normalized.as_str()));
+
+        let provider = providers::read_config(&*store, ProviderKind::ModelGateway)
+            .await
+            .unwrap();
+        assert!(provider.enabled);
+        assert_eq!(provider.base_url.as_deref(), Some(normalized.as_str()));
+        assert!(provider.models.is_empty());
+
+        // Re-pairing the same gateway is idempotent.
+        pair_with_gateway(&*store, &base).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_failed_pairing_changes_nothing() {
+        let (store, _directory) = test_store().await;
+
+        // Unreachable gateway: the probe fails before any write.
+        assert!(pair_with_gateway(&*store, "http://127.0.0.1:9")
+            .await
+            .is_err());
+        assert!(!resolve(&*store, &NoOsPolicy).await.unwrap().managed);
+        let provider = providers::read_config(&*store, ProviderKind::ModelGateway)
+            .await
+            .unwrap();
+        assert!(!provider.enabled);
+        assert!(provider.base_url.is_none());
+
+        // A reachable but conflicting gateway: refused after the probe, and
+        // the original pairing survives in both policy and provider config.
+        let first = serve_meta().await;
+        let second = serve_meta().await;
+        let normalized = pair_with_gateway(&*store, &first).await.unwrap();
+        let error = pair_with_gateway(&*store, &second).await.err().unwrap();
+        assert!(error.to_string().contains("already provisioned"));
+        let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
+        assert_eq!(policy.gateway_url.as_deref(), Some(normalized.as_str()));
+        let provider = providers::read_config(&*store, ProviderKind::ModelGateway)
+            .await
+            .unwrap();
+        assert_eq!(provider.base_url.as_deref(), Some(normalized.as_str()));
+    }
+}

--- a/crates/openwave-server/src/pairing.rs
+++ b/crates/openwave-server/src/pairing.rs
@@ -9,7 +9,7 @@
 //! renderer-writable route.
 
 use openwave_connectors::{GatewayAuth, GatewayAuthConfig};
-use openwave_core::{Result, Store};
+use openwave_core::{AgentError, Result, Store};
 use tokio::sync::Mutex;
 
 use crate::managed_policy;
@@ -38,7 +38,19 @@ pub async fn pair_with_gateway(store: &dyn Store, gateway_url: &str) -> Result<S
     let base_url = config.base_url().to_string();
     GatewayAuth::new(config)?.meta().await?;
     let _guard = PAIRING.lock().await;
-    managed_policy::provision(store, &base_url).await?;
+    // Refuse a conflicting pairing before either write, then write the
+    // provider configuration before the sticky policy. Neither write is
+    // transactional with the other, so the order decides the failure mode:
+    // provider-first fails into a still-unmanaged profile recoverable from
+    // settings, while policy-first could strand a permanently managed
+    // profile with no configured provider.
+    if let Some(existing) = managed_policy::provisioned_url(store).await? {
+        if existing != base_url {
+            return Err(AgentError::config(
+                "this profile is already provisioned to a different gateway",
+            ));
+        }
+    }
     let mut provider = providers::read_config(store, ProviderKind::ModelGateway).await?;
     if provider.base_url.as_deref() != Some(base_url.as_str()) {
         // A model snapshot synced from a previously configured gateway does
@@ -48,6 +60,7 @@ pub async fn pair_with_gateway(store: &dyn Store, gateway_url: &str) -> Result<S
     }
     provider.enabled = true;
     providers::write_config(store, ProviderKind::ModelGateway, &provider).await?;
+    managed_policy::provision(store, &base_url).await?;
     Ok(base_url)
 }
 
@@ -74,6 +87,15 @@ mod tests {
             .unwrap(),
         );
         (store, directory)
+    }
+
+    /// An address nothing listens on: bound to reserve an ephemeral port,
+    /// then dropped, so the probe fails fast and deterministically.
+    async fn unreachable_base() -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        format!("http://{address}")
     }
 
     /// A gateway that answers only the unauthenticated identity probe.
@@ -146,9 +168,8 @@ mod tests {
         let (store, _directory) = test_store().await;
 
         // Unreachable gateway: the probe fails before any write.
-        assert!(pair_with_gateway(&*store, "http://127.0.0.1:9")
-            .await
-            .is_err());
+        let dead = unreachable_base().await;
+        assert!(pair_with_gateway(&*store, &dead).await.is_err());
         assert!(!resolve(&*store, &NoOsPolicy).await.unwrap().managed);
         let provider = providers::read_config(&*store, ProviderKind::ModelGateway)
             .await


### PR DESCRIPTION
Registers the `openwave://` URL scheme and implements deep-link pairing: `openwave://provision?gateway=<url>` validates the gateway and provisions the profile's managed-mode policy.

## What happens on a provision link

1. The desktop shell parses the link against a strict contract — scheme `openwave`, action `provision`, exactly one `gateway` query parameter — and refuses malformed links whole.
2. The main window is surfaced, and the handler waits for the embedded server's store (a provision link commonly *launches* the app, so it must not race boot).
3. The new server-side seam `openwave_server::pair_with_gateway` takes over: it holds the gateway URL to the connectors URL contract, probes the deployment with unauthenticated `GET /api/v1/meta` **before anything is written**, then calls `managed_policy::provision` and points the ModelGateway provider config at the gateway (`base_url` + `enabled`, dropping any model snapshot synced from a previously configured base URL — sign-in resyncs the entitled set).

A failed pairing — malformed link, unreachable gateway, conflicting re-provision — changes nothing and leaves one bounded, secret-free line on stderr and in `pairing.log` under app-data (the raw link is never echoed; gateway errors already strip URLs and token material).

## Delivery path per platform

- **macOS**: opened URLs arrive as the runtime's opened-URL events, which `tauri-plugin-deep-link` re-emits to the one open-URL listener (warm and cold start). The bundler generates the `Info.plist` URL-type registration from the deep-link config in `tauri.conf.json`.
- **Windows / Linux**: the OS launches a second instance with the link as its only argument. `tauri-plugin-single-instance` is now built with its `deep-link` feature, so those arguments are forwarded to the deep-link plugin in the primary process (raising the same open-URL event) instead of being discarded. Cold starts are picked up from the plugin's recorded launch URL right after the listener is registered. Runtime scheme registration (`register_all`) covers dev builds and portable installs.

## Concurrency (carried from the #753 review)

`managed_policy::provision` is a non-atomic check-then-write and the `Store` API offers no cross-call transaction, so `pair_with_gateway` serializes end to end behind a process-local mutex. That is sufficient because exactly one desktop process owns the store — the server's instance lock guarantees it — so there is no cross-process writer for the mutex to miss. The `#[cfg_attr(not(test), allow(dead_code))]` on `provision()` is removed now that it has its production caller.

## Renderer scope: none

The sign-in gate is a parallel slice (#774); once policy flips to managed, the gate presents itself on its next poll/launch. This PR only focuses the main window on receipt. The deep-link plugin's commands are deliberately **not** added to the webview capability, and provisioning is a direct in-process call on the embedded server — no HTTP route, nothing renderer-writable can reach the policy write path.

## Dependencies

`tauri-plugin-deep-link` pinned `=2.4.9` (matches lockfile resolution); `tauri-plugin-single-instance` stays `=2.4.3` with the `deep-link` feature added. Lockfile diff is additive only (the plugin and its transitive deps); no existing pins moved.

## Tests

- `pairing::tests::pairing_provisions_policy_and_points_the_provider` — probe against a fixture gateway, policy provisioned, provider pointed/enabled, stale model snapshot dropped, idempotent re-pair.
- `pairing::tests::a_failed_pairing_changes_nothing` — unreachable gateway writes nothing; a reachable but conflicting gateway is refused after the probe and the original pairing survives in both policy and provider config.
- `deep_link::tests::provision_links_are_held_to_the_contract` — one table over the link contract (well-formed, encoded, wrong action, missing/empty/duplicate/unknown parameters, trailing path, foreign scheme). No test needs a running Tauri app.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace` (1426 passed, 0 failed), `cargo check --workspace --locked` — all green locally on top of current `main`. UI untouched.

Closes #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)