### PR TITLE
feat(retrieval): record where on the page a passage sits

### DIFF
--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -139,7 +139,7 @@ pub use model::{
     ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnAgentRunWait, TurnAgentRunWaitSet,
     TurnAgentRunWaitStatus, TurnCheckpointProgress, TurnClientWait, TurnClientWaitStatus,
     TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer, TurnSteerStatus,
-    MAX_ATTACHMENT_REVISION, MAX_MESSAGE_ATTACHMENTS, MAX_ROOT_ATTACHMENTS,
+    MAX_ATTACHMENT_REVISION, MAX_MESSAGE_ATTACHMENTS, MAX_ROOT_ATTACHMENTS, PAGE_BOUNDS_SCALE,
 };
 pub use preview::{
     format_bytes, ResultEntry, ResultEntryKind, ResultFailure, ToolActionPreview,

--- a/crates/openwave-retrieval/src/document.rs
+++ b/crates/openwave-retrieval/src/document.rs
@@ -6,8 +6,8 @@
 //! from the vector index (offsets in the store, text rehydrated from the source),
 //! and it gives every answer a precise, verifiable pointer back into the source.
 
-pub use openwave_core::{ByteSpan, SourceLocation, SourceRegion};
-use openwave_core::{ChatId, DocumentGeneration, ProjectId};
+pub use openwave_core::{ByteSpan, PageBounds, SourceLocation, SourceRegion, PAGE_BOUNDS_SCALE};
+use openwave_core::{ChatId, DocumentGeneration, ProjectId, RetrievalEvidenceInput};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
@@ -173,9 +173,19 @@ impl Document {
     }
 
     /// Return source regions intersecting `span`, clipped to its boundaries.
+    ///
+    /// Never returns more regions than a piece of evidence is allowed to carry.
+    /// A parser that resolves positions within a page emits many small regions,
+    /// and a span over dense text — a page of short table cells — can overlap
+    /// more of them than [`RetrievalEvidenceInput::MAX_SOURCE_REGIONS`] permits,
+    /// which would make the evidence invalid rather than merely coarse. When
+    /// that happens the regions are coalesced by page: the page a passage came
+    /// from is the part worth keeping, and the geometry within it is the part
+    /// worth losing.
     #[must_use]
     pub fn source_regions_for(&self, span: ByteSpan) -> Vec<SourceRegion> {
-        self.source_regions
+        let clipped: Vec<SourceRegion> = self
+            .source_regions
             .iter()
             .filter_map(|region| {
                 let start = region.span.start.max(span.start);
@@ -185,8 +195,57 @@ impl Document {
                     location: region.location.clone(),
                 })
             })
-            .collect()
+            .collect();
+        if clipped.len() <= RetrievalEvidenceInput::MAX_SOURCE_REGIONS {
+            return clipped;
+        }
+        coalesce_by_page(clipped)
     }
+}
+
+/// Merge consecutive regions that name the same page into one region for that
+/// page, dropping the geometry that distinguished them.
+///
+/// Regions arrive ordered and non-overlapping, so consecutive regions on a page
+/// are contiguous or separated only by text that region map already assigned to
+/// the same page — merging them spans exactly the text they covered between
+/// them.
+fn coalesce_by_page(regions: Vec<SourceRegion>) -> Vec<SourceRegion> {
+    /// The page a region names, when it names one. `SourceLocation` is
+    /// `#[non_exhaustive]`, so a location this crate does not recognize is
+    /// possible in principle; such a region is passed through untouched rather
+    /// than folded into a neighbour it may have nothing to do with.
+    fn page_number(location: &SourceLocation) -> Option<std::num::NonZeroU32> {
+        match location {
+            SourceLocation::Page { number, .. } => Some(*number),
+            _ => None,
+        }
+    }
+
+    let mut merged: Vec<SourceRegion> = Vec::new();
+    for region in regions {
+        let page = page_number(&region.location);
+        let extends_previous = page.is_some()
+            && merged
+                .last()
+                .is_some_and(|previous| page_number(&previous.location) == page);
+        if extends_previous {
+            // Safe: `extends_previous` is false for an empty `merged`.
+            let previous = merged.last_mut().expect("checked non-empty");
+            previous.span = ByteSpan::new(previous.span.start, region.span.end);
+        } else if let Some(number) = page {
+            merged.push(SourceRegion {
+                span: region.span,
+                location: SourceLocation::Page {
+                    number,
+                    bounds: None,
+                },
+            });
+        } else {
+            merged.push(region);
+        }
+    }
+    merged
 }
 
 /// One chunk of a document: a contiguous slice of its text, ready to embed.
