### PR TITLE
docs: record authorization as the gate on the self-host profile

### DIFF
--- a/crates/openwave-server/src/tests/documents.rs
+++ b/crates/openwave-server/src/tests/documents.rs
@@ -2779,3 +2779,99 @@ async fn connect_vector_store_falls_back_to_an_in_memory_index_without_vec_lance
     let reopened = connect_vector_store(&config, 2).await.unwrap();
     assert_eq!(reopened.len().await.unwrap(), 0);
 }
+
+/// Records where the document surface sits in a native embedding, which is the
+/// configuration the desktop actually runs and the one no other test here
+/// builds. Every other test uses the headless router, where these same routes
+/// are on the primary bearer — so none of them can see what the renderer meets.
+///
+/// The renderer holds the primary bearer and nothing else, so today it cannot
+/// read a document it has just listed. That is what this asserts, and it is a
+/// boundary rather than an accident: the second credential gates host authority
+/// (see `docs/host-access.md`). It is also why the desktop's document viewers
+/// are unreachable, so the assertion is expected to invert when that is
+/// resolved — deliberately, by a change that has to come here and say so.
+#[tokio::test]
+async fn a_native_embedding_refuses_the_renderer_its_own_documents() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let state = AppState::new_with_client_executor_id(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        retrieval,
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+        Uuid::new_v4(),
+    )
+    .unwrap();
+    let bearer = format!("Bearer {}", state.token);
+    let executor = state.client_executor_token.to_string();
+    let router = app(state);
+
+    let chat = make_chat(&router, &bearer).await;
+    // Ingest needs the native credential too: in this configuration the whole
+    // document surface is behind it, writes and listings included.
+    let ingest: serde_json::Value = json_body(
+        router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/chats/{}/documents", chat.id))
+                    .header(header::AUTHORIZATION, &bearer)
+                    .header(crate::auth::CLIENT_EXECUTOR_HEADER, &executor)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"uri": "file:///note.txt", "content": "a source"})
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let document_id = ingest["document_id"].as_str().unwrap().to_owned();
+
+    let fetch = |extra: Option<&'static str>| {
+        let executor_owned = extra.map(|_| executor.clone());
+        let router = router.clone();
+        let bearer = bearer.clone();
+        let uri = format!("/chats/{}/documents/{document_id}", chat.id);
+        async move {
+            let mut builder = Request::builder()
+                .uri(uri)
+                .header(header::AUTHORIZATION, bearer);
+            if let Some(token) = executor_owned {
+                builder = builder.header(crate::auth::CLIENT_EXECUTOR_HEADER, token);
+            }
+            router
+                .oneshot(builder.body(Body::empty()).unwrap())
+                .await
+                .unwrap()
+        }
+    };
+
+    // What the renderer sends. It holds the primary bearer and nothing else,
+    // so the document it just listed is unreachable to it.
+    assert_eq!(fetch(None).await.status(), StatusCode::UNAUTHORIZED);
+    // What the native host sends, and why the source list works while the
+    // reader that opens one does not.
+    assert_eq!(fetch(Some("native")).await.status(), StatusCode::OK);
+}

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -73,7 +73,19 @@ code:
 These routes require both the ordinary bearer credential and the native
 client-executor credential. The server supplies the stable executor identity;
 it is never accepted from a body, returned in a response, included in server
-discovery, or exposed to the renderer. Begin and finish retries return stable
+discovery, or exposed to the renderer.
+
+The rule that keeps the two credentials coherent, and the test for whether a new
+route belongs behind the second one: **the client-executor credential gates
+operations that exercise host authority — claiming work to execute locally,
+reading the filesystem, changing folder grants. It does not gate user content.**
+
+A route placed behind it becomes unreachable to the renderer, which holds only
+the primary bearer, and therefore unreachable to every future client that is
+renderer-shaped: a web or mobile client, a self-hosted deployment's browser UI,
+or a CLI. That is the intended consequence for host authority and a defect for
+anything else, so the distinction is worth checking rather than inheriting from
+whichever router a route was added next to. Begin and finish retries return stable
 `begun`/`existing` and `finished`/`existing` dispositions. A missing change and
 a change owned by another executor are both reported as not found, while busy
 and revision conflicts do not identify the pending operation.

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -845,6 +845,24 @@ rejects the self-host profile at startup, and document/blob PostgreSQL parity is
 not comprehensively tested. Production Postgres wiring, remote secret custody,
 object storage, and multi-process ownership remain future integration work.
 
