### PR TITLE
ci: scope the headless lanes to changes that can reach them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
     outputs:
       rust: ${{ steps.scope.outputs.rust }}
       ui: ${{ steps.scope.outputs.ui }}
+      workspace: ${{ steps.scope.outputs.workspace }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -106,8 +107,11 @@ jobs:
           PUSH_HEAD_SHA: ${{ github.event.after }}
         run: |
           full_validation() {
-            echo "rust=true" >> "$GITHUB_OUTPUT"
-            echo "ui=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "rust=true"
+              echo "ui=true"
+              echo "workspace=true"
+            } >> "$GITHUB_OUTPUT"
           }
 
           case "$EVENT_NAME" in
@@ -138,24 +142,43 @@ jobs:
             exit 0
           fi
 
+          # `rust` gates the lanes that cover every crate: rustfmt, clippy, and
+          # the openwave-desktop tests. `workspace` gates the lanes that cover
+          # everything *except* openwave-desktop, so it can stay false when a
+          # change cannot reach them. `workspace` implies `rust`; the gate below
+          # asserts that.
           rust=false
           ui=false
+          workspace=false
           git diff --no-renames --name-only -z "$diff_range" \
             > "$RUNNER_TEMP/changed-files"
           while IFS= read -r -d '' file; do
             case "$file" in
               *.md|docs/*|assets/*|LICENSE|NOTICE) ;;
-              .github/workflows/ci.yml) rust=true; ui=true ;;
+              .github/workflows/ci.yml) rust=true; ui=true; workspace=true ;;
               # Generated from Rust definitions, and a Rust test is what checks
               # the checked-in copy is current. Editing this by hand has to run
-              # that test, or the staleness check has a bypass.
-              crates/openwave-desktop/ui/src/generated/*) rust=true; ui=true ;;
+              # that test, or the staleness check has a bypass. The test lives in
+              # openwave-server (see its wire_types module), so it runs in the
+              # `test` lane rather than the desktop one.
+              crates/openwave-desktop/ui/src/generated/*)
+                rust=true; ui=true; workspace=true ;;
               crates/openwave-desktop/ui/*) ui=true ;;
-              *) rust=true ;;
+              # The manifest forwards features into openwave-server, so it can
+              # change how the rest of the workspace builds. Its sources cannot.
+              crates/openwave-desktop/Cargo.toml) rust=true; workspace=true ;;
+              # Nothing in the workspace depends on openwave-desktop, and the
+              # `test` lane already excludes it, so no edit to its own sources
+              # can change that lane's result. The desktop lane still covers it.
+              crates/openwave-desktop/*) rust=true ;;
+              *) rust=true; workspace=true ;;
             esac
           done < "$RUNNER_TEMP/changed-files"
-          echo "rust=$rust" >> "$GITHUB_OUTPUT"
-          echo "ui=$ui" >> "$GITHUB_OUTPUT"
+          {
+            echo "rust=$rust"
+            echo "ui=$ui"
+            echo "workspace=$workspace"
+          } >> "$GITHUB_OUTPUT"
 
   secrets:
     name: secret scan (gitleaks)
@@ -278,7 +301,7 @@ jobs:
   test:
     name: test
     needs: changes
-    if: ${{ needs.changes.outputs.rust == 'true' }}
+    if: ${{ needs.changes.outputs.workspace == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -326,7 +349,7 @@ jobs:
     # instead of once per push to every open PR: post-merge is late signal, but
     # the feature is off by default in shipped builds. See #760 to restore the
     # pull-request run when durable vectors come back into active development.
-    if: ${{ needs.changes.outputs.rust == 'true' && github.event_name != 'pull_request' }}
+    if: ${{ needs.changes.outputs.workspace == 'true' && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
@@ -384,7 +407,7 @@ jobs:
   postgres:
     name: postgres state machine
     needs: changes
-    if: ${{ needs.changes.outputs.rust == 'true' }}
+    if: ${{ needs.changes.outputs.workspace == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:
@@ -491,6 +514,7 @@ jobs:
           CHANGES_RESULT: ${{ needs.changes.result }}
           RUST_CHANGED: ${{ needs.changes.outputs.rust }}
           UI_CHANGED: ${{ needs.changes.outputs.ui }}
+          WORKSPACE_CHANGED: ${{ needs.changes.outputs.workspace }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           test "$CHANGES_RESULT" = success
@@ -514,18 +538,39 @@ jobs:
               test "$FMT_RESULT" = success
               test "$LINT_RESULT" = success
               test "$DESKTOP_RESULT" = success
-              test "$TEST_RESULT" = success
-              test "$POSTGRES_RESULT" = success
               ;;
             false)
               test "$FMT_RESULT" = skipped
               test "$LINT_RESULT" = skipped
               test "$DESKTOP_RESULT" = skipped
+              ;;
+            *)
+              echo "invalid Rust change detector output: $RUST_CHANGED" >&2
+              exit 1
+              ;;
+          esac
+
+          # A workspace-scoped change is always Rust-scoped. If the detector ever
+          # reports otherwise it has a hole, and the lanes below would be checked
+          # against a scope the ones above never ran for.
+          if test "$WORKSPACE_CHANGED" = true && test "$RUST_CHANGED" != true; then
+            echo "workspace scope without Rust scope; the detector is wrong." >&2
+            exit 1
+          fi
+
+          # The lanes that cover the workspace minus openwave-desktop. A change
+          # confined to that crate's own sources cannot affect them.
+          case "$WORKSPACE_CHANGED" in
+            true)
+              test "$TEST_RESULT" = success
+              test "$POSTGRES_RESULT" = success
+              ;;
+            false)
               test "$TEST_RESULT" = skipped
               test "$POSTGRES_RESULT" = skipped
               ;;
             *)
-              echo "invalid Rust change detector output: $RUST_CHANGED" >&2
+              echo "invalid workspace change detector output: $WORKSPACE_CHANGED" >&2
               exit 1
               ;;
           esac
@@ -537,7 +582,7 @@ jobs:
           if test "$EVENT_NAME" = pull_request; then
             test "$VECTORS_RESULT" = skipped
           else
-            case "$RUST_CHANGED" in
+            case "$WORKSPACE_CHANGED" in
               true) test "$VECTORS_RESULT" = success ;;
               false) test "$VECTORS_RESULT" = skipped ;;
             esac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,9 +115,15 @@ is the whole rule, and it is coarse on purpose:
 - Any changed file outside `*.md`, `docs/`, `assets/`, `LICENSE`, `NOTICE`, and
   `crates/openwave-desktop/ui/` marks the change **Rust** — including
   `Cargo.toml` and `Cargo.lock`. That runs rustfmt, clippy (`--all-targets
-  -D warnings`), the desktop tests, the headless workspace tests, and the
-  PostgreSQL turn-state lane. Every cargo invocation passes `--locked`, so a
-  lockfile drift fails there too.
+  -D warnings`), and the desktop tests. Every cargo invocation passes
+  `--locked`, so a lockfile drift fails there too.
+- A Rust change also marks the **workspace** scope, which adds the headless
+  workspace tests and the PostgreSQL turn-state lane, unless every changed file
+  is one of `openwave-desktop`'s own sources. Nothing in the workspace depends on
+  that crate and the headless lane already excludes it, so those lanes cannot see
+  such a change. Its `Cargo.toml` is not covered by the carve-out — it forwards
+  features into `openwave-server` — and neither is
+  `ui/src/generated/`, whose staleness check lives in `openwave-server`.
 - Any file under `crates/openwave-desktop/ui/` marks it **UI**, which runs
   `pnpm test` and `pnpm build`.
 - The aggregate `fmt · clippy · build · test` check asserts each lane either

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -107,11 +107,20 @@ test("Rust CI requires the same PostgreSQL lane on pull requests and main", () =
     /^on:\n  push:\n    branches: \[main\]\n  pull_request:/m,
   );
   assert.doesNotMatch(ci, /^  build:$/m);
-  assert.match(postgres, /if:.*needs\.changes\.outputs\.rust == 'true'/);
+  // Scoped to the lanes that skip openwave-desktop, but still never exempted
+  // from pull requests the way the durable vector store is.
+  assert.match(postgres, /if:.*needs\.changes\.outputs\.workspace == 'true'/);
   assert.doesNotMatch(postgres, /github\.event_name != 'pull_request'/);
   assert.match(postgres, /OPENWAVE_REQUIRE_POSTGRES_TEST: "true"/);
   assert.match(aggregate, /^\s+postgres,$/m);
   assert.match(aggregate, /test "\$POSTGRES_RESULT" = success/);
+  // The narrower `workspace` scope must imply the `rust` one. Without this the
+  // crate-coverage lanes could be gated on a scope that never ran for them, and
+  // the aggregate would check their results against the wrong bit.
+  assert.match(
+    aggregate,
+    /if test "\$WORKSPACE_CHANGED" = true && test "\$RUST_CHANGED" != true; then/,
+  );
   assert.match(
     aggregate,
     /pull_request\) test "\$PR_TITLE_RESULT" = success ;;/,


### PR DESCRIPTION
The change-scope gate carried one Rust bit, so a change confined to
`openwave-desktop`'s own sources ran the headless workspace tests and the
PostgreSQL turn-state lane as well. Nothing in the workspace depends on
`openwave-desktop`, and the headless lane already passes
`--exclude openwave-desktop`, so those lanes were compiling and testing the rest
of the workspace to learn nothing about the change.

Measured on a Rust PR (run 30399440683) — lanes run concurrently, so wall clock is
the long pole:

| lane | duration |
| --- | --- |
| `test` (workspace − desktop) | 6.4 min ← long pole |
| `clippy` | 4.7 min |
| `desktop test` | 4.4 min |
| `postgres state machine` | 1.9 min |
| `rustfmt` | 0.2 min |

Splitting the Rust bit in two: `rust` still gates rustfmt, clippy, and the desktop
tests, which cover every crate. A new `workspace` bit gates the three lanes that
cover everything *except* `openwave-desktop` — headless tests, PostgreSQL, and the
durable vector store — and stays false when every changed file is one of that
crate's own sources. Those changes now finish in ~4.7 min instead of ~6.5.

Two paths deliberately stay outside the carve-out:

- `crates/openwave-desktop/Cargo.toml` forwards features into `openwave-server`
  (`vec-lance`), so it can change how the rest of the workspace builds.
- `crates/openwave-desktop/ui/src/generated/` has its staleness check in
  `openwave-server`'s `wire_types` module, which runs in the headless lane. Without
  the exception, hand-editing the checked-in copy would skip the test that catches
  it.

`workspace` implies `rust`, and the aggregate gate asserts that instead of letting
a future detector hole fail silently.

## Scale of the win, and what I did not do

This is worth about 1.7 min on roughly 8% of merges. Of the last 60 merges to
`main`, 31 were UI-only (already skipping every Rust lane), 24 touched
`openwave-core` or `openwave-server` and legitimately need everything, and 5 were
confined to `openwave-desktop`.

I looked at a per-crate job split first and rejected it — recorded in #802 so it
isn't re-proposed. Fixed per-job overhead is 1.5–2 min (the PostgreSQL lane runs a
single test file and still takes 1.9), `openwave-core` is 89k of ~180k workspace
LOC with everything depending on it, and file-path granularity finer than this
would introduce a "went green without running the affected crate" hole via feature
unification. Eleven per-crate jobs would add ~20 runner-minutes for near-zero
wall-clock gain.

I also dropped a plan to fold `postgres` into `test`: it runs
`--no-default-features --features postgres`, a different feature hash, so folding
it in serializes a fresh `openwave-core` compile onto the long pole rather than
hiding it under one.

## Verification

- `actionlint` is clean; it was clean on the base commit too, and the grouped
  `>> "$GITHUB_OUTPUT"` redirects keep it that way.
- Extracted the `case` classifier and ran it over representative paths: docs-only,
  UI-only, `ui/src/generated/`, desktop sources, desktop `Cargo.toml`,
  `openwave-core`, `Cargo.lock`, root `Cargo.toml`, `ci.yml`, `scripts/`, and
  mixed desktop-plus-core. Each produced the intended triple, and every path that
  sets `workspace` also sets `rust`.
- This PR touches `ci.yml`, which sets all three bits, so it runs full validation
  — it cannot exercise its own `workspace=false` path. The first
  desktop-sources-only PR after this lands is where that path gets real coverage;
  the aggregate gate's implication check is what makes a detector hole fail loudly
  in the meantime.
- Skipped required checks do not block merges here — `postgres state machine` is a
  required check and #794 merged with it reporting "skipping", which is the same
  mechanism this change extends.

Closes #802