### PR TITLE
fix(desktop): report a connected folder's real access

### DIFF
--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use openwave_core::{ChatId, Store};
 use openwave_host_broker::{
-    ControlRequest, ControlResult, ExecutionContext, GrantSubject, OperationEnvelope,
+    Capability, ControlRequest, ControlResult, ExecutionContext, GrantSubject, OperationEnvelope,
     OperationRequest, OperationResult, RootId, RootSummary,
 };
 use serde::{Deserialize, Serialize};
@@ -153,6 +153,37 @@ pub(crate) struct ConnectedFolder {
     pub(crate) display_name: String,
 }
 
+/// What the agent may do inside one connected folder.
+///
+/// The broker's own capability set also covers subject-wide discovery, which is
+/// not a property of a folder and so has no member here.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum FolderCapability {
+    Read,
+    Write,
+}
+
+impl FolderCapability {
+    fn from_broker(capability: Capability) -> Option<Self> {
+        match capability {
+            Capability::ReadFiles => Some(Self::Read),
+            Capability::WriteFiles => Some(Self::Write),
+            _ => None,
+        }
+    }
+}
+
+/// A connected folder together with what this conversation may currently do in
+/// it, as the broker reports it rather than as the app assumes.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ConnectedFolderAccess {
+    pub(crate) root_id: RootId,
+    pub(crate) display_name: String,
+    pub(crate) capabilities: Vec<FolderCapability>,
+}
+
 #[tauri::command]
 pub(crate) async fn connect_folder(
     app: AppHandle,
@@ -184,7 +215,7 @@ pub(crate) async fn connect_folder(
 pub(crate) async fn list_connected_folders(
     state: State<'_, HostAccess>,
     chat_id: Uuid,
-) -> Result<Vec<ConnectedFolder>, String> {
+) -> Result<Vec<ConnectedFolderAccess>, String> {
     let context = state.context(chat_id).await?;
     let store = state
         .store()
@@ -219,9 +250,14 @@ pub(crate) async fn list_connected_folders(
     Ok(roots
         .into_iter()
         .filter(|root| product_roots.contains(&root.root_id.as_uuid()))
-        .map(|root| ConnectedFolder {
+        .map(|root| ConnectedFolderAccess {
             root_id: root.root_id,
             display_name: root.display_name,
+            capabilities: root
+                .capabilities
+                .into_iter()
+                .filter_map(FolderCapability::from_broker)
+                .collect(),
         })
         .collect())
 }

--- a/crates/openwave-desktop/ui/src/FoldersView.test.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersView.test.tsx
@@ -20,6 +20,13 @@ const chat = {
   project_id: null,
 } as unknown as Chat;
 
+function readWrite(
+  rootId: string,
+  displayName: string,
+): host.ConnectedFolderAccess {
+  return { rootId, displayName, capabilities: ["read", "write"] };
+}
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((complete) => {
@@ -52,14 +59,27 @@ describe("FoldersView", () => {
     expect(host.listApprovedFolders).toHaveBeenCalledOnce();
   });
 
+  // The badge is the only place a reader learns whether the agent can change
+  // files in a folder, so it has to follow the host's answer rather than a
+  // constant the app chose.
+  it("shows each folder's access as the host reports it", async () => {
+    vi.mocked(host.listConnectedFolders).mockResolvedValue([
+      readWrite("writable", "Drafts"),
+      { rootId: "read-only", displayName: "Archive", capabilities: ["read"] },
+    ]);
+    render(<FoldersView chat={chat} />);
+
+    expect(await screen.findByText("Read and write")).toBeInTheDocument();
+    expect(screen.getByText("Read only")).toBeInTheDocument();
+    expect(screen.getAllByText("Read and write")).toHaveLength(1);
+  });
+
   it("offers approved folders that are not already connected", async () => {
     vi.mocked(host.listConnectedFolders)
+      .mockResolvedValueOnce([readWrite("connected", "Current project")])
       .mockResolvedValueOnce([
-        { rootId: "connected", displayName: "Current project" },
-      ])
-      .mockResolvedValueOnce([
-        { rootId: "connected", displayName: "Current project" },
-        { rootId: "available", displayName: "Research" },
+        readWrite("connected", "Current project"),
+        readWrite("available", "Research"),
       ]);
     vi.mocked(host.listApprovedFolders).mockResolvedValue([
       { rootId: "connected", displayName: "Current project" },
@@ -103,26 +123,21 @@ describe("FoldersView", () => {
   it("ignores a late folder response after switching chats", async () => {
     const firstChat = { ...chat, id: "chat-a", title: "Chat A" };
     const secondChat = { ...chat, id: "chat-b", title: "Chat B" };
-    const firstResponse = deferred<host.ConnectedFolder[]>();
-    const secondResponse = deferred<host.ConnectedFolder[]>();
-    vi.mocked(host.listConnectedFolders).mockImplementation(
-      (requestedChat) =>
-        requestedChat.id === firstChat.id
-          ? firstResponse.promise
-          : secondResponse.promise,
+    const firstResponse = deferred<host.ConnectedFolderAccess[]>();
+    const secondResponse = deferred<host.ConnectedFolderAccess[]>();
+    vi.mocked(host.listConnectedFolders).mockImplementation((requestedChat) =>
+      requestedChat.id === firstChat.id
+        ? firstResponse.promise
+        : secondResponse.promise,
     );
 
     const { rerender } = render(<FoldersView chat={firstChat} />);
     rerender(<FoldersView chat={secondChat} />);
 
-    secondResponse.resolve([
-      { rootId: "chat-b-root", displayName: "Chat B folder" },
-    ]);
+    secondResponse.resolve([readWrite("chat-b-root", "Chat B folder")]);
     expect(await screen.findByText("Chat B folder")).toBeInTheDocument();
 
-    firstResponse.resolve([
-      { rootId: "chat-a-root", displayName: "Chat A folder" },
-    ]);
+    firstResponse.resolve([readWrite("chat-a-root", "Chat A folder")]);
     await waitFor(() =>
       expect(screen.queryByText("Chat A folder")).not.toBeInTheDocument(),
     );

--- a/crates/openwave-desktop/ui/src/FoldersView.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersView.tsx
@@ -22,6 +22,8 @@ import {
   listApprovedFolders,
   listConnectedFolders,
   type ConnectedFolder,
+  type ConnectedFolderAccess,
+  type FolderCapability,
 } from "./host";
 import {
   PICKER_BUSY_MESSAGE,
@@ -30,8 +32,9 @@ import {
 } from "./NativePickerLatch";
 
 /**
- * A chat's connected folders: the directories the native host may read on this
- * conversation's behalf.
+ * A chat's connected folders: the directories the native host may reach on this
+ * conversation's behalf, each shown with the access the broker actually grants
+ * it.
  *
  * Two sections rather than one. The first is what this conversation can reach.
  * The second is what this device has already approved and can be reattached
@@ -40,7 +43,7 @@ import {
  * a list.
  */
 export function FoldersView({ chat }: { chat: Chat }) {
-  const [folders, setFolders] = useState<ConnectedFolder[]>([]);
+  const [folders, setFolders] = useState<ConnectedFolderAccess[]>([]);
   const [approvedFolders, setApprovedFolders] = useState<ConnectedFolder[]>([]);
   const [working, setWorking] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -176,8 +179,9 @@ export function FoldersView({ chat }: { chat: Chat }) {
               </EmptyMedia>
               <EmptyTitle>No folders connected</EmptyTitle>
               <EmptyDescription>
-                Connect a folder to let OpenWave read files from your computer in
-                this conversation. It can read only the folders you attach here.
+                Connect a folder to let OpenWave work with files on your
+                computer in this conversation. It can reach only the folders you
+                attach here, and each one shows what it allows.
               </EmptyDescription>
             </EmptyHeader>
             <EmptyContent>{connectButton}</EmptyContent>
@@ -190,7 +194,7 @@ export function FoldersView({ chat }: { chat: Chat }) {
                   <FolderRow
                     key={folder.rootId}
                     name={folder.displayName}
-                    badge={<Badge variant="secondary" size="sm">Read access</Badge>}
+                    badge={<AccessBadge capabilities={folder.capabilities} />}
                     action={
                       <Button
                         variant="outline"
@@ -236,6 +240,32 @@ export function FoldersView({ chat }: { chat: Chat }) {
       </div>
       {confirmDialog}
     </div>
+  );
+}
+
+/**
+ * The folder's access state, read off what the broker reports rather than
+ * assumed from what the app requested.
+ *
+ * Connecting a folder currently grants reading and writing together, so this
+ * renders "Read and write" in practice. It is derived anyway: the moment the
+ * grant ladder narrows, a badge computed from a constant would keep claiming
+ * access the agent no longer has, which is the failure worth designing out.
+ */
+function AccessBadge({ capabilities }: { capabilities: FolderCapability[] }) {
+  const read = capabilities.includes("read");
+  const write = capabilities.includes("write");
+  const label = read
+    ? write
+      ? "Read and write"
+      : "Read only"
+    : write
+      ? "Write only"
+      : "No access";
+  return (
+    <Badge variant={read || write ? "secondary" : "outline"} size="sm">
+      {label}
+    </Badge>
   );
 }
 

--- a/crates/openwave-desktop/ui/src/host.ts
+++ b/crates/openwave-desktop/ui/src/host.ts
@@ -6,6 +6,19 @@ export type ConnectedFolder = {
   displayName: string;
 };
 
+/** What the agent may do inside one connected folder. */
+export type FolderCapability = "read" | "write";
+
+/**
+ * A connected folder and the access the host broker reports for it, checked
+ * against the same authorization the agent's own operations go through. The app
+ * must not substitute an assumption for this — a folder's access state is what
+ * the broker would allow, not what the app asked for.
+ */
+export type ConnectedFolderAccess = ConnectedFolder & {
+  capabilities: FolderCapability[];
+};
+
 export type FolderAccessDecision = "allow" | "decline";
 export type OutputWritebackDecision = "allow" | "decline";
 
@@ -19,7 +32,9 @@ export async function requestUserAttention(): Promise<void> {
   await invoke("request_user_attention");
 }
 
-export function listConnectedFolders(chat: Chat): Promise<ConnectedFolder[]> {
+export function listConnectedFolders(
+  chat: Chat,
+): Promise<ConnectedFolderAccess[]> {
   return invoke("list_connected_folders", { chatId: chat.id });
 }
 

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -37,10 +37,10 @@ use crate::{
         LookupRootAttachmentReceiptResult, OperationEnvelope, OperationRequest,
         OperationResponseEnvelope, OperationResult, PathRequest, ReadFileBinaryResult,
         ReadFileResult, RegisterRootReceipt, RegisterRootRequest, RegisterRootResult, Response,
-        ResponseEnvelope, RevokeRootRequest, RevokeRootResult, RootAttachmentMutationKind,
-        RootAttachmentMutationReceipt, RootAttachmentMutationRequest, RootAttachmentMutationResult,
-        RootSummary, WriteFileMode, WriteFileRequest, WriteFileResult, MAX_READ_FILE_BINARY_BYTES,
-        PROTOCOL_VERSION,
+        ResponseEnvelope, RevokeRootRequest, RevokeRootResult, RootAccess,
+        RootAttachmentMutationKind, RootAttachmentMutationReceipt, RootAttachmentMutationRequest,
+        RootAttachmentMutationResult, RootSummary, WriteFileMode, WriteFileRequest,
+        WriteFileResult, MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
     },
     Capability, ConsentMethod, ConsentRecord, ExecutionContext, Grant, GrantError, GrantId,
     GrantSubject, OperationId, RelativePath, RootAttachment, RootId, RootPolicy, RootPolicyError,
@@ -1959,9 +1959,10 @@ fn list_roots(
             )
             .is_ok()
         })
-        .map(|(root_id, root)| RootSummary {
+        .map(|(root_id, root)| RootAccess {
             root_id: *root_id,
             display_name: root.display_name.clone(),
+            capabilities: root_capabilities(state, context, root_id),
         })
         .take(MAX_LIST_ROOTS + 1)
         .collect::<Vec<_>>();
@@ -1974,6 +1975,25 @@ fn list_roots(
             .then_with(|| left.root_id.to_string().cmp(&right.root_id.to_string()))
     });
     Ok((OperationResult::ListRoots { roots }, Some(grant_id)))
+}
+
+/// Per-folder capabilities this conversation actually holds on one root.
+///
+/// Each candidate is put through the same [`authorize`] call that gates the
+/// corresponding operation rather than read off the grant list, so a reported
+/// capability and an allowed operation cannot disagree. Subject-wide
+/// capabilities are excluded: they are not properties of a folder.
+fn root_capabilities(
+    state: &State,
+    context: ExecutionContext,
+    root_id: &RootId,
+) -> Vec<Capability> {
+    [Capability::ReadFiles, Capability::WriteFiles]
+        .into_iter()
+        .filter(|capability| {
+            authorize(state, context, *capability, Resource::Root(root_id)).is_ok()
+        })
+        .collect()
 }
 
 fn root_display_name(path: &Path) -> String {

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -86,6 +86,16 @@ fn register(
     result
 }
 
+/// The listing shape a folder gets from a plain registration, which grants both
+/// reading and writing.
+fn read_write(root: RootSummary) -> RootAccess {
+    RootAccess {
+        root_id: root.root_id,
+        display_name: root.display_name,
+        capabilities: vec![Capability::ReadFiles, Capability::WriteFiles],
+    }
+}
+
 fn mutate_attachment(
     controller: &Controller,
     operation_id: OperationId,
@@ -422,7 +432,7 @@ fn approved_roots_can_be_explicitly_attached_to_another_standalone_conversation(
         )
         .unwrap(),
         OperationResult::ListRoots {
-            roots: vec![registered.root]
+            roots: vec![read_write(registered.root)]
         }
     );
     assert!(matches!(
@@ -491,7 +501,7 @@ fn reused_standalone_approval_and_chat_attachment_survive_restart() {
         )
         .unwrap(),
         OperationResult::ListRoots {
-            roots: vec![registered.root]
+            roots: vec![read_write(registered.root)]
         }
     );
 }
@@ -529,7 +539,7 @@ fn choosing_the_same_approved_folder_again_reuses_its_host_identity() {
         )
         .unwrap(),
         OperationResult::ListRoots {
-            roots: vec![first.root]
+            roots: vec![read_write(first.root)]
         }
     );
 }
@@ -705,7 +715,7 @@ fn basename_collisions_are_not_offered_as_approved_roots() {
         )
         .unwrap(),
         OperationResult::ListRoots {
-            roots: vec![first.root],
+            roots: vec![read_write(first.root)],
         }
     );
 }
@@ -728,7 +738,7 @@ fn register_list_read_and_revoke_are_one_live_authority_boundary() {
     assert_eq!(
         roots,
         OperationResult::ListRoots {
-            roots: vec![registered.root.clone()]
+            roots: vec![read_write(registered.root.clone())]
         }
     );
     let listing = operate(
@@ -992,7 +1002,7 @@ fn repeated_registration_reuses_the_same_root_and_attaches_new_project_chat() {
         assert_eq!(
             roots,
             OperationResult::ListRoots {
-                roots: vec![first.root.clone()]
+                roots: vec![read_write(first.root.clone())]
             }
         );
     }
@@ -1345,7 +1355,7 @@ fn attach_and_detach_are_exact_conversation_mutations() {
     let second_context = ExecutionContext::project_chat(second_conversation, project_id).unwrap();
     assert!(matches!(
         operate(&broker.operator(), second_context, OperationRequest::ListRoots).unwrap(),
-        OperationResult::ListRoots { roots } if roots == vec![registered.root.clone()]
+        OperationResult::ListRoots { roots } if roots == vec![read_write(registered.root.clone())]
     ));
 
     let detach_id = OperationId::new();
@@ -1366,7 +1376,7 @@ fn attach_and_detach_are_exact_conversation_mutations() {
     ));
     assert!(matches!(
         operate(&broker.operator(), second_context, OperationRequest::ListRoots).unwrap(),
-        OperationResult::ListRoots { roots } if roots == vec![registered.root]
+        OperationResult::ListRoots { roots } if roots == vec![read_write(registered.root)]
     ));
     assert!(
         !mutate_attachment(
@@ -2603,6 +2613,77 @@ fn writes_create_without_clobber_and_retry_from_the_terminal_receipt() {
         b"authoritative revision",
         "create mode never clobbers the destination"
     );
+}
+
+/// The capability set a listing reports is what the broker will actually allow.
+///
+/// The desktop renders this set as a folder's access state, so the two must not
+/// be able to drift: reporting a capability the next operation refuses, or
+/// hiding one it would permit, both mislead the person deciding what the agent
+/// can reach. Dropping the write grant is the only way to reach a read-only
+/// folder today — registration always mints both — so it stands in for a
+/// narrower grant the ladder may later offer.
+#[test]
+fn a_listing_reports_the_capabilities_the_broker_would_authorize() {
+    let (_temp, broker, path) = setup();
+    let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    let registered = register(
+        &broker.controller(),
+        subject,
+        conversation,
+        path.clone(),
+        OperationId::new(),
+    );
+    let context = ExecutionContext::standalone(conversation).unwrap();
+    let root_id = registered.root.root_id;
+    std::fs::create_dir(path.join("published")).unwrap();
+
+    assert_eq!(
+        operate(&broker.operator(), context, OperationRequest::ListRoots).unwrap(),
+        OperationResult::ListRoots {
+            roots: vec![read_write(registered.root)]
+        },
+        "a folder connected through the picker allows reading and writing"
+    );
+
+    broker
+        .shared
+        .state
+        .lock()
+        .unwrap()
+        .grants
+        .retain(|grant| grant.capability() != Capability::WriteFiles);
+
+    let OperationResult::ListRoots { roots } =
+        operate(&broker.operator(), context, OperationRequest::ListRoots).unwrap()
+    else {
+        panic!("unexpected listing result")
+    };
+    assert_eq!(
+        roots.first().map(|root| root.capabilities.as_slice()),
+        Some([Capability::ReadFiles].as_slice()),
+        "write is not reported once the grant behind it is gone"
+    );
+    assert!(matches!(
+        operate(
+            &broker.operator(),
+            context,
+            write_request(
+                OperationId::new(),
+                root_id,
+                "published/report.txt",
+                WriteFileMode::Create,
+                None,
+                b"unauthorized revision",
+            ),
+        ),
+        Err(ErrorResponse {
+            code: ErrorCode::Denied,
+            ..
+        })
+    ));
+    assert!(!path.join("published/report.txt").exists());
 }
 
 #[test]

--- a/crates/openwave-host-broker/src/lib.rs
+++ b/crates/openwave-host-broker/src/lib.rs
@@ -36,8 +36,9 @@ pub use protocol::{
     LookupRootAttachmentReceiptResult, OperationEnvelope, OperationRequest,
     OperationResponseEnvelope, OperationResult, PathRequest, ReadFileBinaryResult, ReadFileResult,
     RegisterRootReceipt, RegisterRootRequest, RegisterRootResult, Response, ResponseEnvelope,
-    RevokeRootRequest, RevokeRootResult, RootAttachmentMutationKind, RootAttachmentMutationReceipt,
-    RootAttachmentMutationRequest, RootAttachmentMutationResult, RootSummary, WriteApproval,
-    WriteFileMode, WriteFileRequest, WriteFileResult, MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
+    RevokeRootRequest, RevokeRootResult, RootAccess, RootAttachmentMutationKind,
+    RootAttachmentMutationReceipt, RootAttachmentMutationRequest, RootAttachmentMutationResult,
+    RootSummary, WriteApproval, WriteFileMode, WriteFileRequest, WriteFileResult,
+    MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
 };
 pub use relative_path::{RelativePath, RelativePathError};

--- a/crates/openwave-host-broker/src/protocol.rs
+++ b/crates/openwave-host-broker/src/protocol.rs
@@ -10,11 +10,12 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
-    ConsentMethod, ExecutionContext, GrantSubject, OperationId, RelativePath, RequestId, RootId,
+    Capability, ConsentMethod, ExecutionContext, GrantSubject, OperationId, RelativePath,
+    RequestId, RootId,
 };
 
 /// Current pre-v1 broker protocol. Bump this for incompatible wire changes.
-pub const PROTOCOL_VERSION: u32 = 7;
+pub const PROTOCOL_VERSION: u32 = 8;
 
 /// Largest file the broker returns as opaque bytes.
 ///
@@ -306,7 +307,7 @@ pub enum ControlResult {
 #[serde(tag = "result", rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum OperationResult {
-    ListRoots { roots: Vec<RootSummary> },
+    ListRoots { roots: Vec<RootAccess> },
     ListDirectory { entries: Vec<DirectoryEntry> },
     ReadFile(ReadFileResult),
     ReadFileBinary(ReadFileBinaryResult),
@@ -336,6 +337,23 @@ pub struct HelloResult {
 pub struct RootSummary {
     pub root_id: RootId,
     pub display_name: String,
+}
+
+/// One reachable folder together with what the broker would actually allow on
+/// it right now.
+///
+/// `capabilities` is not a stored description of the folder. It is produced by
+/// asking the same authorization path that gates the real operations, for this
+/// exact conversation, so a caller that renders it cannot claim access the
+/// broker would refuse — or hide access it would allow. Only per-folder
+/// capabilities appear here; subject-wide ones such as
+/// [`crate::Capability::ListRoots`] are not properties of a folder.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RootAccess {
+    pub root_id: RootId,
+    pub display_name: String,
+    pub capabilities: Vec<Capability>,
 }
 
 /// Result of registering and attaching a selected folder.


### PR DESCRIPTION
The folders panel gave every connected folder the same fixed `Read access`
badge, because that was the only thing the desktop asked for. It is not what
the folder actually allows.

Registration mints three grants for the chosen folder — `ListRoots`,
`ReadFiles` and `WriteFiles` — and does so unconditionally, in three places:
`prepare_registration` for a new folder, `ensure_subject_grants` when an
already-approved folder is reattached, and the state-file v2→v3 migration,
which back-filled a write grant beside every existing read grant.
`registration_is_connected` treats a folder missing any of the three as not
connected. The write grant is live, not decorative: `write_output_to_connected_folder`
reaches the broker's `WriteFile` operation, which calls `authorize_write`
before any bytes land. So the badge was understating the grant — telling
someone a folder was read-only while the agent could publish into it.

A folder's access state is now reported rather than assumed. `ListRoots`
returns `RootAccess`, which carries the per-folder capabilities the broker
would authorize for the asking conversation, computed by putting each
candidate through the same `authorize` call that gates the corresponding
operation. The badge renders that set. Today it reads "Read and write" for
every folder, which is the honest answer; the point of deriving it is that the
answer changes on its own when the grant ladder does, instead of a constant in
the UI quietly going stale.

## Why this is not the capability toggles from #828

I went looking for whether a toggle would gate anything before building one,
and two of the three things it needs are missing:

- **A grant cannot be narrowed after the fact.** The broker's control surface
  is `Hello`, `ListApprovedRoots`, `RegisterRoot`, `AttachRoot`, `DetachRoot`,
  the two receipt lookups, and `RevokeRoot`. Nothing modifies a grant.
  `RevokeRoot` is all-or-nothing and drops the root with every grant scoped to
  it; re-registering mints all three again. A checkbox that unchecked write
  would have had nothing to call.
- **Least privilege has no representation at connect time.** The model-facing
  `RequestedFolderCapability` has exactly one variant, `ReadFiles`, and
  `is_well_formed` requires the proposal to be exactly `[ReadFiles]`. The host
  derives the grant itself and ignores the proposal, which is the right shape —
  but there is currently no path by which a narrower choice reaches
  `prepare_registration`.

A fresh native prompt is *not* the obstacle. The OS-level consent is the
folder picker, plus macOS TCC on first touch of a protected location, and
neither distinguishes reading from writing; the app ships no sandbox
entitlements. `WriteApproval` is per-replacement and comes from OpenWave's own
dialog, not the system's. `ConsentMethod::PermissionDialog` already exists and
is already used for attach, so a capability change would cost an in-app
confirmation and no more.

So the toggles are a broker change first — a scope-narrowing control request
and a capability set threaded through registration — and a panel change
second. Shipping the switches now would have produced exactly the thing worth
avoiding: a control that reads as a restriction while the write grant stays
where it is. #828 stays open for that, with these findings on it.

## Wire and protocol

`PROTOCOL_VERSION` goes to 8. `RootAccess` is deliberately a new type rather
than a field on `RootSummary`: `RootSummary` is embedded in
`RegisterRootResult`, which is persisted inside the broker's mutation receipts,
so widening it would have meant a state-file version and a migration to carry
a value that is only ever computed fresh. `ListApprovedRoots` keeps
`RootSummary` — that list is host-wide rather than subject-scoped, so a
capability set on it would not have a well-defined subject to be true of.

Nothing generated changes; `ConnectedFolder` is hand-written in `host.ts`, and
no `ts_rs` type is touched.

## Tests

Two, both about the claim not being able to drift from the grant:

- `a_listing_reports_the_capabilities_the_broker_would_authorize` registers a
  folder, drops the write grant from broker state, and asserts the listing
  stops reporting write *and* that the next `WriteFile` is denied. Dropping the
  grant directly is the only way to reach a read-only folder today; it stands in
  for the narrower grant the ladder may later offer, and it fails if the
  reported set is ever computed from something other than the authorization
  path.
- `shows each folder's access as the host reports it` renders one read-write
  and one read-only folder and checks each badge follows the host's answer.

The existing `ListRoots` expectations moved to a `read_write` helper, which
names what a plain registration grants rather than repeating the pair.

## Not verified

Not driven in the packaged app, and I cannot exercise a real macOS folder grant
from here — which for this change is most of what matters. What I have checked
is the broker's authorization behaviour under test and the panel's rendering;
what I have not is a live picker producing a listing whose badge I can read.
The read-only badge state in particular has no way to occur in the shipped app
yet, so it is exercised only by the tests above.

Part of #828
Part of #703
