### PR TITLE
feat(egress): egress policy decision layer and enforcement tiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6643,6 +6643,7 @@ dependencies = [
  "futures",
  "libc",
  "openwave-core",
+ "openwave-egress",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -6727,6 +6728,10 @@ dependencies = [
  "windows-sys 0.61.2",
  "zip",
 ]
+
+[[package]]
+name = "openwave-egress"
+version = "0.0.0"
 
 [[package]]
 name = "openwave-host-broker"

--- a/crates/openwave-code-execution/Cargo.toml
+++ b/crates/openwave-code-execution/Cargo.toml
@@ -15,6 +15,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 futures = { workspace = true }
 openwave-core = { path = "../openwave-core", default-features = false }
+openwave-egress = { path = "../openwave-egress" }
 reqwest = { workspace = true }
 serde = { workspace = true }
 ts-rs = { workspace = true }

--- a/crates/openwave-code-execution/src/daytona.rs
+++ b/crates/openwave-code-execution/src/daytona.rs
@@ -3,6 +3,9 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use openwave_core::SecretProvider;
+use openwave_egress::{
+    EgressEnforcement, EgressPolicy, EnforcementException, ExceptionReach, ExceptionScope,
+};
 use reqwest::{Client, Response, StatusCode, Url};
 use serde::{Deserialize, Serialize};
 
@@ -23,6 +26,10 @@ const DAYTONA_START_TIMEOUT: Duration = Duration::from_secs(60);
 const DAYTONA_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const DAYTONA_TRANSPORT_GRACE: Duration = Duration::from_secs(10);
 const MAX_DAYTONA_RESPONSE_BYTES: usize = 1024 * 1024;
+/// Daytona accepts at most this many CIDR entries per sandbox allowlist.
+const DAYTONA_MAX_NETWORK_ALLOW_ENTRIES: usize = 10;
+/// Daytona accepts at most this many domain entries per sandbox allowlist.
+const DAYTONA_MAX_DOMAIN_ALLOW_ENTRIES: usize = 20;
 
 /// Fixed key for Daytona credentials in OpenWave's host secret store.
 pub const DAYTONA_CREDENTIAL_KEY: &str = "code_execution.daytona.api_key";
@@ -68,6 +75,7 @@ pub struct DaytonaExecutionProvider {
     pool: RemoteSessionPool,
     client: Client,
     endpoints: DaytonaEndpoints,
+    egress: Option<EgressPolicy>,
 }
 
 #[derive(Clone)]
@@ -125,7 +133,54 @@ impl DaytonaExecutionProvider {
             pool,
             client,
             endpoints,
+            egress: None,
         })
+    }
+
+    /// Compile an egress policy into every sandbox this provider creates.
+    ///
+    /// Without a policy the provider keeps today's disclosed open-egress
+    /// creation. With one, sandboxes are created with Daytona's block-all
+    /// switch or its per-sandbox allowlists — subject to the vendor exception
+    /// list declared by [`Self::egress_enforcement`], and to Daytona's plan
+    /// gating on per-sandbox network overrides. Fails when the allowlist
+    /// exceeds Daytona's entry limits, before any sandbox is created.
+    pub fn with_egress_policy(mut self, policy: EgressPolicy) -> Result<Self, CodeExecutionError> {
+        if let EgressPolicy::Allowlist(allowlist) = &policy {
+            if allowlist.cidrs().len() > DAYTONA_MAX_NETWORK_ALLOW_ENTRIES {
+                return Err(CodeExecutionError::InvalidRequest(format!(
+                    "Daytona accepts at most {DAYTONA_MAX_NETWORK_ALLOW_ENTRIES} egress address blocks"
+                )));
+            }
+            if allowlist.domains().len() > DAYTONA_MAX_DOMAIN_ALLOW_ENTRIES {
+                return Err(CodeExecutionError::InvalidRequest(format!(
+                    "Daytona accepts at most {DAYTONA_MAX_DOMAIN_ALLOW_ENTRIES} egress domain patterns"
+                )));
+            }
+        }
+        self.egress = Some(policy);
+        Ok(self)
+    }
+
+    /// Host knowledge about Daytona's per-sandbox network enforcement,
+    /// declared as what it actually blocks. Daytona keeps a vendor-curated
+    /// "essential services" list reachable regardless of policy — package
+    /// registries, public git hosting, container registries, and AI APIs —
+    /// each a general-purpose destination, so this surface does not qualify
+    /// as a boundary for third-party-credential-bearing work.
+    #[must_use]
+    pub fn egress_enforcement() -> EgressEnforcement {
+        let curated = |purpose: &'static str| EnforcementException {
+            scope: ExceptionScope::VendorCurated,
+            reach: ExceptionReach::GeneralPurpose,
+            purpose,
+        };
+        EgressEnforcement::external(vec![
+            curated("package registries"),
+            curated("git hosting"),
+            curated("container registries"),
+            curated("AI APIs"),
+        ])
     }
 
     async fn create_sandbox(
@@ -141,7 +196,7 @@ impl DaytonaExecutionProvider {
                     ("openwave_workspace_id", workspace_id),
                     ("code-toolbox-language", "python"),
                 ]),
