### PR TITLE
feat(server): crash-safe durable reverse-RPC operation log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6646,6 +6646,7 @@ dependencies = [
  "openwave-mcp",
  "openwave-retrieval",
  "openwave-router",
+ "openwave-sandbox-protocol",
  "openwave-web-search",
  "reqwest 0.12.28",
  "schemars 1.2.2",

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -354,6 +354,45 @@ pub mod context_checkpoint {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod operation_log {
+    use sea_orm::entity::prelude::*;
+
+    /// One durable reverse-RPC operation-log entry, keyed by `(run_id,
+    /// operation_id)`. Bodies are opaque blobs; the protocol tier owns their
+    /// typed meaning. See `openwave-sandbox-protocol::oplog` and issue #858.
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "operation_log")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub run_id: Uuid,
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub operation_id: Uuid,
+        /// `claimed` | `recorded` | `failed`.
+        pub state: String,
+        /// The serialized request the identity was first claimed with; a later
+        /// re-issue with a different fingerprint is a conflict.
+        pub fingerprint: Vec<u8>,
+        /// Whether the claimed operation carries an external effect.
+        pub external_effect: bool,
+        /// The process lifetime that holds the claim, distinguishing a
+        /// concurrent duplicate from an after-crash re-issue.
+        pub owner_epoch: Uuid,
+        /// The recorded terminal body, `NULL` while `claimed` or once #859
+        /// evicts the body down to a commit marker.
+        pub body: Option<Vec<u8>>,
+        /// Whether the terminal body is still retained (#859 clears this when it
+        /// keeps only a commit marker).
+        pub retained: bool,
+        pub created_at: DateTimeUtc,
+        pub updated_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod message_attachment {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -35,7 +35,105 @@ impl MigratorTrait for Migrator {
             Box::new(AddAgentRunModel),
             Box::new(AddToolResultPreviews),
             Box::new(SplitAgentRunExecution),
+            Box::new(AddOperationLog),
         ]
+    }
+}
+
+/// Adds the durable reverse-RPC operation log (issue #858): a crash-safe,
+/// idempotency-keyed record of host-mediated operations a sandbox-resident run
+/// requested back over the reverse channel.
+///
+/// The table is keyed by `(run_id, operation_id)` and holds the operation's
+/// state machine (`claimed -> recorded | failed`), the request `fingerprint`
+/// that fences a re-issue, an `external_effect` flag, the claiming process
+/// lifetime's `owner_epoch` (which separates a concurrent duplicate from an
+/// after-crash re-issue), and the recorded terminal `body`.
+///
+/// The schema is deliberately shaped for the retention follow-up (#859): `body`
+/// is nullable and paired with a `retained` flag, so #859 can evict a full
+/// response body down to a commit marker — clearing `body` and `retained` while
+/// keeping the row's state, `external_effect`, and timestamps — without a
+/// migration rewrite. This is a purely additive migration (a new table, no
+/// change to existing shapes), with a symmetric `down` and identical shape on
+/// SQLite and PostgreSQL.
+struct AddOperationLog;
+
+impl MigrationName for AddOperationLog {
+    fn name(&self) -> &str {
+        "m20260728_000022_add_operation_log"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddOperationLog {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(OperationLog::Table)
+                    .col(ColumnDef::new(OperationLog::RunId).uuid().not_null())
+                    .col(ColumnDef::new(OperationLog::OperationId).uuid().not_null())
+                    .col(
+                        ColumnDef::new(OperationLog::State)
+                            .string_len(16)
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OperationLog::Fingerprint)
+                            .binary()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OperationLog::ExternalEffect)
+                            .boolean()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(OperationLog::OwnerEpoch).uuid().not_null())
+                    .col(ColumnDef::new(OperationLog::Body).binary().null())
+                    .col(
+                        ColumnDef::new(OperationLog::Retained)
+                            .boolean()
+                            .not_null()
+                            .default(true),
+                    )
+                    .col(
+                        ColumnDef::new(OperationLog::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(OperationLog::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .primary_key(
+                        Index::create()
+                            .name("pk_operation_log")
+                            .col(OperationLog::RunId)
+                            .col(OperationLog::OperationId),
+                    )
+                    .check(Expr::col(OperationLog::State).is_in(["claimed", "recorded", "failed"]))
+                    // A claimed entry has not recorded a body yet.
+                    .check(
+                        Expr::col(OperationLog::State)
+                            .ne("claimed")
+                            .or(Expr::col(OperationLog::Body).is_null()),
+                    )
+                    // An unretained entry keeps only a commit marker, never a body.
+                    .check(
+                        Expr::col(OperationLog::Retained)
+                            .or(Expr::col(OperationLog::Body).is_null()),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(OperationLog::Table).to_owned())
+            .await
     }
 }
 
@@ -6643,6 +6741,21 @@ enum OutputRevisionCitation {
     TurnId,
     EvidenceCallId,
     EvidenceRank,
+}
+
+#[derive(DeriveIden)]
+enum OperationLog {
+    Table,
+    RunId,
+    OperationId,
+    State,
+    Fingerprint,
+    ExternalEffect,
+    OwnerEpoch,
+    Body,
+    Retained,
+    CreatedAt,
+    UpdatedAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -57,7 +57,8 @@ use crate::storage::{
     FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
     FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,
     JournaledToolApprovalOutcome, JournaledTurnOutcome, JournaledTurnSteerOutcome,
-    ParkSandboxToolCallOutcome, ParkTurnForAgentRunInboxOutcome, ParkTurnForAgentRunWaitSetOutcome,
+    OperationClaimOutcome, OperationLogEntry, OperationLogWrite, ParkSandboxToolCallOutcome,
+    ParkTurnForAgentRunInboxOutcome, ParkTurnForAgentRunWaitSetOutcome,
     ParkTurnForClientCallOutcome, RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome,
     RequestToolApprovalOutcome, RequestTurnCancellationOutcome, ResolveSandboxToolCallOutcome,
     ResolveToolCallOutcome, ResumeTurnForAgentRunWaitSetOutcome, Store,
@@ -3058,6 +3059,59 @@ impl Store for DbStore {
 
     async fn list_events(&self, chat_id: ChatId, after: i64) -> Result<Vec<SequencedEvent>> {
         ops::conversation::list_events(self, chat_id, after).await
+    }
+
+    async fn claim_operation(
+        &self,
+        run_id: uuid::Uuid,
+        operation_id: uuid::Uuid,
+        fingerprint: &[u8],
+        external_effect: bool,
+        owner_epoch: uuid::Uuid,
+    ) -> Result<OperationClaimOutcome> {
+        ops::operation_log::claim(
+            self,
+            run_id,
+            operation_id,
+            fingerprint,
+            external_effect,
+            owner_epoch,
+        )
+        .await
+    }
+
+    async fn record_operation(
+        &self,
+        run_id: uuid::Uuid,
+        operation_id: uuid::Uuid,
+        body: &[u8],
+    ) -> Result<OperationLogWrite> {
+        ops::operation_log::record(self, run_id, operation_id, body).await
+    }
+
+    async fn fail_operation(
+        &self,
+        run_id: uuid::Uuid,
+        operation_id: uuid::Uuid,
+        body: &[u8],
+    ) -> Result<OperationLogWrite> {
+        ops::operation_log::fail(self, run_id, operation_id, body).await
+    }
+
+    async fn operation_state(
+        &self,
+        run_id: uuid::Uuid,
+        operation_id: uuid::Uuid,
+    ) -> Result<Option<OperationLogEntry>> {
+        ops::operation_log::state(self, run_id, operation_id).await
+    }
+
+    async fn evict_operation(&self, run_id: uuid::Uuid, operation_id: uuid::Uuid) -> Result<()> {
+        ops::operation_log::evict(self, run_id, operation_id).await
+    }
+
+    async fn operation_log_len(&self, run_id: uuid::Uuid) -> Result<usize> {
+        ops::operation_log::len(self, run_id).await
     }
 }
 

--- a/crates/openwave-core/src/db/ops/mod.rs
+++ b/crates/openwave-core/src/db/ops/mod.rs
@@ -15,6 +15,7 @@ pub(in crate::db) mod context_checkpoint;
 pub(in crate::db) mod conversation;
 pub(in crate::db) mod document;
 pub(in crate::db) mod message_attachment;
+pub(in crate::db) mod operation_log;
 pub(in crate::db) mod output;
 pub(in crate::db) mod root_attachment;
 pub(in crate::db) mod sandbox_tool;

--- a/crates/openwave-core/src/db/ops/operation_log.rs
+++ b/crates/openwave-core/src/db/ops/operation_log.rs
@@ -1,0 +1,234 @@
+//! Durable reverse-RPC operation log (issue #858).
+//!
+//! The store persists an idempotency-keyed operation record and enforces the
+//! commit predicate transactionally, mirroring the run tier's fenced result
+//! commit. Bodies are opaque blobs: the protocol tier
+//! (`openwave-sandbox-protocol::oplog`) owns their typed shape and the mapping
+//! onto `ClaimOutcome`, so this tier carries no reverse-RPC wire types.
+//!
+//! The whole correctness rule is `claim`: an unseen identity is inserted
+//! `Claimed`; a terminal one replays its recorded body; a re-issue with a
+//! different fingerprint conflicts; and a `Claimed` entry is either a concurrent
+//! duplicate of *this* process lifetime (same `owner_epoch`) or the after-crash
+//! ambiguity of a *prior* lifetime (a different `owner_epoch`) that must not
+//! re-execute an external effect.
+
+use chrono::Utc;
+use sea_orm::sea_query::Expr;
+use sea_orm::{
+    ColumnTrait, EntityTrait, IntoActiveModel, PaginatorTrait, QueryFilter, Set, TransactionTrait,
+    TryInsertResult,
+};
+
+use crate::error::Result;
+use crate::storage::{
+    OperationClaimOutcome, OperationLogEntry, OperationLogState, OperationLogWrite,
+};
+
+use super::super::entities::operation_log;
+use super::super::{entities, store_err, DbStore};
+
+const STATE_CLAIMED: &str = "claimed";
+const STATE_RECORDED: &str = "recorded";
+const STATE_FAILED: &str = "failed";
+
+fn state_from_str(state: &str) -> OperationLogState {
+    match state {
+        STATE_RECORDED => OperationLogState::Recorded,
+        STATE_FAILED => OperationLogState::Failed,
+        // Any other stored value is a `claimed` entry; the CHECK constraint
+        // bounds the column to the three known states.
+        _ => OperationLogState::Claimed,
+    }
+}
+
+/// Atomically claim `operation_id` under `run_id`, or observe its existing
+/// state. See the module docs for the predicate.
+pub(in crate::db) async fn claim(
+    store: &DbStore,
+    run_id: uuid::Uuid,
+    operation_id: uuid::Uuid,
+    fingerprint: &[u8],
+    external_effect: bool,
+    owner_epoch: uuid::Uuid,
+) -> Result<OperationClaimOutcome> {
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    let now = Utc::now();
+
+    // The insert is the serialization point: on both backends a duplicate
+    // `(run_id, operation_id)` is refused by the primary key, so exactly one
+    // racing claim inserts and the rest observe the existing row.
+    let inserted = entities::operation_log::Entity::insert(operation_log::ActiveModel {
+        run_id: Set(run_id),
+        operation_id: Set(operation_id),
+        state: Set(STATE_CLAIMED.to_owned()),
+        fingerprint: Set(fingerprint.to_vec()),
+        external_effect: Set(external_effect),
+        owner_epoch: Set(owner_epoch),
+        body: Set(None),
+        retained: Set(true),
+        created_at: Set(now),
+        updated_at: Set(now),
+    })
+    .on_conflict_do_nothing()
+    .exec_without_returning(&transaction)
+    .await
+    .map_err(store_err)?;
+
+    // A do-nothing conflict reports zero rows affected; only a real insert of
+    // one row is a fresh claim.
+    if matches!(inserted, TryInsertResult::Inserted(1)) {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(OperationClaimOutcome::Fresh);
+    }
+
+    let Some(existing) = entities::operation_log::Entity::find_by_id((run_id, operation_id))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    else {
+        // The row was evicted between the refused insert and this read. An
+        // evicted identity can never be re-issued, so refuse rather than
+        // silently re-claiming it.
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(OperationClaimOutcome::Conflict);
+    };
+
+    if existing.fingerprint != fingerprint {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(OperationClaimOutcome::Conflict);
+    }
+
+    let outcome = match state_from_str(&existing.state) {
+        OperationLogState::Recorded => {
+            OperationClaimOutcome::Recorded(existing.body.unwrap_or_default())
+        }
+        OperationLogState::Failed => {
+            OperationClaimOutcome::Failed(existing.body.unwrap_or_default())
+        }
+        OperationLogState::Claimed => {
+            if existing.owner_epoch == owner_epoch {
+                OperationClaimOutcome::OwnedClaim
+            } else if existing.external_effect {
+                OperationClaimOutcome::ForeignClaim
+            } else {
+                // A foreign, no-external-effect claim is safe to re-drive: take
+                // over the claim for this lifetime and report it fresh.
+                let mut active = existing.into_active_model();
+                active.owner_epoch = Set(owner_epoch);
+                active.updated_at = Set(now);
+                sea_orm::ActiveModelTrait::update(active, &transaction)
+                    .await
+                    .map_err(store_err)?;
+                OperationClaimOutcome::Fresh
+            }
+        }
+    };
+    transaction.commit().await.map_err(store_err)?;
+    Ok(outcome)
+}
+
+/// Settle a `Claimed` entry to `Recorded`. Idempotent for an already-`Recorded`
+/// entry (first write wins).
+pub(in crate::db) async fn record(
+    store: &DbStore,
+    run_id: uuid::Uuid,
+    operation_id: uuid::Uuid,
+    body: &[u8],
+) -> Result<OperationLogWrite> {
+    settle(store, run_id, operation_id, STATE_RECORDED, body).await
+}
+
+/// Settle a `Claimed` entry to `Failed`. Idempotent for an already-`Failed`
+/// entry.
+pub(in crate::db) async fn fail(
+    store: &DbStore,
+    run_id: uuid::Uuid,
+    operation_id: uuid::Uuid,
+    body: &[u8],
+) -> Result<OperationLogWrite> {
+    settle(store, run_id, operation_id, STATE_FAILED, body).await
+}
+
+async fn settle(
+    store: &DbStore,
+    run_id: uuid::Uuid,
+    operation_id: uuid::Uuid,
+    terminal: &str,
+    body: &[u8],
+) -> Result<OperationLogWrite> {
+    let now = Utc::now();
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+
+    // The `state = claimed` guard makes the transition atomic and first-writer-
+    // wins: only the write that finds the entry still claimed settles it, so a
+    // racing or re-delivered terminal write never overwrites the first body.
+    let updated = entities::operation_log::Entity::update_many()
+        .col_expr(operation_log::Column::State, Expr::value(terminal))
+        .col_expr(operation_log::Column::Body, Expr::value(body.to_vec()))
+        .col_expr(operation_log::Column::Retained, Expr::value(true))
+        .col_expr(operation_log::Column::UpdatedAt, Expr::value(now))
+        .filter(operation_log::Column::RunId.eq(run_id))
+        .filter(operation_log::Column::OperationId.eq(operation_id))
+        .filter(operation_log::Column::State.eq(STATE_CLAIMED))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+
+    if updated.rows_affected == 1 {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(OperationLogWrite::Committed);
+    }
+
+    let existing = entities::operation_log::Entity::find_by_id((run_id, operation_id))
+        .one(&transaction)
+        .await
+        .map_err(store_err)?;
+    transaction.rollback().await.map_err(store_err)?;
+    Ok(match existing {
+        Some(entry) if entry.state == terminal => OperationLogWrite::AlreadyTerminal,
+        _ => OperationLogWrite::NotClaimed,
+    })
+}
+
+/// Read one entry's current state, if the log knows it.
+pub(in crate::db) async fn state(
+    store: &DbStore,
+    run_id: uuid::Uuid,
+    operation_id: uuid::Uuid,
+) -> Result<Option<OperationLogEntry>> {
+    let entry = entities::operation_log::Entity::find_by_id((run_id, operation_id))
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .map(|row| OperationLogEntry {
+            state: state_from_str(&row.state),
+            body: row.body,
+            external_effect: row.external_effect,
+            retained: row.retained,
+        });
+    Ok(entry)
+}
+
+/// Drop one entry. #859 owns the eviction policy; this removes the row.
+pub(in crate::db) async fn evict(
+    store: &DbStore,
+    run_id: uuid::Uuid,
+    operation_id: uuid::Uuid,
+) -> Result<()> {
+    entities::operation_log::Entity::delete_by_id((run_id, operation_id))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(())
+}
+
+/// How many entries a run currently retains.
+pub(in crate::db) async fn len(store: &DbStore, run_id: uuid::Uuid) -> Result<usize> {
+    let count = entities::operation_log::Entity::find()
+        .filter(operation_log::Column::RunId.eq(run_id))
+        .count(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(count as usize)
+}

--- a/crates/openwave-core/src/db/ops/operation_log.rs
+++ b/crates/openwave-core/src/db/ops/operation_log.rs
@@ -82,14 +82,18 @@ pub(in crate::db) async fn claim(
         return Ok(OperationClaimOutcome::Fresh);
     }
 
+    // Re-reading the row the insert collided with assumes READ COMMITTED: the
+    // concurrently-committed row must be visible to this transaction. That holds
+    // on SQLite (writers serialize) and on Postgres at its default READ
+    // COMMITTED. Under REPEATABLE READ / SERIALIZABLE this read could miss the
+    // row and fall through to a spurious `Conflict` below — which still fails
+    // closed (never a second execution), but is wrong; do not raise the
+    // isolation level without revisiting this.
     let Some(existing) = entities::operation_log::Entity::find_by_id((run_id, operation_id))
         .one(&transaction)
         .await
         .map_err(store_err)?
     else {
-        // The row was evicted between the refused insert and this read. An
-        // evicted identity can never be re-issued, so refuse rather than
-        // silently re-claiming it.
         transaction.rollback().await.map_err(store_err)?;
         return Ok(OperationClaimOutcome::Conflict);
     };
@@ -99,13 +103,21 @@ pub(in crate::db) async fn claim(
         return Ok(OperationClaimOutcome::Conflict);
     }
 
+    // A terminal row carries its body only while retained; once retention (#859)
+    // evicts the body to a commit marker (`body IS NULL`), the outcome is still
+    // known — it ran once — so it must replay as evicted, never as an empty body
+    // (which would decode-fail and be mistaken for ambiguity) and never as a
+    // re-executable fresh claim. Keying off body presence matches the schema's
+    // `CHECK (retained OR body IS NULL)`.
     let outcome = match state_from_str(&existing.state) {
-        OperationLogState::Recorded => {
-            OperationClaimOutcome::Recorded(existing.body.unwrap_or_default())
-        }
-        OperationLogState::Failed => {
-            OperationClaimOutcome::Failed(existing.body.unwrap_or_default())
-        }
+        OperationLogState::Recorded => match existing.body {
+            Some(body) => OperationClaimOutcome::Recorded(body),
+            None => OperationClaimOutcome::TerminalEvicted,
+        },
+        OperationLogState::Failed => match existing.body {
+            Some(body) => OperationClaimOutcome::Failed(body),
+            None => OperationClaimOutcome::TerminalEvicted,
+        },
         OperationLogState::Claimed => {
             if existing.owner_epoch == owner_epoch {
                 OperationClaimOutcome::OwnedClaim
@@ -114,6 +126,12 @@ pub(in crate::db) async fn claim(
             } else {
                 // A foreign, no-external-effect claim is safe to re-drive: take
                 // over the claim for this lifetime and report it fresh.
+                //
+                // Unreachable today — every capability is external-effect — so
+                // there is no second concurrent lifetime to race here. When
+                // read-only capabilities arrive this take-over should become a
+                // CAS on the old `owner_epoch` (update ... WHERE owner_epoch =
+                // observed) so two lifetimes cannot both adopt the same claim.
                 let mut active = existing.into_active_model();
                 active.owner_epoch = Set(owner_epoch);
                 active.updated_at = Set(now);
@@ -210,13 +228,34 @@ pub(in crate::db) async fn state(
     Ok(entry)
 }
 
-/// Drop one entry. #859 owns the eviction policy; this removes the row.
+/// Evict a terminal entry's body down to a commit marker: keep the row and its
+/// state, but drop the recorded body and clear `retained`. A later re-issue then
+/// replays as [`OperationClaimOutcome::TerminalEvicted`] — "done, do not
+/// re-execute" — rather than re-running the effect.
+///
+/// This deliberately does *not* delete the row: a bare delete is the unsafe
+/// variant, because a re-issue of a deleted identity finds nothing, claims
+/// fresh, and re-executes an effect that already ran. Keeping the marker is what
+/// the schema (`body` nullable, `retained` flag) is shaped for. #859 owns the
+/// retention *policy* — when an entry may be evicted (an acknowledgement/cursor
+/// once the sandbox can no longer re-issue it), and whether very old markers are
+/// ever hard-deleted — layered over this safe primitive. A `Claimed` (still
+/// in-flight) entry is left untouched.
 pub(in crate::db) async fn evict(
     store: &DbStore,
     run_id: uuid::Uuid,
     operation_id: uuid::Uuid,
 ) -> Result<()> {
-    entities::operation_log::Entity::delete_by_id((run_id, operation_id))
+    entities::operation_log::Entity::update_many()
+        .col_expr(
+            operation_log::Column::Body,
+            Expr::value(Option::<Vec<u8>>::None),
+        )
+        .col_expr(operation_log::Column::Retained, Expr::value(false))
+        .col_expr(operation_log::Column::UpdatedAt, Expr::value(Utc::now()))
+        .filter(operation_log::Column::RunId.eq(run_id))
+        .filter(operation_log::Column::OperationId.eq(operation_id))
+        .filter(operation_log::Column::State.ne(STATE_CLAIMED))
         .exec(&store.conn)
         .await
         .map_err(store_err)?;

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -15,6 +15,7 @@ mod context_checkpoint;
 mod delegated_file_read;
 mod message_attachment;
 mod multi_agent_wait;
+mod operation_log;
 mod output;
 mod parent_terminal_guard;
 mod root_attachment;

--- a/crates/openwave-core/src/db/tests/operation_log.rs
+++ b/crates/openwave-core/src/db/tests/operation_log.rs
@@ -202,7 +202,7 @@ async fn external_effect_flag_gates_a_foreign_claim() {
 }
 
 #[tokio::test]
-async fn eviction_removes_the_entry() {
+async fn eviction_leaves_a_marker_that_never_re_executes() {
     let (_dir, store) = temp_store().await;
     let run = Uuid::new_v4();
     let op = Uuid::new_v4();
@@ -212,9 +212,25 @@ async fn eviction_removes_the_entry() {
         .unwrap();
     store.record_operation(run, op, b"body").await.unwrap();
 
+    // Eviction keeps the row as a commit marker: state stays terminal, but the
+    // body is gone and `retained` is cleared. The row survives — a bare delete
+    // would let a re-issue re-execute.
     store.evict_operation(run, op).await.unwrap();
-    assert!(store.operation_state(run, op).await.unwrap().is_none());
-    assert_eq!(store.operation_log_len(run).await.unwrap(), 0);
+    let entry = store.operation_state(run, op).await.unwrap().unwrap();
+    assert_eq!(entry.state, OperationLogState::Recorded);
+    assert!(!entry.retained);
+    assert!(entry.body.is_none());
+    assert_eq!(store.operation_log_len(run).await.unwrap(), 1);
+
+    // A re-issue of an evicted op is answered "done, do not re-execute" — never
+    // a fresh claim, and never a decode-of-empty that would look ambiguous.
+    assert_eq!(
+        store
+            .claim_operation(run, op, b"fp", true, Uuid::new_v4())
+            .await
+            .unwrap(),
+        OperationClaimOutcome::TerminalEvicted
+    );
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/db/tests/operation_log.rs
+++ b/crates/openwave-core/src/db/tests/operation_log.rs
@@ -1,0 +1,245 @@
+//! Storage-tier tests for the durable reverse-RPC operation log (#858).
+//!
+//! These exercise the transactional predicate directly, in the raw
+//! `(fingerprint, body)` bytes the store persists — the concurrency race and the
+//! `external_effect` gate are localized here, closest to the transaction. The
+//! typed `ClaimOutcome` mapping and the crash-recovery lifecycle live in the
+//! `openwave-server` durable store, over these same ops.
+
+use std::sync::Arc;
+
+use sea_orm_migration::MigratorTrait;
+use uuid::Uuid;
+
+use super::temp_store;
+use crate::db::migration::Migrator;
+use crate::storage::{OperationClaimOutcome, OperationLogState, OperationLogWrite, Store};
+
+#[tokio::test]
+async fn fresh_claim_records_and_replays_the_body() {
+    let (_dir, store) = temp_store().await;
+    let run = Uuid::new_v4();
+    let op = Uuid::new_v4();
+    let epoch = Uuid::new_v4();
+
+    assert_eq!(
+        store
+            .claim_operation(run, op, b"fingerprint", true, epoch)
+            .await
+            .unwrap(),
+        OperationClaimOutcome::Fresh
+    );
+    assert_eq!(store.operation_log_len(run).await.unwrap(), 1);
+
+    assert_eq!(
+        store
+            .record_operation(run, op, b"the-answer")
+            .await
+            .unwrap(),
+        OperationLogWrite::Committed
+    );
+
+    // A re-issue with the same fingerprint replays the recorded body, whatever
+    // epoch asks — a fresh process lifetime included.
+    let later_epoch = Uuid::new_v4();
+    assert_eq!(
+        store
+            .claim_operation(run, op, b"fingerprint", true, later_epoch)
+            .await
+            .unwrap(),
+        OperationClaimOutcome::Recorded(b"the-answer".to_vec())
+    );
+
+    let entry = store.operation_state(run, op).await.unwrap().unwrap();
+    assert_eq!(entry.state, OperationLogState::Recorded);
+    assert!(entry.retained);
+    assert_eq!(entry.body.as_deref(), Some(&b"the-answer"[..]));
+}
+
+#[tokio::test]
+async fn a_different_fingerprint_conflicts() {
+    let (_dir, store) = temp_store().await;
+    let run = Uuid::new_v4();
+    let op = Uuid::new_v4();
+    let epoch = Uuid::new_v4();
+
+    store
+        .claim_operation(run, op, b"first", true, epoch)
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .claim_operation(run, op, b"second", true, epoch)
+            .await
+            .unwrap(),
+        OperationClaimOutcome::Conflict
+    );
+}
+
+#[tokio::test]
+async fn terminal_writes_are_fenced_and_idempotent() {
+    let (_dir, store) = temp_store().await;
+    let run = Uuid::new_v4();
+    let op = Uuid::new_v4();
+    let epoch = Uuid::new_v4();
+
+    // A terminal write with no claim settles nothing.
+    assert_eq!(
+        store.record_operation(run, op, b"x").await.unwrap(),
+        OperationLogWrite::NotClaimed
+    );
+
+    store
+        .claim_operation(run, op, b"fp", true, epoch)
+        .await
+        .unwrap();
+    assert_eq!(
+        store.record_operation(run, op, b"first").await.unwrap(),
+        OperationLogWrite::Committed
+    );
+    // A re-delivered record is acknowledged, and never overwrites the first body.
+    assert_eq!(
+        store.record_operation(run, op, b"second").await.unwrap(),
+        OperationLogWrite::AlreadyTerminal
+    );
+    assert_eq!(
+        store
+            .operation_state(run, op)
+            .await
+            .unwrap()
+            .unwrap()
+            .body
+            .as_deref(),
+        Some(&b"first"[..])
+    );
+    // Failing an already-recorded entry is refused: no terminal flip-flop.
+    assert_eq!(
+        store.fail_operation(run, op, b"err").await.unwrap(),
+        OperationLogWrite::NotClaimed
+    );
+}
+
+#[tokio::test]
+async fn concurrent_claims_yield_exactly_one_fresh() {
+    let (_dir, store) = temp_store().await;
+    let store = Arc::new(store);
+    let run = Uuid::new_v4();
+    let op = Uuid::new_v4();
+    let epoch = Uuid::new_v4();
+
+    // Many duplicates of one identity race, all from the same process lifetime.
+    let mut handles = Vec::new();
+    for _ in 0..16 {
+        let store = Arc::clone(&store);
+        handles.push(tokio::spawn(async move {
+            store
+                .claim_operation(run, op, b"fp", true, epoch)
+                .await
+                .unwrap()
+        }));
+    }
+
+    let mut fresh = 0;
+    let mut owned = 0;
+    for handle in handles {
+        match handle.await.unwrap() {
+            OperationClaimOutcome::Fresh => fresh += 1,
+            OperationClaimOutcome::OwnedClaim => owned += 1,
+            other => panic!("unexpected concurrent claim outcome: {other:?}"),
+        }
+    }
+    // Exactly one claim executes; the rest attach. A double external effect is
+    // impossible because only one claim was ever `Fresh`.
+    assert_eq!(fresh, 1, "exactly one claim may be fresh");
+    assert_eq!(owned, 15);
+    assert_eq!(store.operation_log_len(run).await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn external_effect_flag_gates_a_foreign_claim() {
+    let (_dir, store) = temp_store().await;
+    let run = Uuid::new_v4();
+    let first_epoch = Uuid::new_v4();
+    let crashed_epoch = Uuid::new_v4();
+
+    // An external-effect claim left dangling by a prior lifetime is ambiguous:
+    // a new lifetime must not re-execute it.
+    let external_op = Uuid::new_v4();
+    store
+        .claim_operation(run, external_op, b"fp", true, first_epoch)
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .claim_operation(run, external_op, b"fp", true, crashed_epoch)
+            .await
+            .unwrap(),
+        OperationClaimOutcome::ForeignClaim
+    );
+
+    // A no-external-effect claim, by contrast, is safe to re-drive: ownership is
+    // taken over and the claim reported fresh.
+    let pure_op = Uuid::new_v4();
+    store
+        .claim_operation(run, pure_op, b"fp", false, first_epoch)
+        .await
+        .unwrap();
+    assert_eq!(
+        store
+            .claim_operation(run, pure_op, b"fp", false, crashed_epoch)
+            .await
+            .unwrap(),
+        OperationClaimOutcome::Fresh
+    );
+    // Now owned by the new lifetime: a same-epoch re-issue attaches.
+    assert_eq!(
+        store
+            .claim_operation(run, pure_op, b"fp", false, crashed_epoch)
+            .await
+            .unwrap(),
+        OperationClaimOutcome::OwnedClaim
+    );
+}
+
+#[tokio::test]
+async fn eviction_removes_the_entry() {
+    let (_dir, store) = temp_store().await;
+    let run = Uuid::new_v4();
+    let op = Uuid::new_v4();
+    store
+        .claim_operation(run, op, b"fp", true, Uuid::new_v4())
+        .await
+        .unwrap();
+    store.record_operation(run, op, b"body").await.unwrap();
+
+    store.evict_operation(run, op).await.unwrap();
+    assert!(store.operation_state(run, op).await.unwrap().is_none());
+    assert_eq!(store.operation_log_len(run).await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn the_operation_log_migration_is_reversible() {
+    let (_dir, store) = temp_store().await;
+    let run = Uuid::new_v4();
+    let op = Uuid::new_v4();
+
+    // The additive migration created the table.
+    store
+        .claim_operation(run, op, b"fp", true, Uuid::new_v4())
+        .await
+        .unwrap();
+
+    // Rolling back the last migration drops it symmetrically...
+    Migrator::down(&store.conn, Some(1)).await.unwrap();
+    assert!(
+        store
+            .claim_operation(run, Uuid::new_v4(), b"fp", true, Uuid::new_v4())
+            .await
+            .is_err(),
+        "the table must be gone after down"
+    );
+
+    // ...and re-applying it restores a working, empty table.
+    Migrator::up(&store.conn, None).await.unwrap();
+    assert_eq!(store.operation_log_len(run).await.unwrap(), 0);
+}

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -172,6 +172,7 @@ pub use storage::{
     FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
     FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, JournaledClientToolCallOutcome,
     JournaledToolApprovalOutcome, JournaledTurnOutcome, JournaledTurnSteerOutcome,
+    OperationClaimOutcome, OperationLogEntry, OperationLogState, OperationLogWrite,
     ParkSandboxToolCallOutcome, ParkTurnForAgentRunInboxOutcome, ParkTurnForAgentRunWaitSetOutcome,
     ParkTurnForClientCallOutcome, PendingChatPrompt, RecordTurnFailureOutcome,
     RequestAgentRunCancellationOutcome, RequestToolApprovalOutcome, RequestTurnCancellationOutcome,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1014,6 +1014,13 @@ pub enum OperationClaimOutcome {
     Recorded(Vec<u8>),
     /// The identity already failed terminally; the opaque error body to replay.
     Failed(Vec<u8>),
+    /// The identity is terminal (recorded or failed) but its body has been
+    /// evicted to a commit marker (#859) and is gone. It ran exactly once and
+    /// must not be re-executed; there is no body to replay. This is distinct
+    /// from a backend failure — the row is intact, only its body is absent — so
+    /// the caller answers "already done, do not re-execute", never the
+    /// after-crash ambiguity.
+    TerminalEvicted,
     /// The identity is `Claimed` by the caller's *own* epoch — a concurrent
     /// duplicate this process lifetime, which attaches to the live execution
     /// rather than re-executing.

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -978,6 +978,85 @@ fn root_attachment_storage_unavailable<T>() -> Result<T> {
     ))
 }
 
+fn operation_log_storage_unavailable<T>() -> Result<T> {
+    Err(AgentError::Store(
+        "durable operation-log storage is not implemented by this Store".into(),
+    ))
+}
+
+/// Where one entry of the durable reverse-RPC operation log stands.
+///
+/// This is the storage-tier projection of the protocol's operation state
+/// machine (`openwave-sandbox-protocol::oplog`): a `Claimed` entry has been
+/// dispatched but has no terminal outcome yet; `Recorded`/`Failed` are terminal.
+/// The recorded body itself is an opaque blob to the store — the protocol tier
+/// owns its typed shape — so this tier stays free of reverse-RPC wire types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperationLogState {
+    /// Dispatched, no terminal outcome recorded.
+    Claimed,
+    /// Terminal success; a response body is retained (unless evicted per #859).
+    Recorded,
+    /// Terminal failure; an error body is retained (unless evicted per #859).
+    Failed,
+}
+
+/// The outcome of atomically claiming an operation identity against the durable
+/// log. This is the storage half of the reverse-RPC commit predicate; the
+/// protocol tier maps it onto `ClaimOutcome`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OperationClaimOutcome {
+    /// The identity was unseen and is now `Claimed`, owned by the caller's
+    /// epoch. The caller must execute the effect exactly once.
+    Fresh,
+    /// The identity is already terminally recorded; the opaque response body to
+    /// replay without re-executing.
+    Recorded(Vec<u8>),
+    /// The identity already failed terminally; the opaque error body to replay.
+    Failed(Vec<u8>),
+    /// The identity is `Claimed` by the caller's *own* epoch — a concurrent
+    /// duplicate this process lifetime, which attaches to the live execution
+    /// rather than re-executing.
+    OwnedClaim,
+    /// The identity is `Claimed` by a *different* epoch that never recorded — the
+    /// after-crash ambiguity for an external-effect operation. The caller must
+    /// fail conservatively rather than re-execute a possibly-spent call.
+    ForeignClaim,
+    /// The identity was reused for a structurally different request fingerprint.
+    Conflict,
+}
+
+/// The outcome of a terminal write (`record`/`fail`) against the durable log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OperationLogWrite {
+    /// The `Claimed` entry transitioned to the requested terminal state.
+    Committed,
+    /// The entry was already in the requested terminal state; an idempotent
+    /// no-op, so a re-delivered terminal write is acknowledged, not rejected.
+    AlreadyTerminal,
+    /// No `Claimed` entry to settle — unknown, or already in the *other*
+    /// terminal state.
+    NotClaimed,
+}
+
+/// A read-back of one durable operation-log entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OperationLogEntry {
+    /// The entry's state.
+    pub state: OperationLogState,
+    /// The recorded terminal body (response for `Recorded`, error for
+    /// `Failed`), present only while the entry is terminal *and* its body is
+    /// still retained. `None` while `Claimed`, or once #859 evicts the body and
+    /// leaves a commit marker.
+    pub body: Option<Vec<u8>>,
+    /// Whether the operation carried an external effect when claimed. Retention
+    /// (#859) and audit read this without re-deriving it from the request.
+    pub external_effect: bool,
+    /// Whether the terminal body is still retained. #859 flips this to `false`
+    /// when it replaces a full body with a commit marker.
+    pub retained: bool,
+}
+
 /// Durable metadata and conversation state.
 ///
 /// Implementations must be safe to share across threads (`Send + Sync`) and are
@@ -2949,6 +3028,82 @@ pub trait Store: Send + Sync {
     /// List a chat's journaled events with `seq` greater than `after`, in
     /// sequence order. Pass `0` to replay from the start.
     async fn list_events(&self, chat_id: ChatId, after: i64) -> Result<Vec<SequencedEvent>>;
+
+    // --- Durable reverse-RPC operation log (issue #858) ---
+    //
+    // These back the crash-safe `OperationStore` seam of
+    // `openwave-sandbox-protocol`. The store persists an opaque
+    // `(fingerprint, body)` pair keyed by `(run_id, operation_id)` and enforces
+    // the commit predicate transactionally; the protocol tier owns the typed
+    // meaning of those bytes and the mapping to `ClaimOutcome`. Retention and
+    // body eviction are #859; `evict_operation` is that seam.
+
+    /// Atomically claim `operation_id` under `run_id` for `fingerprint`, or
+    /// observe its existing state, in a single transaction.
+    ///
+    /// `owner_epoch` identifies the claiming process lifetime: a `Claimed` entry
+    /// found under a *different* epoch is the after-crash ambiguity
+    /// ([`OperationClaimOutcome::ForeignClaim`]) for an `external_effect`
+    /// operation; under the *same* epoch it is a concurrent duplicate
+    /// ([`OperationClaimOutcome::OwnedClaim`]). A foreign `Claimed` with no
+    /// external effect is safe to re-drive, so ownership is taken over and the
+    /// claim reported [`OperationClaimOutcome::Fresh`].
+    async fn claim_operation(
+        &self,
+        _run_id: uuid::Uuid,
+        _operation_id: uuid::Uuid,
+        _fingerprint: &[u8],
+        _external_effect: bool,
+        _owner_epoch: uuid::Uuid,
+    ) -> Result<OperationClaimOutcome> {
+        operation_log_storage_unavailable()
+    }
+
+    /// Settle a `Claimed` entry to `Recorded` with `body`, transactionally.
+    /// Idempotent: a re-delivered record for an already-`Recorded` entry is
+    /// acknowledged ([`OperationLogWrite::AlreadyTerminal`]) without overwriting
+    /// the first-committed body.
+    async fn record_operation(
+        &self,
+        _run_id: uuid::Uuid,
+        _operation_id: uuid::Uuid,
+        _body: &[u8],
+    ) -> Result<OperationLogWrite> {
+        operation_log_storage_unavailable()
+    }
+
+    /// Settle a `Claimed` entry to `Failed` with `body`, transactionally.
+    /// Idempotent for an already-`Failed` entry.
+    async fn fail_operation(
+        &self,
+        _run_id: uuid::Uuid,
+        _operation_id: uuid::Uuid,
+        _body: &[u8],
+    ) -> Result<OperationLogWrite> {
+        operation_log_storage_unavailable()
+    }
+
+    /// The current state of an operation-log entry, if the log knows it.
+    async fn operation_state(
+        &self,
+        _run_id: uuid::Uuid,
+        _operation_id: uuid::Uuid,
+    ) -> Result<Option<OperationLogEntry>> {
+        operation_log_storage_unavailable()
+    }
+
+    /// Drop an entry once the sandbox can no longer re-issue it. This slice
+    /// removes the row; #859 owns *when* eviction is safe and may instead null
+    /// the body and clear `retained` to leave a commit marker.
+    async fn evict_operation(&self, _run_id: uuid::Uuid, _operation_id: uuid::Uuid) -> Result<()> {
+        operation_log_storage_unavailable()
+    }
+
+    /// How many operation-log entries a run currently retains. For tests and,
+    /// later, retention accounting.
+    async fn operation_log_len(&self, _run_id: uuid::Uuid) -> Result<usize> {
+        operation_log_storage_unavailable()
+    }
 }
 
 /// Credential custody: secrets keyed by a stable reference string (e.g.

--- a/crates/openwave-sandbox-protocol/src/host.rs
+++ b/crates/openwave-sandbox-protocol/src/host.rs
@@ -148,6 +148,16 @@ impl CapabilityHost {
                 // it after a crash and must fail closed, which is what we do.
                 None => ReverseWaiter::settled(ambiguous()),
             },
+            // The operation ran once and completed; retention evicted its body.
+            // It is done, so it is never re-executed — but the outcome is known,
+            // so this is a distinct refusal, not the after-crash ambiguity.
+            ClaimOutcome::Replay(OperationState::Evicted) => {
+                ReverseWaiter::settled(Response::Error(ErrorResponse::new(
+                    ErrorCode::OperationEvicted,
+                    "operation already completed; its recorded result was evicted",
+                    false,
+                )))
+            }
             // The durable store's after-crash refusal: never re-execute a call
             // whose external effect cannot be proven unexecuted.
             ClaimOutcome::ClaimedElsewhere => ReverseWaiter::settled(ambiguous()),

--- a/crates/openwave-sandbox-protocol/src/oplog.rs
+++ b/crates/openwave-sandbox-protocol/src/oplog.rs
@@ -86,10 +86,17 @@ pub enum ClaimOutcome {
 /// A crash-safe error the durable store may surface. In-memory writes never
 /// fail, so [`InMemoryOperationStore`] never returns one.
 #[derive(Debug, Clone, thiserror::Error)]
+#[non_exhaustive]
 pub enum StoreError {
     /// The operation identity was not `Claimed` when a terminal write arrived.
     #[error("operation was not in a claimable state for a terminal write")]
     NotClaimed,
+    /// The durable backend failed (I/O, transaction, or (de)serialization).
+    ///
+    /// A durable store surfaces this so a caller never mistakes an unreachable
+    /// database for a clean "not claimed"; the in-memory store never returns it.
+    #[error("operation store backend failure: {0}")]
+    Backend(String),
 }
 
 /// The durable-storage seam for the reverse-RPC operation log.

--- a/crates/openwave-sandbox-protocol/src/oplog.rs
+++ b/crates/openwave-sandbox-protocol/src/oplog.rs
@@ -63,6 +63,13 @@ pub enum OperationState {
     Recorded(ReverseResult),
     /// Terminal failure.
     Failed(ErrorResponse),
+    /// The operation completed terminally, but its recorded body has since been
+    /// evicted to a commit marker by retention (#859). It ran exactly once and
+    /// must not be re-executed; there is simply no body left to replay. This is
+    /// *not* the after-crash ambiguity — the outcome is known, only the payload
+    /// is gone — so it resolves to a distinct, non-ambiguous refusal, never
+    /// [`ClaimOutcome::ClaimedElsewhere`]. An in-memory store never produces it.
+    Evicted,
 }
 
 /// The result of claiming an operation identity against the store.

--- a/crates/openwave-sandbox-protocol/src/protocol.rs
+++ b/crates/openwave-sandbox-protocol/src/protocol.rs
@@ -154,6 +154,11 @@ pub enum ErrorCode {
     /// An operation identity was found `Claimed` with no live execution — a
     /// crash-ambiguous external effect that must not be replayed.
     OperationAmbiguous,
+    /// The operation completed terminally, but its recorded result was evicted
+    /// by retention (#859). It ran exactly once and must not be re-executed;
+    /// unlike [`OperationAmbiguous`](ErrorCode::OperationAmbiguous) the outcome
+    /// is known, only the body is gone.
+    OperationEvicted,
     /// The in-flight request was cancelled over the control lane.
     Cancelled,
     /// The connection dropped before the response arrived.

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -45,8 +45,11 @@ openwave-mcp = { path = "../openwave-mcp" }
 openwave-router = { path = "../openwave-router" }
 openwave-retrieval = { path = "../openwave-retrieval" }
 openwave-web-search = { path = "../openwave-web-search", features = ["http"] }
+openwave-sandbox-protocol = { path = "../openwave-sandbox-protocol" }
 axum = { workspace = true }
-tokio = { workspace = true, features = ["net", "process", "rt", "sync", "macros", "time"] }
+# `rt-multi-thread` backs the durable operation log's synchronous `OperationStore`
+# bridge (`tokio::task::block_in_place`); the host runs on a multi-thread runtime.
+tokio = { workspace = true, features = ["net", "process", "rt", "rt-multi-thread", "sync", "macros", "time"] }
 tower-http = { version = "=0.7.0", features = ["cors"] }
 futures = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/openwave-server/src/durable_oplog.rs
+++ b/crates/openwave-server/src/durable_oplog.rs
@@ -37,6 +37,7 @@
 //! | `Recorded`, same fingerprint | [`ClaimOutcome::Replay`] the recorded response |
 //! | `Failed`, same fingerprint | [`ClaimOutcome::Replay`] the recorded failure |
 //! | `Claimed`, same epoch | [`ClaimOutcome::Replay`]`(Claimed)` — concurrent duplicate attaches |
+//! | terminal, body evicted (#859) | [`ClaimOutcome::Replay`]`(Evicted)` — done, do not re-execute, no body |
 //! | `Claimed`, foreign epoch, external effect | [`ClaimOutcome::ClaimedElsewhere`] — after-crash refusal |
 //! | any state, different fingerprint | [`ClaimOutcome::Conflict`] |
 
@@ -112,6 +113,7 @@ impl DurableOperationStore {
             OperationClaimOutcome::Failed(body) => {
                 ClaimOutcome::Replay(OperationState::Failed(decode::<ErrorResponse>(&body)?))
             }
+            OperationClaimOutcome::TerminalEvicted => ClaimOutcome::Replay(OperationState::Evicted),
             OperationClaimOutcome::OwnedClaim => ClaimOutcome::Replay(OperationState::Claimed),
             OperationClaimOutcome::ForeignClaim => ClaimOutcome::ClaimedElsewhere,
             OperationClaimOutcome::Conflict => ClaimOutcome::Conflict,
@@ -154,20 +156,27 @@ impl DurableOperationStore {
         else {
             return Ok(None);
         };
-        let state = match entry.state {
-            OperationLogState::Claimed => OperationState::Claimed,
-            OperationLogState::Recorded => {
-                OperationState::Recorded(decode::<ReverseResult>(&terminal_body(entry.body)?)?)
+        // A terminal entry whose body has been evicted (#859) reports `Evicted`,
+        // exactly as `claim` does — the outcome is known, only the body is gone.
+        // Keeping the two read paths identical is the point of this arm.
+        let state = match (entry.state, entry.body) {
+            (OperationLogState::Claimed, _) => OperationState::Claimed,
+            (OperationLogState::Recorded, Some(body)) => {
+                OperationState::Recorded(decode::<ReverseResult>(&body)?)
             }
-            OperationLogState::Failed => {
-                OperationState::Failed(decode::<ErrorResponse>(&terminal_body(entry.body)?)?)
+            (OperationLogState::Failed, Some(body)) => {
+                OperationState::Failed(decode::<ErrorResponse>(&body)?)
+            }
+            (OperationLogState::Recorded | OperationLogState::Failed, None) => {
+                OperationState::Evicted
             }
         };
         Ok(Some(state))
     }
 
-    /// Drop a terminal entry once it can no longer be re-issued (#859 owns the
-    /// policy; this removes the row).
+    /// Evict a terminal entry's body down to a commit marker once it can no
+    /// longer be re-issued; a later re-issue then replays as `Evicted`, never
+    /// re-executing. #859 owns the retention policy over this safe primitive.
     pub async fn evict_op(&self, id: OperationId) -> Result<(), StoreError> {
         self.store
             .evict_operation(self.run_id.as_uuid(), id.as_uuid())
@@ -209,8 +218,17 @@ impl OperationStore for DurableOperationStore {
         block_on(self.fail_op(id, error))
     }
 
+    /// Reads fail *open*: a backend error becomes `None` ("unknown"), so this
+    /// must never gate execution — [`claim`](Self::claim) is the execution
+    /// predicate and fails closed. Use this for observation only.
     fn state(&self, id: OperationId) -> Option<OperationState> {
-        block_on(self.state_op(id)).unwrap_or_default()
+        match block_on(self.state_op(id)) {
+            Ok(state) => state,
+            Err(error) => {
+                eprintln!("openwave: durable operation-log state read failed: {error}");
+                None
+            }
+        }
     }
 
     fn evict(&self, id: OperationId) {
@@ -219,18 +237,44 @@ impl OperationStore for DurableOperationStore {
         }
     }
 
+    /// Reads fail *open*: a backend error becomes `0`. For accounting only;
+    /// never gate execution on it (that direction leans toward re-executing).
     fn len(&self) -> usize {
-        block_on(self.len_op()).unwrap_or(0)
+        match block_on(self.len_op()) {
+            Ok(len) => len,
+            Err(error) => {
+                eprintln!("openwave: durable operation-log length read failed: {error}");
+                0
+            }
+        }
     }
 }
 
 /// Drive an async store operation to completion from a synchronous trait method.
 ///
-/// `block_in_place` tells the multi-thread runtime this worker is about to block
-/// so other tasks migrate off it, then the current handle runs the future. The
-/// host runs on a multi-thread runtime, which `rt-multi-thread` guarantees.
-fn block_on<F: std::future::Future>(future: F) -> F::Output {
-    tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(future))
+/// # Precondition (panic)
+///
+/// This uses [`tokio::task::block_in_place`], which **panics** on a
+/// current-thread runtime and outside any runtime. `rt-multi-thread` only makes
+/// the multi-thread flavor *available*; it does not guarantee the host built
+/// one. So this checks the running flavor and, when it is not multi-thread,
+/// fails closed with a [`StoreError`] rather than panicking. #823, which wires
+/// this seam under `CapabilityHost`, MUST drive it from a multi-thread runtime.
+fn block_on<T>(
+    future: impl std::future::Future<Output = Result<T, StoreError>>,
+) -> Result<T, StoreError> {
+    use tokio::runtime::{Handle, RuntimeFlavor};
+    match Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == RuntimeFlavor::MultiThread => {
+            tokio::task::block_in_place(|| handle.block_on(future))
+        }
+        Ok(_) => Err(StoreError::Backend(
+            "durable operation store must run on a multi-thread tokio runtime".to_owned(),
+        )),
+        Err(_) => Err(StoreError::Backend(
+            "durable operation store called outside a tokio runtime".to_owned(),
+        )),
+    }
 }
 
 fn encode<T: serde::Serialize>(value: &T) -> Result<Vec<u8>, StoreError> {
@@ -243,12 +287,6 @@ fn decode<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> Result<T, StoreError>
 
 fn backend(error: openwave_core::AgentError) -> StoreError {
     StoreError::Backend(error.to_string())
-}
-
-/// A terminal entry must carry its body for replay; a `None` here means #859 has
-/// evicted the body down to a commit marker, which cannot be replayed.
-fn terminal_body(body: Option<Vec<u8>>) -> Result<Vec<u8>, StoreError> {
-    body.ok_or_else(|| StoreError::Backend("terminal operation body was evicted".to_owned()))
 }
 
 fn settle(write: OperationLogWrite) -> Result<(), StoreError> {
@@ -314,6 +352,34 @@ mod tests {
         assert!(matches!(
             recovered.state_op(op).await.unwrap(),
             Some(OperationState::Claimed)
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_evicted_marker_replays_as_done_not_ambiguous() {
+        let (_dir, store) = store().await;
+        let run = RunId::new();
+        let op = OperationId::new();
+        let log = DurableOperationStore::new(store, run);
+
+        log.claim_op(op, &request("q")).await.unwrap();
+        log.record_op(op, result("done")).await.unwrap();
+        // Retention (#859) evicts the completed body down to a commit marker.
+        log.evict_op(op).await.unwrap();
+
+        // A re-issue is answered "already recorded, do not re-execute" — an
+        // `Evicted` replay, distinctly NOT the after-crash `ClaimedElsewhere`
+        // ambiguity, and NOT a fresh claim that would re-run the model call.
+        assert!(
+            matches!(
+                log.claim_op(op, &request("q")).await.unwrap(),
+                ClaimOutcome::Replay(OperationState::Evicted)
+            ),
+            "an evicted terminal op must replay as done, never ClaimedElsewhere"
+        );
+        assert!(matches!(
+            log.state_op(op).await.unwrap(),
+            Some(OperationState::Evicted)
         ));
     }
 

--- a/crates/openwave-server/src/durable_oplog.rs
+++ b/crates/openwave-server/src/durable_oplog.rs
@@ -1,0 +1,395 @@
+//! The durable, crash-safe reverse-RPC operation log (issue #858).
+//!
+//! This backs `openwave-sandbox-protocol`'s [`OperationStore`] seam with the
+//! run's persistent [`Store`], so the operation-identity record and its recorded
+//! response survive a host crash — the single biggest correctness risk the
+//! reverse-RPC spike named. It is the reverse-RPC analogue of the run tier's
+//! result-idempotency commit (see `docs/agent-runs.md`): the `OperationId`
+//! fences a re-issue the way the result key fences a duplicate result delivery.
+//!
+//! # Where it lives, and why
+//!
+//! The transactional predicate lives beside the run tier's fenced transitions in
+//! `openwave-core` (the `Store::*_operation` methods), which persist an opaque
+//! `(fingerprint, body)` pair keyed by `(run_id, operation_id)` and know nothing
+//! of reverse-RPC wire types. This adapter, in `openwave-server` — the crate that
+//! already speaks the fenced-transaction `Store` contract *and* the sandbox
+//! protocol — serializes the typed request/response to those bytes, derives the
+//! external-effect flag, and maps the storage outcome onto [`ClaimOutcome`]. The
+//! standalone protocol crate keeps no `openwave-core` dependency.
+//!
+//! # The commit predicate
+//!
+//! Each [`DurableOperationStore`] is scoped to one run and one *process
+//! lifetime*, identified by a random `owner_epoch` minted at construction. That
+//! epoch is what a durable store has and an in-memory one lacks: a `Claimed`
+//! entry found under a *different* epoch is a claim a prior, now-dead lifetime
+//! made and never recorded — the after-crash ambiguity. For an external-effect
+//! operation (a model call with possible partial spend), that resolves to
+//! [`ClaimOutcome::ClaimedElsewhere`], which the protocol host routes to a
+//! conservative `OperationAmbiguous` refusal: it is never replayed. A `Claimed`
+//! entry under the *same* epoch is a concurrent duplicate this lifetime and
+//! attaches to the live execution ([`OperationState::Claimed`]).
+//!
+//! | claim finds | outcome |
+//! | --- | --- |
+//! | nothing | [`ClaimOutcome::Fresh`] — execute once |
+//! | `Recorded`, same fingerprint | [`ClaimOutcome::Replay`] the recorded response |
+//! | `Failed`, same fingerprint | [`ClaimOutcome::Replay`] the recorded failure |
+//! | `Claimed`, same epoch | [`ClaimOutcome::Replay`]`(Claimed)` — concurrent duplicate attaches |
+//! | `Claimed`, foreign epoch, external effect | [`ClaimOutcome::ClaimedElsewhere`] — after-crash refusal |
+//! | any state, different fingerprint | [`ClaimOutcome::Conflict`] |
+
+use std::sync::Arc;
+
+use openwave_core::{OperationClaimOutcome, OperationLogState, OperationLogWrite, Store};
+use openwave_sandbox_protocol::{
+    ids::{OperationId, RunId},
+    oplog::{ClaimOutcome, OperationFingerprint, OperationState, OperationStore, StoreError},
+    protocol::ErrorResponse,
+    reverse::{ReverseRequest, ReverseResult},
+};
+use uuid::Uuid;
+
+/// A durable [`OperationStore`] over one run's persistent [`Store`].
+///
+/// Construct one per run per process lifetime; the `owner_epoch` minted here is
+/// what separates a concurrent duplicate from an after-crash re-issue.
+#[derive(Clone)]
+pub struct DurableOperationStore {
+    store: Arc<dyn Store>,
+    run_id: RunId,
+    owner_epoch: Uuid,
+}
+
+impl DurableOperationStore {
+    /// A durable operation log for `run_id`, owned by a fresh process-lifetime
+    /// epoch.
+    #[must_use]
+    pub fn new(store: Arc<dyn Store>, run_id: RunId) -> Self {
+        Self {
+            store,
+            run_id,
+            owner_epoch: Uuid::new_v4(),
+        }
+    }
+
+    /// Whether a request carries an external effect that must never be replayed
+    /// blindly after a crash. Model inference spends, so it does; the wildcard
+    /// keeps a future capability external-by-default until proven otherwise.
+    fn has_external_effect(request: &ReverseRequest) -> bool {
+        match request {
+            ReverseRequest::ModelInference(_) => true,
+            _ => true,
+        }
+    }
+
+    /// Atomically claim `id`, or resolve its existing state. See the module
+    /// docs for the predicate.
+    pub async fn claim_op(
+        &self,
+        id: OperationId,
+        fingerprint: &OperationFingerprint,
+    ) -> Result<ClaimOutcome, StoreError> {
+        let bytes = encode(fingerprint)?;
+        let external_effect = Self::has_external_effect(fingerprint);
+        let outcome = self
+            .store
+            .claim_operation(
+                self.run_id.as_uuid(),
+                id.as_uuid(),
+                &bytes,
+                external_effect,
+                self.owner_epoch,
+            )
+            .await
+            .map_err(backend)?;
+        Ok(match outcome {
+            OperationClaimOutcome::Fresh => ClaimOutcome::Fresh,
+            OperationClaimOutcome::Recorded(body) => {
+                ClaimOutcome::Replay(OperationState::Recorded(decode::<ReverseResult>(&body)?))
+            }
+            OperationClaimOutcome::Failed(body) => {
+                ClaimOutcome::Replay(OperationState::Failed(decode::<ErrorResponse>(&body)?))
+            }
+            OperationClaimOutcome::OwnedClaim => ClaimOutcome::Replay(OperationState::Claimed),
+            OperationClaimOutcome::ForeignClaim => ClaimOutcome::ClaimedElsewhere,
+            OperationClaimOutcome::Conflict => ClaimOutcome::Conflict,
+        })
+    }
+
+    /// Record a terminal success for a claimed identity; idempotent on redelivery.
+    pub async fn record_op(
+        &self,
+        id: OperationId,
+        result: ReverseResult,
+    ) -> Result<(), StoreError> {
+        let bytes = encode(&result)?;
+        settle(
+            self.store
+                .record_operation(self.run_id.as_uuid(), id.as_uuid(), &bytes)
+                .await
+                .map_err(backend)?,
+        )
+    }
+
+    /// Record a terminal failure for a claimed identity; idempotent on redelivery.
+    pub async fn fail_op(&self, id: OperationId, error: ErrorResponse) -> Result<(), StoreError> {
+        let bytes = encode(&error)?;
+        settle(
+            self.store
+                .fail_operation(self.run_id.as_uuid(), id.as_uuid(), &bytes)
+                .await
+                .map_err(backend)?,
+        )
+    }
+
+    /// The current state of `id`, if the log knows it.
+    pub async fn state_op(&self, id: OperationId) -> Result<Option<OperationState>, StoreError> {
+        let Some(entry) = self
+            .store
+            .operation_state(self.run_id.as_uuid(), id.as_uuid())
+            .await
+            .map_err(backend)?
+        else {
+            return Ok(None);
+        };
+        let state = match entry.state {
+            OperationLogState::Claimed => OperationState::Claimed,
+            OperationLogState::Recorded => {
+                OperationState::Recorded(decode::<ReverseResult>(&terminal_body(entry.body)?)?)
+            }
+            OperationLogState::Failed => {
+                OperationState::Failed(decode::<ErrorResponse>(&terminal_body(entry.body)?)?)
+            }
+        };
+        Ok(Some(state))
+    }
+
+    /// Drop a terminal entry once it can no longer be re-issued (#859 owns the
+    /// policy; this removes the row).
+    pub async fn evict_op(&self, id: OperationId) -> Result<(), StoreError> {
+        self.store
+            .evict_operation(self.run_id.as_uuid(), id.as_uuid())
+            .await
+            .map_err(backend)
+    }
+
+    /// How many entries this run currently retains.
+    pub async fn len_op(&self) -> Result<usize, StoreError> {
+        self.store
+            .operation_log_len(self.run_id.as_uuid())
+            .await
+            .map_err(backend)
+    }
+}
+
+/// The synchronous [`OperationStore`] seam the capability host calls, bridged to
+/// the async store. This runs on the host's multi-thread runtime; #823 owns
+/// wiring it under `CapabilityHost` and the threading around a claim.
+impl OperationStore for DurableOperationStore {
+    fn claim(&self, id: OperationId, fingerprint: &OperationFingerprint) -> ClaimOutcome {
+        match block_on(self.claim_op(id, fingerprint)) {
+            Ok(outcome) => outcome,
+            // A claim that cannot reach durable storage must fail closed: with no
+            // committed claim, executing the effect would risk a double spend the
+            // log could not later fence. Refuse conservatively.
+            Err(error) => {
+                eprintln!("openwave: durable operation-log claim failed, refusing conservatively: {error}");
+                ClaimOutcome::ClaimedElsewhere
+            }
+        }
+    }
+
+    fn record(&self, id: OperationId, result: ReverseResult) -> Result<(), StoreError> {
+        block_on(self.record_op(id, result))
+    }
+
+    fn fail(&self, id: OperationId, error: ErrorResponse) -> Result<(), StoreError> {
+        block_on(self.fail_op(id, error))
+    }
+
+    fn state(&self, id: OperationId) -> Option<OperationState> {
+        block_on(self.state_op(id)).unwrap_or_default()
+    }
+
+    fn evict(&self, id: OperationId) {
+        if let Err(error) = block_on(self.evict_op(id)) {
+            eprintln!("openwave: durable operation-log eviction failed: {error}");
+        }
+    }
+
+    fn len(&self) -> usize {
+        block_on(self.len_op()).unwrap_or(0)
+    }
+}
+
+/// Drive an async store operation to completion from a synchronous trait method.
+///
+/// `block_in_place` tells the multi-thread runtime this worker is about to block
+/// so other tasks migrate off it, then the current handle runs the future. The
+/// host runs on a multi-thread runtime, which `rt-multi-thread` guarantees.
+fn block_on<F: std::future::Future>(future: F) -> F::Output {
+    tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(future))
+}
+
+fn encode<T: serde::Serialize>(value: &T) -> Result<Vec<u8>, StoreError> {
+    serde_json::to_vec(value).map_err(|err| StoreError::Backend(err.to_string()))
+}
+
+fn decode<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> Result<T, StoreError> {
+    serde_json::from_slice(bytes).map_err(|err| StoreError::Backend(err.to_string()))
+}
+
+fn backend(error: openwave_core::AgentError) -> StoreError {
+    StoreError::Backend(error.to_string())
+}
+
+/// A terminal entry must carry its body for replay; a `None` here means #859 has
+/// evicted the body down to a commit marker, which cannot be replayed.
+fn terminal_body(body: Option<Vec<u8>>) -> Result<Vec<u8>, StoreError> {
+    body.ok_or_else(|| StoreError::Backend("terminal operation body was evicted".to_owned()))
+}
+
+fn settle(write: OperationLogWrite) -> Result<(), StoreError> {
+    match write {
+        OperationLogWrite::Committed | OperationLogWrite::AlreadyTerminal => Ok(()),
+        OperationLogWrite::NotClaimed => Err(StoreError::NotClaimed),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openwave_core::DbStore;
+    use openwave_sandbox_protocol::reverse::{ModelInferenceParams, ModelInferenceResult};
+
+    async fn store() -> (tempfile::TempDir, Arc<dyn Store>) {
+        let dir = tempfile::tempdir().unwrap();
+        let url = format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("oplog.db").display()
+        );
+        let store: Arc<dyn Store> = Arc::new(DbStore::connect(&url).await.unwrap());
+        (dir, store)
+    }
+
+    fn request(prompt: &str) -> ReverseRequest {
+        ReverseRequest::ModelInference(ModelInferenceParams {
+            prompt: prompt.to_owned(),
+        })
+    }
+
+    fn result(completion: &str) -> ReverseResult {
+        ReverseResult::ModelInference(ModelInferenceResult {
+            completion: completion.to_owned(),
+        })
+    }
+
+    #[tokio::test]
+    async fn a_claim_left_dangling_by_a_crash_refuses_conservatively() {
+        let (_dir, store) = store().await;
+        let run = RunId::new();
+        let op = OperationId::new();
+
+        // One process lifetime claims but crashes before recording — the entry is
+        // left `Claimed` under the crashed epoch.
+        let crashed = DurableOperationStore::new(Arc::clone(&store), run);
+        assert!(matches!(
+            crashed.claim_op(op, &request("spend")).await.unwrap(),
+            ClaimOutcome::Fresh
+        ));
+        drop(crashed);
+
+        // A fresh lifetime re-issues the same operation. It cannot prove the
+        // model call did not already spend, so it refuses rather than replaying.
+        let recovered = DurableOperationStore::new(Arc::clone(&store), run);
+        assert!(matches!(
+            recovered.claim_op(op, &request("spend")).await.unwrap(),
+            ClaimOutcome::ClaimedElsewhere
+        ));
+
+        // The effect was never recorded, and the entry is still just claimed:
+        // nothing re-executed it.
+        assert!(matches!(
+            recovered.state_op(op).await.unwrap(),
+            Some(OperationState::Claimed)
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_reissue_replays_the_recorded_response() {
+        let (_dir, store) = store().await;
+        let run = RunId::new();
+        let op = OperationId::new();
+        let log = DurableOperationStore::new(store, run);
+
+        log.claim_op(op, &request("q")).await.unwrap();
+        log.record_op(op, result("the-answer")).await.unwrap();
+
+        // A re-issue with the same operation identity returns the recorded body,
+        // never a second execution.
+        match log.claim_op(op, &request("q")).await.unwrap() {
+            ClaimOutcome::Replay(OperationState::Recorded(recorded)) => {
+                assert_eq!(recorded, result("the-answer"));
+            }
+            other => panic!("expected a recorded replay, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_reissue_with_a_different_request_conflicts() {
+        let (_dir, store) = store().await;
+        let run = RunId::new();
+        let op = OperationId::new();
+        let log = DurableOperationStore::new(store, run);
+
+        log.claim_op(op, &request("first")).await.unwrap();
+        assert!(matches!(
+            log.claim_op(op, &request("second")).await.unwrap(),
+            ClaimOutcome::Conflict
+        ));
+    }
+
+    #[tokio::test]
+    async fn recording_is_idempotent_across_redelivery() {
+        let (_dir, store) = store().await;
+        let run = RunId::new();
+        let op = OperationId::new();
+        let log = DurableOperationStore::new(store, run);
+
+        log.claim_op(op, &request("q")).await.unwrap();
+        log.record_op(op, result("first")).await.unwrap();
+        // A re-delivered record is acknowledged, not rejected, and does not
+        // overwrite the first-committed body.
+        log.record_op(op, result("second")).await.unwrap();
+        match log.claim_op(op, &request("q")).await.unwrap() {
+            ClaimOutcome::Replay(OperationState::Recorded(recorded)) => {
+                assert_eq!(recorded, result("first"));
+            }
+            other => panic!("expected the first recorded body, got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn the_synchronous_seam_round_trips() {
+        let (_dir, store) = store().await;
+        let run = RunId::new();
+        let op = OperationId::new();
+        let log = DurableOperationStore::new(store, run);
+
+        // Drive the trait the capability host actually calls, through the
+        // blocking bridge, on a multi-thread runtime.
+        assert!(matches!(
+            OperationStore::claim(&log, op, &request("q")),
+            ClaimOutcome::Fresh
+        ));
+        OperationStore::record(&log, op, result("bridged")).unwrap();
+        match OperationStore::claim(&log, op, &request("q")) {
+            ClaimOutcome::Replay(OperationState::Recorded(recorded)) => {
+                assert_eq!(recorded, result("bridged"));
+            }
+            other => panic!("expected a recorded replay across the bridge, got {other:?}"),
+        }
+    }
+}

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -24,6 +24,7 @@ mod desktop_schema;
 mod document_auditor;
 mod document_stage;
 mod document_worker;
+mod durable_oplog;
 mod error;
 mod event_projection;
 mod extract;
@@ -83,6 +84,7 @@ use openwave_retrieval::{
 
 use resolver::KeyedResolver;
 
+pub use durable_oplog::DurableOperationStore;
 pub use error::ServerError;
 pub use state::AppState;
 


### PR DESCRIPTION
Makes the reverse-RPC operation log durable and crash-safe (#858), replacing the in-memory `OperationStore` behind the protocol seam. The `OperationId` fences a re-issue the way the run tier's result-idempotency key fences a duplicate result delivery (see `docs/agent-runs.md`); this is the reverse-RPC analogue.

## The state machine and commit predicate

Persisted state machine, keyed by `(run_id, operation_id)`:

```
Claimed(dispatched) -> Recorded(response) | Failed(error)
```

The predicate, in one transaction per `claim`:

| claim finds | outcome |
| --- | --- |
| nothing | **Fresh** — insert `Claimed`, execute once |
| `Recorded`, same fingerprint | **Replay** the recorded response — never re-execute |
| `Failed`, same fingerprint | **Replay** the recorded failure |
| `Claimed`, **same** epoch | **Replay(Claimed)** — a concurrent duplicate this lifetime attaches to the live execution |
| `Claimed`, **foreign** epoch, external effect | **ClaimedElsewhere** — the after-crash ambiguity; the host routes it to a conservative `OperationAmbiguous` refusal rather than re-run a possibly-spent call |
| any state, different fingerprint | **Conflict** |

A per-process-lifetime `owner_epoch`, stamped on the row at claim time, is what a durable store has and an in-memory one lacks: it distinguishes a same-lifetime concurrent duplicate (attach) from a prior, now-dead lifetime's dangling `Claimed` (refuse). The insert is the serialization point, so a race resolves to exactly one `Fresh` and never a second external effect. `record`/`fail` are atomic `state = claimed`-guarded transitions — first writer wins and a re-delivered terminal write is acknowledged, not rejected.

## Placement

- **openwave-core** owns the transactional ops (`Store::{claim,record,fail,...}_operation`), beside the run tier's other fenced transitions, over an opaque `(fingerprint, body)` pair — core carries no reverse-RPC wire types. New table + entity + additive migration live here (migrations are core-owned).
- **openwave-server** holds `DurableOperationStore`: it depends on both the `Store` contract and the sandbox protocol, serializes the typed request/response to bytes, derives the external-effect flag, maps the storage outcome onto `ClaimOutcome`, and provides the synchronous `OperationStore` bridge the host calls (`block_in_place` on the host's multi-thread runtime).
- The standalone **openwave-sandbox-protocol** crate gains no `openwave-core` dependency (only a `StoreError::Backend` variant for the durable seam).

## Schema, shaped for #859 (retention/eviction)

The `operation_log` migration is purely additive — a new table, symmetric `down`, identical shape on SQLite and Postgres. The `body` column is nullable and paired with a `retained` flag, so #859 can evict a full response body down to a commit marker — clearing `body` and `retained` while keeping the row's `state`, `external_effect`, and timestamps — **without a migration rewrite**. `evict` currently removes the row; #859 owns *when* eviction is safe.

## Scope

Delivers the durable store and its tests. It is **not** wired into a live sandbox-resident run loop — that is #823 — and is independently testable.

## Verification

- `cargo test` on the three touched crates (`--locked`): core operation-log suite (fresh/replay, conflict, fenced+idempotent terminal writes, concurrent-claim → exactly one `Fresh`, external-effect flag gating, eviction, reversible migration), server durable-store suite (after-crash claim refuses conservatively and never re-executes, re-issue replays the recorded response, different fingerprint conflicts, record idempotent across redelivery, synchronous seam round-trips), protocol crate suite.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all --check`: clean.
- Adding the protocol path dependency changed `Cargo.lock` by exactly one line (the new edge; no version drift).
- The Postgres turn-state lane runs in CI; the migration, `ON CONFLICT DO NOTHING` claim, guarded terminal update, and CHECK constraints are written for both backends.

Closes #858