### PR TITLE
fix(desktop): let the renderer read the document it is drawing

### DIFF
--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -89,6 +89,12 @@ export type ChatMetadataFrame = RendererChatMetadata;
 /** Generated from `ToolApprovalKind`. */
 export type RendererApprovalKind = ToolApprovalKind;
 
+/**
+ * One source as the renderer may see it, paired with `ChatDocumentDetail` on the
+ * server. Deliberately narrower than the catalog summary, which also carries the
+ * source's `uri` and index bookkeeping — neither of which the renderer is given,
+ * because a `uri` can name a place on the reader's disk.
+ */
 export type DocumentDetail = {
   document_id: string;
   media_type: string;

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -54,7 +54,7 @@ use std::sync::Arc;
 
 use axum::extract::DefaultBodyLimit;
 use axum::http::{header, Method};
-use axum::routing::{get, post};
+use axum::routing::{delete, get, post};
 use axum::Router;
 use tokio::net::TcpListener;
 use tower_http::cors::{AllowOrigin, CorsLayer};
@@ -111,11 +111,7 @@ pub fn app(state: AppState) -> Router {
         )
         .route(
             "/chats/{chat_id}/documents/{document_id}",
-            get(routes::get_chat_document).delete(routes::delete_chat_document),
-        )
-        .route(
-            "/chats/{chat_id}/documents/{document_id}/file-content",
-            get(routes::get_chat_document_file_content),
+            delete(routes::delete_chat_document),
         )
         .route(
             "/chats/{chat_id}/documents/{document_id}/retry",
@@ -210,8 +206,23 @@ pub fn app(state: AppState) -> Router {
             "/chats/{id}/client-executions/{call_id}/resolve",
             post(routes::resolve_client_execution),
         );
+    // The reader's half of the document surface. `ChatDocumentDetail` omits the
+    // catalog's `uri` and index bookkeeping, so unlike the full-fidelity routes
+    // below there is nothing here to withhold from an untrusted client — and a
+    // renderer-shaped client, this webview or a web one later, holds only the
+    // primary bearer and is the thing that draws the document.
+    let renderer_document_api = Router::new()
+        .route(
+            "/chats/{chat_id}/documents/{document_id}",
+            get(routes::get_chat_document),
+        )
+        .route(
+            "/chats/{chat_id}/documents/{document_id}/file-content",
+            get(routes::get_chat_document_file_content),
+        );
+
     // A native embedding gives the renderer only the primary bearer, so its
-    // canonical document surface joins the native-only router. A headless
+    // full-fidelity document surface joins the native-only router. A headless
     // embedding has no separate renderer trust boundary and deliberately keeps
     // the same API on its primary bearer for CLI/API compatibility.
     let (client_executor_api, public_document_api) = if state.root_attachment_routes_enabled {
@@ -333,6 +344,7 @@ pub fn app(state: AppState) -> Router {
             axum::routing::delete(routes::delete_provider_credential),
         )
         .merge(public_document_api)
+        .merge(renderer_document_api)
         // The transcript must fetch pixels with its bearer rather than putting
         // a token in an image URL. Unlike image publication, this is renderer
         // presentation of an image already durably attached to the chat.

--- a/crates/openwave-server/src/routes/document.rs
+++ b/crates/openwave-server/src/routes/document.rs
@@ -224,6 +224,48 @@ pub struct DocumentDetail {
     pub content: String,
 }
 
+/// One source as the renderer may see it.
+///
+/// Deliberately narrower than [`DocumentDetail`], which flattens the full
+/// catalog summary. That summary carries `uri` — for a conversation source
+/// either absent or an opaque `connected-folder:{root_id}/{path}` reference, but
+/// for an unscoped source a real filesystem path — along with revision and index
+/// fingerprints that are server bookkeeping. None of it is the renderer's, and a
+/// projection is a guarantee where "it happens to be empty today" is not.
+///
+/// Adding a field here puts it on an untrusted surface. Nothing derived from a
+/// host path belongs in one.
+#[derive(Debug, Serialize)]
+#[cfg_attr(test, derive(serde::Deserialize))]
+pub struct ChatDocumentDetail {
+    /// Stable identifier shared with citations and the file-content route.
+    pub document_id: DocumentId,
+    /// Media type of the canonical content, which selects the viewer.
+    pub media_type: String,
+    pub title: Option<String>,
+    pub processing_status: openwave_core::DocumentProcessingStatus,
+    /// Whether a search of this conversation can match this source.
+    pub searchable: bool,
+    pub updated_at: chrono::DateTime<Utc>,
+    /// Parsed text-of-record. Citation spans index into this string.
+    pub content: String,
+}
+
+impl From<DocumentRecord> for ChatDocumentDetail {
+    fn from(document: DocumentRecord) -> Self {
+        let summary = DocumentSummary::from(&document);
+        Self {
+            document_id: summary.document_id,
+            media_type: summary.media_type,
+            title: summary.title,
+            processing_status: summary.processing_status,
+            searchable: summary.searchable,
+            updated_at: summary.updated_at,
+            content: document.canonical_text,
+        }
+    }
+}
+
 impl From<DocumentRecord> for DocumentDetail {
     fn from(document: DocumentRecord) -> Self {
         Self {
@@ -799,14 +841,14 @@ pub async fn get_project_document(
 pub async fn get_chat_document(
     State(state): State<AppState>,
     Path((chat_id, document_id)): Path<(ChatId, DocumentId)>,
-) -> Result<Json<DocumentDetail>, ServerError> {
+) -> Result<Json<ChatDocumentDetail>, ServerError> {
     require_chat(&state, chat_id).await?;
     state
         .store
         .get_document(document_id)
         .await?
         .filter(|document| document.chat_id == Some(chat_id) && document.project_id.is_none())
-        .map(DocumentDetail::from)
+        .map(ChatDocumentDetail::from)
         .map(Json)
         .ok_or_else(|| ServerError::not_found(format!("document {document_id} not found")))
 }

--- a/crates/openwave-server/src/tests/documents.rs
+++ b/crates/openwave-server/src/tests/documents.rs
@@ -2780,19 +2780,21 @@ async fn connect_vector_store_falls_back_to_an_in_memory_index_without_vec_lance
     assert_eq!(reopened.len().await.unwrap(), 0);
 }
 
-/// Records where the document surface sits in a native embedding, which is the
-/// configuration the desktop actually runs and the one no other test here
-/// builds. Every other test uses the headless router, where these same routes
-/// are on the primary bearer — so none of them can see what the renderer meets.
+/// What the renderer may read in a native embedding, which is the configuration
+/// the desktop runs and the one no other test in this module builds.
 ///
-/// The renderer holds the primary bearer and nothing else, so today it cannot
-/// read a document it has just listed. That is what this asserts, and it is a
-/// boundary rather than an accident: the second credential gates host authority
-/// (see `docs/host-access.md`). It is also why the desktop's document viewers
-/// are unreachable, so the assertion is expected to invert when that is
-/// resolved — deliberately, by a change that has to come here and say so.
+/// The reader's two routes — the narrowed detail projection and the bytes — are
+/// on the primary bearer, because a renderer holds only that and is the thing
+/// drawing the document. Before this, the whole document surface sat behind the
+/// native-only credential, so every viewer in the desktop got a 401 and none of
+/// them had ever loaded a file.
+///
+/// The full-fidelity surface stays where it was, and that is asserted here too:
+/// its catalog carries `uri`, which for an unscoped source is a real filesystem
+/// path. `root_attachment::embedded_renderer_bearer_cannot_reach_canonical_document_routes`
+/// is the test that guards that, and it must keep passing unchanged.
 #[tokio::test]
-async fn a_native_embedding_refuses_the_renderer_its_own_documents() {
+async fn a_native_embedding_serves_the_renderer_the_document_it_draws() {
     let dir = tempfile::tempdir().unwrap();
     let store: Arc<dyn Store> = Arc::new(
         DbStore::connect(&format!(
@@ -2820,13 +2822,15 @@ async fn a_native_embedding_refuses_the_renderer_its_own_documents() {
         Uuid::new_v4(),
     )
     .unwrap();
+    assert!(state.root_attachment_routes_enabled);
     let bearer = format!("Bearer {}", state.token);
     let executor = state.client_executor_token.to_string();
     let router = app(state);
 
     let chat = make_chat(&router, &bearer).await;
-    // Ingest needs the native credential too: in this configuration the whole
-    // document surface is behind it, writes and listings included.
+    // Ingest is full-fidelity and stays native-only, so the host's credential
+    // sets the fixture up. The uri stands in for one a connected-folder import
+    // records; it is the field the renderer must not be handed.
     let ingest: serde_json::Value = json_body(
         router
             .clone()
@@ -2838,8 +2842,12 @@ async fn a_native_embedding_refuses_the_renderer_its_own_documents() {
                     .header(crate::auth::CLIENT_EXECUTOR_HEADER, &executor)
                     .header(header::CONTENT_TYPE, "application/json")
                     .body(Body::from(
-                        serde_json::json!({"uri": "file:///note.txt", "content": "a source"})
-                            .to_string(),
+                        serde_json::json!({
+                            "uri": "file:///Users/private/quarterly-sentinel.md",
+                            "content": "Revenue rose.",
+                            "media_type": "text/markdown",
+                        })
+                        .to_string(),
                     ))
                     .unwrap(),
             )
@@ -2849,29 +2857,68 @@ async fn a_native_embedding_refuses_the_renderer_its_own_documents() {
     .await;
     let document_id = ingest["document_id"].as_str().unwrap().to_owned();
 
-    let fetch = |extra: Option<&'static str>| {
-        let executor_owned = extra.map(|_| executor.clone());
+    let get = |uri: String| {
         let router = router.clone();
         let bearer = bearer.clone();
-        let uri = format!("/chats/{}/documents/{document_id}", chat.id);
         async move {
-            let mut builder = Request::builder()
-                .uri(uri)
-                .header(header::AUTHORIZATION, bearer);
-            if let Some(token) = executor_owned {
-                builder = builder.header(crate::auth::CLIENT_EXECUTOR_HEADER, token);
-            }
             router
-                .oneshot(builder.body(Body::empty()).unwrap())
+                .oneshot(
+                    Request::builder()
+                        .uri(uri)
+                        .header(header::AUTHORIZATION, bearer)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
                 .await
                 .unwrap()
         }
     };
 
-    // What the renderer sends. It holds the primary bearer and nothing else,
-    // so the document it just listed is unreachable to it.
-    assert_eq!(fetch(None).await.status(), StatusCode::UNAUTHORIZED);
-    // What the native host sends, and why the source list works while the
-    // reader that opens one does not.
-    assert_eq!(fetch(Some("native")).await.status(), StatusCode::OK);
+    // The document the reader opens, and the bytes its viewer draws.
+    let detail = get(format!("/chats/{}/documents/{document_id}", chat.id)).await;
+    assert_eq!(detail.status(), StatusCode::OK);
+    let body = String::from_utf8_lossy(&to_bytes(detail.into_body(), usize::MAX).await.unwrap())
+        .into_owned();
+    let detail: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(detail["document_id"], document_id);
+    // Present and a string; no worker runs here, so it is empty until one parses
+    // the source. What matters is that the field the viewers read is served.
+    assert!(detail["content"].is_string());
+    assert_eq!(detail["media_type"], "text/markdown");
+    assert_eq!(
+        get(format!(
+            "/chats/{}/documents/{document_id}/file-content",
+            chat.id
+        ))
+        .await
+        .status(),
+        StatusCode::OK
+    );
+
+    // Nothing about where the file came from, and no index bookkeeping, travels
+    // with it. This is the projection's whole purpose.
+    for sentinel in [
+        "/Users/private",
+        "quarterly-sentinel",
+        "uri",
+        "content_revision",
+        "index_fingerprint",
+    ] {
+        assert!(
+            !body.contains(sentinel),
+            "renderer detail leaked {sentinel}"
+        );
+    }
+
+    // The full-fidelity surface and host authority are both still withheld.
+    assert_eq!(
+        get(format!("/chats/{}/documents", chat.id)).await.status(),
+        StatusCode::UNAUTHORIZED
+    );
+    assert_eq!(
+        get("/root-attachment-changes/pending".into())
+            .await
+            .status(),
+        StatusCode::UNAUTHORIZED
+    );
 }

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -85,7 +85,14 @@ the primary bearer, and therefore unreachable to every future client that is
 renderer-shaped: a web or mobile client, a self-hosted deployment's browser UI,
 or a CLI. That is the intended consequence for host authority and a defect for
 anything else, so the distinction is worth checking rather than inheriting from
-whichever router a route was added next to. Begin and finish retries return stable
+whichever router a route was added next to.
+
+The document surface is the worked example. It sat behind this credential in
+native embeddings, which meant the renderer could list a conversation's sources
+through the native host but could not read one, and no document viewer in the
+desktop could load its bytes. It receives content and returns it; no route there
+reads a path or acts on the machine, so it belongs on the primary bearer and is
+now there in every embedding. Begin and finish retries return stable
 `begun`/`existing` and `finished`/`existing` dispositions. A missing change and
 a change owned by another executor are both reported as not found, while busy
 and revision conflicts do not identify the pending operation.


### PR DESCRIPTION
**No document viewer has ever loaded a file in the desktop app.** Not PDF, spreadsheet, Word, markdown, image, JSON or XML.

In a native embedding the whole document surface sits behind the client-executor credential, which only the trusted native host holds. The renderer has the primary bearer and nothing else, so every request it made for a source returned 401. The source *list* worked because it goes through a Tauri command and the host sends both credentials — which is why this presented as "The document is no longer available" rather than as an obviously broken app.

## What moves, and what does not

Two routes move to the primary bearer in every embedding: the chat-scoped **document detail** and its **file-content**. That is the reader's half — what a client needs to draw a source it is already displaying — and a renderer-shaped client (this webview, or a web or mobile one later) has no other credential to present.

Everything else stays exactly where it was, because **the reason it is there is real.** The catalog summary carries `uri`, which for an unscoped source is a filesystem path, plus revision and index fingerprints that are server bookkeeping. `DocumentDetail` flattens that summary — so serving it to the renderer would have handed over the path too.

## The projection

The detail route now returns `ChatDocumentDetail`: the seven fields a viewer reads, and nothing else.

A projection rather than a filter, deliberately. Conversation sources record either no `uri` or an opaque `connected-folder:{root_id}/{path}` today — I checked the live database, and the one populated case is the opaque form — but "happens to be empty today" is not a guarantee, and `ingest_chat_document` accepts a `uri` from its caller.

Worth noting: the renderer's TypeScript type already declared exactly these seven fields. That's the clearest evidence this is the shape that was intended; the routes were swept behind the credential by a blanket `.merge(document_api)`, not by a decision about this projection.

Nothing consumed the wider shape from this route — the native host checks only the response status, and the renderer's type never had the other fields.

## An earlier version of this was wrong

My first attempt moved the *entire* document surface onto the bearer, reasoning that documents are user content. `root_attachment::embedded_renderer_bearer_cannot_reach_canonical_document_routes` failed immediately — it ingests a document at `file:///Users/private/review-sentinel.md` and asserts the renderer can reach neither it nor the path in it.

That test is why this PR is narrow. It passes unchanged here, and it is the guard on the surface that did not move.

I had also told the reviewer earlier today that no test could see what the renderer meets. That was wrong: this one does, and it is the reason the boundary held.

## Tests

One new: in the native configuration, the reader's two routes are served on the bearer alone, no path or bookkeeping travels with the response (`/Users/private`, `uri`, `content_revision`, `index_fingerprint` all absent), and both the full-fidelity surface and host authority remain refused.

`cargo test -p openwave-server` — 409 pass. UI: 605 tests, `tsc`, `vite build`. `cargo clippy --all-targets` clean, `gitleaks protect --staged` clean.

## Not verified

I could not drive the GUI — this terminal lacks macOS Screen Recording permission, so `screencapture` is refused. So while I am confident the 401 is gone (a test asserts the exact request the renderer makes now succeeds), **I have not watched a document render.** That is the one thing worth checking by hand, and it is also the first time today's viewer work becomes checkable at all.

Refs #853