### PR TITLE
feat(protocol): versioned agent wire protocol and conformance suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6606,6 +6606,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "openwave-sandbox-protocol"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "base64 0.23.0",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "openwave-server"
 version = "0.0.0"
 dependencies = [

--- a/crates/openwave-sandbox-protocol/Cargo.toml
+++ b/crates/openwave-sandbox-protocol/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "openwave-sandbox-protocol"
+description = "UNSTABLE: the versioned sandbox-agent wire protocol — provisioning, init, the resumable event stream, artifact collection, and the reverse-RPC callback channel — with an in-process reference backend and a conformance suite."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+publish = false
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }
+base64 = { workspace = true }
+sha2 = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync", "macros", "time"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "macros", "time"] }
+
+[lints]
+workspace = true

--- a/crates/openwave-sandbox-protocol/src/artifacts.rs
+++ b/crates/openwave-sandbox-protocol/src/artifacts.rs
@@ -1,0 +1,117 @@
+//! Artifact collection scoped to the run.
+//!
+//! The protocol's artifact surface is defined fresh here, scoped to the run,
+//! rather than inherited from the workspace capability. A run exposes a bounded
+//! [`ArtifactManifest`]; the host collects the manifest, then fetches each
+//! artifact's bounded bytes. Workspace artifacts are proposals until the host
+//! accepts them into the conversation's output record — acceptance is a
+//! host-side operation, out of this protocol's scope.
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use serde::{Deserialize, Serialize};
+
+use crate::protocol::{ErrorCode, ErrorResponse, MAX_ARTIFACTS, MAX_ARTIFACT_BYTES};
+
+/// Safe metadata for one collectable artifact.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactEntry {
+    /// The run-relative name the host fetches by.
+    pub name: String,
+    /// The decoded byte length, so the host can bound its work before fetching.
+    pub bytes: usize,
+    /// SHA-256 of the content, for integrity.
+    pub sha256: [u8; 32],
+}
+
+/// The bounded set of artifacts a run exposes for collection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactManifest {
+    pub entries: Vec<ArtifactEntry>,
+}
+
+impl ArtifactManifest {
+    /// Whether the manifest is within its declared bound.
+    #[must_use]
+    pub fn within_bounds(&self) -> bool {
+        self.entries.len() <= MAX_ARTIFACTS
+    }
+}
+
+/// The bounded bytes of one fetched artifact, base64 for the JSON transport.
+///
+/// Content is deliberately not logged or `Debug`-printed.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactContent {
+    pub content_base64: String,
+    pub bytes: usize,
+    pub sha256: [u8; 32],
+}
+
+impl ArtifactContent {
+    /// Encode `bytes` into a bounded artifact content, computing its digest.
+    ///
+    /// # Errors
+    /// [`ErrorCode::TooLarge`] if the content exceeds [`MAX_ARTIFACT_BYTES`].
+    pub fn encode(bytes: &[u8]) -> Result<Self, ErrorResponse> {
+        use sha2::{Digest, Sha256};
+        if bytes.len() > MAX_ARTIFACT_BYTES {
+            return Err(ErrorResponse::new(
+                ErrorCode::TooLarge,
+                "artifact exceeds its size bound",
+                false,
+            ));
+        }
+        let digest: [u8; 32] = Sha256::digest(bytes).into();
+        Ok(Self {
+            content_base64: BASE64.encode(bytes),
+            bytes: bytes.len(),
+            sha256: digest,
+        })
+    }
+
+    /// The digest as fetched.
+    #[must_use]
+    pub const fn digest(&self) -> [u8; 32] {
+        self.sha256
+    }
+}
+
+impl std::fmt::Debug for ArtifactContent {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ArtifactContent")
+            .field("content_base64", &"[redacted]")
+            .field("bytes", &self.bytes)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_computes_digest_and_bounds() {
+        let content = ArtifactContent::encode(b"report").unwrap();
+        assert_eq!(content.bytes, 6);
+        use sha2::{Digest, Sha256};
+        let expected: [u8; 32] = Sha256::digest(b"report").into();
+        assert_eq!(content.digest(), expected);
+    }
+
+    #[test]
+    fn oversize_artifact_is_rejected() {
+        let big = vec![0u8; MAX_ARTIFACT_BYTES + 1];
+        let error = ArtifactContent::encode(&big).unwrap_err();
+        assert_eq!(error.code, ErrorCode::TooLarge);
+    }
+
+    #[test]
+    fn content_bytes_do_not_leak_in_debug() {
+        let content = ArtifactContent::encode(b"secret-bytes").unwrap();
+        assert!(!format!("{content:?}").contains("secret-bytes"));
+    }
+}

