### PR TITLE
fix(cli): re-home credentials stored before dev signing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,25 +46,34 @@ local-only `openwave-dev` identity in a dedicated keychain under
 with its own generated password, so starting a dev build does not need your
 login-keychain password or a Developer ID distribution key.
 
-Every binary is signed with the same fixed identifier, so clicking **Always
-Allow** once covers all dev binaries — including test executables, whose
-hashed file names change between builds. You can set
+Every binary is signed with the same fixed identifier, so an item a signed
+build creates stays readable from every other dev binary — including test
+executables, whose hashed file names change between builds. You can set
 `OPENWAVE_DEV_SIGNING_IDENTITY` to pick an identity explicitly, or set it
 empty to opt out.
 
-The first signed launch may still ask once per existing secret created by an
-older ad-hoc-signed build. Choose **Always Allow** on those prompts; the
-approval then survives rebuilds. If an Apple Development identity is in use
-and the prompt asks for your **login keychain password** instead of a plain
-Allow/Deny, repair that item's partition list once:
+#### Credentials stored before dev signing
+
+Signing fixes items the signed build **created**. Credentials you stored
+earlier belong to that earlier build, and macOS keeps challenging for them —
+one prompt per credential, on every launch. **Always Allow** does not settle
+it: the local `openwave-dev` certificate is self-signed with no team
+identifier, so the approval is pinned to the binary's cdhash and the next
+rebuild invalidates it. (The partition-list repair that Apple documents needs a
+team identifier, so it does not apply either.)
+
+Re-home those credentials once instead, which rewrites each one so the item
+belongs to the dev signature:
 
 ```sh
-security set-generic-password-partition-list \
-  -S "apple-tool:,apple:,teamid:<YOUR_TEAM_ID>" -s openwave.dev -a <account>
+cargo run -p openwave-cli -- rehome-secrets
 ```
 
-(`security find-identity -v -p codesigning` shows the team id in parentheses;
-`security find-generic-password -s openwave.dev` lists the accounts.)
+Run it through Cargo, so the signing runner applies. Each stored credential
+asks for access once or twice more while it is read and its old item removed —
+plain **Allow** is enough — and then stops asking, including after later
+rebuilds. `security find-generic-password -s openwave.dev` lists what the dev
+profile has stored.
 
 ### Desktop UI
 

--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -9,6 +9,10 @@
 //!
 //! `openwave mcp <workspace>` serves the built-in read-only filesystem tools over
 //! MCP stdio, confined to the explicit workspace directory.
+//!
+//! `openwave rehome-secrets` rewrites the profile's stored credentials so their
+//! keychain items belong to the running binary's code signature, which is what
+//! stops macOS asking for credentials an earlier build created.
 
 use std::ffi::OsStr;
 use std::path::PathBuf;
@@ -16,7 +20,8 @@ use std::sync::Arc;
 
 use openwave_core::{AgentError, ChatId, Config, ListDir, ReadFile, Result, ToolCtx, ToolRegistry};
 
-const USAGE: &str = "usage: openwave serve\n       openwave mcp <workspace>";
+const USAGE: &str =
+    "usage: openwave serve\n       openwave mcp <workspace>\n       openwave rehome-secrets";
 
 #[tokio::main]
 async fn main() {
@@ -48,6 +53,12 @@ async fn run() -> Result<()> {
             }
             serve_mcp(workspace.into()).await
         }
+        Some(command) if command == OsStr::new("rehome-secrets") => {
+            if args.next().is_some() {
+                usage_error("rehome-secrets does not accept arguments");
+            }
+            rehome_secrets().await
+        }
         Some(other) => {
             usage_error(&format!("unknown command {other:?}"));
         }
@@ -59,16 +70,23 @@ fn usage_error(message: &str) -> ! {
     std::process::exit(2);
 }
 