@@ -397,6 +456,74 @@ mod tests {
     fn document_slice_is_bounds_safe() {
         let doc = Document::new(DocumentSource::Inline, "text/plain", "hi");
         assert_eq!(doc.slice(ByteSpan::new(0, 99)), None);
+    }
+
+    #[test]
+    fn clipping_never_returns_more_regions_than_evidence_may_carry() {
+        // A page of short cells, each positioned: far more regions than the
+        // evidence cap. Exceeding it does not truncate the evidence, it makes
+        // the evidence invalid — so the clip has to stay inside the cap itself.
+        let count = RetrievalEvidenceInput::MAX_SOURCE_REGIONS * 3;
+        let text = "x".repeat(count);
+        let regions: Vec<SourceRegion> = (0..count)
+            .map(|i| SourceRegion {
+                span: ByteSpan::new(i, i + 1),
+                location: SourceLocation::Page {
+                    number: std::num::NonZeroU32::new(if i < count / 2 { 1 } else { 2 }).unwrap(),
+                    bounds: Some(openwave_core::PageBounds {
+                        left: 0,
+                        top: 0,
+                        width: 10,
+                        height: 10,
+                    }),
+                },
+            })
+            .collect();
+        let document = Document::new(DocumentSource::Inline, "application/pdf", text.clone())
+            .with_source_regions(regions);
+
+        let clipped = document.source_regions_for(ByteSpan::new(0, count));
+        assert!(clipped.len() <= RetrievalEvidenceInput::MAX_SOURCE_REGIONS);
+        // The pages survive the coalescing; only the geometry is given up.
+        let pages: Vec<_> = clipped
+            .iter()
+            .map(|region| match region.location {
+                SourceLocation::Page { number, bounds } => (number.get(), bounds),
+                #[allow(unreachable_patterns)]
+                _ => panic!("expected a page location"),
+            })
+            .collect();
+        assert_eq!(pages, vec![(1, None), (2, None)]);
+        // And the merged regions still tile the span they were clipped from.
+        assert_eq!(clipped[0].span, ByteSpan::new(0, count / 2));
+        assert_eq!(clipped[1].span, ByteSpan::new(count / 2, count));
+    }
+
+    #[test]
+    fn clipping_keeps_geometry_when_it_fits() {
+        let document = Document::new(DocumentSource::Inline, "application/pdf", "alpha beta")
+            .with_source_regions(vec![SourceRegion {
+                span: ByteSpan::new(0, 5),
+                location: SourceLocation::Page {
+                    number: std::num::NonZeroU32::new(1).unwrap(),
+                    bounds: Some(openwave_core::PageBounds {
+                        left: 1,
+                        top: 2,
+                        width: 3,
+                        height: 4,
+                    }),
+                },
+            }]);
+
+        let clipped = document.source_regions_for(ByteSpan::new(0, 10));
+        assert_eq!(clipped.len(), 1);
+        assert!(matches!(
+            clipped[0].location,
+            SourceLocation::Page {
+                bounds: Some(_),
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/openwave-retrieval/src/lib.rs
+++ b/crates/openwave-retrieval/src/lib.rs
@@ -95,7 +95,8 @@ mod vector;
 
 pub use chunk::{Chunker, TextChunker};
 pub use document::{
-    ByteSpan, Chunk, Citation, Document, DocumentSource, ScoredChunk, SourceLocation, SourceRegion,
+    ByteSpan, Chunk, Citation, Document, DocumentSource, PageBounds, ScoredChunk, SourceLocation,
+    SourceRegion, PAGE_BOUNDS_SCALE,
 };
 pub use embed::{Embedder, Embedding, HashEmbedder};
 pub use error::{Result, RetrievalError};

--- a/crates/openwave-retrieval/src/liteparse_image_parser.rs
+++ b/crates/openwave-retrieval/src/liteparse_image_parser.rs
@@ -57,7 +57,7 @@ const IMAGE_MEDIA_TYPES: &[&str] = &[
 /// extracted text, so the durable pipeline reparses affected documents. The
 /// fingerprint describes the intended pipeline (notably OCR-off) and is
 /// deliberately independent of whether PDFium happens to be installed at runtime.
-const IMAGE_FINGERPRINT: &str = "liteparse:v2.8:image:pdfium:markdown:no-ocr:pages:v2";
+const IMAGE_FINGERPRINT: &str = "liteparse:v2.8:image:pdfium:markdown:no-ocr:positioned:v3";
 
 /// Ingests raster images by converting them to a single-page PDF and parsing it
 /// with `liteparse`. With OCR off it produces canonical text only when the image

--- a/crates/openwave-retrieval/src/liteparse_office_parser.rs
+++ b/crates/openwave-retrieval/src/liteparse_office_parser.rs
@@ -48,7 +48,7 @@ const OFFICE_MEDIA_TYPES: &[&str] = &[
 /// extracted text, so the durable pipeline reparses affected documents. The
 /// fingerprint describes the intended pipeline and is deliberately independent
 /// of whether LibreOffice happens to be installed at runtime.
-const OFFICE_FINGERPRINT: &str = "liteparse:v2.8:office:libreoffice:markdown:no-ocr:pages:v2";
+const OFFICE_FINGERPRINT: &str = "liteparse:v2.8:office:libreoffice:markdown:no-ocr:positioned:v3";
 
 /// Extracts Markdown canonical text from Office documents via LibreOffice +
 /// `liteparse`.

--- a/crates/openwave-retrieval/src/liteparse_parser.rs
+++ b/crates/openwave-retrieval/src/liteparse_parser.rs
@@ -25,7 +25,7 @@ const PDF_MEDIA_TYPE: &str = "application/pdf";
 /// Stable identity of this parser's canonical-text behavior. Bump the trailing
 /// version tag whenever an implementation or configuration change can alter the
 /// extracted text, so the durable pipeline reparses affected documents.
-const LITEPARSE_FINGERPRINT: &str = "liteparse:v2.8:pdf:markdown:no-ocr:pages:v2";
+const LITEPARSE_FINGERPRINT: &str = "liteparse:v2.8:pdf:markdown:no-ocr:positioned:v3";
 
 /// Extracts Markdown canonical text from `application/pdf` bytes via `liteparse`.
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/openwave-retrieval/src/liteparse_regions.rs
+++ b/crates/openwave-retrieval/src/liteparse_regions.rs
@@ -1,19 +1,30 @@
-//! Turning a `liteparse` result into canonical text plus its page map.
+//! Turning a `liteparse` result into canonical text plus its source map.
 //!
 //! Shared by the PDF, Office and image parsers, which all reach canonical text
-//! through the same `liteparse` pipeline and so all recover pages the same way.
+//! through the same `liteparse` pipeline and so all recover their pages the
+//! same way.
 //!
-//! The mapping is exact rather than inferred. `liteparse` builds its full text
-//! by joining each page's own rendered Markdown with a fixed separator and
-//! hands back both halves — the joined text and the per-page pieces. Walking
-//! the pieces in order therefore reproduces the byte offsets of the join, so a
-//! page's [`SourceRegion`] is the span the page's text actually occupies. No
-//! substring search, no fuzzy matching: if the accounting does not add up to
-//! exactly the text we were given, we emit no regions at all rather than
-//! citations that point at the wrong page.
+//! Two mappings at different confidences, which is why they are built
+//! differently:
+//!
+//! **Pages are exact.** `liteparse` builds its full text by joining each page's
+//! own rendered Markdown with a fixed separator and hands back both halves, so
+//! walking the pieces in order reproduces the byte offsets of the join. If the
+//! accounting does not add up to exactly the text we were given, we emit no
+//! regions at all rather than citations that point at the wrong page.
+//!
+//! **Positions within a page are recovered.** `liteparse` knows where each line
+//! sits on the page but does not offset-map its lines into the Markdown it
+//! emits — the emitter rewrites bullets, rules and tables — so a line's span
+//! has to be found by scanning the page's Markdown with a forward-only cursor.
+//! Lines that do not turn up (systematically: rewritten bullets, rules,
+//! reflowed table rows) simply get no rectangle. Every page is tiled either
+//! way, so text a scan could not place still resolves to its page, and only
+//! the finer geometry is lost.
 
+use liteparse::types::Rect;
 use liteparse::ParseResult;
-use openwave_core::{ByteSpan, SourceLocation, SourceRegion};
+use openwave_core::{ByteSpan, PageBounds, SourceLocation, SourceRegion, PAGE_BOUNDS_SCALE};
 
 use crate::parse::ParsedDocument;
 
@@ -22,34 +33,97 @@ use crate::parse::ParsedDocument;
 /// drifting on a version bump.
 const PAGE_SEPARATOR: &str = "\n\n-----\n\n";
 
-/// Convert a `liteparse` result into canonical text carrying one region per page.
+/// Most positioned regions to keep for a single page.
+///
+/// Bounds the region map stored alongside the document: without a limit a long
+/// document of dense tables carries tens of thousands of rectangles, each of
+/// which is read and rewritten on every chunking pass. A page that overruns
+/// this keeps its page-level region and loses its geometry — pages that dense
+/// are ones where a per-line highlight would be noise anyway.
+const MAX_POSITIONED_REGIONS_PER_PAGE: usize = 256;
+
+/// One page's contribution to canonical text, with the lines found on it.
+struct PagePiece<'a> {
+    number: usize,
+    markdown: &'a str,
+    lines: Vec<PositionedLine<'a>>,
+}
+
+/// A line of page text and where it sits, once normalized to the page box.
+struct PositionedLine<'a> {
+    text: &'a str,
+    bounds: PageBounds,
+}
+
+/// Convert a `liteparse` result into canonical text carrying its source map.
 pub(crate) fn parsed_document_from(result: ParseResult) -> ParsedDocument {
-    let regions = page_regions(
-        &result.text,
-        result
-            .pages
-            .iter()
-            .map(|page| (page.page_number, page.markdown.as_str())),
-    );
+    let pieces: Vec<_> = result
+        .pages
+        .iter()
+        .map(|page| PagePiece {
+            number: page.page_number,
+            markdown: page.markdown.as_str(),
+            lines: page
+                .projected_lines
+                .iter()
+                .filter_map(|line| {
+                    Some(PositionedLine {
+                        text: line.text.as_str(),
+                        // A line we cannot place is not an error; it just does
+                        // not contribute geometry.
+                        bounds: normalized_bounds(&line.bbox, page.page_width, page.page_height)?,
+                    })
+                })
+                .collect(),
+        })
+        .collect();
+    let regions = source_regions(&result.text, &pieces);
     ParsedDocument::from_text(result.text).with_source_regions(regions)
 }
 
-/// Compute one [`SourceRegion`] per page from the pieces `text` was joined from.
+/// Express a rectangle in page-relative coordinates.
 ///
-/// Takes the pieces rather than a `ParseResult` so the offset arithmetic — the
-/// part that can silently produce wrong citations — is testable without PDFium.
-fn page_regions<'a>(
-    text: &str,
-    pages: impl Iterator<Item = (usize, &'a str)>,
-) -> Vec<SourceRegion> {
+/// Returns `None` for anything that would not survive the trip — a page with no
+/// extent, non-finite coordinates, or a rectangle that normalizes to no area.
+fn normalized_bounds(rect: &Rect, page_width: f32, page_height: f32) -> Option<PageBounds> {
+    let left = fraction_of(rect.x, page_width)?;
+    let top = fraction_of(rect.y, page_height)?;
+    let right = fraction_of(rect.x + rect.width, page_width)?;
+    let bottom = fraction_of(rect.y + rect.height, page_height)?;
+    // Derive extent from the clamped edges so a rectangle overhanging the page
+    // is trimmed to it rather than rejected or left pointing off-page.
+    let bounds = PageBounds {
+        left,
+        top,
+        width: right.checked_sub(left)?,
+        height: bottom.checked_sub(top)?,
+    };
+    bounds.is_valid().then_some(bounds)
+}
+
+/// Position along one axis, as a fraction of the page's extent on that axis.
+fn fraction_of(value: f32, extent: f32) -> Option<u16> {
+    (value.is_finite() && extent.is_finite() && extent > 0.0).then(|| {
+        // Clamped to the page, so the scaled value is always in `u16` range.
+        let fraction = (value / extent).clamp(0.0, 1.0);
+        (fraction * f32::from(PAGE_BOUNDS_SCALE)).round() as u16
+    })
+}
+
+/// Build the document's source map from the pieces `text` was joined from.
+///
+/// Takes plain pieces rather than a `ParseResult` so the offset arithmetic —
+/// the part that can silently produce wrong citations — is testable without
+/// PDFium.
+fn source_regions(text: &str, pages: &[PagePiece<'_>]) -> Vec<SourceRegion> {
     let mut regions = Vec::new();
     let mut offset = 0usize;
-    for (page_number, markdown) in pages {
-        let end = offset + markdown.len();
+    for page in pages {
+        let end = offset + page.markdown.len();
         // A page number is one-based upstream; a zero would mean liteparse
         // changed that contract, and a page we cannot name is one we cannot
         // cite. Drop the whole map rather than guess at a renumbering.
-        let Some(number) = u32::try_from(page_number)
+        let Some(number) = u32::try_from(page.number)
             .ok()
             .and_then(std::num::NonZeroU32::new)
         else {
@@ -58,23 +132,13 @@ fn page_regions<'a>(
         // Bail on any disagreement with the text we were handed: a page piece
         // that is not literally at the offset the join implies means the join
         // contract changed, and every span after it would be wrong.
-        if end > text.len() || &text[offset..end] != markdown {
+        if end > text.len() || &text[offset..end] != page.markdown {
             return Vec::new();
         }
         // Skip empty pages: a region must be nonempty, and a gap where a blank
         // page sits is exactly what the region map is allowed to express.
-        if !markdown.is_empty() {
-            regions.push(SourceRegion {
-                span: ByteSpan::new(offset, end),
-                location: SourceLocation::Page {
-                    number,
-                    // Page granularity for now — `liteparse` exposes per-line
-                    // boxes, but they are not offset-mapped into the emitted
-                    // Markdown, so resolving a span to a rectangle needs a
-                    // matching pass this does not attempt.
-                    bounds: None,
-                },
-            });
+        if !page.markdown.is_empty() {
+            regions.extend(tile_page(offset, page, number));
         }
         offset = end + PAGE_SEPARATOR.len();
     }
@@ -83,6 +147,60 @@ fn page_regions<'a>(
     // means we did not account for the whole document.
     if offset != text.len() + PAGE_SEPARATOR.len() && !(text.is_empty() && offset == 0) {
         return Vec::new();
+    }
+    regions
+}
+
+/// Tile one page's span with regions, positioned where its lines were found.
+///
+/// The result covers the page's whole span with no gaps and no overlaps: the
+/// lines the scan placed carry their rectangle, and everything between them is
+/// covered by a region that names only the page.
+fn tile_page(
+    page_start: usize,
+    page: &PagePiece<'_>,
+    number: std::num::NonZeroU32,
+) -> Vec<SourceRegion> {
+    let markdown = page.markdown;
+    let region = |start: usize, end: usize, bounds: Option<PageBounds>| SourceRegion {
+        span: ByteSpan::new(page_start + start, page_start + end),
+        location: SourceLocation::Page { number, bounds },
+    };
+
+    // Locate each line in the emitted Markdown with a forward-only cursor.
+    // Forward-only is what keeps a repeated line ("Total", a page header) from
+    // matching an earlier occurrence that another line already claimed.
+    let mut placed: Vec<(usize, usize, PageBounds)> = Vec::new();
+    let mut cursor = 0usize;
+    for line in &page.lines {
+        let needle = line.text.trim();
+        if needle.is_empty() {
+            continue;
+        }
+        let Some(at) = markdown[cursor..].find(needle) else {
+            continue;
+        };
+        let start = cursor + at;
+        placed.push((start, start + needle.len(), line.bounds));
+        cursor = start + needle.len();
+        if placed.len() == MAX_POSITIONED_REGIONS_PER_PAGE {
+            // Too dense to be worth positioning: fall back to a bare page.
+            return vec![region(0, markdown.len(), None)];
+        }
+    }
+
+    // Fill the gaps so the page's span stays fully covered.
+    let mut regions = Vec::with_capacity(placed.len() * 2 + 1);
+    let mut filled = 0usize;
+    for (start, end, bounds) in placed {
+        if start > filled {
+            regions.push(region(filled, start, None));
+        }
+        regions.push(region(start, end, Some(bounds)));
+        filled = end;
+    }
+    if filled < markdown.len() {
+        regions.push(region(filled, markdown.len(), None));
     }
     regions
 }
@@ -97,13 +215,31 @@ mod tests {
         pages.join(PAGE_SEPARATOR)
     }
 
-    fn numbered<'a>(pages: &'a [&'a str]) -> impl Iterator<Item = (usize, &'a str)> {
-        pages.iter().enumerate().map(|(i, p)| (i + 1, *p))
+    fn bounds(left: u16, top: u16) -> PageBounds {
+        PageBounds {
+            left,
+            top,
+            width: 100,
+            height: 100,
+        }
+    }
+
+    /// Pages with no positioned lines — the page-map-only case.
+    fn bare<'a>(pages: &'a [&'a str]) -> Vec<PagePiece<'a>> {
+        pages
+            .iter()
+            .enumerate()
+            .map(|(i, markdown)| PagePiece {
+                number: i + 1,
+                markdown,
+                lines: Vec::new(),
+            })
+            .collect()
     }
 
     /// `SourceLocation` is `#[non_exhaustive]`, so destructuring it outside its
     /// own crate needs a match even though it has one variant today.
-    fn page_of(region: &SourceRegion) -> (u32, Option<openwave_core::PageBounds>) {
+    fn page_of(region: &SourceRegion) -> (u32, Option<PageBounds>) {
         match region.location {
             SourceLocation::Page { number, bounds } => (number.get(), bounds),
             #[allow(unreachable_patterns)]
@@ -111,11 +247,23 @@ mod tests {
         }
     }
 
+    /// Assert the map covers `text` exactly once: ordered, gapless, in bounds.
+    /// Every case wants this, and a tiling bug is what would break it.
+    fn assert_tiles(text: &str, regions: &[SourceRegion]) {
+        openwave_core::validate_source_regions(text, regions).expect("regions must be valid");
+        let mut covered = 0usize;
+        for region in regions {
+            assert_eq!(region.span.start, covered, "regions must leave no gap");
+            covered = region.span.end;
+        }
+        assert_eq!(covered, text.len(), "regions must cover the whole text");
+    }
+
     #[test]
     fn regions_span_each_page_in_the_joined_text() {
         let pages = ["# One\n\nalpha", "beta gamma", "## Three\n\ndelta"];
         let text = joined(&pages);
-        let regions = page_regions(&text, numbered(&pages));
+        let regions = source_regions(&text, &bare(&pages));
 
         assert_eq!(regions.len(), 3);
         for (index, region) in regions.iter().enumerate() {
@@ -131,7 +279,7 @@ mod tests {
     fn blank_pages_become_gaps_and_keep_later_pages_aligned() {
         let pages = ["alpha", "", "gamma"];
         let text = joined(&pages);
-        let regions = page_regions(&text, numbered(&pages));
+        let regions = source_regions(&text, &bare(&pages));
 
         // The empty page yields no region, but still shifts page three's span.
         assert_eq!(regions.len(), 2);
@@ -144,16 +292,16 @@ mod tests {
         // Stands in for liteparse changing its join contract on a version bump:
         // wrong spans would silently cite the wrong page, so emit nothing.
         let text = joined(&["alpha", "beta"]);
-        assert!(page_regions(&text, numbered(&["alpha", "different"])).is_empty());
-        assert!(page_regions(&text, numbered(&["alpha"])).is_empty());
-        assert!(page_regions(&text, numbered(&["alpha", "beta", "extra"])).is_empty());
+        assert!(source_regions(&text, &bare(&["alpha", "different"])).is_empty());
+        assert!(source_regions(&text, &bare(&["alpha"])).is_empty());
+        assert!(source_regions(&text, &bare(&["alpha", "beta", "extra"])).is_empty());
     }
 
     #[test]
     fn multibyte_pages_produce_char_boundary_spans() {
         let pages = ["café ☕", "naïve"];
         let text = joined(&pages);
-        let regions = page_regions(&text, numbered(&pages));
+        let regions = source_regions(&text, &bare(&pages));
 
         assert_eq!(regions.len(), 2);
         for region in &regions {
@@ -164,17 +312,158 @@ mod tests {
     }
 
     #[test]
-    fn regions_validate_against_the_canonical_text() {
-        let pages = ["alpha", "beta"];
-        let text = joined(&pages);
-        // The pipeline validates parser output before storing it; page maps
-        // must satisfy the same ordering and boundary rules as any other.
-        openwave_core::validate_source_regions(&text, &page_regions(&text, numbered(&pages)))
-            .expect("page regions must be valid source regions");
+    fn an_empty_document_yields_no_regions() {
+        assert!(source_regions("", &[]).is_empty());
     }
 
     #[test]
-    fn an_empty_document_yields_no_regions() {
-        assert!(page_regions("", std::iter::empty()).is_empty());
+    fn located_lines_carry_bounds_and_unmatched_text_still_carries_its_page() {
+        // "middle" is not among the lines: it stands for the emitter's own
+        // output (a rewritten bullet, a rule) that no line will ever match.
+        let markdown = "alpha middle omega";
+        let text = markdown.to_string();
+        let regions = source_regions(
+            &text,
+            &[PagePiece {
+                number: 1,
+                markdown,
+                lines: vec![
+                    PositionedLine {
+                        text: "alpha",
+                        bounds: bounds(0, 0),
+                    },
+                    PositionedLine {
+                        text: "omega",
+                        bounds: bounds(0, 500),
+                    },
+                ],
+            }],
+        );
+
+        assert_tiles(&text, &regions);
+        let sliced: Vec<_> = regions
+            .iter()
+            .map(|r| (&text[r.span.start..r.span.end], page_of(r).1))
+            .collect();
+        assert_eq!(
+            sliced,
+            vec![
+                ("alpha", Some(bounds(0, 0))),
+                (" middle ", None),
+                ("omega", Some(bounds(0, 500))),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_repeated_line_matches_forward_rather_than_reclaiming_an_earlier_one() {
+        // Page headers and "Total" rows repeat. A backward match would give the
+        // second occurrence the first one's rectangle — a highlight in the
+        // wrong place on the page.
+        let markdown = "Total x Total";
+        let text = markdown.to_string();
+        let regions = source_regions(
+            &text,
+            &[PagePiece {
+                number: 1,
+                markdown,
+                lines: vec![
+                    PositionedLine {
+                        text: "Total",
+                        bounds: bounds(0, 0),
+                    },
+                    PositionedLine {
+                        text: "Total",
+                        bounds: bounds(0, 900),
+                    },
+                ],
+            }],
+        );
+
+        assert_tiles(&text, &regions);
+        assert_eq!(regions.len(), 3);
+        assert_eq!(regions[0].span, ByteSpan::new(0, 5));
+        assert_eq!(page_of(&regions[0]).1, Some(bounds(0, 0)));
+        // The second "Total" is the one at the end of the page, not the start.
+        assert_eq!(regions[2].span, ByteSpan::new(8, 13));
+        assert_eq!(page_of(&regions[2]).1, Some(bounds(0, 900)));
+    }
+
+    #[test]
+    fn a_page_too_dense_to_position_keeps_its_page_and_drops_its_geometry() {
+        let words: Vec<String> = (0..MAX_POSITIONED_REGIONS_PER_PAGE + 10)
+            .map(|i| format!("w{i}"))
+            .collect();
+        let markdown = words.join(" ");
+        let text = markdown.clone();
+        let regions = source_regions(
+            &text,
+            &[PagePiece {
+                number: 1,
+                markdown: &markdown,
+                lines: words
+                    .iter()
+                    .map(|w| PositionedLine {
+                        text: w,
+                        bounds: bounds(0, 0),
+                    })
+                    .collect(),
+            }],
+        );
+
+        assert_tiles(&text, &regions);
+        assert_eq!(regions.len(), 1);
+        assert_eq!(page_of(&regions[0]), (1, None));
+    }
+
+    #[test]
+    fn bounds_are_normalized_to_the_page_and_clamped_to_it() {
+        let rect = Rect {
+            x: 61.2,
+            y: 79.2,
+            width: 306.0,
+            height: 79.2,
+        };
+        // A tenth in from the left, a tenth down, half the width, a tenth tall.
+        assert_eq!(
+            normalized_bounds(&rect, 612.0, 792.0),
+            Some(PageBounds {
+                left: 1_000,
+                top: 1_000,
+                width: 5_000,
+                height: 1_000,
+            })
+        );
+
+        // A rectangle overhanging the page is trimmed to it, not rejected: the
+        // text is really there, and a highlight drawn off-page helps nobody.
+        let overhang = Rect {
+            x: 550.0,
+            y: 0.0,
+            width: 200.0,
+            height: 79.2,
+        };
+        let trimmed = normalized_bounds(&overhang, 612.0, 792.0).expect("should trim to the page");
+        assert!(trimmed.is_valid());
+        assert_eq!(trimmed.left + trimmed.width, PAGE_BOUNDS_SCALE);
+    }
+
+    #[test]
+    fn bounds_that_cannot_be_placed_are_dropped_rather_than_guessed() {
+        let rect = Rect {
+            x: 10.0,
+            y: 10.0,
+            width: 100.0,
+            height: 100.0,
+        };
+        // A page with no extent gives nothing to normalize against.
+        assert_eq!(normalized_bounds(&rect, 0.0, 792.0), None);
+        assert_eq!(normalized_bounds(&rect, f32::NAN, 792.0), None);
+        // A line with no area would be an invalid region, not a thin highlight.
+        let flat = Rect {
+            height: 0.0,
+            ..rect
+        };
+        assert_eq!(normalized_bounds(&flat, 612.0, 792.0), None);
     }
 }

--- a/crates/openwave-retrieval/src/liteparse_regions.rs
+++ b/crates/openwave-retrieval/src/liteparse_regions.rs
@@ -21,6 +21,11 @@
 //! reflowed table rows) simply get no rectangle. Every page is tiled either
 //! way, so text a scan could not place still resolves to its page, and only
 //! the finer geometry is lost.
+//!
+//! Regions are per **block** — paragraph, heading, table — with the block's
+//! rectangle taken as the union of the lines located inside it. That is the
+//! unit a reader points at, and it keeps a citation from highlighting one
+//! clipped line out of the middle of a paragraph.
 
 use liteparse::types::Rect;
 use liteparse::ParseResult;
@@ -39,7 +44,8 @@ const PAGE_SEPARATOR: &str = "\n\n-----\n\n";
 /// document of dense tables carries tens of thousands of rectangles, each of
 /// which is read and rewritten on every chunking pass. A page that overruns
 /// this keeps its page-level region and loses its geometry — pages that dense
-/// are ones where a per-line highlight would be noise anyway.
+/// are ones where a highlight would be noise anyway. Blocks rather than lines
+/// keep ordinary pages an order of magnitude below this.
 const MAX_POSITIONED_REGIONS_PER_PAGE: usize = 256;
 
 /// One page's contribution to canonical text, with the lines found on it.
@@ -153,8 +159,14 @@ fn source_regions(text: &str, pages: &[PagePiece<'_>]) -> Vec<SourceRegion> {
 
 /// Tile one page's span with regions, positioned where its lines were found.
 ///
-/// The result covers the page's whole span with no gaps and no overlaps: the
-/// lines the scan placed carry their rectangle, and everything between them is
+/// The unit is the block — a paragraph, a heading, a table — not the individual
+/// line. A block is what a reader points at and what the rest of the product
+/// treats as one element, so a citation landing anywhere inside a paragraph
+/// highlights the paragraph rather than the one line it clipped. Lines are only
+/// the means of locating the block and measuring its extent.
+///
+/// The result covers the page's whole span with no gaps and no overlaps: blocks
+/// whose lines the scan placed carry a rectangle, and everything else is
 /// covered by a region that names only the page.
 fn tile_page(
     page_start: usize,
@@ -170,7 +182,7 @@ fn tile_page(
     // Locate each line in the emitted Markdown with a forward-only cursor.
     // Forward-only is what keeps a repeated line ("Total", a page header) from
     // matching an earlier occurrence that another line already claimed.
-    let mut placed: Vec<(usize, usize, PageBounds)> = Vec::new();
+    let mut placed: Vec<(usize, PageBounds)> = Vec::new();
     let mut cursor = 0usize;
     for line in &page.lines {
         let needle = line.text.trim();
@@ -181,18 +193,40 @@ fn tile_page(
             continue;
         };
         let start = cursor + at;
-        placed.push((start, start + needle.len(), line.bounds));
+        placed.push((start, line.bounds));
         cursor = start + needle.len();
-        if placed.len() == MAX_POSITIONED_REGIONS_PER_PAGE {
-            // Too dense to be worth positioning: fall back to a bare page.
-            return vec![region(0, markdown.len(), None)];
+    }
+
+    // Attribute each located line to the block it landed in, and take the
+    // block's rectangle as the union of theirs. A block whose lines were only
+    // partly placed still gets a rectangle covering what was found.
+    let mut positioned: Vec<(usize, usize, PageBounds)> = Vec::new();
+    let mut lines = placed.into_iter().peekable();
+    for (start, end) in block_spans(markdown) {
+        let mut bounds: Option<PageBounds> = None;
+        // Lines and blocks are both in ascending order, so this walks each once.
+        while lines.peek().is_some_and(|(at, _)| *at < end) {
+            let (at, line_bounds) = lines.next().expect("peeked");
+            if at >= start {
+                bounds = Some(match bounds {
+                    Some(existing) => union(existing, line_bounds),
+                    None => line_bounds,
+                });
+            }
         }
+        if let Some(bounds) = bounds {
+            positioned.push((start, end, bounds));
+        }
+    }
+    if positioned.len() > MAX_POSITIONED_REGIONS_PER_PAGE {
+        // Too dense to be worth positioning: fall back to a bare page.
+        return vec![region(0, markdown.len(), None)];
     }
 
     // Fill the gaps so the page's span stays fully covered.
-    let mut regions = Vec::with_capacity(placed.len() * 2 + 1);
+    let mut regions = Vec::with_capacity(positioned.len() * 2 + 1);
     let mut filled = 0usize;
-    for (start, end, bounds) in placed {
+    for (start, end, bounds) in positioned {
         if start > filled {
             regions.push(region(filled, start, None));
         }
@@ -203,6 +237,52 @@ fn tile_page(
         regions.push(region(filled, markdown.len(), None));
     }
     regions
+}
+
+/// The spans of the blocks in one page's Markdown.
+///
+/// Blocks are separated by a blank line, which is how the emitter delimits
+/// paragraphs, headings, list items and tables. The separators themselves are
+/// left out, so they fall to the page-only fill.
+fn block_spans(markdown: &str) -> Vec<(usize, usize)> {
+    let bytes = markdown.as_bytes();
+    let mut spans = Vec::new();
+    let mut start = 0usize;
+    let mut index = 0usize;
+    // Scanning bytes is UTF-8 safe here: `\n` cannot occur inside a multi-byte
+    // sequence, so every offset found is a character boundary.
+    while index + 1 < bytes.len() {
+        if bytes[index] == b'\n' && bytes[index + 1] == b'\n' {
+            if index > start {
+                spans.push((start, index));
+            }
+            while index < bytes.len() && bytes[index] == b'\n' {
+                index += 1;
+            }
+            start = index;
+        } else {
+            index += 1;
+        }
+    }
+    if start < markdown.len() {
+        spans.push((start, markdown.len()));
+    }
+    spans
+}
+
+/// The smallest rectangle containing both.
+fn union(a: PageBounds, b: PageBounds) -> PageBounds {
+    let left = a.left.min(b.left);
+    let top = a.top.min(b.top);
+    // No overflow: both operands are valid, so each edge is within the page.
+    let right = (a.left + a.width).max(b.left + b.width);
+    let bottom = (a.top + a.height).max(b.top + b.height);
+    PageBounds {
+        left,
+        top,
+        width: right - left,
+        height: bottom - top,
+    }
 }
 
 #[cfg(test)]
@@ -317,10 +397,11 @@ mod tests {
     }
 
     #[test]
-    fn located_lines_carry_bounds_and_unmatched_text_still_carries_its_page() {
-        // "middle" is not among the lines: it stands for the emitter's own
-        // output (a rewritten bullet, a rule) that no line will ever match.
-        let markdown = "alpha middle omega";
+    fn located_blocks_carry_bounds_and_unplaced_blocks_still_carry_their_page() {
+        // Three blocks; only the first and last have a line the scan can place.
+        // The middle one stands for emitter output (a rewritten bullet, a rule)
+        // that no line will ever match.
+        let markdown = "alpha\n\nmiddle\n\nomega";
         let text = markdown.to_string();
         let regions = source_regions(
             &text,
@@ -349,9 +430,67 @@ mod tests {
             sliced,
             vec![
                 ("alpha", Some(bounds(0, 0))),
-                (" middle ", None),
+                ("\n\nmiddle\n\n", None),
                 ("omega", Some(bounds(0, 500))),
             ]
+        );
+    }
+
+    #[test]
+    fn a_block_takes_the_rectangle_covering_every_line_placed_in_it() {
+        // One paragraph over three lines: a citation clipping any of them
+        // should mark the paragraph, not the single line it happened to hit.
+        let markdown = "first line\nsecond line\nthird line";
+        let text = markdown.to_string();
+        let regions = source_regions(
+            &text,
+            &[PagePiece {
+                number: 1,
+                markdown,
+                lines: vec![
+                    PositionedLine {
+                        text: "first line",
+                        bounds: PageBounds {
+                            left: 1_000,
+                            top: 1_000,
+                            width: 500,
+                            height: 100,
+                        },
+                    },
+                    PositionedLine {
+                        text: "second line",
+                        bounds: PageBounds {
+                            left: 1_000,
+                            top: 1_200,
+                            width: 800,
+                            height: 100,
+                        },
+                    },
+                    PositionedLine {
+                        text: "third line",
+                        bounds: PageBounds {
+                            left: 900,
+                            top: 1_400,
+                            width: 400,
+                            height: 100,
+                        },
+                    },
+                ],
+            }],
+        );
+
+        assert_tiles(&text, &regions);
+        assert_eq!(regions.len(), 1);
+        assert_eq!(
+            page_of(&regions[0]).1,
+            // Leftmost edge, topmost edge, out to the widest line's right edge
+            // and down to the last line's bottom.
+            Some(PageBounds {
+                left: 900,
+                top: 1_000,
+                width: 900,
+                height: 500,
+            })
         );
     }
 
@@ -359,8 +498,8 @@ mod tests {
     fn a_repeated_line_matches_forward_rather_than_reclaiming_an_earlier_one() {
         // Page headers and "Total" rows repeat. A backward match would give the
         // second occurrence the first one's rectangle — a highlight in the
-        // wrong place on the page.
-        let markdown = "Total x Total";
+        // wrong place on the page. Separate blocks so each keeps its own.
+        let markdown = "Total\n\nTotal";
         let text = markdown.to_string();
         let regions = source_regions(
             &text,
@@ -385,16 +524,18 @@ mod tests {
         assert_eq!(regions[0].span, ByteSpan::new(0, 5));
         assert_eq!(page_of(&regions[0]).1, Some(bounds(0, 0)));
         // The second "Total" is the one at the end of the page, not the start.
-        assert_eq!(regions[2].span, ByteSpan::new(8, 13));
+        assert_eq!(regions[2].span, ByteSpan::new(7, 12));
         assert_eq!(page_of(&regions[2]).1, Some(bounds(0, 900)));
     }
 
     #[test]
     fn a_page_too_dense_to_position_keeps_its_page_and_drops_its_geometry() {
+        // One block per cell, which is what a dense table page looks like once
+        // the emitter is done with it.
         let words: Vec<String> = (0..MAX_POSITIONED_REGIONS_PER_PAGE + 10)
             .map(|i| format!("w{i}"))
             .collect();
-        let markdown = words.join(" ");
+        let markdown = words.join("\n\n");
         let text = markdown.clone();
         let regions = source_regions(
             &text,

--- a/crates/openwave-retrieval/tests/liteparse_pdf.rs
+++ b/crates/openwave-retrieval/tests/liteparse_pdf.rs
@@ -59,6 +59,49 @@ async fn maps_each_passage_to_the_page_it_appears_on() {
     assert_eq!(page_of("Bravo"), 2);
 }
 
+/// The geometry half: a real parse should place text on the page, not just name
+/// the page. Asserts the rectangle is plausible rather than exact — the precise
+/// numbers are PDFium's text metrics, which are not ours to pin.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn positions_text_within_the_page_it_appears_on() {
+    let parser = LiteParsePdfParser::new();
+    let parsed = parser
+        .parse(TWO_PAGE_PDF, "application/pdf")
+        .await
+        .expect("liteparse should parse a valid two-page PDF");
+
+    let positioned: Vec<_> = parsed
+        .source_regions
+        .iter()
+        .filter_map(|region| match region.location {
+            SourceLocation::Page { number, bounds } => bounds.map(|bounds| (number.get(), bounds)),
+            #[allow(unreachable_patterns)]
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !positioned.is_empty(),
+        "expected at least one positioned region, got: {:?}",
+        parsed.source_regions
+    );
+    for (page, bounds) in &positioned {
+        assert!(*page >= 1 && *page <= 2, "unexpected page {page}");
+        assert!(
+            bounds.is_valid(),
+            "bounds must lie within the page: {bounds:?}"
+        );
+    }
+    // The fixture draws its text near the top of the page (y = 700 of 792), so
+    // a region placed in the bottom half would mean the vertical axis is
+    // flipped — the classic PDF-coordinates bug, and one a viewer would show.
+    let (_, first) = positioned.first().expect("checked non-empty");
+    assert!(
+        first.top < openwave_retrieval::PAGE_BOUNDS_SCALE / 2,
+        "text drawn near the page top should not land in the bottom half: {first:?}"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn surfaces_an_error_for_bytes_that_are_not_a_pdf() {
     let parser = LiteParsePdfParser::new();


### PR DESCRIPTION
#843 made a citation's page real. `SourceLocation::Page` has carried an optional `bounds` since then with nothing to populate it. This fills it in, so a citation can say *where* on the page it points, which is what #812 needs to draw a highlight.

## Recovering the position

liteparse knows where each line sits on the page but does not offset-map its lines into the Markdown it emits — the emitter rewrites bullets, rules and tables — so line spans have to be recovered by scanning each page's Markdown with a forward-only cursor.

Forward-only is the load-bearing part: a repeated line (a page header, a "Total" row) must not claim an earlier occurrence, or the highlight lands in the wrong place on the page.

I measured this against real documents before building on it:

| document | lines placed | out of order |
|---|---|---|
| 20-page contract | 593/608 (97.5%) | 0 |
| 3-page report | 78/90 (86.7%) | 0 |

The misses are systematic rather than random — private-use bullet glyphs the emitter rewrites to `-`, horizontal rules, table rows reflowed into pipe syntax. All are cases where the emitted text genuinely differs from the line, so they fall back instead of being forced into a match.

## Pages still tile

Emitting regions only where the scan matched would have regressed #843: a passage landing in an unmatched gap would lose its page entirely. Each page's span is fully tiled instead — placed lines carry their rectangle, and everything between them is covered by a region naming only the page. So geometry is the only thing a failed match costs.

## Two caps, for two different failures

- **Evidence validity.** A chunk clipping to more than `MAX_SOURCE_REGIONS` (128) regions does not get truncated — `validate_evidence_item` rejects it outright. A 1200-char chunk over a page of short table cells can reach that where the page-granular map produced one region. `Document::source_regions_for` now coalesces by page when a clip would overrun the cap.
- **Stored size.** A page that positions more regions than is useful keeps its page-level region and drops its geometry, so a long document of dense tables does not carry tens of thousands of rectangles that are read and rewritten on every chunking pass.

Both give up geometry and keep the page, which is the right trade in each case.

## Coordinates

Rectangles are normalized to the page box so a viewer can draw them at any zoom without knowing the page dimensions the parser saw. One overhanging the page is trimmed to it rather than dropped — the text really is there. One that cannot be placed at all (no page extent, non-finite coordinates, no area once normalized) is left off rather than guessed at.

## Tests

- Real two-page PDF through PDFium: positioned regions exist, every rectangle lies within its page, and text drawn near the top of the page does not land in the bottom half — the flipped-axis bug, which is exactly the kind a viewer would render and a unit test would miss.
- Tiling: located lines carry bounds while unmatched text still carries its page, and the regions cover the page with no gaps or overlaps.
- A repeated line matches forward rather than reclaiming the earlier occurrence.
- A page too dense to position keeps its page and drops its geometry.
- Clipping stays within the evidence cap and keeps its pages, and keeps geometry when it fits.
- Normalization: a known rectangle maps to known fractions, an overhanging one is trimmed to the page edge, and unplaceable ones are dropped.

Parser fingerprints bumped again so documents reparse with positions.

Closes #865