### PR TITLE
build: prefer a team-identified certificate for macOS dev signing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,46 +34,62 @@ The Rust toolchain is pinned in [`rust-toolchain.toml`](rust-toolchain.toml);
 
 ### macOS keychain prompts
 
-OpenWave keeps secrets in the login keychain, and macOS ties keychain
-approvals to the binary's code signature — so unsigned dev builds would
-re-trigger the access prompt on every rebuild. To prevent that, `cargo run`
-and `cargo test` launch through
+OpenWave keeps secrets in the login keychain, and macOS ties keychain approvals
+to the binary's code signature — so unsigned dev builds would re-trigger the
+access prompt on every rebuild. To prevent that, `cargo run` and `cargo test`
+launch through
 [`scripts/macos-dev-sign-runner.sh`](scripts/macos-dev-sign-runner.sh), which
-signs the binary with your `openwave-dev` or `Apple Development` certificate
-(whichever exists) before running it. If neither exists, OpenWave creates a
-local-only `openwave-dev` identity in a dedicated keychain under
-`~/Library/Application Support/OpenWave/dev-signing`. That keychain unlocks
-with its own generated password, so starting a dev build does not need your
-login-keychain password or a Developer ID distribution key.
+signs the binary before running it.
 
-Every binary is signed with the same fixed identifier, so an item a signed
-build creates stays readable from every other dev binary — including test
-executables, whose hashed file names change between builds. You can set
-`OPENWAVE_DEV_SIGNING_IDENTITY` to pick an identity explicitly, or set it
-empty to opt out.
+**What makes an approval stick is a team identifier.** macOS records the
+approval as a requirement it can re-evaluate — the code-signing identifier plus
+the certificate's team — and any later build that satisfies it is let through.
+A certificate without a team identifier gives it nothing stable to match, so
+the approval is pinned to that one binary's cdhash and the next rebuild prompts
+again. **Always Allow** cannot settle it either, and the partition-list repair
+Apple documents also needs a team identifier.
 
-#### Credentials stored before dev signing
+So the runner signs with the first of these it finds:
 
-Signing fixes items the signed build **created**. Credentials you stored
-earlier belong to that earlier build, and macOS keeps challenging for them —
-one prompt per credential, on every launch. **Always Allow** does not settle
-it: the local `openwave-dev` certificate is self-signed with no team
-identifier, so the approval is pinned to the binary's cdhash and the next
-rebuild invalidates it. (The partition-list repair that Apple documents needs a
-team identifier, so it does not apply either.)
+1. `$OPENWAVE_DEV_SIGNING_IDENTITY`, if set — set it empty to opt out
+2. an **Apple Development** identity
+3. a **Developer ID Application** identity
+4. an `openwave-dev` certificate already in a searchable keychain
+5. a local-only `openwave-dev` identity it creates in a dedicated keychain
+   under `~/Library/Application Support/OpenWave/dev-signing`
 
-Re-home those credentials once instead, which rewrites each one so the item
-belongs to the dev signature:
+Options 2 and 3 carry a team identifier and are the ones that stop the prompts;
+3 means local development signs with a distribution key, which is the price of
+2 not being available. Option 5 needs no Apple account and unlocks with its own
+generated password, so it never asks for your login-keychain password — but
+being self-signed it has no team identifier, so credential prompts will keep
+returning on rebuild. It is a floor, not a fix.
+
+Every binary is signed with the same fixed identifier (`openwave-dev`), so one
+approval covers every dev binary — including test executables, whose hashed
+file names change between builds.
+
+#### Credentials stored under a different identity
+
+An item is bound to whatever signed the binary that **created** it. Credentials
+stored before dev signing existed — or under an identity you have since moved
+away from, including the self-signed fallback — keep prompting. Re-home them
+once, which rewrites each item under the identity in use now:
 
 ```sh
 cargo run -p openwave-cli -- rehome-secrets
 ```
 
-Run it through Cargo, so the signing runner applies. Each stored credential
-asks for access once or twice more while it is read and its old item removed —
-plain **Allow** is enough — and then stops asking, including after later
-rebuilds. `security find-generic-password -s openwave.dev` lists what the dev
-profile has stored.
+Run it through Cargo so the signing runner applies. Each credential asks for
+access once or twice more while it is read and its old item removed — plain
+**Allow** is enough — and then stops, including after later rebuilds, provided
+the identity carries a team identifier. `security find-generic-password -s
+openwave.dev` lists what the dev profile has stored.
+
+The first build after switching identities may also raise a one-time *codesign
+wants to access key* prompt for the new signing key. **Always Allow** does
+settle that one — `codesign` is a stable Apple-signed binary — or set the
+key's partition list to avoid it up front.
 
 ### Desktop UI
 

