### PR TITLE
feat(desktop): show what a tool call found, read, or wrote

### DIFF
--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -140,7 +140,10 @@ pub use model::{
     TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer, TurnSteerStatus, MAX_ATTACHMENT_REVISION,
     MAX_MESSAGE_ATTACHMENTS, MAX_ROOT_ATTACHMENTS,
 };
-pub use preview::{ToolActionPreview, ToolResultPreview};
+pub use preview::{
+    format_bytes, ResultEntry, ResultEntryKind, ToolActionPreview, ToolResultPreview,
+    MAX_RESULT_ENTRIES, MAX_RESULT_ENTRY_CHARS,
+};
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId,
     RefusalDetails, RefusalOutcome, ResponseFormat, StopReason, ToolChoice, Usage,

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -29,6 +29,12 @@ pub const MAX_RESULT_STREAM_CHARS: usize = 40_000;
 /// at all, because a truncated URI is a different URI.
 pub const MAX_RESULT_VIEW_URI_CHARS: usize = 2 * 1024;
 
+/// Longest label, detail, or meta string one listed result row carries.
+pub const MAX_RESULT_ENTRY_CHARS: usize = 200;
+
+/// Most rows a result preview lists before it counts the rest instead.
+pub const MAX_RESULT_ENTRIES: usize = 50;
+
 /// The action a call will take, in a form a human can inspect.
 ///
 /// Approval cards need this because consent to an action you cannot see is not
@@ -150,6 +156,96 @@ impl ToolActionPreview {
     }
 }
 
+/// What one row of a listed result is, which is what picks its icon.
+///
+/// A closed vocabulary rather than an icon name: the renderer chooses how to
+/// draw a folder, and a tool must not be able to name a glyph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum ResultEntryKind {
+    /// A file, in the chat's scratch or in a connected folder.
+    File,
+    /// A directory.
+    Folder,
+    /// A document added to this conversation as a source.
+    Source,
+    /// A passage matched inside a source.
+    Passage,
+    /// A page on the public web.
+    Link,
+    /// An output this conversation published.
+    Output,
+}
+
+/// One thing a call surfaced.
+///
+/// Three fields because a row reads as three: what it is, where it came from,
+/// and how big or how many. A tool that wants to say more than that is
+/// describing something this projection does not cover.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub struct ResultEntry {
+    pub kind: ResultEntryKind,
+    /// The row's name — a file name, a source title, a page title.
+    pub label: String,
+    /// A secondary hint beside the name — a path, a domain, a section.
+    pub detail: Option<String>,
+    /// Trailing meta — a size, a count, a status word.
+    pub meta: Option<String>,
+}
+
+impl ResultEntry {
+    /// A row that is only its name.
+    #[must_use]
+    pub fn new(kind: ResultEntryKind, label: impl Into<String>) -> Self {
+        Self {
+            kind,
+            label: label.into(),
+            detail: None,
+            meta: None,
+        }
+    }
+
+    /// Add the secondary hint beside the name.
+    #[must_use]
+    pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+
+    /// Add the trailing meta.
+    #[must_use]
+    pub fn with_meta(mut self, meta: impl Into<String>) -> Self {
+        self.meta = Some(meta.into());
+        self
+    }
+}
+
+/// A byte count as a card should read it.
+///
+/// Ported from Brightwave's local-file result rows, which is where this reads
+/// as "12.4 KB" rather than as a number nobody scans.
+#[must_use]
+pub fn format_bytes(bytes: u64) -> String {
+    if bytes < 1024 {
+        return format!("{bytes} B");
+    }
+    let mut value = bytes as f64 / 1024.0;
+    let mut unit = 0;
+    const UNITS: [&str; 3] = ["KB", "MB", "GB"];
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+    // One decimal only where it says something: "1.4 MB" is worth the digit,
+    // "512.0 KB" and "340.0 MB" are not.
+    let unit = UNITS[unit];
+    if value >= 10.0 || (value.fract() * 10.0).round() == 0.0 {
+        format!("{} {unit}", value.round())
+    } else {
+        format!("{value:.1} {unit}")
+    }
+}
+
 /// What a call produced, in a form a human can read.
 ///
 /// A command's output is the whole reason to run it. Withholding it leaves the
@@ -183,7 +279,37 @@ pub enum ToolResultPreview {
         /// The validated `ui://` document reference.
         resource_uri: String,
     },
+    /// What a call found, read, or wrote, as the list of things it was.
+    ///
+    /// One shape for every tool whose result is a list, because what
+    /// distinguishes those tools on screen — the icon, the headline, the verb —
+    /// already comes from the tool's name. Forty tools do not need forty
+    /// variants to say "here is what I found".
+    Entries {
+        entries: Vec<ResultEntry>,
+        /// Rows past [`MAX_RESULT_ENTRIES`], counted rather than shown. A card
+        /// that silently lists the first fifty of two hundred results is
+        /// telling the reader something false.
+        elided: u32,
+    },
 }
+
+/// The tools that may project a list of entries.
+///
+/// Still an allowlist, on the same terms as every other variant: `entries` in a
+/// tool's output data is an opt-in, and a tool not named here does not have
+/// one. An external MCP tool in particular can write whatever it likes into its
+/// data, and must not thereby acquire a card.
+const ENTRY_TOOLS: &[&str] = &[
+    "search",
+    crate::WEB_SEARCH_TOOL,
+    "list_sources",
+    "read_source",
+    "read_file",
+    "list_dir",
+    "write_file",
+    "create_deliverable",
+];
 
 impl ToolResultPreview {
     /// Project the result of a call from the tool's own output.
@@ -236,6 +362,25 @@ impl ToolResultPreview {
                     resource_uri: view.resource_uri.clone(),
                 })
             }
+            // A failed call has no list to show — whatever partial data it left
+            // behind describes work that did not happen.
+            name if ENTRY_TOOLS.contains(&name) && !output.is_error => {
+                let listed = output.data.as_ref()?.get("entries")?.as_array()?;
+                let entries: Vec<_> = listed
+                    .iter()
+                    .take(MAX_RESULT_ENTRIES)
+                    .filter_map(result_entry)
+                    .collect();
+                // A row the clamp rejected is dropped, not counted: `elided`
+                // means "there were more", and folding unreadable rows into it
+                // would make the card claim results the tool never returned.
+                let elided = u32::try_from(listed.len().saturating_sub(MAX_RESULT_ENTRIES))
+                    .unwrap_or(u32::MAX);
+                // An empty list is a result, not the absence of one: a search
+                // that matched nothing and a search that was never projected
+                // look identical in the rail, and only one of them is true.
+                Some(Self::Entries { entries, elided })
+            }
             _ => None,
         }
     }
