### PR TITLE
feat(desktop): a keyboard-shortcuts help dialog

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.tsx
@@ -27,6 +27,7 @@ import { Titlebar } from "./Titlebar";
 import { useActiveChatId } from "./useActiveChatId";
 import { useChatPromptWatcher } from "./useChatPromptWatcher";
 import { useShellShortcuts } from "./ShellShortcuts";
+import { ShortcutsDialog } from "./ShortcutsDialog";
 import { useUiStore } from "./UiStore";
 import { useDesktopUpdates } from "./updates";
 
@@ -62,6 +63,7 @@ export function AppShell() {
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [defaultModelKey, setDefaultModelKey] = useState<string | null>(null);
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [status, setStatus] = useState("starting…");
   const openChatId = useActiveChatId();
   const savingTitle = useChatListStore((state) => state.savingTitle);
@@ -88,6 +90,7 @@ export function AppShell() {
     "zoom-in": zoom.zoomIn,
     "zoom-out": zoom.zoomOut,
     "zoom-reset": zoom.resetZoom,
+    "show-shortcuts": () => setShortcutsOpen(true),
   });
 
   useEffect(() => {
@@ -306,6 +309,7 @@ export function AppShell() {
       >
         <div className={`app-shell${hasMacOverlayTitlebar() ? " with-titlebar" : ""}`}>
           {confirmDialog}
+          <ShortcutsDialog open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
           {hasMacOverlayTitlebar() && <Titlebar />}
           {/* Each route renders its own rail beside its content — see RouteFrame. */}
           <div className="app-body">

--- a/crates/openwave-desktop/ui/src/ShellShortcuts.test.ts
+++ b/crates/openwave-desktop/ui/src/ShellShortcuts.test.ts
@@ -2,8 +2,12 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  groupedShellShortcuts,
   isEditableTarget,
   resolveShellShortcut,
+  SHELL_SHORTCUTS,
+  shortcutKeycaps,
+  usesCommandModifier,
   type ShellShortcutAction,
 } from "./ShellShortcuts";
 
@@ -40,6 +44,7 @@ describe("shell shortcut resolution", () => {
       ["b", "toggle-sidebar"],
       ["n", "new-chat"],
       ["k", "focus-composer"],
+      ["/", "show-shortcuts"],
     ];
     for (const [key, id] of cases) {
       const resolved = resolveShellShortcut(keyEvent({ key }), {
@@ -81,5 +86,29 @@ describe("shell shortcut resolution", () => {
       modalOpen: true,
     });
     expect(resolved).toBeNull();
+  });
+});
+
+describe("shortcut help", () => {
+  it("names the modifier the reader's keyboard actually has", () => {
+    // The table records `mod: true` because the listener takes either modifier;
+    // the help dialog has to pick the one that is true where it is being read.
+    const zoomIn = SHELL_SHORTCUTS.find((def) => def.id === "zoom-in")!;
+    expect(shortcutKeycaps(zoomIn, true)).toEqual(["⌘", "="]);
+    expect(shortcutKeycaps(zoomIn, false)).toEqual(["Ctrl", "="]);
+    expect(usesCommandModifier("Mozilla/5.0 (Macintosh; Intel Mac OS X)")).toBe(
+      true,
+    );
+    expect(usesCommandModifier("Mozilla/5.0 (Windows NT 10.0; Win64)")).toBe(
+      false,
+    );
+  });
+
+  it("files every shortcut under a heading the dialog renders", () => {
+    // A shortcut grouped under a heading nobody lists would vanish from the
+    // help while still firing — the exact drift the dialog exists to prevent.
+    const listed = groupedShellShortcuts().flatMap(({ items }) => items);
+    expect(listed).toHaveLength(SHELL_SHORTCUTS.length);
+    expect(new Set(listed)).toEqual(new Set(SHELL_SHORTCUTS));
   });
 });

--- a/crates/openwave-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/openwave-desktop/ui/src/ShellShortcuts.ts
@@ -14,7 +14,18 @@ export type ShellShortcutAction =
   | "focus-composer"
   | "zoom-in"
   | "zoom-out"
-  | "zoom-reset";
+  | "zoom-reset"
+  | "show-shortcuts";
+
+/** The heading a shortcut sits under in the help dialog. */
+export type ShellShortcutGroup = "Chat" | "View" | "Help";
+
+/** Group headings in the order the help dialog lists them. */
+export const SHELL_SHORTCUT_GROUPS: readonly ShellShortcutGroup[] = [
+  "Chat",
+  "View",
+  "Help",
+];
 
 export type ShellShortcutDef = {
   id: ShellShortcutAction;
@@ -33,6 +44,8 @@ export type ShellShortcutDef = {
   shift?: boolean | "any";
   /** What the shortcut does, phrased for a help dialog. */
   description: string;
+  /** Which heading the help dialog files it under. */
+  group: ShellShortcutGroup;
   /**
    * Whether the shortcut may fire while focus is in a text field. Chorded
    * combos (mod+key) are safe there — they are not something a reader types —
@@ -43,17 +56,11 @@ export type ShellShortcutDef = {
 
 export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
   {
-    id: "toggle-sidebar",
-    keys: ["b"],
-    mod: true,
-    description: "Show or hide the sidebar",
-    allowInEditable: true,
-  },
-  {
     id: "new-chat",
     keys: ["n"],
     mod: true,
     description: "Start a new chat",
+    group: "Chat",
     allowInEditable: true,
   },
   {
@@ -61,6 +68,15 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     keys: ["k"],
     mod: true,
     description: "Focus the message composer",
+    group: "Chat",
+    allowInEditable: true,
+  },
+  {
+    id: "toggle-sidebar",
+    keys: ["b"],
+    mod: true,
+    description: "Show or hide the sidebar",
+    group: "View",
     allowInEditable: true,
   },
   {
@@ -69,6 +85,7 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     mod: true,
     shift: "any",
     description: "Make the interface larger",
+    group: "View",
     allowInEditable: true,
   },
   {
@@ -77,6 +94,7 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     mod: true,
     shift: "any",
     description: "Make the interface smaller",
+    group: "View",
     allowInEditable: true,
   },
   {
@@ -84,9 +102,75 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
     keys: ["0"],
     mod: true,
     description: "Reset the interface size",
+    group: "View",
+    allowInEditable: true,
+  },
+  {
+    id: "show-shortcuts",
+    // `?` is the shifted glyph the same physical key produces, so the reader
+    // reaches this whether or not they think of it as Cmd+Shift+/.
+    keys: ["/", "?"],
+    mod: true,
+    shift: "any",
+    description: "Show keyboard shortcuts",
+    group: "Help",
     allowInEditable: true,
   },
 ];
+
+/**
+ * Whether the platform command modifier is Cmd rather than Ctrl.
+ *
+ * The table records `mod: true` rather than a glyph because the listener
+ * accepts either modifier; only the help dialog has to commit to one, and it
+ * commits to whichever one the reader's keyboard actually has. Takes the
+ * user-agent string rather than reading `navigator` so it is testable.
+ */
+export function usesCommandModifier(userAgent: string): boolean {
+  return /Mac|iPhone|iPad|iPod/.test(userAgent);
+}
+
+/**
+ * The keycaps a shortcut should be drawn as, in the order they are pressed.
+ *
+ * Derived from the same definition the listener matches on, so the help dialog
+ * cannot come to disagree with the binding. Only the first of a definition's
+ * keys is shown — the alternates exist so a shifted glyph still matches, not
+ * because they are a second shortcut worth documenting.
+ */
+export function shortcutKeycaps(
+  def: ShellShortcutDef,
+  command: boolean,
+): string[] {
+  const caps: string[] = [];
+  if (def.mod) caps.push(command ? "⌘" : "Ctrl");
+  if (def.shift === true) caps.push(command ? "⇧" : "Shift");
+  const key = def.keys[0] ?? "";
+  caps.push(key.length === 1 ? key.toUpperCase() : key);
+  return caps;
+}
+
+/**
+ * The shortcuts under their headings, in the order the help dialog lists them.
+ *
+ * Grouping lives here rather than in the dialog so a shortcut cannot go missing
+ * from the help by being filed under a heading nobody renders.
+ */
+export function groupedShellShortcuts(): Array<{
+  group: ShellShortcutGroup;
+  items: ShellShortcutDef[];
+}> {
+  const byGroup = new Map<ShellShortcutGroup, ShellShortcutDef[]>();
+  for (const def of SHELL_SHORTCUTS) {
+    const items = byGroup.get(def.group) ?? [];
+    items.push(def);
+    byGroup.set(def.group, items);
+  }
+  return SHELL_SHORTCUT_GROUPS.flatMap((group) => {
+    const items = byGroup.get(group);
+    return items ? [{ group, items }] : [];
+  });
+}
 
 type ShortcutKeyEvent = Pick<
   KeyboardEvent,

--- a/crates/openwave-desktop/ui/src/ShortcutsDialog.tsx
+++ b/crates/openwave-desktop/ui/src/ShortcutsDialog.tsx
@@ -1,0 +1,98 @@
+import { Fragment, useMemo } from "react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import {
+  groupedShellShortcuts,
+  shortcutKeycaps,
+  usesCommandModifier,
+  type ShellShortcutDef,
+} from "./ShellShortcuts";
+
+function Keycap({ children }: { children: string }) {
+  return (
+    <kbd className="inline-flex h-6 min-w-6 items-center justify-center rounded border bg-muted/60 px-1.5 font-sans text-[11px] leading-none font-medium text-foreground/80">
+      {children}
+    </kbd>
+  );
+}
+
+function ShortcutRow({
+  shortcut,
+  command,
+}: {
+  shortcut: ShellShortcutDef;
+  command: boolean;
+}) {
+  const caps = shortcutKeycaps(shortcut, command);
+  return (
+    <>
+      <span className="truncate text-sm text-foreground/90">
+        {shortcut.description}
+      </span>
+      <span className="flex shrink-0 items-center gap-1">
+        {caps.map((cap) => (
+          <Keycap key={cap}>{cap}</Keycap>
+        ))}
+      </span>
+    </>
+  );
+}
+
+/**
+ * What the keyboard can reach, read straight out of `SHELL_SHORTCUTS`.
+ *
+ * Rendering from the table the listener matches on is the point: a hand-written
+ * second copy would drift the first time a binding changed, and a help dialog
+ * that misstates the keys is worse than no dialog at all.
+ */
+export function ShortcutsDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const command = useMemo(() => usesCommandModifier(navigator.userAgent), []);
+  const groups = useMemo(() => groupedShellShortcuts(), []);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md gap-6">
+        <DialogHeader>
+          <DialogTitle>Keyboard shortcuts</DialogTitle>
+          <DialogDescription>
+            These act on the app frame, so they work from every screen.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid max-h-[65vh] grid-cols-[1fr_auto] items-center gap-x-6 gap-y-2 overflow-y-auto pr-1">
+          {groups.map(({ group, items }, index) => (
+            <Fragment key={group}>
+              <h3
+                className={cn(
+                  "col-span-2 text-[11px] font-semibold tracking-[0.08em] text-muted-foreground uppercase",
+                  index > 0 && "mt-4",
+                )}
+              >
+                {group}
+              </h3>
+              {items.map((shortcut) => (
+                <ShortcutRow
+                  key={shortcut.id}
+                  shortcut={shortcut}
+                  command={command}
+                />
+              ))}
+            </Fragment>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
Closes #790

Cmd+/ (Ctrl+/ off macOS) opens a dialog listing every shell shortcut. It renders from `SHELL_SHORTCUTS` rather than from a second hand-written list — the table already carried a `description` per binding written for exactly this, and reading the same table the listener acts on is what keeps the help from drifting the first time a binding changes.

Three supporting pieces:

- **`group` on each definition**, so the dialog can file entries under Chat / View / Help headings. `groupedShellShortcuts()` lives beside the table rather than in the component, so a shortcut filed under a heading nobody renders can't silently vanish from the help while still firing.
- **`shortcutKeycaps()`** turns a definition into the caps to draw. The table records `mod: true` because the listener accepts either modifier; only the dialog has to commit to one, and it commits to whichever the reader's keyboard has — ⌘ on macOS, Ctrl elsewhere. Only the first of a definition's keys is shown: the alternates exist so a shifted glyph still matches, not because they're a second shortcut worth documenting.
- **`show-shortcuts` itself** is bound to `/` and `?` with `shift: "any"`, so it's reachable whether or not the reader thinks of it as Cmd+Shift+/.

The existing modal guard suppresses shell shortcuts while a dialog is open, so Cmd+/ doesn't toggle the dialog shut — Esc and the close button do. That guard is deliberate and left alone.

## Tests

Three additions to `ShellShortcuts.test.ts`, no new file:

- `/` added to the existing chorded-shortcut case list (one line).
- Keycap formatting across both platforms, since a help dialog naming the wrong modifier is the failure this feature exists to avoid.
- Every shortcut appears under some rendered heading — the drift the dialog is meant to prevent, caught without a DOM.

Verified `tsc`, `pnpm test` (605 passing), and `pnpm build`. The dialog's appearance in the running app is unverified.