### PR TITLE
feat(desktop): report progress while a large source downloads

### DIFF
--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -805,3 +805,90 @@ describe("parseToolResultPreview closed results", () => {
     }
   });
 });
+
+describe("source download progress", () => {
+  /** A response whose body arrives in chunks, as a real transfer would. */
+  function streamed(chunks: string[], headers: Record<string, string> = {}) {
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+        controller.close();
+      },
+    });
+    return new Response(body, { status: 200, headers });
+  }
+
+  const megabyte = "x".repeat(1024 * 1024);
+
+  it("reports against the declared length, ending on the total", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        streamed([megabyte, megabyte, megabyte], {
+          "Content-Length": String(3 * 1024 * 1024),
+          "Content-Type": "text/markdown",
+        }),
+      ),
+    );
+    const client = new ApiClient("http://127.0.0.1", "token");
+    const seen: number[] = [];
+
+    const blob = await client.getChatDocumentFile("chat-1", "doc-1", undefined, (p) =>
+      seen.push(p.loaded),
+    );
+
+    // Every chunk but the last may be swallowed by the throttle; the last must
+    // not be, or the bar stops short of the end.
+    expect(seen.at(-1)).toBe(3 * 1024 * 1024);
+    expect(blob.size).toBe(3 * 1024 * 1024);
+    // The stored media type has to survive being reassembled from chunks.
+    expect(blob.type).toBe("text/markdown");
+  });
+
+  it("stays quiet for a small file, whose bar would only flash", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        streamed(["small"], { "Content-Length": "5" }),
+      ),
+    );
+    const client = new ApiClient("http://127.0.0.1", "token");
+    const onProgress = vi.fn();
+
+    const bytes = await client.getDocumentFileContent("doc-1", undefined, onProgress);
+
+    expect(onProgress).not.toHaveBeenCalled();
+    expect(new TextDecoder().decode(bytes)).toBe("small");
+  });
+
+  it("stays quiet when the response declares no length to divide by", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(streamed([megabyte, megabyte, megabyte])),
+    );
+    const client = new ApiClient("http://127.0.0.1", "token");
+    const onProgress = vi.fn();
+
+    const bytes = await client.getDocumentFileContent("doc-1", undefined, onProgress);
+
+    expect(onProgress).not.toHaveBeenCalled();
+    expect(bytes.length).toBe(3 * 1024 * 1024);
+  });
+
+  it("surfaces the server's own message when the transfer is refused", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ message: "source has been deleted" }), {
+          status: 410,
+        }),
+      ),
+    );
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    await expect(client.getDocumentFileContent("doc-1")).rejects.toThrow(
+      "410: source has been deleted",
+    );
+  });
+});

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -416,6 +416,59 @@ export const RENDERER_FOLDER_ACCESS_REASON =
 const WS_HANDSHAKE = "openwave-v1";
 const WS_TOKEN_PREFIX = "openwave-token.";
 