-/// Bind the server and run its accept loop, announcing where to reach it.
-async fn serve() -> Result<()> {
+/// Configuration for the profile this build talks to.
+///
+/// Debug builds keep their own keychain service, matching the desktop's
+/// dev/release split: a dev daemon must not mutate release secret state.
+fn profile_config() -> Result<Config> {
     #[cfg_attr(not(debug_assertions), allow(unused_mut))]
     let mut config = Config::from_env()?;
-    // Debug builds keep their own keychain service, matching the desktop's
-    // dev/release split: a dev daemon must not mutate release secret state.
     #[cfg(debug_assertions)]
     {
         config.keychain_service = Some("openwave.dev".into());
     }
+    Ok(config)
+}
+
+/// Bind the server and run its accept loop, announcing where to reach it.
+async fn serve() -> Result<()> {
+    let config = profile_config()?;
     let server = openwave_server::bind_configured(config).await?;
     // The address and token are the client's entry point: the parent process that
     // launched the daemon reads them from stdout to connect. The token is a secret,
@@ -77,6 +95,49 @@ async fn serve() -> Result<()> {
     println!("openwave: listening on http://{}", server.local_addr());
     println!("openwave: token {}", server.token());
     server.serve().await
+}
+
+/// Rewrite each stored credential so the item belongs to this binary's code
+/// signature.
+///
+/// macOS keeps prompting for credentials an earlier, differently signed build
+/// created — see [`openwave_server::secret_rehome`] for why an approval given at
+/// that prompt does not survive the next rebuild. Run this through Cargo
+/// (`cargo run -p openwave-cli -- rehome-secrets`) so the dev signing runner
+/// applies; each credential asks for access once more, and then stops asking.
+async fn rehome_secrets() -> Result<()> {
+    use openwave_server::secret_rehome::RehomeOutcome;
+
+    let config = profile_config()?;
+    let mut touched = 0usize;
+    let mut lost = 0usize;
+    for (key, outcome) in openwave_server::rehome_configured_secrets(&config).await {
+        match outcome {
+            RehomeOutcome::Absent => {}
+            RehomeOutcome::Rehomed => {
+                touched += 1;
+                println!("openwave: re-homed {key}");
+            }
+            RehomeOutcome::Skipped(reason) => {
+                touched += 1;
+                eprintln!("openwave: left {key} as it was — {reason}");
+            }
+            RehomeOutcome::Lost(reason) => {
+                touched += 1;
+                lost += 1;
+                eprintln!("openwave: lost {key} — {reason}; store this credential again");
+            }
+        }
+    }
+    if touched == 0 {
+        println!("openwave: no stored credentials to re-home");
+    }
+    if lost > 0 {
+        return Err(AgentError::msg(format!(
+            "{lost} credential(s) were removed but could not be stored again"
+        )));
+    }
+    Ok(())
 }
 
 /// Serve the built-in read-only filesystem tools over MCP stdio.

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -39,6 +39,8 @@ mod resolver;
 mod routes;
 mod sandbox_agent_run_worker;
 mod sandbox_web_search_worker;
+/// Rewriting stored credentials so the running binary owns their keychain items.
+pub mod secret_rehome;
 mod source_tools;
 mod state;
 mod turn_worker;
@@ -579,6 +581,22 @@ pub async fn bind_configured_with_desktop_executor(
     bind_inner(config, Some(client_executor_id), mcp_servers).await
 }
 
+/// The secret store the configured profile keeps its credentials in.
+fn secret_provider(config: &Config) -> Arc<dyn SecretProvider> {
+    Arc::new(match &config.keychain_service {
+        Some(service) => KeychainSecretProvider::with_service(service),
+        None => KeychainSecretProvider::new(),
+    })
+}
+
+/// Re-home the configured profile's credentials — see [`secret_rehome`]. Does
+/// not open the data directory, so it runs without the daemon's instance lock.
+pub async fn rehome_configured_secrets(
+    config: &Config,
+) -> Vec<(String, secret_rehome::RehomeOutcome)> {
+    secret_rehome::rehome_secrets(&*secret_provider(config)).await
+}
+
 async fn bind_inner(
     config: Config,
     client_executor_id: Option<Uuid>,
@@ -589,10 +607,7 @@ async fn bind_inner(
     // directory and its worker set.
     let instance_lock = InstanceLock::acquire(&config)?;
     let store = connect_store(&config).await?;
-    let secrets: Arc<dyn SecretProvider> = Arc::new(match &config.keychain_service {
-        Some(service) => KeychainSecretProvider::with_service(service),
-        None => KeychainSecretProvider::new(),
-    });
+    let secrets = secret_provider(&config);
     // Pre-providers installs may only have an env/legacy key — enable Anthropic
     // so `KeyedResolver`'s enabled check doesn't fail-closed on upgrade.
     providers::migrate_legacy_anthropic(&*store, &*secrets).await?;

--- a/crates/openwave-server/src/secret_rehome.rs
+++ b/crates/openwave-server/src/secret_rehome.rs
@@ -1,0 +1,221 @@
+//! Re-home stored credentials so the running binary owns their keychain items.
+//!
+//! macOS grants keychain access on the code signature of the process that
+//! *created* an item. An item created by a binary carrying the dev designated
+//! requirement (`identifier "openwave-dev" and certificate leaf = H"…"`) stays
+//! readable after a rebuild and from a binary at another path. An item created
+//! by some earlier build is a different matter: the access prompt returns, and
+//! because the dev certificate is self-signed with no team identifier, the
+//! approval given at that prompt is pinned to the binary's cdhash — the next
+//! rebuild invalidates it. Credentials stored before a machine had a stable dev
+//! identity therefore prompt once per credential on every launch, forever.
+//!
+//! Rewriting each value from a signed binary is the durable repair: delete the
+//! item, then store the value again so the new item belongs to the current
+//! signature. Read the value first and hold it in memory, so a failure to
+//! delete leaves the credential in place.
+
+use openwave_code_execution::{DAYTONA_CREDENTIAL_KEY, E2B_CREDENTIAL_KEY};
+use openwave_core::SecretProvider;
+use openwave_web_search::WebSearchProviderKind;
+
+use crate::providers::{ProviderKind, LEGACY_ANTHROPIC_API_KEY};
+
+/// Credential keys for the web-search providers. `credential_key` is a `const
+/// fn`, so the keys resolve here rather than being spelled out again.
+const WEB_SEARCH_CREDENTIAL_KEYS: &[&str] = &[
+    WebSearchProviderKind::Exa.credential_key(),
+    WebSearchProviderKind::Tavily.credential_key(),
+];
+
+/// Credential keys for the code-execution providers that take one (`Local`
+/// runs in the host sandbox and has none).
+const CODE_EXECUTION_CREDENTIAL_KEYS: &[&str] = &[E2B_CREDENTIAL_KEY, DAYTONA_CREDENTIAL_KEY];
+
+/// What happened to one key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RehomeOutcome {
+    /// Nothing is stored under this key.
+    Absent,
+    /// The value was rewritten and read back unchanged.
+    Rehomed,
+    /// The value is still stored, and still owned by whatever created it.
+    Skipped(String),
+    /// The item was deleted but could not be written back: the credential is
+    /// gone and has to be entered again.
+    Lost(String),
+}
+
+/// Every key the application may store a credential under.
+#[must_use]
+pub fn stored_secret_keys() -> Vec<String> {
+    let mut keys: Vec<String> = ProviderKind::ALL
+        .iter()
+        .map(|kind| kind.credential_key())
+        .collect();
+    keys.push(LEGACY_ANTHROPIC_API_KEY.to_string());
+    keys.extend(
+        WEB_SEARCH_CREDENTIAL_KEYS
+            .iter()
+            .chain(CODE_EXECUTION_CREDENTIAL_KEYS)
+            .map(|key| (*key).to_string()),
+    );
+    keys
+}
+
+/// Re-home every stored credential, reporting each key in the order of
+/// [`stored_secret_keys`].
+pub async fn rehome_secrets(secrets: &dyn SecretProvider) -> Vec<(String, RehomeOutcome)> {
+    let mut outcomes = Vec::new();
+    for key in stored_secret_keys() {
+        let outcome = rehome_one(secrets, &key).await;
+        outcomes.push((key, outcome));
+    }
+    outcomes
+}
+
+async fn rehome_one(secrets: &dyn SecretProvider, key: &str) -> RehomeOutcome {
+    let value = match secrets.get_secret(key).await {
+        Ok(Some(value)) => value,
+        Ok(None) => return RehomeOutcome::Absent,
+        Err(error) => return RehomeOutcome::Skipped(format!("could not read it: {error}")),
+    };
+    if let Err(error) = secrets.delete_secret(key).await {
+        return RehomeOutcome::Skipped(format!("could not remove the old item: {error}"));
+    }
+    if let Err(error) = secrets.set_secret(key, &value).await {
+        return RehomeOutcome::Lost(format!("could not store it again: {error}"));
+    }
+    match secrets.get_secret(key).await {
+        Ok(Some(stored)) if stored == value => RehomeOutcome::Rehomed,
+        Ok(_) => RehomeOutcome::Lost("it did not read back unchanged".to_string()),
+        Err(error) => RehomeOutcome::Lost(format!("it could not be read back: {error}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+    use openwave_core::Result;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingSecrets {
+        values: Mutex<BTreeMap<String, String>>,
+        ops: Mutex<Vec<String>>,
+        fail_delete: bool,
+    }
+
+    #[async_trait]
+    impl SecretProvider for RecordingSecrets {
+        async fn get_secret(&self, key: &str) -> Result<Option<String>> {
+            Ok(self.values.lock().unwrap().get(key).cloned())
+        }
+
+        async fn set_secret(&self, key: &str, value: &str) -> Result<()> {
+            self.ops.lock().unwrap().push(format!("set {key}"));
+            self.values
+                .lock()
+                .unwrap()
+                .insert(key.to_string(), value.to_string());
+            Ok(())
+        }
+
+        async fn delete_secret(&self, key: &str) -> Result<()> {
+            self.ops.lock().unwrap().push(format!("delete {key}"));
+            if self.fail_delete {
+                return Err(openwave_core::AgentError::Secret("denied".into()));
+            }
+            self.values.lock().unwrap().remove(key);
+            Ok(())
+        }
+    }
+
+    /// The repair only works if the item is removed before the value is stored
+    /// again — an in-place update keeps the original item, and with it the
+    /// ownership that makes macOS prompt.
+    #[tokio::test]
+    async fn stored_values_are_deleted_then_written_back_intact() {
+        let key = ProviderKind::Anthropic.credential_key();
+        let secrets = RecordingSecrets::default();
+        secrets.set_secret(&key, "sk-ant-123").await.unwrap();
+        secrets.ops.lock().unwrap().clear();
+
+        let outcomes = rehome_secrets(&secrets).await;
+
+        let ops = secrets.ops.lock().unwrap().clone();
+        assert_eq!(ops, vec![format!("delete {key}"), format!("set {key}")]);
+        assert_eq!(
+            secrets.get_secret(&key).await.unwrap().as_deref(),
+            Some("sk-ant-123")
+        );
+        assert_eq!(
+            outcomes
+                .iter()
+                .find(|(candidate, _)| *candidate == key)
+                .map(|(_, outcome)| outcome),
+            Some(&RehomeOutcome::Rehomed)
+        );
+        assert!(outcomes
+            .iter()
+            .filter(|(candidate, _)| *candidate != key)
+            .all(|(_, outcome)| *outcome == RehomeOutcome::Absent));
+    }
+
+    /// A credential we cannot remove is left alone rather than reported as
+    /// repaired: the prompt will return, which is better than losing the value.
+    #[tokio::test]
+    async fn an_undeletable_credential_is_kept_and_reported() {
+        let key = ProviderKind::Anthropic.credential_key();
+        let secrets = RecordingSecrets {
+            fail_delete: true,
+            ..RecordingSecrets::default()
+        };
+        secrets.set_secret(&key, "sk-ant-123").await.unwrap();
+
+        let outcomes = rehome_secrets(&secrets).await;
+
+        assert_eq!(
+            secrets.get_secret(&key).await.unwrap().as_deref(),
+            Some("sk-ant-123")
+        );
+        let outcome = outcomes
+            .into_iter()
+            .find(|(candidate, _)| *candidate == key)
+            .map(|(_, outcome)| outcome)
+            .unwrap();
+        assert!(matches!(outcome, RehomeOutcome::Skipped(_)), "{outcome:?}");
+    }
+
+    /// A provider whose credential key is missing here would keep prompting
+    /// with no way to repair it. The matches are exhaustive, so adding a kind
+    /// fails to compile until its key is listed.
+    #[test]
+    fn every_credentialed_provider_kind_is_covered() {
+        let keys = stored_secret_keys();
+
+        for kind in ProviderKind::ALL {
+            assert!(keys.contains(&kind.credential_key()), "{kind:?}");
+        }
+        for kind in [WebSearchProviderKind::Exa, WebSearchProviderKind::Tavily] {
+            match kind {
+                WebSearchProviderKind::Exa | WebSearchProviderKind::Tavily => {}
+            }
+            assert!(
+                keys.iter().any(|key| key == kind.credential_key()),
+                "{kind:?}"
+            );
+        }
+        // `CodeExecutionProviderKind` is `#[non_exhaustive]`, so a match here
+        // cannot stand in for coverage; assert the credentialed kinds' keys
+        // directly (`Local` runs in the host sandbox and stores nothing).
+        for expected in [E2B_CREDENTIAL_KEY, DAYTONA_CREDENTIAL_KEY] {
+            assert!(keys.iter().any(|key| key == expected), "{expected}");
+        }
+        assert!(keys.iter().any(|key| key == LEGACY_ANTHROPIC_API_KEY));
+    }
+}


### PR DESCRIPTION
Closes #792

## Problem

#741 gave dev binaries a stable designated requirement, and that part works: an item a signed build **creates** stays readable after a rebuild and from a binary at another path. Credentials stored *before* a machine had the dev identity belong to the earlier build, so the access prompt returns — one per credential, on every `cargo tauri dev`.

**Always Allow** does not settle it. The approval is recorded, but the local `openwave-dev` certificate is self-signed with no team identifier, so it is pinned to the binary's cdhash and the next rebuild invalidates it. `CONTRIBUTING.md` claimed the opposite, and the partition-list repair it pointed at needs a team identifier, so it cannot help either.

## What

`openwave rehome-secrets` rewrites each stored credential so its keychain item belongs to the running binary's signature: read the value, delete the item, store it again, read it back to confirm. Run through Cargo, the signing runner applies, so the new items carry the dev designated requirement and stop prompting.

Reading first and holding the value in memory means a delete the process is not allowed to do leaves the credential in place rather than losing it — that is the `Skipped` outcome; `Lost` is reserved for the case where the item is gone and could not be written back, and the command exits non-zero on it.

The key list covers every `ProviderKind` including the legacy Anthropic key, both web-search providers, and the credentialed code-execution providers. A provider missing from it would keep prompting with no way to repair it, which is what the coverage test guards.

`serve` and the new command now share one `profile_config`, and the server's secret-provider construction is factored so the command can build the profile's store without opening the data directory or taking the daemon's instance lock.

`CONTRIBUTING.md` replaces the wrong guidance with this procedure.

## Testing

Three tests in `secret_rehome`: stored values are deleted before being written back and survive intact, an undeletable credential is kept and reported rather than lost, and every credentialed kind's key is in the list. `cargo fmt --check` and `cargo clippy -p openwave-server -p openwave-cli --all-targets -D warnings` are clean.

Ran the command end to end with `OPENWAVE_KEYCHAIN_MOCK=1`: the runner signed the binary as `Identifier=openwave-dev` and it reported nothing to re-home against the empty mock.

The macOS behavior it is built on was measured directly, with a scratch `keyring` binary signed with the same identity and identifier:

| case | result |
| --- | --- |
| item created by the signed binary, read after a code change (cdhash `7dc3d9e8…` → `bb8130a3…`) | silent |
| same item read from a copy of the binary at another path | silent |
| item created by an ad-hoc build, first read from the signed binary | blocks on the dialog |
| that item after approving, read again from the same binary | silent, 0.23s |
| that item read from a rebuilt and re-signed binary (same identity and identifier) | blocks on the dialog again |

I also repaired my own dev profile along the same read/delete/rewrite path before writing the command: three credentials that had prompted on every launch now read silently, including from a binary rebuilt to a different cdhash. The command's own macOS path is unexercised beyond the mock run — re-running it on an already-repaired profile only re-homes items that are already correct.