### PR TITLE
feat(desktop): report what a tool call could not do, beside what it did

### DIFF
--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -141,8 +141,8 @@ pub use model::{
     MAX_MESSAGE_ATTACHMENTS, MAX_ROOT_ATTACHMENTS,
 };
 pub use preview::{
-    format_bytes, ResultEntry, ResultEntryKind, ToolActionPreview, ToolResultPreview,
-    MAX_RESULT_ENTRIES, MAX_RESULT_ENTRY_CHARS,
+    format_bytes, ResultEntry, ResultEntryKind, ResultFailure, ToolActionPreview,
+    ToolResultPreview, MAX_RESULT_ENTRIES, MAX_RESULT_ENTRY_CHARS,
 };
 pub use provider::{
     ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId,

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -220,6 +220,53 @@ impl ResultEntry {
     }
 }
 
+/// One thing a call could not do.
+///
+/// A batch tool succeeds and fails in the same breath — five files import, two
+/// do not — and a card that lists only what worked is not reporting, it is
+/// flattering. Every one of Brightwave's local-file results carries a parallel
+/// failures list for exactly this reason.
+///
+/// Two fields because that is what a failure row reads as, and it is what
+/// Brightwave's own card normalizes its three failure shapes down to before
+/// rendering them: the thing that failed, and why.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+pub struct ResultFailure {
+    /// What failed, when the tool can name it. `None` when the tool cannot —
+    /// a folder it could not even read the name of — and the row then leads
+    /// with a generic noun rather than being dropped. A failure the reader
+    /// never sees is worse than one it cannot fully name.
+    pub label: Option<String>,
+    /// Why it failed, in the tool's own words.
+    ///
+    /// This is tool-authored text, and it crosses on the same terms as a
+    /// command's stderr already does: what the boundary keeps out is model- and
+    /// provider-authored text and private diagnostics, and this is a message
+    /// our own tool wrote for a person to act on. Clamped like every other
+    /// field; a failure nobody can read is not a report.
+    pub error: String,
+}
+
+impl ResultFailure {
+    /// A failure the tool can name.
+    #[must_use]
+    pub fn new(label: impl Into<String>, error: impl Into<String>) -> Self {
+        Self {
+            label: Some(label.into()),
+            error: error.into(),
+        }
+    }
+
+    /// A failure the tool cannot name.
+    #[must_use]
+    pub fn unnamed(error: impl Into<String>) -> Self {
+        Self {
+            label: None,
+            error: error.into(),
+        }
+    }
+}
+
 /// A byte count as a card should read it.
 ///
 /// Ported from Brightwave's local-file result rows, which is where this reads