--- a/crates/openwave-sandbox-protocol/src/conformance.rs
+++ b/crates/openwave-sandbox-protocol/src/conformance.rs
@@ -1,0 +1,540 @@
+//! The protocol conformance suite.
+//!
+//! This is the CI artifact for the protocol per the design's Testing section:
+//! one suite, shipped against the [in-process reference backend](crate::reference),
+//! and — once the local container backend lands (delivery-sequence step 7.1) —
+//! run against it too, by re-pointing these scenarios at that backend behind the
+//! same seam. Each scenario is a standalone async function that constructs its
+//! own fixture and panics on a contract violation, so `tests/conformance.rs` can
+//! surface them as individual CI checks.
+//!
+//! The four contract areas the suite must cover, and where:
+//!
+//! - **version-mismatch refusal** — [`version_mismatch_is_refused`];
+//! - **deny-by-default** — [`deny_by_default_refuses_ungranted_capability`];
+//! - **the event-stream resumable-cursor contract** —
+//!   [`event_stream_resumes_from_committed_cursor`] and
+//!   [`event_buffer_overflow_checkpoints_and_resumes`];
+//! - **reverse-RPC correlation / cancellation / disconnect-reissue** —
+//!   [`reverse_rpc_correlates_concurrent_calls`],
+//!   [`reverse_rpc_cancel_aborts_in_flight`],
+//!   [`reverse_rpc_disconnect_fails_inflight_then_reissue_replays`], and
+//!   [`reverse_rpc_reissue_with_a_different_request_conflicts`].
+//!
+//! Two further scenarios pin the provision/address/destroy decomposition
+//! ([`self_hosted_and_managed_share_one_attach_path`]) and artifact collection
+//! ([`artifact_collection_roundtrips_and_is_bounded`]).
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use tokio::sync::Semaphore;
+
+use crate::{
+    ids::{EventCursor, OperationId, RunId, Sequence},
+    oplog::{InMemoryOperationStore, OperationStore},
+    protocol::{AttachRequest, ErrorCode, Response, PROTOCOL_VERSION},
+    provisioning::{ProvisionRequest, SandboxBackend, TransportSecret},
+    reference::{ReferenceBackend, ReferenceSandbox, ReverseCallOutcome, Session},
+    reverse::{
+        Capability, CapabilityResponder, GrantSet, ModelInferenceParams, ModelInferenceResult,
+        ReverseRequest, ReverseResult, RunProvenance,
+    },
+    CapabilityHost,
+};
+
+/// A responder that answers instantly and counts how many times it ran — the
+/// exactly-once witness for idempotent replay.
+struct EchoResponder {
+    executions: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl CapabilityResponder for EchoResponder {
+    async fn respond(&self, request: ReverseRequest) -> Response<ReverseResult> {
+        self.executions.fetch_add(1, Ordering::SeqCst);
+        let ReverseRequest::ModelInference(params) = request;
+        Response::Ok(ReverseResult::ModelInference(ModelInferenceResult {
+            completion: format!("echo:{}", params.prompt),
+        }))
+    }
+}
+
+/// A responder that blocks until the test releases a gate, so cancellation and
+/// disconnect can be observed mid-flight.
+struct GateResponder {
+    gate: Arc<Semaphore>,
+    started: Arc<AtomicUsize>,
+    finished: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl CapabilityResponder for GateResponder {
+    async fn respond(&self, request: ReverseRequest) -> Response<ReverseResult> {
+        self.started.fetch_add(1, Ordering::SeqCst);
+        let permit = self.gate.acquire().await.expect("gate open");
+        permit.forget();
+        self.finished.fetch_add(1, Ordering::SeqCst);
+        let ReverseRequest::ModelInference(params) = request;
+        Response::Ok(ReverseResult::ModelInference(ModelInferenceResult {
+            completion: format!("done:{}", params.prompt),
+        }))
+    }
+}
+
+fn infer(prompt: &str) -> ReverseRequest {
+    ReverseRequest::ModelInference(ModelInferenceParams {
+        prompt: prompt.to_owned(),
+    })
+}
+
+fn completion(result: &ReverseResult) -> String {
+    match result {
+        ReverseResult::ModelInference(result) => result.completion.clone(),
+    }
+}
+
+fn host_with(
+    grants: Vec<Capability>,
+    responder: Arc<dyn CapabilityResponder>,
+) -> (CapabilityHost, InMemoryOperationStore) {
+    let store = InMemoryOperationStore::new();
+    let provenance = RunProvenance {
+        run_id: RunId::new(),
+        provider: "reference".to_owned(),
+    };
+    let host = CapabilityHost::new(
+        GrantSet::new(provenance, grants),
+        responder,
+        Arc::new(store.clone()),
+    );
+    (host, store)
+}
+
+fn secret() -> TransportSecret {
+    TransportSecret::new("per-run-transport-secret")
+}
+
+fn provision_request() -> ProvisionRequest {
+    ProvisionRequest {
+        run_id: RunId::new(),
+        tag: crate::ids::SandboxTag::new(),
+        lifetime_cap_secs: None,
+    }
+}
+
+fn attach_request() -> AttachRequest {
+    AttachRequest {
+        protocol_version: PROTOCOL_VERSION,
+        run_id: RunId::new(),
+        resume_from: EventCursor::START,
+    }
+}
+
+/// Attach a session to a self-hosted reference sandbox at `base_url`.
+async fn attach(
+    backend: &ReferenceBackend,
+    host: CapabilityHost,
+    resume_from: EventCursor,
+) -> Session {
+    let handle = backend
+        .provision(provision_request())
+        .await
+        .expect("provision");
+    let address = backend.address(&handle).await.expect("address");
+    backend
+        .connect(
+            &address,
+            AttachRequest {
+                protocol_version: PROTOCOL_VERSION,
+                run_id: RunId::new(),
+                resume_from,
+            },
+            host,
+        )
+        .expect("connect")
+}
+
+/// A version-skewed peer is refused, never attached.
+pub async fn version_mismatch_is_refused() {
+    let sandbox = ReferenceSandbox::with_config(PROTOCOL_VERSION + 1, 8);
+    let backend = ReferenceBackend::self_hosted("inproc://skewed", secret(), sandbox);
+    let handle = backend
+        .provision(provision_request())
+        .await
+        .expect("provision");
+    let address = backend.address(&handle).await.expect("address");
+
+    let (host, _store) = host_with(vec![Capability::ModelInference], echo().0);
+    match backend.connect(&address, attach_request(), host) {
+        Err(crate::reference::ConnectError::ProtocolVersion { host, sandbox }) => {
+            assert_eq!(host, PROTOCOL_VERSION);
+            assert_eq!(sandbox, PROTOCOL_VERSION + 1);
+        }
+        Err(other) => panic!("expected a version-mismatch refusal, got {other:?}"),
+        Ok(_) => panic!("a version mismatch must refuse the connection"),
+    }
+}
+
+/// An ungranted capability is refused and never executes.
+pub async fn deny_by_default_refuses_ungranted_capability() {
+    let (responder, executions) = echo();
+    // Grant nothing.
+    let (host, store) = host_with(Vec::new(), responder);
+    let sandbox = ReferenceSandbox::new();
+    let control = sandbox.control();
+    let backend = ReferenceBackend::self_hosted("inproc://deny", secret(), sandbox);
+    let session = attach(&backend, host, EventCursor::START).await;
+    assert!(
+        session.accepted().granted_capabilities.is_empty(),
+        "an ungranted run advertises no capabilities"
+    );
+
+    let outcome = control
+        .issue_reverse(OperationId::new(), infer("nope"))
+        .await;
+    match outcome {
+        ReverseCallOutcome::Settled(Response::Error(error)) => {
+            assert_eq!(error.code, ErrorCode::Denied);
+        }
+        other => panic!("expected a deny-by-default refusal, got {other:?}"),
+    }
+    assert_eq!(
+        executions.load(Ordering::SeqCst),
+        0,
+        "a denied request must never execute"
+    );
+    assert!(store.is_empty(), "a denied request records no operation");
+}
+
+/// The event stream is monotonic and gapless, and a resume returns only events
+/// strictly newer than the committed cursor.
+pub async fn event_stream_resumes_from_committed_cursor() {
+    let (host, _store) = host_with(Vec::new(), echo().0);
+    let sandbox = ReferenceSandbox::new();
+    let control = sandbox.control();
+    for letter in ["a", "b", "c", "d", "e"] {
+        control.emit_progress(letter).expect("emit");
+    }
+    let backend = ReferenceBackend::self_hosted("inproc://events", secret(), sandbox);
+    let session = attach(&backend, host, EventCursor::START).await;
+
+    let all = session.events_since(EventCursor::START);
+    let sequences: Vec<u64> = all
+        .events
+        .iter()
+        .map(|event| event.sequence.get())
+        .collect();
+    assert_eq!(
+        sequences,
+        vec![1, 2, 3, 4, 5],
+        "monotonic and gapless from one"
+    );
+
+    // Resume from a committed cursor: only newer events.
+    let resumed = session.events_since(EventCursor::committed(Sequence::new(2)));
+    let resumed_sequences: Vec<u64> = resumed
+        .events
+        .iter()
+        .map(|event| event.sequence.get())
+        .collect();
+    assert_eq!(resumed_sequences, vec![3, 4, 5]);
+
+    // A re-delivery after committing further discards what is at or below the
+    // cursor and never skips.
+    let redelivered = session.events_since(EventCursor::committed(Sequence::new(4)));
+    let redelivered_sequences: Vec<u64> = redelivered
+        .events
+        .iter()
+        .map(|event| event.sequence.get())
+        .collect();
+    assert_eq!(redelivered_sequences, vec![5]);
+}
+
+/// The un-acknowledged buffer overflow checkpoints and stops producing, and a
+/// drain that advances the cursor lets production resume.
+pub async fn event_buffer_overflow_checkpoints_and_resumes() {
+    let (host, _store) = host_with(Vec::new(), echo().0);
+    let sandbox = ReferenceSandbox::with_config(PROTOCOL_VERSION, 2);
+    let control = sandbox.control();
+    control.emit_progress("one").expect("first fits");
+    control.emit_progress("two").expect("second fits");
+    assert_eq!(
+        control.emit_progress("three"),
+        Err(crate::reference::EmitError::Overflow),
+        "a full buffer checkpoints rather than dropping"
+    );
+
+    let backend = ReferenceBackend::self_hosted("inproc://overflow", secret(), sandbox);
+    let session = attach(&backend, host, EventCursor::START).await;
+    let drained = session.events_since(EventCursor::START);
+    assert_eq!(drained.events.len(), 2);
+
+    // Draining advanced the cursor; production resumes.
+    control
+        .emit_progress("three")
+        .expect("production resumes after the drain");
+}
+
+/// Overlapping reverse calls each receive their own response over one session.
+pub async fn reverse_rpc_correlates_concurrent_calls() {
+    let (host, _store) = host_with(vec![Capability::ModelInference], echo().0);
+    let sandbox = ReferenceSandbox::new();
+    let control = sandbox.control();
+    let backend = ReferenceBackend::self_hosted("inproc://correlate", secret(), sandbox);
+    let _session = attach(&backend, host, EventCursor::START).await;
+
+    let mut tasks = Vec::new();
+    for index in 0..5u32 {
+        let control = control.clone();
+        tasks.push(tokio::spawn(async move {
+            let outcome = control
+                .issue_reverse(OperationId::new(), infer(&format!("q{index}")))
+                .await;
+            (index, outcome)
+        }));
+    }
+    for task in tasks {
+        let (index, outcome) = task.await.expect("join");
+        match outcome {
+            ReverseCallOutcome::Settled(Response::Ok(result)) => {
+                assert_eq!(completion(&result), format!("echo:q{index}"));
+            }
+            other => panic!("expected a correlated answer, got {other:?}"),
+        }
+    }
+}
+
+/// A control-lane cancel aborts the in-flight execution; the effect never
+/// finishes and a re-issue returns the recorded `Cancelled`.
+pub async fn reverse_rpc_cancel_aborts_in_flight() {
+    let (responder, started, finished, gate) = gated();
+    let (host, _store) = host_with(vec![Capability::ModelInference], responder);
+    let sandbox = ReferenceSandbox::new();
+    let control = sandbox.control();
+    let backend = ReferenceBackend::self_hosted("inproc://cancel", secret(), sandbox);
+    let _session = attach(&backend, host, EventCursor::START).await;
+
+    let operation = OperationId::new();
+    let issue = {
+        let control = control.clone();
+        tokio::spawn(async move { control.issue_reverse(operation, infer("slow")).await })
+    };
+    while started.load(Ordering::SeqCst) == 0 {
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+
+    control.cancel_reverse(operation);
+    match issue.await.expect("join") {
+        ReverseCallOutcome::Settled(Response::Error(error)) => {
+            assert_eq!(error.code, ErrorCode::Cancelled);
+        }
+        other => panic!("expected a cancelled response, got {other:?}"),
+    }
+
+    // Even once a permit is offered, the aborted execution never finished.
+    gate.add_permits(1);
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    assert_eq!(started.load(Ordering::SeqCst), 1);
+    assert_eq!(finished.load(Ordering::SeqCst), 0);
+}
+
+/// A disconnect fails the in-flight call while the host's execution keeps
+/// running; re-issuing the same identity on a fresh session replays the recorded
+/// answer and the effect ran exactly once.
+pub async fn reverse_rpc_disconnect_fails_inflight_then_reissue_replays() {
+    let (responder, started, finished, gate) = gated();
+    let (host, store) = host_with(vec![Capability::ModelInference], responder);
+    let sandbox = ReferenceSandbox::new();
+    let control = sandbox.control();
+    let backend = ReferenceBackend::self_hosted("inproc://disconnect", secret(), sandbox);
+    let handle = backend
+        .provision(provision_request())
+        .await
+        .expect("provision");
+    let address = backend.address(&handle).await.expect("address");
+
+    // The run-scoped host outlives any single connection.
+    let session1 = backend
+        .connect(&address, attach_request(), host.clone())
+        .expect("connect");
+    let operation = OperationId::new();
+    let issue = {
+        let control = control.clone();
+        tokio::spawn(async move { control.issue_reverse(operation, infer("job")).await })
+    };
+    while started.load(Ordering::SeqCst) == 0 {
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+
+    // Drop the connection with the request still executing.
+    drop(session1);
+    match issue.await.expect("join") {
+        ReverseCallOutcome::Disconnected => {}
+        other => panic!("expected a disconnect, got {other:?}"),
+    }
+
+    // The detached execution survives; let it finish and record.
+    gate.add_permits(1);
+
+    // Reconnect on the same address and run-scoped host, then re-issue.
+    let _session2 = backend
+        .connect(&address, attach_request(), host.clone())
+        .expect("reconnect");
+
+    let replayed = control.issue_reverse(operation, infer("job")).await;
+    match replayed {
+        ReverseCallOutcome::Settled(Response::Ok(result)) => {
+            assert_eq!(completion(&result), "done:job");
+        }
+        other => panic!("expected a recorded replay, got {other:?}"),
+    }
+    assert_eq!(
+        finished.load(Ordering::SeqCst),
+        1,
+        "the effect ran exactly once"
+    );
+    assert_eq!(store.len(), 1);
+}
+
+/// Re-issuing an operation identity with a different request is refused.
+pub async fn reverse_rpc_reissue_with_a_different_request_conflicts() {
+    let (host, _store) = host_with(vec![Capability::ModelInference], echo().0);
+    let sandbox = ReferenceSandbox::new();
+    let control = sandbox.control();
+    let backend = ReferenceBackend::self_hosted("inproc://conflict", secret(), sandbox);
+    let _session = attach(&backend, host, EventCursor::START).await;
+
+    let operation = OperationId::new();
+    control.issue_reverse(operation, infer("first")).await;
+    let conflict = control.issue_reverse(operation, infer("second")).await;
+    match conflict {
+        ReverseCallOutcome::Settled(Response::Error(error)) => {
+            assert_eq!(error.code, ErrorCode::OperationIdConflict);
+        }
+        other => panic!("expected an operation-id conflict, got {other:?}"),
+    }
+}
+
+/// The self-hosted backend (no provisioning) and the managed backend drive one
+/// attach path with no special case.
+pub async fn self_hosted_and_managed_share_one_attach_path() {
+    // Managed: provision stands up a fresh sandbox.
+    let managed = ReferenceBackend::managed(secret());
+    drive_one_run(&managed, None).await;
+
+    // Self-hosted: provision is a no-op over a pre-supplied endpoint.
+    let sandbox = ReferenceSandbox::new();
+    let self_hosted = ReferenceBackend::self_hosted("inproc://self-hosted", secret(), sandbox);
+    drive_one_run(&self_hosted, Some("inproc://self-hosted")).await;
+}
+
+async fn drive_one_run(backend: &ReferenceBackend, _endpoint: Option<&str>) {
+    let (host, store) = host_with(vec![Capability::ModelInference], echo().0);
+    let handle = backend
+        .provision(provision_request())
+        .await
+        .expect("provision");
+    let address = backend.address(&handle).await.expect("address");
+    let control = backend
+        .control(&handle)
+        .expect("control resolves for both modes");
+    let session = backend
+        .connect(
+            &address,
+            AttachRequest {
+                protocol_version: PROTOCOL_VERSION,
+                run_id: RunId::new(),
+                resume_from: EventCursor::START,
+            },
+            host,
+        )
+        .expect("connect travels one path for both modes");
+
+    let outcome = control
+        .issue_reverse(OperationId::new(), infer("hello"))
+        .await;
+    assert!(
+        matches!(outcome, ReverseCallOutcome::Settled(Response::Ok(_))),
+        "a reverse call succeeds on both backends"
+    );
+    assert_eq!(store.len(), 1);
+    drop(session);
+    backend
+        .destroy(&handle)
+        .await
+        .expect("destroy is idempotent for both modes");
+}
+
+/// Artifact collection round-trips a manifest and bounded content, and refuses a
+/// missing name.
+pub async fn artifact_collection_roundtrips_and_is_bounded() {
+    let (host, _store) = host_with(Vec::new(), echo().0);
+    let sandbox = ReferenceSandbox::new();
+    let control = sandbox.control();
+    control.put_artifact("report.md", b"hello".to_vec());
+    control.put_artifact("data.bin", vec![1u8, 2, 3, 4]);
+    let backend = ReferenceBackend::self_hosted("inproc://artifacts", secret(), sandbox);
+    let session = attach(&backend, host, EventCursor::START).await;
+
+    let manifest = session.collect_artifacts();
+    assert!(manifest.within_bounds());
+    let names: Vec<&str> = manifest
+        .entries
+        .iter()
+        .map(|entry| entry.name.as_str())
+        .collect();
+    assert_eq!(names, vec!["data.bin", "report.md"]);
+
+    let content = session.fetch_artifact("report.md").expect("fetch");
+    assert_eq!(content.bytes, 5);
+    use sha2::{Digest, Sha256};
+    let expected: [u8; 32] = Sha256::digest(b"hello").into();
+    assert_eq!(content.digest(), expected);
+
+    let missing = session
+        .fetch_artifact("nope")
+        .expect_err("missing is refused");
+    assert_eq!(missing.code, ErrorCode::NotFound);
+}
+
+/// Run every conformance scenario in sequence.
+pub async fn run_all() {
+    version_mismatch_is_refused().await;
+    deny_by_default_refuses_ungranted_capability().await;
+    event_stream_resumes_from_committed_cursor().await;
+    event_buffer_overflow_checkpoints_and_resumes().await;
+    reverse_rpc_correlates_concurrent_calls().await;
+    reverse_rpc_cancel_aborts_in_flight().await;
+    reverse_rpc_disconnect_fails_inflight_then_reissue_replays().await;
+    reverse_rpc_reissue_with_a_different_request_conflicts().await;
+    self_hosted_and_managed_share_one_attach_path().await;
+    artifact_collection_roundtrips_and_is_bounded().await;
+}
+
+fn echo() -> (Arc<dyn CapabilityResponder>, Arc<AtomicUsize>) {
+    let executions = Arc::new(AtomicUsize::new(0));
+    let responder = Arc::new(EchoResponder {
+        executions: Arc::clone(&executions),
+    });
+    (responder, executions)
+}
+
+fn gated() -> (
+    Arc<dyn CapabilityResponder>,
+    Arc<AtomicUsize>,
+    Arc<AtomicUsize>,
+    Arc<Semaphore>,
+) {
+    let gate = Arc::new(Semaphore::new(0));
+    let started = Arc::new(AtomicUsize::new(0));
+    let finished = Arc::new(AtomicUsize::new(0));
+    let responder = Arc::new(GateResponder {
+        gate: Arc::clone(&gate),
+        started: Arc::clone(&started),
+        finished: Arc::clone(&finished),
+    });
+    (responder, started, finished, gate)
+}

--- a/crates/openwave-sandbox-protocol/src/conformance.rs
+++ b/crates/openwave-sandbox-protocol/src/conformance.rs
@@ -35,7 +35,10 @@ use tokio::sync::Semaphore;
 use crate::{
     ids::{EventCursor, OperationId, RunId, Sequence},
     oplog::{InMemoryOperationStore, OperationStore},
-    protocol::{AttachRequest, ErrorCode, Response, PROTOCOL_VERSION},
+    protocol::{
+        AttachRequest, ErrorCode, Response, MAX_BUFFERED_EVENTS, MAX_EVENT_PAYLOAD_BYTES,
+        MAX_MODEL_PROMPT_BYTES, PROTOCOL_VERSION,
+    },
     provisioning::{ProvisionRequest, SandboxBackend, TransportSecret},
     reference::{ReferenceBackend, ReferenceSandbox, ReverseCallOutcome, Session},
     reverse::{
@@ -159,7 +162,7 @@ async fn attach(
 
 /// A version-skewed peer is refused, never attached.
 pub async fn version_mismatch_is_refused() {
-    let sandbox = ReferenceSandbox::with_config(PROTOCOL_VERSION + 1, 8);
+    let sandbox = ReferenceSandbox::with_config(PROTOCOL_VERSION + 1, 8, 4);
     let backend = ReferenceBackend::self_hosted("inproc://skewed", secret(), sandbox);
     let handle = backend
         .provision(provision_request())
@@ -169,9 +172,11 @@ pub async fn version_mismatch_is_refused() {
 
     let (host, _store) = host_with(vec![Capability::ModelInference], echo().0);
     match backend.connect(&address, attach_request(), host) {
-        Err(crate::reference::ConnectError::ProtocolVersion { host, sandbox }) => {
-            assert_eq!(host, PROTOCOL_VERSION);
-            assert_eq!(sandbox, PROTOCOL_VERSION + 1);
+        Err(crate::reference::ConnectError::VersionRefused(refused)) => {
+            // The skew answer is an on-wire refusal carrying the sandbox's own
+            // version, and no session was established.
+            assert_eq!(refused.protocol_version, PROTOCOL_VERSION + 1);
+            assert_eq!(refused.code, ErrorCode::ProtocolVersion);
         }
         Err(other) => panic!("expected a version-mismatch refusal, got {other:?}"),
         Ok(_) => panic!("a version mismatch must refuse the connection"),
@@ -257,7 +262,7 @@ pub async fn event_stream_resumes_from_committed_cursor() {
 /// drain that advances the cursor lets production resume.
 pub async fn event_buffer_overflow_checkpoints_and_resumes() {
     let (host, _store) = host_with(Vec::new(), echo().0);
-    let sandbox = ReferenceSandbox::with_config(PROTOCOL_VERSION, 2);
+    let sandbox = ReferenceSandbox::with_config(PROTOCOL_VERSION, 2, 4);
     let control = sandbox.control();
     control.emit_progress("one").expect("first fits");
     control.emit_progress("two").expect("second fits");
@@ -431,13 +436,26 @@ pub async fn self_hosted_and_managed_share_one_attach_path() {
     drive_one_run(&self_hosted, Some("inproc://self-hosted")).await;
 }
 
-async fn drive_one_run(backend: &ReferenceBackend, _endpoint: Option<&str>) {
+async fn drive_one_run(backend: &ReferenceBackend, endpoint: Option<&str>) {
     let (host, store) = host_with(vec![Capability::ModelInference], echo().0);
     let handle = backend
         .provision(provision_request())
         .await
         .expect("provision");
     let address = backend.address(&handle).await.expect("address");
+    match endpoint {
+        // A self-hosted backend's provision is a no-op: address must resolve to
+        // the exact user-supplied endpoint, not a freshly minted one.
+        Some(endpoint) => assert_eq!(
+            address.base_url, endpoint,
+            "self-hosted address routes to the user-supplied endpoint"
+        ),
+        // A managed backend mints its own reachable endpoint.
+        None => assert!(
+            address.base_url.starts_with("inproc://"),
+            "managed backend provisions its own endpoint"
+        ),
+    }
     let control = backend
         .control(&handle)
         .expect("control resolves for both modes");
@@ -479,7 +497,7 @@ pub async fn artifact_collection_roundtrips_and_is_bounded() {
     let backend = ReferenceBackend::self_hosted("inproc://artifacts", secret(), sandbox);
     let session = attach(&backend, host, EventCursor::START).await;
 
-    let manifest = session.collect_artifacts();
+    let manifest = session.collect_artifacts().expect("manifest within bounds");
     assert!(manifest.within_bounds());
     let names: Vec<&str> = manifest
         .entries
@@ -500,14 +518,121 @@ pub async fn artifact_collection_roundtrips_and_is_bounded() {
     assert_eq!(missing.code, ErrorCode::NotFound);
 }
 
+/// An over-bound inbound reverse request is refused before it executes.
+pub async fn over_bound_request_is_refused() {
+    let (responder, executions) = echo();
+    let (host, store) = host_with(vec![Capability::ModelInference], responder);
+    let sandbox = ReferenceSandbox::new();
+    let control = sandbox.control();
+    let backend = ReferenceBackend::self_hosted("inproc://bound-req", secret(), sandbox);
+    let _session = attach(&backend, host, EventCursor::START).await;
+
+    let oversize = "x".repeat(MAX_MODEL_PROMPT_BYTES + 1);
+    let outcome = control
+        .issue_reverse(OperationId::new(), infer(&oversize))
+        .await;
+    match outcome {
+        ReverseCallOutcome::Settled(Response::Error(error)) => {
+            assert_eq!(error.code, ErrorCode::TooLarge);
+        }
+        other => panic!("expected an over-bound refusal, got {other:?}"),
+    }
+    assert_eq!(
+        executions.load(Ordering::SeqCst),
+        0,
+        "an over-bound request must never execute"
+    );
+    assert!(
+        store.is_empty(),
+        "an over-bound request records no operation"
+    );
+}
+
+/// An over-bound event is refused rather than emitted.
+pub async fn over_bound_event_is_refused() {
+    let sandbox = ReferenceSandbox::new();
+    let control = sandbox.control();
+    let oversize = "y".repeat(MAX_EVENT_PAYLOAD_BYTES + 1);
+    assert_eq!(
+        control.emit_progress(oversize),
+        Err(crate::reference::EmitError::TooLarge),
+        "an over-bound event must be refused, not emitted"
+    );
+    // A within-bound event still emits, so the refusal is specific to the bound.
+    control.emit_progress("ok").expect("a bounded event emits");
+}
+
+/// A control-lane cancel lands even while the request lane is saturated: the
+/// reserved lane is not subject to request backpressure.
+pub async fn control_lane_cancel_preempts_saturated_request_lane() {
+    // The gate is never released: these calls stay in flight to keep the
+    // request lane saturated, and are abandoned when the test ends.
+    let (responder, started, finished, _gate) = gated();
+    let (host, _store) = host_with(vec![Capability::ModelInference], responder);
+    // A request lane with exactly two in-flight permits.
+    let sandbox = ReferenceSandbox::with_config(PROTOCOL_VERSION, MAX_BUFFERED_EVENTS, 2);
+    let control = sandbox.control();
+    let backend = ReferenceBackend::self_hosted("inproc://saturated", secret(), sandbox);
+    let _session = attach(&backend, host, EventCursor::START).await;
+
+    // Saturate the request lane: two gated calls hold both permits.
+    let target = OperationId::new();
+    let call_a = {
+        let control = control.clone();
+        tokio::spawn(async move { control.issue_reverse(target, infer("a")).await })
+    };
+    let call_b = {
+        let control = control.clone();
+        tokio::spawn(async move { control.issue_reverse(OperationId::new(), infer("b")).await })
+    };
+    while started.load(Ordering::SeqCst) < 2 {
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+
+    // A third call cannot even register: no permit is free while the lane is
+    // saturated. It never reaches the responder.
+    let call_c = {
+        let control = control.clone();
+        tokio::spawn(async move { control.issue_reverse(OperationId::new(), infer("c")).await })
+    };
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    assert_eq!(
+        started.load(Ordering::SeqCst),
+        2,
+        "a third request is blocked behind request backpressure"
+    );
+
+    // The cancel travels the reserved control lane, acquires no request permit,
+    // and lands despite the saturated request lane.
+    control.cancel_reverse(target);
+    match call_a.await.expect("join") {
+        ReverseCallOutcome::Settled(Response::Error(error)) => {
+            assert_eq!(error.code, ErrorCode::Cancelled);
+        }
+        other => panic!("expected the cancel to land, got {other:?}"),
+    }
+    assert_eq!(
+        finished.load(Ordering::SeqCst),
+        0,
+        "the cancelled effect never finished"
+    );
+
+    // Cleanup: the still-blocked calls are abandoned with the test.
+    call_b.abort();
+    call_c.abort();
+}
+
 /// Run every conformance scenario in sequence.
 pub async fn run_all() {
     version_mismatch_is_refused().await;
     deny_by_default_refuses_ungranted_capability().await;
+    over_bound_request_is_refused().await;
+    over_bound_event_is_refused().await;
     event_stream_resumes_from_committed_cursor().await;
     event_buffer_overflow_checkpoints_and_resumes().await;
     reverse_rpc_correlates_concurrent_calls().await;
     reverse_rpc_cancel_aborts_in_flight().await;
+    control_lane_cancel_preempts_saturated_request_lane().await;
     reverse_rpc_disconnect_fails_inflight_then_reissue_replays().await;
     reverse_rpc_reissue_with_a_different_request_conflicts().await;
     self_hosted_and_managed_share_one_attach_path().await;

--- a/crates/openwave-sandbox-protocol/src/events.rs
+++ b/crates/openwave-sandbox-protocol/src/events.rs
@@ -1,0 +1,121 @@
+//! The resumable, monotonically sequenced event stream.
+//!
+//! Events carry the sandbox's monotonic [`Sequence`]. The host resumes from its
+//! last committed [`EventCursor`], commits a batch, and advances its cursor in
+//! one transaction; a re-delivered sequence at or below the cursor is discarded,
+//! so a crash between read and commit re-reads without duplicating and never
+//! skips. The wire types here are what that contract is expressed over; the
+//! reference backend and the conformance suite exercise it.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ids::{EventCursor, Sequence},
+    protocol::MAX_EVENT_PAYLOAD_BYTES,
+};
+
+/// One event the sandbox emits, stamped with its monotonic sequence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SandboxEvent {
+    /// Monotonic per-run sequence; ordering is the stream's contract.
+    pub sequence: Sequence,
+    /// The bounded payload.
+    pub payload: EventPayload,
+}
+
+/// The bounded content of one event.
+///
+/// The variants are deliberately narrow for this slice; the enum is
+/// `#[non_exhaustive]` so richer progress and structured deliverables join
+/// without a breaking change.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "body", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum EventPayload {
+    /// A bounded UTF-8 progress line.
+    Progress(String),
+    /// The run's terminal result submission.
+    Result(String),
+}
+
+impl EventPayload {
+    /// Whether the payload is within its declared per-event bound.
+    #[must_use]
+    pub fn within_bounds(&self) -> bool {
+        let len = match self {
+            EventPayload::Progress(text) | EventPayload::Result(text) => text.len(),
+        };
+        len <= MAX_EVENT_PAYLOAD_BYTES
+    }
+}
+
+/// A batch of events the sandbox delivers on a resume, plus the state of the
+/// stream after them.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EventBatch {
+    /// Events strictly newer than the requested cursor, in ascending sequence.
+    pub events: Vec<SandboxEvent>,
+    /// Whether the sandbox had to checkpoint and stop producing because its
+    /// un-acknowledged buffer overflowed. A resume that drains past the overflow
+    /// clears it; this is a state the host resumes, not a terminal one.
+    pub overflowed: bool,
+}
+
+impl EventBatch {
+    /// The cursor the host should commit after consuming this batch: the highest
+    /// sequence delivered, or the prior cursor if the batch was empty.
+    #[must_use]
+    pub fn next_cursor(&self, previous: EventCursor) -> EventCursor {
+        self.events
+            .last()
+            .map_or(previous, |event| EventCursor::committed(event.sequence))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_advances_cursor_to_highest_sequence() {
+        let batch = EventBatch {
+            events: vec![
+                SandboxEvent {
+                    sequence: Sequence::new(3),
+                    payload: EventPayload::Progress("a".to_owned()),
+                },
+                SandboxEvent {
+                    sequence: Sequence::new(4),
+                    payload: EventPayload::Progress("b".to_owned()),
+                },
+            ],
+            overflowed: false,
+        };
+        assert_eq!(
+            batch.next_cursor(EventCursor::committed(Sequence::new(2))),
+            EventCursor::committed(Sequence::new(4))
+        );
+
+        let empty = EventBatch {
+            events: vec![],
+            overflowed: false,
+        };
+        let previous = EventCursor::committed(Sequence::new(4));
+        assert_eq!(empty.next_cursor(previous), previous);
+    }
+
+    #[test]
+    fn event_roundtrips() {
+        let event = SandboxEvent {
+            sequence: Sequence::FIRST,
+            payload: EventPayload::Result("done".to_owned()),
+        };
+        let encoded = serde_json::to_string(&event).unwrap();
+        assert_eq!(
+            serde_json::from_str::<SandboxEvent>(&encoded).unwrap(),
+            event
+        );
+    }
+}

--- a/crates/openwave-sandbox-protocol/src/host.rs
+++ b/crates/openwave-sandbox-protocol/src/host.rs
@@ -106,6 +106,15 @@ impl CapabilityHost {
         if !self.shared.grants.allows(envelope.request.capability()) {
             return ReverseWaiter::settled(Response::Error(ErrorResponse::denied()));
         }
+        // An inbound request is untrusted input. Refuse an over-bound one before
+        // claiming or executing it — never forward it to the responder.
+        if !envelope.request.within_bounds() {
+            return ReverseWaiter::settled(Response::Error(ErrorResponse::new(
+                ErrorCode::TooLarge,
+                "reverse request exceeds its per-capability bound",
+                false,
+            )));
+        }
 
         let id = envelope.operation_id;
         let fingerprint = envelope.request.clone();
@@ -239,6 +248,17 @@ async fn execute(
         )),
     };
 
+    // Enforce the result bound before recording: a responder that returns an
+    // over-bound completion has its result rejected, not persisted.
+    let settled = match settled {
+        Response::Ok(result) if !result.within_bounds() => Response::Error(ErrorResponse::new(
+            ErrorCode::TooLarge,
+            "reverse result exceeds its per-capability bound",
+            false,
+        )),
+        settled => settled,
+    };
+
     // Record durably first, so a re-issue racing this completion observes the
     // terminal state in the store rather than a `Claimed` with a vanishing
     // in-flight entry.
@@ -254,4 +274,97 @@ async fn execute(
     // A dropped receiver only means no connection is currently waiting; the
     // recorded outcome still stands for a later re-issue.
     let _ = outcome.send(Outcome::Settled(settled));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::{
+        ids::{OperationId, RequestId, RunId},
+        oplog::{ClaimOutcome, OperationFingerprint, OperationState, OperationStore, StoreError},
+        protocol::PROTOCOL_VERSION,
+        reverse::{
+            Capability, CapabilityResponder, GrantSet, ModelInferenceParams, ModelInferenceResult,
+            ReverseEnvelope, ReverseRequest, ReverseResult, RunProvenance,
+        },
+    };
+
+    use super::*;
+
+    /// A store that reports every claim as `ClaimedElsewhere` — the after-crash
+    /// state a durable store surfaces for a `Claimed` entry it did not itself
+    /// dispatch. In-memory stores can never reach it, so it is faked here.
+    struct CrashedStore;
+
+    impl OperationStore for CrashedStore {
+        fn claim(&self, _id: OperationId, _fingerprint: &OperationFingerprint) -> ClaimOutcome {
+            ClaimOutcome::ClaimedElsewhere
+        }
+        fn record(&self, _id: OperationId, _result: ReverseResult) -> Result<(), StoreError> {
+            Ok(())
+        }
+        fn fail(&self, _id: OperationId, _error: ErrorResponse) -> Result<(), StoreError> {
+            Ok(())
+        }
+        fn state(&self, _id: OperationId) -> Option<OperationState> {
+            None
+        }
+        fn evict(&self, _id: OperationId) {}
+        fn len(&self) -> usize {
+            0
+        }
+    }
+
+    struct CountingResponder {
+        executions: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl CapabilityResponder for CountingResponder {
+        async fn respond(&self, _request: ReverseRequest) -> Response<ReverseResult> {
+            self.executions.fetch_add(1, Ordering::SeqCst);
+            Response::Ok(ReverseResult::ModelInference(ModelInferenceResult {
+                completion: "should never run".to_owned(),
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn claimed_after_crash_refuses_conservatively_and_never_executes() {
+        let executions = Arc::new(AtomicUsize::new(0));
+        let provenance = RunProvenance {
+            run_id: RunId::new(),
+            provider: "test".to_owned(),
+        };
+        let host = CapabilityHost::new(
+            GrantSet::new(provenance, [Capability::ModelInference]),
+            Arc::new(CountingResponder {
+                executions: Arc::clone(&executions),
+            }),
+            Arc::new(CrashedStore),
+        );
+
+        let response = host
+            .dispatch(ReverseEnvelope {
+                protocol_version: PROTOCOL_VERSION,
+                request_id: RequestId::new(),
+                operation_id: OperationId::new(),
+                request: ReverseRequest::ModelInference(ModelInferenceParams {
+                    prompt: "resume after crash".to_owned(),
+                }),
+            })
+            .wait()
+            .await;
+
+        match response {
+            Response::Error(error) => assert_eq!(error.code, ErrorCode::OperationAmbiguous),
+            Response::Ok(_) => panic!("a claimed-after-crash call must not be replayed"),
+        }
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            0,
+            "a conservatively-refused call must never execute"
+        );
+    }
 }

--- a/crates/openwave-sandbox-protocol/src/host.rs
+++ b/crates/openwave-sandbox-protocol/src/host.rs
@@ -1,0 +1,257 @@
+//! The run-scoped reverse-RPC capability host: deny-by-default authorization,
+//! execute-once dispatch over the [`OperationStore`] seam, and control-lane
+//! cancellation.
+//!
+//! The structural decision that carries the weight — the same one the spike
+//! proved — is the split between run-scoped state and connection-scoped state.
+//! A [`CapabilityHost`] holds the grant set, the responder, and the operation
+//! log; it outlives any single connection. A connection is transient plumbing
+//! that forwards request frames in and response frames out. When a connection
+//! drops and the supervisor reconnects, it reattaches to the *same*
+//! `CapabilityHost`, so the operation log is exactly where idempotent replay is
+//! served from.
+//!
+//! Each `OperationId` runs its capability at most once. The execution is a
+//! spawned task that records its outcome in the store and publishes it on a
+//! `watch` channel; the connection's per-request forwarder merely awaits that
+//! outcome. Because the two are decoupled, a dropped connection cannot abort an
+//! execution — it keeps running and records for a later re-issue — while a
+//! control-lane cancel *can*, because the execution selects on a cancel signal.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use tokio::sync::{oneshot, watch};
+
+use crate::{
+    ids::OperationId,
+    oplog::{ClaimOutcome, OperationState, OperationStore},
+    protocol::{require_version, ErrorCode, ErrorResponse, Response},
+    reverse::{
+        Capability, CapabilityResponder, GrantSet, ReverseEnvelope, ReverseRequest, ReverseResult,
+    },
+};
+
+/// Where a dispatched operation stands for the waiters attached to it.
+#[derive(Clone)]
+enum Outcome {
+    Pending,
+    Settled(Response<ReverseResult>),
+}
+
+/// Process-local record of an in-flight execution, keyed by `OperationId`.
+struct Inflight {
+    /// Cloned by every attaching connection; the execution task drives it.
+    outcome: watch::Receiver<Outcome>,
+    /// Taken and fired by the first control-lane cancel for this operation.
+    cancel: Mutex<Option<oneshot::Sender<()>>>,
+}
+
+struct Shared {
+    grants: GrantSet,
+    responder: Arc<dyn CapabilityResponder>,
+    store: Arc<dyn OperationStore>,
+    inflight: Mutex<HashMap<OperationId, Arc<Inflight>>>,
+}
+
+/// The run-scoped reverse-RPC server. Cloneable; every clone shares one log.
+#[derive(Clone)]
+pub struct CapabilityHost {
+    shared: Arc<Shared>,
+}
+
+impl CapabilityHost {
+    /// Build a host for one run: `grants` authorizes deny-by-default, `responder`
+    /// executes granted capabilities, and `store` records operation identities.
+    #[must_use]
+    pub fn new(
+        grants: GrantSet,
+        responder: Arc<dyn CapabilityResponder>,
+        store: Arc<dyn OperationStore>,
+    ) -> Self {
+        Self {
+            shared: Arc::new(Shared {
+                grants,
+                responder,
+                store,
+                inflight: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    /// The grant set, for the attach handshake's capability advertisement.
+    #[must_use]
+    pub fn grants(&self) -> &GrantSet {
+        &self.shared.grants
+    }
+
+    /// Resolve one reverse request to the outcome its response will be read
+    /// from. This is the whole idempotency rule in one place.
+    ///
+    /// Version and capability failures fail closed, pre-settled, and never
+    /// execute. An unknown identity is claimed and executed once; a terminal
+    /// identity replays its recorded outcome; a concurrent duplicate attaches to
+    /// the live execution; a reused identity with a different request conflicts.
+    #[must_use]
+    pub fn dispatch(&self, envelope: ReverseEnvelope) -> ReverseWaiter {
+        if require_version(envelope.protocol_version).is_err() {
+            return ReverseWaiter::settled(Response::Error(ErrorResponse::new(
+                ErrorCode::ProtocolVersion,
+                "sandbox protocol version mismatch",
+                false,
+            )));
+        }
+        if !self.shared.grants.allows(envelope.request.capability()) {
+            return ReverseWaiter::settled(Response::Error(ErrorResponse::denied()));
+        }
+
+        let id = envelope.operation_id;
+        let fingerprint = envelope.request.clone();
+        let mut inflight = self.shared.inflight.lock().expect("inflight lock");
+        match self.shared.store.claim(id, &fingerprint) {
+            ClaimOutcome::Fresh => {
+                let (outcome_tx, outcome_rx) = watch::channel(Outcome::Pending);
+                let (cancel_tx, cancel_rx) = oneshot::channel();
+                inflight.insert(
+                    id,
+                    Arc::new(Inflight {
+                        outcome: outcome_rx.clone(),
+                        cancel: Mutex::new(Some(cancel_tx)),
+                    }),
+                );
+                drop(inflight);
+                let shared = Arc::clone(&self.shared);
+                tokio::spawn(execute(shared, id, envelope.request, cancel_rx, outcome_tx));
+                ReverseWaiter::pending(outcome_rx)
+            }
+            ClaimOutcome::Replay(OperationState::Recorded(result)) => {
+                ReverseWaiter::settled(Response::Ok(result))
+            }
+            ClaimOutcome::Replay(OperationState::Failed(error)) => {
+                ReverseWaiter::settled(Response::Error(error))
+            }
+            ClaimOutcome::Replay(OperationState::Claimed) => match inflight.get(&id) {
+                Some(entry) => ReverseWaiter::pending(entry.outcome.clone()),
+                // In-memory: a `Claimed` entry always has a live in-flight
+                // execution, so this arm is unreachable. A durable store reaches
+                // it after a crash and must fail closed, which is what we do.
+                None => ReverseWaiter::settled(ambiguous()),
+            },
+            // The durable store's after-crash refusal: never re-execute a call
+            // whose external effect cannot be proven unexecuted.
+            ClaimOutcome::ClaimedElsewhere => ReverseWaiter::settled(ambiguous()),
+            ClaimOutcome::Conflict => ReverseWaiter::settled(Response::Error(ErrorResponse::new(
+                ErrorCode::OperationIdConflict,
+                "operation identity was reused for a different request",
+                false,
+            ))),
+        }
+    }
+
+    /// Fire the control-lane cancel for an in-flight operation, if any.
+    ///
+    /// This is invoked from the reserved control lane, never the request lane,
+    /// so it is not queued behind request backpressure.
+    pub fn cancel(&self, operation_id: OperationId) {
+        let entry = self
+            .shared
+            .inflight
+            .lock()
+            .expect("inflight lock")
+            .get(&operation_id)
+            .map(Arc::clone);
+        if let Some(entry) = entry {
+            if let Some(sender) = entry.cancel.lock().expect("cancel lock").take() {
+                let _ = sender.send(());
+            }
+        }
+    }
+
+    /// The capabilities this run may request, for the attach advertisement.
+    #[must_use]
+    pub fn granted_capabilities(&self) -> Vec<Capability> {
+        self.shared.grants.granted()
+    }
+}
+
+/// A handle to one reverse operation's eventual outcome, decoupled from the
+/// connection that requested it.
+pub struct ReverseWaiter {
+    outcome: watch::Receiver<Outcome>,
+}
+
+impl ReverseWaiter {
+    fn settled(response: Response<ReverseResult>) -> Self {
+        let (tx, rx) = watch::channel(Outcome::Settled(response));
+        // `watch` retains the last value for existing receivers, so dropping the
+        // sender here is fine.
+        drop(tx);
+        Self { outcome: rx }
+    }
+
+    fn pending(outcome: watch::Receiver<Outcome>) -> Self {
+        Self { outcome }
+    }
+
+    /// Await the operation's settled outcome, tolerating a value already settled
+    /// before this waiter attached (a pre-settled error, or a replay).
+    pub async fn wait(mut self) -> Response<ReverseResult> {
+        loop {
+            if let Outcome::Settled(response) = &*self.outcome.borrow() {
+                return response.clone();
+            }
+            if self.outcome.changed().await.is_err() {
+                return Response::Error(ErrorResponse::new(
+                    ErrorCode::Internal,
+                    "operation ended without recording an outcome",
+                    true,
+                ));
+            }
+        }
+    }
+}
+
+fn ambiguous() -> Response<ReverseResult> {
+    Response::Error(ErrorResponse::new(
+        ErrorCode::OperationAmbiguous,
+        "operation is claimed with no provable outcome and will not be replayed",
+        false,
+    ))
+}
+
+/// Run one operation's capability exactly once, honoring a cancel signal, and
+/// record its terminal outcome durably before publishing it.
+async fn execute(
+    shared: Arc<Shared>,
+    id: OperationId,
+    request: ReverseRequest,
+    cancel: oneshot::Receiver<()>,
+    outcome: watch::Sender<Outcome>,
+) {
+    let settled = tokio::select! {
+        response = shared.responder.respond(request) => response,
+        _ = cancel => Response::Error(ErrorResponse::new(
+            ErrorCode::Cancelled,
+            "reverse request was cancelled",
+            false,
+        )),
+    };
+
+    // Record durably first, so a re-issue racing this completion observes the
+    // terminal state in the store rather than a `Claimed` with a vanishing
+    // in-flight entry.
+    match &settled {
+        Response::Ok(result) => {
+            let _ = shared.store.record(id, result.clone());
+        }
+        Response::Error(error) => {
+            let _ = shared.store.fail(id, error.clone());
+        }
+    }
+    shared.inflight.lock().expect("inflight lock").remove(&id);
+    // A dropped receiver only means no connection is currently waiting; the
+    // recorded outcome still stands for a later re-issue.
+    let _ = outcome.send(Outcome::Settled(settled));
+}

--- a/crates/openwave-sandbox-protocol/src/ids.rs
+++ b/crates/openwave-sandbox-protocol/src/ids.rs
@@ -1,0 +1,199 @@
+//! Opaque identities carried across the sandbox-agent boundary.
+//!
+//! The UUID newtypes mirror `openwave-host-broker`'s `id` module deliberately:
+//! nil is a sentinel and never a valid persisted identity, and every identity
+//! round-trips through serde as a bare string. The event stream's sequence and
+//! cursor are ordinal `u64`s rather than opaque UUIDs, because their ordering
+//! *is* their contract.
+
+use std::{fmt, str::FromStr};
+
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
+use thiserror::Error;
+use uuid::Uuid;
+
+/// An identity received over the wire violated a protocol invariant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum IdError {
+    /// Nil is a sentinel, not a valid sandbox-protocol identity.
+    #[error("sandbox-protocol identities must not be nil")]
+    Nil,
+}
+
+/// Text parsing failure for an opaque identity.
+#[derive(Debug, Error)]
+pub enum ParseIdError {
+    /// The value was not a UUID.
+    #[error(transparent)]
+    InvalidUuid(#[from] uuid::Error),
+    /// Nil is syntactically a UUID but not a valid identity.
+    #[error(transparent)]
+    InvalidIdentity(#[from] IdError),
+}
+
+macro_rules! uuid_id {
+    ($name:ident, $description:literal) => {
+        #[doc = $description]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize)]
+        #[serde(transparent)]
+        pub struct $name(Uuid);
+
+        impl $name {
+            /// Allocate a fresh random identity.
+            #[must_use]
+            pub fn new() -> Self {
+                Self(Uuid::new_v4())
+            }
+
+            /// Validate an identity received from trusted state.
+            pub fn from_uuid(id: Uuid) -> Result<Self, IdError> {
+                if id.is_nil() {
+                    Err(IdError::Nil)
+                } else {
+                    Ok(Self(id))
+                }
+            }
+
+            /// Return the underlying UUID.
+            #[must_use]
+            pub const fn as_uuid(self) -> Uuid {
+                self.0
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0.fmt(formatter)
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = ParseIdError;
+
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                Self::from_uuid(Uuid::parse_str(value)?).map_err(Into::into)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let id = Uuid::deserialize(deserializer)?;
+                Self::from_uuid(id).map_err(D::Error::custom)
+            }
+        }
+    };
+}
+
+uuid_id!(
+    RunId,
+    "Durable identity of one sandbox-resident agent run.\n\nThe reverse-RPC operation log, event cursor, and grant provenance are all\nscoped to this run and outlive any single connection to the sandbox."
+);
+uuid_id!(
+    OperationId,
+    "Durable per-run identity for one idempotent reverse operation.\n\nStable across reconnects: a request re-issued after a disconnect carries the\nsame `OperationId` and is answered from the recorded outcome, never executed\ntwice."
+);
+uuid_id!(
+    RequestId,
+    "Per-attempt correlation identity for one request/response pair.\n\nA re-issue of the same operation over a fresh connection uses a new\n`RequestId` but the same `OperationId`."
+);
+uuid_id!(
+    SandboxTag,
+    "Host-minted correlation tag stamped into a provisioned sandbox's metadata.\n\nThe host commits this tag on the run before asking the backend for a sandbox\nand uses it to reclaim an orphan by listing the backend's sandboxes by tag."
+);
+
+/// Monotonic sequence number the sandbox stamps onto each event it emits.
+///
+/// Sequence numbers start at one, increase by one per event, and never repeat
+/// within a run. Their ordering is the event stream's contract: the host
+/// commits a batch, advances its cursor to the highest sequence it committed,
+/// and discards any re-delivered sequence at or below that cursor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Sequence(u64);
+
+impl Sequence {
+    /// The first sequence number an event may carry.
+    pub const FIRST: Sequence = Sequence(1);
+
+    /// Wrap a raw sequence value. Zero is reserved for [`EventCursor::START`].
+    #[must_use]
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// The raw ordinal.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// The next sequence number after this one.
+    #[must_use]
+    pub const fn next(self) -> Self {
+        Self(self.0 + 1)
+    }
+}
+
+/// The host's committed position in a run's event stream.
+///
+/// A cursor of [`EventCursor::START`] (zero) requests the stream from its
+/// beginning. On reattachment the host resumes from its last committed cursor,
+/// so the sandbox replays only events strictly newer than it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct EventCursor(u64);
+
+impl EventCursor {
+    /// Resume from the very start of the stream.
+    pub const START: EventCursor = EventCursor(0);
+
+    /// A cursor that has committed up to and including `sequence`.
+    #[must_use]
+    pub const fn committed(sequence: Sequence) -> Self {
+        Self(sequence.0)
+    }
+
+    /// The raw committed ordinal.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// Whether `sequence` is newer than this cursor and so must be delivered.
+    #[must_use]
+    pub const fn precedes(self, sequence: Sequence) -> bool {
+        self.0 < sequence.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opaque_ids_roundtrip_and_reject_nil() {
+        let run = RunId::new();
+        let encoded = serde_json::to_string(&run).unwrap();
+        assert_eq!(serde_json::from_str::<RunId>(&encoded).unwrap(), run);
+        assert_eq!(run.to_string().parse::<RunId>().unwrap(), run);
+        assert!(serde_json::from_str::<RunId>(&format!("\"{}\"", Uuid::nil())).is_err());
+        assert!(serde_json::from_str::<OperationId>(&format!("\"{}\"", Uuid::nil())).is_err());
+    }
+
+    #[test]
+    fn cursor_delivers_only_newer_sequences() {
+        let cursor = EventCursor::committed(Sequence::new(4));
+        assert!(!cursor.precedes(Sequence::new(4)));
+        assert!(cursor.precedes(Sequence::new(5)));
+        assert_eq!(Sequence::FIRST.next(), Sequence::new(2));
+    }
+}

--- a/crates/openwave-sandbox-protocol/src/init.rs
+++ b/crates/openwave-sandbox-protocol/src/init.rs
@@ -1,0 +1,126 @@
+//! The run init the host delivers after the sandbox handle commits.
+//!
+//! Only after the handle is committed onto the run row does the host deliver
+//! the task, the scoped token, and the policy snapshot — a sandbox reclaimed
+//! before that point never executed anything. Init is delivered once per
+//! attempt; a sandbox-resident run has exactly one execution attempt.
+//!
+//! No long-lived credential ever enters this payload. A detached-admitted run
+//! carries a short-lived, scoped token; an attached-only run proxies inference
+//! through the host and carries none.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ids::RunId,
+    reverse::{Capability, RunProvenance},
+};
+
+/// A short-lived, scoped model credential, held by the supervisor and never the
+/// agent. Absent for an attached-only run, which proxies inference through the
+/// host over the reverse channel.
+///
+/// Never logged or `Debug`-printed.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ScopedModelToken(String);
+
+impl ScopedModelToken {
+    /// Wrap a minted token.
+    #[must_use]
+    pub fn new(token: impl Into<String>) -> Self {
+        Self(token.into())
+    }
+
+    /// The raw token, for the supervisor's egress boundary.
+    #[must_use]
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for ScopedModelToken {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ScopedModelToken([redacted])")
+    }
+}
+
+/// The policy snapshot the run enforces while unattached.
+///
+/// For an unattached run, policy is this snapshot delivered at admission;
+/// revoking a grant while the run is unattached takes effect at reattachment,
+/// not instantly. On a supervisor-only enforcement tier these entries are
+/// policy, not a boundary — a fact the host tracks out-of-band, never a wire
+/// claim the backend makes about itself.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PolicySnapshot {
+    /// Destinations the run may open a connection to, snapshotted at admission.
+    pub egress_allowlist: Vec<String>,
+    /// The reverse-RPC capabilities granted to this run, deny-by-default.
+    pub granted_capabilities: Vec<Capability>,
+}
+
+/// Whether the run may keep working while unattached.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AdmissionMode {
+    /// The default: must not work while unattached; checkpoints and waits.
+    AttachedOnly,
+    /// May keep working through host absence, within the run's bounds.
+    Detached,
+}
+
+/// The task and context the host delivers to a freshly provisioned sandbox.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RunInit {
+    /// The run this init belongs to.
+    pub run_id: RunId,
+    /// Provenance for audit and consent-prompt rendering.
+    pub provenance: RunProvenance,
+    /// The delegated task, as bounded UTF-8.
+    pub task: String,
+    /// Absolute deadline for the whole run, in Unix seconds.
+    pub deadline_unix_secs: u64,
+    /// Whether the run may work unattached.
+    pub admission: AdmissionMode,
+    /// The policy the supervisor enforces while unattached.
+    pub policy: PolicySnapshot,
+    /// The scoped model token for a detached run; absent for attached-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scoped_token: Option<ScopedModelToken>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn init_roundtrips_and_omits_absent_token() {
+        let init = RunInit {
+            run_id: RunId::new(),
+            provenance: RunProvenance {
+                run_id: RunId::new(),
+                provider: "reference".to_owned(),
+            },
+            task: "summarize the corpus".to_owned(),
+            deadline_unix_secs: 1_800_000_000,
+            admission: AdmissionMode::AttachedOnly,
+            policy: PolicySnapshot {
+                egress_allowlist: vec![],
+                granted_capabilities: vec![Capability::ModelInference],
+            },
+            scoped_token: None,
+        };
+        let encoded = serde_json::to_value(&init).unwrap();
+        assert!(encoded.get("scoped_token").is_none());
+        assert_eq!(serde_json::from_value::<RunInit>(encoded).unwrap(), init);
+    }
+
+    #[test]
+    fn scoped_token_and_transport_secret_do_not_leak_in_debug() {
+        let token = ScopedModelToken::new("super-secret");
+        assert!(!format!("{token:?}").contains("super-secret"));
+    }
+}

--- a/crates/openwave-sandbox-protocol/src/lib.rs
+++ b/crates/openwave-sandbox-protocol/src/lib.rs
@@ -35,6 +35,23 @@
 //! correctness-critical designs that get their own focused review and are
 //! tracked as follow-ups (see [`oplog`]). The
 //! [`OperationStore`](oplog::OperationStore) trait is the seam they plug into.
+//!
+//! # Scope of this crate: the types, not the byte transport
+//!
+//! What this crate defines and pins is the **wire types and their semantics**:
+//! the serde representations (round-tripped and golden-encoding-asserted in the
+//! tests, so a cross-language self-hoster has a representation spec), the
+//! version handshake, the deny-by-default and idempotency rules, the event-
+//! cursor contract, and the per-capability bounds. What it deliberately does
+//! **not** define is the concrete byte transport: **wire framing** (how a frame
+//! is delimited on a socket) and **lane multiplexing** (how the request lane and
+//! the reserved control lane share one connection) are transport-specific and
+//! belong to a concrete backend — the local container backend in delivery-
+//! sequence step 7, exercised there as the managed `exec` adapters are. The
+//! [reference backend](reference) passes typed frames in-process to pin
+//! semantics; it is not the byte transport, and "a public versioned interface
+//! third parties implement" means these types and rules, plus a concrete
+//! transport a backend supplies.
 
 pub mod artifacts;
 pub mod conformance;
@@ -52,9 +69,10 @@ pub use host::{CapabilityHost, ReverseWaiter};
 pub use ids::{EventCursor, OperationId, RequestId, RunId, SandboxTag, Sequence};
 pub use oplog::{ClaimOutcome, InMemoryOperationStore, OperationState, OperationStore, StoreError};
 pub use protocol::{
-    require_version, AttachAccepted, AttachRequest, ErrorCode, ErrorResponse, Response,
-    MAX_ARTIFACTS, MAX_ARTIFACT_BYTES, MAX_BUFFERED_EVENTS, MAX_EVENT_PAYLOAD_BYTES,
-    MAX_FRAME_BYTES, MAX_MODEL_COMPLETION_BYTES, MAX_MODEL_PROMPT_BYTES, PROTOCOL_VERSION,
+    handshake, require_version, AttachAccepted, AttachRefused, AttachRequest, ErrorCode,
+    ErrorResponse, HandshakeResponse, Response, MAX_ARTIFACTS, MAX_ARTIFACT_BYTES,
+    MAX_BUFFERED_EVENTS, MAX_EVENT_PAYLOAD_BYTES, MAX_FRAME_BYTES, MAX_INFLIGHT_REQUESTS,
+    MAX_MODEL_COMPLETION_BYTES, MAX_MODEL_PROMPT_BYTES, PROTOCOL_VERSION,
 };
 pub use provisioning::{
     BackendError, ProvisionRequest, SandboxAddress, SandboxBackend, SandboxHandle, TransportSecret,

--- a/crates/openwave-sandbox-protocol/src/lib.rs
+++ b/crates/openwave-sandbox-protocol/src/lib.rs
@@ -1,0 +1,66 @@
+//! The versioned sandbox-agent wire protocol.
+//!
+//! This crate defines the boundary between the OpenWave host and a
+//! sandbox-resident agent run: provisioning, run init, the resumable,
+//! monotonically sequenced event stream, artifact collection, and the reverse-RPC
+//! callback channel with host-proxied model inference as its first capability.
+//! It is a public, versioned interface third parties implement — a self-hosted
+//! backend means someone other than OpenWave runs the sandbox side of it — so
+//! the wire contract, not any one backend, is the deliverable. OpenWave's own
+//! backends are its first consumers; the [in-process reference](reference) here
+//! is the first of them and the target the [conformance suite](conformance)
+//! runs against.
+//!
+//! It follows the [`openwave-host-broker`](https://docs.rs/openwave-host-broker)
+//! envelope discipline deliberately: a single [`PROTOCOL_VERSION`] checked for
+//! *exact equality* with a handshake on attach, deny-by-default capability
+//! gating, a durable per-run operation identity that fences idempotent replay,
+//! and bounded typed results with explicit per-capability bounds.
+//!
+//! # UNSTABLE
+//!
+//! **This protocol is unstable and unversioned for compatibility purposes until
+//! a named release.** While OpenWave is pre-1.0 nobody should build on it
+//! without expecting breakage: the wire types, the [`PROTOCOL_VERSION`], and the
+//! trait shapes may all change without a migration path. The exact-equality
+//! version check exists to make a skew a hard, visible refusal rather than a
+//! silent misinterpretation, not to promise forward compatibility.
+//!
+//! # What this slice ships, and what it defers
+//!
+//! This slice ships the protocol contract, the reference backend, and the
+//! conformance suite. It backs the reverse-RPC operation log with an
+//! **in-memory** [`OperationStore`](oplog::OperationStore); the crash-safe
+//! durable operation log (#858) and its retention/eviction policy (#859) are
+//! correctness-critical designs that get their own focused review and are
+//! tracked as follow-ups (see [`oplog`]). The
+//! [`OperationStore`](oplog::OperationStore) trait is the seam they plug into.
+
+pub mod artifacts;
+pub mod conformance;
+pub mod events;
+pub mod host;
+pub mod ids;
+pub mod init;
+pub mod oplog;
+pub mod protocol;
+pub mod provisioning;
+pub mod reference;
+pub mod reverse;
+
+pub use host::{CapabilityHost, ReverseWaiter};
+pub use ids::{EventCursor, OperationId, RequestId, RunId, SandboxTag, Sequence};
+pub use oplog::{ClaimOutcome, InMemoryOperationStore, OperationState, OperationStore, StoreError};
+pub use protocol::{
+    require_version, AttachAccepted, AttachRequest, ErrorCode, ErrorResponse, Response,
+    MAX_ARTIFACTS, MAX_ARTIFACT_BYTES, MAX_BUFFERED_EVENTS, MAX_EVENT_PAYLOAD_BYTES,
+    MAX_FRAME_BYTES, MAX_MODEL_COMPLETION_BYTES, MAX_MODEL_PROMPT_BYTES, PROTOCOL_VERSION,
+};
+pub use provisioning::{
+    BackendError, ProvisionRequest, SandboxAddress, SandboxBackend, SandboxHandle, TransportSecret,
+};
+pub use reverse::{
+    Capability, CapabilityResponder, ControlFrame, GrantSet, ModelInferenceParams,
+    ModelInferenceResult, RequestFrame, ReverseEnvelope, ReverseRequest, ReverseResponseEnvelope,
+    ReverseResult, RunProvenance,
+};

--- a/crates/openwave-sandbox-protocol/src/oplog.rs
+++ b/crates/openwave-sandbox-protocol/src/oplog.rs
@@ -1,0 +1,309 @@
+//! Operation identity and the durable-storage seam for reverse-RPC idempotency.
+//!
+//! Two identities travel on every reverse request, mirroring the broker's split
+//! between transport correlation and idempotency identity:
+//!
+//! - [`RequestId`](crate::ids::RequestId) correlates one request frame with one
+//!   response frame; a re-issue after reconnect uses a *new* one.
+//! - [`OperationId`](crate::ids::OperationId) is the durable per-run identity; a
+//!   re-issue uses the *same* one, and that is what makes the answer idempotent.
+//!
+//! The log is a small state machine keyed by `OperationId`:
+//! [`OperationState::Claimed`] on dispatch, then terminal
+//! [`OperationState::Recorded`] or [`OperationState::Failed`]. The
+//! [`OperationStore`] trait is the seam a durable, crash-safe implementation
+//! plugs into; this module ships only an [`InMemoryOperationStore`].
+//!
+//! # TODO: durable, crash-safe operation log (follow-ups #858 and #859)
+//!
+//! This in-memory store is **not** crash-safe and has **no retention**, and
+//! those are deliberately out of scope for this protocol slice (see the crate
+//! docs) so the durable correctness work gets its own focused review. Two
+//! follow-ups own them:
+//!
+//! 1. **Commit ordering (#858).** A durable store persists the
+//!    `Claimed -> Recorded / Failed` transition on the run, committed
+//!    transactionally, and answers a re-issue from `Recorded`. Critically, a
+//!    re-issue that finds a `Claimed` entry *with no live in-flight execution* —
+//!    the after-crash case an in-memory store can never reach, because a live
+//!    process always still holds the execution — must fail conservatively with
+//!    [`ErrorCode::OperationAmbiguous`](crate::protocol::ErrorCode::OperationAmbiguous)
+//!    rather than re-execute a call that may already have spent. The
+//!    [`ClaimOutcome::ClaimedElsewhere`] arm is where that predicate belongs;
+//!    in memory it is unreachable, and [`InMemoryOperationStore`] documents why.
+//! 2. **Retention / eviction (#859).** A sandbox-resident loop issues a reverse
+//!    request per step, so the log is a high-cardinality, per-step structure,
+//!    not the bounded receipt it resembles. [`OperationStore::evict`] is the
+//!    eviction seam; a durable store keys retention to un-acknowledged
+//!    operations and may keep only a commit marker past acknowledgement.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use crate::{
+    ids::OperationId,
+    protocol::ErrorResponse,
+    reverse::{ReverseRequest, ReverseResult},
+};
+
+/// The immutable fingerprint an `OperationId` was first claimed with.
+///
+/// A later re-issue whose request differs is a conflict, exactly as the broker
+/// treats a reused mutation identity with a different fingerprint.
+pub type OperationFingerprint = ReverseRequest;
+
+/// Where one operation stands in the log.
+#[derive(Debug, Clone)]
+pub enum OperationState {
+    /// Claimed and dispatched; no terminal outcome recorded yet.
+    Claimed,
+    /// Terminal success, keyed by the operation identity.
+    Recorded(ReverseResult),
+    /// Terminal failure.
+    Failed(ErrorResponse),
+}
+
+/// The result of claiming an operation identity against the store.
+#[derive(Debug, Clone)]
+pub enum ClaimOutcome {
+    /// The identity was unknown; it is now `Claimed` and the caller must
+    /// execute exactly once.
+    Fresh,
+    /// The identity is already terminal; answer the re-issue from this outcome
+    /// without re-executing.
+    Replay(OperationState),
+    /// The identity is `Claimed` and the durable store cannot prove whether its
+    /// external effect ran — the after-crash ambiguity. The caller must fail
+    /// conservatively rather than re-execute. Unreachable for
+    /// [`InMemoryOperationStore`]; see its docs.
+    ClaimedElsewhere,
+    /// The identity was reused for a structurally different request.
+    Conflict,
+}
+
+/// A crash-safe error the durable store may surface. In-memory writes never
+/// fail, so [`InMemoryOperationStore`] never returns one.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum StoreError {
+    /// The operation identity was not `Claimed` when a terminal write arrived.
+    #[error("operation was not in a claimable state for a terminal write")]
+    NotClaimed,
+}
+
+/// The durable-storage seam for the reverse-RPC operation log.
+///
+/// A production implementation persists these transitions transactionally on
+/// the run (see the module-level TODO). The trait is intentionally small: claim
+/// an identity, record its terminal outcome, read it back, and evict it once it
+/// can no longer be re-issued.
+pub trait OperationStore: Send + Sync {
+    /// Atomically claim `id` for `fingerprint`, or observe its existing state.
+    fn claim(&self, id: OperationId, fingerprint: &OperationFingerprint) -> ClaimOutcome;
+
+    /// Record a terminal success for a previously `Claimed` identity.
+    ///
+    /// # Errors
+    /// [`StoreError::NotClaimed`] if the identity is not currently `Claimed`.
+    fn record(&self, id: OperationId, result: ReverseResult) -> Result<(), StoreError>;
+
+    /// Record a terminal failure for a previously `Claimed` identity.
+    ///
+    /// # Errors
+    /// [`StoreError::NotClaimed`] if the identity is not currently `Claimed`.
+    fn fail(&self, id: OperationId, error: ErrorResponse) -> Result<(), StoreError>;
+
+    /// The current state of `id`, if the log knows it.
+    fn state(&self, id: OperationId) -> Option<OperationState>;
+
+    /// Drop a terminal entry once the sandbox can no longer re-issue `id`.
+    ///
+    /// The retention follow-up (see the module TODO) defines *when* this is
+    /// safe — keyed to an acknowledgement/cursor on the reverse channel. This
+    /// slice exposes the seam without a policy.
+    fn evict(&self, id: OperationId);
+
+    /// How many operations the log currently retains. Chiefly for tests and,
+    /// later, retention accounting.
+    fn len(&self) -> usize;
+
+    /// Whether the log is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// A process-local, insert-mostly [`OperationStore`] for the reference backend
+/// and tests.
+///
+/// It is **not** crash-safe: because a live process always still holds the
+/// in-flight execution behind a `Claimed` entry, [`ClaimOutcome::ClaimedElsewhere`]
+/// is unreachable here — an in-memory `Claimed` is never crash-ambiguous, it is
+/// simply concurrent, and a concurrent duplicate attaches to the running
+/// execution instead (handled by the caller, not the store). A durable store
+/// must return [`ClaimOutcome::ClaimedElsewhere`] for a `Claimed` entry it did
+/// not itself dispatch this process lifetime.
+#[derive(Clone, Default)]
+pub struct InMemoryOperationStore {
+    entries: Arc<Mutex<HashMap<OperationId, Entry>>>,
+}
+
+struct Entry {
+    fingerprint: OperationFingerprint,
+    state: OperationState,
+}
+
+impl InMemoryOperationStore {
+    /// A fresh, empty log.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl OperationStore for InMemoryOperationStore {
+    fn claim(&self, id: OperationId, fingerprint: &OperationFingerprint) -> ClaimOutcome {
+        let mut entries = self.entries.lock().expect("operation log lock");
+        match entries.get(&id) {
+            None => {
+                entries.insert(
+                    id,
+                    Entry {
+                        fingerprint: fingerprint.clone(),
+                        state: OperationState::Claimed,
+                    },
+                );
+                ClaimOutcome::Fresh
+            }
+            Some(entry) if &entry.fingerprint != fingerprint => ClaimOutcome::Conflict,
+            Some(entry) => match &entry.state {
+                // A concurrent duplicate; the caller attaches to the live
+                // execution. A durable store instead cannot tell this apart
+                // from an after-crash `Claimed`, and must fail closed.
+                OperationState::Claimed => ClaimOutcome::Replay(OperationState::Claimed),
+                terminal => ClaimOutcome::Replay(terminal.clone()),
+            },
+        }
+    }
+
+    fn record(&self, id: OperationId, result: ReverseResult) -> Result<(), StoreError> {
+        self.settle(id, OperationState::Recorded(result))
+    }
+
+    fn fail(&self, id: OperationId, error: ErrorResponse) -> Result<(), StoreError> {
+        self.settle(id, OperationState::Failed(error))
+    }
+
+    fn state(&self, id: OperationId) -> Option<OperationState> {
+        self.entries
+            .lock()
+            .expect("operation log lock")
+            .get(&id)
+            .map(|entry| entry.state.clone())
+    }
+
+    fn evict(&self, id: OperationId) {
+        self.entries.lock().expect("operation log lock").remove(&id);
+    }
+
+    fn len(&self) -> usize {
+        self.entries.lock().expect("operation log lock").len()
+    }
+}
+
+impl InMemoryOperationStore {
+    fn settle(&self, id: OperationId, terminal: OperationState) -> Result<(), StoreError> {
+        let mut entries = self.entries.lock().expect("operation log lock");
+        match entries.get_mut(&id) {
+            Some(entry) if matches!(entry.state, OperationState::Claimed) => {
+                entry.state = terminal;
+                Ok(())
+            }
+            _ => Err(StoreError::NotClaimed),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reverse::{ModelInferenceParams, ModelInferenceResult};
+
+    fn request(prompt: &str) -> ReverseRequest {
+        ReverseRequest::ModelInference(ModelInferenceParams {
+            prompt: prompt.to_owned(),
+        })
+    }
+
+    fn result(text: &str) -> ReverseResult {
+        ReverseResult::ModelInference(ModelInferenceResult {
+            completion: text.to_owned(),
+        })
+    }
+
+    #[test]
+    fn claim_records_and_replays() {
+        let store = InMemoryOperationStore::new();
+        let id = OperationId::new();
+        assert!(matches!(
+            store.claim(id, &request("q")),
+            ClaimOutcome::Fresh
+        ));
+
+        // A concurrent duplicate before the terminal write attaches, not conflicts.
+        assert!(matches!(
+            store.claim(id, &request("q")),
+            ClaimOutcome::Replay(OperationState::Claimed)
+        ));
+
+        store.record(id, result("a")).unwrap();
+        match store.claim(id, &request("q")) {
+            ClaimOutcome::Replay(OperationState::Recorded(recorded)) => {
+                assert_eq!(recorded, result("a"));
+            }
+            other => panic!("expected a recorded replay, got {other:?}"),
+        }
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn a_different_request_conflicts() {
+        let store = InMemoryOperationStore::new();
+        let id = OperationId::new();
+        store.claim(id, &request("first"));
+        assert!(matches!(
+            store.claim(id, &request("second")),
+            ClaimOutcome::Conflict
+        ));
+    }
+
+    #[test]
+    fn terminal_write_requires_a_claim() {
+        let store = InMemoryOperationStore::new();
+        let id = OperationId::new();
+        assert!(matches!(
+            store.record(id, result("a")),
+            Err(StoreError::NotClaimed)
+        ));
+
+        store.claim(id, &request("q"));
+        store.record(id, result("a")).unwrap();
+        // No double-settle.
+        assert!(matches!(
+            store.record(id, result("b")),
+            Err(StoreError::NotClaimed)
+        ));
+    }
+
+    #[test]
+    fn eviction_removes_the_entry() {
+        let store = InMemoryOperationStore::new();
+        let id = OperationId::new();
+        store.claim(id, &request("q"));
+        store.record(id, result("a")).unwrap();
+        store.evict(id);
+        assert!(store.is_empty());
+        assert!(store.state(id).is_none());
+    }
+}

--- a/crates/openwave-sandbox-protocol/src/protocol.rs
+++ b/crates/openwave-sandbox-protocol/src/protocol.rs
@@ -42,6 +42,12 @@ pub const MAX_ARTIFACTS: usize = 256;
 /// Largest single artifact the protocol returns as opaque bytes.
 pub const MAX_ARTIFACT_BYTES: usize = 8 * 1024 * 1024;
 
+/// Largest number of reverse requests one connection keeps in flight before the
+/// request lane applies backpressure. The reserved control lane
+/// ([`ControlFrame`](crate::reverse::ControlFrame)) is not subject to this bound,
+/// so a cancel or a heartbeat preempts a saturated request backlog.
+pub const MAX_INFLIGHT_REQUESTS: usize = 16;
+
 /// The host's request to attach to a provisioned sandbox.
 ///
 /// `resume_from` is the host's last committed [`EventCursor`]; a fresh run
@@ -59,16 +65,29 @@ pub struct AttachRequest {
     pub resume_from: EventCursor,
 }
 
-/// The sandbox supervisor's answer to an [`AttachRequest`].
+/// The sandbox supervisor's answer to an [`AttachRequest`], as an on-wire frame.
 ///
-/// It is returned even on a version mismatch so the host learns the sandbox's
-/// version rather than a blank refusal — the same courtesy the broker's `Hello`
-/// extends. A mismatch still denies the connection; the fields describe why.
+/// The sandbox always answers a handshake: it [`Accepted`](HandshakeResponse::Accepted)
+/// the connection, or it [`Refused`](HandshakeResponse::Refused) it and returns
+/// the sandbox's own version so the host learns the mismatch rather than getting
+/// a blank refusal — the same courtesy the broker's `Hello` extends. A refusal
+/// still leaves the connection unusable. Backends compute this with
+/// [`handshake`]; the reference backend surfaces a refusal as
+/// [`ConnectError::VersionRefused`](crate::reference::ConnectError::VersionRefused).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HandshakeResponse {
+    /// The versions matched exactly; the connection is established.
+    Accepted(AttachAccepted),
+    /// The versions did not match; the connection is refused.
+    Refused(AttachRefused),
+}
+
+/// The accepted-attach frame the sandbox returns when versions match exactly.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AttachAccepted {
-    /// The version the sandbox speaks. Equal to the host's on an accepted
-    /// attach; different on a refusal.
+    /// The version the sandbox speaks; equal to the host's on an accepted attach.
     pub protocol_version: u32,
     /// The reverse-RPC capabilities the sandbox may request over this
     /// connection, resolved deny-by-default from the run's grants.
@@ -76,6 +95,46 @@ pub struct AttachAccepted {
     /// The highest sequence the sandbox currently holds, so the host can bound
     /// how far a resume will carry it.
     pub latest_sequence: Option<crate::ids::Sequence>,
+}
+
+/// The refused-attach frame the sandbox returns on a version mismatch.
+///
+/// It carries the sandbox's own version so the host — or a third-party backend's
+/// host — learns what the peer speaks. The connection is not established.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AttachRefused {
+    /// The version the sandbox speaks, different from the host's.
+    pub protocol_version: u32,
+    /// Always [`ErrorCode::ProtocolVersion`] today; carried for symmetry with
+    /// other refusals.
+    pub code: ErrorCode,
+}
+
+/// Compute the sandbox's handshake answer for one attach — the canonical answer
+/// a backend returns, so a third-party implementation has an exact example.
+///
+/// Exact-equality on the version, mirroring the host broker: equal versions
+/// accept; anything else refuses and returns the sandbox's version.
+#[must_use]
+pub fn handshake(
+    request: &AttachRequest,
+    sandbox_version: u32,
+    granted_capabilities: Vec<crate::reverse::Capability>,
+    latest_sequence: Option<crate::ids::Sequence>,
+) -> HandshakeResponse {
+    if request.protocol_version == sandbox_version {
+        HandshakeResponse::Accepted(AttachAccepted {
+            protocol_version: sandbox_version,
+            granted_capabilities,
+            latest_sequence,
+        })
+    } else {
+        HandshakeResponse::Refused(AttachRefused {
+            protocol_version: sandbox_version,
+            code: ErrorCode::ProtocolVersion,
+        })
+    }
 }
 
 /// Stable failure classes carried across the sandbox-agent boundary.
@@ -210,6 +269,49 @@ mod tests {
         let error = require_version(PROTOCOL_VERSION + 1).unwrap_err();
         assert_eq!(error.code, ErrorCode::ProtocolVersion);
         assert!(!error.retryable);
+    }
+
+    #[test]
+    fn handshake_accepts_on_match_and_refuses_on_skew() {
+        let request = AttachRequest {
+            protocol_version: PROTOCOL_VERSION,
+            run_id: RunId::new(),
+            resume_from: EventCursor::START,
+        };
+        match handshake(
+            &request,
+            PROTOCOL_VERSION,
+            vec![Capability::ModelInference],
+            None,
+        ) {
+            HandshakeResponse::Accepted(accepted) => {
+                assert_eq!(accepted.protocol_version, PROTOCOL_VERSION);
+                assert_eq!(
+                    accepted.granted_capabilities,
+                    vec![Capability::ModelInference]
+                );
+            }
+            HandshakeResponse::Refused(_) => panic!("matching versions must accept"),
+        }
+
+        // A skewed attach is answered with an on-wire refusal carrying the
+        // sandbox's own version, not a blank error.
+        let skewed = handshake(&request, PROTOCOL_VERSION + 1, Vec::new(), None);
+        match skewed {
+            HandshakeResponse::Refused(refused) => {
+                assert_eq!(refused.protocol_version, PROTOCOL_VERSION + 1);
+                assert_eq!(refused.code, ErrorCode::ProtocolVersion);
+            }
+            HandshakeResponse::Accepted(_) => panic!("skewed versions must refuse"),
+        }
+
+        // The refusal frame round-trips and is externally tagged.
+        let encoded = serde_json::to_value(&skewed).unwrap();
+        assert!(encoded.get("refused").is_some());
+        assert_eq!(
+            serde_json::from_value::<HandshakeResponse>(encoded).unwrap(),
+            skewed
+        );
     }
 
     #[test]

--- a/crates/openwave-sandbox-protocol/src/protocol.rs
+++ b/crates/openwave-sandbox-protocol/src/protocol.rs
@@ -1,0 +1,226 @@
+//! Versioning, the attach handshake, transport-stable errors, and the explicit
+//! result bounds every capability is measured against.
+//!
+//! The shape follows `openwave-host-broker`'s protocol module: a single
+//! [`PROTOCOL_VERSION`] checked for *exact equality*, a [`Hello`](AttachRequest)
+//! style handshake that is answered even across a version skew so a peer can
+//! discover the mismatch, and a [`Response`] that carries either a typed success
+//! or a safe, transport-stable [`ErrorResponse`].
+
+use serde::{Deserialize, Serialize};
+
+use crate::ids::{EventCursor, RunId};
+
+/// Current sandbox-agent wire protocol.
+///
+/// Bump this for any incompatible wire change. The host checks it for exact
+/// equality and refuses a differing peer, exactly as the host broker does; the
+/// protocol is [UNSTABLE](crate) until a named release and offers no
+/// negotiation window across versions.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// Largest single reverse-RPC or event frame a conforming transport accepts,
+/// so a peer cannot force unbounded buffering with one enormous frame.
+pub const MAX_FRAME_BYTES: usize = 1024 * 1024;
+
+/// Largest prompt one host-proxied model inference request may carry.
+pub const MAX_MODEL_PROMPT_BYTES: usize = 512 * 1024;
+
+/// Largest completion one host-proxied model inference result may carry.
+pub const MAX_MODEL_COMPLETION_BYTES: usize = 512 * 1024;
+
+/// Largest UTF-8 payload one sandbox event may carry.
+pub const MAX_EVENT_PAYLOAD_BYTES: usize = 64 * 1024;
+
+/// Largest number of un-acknowledged events the sandbox buffers before it
+/// checkpoints and stops producing rather than dropping events.
+pub const MAX_BUFFERED_EVENTS: usize = 4_096;
+
+/// Largest number of artifacts one run may expose for collection.
+pub const MAX_ARTIFACTS: usize = 256;
+
+/// Largest single artifact the protocol returns as opaque bytes.
+pub const MAX_ARTIFACT_BYTES: usize = 8 * 1024 * 1024;
+
+/// The host's request to attach to a provisioned sandbox.
+///
+/// `resume_from` is the host's last committed [`EventCursor`]; a fresh run
+/// attaches at [`EventCursor::START`]. The handshake is the first thing that
+/// crosses a new connection, before any event or reverse request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AttachRequest {
+    /// The version the host speaks. The sandbox refuses a value it does not
+    /// speak exactly.
+    pub protocol_version: u32,
+    /// The run this connection carries.
+    pub run_id: RunId,
+    /// Where to resume the event stream from.
+    pub resume_from: EventCursor,
+}
+
+/// The sandbox supervisor's answer to an [`AttachRequest`].
+///
+/// It is returned even on a version mismatch so the host learns the sandbox's
+/// version rather than a blank refusal — the same courtesy the broker's `Hello`
+/// extends. A mismatch still denies the connection; the fields describe why.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AttachAccepted {
+    /// The version the sandbox speaks. Equal to the host's on an accepted
+    /// attach; different on a refusal.
+    pub protocol_version: u32,
+    /// The reverse-RPC capabilities the sandbox may request over this
+    /// connection, resolved deny-by-default from the run's grants.
+    pub granted_capabilities: Vec<crate::reverse::Capability>,
+    /// The highest sequence the sandbox currently holds, so the host can bound
+    /// how far a resume will carry it.
+    pub latest_sequence: Option<crate::ids::Sequence>,
+}
+
+/// Stable failure classes carried across the sandbox-agent boundary.
+///
+/// Every arm is transport-safe: it names a class, never a host-internal path,
+/// credential, or raw OS error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ErrorCode {
+    /// The request did not match the host's exact [`PROTOCOL_VERSION`].
+    ProtocolVersion,
+    /// The requested capability was not granted to this run.
+    Denied,
+    /// The operation identity was reused for a different request.
+    OperationIdConflict,
+    /// An operation identity was found `Claimed` with no live execution — a
+    /// crash-ambiguous external effect that must not be replayed.
+    OperationAmbiguous,
+    /// The in-flight request was cancelled over the control lane.
+    Cancelled,
+    /// The connection dropped before the response arrived.
+    Disconnected,
+    /// The request was structurally invalid.
+    InvalidRequest,
+    /// A result exceeded its declared per-capability bound.
+    TooLarge,
+    /// The named artifact does not exist.
+    NotFound,
+    /// The host could not settle the operation.
+    Internal,
+}
+
+/// Safe error payload; it carries no host-internal detail.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ErrorResponse {
+    pub code: ErrorCode,
+    pub message: String,
+    /// Whether re-issuing the same operation identity may succeed later.
+    pub retryable: bool,
+}
+
+impl ErrorResponse {
+    /// Build a transport-stable error.
+    #[must_use]
+    pub fn new(code: ErrorCode, message: &str, retryable: bool) -> Self {
+        Self {
+            code,
+            message: message.to_owned(),
+            retryable,
+        }
+    }
+
+    /// The canonical deny-by-default refusal.
+    #[must_use]
+    pub fn denied() -> Self {
+        Self::new(
+            ErrorCode::Denied,
+            "capability is not granted to this run",
+            false,
+        )
+    }
+}
+
+/// Typed success or a transport-stable error.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", content = "payload", rename_all = "snake_case")]
+pub enum Response<T> {
+    Ok(T),
+    Error(ErrorResponse),
+}
+
+impl<T> Response<T> {
+    /// Whether this response is a success.
+    #[must_use]
+    pub const fn is_ok(&self) -> bool {
+        matches!(self, Response::Ok(_))
+    }
+}
+
+/// Whether `received` matches the exact protocol this build speaks.
+///
+/// # Errors
+/// Returns a [`ErrorCode::ProtocolVersion`] response when the versions differ.
+pub fn require_version(received: u32) -> Result<(), ErrorResponse> {
+    if received == PROTOCOL_VERSION {
+        Ok(())
+    } else {
+        Err(ErrorResponse::new(
+            ErrorCode::ProtocolVersion,
+            "sandbox protocol version mismatch",
+            false,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ids::Sequence;
+    use crate::reverse::Capability;
+
+    #[test]
+    fn attach_handshake_roundtrips() {
+        let request = AttachRequest {
+            protocol_version: PROTOCOL_VERSION,
+            run_id: RunId::new(),
+            resume_from: EventCursor::committed(Sequence::new(7)),
+        };
+        let encoded = serde_json::to_string(&request).unwrap();
+        assert_eq!(
+            serde_json::from_str::<AttachRequest>(&encoded).unwrap(),
+            request
+        );
+
+        let accepted = AttachAccepted {
+            protocol_version: PROTOCOL_VERSION,
+            granted_capabilities: vec![Capability::ModelInference],
+            latest_sequence: Some(Sequence::new(7)),
+        };
+        let encoded = serde_json::to_string(&accepted).unwrap();
+        assert_eq!(
+            serde_json::from_str::<AttachAccepted>(&encoded).unwrap(),
+            accepted
+        );
+    }
+
+    #[test]
+    fn version_check_is_exact_equality() {
+        assert!(require_version(PROTOCOL_VERSION).is_ok());
+        let error = require_version(PROTOCOL_VERSION + 1).unwrap_err();
+        assert_eq!(error.code, ErrorCode::ProtocolVersion);
+        assert!(!error.retryable);
+    }
+
+    #[test]
+    fn response_tags_success_and_error_distinctly() {
+        let ok: Response<u32> = Response::Ok(1);
+        let encoded = serde_json::to_value(&ok).unwrap();
+        assert_eq!(encoded["status"], "ok");
+
+        let err: Response<u32> = Response::Error(ErrorResponse::denied());
+        let encoded = serde_json::to_value(&err).unwrap();
+        assert_eq!(encoded["status"], "error");
+        assert_eq!(encoded["payload"]["code"], "denied");
+    }
+}

--- a/crates/openwave-sandbox-protocol/src/provisioning.rs
+++ b/crates/openwave-sandbox-protocol/src/provisioning.rs
@@ -1,0 +1,141 @@
+//! The provision / address / destroy backend decomposition.
+//!
+//! A sandbox backend is exactly three operations, and the self-hosted case —
+//! no provisioning, just an address and a credential — is the conformance test
+//! for this decomposition: if it needs a special case, the abstraction is
+//! wrong. So [`SandboxBackend::provision`] may be a no-op wrapping a
+//! user-supplied endpoint, and [`SandboxBackend::destroy`] may be a no-op; the
+//! host drives them identically either way.
+//!
+//! Reachability of a self-hosted backend is the user's responsibility: the
+//! endpoint must be dialable from the host by the user's own means. OpenWave
+//! operates no rendezvous or relay.
+
+use serde::{Deserialize, Serialize};
+
+use crate::ids::{RunId, SandboxTag};
+
+/// A backend failed a provisioning operation without widening host trust.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum BackendError {
+    /// The backend could not provision a sandbox.
+    #[error("sandbox provisioning failed: {0}")]
+    Provision(String),
+    /// The handle does not resolve to a reachable address.
+    #[error("sandbox handle is not addressable: {0}")]
+    Unaddressable(String),
+    /// Teardown could not be confirmed. Teardown is idempotent, so the caller
+    /// re-drives the obligation rather than abandoning it.
+    #[error("sandbox teardown is unconfirmed: {0}")]
+    Teardown(String),
+    /// The handle names no sandbox this backend provisioned.
+    #[error("no sandbox matches this handle")]
+    UnknownHandle,
+}
+
+/// The host's request to provision a sandbox for one run.
+///
+/// The host commits a durable provisioning intent carrying `tag` before this
+/// call, and the backend stamps the tag into the sandbox's metadata so an orphan
+/// sweep can reclaim a sandbox whose intent later lapsed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProvisionRequest {
+    /// The run this sandbox serves.
+    pub run_id: RunId,
+    /// Host-minted correlation tag to stamp into sandbox metadata.
+    pub tag: SandboxTag,
+    /// The outer lifetime cap, in seconds, if the backend can enforce one from
+    /// outside the sandbox. `None` means the backend cannot cap lifetime, which
+    /// (per the design) makes the run attached-only.
+    pub lifetime_cap_secs: Option<u64>,
+}
+
+/// An opaque, backend-specific handle to a provisioned sandbox.
+///
+/// The host commits this onto the run row with the attempt's result idempotency
+/// key. It is transport-neutral: what it means is the backend's business, and
+/// the host only ever hands it back to [`SandboxBackend::address`] and
+/// [`SandboxBackend::destroy`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SandboxHandle {
+    /// The backend's own identifier for the sandbox (a container id, a vendor
+    /// sandbox id, or a user-supplied endpoint key for a self-hosted backend).
+    pub reference: String,
+    /// The correlation tag this sandbox was stamped with, echoed back for the
+    /// orphan sweep.
+    pub tag: SandboxTag,
+}
+
+/// A per-run bearer credential the supervisor requires on every request.
+///
+/// It is a bearer secret and a deduplication aid, not proof of sandbox
+/// authenticity: whoever carries it can impersonate the run to the host, which
+/// is a trust-model fact, not fine print. It is never logged or `Debug`-printed.
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TransportSecret(String);
+
+impl TransportSecret {
+    /// Wrap a minted secret.
+    #[must_use]
+    pub fn new(secret: impl Into<String>) -> Self {
+        Self(secret.into())
+    }
+
+    /// The raw secret, for presenting on the transport.
+    #[must_use]
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for TransportSecret {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("TransportSecret([redacted])")
+    }
+}
+
+/// A reachable base URL plus the per-run credential the host presents.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SandboxAddress {
+    /// Where the host dials the sandbox supervisor. For a local container this
+    /// is a loopback address; for a self-hosted backend it is the user-supplied
+    /// endpoint; for the reference backend it is an in-process locator.
+    pub base_url: String,
+    /// The bearer credential to present on every request.
+    pub transport_secret: TransportSecret,
+}
+
+/// The provision / address / destroy contract a sandbox backend implements.
+///
+/// Every method is host-driven; the sandbox never dials the host. Real backends
+/// perform network I/O, so the trait is async and dyn-compatible.
+#[async_trait::async_trait]
+pub trait SandboxBackend: Send + Sync {
+    /// Provision a sandbox for a run, returning an opaque handle.
+    ///
+    /// May be a no-op that wraps a user-supplied endpoint (the self-hosted
+    /// case), in which case the returned handle simply names that endpoint.
+    ///
+    /// # Errors
+    /// [`BackendError::Provision`] if the backend cannot stand up a sandbox.
+    async fn provision(&self, request: ProvisionRequest) -> Result<SandboxHandle, BackendError>;
+
+    /// Resolve a handle to a reachable address.
+    ///
+    /// # Errors
+    /// [`BackendError::Unaddressable`] or [`BackendError::UnknownHandle`] if the
+    /// handle does not resolve.
+    async fn address(&self, handle: &SandboxHandle) -> Result<SandboxAddress, BackendError>;
+
+    /// Destroy a sandbox. Idempotent from the host's side, and may be a no-op
+    /// for a self-hosted backend the user tears down by their own means.
+    ///
+    /// # Errors
+    /// [`BackendError::Teardown`] if teardown could not be confirmed; the caller
+    /// re-drives the obligation on the next sweep.
+    async fn destroy(&self, handle: &SandboxHandle) -> Result<(), BackendError>;
+}

--- a/crates/openwave-sandbox-protocol/src/reference.rs
+++ b/crates/openwave-sandbox-protocol/src/reference.rs
@@ -24,7 +24,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use tokio::sync::watch;
+use tokio::sync::{watch, Semaphore};
 use uuid::Uuid;
 
 use crate::{
@@ -33,7 +33,8 @@ use crate::{
     host::CapabilityHost,
     ids::{EventCursor, OperationId, RunId, Sequence},
     protocol::{
-        AttachAccepted, AttachRequest, ErrorCode, ErrorResponse, Response, MAX_BUFFERED_EVENTS,
+        handshake, AttachAccepted, AttachRefused, AttachRequest, ErrorCode, ErrorResponse,
+        HandshakeResponse, Response, MAX_ARTIFACTS, MAX_BUFFERED_EVENTS, MAX_INFLIGHT_REQUESTS,
         PROTOCOL_VERSION,
     },
     provisioning::{
@@ -47,9 +48,11 @@ use crate::{
 /// Why attaching a host to a sandbox failed.
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum ConnectError {
-    /// The versions did not match exactly; the connection is refused.
-    #[error("protocol version mismatch: host speaks {host}, sandbox speaks {sandbox}")]
-    ProtocolVersion { host: u32, sandbox: u32 },
+    /// The versions did not match exactly; the sandbox answered with an on-wire
+    /// [`AttachRefused`] carrying its own version, and the connection is not
+    /// established.
+    #[error("attach refused: sandbox speaks protocol version {}", .0.protocol_version)]
+    VersionRefused(AttachRefused),
     /// The address resolves to no reachable sandbox.
     #[error("sandbox address is not reachable: {0}")]
     Unreachable(String),
@@ -63,6 +66,9 @@ pub enum EmitError {
     /// the host's cursor clears this.
     #[error("event buffer overflowed; sandbox checkpointed")]
     Overflow,
+    /// The event payload exceeds its declared per-event bound and is refused.
+    #[error("event payload exceeds its per-event bound")]
+    TooLarge,
 }
 
 /// The outcome of one sandbox-originated reverse call over the current session.
@@ -79,11 +85,16 @@ pub enum ReverseCallOutcome {
 struct AttachedHost {
     host: CapabilityHost,
     disconnect: watch::Receiver<bool>,
+    /// The request lane's in-flight bound for this connection. Reverse requests
+    /// acquire a permit and back up when the host is slow; the reserved control
+    /// lane (cancel) does not touch it.
+    request_permits: Arc<Semaphore>,
 }
 
 struct Inner {
     protocol_version: u32,
     buffer_cap: usize,
+    request_lane_capacity: usize,
     events: Vec<SandboxEvent>,
     next_seq: u64,
     acked_through: u64,
@@ -100,20 +111,26 @@ pub struct ReferenceSandbox {
 
 impl ReferenceSandbox {
     /// A sandbox speaking the current [`PROTOCOL_VERSION`] with the default
-    /// event-buffer bound.
+    /// event-buffer and request-lane bounds.
     #[must_use]
     pub fn new() -> Self {
-        Self::with_config(PROTOCOL_VERSION, MAX_BUFFERED_EVENTS)
+        Self::with_config(PROTOCOL_VERSION, MAX_BUFFERED_EVENTS, MAX_INFLIGHT_REQUESTS)
     }
 
-    /// A sandbox with an explicit protocol version and event-buffer bound, for
-    /// exercising version refusal and overflow at a small, cheap scale.
+    /// A sandbox with explicit protocol version, event-buffer bound, and
+    /// request-lane capacity, for exercising version refusal, overflow, and
+    /// backpressure at a small, cheap scale.
     #[must_use]
-    pub fn with_config(protocol_version: u32, buffer_cap: usize) -> Self {
+    pub fn with_config(
+        protocol_version: u32,
+        buffer_cap: usize,
+        request_lane_capacity: usize,
+    ) -> Self {
         Self {
             inner: Arc::new(Mutex::new(Inner {
                 protocol_version,
                 buffer_cap: buffer_cap.max(1),
+                request_lane_capacity: request_lane_capacity.max(1),
                 events: Vec::new(),
                 next_seq: Sequence::FIRST.get(),
                 acked_through: EventCursor::START.get(),
@@ -139,6 +156,13 @@ impl ReferenceSandbox {
     fn latest_sequence(&self) -> Option<Sequence> {
         let inner = self.inner.lock().expect("sandbox lock");
         (inner.next_seq > Sequence::FIRST.get()).then(|| Sequence::new(inner.next_seq - 1))
+    }
+
+    fn request_lane_capacity(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("sandbox lock")
+            .request_lane_capacity
     }
 
     fn attach(&self, host: AttachedHost) {
@@ -180,6 +204,9 @@ impl SandboxControl {
     }
 
     fn emit(&self, payload: EventPayload) -> Result<Sequence, EmitError> {
+        if !payload.within_bounds() {
+            return Err(EmitError::TooLarge);
+        }
         let mut inner = self.sandbox.inner.lock().expect("sandbox lock");
         let unacked = (inner.next_seq - 1).saturating_sub(inner.acked_through);
         if unacked >= inner.buffer_cap as u64 {
@@ -205,17 +232,28 @@ impl SandboxControl {
     /// Originate one reverse request over the currently attached session.
     ///
     /// Reverse-RPC availability is keyed to attachment: with no attached host
-    /// this returns [`ReverseCallOutcome::Disconnected`]. The request lane
-    /// carries the call; a disconnect mid-flight fails it while the host's
-    /// execution keeps running.
+    /// this returns [`ReverseCallOutcome::Disconnected`]. The call first acquires
+    /// a request-lane permit — the backpressure point — so a saturated request
+    /// lane blocks new requests here rather than buffering without bound; the
+    /// permit is held until the call settles. A disconnect mid-flight fails it
+    /// while the host's execution keeps running.
     pub async fn issue_reverse(
         &self,
         operation_id: OperationId,
         request: ReverseRequest,
     ) -> ReverseCallOutcome {
-        let Some((host, mut disconnect)) = self.attached() else {
+        let Some((host, mut disconnect, permits)) = self.attached() else {
             return ReverseCallOutcome::Disconnected;
         };
+        // Backpressure: block on a request-lane permit before registering the
+        // request. Held by `_permit` for the lifetime of the call.
+        let _permit = match permits.acquire_owned().await {
+            Ok(permit) => permit,
+            Err(_) => return ReverseCallOutcome::Disconnected,
+        };
+        if *disconnect.borrow() {
+            return ReverseCallOutcome::Disconnected;
+        }
         let envelope = ReverseEnvelope {
             protocol_version: self.sandbox.protocol_version(),
             request_id: RequestId::new(),
@@ -231,20 +269,25 @@ impl SandboxControl {
 
     /// Cancel an in-flight reverse operation over the reserved control lane.
     ///
-    /// This reaches the host directly rather than through the request lane, so
-    /// it is never queued behind request backpressure.
+    /// This reaches the host directly rather than through the request lane, and
+    /// acquires no request-lane permit, so it is never queued behind request
+    /// backpressure — a cancel lands even while the request lane is saturated.
     pub fn cancel_reverse(&self, operation_id: OperationId) {
-        if let Some((host, _)) = self.attached() {
+        if let Some((host, _, _)) = self.attached() {
             host.cancel(operation_id);
         }
     }
 
-    fn attached(&self) -> Option<(CapabilityHost, watch::Receiver<bool>)> {
+    #[allow(clippy::type_complexity)]
+    fn attached(&self) -> Option<(CapabilityHost, watch::Receiver<bool>, Arc<Semaphore>)> {
         let inner = self.sandbox.inner.lock().expect("sandbox lock");
-        inner
-            .attached
-            .as_ref()
-            .map(|attached| (attached.host.clone(), attached.disconnect.clone()))
+        inner.attached.as_ref().map(|attached| {
+            (
+                attached.host.clone(),
+                attached.disconnect.clone(),
+                Arc::clone(&attached.request_permits),
+            )
+        })
     }
 }
 
@@ -306,10 +349,21 @@ impl Session {
     }
 
     /// The bounded manifest of artifacts the run exposes.
-    #[must_use]
-    pub fn collect_artifacts(&self) -> ArtifactManifest {
+    ///
+    /// # Errors
+    /// [`ErrorCode::TooLarge`] if the run exposes more than [`MAX_ARTIFACTS`] —
+    /// the manifest is untrusted input and its cardinality is bounded before it
+    /// crosses to the host.
+    pub fn collect_artifacts(&self) -> Result<ArtifactManifest, ErrorResponse> {
         use sha2::{Digest, Sha256};
         let inner = self.sandbox.inner.lock().expect("sandbox lock");
+        if inner.artifacts.len() > MAX_ARTIFACTS {
+            return Err(ErrorResponse::new(
+                ErrorCode::TooLarge,
+                "artifact manifest exceeds its bound",
+                false,
+            ));
+        }
         let mut entries: Vec<ArtifactEntry> = inner
             .artifacts
             .iter()
@@ -320,7 +374,7 @@ impl Session {
             })
             .collect();
         entries.sort_by(|a, b| a.name.cmp(&b.name));
-        ArtifactManifest { entries }
+        Ok(ArtifactManifest { entries })
     }
 
     /// Fetch one artifact's bounded bytes.
@@ -414,10 +468,14 @@ impl ReferenceBackend {
     /// Attach a run-scoped host to the addressed sandbox, performing the version
     /// handshake and wiring reverse RPC to `host`.
     ///
+    /// The handshake is computed by the shared [`handshake`] function — the
+    /// canonical answer a backend returns — so a skew yields an on-wire
+    /// [`AttachRefused`] rather than an out-of-band decision.
+    ///
     /// # Errors
-    /// [`ConnectError::ProtocolVersion`] on a version mismatch (the connection
-    /// is refused), or [`ConnectError::Unreachable`] if the address resolves to
-    /// no sandbox.
+    /// [`ConnectError::VersionRefused`] on a version mismatch (carrying the
+    /// sandbox's on-wire refusal; the connection is not established), or
+    /// [`ConnectError::Unreachable`] if the address resolves to no sandbox.
     pub fn connect(
         &self,
         address: &SandboxAddress,
@@ -432,23 +490,23 @@ impl ReferenceBackend {
             .cloned()
             .ok_or_else(|| ConnectError::Unreachable(address.base_url.clone()))?;
 
-        let sandbox_version = sandbox.protocol_version();
-        if attach.protocol_version != sandbox_version {
-            return Err(ConnectError::ProtocolVersion {
-                host: attach.protocol_version,
-                sandbox: sandbox_version,
-            });
-        }
+        let accepted = match handshake(
+            &attach,
+            sandbox.protocol_version(),
+            host.granted_capabilities(),
+            sandbox.latest_sequence(),
+        ) {
+            HandshakeResponse::Accepted(accepted) => accepted,
+            HandshakeResponse::Refused(refused) => {
+                return Err(ConnectError::VersionRefused(refused))
+            }
+        };
 
         let (disconnect_tx, disconnect_rx) = watch::channel(false);
-        let accepted = AttachAccepted {
-            protocol_version: sandbox_version,
-            granted_capabilities: host.granted_capabilities(),
-            latest_sequence: sandbox.latest_sequence(),
-        };
         sandbox.attach(AttachedHost {
             host,
             disconnect: disconnect_rx,
+            request_permits: Arc::new(Semaphore::new(sandbox.request_lane_capacity())),
         });
         Ok(Session {
             sandbox,

--- a/crates/openwave-sandbox-protocol/src/reference.rs
+++ b/crates/openwave-sandbox-protocol/src/reference.rs
@@ -1,0 +1,558 @@
+//! An in-process reference implementation of the sandbox-agent boundary.
+//!
+//! This is the protocol's first consumer and the target the conformance suite
+//! runs against in CI. It implements the [`SandboxBackend`] decomposition and a
+//! connectable, resumable sandbox that speaks the real wire types — provisioning
+//! and addressing, the version handshake, the resumable event stream, reverse
+//! RPC over a run-scoped [`CapabilityHost`], and artifact collection.
+//!
+//! It is not a transport: frames are passed as typed values across in-process
+//! channels rather than serialized over a socket, because the contract this
+//! backend exists to pin is the protocol's *semantics* (version refusal,
+//! deny-by-default, the cursor contract, reverse-RPC correlation / cancellation
+//! / disconnect-reissue), not byte framing. Byte framing is a concrete backend's
+//! job (delivery-sequence step 7) and is exercised separately; the wire types
+//! here all round-trip through serde, pinned by unit tests.
+//!
+//! The reference sandbox is driven from the test's side through a
+//! [`SandboxControl`] — it emits events, exposes artifacts, and originates
+//! reverse requests on command. A future container backend stands in for this
+//! by running a scripted agent behind the same protocol seam.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use tokio::sync::watch;
+use uuid::Uuid;
+
+use crate::{
+    artifacts::{ArtifactContent, ArtifactEntry, ArtifactManifest},
+    events::{EventBatch, EventPayload, SandboxEvent},
+    host::CapabilityHost,
+    ids::{EventCursor, OperationId, RunId, Sequence},
+    protocol::{
+        AttachAccepted, AttachRequest, ErrorCode, ErrorResponse, Response, MAX_BUFFERED_EVENTS,
+        PROTOCOL_VERSION,
+    },
+    provisioning::{
+        BackendError, ProvisionRequest, SandboxAddress, SandboxBackend, SandboxHandle,
+        TransportSecret,
+    },
+    reverse::{ReverseEnvelope, ReverseRequest, ReverseResult},
+    RequestId,
+};
+
+/// Why attaching a host to a sandbox failed.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum ConnectError {
+    /// The versions did not match exactly; the connection is refused.
+    #[error("protocol version mismatch: host speaks {host}, sandbox speaks {sandbox}")]
+    ProtocolVersion { host: u32, sandbox: u32 },
+    /// The address resolves to no reachable sandbox.
+    #[error("sandbox address is not reachable: {0}")]
+    Unreachable(String),
+}
+
+/// The sandbox could not accept an emitted event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum EmitError {
+    /// The un-acknowledged event buffer is full; the sandbox has checkpointed
+    /// and stopped producing rather than dropping events. A drain that advances
+    /// the host's cursor clears this.
+    #[error("event buffer overflowed; sandbox checkpointed")]
+    Overflow,
+}
+
+/// The outcome of one sandbox-originated reverse call over the current session.
+#[derive(Debug, Clone)]
+pub enum ReverseCallOutcome {
+    /// The host settled the call (success or a transport-stable error).
+    Settled(Response<ReverseResult>),
+    /// The connection dropped before a response arrived; the host's execution
+    /// keeps running and records, so re-issuing the same `OperationId` on a
+    /// fresh session returns the recorded outcome.
+    Disconnected,
+}
+
+struct AttachedHost {
+    host: CapabilityHost,
+    disconnect: watch::Receiver<bool>,
+}
+
+struct Inner {
+    protocol_version: u32,
+    buffer_cap: usize,
+    events: Vec<SandboxEvent>,
+    next_seq: u64,
+    acked_through: u64,
+    overflowed: bool,
+    artifacts: HashMap<String, Vec<u8>>,
+    attached: Option<AttachedHost>,
+}
+
+/// One run-scoped reference sandbox. Cloneable; every clone shares one state.
+#[derive(Clone)]
+pub struct ReferenceSandbox {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl ReferenceSandbox {
+    /// A sandbox speaking the current [`PROTOCOL_VERSION`] with the default
+    /// event-buffer bound.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_config(PROTOCOL_VERSION, MAX_BUFFERED_EVENTS)
+    }
+
+    /// A sandbox with an explicit protocol version and event-buffer bound, for
+    /// exercising version refusal and overflow at a small, cheap scale.
+    #[must_use]
+    pub fn with_config(protocol_version: u32, buffer_cap: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner {
+                protocol_version,
+                buffer_cap: buffer_cap.max(1),
+                events: Vec::new(),
+                next_seq: Sequence::FIRST.get(),
+                acked_through: EventCursor::START.get(),
+                overflowed: false,
+                artifacts: HashMap::new(),
+                attached: None,
+            })),
+        }
+    }
+
+    /// The test-facing handle that drives this sandbox's side of the run.
+    #[must_use]
+    pub fn control(&self) -> SandboxControl {
+        SandboxControl {
+            sandbox: self.clone(),
+        }
+    }
+
+    fn protocol_version(&self) -> u32 {
+        self.inner.lock().expect("sandbox lock").protocol_version
+    }
+
+    fn latest_sequence(&self) -> Option<Sequence> {
+        let inner = self.inner.lock().expect("sandbox lock");
+        (inner.next_seq > Sequence::FIRST.get()).then(|| Sequence::new(inner.next_seq - 1))
+    }
+
+    fn attach(&self, host: AttachedHost) {
+        self.inner.lock().expect("sandbox lock").attached = Some(host);
+    }
+
+    fn detach(&self) {
+        self.inner.lock().expect("sandbox lock").attached = None;
+    }
+}
+
+impl Default for ReferenceSandbox {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// The test-facing driver for the sandbox side of a reference run.
+#[derive(Clone)]
+pub struct SandboxControl {
+    sandbox: ReferenceSandbox,
+}
+
+impl SandboxControl {
+    /// Emit a bounded progress line, returning its assigned sequence.
+    ///
+    /// # Errors
+    /// [`EmitError::Overflow`] when the un-acknowledged buffer is full.
+    pub fn emit_progress(&self, text: impl Into<String>) -> Result<Sequence, EmitError> {
+        self.emit(EventPayload::Progress(text.into()))
+    }
+
+    /// Emit the run's terminal result submission, returning its sequence.
+    ///
+    /// # Errors
+    /// [`EmitError::Overflow`] when the un-acknowledged buffer is full.
+    pub fn emit_result(&self, text: impl Into<String>) -> Result<Sequence, EmitError> {
+        self.emit(EventPayload::Result(text.into()))
+    }
+
+    fn emit(&self, payload: EventPayload) -> Result<Sequence, EmitError> {
+        let mut inner = self.sandbox.inner.lock().expect("sandbox lock");
+        let unacked = (inner.next_seq - 1).saturating_sub(inner.acked_through);
+        if unacked >= inner.buffer_cap as u64 {
+            inner.overflowed = true;
+            return Err(EmitError::Overflow);
+        }
+        let sequence = Sequence::new(inner.next_seq);
+        inner.events.push(SandboxEvent { sequence, payload });
+        inner.next_seq += 1;
+        Ok(sequence)
+    }
+
+    /// Expose an artifact for later collection.
+    pub fn put_artifact(&self, name: impl Into<String>, bytes: impl Into<Vec<u8>>) {
+        self.sandbox
+            .inner
+            .lock()
+            .expect("sandbox lock")
+            .artifacts
+            .insert(name.into(), bytes.into());
+    }
+
+    /// Originate one reverse request over the currently attached session.
+    ///
+    /// Reverse-RPC availability is keyed to attachment: with no attached host
+    /// this returns [`ReverseCallOutcome::Disconnected`]. The request lane
+    /// carries the call; a disconnect mid-flight fails it while the host's
+    /// execution keeps running.
+    pub async fn issue_reverse(
+        &self,
+        operation_id: OperationId,
+        request: ReverseRequest,
+    ) -> ReverseCallOutcome {
+        let Some((host, mut disconnect)) = self.attached() else {
+            return ReverseCallOutcome::Disconnected;
+        };
+        let envelope = ReverseEnvelope {
+            protocol_version: self.sandbox.protocol_version(),
+            request_id: RequestId::new(),
+            operation_id,
+            request,
+        };
+        let waiter = host.dispatch(envelope);
+        tokio::select! {
+            response = waiter.wait() => ReverseCallOutcome::Settled(response),
+            () = wait_disconnected(&mut disconnect) => ReverseCallOutcome::Disconnected,
+        }
+    }
+
+    /// Cancel an in-flight reverse operation over the reserved control lane.
+    ///
+    /// This reaches the host directly rather than through the request lane, so
+    /// it is never queued behind request backpressure.
+    pub fn cancel_reverse(&self, operation_id: OperationId) {
+        if let Some((host, _)) = self.attached() {
+            host.cancel(operation_id);
+        }
+    }
+
+    fn attached(&self) -> Option<(CapabilityHost, watch::Receiver<bool>)> {
+        let inner = self.sandbox.inner.lock().expect("sandbox lock");
+        inner
+            .attached
+            .as_ref()
+            .map(|attached| (attached.host.clone(), attached.disconnect.clone()))
+    }
+}
+
+async fn wait_disconnected(disconnect: &mut watch::Receiver<bool>) {
+    loop {
+        if *disconnect.borrow() {
+            return;
+        }
+        // A closed channel (the Session was dropped without setting the flag)
+        // is also a disconnect.
+        if disconnect.changed().await.is_err() {
+            return;
+        }
+    }
+}
+
+/// The host's connection to a reference sandbox. Dropping it models the
+/// connection dropping: the sandbox detaches and any in-flight reverse call
+/// fails with [`ReverseCallOutcome::Disconnected`].
+pub struct Session {
+    sandbox: ReferenceSandbox,
+    accepted: AttachAccepted,
+    disconnect: watch::Sender<bool>,
+}
+
+impl Session {
+    /// The handshake result: the sandbox's version, the granted capabilities,
+    /// and the highest sequence it holds.
+    #[must_use]
+    pub fn accepted(&self) -> &AttachAccepted {
+        &self.accepted
+    }
+
+    /// Drain events strictly newer than `cursor`, advancing the sandbox's
+    /// acknowledgement in the same call — the host commits a batch and advances
+    /// its cursor in one transaction, and a re-delivered sequence at or below
+    /// the cursor is never returned.
+    #[must_use]
+    pub fn events_since(&self, cursor: EventCursor) -> EventBatch {
+        let mut inner = self.sandbox.inner.lock().expect("sandbox lock");
+        let events: Vec<SandboxEvent> = inner
+            .events
+            .iter()
+            .filter(|event| cursor.precedes(event.sequence))
+            .cloned()
+            .collect();
+        let highest = events
+            .last()
+            .map_or(cursor.get(), |event| event.sequence.get());
+        inner.acked_through = inner.acked_through.max(cursor.get()).max(highest);
+        let unacked = (inner.next_seq - 1).saturating_sub(inner.acked_through);
+        if unacked < inner.buffer_cap as u64 {
+            inner.overflowed = false;
+        }
+        EventBatch {
+            events,
+            overflowed: inner.overflowed,
+        }
+    }
+
+    /// The bounded manifest of artifacts the run exposes.
+    #[must_use]
+    pub fn collect_artifacts(&self) -> ArtifactManifest {
+        use sha2::{Digest, Sha256};
+        let inner = self.sandbox.inner.lock().expect("sandbox lock");
+        let mut entries: Vec<ArtifactEntry> = inner
+            .artifacts
+            .iter()
+            .map(|(name, bytes)| ArtifactEntry {
+                name: name.clone(),
+                bytes: bytes.len(),
+                sha256: Sha256::digest(bytes).into(),
+            })
+            .collect();
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
+        ArtifactManifest { entries }
+    }
+
+    /// Fetch one artifact's bounded bytes.
+    ///
+    /// # Errors
+    /// [`ErrorCode::NotFound`] if no artifact has that name, or
+    /// [`ErrorCode::TooLarge`] if it exceeds its bound.
+    pub fn fetch_artifact(&self, name: &str) -> Result<ArtifactContent, ErrorResponse> {
+        let bytes = {
+            let inner = self.sandbox.inner.lock().expect("sandbox lock");
+            inner.artifacts.get(name).cloned()
+        };
+        match bytes {
+            Some(bytes) => ArtifactContent::encode(&bytes),
+            None => Err(ErrorResponse::new(
+                ErrorCode::NotFound,
+                "no artifact matches this name",
+                false,
+            )),
+        }
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        let _ = self.disconnect.send(true);
+        self.sandbox.detach();
+    }
+}
+
+enum Provisioning {
+    Managed,
+    SelfHosted,
+}
+
+/// An in-process [`SandboxBackend`] plus the attach path the conformance suite
+/// drives.
+///
+/// Two modes exercise the provision/address/destroy decomposition without a
+/// special case at attach: `managed` stands up a fresh sandbox per run;
+/// `self_hosted` wraps a user-supplied endpoint whose provision and destroy are
+/// no-ops. Both resolve to the same [`Session`] through [`ReferenceBackend::connect`].
+pub struct ReferenceBackend {
+    mode: Provisioning,
+    secret: TransportSecret,
+    registry: Mutex<HashMap<String, ReferenceSandbox>>,
+    handles: Mutex<HashMap<String, String>>,
+}
+
+impl ReferenceBackend {
+    /// A backend that provisions a fresh sandbox per run.
+    #[must_use]
+    pub fn managed(secret: TransportSecret) -> Self {
+        Self {
+            mode: Provisioning::Managed,
+            secret,
+            registry: Mutex::new(HashMap::new()),
+            handles: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// A backend wrapping a pre-existing, user-supplied endpoint. Provision and
+    /// destroy are no-ops; the sandbox already exists at `base_url`.
+    #[must_use]
+    pub fn self_hosted(
+        base_url: impl Into<String>,
+        secret: TransportSecret,
+        sandbox: ReferenceSandbox,
+    ) -> Self {
+        let base_url = base_url.into();
+        let registry = Mutex::new(HashMap::from([(base_url, sandbox)]));
+        Self {
+            mode: Provisioning::SelfHosted,
+            secret,
+            registry,
+            handles: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// The driver for the sandbox behind `handle`, if it is registered.
+    #[must_use]
+    pub fn control(&self, handle: &SandboxHandle) -> Option<SandboxControl> {
+        let base_url = self.base_url_for(handle)?;
+        self.registry
+            .lock()
+            .expect("registry lock")
+            .get(&base_url)
+            .map(ReferenceSandbox::control)
+    }
+
+    /// Attach a run-scoped host to the addressed sandbox, performing the version
+    /// handshake and wiring reverse RPC to `host`.
+    ///
+    /// # Errors
+    /// [`ConnectError::ProtocolVersion`] on a version mismatch (the connection
+    /// is refused), or [`ConnectError::Unreachable`] if the address resolves to
+    /// no sandbox.
+    pub fn connect(
+        &self,
+        address: &SandboxAddress,
+        attach: AttachRequest,
+        host: CapabilityHost,
+    ) -> Result<Session, ConnectError> {
+        let sandbox = self
+            .registry
+            .lock()
+            .expect("registry lock")
+            .get(&address.base_url)
+            .cloned()
+            .ok_or_else(|| ConnectError::Unreachable(address.base_url.clone()))?;
+
+        let sandbox_version = sandbox.protocol_version();
+        if attach.protocol_version != sandbox_version {
+            return Err(ConnectError::ProtocolVersion {
+                host: attach.protocol_version,
+                sandbox: sandbox_version,
+            });
+        }
+
+        let (disconnect_tx, disconnect_rx) = watch::channel(false);
+        let accepted = AttachAccepted {
+            protocol_version: sandbox_version,
+            granted_capabilities: host.granted_capabilities(),
+            latest_sequence: sandbox.latest_sequence(),
+        };
+        sandbox.attach(AttachedHost {
+            host,
+            disconnect: disconnect_rx,
+        });
+        Ok(Session {
+            sandbox,
+            accepted,
+            disconnect: disconnect_tx,
+        })
+    }
+
+    fn base_url_for(&self, handle: &SandboxHandle) -> Option<String> {
+        self.handles
+            .lock()
+            .expect("handles lock")
+            .get(&handle.reference)
+            .cloned()
+    }
+}
+
+#[async_trait::async_trait]
+impl SandboxBackend for ReferenceBackend {
+    async fn provision(&self, request: ProvisionRequest) -> Result<SandboxHandle, BackendError> {
+        match self.mode {
+            Provisioning::Managed => {
+                let base_url = format!("inproc://{}", Uuid::new_v4());
+                self.registry
+                    .lock()
+                    .expect("registry lock")
+                    .insert(base_url.clone(), ReferenceSandbox::new());
+                let reference = provision_reference(request.run_id);
+                self.handles
+                    .lock()
+                    .expect("handles lock")
+                    .insert(reference.clone(), base_url);
+                Ok(SandboxHandle {
+                    reference,
+                    tag: request.tag,
+                })
+            }
+            Provisioning::SelfHosted => {
+                // No-op: the endpoint already exists. Map a handle onto it so
+                // address/destroy travel the same path as the managed case.
+                let base_url = self
+                    .registry
+                    .lock()
+                    .expect("registry lock")
+                    .keys()
+                    .next()
+                    .cloned()
+                    .ok_or_else(|| {
+                        BackendError::Provision("no self-hosted endpoint registered".to_owned())
+                    })?;
+                let reference = provision_reference(request.run_id);
+                self.handles
+                    .lock()
+                    .expect("handles lock")
+                    .insert(reference.clone(), base_url);
+                Ok(SandboxHandle {
+                    reference,
+                    tag: request.tag,
+                })
+            }
+        }
+    }
+
+    async fn address(&self, handle: &SandboxHandle) -> Result<SandboxAddress, BackendError> {
+        let base_url = self
+            .base_url_for(handle)
+            .ok_or(BackendError::UnknownHandle)?;
+        if !self
+            .registry
+            .lock()
+            .expect("registry lock")
+            .contains_key(&base_url)
+        {
+            return Err(BackendError::Unaddressable(base_url));
+        }
+        Ok(SandboxAddress {
+            base_url,
+            transport_secret: self.secret.clone(),
+        })
+    }
+
+    async fn destroy(&self, handle: &SandboxHandle) -> Result<(), BackendError> {
+        let base_url = self.base_url_for(handle);
+        self.handles
+            .lock()
+            .expect("handles lock")
+            .remove(&handle.reference);
+        match self.mode {
+            // Idempotent teardown of the managed sandbox.
+            Provisioning::Managed => {
+                if let Some(base_url) = base_url {
+                    self.registry
+                        .lock()
+                        .expect("registry lock")
+                        .remove(&base_url);
+                }
+                Ok(())
+            }
+            // No-op: the user tears down their own endpoint.
+            Provisioning::SelfHosted => Ok(()),
+        }
+    }
+}
+
+fn provision_reference(run_id: RunId) -> String {
+    format!("{run_id}:{}", Uuid::new_v4())
+}

--- a/crates/openwave-sandbox-protocol/src/reverse.rs
+++ b/crates/openwave-sandbox-protocol/src/reverse.rs
@@ -72,6 +72,17 @@ impl ReverseRequest {
             ReverseRequest::ModelInference(_) => Capability::ModelInference,
         }
     }
+
+    /// Whether this inbound request is within its declared per-capability bound.
+    ///
+    /// The host checks this before executing: a request is untrusted input, and
+    /// an over-bound one is refused, not forwarded.
+    #[must_use]
+    pub fn within_bounds(&self) -> bool {
+        match self {
+            ReverseRequest::ModelInference(params) => params.within_bounds(),
+        }
+    }
 }
 
 /// A bounded typed success for one reverse request.
@@ -219,6 +230,19 @@ impl GrantSet {
 pub trait CapabilityResponder: Send + Sync {
     /// Execute one reverse request and return its bounded outcome.
     async fn respond(&self, request: ReverseRequest) -> Response<ReverseResult>;
+}
+
+impl ReverseResult {
+    /// Whether this result is within its declared per-capability bound.
+    ///
+    /// The host checks this before recording: a responder that returns an
+    /// over-bound completion has its result rejected rather than persisted.
+    #[must_use]
+    pub fn within_bounds(&self) -> bool {
+        match self {
+            ReverseResult::ModelInference(result) => result.within_bounds(),
+        }
+    }
 }
 
 impl ModelInferenceResult {

--- a/crates/openwave-sandbox-protocol/src/reverse.rs
+++ b/crates/openwave-sandbox-protocol/src/reverse.rs
@@ -1,0 +1,298 @@
+//! The reverse-RPC callback channel: wire types, capability grants with run
+//! provenance, and the two-lane frame model.
+//!
+//! Direction rule (unchanged from the design): the host dials the sandbox and
+//! holds the connection; "reverse" names only which side originates *requests*
+//! over it. The sandbox supervisor originates reverse requests; the host
+//! answers them, authorized deny-by-default by the run's grants and recorded
+//! idempotently by [`OperationId`](crate::ids::OperationId).
+//!
+//! Two lanes multiplex over one connection. The **request lane**
+//! ([`RequestFrame`]) carries reverse requests and their responses and is
+//! subject to backpressure. The **control lane** ([`ControlFrame`]) carries
+//! cancellation and liveness and is deliberately *separate*, so a cancel or a
+//! heartbeat is never stuck behind the request backlog it is trying to relieve
+//! — the gap the reverse-RPC spike flagged for this step to close.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ids::{OperationId, RequestId, RunId},
+    protocol::Response,
+};
+
+/// A host-mediated capability the sandbox may request back over the channel.
+///
+/// Model inference is the first and, for this protocol slice, only carried
+/// capability: a sandbox-resident loop cannot take a single step without it.
+/// The enum is `#[non_exhaustive]` so host search and consent prompts join as
+/// variants without a breaking change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum Capability {
+    /// Run one model completion through the host, which is the model proxy.
+    ModelInference,
+}
+
+/// Parameters for one host-proxied model completion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ModelInferenceParams {
+    pub prompt: String,
+}
+
+/// Bounded result of one host-proxied model completion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ModelInferenceResult {
+    pub completion: String,
+}
+
+/// A capability-checked reverse request the sandbox issues to the host.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "capability",
+    content = "payload",
+    rename_all = "snake_case",
+    deny_unknown_fields
+)]
+#[non_exhaustive]
+pub enum ReverseRequest {
+    ModelInference(ModelInferenceParams),
+}
+
+impl ReverseRequest {
+    /// Capability this request is gated on, for deny-by-default authorization.
+    #[must_use]
+    pub const fn capability(&self) -> Capability {
+        match self {
+            ReverseRequest::ModelInference(_) => Capability::ModelInference,
+        }
+    }
+}
+
+/// A bounded typed success for one reverse request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "capability", content = "payload", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ReverseResult {
+    ModelInference(ModelInferenceResult),
+}
+
+/// A reverse request the sandbox multiplexes toward the host on the request
+/// lane.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReverseEnvelope {
+    pub protocol_version: u32,
+    pub request_id: RequestId,
+    pub operation_id: OperationId,
+    pub request: ReverseRequest,
+}
+
+/// The host's correlated answer to one reverse request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReverseResponseEnvelope {
+    pub protocol_version: u32,
+    pub request_id: RequestId,
+    pub operation_id: OperationId,
+    pub response: Response<ReverseResult>,
+}
+
+/// A unit of the request lane: a request sandbox -> host or a response host ->
+/// sandbox, correlated by [`RequestId`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "frame",
+    content = "body",
+    rename_all = "snake_case",
+    deny_unknown_fields
+)]
+#[non_exhaustive]
+pub enum RequestFrame {
+    Request(ReverseEnvelope),
+    Response(ReverseResponseEnvelope),
+}
+
+/// A unit of the **reserved control lane**, distinct from the request lane so
+/// it is never subject to request backpressure.
+///
+/// Cancellation flows sandbox -> host; liveness flows in both directions. A
+/// conforming transport MUST carry this lane independently of [`RequestFrame`]
+/// (a separate stream, queue, or priority), so a [`ControlFrame::Cancel`] can
+/// preempt a saturated request backlog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "control",
+    content = "body",
+    rename_all = "snake_case",
+    deny_unknown_fields
+)]
+#[non_exhaustive]
+pub enum ControlFrame {
+    /// Cancel an in-flight reverse operation by its durable identity.
+    Cancel { operation_id: OperationId },
+    /// Liveness probe.
+    Ping { nonce: u64 },
+    /// Liveness response.
+    Pong { nonce: u64 },
+}
+
+/// Provenance carried on every reverse operation for audit.
+///
+/// Consent prompts arriving over the reverse channel are rendered with this —
+/// which run, which provider — so the user knows who is asking.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RunProvenance {
+    /// The run whose grants authorize the operation.
+    pub run_id: RunId,
+    /// The provider that stood up the sandbox, treated as untrusted attribution.
+    pub provider: String,
+}
+
+/// The deny-by-default grant set resolved for one run at admission.
+///
+/// A capability absent from [`GrantSet::capabilities`] is refused and never
+/// executes. The set is host state, never a claim the sandbox makes about
+/// itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GrantSet {
+    provenance: RunProvenance,
+    capabilities: BTreeSet<Capability>,
+}
+
+impl GrantSet {
+    /// Build a grant set for `provenance` granting exactly `capabilities`.
+    #[must_use]
+    pub fn new(
+        provenance: RunProvenance,
+        capabilities: impl IntoIterator<Item = Capability>,
+    ) -> Self {
+        Self {
+            provenance,
+            capabilities: capabilities.into_iter().collect(),
+        }
+    }
+
+    /// A grant set that authorizes nothing — the deny-by-default default.
+    #[must_use]
+    pub fn none(provenance: RunProvenance) -> Self {
+        Self {
+            provenance,
+            capabilities: BTreeSet::new(),
+        }
+    }
+
+    /// Whether `capability` is granted to this run.
+    #[must_use]
+    pub fn allows(&self, capability: Capability) -> bool {
+        self.capabilities.contains(&capability)
+    }
+
+    /// The run provenance carried for audit.
+    #[must_use]
+    pub const fn provenance(&self) -> &RunProvenance {
+        &self.provenance
+    }
+
+    /// The granted capabilities, for the attach handshake's advertisement.
+    #[must_use]
+    pub fn granted(&self) -> Vec<Capability> {
+        self.capabilities.iter().copied().collect()
+    }
+}
+
+/// The host's execution of a granted capability — its model proxy and, later,
+/// host search and consent prompts.
+///
+/// Called at most once per [`OperationId`](crate::ids::OperationId); the
+/// operation log, not this trait, enforces that. An implementation should be
+/// cancel-safe: the host aborts the returned future when the sandbox cancels,
+/// so partial work must not leave an unrecorded external effect the design
+/// would then have to reconcile.
+#[async_trait::async_trait]
+pub trait CapabilityResponder: Send + Sync {
+    /// Execute one reverse request and return its bounded outcome.
+    async fn respond(&self, request: ReverseRequest) -> Response<ReverseResult>;
+}
+
+impl ModelInferenceResult {
+    /// Whether the completion is within its declared per-capability bound.
+    #[must_use]
+    pub fn within_bounds(&self) -> bool {
+        self.completion.len() <= crate::protocol::MAX_MODEL_COMPLETION_BYTES
+    }
+}
+
+impl ModelInferenceParams {
+    /// Whether the prompt is within its declared per-capability bound.
+    #[must_use]
+    pub fn within_bounds(&self) -> bool {
+        self.prompt.len() <= crate::protocol::MAX_MODEL_PROMPT_BYTES
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::PROTOCOL_VERSION;
+
+    #[test]
+    fn request_frame_roundtrips() {
+        let frame = RequestFrame::Request(ReverseEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: RequestId::new(),
+            operation_id: OperationId::new(),
+            request: ReverseRequest::ModelInference(ModelInferenceParams {
+                prompt: "hello".to_owned(),
+            }),
+        });
+        let encoded = serde_json::to_string(&frame).unwrap();
+        assert_eq!(
+            serde_json::from_str::<RequestFrame>(&encoded).unwrap(),
+            frame
+        );
+    }
+
+    #[test]
+    fn control_frame_is_a_distinct_wire_shape() {
+        let cancel = ControlFrame::Cancel {
+            operation_id: OperationId::new(),
+        };
+        let encoded = serde_json::to_value(cancel).unwrap();
+        assert_eq!(encoded["control"], "cancel");
+        assert_eq!(
+            serde_json::from_value::<ControlFrame>(encoded).unwrap(),
+            cancel
+        );
+    }
+
+    #[test]
+    fn unknown_fields_are_rejected() {
+        let encoded = format!(
+            r#"{{"protocol_version":1,"request_id":"{}","operation_id":"{}","request":{{"capability":"model_inference","payload":{{"prompt":"hi","extra":true}}}}}}"#,
+            RequestId::new(),
+            OperationId::new(),
+        );
+        assert!(serde_json::from_str::<ReverseEnvelope>(&encoded).is_err());
+    }
+
+    #[test]
+    fn grant_set_denies_by_default() {
+        let provenance = RunProvenance {
+            run_id: RunId::new(),
+            provider: "reference".to_owned(),
+        };
+        let empty = GrantSet::none(provenance.clone());
+        assert!(!empty.allows(Capability::ModelInference));
+
+        let granted = GrantSet::new(provenance, [Capability::ModelInference]);
+        assert!(granted.allows(Capability::ModelInference));
+        assert_eq!(granted.granted(), vec![Capability::ModelInference]);
+    }
+}

--- a/crates/openwave-sandbox-protocol/tests/conformance.rs
+++ b/crates/openwave-sandbox-protocol/tests/conformance.rs
@@ -18,6 +18,21 @@ async fn deny_by_default_refuses_ungranted_capability() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn over_bound_request_is_refused() {
+    conformance::over_bound_request_is_refused().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn over_bound_event_is_refused() {
+    conformance::over_bound_event_is_refused().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn control_lane_cancel_preempts_saturated_request_lane() {
+    conformance::control_lane_cancel_preempts_saturated_request_lane().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn event_stream_resumes_from_committed_cursor() {
     conformance::event_stream_resumes_from_committed_cursor().await;
 }

--- a/crates/openwave-sandbox-protocol/tests/conformance.rs
+++ b/crates/openwave-sandbox-protocol/tests/conformance.rs
@@ -1,0 +1,58 @@
+//! The protocol conformance suite, surfaced as individual CI checks.
+//!
+//! Each test drives one scenario from [`openwave_sandbox_protocol::conformance`]
+//! against the in-process reference backend. Once the local container backend
+//! lands (delivery-sequence step 7.1), the same scenarios re-point at it behind
+//! the protocol seam; the assertions do not change.
+
+use openwave_sandbox_protocol::conformance;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn version_mismatch_is_refused() {
+    conformance::version_mismatch_is_refused().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn deny_by_default_refuses_ungranted_capability() {
+    conformance::deny_by_default_refuses_ungranted_capability().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn event_stream_resumes_from_committed_cursor() {
+    conformance::event_stream_resumes_from_committed_cursor().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn event_buffer_overflow_checkpoints_and_resumes() {
+    conformance::event_buffer_overflow_checkpoints_and_resumes().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reverse_rpc_correlates_concurrent_calls() {
+    conformance::reverse_rpc_correlates_concurrent_calls().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reverse_rpc_cancel_aborts_in_flight() {
+    conformance::reverse_rpc_cancel_aborts_in_flight().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reverse_rpc_disconnect_fails_inflight_then_reissue_replays() {
+    conformance::reverse_rpc_disconnect_fails_inflight_then_reissue_replays().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reverse_rpc_reissue_with_a_different_request_conflicts() {
+    conformance::reverse_rpc_reissue_with_a_different_request_conflicts().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn self_hosted_and_managed_share_one_attach_path() {
+    conformance::self_hosted_and_managed_share_one_attach_path().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn artifact_collection_roundtrips_and_is_bounded() {
+    conformance::artifact_collection_roundtrips_and_is_bounded().await;
+}

--- a/crates/openwave-sandbox-protocol/tests/wire_format.rs
+++ b/crates/openwave-sandbox-protocol/tests/wire_format.rs
@@ -1,0 +1,308 @@
+//! Wire-format spec for the sandbox-agent protocol.
+//!
+//! Two things every wire type must satisfy, and a symmetric round-trip alone
+//! proves neither:
+//!
+//! - **Round-trip**: `serialize` then `deserialize` yields the original value.
+//! - **Golden encoding**: the exact JSON shape — discriminant keys and field
+//!   names — matches this spec, so a silent serde `tag`/`rename_all` change is
+//!   caught and a cross-language self-hoster has a representation to implement
+//!   against, exactly as `openwave-host-broker` pins `encoded["request"]["control"]`.
+//!
+//! Byte framing and lane multiplexing are out of scope here (they are a concrete
+//! backend's, per the crate docs); this file pins the *types* that cross the
+//! boundary.
+
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::{json, Value};
+
+use openwave_sandbox_protocol::{
+    artifacts::{ArtifactContent, ArtifactEntry, ArtifactManifest},
+    events::{EventBatch, EventPayload, SandboxEvent},
+    ids::{EventCursor, OperationId, RequestId, RunId, SandboxTag, Sequence},
+    AttachAccepted, AttachRefused, AttachRequest, Capability, ControlFrame, ErrorCode,
+    ErrorResponse, HandshakeResponse, ModelInferenceParams, ModelInferenceResult, ProvisionRequest,
+    RequestFrame, Response, ReverseEnvelope, ReverseRequest, ReverseResponseEnvelope,
+    ReverseResult, RunProvenance, SandboxAddress, SandboxHandle, TransportSecret, PROTOCOL_VERSION,
+};
+
+/// Assert a value round-trips through JSON unchanged.
+fn roundtrip<T>(value: &T)
+where
+    T: Serialize + DeserializeOwned + PartialEq + std::fmt::Debug,
+{
+    let encoded = serde_json::to_string(value).expect("serialize");
+    let decoded: T = serde_json::from_str(&encoded).expect("deserialize");
+    assert_eq!(&decoded, value, "round-trip changed the value");
+}
+
+/// Assert a value's encoded JSON has exactly the given top-level shape at the
+/// named pointers.
+fn golden<T: Serialize>(value: &T, checks: &[(&str, Value)]) {
+    let encoded = serde_json::to_value(value).expect("serialize");
+    for (pointer, expected) in checks {
+        let found = encoded
+            .pointer(pointer)
+            .unwrap_or_else(|| panic!("missing pointer {pointer} in {encoded}"));
+        assert_eq!(found, expected, "golden mismatch at {pointer}");
+    }
+}
+
+#[test]
+fn attach_handshake_wire_shapes() {
+    let request = AttachRequest {
+        protocol_version: PROTOCOL_VERSION,
+        run_id: RunId::new(),
+        resume_from: EventCursor::committed(Sequence::new(3)),
+    };
+    roundtrip(&request);
+    golden(
+        &request,
+        &[
+            ("/protocol_version", json!(PROTOCOL_VERSION)),
+            ("/resume_from", json!(3)),
+        ],
+    );
+
+    let accepted = HandshakeResponse::Accepted(AttachAccepted {
+        protocol_version: PROTOCOL_VERSION,
+        granted_capabilities: vec![Capability::ModelInference],
+        latest_sequence: Some(Sequence::new(3)),
+    });
+    roundtrip(&accepted);
+    golden(
+        &accepted,
+        &[
+            ("/accepted/protocol_version", json!(PROTOCOL_VERSION)),
+            ("/accepted/granted_capabilities/0", json!("model_inference")),
+            ("/accepted/latest_sequence", json!(3)),
+        ],
+    );
+
+    let refused = HandshakeResponse::Refused(AttachRefused {
+        protocol_version: PROTOCOL_VERSION + 1,
+        code: ErrorCode::ProtocolVersion,
+    });
+    roundtrip(&refused);
+    golden(
+        &refused,
+        &[
+            ("/refused/protocol_version", json!(PROTOCOL_VERSION + 1)),
+            ("/refused/code", json!("protocol_version")),
+        ],
+    );
+}
+
+#[test]
+fn error_and_response_wire_shapes() {
+    let error = ErrorResponse::new(ErrorCode::TooLarge, "too big", false);
+    roundtrip(&error);
+    golden(
+        &error,
+        &[("/code", json!("too_large")), ("/retryable", json!(false))],
+    );
+
+    let ok: Response<u32> = Response::Ok(7);
+    golden(&ok, &[("/status", json!("ok")), ("/payload", json!(7))]);
+    roundtrip(&ok);
+
+    let err: Response<u32> = Response::Error(ErrorResponse::denied());
+    golden(
+        &err,
+        &[
+            ("/status", json!("error")),
+            ("/payload/code", json!("denied")),
+        ],
+    );
+    roundtrip(&err);
+}
+
+#[test]
+fn reverse_request_and_result_wire_shapes() {
+    golden(
+        &Capability::ModelInference,
+        &[("", json!("model_inference"))],
+    );
+
+    let request = ReverseRequest::ModelInference(ModelInferenceParams {
+        prompt: "hi".to_owned(),
+    });
+    roundtrip(&request);
+    golden(
+        &request,
+        &[
+            ("/capability", json!("model_inference")),
+            ("/payload/prompt", json!("hi")),
+        ],
+    );
+
+    let result = ReverseResult::ModelInference(ModelInferenceResult {
+        completion: "done".to_owned(),
+    });
+    roundtrip(&result);
+    golden(
+        &result,
+        &[
+            ("/capability", json!("model_inference")),
+            ("/payload/completion", json!("done")),
+        ],
+    );
+}
+
+#[test]
+fn reverse_envelopes_and_frames_wire_shapes() {
+    let envelope = ReverseEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: RequestId::new(),
+        operation_id: OperationId::new(),
+        request: ReverseRequest::ModelInference(ModelInferenceParams {
+            prompt: "q".to_owned(),
+        }),
+    };
+    roundtrip(&envelope);
+
+    let response = ReverseResponseEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: RequestId::new(),
+        operation_id: OperationId::new(),
+        response: Response::Ok(ReverseResult::ModelInference(ModelInferenceResult {
+            completion: "a".to_owned(),
+        })),
+    };
+    roundtrip(&response);
+
+    let request_frame = RequestFrame::Request(envelope);
+    roundtrip(&request_frame);
+    golden(&request_frame, &[("/frame", json!("request"))]);
+
+    let response_frame = RequestFrame::Response(response);
+    golden(&response_frame, &[("/frame", json!("response"))]);
+    roundtrip(&response_frame);
+}
+
+#[test]
+fn control_lane_frames_wire_shapes() {
+    let cancel = ControlFrame::Cancel {
+        operation_id: OperationId::new(),
+    };
+    roundtrip(&cancel);
+    golden(&cancel, &[("/control", json!("cancel"))]);
+
+    let ping = ControlFrame::Ping { nonce: 9 };
+    roundtrip(&ping);
+    golden(
+        &ping,
+        &[("/control", json!("ping")), ("/body/nonce", json!(9))],
+    );
+
+    let pong = ControlFrame::Pong { nonce: 9 };
+    roundtrip(&pong);
+    golden(&pong, &[("/control", json!("pong"))]);
+}
+
+#[test]
+fn event_stream_wire_shapes() {
+    let progress = SandboxEvent {
+        sequence: Sequence::new(1),
+        payload: EventPayload::Progress("working".to_owned()),
+    };
+    roundtrip(&progress);
+    golden(
+        &progress,
+        &[
+            ("/sequence", json!(1)),
+            ("/payload/kind", json!("progress")),
+            ("/payload/body", json!("working")),
+        ],
+    );
+
+    let result = SandboxEvent {
+        sequence: Sequence::new(2),
+        payload: EventPayload::Result("final".to_owned()),
+    };
+    roundtrip(&result);
+    golden(&result, &[("/payload/kind", json!("result"))]);
+
+    let batch = EventBatch {
+        events: vec![progress],
+        overflowed: false,
+    };
+    roundtrip(&batch);
+    golden(
+        &batch,
+        &[
+            ("/overflowed", json!(false)),
+            ("/events/0/sequence", json!(1)),
+        ],
+    );
+}
+
+#[test]
+fn artifact_wire_shapes() {
+    let entry = ArtifactEntry {
+        name: "report.md".to_owned(),
+        bytes: 5,
+        sha256: [0u8; 32],
+    };
+    roundtrip(&entry);
+    golden(
+        &entry,
+        &[("/name", json!("report.md")), ("/bytes", json!(5))],
+    );
+
+    let manifest = ArtifactManifest {
+        entries: vec![entry],
+    };
+    roundtrip(&manifest);
+    golden(&manifest, &[("/entries/0/name", json!("report.md"))]);
+
+    let content = ArtifactContent::encode(b"hello").expect("encode");
+    roundtrip(&content);
+    golden(&content, &[("/bytes", json!(5))]);
+    // The digest is a 32-byte array on the wire.
+    let encoded = serde_json::to_value(&content).unwrap();
+    assert_eq!(encoded["sha256"].as_array().map(Vec::len), Some(32));
+}
+
+#[test]
+fn provisioning_wire_shapes() {
+    let request = ProvisionRequest {
+        run_id: RunId::new(),
+        tag: SandboxTag::new(),
+        lifetime_cap_secs: Some(3600),
+    };
+    roundtrip(&request);
+    golden(&request, &[("/lifetime_cap_secs", json!(3600))]);
+
+    let handle = SandboxHandle {
+        reference: "container-abc".to_owned(),
+        tag: SandboxTag::new(),
+    };
+    roundtrip(&handle);
+    golden(&handle, &[("/reference", json!("container-abc"))]);
+
+    let address = SandboxAddress {
+        base_url: "https://sandbox.example".to_owned(),
+        transport_secret: TransportSecret::new("s3cr3t"),
+    };
+    roundtrip(&address);
+    golden(
+        &address,
+        &[
+            ("/base_url", json!("https://sandbox.example")),
+            // The secret is transparent on the wire (a bearer credential), even
+            // though it is redacted in Debug output.
+            ("/transport_secret", json!("s3cr3t")),
+        ],
+    );
+}
+
+#[test]
+fn run_provenance_wire_shape() {
+    let provenance = RunProvenance {
+        run_id: RunId::new(),
+        provider: "reference".to_owned(),
+    };
+    roundtrip(&provenance);
+    golden(&provenance, &[("/provider", json!("reference"))]);
+}

--- a/docs/crates.md
+++ b/docs/crates.md
@@ -14,7 +14,7 @@ libraries.
       libraries          openwave-mcp          openwave-retrieval
                          openwave-router       openwave-web-search
                          openwave-host-broker  openwave-code-execution
-                         openwave-egress
+                         openwave-egress       openwave-sandbox-protocol
                                             │
       the seam                         openwave-core
 
@@ -106,6 +106,28 @@ scratch tools remain separate and confined to app storage.
 See [Host access and connected folders](host-access.md).
 
 **Depends on:** no OpenWave client crate.
+
+## `openwave-sandbox-protocol` — the sandbox-agent wire protocol 🟡
+
+The versioned boundary between the host and a sandbox-resident agent run —
+provisioning, run init, the resumable monotonically sequenced event stream,
+artifact collection, and the reverse-RPC callback channel with host-proxied
+model inference as its first capability. It is a public interface third parties
+implement (a self-hosted backend runs the sandbox side of it), so the wire
+contract, not any one backend, is the deliverable. It follows the host-broker
+envelope discipline: a `PROTOCOL_VERSION` checked for exact equality with an
+attach handshake, deny-by-default capability grants carrying run provenance, a
+reserved control lane for cancel/liveness kept off the request lane, and bounded
+typed results with explicit per-capability bounds. The provision/address/destroy
+decomposition treats a self-hosted backend (no provisioning, just an address and
+a credential) as the conformance test rather than a special case. It ships an
+in-process reference backend and a conformance suite (the CI artifact), plus the
+operation-identity state machine backed by an in-memory store behind a durable
+seam. **The protocol is UNSTABLE until a named release.** The crash-safe durable
+operation log and its retention are split into focused follow-ups.
+See [Execution providers and sandbox-resident agent runs](sandbox-providers.md).
+
+**Depends on:** no OpenWave crate (standalone wire contract).
 
 ## `openwave-retrieval` — parsing, search, citations 🟢
 

--- a/docs/sandbox-providers.md
+++ b/docs/sandbox-providers.md
@@ -540,7 +540,17 @@ The implementation is intentionally incremental:
    shipped in this step against an in-process reference backend, and run in
    CI against the local container backend from the next step onward. This
    step exists whether or not the spike says go; its reverse-RPC surface is
-   shaped by the spike's outcome.
+   shaped by the spike's outcome. *(Contract, reference backend, and
+   conformance suite shipped — the `openwave-sandbox-protocol` crate:
+   `PROTOCOL_VERSION` with an exact-equality check and an attach handshake,
+   deny-by-default capability grants with run provenance, a reserved control
+   lane for cancel/liveness, the resumable event-cursor contract, artifact
+   collection, and reverse-RPC model inference with an operation-identity log.
+   The protocol is declared UNSTABLE until a named release. The crash-safe
+   durable operation log (#858) and its retention/eviction (#859) are split
+   out as correctness-critical follow-ups so each gets a focused review; the
+   protocol ships an in-memory `OperationStore` behind the seam they plug
+   into.)*
 7. Sandbox-resident agent runs, in order:
    1. Local container first, attached-only — no vendor account, the
       development loop for everything after, and the reference a
@@ -632,7 +642,14 @@ Consistent with the repository's testing policy, the CI artifact for the
 protocol is one conformance suite, shipped with the protocol step against an
 in-process reference backend and run against the local container backend
 once it exists, including the semantics cases listed in the delivery
-sequence. The managed adapters keep their existing CI coverage through
+sequence. That suite has landed in `openwave-sandbox-protocol` (the
+`conformance` module, surfaced as `tests/conformance.rs`): it covers version-
+mismatch refusal, deny-by-default, the resumable event-cursor contract and
+buffer-overflow checkpointing, reverse-RPC correlation / cancellation /
+disconnect-reissue and operation-id conflict, the provision/address/destroy
+decomposition with the self-hosted backend as the no-special-case test, and
+artifact collection. Re-pointing those scenarios at the local container
+backend is the next step's work; the assertions do not change. The managed adapters keep their existing CI coverage through
 injected HTTP seams; what stays out of CI is live vendor exercise, which
 needs paid accounts and credentials, is unrunnable on forks, and flakes.
 Live verification is out-of-band with repository secrets. Bounding coverage


### PR DESCRIPTION
Delivery-sequence step 6 of `docs/sandbox-providers.md`: the sandbox-agent boundary as a public, versioned interface third parties implement. New crate `openwave-sandbox-protocol`.

## What this ships

- **The protocol contract.** `PROTOCOL_VERSION` checked for **exact equality** with an attach handshake (answered even across a skew so the peer learns the mismatch, then refused), following the `openwave-host-broker` envelope shape. Provisioning, run init, the resumable monotonically sequenced event stream, artifact collection, and the reverse-RPC callback channel with host-proxied **model inference** as the first capability. Deny-by-default capability grants carrying **run provenance**; bounded typed results with explicit per-capability bounds (`MAX_*`). The shipped broker is not touched.
- **Two things the reverse-RPC spike flagged, closed here.** A **reserved control lane** (`ControlFrame`: cancel + ping/pong) distinct from the request lane (`RequestFrame`), so a cancel is never queued behind the request backlog it is trying to relieve. And the **version handshake on attach**, not only per request.
- **The provision/address/destroy decomposition** as a trait (`SandboxBackend`): provision returns a handle (may be a no-op wrapping a user-supplied endpoint), address maps a handle to a reachable base URL, destroy may be a no-op. The **self-hosted backend** — no provisioning, just an address and a credential — is the conformance test, not a special case: `self_hosted_and_managed_share_one_attach_path` drives both through one attach path.
- **An in-process reference backend** implementing the protocol, and a **conformance suite** (the CI artifact per the doc's Testing section): version-mismatch refusal, deny-by-default, the resumable event-cursor contract, buffer-overflow checkpoint/resume, reverse-RPC correlation / cancellation / disconnect-reissue, operation-id conflict, the backend decomposition, and artifact collection. Ten scenarios, surfaced individually in `tests/conformance.rs`.
- **UNSTABLE until a named release** — stated in the crate docs and the module.
- **Operation-identity types** (`OperationId`, the `Claimed -> Recorded / Failed` state machine) are protocol-level, backed by an **in-memory `OperationStore`** with a clearly-marked trait seam where durable persistence plugs in. `CapabilityHost` already routes a `Claimed`-after-crash external-effect call to a conservative `OperationAmbiguous` refusal through the `ClaimedElsewhere` seam the durable store will fill.

## Why the durable op-log is split out

Per CLAUDE.md's small-focused-PR rule, and because the spike named the durable operation log as the single biggest correctness risk, the two durable-storage designs get their own focused reviews instead of being crammed here:

- **#858** — the crash-safe durable operation log: the `Claimed -> Recorded/Failed` machine committed transactionally on the run, keyed by `OperationId`, with the commit predicate that answers a re-issue from `Recorded` and fails a `Claimed`-after-crash external-effect call conservatively (never re-executes). Mirrors `docs/agent-runs.md`'s result-idempotency-key.
- **#859** — operation-log retention/eviction: what bounds the log, when a `Recorded` entry is evictable (an ack/cursor once the `OperationId` can no longer be re-issued), and whether to retain the full response body or a commit marker. Addresses the unbounded-per-loop cardinality problem from the findings doc.

This keeps this PR reviewable; the durable correctness work gets the scrutiny it needs on its own.

## Docs

- `docs/sandbox-providers.md`: marked the protocol step's contract + conformance portion landed; expanded the Testing section to describe the shipped suite; referenced #858/#859.
- `docs/crates.md`: added the crate to the diagram and the library list.

## Verification

- `cargo test -p openwave-sandbox-protocol --locked` — 20 unit + 10 conformance tests pass.
- `cargo clippy -p openwave-sandbox-protocol --all-targets --locked -- -D warnings` — clean.
- `cargo fmt -p openwave-sandbox-protocol -- --check` — clean.
- Lockfile: only the new crate entry added; no version drift of existing deps. No ts-rs wire types touched.

Not driven in the running app — this is a library crate with no UI surface.

Part of #822