-                network_block_all: false,
+                network: daytona_network_settings(self.egress.as_ref()),
                 auto_stop_interval: DAYTONA_IDLE_MINUTES,
                 // Delete once the idle stop happens. A later command creates a
                 // fresh chat workspace instead of leaving stopped resources.
@@ -392,9 +447,66 @@ impl CodeExecutionProvider for DaytonaExecutionProvider {
 #[serde(rename_all = "camelCase")]
 struct CreateSandboxRequest<'a> {
     labels: HashMap<&'static str, &'a str>,
-    network_block_all: bool,
+    #[serde(flatten)]
+    network: DaytonaNetworkSettings,
     auto_stop_interval: u32,
     auto_delete_interval: u32,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DaytonaNetworkSettings {
+    network_block_all: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    network_allow_list: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    domain_allow_list: Option<String>,
+}
+
+/// Compile the host policy into Daytona's creation-time network controls. No
+/// policy keeps today's disclosed open-egress sandbox. Block-all and the
+/// empty allowlist use the block-all switch; a non-empty allowlist becomes
+/// Daytona's comma-separated CIDR and wildcard-domain allowlists, which deny
+/// every other destination the vendor's exception list does not keep open.
+fn daytona_network_settings(policy: Option<&EgressPolicy>) -> DaytonaNetworkSettings {
+    let open = DaytonaNetworkSettings {
+        network_block_all: false,
+        network_allow_list: None,
+        domain_allow_list: None,
+    };
+    match policy {
+        None => open,
+        Some(EgressPolicy::BlockAll) => DaytonaNetworkSettings {
+            network_block_all: true,
+            ..open
+        },
+        Some(EgressPolicy::Allowlist(allowlist)) => {
+            if allowlist.is_empty() {
+                return DaytonaNetworkSettings {
+                    network_block_all: true,
+                    ..open
+                };
+            }
+            DaytonaNetworkSettings {
+                network_block_all: false,
+                network_allow_list: comma_joined(allowlist.cidrs()),
+                domain_allow_list: comma_joined(allowlist.domains()),
+            }
+        }
+    }
+}
+
+fn comma_joined<T: ToString>(entries: &[T]) -> Option<String> {
+    if entries.is_empty() {
+        return None;
+    }
+    Some(
+        entries
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(","),
+    )
 }
 
 #[derive(Deserialize)]
@@ -726,6 +838,8 @@ mod tests {
             .map(|(_, _, body)| body)
             .unwrap();
         assert_eq!(create_body["networkBlockAll"], false);
+        assert!(create_body.get("networkAllowList").is_none());
+        assert!(create_body.get("domainAllowList").is_none());
         assert_eq!(create_body["autoStopInterval"], DAYTONA_IDLE_MINUTES);
         assert_eq!(create_body["autoDeleteInterval"], 0);
         assert_eq!(create_body["labels"]["openwave_workspace_id"], "chat-123");
@@ -741,6 +855,61 @@ mod tests {
         assert_eq!(execute_body["cwd"], ".");
         assert_eq!(execute_body["timeout"], 5);
         server.abort();
+    }
+
+    #[test]
+    fn daytona_compiles_the_egress_policy_into_creation_network_fields() {
+        use openwave_egress::{CidrBlock, DomainPattern, EgressAllowlist};
+
+        let allowlist = |domains: &[&str], cidrs: &[&str]| {
+            EgressPolicy::Allowlist(EgressAllowlist::new(
+                domains
+                    .iter()
+                    .map(|pattern| DomainPattern::parse(pattern).unwrap())
+                    .collect(),
+                cidrs
+                    .iter()
+                    .map(|block| CidrBlock::parse(block).unwrap())
+                    .collect(),
+            ))
+        };
+
+        // The wire shape Daytona receives, pinned through the same serde
+        // struct the creation request embeds.
+        let policy = allowlist(&["*.pypi.org", "crates.io"], &["140.82.112.0/20"]);
+        let body = serde_json::to_value(daytona_network_settings(Some(&policy))).unwrap();
+        assert_eq!(body["networkBlockAll"], false);
+        assert_eq!(body["networkAllowList"], "140.82.112.0/20");
+        assert_eq!(body["domainAllowList"], "*.pypi.org,crates.io");
+
+        // Block-all and the empty allowlist both fail closed on the switch.
+        for policy in [EgressPolicy::BlockAll, allowlist(&[], &[])] {
+            let body = serde_json::to_value(daytona_network_settings(Some(&policy))).unwrap();
+            assert_eq!(body, json!({ "networkBlockAll": true }));
+        }
+
+        // Vendor entry limits fail before any sandbox is created.
+        let provider = || {
+            DaytonaExecutionProvider::new(
+                DaytonaCredential::parse("test-daytona-key").unwrap(),
+                Duration::from_secs(5),
+            )
+            .unwrap()
+        };
+        let cidrs: Vec<String> = (0..11).map(|index| format!("10.0.{index}.0/24")).collect();
+        let cidr_refs: Vec<&str> = cidrs.iter().map(String::as_str).collect();
+        assert!(matches!(
+            provider().with_egress_policy(allowlist(&[], &cidr_refs)),
+            Err(CodeExecutionError::InvalidRequest(_))
+        ));
+        let domains: Vec<String> = (0..21)
+            .map(|index| format!("host{index}.example.com"))
+            .collect();
+        let domain_refs: Vec<&str> = domains.iter().map(String::as_str).collect();
+        assert!(matches!(
+            provider().with_egress_policy(allowlist(&domain_refs, &[])),
+            Err(CodeExecutionError::InvalidRequest(_))
+        ));
     }
 
     #[tokio::test]

--- a/crates/openwave-code-execution/src/e2b.rs
+++ b/crates/openwave-code-execution/src/e2b.rs
@@ -5,6 +5,10 @@ use std::time::{Duration, Instant};
 use async_trait::async_trait;
 use futures::StreamExt as _;
 use openwave_core::SecretProvider;
+use openwave_egress::{
+    CidrBlock, EgressEnforcement, EgressPolicy, EnforcementException, ExceptionReach,
+    ExceptionScope,
+};
 use reqwest::{Client, Response, StatusCode};
 use serde::{Deserialize, Serialize};
 
@@ -75,6 +79,7 @@ pub struct E2BExecutionProvider {
     pool: RemoteSessionPool,
     client: Client,
     endpoints: E2BEndpoints,
+    egress: Option<EgressPolicy>,
 }
 
 #[derive(Clone)]
@@ -132,7 +137,43 @@ impl E2BExecutionProvider {
             pool,
             client,
             endpoints,
+            egress: None,
         })
+    }
+
+    /// Compile an egress policy into every sandbox this provider creates.
+    ///
+    /// Without a policy the provider keeps today's disclosed open-egress
+    /// creation. With one, sandboxes are created deny-by-default and the
+    /// allowlist becomes E2B's per-sandbox `allowOut` rules — subject to the
+    /// enforcement holes declared by [`Self::egress_enforcement`].
+    #[must_use]
+    pub fn with_egress_policy(mut self, policy: EgressPolicy) -> Self {
+        self.egress = Some(policy);
+        self
+    }
+
+    /// Host knowledge about E2B's per-sandbox network enforcement, declared
+    /// as what it actually blocks. Vendor exceptions: DNS to `8.8.8.8` stays
+    /// open regardless of policy, and domain-pattern rules are enforced only
+    /// on ports 80 and 443, so a name denied only by a domain rule may stay
+    /// reachable on other ports.
+    #[must_use]
+    pub fn egress_enforcement() -> EgressEnforcement {
+        EgressEnforcement::external(vec![
+            EnforcementException {
+                scope: ExceptionScope::Address(
+                    CidrBlock::parse("8.8.8.8/32").expect("static exception block parses"),
+                ),
+                reach: ExceptionReach::Narrow,
+                purpose: "DNS resolution",
+            },
+            EnforcementException {
+                scope: ExceptionScope::DomainRulePortLimit(vec![80, 443]),
+                reach: ExceptionReach::GeneralPurpose,
+                purpose: "domain filtering covers HTTP and HTTPS ports only",
+            },
+        ])
     }
 
     async fn create_sandbox(
@@ -143,6 +184,7 @@ impl E2BExecutionProvider {
             "{}/sandboxes",
             self.endpoints.api_base.trim_end_matches('/')
         );
+        let network = e2b_network_settings(self.egress.as_ref());
         let response = self
             .client
             .post(url)
@@ -151,7 +193,8 @@ impl E2BExecutionProvider {
                 template_id: E2B_TEMPLATE,
                 timeout: E2B_SANDBOX_TTL_SECONDS,
                 secure: true,
-                allow_internet_access: true,
+                allow_internet_access: network.allow_internet_access,
+                network: network.network,
                 metadata: HashMap::from([("openwave_workspace_id", workspace_id)]),
             })
             .send()