@@ -287,6 +334,11 @@ pub enum ToolResultPreview {
     /// variants to say "here is what I found".
     Entries {
         entries: Vec<ResultEntry>,
+        /// What the same call could not do. Bounded and counted on the same
+        /// terms as `entries`, and elided into the same tally: the card's job
+        /// is to be honest about how much it is not showing, and a hidden
+        /// failure is the worst thing to hide.
+        failures: Vec<ResultFailure>,
         /// Rows past [`MAX_RESULT_ENTRIES`], counted rather than shown. A card
         /// that silently lists the first fifty of two hundred results is
         /// telling the reader something false.
@@ -365,21 +417,40 @@ impl ToolResultPreview {
             // A failed call has no list to show — whatever partial data it left
             // behind describes work that did not happen.
             name if ENTRY_TOOLS.contains(&name) && !output.is_error => {
-                let listed = output.data.as_ref()?.get("entries")?.as_array()?;
+                let data = output.data.as_ref()?;
+                let listed = data.get("entries")?.as_array()?;
                 let entries: Vec<_> = listed
                     .iter()
                     .take(MAX_RESULT_ENTRIES)
                     .filter_map(result_entry)
                     .collect();
-                // A row the clamp rejected is dropped, not counted: `elided`
-                // means "there were more", and folding unreadable rows into it
-                // would make the card claim results the tool never returned.
-                let elided = u32::try_from(listed.len().saturating_sub(MAX_RESULT_ENTRIES))
-                    .unwrap_or(u32::MAX);
+                // Failures are optional — most tools have none — but a tool
+                // that reports them gets them bounded the same way.
+                let reported = data
+                    .get("failures")
+                    .and_then(Value::as_array)
+                    .map_or(&[][..], Vec::as_slice);
+                let failures: Vec<_> = reported
+                    .iter()
+                    .take(MAX_RESULT_ENTRIES)
+                    .filter_map(result_failure)
+                    .collect();
+                // Everything the call produced that this card is not showing,
+                // whether it was cut at the limit or dropped by the clamp.
+                // Both are rows the tool returned and the reader will not see,
+                // which is the only thing `elided` is claiming.
+                let elided = u32::try_from(
+                    (listed.len() - entries.len()) + (reported.len() - failures.len()),
+                )
+                .unwrap_or(u32::MAX);
                 // An empty list is a result, not the absence of one: a search
                 // that matched nothing and a search that was never projected
                 // look identical in the rail, and only one of them is true.
-                Some(Self::Entries { entries, elided })
+                Some(Self::Entries {
+                    entries,
+                    failures,
+                    elided,
+                })
             }
             _ => None,
         }
@@ -431,6 +502,19 @@ fn result_entry(value: &Value) -> Option<ResultEntry> {
 
 fn entry_field(value: Option<&Value>) -> Option<String> {
     clamp(value?.as_str()?, MAX_RESULT_ENTRY_CHARS)
+}
+
+/// Bound one failure row, or drop it.
+///
+/// The error is what makes the row worth showing, so a failure without a
+/// readable one is dropped — and counted into `elided`, so the card still
+/// reports that something went unshown. The label is genuinely optional and
+/// clamps away on its own without taking the row with it.
+fn result_failure(value: &Value) -> Option<ResultFailure> {
+    Some(ResultFailure {
+        label: entry_field(value.get("label")),
+        error: clamp(value.get("error")?.as_str()?, MAX_RESULT_ENTRY_CHARS)?,
+    })
 }
 
 /// Bound a captured stream, keeping its newlines: output without line breaks
@@ -754,14 +838,21 @@ mod tests {
             "detail": "reports/\nq3.md",
             "meta": 7,
         });
-        let Some(ToolResultPreview::Entries { entries, elided }) = ToolResultPreview::build(
+        // One row the clamp will reject outright: no label to lead with.
+        rows.push(serde_json::json!({ "kind": "file" }));
+        let Some(ToolResultPreview::Entries {
+            entries, elided, ..
+        }) = ToolResultPreview::build(
             "list_dir",
             &ToolOutput::text("listing").with_data(serde_json::json!({ "entries": rows })),
-        ) else {
+        )
+        else {
             panic!("list_dir projects a list");
         };
         assert_eq!(entries.len(), MAX_RESULT_ENTRIES);
-        assert_eq!(elided, 7);
+        // Cut at the limit and dropped by the clamp both count: they are rows
+        // the call produced that the reader will not see.
+        assert_eq!(elided, 8);
         assert_eq!(entries[0].label.chars().count(), MAX_RESULT_ENTRY_CHARS);
         assert_eq!(entries[0].detail.as_deref(), Some("reports/q3.md"));
         // A hint that is not a string is dropped; the row survives without it.
@@ -779,9 +870,60 @@ mod tests {
             ),
             Some(ToolResultPreview::Entries {
                 entries: Vec::new(),
+                failures: Vec::new(),
                 elided: 0,
             })
         );
+    }
+
+    #[test]
+    fn a_batch_call_reports_what_it_could_not_do_beside_what_it_did() {
+        // Listing only the successes is not reporting, it is flattering: a card
+        // that says "Imported 3" for a call that also failed two has told the
+        // reader something false by omission.
+        let output = ToolOutput::text("imported 3 of 5")
+            .with_entries(vec![ResultEntry::new(ResultEntryKind::File, "q3.md")])
+            .with_failures(vec![
+                ResultFailure::new("q4.md", "file is not valid UTF-8"),
+                // A tool that cannot even name what failed still reports it.
+                ResultFailure::unnamed("the folder is no longer available"),
+            ]);
+        assert_eq!(
+            ToolResultPreview::build("read_file", &output),
+            Some(ToolResultPreview::Entries {
+                entries: vec![ResultEntry::new(ResultEntryKind::File, "q3.md")],
+                failures: vec![
+                    ResultFailure::new("q4.md", "file is not valid UTF-8"),
+                    ResultFailure::unnamed("the folder is no longer available"),
+                ],
+                elided: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn a_failure_without_a_readable_reason_is_dropped_but_still_counted() {
+        // The reason is the whole of what a failure row is for, so a row
+        // without one cannot render — but vanishing silently would leave the
+        // card quietly under-reporting how much went wrong.
+        let Some(ToolResultPreview::Entries {
+            failures, elided, ..
+        }) = ToolResultPreview::build(
+            "read_file",
+            &ToolOutput::text("done").with_data(serde_json::json!({
+                "entries": [],
+                "failures": [
+                    { "label": "q4.md", "error": "unreadable" },
+                    { "label": "q5.md" },
+                    { "label": "q6.md", "error": "\u{0}\u{1b}" },
+                ],
+            })),
+        )
+        else {
+            panic!("read_file projects a list");
+        };
+        assert_eq!(failures, vec![ResultFailure::new("q4.md", "unreadable")]);
+        assert_eq!(elided, 2);
     }
 
     #[test]

--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -484,13 +484,27 @@ impl ToolOutput {
     /// project nothing — see [`crate::ToolResultPreview::Entries`], which
     /// clamps every row before it crosses.
     #[must_use]
-    pub fn with_entries(mut self, entries: Vec<crate::ResultEntry>) -> Self {
-        let entries = serde_json::json!(entries);
+    pub fn with_entries(self, entries: Vec<crate::ResultEntry>) -> Self {
+        self.with_projected("entries", serde_json::json!(entries))
+    }
+
+    /// Report what this call could not do, beside what it did.
+    ///
+    /// A batch tool that lists only its successes is not reporting. Carried
+    /// alongside [`Self::with_entries`] rather than instead of it — a call that
+    /// imported three files and failed two has both to say.
+    #[must_use]
+    pub fn with_failures(self, failures: Vec<crate::ResultFailure>) -> Self {
+        self.with_projected("failures", serde_json::json!(failures))
+    }
+
+    /// Merge one renderer-projected key into this output's structured data.
+    fn with_projected(mut self, key: &str, value: Value) -> Self {
         match self.data.as_mut().and_then(Value::as_object_mut) {
             Some(data) => {
-                data.insert("entries".into(), entries);
+                data.insert(key.into(), value);
             }
-            None => self.data = Some(serde_json::json!({ "entries": entries })),
+            None => self.data = Some(serde_json::json!({ key: value })),
         }
         self
     }

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -648,6 +648,7 @@ describe("mcp app views", () => {
                 { kind: "file", label: "notes.md", detail: null, meta: "1.2 KB" },
                 { kind: "folder", label: "reports", detail: null, meta: null },
               ],
+              failures: [],
             },
           },
         ]}
@@ -680,6 +681,61 @@ describe("mcp app views", () => {
     expect(screen.getByText("notes.md")).toBeInTheDocument();
     expect(screen.getByText("reports")).toBeInTheDocument();
     expect(screen.getByText("3 more not shown")).toBeInTheDocument();
+  });
+
+  it("says on the collapsed header that some of the call failed", async () => {
+    const user = userEvent.setup();
+    render(
+      <MessageList
+        messages={[
+          {
+            id: "t1",
+            role: "tool",
+            callId: "c1",
+            name: "read_file",
+            status: "completed",
+            result: {
+              tool: "entries",
+              elided: 0,
+              entries: [
+                { kind: "file", label: "q3.md", detail: null, meta: null },
+              ],
+              failures: [
+                { label: "q4.md", error: "file is not valid UTF-8" },
+                { label: null, error: "the folder is no longer available" },
+              ],
+            },
+          },
+        ]}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    // A partial success read as a clean one is the failure this whole channel
+    // exists to prevent: the reader must not have to open the card to find out
+    // that two of the three files never made it.
+    const card = screen.getByRole("status", {
+      name: "Read a file: File read complete",
+    });
+    expect(within(card).getByText(/1 result · 2 failed/)).toBeInTheDocument();
+
+    await user.click(within(card).getByRole("button"));
+    expect(screen.getByText("file is not valid UTF-8")).toBeInTheDocument();
+    // A failure the tool could not name still gets a row rather than vanishing.
+    expect(screen.getByText("the folder is no longer available")).toBeInTheDocument();
+    expect(screen.getByText("Item")).toBeInTheDocument();
   });
 });
 

--- a/crates/openwave-desktop/ui/src/ToolEntriesCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolEntriesCard.tsx
@@ -11,7 +11,12 @@ import {
   type LucideIcon,
 } from "lucide-react";
 
-import type { EntriesResultPreview, ResultEntry, ResultEntryKind } from "./api";
+import type {
+  EntriesResultPreview,
+  ResultEntry,
+  ResultEntryKind,
+  ResultFailure,
+} from "./api";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { ToolCardShell } from "./ToolCardShell";
@@ -54,7 +59,7 @@ const ENTRY_ICONS: Record<ResultEntryKind, LucideIcon> = {
  */
 export function ToolEntriesCard({ name, status, result }: ToolEntriesCardProps) {
   const presentation = toolCallPresentation(name, status);
-  const { entries, elided } = result;
+  const { entries, failures, elided } = result;
   const total = entries.length + elided;
 
   return (
@@ -62,25 +67,63 @@ export function ToolEntriesCard({ name, status, result }: ToolEntriesCardProps) 
       label={`${presentation.label}: ${presentation.statusLabel}`}
       icon={<ToolIcon name={name} className="size-3.5 shrink-0" />}
       title={presentation.title}
-      badge={<EntriesBadge presentation={presentation} total={total} />}
+      badge={
+        <EntriesBadge
+          presentation={presentation}
+          total={total}
+          failureCount={failures.length}
+        />
+      }
     >
-      {entries.length === 0 ? (
+      {entries.length === 0 && failures.length === 0 ? (
         <p className="text-muted-foreground px-2.5 py-2 text-xs">
           {emptyMessage(presentation.tone)}
         </p>
-      ) : (
+      ) : null}
+      {entries.length > 0 && (
         <div className="flex max-h-56 flex-col gap-0.5 overflow-auto p-1">
           {entries.map((entry, index) => (
             <EntryRow key={`${entry.kind}:${entry.label}:${index}`} entry={entry} />
           ))}
         </div>
       )}
+      <FailureRows failures={failures} />
       {elided > 0 && (
         <p className="text-muted-foreground border-t px-2.5 py-1.5 text-xs">
           {elided} more not shown
         </p>
       )}
     </ToolCardShell>
+  );
+}
+
+/**
+ * What the call could not do, below what it did and divided from it.
+ *
+ * Its own section rather than rows mixed into the list: a failure is not a
+ * result with a bad outcome, it is the absence of one, and a reader scanning
+ * for what they got should not have to check each row for whether it counted.
+ */
+function FailureRows({ failures }: { failures: ResultFailure[] }) {
+  if (failures.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-0.5 border-t p-1">
+      {failures.map((failure, index) => (
+        <div
+          key={`${failure.label ?? ""}:${index}`}
+          className="flex items-start gap-2 rounded p-1 px-1.5 text-sm"
+        >
+          <X
+            className="text-destructive mt-0.5 size-4 shrink-0"
+            aria-hidden="true"
+          />
+          <span className="truncate">{failure.label ?? "Item"}</span>
+          <span className="text-destructive ml-auto min-w-0 truncate text-right text-xs">
+            {failure.error}
+          </span>
+        </div>
+      ))}
+    </div>
   );
 }
 
@@ -112,9 +155,11 @@ function EntryRow({ entry }: { entry: ResultEntry }) {
 function EntriesBadge({
   presentation,
   total,
+  failureCount,
 }: {
   presentation: { tone: string; badgeLabel: string };
   total: number;
+  failureCount: number;
 }) {
   if (presentation.tone === "running") {
     return (
@@ -125,6 +170,15 @@ function EntriesBadge({
     );
   }
   if (presentation.tone === "completed") {
+    // A partial success is not a success. The badge carries the failure count
+    // so a collapsed card cannot read as "12 results" when two of them failed.
+    if (failureCount > 0) {
+      return (
+        <Badge variant="warning" className="shrink-0 gap-1">
+          {total} {total === 1 ? "result" : "results"} · {failureCount} failed
+        </Badge>
+      );
+    }
     return (
       <Badge
         variant={total === 0 ? "outline" : "success"}

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -819,20 +819,31 @@ describe("parseToolResultPreview closed results", () => {
           { kind: "file", label: "" },
           { kind: "folder", label: "reports" },
         ],
+        failures: [
+          { label: "q4.md", error: "unreadable" },
+          // No reason to show, so no row — but still counted.
+          { label: "q5.md" },
+        ],
       }),
     ).toEqual({
       tool: "entries",
-      elided: 4,
+      elided: 5,
       entries: [
         { kind: "file", label: "notes.md", detail: "scratch", meta: "1.2 KB" },
         { kind: "folder", label: "reports", detail: null, meta: null },
       ],
+      failures: [{ label: "q4.md", error: "unreadable" }],
     });
   });
 
   it("keeps an empty list, which is a result and not the absence of one", () => {
     expect(
-      parseToolResultPreview({ tool: "entries", entries: [], elided: 0 }),
-    ).toEqual({ tool: "entries", entries: [], elided: 0 });
+      parseToolResultPreview({
+        tool: "entries",
+        entries: [],
+        failures: [],
+        elided: 0,
+      }),
+    ).toEqual({ tool: "entries", entries: [], failures: [], elided: 0 });
   });
 });

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -281,6 +281,8 @@ export type ToolResultPreview =
       /** What a call found, read, or wrote, as the list of things it was. */
       tool: "entries";
       entries: ResultEntry[];
+      /** What the same call could not do. */
+      failures: ResultFailure[];
       /** Rows the server bounded away, counted rather than shown. */
       elided: number;
     };
@@ -291,6 +293,14 @@ export type ResultEntry = {
   label: string;
   detail: string | null;
   meta: string | null;
+};
+
+/** One thing a listed call could not do. */
+export type ResultFailure = {
+  /** What failed, when the tool could name it. */
+  label: string | null;
+  /** Why, in the tool's own words. */
+  error: string;
 };
 
 /** The entries-shaped result the list card renders. */
@@ -1513,6 +1523,23 @@ function parseResultEntry(value: unknown): ResultEntry | null {
 }
 
 /**
+ * Validate one failure row.
+ *
+ * The reason is what the row exists to say, so a row without a readable one is
+ * dropped — and, like a dropped entry, counted as not shown rather than
+ * vanishing. A failure the card quietly omits is the worst kind of omission.
+ */
+function parseResultFailure(value: unknown): ResultFailure | null {
+  if (!isRecord(value)) return null;
+  const { error } = value;
+  const label = value.label ?? null;
+  if (typeof error !== "string" || error.length === 0 || !isOptionalString(label)) {
+    return null;
+  }
+  return { label, error };
+}
+
+/**
  * Validate a result field by field, on the same terms as an action: anything
  * that cannot be fully verified is dropped rather than half-rendered.
  */
@@ -1537,20 +1564,32 @@ export function parseToolResultPreview(
     return { tool: "mcp_app", server, resourceUri: resource_uri };
   }
   if (value.tool === "entries") {
-    const { entries, elided }: UncheckedEntriesResult = value;
-    if (!Array.isArray(entries) || !Number.isInteger(elided) || Number(elided) < 0) {
+    const { entries, failures, elided }: UncheckedEntriesResult = value;
+    if (
+      !Array.isArray(entries) ||
+      !Array.isArray(failures) ||
+      !Number.isInteger(elided) ||
+      Number(elided) < 0
+    ) {
       return null;
     }
-    const parsed = entries
+    const parsedEntries = entries
       .map(parseResultEntry)
       .filter((entry): entry is ResultEntry => entry !== null);
+    const parsedFailures = failures
+      .map(parseResultFailure)
+      .filter((failure): failure is ResultFailure => failure !== null);
     // Rows this parser rejected are counted with the ones the server bounded
     // away, because in both cases the card is showing fewer results than the
     // call returned and has to say so.
     return {
       tool: "entries",
-      entries: parsed,
-      elided: Number(elided) + (entries.length - parsed.length),
+      entries: parsedEntries,
+      failures: parsedFailures,
+      elided:
+        Number(elided) +
+        (entries.length - parsedEntries.length) +
+        (failures.length - parsedFailures.length),
     };
   }
   if (value.tool !== "exec") return null;

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -722,6 +722,37 @@ meta: string | null, };
 export type ResultEntryKind = "file" | "folder" | "source" | "passage" | "link" | "output";
 
 /**
+ * One thing a call could not do.
+ *
+ * A batch tool succeeds and fails in the same breath — five files import, two
+ * do not — and a card that lists only what worked is not reporting, it is
+ * flattering. Every one of Brightwave's local-file results carries a parallel
+ * failures list for exactly this reason.
+ *
+ * Two fields because that is what a failure row reads as, and it is what
+ * Brightwave's own card normalizes its three failure shapes down to before
+ * rendering them: the thing that failed, and why.
+ */
+export type ResultFailure = { 
+/**
+ * What failed, when the tool can name it. `None` when the tool cannot —
+ * a folder it could not even read the name of — and the row then leads
+ * with a generic noun rather than being dropped. A failure the reader
+ * never sees is worse than one it cannot fully name.
+ */
+label: string | null, 
+/**
+ * Why it failed, in the tool's own words.
+ *
+ * This is tool-authored text, and it crosses on the same terms as a
+ * command's stderr already does: what the boundary keeps out is model- and
+ * provider-authored text and private diagnostics, and this is a message
+ * our own tool wrote for a person to act on. Clamped like every other
+ * field; a failure nobody can read is not a report.
+ */
+error: string, };
+
+/**
  * Why a root appears in one conversation's exact ordered projection.
  */
 export type RootAttachmentOrigin = "project_default" | "conversation";
@@ -818,6 +849,13 @@ server: string,
  * The validated `ui://` document reference.
  */
 resource_uri: string, } | { "tool": "entries", entries: Array<ResultEntry>, 
+/**
+ * What the same call could not do. Bounded and counted on the same
+ * terms as `entries`, and elided into the same tally: the card's job
+ * is to be honest about how much it is not showing, and a hidden
+ * failure is the worst thing to hide.
+ */
+failures: Array<ResultFailure>, 
 /**
  * Rows past [`MAX_RESULT_ENTRIES`], counted rather than shown. A card
  * that silently lists the first fifty of two hundred results is

--- a/crates/openwave-retrieval/src/search.rs
+++ b/crates/openwave-retrieval/src/search.rs
@@ -625,6 +625,7 @@ mod tests {
                     openwave_core::ResultEntryKind::Passage,
                     "Jupiter is the largest planet in the Solar System, a gas giant.",
                 )],
+                failures: Vec::new(),
                 elided: 0,
             })
         );


### PR DESCRIPTION
Follows #800. A batch tool succeeds and fails in the same breath — five files
import, two do not — and a card that lists only the successes is not reporting,
it is flattering. `Entries` had no way to say so at all.

## What alpha does

Every local-file result in Brightwave carries a `failures` list parallel to its
successes:

```python
class ClientLocalFilesImportResult(...):
    documents: list[ImportedLocalDocument]
    failures: list[LocalFileImportFailure] = Field(default_factory=list)
```

There are three such failure shapes (`LocalFileRootFailure`,
`LocalFileImportFailure`, `LocalFileWriteFailure`), and `local-file-results.tsx`
normalizes all three down to the same two fields before rendering:

```tsx
failures.map((f) => ({ label: f.name ?? f.relative_path ?? "file", error: f.error }))
```

So `ResultFailure` is exactly those two fields — the normalized form the card
actually draws, rather than three shapes we'd only collapse again.

The card layout is ported too: a divided section under the results
(`LocalFileFailures`), and a warning-toned header count in place of the success
badge (`CountBadge` with `variant={failureCount > 0 ? "warning" : "success"}`).
That header count is the part that matters — a collapsed card must not read as
"12 results" when two of them failed.

## Shape decisions

- **`label` is optional.** A tool cannot always name what failed — a folder it
  could not read the name of. Alpha models this the same way and falls back in
  the renderer. A failure the reader never sees is worse than one that leads
  with a generic noun.
- **`error` is required.** It is the whole of what the row exists to say, so a
  row without a readable one is dropped — and counted, so the card still
  reports that something went unshown.
- **The error text crosses the boundary.** It is tool-authored, on the same
  terms as a command's stderr already is: what the boundary keeps out is model-
  and provider-authored text and private diagnostics, and this is a message our
  own tool wrote for a person to act on. Clamped like every other field.

## Drive-by fix

The Rust projection dropped malformed rows silently while the renderer's parser
counted them into `elided` — an inconsistency #800 introduced. Both now count
them. `elided` means "rows the call produced that you are not seeing", and
whether a row was cut at the limit or rejected by the clamp does not change that
it is one.

## No producer yet, deliberately

None of the eight wired tools can partially fail — they are all single-shot. The
shape lands now because **persistence is the next slice**, and changing a
persisted shape afterwards is the expensive kind of change. The connected-folder
tools are what will populate it.

While mapping that out I found persistence and the folder tools share a
prerequisite: `ClientExecutionResolution` carries `result: String` only, with no
structured channel, so neither can project a result until the resolve path
carries a `ToolResultPreview`. That threading is the next PR and unblocks both.

## Tests

Two in `preview.rs` — a batch call carrying both successes and failures
(including an unnamed one), and a failure with no readable reason being dropped
but counted. One DOM test that the collapsed header says `1 result · 2 failed`
before anything is opened, which is the regression this whole channel exists to
prevent. Existing parser test extended to cover a rejected failure row.

Refs #783