+**Authorization is the gate on this profile, and it is not built.** The API has
+no per-user authorization at all: `auth.rs` is a per-launch bearer on a loopback
+port, which answers "is this the client this process handed a token to" — a
+capability check on a local process, not a principal. No route is owner-scoped;
+`require_chat` checks that a chat *exists* and nothing else, and the document,
+project, and settings surfaces are the same. Identity work (#578) is deliberately
+attributive only and states that no read path consults it, so it does not close
+this.
+
+That is the right trade for a local-first desktop, where the bearer is
+per-launch, loopback-only, and belongs to the one person at the machine. It stops
+being right the moment more than one person's data shares a store: an existence
+check that passes for any authenticated caller is an authorization bug as soon as
+callers differ. Finishing this profile without resolving a principal in the
+request path and scoping queries by owner would ship a multi-user server whose
+every mode degrades to "any authenticated caller can see everything". Tracked as
+a gate in #853, which any shared-deployment work should be blocked on.
+
 ## Where the code lives
 
 | Area | Start here | What it owns |
@@ -915,6 +933,9 @@ The main next steps are:
   sandbox-safe capabilities without widening exact delegated-file or spawn
   authority;
 - add richer parsers and wire indexed search into MCP;
+- resolve a principal in the request path and scope queries by owner (#853)
+  before finishing the self-host profile, which is otherwise a multi-user server
+  with no per-user authorization;
 - finish the self-host profile rather than only testing Postgres state logic;
 - add health-aware provider failover;
 - add output deletion, version history, richer formats, and durable export


### PR DESCRIPTION
Following the document-viewer 401: the underlying issue is that **the API has no per-user authorization, and nothing recorded that as a prerequisite for anything.**

`auth.rs` is a per-launch bearer on a loopback port — it answers "is this the client this process handed a token to", which is a capability check on a local process, not a principal. No route is owner-scoped: `require_chat` checks a chat *exists* and nothing else, same for the document, project and settings surfaces.

That is the right trade for a local-first desktop, where the bearer is per-launch, loopback-only, and belongs to the one person at the machine. It stops being right the moment more than one person's data shares a store — an existence check that passes for any authenticated caller is an authorization bug as soon as callers differ.

**The part worth flagging:** a reader could reasonably conclude this was already handled. #578 is titled as identity work and is open, but it is deliberately *attributive* and says outright that "no read path consults identity: no query gains an owner predicate, no handler signature changes, no authorization decision reads it." So nothing open covered it. That's what this fixes.

## What changed

- **`docs/how-openwave-works.md`, Self-host section** — states the gap plainly and why it matters for that profile specifically, and notes that #578 does not close it. The roadmap list now puts resolving a principal and owner-scoping queries *before* finishing the self-host profile rather than after.
- **`docs/host-access.md`** — writes down the rule that keeps the two credentials coherent, since the absence of one is how this was found: *the client-executor credential gates operations that exercise host authority, not user content.* Plus the consequence, which is the useful half: a route behind it is unreachable to the renderer, and therefore to every future client that is renderer-shaped — a web or mobile client, a self-hosted browser UI, a CLI. Intended for host authority; a defect for anything else.
- **#853** filed as the gate itself, to be blocked on by shared-deployment work.

## The test

`a_native_embedding_refuses_the_renderer_its_own_documents` builds the router the desktop actually runs (`new_with_client_executor_id`, so `root_attachment_routes_enabled` is true) and asks from the renderer's position: with the primary bearer alone it is **401** for a document it just listed; with the native credential added, **200**.

Every other test in that module builds the headless router, where those routes sit on the bearer. That is precisely why the suite cannot see what the desktop meets — and why the happy-path assertion I added earlier today passed while the app was failing. I verified the wrong configuration and reported it as reassurance.

The assertion pins current behaviour, including the part that is a defect. That is deliberate: it is expected to invert when the document surface moves onto the bearer, by a change that has to come to this test and say so, rather than one that silently alters a boundary.

## Still open, deliberately not in this PR

The document viewers remain unreachable in the desktop app — no PDF, spreadsheet, Word, markdown, image, JSON or XML original has ever loaded there. That fix is the `document_api` split we discussed; it is a code change with a security boundary attached and belongs in its own PR, not smuggled into a docs one. #851 is closed but the underlying 401 is not; #853 carries the context.

## Not verified

Docs. The test is verified: `cargo fmt --check`, `cargo clippy --all-targets`, and the 38 tests in that module pass. I could not drive the GUI — this terminal lacks macOS Screen Recording permission, so `screencapture` is refused.

Refs #853, #851