### PR TITLE
feat(desktop): open a citation at the passage it quoted

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -415,6 +415,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
           <DocumentDetailRoot
             chatId={chatId}
             documentID={panel.documentId}
+            citationId={panel.citationId}
             position={side}
           />
         ) : (

--- a/crates/openwave-desktop/ui/src/components/document/citationSpan.ts
+++ b/crates/openwave-desktop/ui/src/components/document/citationSpan.ts
@@ -1,0 +1,54 @@
+/** A citation's half-open byte range in a document's canonical text. */
+export type CitationSpan = { start: number; end: number };
+
+/** A half-open range of JavaScript string indices. */
+export type CharRange = { start: number; end: number };
+
+/**
+ * Where a citation's byte span falls in the JavaScript string holding the same
+ * text.
+ *
+ * Spans are UTF-8 byte offsets, which is how the text of record is indexed
+ * where it is produced; a JavaScript string is indexed by UTF-16 code unit. The
+ * two agree only while the text stays ASCII, so a single accent or emoji before
+ * the citation would otherwise shift the highlight off the passage. The walk
+ * stops at the end of the span rather than scanning the whole document, so the
+ * cost is the offset rather than the file.
+ *
+ * Returns `null` for a span that does not describe a passage in this text — an
+ * empty range, or one starting past the end because the document was re-read
+ * since the citation was made. The document is still worth opening in that
+ * case, just not at a position invented for it.
+ */
+export function charRangeForByteSpan(
+  text: string,
+  span: CitationSpan,
+): CharRange | null {
+  if (!Number.isSafeInteger(span.start) || !Number.isSafeInteger(span.end)) return null;
+  if (span.start < 0 || span.end <= span.start) return null;
+
+  let byte = 0;
+  let index = 0;
+  let start: number | null = null;
+  while (index < text.length) {
+    if (start === null && byte >= span.start) start = index;
+    if (byte >= span.end) break;
+    const codePoint = text.codePointAt(index)!;
+    byte += utf8Length(codePoint);
+    index += codePoint > 0xffff ? 2 : 1;
+  }
+
+  if (start === null) {
+    if (byte < span.start) return null;
+    start = text.length;
+  }
+  const end = Math.min(index, text.length);
+  return end > start ? { start, end } : null;
+}
+
+function utf8Length(codePoint: number): number {
+  if (codePoint < 0x80) return 1;
+  if (codePoint < 0x800) return 2;
+  if (codePoint < 0x10000) return 3;
+  return 4;
+}

--- a/crates/openwave-desktop/ui/src/components/document/document-details.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/document-details.tsx
@@ -1,5 +1,5 @@
 import { Loader2Icon } from "lucide-react";
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef } from "react";
 
 import type { DocumentDetail } from "@/api";
 import { useApp } from "@/AppContext";
@@ -7,6 +7,7 @@ import {
   DocumentViewer,
   hasOriginalViewer,
 } from "@/document/DocumentViewer";
+import { charRangeForByteSpan, type CitationSpan } from "./citationSpan";
 import { DocumentError } from "./error";
 import { ImageViewer } from "./image-viewer";
 import { MarkdownViewer, type HighlightRange } from "./markdown-viewer";
@@ -73,6 +74,14 @@ type DocumentDetailsProps = {
    * dot-notation path for JSON, an XPath expression for XML.
    */
   highlightPath?: string;
+  /**
+   * Byte range in the extracted text to highlight and scroll to, when opened
+   * from a citation. Distinct from `highlightRange`, which addresses characters
+   * of the original file rather than bytes of the text read out of it.
+   */
+  citationSpan?: CitationSpan;
+  /** Page of a paginated original to open on, when opened from a citation. */
+  targetPage?: number;
 };
 
 /**
@@ -92,6 +101,8 @@ export function DocumentDetails({
   hasOriginalDocumentTab,
   highlightRange,
   highlightPath,
+  citationSpan,
+  targetPage,
 }: DocumentDetailsProps) {
   const { client } = useApp();
   const type = baseMediaType(info.media_type);
@@ -106,6 +117,7 @@ export function DocumentDetails({
               client={client}
               documentId={info.document_id}
               mediaType={type}
+              targetPage={targetPage}
               className="bg-page-background grow p-4 pt-2"
             />
           ) : type.startsWith("image/") ? (
@@ -143,7 +155,9 @@ export function DocumentDetails({
           )}
         </>
       )}
-      {view === "extracted_text" && <ExtractedText info={info} />}
+      {view === "extracted_text" && (
+        <ExtractedText info={info} citationSpan={citationSpan} />
+      )}
 
     </div>
   );
@@ -160,11 +174,36 @@ function ViewerLoading() {
 /**
  * The text of record, rendered as one contiguous run rather than paginated.
  *
- * That is deliberate: citation offsets index into this exact string, so the
- * day a citation has to be scrolled to and highlighted there is a single text
- * node to find the offset in.
+ * That is what makes a citation reachable: its offsets index into this exact
+ * string, so the cited passage is a slice of the rendered content rather than
+ * something to go looking for. A citation splits the run in three around the
+ * passage, which changes nothing about how it reads or wraps.
  */
