### PR TITLE
fix(desktop): stop reporting an unreachable source as a deleted one

### DIFF
--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -486,6 +486,23 @@ function throttle(
   };
 }
 
+/**
+ * A rejected response, carrying the status so a caller can tell why.
+ *
+ * The status is what separates "this is gone" from "we could not reach the
+ * server": a panel that cannot tell those apart has to guess, and guessing
+ * wrong tells a reader their file was deleted when it was not.
+ */
+export class HttpError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "HttpError";
+  }
+}
+
 /** The server's own message for a failed response, or its status text. */
 async function throwIfNotOk(response: Response): Promise<void> {
   if (response.ok) return;
@@ -496,7 +513,7 @@ async function throwIfNotOk(response: Response): Promise<void> {
   } catch {
     /* ignore */
   }
-  throw new Error(`${response.status}: ${detail}`);
+  throw new HttpError(response.status, `${response.status}: ${detail}`);
 }
 
 export class ApiClient {
@@ -519,16 +536,7 @@ export class ApiClient {
     expectedStatus?: number,
   ): Promise<T> {
     const response = await fetch(`${this.baseUrl}${path}`, init);
-    if (!response.ok) {
-      let detail = response.statusText;
-      try {
-        const body = (await response.json()) as { message?: string };
-        if (body.message) detail = body.message;
-      } catch {
-        /* ignore */
-      }
-      throw new Error(`${response.status}: ${detail}`);
-    }
+    await throwIfNotOk(response);
     if (expectedStatus !== undefined && response.status !== expectedStatus) {
       throw new Error(
         `unexpected response status: expected ${expectedStatus}, received ${response.status}`,

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-import type { ApiClient, DocumentDetail } from "@/api";
+import { HttpError, type ApiClient, type DocumentDetail } from "@/api";
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import type { AssistantSource } from "@/AssistantSources";
 import { useChatSessionStore } from "@/ChatSessionStore";
@@ -100,6 +100,20 @@ async function openPanel(
     { initialUrl: "/c/chat-1?left=sources.doc-1&right=chat" },
   );
   return { ...rendered, client: client as unknown as ApiClient & typeof client, download };
+}
+
+async function openFailingPanel(rejection: unknown) {
+  const client = {
+    getChatDocument: vi.fn().mockRejectedValue(rejection),
+    getChatDocumentFile: vi.fn(),
+  };
+  const rendered = await renderWithRouter(
+    <AppContextProvider value={{ client } as unknown as AppContextValue}>
+      <DocumentDetailRoot chatId="chat-1" documentID="doc-1" position="left" />
+    </AppContextProvider>,
+    { initialUrl: "/c/chat-1?left=sources.doc-1&right=chat" },
+  );
+  return { ...rendered, client };
 }
 
 /**
@@ -404,5 +418,48 @@ describe("DocumentDetailRoot", () => {
     );
 
     expect(await screen.findByText("Unable to parse JSON")).toBeVisible();
+  });
+});
+
+// Every way this load can fail used to read as "the document is no longer
+// available", which is a claim about the document that only a 404 supports.
+describe("DocumentDetailRoot load failures", () => {
+  it("says a source is gone only when the server says it is gone", async () => {
+    await openFailingPanel(new HttpError(404, "404: document not found"));
+
+    expect(
+      await screen.findByText("The document is no longer available."),
+    ).toBeVisible();
+    // Nothing to retry: asking again cannot bring it back.
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+  });
+
+  it("reports a server failure as a failure, and asks again on request", async () => {
+    const { client } = await openFailingPanel(new HttpError(500, "500: internal error"));
+
+    expect(
+      await screen.findByText("The document could not be loaded (500)."),
+    ).toBeVisible();
+    expect(screen.queryByText("The document is no longer available.")).toBeNull();
+
+    // A retry that succeeds leaves the reader on the document. A format with no
+    // viewer opens on its extracted text, so no byte fetch is needed to see it.
+    client.getChatDocument.mockResolvedValue(
+      detail({
+        media_type: "application/vnd.ms-outlook",
+        title: "Mailbox.pst",
+        content: "Recovered.",
+        searchable: true,
+      }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(await screen.findByText("Recovered.")).toBeVisible();
+  });
+
+  it("reports a dropped connection as a failure rather than a deletion", async () => {
+    await openFailingPanel(new TypeError("Load failed"));
+
+    expect(await screen.findByText("The document could not be loaded.")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeVisible();
   });
 });

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import type { DocumentDetail } from "@/api";
+import { HttpError, type DocumentDetail } from "@/api";
 import { useApp } from "@/AppContext";
 import {
   DocumentDetails,
@@ -8,6 +8,7 @@ import {
   type DocumentView,
 } from "@/components/document/document-details";
 import { DocumentError } from "@/components/document/error";
+import { Button } from "@/components/ui/button";
 import { isPaginatedOriginalViewer } from "@/document/DocumentViewer";
 import { exportLibraryDocument } from "@/documents";
 import { hasNativeHost } from "@/host";
@@ -50,27 +51,28 @@ export function DocumentDetailRoot({
   const { client } = useApp();
   const { openPanel } = usePanelNav();
   const [info, setInfo] = useState<DocumentDetail | null>(null);
-  const [loadError, setLoadError] = useState(false);
+  const [loadError, setLoadError] = useState<LoadError | null>(null);
+  const [reloads, setReloads] = useState(0);
   const [downloading, setDownloading] = useState(false);
   const [downloadError, setDownloadError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     setInfo(null);
-    setLoadError(false);
+    setLoadError(null);
     setDownloadError(null);
     void client
       .getChatDocument(chatId, documentID)
       .then((next) => {
         if (!cancelled) setInfo(next);
       })
-      .catch(() => {
-        if (!cancelled) setLoadError(true);
+      .catch((caught) => {
+        if (!cancelled) setLoadError(describeLoadFailure(caught));
       });
     return () => {
       cancelled = true;
     };
-  }, [client, chatId, documentID]);
+  }, [client, chatId, documentID, reloads]);
 
   const hasOriginalDocumentTab =
     info != null && info.processing_status !== "failed" && isDocumentRenderable(info.media_type);
@@ -136,7 +138,21 @@ export function DocumentDetailRoot({
       }
     >
       {loadError ? (
-        <DocumentError>The document is no longer available.</DocumentError>
+        <DocumentError>
+          <div className="flex flex-col items-center gap-3">
+            <span>{loadError.message}</span>
+            {loadError.retriable && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="font-normal"
+                onClick={() => setReloads((count) => count + 1)}
+              >
+                Try again
+              </Button>
+            )}
+          </div>
+        </DocumentError>
       ) : info ? (
         <DocumentDetails
           chatId={chatId}
@@ -158,6 +174,31 @@ export function DocumentDetailRoot({
       )}
     </PanelFrame>
   );
+}
+
+/** Why the source did not load, and whether asking again could help. */
+type LoadError = { message: string; retriable: boolean };
+
+/**
+ * What to say when a source will not load.
+ *
+ * Only a 404 means the source is gone, and that is the only case allowed to say
+ * so. Everything else — an expired token, a server that fell over, a connection
+ * that dropped — is about reaching the source rather than the source itself, and
+ * is worth asking again for. Collapsing the two told readers a file had been
+ * deleted whenever the app could not reach its own server.
+ */
+function describeLoadFailure(error: unknown): LoadError {
+  if (error instanceof HttpError && error.status === 404) {
+    return { message: "The document is no longer available.", retriable: false };
+  }
+  if (error instanceof HttpError) {
+    return {
+      message: `The document could not be loaded (${error.status}).`,
+      retriable: true,
+    };
+  }
+  return { message: "The document could not be loaded.", retriable: true };
 }
 
 function documentTitle(info: DocumentDetail): string {

--- a/crates/openwave-server/src/tests/documents.rs
+++ b/crates/openwave-server/src/tests/documents.rs
@@ -1179,6 +1179,13 @@ async fn chat_document_routes_isolate_sources_search_and_delete_lifecycle() {
         second_list["documents"][0]["document_id"],
         second_id.to_string()
     );
+    // The happy path, which this test asserted around rather than through: the
+    // conversation that owns a source can fetch it by id. Without this, a
+    // detail route that never resolves anything still passes the isolation
+    // assertions below.
+    let owned: serde_json::Value =
+        json_body(get(format!("/chats/{}/documents/{first_id}", first.id)).await).await;
+    assert_eq!(owned["document_id"], first_id.to_string());
     assert_eq!(
         get(format!("/chats/{}/documents/{second_id}", first.id))
             .await


### PR DESCRIPTION
Opening a source showed **"The document is no longer available."** for every way the load could fail. `DocumentDetailRoot` caught with `catch(() => setLoadError(true))`, so a 401, a 500, a timeout and a dropped connection all rendered as a claim that the document had been deleted — which the panel can only be sure of on a 404. No retry, and nothing saying what actually happened.

`ApiClient` now throws an `HttpError` carrying the status:

- **404** keeps the present wording. That one is true.
- **Any other status** says the load failed, names the status, and offers *Try again*.
- **A non-HTTP failure** (dropped connection) says the same without a status.

This also folds the JSON helper's private copy of the rejection into `throwIfNotOk`, which was already the single place a failed response becomes an error.

## Why this came up

You reported this message appearing whenever you open a document. **I could not tell from the message which failure it was** — and that is the substance of the bug: the panel had thrown away the one piece of information that would have identified it.

What I ruled out while digging, so it's on record:

- **The server route is fine.** `GET /chats/{chat_id}/documents/{document_id}` resolves a source its own conversation owns. The existing isolation test asserted *around* that — it checked the wrong chat gets a 404 — but never *through* it, so a detail route that resolved nothing would have passed. That happy-path assertion is added here.
- **The stored data is correctly scoped.** All nine documents in the live dev database carry a `chat_id` and a null `project_id`, which is what both the list and detail paths require.
- **Not the panel URL.** `parseSourcesTarget` passes a plain UUID through unchanged.
- **Not a host/server id mismatch.** The sources list is fetched by the Tauri host from the same `/chats/{id}/documents` endpoint, so the ids match by construction, and `resolve_conversation_scope` returns the chat id unchanged rather than remapping it.

So the cause is still open. With this in, the panel will name it — please reopen with whatever it says now, and I'll chase that. If it reads **"could not be loaded (401)"** the renderer's per-launch token is stale relative to the server; a plain **404** means the id genuinely isn't resolving for that conversation and I'll want the chat and document ids.

## Tests

Three, one per failure class, driven through the panel with a rejecting client — including that a retry which succeeds leaves the reader on the document. Plus the server-side happy path noted above.

## Not verified

I have not reproduced your failure, so I cannot claim this fixes it — it makes it diagnosable and stops the panel asserting something it does not know. The messages themselves are unverified in the packaged app.

Closes #851