### PR TITLE
chore(reverse-rpc): host-held callback channel feasibility spike

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6588,6 +6588,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "openwave-reverse-rpc-spike"
+version = "0.0.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "openwave-router"
 version = "0.0.0"
 dependencies = [

--- a/crates/openwave-reverse-rpc-spike/Cargo.toml
+++ b/crates/openwave-reverse-rpc-spike/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "openwave-reverse-rpc-spike"
+description = "SPIKE: feasibility prototype for the host-held reverse-RPC callback channel. Not wired into the server."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+publish = false
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "sync", "io-util", "time"] }
+
+[lints]
+workspace = true

--- a/crates/openwave-reverse-rpc-spike/src/host.rs
+++ b/crates/openwave-reverse-rpc-spike/src/host.rs
@@ -1,0 +1,263 @@
+//! The host side of the reverse channel: the run-scoped capability server.
+//!
+//! The key structural decision is the split between run-scoped state and
+//! connection-scoped state. [`CapabilityHost`] holds the grant set, the model
+//! proxy, and the operation log; it outlives any single connection. A
+//! connection is just transient plumbing that reads request frames and writes
+//! response frames. When a connection drops and the supervisor reconnects, it
+//! reattaches to the *same* `CapabilityHost`, so the operation log — the durable
+//! per-run identity map — is exactly where idempotent replay is served from.
+//!
+//! Each `OperationId` runs its capability at most once. The execution is a
+//! spawned task that writes its outcome into a `watch` channel; the connection's
+//! per-request task merely awaits that outcome and forwards it. Because the two
+//! are decoupled, a dropped connection cannot abort an execution (it keeps
+//! running and records its outcome for a later re-issue), while an explicit
+//! cancel *can* (it fires a signal the execution selects on).
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use tokio::{
+    io::{AsyncRead, AsyncWrite, BufReader},
+    sync::{oneshot, watch, Mutex as AsyncMutex},
+    task::JoinSet,
+};
+
+use crate::{
+    model::ModelProvider,
+    protocol::{
+        CancelFrame, Capability, ErrorCode, ErrorResponse, Frame, OperationId, Response,
+        ReverseEnvelope, ReverseRequest, ReverseResponseEnvelope, ReverseResult, PROTOCOL_VERSION,
+    },
+    transport::{read_frame, write_frame, FrameError},
+};
+
+/// Where an operation stands. `Pending` until its single execution settles.
+#[derive(Debug, Clone)]
+enum Outcome {
+    Pending,
+    Settled(Response<ReverseResult>),
+}
+
+/// One durable operation-log entry, keyed by `OperationId`.
+struct OperationEntry {
+    /// The request this identity was first claimed with. A later re-issue whose
+    /// request differs is a conflict, exactly as the broker treats a reused
+    /// operation identity with a different fingerprint.
+    fingerprint: ReverseRequest,
+    /// Cloned by every attaching connection; the execution task drives it.
+    outcome: watch::Receiver<Outcome>,
+    /// Taken and fired by the first cancel for this operation.
+    cancel: Mutex<Option<oneshot::Sender<()>>>,
+}
+
+struct HostShared {
+    grants: Vec<Capability>,
+    model: Arc<dyn ModelProvider>,
+    log: Mutex<HashMap<OperationId, Arc<OperationEntry>>>,
+}
+
+/// The run-scoped reverse-RPC server. Cloneable; every clone shares one log.
+#[derive(Clone)]
+pub struct CapabilityHost {
+    shared: Arc<HostShared>,
+}
+
+impl CapabilityHost {
+    /// Build a host granting exactly `grants` and proxying `model`.
+    ///
+    /// Deny-by-default: a capability absent from `grants` is refused.
+    #[must_use]
+    pub fn new(model: Arc<dyn ModelProvider>, grants: Vec<Capability>) -> Self {
+        Self {
+            shared: Arc::new(HostShared {
+                grants,
+                model,
+                log: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    /// How many distinct operations this run has ever admitted. Test-facing;
+    /// lets a test assert that a replay added no new execution.
+    #[must_use]
+    pub fn operation_count(&self) -> usize {
+        self.shared.log.lock().expect("log lock").len()
+    }
+
+    /// Resolve a request to the receiver its response will be read from.
+    ///
+    /// This is the whole idempotency rule in one place: an unknown identity is
+    /// claimed and executed once; a known identity attaches to the existing
+    /// outcome without re-executing; a known identity with a different request
+    /// is a conflict. Version and capability checks fail closed, pre-settled.
+    fn dispatch(&self, envelope: ReverseEnvelope) -> watch::Receiver<Outcome> {
+        if envelope.protocol_version != PROTOCOL_VERSION {
+            return settled_error(
+                ErrorCode::ProtocolVersion,
+                "reverse-rpc protocol version mismatch",
+                false,
+            );
+        }
+        if !self.shared.grants.contains(&envelope.request.capability()) {
+            return settled_error(
+                ErrorCode::Denied,
+                "capability is not granted to this run",
+                false,
+            );
+        }
+
+        let mut log = self.shared.log.lock().expect("log lock");
+        if let Some(entry) = log.get(&envelope.operation_id) {
+            if entry.fingerprint == envelope.request {
+                return entry.outcome.clone();
+            }
+            return settled_error(
+                ErrorCode::OperationIdConflict,
+                "operation identity was reused for a different request",
+                false,
+            );
+        }
+
+        let (outcome_tx, outcome_rx) = watch::channel(Outcome::Pending);
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        log.insert(
+            envelope.operation_id,
+            Arc::new(OperationEntry {
+                fingerprint: envelope.request.clone(),
+                outcome: outcome_rx.clone(),
+                cancel: Mutex::new(Some(cancel_tx)),
+            }),
+        );
+        let model = Arc::clone(&self.shared.model);
+        tokio::spawn(execute(model, envelope.request, cancel_rx, outcome_tx));
+        outcome_rx
+    }
+
+    /// Fire the cancel signal for an operation if it is still in flight.
+    fn cancel(&self, cancel: CancelFrame) {
+        let entry = {
+            let log = self.shared.log.lock().expect("log lock");
+            log.get(&cancel.operation_id).map(Arc::clone)
+        };
+        if let Some(entry) = entry {
+            if let Some(sender) = entry.cancel.lock().expect("cancel lock").take() {
+                let _ = sender.send(());
+            }
+        }
+    }
+}
+
+/// Run one operation's capability exactly once, honoring a cancel signal.
+async fn execute(
+    model: Arc<dyn ModelProvider>,
+    request: ReverseRequest,
+    cancel: oneshot::Receiver<()>,
+    outcome: watch::Sender<Outcome>,
+) {
+    let settled = match request {
+        ReverseRequest::ModelInference(params) => {
+            tokio::select! {
+                completion = model.complete(params) => {
+                    Response::Ok(ReverseResult::ModelInference(completion))
+                }
+                _ = cancel => {
+                    Response::Error(ErrorResponse::new(
+                        ErrorCode::Cancelled,
+                        "reverse request was cancelled",
+                        false,
+                    ))
+                }
+            }
+        }
+    };
+    // A dropped receiver only means no connection is currently waiting; the
+    // recorded outcome still stands for a later re-issue, so ignore the error.
+    let _ = outcome.send(Outcome::Settled(settled));
+}
+
+/// Serve one connection against `host` until the peer closes it.
+///
+/// Returns when the read half reaches EOF or errors — i.e. the connection
+/// dropped. The per-request response forwarders live in a [`JoinSet`] scoped to
+/// this connection, so aborting this future (a simulated disconnect) tears them
+/// down and releases the write half. The *execution* tasks are detached and so
+/// keep running past the disconnect, recording their outcome for a later
+/// re-issue — the asymmetry the disconnect semantics require.
+pub async fn serve_connection<S>(host: CapabilityHost, stream: S) -> Result<(), FrameError>
+where
+    S: AsyncRead + AsyncWrite + Send + 'static,
+{
+    let (read_half, write_half) = tokio::io::split(stream);
+    let mut reader = BufReader::new(read_half);
+    let writer = Arc::new(AsyncMutex::new(write_half));
+    let mut forwarders: JoinSet<()> = JoinSet::new();
+
+    loop {
+        let frame = match read_frame(&mut reader).await {
+            Ok(frame) => frame,
+            // Closed or malformed both end this connection; the supervisor
+            // reconnects and re-issues, which is safe by the idempotency rule.
+            Err(_) => break,
+        };
+        match frame {
+            Frame::Request(envelope) => {
+                let request_id = envelope.request_id;
+                let operation_id = envelope.operation_id;
+                let mut outcome = host.dispatch(envelope);
+                let writer = Arc::clone(&writer);
+                forwarders.spawn(async move {
+                    let response = wait_settled(&mut outcome).await;
+                    let frame = Frame::Response(ReverseResponseEnvelope {
+                        protocol_version: PROTOCOL_VERSION,
+                        request_id,
+                        operation_id,
+                        response,
+                    });
+                    let mut guard = writer.lock().await;
+                    // A write failure means the connection dropped mid-response;
+                    // the outcome is already recorded for re-issue, so drop it.
+                    let _ = write_frame(&mut *guard, &frame).await;
+                });
+            }
+            Frame::Cancel(cancel) => host.cancel(cancel),
+            // The host is the responder on this channel; it never receives
+            // responses. Ignore rather than trusting peer-shaped input.
+            Frame::Response(_) => {}
+        }
+        while forwarders.try_join_next().is_some() {}
+    }
+    Ok(())
+}
+
+/// Await an operation's settled outcome, tolerating a value that was already
+/// settled before this waiter attached (a pre-settled error, or a replay).
+async fn wait_settled(outcome: &mut watch::Receiver<Outcome>) -> Response<ReverseResult> {
+    loop {
+        if let Outcome::Settled(response) = &*outcome.borrow() {
+            return response.clone();
+        }
+        if outcome.changed().await.is_err() {
+            return Response::Error(ErrorResponse::new(
+                ErrorCode::Internal,
+                "operation ended without recording an outcome",
+                true,
+            ));
+        }
+    }
+}
+
+/// Build a receiver that is already settled on an error, for fail-closed paths.
+fn settled_error(code: ErrorCode, message: &str, retryable: bool) -> watch::Receiver<Outcome> {
+    let (tx, rx) = watch::channel(Outcome::Settled(Response::Error(ErrorResponse::new(
+        code, message, retryable,
+    ))));
+    // Keep the sender alive for the lifetime of the value by leaking it into the
+    // receiver's channel: dropping it here is fine because `watch` retains the
+    // last sent value for existing receivers.
+    drop(tx);
+    rx
+}

--- a/crates/openwave-reverse-rpc-spike/src/lib.rs
+++ b/crates/openwave-reverse-rpc-spike/src/lib.rs
@@ -1,0 +1,41 @@
+//! SPIKE — reverse-RPC callback channel feasibility. **Not wired into the
+//! server, and not a shipped feature.**
+//!
+//! This crate is the prototype behind the go/no-go in
+//! `docs/spikes/reverse-rpc-findings.md`. It exists to prove (or fail to prove)
+//! the hard parts of the callback channel that step 5 of the sandbox-provider
+//! delivery sequence calls the highest-risk unproven element of the design:
+//!
+//! - a host-held bidirectional connection the sandbox supervisor multiplexes
+//!   reverse requests back over, with model inference as the first capability;
+//! - durable per-run **operation identity** with recorded responses, so a
+//!   request re-issued after a reconnect is answered once, not executed twice;
+//! - request/response **correlation** over one connection, **cancellation** of
+//!   an in-flight request, and **backpressure** against a slow host;
+//! - **disconnect semantics**: an in-flight request whose connection drops is
+//!   failed to the sandbox side and is safe to re-issue.
+//!
+//! It follows the `openwave-host-broker` envelope shape on purpose — versioned
+//! protocol with an exact-equality version check, deny-by-default capability
+//! gating, a per-operation idempotency identity, and bounded typed results —
+//! rather than inventing a parallel style. The shipped host broker is not
+//! touched.
+//!
+//! The transport is a `tokio::io::duplex` pipe between two tasks; see
+//! [`transport`]. That is the cheapest thing that still exercises real framing
+//! and real concurrency, and dropping a half models a dropped connection. No
+//! real E2B/Daytona backend is stood up.
+
+pub mod host;
+pub mod model;
+pub mod protocol;
+pub mod supervisor;
+pub mod transport;
+
+pub use host::{serve_connection, CapabilityHost};
+pub use model::{Completion, ModelProvider};
+pub use protocol::{
+    Capability, ErrorCode, ErrorResponse, ModelInferenceParams, ModelInferenceResult, OperationId,
+    RequestId, ReverseRequest, ReverseResult, PROTOCOL_VERSION,
+};
+pub use supervisor::{Call, ClientError, ReverseClient};

--- a/crates/openwave-reverse-rpc-spike/src/model.rs
+++ b/crates/openwave-reverse-rpc-spike/src/model.rs
@@ -1,0 +1,21 @@
+//! The first carried capability: host-proxied model inference.
+//!
+//! In the real system this is the host's model provider — the same
+//! credential-free request that already crosses the execution seam. The spike
+//! only needs a trait the host can call and test doubles that let a test hold a
+//! completion open (to exercise cancellation, disconnect, and backpressure) and
+//! count executions (to prove exactly-once under replay).
+
+use std::{future::Future, pin::Pin};
+
+use crate::protocol::{ModelInferenceParams, ModelInferenceResult};
+
+/// A boxed future so the host can hold the model behind `dyn`.
+pub type Completion<'a> = Pin<Box<dyn Future<Output = ModelInferenceResult> + Send + 'a>>;
+
+/// The host's model proxy, as the reverse channel sees it.
+pub trait ModelProvider: Send + Sync {
+    /// Run one completion. Called at most once per `OperationId`; the host's
+    /// operation log — not this trait — enforces that.
+    fn complete(&self, params: ModelInferenceParams) -> Completion<'_>;
+}

--- a/crates/openwave-reverse-rpc-spike/src/protocol.rs
+++ b/crates/openwave-reverse-rpc-spike/src/protocol.rs
@@ -1,0 +1,274 @@
+//! Versioned wire types for the reverse-RPC callback channel.
+//!
+//! This mirrors the `openwave-host-broker` envelope shape deliberately: a
+//! versioned protocol with an exact-equality version check, a deny-by-default
+//! capability gate, a durable per-run operation identity, and a bounded typed
+//! result or a transport-stable error. The identity newtypes are re-derived
+//! locally rather than imported so the spike stays standalone; the real
+//! protocol step (#822) should share the broker's identity and envelope
+//! conventions rather than fork them.
+
+use std::{fmt, str::FromStr};
+
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+/// Current reverse-RPC protocol. Bumped for any incompatible wire change and
+/// checked for exact equality, exactly as the host broker checks its own.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// A broker-style opaque identity refused a nil sentinel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("reverse-rpc identities must not be nil")]
+pub struct NilIdentity;
+
+macro_rules! uuid_id {
+    ($name:ident, $doc:literal) => {
+        #[doc = $doc]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+        #[serde(transparent)]
+        pub struct $name(Uuid);
+
+        impl $name {
+            /// Allocate a fresh random identity.
+            #[must_use]
+            pub fn new() -> Self {
+                Self(Uuid::new_v4())
+            }
+
+            /// Return the underlying UUID.
+            #[must_use]
+            pub const fn as_uuid(self) -> Uuid {
+                self.0
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0.fmt(formatter)
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = uuid::Error;
+
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                Ok(Self(Uuid::parse_str(value)?))
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let id = Uuid::deserialize(deserializer)?;
+                if id.is_nil() {
+                    Err(D::Error::custom(NilIdentity))
+                } else {
+                    Ok(Self(id))
+                }
+            }
+        }
+    };
+}
+
+uuid_id!(
+    OperationId,
+    "Durable per-run identity for one idempotent reverse operation.\n\nStable across reconnects: a request re-issued after a disconnect carries the\nsame `OperationId` and is answered from the recorded outcome, never executed\ntwice."
+);
+uuid_id!(
+    RequestId,
+    "Per-attempt correlation identity for one request/response pair.\n\nA re-issue of the same operation over a fresh connection uses a new\n`RequestId` but the same `OperationId`."
+);
+
+/// Host-mediated capabilities the sandbox may request back over the channel.
+///
+/// Model inference is the first and, for the spike, only carried capability:
+/// a sandbox-resident loop cannot take a single step without it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum Capability {
+    /// Run one model completion through the host, which is the model proxy.
+    ModelInference,
+}
+
+/// Parameters for one host-proxied model completion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ModelInferenceParams {
+    pub prompt: String,
+}
+
+/// Bounded result of one host-proxied model completion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ModelInferenceResult {
+    pub completion: String,
+}
+
+/// Capability-checked reverse request the sandbox issues to the host.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "capability",
+    content = "payload",
+    rename_all = "snake_case",
+    deny_unknown_fields
+)]
+#[non_exhaustive]
+pub enum ReverseRequest {
+    ModelInference(ModelInferenceParams),
+}
+
+impl ReverseRequest {
+    /// Capability this request is gated on, for deny-by-default authorization.
+    #[must_use]
+    pub const fn capability(&self) -> Capability {
+        match self {
+            ReverseRequest::ModelInference(_) => Capability::ModelInference,
+        }
+    }
+}
+
+/// Bounded typed success for one reverse request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "capability", content = "payload", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ReverseResult {
+    ModelInference(ModelInferenceResult),
+}
+
+/// Stable failure classes carried over the reverse channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ErrorCode {
+    /// The request envelope did not match the host's exact protocol version.
+    ProtocolVersion,
+    /// The requested capability was not granted to this run.
+    Denied,
+    /// The operation identity was reused for a different request.
+    OperationIdConflict,
+    /// The in-flight request was cancelled by the sandbox.
+    Cancelled,
+    /// The host could not settle the operation.
+    Internal,
+}
+
+/// Transport-stable error payload; carries no host-internal detail.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ErrorResponse {
+    pub code: ErrorCode,
+    pub message: String,
+    /// Whether re-issuing the same operation identity may succeed later.
+    pub retryable: bool,
+}
+
+impl ErrorResponse {
+    pub(crate) fn new(code: ErrorCode, message: &str, retryable: bool) -> Self {
+        Self {
+            code,
+            message: message.to_owned(),
+            retryable,
+        }
+    }
+}
+
+/// Typed success or a transport-stable error.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", content = "payload", rename_all = "snake_case")]
+pub enum Response<T> {
+    Ok(T),
+    Error(ErrorResponse),
+}
+
+/// A reverse request the sandbox supervisor multiplexes toward the host.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReverseEnvelope {
+    pub protocol_version: u32,
+    pub request_id: RequestId,
+    pub operation_id: OperationId,
+    pub request: ReverseRequest,
+}
+
+/// The host's correlated answer to one reverse request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReverseResponseEnvelope {
+    pub protocol_version: u32,
+    pub request_id: RequestId,
+    pub operation_id: OperationId,
+    pub response: Response<ReverseResult>,
+}
+
+/// A cancellation of an in-flight reverse request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CancelFrame {
+    pub request_id: RequestId,
+    pub operation_id: OperationId,
+}
+
+/// One unit multiplexed over the single bidirectional connection.
+///
+/// Requests and cancellations flow sandbox -> host; responses flow host ->
+/// sandbox. All three share one framed byte stream, so correlation is by
+/// `request_id` rather than by a dedicated socket per call.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "frame",
+    content = "body",
+    rename_all = "snake_case",
+    deny_unknown_fields
+)]
+pub enum Frame {
+    Request(ReverseEnvelope),
+    Response(ReverseResponseEnvelope),
+    Cancel(CancelFrame),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identities_reject_nil() {
+        let encoded = format!("\"{}\"", Uuid::nil());
+        assert!(serde_json::from_str::<OperationId>(&encoded).is_err());
+        assert!(serde_json::from_str::<RequestId>(&encoded).is_err());
+    }
+
+    #[test]
+    fn frames_roundtrip_over_json() {
+        let frame = Frame::Request(ReverseEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: RequestId::new(),
+            operation_id: OperationId::new(),
+            request: ReverseRequest::ModelInference(ModelInferenceParams {
+                prompt: "hello".to_owned(),
+            }),
+        });
+        let encoded = serde_json::to_string(&frame).unwrap();
+        assert_eq!(serde_json::from_str::<Frame>(&encoded).unwrap(), frame);
+    }
+
+    #[test]
+    fn unknown_fields_are_rejected() {
+        let encoded = format!(
+            r#"{{"protocol_version":1,"request_id":"{}","operation_id":"{}","request":{{"capability":"model_inference","payload":{{"prompt":"hi","extra":true}}}}}}"#,
+            RequestId::new(),
+            OperationId::new(),
+        );
+        assert!(serde_json::from_str::<ReverseEnvelope>(&encoded).is_err());
+    }
+}