@@ -291,7 +334,49 @@ struct CreateSandboxRequest<'a> {
     timeout: u64,
     secure: bool,
     allow_internet_access: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    network: Option<E2BNetworkConfig>,
     metadata: HashMap<&'static str, &'a str>,
+}
+
+#[derive(Serialize)]
+struct E2BNetworkConfig {
+    #[serde(rename = "allowOut")]
+    allow_out: Vec<String>,
+}
+
+struct E2BNetworkSettings {
+    allow_internet_access: bool,
+    network: Option<E2BNetworkConfig>,
+}
+
+/// Compile the host policy into E2B's creation-time network controls. No
+/// policy keeps today's disclosed open-egress sandbox; any policy creates the
+/// sandbox deny-by-default, with allowlist entries (wildcard domains and CIDR
+/// blocks) as `allowOut` holes through the blocked default.
+fn e2b_network_settings(policy: Option<&EgressPolicy>) -> E2BNetworkSettings {
+    let Some(policy) = policy else {
+        return E2BNetworkSettings {
+            allow_internet_access: true,
+            network: None,
+        };
+    };
+    let network = match policy {
+        EgressPolicy::BlockAll => None,
+        EgressPolicy::Allowlist(allowlist) => {
+            let allow_out: Vec<String> = allowlist
+                .domains()
+                .iter()
+                .map(ToString::to_string)
+                .chain(allowlist.cidrs().iter().map(ToString::to_string))
+                .collect();
+            (!allow_out.is_empty()).then_some(E2BNetworkConfig { allow_out })
+        }
+    };
+    E2BNetworkSettings {
+        allow_internet_access: false,
+        network,
+    }
 }
 
 #[derive(Serialize)]
