### PR TITLE
feat(desktop): show what a connected-folder call found

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -2884,6 +2884,31 @@ impl Store for DbStore {
             now,
             resolution,
             resolved_at,
+            None,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn resolve_client_tool_call_and_append_event_with_rows(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<Utc>,
+        rows: Option<&serde_json::Value>,
+    ) -> Result<JournaledClientToolCallOutcome> {
+        ops::client_execution::resolve_client_tool_call_and_append_event(
+            self,
+            id,
+            chat_id,
+            lease_token,
+            now,
+            resolution,
+            resolved_at,
+            rows,
         )
         .await
     }
@@ -2905,6 +2930,31 @@ impl Store for DbStore {
             now,
             resolution,
             resolved_at,
+            None,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn resolve_expired_client_tool_call_and_append_event_with_rows(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<Utc>,
+        rows: Option<&serde_json::Value>,
+    ) -> Result<JournaledClientToolCallOutcome> {
+        ops::client_execution::resolve_expired_client_tool_call_and_append_event(
+            self,
+            id,
+            chat_id,
+            lease_token,
+            now,
+            resolution,
+            resolved_at,
+            rows,
         )
         .await
     }

--- a/crates/openwave-core/src/db/ops/client_execution.rs
+++ b/crates/openwave-core/src/db/ops/client_execution.rs
@@ -297,6 +297,7 @@ pub(in crate::db) async fn resolve_server_tool_call(
         resolution,
         None,
         None,
+        None,
     )
     .await?
     .outcome)
@@ -318,6 +319,7 @@ pub(in crate::db) async fn resolve_server_tool_call_with_evidence(
         resolution,
         Some(evidence),
         preview,
+        None,
     )
     .await?
     .outcome)
@@ -350,6 +352,7 @@ pub(in crate::db) async fn resolve_claimed_server_tool_call_with_evidence(
         resolution,
         Some(evidence),
         preview,
+        None,
     )
     .await?
     .outcome)
@@ -380,6 +383,7 @@ pub(in crate::db) async fn abandon_inherited_server_tool_call(
         resolution,
         None,
         None,
+        None,
     )
     .await?
     .outcome)