--- a/scripts/macos-dev-sign-runner.sh
+++ b/scripts/macos-dev-sign-runner.sh
@@ -18,11 +18,27 @@
 # executables, whose hashed file names would otherwise produce a fresh
 # designated requirement (and a fresh prompt) on every rebuild.
 #
+# That only holds for a certificate carrying a team identifier. macOS builds
+# the ACL entry from a requirement it can re-evaluate — identifier plus the
+# leaf's team — and any later build satisfying it is let through. A
+# self-signed certificate has no team identifier, so there is nothing stable
+# to match on and the approval is pinned to the binary's cdhash instead: the
+# next rebuild invalidates it and the prompt returns. A team-identified
+# identity therefore wins over the local-only one, even though using one means
+# development touches a distribution key that it otherwise would not.
+#
 # Identity, in order of preference:
 #   1. $OPENWAVE_DEV_SIGNING_IDENTITY (set to opt out with an empty value)
-#   2. an "openwave-dev" self-signed certificate, if one exists
-#   3. the first "Apple Development" identity in the keychain
-#   4. a local-only "openwave-dev" identity bootstrapped in its own keychain
+#   2. the first "Apple Development" identity — team-identified, and the one
+#      meant for local builds
+#   3. the first "Developer ID Application" identity — also team-identified
+#   4. an "openwave-dev" certificate already in a searchable keychain
+#   5. a local-only "openwave-dev" identity bootstrapped in its own keychain,
+#      which stops the per-rebuild prompt for nothing else on the list
+#
+# Switching between identities re-homes nothing: credentials stored under the
+# previous one keep prompting until `cargo run -p openwave-cli --
+# rehome-secrets` rewrites them.
 
 set -euo pipefail
 