+/** How far a source download has got, when its length is known. */
+export type FileDownloadProgress = {
+  loaded: number;
+  total: number;
+  /** `loaded` over `total`, as 0–100. */
+  percentage: number;
+};
+
+/**
+ * The size below which a transfer is not worth reporting on.
+ *
+ * A bar that appears and vanishes is worse than no bar, and a source under this
+ * arrives in a couple of chunks — most of them from a sidecar on this machine.
+ * Well under the 16 MB a source may be, so the files big enough to wait on do
+ * still report.
+ */
+const PROGRESS_MIN_BYTES = 2 * 1024 * 1024;
+
+/** Progress updates are worth at most one re-render per frame budget. */
+const PROGRESS_THROTTLE_MS = 100;
+
+/**
+ * Rate-limit progress callbacks, always letting the last one through.
+ *
+ * Without the trailing call the bar can stop short of the end: the final chunk
+ * usually lands inside the throttle window of the one before it.
+ */
+function throttle(
+  report: (progress: FileDownloadProgress) => void,
+): (progress: FileDownloadProgress) => void {
+  let last = 0;
+  return (progress) => {
+    const now = Date.now();
+    if (progress.loaded >= progress.total || now - last >= PROGRESS_THROTTLE_MS) {
+      last = now;
+      report(progress);
+    }
+  };
+}
+
+/** The server's own message for a failed response, or its status text. */
+async function throwIfNotOk(response: Response): Promise<void> {
+  if (response.ok) return;
+  let detail = response.statusText;
+  try {
+    const body = (await response.json()) as { message?: string };
+    if (body.message) detail = body.message;
+  } catch {
+    /* ignore */
+  }
+  throw new Error(`${response.status}: ${detail}`);
+}
+
 export class ApiClient {
   constructor(
     readonly baseUrl: string,
@@ -762,17 +815,65 @@ export class ApiClient {
       headers: this.headers(),
       signal,
     });
-    if (!response.ok) {
-      let detail = response.statusText;
-      try {
-        const body = (await response.json()) as { message?: string };
-        if (body.message) detail = body.message;
-      } catch {
-        /* ignore */
-      }
-      throw new Error(`${response.status}: ${detail}`);
-    }
+    await throwIfNotOk(response);
     return response.blob();
+  }
+
+  /**
+   * Bytes read as they arrive, reporting how much has landed.
+   *
+   * Reading the body as a stream rather than awaiting it whole is the only way
+   * to say anything about a transfer while it is still running. It costs an
+   * extra copy — the chunks are joined once at the end — which is why the
+   * callers that have nothing to report progress to still use {@link blob}.
+   *
+   * `onProgress` is only ever called when the response declares its length:
+   * without a total there is no fraction to report, and a byte count climbing
+   * toward an unknown end is not worth a progress bar.
+   */
+  private async streamBytes(
+    path: string,
+    signal?: AbortSignal,
+    onProgress?: (progress: FileDownloadProgress) => void,
+  ): Promise<{ bytes: Uint8Array; contentType: string | null }> {
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      headers: this.headers(),
+      signal,
+    });
+    await throwIfNotOk(response);
+
+    const contentType = response.headers.get("Content-Type");
+    const declared = Number(response.headers.get("Content-Length"));
+    const total = Number.isSafeInteger(declared) && declared > 0 ? declared : 0;
+
+    // No reader to stream from (an old runtime, or a mocked response in a
+    // test): take the whole body and skip straight to the finished state.
+    if (!response.body) {
+      const bytes = new Uint8Array(await response.arrayBuffer());
+      return { bytes, contentType };
+    }
+
+    const report =
+      onProgress && total > PROGRESS_MIN_BYTES ? throttle(onProgress) : null;
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let loaded = 0;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      loaded += value.length;
+      report?.({ loaded, total, percentage: (loaded / total) * 100 });
+    }
+
+    const bytes = new Uint8Array(loaded);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return { bytes, contentType };
   }
 
   getChatImageAttachment(
@@ -796,22 +897,14 @@ export class ApiClient {
   async getDocumentFileContent(
     documentId: string,
     signal?: AbortSignal,
+    onProgress?: (progress: FileDownloadProgress) => void,
   ): Promise<Uint8Array> {
-    const response = await fetch(
-      `${this.baseUrl}/documents/${encodeURIComponent(documentId)}/file-content`,
-      { headers: this.headers(), signal },
+    const { bytes } = await this.streamBytes(
+      `/documents/${encodeURIComponent(documentId)}/file-content`,
+      signal,
+      onProgress,
     );
-    if (!response.ok) {
-      let detail = response.statusText;
-      try {
-        const body = (await response.json()) as { message?: string };
-        if (body.message) detail = body.message;
-      } catch {
-        /* ignore */
-      }
-      throw new Error(`${response.status}: ${detail}`);
-    }
-    return new Uint8Array(await response.arrayBuffer());
+    return bytes;
   }
 
   /** One source's extracted text and catalog metadata. */
@@ -829,15 +922,20 @@ export class ApiClient {
    * can show the file the reader gave us without the renderer learning where
    * on disk it came from.
    */
-  getChatDocumentFile(
+  async getChatDocumentFile(
     chatId: string,
     documentId: string,
     signal?: AbortSignal,
+    onProgress?: (progress: FileDownloadProgress) => void,
   ): Promise<Blob> {
-    return this.blob(
+    const { bytes, contentType } = await this.streamBytes(
       `/chats/${encodeURIComponent(chatId)}/documents/${encodeURIComponent(documentId)}/file-content`,
       signal,
+      onProgress,
     );
+    // The stored media type is what the viewers dispatch on, so it has to
+    // survive being reassembled from chunks.
+    return new Blob([bytes], contentType ? { type: contentType } : undefined);
   }
 
   patchChatTitle(chatId: string, title: string | null): Promise<Chat> {

--- a/crates/openwave-desktop/ui/src/components/document/FileDownloadProgress.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/FileDownloadProgress.tsx
@@ -1,0 +1,52 @@
+import { Loader2Icon } from "lucide-react";
+import type { HTMLAttributes } from "react";
+
+import type { FileDownloadProgress } from "@/api";
+import { Progress } from "@/components/ui/progress";
+import { cn } from "@/lib/utils";
+
+/**
+ * How far a large source has got, in place of a spinner that says nothing.
+ *
+ * Only rendered once a transfer has a declared length, so there is always a
+ * total to divide by — a viewer with no progress to show keeps its spinner.
+ */
+export function FileDownloadProgressIndicator({
+  progress,
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement> & { progress: FileDownloadProgress }) {
+  const percentage = Math.min(100, Math.max(0, progress.percentage));
+
+  return (
+    <div
+      className={cn(
+        "flex h-64 items-center justify-center text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      <div className="flex flex-col items-center gap-3">
+        <Loader2Icon className="size-6 animate-spin" />
+        <div className="flex flex-col items-center gap-1">
+          <p>Downloading document…</p>
+          <div className="flex items-center gap-2 text-sm">
+            <span className="tabular-nums">{Math.round(percentage)}%</span>
+            <span className="text-muted-foreground/70 tabular-nums">
+              ({megabytes(progress.loaded)} / {megabytes(progress.total)} MB)
+            </span>
+          </div>
+        </div>
+        <Progress
+          value={percentage}
+          aria-label="Download progress"
+          className="w-64"
+        />
+      </div>
+    </div>
+  );
+}
+
+function megabytes(bytes: number): string {
+  return (bytes / (1024 * 1024)).toFixed(1);
+}

--- a/crates/openwave-desktop/ui/src/components/document/image-viewer.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/image-viewer.tsx
@@ -3,6 +3,7 @@ import type { HTMLAttributes } from "react";
 import { useEffect, useState } from "react";
 
 import { cn } from "@/lib/utils";
+import { FileDownloadProgressIndicator } from "./FileDownloadProgress";
 import { useFileDownload } from "./useFileDownload";
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
@@ -32,12 +33,16 @@ export function ImageViewer({ chatId, documentID, className, ...restProps }: Pro
   if (fileDownload.isLoading) {
     return (
       <div className={cn("relative overflow-auto", className)} {...restProps}>
-        <div className="flex h-64 items-center justify-center text-muted-foreground">
-          <div className="flex flex-col items-center gap-2">
-            <Loader2Icon className="size-6 animate-spin" />
-            <p>Loading image…</p>
+        {fileDownload.progress ? (
+          <FileDownloadProgressIndicator progress={fileDownload.progress} />
+        ) : (
+          <div className="flex h-64 items-center justify-center text-muted-foreground">
+            <div className="flex flex-col items-center gap-2">
+              <Loader2Icon className="size-6 animate-spin" />
+              <p>Loading image…</p>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     );
   }

--- a/crates/openwave-desktop/ui/src/components/document/json-viewer.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/json-viewer.tsx
@@ -23,6 +23,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { FileDownloadProgressIndicator } from "./FileDownloadProgress";
 import { useFileDownload } from "./useFileDownload";
 import { cn } from "@/lib/utils";
 
@@ -204,7 +205,11 @@ export function JsonViewer({
         className={cn("flex items-center justify-center", className)}
         {...props}
       >
-        <Loader2Icon className="text-muted-foreground size-6 animate-spin" />
+        {fileDownload.progress ? (
+          <FileDownloadProgressIndicator progress={fileDownload.progress} />
+        ) : (
+          <Loader2Icon className="text-muted-foreground size-6 animate-spin" />
+        )}
       </div>
     );
   }

--- a/crates/openwave-desktop/ui/src/components/document/markdown-viewer.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/markdown-viewer.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { extractHeadings } from "@/markdownHeadings";
 import { MessageMarkdown } from "@/MessageMarkdown";
+import { FileDownloadProgressIndicator } from "./FileDownloadProgress";
 import { MarkdownOutline } from "./MarkdownOutline";
 import { useFileDownload } from "./useFileDownload";
 
@@ -181,7 +182,11 @@ export function MarkdownViewer({
   if (fileDownload.isLoading) {
     return (
       <div className={cn("flex items-center justify-center", className)} {...props}>
-        <Loader2Icon className="size-6 animate-spin" />
+        {fileDownload.progress ? (
+          <FileDownloadProgressIndicator progress={fileDownload.progress} />
+        ) : (
+          <Loader2Icon className="size-6 animate-spin" />
+        )}
       </div>
     );
   }

--- a/crates/openwave-desktop/ui/src/components/document/useFileDownload.ts
+++ b/crates/openwave-desktop/ui/src/components/document/useFileDownload.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import type { FileDownloadProgress } from "@/api";
 import { useApp } from "@/AppContext";
 
 export type ParseAsType = "text" | "blob";
@@ -23,6 +24,11 @@ export interface FileDownloadResult<T extends ParseAsType> {
   isError: boolean;
   /** The stored media type, once the response has arrived. */
   contentType: string | null;
+  /**
+   * How far the transfer has got, or null when there is nothing to report —
+   * a small file, or a response that never declared its length.
+   */
+  progress: FileDownloadProgress | null;
 }
 
 /**
@@ -49,9 +55,14 @@ export function useFileDownload<T extends ParseAsType = "blob">(
       return;
     }
     const controller = new AbortController();
-    setResult({ data: null, isLoading: true, isError: false, contentType: null });
+    setResult({ ...idle, isLoading: true });
     void client
-      .getChatDocumentFile(chatId, documentID, controller.signal)
+      .getChatDocumentFile(chatId, documentID, controller.signal, (progress) => {
+        if (controller.signal.aborted) return;
+        setResult((current) =>
+          current.isLoading ? { ...current, progress } : current,
+        );
+      })
       .then(async (blob) => {
         const data = (parseAs === "text" ? await blob.text() : blob) as ParsedData<T>;
         if (controller.signal.aborted) return;
@@ -60,11 +71,12 @@ export function useFileDownload<T extends ParseAsType = "blob">(
           isLoading: false,
           isError: false,
           contentType: blob.type || null,
+          progress: null,
         });
       })
       .catch(() => {
         if (controller.signal.aborted) return;
-        setResult({ data: null, isLoading: false, isError: true, contentType: null });
+        setResult({ ...idle, isError: true });
       });
     return () => controller.abort();
   }, [client, chatId, documentID, parseAs, enabled]);
@@ -77,4 +89,5 @@ const idle = {
   isLoading: false,
   isError: false,
   contentType: null,
+  progress: null,
 } as const;

--- a/crates/openwave-desktop/ui/src/components/document/xml-viewer.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/xml-viewer.tsx
@@ -22,6 +22,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { FileDownloadProgressIndicator } from "./FileDownloadProgress";
 import { useFileDownload } from "./useFileDownload";
 import { cn } from "@/lib/utils";
 
@@ -293,7 +294,11 @@ export function XmlViewer({
         className={cn("flex items-center justify-center", className)}
         {...props}
       >
-        <Loader2Icon className="text-muted-foreground size-6 animate-spin" />
+        {fileDownload.progress ? (
+          <FileDownloadProgressIndicator progress={fileDownload.progress} />
+        ) : (
+          <Loader2Icon className="text-muted-foreground size-6 animate-spin" />
+        )}
       </div>
     );
   }

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
@@ -62,10 +62,12 @@ describe("DocumentDetailRoot", () => {
       "src",
       "blob:document",
     );
+    // Addressed by document id inside its conversation, never by a host path.
     expect(client.getChatDocumentFile).toHaveBeenCalledWith(
       "chat-1",
       "doc-1",
       expect.anything(),
+      expect.any(Function),
     );
 
     await user.click(screen.getByRole("button", { name: "Download" }));

--- a/crates/openwave-desktop/ui/src/document/PdfViewer.tsx
+++ b/crates/openwave-desktop/ui/src/document/PdfViewer.tsx
@@ -14,7 +14,8 @@ import { Document, Page, pdfjs } from "react-pdf";
 // security policy. Vite emits the file and rewrites this to its final URL.
 import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
 
-import type { ApiClient } from "@/api";
+import type { ApiClient, FileDownloadProgress } from "@/api";
+import { FileDownloadProgressIndicator } from "@/components/document/FileDownloadProgress";
 import { Button } from "@/components/ui/button";
 import { useRegisterPdfControls } from "@/document/PdfControlsContext";
 import { usePdfPageState } from "@/document/usePdfPageState";
@@ -77,6 +78,7 @@ export function PdfViewer({
   const [bytes, setBytes] = useState<Uint8Array | null>(null);
   const [loadFailed, setLoadFailed] = useState(false);
   const [numPages, setNumPages] = useState(0);
+  const [progress, setProgress] = useState<FileDownloadProgress | null>(null);
 
   // Reset scale, error state and page count on document change.
   useEffect(() => {
@@ -88,13 +90,20 @@ export function PdfViewer({
   useEffect(() => {
     const abort = new AbortController();
     setBytes(null);
+    setProgress(null);
     void client
-      .getDocumentFileContent(documentId, abort.signal)
+      .getDocumentFileContent(documentId, abort.signal, (next) => {
+        if (!abort.signal.aborted) setProgress(next);
+      })
       .then((data) => {
-        if (!abort.signal.aborted) setBytes(data);
+        if (abort.signal.aborted) return;
+        setBytes(data);
+        setProgress(null);
       })
       .catch(() => {
-        if (!abort.signal.aborted) setLoadFailed(true);
+        if (abort.signal.aborted) return;
+        setLoadFailed(true);
+        setProgress(null);
       });
     return () => abort.abort();
   }, [client, documentId]);
@@ -304,10 +313,14 @@ export function PdfViewer({
             }
           }}
           noData={
-            <div className="flex items-center justify-center gap-2">
-              Fetching document…
-              <Loader2Icon className="size-4 animate-spin" />
-            </div>
+            progress ? (
+              <FileDownloadProgressIndicator progress={progress} />
+            ) : (
+              <div className="flex items-center justify-center gap-2">
+                Fetching document…
+                <Loader2Icon className="size-4 animate-spin" />
+              </div>
+            )
           }
           loading={
             <div className="flex justify-center">

--- a/crates/openwave-desktop/ui/src/document/UniverDocumentViewer.tsx
+++ b/crates/openwave-desktop/ui/src/document/UniverDocumentViewer.tsx
@@ -10,6 +10,7 @@ import { useEffect, useRef, useState } from "react";
 import type { ApiClient } from "@/api";
 import { cn } from "@/lib/utils";
 import { docxToUniver } from "./docx-to-univer";
+import { FileDownloadProgressIndicator } from "@/components/document/FileDownloadProgress";
 import { useFileDownload } from "./useFileDownload";
 
 // The MODERN flavor hardcodes page width to 595/0.75 ≈ 793px. To fill the
@@ -154,14 +155,18 @@ export default function UniverDocumentViewer({
       <style dangerouslySetInnerHTML={{ __html: UNIVER_VIEWER_STYLES }} />
       {isLoading && (
         <div className="bg-background/80 absolute inset-0 z-10 flex items-center justify-center">
-          <div className="text-muted-foreground flex flex-col items-center gap-2">
-            <Loader2Icon className="size-6 animate-spin" />
-            <p>
-              {fileDownload.isLoading
-                ? "Loading document…"
-                : "Reading document…"}
-            </p>
-          </div>
+          {fileDownload.progress ? (
+            <FileDownloadProgressIndicator progress={fileDownload.progress} />
+          ) : (
+            <div className="text-muted-foreground flex flex-col items-center gap-2">
+              <Loader2Icon className="size-6 animate-spin" />
+              <p>
+                {fileDownload.isLoading
+                  ? "Loading document…"
+                  : "Reading document…"}
+              </p>
+            </div>
+          )}
         </div>
       )}
       <div

--- a/crates/openwave-desktop/ui/src/document/UniverSpreadsheetViewer.tsx
+++ b/crates/openwave-desktop/ui/src/document/UniverSpreadsheetViewer.tsx
@@ -20,6 +20,7 @@ import { resolveTheme } from "@/theme";
 import UniverFormulaWorker from "@/workers/univer-formula.worker?worker&inline";
 import { SpreadsheetShortcutsInfoBar } from "./SpreadsheetShortcutsInfo";
 import { parseCellAddress } from "./spreadsheet";
+import { FileDownloadProgressIndicator } from "@/components/document/FileDownloadProgress";
 import { useFileDownload } from "./useFileDownload";
 import { useUniverWorker } from "./useUniverWorker";
 
@@ -360,7 +361,11 @@ export default function UniverSpreadsheetViewer({
   if (fileDownload.isLoading) {
     return (
       <div className={cn("relative overflow-auto", className)} {...restProps}>
-        <ViewerMessage spinner>Loading spreadsheet…</ViewerMessage>
+        {fileDownload.progress ? (
+          <FileDownloadProgressIndicator progress={fileDownload.progress} />
+        ) : (
+          <ViewerMessage spinner>Loading spreadsheet…</ViewerMessage>
+        )}
       </div>
     );
   }

--- a/crates/openwave-desktop/ui/src/document/useFileDownload.ts
+++ b/crates/openwave-desktop/ui/src/document/useFileDownload.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import type { ApiClient } from "@/api";
+import type { ApiClient, FileDownloadProgress } from "@/api";
 
 /**
  * A source document's original bytes, held for the life of the process.
@@ -16,6 +16,12 @@ export type FileDownload = {
   data: ArrayBuffer | null;
   isLoading: boolean;
   error: Error | null;
+  /**
+   * How far the transfer has got, or null when there is nothing to report — a
+   * small file, a response that never declared its length, or a cache hit,
+   * which is instant and has no transfer to report on.
+   */
+  progress: FileDownloadProgress | null;
 };
 
 export function useFileDownload(
@@ -27,6 +33,7 @@ export function useFileDownload(
   );
   const [error, setError] = useState<Error | null>(null);
   const [isLoading, setIsLoading] = useState(!byteCache.has(documentId));
+  const [progress, setProgress] = useState<FileDownloadProgress | null>(null);
   const requestRef = useRef(0);
 
   useEffect(() => {
@@ -36,6 +43,7 @@ export function useFileDownload(
       setBytes(cached);
       setError(null);
       setIsLoading(false);
+      setProgress(null);
       return;
     }
 
@@ -43,12 +51,18 @@ export function useFileDownload(
     setBytes(null);
     setError(null);
     setIsLoading(true);
+    setProgress(null);
 
     void (async () => {
       try {
         const downloaded = await client.getDocumentFileContent(
           documentId,
           controller.signal,
+          (next) => {
+            if (!controller.signal.aborted && request === requestRef.current) {
+              setProgress(next);
+            }
+          },
         );
         if (request !== requestRef.current) return;
         byteCache.set(documentId, downloaded);
@@ -57,7 +71,10 @@ export function useFileDownload(
         if (controller.signal.aborted || request !== requestRef.current) return;
         setError(err instanceof Error ? err : new Error(String(err)));
       } finally {
-        if (request === requestRef.current) setIsLoading(false);
+        if (request === requestRef.current) {
+          setIsLoading(false);
+          setProgress(null);
+        }
       }
     })();
 
@@ -72,5 +89,5 @@ export function useFileDownload(
     ) as ArrayBuffer;
   }, [bytes]);
 
-  return { data, isLoading, error };
+  return { data, isLoading, error, progress };
 }


### PR DESCRIPTION
Opening a large original showed a bare spinner for as long as the transfer took, with no way to tell whether it was progressing or hung.

## Why this wasn't a one-component change

Every download awaited the whole body — `ApiClient.blob` returned `response.blob()` — so there was no intermediate state to report. The bytes are now read as a stream in one place, `streamBytes`, and both document endpoints go through it.

That placement matters because there are **three** download paths, and the formats where waiting is actually felt don't use the one you'd guess:

| path | used by |
| --- | --- |
| `components/document/useFileDownload` | markdown, image, JSON, XML |
| `document/useFileDownload` (byte-cached) | spreadsheets, Word documents |
| `PdfViewer`'s own effect | PDFs |

Putting the streaming in the client rather than in a hook means all three report from one implementation. (The duplication itself is #678 and is untouched here — this change doesn't make it worse or better, it just declines to pick a side.)

## When the spinner stays

Each viewer keeps its spinner as the fallback, because there are two cases with nothing to report:

- **No `Content-Length`.** No total, so no fraction. A byte count climbing toward an unknown end isn't worth a bar.
- **Under 2 MB.** The bar would appear and vanish, which reads worse than no bar. The threshold sits well under the 16 MB a source may be, so files big enough to wait on still report. Worth knowing: most sources here come from a sidecar on the same machine, and the threshold is what keeps that case quiet — this feature mostly earns its keep in gateway/managed mode.

## One subtlety worth flagging

Progress callbacks are throttled to 100 ms, and the throttle **always lets the final one through**. Without that the bar visibly stops short of the end, because the last chunk usually lands inside the previous chunk's throttle window. There's a test for exactly that (`expect(seen.at(-1)).toBe(3 * 1024 * 1024)`) since it's the kind of thing that looks fine in code review and wrong on screen.

## Incidental

Three copies of the same failed-response error extraction folded into one `throwIfNotOk` — routing both endpoints through `streamBytes` would otherwise have created a fourth.

## Tests

Four over `streamBytes`, driven through a real `ReadableStream` rather than a mocked client: reports against the declared length and ends on the total; stays quiet under the threshold; stays quiet with no `Content-Length`; and surfaces the server's own message on a refused transfer. Plus the media type surviving reassembly from chunks, which is what the viewers dispatch on.

One existing assertion loosened — `getChatDocumentFile` had its arity pinned at three args and now takes an optional fourth.

## Not verified

Not driven in the packaged app, and this is the change where that gap is widest: I have not watched a real bar fill. Against the local sidecar most sources won't cross the 2 MB threshold at all, so the honest test is a >2 MB source over a gateway, which I haven't run. The logic is covered by unit tests through a real stream; the visible behaviour is not.

Closes #799
Part of #703