@@ -396,6 +400,7 @@ pub(in crate::db) async fn list_retrieval_evidence(
         .collect()
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(in crate::db) async fn resolve_client_tool_call_and_append_event(
     store: &DbStore,
     id: CallId,
@@ -404,6 +409,7 @@ pub(in crate::db) async fn resolve_client_tool_call_and_append_event(
     now: DateTime<Utc>,
     resolution: &ToolCallResolution,
     resolved_at: DateTime<Utc>,
+    rows: Option<&serde_json::Value>,
 ) -> Result<JournaledClientToolCallOutcome> {
     if lease_token.is_nil() {
         return Err(AgentError::Store(
@@ -422,10 +428,12 @@ pub(in crate::db) async fn resolve_client_tool_call_and_append_event(
         resolution,
         None,
         None,
+        rows,
     )
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(in crate::db) async fn resolve_expired_client_tool_call_and_append_event(
     store: &DbStore,
     id: CallId,
@@ -434,6 +442,7 @@ pub(in crate::db) async fn resolve_expired_client_tool_call_and_append_event(
     now: DateTime<Utc>,
     resolution: &ToolCallResolution,
     resolved_at: DateTime<Utc>,
+    rows: Option<&serde_json::Value>,
 ) -> Result<JournaledClientToolCallOutcome> {
     if lease_token.is_nil() {
         return Err(AgentError::Store(
@@ -452,6 +461,7 @@ pub(in crate::db) async fn resolve_expired_client_tool_call_and_append_event(
         resolution,
         None,
         None,
+        rows,
     )
     .await
 }
@@ -471,6 +481,7 @@ pub(in crate::db) async fn list_pending_client_tool_calls(
     models.into_iter().map(tool_call_from_model).collect()
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn resolve_tool_call(
     store: &DbStore,
     id: CallId,
@@ -479,6 +490,7 @@ async fn resolve_tool_call(
     resolution: &ToolCallResolution,
     evidence: Option<&[RetrievalEvidenceInput]>,
     preview: Option<&crate::ToolResultPreview>,
+    rows: Option<&serde_json::Value>,
 ) -> Result<JournaledClientToolCallOutcome> {
     validate_resolution(resolution)?;
     let resolved_at = canonical_db_timestamp(resolved_at)?;
@@ -604,6 +616,7 @@ async fn resolve_tool_call(
     }
 
     let (error_code, error_detail) = resolution_error(resolution);
+    let resolved_name = existing.name.clone();
     let approval_status = existing.approval_status.clone();
     let approval_requested_at = existing.approval_requested_at;
     let mut active: entities::tool_call::ActiveModel = existing.into();
@@ -612,6 +625,25 @@ async fn resolve_tool_call(
     // Serialization of a closed, already-clamped projection cannot fail in
     // practice; a store write is the wrong place to panic if it ever did, and
     // losing the card is the whole cost.
+    // A server call hands in a projection it already built. A client call hands
+    // in the *rows it reported*, and the projection is built here — against the
+    // name on the row rather than anything the executor claimed, so the
+    // allowlist decides whether this tool may have a card at all and every row
+    // goes through the same clamp a server-side one does.
+    let projected = rows.and_then(|rows| {
+        crate::ToolResultPreview::build(
+            &resolved_name,
+            &crate::ToolOutput {
+                content: String::new(),
+                data: Some(rows.clone()),
+                is_error: resolution.status() != ToolCallStatus::Completed,
+                error_category: None,
+                ui_view: None,
+                private_evidence: Vec::new(),
+            },
+        )
+    });
+    let preview = preview.or(projected.as_ref());
     active.result_preview = Set(preview.and_then(|preview| serde_json::to_value(preview).ok()));
     active.error_code = Set(error_code);
     active.error_detail = Set(error_detail);

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -1317,6 +1317,7 @@ mod tests {
 
     /// Calls that resolved before projections were retained still rebuild the
     /// one enumerated signal history could always recover.
+    ///
     #[test]
     fn a_call_with_no_retained_projection_falls_back_to_its_stored_signal() {
         let activity = tool_activity_from_call(

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -244,6 +244,13 @@ pub struct ResultFailure {
     /// provider-authored text and private diagnostics, and this is a message
     /// our own tool wrote for a person to act on. Clamped like every other
     /// field; a failure nobody can read is not a report.
+    ///
+    /// "Our own tool wrote" is the load-bearing part, and it is a habit rather
+    /// than something the type can enforce. Write the sentence — "file is not
+    /// valid UTF-8" — instead of forwarding a `std::io::Error`, a broker
+    /// failure, or any other error whose `Display` you do not control. Those
+    /// interpolate whatever they were handed, which is how a host path ends up
+    /// on a card nobody meant to put it on.
     pub error: String,
 }
 

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -361,6 +361,15 @@ const ENTRY_TOOLS: &[&str] = &[
     "list_dir",
     "write_file",
     "create_deliverable",
+    // Executed on the desktop, which authors their rows and posts them back.
+    // The allowlist is checked against the *stored* call name rather than
+    // anything the client asserts, so a client cannot grant itself a card for a
+    // tool that has none.
+    crate::LIST_CONNECTED_FOLDERS_TOOL,
+    crate::LIST_FOLDER_TOOL,
+    crate::READ_CONNECTED_FILE_TOOL,
+    crate::IMPORT_CONNECTED_FILE_TOOL,
+    crate::WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
 ];
 
 impl ToolResultPreview {
@@ -817,6 +826,16 @@ mod tests {
         );
         assert_eq!(ToolResultPreview::build("read_tool_result", &output), None);
         assert!(ToolResultPreview::build("read_file", &output).is_some());
+
+        // The connected-folder tools run on the desktop, which authors its own
+        // rows and posts them back. The name checked here is the one stored on
+        // the call, never one the executor supplied, so an executor cannot
+        // award itself a card for a tool that projects nothing.
+        assert!(ToolResultPreview::build(crate::LIST_FOLDER_TOOL, &output).is_some());
+        assert_eq!(
+            ToolResultPreview::build(crate::REQUEST_FOLDER_ACCESS_TOOL, &output),
+            None
+        );
 
         // Nor does a call that failed: whatever rows it left behind describe
         // work that did not happen.

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -2751,6 +2751,37 @@ pub trait Store: Send + Sync {
         resolved_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<JournaledClientToolCallOutcome>;
 
+    /// Resolve a live client call, retaining the rows it reported.
+    ///
+    /// `rows` is the executor's *unvalidated* `{entries, failures}` payload, not
+    /// a projection. The store builds the projection from it against the call's
+    /// own stored name, so the allowlist and every clamp are applied here rather
+    /// than trusted from the executor — a client cannot award itself a card for
+    /// a tool that has none, nor an unbounded row.
+    ///
+    /// The default drops the rows, which costs the card and nothing else.
+    #[allow(clippy::too_many_arguments)]
+    async fn resolve_client_tool_call_and_append_event_with_rows(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+        _rows: Option<&serde_json::Value>,
+    ) -> Result<JournaledClientToolCallOutcome> {
+        self.resolve_client_tool_call_and_append_event(
+            id,
+            chat_id,
+            lease_token,
+            now,
+            resolution,
+            resolved_at,
+        )
+        .await
+    }
+
     /// Resolve a known outcome after the exact client lease expired.
     ///
     /// This is the explicit recovery path for an ambiguous native interaction;
@@ -2788,6 +2819,30 @@ pub trait Store: Send + Sync {
         resolution: &ToolCallResolution,
         resolved_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<JournaledClientToolCallOutcome>;
+
+    /// The expired-lease counterpart of
+    /// [`Self::resolve_client_tool_call_and_append_event_with_rows`].
+    #[allow(clippy::too_many_arguments)]
+    async fn resolve_expired_client_tool_call_and_append_event_with_rows(
+        &self,
+        id: CallId,
+        chat_id: ChatId,
+        lease_token: uuid::Uuid,
+        now: chrono::DateTime<chrono::Utc>,
+        resolution: &ToolCallResolution,
+        resolved_at: chrono::DateTime<chrono::Utc>,
+        _rows: Option<&serde_json::Value>,
+    ) -> Result<JournaledClientToolCallOutcome> {
+        self.resolve_expired_client_tool_call_and_append_event(
+            id,
+            chat_id,
+            lease_token,
+            now,
+            resolution,
+            resolved_at,
+        )
+        .await
+    }
 
     /// List unclaimed and claimed client work for authoritative recovery.
     async fn list_pending_client_tool_calls(&self, chat_id: ChatId) -> Result<Vec<ToolCallRecord>>;

--- a/crates/openwave-desktop/src/client_execution.rs
+++ b/crates/openwave-desktop/src/client_execution.rs
@@ -516,6 +516,7 @@ fn connected_resolution(
     Ok(StoredResolution::Completed {
         result: serde_json::to_string(&result)
             .map_err(|_| "could not encode folder-access result".to_owned())?,
+        rows: None,
     })
 }
 
@@ -523,6 +524,7 @@ fn declined_resolution() -> Result<StoredResolution, String> {
     Ok(StoredResolution::Completed {
         result: serde_json::to_string(&RequestFolderAccessResult::Declined)
             .map_err(|_| "could not encode folder-access result".to_owned())?,
+        rows: None,
     })
 }
 
@@ -626,14 +628,14 @@ mod tests {
             display_name: "Documents".into(),
         })
         .unwrap();
-        let StoredResolution::Completed { result } = connected else {
+        let StoredResolution::Completed { result, .. } = connected else {
             panic!("expected completed result")
         };
         assert!(result.contains("connected"));
         assert!(!result.contains("/Users/"));
         assert!(matches!(
             declined_resolution().unwrap(),
-            StoredResolution::Completed { result } if result.contains("declined")
+            StoredResolution::Completed { result, .. } if result.contains("declined")
         ));
     }
 

--- a/crates/openwave-desktop/src/client_execution/folder_operations.rs
+++ b/crates/openwave-desktop/src/client_execution/folder_operations.rs
@@ -10,8 +10,8 @@ use std::collections::HashSet;
 use openwave_core::{
     validate_import_connected_file_arguments, validate_list_connected_folders_arguments,
     validate_list_folder_arguments, validate_read_connected_file_arguments, CallId, ListFolderArgs,
-    ReadConnectedFileArgs, ToolCallExecution, ToolCallRecord, ToolCallStatus,
-    IMPORT_CONNECTED_FILE_TOOL, LIST_CONNECTED_FOLDERS_TOOL, LIST_FOLDER_TOOL,
+    ReadConnectedFileArgs, ResultEntry, ResultEntryKind, ToolCallExecution, ToolCallRecord,
+    ToolCallStatus, IMPORT_CONNECTED_FILE_TOOL, LIST_CONNECTED_FOLDERS_TOOL, LIST_FOLDER_TOOL,
     READ_CONNECTED_FILE_TOOL,
 };
 use openwave_host_broker::{
@@ -280,7 +280,7 @@ async fn execute_operation(
         })
         .await;
     match result {
-        Ok(result) => serialize_result(result),
+        Ok(result) => serialize_result(call, result),
         // Broker transport errors are intentionally not surfaced to the model.
         // Authorization is rechecked by the broker before bytes are released.
         Err(_) => unavailable(
@@ -317,29 +317,75 @@ fn broker_request(call: &ToolCallRecord) -> Result<OperationRequest, ()> {
     }
 }
 
-fn serialize_result(result: OperationResult) -> StoredResolution {
-    let result = match result {
-        OperationResult::ListRoots { roots } => serde_json::json!({
-            "status": "ok",
-            "folders": roots.into_iter().take(MAX_DIRECTORY_ENTRIES).map(|root| serde_json::json!({
-                "root_id": root.root_id,
-                "display_name": root.display_name,
-            })).collect::<Vec<_>>(),
-        }),
-        OperationResult::ListDirectory { entries } => serde_json::json!({
-            "status": "ok",
-            "entries": entries.into_iter().take(MAX_DIRECTORY_ENTRIES).map(|entry| serde_json::json!({
-                "name": entry.name,
-                "kind": entry.kind,
-            })).collect::<Vec<_>>(),
-        }),
+fn serialize_result(call: &ToolCallRecord, result: OperationResult) -> StoredResolution {
+    // The rows are built from the same values the model-facing payload is, so
+    // the card and the model can never disagree about what the folder held.
+    let (result, rows) = match result {
+        OperationResult::ListRoots { roots } => {
+            let roots: Vec<_> = roots.into_iter().take(MAX_DIRECTORY_ENTRIES).collect();
+            let rows = roots
+                .iter()
+                .map(|root| ResultEntry::new(ResultEntryKind::Folder, root.display_name.clone()))
+                .collect();
+            (
+                serde_json::json!({
+                    "status": "ok",
+                    "folders": roots.iter().map(|root| serde_json::json!({
+                        "root_id": root.root_id,
+                        "display_name": root.display_name,
+                    })).collect::<Vec<_>>(),
+                }),
+                rows,
+            )
+        }
+        OperationResult::ListDirectory { entries } => {
+            let entries: Vec<_> = entries.into_iter().take(MAX_DIRECTORY_ENTRIES).collect();
+            let rows = entries
+                .iter()
+                .map(|entry| {
+                    // The broker's own word for what an entry is; anything that
+                    // is not a directory reads as a file.
+                    let kind = if format!("{:?}", entry.kind).to_lowercase().contains("dir") {
+                        ResultEntryKind::Folder
+                    } else {
+                        ResultEntryKind::File
+                    };
+                    ResultEntry::new(kind, entry.name.clone())
+                })
+                .collect();
+            (
+                serde_json::json!({
+                    "status": "ok",
+                    "entries": entries.iter().map(|entry| serde_json::json!({
+                        "name": entry.name,
+                        "kind": entry.kind,
+                    })).collect::<Vec<_>>(),
+                }),
+                rows,
+            )
+        }
         OperationResult::ReadFile(file) => {
             let (content, truncated) = truncate_utf8(&file.content, MAX_FILE_CONTENT_BYTES);
-            serde_json::json!({
-                "status": "ok",
-                "content": content,
-                "truncated": truncated,
-            })
+            // The file's text is what the model reads and far too much for a
+            // card, so the row reports the read rather than replaying it.
+            // The name comes from the request: a read result is bytes, and
+            // only the arguments say which file they came from.
+            let path = serde_json::from_value::<ReadConnectedFileArgs>(call.arguments.clone())
+                .map(|args| args.path)
+                .unwrap_or_default();
+            let mut row = ResultEntry::new(ResultEntryKind::File, read_file_name(&path))
+                .with_meta(openwave_core::format_bytes(content.len() as u64));
+            if truncated {
+                row = row.with_detail("truncated at the read limit");
+            }
+            (
+                serde_json::json!({
+                    "status": "ok",
+                    "content": content,
+                    "truncated": truncated,
+                }),
+                vec![row],
+            )
         }
         _ => {
             return unavailable(
@@ -349,9 +395,10 @@ fn serialize_result(result: OperationResult) -> StoredResolution {
         }
     };
     match serde_json::to_string(&result) {
-        Ok(result) if result.len() <= MAX_RESULT_CONTENT_BYTES => {
-            StoredResolution::Completed { result }
-        }
+        Ok(result) if result.len() <= MAX_RESULT_CONTENT_BYTES => StoredResolution::Completed {
+            result,
+            rows: Some(serde_json::json!({ "entries": rows })),
+        },
         _ => unavailable(
             "result_too_large",
             "The connected-folder result was too large to return.",
@@ -437,6 +484,19 @@ fn is_connected_folder_call(call: &ToolCallRecord) -> bool {
     }
 }
 
+/// The last segment of a connected-folder path, so a row leads with the file.
+fn read_file_name(path: &str) -> String {
+    let name = path
+        .rsplit('/')
+        .find(|segment| !segment.is_empty())
+        .unwrap_or(path);
+    if name.is_empty() {
+        "file".to_owned()
+    } else {
+        name.to_owned()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -444,17 +504,45 @@ mod tests {
 
     #[test]
     fn results_are_bounded_and_do_not_include_host_error_detail() {
-        let result = serialize_result(OperationResult::ReadFile(
-            openwave_host_broker::ReadFileResult {
+        let call = ToolCallRecord {
+            id: CallId::new(),
+            chat_id: ChatId::new(),
+            turn_id: openwave_core::TurnId::new(),
+            provider_id: "tool-1".into(),
+            name: READ_CONNECTED_FILE_TOOL.into(),
+            arguments: serde_json::json!({
+                "root_id": uuid::Uuid::new_v4(),
+                "path": "reports/q3.md",
+            }),
+            execution: ToolCallExecution::Client,
+            status: ToolCallStatus::Pending,
+            result: None,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
+            created_at: chrono::Utc::now(),
+            resolved_at: None,
+        };
+        let result = serialize_result(
+            &call,
+            OperationResult::ReadFile(openwave_host_broker::ReadFileResult {
                 content: "x".repeat(MAX_FILE_CONTENT_BYTES + 1),
                 bytes: MAX_FILE_CONTENT_BYTES + 1,
-            },
-        ));
-        let StoredResolution::Completed { result } = result else {
+            }),
+        );
+        let StoredResolution::Completed { result, rows } = result else {
             panic!("expected bounded result");
         };
         assert!(result.len() <= MAX_RESULT_CONTENT_BYTES);
         assert!(result.contains("\"truncated\":true"));
+        // The card reports the read rather than replaying the file, and names
+        // the file from the request — a read result is only bytes.
+        let rows = rows.expect("a completed read reports its row");
+        assert_eq!(rows["entries"][0]["label"], "q3.md");
+        assert_eq!(rows["entries"][0]["kind"], "file");
+        assert_eq!(rows["entries"][0]["detail"], "truncated at the read limit");
+        assert!(!rows.to_string().contains('x'));
     }
 
     #[test]

--- a/crates/openwave-desktop/src/client_execution/output_writeback.rs
+++ b/crates/openwave-desktop/src/client_execution/output_writeback.rs
@@ -406,6 +406,14 @@ async fn execute_receipt(
                     "Published output {} revision {} to the connected folder.",
                     receipt.output_id, receipt.revision_id
                 ),
+                rows: Some(serde_json::json!({
+                    "entries": [openwave_core::ResultEntry::new(
+                        openwave_core::ResultEntryKind::Output,
+                        file_name(&receipt.relative_path),
+                    )
+                    .with_detail(receipt.relative_path.clone())
+                    .with_meta(openwave_core::format_bytes(receipt.byte_len))],
+                })),
             }
         }
         Ok(_) => unavailable("output_writeback_broker_protocol"),
@@ -488,4 +496,13 @@ fn broker_resolution(error: &BrokerClientError) -> StoredResolution {
         _ => "output_writeback_unavailable",
     };
     unavailable(code)
+}
+
+/// The last segment of a connected-folder path, so a row leads with the file
+/// rather than the path it sits under.
+fn file_name(path: &str) -> String {
+    path.rsplit('/')
+        .find(|segment| !segment.is_empty())
+        .unwrap_or(path)
+        .to_owned()
 }

--- a/crates/openwave-desktop/src/client_execution/receipt_store.rs
+++ b/crates/openwave-desktop/src/client_execution/receipt_store.rs
@@ -303,6 +303,15 @@ pub(super) enum AttachmentPhase {
 pub(super) enum StoredResolution {
     Completed {
         result: String,
+        /// What the operation surfaced, as `{entries, failures}`, for the
+        /// renderer's card.
+        ///
+        /// Defaulted so a receipt written before this field still loads: a
+        /// crash-recovery format that refused older receipts would strand the
+        /// very work it exists to finish. An older receipt simply reports no
+        /// rows, which is what it knew.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        rows: Option<serde_json::Value>,
     },
     Failed {
         result: String,
@@ -1437,6 +1446,7 @@ mod tests {
 
         receipt.phase = FolderOperationPhase::DispatchStarted;
         receipt.resolution = Some(StoredResolution::Completed {
+            rows: None,
             result: r#"{"status":"written"}"#.to_owned(),
         });
         store.save_output_writeback(&receipt).unwrap();
@@ -1470,6 +1480,7 @@ mod tests {
         assert!(!debug.contains(&temp.path().display().to_string()));
 
         receipt.resolution = Some(StoredResolution::Completed {
+            rows: None,
             result: r#"{"status":"connected"}"#.into(),
         });
         store.save(&receipt).unwrap();

--- a/crates/openwave-desktop/src/client_execution/source_import.rs
+++ b/crates/openwave-desktop/src/client_execution/source_import.rs
@@ -213,8 +213,19 @@ fn title_from_path(path: &str) -> Option<String> {
 }
 
 fn imported(result: ImportConnectedFileResult) -> StoredResolution {
+    // An import that reports the source it added is the whole point of the
+    // card; anything that did not add one has no row to show.
+    let rows = match &result {
+        ImportConnectedFileResult::Imported { title, .. } => Some(serde_json::json!({
+            "entries": [openwave_core::ResultEntry::new(
+                openwave_core::ResultEntryKind::Source,
+                title.clone(),
+            )],
+        })),
+        _ => None,
+    };
     match serde_json::to_string(&result) {
-        Ok(result) => StoredResolution::Completed { result },
+        Ok(result) => StoredResolution::Completed { result, rows },
         Err(_) => unavailable("That file could not be added to this conversation."),
     }
 }
@@ -323,7 +334,7 @@ mod tests {
             bytes: 1_024,
             readiness: SourceReadiness::Processing,
         });
-        let StoredResolution::Completed { result } = imported else {
+        let StoredResolution::Completed { result, .. } = imported else {
             panic!("a successful import completes");
         };
         // The model learns the source exists and that it is not ready yet; it

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -762,6 +762,13 @@ label: string | null,
  * provider-authored text and private diagnostics, and this is a message
  * our own tool wrote for a person to act on. Clamped like every other
  * field; a failure nobody can read is not a report.
+ *
+ * "Our own tool wrote" is the load-bearing part, and it is a habit rather
+ * than something the type can enforce. Write the sentence — "file is not
+ * valid UTF-8" — instead of forwarding a `std::io::Error`, a broker
+ * failure, or any other error whose `Display` you do not control. Those
+ * interpolate whatever they were handed, which is how a host path ends up
+ * on a card nobody meant to put it on.
  */
 error: string, };
 

--- a/crates/openwave-server/src/routes/client_execution.rs
+++ b/crates/openwave-server/src/routes/client_execution.rs
@@ -80,6 +80,15 @@ pub struct ClientExecutionHeartbeat {
 pub enum ClientExecutionResolution {
     Completed {
         result: String,
+        /// What the executor surfaced, as `{entries, failures}`.
+        ///
+        /// Unvalidated here on purpose: the store builds the projection from it
+        /// against the call's own stored name, so the allowlist and the clamps
+        /// are applied where the name is authoritative rather than trusted from
+        /// a client that could name any tool. Absent from executors that
+        /// predate this field, which simply report no rows.
+        #[serde(default)]
+        rows: Option<serde_json::Value>,
     },
     Failed {
         result: String,
@@ -93,9 +102,18 @@ pub enum ClientExecutionResolution {
 }
 
 impl ClientExecutionResolution {
+    /// The rows the executor reported, if it reported any. Only a completed
+    /// call has any — a failure describes work that did not happen.
+    fn rows(&self) -> Option<&serde_json::Value> {
+        match self {
+            Self::Completed { rows, .. } => rows.as_ref(),
+            Self::Failed { .. } | Self::Cancelled { .. } => None,
+        }
+    }
+
     fn into_core(self) -> ToolCallResolution {
         match self {
-            Self::Completed { result } => ToolCallResolution::Completed { result },
+            Self::Completed { result, .. } => ToolCallResolution::Completed { result },
             Self::Failed {
                 result,
                 error_code,
@@ -329,30 +347,33 @@ pub async fn resolve_client_execution(
 ) -> Result<Json<ResolvedClientExecution>, ServerError> {
     ensure_chat(&state, id).await?;
     ensure_non_nil(body.lease_token, "lease_token")?;
+    let rows = body.resolution.rows().cloned();
     let resolution = body.resolution.into_core();
     validate_resolution(&resolution)?;
     let now = Utc::now();
     let mut resolution_receipt = state
         .store
-        .resolve_client_tool_call_and_append_event(
+        .resolve_client_tool_call_and_append_event_with_rows(
             call_id,
             id,
             body.lease_token,
             now,
             &resolution,
             now,
+            rows.as_ref(),
         )
         .await?;
     if resolution_receipt.outcome == ResolveToolCallOutcome::LeaseLost {
         resolution_receipt = state
             .store
-            .resolve_expired_client_tool_call_and_append_event(
+            .resolve_expired_client_tool_call_and_append_event_with_rows(
                 call_id,
                 id,
                 body.lease_token,
                 now,
                 &resolution,
                 now,
+                rows.as_ref(),
             )
             .await?;
     }


### PR DESCRIPTION
The last piece of #809, on top of #800, #805, #807 and #813.

Connected-folder calls announce that they finish now (#813) but still showed
nothing about what they did. Their results come back from the desktop over a
wire carrying only a model-facing string, so `ToolResultPreview::build` had no
structured data to read.

The structure already existed and was being thrown away: `serialize_result`
built `{"status":"ok","folders":[…]}` and then stringified it for the model. It
now reports rows alongside, built from the same values the model-facing payload
is, so the card and the model cannot disagree about what the folder held.

## The executor posts rows, not a projection

This is the part worth reviewing. The desktop is a client of this API like any
other, so it sends its `{entries, failures}` **unvalidated** and the store builds
the projection from them against the name on the call's own row:

```rust
let projected = rows.and_then(|rows| {
    crate::ToolResultPreview::build(&resolved_name, /* … */)
});
```

So the tool-name allowlist and every clamp are applied where the name is
authoritative rather than trusted from a client that could name any tool. An
executor cannot award itself a card for a tool that projects nothing, nor an
unbounded row. Tested from identical rows: `list_folder` projects,
`request_folder_access` does not.

Alpha posts typed client results and stores them as JSONB — same division of
labour (the executor knows what it did), but our boundary is closed, so the
validation happens server-side rather than being implied by the type.

## Receipt compatibility

`rows` is also carried on `StoredResolution`, which is a receipt read after a
crash, so the field defaults. A recovery format that refused older receipts
would strand the very work it exists to finish; an older receipt reports no
rows, which is what it knew.

## What each tool reports

- `list_connected_folders` — a folder row per authorized root
- `list_folder` — files and directories, kinded from the broker's own entry kind
- `read_connected_file` — the file and its size, named from the *request*
  (a read result is only bytes), marked when truncated. It reports the read
  rather than replaying the text: that is what the model gets, and it is far too
  much for a card
- `import_connected_file` — the source it added, when it added one
- `write_output_to_connected_folder` — the output and its size

`request_folder_access` and `connect_folder` deliberately stay off the
allowlist: their outcome is already the whole of what the rail line says, and a
card would restate it.

Closes #809