@@ -654,6 +739,7 @@ mod tests {
 
     async fn mock_provider(
         mode: ProcessMode,
+        egress: Option<EgressPolicy>,
     ) -> (
         E2BExecutionProvider,
         Arc<MockState>,
@@ -682,6 +768,10 @@ mod tests {
             },
         )
         .unwrap();
+        let provider = match egress {
+            Some(policy) => provider.with_egress_policy(policy),
+            None => provider,
+        };
         (provider, state, server)
     }
 
@@ -817,7 +907,7 @@ mod tests {
 
     #[tokio::test]
     async fn e2b_reuses_the_chat_sandbox_and_replays_an_exact_execution() {
-        let (provider, state, server) = mock_provider(ProcessMode::Complete).await;
+        let (provider, state, server) = mock_provider(ProcessMode::Complete, None).await;
         let first_request = request("execution-1", "workspace-1", "first");
         let first = provider.execute(first_request.clone()).await.unwrap();
         assert_eq!(first.provider, CodeExecutionProviderKind::E2b);
@@ -862,6 +952,7 @@ mod tests {
         assert_eq!(create["metadata"]["openwave_workspace_id"], "workspace-1");
         assert_eq!(create["secure"], true);
         assert_eq!(create["allow_internet_access"], true);
+        assert!(create.get("network").is_none());
 
         let bodies = state.start_bodies.lock().unwrap();
         let first_start = decode_start_request(&bodies[0]);
@@ -873,8 +964,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn e2b_compiles_the_egress_policy_into_the_creation_request() {
+        use openwave_egress::{CidrBlock, DomainPattern, EgressAllowlist};
+
+        let policy = EgressPolicy::Allowlist(EgressAllowlist::new(
+            vec![DomainPattern::parse("*.pypi.org").unwrap()],
+            vec![CidrBlock::parse("140.82.112.0/20").unwrap()],
+        ));
+        let (provider, state, server) = mock_provider(ProcessMode::Complete, Some(policy)).await;
+        provider
+            .execute(request("execution-net", "workspace-net", "hello"))
+            .await
+            .unwrap();
+        let create = state.create_body.lock().unwrap().clone().unwrap();
+        assert_eq!(create["allow_internet_access"], false);
+        assert_eq!(
+            create["network"]["allowOut"],
+            json!(["*.pypi.org", "140.82.112.0/20"])
+        );
+
+        // Block-all needs no allow rules: the blocked default is the policy.
+        let block_all = e2b_network_settings(Some(&EgressPolicy::BlockAll));
+        assert!(!block_all.allow_internet_access);
+        assert!(block_all.network.is_none());
+        server.abort();
+    }
+
+    #[tokio::test]
     async fn e2b_projects_connect_deadlines_to_the_bounded_timeout_result() {
-        let (provider, state, server) = mock_provider(ProcessMode::Timeout).await;
+        let (provider, state, server) = mock_provider(ProcessMode::Timeout, None).await;
         let response = provider
             .execute(request("execution-timeout", "workspace-timeout", "slow"))
             .await

--- a/crates/openwave-code-execution/src/local.rs
+++ b/crates/openwave-code-execution/src/local.rs
@@ -68,6 +68,15 @@ impl LocalExecutionProvider {
         cfg!(target_os = "macos") && Path::new(SANDBOX_EXEC).is_file()
     }
 
+    /// Host knowledge about the local adapter's egress enforcement: the
+    /// Seatbelt profile denies network outright, from outside the workload,
+    /// with no exceptions. The one shipped surface that qualifies as a
+    /// boundary for third-party-credential-bearing work.
+    #[must_use]
+    pub fn egress_enforcement() -> openwave_egress::EgressEnforcement {
+        openwave_egress::EgressEnforcement::external(Vec::new())
+    }
+
     fn resolve_paths(
         &self,
         request: &CodeExecutionRequest,

--- a/crates/openwave-egress/Cargo.toml
+++ b/crates/openwave-egress/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "openwave-egress"
+description = "OpenWave egress policy: one dependency-free decision layer for every enforcement point."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/crates/openwave-egress/src/lib.rs
+++ b/crates/openwave-egress/src/lib.rs
@@ -1,0 +1,516 @@
+//! The egress policy decision layer.
+//!
+//! One dependency-free module answers one question — may this workload open a
+//! connection to this destination? — and every enforcement point consults it:
+//! the local execution adapter (which denies network outright today), the
+//! future sandbox supervisor, and provider-level controls where a managed
+//! vendor exposes them. Keeping it std-only is deliberate: the in-sandbox
+//! supervisor must be able to consult the same decision without pulling an
+//! HTTP client or async runtime into the sandbox image.
+//!
+//! The policy is an allowlist and the answer is deny by default: a
+//! destination is permitted only when a granted domain pattern or address
+//! block matches it. [`EgressPolicy::BlockAll`] and an empty allowlist both
+//! deny everything.
+//!
+//! Enforcement is tiered, and the tier is stated rather than implied
+//! ([`EnforcementTier`]). Policy enforced from outside the sandbox is a
+//! boundary; supervisor-enforced policy shares a failure domain with the
+//! workload and is defense in depth. Whether a backend has the external tier
+//! is host knowledge — a capability the host establishes itself or one
+//! compiled into a shipped adapter ([`EgressEnforcement`]) — never a claim a
+//! backend makes about itself. The declaration describes what the enforcement
+//! actually blocks, vendor exceptions included, and the admission rule for
+//! third-party-credential-bearing work runs against that honest declaration.
+
+use std::fmt;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+/// Longest accepted destination host or domain pattern, in bytes.
+pub const MAX_DOMAIN_BYTES: usize = 253;
+
+/// A rejected pattern, address block, or destination.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EgressError {
+    InvalidDomainPattern(String),
+    InvalidCidr(String),
+    InvalidDestination(String),
+}
+
+impl fmt::Display for EgressError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidDomainPattern(value) => {
+                write!(formatter, "invalid egress domain pattern: {value}")
+            }
+            Self::InvalidCidr(value) => {
+                write!(formatter, "invalid egress address block: {value}")
+            }
+            Self::InvalidDestination(value) => {
+                write!(formatter, "invalid egress destination: {value}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for EgressError {}
+
+/// An exact host (`api.example.com`) or a single leading wildcard
+/// (`*.example.com`) over lowercase DNS labels.
+///
+/// A wildcard matches any subdomain but never the bare suffix itself:
+/// `*.example.com` matches `files.example.com`, not `example.com`. Grants
+/// stay as narrow as they read.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DomainPattern {
+    /// Lowercased suffix without the wildcard marker.
+    suffix: String,
+    wildcard: bool,
+}
+
+impl DomainPattern {
+    pub fn parse(value: impl AsRef<str>) -> Result<Self, EgressError> {
+        let value = value.as_ref();
+        let invalid = || EgressError::InvalidDomainPattern(value.to_owned());
+        let (wildcard, host) = match value.strip_prefix("*.") {
+            Some(rest) => (true, rest),
+            None => (false, value),
+        };
+        let host = host.to_ascii_lowercase();
+        validate_host(&host).ok_or_else(invalid)?;
+        Ok(Self {
+            suffix: host,
+            wildcard,
+        })
+    }
+
+    #[must_use]
+    pub fn matches(&self, host: &str) -> bool {
+        if host.len() > MAX_DOMAIN_BYTES {
+            return false;
+        }
+        let host = host.to_ascii_lowercase();
+        if self.wildcard {
+            host.strip_suffix(self.suffix.as_str())
+                .and_then(|prefix| prefix.strip_suffix('.'))
+                .is_some_and(|labels| !labels.is_empty())
+        } else {
+            host == self.suffix
+        }
+    }
+}
+
+impl fmt::Display for DomainPattern {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.wildcard {
+            write!(formatter, "*.{}", self.suffix)
+        } else {
+            formatter.write_str(&self.suffix)
+        }
+    }
+}
+
+/// Accept lowercase DNS-shaped hosts: dot-separated labels of
+/// `[a-z0-9-]`, no hyphen at a label edge, not an IP literal.
+fn validate_host(host: &str) -> Option<()> {
+    if host.is_empty() || host.len() > MAX_DOMAIN_BYTES || host.parse::<IpAddr>().is_ok() {
+        return None;
+    }
+    let valid = host.split('.').all(|label| {
+        !label.is_empty()
+            && label.len() <= 63
+            && !label.starts_with('-')
+            && !label.ends_with('-')
+            && label
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    });
+    valid.then_some(())
+}
+
+/// An IPv4 or IPv6 address block in CIDR notation; a bare address is the
+/// single-address block. The stored address is masked to the network address,
+/// so `10.0.0.5/8` and `10.0.0.0/8` are the same block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CidrBlock {
+    network: IpAddr,
+    prefix: u8,
+}
+
+impl CidrBlock {
+    pub fn parse(value: impl AsRef<str>) -> Result<Self, EgressError> {
+        let value = value.as_ref();
+        let invalid = || EgressError::InvalidCidr(value.to_owned());
+        let (address, prefix) = match value.split_once('/') {
+            Some((address, prefix)) => {
+                let address: IpAddr = address.parse().map_err(|_| invalid())?;
+                // Reject leading zeros / signs that `u8: FromStr` would accept.
+                if !prefix.bytes().all(|byte| byte.is_ascii_digit()) {
+                    return Err(invalid());
+                }
+                (address, prefix.parse::<u8>().map_err(|_| invalid())?)
+            }
+            None => {
+                let address: IpAddr = value.parse().map_err(|_| invalid())?;
+                let prefix = match address {
+                    IpAddr::V4(_) => 32,
+                    IpAddr::V6(_) => 128,
+                };
+                (address, prefix)
+            }
+        };
+        let bits = match address {
+            IpAddr::V4(_) => 32,
+            IpAddr::V6(_) => 128,
+        };
+        if prefix > bits {
+            return Err(invalid());
+        }
+        Ok(Self {
+            network: mask_address(address, prefix),
+            prefix,
+        })
+    }
+
+    #[must_use]
+    pub fn contains(&self, address: IpAddr) -> bool {
+        match (self.network, address) {
+            (IpAddr::V4(_), IpAddr::V4(_)) | (IpAddr::V6(_), IpAddr::V6(_)) => {
+                mask_address(address, self.prefix) == self.network
+            }
+            // A mixed-family comparison is a miss, never a mapping guess.
+            _ => false,
+        }
+    }
+}
+
+impl fmt::Display for CidrBlock {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}/{}", self.network, self.prefix)
+    }
+}
+
+fn mask_address(address: IpAddr, prefix: u8) -> IpAddr {
+    match address {
+        IpAddr::V4(v4) => {
+            let bits = u32::from(v4);
+            let mask = if prefix == 0 {
+                0
+            } else {
+                u32::MAX << (32 - u32::from(prefix))
+            };
+            IpAddr::V4(Ipv4Addr::from(bits & mask))
+        }
+        IpAddr::V6(v6) => {
+            let bits = u128::from(v6);
+            let mask = if prefix == 0 {
+                0
+            } else {
+                u128::MAX << (128 - u32::from(prefix))
+            };
+            IpAddr::V6(Ipv6Addr::from(bits & mask))
+        }
+    }
+}
+
+/// One destination a workload wants to reach: a DNS name before resolution,
+/// or a literal address.
+///
+/// The layer never resolves names. A domain destination is decided against
+/// domain patterns and an address destination against address blocks; a
+/// domain grant says nothing about the addresses it resolves to, and
+/// vice versa.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum EgressDestination {
+    Domain(String),
+    Address(IpAddr),
+}
+
+impl EgressDestination {
+    /// Classify a connect target: an IP literal is an address, anything else
+    /// must be a valid lowercase host name.
+    pub fn parse(value: impl AsRef<str>) -> Result<Self, EgressError> {
+        let value = value.as_ref();
+        if let Ok(address) = value.parse::<IpAddr>() {
+            return Ok(Self::Address(address));
+        }
+        let host = value.to_ascii_lowercase();
+        validate_host(&host).ok_or_else(|| EgressError::InvalidDestination(value.to_owned()))?;
+        Ok(Self::Domain(host))
+    }
+}
+
+/// The granted allowlist: domain patterns and address blocks.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct EgressAllowlist {
+    domains: Vec<DomainPattern>,
+    cidrs: Vec<CidrBlock>,
+}
+
+impl EgressAllowlist {
+    #[must_use]
+    pub fn new(domains: Vec<DomainPattern>, cidrs: Vec<CidrBlock>) -> Self {
+        Self { domains, cidrs }
+    }
+
+    #[must_use]
+    pub fn domains(&self) -> &[DomainPattern] {
+        &self.domains
+    }
+
+    #[must_use]
+    pub fn cidrs(&self) -> &[CidrBlock] {
+        &self.cidrs
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.domains.is_empty() && self.cidrs.is_empty()
+    }
+}
+
+/// The one policy every enforcement point consults. Deny by default: only an
+/// explicit grant permits a destination, and an empty allowlist is
+/// indistinguishable from [`EgressPolicy::BlockAll`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EgressPolicy {
+    BlockAll,
+    Allowlist(EgressAllowlist),
+}
+
+impl EgressPolicy {
+    /// May a workload under this policy open a connection to `destination`?
+    #[must_use]
+    pub fn permits(&self, destination: &EgressDestination) -> bool {
+        let Self::Allowlist(allowlist) = self else {
+            return false;
+        };
+        match destination {
+            EgressDestination::Domain(host) => allowlist
+                .domains
+                .iter()
+                .any(|pattern| pattern.matches(host)),
+            EgressDestination::Address(address) => {
+                allowlist.cidrs.iter().any(|block| block.contains(*address))
+            }
+        }
+    }
+}
+
+/// Where an egress policy is enforced relative to the workload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EnforcementTier {
+    /// Enforced from outside the sandbox — the OS denying network to a local
+    /// process, a host-configured firewall, a vendor's per-sandbox network
+    /// policy. A boundary.
+    External,
+    /// Enforced by the in-sandbox supervisor, which shares a failure domain
+    /// with the workload. Defense in depth, never a boundary.
+    Supervisor,
+}
+
+/// How far one enforcement exception reaches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ExceptionReach {
+    /// A fixed, narrow service that is not a general-purpose destination.
+    Narrow,
+    /// A general-purpose destination stays reachable — a ready exfiltration
+    /// channel (public git hosting, registries that accept uploads).
+    GeneralPurpose,
+}
+
+/// What one exception leaves reachable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExceptionScope {
+    /// A destination matched by name.
+    Domain(DomainPattern),
+    /// A destination matched by address.
+    Address(CidrBlock),
+    /// Domain-pattern rules are enforced only on these ports; a destination
+    /// denied only by a domain rule may stay reachable on any other port.
+    DomainRulePortLimit(Vec<u16>),
+    /// A vendor-curated destination set the host cannot enumerate (an
+    /// "essential services" list the vendor maintains and may change).
+    VendorCurated,
+}
+
+/// One hole a backend's enforcement leaves open regardless of the configured
+/// policy, declared honestly instead of hidden behind a feature name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnforcementException {
+    pub scope: ExceptionScope,
+    pub reach: ExceptionReach,
+    /// The vendor's stated purpose for the hole ("DNS resolution",
+    /// "package registries", …) for settings and audit surfaces.
+    pub purpose: &'static str,
+}
+
+/// A backend's egress enforcement, declared as what it actually blocks.
+///
+/// This is host knowledge: the host establishes it itself (the boundary it
+/// configures around a local container) or ships it compiled into a managed
+/// vendor's adapter. It is never populated from anything a backend claims
+/// about itself over the wire.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EgressEnforcement {
+    tier: EnforcementTier,
+    exceptions: Vec<EnforcementException>,
+}
+
+impl EgressEnforcement {
+    /// Enforcement applied from outside the sandbox, with every hole the
+    /// vendor's mechanism leaves open stated up front.
+    #[must_use]
+    pub fn external(exceptions: Vec<EnforcementException>) -> Self {
+        Self {
+            tier: EnforcementTier::External,
+            exceptions,
+        }
+    }
+
+    /// Enforcement carried only by the in-sandbox supervisor.
+    #[must_use]
+    pub fn supervisor() -> Self {
+        Self {
+            tier: EnforcementTier::Supervisor,
+            exceptions: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn tier(&self) -> EnforcementTier {
+        self.tier
+    }
+
+    #[must_use]
+    pub fn exceptions(&self) -> &[EnforcementException] {
+        &self.exceptions
+    }
+
+    /// The admission rule for third-party-credential-bearing work: only the
+    /// external tier qualifies, and an enforcement surface whose exceptions
+    /// leave a general-purpose destination reachable does not qualify no
+    /// matter what the vendor calls the feature.
+    #[must_use]
+    pub fn is_credential_boundary(&self) -> bool {
+        self.tier == EnforcementTier::External
+            && self
+                .exceptions
+                .iter()
+                .all(|exception| exception.reach == ExceptionReach::Narrow)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn allowlist(domains: &[&str], cidrs: &[&str]) -> EgressPolicy {
+        EgressPolicy::Allowlist(EgressAllowlist::new(
+            domains
+                .iter()
+                .map(|pattern| DomainPattern::parse(pattern).unwrap())
+                .collect(),
+            cidrs
+                .iter()
+                .map(|block| CidrBlock::parse(block).unwrap())
+                .collect(),
+        ))
+    }
+
+    fn domain(host: &str) -> EgressDestination {
+        EgressDestination::parse(host).unwrap()
+    }
+
+    #[test]
+    fn policy_denies_by_default_and_permits_only_explicit_grants() {
+        let policy = allowlist(&["api.example.com", "*.pypi.org"], &["140.82.112.0/20"]);
+
+        assert!(policy.permits(&domain("api.example.com")));
+        assert!(policy.permits(&domain("Files.PYPI.org")));
+        assert!(policy.permits(&domain("140.82.114.4")));
+
+        // Wildcards never widen to the bare suffix, other subdomains, or
+        // suffix tricks; addresses outside the block and unrelated hosts miss.
+        assert!(!policy.permits(&domain("pypi.org")));
+        assert!(!policy.permits(&domain("evil-pypi.org")));
+        assert!(!policy.permits(&domain("sub.api.example.com")));
+        assert!(!policy.permits(&domain("140.82.128.4")));
+        assert!(!policy.permits(&domain("attacker.example")));
+
+        // Domain grants decide names and CIDR grants decide addresses;
+        // neither crosses over, and IPv6 never matches a v4 block.
+        assert!(!allowlist(&["*.example.com"], &[]).permits(&domain("93.184.216.34")));
+        assert!(!allowlist(&[], &["0.0.0.0/0"]).permits(&domain("example.com")));
+        assert!(!allowlist(&[], &["0.0.0.0/0"]).permits(&domain("::1")));
+
+        assert!(!EgressPolicy::BlockAll.permits(&domain("example.com")));
+        assert!(!allowlist(&[], &[]).permits(&domain("example.com")));
+    }
+
+    #[test]
+    fn malformed_grants_and_destinations_are_rejected_at_parse() {
+        for pattern in [
+            "",
+            "*.",
+            "*",
+            "a.*.example.com",
+            "exa mple.com",
+            "-a.example.com",
+            "8.8.8.8",
+        ] {
+            assert!(DomainPattern::parse(pattern).is_err(), "{pattern:?} parsed");
+        }
+        for cidr in [
+            "",
+            "10.0.0.0/33",
+            "::/129",
+            "example.com",
+            "10.0.0.0/ 8",
+            "10.0.0.0/+8",
+        ] {
+            assert!(CidrBlock::parse(cidr).is_err(), "{cidr:?} parsed");
+        }
+        assert!(EgressDestination::parse("not a host").is_err());
+
+        // Non-network addresses are masked to their block, and bare
+        // addresses are the single-address block.
+        assert_eq!(
+            CidrBlock::parse("10.0.0.5/8").unwrap(),
+            CidrBlock::parse("10.0.0.0/8").unwrap()
+        );
+        assert_eq!(
+            CidrBlock::parse("8.8.8.8").unwrap().to_string(),
+            "8.8.8.8/32"
+        );
+        assert!(CidrBlock::parse("2001:db8::/32")
+            .unwrap()
+            .contains("2001:db8::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn credential_admission_runs_against_the_declared_exceptions() {
+        // The local adapter's outright network denial: external, no holes.
+        assert!(EgressEnforcement::external(Vec::new()).is_credential_boundary());
+
+        // A narrow, fixed exception keeps the boundary.
+        let narrow = EgressEnforcement::external(vec![EnforcementException {
+            scope: ExceptionScope::Address(CidrBlock::parse("8.8.8.8/32").unwrap()),
+            reach: ExceptionReach::Narrow,
+            purpose: "DNS resolution",
+        }]);
+        assert!(narrow.is_credential_boundary());
+
+        // One general-purpose hole disqualifies the whole surface, whatever
+        // the vendor calls the feature.
+        let leaky = EgressEnforcement::external(vec![EnforcementException {
+            scope: ExceptionScope::VendorCurated,
+            reach: ExceptionReach::GeneralPurpose,
+            purpose: "git hosting",
+        }]);
+        assert!(!leaky.is_credential_boundary());
+
+        // Supervisor enforcement is defense in depth, never a boundary.
+        assert!(!EgressEnforcement::supervisor().is_credential_boundary());
+    }
+}

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -14,6 +14,7 @@ libraries.
       libraries          openwave-mcp          openwave-retrieval
                          openwave-router       openwave-web-search
                          openwave-host-broker  openwave-code-execution
+                         openwave-egress
                                             │
       the seam                         openwave-core
 
@@ -158,7 +159,23 @@ adapter behind the same contract.
 
 See [Code execution](code-execution.md).
 
-**Depends on:** `openwave-core`.
+**Depends on:** `openwave-core`, `openwave-egress`.
+
+## `openwave-egress` — egress policy decisions 🟢
+
+The dependency-free decision layer from
+[sandbox providers](sandbox-providers.md): one deny-by-default allowlist
+policy (wildcard domain patterns and CIDR blocks) answering whether a workload
+may open a connection to a destination, consulted by every enforcement point.
+It also owns the enforcement-tier vocabulary — external enforcement is a
+boundary, supervisor enforcement is defense in depth — and the per-backend
+enforcement declaration, stated as what the mechanism actually blocks with
+vendor exceptions included, which the admission rule for
+third-party-credential-bearing work checks. Deliberately std-only so the
+future in-sandbox supervisor can consult the same decision without pulling an
+HTTP client or async runtime into the sandbox image.
+
+**Depends on:** nothing in the workspace.
 
 ## `openwave-mcp` — the MCP face 🟡
 


### PR DESCRIPTION
Step 3 of the delivery sequence in docs/sandbox-providers.md: the egress decision layer, the enforcement-tier surface, and the per-backend external-enforcement declaration, with the managed exec adapters' vendor network controls made expressible from a policy.

## What's here

- **`openwave-egress`** — a new std-only, dependency-free crate. `EgressPolicy` answers "may this workload open a connection to this destination?" over an allowlist of wildcard domain patterns and CIDR blocks, or block-all; deny by default, and an empty allowlist denies everything. The layer never resolves names: domain grants decide names, CIDR grants decide addresses, and neither crosses over. It is deliberately free of workspace and external dependencies so the future in-sandbox supervisor can consult the same decision without pulling an HTTP client or async runtime into the sandbox image.
- **Enforcement tiers as data.** `EnforcementTier::External` (a boundary) versus `Supervisor` (defense in depth), and `EgressEnforcement` — the per-backend declaration of what the enforcement actually blocks, vendor exceptions included, never a feature name. `is_credential_boundary()` is the admission rule: external tier and no exception that leaves a general-purpose destination reachable.
- **Adapter declarations, compiled in as host knowledge.** E2B declares the always-open DNS path to 8.8.8.8 (narrow) and that its domain rules cover ports 80/443 only (general-purpose gap). Daytona declares its vendor-curated essential-services exceptions — package registries, git hosting, container registries, AI APIs — each general-purpose, so neither managed surface qualifies for credential-bearing work. The local adapter's outright network denial is the one shipped surface that does.
- **Creation-time vendor controls, expressible but not yet driven.** `with_egress_policy` on both managed adapters compiles the policy into the sandbox-creation request: E2B to `allow_internet_access` plus `network.allowOut` entries; Daytona to `networkBlockAll` / comma-separated `networkAllowList` and `domainAllowList`, with the 10-CIDR/20-domain entry limits rejected before any sandbox is created. **No behavior change in this PR**: nothing sets a policy yet, and the default creation bodies are byte-identical (pinned by the existing mock assertions, now extended to assert the absence of the new fields).

## Out of scope, still open on #819

- Flipping the shipped default away from open-egress creation and the user-facing grant/consent surface for allowlists (the broker-model wiring), which is where the admission check gets consulted.
- Live vendor exercise: the exact vendor field semantics (E2B `allowOut` precedence, Daytona `domainAllowList` shape) are pinned at the injected-HTTP seam per the testing policy in docs/sandbox-providers.md; live verification is out-of-band with real accounts before the default flips.

## Verification

- `cargo check -p openwave-egress -p openwave-code-execution --locked`
- `cargo test -p openwave-code-execution -p openwave-egress` (18 passing)
- `cargo clippy --all-targets` clean on both touched crates; `cargo fmt`
- Lockfile change is only the new workspace member's entries.

Part of #819