--- a/crates/openwave-reverse-rpc-spike/src/supervisor.rs
+++ b/crates/openwave-reverse-rpc-spike/src/supervisor.rs
@@ -1,0 +1,237 @@
+//! The sandbox side of the reverse channel: the supervisor's RPC client.
+//!
+//! The supervisor multiplexes many reverse requests over one connection.
+//! Correlation is by `RequestId`: a reader task fans each response frame to the
+//! waiting caller's one-shot. Two bounds cap how much a slow host lets the
+//! sandbox buffer — a semaphore of in-flight permits and a bounded outbound
+//! frame queue — so `call` awaits rather than growing memory when the host
+//! stops draining. A dropped connection fails every in-flight call with
+//! [`ClientError::Disconnected`], and each is safe to re-issue against the same
+//! host by the idempotency rule, carrying the same `OperationId`.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+};
+
+use tokio::{
+    io::{AsyncRead, AsyncWrite, BufReader},
+    sync::{mpsc, oneshot, OwnedSemaphorePermit, Semaphore},
+};
+
+use crate::{
+    protocol::{
+        CancelFrame, ErrorResponse, Frame, OperationId, RequestId, Response, ReverseEnvelope,
+        ReverseRequest, ReverseResult, PROTOCOL_VERSION,
+    },
+    transport::{read_frame, write_frame},
+};
+
+/// Why one reverse call did not return a result.
+#[derive(Debug, thiserror::Error)]
+pub enum ClientError {
+    /// The connection dropped; re-issue the same operation identity to retry.
+    #[error("the reverse-rpc connection dropped before a response arrived")]
+    Disconnected,
+    /// The host answered with a transport-stable error (denied, cancelled,
+    /// conflict, version, internal).
+    #[error("the host rejected the reverse request: {}", .0.message)]
+    Rejected(ErrorResponse),
+}
+
+/// What the reader task delivers to a waiting caller.
+enum CallOutcome {
+    Settled(Response<ReverseResult>),
+    Disconnected,
+}
+
+struct ClientShared {
+    outbound: mpsc::Sender<Frame>,
+    pending: Mutex<HashMap<RequestId, oneshot::Sender<CallOutcome>>>,
+    permits: Arc<Semaphore>,
+    closed: AtomicBool,
+}
+
+impl ClientShared {
+    /// Fail every in-flight call once, on the first disconnect to be observed.
+    fn fail_all(&self) {
+        if self.closed.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let mut pending = self.pending.lock().expect("pending lock");
+        for (_, sender) in pending.drain() {
+            let _ = sender.send(CallOutcome::Disconnected);
+        }
+    }
+}
+
+/// The supervisor's reverse-RPC client over one connection.
+#[derive(Clone)]
+pub struct ReverseClient {
+    shared: Arc<ClientShared>,
+}
+
+impl ReverseClient {
+    /// Open a client over `stream`, allowing `max_in_flight` outstanding calls.
+    ///
+    /// `max_in_flight` bounds both the in-flight semaphore and the outbound
+    /// frame queue, so neither the request path nor the write path can buffer
+    /// without limit while the host is slow.
+    #[must_use]
+    pub fn connect<S>(stream: S, max_in_flight: usize) -> Self
+    where
+        S: AsyncRead + AsyncWrite + Send + 'static,
+    {
+        let capacity = max_in_flight.max(1);
+        let (read_half, write_half) = tokio::io::split(stream);
+        let (outbound_tx, mut outbound_rx) = mpsc::channel::<Frame>(capacity);
+        let shared = Arc::new(ClientShared {
+            outbound: outbound_tx,
+            pending: Mutex::new(HashMap::new()),
+            permits: Arc::new(Semaphore::new(capacity)),
+            closed: AtomicBool::new(false),
+        });
+
+        // Writer task: serialize the outbound queue onto the wire.
+        let writer_shared = Arc::clone(&shared);
+        tokio::spawn(async move {
+            let mut write_half = write_half;
+            while let Some(frame) = outbound_rx.recv().await {
+                if write_frame(&mut write_half, &frame).await.is_err() {
+                    break;
+                }
+            }
+            writer_shared.fail_all();
+        });
+
+        // Reader task: fan responses back to their waiting callers.
+        let reader_shared = Arc::clone(&shared);
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(read_half);
+            loop {
+                match read_frame(&mut reader).await {
+                    Ok(Frame::Response(envelope)) => {
+                        let sender = reader_shared
+                            .pending
+                            .lock()
+                            .expect("pending lock")
+                            .remove(&envelope.request_id);
+                        if let Some(sender) = sender {
+                            let _ = sender.send(CallOutcome::Settled(envelope.response));
+                        }
+                    }
+                    // The supervisor issues requests and cancels; it does not
+                    // service them. Ignore rather than trusting peer input.
+                    Ok(Frame::Request(_) | Frame::Cancel(_)) => {}
+                    Err(_) => break,
+                }
+            }
+            reader_shared.fail_all();
+        });
+
+        Self { shared }
+    }
+
+    /// Issue one reverse request under the durable `operation_id`.
+    ///
+    /// Awaits an in-flight permit first — this is the backpressure point — then
+    /// registers correlation state and enqueues the request frame. The returned
+    /// [`Call`] resolves to the host's answer and can be cancelled meanwhile.
+    pub async fn call(
+        &self,
+        operation_id: OperationId,
+        request: ReverseRequest,
+    ) -> Result<Call, ClientError> {
+        let permit = Arc::clone(&self.shared.permits)
+            .acquire_owned()
+            .await
+            .map_err(|_| ClientError::Disconnected)?;
+        if self.shared.closed.load(Ordering::SeqCst) {
+            return Err(ClientError::Disconnected);
+        }
+
+        let request_id = RequestId::new();
+        let (tx, rx) = oneshot::channel();
+        self.shared
+            .pending
+            .lock()
+            .expect("pending lock")
+            .insert(request_id, tx);
+
+        let envelope = ReverseEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id,
+            operation_id,
+            request,
+        };
+        if self
+            .shared
+            .outbound
+            .send(Frame::Request(envelope))
+            .await
+            .is_err()
+        {
+            self.shared
+                .pending
+                .lock()
+                .expect("pending lock")
+                .remove(&request_id);
+            return Err(ClientError::Disconnected);
+        }
+
+        Ok(Call {
+            request_id,
+            operation_id,
+            rx,
+            shared: Arc::clone(&self.shared),
+            _permit: permit,
+        })
+    }
+}
+
+/// A single in-flight reverse call. Awaiting [`Call::wait`] releases its
+/// in-flight permit; [`Call::cancel`] asks the host to abort it.
+pub struct Call {
+    request_id: RequestId,
+    operation_id: OperationId,
+    rx: oneshot::Receiver<CallOutcome>,
+    shared: Arc<ClientShared>,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl Call {
+    /// Transport correlation identity of this attempt.
+    #[must_use]
+    pub fn request_id(&self) -> RequestId {
+        self.request_id
+    }
+
+    /// Durable operation identity carried by this call. Re-issue with the same
+    /// value after a disconnect to receive the recorded outcome.
+    #[must_use]
+    pub fn operation_id(&self) -> OperationId {
+        self.operation_id
+    }
+
+    /// Ask the host to cancel this in-flight operation. Best-effort: if the
+    /// outbound queue is momentarily full the signal is dropped, matching a real
+    /// transport where a cancel can lose the race with completion.
+    pub fn cancel(&self) {
+        let _ = self.shared.outbound.try_send(Frame::Cancel(CancelFrame {
+            request_id: self.request_id,
+            operation_id: self.operation_id,
+        }));
+    }
+
+    /// Await the host's answer.
+    pub async fn wait(self) -> Result<ReverseResult, ClientError> {
+        match self.rx.await {
+            Ok(CallOutcome::Settled(Response::Ok(result))) => Ok(result),
+            Ok(CallOutcome::Settled(Response::Error(error))) => Err(ClientError::Rejected(error)),
+            Ok(CallOutcome::Disconnected) | Err(_) => Err(ClientError::Disconnected),
+        }
+    }
+}

--- a/crates/openwave-reverse-rpc-spike/src/transport.rs
+++ b/crates/openwave-reverse-rpc-spike/src/transport.rs
@@ -1,0 +1,66 @@
+//! Newline-delimited JSON framing over an async byte duplex.
+//!
+//! The spike runs the host and the sandbox supervisor as two tasks joined by a
+//! `tokio::io::duplex` pipe. That is the cheapest transport that still exercises
+//! the two hard properties a real socket has: genuine framing (a frame can span
+//! reads, and multiple frames can share one read) and genuine concurrency (both
+//! ends make progress on the runtime at once). Dropping either half models a
+//! dropped connection. The framing here mirrors the broker sidecar's
+//! hand-rolled newline protocol rather than pulling in a codec dependency.
+
+use tokio::io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+
+use crate::protocol::Frame;
+
+/// Largest single frame accepted or emitted, so a peer cannot force unbounded
+/// buffering with one enormous line. Model prompts and completions in the spike
+/// are tiny; this only needs to bound abuse.
+pub const MAX_FRAME_BYTES: usize = 1024 * 1024;
+
+/// Why a framed read stopped yielding frames.
+#[derive(Debug, thiserror::Error)]
+pub enum FrameError {
+    #[error("the connection closed")]
+    Closed,
+    #[error("a frame exceeded {MAX_FRAME_BYTES} bytes")]
+    TooLarge,
+    #[error("a frame was not valid JSON")]
+    Malformed,
+    #[error("transport i/o failed: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Read the next frame from a buffered reader, or signal why none came.
+pub async fn read_frame<R>(reader: &mut BufReader<R>) -> Result<Frame, FrameError>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    // `read_until` internally loops until the delimiter or EOF, so a frame that
+    // spans several underlying reads is reassembled here, and `BufReader`
+    // retains any bytes past the newline for the next frame — exactly the
+    // framing behavior a real socket forces on us.
+    let mut line = Vec::new();
+    let read = reader.read_until(b'\n', &mut line).await?;
+    if read == 0 {
+        return Err(FrameError::Closed);
+    }
+    if line.len() > MAX_FRAME_BYTES {
+        return Err(FrameError::TooLarge);
+    }
+    if line.last() == Some(&b'\n') {
+        line.pop();
+    }
+    serde_json::from_slice(&line).map_err(|_| FrameError::Malformed)
+}
+
+/// Write one frame followed by its newline delimiter and flush it.
+pub async fn write_frame<W>(writer: &mut W, frame: &Frame) -> Result<(), FrameError>
+where
+    W: AsyncWrite + Unpin,
+{
+    let mut encoded = serde_json::to_vec(frame).map_err(|_| FrameError::Malformed)?;
+    encoded.push(b'\n');
+    writer.write_all(&encoded).await?;
+    writer.flush().await?;
+    Ok(())
+}

--- a/crates/openwave-reverse-rpc-spike/tests/reverse_rpc.rs
+++ b/crates/openwave-reverse-rpc-spike/tests/reverse_rpc.rs
@@ -1,0 +1,371 @@
+//! Scenario tests for the reverse-RPC spike.
+//!
+//! Each test drives the real host and supervisor across a `tokio::io::duplex`
+//! pipe and asserts one of the properties the go/no-go depends on: idempotent
+//! replay across a reconnect, correlation over one connection, cancellation of
+//! an in-flight request, backpressure against a slow host, and a disconnect
+//! failing an in-flight request while leaving it safe to re-issue.
+
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use tokio::{sync::Semaphore, task::JoinHandle, time::timeout};
+
+use openwave_reverse_rpc_spike::{
+    model::Completion, serve_connection, Capability, CapabilityHost, ClientError,
+    ModelInferenceParams, ModelInferenceResult, ModelProvider, OperationId, ReverseClient,
+    ReverseRequest, ReverseResult,
+};
+
+/// A model that completes instantly and counts how many times it actually ran.
+/// The counter is the exactly-once witness for idempotent replay.
+struct EchoModel {
+    executions: Arc<AtomicUsize>,
+}
+
+impl EchoModel {
+    fn new() -> Self {
+        Self {
+            executions: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn executions(&self) -> usize {
+        self.executions.load(Ordering::SeqCst)
+    }
+}
+
+impl ModelProvider for EchoModel {
+    fn complete(&self, params: ModelInferenceParams) -> Completion<'_> {
+        let executions = Arc::clone(&self.executions);
+        Box::pin(async move {
+            executions.fetch_add(1, Ordering::SeqCst);
+            ModelInferenceResult {
+                completion: format!("echo:{}", params.prompt),
+            }
+        })
+    }
+}
+
+/// A model whose completions block until the test releases a gate permit.
+/// `started` counts entries; `finished` counts completions that ran to the end,
+/// so a cancelled or disconnected completion is visible as started-but-unfinished.
+struct GatedModel {
+    gate: Arc<Semaphore>,
+    started: Arc<AtomicUsize>,
+    finished: Arc<AtomicUsize>,
+}
+
+impl GatedModel {
+    fn new() -> Self {
+        Self {
+            gate: Arc::new(Semaphore::new(0)),
+            started: Arc::new(AtomicUsize::new(0)),
+            finished: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    /// Let one blocked completion run to the end.
+    fn release_one(&self) {
+        self.gate.add_permits(1);
+    }
+}
+
+impl ModelProvider for GatedModel {
+    fn complete(&self, params: ModelInferenceParams) -> Completion<'_> {
+        let gate = Arc::clone(&self.gate);
+        let started = Arc::clone(&self.started);
+        let finished = Arc::clone(&self.finished);
+        Box::pin(async move {
+            started.fetch_add(1, Ordering::SeqCst);
+            let permit = gate.acquire().await.expect("gate open");
+            permit.forget();
+            finished.fetch_add(1, Ordering::SeqCst);
+            ModelInferenceResult {
+                completion: format!("done:{}", params.prompt),
+            }
+        })
+    }
+}
+
+fn infer(prompt: &str) -> ReverseRequest {
+    ReverseRequest::ModelInference(ModelInferenceParams {
+        prompt: prompt.to_owned(),
+    })
+}
+
+fn completion(result: ReverseResult) -> String {
+    match result {
+        ReverseResult::ModelInference(result) => result.completion,
+        #[allow(unreachable_patterns)]
+        _ => panic!("unexpected reverse result variant"),
+    }
+}
+
+/// Attach a fresh connection to `host`, returning the client and the server
+/// task. Aborting the server task models the connection dropping.
+fn connect(host: &CapabilityHost, max_in_flight: usize) -> (ReverseClient, JoinHandle<()>) {
+    let (host_side, client_side) = tokio::io::duplex(64 * 1024);
+    let host = host.clone();
+    let server = tokio::spawn(async move {
+        let _ = serve_connection(host, host_side).await;
+    });
+    let client = ReverseClient::connect(client_side, max_in_flight);
+    (client, server)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn idempotent_replay_across_reconnect() {
+    let model = Arc::new(EchoModel::new());
+    let host = CapabilityHost::new(
+        Arc::clone(&model) as Arc<dyn ModelProvider>,
+        vec![Capability::ModelInference],
+    );
+    let operation = OperationId::new();
+
+    let (client1, server1) = connect(&host, 4);
+    let first = client1
+        .call(operation, infer("forecast"))
+        .await
+        .expect("issue")
+        .wait()
+        .await
+        .expect("first response");
+    assert_eq!(completion(first), "echo:forecast");
+    assert_eq!(model.executions(), 1);
+
+    // The connection drops — as if the response was already delivered but the
+    // host slept, or it was lost — and the supervisor reconnects.
+    server1.abort();
+    drop(client1);
+
+    let (client2, _server2) = connect(&host, 4);
+    let replayed = client2
+        .call(operation, infer("forecast"))
+        .await
+        .expect("re-issue")
+        .wait()
+        .await
+        .expect("replayed response");
+
+    // Same recorded answer, and the model ran exactly once across both attempts.
+    assert_eq!(completion(replayed), "echo:forecast");
+    assert_eq!(
+        model.executions(),
+        1,
+        "replay must not execute a second time"
+    );
+    assert_eq!(host.operation_count(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reissue_with_a_different_request_is_a_conflict() {
+    let model = Arc::new(EchoModel::new());
+    let host = CapabilityHost::new(
+        model as Arc<dyn ModelProvider>,
+        vec![Capability::ModelInference],
+    );
+    let operation = OperationId::new();
+
+    let (client, _server) = connect(&host, 4);
+    client
+        .call(operation, infer("first"))
+        .await
+        .expect("issue")
+        .wait()
+        .await
+        .expect("response");
+
+    let conflict = client
+        .call(operation, infer("second"))
+        .await
+        .expect("issue")
+        .wait()
+        .await;
+    match conflict {
+        Err(ClientError::Rejected(error)) => {
+            assert_eq!(
+                error.code,
+                openwave_reverse_rpc_spike::ErrorCode::OperationIdConflict
+            );
+        }
+        other => panic!("expected an operation-id conflict, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_calls_correlate_to_their_own_responses() {
+    let model = Arc::new(EchoModel::new());
+    let host = CapabilityHost::new(
+        model as Arc<dyn ModelProvider>,
+        vec![Capability::ModelInference],
+    );
+    let (client, _server) = connect(&host, 8);
+
+    // Issue several overlapping calls, then await them. Each must get exactly
+    // its own answer back over the one multiplexed connection.
+    let mut calls = Vec::new();
+    for index in 0..5 {
+        let call = client
+            .call(OperationId::new(), infer(&format!("q{index}")))
+            .await
+            .expect("issue");
+        calls.push((index, call));
+    }
+    for (index, call) in calls {
+        let result = call.wait().await.expect("response");
+        assert_eq!(completion(result), format!("echo:q{index}"));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancel_aborts_an_in_flight_request() {
+    let model = Arc::new(GatedModel::new());
+    let host = CapabilityHost::new(
+        Arc::clone(&model) as Arc<dyn ModelProvider>,
+        vec![Capability::ModelInference],
+    );
+    let (client, _server) = connect(&host, 4);
+
+    let call = client
+        .call(OperationId::new(), infer("slow"))
+        .await
+        .expect("issue");
+    // Let the host reach the model and block on the closed gate.
+    while model.started.load(Ordering::SeqCst) == 0 {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    call.cancel();
+    match call.wait().await {
+        Err(ClientError::Rejected(error)) => {
+            assert_eq!(error.code, openwave_reverse_rpc_spike::ErrorCode::Cancelled);
+        }
+        other => panic!("expected a cancelled response, got {other:?}"),
+    }
+
+    // Even if a permit arrives now, the aborted completion never finished its
+    // effect — cancellation actually interrupted the in-flight work.
+    model.release_one();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(model.started.load(Ordering::SeqCst), 1);
+    assert_eq!(model.finished.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn backpressure_blocks_new_calls_until_the_host_drains() {
+    let model = Arc::new(GatedModel::new());
+    let host = CapabilityHost::new(
+        Arc::clone(&model) as Arc<dyn ModelProvider>,
+        vec![Capability::ModelInference],
+    );
+    // Two in-flight permits; the host is paused (gate closed), so it drains
+    // nothing until the test releases it.
+    let (client, _server) = connect(&host, 2);
+
+    let call1 = client
+        .call(OperationId::new(), infer("a"))
+        .await
+        .expect("first");
+    let call2 = client
+        .call(OperationId::new(), infer("b"))
+        .await
+        .expect("second");
+
+    // A third call cannot make progress: no permit is free while the host holds
+    // both in flight. That bound is the sandbox's protection against unbounded
+    // buffering behind a slow host.
+    let blocked = timeout(
+        Duration::from_millis(100),
+        client.call(OperationId::new(), infer("c")),
+    )
+    .await;
+    assert!(
+        blocked.is_err(),
+        "a third call must block under backpressure"
+    );
+
+    // Let the host drain the two in-flight calls, freeing their permits.
+    model.release_one();
+    model.release_one();
+    assert_eq!(completion(call1.wait().await.expect("a")), "done:a");
+    assert_eq!(completion(call2.wait().await.expect("b")), "done:b");
+
+    // Now the third call proceeds.
+    model.release_one();
+    let third = timeout(
+        Duration::from_secs(1),
+        client.call(OperationId::new(), infer("c")),
+    )
+    .await
+    .expect("permit freed")
+    .expect("third issue");
+    assert_eq!(completion(third.wait().await.expect("c")), "done:c");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn disconnect_fails_inflight_and_reissue_returns_the_recorded_response() {
+    let model = Arc::new(GatedModel::new());
+    let host = CapabilityHost::new(
+        Arc::clone(&model) as Arc<dyn ModelProvider>,
+        vec![Capability::ModelInference],
+    );
+    let operation = OperationId::new();
+
+    let (client1, server1) = connect(&host, 4);
+    let call = client1.call(operation, infer("job")).await.expect("issue");
+    while model.started.load(Ordering::SeqCst) == 0 {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    // Drop the connection with the request still executing.
+    server1.abort();
+    match call.wait().await {
+        Err(ClientError::Disconnected) => {}
+        other => panic!("expected a disconnect failure, got {other:?}"),
+    }
+
+    // The detached execution survives the disconnect; let it finish and record.
+    model.release_one();
+
+    // Reconnect and re-issue the same operation identity: the recorded outcome
+    // comes back, and the model still ran exactly once.
+    let (client2, _server2) = connect(&host, 4);
+    let replayed = client2
+        .call(operation, infer("job"))
+        .await
+        .expect("re-issue")
+        .wait()
+        .await
+        .expect("recorded response");
+    assert_eq!(completion(replayed), "done:job");
+    assert_eq!(model.finished.load(Ordering::SeqCst), 1);
+    assert_eq!(host.operation_count(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn ungranted_capability_is_denied_by_default() {
+    let model = Arc::new(EchoModel::new());
+    // No capabilities granted.
+    let host = CapabilityHost::new(Arc::clone(&model) as Arc<dyn ModelProvider>, Vec::new());
+    let (client, _server) = connect(&host, 4);
+
+    let denied = client
+        .call(OperationId::new(), infer("nope"))
+        .await
+        .expect("issue")
+        .wait()
+        .await;
+    match denied {
+        Err(ClientError::Rejected(error)) => {
+            assert_eq!(error.code, openwave_reverse_rpc_spike::ErrorCode::Denied);
+        }
+        other => panic!("expected a deny-by-default rejection, got {other:?}"),
+    }
+    assert_eq!(model.executions(), 0, "a denied request must never execute");
+}

--- a/docs/spikes/reverse-rpc-findings.md
+++ b/docs/spikes/reverse-rpc-findings.md
@@ -15,15 +15,17 @@ demonstrated by a passing test against a real framed transport and a real
 concurrent host and supervisor. None of them required exotic machinery; each
 falls out of the same envelope discipline `openwave-host-broker` already uses.
 
-The GO carries **one condition that #822 must discharge**, not a caveat that can
-be deferred: the operation-identity record and its recorded response must be
-*durable* and committed in the right order relative to the model call's external
-effect. The spike proves idempotency across a reconnect within a single host
-process; it does **not** prove it across a host crash, and a host crash mid-call
-reintroduces exactly the ambiguous-external-effect problem the run tier already
-fails conservatively on. This is a known, bounded piece of work with a clear
-shape (below), not an open research question — which is why the recommendation
-is GO rather than "GO if."
+The GO carries **a durable-storage condition #822 must discharge**, not a caveat
+that can be deferred. It has two co-equal parts, both about the operation log:
+(1) the operation-identity record and its recorded response must be *durable* and
+committed in the right order relative to the model call's external effect; and
+(2) that log must have a stated **retention** story, because a sandbox-resident
+loop makes it a high-cardinality per-step structure rather than the bounded
+receipt it resembles. The spike proves idempotency across a reconnect within a
+single host process; it does **not** prove it across a host crash (part 1), and
+its in-memory log is insert-only with no eviction (part 2). Both are known,
+bounded pieces of work with a clear shape (below), not open research questions —
+which is why the recommendation is GO rather than "GO if."
 
 ## What the prototype exercises
 
@@ -119,6 +121,51 @@ is durable state on the **run**, and it maps cleanly onto machinery
   counterpart to that resumable event stream — the host commits a response once,
   keyed by `OperationId`, and a re-delivery is answered from the commit.
 
+### Operation-log retention
+
+The commit-ordering problem above is one of **two** durable-storage design items
+#822 must own; this is the co-equal second, and neither the findings above nor
+sandbox-providers.md currently addresses it.
+
+The analogy to the run tier's "immutable typed receipt keyed by the child" holds
+for *shape* but breaks on *cardinality*, and the break matters. That receipt is
+bounded: one per attempt, a handful of children per run. The reverse-RPC
+operation log is not. A sandbox-resident **loop** issues a reverse model-inference
+request on every step, so a single run can produce thousands of distinct
+`OperationId`s, each with a recorded `Response`. The spike's insert-only
+`HashMap` retaining every full response body is therefore not a small version of
+the durable structure — it is a fundamentally higher-cardinality, unbounded-per-run
+one, and persisting it naively would grow the run row without limit and keep
+every model completion the run ever made.
+
+#822 must decide, explicitly, three things it can leave unstated today only
+because the spike is in-memory and short-lived:
+
+- **What bounds the log.** Is it size-bounded, count-bounded, or bounded by the
+  run's own lifetime? A sandbox-resident run is already bounded by its absolute
+  deadline, the provider lifetime cap, and the token lifetime (invariant 5), so
+  the log's worst case is finite — but "finite" at thousands of entries times a
+  full response body each is still a real storage cost that needs a stated cap.
+- **When a `Recorded` entry can be evicted.** The idempotency guarantee only has
+  to hold while the sandbox can still re-issue that `OperationId`. Once the
+  supervisor has acknowledged consuming the response — the same
+  consume-and-advance-a-cursor shape the event stream already uses — that
+  `OperationId` can never be re-issued, so its recorded entry is safe to evict.
+  This argues for an acknowledgement/cursor protocol on the reverse channel, not
+  an unbounded log: retention is keyed to un-acknowledged operations, not to the
+  whole run history.
+- **Whether the full `Response` body must be retained, or just a commit marker.**
+  Replay requires returning the recorded response *body*, so an un-acknowledged
+  entry must keep it. But an entry that must be retained past acknowledgement for
+  audit or accounting may only need a commit marker (`OperationId` + outcome
+  class + a spend/audit reference), not the completion text. Splitting "retained
+  for replay" from "retained for audit" is what keeps the durable log from
+  carrying every model completion verbatim for the run's whole life.
+
+This is a scoping addition, not a design the spike solves. The point is that the
+durable operation log is a higher-cardinality structure than the receipt it
+resembles, and #822 owns its retention story alongside its commit ordering.
+
 ## Cancellation and backpressure
 
 **Cancellation** (`Call::cancel` → `CancelFrame` → `CapabilityHost::cancel`)
@@ -162,6 +209,12 @@ paused host.
   repository-wide rule that ambiguous execution is failed, never replayed. The
   spike does not implement crash durability; it demonstrates the reconnect path
   the durable record would sit under.
+- **The operation log only grows.** The spike's log is a
+  `HashMap<OperationId, Arc<OperationEntry>>` that only ever inserts and retains
+  the full recorded `Response` per entry. That is fine for a spike but wrong for
+  a real run: it has no retention, eviction, or GC, and its cardinality is
+  fundamentally higher than the receipts it is analogized to (see the retention
+  section below).
 - **Single capability.** Only model inference is carried, as the issue scopes.
   The `ReverseRequest`/`ReverseResult` enums are `#[non_exhaustive]` and adding a
   capability (host search, consent prompt) is a variant plus a handler; the
@@ -188,8 +241,11 @@ either double-spend (re-execute a call that already ran) or lose work
 (fail a call that could have been recorded). It is the same class of problem the
 run tier already solved for result commit with an idempotency key and a
 single-predicate check, so the pattern to copy exists — but it must be built
-deliberately at the protocol step, not assumed. Everything else the spike
-touched was straightforward.
+deliberately at the protocol step, not assumed. Its co-equal companion is the
+operation log's **retention** story (above): a sandbox-resident loop makes the
+durable log a high-cardinality, per-step structure, so #822 owns both how the
+log commits and how it is bounded and evicted. Everything else the spike touched
+was straightforward.
 
 Had the spike been NO-GO, the design already names the cost:
 sandbox-resident runs would require a scoped-token issuer **even while
@@ -208,16 +264,22 @@ sandbox-resident runs can proxy inference through the host.
    external effect fails conservatively rather than re-executing, and the record
    is the run's, surviving any single connection. This is the biggest risk and
    the gating design decision.
-2. **A reserved control lane** for cancel and liveness, separate from the
+2. **Operation-log retention** (see the retention section). Co-equal with item 1:
+   bound the durable log, define when a `Recorded` entry is evictable (an
+   acknowledgement/cursor once the sandbox can no longer re-issue the
+   `OperationId`), and decide whether an entry retains the full `Response` body
+   or only a commit marker. The log is per-step and unbounded-per-run without
+   this, unlike the bounded receipt it resembles.
+3. **A reserved control lane** for cancel and liveness, separate from the
    request/response backlog, so cancellation and heartbeats are never subject to
    request backpressure.
-3. **Version negotiation** on connect, following the broker's exact-equality
+4. **Version negotiation** on connect, following the broker's exact-equality
    `PROTOCOL_VERSION` check (the spike checks equality per request; the protocol
    should also handshake on attach, as the broker's `Hello` does).
-4. **Capability grant provenance.** The spike takes a static grant set; the real
+5. **Capability grant provenance.** The spike takes a static grant set; the real
    host resolves grants per run at admission, deny-by-default, and audits each
    reverse operation with run provenance, as the reachability section requires
    for consent prompts.
-5. **Bounded results and frame-size limits** carried into the protocol
+6. **Bounded results and frame-size limits** carried into the protocol
    explicitly (the spike bounds frame size; the protocol should state per-capability
    result bounds as the broker states `MAX_*` limits).

--- a/docs/spikes/reverse-rpc-findings.md
+++ b/docs/spikes/reverse-rpc-findings.md
@@ -1,0 +1,223 @@
+# Reverse-RPC callback channel — spike findings
+
+Spike for [sandbox-providers.md](../sandbox-providers.md) step 5, issue #821. The
+prototype lives in `crates/openwave-reverse-rpc-spike` and is **not wired into
+the server**. This document is the deliverable; the code exists to back its
+claims with runnable tests.
+
+## Verdict: GO
+
+The host-held reverse-RPC callback channel is buildable at acceptable
+complexity. Every hard part the design named — request/response correlation over
+one multiplexed connection, durable per-run operation identity with recorded
+responses, cancellation, backpressure, and disconnect-fails-inflight — is
+demonstrated by a passing test against a real framed transport and a real
+concurrent host and supervisor. None of them required exotic machinery; each
+falls out of the same envelope discipline `openwave-host-broker` already uses.
+
+The GO carries **one condition that #822 must discharge**, not a caveat that can
+be deferred: the operation-identity record and its recorded response must be
+*durable* and committed in the right order relative to the model call's external
+effect. The spike proves idempotency across a reconnect within a single host
+process; it does **not** prove it across a host crash, and a host crash mid-call
+reintroduces exactly the ambiguous-external-effect problem the run tier already
+fails conservatively on. This is a known, bounded piece of work with a clear
+shape (below), not an open research question — which is why the recommendation
+is GO rather than "GO if."
+
+## What the prototype exercises
+
+All tests are in `crates/openwave-reverse-rpc-spike/tests/reverse_rpc.rs` and run
+under `cargo test -p openwave-reverse-rpc-spike`.
+
+| Property | Test | What it proves |
+| --- | --- | --- |
+| Idempotent replay across reconnect | `idempotent_replay_across_reconnect` | Same `OperationId` re-issued on a fresh connection returns the recorded answer; the model ran exactly once. |
+| Operation-id conflict | `reissue_with_a_different_request_is_a_conflict` | Reusing an identity for a different request is refused, as the broker refuses a reused mutation identity. |
+| Correlation | `concurrent_calls_correlate_to_their_own_responses` | Five overlapping calls over one connection each receive their own response, matched by `RequestId`. |
+| Cancellation | `cancel_aborts_an_in_flight_request` | A cancel aborts the in-flight completion; the model's effect never finishes, and the caller sees `Cancelled`. |
+| Backpressure | `backpressure_blocks_new_calls_until_the_host_drains` | With the host paused, a new call blocks on the in-flight bound instead of buffering, and unblocks only as the host drains. |
+| Disconnect fails in-flight + safe re-issue | `disconnect_fails_inflight_and_reissue_returns_the_recorded_response` | A dropped connection fails the in-flight call with `Disconnected`; the detached execution keeps running and records; re-issue after reconnect returns the recorded answer, model still ran once. |
+| Deny-by-default | `ungranted_capability_is_denied_by_default` | An ungranted capability is refused and never executes. |
+
+## Transport choice
+
+The spike runs the host and the sandbox supervisor as two `tokio` tasks joined
+by a `tokio::io::duplex` pipe, speaking newline-delimited JSON frames
+(`src/transport.rs`). This is the cheapest transport that still exercises the two
+properties a real socket forces on the design:
+
+- **Real framing.** A frame can span several underlying reads, and several
+  frames can arrive in one read; `read_until` over a `BufReader` reassembles and
+  retains the remainder, exactly as the shipped broker sidecar's hand-rolled
+  newline protocol does. Nothing here relies on passing Rust structs through an
+  in-process channel, which would have tested nothing about the wire.
+- **Real concurrency.** Both ends make progress on the runtime at once, so
+  correlation, out-of-order completion, and backpressure are genuine, not
+  simulated by sequencing.
+
+Dropping either half of the duplex models a dropped connection, which is how the
+disconnect test induces a failure. No E2B/Daytona backend is stood up; per the
+delivery sequence, the vendor seam is exercised at the protocol boundary later,
+not in this spike.
+
+For production the frame transport is an implementation detail behind the same
+`Frame` enum: loopback TCP for a local container, a TLS-fronted stream for a
+managed vendor. The design's direction rule (host dials, sandbox never dials)
+is unaffected — the host still opens the connection; "reverse" refers only to
+which side originates *requests* over it, and the spike models precisely that:
+the supervisor originates requests, the host answers.
+
+## Operation identity and recorded responses
+
+This is the heart of the spike. Two identities travel on every request, mirroring
+the broker's split between transport correlation and idempotency identity:
+
+- `RequestId` — per-attempt, correlates one request frame with one response
+  frame. A re-issue after reconnect uses a **new** `RequestId`.
+- `OperationId` — durable per-run identity. A re-issue uses the **same**
+  `OperationId`, and that is what makes the answer idempotent.
+
+The host keeps an operation log keyed by `OperationId` (`src/host.rs`,
+`CapabilityHost`). The whole idempotency rule is one function, `dispatch`:
+
+- unknown identity → claim it, spawn the capability's execution **once**, return
+  a handle to its outcome;
+- known identity, same request → attach to the existing outcome without
+  re-executing (this serves both a reconnect replay and a concurrent duplicate);
+- known identity, different request → `OperationIdConflict`, the same refusal the
+  broker gives a reused mutation identity with a different fingerprint.
+
+The execution runs as a task **decoupled from the connection**: it writes its
+result into a `watch` channel that the per-request forwarder reads. That
+decoupling is what gives the disconnect semantics for free — a dropped
+connection tears down the forwarder but not the execution, so the execution
+finishes and records, and a later re-issue reads the record. An explicit cancel,
+by contrast, fires a signal the execution selects on, so cancel *can* abort what
+disconnect cannot.
+
+### Where this persists in the real system
+
+The spike's operation log is in-memory (`HashMap<OperationId, _>` behind a
+`Mutex`) and its recorded response is a `watch` value. In production this record
+is durable state on the **run**, and it maps cleanly onto machinery
+[agent-runs.md](../agent-runs.md) and
+[sandbox-providers.md](../sandbox-providers.md) already describe:
+
+- The recorded outcome is an **immutable typed receipt keyed by the operation**,
+  the same shape as the run tier's "immutable typed receipt keyed by the child"
+  for final sandbox output, and the `WriteFile` mutation receipt in the broker
+  (`operation_id` → terminal `Result`).
+- The record's lifecycle is a small state machine — `Claimed(dispatched)` →
+  `Recorded(response)` / `Failed` — persisted alongside the run row, under the
+  same transactional serialization the run tier uses for durable transitions.
+  The `OperationId` is the reverse-RPC analogue of the run's result idempotency
+  key: it fences a re-issue the way the result key fences a duplicate result
+  delivery.
+- Reconnect draining already exists as a concept: the run's event stream resumes
+  from a committed cursor. Recorded reverse-RPC responses are the request/response
+  counterpart to that resumable event stream — the host commits a response once,
+  keyed by `OperationId`, and a re-delivery is answered from the commit.
+
+## Cancellation and backpressure
+
+**Cancellation** (`Call::cancel` → `CancelFrame` → `CapabilityHost::cancel`)
+fires a one-shot the execution's `select!` is waiting on, so the in-flight model
+future is dropped rather than run to completion. The test asserts the model's
+effect counter never advances after cancel even once a permit is offered — the
+work was genuinely interrupted, not merely reported cancelled. Cancellation is
+recorded as a terminal `Cancelled` outcome, so a later re-issue of a cancelled
+operation returns `Cancelled` rather than starting a second execution. That
+choice deliberately matches the design's conservative stance: a model call with
+possible partial spend is not silently retried.
+
+**Backpressure** has two layers on the supervisor:
+
+- an in-flight **semaphore** (`max_in_flight` permits); `call` awaits a permit
+  before it will even register a request, and the permit is held by the live
+  `Call` until its result is taken. When the host stops answering, permits are
+  not returned, and new calls block.
+- a **bounded outbound queue** feeding the writer task, so the write path cannot
+  buffer past its capacity either.
+
+The test pauses the host, saturates the two permits, and asserts a third call
+does not complete within a timeout — then releases the host and watches the
+third call proceed as permits free. This is backpressure keyed to consumer
+progress, not a fixed-size buffer that eventually drops: the sandbox is bounded
+by how fast the host drains, which is what the design requires of a slow or
+paused host.
+
+## Failure modes hit, and honest limits
+
+- **Cancel shares the outbound queue.** `Call::cancel` uses a non-blocking
+  `try_send`; under a full queue the cancel is dropped. A production channel
+  needs a **reserved control lane** for cancel (and heartbeats) so a cancel is
+  never blocked behind the very backlog it is trying to relieve. This is a small
+  protocol addition, flagged for #822, not a design flaw.
+- **In-flight dedup is process-local.** The spike attaches a reconnect re-issue
+  to the *same running future*. Across a host crash that future is gone. The
+  durable record's `Claimed` state must therefore be the source of truth, and a
+  re-issue that finds `Claimed` after a crash **cannot safely re-execute** a
+  call with an external effect — it fails conservatively, matching the
+  repository-wide rule that ambiguous execution is failed, never replayed. The
+  spike does not implement crash durability; it demonstrates the reconnect path
+  the durable record would sit under.
+- **Single capability.** Only model inference is carried, as the issue scopes.
+  The `ReverseRequest`/`ReverseResult` enums are `#[non_exhaustive]` and adding a
+  capability (host search, consent prompt) is a variant plus a handler; the
+  gating and idempotency paths are capability-agnostic.
+- **Trust and transport authenticity are out of scope.** Per the doc's trust
+  model, a managed vendor's control plane can impersonate the run; the spike
+  does not defend against that and is not meant to. Per-run transport secret,
+  TLS identity pinning, and loopback pinning are transport concerns for the
+  protocol step.
+
+## Complexity and risk assessment
+
+Complexity is **moderate and bounded**. The prototype is ~4 small modules of
+ordinary async Rust with no new dependency beyond `tokio` features already in the
+workspace pin. The structural idea that carries the weight — split run-scoped
+state (grants, operation log, model proxy) from connection-scoped state
+(framing, forwarders) — is the same host/connection split the broker already
+draws between its `Controller`/`Operator` surfaces and its sidecar. There is no
+event loop to hand-roll, no custom executor, no unsafe.
+
+The **single biggest risk** is durable operation-identity commit ordering
+against the model call's external effect. Get the commit predicate wrong and you
+either double-spend (re-execute a call that already ran) or lose work
+(fail a call that could have been recorded). It is the same class of problem the
+run tier already solved for result commit with an idempotency key and a
+single-predicate check, so the pattern to copy exists — but it must be built
+deliberately at the protocol step, not assumed. Everything else the spike
+touched was straightforward.
+
+Had the spike been NO-GO, the design already names the cost:
+sandbox-resident runs would require a scoped-token issuer **even while
+attached**, so an install whose only model credential is a long-lived provider
+key could not run them at all; and host-mediated capabilities (host search,
+consent prompts) would be absent from sandbox-resident runs entirely. That is a
+hard product regression, and the spike's result avoids it: attached
+sandbox-resident runs can proxy inference through the host.
+
+## What #822 (the protocol step) must nail down
+
+1. **Durable operation record + commit predicate.** Persist the operation log on
+   the run: `Claimed(dispatched)` → `Recorded(response)` / `Failed`, committed
+   transactionally, keyed by `OperationId`. Define the commit predicate so a
+   re-issue is answered from `Recorded`, a `Claimed`-after-crash call with an
+   external effect fails conservatively rather than re-executing, and the record
+   is the run's, surviving any single connection. This is the biggest risk and
+   the gating design decision.
+2. **A reserved control lane** for cancel and liveness, separate from the
+   request/response backlog, so cancellation and heartbeats are never subject to
+   request backpressure.
+3. **Version negotiation** on connect, following the broker's exact-equality
+   `PROTOCOL_VERSION` check (the spike checks equality per request; the protocol
+   should also handshake on attach, as the broker's `Hello` does).
+4. **Capability grant provenance.** The spike takes a static grant set; the real
+   host resolves grants per run at admission, deny-by-default, and audits each
+   reverse operation with run provenance, as the reachability section requires
+   for consent prompts.
+5. **Bounded results and frame-size limits** carried into the protocol
+   explicitly (the spike bounds frame size; the protocol should state per-capability
+   result bounds as the broker states `MAX_*` limits).


### PR DESCRIPTION
## Verdict: GO

The host-held reverse-RPC callback channel is buildable at acceptable complexity and risk. A real prototype (`crates/openwave-reverse-rpc-spike`, not wired into the server) demonstrates every hard part the design named — correlation over one multiplexed connection, per-run operation identity with recorded responses, cancellation, backpressure, and disconnect-fails-inflight — each backed by a passing test against a real framed transport and a real concurrent host + supervisor. The idempotency test proves that a re-issue after a reconnect returns the recorded response and the model ran exactly once **in-process**; it does not (and is not meant to) prove durability across a host crash. None of this required exotic machinery; each property falls out of the same envelope discipline `openwave-host-broker` already uses.

The GO carries a **durable-storage condition #822 must discharge**, not a deferrable caveat — with two co-equal parts, both about the operation log:

1. **Crash-safe commit ordering.** The operation-identity record and its recorded response must be durable and committed in the right order relative to the model call's external effect, so a `Claimed`-after-crash call fails conservatively rather than re-executing. The spike shows the reconnect path this record sits under, not the crash durability itself. The run tier's result-idempotency-key pattern is the template.
2. **Retention.** A sandbox-resident *loop* issues a reverse model-inference request per step, so the durable log is a high-cardinality, unbounded-per-run structure — not the bounded per-child receipt it resembles. #822 must decide what bounds it, when a `Recorded` entry is evictable (an acknowledgement/cursor once the `OperationId` can no longer be re-issued), and whether entries retain the full response body or just a commit marker. The spike's in-memory log is insert-only with no eviction.

Both are bounded, well-shaped work, which is why the recommendation is GO, not "GO if".

This is a **spike**: it will not auto-merge and is not a shipped feature. Full reasoning, the persistence mapping onto the run row/store, the retention analysis, the failure modes, and the risk assessment are in `docs/spikes/reverse-rpc-findings.md`.

## What it exercises

Modeled on the shipped broker envelope (versioned protocol with an exact-equality version check, deny-by-default capability gating, per-run operation identity, bounded typed results). The shipped host-broker is untouched. Transport is a `tokio::io::duplex` pipe between two tasks speaking newline-delimited JSON frames — the cheapest thing that still exercises real framing and real concurrency; dropping a half models a dropped connection. No E2B/Daytona backend is stood up. Model inference is the first (only) carried capability.

Tests in `crates/openwave-reverse-rpc-spike/tests/reverse_rpc.rs`:

- **Idempotent replay across reconnect** — same `OperationId` re-issued on a fresh connection returns the recorded answer; the model ran exactly once (in-process).
- **Operation-id conflict** — reusing an identity for a different request is refused.
- **Correlation** — five overlapping calls over one connection each get their own response, matched by `RequestId`.
- **Cancellation** — a cancel aborts the in-flight completion; the effect never finishes.
- **Backpressure** — with the host paused, a new call blocks on the in-flight bound instead of buffering, and unblocks only as the host drains.
- **Disconnect fails in-flight + safe re-issue** — a dropped connection fails the in-flight call with `Disconnected`; the detached execution keeps running and records; re-issue after reconnect returns the recorded answer, model still ran once.
- **Deny-by-default** — an ungranted capability is refused and never executes.

## Verification

- `cargo test -p openwave-reverse-rpc-spike --locked` — 10 passed (3 unit + 7 scenario), 0 failed.
- `cargo clippy -p openwave-reverse-rpc-spike --all-targets --locked -- -D warnings` — clean.
- `cargo fmt -p openwave-reverse-rpc-spike -- --check` — clean.
- `Cargo.lock` change is only the new package entry; no existing dependency version drifted. Deps reuse workspace-pinned `tokio`/`serde`/`serde_json`/`thiserror`/`uuid`.

## For the protocol step (#822)

Two co-equal durable-storage items lead: **crash-safe commit ordering** and **operation-log retention** (both described above and detailed in the findings doc). Alongside them: a reserved control lane for cancel/liveness separate from the request backlog; a version handshake on attach; per-run grant provenance with audit; explicit per-capability result bounds.

Closes #821
