### PR TITLE
perf(server): read each stored credential once per process

### DIFF
--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -46,6 +46,7 @@ pub mod model;
 pub mod preview;
 pub mod provider;
 mod renderer_tool;
+pub mod secret_cache;
 pub mod semantic_checkpoint;
 pub mod steer;
 pub mod storage;
@@ -149,6 +150,7 @@ pub use provider::{
     RefusalDetails, RefusalOutcome, ResponseFormat, StopReason, ToolChoice, Usage,
 };
 pub use renderer_tool::RendererToolName;
+pub use secret_cache::CachingSecretProvider;
 pub use semantic_checkpoint::{
     ContextCheckpoint, ContextCheckpointPayloadV1, SaveContextCheckpointOutcome,
     CONTEXT_CHECKPOINT_FORMAT_V1, MAX_CONTEXT_CHECKPOINT_BYTES, MAX_CONTEXT_CHECKPOINT_ITEMS,

--- a/crates/openwave-core/src/secret_cache.rs
+++ b/crates/openwave-core/src/secret_cache.rs
@@ -1,0 +1,151 @@
+//! A [`SecretProvider`] decorator that reads each key at most once.
+//!
+//! Credential reads sit on the per-turn path: the resolver rebuilds its route
+//! set for every turn, and building a route reads that provider's credential.
+//! Against the OS keychain each of those is a round-trip to the platform
+//! credential store — and on macOS, where an item's access approval is tied to
+//! the code signature of the binary that created it, a read whose approval no
+//! longer holds raises a visible prompt. Reading once per process instead of
+//! once per turn takes both costs off the hot path.
+//!
+//! Reads are memoized, misses included. Writes and deletes pass through and
+//! then drop the key's cached entry — whether or not they succeeded, so a
+//! failed write can't leave a stale value behind. A write deliberately does
+//! *not* seed the cache: the read that follows is a real one, which keeps
+//! read-back verification (see `secret_rehome` in `openwave-server`) honest.
+//!
+//! The tradeoff is that edits made outside this process — Keychain Access, the
+//! CLI, another running instance — are not observed until the process restarts.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+
+use crate::error::Result;
+use crate::storage::SecretProvider;
+
+/// Wraps a [`SecretProvider`], serving repeat reads of a key from memory.
+pub struct CachingSecretProvider {
+    inner: Arc<dyn SecretProvider>,
+    /// Key → last known value. An entry of `None` records a confirmed miss.
+    cache: Mutex<HashMap<String, Option<String>>>,
+}
+
+impl CachingSecretProvider {
+    /// Cache reads against `inner`.
+    #[must_use]
+    pub fn new(inner: Arc<dyn SecretProvider>) -> Self {
+        Self {
+            inner,
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn cached(&self, key: &str) -> Option<Option<String>> {
+        self.cache.lock().unwrap().get(key).cloned()
+    }
+
+    fn store(&self, key: &str, value: Option<String>) {
+        self.cache.lock().unwrap().insert(key.to_string(), value);
+    }
+
+    fn invalidate(&self, key: &str) {
+        self.cache.lock().unwrap().remove(key);
+    }
+}
+
+impl std::fmt::Debug for CachingSecretProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never render the values.
+        f.debug_struct("CachingSecretProvider")
+            .field("cached_keys", &self.cache.lock().unwrap().len())
+            .finish()
+    }
+}
+
+#[async_trait]
+impl SecretProvider for CachingSecretProvider {
+    async fn get_secret(&self, key: &str) -> Result<Option<String>> {
+        // Two concurrent misses on one key both reach `inner`; they resolve to
+        // the same value, so the only cost is the duplicate read.
+        if let Some(hit) = self.cached(key) {
+            return Ok(hit);
+        }
+        let value = self.inner.get_secret(key).await?;
+        self.store(key, value.clone());
+        Ok(value)
+    }
+
+    async fn set_secret(&self, key: &str, value: &str) -> Result<()> {
+        let result = self.inner.set_secret(key, value).await;
+        self.invalidate(key);
+        result
+    }
+
+    async fn delete_secret(&self, key: &str) -> Result<()> {
+        let result = self.inner.delete_secret(key).await;
+        self.invalidate(key);
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    /// Counts reads so a test can tell a cache hit from a fetch.
+    #[derive(Default)]
+    struct CountingSecrets {
+        value: Mutex<Option<String>>,
+        reads: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl SecretProvider for CountingSecrets {
+        async fn get_secret(&self, _key: &str) -> Result<Option<String>> {
+            self.reads.fetch_add(1, Ordering::SeqCst);
+            Ok(self.value.lock().unwrap().clone())
+        }
+
+        async fn set_secret(&self, _key: &str, value: &str) -> Result<()> {
+            *self.value.lock().unwrap() = Some(value.to_string());
+            Ok(())
+        }
+
+        async fn delete_secret(&self, _key: &str) -> Result<()> {
+            *self.value.lock().unwrap() = None;
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn repeat_reads_are_served_from_memory_until_a_write_lands() {
+        let inner = Arc::new(CountingSecrets::default());
+        let secrets = CachingSecretProvider::new(inner.clone());
+        let key = "provider.anthropic.credential";
+
+        // A miss is cached too — the resolver asks about every provider kind,
+        // including the ones nothing is stored for.
+        assert_eq!(secrets.get_secret(key).await.unwrap(), None);
+        assert_eq!(secrets.get_secret(key).await.unwrap(), None);
+        assert_eq!(inner.reads.load(Ordering::SeqCst), 1);
+
+        secrets.set_secret(key, "sk-123").await.unwrap();
+        assert_eq!(
+            secrets.get_secret(key).await.unwrap().as_deref(),
+            Some("sk-123")
+        );
+        assert_eq!(
+            secrets.get_secret(key).await.unwrap().as_deref(),
+            Some("sk-123")
+        );
+        assert_eq!(inner.reads.load(Ordering::SeqCst), 2);
+
+        secrets.delete_secret(key).await.unwrap();
+        assert_eq!(secrets.get_secret(key).await.unwrap(), None);
+        assert_eq!(inner.reads.load(Ordering::SeqCst), 3);
+    }
+}

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -70,9 +70,9 @@ use openwave_core::{
     validate_import_connected_file_arguments, validate_list_connected_folders_arguments,
     validate_list_folder_arguments, validate_read_connected_file_arguments,
     validate_request_folder_access_arguments, validate_write_output_to_connected_folder_arguments,
-    write_output_to_connected_folder_tool_spec, AgentConfig, AgentError, Config, CreateDeliverable,
-    KeychainSecretProvider, ListDir, Profile, ReadFile, Result, SecretProvider, Store, Tool,
-    ToolRegistry, WriteFile,
+    write_output_to_connected_folder_tool_spec, AgentConfig, AgentError, CachingSecretProvider,
+    Config, CreateDeliverable, KeychainSecretProvider, ListDir, Profile, ReadFile, Result,
+    SecretProvider, Store, Tool, ToolRegistry, WriteFile,
 };
 #[cfg(feature = "vec-lance")]
 use openwave_retrieval::LanceVectorStore;
@@ -598,11 +598,17 @@ pub async fn bind_configured_with_desktop_executor(
 }
 
 /// The secret store the configured profile keeps its credentials in.
+///
+/// Wrapped in a [`CachingSecretProvider`] so a key costs one keychain read per
+/// process rather than one per turn: [`resolver::ConfiguredResolver`] rebuilds
+/// its route set on every turn, and each candidate route reads its provider's
+/// credential to decide whether it exists.
 fn secret_provider(config: &Config) -> Arc<dyn SecretProvider> {
-    Arc::new(match &config.keychain_service {
+    let keychain: Arc<dyn SecretProvider> = Arc::new(match &config.keychain_service {
         Some(service) => KeychainSecretProvider::with_service(service),
         None => KeychainSecretProvider::new(),
-    })
+    });
+    Arc::new(CachingSecretProvider::new(keychain))
 }
 
 /// Re-home the configured profile's credentials — see [`secret_rehome`]. Does


### PR DESCRIPTION
Closes #861.

`ConfiguredResolver::resolve` rebuilds its route set for every turn, and
`providers::collect_routes` reads the stored credential for each enabled
provider kind while doing it. The provider cache in `resolver.rs` compares a
fingerprint derived from those routes, so it sits downstream of the reads —
they happen on every turn whether or not the cached router is reused. Web
search and code execution read their credentials on the same per-use pattern.

Against the OS keychain each read is a round-trip to the platform credential
store. On macOS, where an item's access approval is tied to the code signature
of the binary that created it, a read whose approval no longer holds raises a
visible prompt rather than failing quietly — so the per-turn reads turn into
per-turn dialogs on any build whose signature has moved.

Caching in the resolver would have fixed only the route path and would have
needed an explicit invalidation signal plumbed from the settings routes. This
caches at the `SecretProvider` seam instead: `CachingSecretProvider` memoizes
reads, misses included, and drops a key's entry on write or delete. Every
reader and writer in the process shares the one `Arc<dyn SecretProvider>` built
in `secret_provider`, so rotating a credential in the app invalidates the entry
with no generation counter, and the web-search and code-execution paths get the
same treatment for free.

A write invalidates rather than seeds the cache. That's deliberate: the read
that follows is a real one, which keeps `secret_rehome`'s read-back an honest
verification instead of an echo of what it just wrote. Invalidation happens
whether or not the write succeeded, so a failed write can't strand a stale
value.

Credentials were already resident for the life of the process — `Route.api_key`
is a plain `String` and the built router is cached — so this doesn't change the
exposure of model keys. It does keep the web-search and code-execution keys
resident where they were previously transient.

The cost is that credential edits made outside the process (Keychain Access,
the CLI while the app runs) are not observed until restart. Documented at the
top of the module.

One test: repeat reads are served from memory, and a write or delete is
observed by the next read. That's the invariant the whole change rests on — if
invalidation broke, the app would keep using a rotated-away credential, which
is silent and would be miserable to track down.