### PR TITLE
fix(desktop): bound the source-document byte cache

### DIFF
--- a/crates/openwave-desktop/ui/src/document/useFileDownload.test.ts
+++ b/crates/openwave-desktop/ui/src/document/useFileDownload.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { createByteCache } from "./useFileDownload";
+
+function file(bytes: number) {
+  return { bytes: new Uint8Array(bytes), contentType: null };
+}
+
+describe("createByteCache", () => {
+  it("evicts the least recently read source, not the oldest one", () => {
+    const cache = createByteCache(10);
+    cache.set("first", file(4));
+    cache.set("second", file(4));
+
+    // The reader flips back to the first source, which makes the second the one
+    // they have not looked at for longest even though it arrived later.
+    expect(cache.get("first")?.bytes.byteLength).toBe(4);
+
+    cache.set("third", file(4));
+
+    expect(cache.get("second")).toBeUndefined();
+    expect(cache.get("first")?.bytes.byteLength).toBe(4);
+    expect(cache.get("third")?.bytes.byteLength).toBe(4);
+  });
+
+  it("refuses a source larger than the whole budget rather than emptying itself", () => {
+    const cache = createByteCache(10);
+    cache.set("workbook", file(6));
+    cache.set("oversized", file(11));
+
+    expect(cache.get("oversized")).toBeUndefined();
+    expect(cache.get("workbook")?.bytes.byteLength).toBe(6);
+  });
+
+  it("does not charge twice for a source cached again", () => {
+    const cache = createByteCache(10);
+    cache.set("report", file(6));
+    cache.set("report", file(6));
+    cache.set("note", file(4));
+
+    expect(cache.get("report")?.bytes.byteLength).toBe(6);
+    expect(cache.get("note")?.bytes.byteLength).toBe(4);
+  });
+});

--- a/crates/openwave-desktop/ui/src/document/useFileDownload.ts
+++ b/crates/openwave-desktop/ui/src/document/useFileDownload.ts
@@ -15,7 +15,21 @@ type Decoded<F extends FileDownloadFormat> = F extends "text"
 type StoredFile = { bytes: Uint8Array; contentType: string | null };
 
 /**
- * Source documents' original bytes, held for the life of the process.
+ * How many bytes of source documents may be held at once.
+ *
+ * The budget is on total bytes rather than on entries because the cost being
+ * bounded is memory: a cap of "ten documents" treats a 12 MB workbook and a
+ * 4 KB note as the same thing. A source cannot exceed 16 MB — the import limit
+ * both the server and the renderer enforce — so 64 MB holds four of the largest
+ * files a reader can open, or dozens of ordinary ones. That is generous for an
+ * access pattern of "the source I am reading, and the one before it", while
+ * still being small next to what a desktop renderer already occupies, and it no
+ * longer grows with the length of the session.
+ */
+const MAX_CACHED_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Source documents' original bytes, held across viewer mounts.
  *
  * A document's content is immutable once imported — replacing a file produces a
  * new document with a new id — so a cache hit can never be stale. It earns its
@@ -23,11 +37,67 @@ type StoredFile = { bytes: Uint8Array; contentType: string | null };
  * between the original and the extracted text: without the cache, every flip
  * back re-downloads the whole file and redraws from a spinner.
  *
- * Nothing is evicted, so a long session that opens many large sources holds
- * them all. That was already true of the workbook and PDF viewers, which cached
- * the biggest files of the seven.
+ * Eviction is least-recently-*read*, not least-recently-inserted: the document a
+ * reader keeps flipping back to is the one worth keeping, however long ago it
+ * was downloaded.
  */
