### PR TITLE
chore(protocol): golden-pin reverse-envelope fields and test over-bound result path

### DIFF
--- a/crates/openwave-sandbox-protocol/src/host.rs
+++ b/crates/openwave-sandbox-protocol/src/host.rs
@@ -292,8 +292,11 @@ mod tests {
 
     use crate::{
         ids::{OperationId, RequestId, RunId},
-        oplog::{ClaimOutcome, OperationFingerprint, OperationState, OperationStore, StoreError},
-        protocol::PROTOCOL_VERSION,
+        oplog::{
+            ClaimOutcome, InMemoryOperationStore, OperationFingerprint, OperationState,
+            OperationStore, StoreError,
+        },
+        protocol::{MAX_MODEL_COMPLETION_BYTES, PROTOCOL_VERSION},
         reverse::{
             Capability, CapabilityResponder, GrantSet, ModelInferenceParams, ModelInferenceResult,
             ReverseEnvelope, ReverseRequest, ReverseResult, RunProvenance,
@@ -337,6 +340,72 @@ mod tests {
             Response::Ok(ReverseResult::ModelInference(ModelInferenceResult {
                 completion: "should never run".to_owned(),
             }))
+        }
+    }
+
+    /// A responder that runs and returns an over-bound completion — the result
+    /// bound must reject it after execution, on the record path.
+    struct OverBoundResponder {
+        executions: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl CapabilityResponder for OverBoundResponder {
+        async fn respond(&self, _request: ReverseRequest) -> Response<ReverseResult> {
+            self.executions.fetch_add(1, Ordering::SeqCst);
+            Response::Ok(ReverseResult::ModelInference(ModelInferenceResult {
+                completion: "x".repeat(MAX_MODEL_COMPLETION_BYTES + 1),
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn over_bound_completion_is_refused_and_never_recorded() {
+        let executions = Arc::new(AtomicUsize::new(0));
+        let provenance = RunProvenance {
+            run_id: RunId::new(),
+            provider: "test".to_owned(),
+        };
+        let store = InMemoryOperationStore::new();
+        let host = CapabilityHost::new(
+            GrantSet::new(provenance, [Capability::ModelInference]),
+            Arc::new(OverBoundResponder {
+                executions: Arc::clone(&executions),
+            }),
+            Arc::new(store.clone()),
+        );
+
+        // The request is within bounds, so it clears the pre-execution gate and
+        // reaches the responder; only the completion is over-bound.
+        let operation_id = OperationId::new();
+        let response = host
+            .dispatch(ReverseEnvelope {
+                protocol_version: PROTOCOL_VERSION,
+                request_id: RequestId::new(),
+                operation_id,
+                request: ReverseRequest::ModelInference(ModelInferenceParams {
+                    prompt: "within bounds".to_owned(),
+                }),
+            })
+            .wait()
+            .await;
+
+        match response {
+            Response::Error(error) => assert_eq!(error.code, ErrorCode::TooLarge),
+            Response::Ok(_) => panic!("an over-bound completion must be refused"),
+        }
+        // The witness that this is the result path, not the request bound: the
+        // responder actually ran and produced the over-bound completion.
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            1,
+            "the responder executed before its over-bound result was rejected"
+        );
+        // The refusal is recorded as a terminal failure, never as a Recorded
+        // success — the over-bound completion is not persisted.
+        match store.state(operation_id) {
+            Some(OperationState::Failed(error)) => assert_eq!(error.code, ErrorCode::TooLarge),
+            other => panic!("an over-bound completion must be Failed, not Recorded, got {other:?}"),
         }
     }
 

--- a/crates/openwave-sandbox-protocol/tests/wire_format.rs
+++ b/crates/openwave-sandbox-protocol/tests/wire_format.rs
@@ -151,25 +151,51 @@ fn reverse_request_and_result_wire_shapes() {
 
 #[test]
 fn reverse_envelopes_and_frames_wire_shapes() {
+    // `RequestId`/`OperationId` are `Copy` and serialize transparently as their
+    // UUID string, so capturing them lets us pin the enclosing field name
+    // exactly rather than merely round-tripping it.
+    let request_id = RequestId::new();
+    let operation_id = OperationId::new();
     let envelope = ReverseEnvelope {
         protocol_version: PROTOCOL_VERSION,
-        request_id: RequestId::new(),
-        operation_id: OperationId::new(),
+        request_id,
+        operation_id,
         request: ReverseRequest::ModelInference(ModelInferenceParams {
             prompt: "q".to_owned(),
         }),
     };
     roundtrip(&envelope);
+    golden(
+        &envelope,
+        &[
+            ("/protocol_version", json!(PROTOCOL_VERSION)),
+            ("/request_id", json!(request_id.to_string())),
+            ("/operation_id", json!(operation_id.to_string())),
+            ("/request/capability", json!("model_inference")),
+            ("/request/payload/prompt", json!("q")),
+        ],
+    );
 
     let response = ReverseResponseEnvelope {
         protocol_version: PROTOCOL_VERSION,
-        request_id: RequestId::new(),
-        operation_id: OperationId::new(),
+        request_id,
+        operation_id,
         response: Response::Ok(ReverseResult::ModelInference(ModelInferenceResult {
             completion: "a".to_owned(),
         })),
     };
     roundtrip(&response);
+    golden(
+        &response,
+        &[
+            ("/protocol_version", json!(PROTOCOL_VERSION)),
+            ("/request_id", json!(request_id.to_string())),
+            ("/operation_id", json!(operation_id.to_string())),
+            ("/response/status", json!("ok")),
+            ("/response/payload/capability", json!("model_inference")),
+            ("/response/payload/payload/completion", json!("a")),
+        ],
+    );
 
     let request_frame = RequestFrame::Request(envelope);
     roundtrip(&request_frame);


### PR DESCRIPTION
Two low-risk follow-ups from the re-review of #860 (protocol contract). Both harden the permanent wire contract and its test coverage; no behavior change.

## Golden-pin the reverse envelopes' inner fields

`ReverseEnvelope` and `ReverseResponseEnvelope` had a serde round-trip but only the enclosing `RequestFrame` discriminant (`/frame`) was golden-pinned. Their own wire-crossing fields — `protocol_version`, `request_id`, `operation_id`, and `request`/`response` — were not, so a serde rename of one would pass round-trip silently. The envelopes now get golden-encoding assertions pinning those field and tag names exactly, meeting the same catch-a-rename bar the other wire types already meet. The two ids are captured before construction (both are `Copy` and serialize transparently as their UUID string) so the pin is on the field name, not a value coincidence.

## Cover the over-bound result path

`execute` rewrites an over-bound completion to a bounded `TooLarge` refusal before recording. That is on the live path and unit-testable, but only the over-bound *request* and *event* paths had dedicated scenarios. A new unit test drives an over-bound completion through `execute` and asserts it is refused (`TooLarge`) and left `Failed` in the store — never `Recorded`. A real witness (the responder's execution count) confirms this is the result path after execution, not the pre-execution request bound.

## Verification

`cargo test -p openwave-sandbox-protocol --locked`, `cargo clippy -p openwave-sandbox-protocol --all-targets -- -D warnings`, and `cargo fmt --check` all pass.

Closes #864