@@ -261,10 +406,31 @@ impl ToolResultPreview {
     pub fn has_output(&self) -> bool {
         match self {
             Self::Exec { stdout, stderr, .. } => !stdout.is_empty() || !stderr.is_empty(),
-            Self::WebSearchProviderRequired => true,
-            Self::McpApp { .. } => true,
+            Self::WebSearchProviderRequired | Self::McpApp { .. } => true,
+            // An empty list is still something to show, and saying so is the
+            // point: the card reports that the call found nothing.
+            Self::Entries { .. } => true,
         }
     }
+}
+
+/// Bound one listed row, or drop it.
+///
+/// A row without a readable label is not a row — it would render as an empty
+/// line the reader cannot interpret. `detail` and `meta` are genuinely
+/// optional, so one that clamps away to nothing simply goes missing rather than
+/// taking its row with it.
+fn result_entry(value: &Value) -> Option<ResultEntry> {
+    Some(ResultEntry {
+        kind: serde_json::from_value(value.get("kind")?.clone()).ok()?,
+        label: clamp(value.get("label")?.as_str()?, MAX_RESULT_ENTRY_CHARS)?,
+        detail: entry_field(value.get("detail")),
+        meta: entry_field(value.get("meta")),
+    })
+}
+
+fn entry_field(value: Option<&Value>) -> Option<String> {
+    clamp(value?.as_str()?, MAX_RESULT_ENTRY_CHARS)
 }
 
 /// Bound a captured stream, keeping its newlines: output without line breaks
@@ -540,17 +706,111 @@ mod tests {
             );
         }
 
-        // The searches project an *action* so their query can be reviewed, and
-        // deliberately no *result*: what a search returned is the answer the
-        // model works from, not something the transcript restates.
-        for tool in ["search", "web_search"] {
-            let arguments = serde_json::json!({ "query": "private" });
-            assert!(ToolActionPreview::build(tool, &arguments).is_some());
+        // A tool on the entries allowlist still projects nothing until it opts
+        // in: the allowlist says who *may* have a card, and the `entries` key
+        // in the tool's own output is the opt-in.
+        for tool in ["search", "web_search", "write_file"] {
             assert_eq!(
-                ToolResultPreview::build(tool, &output_with_data(arguments.clone())),
+                ToolResultPreview::build(
+                    tool,
+                    &output_with_data(serde_json::json!({ "query": "private" }))
+                ),
                 None
             );
         }
+    }
+
+    #[test]
+    fn only_an_allowlisted_tool_gets_a_card_from_its_own_output() {
+        // `entries` is a projection a tool opts into, not a channel anything
+        // can write to. An external MCP tool controls its structured data
+        // outright, so the allowlist — not the key — is what grants the card.
+        let output = ToolOutput::text("done")
+            .with_entries(vec![ResultEntry::new(ResultEntryKind::File, "notes.md")]);
+        assert_eq!(
+            ToolResultPreview::build("mcp__gateway__tool", &output),
+            None
+        );
+        assert_eq!(ToolResultPreview::build("read_tool_result", &output), None);
+        assert!(ToolResultPreview::build("read_file", &output).is_some());
+
+        // Nor does a call that failed: whatever rows it left behind describe
+        // work that did not happen.
+        let mut failed = output.clone();
+        failed.is_error = true;
+        assert_eq!(ToolResultPreview::build("read_file", &failed), None);
+    }
+
+    #[test]
+    fn a_listed_result_is_bounded_row_by_row_and_counts_what_it_dropped() {
+        let long = "a".repeat(MAX_RESULT_ENTRY_CHARS * 2);
+        let mut rows: Vec<_> = (0..MAX_RESULT_ENTRIES + 7)
+            .map(|index| serde_json::json!({ "kind": "file", "label": index.to_string() }))
+            .collect();
+        rows[0] = serde_json::json!({
+            "kind": "file",
+            "label": long,
+            // Control characters could otherwise forge row structure.
+            "detail": "reports/\nq3.md",
+            "meta": 7,
+        });
+        let Some(ToolResultPreview::Entries { entries, elided }) = ToolResultPreview::build(
+            "list_dir",
+            &ToolOutput::text("listing").with_data(serde_json::json!({ "entries": rows })),
+        ) else {
+            panic!("list_dir projects a list");
+        };
+        assert_eq!(entries.len(), MAX_RESULT_ENTRIES);
+        assert_eq!(elided, 7);
+        assert_eq!(entries[0].label.chars().count(), MAX_RESULT_ENTRY_CHARS);
+        assert_eq!(entries[0].detail.as_deref(), Some("reports/q3.md"));
+        // A hint that is not a string is dropped; the row survives without it.
+        assert_eq!(entries[0].meta, None);
+    }
+
+    #[test]
+    fn a_call_that_found_nothing_says_so_rather_than_projecting_nothing() {
+        // "Searched and matched nothing" and "searched" are the same muted rail
+        // line, and only the first is a fact. An empty list is the difference.
+        assert_eq!(
+            ToolResultPreview::build(
+                "search",
+                &ToolOutput::text("No matching passages found.").with_entries(Vec::new()),
+            ),
+            Some(ToolResultPreview::Entries {
+                entries: Vec::new(),
+                elided: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn a_listed_result_carries_only_the_three_fields_a_row_reads_as() {
+        // The projection is closed the same way every other variant is: the
+        // tool's output text and its other structured data stay behind it.
+        let output = ToolOutput::text("Published output 41ff revision 3 (900 bytes).")
+            .with_data(serde_json::json!({ "output_id": "41ff", "revision_count": 3 }))
+            .with_entries(vec![
+                ResultEntry::new(ResultEntryKind::Output, "q3.md").with_meta(format_bytes(900))
+            ]);
+        let json = serde_json::to_string(
+            &ToolResultPreview::build("create_deliverable", &output).unwrap(),
+        )
+        .unwrap();
+        assert!(json.contains(r#""label":"q3.md""#));
+        assert!(json.contains(r#""meta":"900 B""#));
+        assert!(!json.contains("41ff"));
+        assert!(!json.contains("revision_count"));
+    }
+
+    #[test]
+    fn byte_counts_read_as_sizes_and_keep_a_digit_only_where_it_says_something() {
+        assert_eq!(format_bytes(0), "0 B");
+        assert_eq!(format_bytes(900), "900 B");
+        assert_eq!(format_bytes(1024), "1 KB");
+        assert_eq!(format_bytes(1536), "1.5 KB");
+        assert_eq!(format_bytes(20 * 1024), "20 KB");
+        assert_eq!(format_bytes(3 * 1024 * 1024 + 512 * 1024), "3.5 MB");
     }
 
     #[test]

--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -476,6 +476,25 @@ impl ToolOutput {
         self
     }
 
+    /// Offer the renderer a list of what this call surfaced.
+    ///
+    /// The tool's own output text is what the model reads and is written for
+    /// the model; these rows are what a person reads. Attached here rather than
+    /// hand-built into `data` so a tool cannot get the key wrong and silently
+    /// project nothing — see [`crate::ToolResultPreview::Entries`], which
+    /// clamps every row before it crosses.
+    #[must_use]
+    pub fn with_entries(mut self, entries: Vec<crate::ResultEntry>) -> Self {
+        let entries = serde_json::json!(entries);
+        match self.data.as_mut().and_then(Value::as_object_mut) {
+            Some(data) => {
+                data.insert("entries".into(), entries);
+            }
+            None => self.data = Some(serde_json::json!({ "entries": entries })),
+        }
+        self
+    }
+
     /// Attach bounded evidence that never serializes into events or renderer DTOs.
     #[must_use]
     pub fn with_private_evidence(mut self, evidence: Vec<crate::RetrievalEvidenceInput>) -> Self {

--- a/crates/openwave-core/src/tools/create_deliverable.rs
+++ b/crates/openwave-core/src/tools/create_deliverable.rs
@@ -187,6 +187,7 @@ impl Tool for CreateDeliverable {
             citations: Vec::new(),
             created_at: call.created_at,
         };
+        let listed = filename.clone();
         let record = match requested_output_id {
             Some(existing) => self.store.append_output_revision(existing, &revision).await,
             None => {
@@ -209,7 +210,16 @@ impl Tool for CreateDeliverable {
                 "output_id": record.id,
                 "revision_id": record.current_revision,
                 "revision_count": record.revision_count,
-            }))),
+            }))
+            // The revision number is the fact a reader needs: a second
+            // `create_deliverable` on the same output looks identical in the
+            // rail whether it replaced the file or appended to its history.
+            .with_entries(vec![crate::ResultEntry::new(
+                crate::ResultEntryKind::Output,
+                listed,
+            )
+            .with_detail(format!("revision {}", record.current_revision))
+            .with_meta(crate::format_bytes(content_len as u64))])),
             Err(error) => Ok(ToolOutput::error(format!(
                 "could not publish deliverable: {error}"
             ))),

--- a/crates/openwave-core/src/tools/list_dir.rs
+++ b/crates/openwave-core/src/tools/list_dir.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::error::Result;
+use crate::preview::{ResultEntry, ResultEntryKind};
 use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 
 use super::arguments;
@@ -49,7 +50,14 @@ impl Tool for ListDir {
         };
         let result = tokio::task::spawn_blocking(move || list_directory(&workspace, &path)).await;
         match result {
-            Ok(Ok(listing)) => Ok(ToolOutput::text(listing)),
+            Ok(Ok(listing)) => Ok(ToolOutput::text(&listing).with_entries(directory_entries(
+                &listing,
+                if relative == "." {
+                    None
+                } else {
+                    Some(relative)
+                },
+            ))),
             Ok(Err(error)) => Ok(ToolOutput::error(format!(
                 "could not list {relative}: {error}"
             ))),
@@ -58,4 +66,27 @@ impl Tool for ListDir {
             ))),
         }
     }
+}
+
+/// The listing as rows, read back out of the text the model is given.
+///
+/// Derived from that one string rather than built alongside it, so the card and
+/// the model can never disagree about what the directory holds. The trailing
+/// slash `list_directory` appends is what marks a directory, and it is dropped
+/// from the row: the icon says it better.
+fn directory_entries(listing: &str, path: Option<&str>) -> Vec<ResultEntry> {
+    listing
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(|line| {
+            let entry = match line.strip_suffix('/') {
+                Some(name) => ResultEntry::new(ResultEntryKind::Folder, name),
+                None => ResultEntry::new(ResultEntryKind::File, line),
+            };
+            match path {
+                Some(path) => entry.with_detail(path),
+                None => entry,
+            }
+        })
+        .collect()
 }

