### PR TITLE
feat(desktop): outline a markdown source's headings

### DIFF
--- a/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from "react";
+import { isValidElement, memo, useMemo, type ReactNode } from "react";
 import ReactMarkdown, {
   type Components,
   type Options,
@@ -10,6 +10,7 @@ import rehypeKatex from "rehype-katex";
 import { ClipboardCopyButton } from "./ClipboardCopyButton";
 import { splitMarkdownBlocks } from "./markdownBlocks";
 import { escapeLatexText } from "./markdownLatex";
+import { slugify } from "./markdownHeadings";
 
 /**
  * Keep model-generated navigation deliberately narrow. `react-markdown` does
@@ -118,6 +119,38 @@ const components: Components = {
   blockquote: ({ children }) => <blockquote>{children}</blockquote>,
 };
 
+/**
+ * The same components, with every heading carrying the slug id derived from its
+ * own text — which is how the source viewer's outline finds a section to scroll
+ * to without the two sides agreeing on anything but {@link slugify}.
+ *
+ * Opt-in rather than always on: a transcript renders many messages into one
+ * document, and headings from different messages would collide on id.
+ */
+const componentsWithHeadingIds: Components = {
+  ...components,
+  ...Object.fromEntries(
+    (["h1", "h2", "h3", "h4", "h5", "h6"] as const).map((tag) => [
+      tag,
+      ({ children }: { children?: ReactNode }) => {
+        const Tag = tag;
+        return <Tag id={slugify(headingText(children))}>{children}</Tag>;
+      },
+    ]),
+  ),
+};
+
+/** A heading's plain text, from whatever inline nodes it was rendered as. */
+function headingText(children: ReactNode): string {
+  if (typeof children === "string") return children;
+  if (typeof children === "number") return String(children);
+  if (Array.isArray(children)) return children.map(headingText).join("");
+  if (isValidElement<{ children?: ReactNode }>(children)) {
+    return headingText(children.props.children);
+  }
+  return "";
+}
+
 // `singleDollarTextMath: false` keeps a bare `$` (a price, a shell variable)
 // from being read as a math delimiter; display and inline math still arrive
 // through the `$$…$$` / `$…$` forms that `escapeLatexText` normalizes to.
@@ -150,13 +183,19 @@ export function processMarkdownContent(input: string): string {
  * block. Every settled block above it hits this memo and is left untouched,
  * turning a per-tick full-document re-parse into work proportional to the tail.
  */
-const MarkdownBlock = memo(function MarkdownBlock({ block }: { block: string }) {
+const MarkdownBlock = memo(function MarkdownBlock({
+  block,
+  headingIds,
+}: {
+  block: string;
+  headingIds: boolean;
+}) {
   const processed = useMemo(() => processMarkdownContent(block), [block]);
   return (
     <ReactMarkdown
       remarkPlugins={remarkPlugins}
       rehypePlugins={rehypePlugins}
-      components={components}
+      components={headingIds ? componentsWithHeadingIds : components}
       skipHtml
       urlTransform={(url) => safeMarkdownUrl(url) ?? ""}
     >
@@ -167,10 +206,16 @@ const MarkdownBlock = memo(function MarkdownBlock({ block }: { block: string }) 
 
 interface MessageMarkdownProps {
   children: string;
+  /**
+   * Give every heading a slug id, for a caller that means to scroll to one.
+   * Off for transcripts, where headings from separate messages would collide.
+   */
+  headingIds?: boolean;
 }
 
 export const MessageMarkdown = memo(function MessageMarkdown({
   children,
+  headingIds = false,
 }: MessageMarkdownProps) {
   const blocks = useMemo(() => splitMarkdownBlocks(children), [children]);
   return (
@@ -179,7 +224,7 @@ export const MessageMarkdown = memo(function MessageMarkdown({
         // Blocks are append-only while streaming: the prefix is immutable and
         // only the tail grows, so the array index is a stable identity that
         // keeps the growing block mounted across ticks.
-        <MarkdownBlock key={index} block={block} />
+        <MarkdownBlock key={index} block={block} headingIds={headingIds} />
       ))}
     </div>
   );

--- a/crates/openwave-desktop/ui/src/components/document/MarkdownOutline.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/MarkdownOutline.tsx
@@ -1,0 +1,82 @@
+import { ListTreeIcon } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { WithTooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type { MarkdownHeading } from "@/markdownHeadings";
+
+/**
+ * Nesting is drawn with indentation rather than a tree, because the outline of a
+ * document that skips from h1 to h4 should still read as a flat ordered list of
+ * places to go. Levels 5 and 6 share an indent: past four the indent costs more
+ * width than the extra depth conveys.
+ */
+const LEVEL_INDENT: Record<number, string> = {
+  1: "pl-2",
+  2: "pl-5",
+  3: "pl-8",
+  4: "pl-11",
+  5: "pl-14",
+  6: "pl-14",
+};
+
+export function MarkdownOutline({
+  headings,
+  onNavigate,
+  triggerClassName,
+}: {
+  headings: MarkdownHeading[];
+  /** Reveal the heading with this id. */
+  onNavigate: (id: string) => void;
+  triggerClassName?: string;
+}) {
+  const [open, setOpen] = useState(false);
+
+  if (headings.length === 0) return null;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <WithTooltip label="Document outline">
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Document outline"
+            className={triggerClassName}
+          >
+            <ListTreeIcon className="size-4" />
+          </Button>
+        </PopoverTrigger>
+      </WithTooltip>
+      <PopoverContent
+        align="end"
+        sideOffset={4}
+        className="w-72 p-1"
+        // Returning focus to the trigger would scroll the document back to
+        // where it was, undoing the jump the reader just asked for.
+        onCloseAutoFocus={(event) => event.preventDefault()}
+      >
+        <div className="max-h-80 space-y-0.5 overflow-y-auto">
+          {headings.map((heading, index) => (
+            <button
+              key={`${heading.id}-${index}`}
+              type="button"
+              className={cn(
+                "flex w-full cursor-pointer items-center rounded-md py-1.5 pr-2 text-left text-sm transition-colors hover:bg-muted",
+                LEVEL_INDENT[heading.level],
+              )}
+              onClick={() => {
+                onNavigate(heading.id);
+                setOpen(false);
+              }}
+            >
+              <span className="truncate">{heading.text}</span>
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/crates/openwave-desktop/ui/src/components/document/markdown-viewer.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/markdown-viewer.tsx
@@ -1,9 +1,11 @@
 import { FileIcon, Loader2Icon } from "lucide-react";
 import type { HTMLAttributes } from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
+import { extractHeadings } from "@/markdownHeadings";
 import { MessageMarkdown } from "@/MessageMarkdown";
+import { MarkdownOutline } from "./MarkdownOutline";
 import { useFileDownload } from "./useFileDownload";
 
 /** A character range in the raw file, as a citation reports it. */
@@ -102,6 +104,17 @@ export function MarkdownViewer({
     [fullContent],
   );
 
+  const headings = useMemo(
+    () => (markdown ? extractHeadings(fullContent) : []),
+    [markdown, fullContent],
+  );
+
+  const scrollToHeading = useCallback((id: string) => {
+    containerRef.current
+      ?.querySelector(`#${CSS.escape(id)}`)
+      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
+
   // For citation mode: locate the chunk containing the highlight
   const citationInfo = useMemo(() => {
     if (!highlightRange || !fullContent) return null;
@@ -190,12 +203,23 @@ export function MarkdownViewer({
 
   return (
     <div className={cn("relative flex min-h-0 flex-1 flex-col", className)} {...props}>
+      {headings.length > 0 && (
+        <div className="absolute top-2 right-2 z-10">
+          <MarkdownOutline
+            headings={headings}
+            onNavigate={scrollToHeading}
+            triggerClassName="bg-background/80 backdrop-blur-sm"
+          />
+        </div>
+      )}
       <div ref={containerRef} className="min-h-0 flex-1 overflow-auto p-6">
         <div className="mx-auto max-w-4xl">
           <div ref={anchorRef} />
           {visibleChunks.map((chunk, i) =>
             markdown ? (
-              <MessageMarkdown key={startChunkIndex + i}>{chunk}</MessageMarkdown>
+              <MessageMarkdown key={startChunkIndex + i} headingIds>
+                {chunk}
+              </MessageMarkdown>
             ) : (
               <pre
                 key={startChunkIndex + i}

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
@@ -112,6 +112,42 @@ describe("DocumentDetailRoot", () => {
     expect(screen.queryByText(body)).toBeNull();
   });
 
+  // The outline slugs the raw markdown and the renderer slugs the rendered
+  // heading, independently. This is the only test that puts the two together,
+  // so it is what would catch them drifting apart.
+  it("lists a markdown source's headings and scrolls to one", async () => {
+    const user = userEvent.setup();
+    await openPanel(
+      detail({ media_type: "text/markdown", title: "Report.md" }),
+      vi.fn(),
+      new Blob(["# Quarterly report\n\nBody.\n\n## Revenue by **segment**\n\nMore.\n"]),
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Document outline" }));
+    const entry = await screen.findByRole("button", { name: "Revenue by segment" });
+
+    const scrollIntoView = vi.fn();
+    const heading = document.querySelector("#revenue-by-segment");
+    expect(heading).not.toBeNull();
+    heading!.scrollIntoView = scrollIntoView;
+
+    await user.click(entry);
+    expect(scrollIntoView).toHaveBeenCalled();
+  });
+
+  it("offers no outline for a source that is text rather than markdown", async () => {
+    await openPanel(
+      detail({ media_type: "text/plain", title: "Notes.txt" }),
+      vi.fn(),
+      new Blob(["# Not a heading, just a line that starts with a hash\n"]),
+    );
+
+    expect(
+      await screen.findByText(/Not a heading, just a line that starts with a hash/),
+    ).toBeVisible();
+    expect(screen.queryByRole("button", { name: "Document outline" })).toBeNull();
+  });
+
   it("says so when a structured source will not parse", async () => {
     await openPanel(
       detail({ media_type: "application/json", title: "Truncated.json" }),

--- a/crates/openwave-desktop/ui/src/markdownHeadings.test.ts
+++ b/crates/openwave-desktop/ui/src/markdownHeadings.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { extractHeadings, slugify } from "./markdownHeadings";
+
+describe("extractHeadings", () => {
+  it("reads a document's headings with their depth, ignoring what is not one", () => {
+    const headings = extractHeadings(
+      [
+        "# Quarterly report",
+        "",
+        "Not a heading. #hashtag either.",
+        "",
+        "## Revenue by **segment**",
+        "",
+        "```",
+        "# a comment in a fenced block",
+        "```",
+        "",
+        "####### Seven hashes is not a heading",
+        "",
+        "###### Footnotes",
+      ].join("\n"),
+    );
+
+    expect(headings).toEqual([
+      { level: 1, text: "Quarterly report", id: "quarterly-report" },
+      // Inline emphasis is stripped, so the id matches the text as rendered.
+      { level: 2, text: "Revenue by segment", id: "revenue-by-segment" },
+      { level: 6, text: "Footnotes", id: "footnotes" },
+    ]);
+  });
+
+  // A `#` line inside a fence is a comment, not a heading, and listing it puts
+  // an entry in the outline that scrolls nowhere — the renderer never made a
+  // heading with that id.
+  it("does not read comments inside fenced code as headings", () => {
+    expect(
+      extractHeadings("# Setup\n\n~~~sh\n# install the thing\n~~~\n\n## Done"),
+    ).toEqual([
+      { level: 1, text: "Setup", id: "setup" },
+      { level: 2, text: "Done", id: "done" },
+    ]);
+
+    // An unclosed fence runs to the end, as the renderer also treats it.
+    expect(extractHeadings("# Setup\n\n```\n# still code\n")).toEqual([
+      { level: 1, text: "Setup", id: "setup" },
+    ]);
+  });
+
+  // The outline slugs the raw source and the renderer slugs the rendered node.
+  // Nothing is passed between them, so agreement rests entirely on slugify —
+  // a heading whose two ids differ is one the outline silently cannot reach.
+  it("reduces punctuation and spacing the same way from either side", () => {
+    expect(slugify("Q3 2026 — Revenue & Margin (draft)")).toBe(
+      "q3-2026-revenue-margin-draft",
+    );
+    expect(slugify("  Leading and trailing  ")).toBe("leading-and-trailing");
+    expect(slugify("Hyphens---collapse")).toBe("hyphens-collapse");
+  });
+});

--- a/crates/openwave-desktop/ui/src/markdownHeadings.ts
+++ b/crates/openwave-desktop/ui/src/markdownHeadings.ts
@@ -1,0 +1,80 @@
+/**
+ * A markdown document's headings, and the ids they are addressed by.
+ *
+ * The ids are derived from the heading text rather than assigned, so the
+ * outline can compute one from the raw source and the renderer can compute the
+ * same one from the rendered node without either passing anything to the other.
+ * That only holds while both call {@link slugify} — a heading whose id is
+ * generated two different ways is a heading the outline cannot scroll to.
+ */
+
+export type MarkdownHeading = {
+  level: number;
+  text: string;
+  id: string;
+};
+
+/** Heading text reduced to a stable, URL-shaped id. */
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/** Drop the inline markup a heading's text may carry, keeping the words. */
+function stripInline(text: string): string {
+  return text
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/_([^_]+)_/g, "$1")
+    .replace(/`([^`]+)`/g, "$1")
+    .trim();
+}
+
+const HEADING = /^(#{1,6})\s+(.+)$/;
+const FENCE = /^\s{0,3}(```+|~~~+)/;
+
+/**
+ * The ATX headings of a raw markdown document, in the order they appear.
+ *
+ * Fenced blocks are skipped: a shell comment or a C preprocessor line inside
+ * one starts with `#` but is not a heading, and listing it would put an entry
+ * in the outline that scrolls nowhere — the renderer never made a heading for
+ * it to scroll to. An unclosed fence runs to the end of the document, which is
+ * how the renderer treats it too.
+ *
+ * Indented code needs no such handling: a heading's `#` has to be within three
+ * spaces of the margin, and a four-space block is already past that.
+ */
+export function extractHeadings(markdown: string): MarkdownHeading[] {
+  const headings: MarkdownHeading[] = [];
+  let fence: string | null = null;
+
+  for (const line of markdown.split("\n")) {
+    const fenceMatch = FENCE.exec(line);
+    if (fenceMatch) {
+      const marker = fenceMatch[1]!;
+      if (fence === null) {
+        fence = marker[0]!;
+        continue;
+      }
+      // Only a fence of the same character closes one, and a closing fence has
+      // to be at least as long as the one it closes.
+      if (marker[0] === fence) fence = null;
+      continue;
+    }
+    if (fence !== null) continue;
+
+    const match = HEADING.exec(line);
+    if (!match) continue;
+    const text = stripInline(match[2]!);
+    if (!text) continue;
+    headings.push({ level: match[1]!.length, text, id: slugify(text) });
+  }
+
+  return headings;
+}


### PR DESCRIPTION
A long markdown source could only be read top to bottom — no way to see its shape or jump to a section. The viewer now carries the floating outline control from the wider product: top-right of the content, listing the headings, each scrolling to its section.

## How the ids line up

Heading ids are derived on both sides rather than passed between them: the outline slugs the raw markdown, `MessageMarkdown` slugs the rendered heading, and they agree because both call `slugify`. That keeps the viewer from threading ids into the renderer, at the cost of a coupling that is invisible when it breaks — a heading whose two ids differ is one the outline silently cannot reach. That is what most of the extraction tests are guarding, plus one end-to-end test that puts both sides together and clicks through.

`headingIds` is opt-in on `MessageMarkdown`. A transcript renders many messages into one document, where headings from separate messages would collide.

## A defect from the source

Extraction did not skip fenced code, so this listed two headings:

````md
# Setup

```sh
# install the thing
```
````

The second scrolled nowhere, because the renderer never made a heading with that id. Fences are now skipped, and an unclosed one runs to the end of the document the way the renderer treats it. Indented code needs no handling — a heading's `#` has to be within three spaces of the margin, and a four-space block is already past that.

Found by writing the test, not by reading the code.

## Deliberately left out

- **The outline provider.** Upstream has a context that bridges the outline up into a panel header instead of floating it. Nothing here consumes it — the panel header belongs to the panel, which also draws formats with no outline — so it would be plumbing with no caller.
- **Download progress**, which #780 originally also covered. `ApiClient.blob` awaits `response.blob()`, so there is no intermediate state to report; that needs a streaming download first and is now #799.

## Not verified

Not driven in the packaged app. The scroll is asserted through a stubbed `scrollIntoView` under jsdom, which does not implement scrolling — whether the jump lands where a reader expects, with the panel's own scroll container and sticky chrome, wants a look in the real window.

Closes #780
Part of #703