### PR TITLE
fix(desktop): stop the phase line rendering as an empty pulsing row

### DIFF
--- a/crates/openwave-desktop/ui/src/useTypewriterOnce.test.ts
+++ b/crates/openwave-desktop/ui/src/useTypewriterOnce.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useTypewriterOnce } from "./useTypewriterOnce";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe("phase label typing", () => {
+  it("never renders a blank frame", () => {
+    // The row it labels also pulses while its phase is live, so an empty frame
+    // does not read as text arriving — it reads as something that failed to
+    // load. This was visible for most of a second on a real phase line.
+    const { result } = renderHook(() =>
+      useTypewriterOnce("Requesting folder access", true),
+    );
+    expect(result.current).toBe("R");
+  });
+
+  it("takes about as long for a long label as a short one", () => {
+    // Paced per character, a phase line that grew as its calls settled crawled
+    // for over a second while a short one appeared at once.
+    const long = "Checking connected folders and 1 other task";
+    const { result } = renderHook(() => useTypewriterOnce(long, true));
+
+    act(() => void vi.advanceTimersByTime(400));
+    expect(result.current).toBe(long);
+  });
+
+  it("shows a settled label at once and never animates it", () => {
+    const { result } = renderHook(() =>
+      useTypewriterOnce("Browsed files", false),
+    );
+    expect(result.current).toBe("Browsed files");
+  });
+});

--- a/crates/openwave-desktop/ui/src/useTypewriterOnce.ts
+++ b/crates/openwave-desktop/ui/src/useTypewriterOnce.ts
@@ -1,6 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 
-const TYPE_INTERVAL_MS = 30;
+/** How long a whole label takes to type, however long the label is. */
+const TYPE_DURATION_MS = 360;
+
+/** One tick per frame; longer labels advance further per tick, not slower. */
+const TYPE_INTERVAL_MS = 16;
 
 /**
  * Types a label out once, the first time it appears while the phase is active,
@@ -10,7 +14,9 @@ const TYPE_INTERVAL_MS = 30;
  * calls settles and nudges the wording.
  */
 export function useTypewriterOnce(text: string, active: boolean): string {
-  const [displayed, setDisplayed] = useState(() => (active ? "" : text));
+  const [displayed, setDisplayed] = useState(() =>
+    active ? text.slice(0, 1) : text,
+  );
   const timerRef = useRef<number | null>(null);
   const mountedRef = useRef(false);
   const hasTypedRef = useRef(false);
@@ -35,10 +41,23 @@ export function useTypewriterOnce(text: string, active: boolean): string {
         setDisplayed(target);
         return;
       }
-      let i = 0;
-      setDisplayed("");
+      // Never a blank frame. The first character lands synchronously, because
+      // an empty row that is also pulsing does not read as text arriving — it
+      // reads as something that failed to load.
+      let i = 1;
+      setDisplayed(target.slice(0, 1));
+      if (target.length === 1) return;
+      // Paced by the whole label rather than per character, so a phase line
+      // that grows — "Checking connected folders and 1 other task" — takes the
+      // same moment to appear as a short one instead of crawling. A longer
+      // label advances further each tick; slowing the tick instead would just
+      // trade a crawl for a stutter.
+      const step = Math.max(
+        1,
+        Math.ceil(target.length / (TYPE_DURATION_MS / TYPE_INTERVAL_MS)),
+      );
       timerRef.current = window.setInterval(() => {
-        i += 1;
+        i += step;
         setDisplayed(target.slice(0, i));
         if (i >= target.length) stop();
       }, TYPE_INTERVAL_MS);


### PR DESCRIPTION
Found by actually running the app.

The tool rail's phase label typed itself out from an empty string at a fixed
30ms per character:

```ts
const TYPE_INTERVAL_MS = 30;
// ...
setDisplayed("");
timerRef.current = window.setInterval(() => {
  setDisplayed(target.slice(0, i));
}, TYPE_INTERVAL_MS);
```

So a phase labelled "Requesting folder access" spent ~720ms showing an icon, a
chevron, and nothing between them. It also carries `animate-pulse`, because the
phase is live — and an empty *pulsing* row does not read as text arriving, it
reads as something that failed to load.

Length made it worse rather than better, in exactly the wrong place. Phase
labels grow as their calls settle: "Checking connected folders and 1 other
task" is 43 characters, so the blank-to-legible stretch ran past a second right
when the most was happening.

## Two changes

**The first character lands synchronously**, so there is never a blank frame.

**Paced by the whole label, not per character.** A longer label advances further
each tick rather than ticking slower — slowing the tick would only trade a crawl
for a stutter, and going below one frame buys nothing. Every phase line now
appears in about the same moment (~360ms) whatever its length.

## Why no test caught it

Every assertion we had checks the label's *text*, which was always correct — it
was correct while invisible, and correct a second later. Nothing asserted what
was on screen in between. The three tests added here pin that: no blank first
frame, a long label finishing in the same budget as a short one, and a settled
label still appearing at once with no animation.

The hook is shared with the chat-title rename animation, which gets the same
treatment and wants it for the same reason.