-function ExtractedText({ info }: { info: DocumentDetail }) {
+function ExtractedText({
+  info,
+  citationSpan,
+}: {
+  info: DocumentDetail;
+  citationSpan?: CitationSpan;
+}) {
+  // The span is derived afresh from the transcript on every update it makes, so
+  // the offsets are what this depends on rather than the object holding them.
+  const spanStart = citationSpan?.start;
+  const spanEnd = citationSpan?.end;
+  const cited = useMemo(
+    () =>
+      spanStart != null && spanEnd != null
+        ? charRangeForByteSpan(info.content, { start: spanStart, end: spanEnd })
+        : null,
+    [info.content, spanStart, spanEnd],
+  );
+
+  const citedRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    if (!cited) return;
+    citedRef.current?.scrollIntoView({ block: "center" });
+  }, [cited]);
+
   if (info.content.length === 0) {
     switch (info.processing_status) {
       case "failed":
@@ -183,7 +222,21 @@ function ExtractedText({ info }: { info: DocumentDetail }) {
   return (
     <div className="min-h-0 grow overflow-auto p-6">
       <pre className="mx-auto max-w-4xl font-sans text-sm leading-relaxed break-words whitespace-pre-wrap">
-        {info.content}
+        {cited ? (
+          <>
+            {info.content.slice(0, cited.start)}
+            <mark
+              ref={citedRef}
+              aria-label="Cited passage"
+              className="rounded bg-yellow-200/60 dark:bg-yellow-500/25"
+            >
+              {info.content.slice(cited.start, cited.end)}
+            </mark>
+            {info.content.slice(cited.end)}
+          </>
+        ) : (
+          info.content
+        )}
       </pre>
     </div>
   );

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
@@ -5,15 +5,57 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import type { ApiClient, DocumentDetail } from "@/api";
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
+import type { AssistantSource } from "@/AssistantSources";
+import { useChatSessionStore } from "@/ChatSessionStore";
 import { renderWithRouter } from "../test/router";
 import { DocumentDetailRoot } from "./DocumentDetailRoot";
 
-afterEach(cleanup);
+// pdf.js draws to a canvas and runs a worker, neither of which jsdom has, so
+// the page targeting is observed through a stand-in that keeps the real page
+// state hook — the part the panel actually drives.
+vi.mock("@/document/PdfViewer", async () => {
+  const { usePdfPageState } = await import("@/document/usePdfPageState");
+  return {
+    PdfViewer: ({
+      documentId,
+      targetPage,
+    }: {
+      documentId: string;
+      targetPage?: number;
+    }) => {
+      const { currentPage, setCurrentPage } = usePdfPageState(documentId, {
+        numPages: 20,
+        targetPage,
+      });
+      return (
+        <div>
+          <span>Page {currentPage}</span>
+          <button type="button" onClick={() => setCurrentPage(currentPage + 1)}>
+            Next page
+          </button>
+        </div>
+      );
+    },
+  };
+});
+
+const scrolledTo: Element[] = [];
+
+afterEach(() => {
+  cleanup();
+  useChatSessionStore.getState().reset();
+  window.sessionStorage.clear();
+  scrolledTo.length = 0;
+});
 
 beforeAll(() => {
   // jsdom implements neither half of the object-URL API the image viewer uses.
   URL.createObjectURL = vi.fn(() => "blob:document");
   URL.revokeObjectURL = vi.fn();
+  // jsdom does not scroll, so the scrolled-to element is recorded instead.
+  Element.prototype.scrollIntoView = function (this: Element) {
+    scrolledTo.push(this);
+  };
 });
 
 function detail(overrides: Partial<DocumentDetail> = {}): DocumentDetail {
@@ -51,6 +93,60 @@ async function openPanel(
     { initialUrl: "/c/chat-1?left=sources.doc-1&right=chat" },
   );
   return { ...rendered, client: client as unknown as ApiClient & typeof client, download };
+}
+
+/**
+ * The transcript beside the panel, holding the citation the panel is opened
+ * from. This is where the panel resolves it: no request is made for it.
+ */
+function seedTranscript(source: Partial<AssistantSource> & { id: string }) {
+  useChatSessionStore.getState().update((session) => ({
+    ...session,
+    messages: [
+      {
+        id: "m1",
+        role: "assistant",
+        text: "Revenue rose in the second quarter.",
+        sources: [
+          {
+            ordinal: 1,
+            documentId: "doc-1",
+            span: { start: 0, end: 0 },
+            excerpt: "",
+            heading: null,
+            pages: [],
+            ...source,
+          },
+        ],
+      },
+    ],
+  }));
+}
+
+async function openCitation(info: DocumentDetail, citationId: string) {
+  const client = {
+    getChatDocument: vi.fn().mockResolvedValue(info),
+    getChatDocumentFile: vi.fn().mockResolvedValue(new Blob(["bytes"])),
+    getDocumentFileContent: vi.fn().mockResolvedValue(new Uint8Array()),
+  };
+  return renderWithRouter(
+    <AppContextProvider value={{ client } as unknown as AppContextValue}>
+      <DocumentDetailRoot
+        chatId="chat-1"
+        documentID="doc-1"
+        citationId={citationId}
+        position="left"
+      />
+    </AppContextProvider>,
+    { initialUrl: `/c/chat-1?left=sources.doc-1.${citationId}&right=chat` },
+  );
+}
+
+/** Byte offsets of a passage, which is how a citation reports its span. */
+function byteSpan(text: string, passage: string) {
+  const encoder = new TextEncoder();
+  const start = encoder.encode(text.slice(0, text.indexOf(passage))).length;
+  return { start, end: start + encoder.encode(passage).length };
 }
 
 describe("DocumentDetailRoot", () => {
@@ -148,6 +244,60 @@ describe("DocumentDetailRoot", () => {
       await screen.findByText(/Not a heading, just a line that starts with a hash/),
     ).toBeVisible();
     expect(screen.queryByRole("button", { name: "Document outline" })).toBeNull();
+  });
+
+  // The passage sits behind an accented character, so the byte offsets a
+  // citation carries no longer line up with JavaScript's string indices. An
+  // off-by-one conversion highlights the wrong words and this is what catches it.
+  const CITED_CONTENT = "Café notes\n\nRevenue rose 12% in the second quarter.\n";
+  const CITED_PASSAGE = "Revenue rose 12%";
+
+  it("opens a citation on the passage it quoted, highlighted and scrolled to", async () => {
+    seedTranscript({ id: "cite-1", span: byteSpan(CITED_CONTENT, CITED_PASSAGE) });
+    await openCitation(
+      // A source whose original view could be drawn, but cannot show a span:
+      // the citation lands on the extracted text, where the passage is.
+      detail({ media_type: "text/plain", title: "Notes.txt", content: CITED_CONTENT }),
+      "cite-1",
+    );
+
+    const cited = await screen.findByText(CITED_PASSAGE);
+    expect(cited.tagName).toBe("MARK");
+    expect(scrolledTo).toContain(cited);
+    // Split around the passage rather than reduced to it: the text of record
+    // still reads as one run, which is what the offsets index into.
+    expect(document.querySelector("pre")?.textContent).toBe(CITED_CONTENT);
+  });
+
+  it("opens the same source at the top when no citation led there", async () => {
+    await openPanel(
+      detail({ media_type: "text/plain", title: "Notes.txt", content: CITED_CONTENT }),
+    );
+
+    expect(
+      await screen.findByRole("tab", { name: "Original document", selected: true }),
+    ).toBeVisible();
+    expect(document.querySelector("mark")).toBeNull();
+  });
+
+  it("opens a paginated citation on its recorded page, then lets the reader leave", async () => {
+    const user = userEvent.setup();
+    seedTranscript({ id: "cite-2", pages: [4, 5], span: { start: 10, end: 20 } });
+    await openCitation(
+      detail({ media_type: "application/pdf", title: "Report.pdf", content: "text" }),
+      "cite-2",
+    );
+
+    // The span starts on page 4; the page remembered for this source is not it.
+    expect(await screen.findByText("Page 4")).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+    expect(await screen.findByText("Page 5")).toBeVisible();
+
+    // The transcript keeps arriving while the panel is open, and the citation is
+    // re-resolved with it. The page it asked for must not be applied twice.
+    seedTranscript({ id: "cite-2", pages: [4, 5], span: { start: 10, end: 20 } });
+    expect(await screen.findByText("Page 5")).toBeVisible();
   });
 
   it("says so when a structured source will not parse", async () => {

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
@@ -8,11 +8,13 @@ import {
   type DocumentView,
 } from "@/components/document/document-details";
 import { DocumentError } from "@/components/document/error";
+import { isPaginatedOriginalViewer } from "@/document/DocumentViewer";
 import { exportLibraryDocument } from "@/documents";
 import { hasNativeHost } from "@/host";
 import { PanelFrame } from "@/panel/PanelFrame";
 import type { PanelPosition } from "@/panel/panelTypes";
 import { usePanelNav } from "@/panel/usePanelNav";
+import { useCitationPlacement } from "./citationPlacement";
 import {
   DocumentDetailActions,
   DocumentDetailBreadcrumb,
@@ -22,16 +24,26 @@ type Props = {
   chatId: string;
   documentID: string;
   position: PanelPosition;
+  /**
+   * The citation this panel was opened from, as the third part of its address.
+   * It names a place inside the document: the passage to highlight, and the
+   * page to open on where the source has pages.
+   */
+  citationId?: string;
   /** Resolves false when the reader dismissed the save dialog. */
   download?: (chatId: string, documentID: string) => Promise<boolean>;
   canDownload?: boolean;
 };
 
-/** One source, opened in a panel addressed as `sources.{documentId}`. */
+/**
+ * One source, opened in a panel addressed as `sources.{documentId}`, or as
+ * `sources.{documentId}.{citationId}` when a citation led here.
+ */
 export function DocumentDetailRoot({
   chatId,
   documentID,
   position,
+  citationId,
   download = exportLibraryDocument,
   canDownload = hasNativeHost(),
 }: Props) {
@@ -65,11 +77,27 @@ export function DocumentDetailRoot({
 
   const [view, setView] = useState<DocumentView>("original_doc");
 
+  const placement = useCitationPlacement(documentID, citationId);
+  const citationPage =
+    placement?.page != null && info != null && isPaginatedOriginalViewer(info.media_type)
+      ? placement.page
+      : undefined;
+
+  // Arriving from a citation, land on whichever view can show where it points:
+  // the recorded page of a paginated original, or else the extracted text,
+  // where the passage itself is highlighted. A citation the transcript cannot
+  // resolve opens the document the same way the source list does.
+  const citationView: DocumentView | null = !placement
+    ? null
+    : citationPage != null
+      ? "original_doc"
+      : "extracted_text";
+
   // Reset the view when the document changes. A format with no viewer has only
   // the extracted text to land on.
   useEffect(() => {
-    setView(hasOriginalDocumentTab ? "original_doc" : "extracted_text");
-  }, [documentID, hasOriginalDocumentTab]);
+    setView(citationView ?? (hasOriginalDocumentTab ? "original_doc" : "extracted_text"));
+  }, [documentID, hasOriginalDocumentTab, citationView]);
 
   const documentName = info ? documentTitle(info) : undefined;
 
@@ -115,6 +143,8 @@ export function DocumentDetailRoot({
           info={info}
           view={view}
           hasOriginalDocumentTab={hasOriginalDocumentTab}
+          citationSpan={placement?.span}
+          targetPage={citationPage}
         />
       ) : (
         <p className="p-6 text-sm text-muted-foreground" role="status">

--- a/crates/openwave-desktop/ui/src/document-detail/citationPlacement.ts
+++ b/crates/openwave-desktop/ui/src/document-detail/citationPlacement.ts
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+
+import { useChatSessionStore } from "@/ChatSessionStore";
+import type { CitationSpan } from "@/components/document/citationSpan";
+import type { ChatMessage } from "@/MessageList";
+
+/** Where in one source a citation points, as the panel needs to open it. */
+export type CitationPlacement = {
+  /** Half-open byte range of the passage in the document's canonical text. */
+  span: CitationSpan;
+  /** The page the passage was recorded on, for a paginated source. */
+  page?: number;
+};
+
+/**
+ * Resolve a citation against the transcript loaded beside the panel.
+ *
+ * Everything the panel needs is already in the open conversation — the reader
+ * clicked the citation there — so this reads the session rather than asking the
+ * server to look up evidence it just sent. A citation the transcript does not
+ * have resolves to nothing, which is the case for a restored or shared URL
+ * pointing into a conversation whose history is not on screen; the panel then
+ * opens the document as though it had been reached from the source list.
+ */
+export function findCitationPlacement(
+  messages: readonly ChatMessage[],
+  documentId: string,
+  citationId: string,
+): CitationPlacement | null {
+  for (const message of messages) {
+    if (message.role !== "assistant") continue;
+    for (const source of message.sources) {
+      if (source.id !== citationId || source.documentId !== documentId) continue;
+      return {
+        span: { start: source.span.start, end: source.span.end },
+        page: earliestPage(source.pages),
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * The first page the passage was recorded on, where any was.
+ *
+ * A span can cross a page break, and the place to open is where it starts.
+ */
+function earliestPage(pages: readonly number[]): number | undefined {
+  const numbered = pages.filter((page) => Number.isSafeInteger(page) && page > 0);
+  return numbered.length > 0 ? Math.min(...numbered) : undefined;
+}
+
+/** {@link findCitationPlacement} against the live session. */
+export function useCitationPlacement(
+  documentId: string,
+  citationId: string | undefined,
+): CitationPlacement | null {
+  const messages = useChatSessionStore((session) => session.messages);
+  return useMemo(
+    () => (citationId ? findCitationPlacement(messages, documentId, citationId) : null),
+    [messages, documentId, citationId],
+  );
+}

--- a/crates/openwave-desktop/ui/src/document/DocumentViewer.tsx
+++ b/crates/openwave-desktop/ui/src/document/DocumentViewer.tsx
@@ -52,6 +52,15 @@ export function hasOriginalViewer(mediaType: string): boolean {
   );
 }
 
+/**
+ * Whether this format's original view has pages, and so can be opened at the
+ * one a citation was recorded on. The others draw the source as a single run,
+ * where a page number means nothing.
+ */
+export function isPaginatedOriginalViewer(mediaType: string): boolean {
+  return normalizeMediaType(mediaType) === "application/pdf";
+}
+
 interface DocumentViewerProps {
   client: Pick<ApiClient, "getDocumentFileContent">;
   documentId: string;


### PR DESCRIPTION
Closes #674. Follow-up to #545, which landed the data and the address and stopped there: the panel at `sources.{documentId}.{citationId}` ignored the citation half of it and opened the source at the top.

## What it does now

- **The extracted text marks the cited passage and scrolls to it.** The run is split in three around it rather than reduced to it, so the text of record still reads as one contiguous string — which is what the offsets index into.
- **A paginated source opens on the recorded page.** That overrides the page remembered for the document, once: `usePdfPageState` already applies a requested page once per `(document, page)` and does nothing on later renders, so paging away afterwards sticks and the citation does not drag the reader back. The panel takes the first page of the span, since a span can cross a break and the place to open is where it starts.
- **The citation is resolved from the loaded transcript.** `useCitationPlacement` reads the session store the reader clicked the citation in; nothing is fetched. A citation the transcript does not have — a restored or shared URL into a conversation whose history is not on screen — resolves to nothing and the document opens as it would from the source list.

Two things fell out of doing it:

- Spans are UTF-8 byte offsets; a JavaScript string is indexed by UTF-16 code unit. The two agree only while the text is ASCII, so `charRangeForByteSpan` converts rather than assuming. A single accent ahead of a citation would otherwise shift the highlight off the passage. The walk stops at the end of the span, so the cost is the offset rather than the document.
- Arriving from a citation now chooses the view: the recorded page where the original has pages, the extracted text otherwise. Landing on an original view that cannot show a span means the highlight is there and invisible, which is no better than not having it.

`highlightRange` and `highlightPath` on `DocumentDetails` are still uncalled, deliberately. `highlightRange` addresses characters of the original file and `highlightPath` a node in a parsed tree; a citation carries neither — byte offsets into extracted text are not raw-file character offsets for any format whose extraction is not the identity, and no citation carries a node path at all. Feeding one with the other would point confidently at the wrong place. Follow-up filed for drawing the highlight in the original-document views.

## Tests

Three added to `DocumentDetailRoot.dom.test.tsx`, all through the panel from its URL:

- A citation opens on the passage, marked and scrolled to, with the run intact. The content has an accented character ahead of the passage, so an off-by-one in the byte conversion fails it.
- The same source with no citation opens on the original view with nothing marked.
- A paginated citation opens on page 4, pages to 5, and stays on 5 when the transcript updates and the citation is re-resolved.

Both new behaviours were mutation-checked: removing the page hand-off (or the once-per-target guard) fails the third, and treating byte offsets as string indices fails the first.

## What is not verified

Almost all of the visible behaviour. jsdom does not scroll, so the scroll is asserted through a recorded `scrollIntoView`; whether the passage actually ends up in view, and whether the highlight reads well against either theme, is unverified. pdf.js needs a canvas and a worker, so the PDF viewer is stood in for by a component that keeps the real page-state hook — the page the panel asks for is checked, the rendered page is not. I did not drive the app.