@@ -34,7 +50,10 @@ find_identity() {
   local identities
   identities="$(security find-identity -v -p codesigning 2>/dev/null)" || return 0
   local pattern
-  for pattern in '"\(openwave-dev\)"' '"\(Apple Development: [^"]*\)"'; do
+  for pattern in \
+    '"\(Apple Development: [^"]*\)"' \
+    '"\(Developer ID Application: [^"]*\)"' \
+    '"\(openwave-dev\)"'; do
     local match
     match="$(sed -n "s/.*${pattern}.*/\\1/p" <<<"$identities" | head -n 1)"
     if [[ -n "$match" ]]; then
@@ -42,18 +61,18 @@ find_identity() {
       return 0
     fi
   done
+  return 0
 }
 
 if [[ -n "${OPENWAVE_DEV_SIGNING_IDENTITY+x}" ]]; then
   identity="$OPENWAVE_DEV_SIGNING_IDENTITY"
-elif "$script_dir/setup-macos-dev-signing.sh" --existing-only; then
-  # The bootstrapped certificate is intentionally self-signed and untrusted,
-  # so `security find-identity -p codesigning` does not list it even though
-  # codesign can use it. Check its dedicated keychain first.
-  identity="openwave-dev"
 else
   identity="$(find_identity)"
   if [[ -z "$identity" ]]; then
+    # Nothing team-identified to sign with. The bootstrapped certificate is
+    # self-signed and untrusted, so `security find-identity -p codesigning`
+    # never lists it even though codesign can use it; setting it up (or
+    # confirming it is already there) is what makes it available.
     if "$script_dir/setup-macos-dev-signing.sh"; then
       identity="openwave-dev"
     else

--- a/scripts/macos-dev-signing.test.mjs
+++ b/scripts/macos-dev-signing.test.mjs
@@ -16,24 +16,24 @@ import test from "node:test";
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 const runner = join(scriptsDir, "macos-dev-sign-runner.sh");
 
-test("bootstraps and reuses local signing when only Developer ID exists", async () => {
-  const root = await mkdtemp(join(tmpdir(), "openwave-dev-signing-"));
+/// Stand up a fake `security`/`codesign`/target binary on PATH and run the
+/// runner over it, returning every command it issued. `identities` is what the
+/// fake `security find-identity` prints.
+async function runWithIdentities(root, identities) {
   const binDir = join(root, "bin");
   const log = join(root, "commands.log");
   const probe = join(root, "probe");
   await mkdir(binDir);
 
-  try {
-    const security = join(binDir, "security");
-    await writeFile(
-      security,
-      `#!/usr/bin/env bash
+  const security = join(binDir, "security");
+  await writeFile(
+    security,
+    `#!/usr/bin/env bash
 set -euo pipefail
 printf 'security %s\\n' "$*" >>"$OPENWAVE_TEST_LOG"
 case "$1" in
   find-identity)
-    printf '  1) ABCDEF "Developer ID Application: Example (TEAMID)"\\n'
-    printf '     1 valid identities found\\n'
+    printf '%s' "$OPENWAVE_TEST_IDENTITIES"
     ;;
   create-keychain)
     keychain="\${!#}"
@@ -51,54 +51,110 @@ case "$1" in
     ;;
 esac
 `,
-    );
+  );
 
-    const codesign = join(binDir, "codesign");
-    await writeFile(
-      codesign,
-      `#!/usr/bin/env bash
+  const codesign = join(binDir, "codesign");
+  await writeFile(
+    codesign,
+    `#!/usr/bin/env bash
 set -euo pipefail
 if [[ "$1" == "--display" ]]; then
   exit 1
 fi
 printf 'codesign %s\\n' "$*" >>"$OPENWAVE_TEST_LOG"
 `,
-    );
+  );
 
-    await writeFile(
-      probe,
-      `#!/usr/bin/env bash
+  await writeFile(
+    probe,
+    `#!/usr/bin/env bash
 printf 'exec %s\\n' "$*" >>"$OPENWAVE_TEST_LOG"
 `,
+  );
+  await Promise.all([
+    chmod(security, 0o755),
+    chmod(codesign, 0o755),
+    chmod(probe, 0o755),
+  ]);
+
+  const env = {
+    ...process.env,
+    OPENWAVE_DEV_SIGNING_DIR: join(root, "signing"),
+    OPENWAVE_TEST_LOG: log,
+    OPENWAVE_TEST_IDENTITIES: identities,
+    OPENWAVE_TEST_LOGIN_KEYCHAIN: join(root, "login.keychain-db"),
+    PATH: `${binDir}:${process.env.PATH}`,
+  };
+
+  for (const argument of ["first", "second"]) {
+    const result = spawnSync(runner, [probe, argument], {
+      encoding: "utf8",
+      env,
+    });
+    assert.equal(result.status, 0, result.stderr);
+  }
+
+  return readFile(log, "utf8");
+}
+
+// A team identifier is the whole point: without one, macOS pins the keychain
+// approval to the binary's cdhash and the next rebuild prompts again. So a
+// team-identified certificate has to beat the local-only fallback, even though
+// it means development signs with a distribution key.
+test("prefers a team-identified identity over bootstrapping a local one", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwave-dev-signing-"));
+  try {
+    const commands = await runWithIdentities(
+      root,
+      '  1) ABCDEF "Developer ID Application: Example (TEAMID)"\n     1 valid identities found\n',
     );
-    await Promise.all([
-      chmod(security, 0o755),
-      chmod(codesign, 0o755),
-      chmod(probe, 0o755),
-    ]);
 
-    const env = {
-      ...process.env,
-      OPENWAVE_DEV_SIGNING_DIR: join(root, "signing"),
-      OPENWAVE_TEST_LOG: log,
-      OPENWAVE_TEST_LOGIN_KEYCHAIN: join(root, "login.keychain-db"),
-      PATH: `${binDir}:${process.env.PATH}`,
-    };
+    assert.equal(commands.match(/security create-keychain/g), null);
+    assert.equal(
+      commands.match(
+        /codesign --force --sign Developer ID Application: Example \(TEAMID\)/g,
+      )?.length,
+      2,
+    );
+    assert.match(commands, /codesign .*--identifier openwave-dev/);
+    assert.match(commands, /exec first/);
+    assert.match(commands, /exec second/);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
 
-    for (const argument of ["first", "second"]) {
-      const result = spawnSync(runner, [probe, argument], {
-        encoding: "utf8",
-        env,
-      });
-      assert.equal(result.status, 0, result.stderr);
-    }
+test("prefers Apple Development over Developer ID", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwave-dev-signing-"));
+  try {
+    const commands = await runWithIdentities(
+      root,
+      '  1) ABCDEF "Developer ID Application: Example (TEAMID)"\n' +
+        '  2) 123456 "Apple Development: dev@example.com (OTHERID)"\n' +
+        "     2 valid identities found\n",
+    );
 
-    const commands = await readFile(log, "utf8");
+    assert.match(
+      commands,
+      /codesign --force --sign Apple Development: dev@example\.com \(OTHERID\)/,
+    );
+    assert.equal(commands.match(/Developer ID Application/g), null);
+  } finally {
+    await rm(root, { force: true, recursive: true });
+  }
+});
+
+test("bootstraps local signing when no identity exists", async () => {
+  const root = await mkdtemp(join(tmpdir(), "openwave-dev-signing-"));
+  try {
+    const commands = await runWithIdentities(root, "     0 valid identities found\n");
+
     assert.equal(commands.match(/security create-keychain/g)?.length, 1);
     assert.equal(commands.match(/security import/g)?.length, 1);
-    assert.equal(commands.match(/security find-identity/g)?.length, 1);
-    assert.equal(commands.match(/codesign --force --sign openwave-dev/g)?.length, 2);
-    assert.match(commands, /codesign .*--identifier openwave-dev/);
+    assert.equal(
+      commands.match(/codesign --force --sign openwave-dev/g)?.length,
+      2,
+    );
     assert.match(commands, /exec first/);
     assert.match(commands, /exec second/);
   } finally {

--- a/scripts/setup-macos-dev-signing.sh
+++ b/scripts/setup-macos-dev-signing.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 
-# Create the local-only signing identity used when a macOS contributor does
-# not already have an openwave-dev or Apple Development identity.
+# Create the local-only signing identity used when a macOS contributor has no
+# team-identified code-signing identity at all — see the preference list in
+# macos-dev-sign-runner.sh.
 #
-# The identity lives in a dedicated keychain rather than the login keychain:
-# OpenWave can unlock it without asking for the login password, and routine
-# development never needs access to a Developer ID distribution key. The
-# certificate is self-signed and untrusted, which is sufficient for a stable
-# designated requirement on local binaries. Its private key has no value
-# outside this machine.
+# The identity lives in a dedicated keychain rather than the login keychain, so
+# OpenWave can unlock it without asking for the login password. Its private key
+# has no value outside this machine.
+#
+# Being self-signed, the certificate carries no team identifier, so a keychain
+# ACL granted to a binary it signed is pinned to that binary's cdhash and does
+# not survive a rebuild. It gives local binaries a stable identity for
+# everything else, but it cannot make credential approvals stick — which is why
+# the runner reaches for it last.
 
 set -euo pipefail
 
@@ -16,7 +20,6 @@ state_dir="${OPENWAVE_DEV_SIGNING_DIR:-${HOME}/Library/Application Support/OpenW
 keychain="$state_dir/openwave-dev.keychain-db"
 password_file="$state_dir/keychain-password"
 lock_dir="$state_dir/setup.lock"
-existing_only="${1:-}"
 
 umask 077
 mkdir -p "$state_dir"
@@ -52,10 +55,6 @@ ensure_searchable() {
 if keychain_is_ready; then
   ensure_searchable
   exit 0
-fi
-
-if [[ "$existing_only" == "--existing-only" ]]; then
-  exit 1
 fi
 
 acquired_lock=false


### PR DESCRIPTION
Dev signing exists to stop the keychain access prompt returning on every
rebuild. It does not achieve that, and the reason is structural.

macOS records a keychain approval as a requirement it can re-evaluate: the
code-signing identifier plus the certificate's team identifier. Any later build
satisfying that requirement is let through. The local-only `openwave-dev`
certificate is self-signed and has no team identifier, so there is nothing
stable to record — macOS pins the approval to the creating binary's cdhash
instead, and the next rebuild invalidates it. `rehome-secrets` cannot repair
that, because the item it rewrites is pinned exactly the same way. The prompt I
saw named the credential item (`openwave.dev`, the debug profile's keychain
service) and asked for the login password to authorize the access, which is the
signature of an ACL the requesting binary does not satisfy.

`CONTRIBUTING.md` claimed the opposite — that a shared identifier alone makes an
item readable from every other dev binary across rebuilds. That holds only with
a team identifier, and the doc conceded as much two paragraphs later while
still recommending re-homing as the cure. Corrected here.

The fix is to sign with a certificate that has a team identifier when the
machine has one. Preference order is now:

1. `$OPENWAVE_DEV_SIGNING_IDENTITY`
2. Apple Development
3. Developer ID Application
4. an existing `openwave-dev` certificate
5. the bootstrapped local-only certificate

**This reverses a deliberate decision and reviewers should weigh that.**
`setup-macos-dev-signing.sh` previously stated that routine development never
needs access to a Developer ID distribution key, and the runner short-circuited
to the self-signed certificate before looking at what else was installed — the
old test was named for that behavior. Preferring Apple Development keeps the
original intent where that identity exists; falling through to Developer ID
Application means development signs with a distribution key on machines that
have only that. That is the trade being made, and it is the one that stops the
prompts.

Contributors with no Apple identity are unaffected: they keep the local-only
certificate and keep the prompts with it. It still stops binaries being ad-hoc
signed, which is worth having, but it is a floor rather than a fix, and the
script and the docs now say so rather than implying it solves the problem.

Verified locally: the runner now signs with the team-identified certificate,
and the resulting requirement is `identifier "openwave-dev" and anchor apple
generic and … certificate leaf[subject.OU] = <team>`, which is re-evaluable
across rebuilds and across binaries. Credentials re-homed under it read back
unchanged. What I have not verified is the end of the story — that a rebuilt
desktop app no longer prompts — since that needs a rebuild-and-run cycle rather
than a signature inspection.

The script tests were restructured around a shared harness and now cover three
cases: a team-identified certificate beats bootstrapping, Apple Development
beats Developer ID Application, and bootstrapping still happens when no
identity exists. The `--existing-only` flag went with the short-circuit that
was its only caller.