--- a/crates/openwave-core/src/tools/private_scratch.rs
+++ b/crates/openwave-core/src/tools/private_scratch.rs
@@ -30,6 +30,27 @@ pub(super) fn relative_path(rel: &str) -> std::result::Result<PathBuf, String> {
     Ok(path.to_path_buf())
 }
 
+/// The last segment of a scratch-relative path, for a card row's name.
+///
+/// A row leads with the file rather than the path so a column of results stays
+/// scannable; the full path is the row's secondary hint. A path that ends in a
+/// separator has no last segment, and there is nothing better to show than what
+/// the model asked for.
+pub(super) fn file_name(path: &str) -> &str {
+    Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(path)
+}
+
+/// How many lines a read returned, phrased for a card.
+pub(super) fn line_count(content: &str) -> String {
+    // A file with no trailing newline still has a last line, and an empty file
+    // has none — which `lines()` gets right and a newline count does not.
+    let lines = content.lines().count();
+    format!("{lines} {}", if lines == 1 { "line" } else { "lines" })
+}
+
 pub(super) fn read_utf8_file(workspace: &Dir, path: &Path) -> std::result::Result<String, String> {
     let bytes = read_regular_file_bytes(workspace, path, MAX_READ_FILE_BYTES)?;
     String::from_utf8(bytes).map_err(|_| "file is not valid UTF-8".into())

--- a/crates/openwave-core/src/tools/read_file.rs
+++ b/crates/openwave-core/src/tools/read_file.rs
@@ -4,11 +4,12 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::error::Result;
+use crate::preview::{ResultEntry, ResultEntryKind};
 use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 
 use super::arguments;
 use super::definitions;
-use super::private_scratch::{read_utf8_file, relative_path};
+use super::private_scratch::{file_name, line_count, read_utf8_file, relative_path};
 
 /// `read_file` — read a UTF-8 text file from private scratch.
 pub struct ReadFile;
@@ -44,7 +45,19 @@ impl Tool for ReadFile {
         };
         let result = tokio::task::spawn_blocking(move || read_utf8_file(&workspace, &path)).await;
         match result {
-            Ok(Ok(content)) => Ok(ToolOutput::text(content)),
+            // The file's own text is what the model needs and is far too much
+            // for a card, so the row reports the read rather than replaying it:
+            // the path, and how much of it came back.
+            Ok(Ok(content)) => {
+                let entry = ResultEntry::new(ResultEntryKind::File, file_name(&arguments.path))
+                    .with_detail(&arguments.path)
+                    .with_meta(format!(
+                        "{} · {}",
+                        crate::preview::format_bytes(content.len() as u64),
+                        line_count(&content)
+                    ));
+                Ok(ToolOutput::text(content).with_entries(vec![entry]))
+            }
             Ok(Err(error)) => Ok(ToolOutput::error(format!(
                 "could not read {}: {error}",
                 arguments.path

--- a/crates/openwave-core/src/tools/write_file.rs
+++ b/crates/openwave-core/src/tools/write_file.rs
@@ -4,11 +4,12 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::error::Result;
+use crate::preview::{ResultEntry, ResultEntryKind};
 use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
 
 use super::arguments;
 use super::definitions;
-use super::private_scratch::{relative_path, write_utf8_file};
+use super::private_scratch::{file_name, relative_path, write_utf8_file};
 
 /// `write_file` — atomically write a UTF-8 text file into private scratch.
 pub struct WriteFile;
@@ -52,7 +53,13 @@ impl Tool for WriteFile {
             Ok(Ok(())) => Ok(ToolOutput::text(format!(
                 "wrote {} bytes to {}",
                 content_len, arguments.path
-            ))),
+            ))
+            .with_entries(vec![ResultEntry::new(
+                ResultEntryKind::File,
+                file_name(&arguments.path),
+            )
+            .with_detail(&arguments.path)
+            .with_meta(crate::preview::format_bytes(content_len as u64))])),
             Ok(Err(error)) => Ok(ToolOutput::error(format!(
                 "could not write {}: {error}",
                 arguments.path

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ApprovalCard } from "./ApprovalCard";
@@ -628,6 +628,58 @@ describe("mcp app views", () => {
     expect(
       await screen.findByTitle("MCP App view from gateway"),
     ).toBeInTheDocument();
+  });
+
+  it("surfaces what a call found, behind one line until it is opened", async () => {
+    const user = userEvent.setup();
+    render(
+      <MessageList
+        messages={[
+          {
+            id: "t1",
+            role: "tool",
+            callId: "c1",
+            name: "list_dir",
+            status: "completed",
+            result: {
+              tool: "entries",
+              elided: 3,
+              entries: [
+                { kind: "file", label: "notes.md", detail: null, meta: "1.2 KB" },
+                { kind: "folder", label: "reports", detail: null, meta: null },
+              ],
+            },
+          },
+        ]}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    // The count is on the collapsed header, and it counts the rows the card is
+    // not showing — a reader must not have to open the card to learn there
+    // were five results.
+    const card = screen.getByRole("status", {
+      name: "Browse files: File browse complete",
+    });
+    expect(within(card).getByText("5 results")).toBeInTheDocument();
+    expect(screen.queryByText("notes.md")).not.toBeInTheDocument();
+
+    await user.click(within(card).getByRole("button"));
+    expect(screen.getByText("notes.md")).toBeInTheDocument();
+    expect(screen.getByText("reports")).toBeInTheDocument();
+    expect(screen.getByText("3 more not shown")).toBeInTheDocument();
   });
 });
 

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -24,6 +24,7 @@ import { MessageFooter } from "./MessageFooter";
 import { AssistantSources, type AssistantSource } from "./AssistantSources";
 import { McpAppCard } from "./McpAppCard";
 import { ToolCommandCard, type ToolCallStatus } from "./ToolCallCard";
+import { ToolEntriesCard } from "./ToolEntriesCard";
 import { ErrorBoundary } from "./ErrorBoundary";
 import { ToolActivityGroup } from "./ToolActivityGroup";
 import { WelcomeState } from "./WelcomeState";
@@ -541,6 +542,20 @@ function surfacedCards(
           resourceUri={entry.result.resourceUri}
           chatId={chatId}
           callId={entry.callId}
+        />,
+      );
+      continue;
+    }
+    // Also keyed on the result, and for the same reason as an MCP view: what
+    // the call found is the card, and most of these tools project no action
+    // preview because their arguments say nothing a reader needs.
+    if (entry.result?.tool === "entries" && !parked.has(entry.callId)) {
+      cards.push(
+        <ToolEntriesCard
+          key={entry.id}
+          name={entry.name}
+          status={entry.status}
+          result={entry.result}
         />,
       );
       continue;

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -1,5 +1,5 @@
-import { useId, useState } from "react";
-import { Check, ChevronDown, Clock, Loader2, Terminal, X } from "lucide-react";
+import { useState } from "react";
+import { Check, Clock, Loader2, Terminal, X } from "lucide-react";
 import {
   isRendererToolName,
   type ExecResultPreview,
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import type { ToolTone } from "./ToolStatusIcon";
 import { ScrollableContainer } from "./ScrollableContainer";
+import { ToolCardShell } from "./ToolCardShell";
 import { toolPreviewPresentation } from "./ToolPreview";
 
 export type ToolCallStatus =
@@ -229,88 +230,63 @@ export function ToolCommandCard({
   const presentation = toolCallPresentation(name, status);
   const command = toolPreviewPresentation(preview, result);
   const running = presentation.tone === "running";
-  const [expanded, setExpanded] = useState(running);
   const [tab, setTab] = useState<"command" | "output">("output");
-  const bodyId = useId();
   const output = commandOutput(result);
   // A command that finished silently has nothing to tab between, and a
   // "Command / Output → no output" pair reads as confusing noise.
   const tabbed = running || output !== null;
 
   return (
-    <section
-      className="bg-background max-w-prose overflow-hidden rounded-lg border"
-      aria-label={`${presentation.label}: ${presentation.statusLabel}`}
-      role="status"
-      aria-live="polite"
-      aria-atomic="true"
+    <ToolCardShell
+      label={`${presentation.label}: ${presentation.statusLabel}`}
+      icon={<Terminal className="size-3.5 shrink-0" aria-hidden="true" />}
+      title={command.headline}
+      titleClassName="font-mono"
+      badge={<ToolStatusBadge presentation={presentation} result={result} />}
+      defaultExpanded={running}
     >
-      <button
-        type="button"
-        className="hover:bg-muted/50 focus-visible:ring-ring flex w-full items-center justify-between gap-2 px-2.5 py-1.5 text-left transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden"
-        aria-expanded={expanded}
-        aria-controls={bodyId}
-        onClick={() => setExpanded((current) => !current)}
-      >
-        <span className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs font-medium">
-          <ChevronDown
-            className={cn(
-              "size-3.5 shrink-0 transition-transform",
-              !expanded && "-rotate-90",
-            )}
-            aria-hidden="true"
-          />
-          <Terminal className="size-3.5 shrink-0" aria-hidden="true" />
-          <span className="truncate font-mono">{command.headline}</span>
-        </span>
-        <ToolStatusBadge presentation={presentation} result={result} />
-      </button>
-      {expanded && (
-        <div id={bodyId} className="border-t">
-          {tabbed && (
-            <div
-              role="tablist"
-              aria-label="Command detail"
-              className="flex w-full items-center justify-start gap-1 border-b px-1"
+      {tabbed && (
+        <div
+          role="tablist"
+          aria-label="Command detail"
+          className="flex w-full items-center justify-start gap-1 border-b px-1"
+        >
+          {(["command", "output"] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              role="tab"
+              aria-selected={tab === value}
+              onClick={() => setTab(value)}
+              className={cn(
+                "cursor-pointer rounded-md px-2.5 py-1 text-xs font-medium capitalize transition-colors",
+                tab === value
+                  ? "text-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
             >
-              {(["command", "output"] as const).map((value) => (
-                <button
-                  key={value}
-                  type="button"
-                  role="tab"
-                  aria-selected={tab === value}
-                  onClick={() => setTab(value)}
-                  className={cn(
-                    "cursor-pointer rounded-md px-2.5 py-1 text-xs font-medium capitalize transition-colors",
-                    tab === value
-                      ? "text-foreground"
-                      : "text-muted-foreground hover:text-foreground",
-                  )}
-                >
-                  {value}
-                </button>
-              ))}
-            </div>
-          )}
-          <div className="p-1">
-            {!tabbed || tab === "command" ? (
-              <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
-                {command.detail}
-              </ScrollableContainer>
-            ) : output === null ? (
-              <p className="text-muted-foreground flex items-center gap-1.5 p-2 text-xs">
-                <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
-                Waiting for output…
-              </p>
-            ) : (
-              <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
-                {output}
-              </ScrollableContainer>
-            )}
-          </div>
+              {value}
+            </button>
+          ))}
         </div>
       )}
-    </section>
+      <div className="p-1">
+        {!tabbed || tab === "command" ? (
+          <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
+            {command.detail}
+          </ScrollableContainer>
+        ) : output === null ? (
+          <p className="text-muted-foreground flex items-center gap-1.5 p-2 text-xs">
+            <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+            Waiting for output…
+          </p>
+        ) : (
+          <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
+            {output}
+          </ScrollableContainer>
+        )}
+      </div>
+    </ToolCardShell>
   );
 }
 

--- a/crates/openwave-desktop/ui/src/ToolCardShell.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCardShell.tsx
@@ -1,0 +1,78 @@
+import { useId, useState, type ReactNode } from "react";
+import { ChevronDown } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type ToolCardShellProps = {
+  /** What ran, drawn from the tool's allowlisted name. */
+  icon: ReactNode;
+  /** The one line the card is worth reading for. */
+  title: ReactNode;
+  /** Monospace when the title is a command rather than prose. */
+  titleClassName?: string;
+  /** The outcome, always visible — a collapsed card still has to report. */
+  badge: ReactNode;
+  /** Open on mount, which is worth doing only while work is still happening. */
+  defaultExpanded?: boolean;
+  children: ReactNode;
+  /** Assistive label; the visible title is usually not the whole sentence. */
+  label: string;
+};
+
+/**
+ * The chrome every tool-result card shares: one header line that names what ran
+ * and how it ended, over a body the reader opens when they want it.
+ *
+ * A transcript should read as a conversation with occasional notes about what
+ * the agent did, not as a log. So the default is one line, the outcome stays on
+ * that line, and the detail is one click away — a stream of tool calls stays
+ * scannable instead of flooding the conversation with output.
+ */
+export function ToolCardShell({
+  icon,
+  title,
+  titleClassName,
+  badge,
+  defaultExpanded = false,
+  children,
+  label,
+}: ToolCardShellProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const bodyId = useId();
+
+  return (
+    <section
+      className="bg-background max-w-prose overflow-hidden rounded-lg border"
+      aria-label={label}
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <button
+        type="button"
+        className="hover:bg-muted/50 focus-visible:ring-ring flex w-full items-center justify-between gap-2 px-2.5 py-1.5 text-left transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden"
+        aria-expanded={expanded}
+        aria-controls={bodyId}
+        onClick={() => setExpanded((current) => !current)}
+      >
+        <span className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs font-medium">
+          <ChevronDown
+            className={cn(
+              "size-3.5 shrink-0 transition-transform",
+              !expanded && "-rotate-90",
+            )}
+            aria-hidden="true"
+          />
+          {icon}
+          <span className={cn("truncate", titleClassName)}>{title}</span>
+        </span>
+        {badge}
+      </button>
+      {expanded && (
+        <div id={bodyId} className="border-t">
+          {children}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/crates/openwave-desktop/ui/src/ToolEntriesCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolEntriesCard.tsx
@@ -1,0 +1,156 @@
+import {
+  Check,
+  File,
+  FileOutput,
+  Folder,
+  Globe,
+  Loader2,
+  Quote,
+  BookOpenText as Source,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+
+import type { EntriesResultPreview, ResultEntry, ResultEntryKind } from "./api";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { ToolCardShell } from "./ToolCardShell";
+import { ToolIcon } from "./ToolIcon";
+import { toolCallPresentation, type ToolCallStatus } from "./ToolCallCard";
+
+type ToolEntriesCardProps = {
+  name: string;
+  status: ToolCallStatus;
+  /** What the call surfaced, once it has surfaced anything. */
+  result: EntriesResultPreview;
+};
+
+/**
+ * What one row is, drawn from the server's closed vocabulary.
+ *
+ * Keyed by [`ResultEntryKind`] so a kind added to that union without a glyph
+ * fails to compile rather than rendering a hole in the middle of a list.
+ */
+const ENTRY_ICONS: Record<ResultEntryKind, LucideIcon> = {
+  file: File,
+  folder: Folder,
+  source: Source,
+  passage: Quote,
+  link: Globe,
+  output: FileOutput,
+};
+
+/**
+ * The card for a call that found, read, or wrote a list of things.
+ *
+ * One card for every such tool rather than one per tool: what distinguishes a
+ * source search from a directory listing on screen is the icon, the headline,
+ * and the count — all of which already come from the tool's own name. The rows
+ * differ only in what they are, which the server says per row.
+ *
+ * An empty list still gets a card, and that is the point. A search that matched
+ * nothing and a search whose result was never projected are the same muted rail
+ * line, and only one of them is a fact about the conversation.
+ */
+export function ToolEntriesCard({ name, status, result }: ToolEntriesCardProps) {
+  const presentation = toolCallPresentation(name, status);
+  const { entries, elided } = result;
+  const total = entries.length + elided;
+
+  return (
+    <ToolCardShell
+      label={`${presentation.label}: ${presentation.statusLabel}`}
+      icon={<ToolIcon name={name} className="size-3.5 shrink-0" />}
+      title={presentation.title}
+      badge={<EntriesBadge presentation={presentation} total={total} />}
+    >
+      {entries.length === 0 ? (
+        <p className="text-muted-foreground px-2.5 py-2 text-xs">
+          {emptyMessage(presentation.tone)}
+        </p>
+      ) : (
+        <div className="flex max-h-56 flex-col gap-0.5 overflow-auto p-1">
+          {entries.map((entry, index) => (
+            <EntryRow key={`${entry.kind}:${entry.label}:${index}`} entry={entry} />
+          ))}
+        </div>
+      )}
+      {elided > 0 && (
+        <p className="text-muted-foreground border-t px-2.5 py-1.5 text-xs">
+          {elided} more not shown
+        </p>
+      )}
+    </ToolCardShell>
+  );
+}
+
+function EntryRow({ entry }: { entry: ResultEntry }) {
+  const Icon = ENTRY_ICONS[entry.kind];
+  return (
+    <div className="hover:bg-muted flex items-center gap-2 rounded p-1 px-1.5 text-sm transition-colors">
+      <Icon className="text-muted-foreground size-4 shrink-0" aria-hidden="true" />
+      <span className="truncate">{entry.label}</span>
+      {entry.detail !== null && (
+        <span className="text-muted-foreground truncate text-xs">
+          {entry.detail}
+        </span>
+      )}
+      {entry.meta !== null && (
+        <span className="text-muted-foreground ml-auto shrink-0 text-xs tabular-nums">
+          {entry.meta}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The count is the outcome here, the way an exit code is for a command: "Done"
+ * says nothing a reader could not already assume, and "Found 0" is the single
+ * most useful thing a search can report.
+ */
+function EntriesBadge({
+  presentation,
+  total,
+}: {
+  presentation: { tone: string; badgeLabel: string };
+  total: number;
+}) {
+  if (presentation.tone === "running") {
+    return (
+      <Badge variant="outline" className="shrink-0 gap-1">
+        <Loader2 className="size-3 animate-spin" aria-hidden="true" />
+        Running…
+      </Badge>
+    );
+  }
+  if (presentation.tone === "completed") {
+    return (
+      <Badge
+        variant={total === 0 ? "outline" : "success"}
+        className="shrink-0 gap-1"
+      >
+        {total > 0 && <Check className="size-3" aria-hidden="true" />}
+        {total} {total === 1 ? "result" : "results"}
+      </Badge>
+    );
+  }
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "text-muted-foreground shrink-0 gap-1",
+        presentation.tone === "failed" && "text-destructive",
+      )}
+    >
+      <X className="size-3" aria-hidden="true" />
+      {presentation.badgeLabel}
+    </Badge>
+  );
+}
+
+function emptyMessage(tone: string): string {
+  if (tone === "running") return "Waiting for results…";
+  if (tone === "completed") return "Nothing was found.";
+  return "No results.";
+}

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -804,4 +804,35 @@ describe("parseToolResultPreview closed results", () => {
       expect(parseToolResultPreview(value)).toBeNull();
     }
   });
+
+  it("drops rows it cannot read and counts them as not shown", () => {
+    // A row the parser rejects is a result the call returned and the card is
+    // not showing. Dropping it silently would leave the count saying the
+    // search found three things when it found five.
+    expect(
+      parseToolResultPreview({
+        tool: "entries",
+        elided: 2,
+        entries: [
+          { kind: "file", label: "notes.md", detail: "scratch", meta: "1.2 KB" },
+          { kind: "sabotage", label: "notes.md" },
+          { kind: "file", label: "" },
+          { kind: "folder", label: "reports" },
+        ],
+      }),
+    ).toEqual({
+      tool: "entries",
+      elided: 4,
+      entries: [
+        { kind: "file", label: "notes.md", detail: "scratch", meta: "1.2 KB" },
+        { kind: "folder", label: "reports", detail: null, meta: null },
+      ],
+    });
+  });
+
+  it("keeps an empty list, which is a result and not the absence of one", () => {
+    expect(
+      parseToolResultPreview({ tool: "entries", entries: [], elided: 0 }),
+    ).toEqual({ tool: "entries", entries: [], elided: 0 });
+  });
 });

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -48,6 +48,7 @@ import {
   type RendererRefusal,
   type RendererSequencedEvent,
   type RendererToolName,
+  type ResultEntryKind,
   type ToolActionPreview,
   type TranscriptImageAttachment as WireTranscriptImageAttachment,
   type TranscriptRole,
@@ -61,6 +62,7 @@ export type {
   ChatToolActivityStatus,
   TranscriptRole,
   RendererToolName,
+  ResultEntryKind,
   ToolActionPreview,
   RendererRefusal,
 };
@@ -274,7 +276,25 @@ export type ToolResultPreview =
       tool: "mcp_app";
       server: string;
       resourceUri: string;
+    }
+  | {
+      /** What a call found, read, or wrote, as the list of things it was. */
+      tool: "entries";
+      entries: ResultEntry[];
+      /** Rows the server bounded away, counted rather than shown. */
+      elided: number;
     };
+
+/** One row of a listed result. */
+export type ResultEntry = {
+  kind: ResultEntryKind;
+  label: string;
+  detail: string | null;
+  meta: string | null;
+};
+
+/** The entries-shaped result the list card renders. */
+export type EntriesResultPreview = Extract<ToolResultPreview, { tool: "entries" }>;
 
 /** The exec-shaped result the command card renders. */
 export type ExecResultPreview = Extract<ToolResultPreview, { tool: "exec" }>;
@@ -1444,6 +1464,46 @@ type UncheckedMcpAppResult = Partial<
   Record<keyof Extract<WireToolResultPreview, { tool: "mcp_app" }>, unknown>
 >;
 
+type UncheckedEntriesResult = Partial<
+  Record<keyof Extract<WireToolResultPreview, { tool: "entries" }>, unknown>
+>;
+
+const RESULT_ENTRY_KINDS: readonly ResultEntryKind[] = [
+  "file",
+  "folder",
+  "source",
+  "passage",
+  "link",
+  "output",
+];
+
+/**
+ * Validate one listed row.
+ *
+ * A row is dropped rather than partially rendered, on the same terms as a whole
+ * preview: a row with no label is a blank line the reader cannot interpret, and
+ * an unrecognized kind would reach the icon map with nothing to draw.
+ */
+function parseResultEntry(value: unknown): ResultEntry | null {
+  if (!isRecord(value)) return null;
+  const { kind, label } = value;
+  // A missing hint is faithfully the absence the row shows, so `detail` and
+  // `meta` are normalized rather than validated — only a present value of the
+  // wrong type would be a reason to distrust the row, and it drops that field.
+  const detail = value.detail ?? null;
+  const meta = value.meta ?? null;
+  if (
+    typeof label !== "string" ||
+    label.length === 0 ||
+    !(RESULT_ENTRY_KINDS as readonly unknown[]).includes(kind) ||
+    !isOptionalString(detail) ||
+    !isOptionalString(meta)
+  ) {
+    return null;
+  }
+  return { kind: kind as ResultEntryKind, label, detail, meta };
+}
+
 /**
  * Validate a result field by field, on the same terms as an action: anything
  * that cannot be fully verified is dropped rather than half-rendered.
@@ -1467,6 +1527,23 @@ export function parseToolResultPreview(
       return null;
     }
     return { tool: "mcp_app", server, resourceUri: resource_uri };
+  }
+  if (value.tool === "entries") {
+    const { entries, elided }: UncheckedEntriesResult = value;
+    if (!Array.isArray(entries) || !Number.isInteger(elided) || Number(elided) < 0) {
+      return null;
+    }
+    const parsed = entries
+      .map(parseResultEntry)
+      .filter((entry): entry is ResultEntry => entry !== null);
+    // Rows this parser rejected are counted with the ones the server bounded
+    // away, because in both cases the card is showing fewer results than the
+    // call returned and has to say so.
+    return {
+      tool: "entries",
+      entries: parsed,
+      elided: Number(elided) + (entries.length - parsed.length),
+    };
   }
   if (value.tool !== "exec") return null;
   const { exit_code, timed_out, output_truncated, stdout, stderr }: UncheckedExecResult = value;

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -693,6 +693,35 @@ export type RendererToolStatus = "completed" | "failed";
 export type RequestedFolderHint = "documents" | "downloads";
 
 /**
+ * One thing a call surfaced.
+ *
+ * Three fields because a row reads as three: what it is, where it came from,
+ * and how big or how many. A tool that wants to say more than that is
+ * describing something this projection does not cover.
+ */
+export type ResultEntry = { kind: ResultEntryKind, 
+/**
+ * The row's name — a file name, a source title, a page title.
+ */
+label: string, 
+/**
+ * A secondary hint beside the name — a path, a domain, a section.
+ */
+detail: string | null, 
+/**
+ * Trailing meta — a size, a count, a status word.
+ */
+meta: string | null, };
+
+/**
+ * What one row of a listed result is, which is what picks its icon.
+ *
+ * A closed vocabulary rather than an icon name: the renderer chooses how to
+ * draw a folder, and a tool must not be able to name a glyph.
+ */
+export type ResultEntryKind = "file" | "folder" | "source" | "passage" | "link" | "output";
+
+/**
  * Why a root appears in one conversation's exact ordered projection.
  */
 export type RootAttachmentOrigin = "project_default" | "conversation";
@@ -788,7 +817,13 @@ server: string,
 /**
  * The validated `ui://` document reference.
  */
-resource_uri: string, };
+resource_uri: string, } | { "tool": "entries", entries: Array<ResultEntry>, 
+/**
+ * Rows past [`MAX_RESULT_ENTRIES`], counted rather than shown. A card
+ * that silently lists the first fifty of two hundred results is
+ * telling the reader something false.
+ */
+elided: number, };
 
 /**
  * One renderer-safe image identity attached to a historical user message.

--- a/crates/openwave-retrieval/src/search.rs
+++ b/crates/openwave-retrieval/src/search.rs
@@ -20,8 +20,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use openwave_core::{
-    format_source_reference, ApprovalClass, AssistantCitationReference, Result,
-    RetrievalEvidenceInput, RetrievalEvidenceSource, Tool, ToolCtx, ToolOutput, ToolSpec,
+    format_source_reference, ApprovalClass, AssistantCitationReference, Result, ResultEntry,
+    ResultEntryKind, RetrievalEvidenceInput, RetrievalEvidenceSource, Tool, ToolCtx, ToolOutput,
+    ToolSpec,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -207,7 +208,10 @@ impl Tool for SearchTool {
 
         let mut citations: Vec<Citation> = hits.into_iter().map(Citation::from).collect();
         if citations.is_empty() {
-            return Ok(ToolOutput::text("No matching passages found."));
+            // An empty list, not an absent one: "searched and found nothing" is
+            // the useful thing to show, and it is what the rail alone cannot
+            // distinguish from "searched".
+            return Ok(ToolOutput::text("No matching passages found.").with_entries(Vec::new()));
         }
         let mut source_tokens = citations
             .iter()
@@ -255,9 +259,43 @@ impl Tool for SearchTool {
             })
             .collect::<std::result::Result<Vec<_>, _>>();
         match evidence {
-            Ok(evidence) => Ok(ToolOutput::text(content).with_private_evidence(evidence)),
+            Ok(evidence) => Ok(ToolOutput::text(content)
+                .with_entries(citations.iter().map(passage_entry).collect())
+                .with_private_evidence(evidence)),
             Err(output) => Ok(output),
         }
+    }
+}
+
+/// One matched passage as a card row.
+///
+/// The section heading leads when the document has one, because it says where
+/// in the document the match is — which is what someone scanning the card wants
+/// and what a relevance score is not. Without headings the passage has to speak
+/// for itself, so the row falls back to its opening line.
+///
+/// That fallback is the one place this projection carries document text, and it
+/// is deliberate: what the renderer boundary keeps out is model- and
+/// provider-authored text and private diagnostics, and a passage is neither —
+/// it is a span of the reader's own source, which is the entire thing they
+/// asked to be shown. It crosses clamped to one bounded line like every other
+/// row, and the snippet the model works from stays behind the boundary.
+fn passage_entry(citation: &Citation) -> ResultEntry {
+    let label = if citation.heading_path.is_empty() {
+        citation
+            .snippet
+            .lines()
+            .map(str::trim)
+            .find(|line| !line.is_empty())
+            .unwrap_or("Matched passage")
+            .to_owned()
+    } else {
+        citation.heading_path.join(" › ")
+    };
+    let entry = ResultEntry::new(ResultEntryKind::Passage, label);
+    match render_pages(citation).trim_start().to_owned() {
+        pages if pages.is_empty() => entry,
+        pages => entry.with_detail(pages),
     }
 }
 
@@ -577,7 +615,19 @@ mod tests {
             out.content
         );
 
-        assert!(out.data.is_none());
+        // The passage is offered to the renderer as one row, and the row is the
+        // whole of what crosses: the snippet the model reads stays behind the
+        // boundary unless the passage has no heading to name it by.
+        assert_eq!(
+            openwave_core::ToolResultPreview::build("search", &out),
+            Some(openwave_core::ToolResultPreview::Entries {
+                entries: vec![openwave_core::ResultEntry::new(
+                    openwave_core::ResultEntryKind::Passage,
+                    "Jupiter is the largest planet in the Solar System, a gas giant.",
+                )],
+                elided: 0,
+            })
+        );
         assert_eq!(out.private_evidence.len(), 1);
         assert!(out.private_evidence[0].snippet.contains("Jupiter"));
         assert_eq!(out.private_evidence[0].rank, 1);

--- a/crates/openwave-server/src/source_tools.rs
+++ b/crates/openwave-server/src/source_tools.rs
@@ -135,12 +135,30 @@ impl Tool for ListSourcesTool {
             }
         };
         if records.is_empty() {
-            return Ok(ToolOutput::text(
-                "No sources have been added to this conversation.",
-            ));
+            return Ok(
+                ToolOutput::text("No sources have been added to this conversation.")
+                    // Projected empty rather than not projected: "no sources" and "the
+                    // renderer was told nothing" are different facts, and only the card
+                    // can tell them apart.
+                    .with_entries(Vec::new()),
+            );
         }
 
         let truncated = records.len() > MAX_LISTED_SOURCES as usize;
+        // The readiness word is the one thing a reader has to see here: a
+        // source that is still processing, or that holds no searchable text,
+        // is a source the next answer will quietly fail to use.
+        let entries = records
+            .iter()
+            .take(MAX_LISTED_SOURCES as usize)
+            .map(|record| {
+                openwave_core::ResultEntry::new(
+                    openwave_core::ResultEntryKind::Source,
+                    record.title.as_deref().unwrap_or("Untitled source"),
+                )
+                .with_meta(readiness_label(record.readiness().as_str()))
+            })
+            .collect();
         let visible = records
             .into_iter()
             .take(MAX_LISTED_SOURCES as usize)
@@ -165,7 +183,8 @@ impl Tool for ListSourcesTool {
         Ok(ToolOutput::text(format!(
             "Sources in this conversation:\n{}",
             serde_json::to_string_pretty(&body).expect("bounded source metadata always serializes")
-        )))
+        ))
+        .with_entries(entries))
     }
 }
 
@@ -312,7 +331,34 @@ impl Tool for ReadSourceTool {
             source_regions,
             source,
         };
-        Ok(ToolOutput::text(content).with_private_evidence(vec![evidence]))
+        Ok(ToolOutput::text(content)
+            .with_entries(vec![openwave_core::ResultEntry::new(
+                openwave_core::ResultEntryKind::Source,
+                title,
+            )
+            // Which slice of the source was read, because a source read in
+            // twelve-thousand-character windows produces twelve identical rail
+            // lines and the range is the only thing telling them apart.
+            .with_meta(format!(
+                "characters {}–{} of {}",
+                window.start_character, window.end_character, window.total_characters
+            ))])
+            .with_private_evidence(vec![evidence]))
+    }
+}
+
+/// The readiness word a source row shows.
+///
+/// Mapped rather than passed through: the tool's vocabulary is written for the
+/// model and says so — `stored_not_searchable` is a contract term, not
+/// something to put in front of a reader.
+fn readiness_label(readiness: &str) -> &'static str {
+    match readiness {
+        "searchable" => "Searchable",
+        "processing" => "Processing",
+        "stored_not_searchable" => "No text",
+        "failed" => "Failed",
+        _ => "Unknown",
     }
 }
 

--- a/crates/openwave-web-search/src/tool.rs
+++ b/crates/openwave-web-search/src/tool.rs
@@ -2,12 +2,17 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use openwave_core::{
-    ApprovalClass, Tool, ToolCtx, ToolErrorCategory, ToolOutput, ToolSpec, WebSearchArgs,
+    ApprovalClass, ResultEntry, ResultEntryKind, Tool, ToolCtx, ToolErrorCategory, ToolOutput,
+    ToolSpec, WebSearchArgs,
 };
 use serde_json::Value;
 use thiserror::Error;
+use url::Url;
 
-use crate::{SearchDomain, WebSearchError, WebSearchProvider, WebSearchRequest, MAX_OUTPUT_BYTES};
+use crate::{
+    SearchDomain, WebSearchError, WebSearchProvider, WebSearchRequest, WebSearchResult,
+    MAX_OUTPUT_BYTES,
+};
 
 /// Default result count when a model omits `max_results`.
 pub const DEFAULT_MAX_RESULTS: usize = openwave_core::DEFAULT_WEB_SEARCH_RESULTS;
@@ -96,7 +101,24 @@ impl Tool for WebSearchTool {
                 ))
             }
         };
-        Ok(ToolOutput::text(result))
+        let entries = response.results.iter().map(page_entry).collect();
+        Ok(ToolOutput::text(result).with_entries(entries))
+    }
+}
+
+/// One web result as a card row.
+///
+/// The host, not the whole URL: a column of rows is for telling results apart,
+/// and forty characters of query string does that worse than "sec.gov" does.
+/// A URL the parser rejects still gets a row — its title is the result.
+fn page_entry(result: &WebSearchResult) -> ResultEntry {
+    let entry = ResultEntry::new(ResultEntryKind::Link, &result.title);
+    match Url::parse(&result.url).ok().and_then(|url| {
+        url.host_str()
+            .map(|host| host.trim_start_matches("www.").to_owned())
+    }) {
+        Some(host) => entry.with_detail(host),
+        None => entry,
     }
 }
 


### PR DESCRIPTION
Only `exec` projected a result, so every other tool settled into a one-line rail
entry and showed nothing about what it actually did. A `search` that matched
twelve passages, a `create_deliverable` that published an output, and a
`list_dir` over an empty directory were all the same line of muted text.

## One card, not forty

Brightwave renders roughly forty per-tool result components. Most of them are
the same card: a collapsed header — icon, title, outcome badge — over a list of
rows, each a name with an optional path hint and a trailing count. This ports
that shape once instead of forty times.

What distinguishes these tools on screen already comes from the tool's own name:
the icon, the headline, the verb. So the projection only has to say what each
*row* is. `ToolResultPreview::Entries` carries a list of `ResultEntry` — a
closed `ResultEntryKind` (file, folder, source, passage, link, output), a label,
and two optional hints — plus a count of rows it bounded away.

## The boundary is unchanged

`entries` is an opt-in a tool writes into its own output, and the tool must
*also* be on an allowlist. Both halves matter: an external MCP tool controls its
structured data outright, so the key alone must not buy it a card. Rows are
clamped field by field like every other projection, a row that fails validation
is dropped and counted rather than half-rendered, and a failed call projects
nothing — whatever partial data it left behind describes work that did not
happen.

The one place document text crosses is a passage row for a document with no
heading to name it by. That is a span of the reader's own source rather than
model- or provider-authored text, and it is the entire thing they asked to be
shown; it is clamped to one bounded line like every other row.

## Wired for

`search`, `web_search`, `list_sources`, `read_source`, `read_file`, `list_dir`,
`write_file`, `create_deliverable`.

An empty list still gets a card, which is the point: "searched and matched
nothing" and "searched" are the same muted rail line today, and only one of them
is a fact about the conversation.

The command card moves onto a shared `ToolCardShell`, so both cards collapse,
report their outcome on the header, and stay scannable in a column.

## Not in this PR

- **Cards do not survive a reload.** Terminal activity rebuilds through
  `ToolResultPreview::from_stored_error`, which recovers only the web-search
  setup signal — so reopening a chat loses these cards, and loses a command's
  output too. Pre-existing, and the next slice under #783.
- Connected-folder client tools, whose results come back from the desktop host.

## Tests

Six in `preview.rs` covering the allowlist (an MCP tool writing `entries` gets
no card), per-row clamping and the elided count, the empty-list case, that only
the three row fields cross, and byte formatting. Two parser tests in `api.test.ts`
for rows the renderer rejects being counted as not-shown. One DOM test that the
count is on the collapsed header — a reader must not have to open a card to
learn there were five results.

The retrieval search test now asserts the projected row instead of
`data.is_none()`, which the `entries` payload made false.

Refs #783