### PR TITLE
feat(desktop): mark a citation's passage in a text original

### DIFF
--- a/crates/openwave-desktop/ui/package.json
+++ b/crates/openwave-desktop/ui/package.json
@@ -62,6 +62,7 @@
     "@testing-library/jest-dom": "7.0.0",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",
+    "@types/hast": "3.0.5",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "4.7.0",

--- a/crates/openwave-desktop/ui/pnpm-lock.yaml
+++ b/crates/openwave-desktop/ui/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       '@testing-library/user-event':
         specifier: 14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/hast':
+        specifier: 3.0.5
+        version: 3.0.5
       '@types/react':
         specifier: 19.2.17
         version: 19.2.17

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
@@ -8,6 +8,12 @@ import remarkMath from "remark-math";
 import rehypeHighlight from "rehype-highlight";
 import rehypeKatex from "rehype-katex";
 import { ClipboardCopyButton } from "./ClipboardCopyButton";
+import {
+  pieceStartOffsets,
+  rangeWithinPiece,
+  rehypeHighlightRange,
+  type HighlightRange,
+} from "./components/document/citationMark";
 import { splitMarkdownBlocks } from "./markdownBlocks";
 import { escapeLatexText } from "./markdownLatex";
 import { slugify } from "./markdownHeadings";