-const byteCache = new Map<string, StoredFile>();
+export type ByteCache = {
+  get(key: string): StoredFile | undefined;
+  set(key: string, file: StoredFile): void;
+  clear(): void;
+};
+
+/**
+ * A byte cache bounded to `budgetBytes`, evicting least-recently-read first.
+ *
+ * Exported so the eviction policy can be exercised against a budget small
+ * enough to test; the hook uses the one below.
+ */
+export function createByteCache(budgetBytes: number): ByteCache {
+  // A Map iterates in insertion order, so re-inserting on every read leaves the
+  // first key as the least recently read one.
+  const entries = new Map<string, StoredFile>();
+  let heldBytes = 0;
+
+  return {
+    get(key) {
+      const file = entries.get(key);
+      if (!file) return undefined;
+      entries.delete(key);
+      entries.set(key, file);
+      return file;
+    },
+
+    set(key, file) {
+      const previous = entries.get(key);
+      if (previous) {
+        entries.delete(key);
+        heldBytes -= previous.bytes.byteLength;
+      }
+      // A file larger than the whole budget is not admitted. Taking it would
+      // mean evicting every other entry and still not fitting, so the reader
+      // would lose a working set they are using to make room for something the
+      // cache cannot keep anyway. Such a source re-downloads on each flip.
+      if (file.bytes.byteLength > budgetBytes) return;
+
+      entries.set(key, file);
+      heldBytes += file.bytes.byteLength;
+      // The new entry fits on its own, so this always stops before reaching it.
+      for (const [oldest, evicted] of entries) {
+        if (heldBytes <= budgetBytes) break;
+        entries.delete(oldest);
+        heldBytes -= evicted.bytes.byteLength;
+      }
+    },
+
+    clear() {
+      entries.clear();
+      heldBytes = 0;
+    },
+  };
+}
+
+const byteCache = createByteCache(MAX_CACHED_BYTES);
 
 /** Drop the cache so one test's bytes cannot answer another's download. */
 export function clearFileDownloadCache(): void {
@@ -73,7 +143,7 @@ export function useFileDownload<F extends FileDownloadFormat>(
     () => byteCache.get(key) ?? null,
   );
   const [error, setError] = useState<Error | null>(null);
-  const [isLoading, setIsLoading] = useState(!byteCache.has(key));
+  const [isLoading, setIsLoading] = useState(file === null);
   const [progress, setProgress] = useState<FileDownloadProgress | null>(null);
   const requestRef = useRef(0);
 


### PR DESCRIPTION
`document/useFileDownload` keeps a source's original bytes across viewer mounts
and nothing ever evicted them, so a session working through a folder of large
spreadsheets held every one of them until the app restarted. #814 made that
cache shared by all seven viewers, which is what makes the ceiling worth
deciding.

The property it exists for is unchanged, and is why the cache stays rather than
going away: a document's bytes are immutable once imported — replacing a file
produces a new document with a new id — and the panel unmounts the viewer on
every switch between the original and the extracted text, so without a cache
each flip back re-downloads the whole file and redraws from a spinner.

## The policy

**Bytes, not entries.** The cost being bounded is memory, so the budget is on
total bytes. A cap of "ten documents" would treat a 12 MB workbook and a 4 KB
note as the same thing, which is exactly wrong for the case in the issue.

**64 MB.** A source cannot exceed 16 MB — `MAX_RAW_DOCUMENT_BYTES` on the server,
`MAX_SOURCE_BYTES` in the renderer — so the budget holds four of the largest
files a reader can open, or dozens of ordinary ones. The access pattern is "the
source I am reading, and the one before it", so that is generous for what the
cache is for while staying small next to what the renderer already occupies. It
is a named constant with the reasoning beside it, not a literal at the call
site. I have not measured whether 64 MB is the right number against real usage;
it is a ceiling chosen to be clearly enough, and easy to move if it is not.

**Least recently read, not least recently inserted.** The document a reader
keeps flipping back to is the one worth keeping, however long ago it arrived.
A `Map` iterates in insertion order, so re-inserting on each read leaves the
first key as the least recently read one and eviction just walks from the front.

**A source larger than the whole budget is not admitted.** Taking it would mean
evicting every other entry and still not fitting — the reader loses a working
set they are actively using to make room for something the cache cannot keep.
Such a source simply re-downloads on each flip. Nothing can hit this today, with
a 16 MB import limit against a 64 MB budget; it is written down so the answer
does not depend on those two numbers staying that far apart.

## Testing

The cache is extracted as `createByteCache(budgetBytes)` so the policy can be
driven against a budget small enough to assert on, rather than poking at a
module-level `Map` from outside. Three cases, all behavioural: that a re-read
entry outlives a newer one it displaces, that an oversized entry is refused
without emptying the cache, and that caching the same key twice is not charged
twice — the last is where the accounting would silently drift.

The existing `DocumentDetailRoot` case asserting that flipping between the
original and the extracted text downloads once still passes; it pins the
property the cache exists for.

`npx tsc --noEmit`, `npx vitest run` (84 files, 592 tests) and `npx vite build`
all pass, before and after rebasing onto `main`. I have not driven the running
app, so whether the budget is well-calibrated in practice is unverified.

Closes #815