### PR TITLE
feat(desktop): retain what a tool call produced so its card survives a reload

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1873,11 +1873,12 @@ impl Agent {
                 (self.run_tool(chat, turn_id, call, events, None).await, true)
             }
         };
+        let preview = ToolResultPreview::build(&call.name, &output);
         events.send(AgentEvent::ToolCallCompleted {
             call_id: call.call_id,
             output: self.tool_output_for_event(&output, call.call_id),
             action: call_action_preview(call),
-            result: ToolResultPreview::build(&call.name, &output),
+            result: preview.clone(),
         });
         if needs_resolution {
             let resolution = if output.is_error {
@@ -1902,6 +1903,7 @@ impl Agent {
                     call.call_id,
                     &resolution,
                     &output.private_evidence,
+                    preview.as_ref(),
                 )
                 .await?;
             if !matches!(
@@ -2213,18 +2215,25 @@ impl Agent {
         call_id: CallId,
         resolution: &ToolCallResolution,
         evidence: &[crate::RetrievalEvidenceInput],
+        preview: Option<&ToolResultPreview>,
     ) -> Result<ResolveToolCallOutcome> {
         let resolved_at = Utc::now();
         let Some(lease_token) = self.durable_steer_lease else {
             return self
                 .store
-                .resolve_server_tool_call_with_evidence(call_id, resolution, resolved_at, evidence)
+                .resolve_server_tool_call_with_artifacts(
+                    call_id,
+                    resolution,
+                    resolved_at,
+                    evidence,
+                    preview,
+                )
                 .await;
         };
         loop {
             match self
                 .store
-                .resolve_claimed_server_tool_call_with_evidence(
+                .resolve_claimed_server_tool_call_with_artifacts(
                     call_id,
                     chat_id,
                     turn_id,
@@ -2233,6 +2242,7 @@ impl Agent {
                     resolution,
                     resolved_at,
                     evidence,
+                    preview,
                 )
                 .await
             {

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -1015,6 +1015,10 @@ pub mod tool_call {
         pub execution: String,
         pub status: String,
         pub result: Option<String>,
+        /// The closed renderer projection of what this call produced, as it
+        /// crossed the boundary live. `None` for a call that projected none.
+        #[sea_orm(column_type = "JsonBinary", nullable)]
+        pub result_preview: Option<Json>,
         pub error_code: Option<String>,
         pub error_detail: Option<String>,
         pub approval_status: Option<String>,

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -33,7 +33,58 @@ impl MigratorTrait for Migrator {
             Box::new(AddStandingToolGrants),
             Box::new(AddContextCheckpointUsage),
             Box::new(AddAgentRunModel),
+            Box::new(AddToolResultPreviews),
         ]
+    }
+}
+
+/// Retains the renderer projection of what a tool call produced.
+///
+/// Terminal activity was rebuilt from the stored failure code alone, which
+/// recovers one enumerated setup signal and nothing else — so reopening a chat
+/// lost every result card, including a command's own output. The projection is
+/// already closed and clamped when it is built, so what lands here is exactly
+/// what crossed the boundary live and nothing more.
+///
+/// Deliberately the *projected* form rather than the tool output it was built
+/// from. Brightwave persists the internal result and projects on read, which
+/// lets the projection change without a migration; that trade needs a boundary
+/// that keeps arbitrary tool data out on the way *out*, and ours keeps it out
+/// on the way *in*. Storing only what already crossed means a later bug in the
+/// read path has nothing to leak.
+///
+/// Nullable because every call resolved before this migration has no projection
+/// to recover, and because most calls never project one at all.
+struct AddToolResultPreviews;
+
+impl MigrationName for AddToolResultPreviews {
+    fn name(&self) -> &str {
+        "m20260728_000020_add_tool_result_previews"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddToolResultPreviews {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ToolCall::Table)
+                    .add_column(ColumnDef::new(ToolCall::ResultPreview).json_binary())
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(ToolCall::Table)
+                    .drop_column(ToolCall::ResultPreview)
+                    .to_owned(),
+            )
+            .await
     }
 }
 
@@ -6565,6 +6616,7 @@ enum ToolCall {
     Execution,
     Status,
     Result,
+    ResultPreview,
     ErrorCode,
     ErrorDetail,
     ApprovalStatus,

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -2760,6 +2760,54 @@ impl Store for DbStore {
             resolution,
             resolved_at,
             evidence,
+            None,
+        )
+        .await
+    }
+
+    async fn resolve_server_tool_call_with_artifacts(
+        &self,
+        id: CallId,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<Utc>,
+        evidence: &[crate::RetrievalEvidenceInput],
+        preview: Option<&crate::ToolResultPreview>,
+    ) -> Result<ResolveToolCallOutcome> {
+        ops::client_execution::resolve_server_tool_call_with_evidence(
+            self,
+            id,
+            resolution,
+            resolved_at,
+            evidence,
+            preview,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn resolve_claimed_server_tool_call_with_artifacts(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<Utc>,
+        evidence: &[crate::RetrievalEvidenceInput],
+        preview: Option<&crate::ToolResultPreview>,
+    ) -> Result<ResolveToolCallOutcome> {
+        ops::client_execution::resolve_claimed_server_tool_call_with_evidence(
+            self,
+            id,
+            chat_id,
+            turn_id,
+            lease_token,
+            now,
+            resolution,
+            resolved_at,
+            evidence,
+            preview,
         )
         .await
     }
@@ -2786,6 +2834,7 @@ impl Store for DbStore {
             resolution,
             resolved_at,
             evidence,
+            None,
         )
         .await
     }

--- a/crates/openwave-core/src/db/ops/client_execution.rs
+++ b/crates/openwave-core/src/db/ops/client_execution.rs
@@ -62,6 +62,7 @@ pub(in crate::db) async fn accept_tool_call(
         execution: Set(call.execution.as_str().into()),
         status: Set(ToolCallStatus::Pending.as_str().into()),
         result: Set(None),
+        result_preview: Set(None),
         error_code: Set(None),
         error_detail: Set(None),
         approval_status: Set(None),
@@ -143,6 +144,7 @@ pub(in crate::db) async fn accept_claimed_tool_call(
         execution: Set(call.execution.as_str().into()),
         status: Set(ToolCallStatus::Pending.as_str().into()),
         result: Set(None),
+        result_preview: Set(None),
         error_code: Set(None),
         error_detail: Set(None),
         approval_status: Set(None),
@@ -294,6 +296,7 @@ pub(in crate::db) async fn resolve_server_tool_call(
         resolved_at,
         resolution,
         None,
+        None,
     )
     .await?
     .outcome)
@@ -305,6 +308,7 @@ pub(in crate::db) async fn resolve_server_tool_call_with_evidence(
     resolution: &ToolCallResolution,
     resolved_at: DateTime<Utc>,
     evidence: &[RetrievalEvidenceInput],
+    preview: Option<&crate::ToolResultPreview>,
 ) -> Result<ResolveToolCallOutcome> {
     Ok(resolve_tool_call(
         store,
@@ -313,6 +317,7 @@ pub(in crate::db) async fn resolve_server_tool_call_with_evidence(
         resolved_at,
         resolution,
         Some(evidence),
+        preview,
     )
     .await?
     .outcome)
@@ -329,6 +334,7 @@ pub(in crate::db) async fn resolve_claimed_server_tool_call_with_evidence(
     resolution: &ToolCallResolution,
     resolved_at: DateTime<Utc>,
     evidence: &[RetrievalEvidenceInput],
+    preview: Option<&crate::ToolResultPreview>,
 ) -> Result<ResolveToolCallOutcome> {
     Ok(resolve_tool_call(
         store,
@@ -343,6 +349,7 @@ pub(in crate::db) async fn resolve_claimed_server_tool_call_with_evidence(
         resolved_at,
         resolution,
         Some(evidence),
+        preview,
     )
     .await?
     .outcome)
@@ -371,6 +378,7 @@ pub(in crate::db) async fn abandon_inherited_server_tool_call(
         },
         resolved_at,
         resolution,
+        None,
         None,
     )
     .await?
@@ -413,6 +421,7 @@ pub(in crate::db) async fn resolve_client_tool_call_and_append_event(
         resolved_at,
         resolution,
         None,
+        None,
     )
     .await
 }
@@ -442,6 +451,7 @@ pub(in crate::db) async fn resolve_expired_client_tool_call_and_append_event(
         resolved_at,
         resolution,
         None,
+        None,
     )
     .await
 }
@@ -468,6 +478,7 @@ async fn resolve_tool_call(
     resolved_at: DateTime<Utc>,
     resolution: &ToolCallResolution,
     evidence: Option<&[RetrievalEvidenceInput]>,
+    preview: Option<&crate::ToolResultPreview>,
 ) -> Result<JournaledClientToolCallOutcome> {
     validate_resolution(resolution)?;
     let resolved_at = canonical_db_timestamp(resolved_at)?;
@@ -598,6 +609,10 @@ async fn resolve_tool_call(
     let mut active: entities::tool_call::ActiveModel = existing.into();
     active.status = Set(resolution.status().as_str().into());
     active.result = Set(Some(resolution.result().to_owned()));
+    // Serialization of a closed, already-clamped projection cannot fail in
+    // practice; a store write is the wrong place to panic if it ever did, and
+    // losing the card is the whole cost.
+    active.result_preview = Set(preview.and_then(|preview| serde_json::to_value(preview).ok()));
     active.error_code = Set(error_code);
     active.error_detail = Set(error_detail);
     active.client_lease_expires_at = Set(None);

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -774,12 +774,21 @@ where
         .map_err(store_err)?
         .into_iter()
         .filter(|call| terminal_turn_ids.contains(&call.turn_id))
-        .map(super::client_execution::tool_call_from_model)
-        .map(|call| call.map(tool_activity_from_call))
+        .map(|model| {
+            // Read off the model before it is narrowed to a record: the
+            // projection is renderer state and has no place on the canonical
+            // tool-call record the rest of the store passes around.
+            let stored_preview = model.result_preview.clone();
+            super::client_execution::tool_call_from_model(model)
+                .map(|call| tool_activity_from_call(call, stored_preview))
+        })
         .collect::<Result<Vec<_>>>()
 }
 
-fn tool_activity_from_call(call: ToolCallRecord) -> ChatToolActivitySnapshot {
+fn tool_activity_from_call(
+    call: ToolCallRecord,
+    stored_preview: Option<serde_json::Value>,
+) -> ChatToolActivitySnapshot {
     let status = match call.status {
         crate::model::ToolCallStatus::Completed => ChatToolActivityStatus::Completed,
         crate::model::ToolCallStatus::Failed => ChatToolActivityStatus::Failed,
@@ -788,13 +797,30 @@ fn tool_activity_from_call(call: ToolCallRecord) -> ChatToolActivitySnapshot {
             unreachable!("pending tool calls are excluded from durable activity")
         }
     };
+    // A retained projection is what the call actually produced, so it outranks
+    // anything rebuilt from the failure code — that fallback exists for calls
+    // resolved before projections were retained at all.
+    let (result, result_unreadable) = match stored_preview {
+        Some(stored) => match serde_json::from_value(stored) {
+            Ok(preview) => (Some(preview), false),
+            // The union is allowed to move. A row that no longer parses is a
+            // result this build cannot show, which is a different fact from
+            // this call having produced none.
+            Err(_) => (None, true),
+        },
+        None => (
+            crate::preview::ToolResultPreview::from_stored_error(
+                &call.name,
+                call.error_code.as_deref(),
+            ),
+            false,
+        ),
+    };
     ChatToolActivitySnapshot {
         tool: crate::RendererToolName::from(call.name.as_str()),
         action: crate::preview::ToolActionPreview::build(&call.name, &call.arguments),
-        result: crate::preview::ToolResultPreview::from_stored_error(
-            &call.name,
-            call.error_code.as_deref(),
-        ),
+        result,
+        result_unreadable,
         background_agent_run_id: (call.name == crate::agent_tools::SPAWN_SANDBOX_AGENT_TOOL)
             .then(|| crate::AgentRunId::sandbox_for_spawn_call(call.id)),
         status,
@@ -1224,5 +1250,83 @@ fn role_from_db(text: &str) -> Result<Role> {
         "assistant" => Ok(Role::Assistant),
         "tool" => Ok(Role::Tool),
         other => Err(AgentError::Store(format!("unknown role: {other}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::id::CallId;
+    use crate::preview::{ResultEntry, ResultEntryKind, ToolResultPreview};
+
+    fn terminal_call(name: &str, error_code: Option<&str>) -> ToolCallRecord {
+        ToolCallRecord {
+            id: CallId::new(),
+            chat_id: ChatId::new(),
+            turn_id: crate::TurnId::new(),
+            provider_id: "provider".into(),
+            name: name.into(),
+            arguments: serde_json::json!({}),
+            execution: crate::model::ToolCallExecution::Server,
+            status: crate::model::ToolCallStatus::Completed,
+            result: Some("model-facing text".into()),
+            error_code: error_code.map(Into::into),
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
+            created_at: chrono::Utc::now(),
+            resolved_at: Some(chrono::Utc::now()),
+        }
+    }
+
+    /// The whole point of retaining a projection: reopening a chat shows the
+    /// card the reader saw live, rather than the muted rail line that used to
+    /// be all history could rebuild.
+    #[test]
+    fn a_retained_projection_comes_back_as_the_card_it_was() {
+        let stored = serde_json::to_value(ToolResultPreview::Entries {
+            entries: vec![ResultEntry::new(ResultEntryKind::File, "notes.md")],
+            failures: Vec::new(),
+            elided: 0,
+        })
+        .unwrap();
+        let activity = tool_activity_from_call(terminal_call("list_dir", None), Some(stored));
+        assert_eq!(
+            activity.result,
+            Some(ToolResultPreview::Entries {
+                entries: vec![ResultEntry::new(ResultEntryKind::File, "notes.md")],
+                failures: Vec::new(),
+                elided: 0,
+            })
+        );
+        assert!(!activity.result_unreadable);
+    }
+
+    /// The projection is a closed union that is allowed to move, so a row
+    /// written by an older build may no longer parse. Rendering nothing would
+    /// claim the call produced nothing, which is a different and untrue thing.
+    #[test]
+    fn a_projection_this_build_cannot_read_says_so_rather_than_vanishing() {
+        let activity = tool_activity_from_call(
+            terminal_call("list_dir", None),
+            Some(serde_json::json!({ "tool": "a_variant_from_the_future" })),
+        );
+        assert_eq!(activity.result, None);
+        assert!(activity.result_unreadable);
+    }
+
+    /// Calls that resolved before projections were retained still rebuild the
+    /// one enumerated signal history could always recover.
+    #[test]
+    fn a_call_with_no_retained_projection_falls_back_to_its_stored_signal() {
+        let activity = tool_activity_from_call(
+            terminal_call(crate::WEB_SEARCH_TOOL, Some("configuration_required")),
+            None,
+        );
+        assert_eq!(
+            activity.result,
+            Some(ToolResultPreview::WebSearchProviderRequired)
+        );
+        assert!(!activity.result_unreadable);
     }
 }

--- a/crates/openwave-core/src/db/ops/turn/client_wait.rs
+++ b/crates/openwave-core/src/db/ops/turn/client_wait.rs
@@ -146,6 +146,7 @@ pub(in crate::db) async fn park_turn_for_client_tool_call(
         execution: Set(checkpoint_execution(&call.name).as_str().into()),
         status: Set(ToolCallStatus::Pending.as_str().into()),
         result: Set(None),
+        result_preview: Set(None),
         error_code: Set(None),
         error_detail: Set(None),
         approval_status: Set(None),

--- a/crates/openwave-core/src/db/ops/turn/multi_agent_run_wait.rs
+++ b/crates/openwave-core/src/db/ops/turn/multi_agent_run_wait.rs
@@ -395,6 +395,7 @@ pub(in crate::db) async fn park_turn_for_agent_run_wait_set(
         execution: Set(ToolCallExecution::Orchestration.as_str().into()),
         status: Set(ToolCallStatus::Pending.as_str().into()),
         result: Set(None),
+        result_preview: Set(None),
         error_code: Set(None),
         error_detail: Set(None),
         approval_status: Set(None),

--- a/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
+++ b/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
@@ -223,6 +223,7 @@ where
         execution: Set(ToolCallExecution::Orchestration.as_str().into()),
         status: Set(ToolCallStatus::Completed.as_str().into()),
         result: Set(Some(request.result.clone())),
+        result_preview: Set(None),
         error_code: Set(None),
         error_detail: Set(None),
         approval_status: Set(None),

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -176,6 +176,17 @@ pub struct ChatToolActivitySnapshot {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub result: Option<crate::preview::ToolResultPreview>,
+    /// Set when this call retained a projection that no longer deserializes.
+    ///
+    /// The projection is a closed union that is allowed to move, and rows
+    /// written before a change may no longer parse against it. Distinguishing
+    /// that from "this call projected nothing" is the difference between a card
+    /// that says its result can no longer be shown and one that silently
+    /// vanishes — which would read as the call never having produced anything.
+    ///
+    /// A property of reading storage, not of the result: the live stream builds
+    /// its projection in memory and can never set this.
+    pub result_unreadable: bool,
     // Present only for the fixed `spawn_sandbox_agent` renderer tool. It lets
     // the transcript attach the durable child status without exposing a
     // canonical tool record, delegated task, or executor identity.
@@ -2610,6 +2621,26 @@ pub trait Store: Send + Sync {
             .await
     }
 
+    /// Resolve a server call, retaining its evidence and the renderer
+    /// projection of what it produced.
+    ///
+    /// Separate from [`Self::resolve_server_tool_call_with_evidence`] rather
+    /// than replacing it: most callers resolve a call that projects nothing,
+    /// and a store that cannot retain a projection should still resolve. The
+    /// default drops the projection, which costs the card on reload and
+    /// nothing else.
+    async fn resolve_server_tool_call_with_artifacts(
+        &self,
+        id: CallId,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+        evidence: &[crate::RetrievalEvidenceInput],
+        _preview: Option<&crate::ToolResultPreview>,
+    ) -> Result<ResolveToolCallOutcome> {
+        self.resolve_server_tool_call_with_evidence(id, resolution, resolved_at, evidence)
+            .await
+    }
+
     /// Resolve a server tool result and retain its evidence only if the same
     /// live turn lease that accepted the call still owns the turn. The result,
     /// evidence, and lease comparison commit atomically.
@@ -2626,6 +2657,34 @@ pub trait Store: Send + Sync {
         _evidence: &[crate::RetrievalEvidenceInput],
     ) -> Result<ResolveToolCallOutcome> {
         turn_storage_unavailable()
+    }
+
+    /// The claimed-lease counterpart of
+    /// [`Self::resolve_server_tool_call_with_artifacts`].
+    #[allow(clippy::too_many_arguments)]
+    async fn resolve_claimed_server_tool_call_with_artifacts(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        turn_id: TurnId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+        evidence: &[crate::RetrievalEvidenceInput],
+        _preview: Option<&crate::ToolResultPreview>,
+    ) -> Result<ResolveToolCallOutcome> {
+        self.resolve_claimed_server_tool_call_with_evidence(
+            id,
+            chat_id,
+            turn_id,
+            lease_token,
+            now,
+            resolution,
+            resolved_at,
+            evidence,
+        )
+        .await
     }
 
     /// Resolve a pending server call recovered at worker startup without

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -37,6 +37,7 @@ describe("terminal transcript presentation", () => {
       tool_activity: [
         {
           tool: "spawn_sandbox_agent",
+          result_unreadable: false,
           status: "completed",
           started_at: "2026-07-27T12:00:00Z",
           finished_at: "2026-07-27T12:00:01Z",
@@ -62,6 +63,7 @@ describe("terminal transcript presentation", () => {
         {
           tool: "web_search",
           result: { tool: "web_search_provider_required" },
+          result_unreadable: false,
           status: "failed",
           started_at: "2026-07-27T12:00:00Z",
           finished_at: "2026-07-27T12:00:01Z",

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -74,6 +74,8 @@ export type ChatMessage =
       preview?: ToolActionPreview | null;
       /** What the call produced, once it has produced anything. */
       result?: ToolResultPreview | null;
+      /** Set when a retained projection no longer parses against this build. */
+      resultUnreadable?: boolean;
     }
   | {
       id: string;
@@ -524,6 +526,21 @@ function surfacedCards(
       continue;
     }
     if (entry.role !== "tool") continue;
+    // A call whose retained projection this build can no longer read. Saying so
+    // beats rendering nothing: the alternative reads as a call that produced
+    // no result, which is a different and untrue claim.
+    if (entry.resultUnreadable && !parked.has(entry.callId)) {
+      cards.push(
+        <p
+          key={entry.id}
+          className="text-muted-foreground bg-muted max-w-prose rounded-md px-3 py-2 text-xs"
+          role="status"
+        >
+          This tool completed, but its result can no longer be displayed.
+        </p>,
+      );
+      continue;
+    }
     if (
       entry.result?.tool === "web_search_provider_required" &&
       !parked.has(entry.callId)

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
@@ -23,6 +23,7 @@ describe("hydrateTranscriptHistory", () => {
       [
         {
           tool: "web_search",
+          result_unreadable: false,
           status: "completed",
           started_at: "2026-07-16T10:00:01Z",
           finished_at: "2026-07-16T10:00:01Z",
@@ -46,12 +47,14 @@ describe("hydrateTranscriptHistory", () => {
     const entries = hydrateTranscriptHistory([], [
       {
         tool: "spawn_sandbox_agent",
+        result_unreadable: false,
         status: "completed",
         started_at: "2026-07-16T10:00:00Z",
         finished_at: "2026-07-16T10:00:00Z",
       },
       {
         tool: "wait_for_agents",
+        result_unreadable: false,
         status: "completed",
         started_at: "2026-07-16T10:00:01Z",
         finished_at: "2026-07-16T10:00:02Z",
@@ -69,6 +72,7 @@ describe("hydrateTranscriptHistory", () => {
     const entries = hydrateTranscriptHistory([], [
       {
         tool: "ask_user_questions",
+        result_unreadable: false,
         status: "completed",
         started_at: "2026-07-16T10:00:00Z",
         finished_at: "2026-07-16T10:00:01Z",
@@ -84,6 +88,7 @@ describe("hydrateTranscriptHistory", () => {
     const entries = hydrateTranscriptHistory([], [
       {
         tool: "read_delegated_file",
+        result_unreadable: false,
         status: "completed",
         started_at: "2026-07-16T10:00:00Z",
         finished_at: "2026-07-16T10:00:01Z",
@@ -100,18 +105,21 @@ describe("hydrateTranscriptHistory", () => {
     const entries = hydrateTranscriptHistory([], [
       {
         tool: "list_sources",
+        result_unreadable: false,
         status: "completed",
         started_at: "2026-07-16T10:00:00Z",
         finished_at: "2026-07-16T10:00:00Z",
       },
       {
         tool: "read_source",
+        result_unreadable: false,
         status: "completed",
         started_at: "2026-07-16T10:00:01Z",
         finished_at: "2026-07-16T10:00:01Z",
       },
       {
         tool: "search",
+        result_unreadable: false,
         status: "completed",
         started_at: "2026-07-16T10:00:02Z",
         finished_at: "2026-07-16T10:00:02Z",
@@ -129,6 +137,7 @@ describe("hydrateTranscriptHistory", () => {
     const entries = hydrateTranscriptHistory([], [
       {
         tool: "create_deliverable",
+        result_unreadable: false,
         status: "completed",
         started_at: "2026-07-16T10:00:00Z",
         finished_at: "2026-07-16T10:00:01Z",
@@ -206,6 +215,7 @@ describe("hydrateTranscriptHistory", () => {
     const [entry] = hydrateTranscriptHistory([], [
       {
         tool: "other",
+        result_unreadable: false,
         status: "failed",
         started_at: "2026-07-16T10:00:00Z",
         finished_at: null,

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -91,6 +91,10 @@ export function hydrateTranscriptHistory(
       // Arbitrary result text stays server-side. A tool can retain only a
       // closed renderer result such as an actionable configuration signal.
       result: parseToolResultPreview(activity.result),
+      // A projection the server retained but this build cannot read is a
+      // different fact from a call that projected nothing, and the card says so
+      // rather than silently showing no result at all.
+      resultUnreadable: activity.result_unreadable,
       createdAt: activity.started_at,
     })),
   ];

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -210,7 +210,20 @@ action?: ToolActionPreview,
  * Closed projection of an actionable result. Arbitrary result text is
  * never included.
  */
-result?: ToolResultPreview, background_agent_run_id?: AgentRunId, status: ChatToolActivityStatus, started_at: string, finished_at: string | null, };
+result?: ToolResultPreview, 
+/**
+ * Set when this call retained a projection that no longer deserializes.
+ *
+ * The projection is a closed union that is allowed to move, and rows
+ * written before a change may no longer parse against it. Distinguishing
+ * that from "this call projected nothing" is the difference between a card
+ * that says its result can no longer be shown and one that silently
+ * vanishes — which would read as the call never having produced anything.
+ *
+ * A property of reading storage, not of the result: the live stream builds
+ * its projection in memory and can never set this.
+ */
+result_unreadable: boolean, background_agent_run_id?: AgentRunId, status: ChatToolActivityStatus, started_at: string, finished_at: string | null, };
 
 /**
  * Fixed lifecycle vocabulary exposed for a historical tool card.

--- a/crates/openwave-server/src/tests/conversations.rs
+++ b/crates/openwave-server/src/tests/conversations.rs
@@ -719,6 +719,108 @@ async fn chat_transcript_replays_only_visible_durable_messages() {
 }
 
 #[tokio::test]
+async fn a_retained_result_projection_survives_reopening_the_chat() {
+    // Terminal activity used to be rebuilt from the stored failure code alone,
+    // which recovers one enumerated setup signal and nothing else — so every
+    // result card vanished on reload, including a command's own output. The
+    // projection is now retained with the resolution and comes back with it.
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+
+    assert_eq!(
+        send_message(&router, &bearer, chat.id, "finish a turn first").await,
+        StatusCode::ACCEPTED
+    );
+    wait_for_turn(&store, chat.id).await;
+    let turn = store
+        .list_turn_runs(chat.id)
+        .await
+        .unwrap()
+        .into_iter()
+        .next()
+        .expect("accepted turn exists");
+
+    let call_id = CallId::new();
+    let started_at = chrono::Utc::now();
+    store
+        .accept_tool_call(&ToolCallRecord {
+            id: call_id,
+            chat_id: chat.id,
+            turn_id: turn.id,
+            provider_id: "provider-list".into(),
+            name: "list_dir".into(),
+            arguments: serde_json::json!({ "path": "reports" }),
+            execution: ToolCallExecution::Server,
+            status: ToolCallStatus::Pending,
+            result: None,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
+            created_at: started_at,
+            resolved_at: None,
+        })
+        .await
+        .unwrap();
+    let preview = openwave_core::ToolResultPreview::Entries {
+        entries: vec![openwave_core::ResultEntry::new(
+            openwave_core::ResultEntryKind::File,
+            "q3.md",
+        )],
+        failures: vec![openwave_core::ResultFailure::new("q4.md", "unreadable")],
+        elided: 0,
+    };
+    assert_eq!(
+        store
+            .resolve_server_tool_call_with_artifacts(
+                call_id,
+                &ToolCallResolution::Completed {
+                    result: "private model-facing listing".into(),
+                },
+                started_at + chrono::Duration::seconds(1),
+                &[],
+                Some(&preview),
+            )
+            .await
+            .unwrap(),
+        openwave_core::ResolveToolCallOutcome::Resolved
+    );
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(format!("/chats/{}/messages", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = String::from_utf8(
+        to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .to_vec(),
+    )
+    .unwrap();
+    // The model-facing result text is not what came back — only the projection.
+    assert!(!body.contains("private model-facing listing"));
+    let transcript: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let card = transcript["tool_activity"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|card| card["tool"] == "list_dir")
+        .expect("the listing is in terminal activity");
+    assert_eq!(card["result"]["tool"], "entries");
+    assert_eq!(card["result"]["entries"][0]["label"], "q3.md");
+    assert_eq!(card["result"]["failures"][0]["error"], "unreadable");
+    assert_eq!(card["result_unreadable"], serde_json::json!(false));
+}
+
+#[tokio::test]
 async fn transcript_tool_activity_is_allowlisted_and_redacts_canonical_tool_data() {
     let (router, token, store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");


### PR DESCRIPTION
Follows #800 and #805. Terminal activity was rebuilt from the stored failure
code alone:

```rust
result: ToolResultPreview::from_stored_error(&call.name, call.error_code.as_deref()),
```

which recovers exactly one enumerated setup signal and nothing else. Reopening a
chat lost every result card — including a command's own output, which predates
the listed-result cards entirely.

## What lands

A nullable `result_preview` column, written with the resolution in the same
transaction, so a card cannot outlive or precede the outcome it describes. The
agent builds the projection once and uses it for both the live event and the
write — the card on reload is the same one the reader saw live, not a second
guess at it.

## Storing the projection, not the output — a deliberate split from alpha

Brightwave persists the *internal* result and projects on read through
`client_result_dump()`. That lets the projection change without a migration, and
it works there because the boundary is default-open: `model_dump()` unless a
subclass excludes something.

Ours is default-closed — we enumerate what may cross. Persisting raw tool output
and filtering on the way out would move the guarantee from "never stored" to
"correctly filtered on every read", which is strictly weaker. So what lands in
the column is what already crossed the boundary, already clamped, and a later
bug in the read path has nothing to leak.

## The cost of that choice, and alpha's answer to it

Storing the projected form means rows written by an older build may stop parsing
when the union moves. Brightwave handles exactly this with `result_unreadable`
and a card reading "this tool completed successfully, but its result format has
changed and can no longer be displayed" — re-validation on read, no versioning
of stored payloads. Same answer here, same reasoning: rendering nothing would
claim the call produced nothing, which is a different and untrue thing.

`result_unreadable` is a property of *reading storage*, not of the result. The
live stream builds its projection in memory and can never set it.

## Threading

New `resolve_*_with_artifacts` store methods beside the existing
`_with_evidence` ones, rather than widening five signatures already carrying
`#[allow(clippy::too_many_arguments)]`. Defaults delegate and drop the
projection, so a store that cannot retain one still resolves — the cost is the
card on reload and nothing else. This is how the trait already grows.

Putting the projection on `ToolCallResolution` would have been the tidier home,
but it is a struct-variant enum with 41 literal construction sites, most of them
tests.

## Still not covered

Client-executed calls retain nothing. `ClientExecutionResolution` is:

```rust
Completed { result: String }
```

No structured channel — the desktop already builds `{"status":"ok","folders":[…]}`
and then stringifies it away for the model. Widening that wire is what the
connected-folder tools need, and it now has a column to land in.

## Tests

Three on the read path: a retained projection comes back as the card it was; a
stored shape this build cannot parse sets `result_unreadable` instead of
vanishing; a call with no retained projection still falls back to the enumerated
signal, so chats resolved before this migration are unaffected.

One end-to-end through the HTTP transcript — resolve a `list_dir` with entries
and a failure, refetch, assert the card comes back and the model-facing result
text still does not.

Refs #783