@@ -26,17 +32,62 @@ import { slugify } from "./markdownHeadings";
  * indentation no longer leaks and the parsed block structure renders cleanly.
  */
 export function preserveLineBreaks(input: string): string {
-  // Fenced code is source text: hard-break spaces would corrupt what the
-  // block renders and what the copy control yields. The `$` alternative keeps
-  // a still-streaming, unclosed fence untouched too.
-  return input
-    .split(/(```[\s\S]*?(?:```|$))/)
-    .map((segment) =>
-      segment.startsWith("```")
-        ? segment
-        : segment.replace(/([^\n])\n(?!\n)/g, "$1  \n"),
-    )
-    .join("");
+  const points = hardBreakInsertions(input);
+  if (points.length === 0) return input;
+
+  let result = "";
+  let from = 0;
+  for (const point of points) {
+    result += input.slice(from, point) + "  ";
+    from = point;
+  }
+  return result + input.slice(from);
+}
+
+/**
+ * The offsets in `input` that {@link preserveLineBreaks} inserts two spaces
+ * before — every single newline outside a fence.
+ *
+ * The rewrite is defined in terms of these positions rather than the other way
+ * round, so a caller that needs to know where a source offset ended up after it
+ * — placing a citation's mark in the parsed tree — asks the same scan instead of
+ * modelling the transform a second time and drifting from it.
+ */
+function hardBreakInsertions(input: string): number[] {
+  const points: number[] = [];
+  let offset = 0;
+  // Fenced code is source text: hard-break spaces would corrupt what the block
+  // renders and what the copy control yields. The `$` alternative keeps a
+  // still-streaming, unclosed fence untouched too.
+  for (const segment of input.split(/(```[\s\S]*?(?:```|$))/)) {
+    if (!segment.startsWith("```")) {
+      const singleNewline = /[^\n]\n(?!\n)/g;
+      let match: RegExpExecArray | null;
+      while ((match = singleNewline.exec(segment)) !== null) {
+        points.push(offset + match.index + 1);
+      }
+    }
+    offset += segment.length;
+  }
+  return points;
+}
+
+/**
+ * Where an offset in the Markdown source lands in the string the parser is
+ * handed — the same offset plus the hard breaks inserted ahead of it.
+ *
+ * Only the line-break rewrite shifts anything: {@link escapeLatexText} rewrites
+ * LaTeX delimiters, so a caller that means to address the parsed tree has to
+ * establish that it left the source alone before this arithmetic means
+ * anything.
+ */
+export function hardBreakOffset(input: string, offset: number): number {
+  let shift = 0;
+  for (const point of hardBreakInsertions(input)) {
+    if (point >= offset) break;
+    shift += 2;
+  }
+  return offset + shift;
 }
 
 /**
@@ -159,7 +210,7 @@ const remarkPlugins: Options["remarkPlugins"] = [
   [remarkMath, { singleDollarTextMath: false }],
 ];
 
-const rehypePlugins: Options["rehypePlugins"] = [
+const rehypePlugins: NonNullable<Options["rehypePlugins"]> = [
   // Highlight only fence-tagged languages; auto-detection on unlabeled blocks
   // guesses wrong too often to be worth it.
   [rehypeHighlight, { detect: false }],
@@ -186,15 +237,24 @@ export function processMarkdownContent(input: string): string {
 const MarkdownBlock = memo(function MarkdownBlock({
   block,
   headingIds,
+  highlightStart,
+  highlightEnd,
 }: {
   block: string;
   headingIds: boolean;
+  /** Range to mark, in this block's own source. Primitives, so memo compares. */
+  highlightStart?: number;
+  highlightEnd?: number;
 }) {
   const processed = useMemo(() => processMarkdownContent(block), [block]);
+  const plugins = useMemo(
+    () => blockRehypePlugins(block, highlightStart, highlightEnd),
+    [block, highlightStart, highlightEnd],
+  );
   return (
     <ReactMarkdown
       remarkPlugins={remarkPlugins}
-      rehypePlugins={rehypePlugins}
+      rehypePlugins={plugins}
       components={headingIds ? componentsWithHeadingIds : components}
       skipHtml
       urlTransform={(url) => safeMarkdownUrl(url) ?? ""}
@@ -204,6 +264,40 @@ const MarkdownBlock = memo(function MarkdownBlock({
   );
 });
 
+/**
+ * The pipeline for one block, with the citation's mark added when the block
+ * holds one.
+ *
+ * The marker runs before the rest because it is the only pass that depends on
+ * text nodes still standing where they were read from: syntax highlighting and
+ * math rewrite their subtrees and drop those positions, so a passage inside a
+ * code fence or a formula goes unmarked rather than marked by guesswork.
+ *
+ * A block whose LaTeX delimiters the pipeline rewrites is left alone for the
+ * same reason — the rewrite moves text the offsets were measured against, and
+ * only the hard-break insertion can be accounted for.
+ */
+function blockRehypePlugins(
+  block: string,
+  start: number | undefined,
+  end: number | undefined,
+): NonNullable<Options["rehypePlugins"]> {
+  if (start == null || end == null || end <= start) return rehypePlugins;
+  if (escapeLatexText(block) !== block) return rehypePlugins;
+  return [
+    [
+      rehypeHighlightRange,
+      {
+        range: {
+          start: hardBreakOffset(block, start),
+          end: hardBreakOffset(block, end),
+        },
+      },
+    ],
+    ...rehypePlugins,
+  ];
+}
+
 interface MessageMarkdownProps {
   children: string;
   /**
@@ -211,21 +305,43 @@ interface MessageMarkdownProps {
    * Off for transcripts, where headings from separate messages would collide.
    */
   headingIds?: boolean;
+  /**
+   * Half-open character range of `children` to mark as the cited passage.
+   *
+   * Addresses the source rather than the rendering, which is what makes it
+   * answerable: the range is carried down to whichever blocks it covers and
+   * placed against the offsets the parser recorded for each of them.
+   */
+  highlightRange?: HighlightRange;
 }
 
 export const MessageMarkdown = memo(function MessageMarkdown({
   children,
   headingIds = false,
+  highlightRange,
 }: MessageMarkdownProps) {
   const blocks = useMemo(() => splitMarkdownBlocks(children), [children]);
+  const blockStarts = useMemo(() => pieceStartOffsets(blocks), [blocks]);
+
   return (
     <div className="message-markdown">
-      {blocks.map((block, index) => (
-        // Blocks are append-only while streaming: the prefix is immutable and
-        // only the tail grows, so the array index is a stable identity that
-        // keeps the growing block mounted across ticks.
-        <MarkdownBlock key={index} block={block} headingIds={headingIds} />
-      ))}
+      {blocks.map((block, index) => {
+        const inBlock = highlightRange
+          ? rangeWithinPiece(highlightRange, blockStarts[index]!, block.length)
+          : null;
+        return (
+          // Blocks are append-only while streaming: the prefix is immutable and
+          // only the tail grows, so the array index is a stable identity that
+          // keeps the growing block mounted across ticks.
+          <MarkdownBlock
+            key={index}
+            block={block}
+            headingIds={headingIds}
+            highlightStart={inBlock?.start}
+            highlightEnd={inBlock?.end}
+          />
+        );
+      })}
     </div>
   );
 });

--- a/crates/openwave-desktop/ui/src/components/document/citationMark.ts
+++ b/crates/openwave-desktop/ui/src/components/document/citationMark.ts
@@ -1,0 +1,129 @@
+import type { Element, Root, RootContent, Text } from "hast";
+
+/** A half-open character range in the source a tree was parsed from. */
+export type HighlightRange = { start: number; end: number };
+
+/**
+ * How a cited passage reads wherever it is drawn — the extracted text, a plain
+ * original, a rendered one — kept in one place so the three agree.
+ *
+ * The class is the hook a viewer scrolls to; the style is separate from it
+ * because the mark inside a rendered tree is built by the plugin below rather
+ * than written as an element.
+ */
+export const CITATION_MARK_CLASS = "citation-mark";
+export const CITATION_MARK_STYLE = "rounded bg-yellow-200/60 dark:bg-yellow-500/25";
+export const CITATION_MARK_LABEL = "Cited passage";
+
+/**
+ * Where each piece of a split text begins in the text it was split from.
+ *
+ * Both splits a citation has to survive — the viewer's chunks, the renderer's
+ * blocks — are the verbatim source in order, so a piece starts at the sum of the
+ * lengths before it and a range can be clipped onto it exactly.
+ */
+export function pieceStartOffsets(pieces: readonly string[]): number[] {
+  let offset = 0;
+  return pieces.map((piece) => {
+    const start = offset;
+    offset += piece.length;
+    return start;
+  });
+}
+
+/**
+ * The part of a range that falls inside one piece, in that piece's own offsets,
+ * or null for a piece the range does not reach. A passage crossing a boundary is
+ * marked in both pieces rather than in neither.
+ */
+export function rangeWithinPiece(
+  range: HighlightRange,
+  pieceStart: number,
+  pieceLength: number,
+): HighlightRange | null {
+  const start = Math.max(range.start - pieceStart, 0);
+  const end = Math.min(range.end - pieceStart, pieceLength);
+  return end > start ? { start, end } : null;
+}
+
+/**
+ * Mark the text a character range covers, wherever it landed in the tree.
+ *
+ * The range addresses the string the parser was handed, which is what makes
+ * this possible at all: every text node in a hast tree carries the offsets it
+ * was read from, so the passage is found by arithmetic rather than by matching
+ * its text against the rendered output. A range that spans several nodes — a
+ * sentence with a bold word in it, or a passage crossing a paragraph — marks
+ * each of them, since the words in between are not contiguous in the tree.
+ *
+ * Nodes whose position was dropped by an earlier transform are skipped rather
+ * than guessed at; in practice that is syntax-highlighted code and rendered
+ * math, whose text no longer stands in one-to-one relation to its source.
+ */
+export function rehypeHighlightRange({ range }: { range: HighlightRange }) {
+  return (tree: Root) => {
+    if (range.end <= range.start) return;
+    markRange(tree, range.start, range.end);
+  };
+}
+
+function markRange(parent: Root | Element, start: number, end: number): void {
+  // Backwards, so replacing one child cannot shift the index of an unvisited one.
+  for (let i = parent.children.length - 1; i >= 0; i--) {
+    const child = parent.children[i]!;
+    if (child.type === "element") {
+      markRange(child, start, end);
+      continue;
+    }
+    if (child.type !== "text") continue;
+
+    const nodeStart = child.position?.start.offset;
+    const nodeEnd = child.position?.end.offset;
+    if (nodeStart == null || nodeEnd == null) continue;
+    if (nodeEnd <= start || nodeStart >= end) continue;
+
+    const replacement = splitAroundOverlap(child, nodeStart, start, end);
+    if (replacement) parent.children.splice(i, 1, ...replacement);
+  }
+}
+
+/**
+ * One text node split in three around the part of it the range covers.
+ *
+ * A node's text is its source verbatim in all but a few cases — an escape, a
+ * character reference — where it is shorter, and the offsets inside it are that
+ * much further along than the text is. The overlap is clamped to the text
+ * actually held, so the worst that costs is a boundary drawn a character or two
+ * off inside the one node that held the escape.
+ */
+function splitAroundOverlap(
+  node: Text,
+  nodeStart: number,
+  start: number,
+  end: number,
+): RootContent[] | null {
+  const text = node.value;
+  const from = clamp(start - nodeStart, 0, text.length);
+  const to = clamp(end - nodeStart, from, text.length);
+  if (to === from) return null;
+
+  const mark: Element = {
+    type: "element",
+    tagName: "mark",
+    properties: {
+      className: [CITATION_MARK_CLASS, ...CITATION_MARK_STYLE.split(" ")],
+      ariaLabel: CITATION_MARK_LABEL,
+    },
+    children: [{ type: "text", value: text.slice(from, to) }],
+  };
+
+  const parts: RootContent[] = [];
+  if (from > 0) parts.push({ type: "text", value: text.slice(0, from) });
+  parts.push(mark);
+  if (to < text.length) parts.push({ type: "text", value: text.slice(to) });
+  return parts;
+}
+
+function clamp(value: number, low: number, high: number): number {
+  return Math.min(Math.max(value, low), high);
+}

--- a/crates/openwave-desktop/ui/src/components/document/document-details.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/document-details.tsx
@@ -17,10 +17,16 @@ import {
   DocumentViewer,
   hasOriginalViewer,
 } from "@/document/DocumentViewer";
+import { cn } from "@/lib/utils";
+import {
+  CITATION_MARK_CLASS,
+  CITATION_MARK_LABEL,
+  CITATION_MARK_STYLE,
+} from "./citationMark";
 import { charRangeForByteSpan, type CitationSpan } from "./citationSpan";
 import { DocumentError } from "./error";
 import { ImageViewer } from "./image-viewer";
-import { MarkdownViewer, type HighlightRange } from "./markdown-viewer";
+import { MarkdownViewer } from "./markdown-viewer";
 
 // Both tree viewers carry their own parsing and node machinery, and neither is
 // on the path of the formats readers open most, so they load on demand.
@@ -77,17 +83,20 @@ type DocumentDetailsProps = {
   info: DocumentDetail;
   view: DocumentView;
   hasOriginalDocumentTab?: boolean;
-  /** Character range in the original to reveal, when opened from a citation. */
-  highlightRange?: HighlightRange;
   /**
    * Node to reveal in a tree viewer, when opened from a citation: a
    * dot-notation path for JSON, an XPath expression for XML.
+   *
+   * Uncalled, and not derivable from a citation: a citation addresses a byte
+   * range of the text read out of the file, and which node of the parsed tree
+   * that range came from is not recorded anywhere. The viewers honour the prop,
+   * so a producer of node paths would only have to reach this far.
    */
   highlightPath?: string;
   /**
-   * Byte range in the extracted text to highlight and scroll to, when opened
-   * from a citation. Distinct from `highlightRange`, which addresses characters
-   * of the original file rather than bytes of the text read out of it.
+   * Byte range of the cited passage in the text of record, when opened from a
+   * citation. Highlighted in the extracted text, and in a text-shaped original,
+   * whose text of record is the file verbatim.
    */
   citationSpan?: CitationSpan;
   /** Page of a paginated original to open on, when opened from a citation. */
@@ -109,7 +118,6 @@ export function DocumentDetails({
   info,
   view,
   hasOriginalDocumentTab,
-  highlightRange,
   highlightPath,
   citationSpan,
   targetPage,
@@ -159,11 +167,14 @@ export function DocumentDetails({
               )}
             </Suspense>
           ) : (
+            // Everything that reaches here is a `text/*` source, and nothing is
+            // extracted out of those: the text of record is the file, so the
+            // citation's own offsets address what the viewer draws.
             <MarkdownViewer
               client={client}
               chatId={chatId}
               documentID={info.document_id}
-              highlightRange={highlightRange}
+              citationSpan={citationSpan}
               markdown={type === "text/markdown"}
               className="bg-page-background grow"
             />
@@ -242,8 +253,8 @@ function ExtractedText({
             {info.content.slice(0, cited.start)}
             <mark
               ref={citedRef}
-              aria-label="Cited passage"
-              className="rounded bg-yellow-200/60 dark:bg-yellow-500/25"
+              aria-label={CITATION_MARK_LABEL}
+              className={cn(CITATION_MARK_CLASS, CITATION_MARK_STYLE)}
             >
               {info.content.slice(cited.start, cited.end)}
             </mark>

--- a/crates/openwave-desktop/ui/src/components/document/markdown-viewer.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/markdown-viewer.tsx
@@ -7,11 +7,16 @@ import { useFileDownload } from "@/document/useFileDownload";
 import { cn } from "@/lib/utils";
 import { extractHeadings } from "@/markdownHeadings";
 import { MessageMarkdown } from "@/MessageMarkdown";
+import {
+  CITATION_MARK_CLASS,
+  CITATION_MARK_LABEL,
+  CITATION_MARK_STYLE,
+  pieceStartOffsets,
+  rangeWithinPiece,
+} from "./citationMark";
+import { charRangeForByteSpan, type CitationSpan } from "./citationSpan";
 import { FileDownloadProgressIndicator } from "./FileDownloadProgress";
 import { MarkdownOutline } from "./MarkdownOutline";
-
-/** A character range in the raw file, as a citation reports it. */
-export type HighlightRange = { start: number; end: number };
 
 // Each chunk is rendered as a separate markdown block. 50K chars is
 // comfortably fast for the parser to handle in one pass.
@@ -53,34 +58,19 @@ export function splitIntoChunks(text: string, chunkSize: number): string[] {
   return chunks;
 }
 
-/**
- * Find which chunk a character offset falls in, and the offset of that chunk's
- * start within the full text.
- */
-export function findChunkForOffset(
-  chunks: string[],
-  offset: number,
-): { index: number; chunkStart: number } | null {
-  let chunkStart = 0;
-  for (let i = 0; i < chunks.length; i++) {
-    if (offset < chunkStart + chunks[i]!.length) {
-      return { index: i, chunkStart };
-    }
-    chunkStart += chunks[i]!.length;
-  }
-  return null;
-}
-
 interface Props extends HTMLAttributes<HTMLDivElement> {
   client: Pick<ApiClient, "getChatDocumentFile">;
   chatId: string;
   documentID: string;
   /**
-   * Character range in the raw file to reveal, as a citation reports it. The
-   * range decides which chunk is rendered first and what is scrolled to;
-   * drawing the highlight itself is not implemented yet.
+   * Byte range of the cited passage, when a citation led here.
+   *
+   * A citation reports its span in the text of record, which for a text-shaped
+   * source is the file itself: nothing is extracted out of it, so the offsets
+   * address the very characters this viewer draws. That is what lets the mark
+   * follow the reader from the extracted text onto the original.
    */
-  highlightRange?: HighlightRange;
+  citationSpan?: CitationSpan;
   /** Render the file as markdown rather than as the text it literally is. */
   markdown?: boolean;
 }
@@ -90,13 +80,12 @@ export function MarkdownViewer({
   client,
   chatId,
   documentID,
-  highlightRange,
+  citationSpan,
   markdown = false,
   className,
   ...props
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const anchorRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
   const fileDownload = useFileDownload(client, chatId, documentID, {
@@ -121,17 +110,33 @@ export function MarkdownViewer({
       ?.scrollIntoView({ behavior: "smooth", block: "start" });
   }, []);
 
-  // For citation mode: locate the chunk containing the highlight
-  const citationInfo = useMemo(() => {
-    if (!highlightRange || !fullContent) return null;
-    const hit = findChunkForOffset(chunks, highlightRange.start);
-    return hit ? { chunkIndex: hit.index } : null;
-  }, [highlightRange, fullContent, chunks]);
+  // The span is re-derived from the transcript on every update it makes, so what
+  // this depends on is the offsets rather than the object carrying them.
+  const spanStart = citationSpan?.start;
+  const spanEnd = citationSpan?.end;
+  const cited = useMemo(
+    () =>
+      spanStart != null && spanEnd != null && fullContent
+        ? charRangeForByteSpan(fullContent, { start: spanStart, end: spanEnd })
+        : null,
+    [fullContent, spanStart, spanEnd],
+  );
+
+  const chunkStarts = useMemo(() => pieceStartOffsets(chunks), [chunks]);
+
+  // For citation mode: the chunk the passage begins in — the last one starting
+  // at or before it.
+  const citationChunk = useMemo(() => {
+    if (!cited) return null;
+    for (let i = chunkStarts.length - 1; i >= 0; i--) {
+      if (chunkStarts[i]! <= cited.start) return i;
+    }
+    return null;
+  }, [cited, chunkStarts]);
 
   // In citation mode, skip the chunks before it rather than parsing megabytes
   // of text the reader has not asked to see yet.
-  const startChunkIndex =
-    citationInfo != null ? Math.max(0, citationInfo.chunkIndex - 1) : 0;
+  const startChunkIndex = citationChunk != null ? Math.max(0, citationChunk - 1) : 0;
   const maxRenderableChunks = chunks.length - startChunkIndex;
   const initialCount = Math.min(INITIAL_CHUNK_COUNT, maxRenderableChunks);
 
@@ -160,19 +165,24 @@ export function MarkdownViewer({
     return () => observer.disconnect();
   }, [renderedCount, maxRenderableChunks]);
 
-  // Scroll to the citation anchor after it renders
+  // Scroll to the passage itself, whichever way the original is drawn: the mark
+  // is what the reader came for, and a range marked in several nodes — a
+  // sentence with a bold word in it — begins at the first of them.
+  //
+  // Once per passage, not once per render. The mark can arrive a commit after
+  // the citation resolves, since the chunk holding it may not be among those
+  // already drawn, and appending chunks as the reader scrolls must not drag them
+  // back to where they started reading.
+  const scrolledTo = useRef<string | null>(null);
   useEffect(() => {
-    if (!citationInfo) return;
-    requestAnimationFrame(() => {
-      const container = containerRef.current;
-      const anchor = anchorRef.current;
-      if (!container || !anchor) return;
-      const containerRect = container.getBoundingClientRect();
-      const anchorRect = anchor.getBoundingClientRect();
-      const scrollTarget = anchorRect.top - containerRect.top + container.scrollTop;
-      container.scrollTo({ top: Math.max(0, scrollTarget - 40), behavior: "instant" });
-    });
-  }, [citationInfo]);
+    if (!cited) return;
+    const passage = `${cited.start}:${cited.end}`;
+    if (scrolledTo.current === passage) return;
+    const mark = containerRef.current?.querySelector(`.${CITATION_MARK_CLASS}`);
+    if (!mark) return;
+    scrolledTo.current = passage;
+    mark.scrollIntoView({ block: "center" });
+  }, [cited, renderedCount]);
 
   if (fileDownload.error) {
     return (
@@ -224,10 +234,16 @@ export function MarkdownViewer({
       )}
       <div ref={containerRef} className="min-h-0 flex-1 overflow-auto p-6">
         <div className="mx-auto max-w-4xl">
-          <div ref={anchorRef} />
-          {visibleChunks.map((chunk, i) =>
-            markdown ? (
-              <MessageMarkdown key={startChunkIndex + i} headingIds>
+          {visibleChunks.map((chunk, i) => {
+            const inChunk = cited
+              ? rangeWithinPiece(cited, chunkStarts[startChunkIndex + i]!, chunk.length)
+              : null;
+            return markdown ? (
+              <MessageMarkdown
+                key={startChunkIndex + i}
+                headingIds
+                highlightRange={inChunk ?? undefined}
+              >
                 {chunk}
               </MessageMarkdown>
             ) : (
@@ -235,10 +251,23 @@ export function MarkdownViewer({
                 key={startChunkIndex + i}
                 className="font-mono text-xs break-words whitespace-pre-wrap"
               >
-                {chunk}
+                {inChunk ? (
+                  <>
+                    {chunk.slice(0, inChunk.start)}
+                    <mark
+                      aria-label={CITATION_MARK_LABEL}
+                      className={cn(CITATION_MARK_CLASS, CITATION_MARK_STYLE)}
+                    >
+                      {chunk.slice(inChunk.start, inChunk.end)}
+                    </mark>
+                    {chunk.slice(inChunk.end)}
+                  </>
+                ) : (
+                  chunk
+                )}
               </pre>
-            ),
-          )}
+            );
+          })}
           {hasMoreChunks && (
             <div ref={sentinelRef} className="flex items-center justify-center py-8">
               <Loader2Icon className="size-5 animate-spin text-muted-foreground" />

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
@@ -130,11 +130,15 @@ function seedTranscript(source: Partial<AssistantSource> & { id: string }) {
   }));
 }
 
-async function openCitation(info: DocumentDetail, citationId: string) {
+async function openCitation(
+  info: DocumentDetail,
+  citationId: string,
+  body = "bytes",
+) {
   const client = {
     getChatDocument: vi.fn().mockResolvedValue(info),
     getChatDocumentFile: vi.fn().mockResolvedValue({
-      bytes: new TextEncoder().encode("bytes"),
+      bytes: new TextEncoder().encode(body),
       contentType: info.media_type,
     }),
   };
@@ -287,6 +291,65 @@ describe("DocumentDetailRoot", () => {
       await screen.findByRole("tab", { name: "Original document", selected: true }),
     ).toBeVisible();
     expect(document.querySelector("mark")).toBeNull();
+  });
+
+  // A text source is its own text of record — nothing is read out of it — so the
+  // citation's offsets address the original as well as the extracted text, and
+  // the mark follows the reader from one view to the other.
+  //
+  // The passage sits behind an accent and behind a single newline the renderer
+  // turns into a hard break, which are the two ways a source offset stops
+  // agreeing with the position it is drawn at: the first shifts the byte
+  // conversion, the second shifts the offsets the parser recorded.
+  const MARKDOWN_CONTENT =
+    "# Café notes\n\nQuarter one was flat.\nRevenue rose **12%** in the second quarter.\n";
+  const MARKDOWN_PASSAGE = "Revenue rose **12%** in the second";
+
+  it("marks the cited passage in a rendered markdown original", async () => {
+    const user = userEvent.setup();
+    seedTranscript({
+      id: "cite-3",
+      span: byteSpan(MARKDOWN_CONTENT, MARKDOWN_PASSAGE),
+    });
+    await openCitation(
+      detail({
+        media_type: "text/markdown",
+        title: "Report.md",
+        content: MARKDOWN_CONTENT,
+      }),
+      "cite-3",
+      MARKDOWN_CONTENT,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: "Original document" }));
+    await screen.findByText(/Quarter one was flat/);
+
+    // The passage spans an emphasized word, which is three places in the
+    // rendered tree rather than one run: the words between them are not
+    // adjacent there, so each is marked where it stands.
+    const marks = Array.from(document.querySelectorAll("mark"));
+    expect(marks.map((mark) => mark.textContent).join("")).toBe(
+      "Revenue rose 12% in the second",
+    );
+    expect(document.querySelector("strong mark")?.textContent).toBe("12%");
+    expect(scrolledTo).toContain(marks[0]);
+  });
+
+  it("marks the cited passage in an original drawn as plain text", async () => {
+    const user = userEvent.setup();
+    seedTranscript({ id: "cite-4", span: byteSpan(CITED_CONTENT, CITED_PASSAGE) });
+    await openCitation(
+      detail({ media_type: "text/plain", title: "Notes.txt", content: CITED_CONTENT }),
+      "cite-4",
+      CITED_CONTENT,
+    );
+
+    await user.click(await screen.findByRole("tab", { name: "Original document" }));
+
+    const marks = await screen.findAllByText(CITED_PASSAGE);
+    expect(marks.every((mark) => mark.tagName === "MARK")).toBe(true);
+    // Drawn as written, the file still reads as one run around the mark.
+    expect(document.querySelector("pre")?.textContent).toBe(CITED_CONTENT);
   });
 
   it("opens a paginated citation on its recorded page, then lets the reader leave", async () => {


### PR DESCRIPTION
Part of #812. #811 landed the citation's mark in the extracted text and the recorded page in the PDF viewer, and left the original-document views alone because neither of the props they take could be fed from a citation. This does the half that the data actually supports, and reports on the two it does not.

## What the data supports

**A text-shaped source is its own text of record.** `PlainTextParser` claims every `text/*` type and returns the bytes decoded and otherwise untouched — no BOM handling, no newline normalization, no trimming, and the liteparse parsers cannot intercept a text type. So a citation's byte offsets into the extracted text are byte offsets into the file, and the original view can draw the mark from the same span the extracted text does. That is the whole change: the panel already passes `citationSpan` down, and `MarkdownViewer` now converts it against the file it downloaded rather than taking a character range nobody produces.

- **Drawn as written** — a plain-text original splits its `<pre>` in three around the mark, the same way the extracted text does.
- **Rendered as Markdown** — placed by offset arithmetic rather than by matching text. The range is clipped onto the chunk being drawn and then onto the block being parsed (both are the verbatim source in order, so this is exact), shifted by the hard breaks the renderer inserts ahead of it, and a rehype pass splits the text nodes whose recorded source positions it covers. A passage that crosses emphasis or a paragraph is marked in each place it lands, since those words are not one run in the tree.
- **Scrolled to, once per passage.** The mark is what the reader came for, so the viewer scrolls to it rather than to the top of the chunk holding it — but only until it has, so appending chunks as the reader scrolls does not drag them back.

Two deliberate refusals inside that. `escapeLatexText` rewrites LaTeX delimiters, and a block it changes has its highlight dropped, because the offsets were measured against text that moved. Syntax highlighting and math rewrite their subtrees and discard the positions the placement depends on, so a passage inside a fence or a formula goes unmarked. Both leave the mark absent rather than drawn over the wrong words.

`preserveLineBreaks` is now written in terms of the positions it inserts at, and the offset mapping reads the same scan — so the two cannot drift apart, which they would if the mapping modelled the rewrite a second time.

Arriving from a citation still lands on the extracted text for an unpaginated source, unchanged from #811. The mark is guaranteed there and can be dropped in the cases above, so the view that always shows the passage is still the one to open on; flipping to the original now keeps it.

## What the data does not support, and why not

Neither is a rendering problem, and I did not add anything server-side for them.

- **The tree viewers.** `JsonViewer` and `XmlViewer` implement `highlightPath` fully, and no citation carries a node path — not in the wire type, the snapshot, the evidence, or the chunk. A path inferred from the text a range covers would point at the wrong node as soon as a value repeats. The prop keeps its pass-through and now says so. Filed as #846.
- **The PDF.** Marking a passage on a page needs its boxes, and a citation carries a byte span plus page numbers and nothing else. For a PDF the extracted text is Markdown the parser emitted rather than the file's text layer, so a span cannot be mapped back to the page afterwards; the mapping has to be recorded during extraction. liteparse computes per-word boxes and the parser drops them. Filed as #844.

One thing fell out of the audit that is worth its own issue: **the page list a citation carries is always empty in production.** Pages come from the evidence's `SourceRegion`s, no parser emits any, and `SourceLocation::Page` is constructed only in tests. #811's page hand-off is correct and currently unreachable. Filed as #843.

## Tests

Two added to `DocumentDetailRoot.dom.test.tsx`, both through the panel from `sources.doc-1.{citationId}` and then onto the original view:

- A Markdown source whose cited passage spans an emphasized word: the three marks read as the passage and nothing beyond it, the middle one inside the `<strong>`, and it is what was scrolled to. The passage sits behind an accented character and behind a single newline the renderer turns into a hard break — the two ways a source offset stops agreeing with where it is drawn. Dropping the hard-break mapping marks `'Revenue rose 12% in the seco'`; treating the byte offsets as string indices marks `'evenue rose 12% in the second '`. Both were checked.
- A plain-text source, where the same range is drawn as a split `<pre>`: marked, with the file still reading as one run around it.

One dependency: `@types/hast`, pinned to the 3.0.5 the lockfile already resolved for `react-markdown`, for the tree the rehype pass walks.

## What is not verified

Whether the passage ends up in view and whether the mark reads well in either theme — jsdom does not scroll or lay out, so the scroll is observed through a recorded `scrollIntoView`. I did not drive the app. A citation into a document large enough to chunk is covered by the arithmetic and the clipping but not by a test; the fixtures are all one chunk.