### PR TITLE
feat(execution): apply configurable egress policy to E2B and Daytona sandboxes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6643,6 +6643,7 @@ dependencies = [
  "openwave-code-execution",
  "openwave-connectors",
  "openwave-core",
+ "openwave-egress",
  "openwave-mcp",
  "openwave-retrieval",
  "openwave-router",

--- a/crates/openwave-code-execution/src/daytona.rs
+++ b/crates/openwave-code-execution/src/daytona.rs
@@ -165,6 +165,15 @@ impl DaytonaExecutionProvider {
         Ok(self)
     }
 
+    /// The egress policy compiled into this provider's sandboxes, or `None` for
+    /// today's open-internet creation. Exposed so the host wiring that selects
+    /// and applies a policy can be verified without a live API.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn egress_policy(&self) -> Option<&EgressPolicy> {
+        self.egress.as_ref()
+    }
+
     /// Host knowledge about Daytona's per-sandbox network enforcement,
     /// declared as what it actually blocks. Daytona keeps a vendor-curated
     /// "essential services" list reachable regardless of policy — package

--- a/crates/openwave-code-execution/src/e2b.rs
+++ b/crates/openwave-code-execution/src/e2b.rs
@@ -157,6 +157,17 @@ impl E2BExecutionProvider {
         self
     }
 
+    /// The egress policy compiled into this provider's sandboxes, or `None` for
+    /// today's open-internet creation. Exposed so the host wiring that selects
+    /// and applies a policy can be verified without a live API — a dropped
+    /// policy in that path reverts a configured allowlist to open egress, and
+    /// this is what a test asserts against.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn egress_policy(&self) -> Option<&EgressPolicy> {
+        self.egress.as_ref()
+    }
+
     /// Host knowledge about E2B's per-sandbox network enforcement, declared
     /// as what it actually blocks. Vendor exceptions: DNS to `8.8.8.8` stays
     /// open regardless of policy, and domain-pattern rules are enforced only

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -12,6 +12,7 @@ import {
   type CodeExecutionConfigInfo as WireCodeExecutionConfigInfo,
   type CodeExecutionCredentialReadiness as WireCodeExecutionCredentialReadiness,
   type CodeExecutionProviderKind as WireCodeExecutionProviderKind,
+  type EgressConfig as WireEgressConfig,
   type CustomModelConfig as WireCustomModelConfig,
   type McpHealth as WireMcpHealth,
   type McpServerDefinition as WireMcpServerDefinition,
@@ -169,6 +170,12 @@ export type CodeExecutionConfigInfo = WireCodeExecutionConfigInfo;
 /** Readiness only: the API never returns a saved managed-provider key. */
 export type CodeExecutionCredentialReadiness =
   WireCodeExecutionCredentialReadiness;
+
+/**
+ * Host-owned egress policy for the managed sandboxes. Never a secret: only
+ * domain patterns and CIDR blocks, or `open` for today's unrestricted egress.
+ */
+export type EgressConfig = WireEgressConfig;
 
 export type McpHealth = WireMcpHealth;
 
@@ -673,6 +680,7 @@ export class ApiClient {
   putCodeExecutionConfig(body: {
     provider?: CodeExecutionProviderKind | null;
     timeout_ms?: number;
+    egress?: EgressConfig;
   }): Promise<CodeExecutionConfigInfo> {
     return this.json("/code-execution", {
       method: "PUT",

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -292,18 +292,14 @@ export type CodeExecutionCredentialReadiness = { provider: CodeExecutionProvider
  * A managed provider's egress-enforcement status, as host knowledge rather
  * than a claim the backend makes about itself.
  */
-export type CodeExecutionEgressEnforcement = { provider: CodeExecutionProviderKind, 
+export type CodeExecutionEgressEnforcement = { provider: CodeExecutionProviderKind, status: EgressEnforcementStatus, 
 /**
- * `true` once the vendor's per-sandbox network semantics are confirmed to
- * enforce the configured allowlist. E2B is confirmed; Daytona is not yet,
- * so a configured policy is applied but must not be relied on as a
- * boundary until its deny-all semantics are confirmed against the live API.
+ * Destinations the vendor's mechanism keeps reachable regardless of the
+ * configured policy — each a short purpose string straight from the
+ * enforcement model, so the settings surface can show the caveat inline
+ * instead of burying it in prose the user skims past.
  */
-confirmed: boolean, 
-/**
- * Plain-language disclosure for the settings surface.
- */
-note: string, };
+gaps: Array<string>, };
 
 /**
  * Renderer-safe egress policy plus per-provider enforcement disclosure.
@@ -373,6 +369,16 @@ export type DocumentId = string;
  * `PUT` time rather than silently widening egress at sandbox creation.
  */
 export type EgressConfig = { "mode": "open" } | { "mode": "allowlist", domains: Array<string>, cidrs: Array<string>, };
+
+/**
+ * The honest state of a managed provider's egress enforcement.
+ *
+ * Derived from the shipped enforcement model, never asserted per provider, so
+ * the settings surface and the decision layer cannot disagree: if the model
+ * says a vendor's mechanism leaves a general-purpose destination reachable,
+ * the surface must not present it as a full boundary.
+ */
+export type EgressEnforcementStatus = "boundary" | "applied_with_gaps" | "unconfirmed";
 
 /**
  * One entitled connected app, with the slugs of the MCP endpoints that

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -275,12 +275,51 @@ end: number, };
 /**
  * Renderer-safe configuration and readiness.
  */
-export type CodeExecutionConfigInfo = { provider?: CodeExecutionProviderKind, timeout_ms: number, available: boolean, has_credential: boolean, };
+export type CodeExecutionConfigInfo = { provider?: CodeExecutionProviderKind, timeout_ms: number, available: boolean, has_credential: boolean, 
+/**
+ * The configured egress policy and each managed provider's enforcement
+ * status, so the renderer can present the policy and disclose which
+ * providers actually restrict egress today.
+ */
+egress: CodeExecutionEgressInfo, };
 
 /**
  * Renderer-safe readiness for one managed provider's fixed credential slot.
  */
 export type CodeExecutionCredentialReadiness = { provider: CodeExecutionProviderKind, has_credential: boolean, };
+
+/**
+ * A managed provider's egress-enforcement status, as host knowledge rather
+ * than a claim the backend makes about itself.
+ */
+export type CodeExecutionEgressEnforcement = { provider: CodeExecutionProviderKind, 
+/**
+ * `true` once the vendor's per-sandbox network semantics are confirmed to
+ * enforce the configured allowlist. E2B is confirmed; Daytona is not yet,
+ * so a configured policy is applied but must not be relied on as a
+ * boundary until its deny-all semantics are confirmed against the live API.
+ */
+confirmed: boolean, 
+/**
+ * Plain-language disclosure for the settings surface.
+ */
+note: string, };
+
+/**
+ * Renderer-safe egress policy plus per-provider enforcement disclosure.
+ */
+export type CodeExecutionEgressInfo = { 
+/**
+ * The configured host policy. `Open` is the default: managed sandboxes are
+ * created with open internet access. An allowlist restricts every managed
+ * sandbox created afterwards.
+ */
+policy: EgressConfig, 
+/**
+ * One row per managed provider, stating whether its egress restriction is
+ * confirmed against the live vendor API or still pending confirmation.
+ */
+enforcement: Array<CodeExecutionEgressEnforcement>, };
 
 /**
  * A configured code-execution backend.
@@ -316,6 +355,24 @@ max_output_tokens: number, };
  * preserves the existing stable URI identity used by retrieval ingestion.
  */
 export type DocumentId = string;
+
+/**
+ * Host-owned, non-secret egress policy for the managed exec sandboxes.
+ *
+ * The model never sets this (invariant 1): it is host configuration, carries
+ * no secret, and accepts no endpoint. `Open` is the default and preserves
+ * exec's out-of-the-box behavior — E2B and Daytona are created with open
+ * internet access, as they always have been. Egress restriction is opt-in:
+ * an `Allowlist` switches every managed sandbox created afterwards to
+ * deny-by-default and compiles the listed domain patterns and CIDR blocks
+ * into the vendor's per-sandbox network controls. An empty allowlist denies
+ * everything on both axes.
+ *
+ * The strings are validated to the same [`DomainPattern`] and [`CidrBlock`]
+ * grammar the decision layer uses, so a malformed grant is rejected at
+ * `PUT` time rather than silently widening egress at sandbox creation.
+ */
+export type EgressConfig = { "mode": "open" } | { "mode": "allowlist", domains: Array<string>, cidrs: Array<string>, };
 
 /**
  * One entitled connected app, with the slugs of the MCP endpoints that

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
@@ -15,6 +15,19 @@ import type {
 } from "../api";
 import { CodeExecutionPanel } from "./CodeExecutionPanel";
 
+/** The default egress projection: open policy, E2B confirmed, Daytona pending. */
+const OPEN_EGRESS: CodeExecutionConfigInfo["egress"] = {
+  policy: { mode: "open" },
+  enforcement: [
+    { provider: "e2b", confirmed: true, note: "E2B enforces the allowlist." },
+    {
+      provider: "daytona",
+      confirmed: false,
+      note: "Applied but pending live confirmation.",
+    },
+  ],
+};
+
 function clientFor(
   config: CodeExecutionConfigInfo,
   credentials: CodeExecutionCredentialReadiness[] = [
@@ -57,6 +70,7 @@ describe("CodeExecutionPanel", () => {
         timeout_ms: 20_000,
         available: false,
         has_credential: false,
+        egress: OPEN_EGRESS,
       });
 
     render(<CodeExecutionPanel client={client} />);
@@ -82,9 +96,11 @@ describe("CodeExecutionPanel", () => {
       "daytona",
       "daytona-secret",
     );
+    // Egress restriction is opt-in: an untouched panel saves the open policy.
     expect(putCodeExecutionConfig).toHaveBeenCalledWith({
       provider: "e2b",
       timeout_ms: 30_000,
+      egress: { mode: "open" },
     });
     // A provider must not go active in a pass that failed to store its key.
     expect(
@@ -99,6 +115,7 @@ describe("CodeExecutionPanel", () => {
         timeout_ms: 20_000,
         available: true,
         has_credential: true,
+        egress: OPEN_EGRESS,
       },
       [
         { provider: "e2b", has_credential: true },
@@ -118,12 +135,48 @@ describe("CodeExecutionPanel", () => {
     expect(deleteCodeExecutionCredential).toHaveBeenCalledTimes(1);
   });
 
+  it("sends a domain-and-CIDR allowlist once egress restriction is turned on", async () => {
+    const { client, putCodeExecutionConfig } = clientFor({
+      provider: "e2b",
+      timeout_ms: 20_000,
+      available: true,
+      has_credential: true,
+      egress: OPEN_EGRESS,
+    });
+
+    render(<CodeExecutionPanel client={client} />);
+
+    fireEvent.click(
+      await screen.findByRole("switch", { name: "Restrict network egress" }),
+    );
+    fireEvent.change(screen.getByLabelText(/Allowed domains/), {
+      target: { value: "*.pypi.org\nfiles.pythonhosted.org" },
+    });
+    fireEvent.change(screen.getByLabelText(/Allowed address blocks/), {
+      target: { value: "140.82.112.0/20" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+
+    await waitFor(() =>
+      expect(putCodeExecutionConfig).toHaveBeenCalledWith({
+        provider: "e2b",
+        timeout_ms: 20_000,
+        egress: {
+          mode: "allowlist",
+          domains: ["*.pypi.org", "files.pythonhosted.org"],
+          cidrs: ["140.82.112.0/20"],
+        },
+      }),
+    );
+  });
+
   it("rejects a timeout outside the bounds before touching the server", async () => {
     const { client, putCodeExecutionConfig } = clientFor({
       provider: "local",
       timeout_ms: 20_000,
       available: true,
       has_credential: false,
+      egress: OPEN_EGRESS,
     });
 
     render(<CodeExecutionPanel client={client} />);

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
@@ -15,15 +15,19 @@ import type {
 } from "../api";
 import { CodeExecutionPanel } from "./CodeExecutionPanel";
 
-/** The default egress projection: open policy, E2B confirmed, Daytona pending. */
+/** The default egress projection: open policy, E2B applied-with-gaps, Daytona unconfirmed. */
 const OPEN_EGRESS: CodeExecutionConfigInfo["egress"] = {
   policy: { mode: "open" },
   enforcement: [
-    { provider: "e2b", confirmed: true, note: "E2B enforces the allowlist." },
+    {
+      provider: "e2b",
+      status: "applied_with_gaps",
+      gaps: ["DNS resolution", "domain filtering covers HTTP and HTTPS ports only"],
+    },
     {
       provider: "daytona",
-      confirmed: false,
-      note: "Applied but pending live confirmation.",
+      status: "unconfirmed",
+      gaps: ["package registries", "git hosting"],
     },
   ],
 };
@@ -168,6 +172,26 @@ describe("CodeExecutionPanel", () => {
         },
       }),
     );
+  });
+
+  it("does not present E2B as a full boundary and surfaces its gaps inline", async () => {
+    const { client } = clientFor({
+      provider: "e2b",
+      timeout_ms: 20_000,
+      available: true,
+      has_credential: true,
+      egress: OPEN_EGRESS,
+    });
+
+    render(<CodeExecutionPanel client={client} />);
+
+    // The E2B badge must read "not a full boundary", never a plain green
+    // "Enforced"/boundary, and the reachable holes are shown next to it.
+    await screen.findByText(/not a full boundary/i);
+    expect(screen.queryByText(/^Boundary$/)).toBeNull();
+    expect(
+      screen.getByText(/domain filtering covers HTTP and HTTPS ports only/i),
+    ).toBeInTheDocument();
   });
 
   it("rejects a timeout outside the bounds before touching the server", async () => {

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
@@ -5,8 +5,11 @@ import type {
   CodeExecutionConfigInfo,
   CodeExecutionCredentialReadiness,
   CodeExecutionProviderKind,
+  EgressConfig,
 } from "../api";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import {
   ActiveProviderField,
   ProviderCredentialField,
@@ -15,6 +18,7 @@ import {
 } from "./ProviderFields";
 import {
   SettingsError,
+  SettingsField,
   SettingsPanel,
   SettingsSection,
   SettingsStatus,
@@ -38,6 +42,10 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
   const [apiKeys, setApiKeys] = useState<
     Partial<Record<CodeExecutionProviderKind, string>>
   >({});
+  // Egress restriction is opt-in: off means today's open-internet sandboxes.
+  const [restrictEgress, setRestrictEgress] = useState(false);
+  const [egressDomains, setEgressDomains] = useState("");
+  const [egressCidrs, setEgressCidrs] = useState("");
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [removing, setRemoving] = useState<CodeExecutionProviderKind | null>(
@@ -60,6 +68,7 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
         setCredentials(nextCredentials.credentials);
         setProvider(nextConfig.provider ?? "");
         setTimeoutSeconds(String(nextConfig.timeout_ms / 1000));
+        hydrateEgress(nextConfig.egress.policy);
       } catch (err) {
         if (!cancelled) setError(String(err));
       } finally {
@@ -73,6 +82,18 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
 
   const working = saving || removing !== null;
   const state = codeExecutionState(config);
+
+  function hydrateEgress(policy: EgressConfig) {
+    if (policy.mode === "allowlist") {
+      setRestrictEgress(true);
+      setEgressDomains(policy.domains.join("\n"));
+      setEgressCidrs(policy.cidrs.join("\n"));
+    } else {
+      setRestrictEgress(false);
+      setEgressDomains("");
+      setEgressCidrs("");
+    }
+  }
 
   async function save() {
     const timeout = timeoutMsFromSeconds(
@@ -99,12 +120,20 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
       const nextConfig = await client.putCodeExecutionConfig({
         provider: provider || null,
         timeout_ms: timeout.timeoutMs,
+        egress: restrictEgress
+          ? {
+              mode: "allowlist",
+              domains: splitEntries(egressDomains),
+              cidrs: splitEntries(egressCidrs),
+            }
+          : { mode: "open" },
       });
       const nextCredentials = await client.listCodeExecutionCredentials();
       setConfig(nextConfig);
       setCredentials(nextCredentials.credentials);
       setProvider(nextConfig.provider ?? "");
       setTimeoutSeconds(String(nextConfig.timeout_ms / 1000));
+      hydrateEgress(nextConfig.egress.policy);
       toast.success("Saved code-execution settings");
     } catch (err) {
       setError(String(err));
@@ -206,6 +235,72 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
             />
           </SettingsSection>
 
+          <SettingsSection
+            title="Network egress"
+            description="Cloud sandboxes reach the internet freely by default. Turn on restriction to allow only the destinations you list; everything else is denied. The local sandbox already blocks all network."
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex flex-col gap-0.5">
+                <span className="font-bold">Restrict network egress</span>
+                <span className="text-sm text-muted-foreground">
+                  {restrictEgress
+                    ? "Only the domains and address blocks below are reachable from the cloud sandbox."
+                    : "Open egress — the cloud sandbox can reach any destination, as it does today."}
+                </span>
+              </div>
+              <Switch
+                checked={restrictEgress}
+                disabled={working}
+                onCheckedChange={setRestrictEgress}
+                aria-label="Restrict network egress"
+              />
+            </div>
+
+            {restrictEgress && (
+              <>
+                <SettingsField
+                  label="Allowed domains"
+                  hint="One per line. An exact host (api.example.com) or a leading wildcard (*.pypi.org)."
+                >
+                  <textarea
+                    className={ENTRY_TEXTAREA_CLASS}
+                    rows={4}
+                    spellCheck={false}
+                    value={egressDomains}
+                    disabled={working}
+                    placeholder={"*.pypi.org\nfiles.pythonhosted.org"}
+                    onChange={(event) => setEgressDomains(event.target.value)}
+                  />
+                </SettingsField>
+
+                <SettingsField
+                  label="Allowed address blocks"
+                  hint="One per line, in CIDR notation (140.82.112.0/20) or a bare address."
+                >
+                  <textarea
+                    className={ENTRY_TEXTAREA_CLASS}
+                    rows={3}
+                    spellCheck={false}
+                    value={egressCidrs}
+                    disabled={working}
+                    placeholder={"140.82.112.0/20"}
+                    onChange={(event) => setEgressCidrs(event.target.value)}
+                  />
+                </SettingsField>
+
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  An empty allowlist blocks all egress. Domain and address rules
+                  are independent: a domain grant never opens a raw IP, and an
+                  address block never opens a hostname.
+                </p>
+              </>
+            )}
+
+            <EgressEnforcementDisclosure
+              enforcement={config.egress.enforcement}
+            />
+          </SettingsSection>
+
           {/* One save for the whole surface: it stores every key typed above
               and the selection together, so a provider cannot go active in a
               pass that failed to save its key. */}
@@ -226,6 +321,50 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
       )}
       {error && <SettingsError>{error}</SettingsError>}
     </SettingsPanel>
+  );
+}
+
+/** Textarea styled to match the shared `Input`, sized for a list of entries. */
+const ENTRY_TEXTAREA_CLASS =
+  "flex w-full rounded-md border border-border bg-background px-3 py-2 font-mono text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
+
+/**
+ * Split a textarea of grants into trimmed, non-empty entries. Newlines and
+ * commas both separate, so a pasted comma-joined list works as well as one per
+ * line; the server re-validates each entry's grammar.
+ */
+function splitEntries(value: string): string[] {
+  return value
+    .split(/[\n,]/)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+/**
+ * Per-provider egress enforcement, disclosed honestly: which managed providers
+ * actually restrict egress today (confirmed) versus applied-but-unconfirmed.
+ */
+function EgressEnforcementDisclosure({
+  enforcement,
+}: {
+  enforcement: CodeExecutionConfigInfo["egress"]["enforcement"];
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      {enforcement.map((row) => (
+        <div key={row.provider} className="flex items-start gap-2 text-sm">
+          <Badge variant={row.confirmed ? "success" : "warning"} size="sm">
+            {row.confirmed ? "Enforced" : "Pending"}
+          </Badge>
+          <span className="text-muted-foreground">
+            <span className="font-medium text-foreground">
+              {codeExecutionProviderLabel(row.provider)}
+            </span>{" "}
+            — {row.note}
+          </span>
+        </div>
+      ))}
+    </div>
   );
 }
 

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
@@ -340,9 +340,40 @@ function splitEntries(value: string): string[] {
     .filter((entry) => entry.length > 0);
 }
 
+type EgressEnforcementRow =
+  CodeExecutionConfigInfo["egress"]["enforcement"][number];
+
 /**
- * Per-provider egress enforcement, disclosed honestly: which managed providers
- * actually restrict egress today (confirmed) versus applied-but-unconfirmed.
+ * How each enforcement status reads: the badge never claims a boundary a
+ * provider does not have, and the caveat sits inline beside it rather than in
+ * prose below. Driven by the server's status, which is itself derived from the
+ * enforcement model, so the UI cannot oversell what the model won't back.
+ */
+const EGRESS_STATUS_PRESENTATION: Record<
+  EgressEnforcementRow["status"],
+  { badge: "success" | "warning" | "critical"; label: string; lead: string }
+> = {
+  boundary: {
+    badge: "success",
+    label: "Boundary",
+    lead: "Enforced as a full network boundary.",
+  },
+  applied_with_gaps: {
+    badge: "warning",
+    label: "Applied — not a full boundary",
+    lead: "The allowlist is applied, but these stay reachable regardless of policy:",
+  },
+  unconfirmed: {
+    badge: "warning",
+    label: "Unconfirmed",
+    lead: "A policy is sent at creation, but enforcement is not yet confirmed against the live API. These stay reachable regardless of policy:",
+  },
+};
+
+/**
+ * Per-provider egress enforcement, disclosed honestly: the badge reflects the
+ * model's own status and the gaps the vendor leaves open are listed inline, so
+ * a provider that is not a full boundary can never read as one.
  */
 function EgressEnforcementDisclosure({
   enforcement,
@@ -351,19 +382,23 @@ function EgressEnforcementDisclosure({
 }) {
   return (
     <div className="flex flex-col gap-2">
-      {enforcement.map((row) => (
-        <div key={row.provider} className="flex items-start gap-2 text-sm">
-          <Badge variant={row.confirmed ? "success" : "warning"} size="sm">
-            {row.confirmed ? "Enforced" : "Pending"}
-          </Badge>
-          <span className="text-muted-foreground">
-            <span className="font-medium text-foreground">
-              {codeExecutionProviderLabel(row.provider)}
-            </span>{" "}
-            — {row.note}
-          </span>
-        </div>
-      ))}
+      {enforcement.map((row) => {
+        const presentation = EGRESS_STATUS_PRESENTATION[row.status];
+        return (
+          <div key={row.provider} className="flex items-start gap-2 text-sm">
+            <Badge variant={presentation.badge} size="sm">
+              {presentation.label}
+            </Badge>
+            <span className="text-muted-foreground">
+              <span className="font-medium text-foreground">
+                {codeExecutionProviderLabel(row.provider)}
+              </span>{" "}
+              — {presentation.lead}
+              {row.gaps.length > 0 && ` ${row.gaps.join("; ")}.`}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -41,6 +41,7 @@ vec-lance = ["openwave-retrieval/vec-lance"]
 openwave-code-execution = { path = "../openwave-code-execution" }
 openwave-core = { path = "../openwave-core", default-features = false, features = ["sqlite", "tools", "keychain", "blob-fs"] }
 openwave-connectors = { path = "../openwave-connectors" }
+openwave-egress = { path = "../openwave-egress" }
 openwave-mcp = { path = "../openwave-mcp" }
 openwave-router = { path = "../openwave-router" }
 openwave-retrieval = { path = "../openwave-retrieval" }

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -19,7 +19,9 @@ use openwave_code_execution::{
     E2B_CREDENTIAL_KEY,
 };
 use openwave_core::{Result, SecretProvider, Store};
-use openwave_egress::{CidrBlock, DomainPattern, EgressAllowlist, EgressError, EgressPolicy};
+use openwave_egress::{
+    CidrBlock, DomainPattern, EgressAllowlist, EgressEnforcement, EgressError, EgressPolicy,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::error::ServerError;
@@ -157,6 +159,41 @@ fn resolve_egress_policy(
     })
 }
 
+/// Build the E2B adapter with the configured egress policy applied.
+///
+/// This is the wiring a dropped-policy regression would silently break —
+/// reverting a configured allowlist to open egress — so it is a named function
+/// the resolve path and its test share, rather than an inline arm nothing
+/// exercises. `Open` leaves today's open-internet creation intact.
+fn configured_e2b(
+    credential: E2BCredential,
+    timeout: Duration,
+    pool: RemoteSessionPool,
+    egress: &EgressConfig,
+) -> std::result::Result<E2BExecutionProvider, CodeExecutionError> {
+    let provider = E2BExecutionProvider::with_session_pool(credential, timeout, pool)?;
+    Ok(match resolve_egress_policy(egress)? {
+        Some(policy) => provider.with_egress_policy(policy),
+        None => provider,
+    })
+}
+
+/// Build the Daytona adapter with the configured egress policy applied. The
+/// same policy compiles into Daytona's block-all switch and allowlists; an
+/// over-limit allowlist is rejected here before any sandbox is created.
+fn configured_daytona(
+    credential: DaytonaCredential,
+    timeout: Duration,
+    pool: RemoteSessionPool,
+    egress: &EgressConfig,
+) -> std::result::Result<DaytonaExecutionProvider, CodeExecutionError> {
+    let provider = DaytonaExecutionProvider::with_session_pool(credential, timeout, pool)?;
+    match resolve_egress_policy(egress)? {
+        Some(policy) => provider.with_egress_policy(policy),
+        None => Ok(provider),
+    }
+}
+
 /// Renderer-safe configuration and readiness.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub struct CodeExecutionConfigInfo {
@@ -184,43 +221,93 @@ pub struct CodeExecutionEgressInfo {
     pub enforcement: Vec<CodeExecutionEgressEnforcement>,
 }
 
+/// The honest state of a managed provider's egress enforcement.
+///
+/// Derived from the shipped enforcement model, never asserted per provider, so
+/// the settings surface and the decision layer cannot disagree: if the model
+/// says a vendor's mechanism leaves a general-purpose destination reachable,
+/// the surface must not present it as a full boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+pub enum EgressEnforcementStatus {
+    /// External enforcement with no general-purpose holes: a full network
+    /// boundary. No managed provider reaches this today.
+    Boundary,
+    /// External enforcement is applied, but the vendor's mechanism leaves
+    /// general-purpose destinations reachable, so a configured allowlist is
+    /// not a full boundary and must not be presented as one.
+    AppliedWithGaps,
+    /// A policy is sent at creation, but the vendor's enforcement is not yet
+    /// confirmed against the live API.
+    Unconfirmed,
+}
+
 /// A managed provider's egress-enforcement status, as host knowledge rather
 /// than a claim the backend makes about itself.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub struct CodeExecutionEgressEnforcement {
     pub provider: CodeExecutionProviderKind,
-    /// `true` once the vendor's per-sandbox network semantics are confirmed to
-    /// enforce the configured allowlist. E2B is confirmed; Daytona is not yet,
-    /// so a configured policy is applied but must not be relied on as a
-    /// boundary until its deny-all semantics are confirmed against the live API.
-    pub confirmed: bool,
-    /// Plain-language disclosure for the settings surface.
-    pub note: String,
+    pub status: EgressEnforcementStatus,
+    /// Destinations the vendor's mechanism keeps reachable regardless of the
+    /// configured policy — each a short purpose string straight from the
+    /// enforcement model, so the settings surface can show the caveat inline
+    /// instead of burying it in prose the user skims past.
+    pub gaps: Vec<String>,
 }
 
-/// The managed providers' egress-enforcement disclosure. This is host
-/// knowledge compiled into the build — E2B's per-sandbox `allowOut` semantics
-/// are documented and confirmed, while Daytona's empty-but-present allowlist
-/// "deny that axis" behavior is not yet confirmed against the live API.
+/// The managed providers' egress-enforcement disclosure, derived from the
+/// shipped [`EgressEnforcement`] declarations.
+///
+/// E2B's enforcement is confirmed against the live API, so its status is
+/// whatever the model reports — and the model reports *not a boundary*, because
+/// its domain rules cover only HTTP/HTTPS ports and DNS stays open. Daytona's
+/// wiring is not yet confirmed against the live API (its empty-but-present
+/// "deny that axis" semantics are unverified), which dominates the display
+/// regardless of tier.
 fn egress_enforcement_status() -> Vec<CodeExecutionEgressEnforcement> {
     vec![
-        CodeExecutionEgressEnforcement {
-            provider: CodeExecutionProviderKind::E2b,
-            confirmed: true,
-            note: "E2B enforces the per-sandbox allowlist. DNS resolution and \
-                   non-HTTP/S ports stay reachable regardless of policy."
-                .to_owned(),
-        },
-        CodeExecutionEgressEnforcement {
-            provider: CodeExecutionProviderKind::Daytona,
-            confirmed: false,
-            note: "A configured policy is sent at creation, but whether an empty \
-                   allowlist denies that axis is not yet confirmed against the \
-                   live Daytona API, and Daytona keeps general-purpose services \
-                   reachable. Do not rely on it as a network boundary yet."
-                .to_owned(),
-        },
+        enforcement_row(
+            CodeExecutionProviderKind::E2b,
+            &E2BExecutionProvider::egress_enforcement(),
+            true,
+        ),
+        enforcement_row(
+            CodeExecutionProviderKind::Daytona,
+            &DaytonaExecutionProvider::egress_enforcement(),
+            false,
+        ),
     ]
+}
+
+/// Project one provider's enforcement declaration into the renderer-safe row.
+///
+/// The status reads straight from the model: an unconfirmed vendor is
+/// `Unconfirmed`; otherwise `is_credential_boundary()` — external tier with no
+/// general-purpose holes — decides `Boundary` versus `AppliedWithGaps`. Every
+/// declared exception is surfaced as a gap so nothing the vendor leaves open is
+/// hidden from the user.
+fn enforcement_row(
+    provider: CodeExecutionProviderKind,
+    enforcement: &EgressEnforcement,
+    confirmed: bool,
+) -> CodeExecutionEgressEnforcement {
+    let status = if !confirmed {
+        EgressEnforcementStatus::Unconfirmed
+    } else if enforcement.is_credential_boundary() {
+        EgressEnforcementStatus::Boundary
+    } else {
+        EgressEnforcementStatus::AppliedWithGaps
+    };
+    let gaps = enforcement
+        .exceptions()
+        .iter()
+        .map(|exception| exception.purpose.to_owned())
+        .collect();
+    CodeExecutionEgressEnforcement {
+        provider,
+        status,
+        gaps,
+    }
 }
 
 impl CodeExecutionEgressInfo {
@@ -459,38 +546,23 @@ impl ConfiguredCodeExecutionProvider {
                 let credential = E2BCredential::load(&*self.secrets)
                     .await?
                     .ok_or(CodeExecutionError::NotConfigured)?;
-                let provider = E2BExecutionProvider::with_session_pool(
+                Ok(Box::new(configured_e2b(
                     credential,
                     Duration::from_millis(config.timeout_ms),
                     self.remote_sessions.clone(),
-                )?;
-                // A configured allowlist becomes E2B's per-sandbox network
-                // rules; `Open` leaves today's open-internet creation intact.
-                let provider = match resolve_egress_policy(&config.egress)? {
-                    Some(policy) => provider.with_egress_policy(policy),
-                    None => provider,
-                };
-                Ok(Box::new(provider))
+                    &config.egress,
+                )?))
             }
             CodeExecutionProviderKind::Daytona => {
                 let credential = DaytonaCredential::load(&*self.secrets)
                     .await?
                     .ok_or(CodeExecutionError::NotConfigured)?;
-                let provider = DaytonaExecutionProvider::with_session_pool(
+                Ok(Box::new(configured_daytona(
                     credential,
                     Duration::from_millis(config.timeout_ms),
                     self.remote_sessions.clone(),
-                )?;
-                // The same policy compiles into Daytona's block-all switch and
-                // allowlists. Enforcement of the empty-present "deny that axis"
-                // case is still pending live confirmation (see the enforcement
-                // disclosure in `egress_enforcement_status`); the default
-                // (`Open` -> open egress) is unchanged.
-                let provider = match resolve_egress_policy(&config.egress)? {
-                    Some(policy) => provider.with_egress_policy(policy)?,
-                    None => provider,
-                };
-                Ok(Box::new(provider))
+                    &config.egress,
+                )?))
             }
             _ => Err(CodeExecutionError::Unavailable(
                 "selected provider is not supported by this build".into(),
@@ -709,24 +781,87 @@ mod tests {
     }
 
     #[test]
-    fn egress_enforcement_reports_e2b_confirmed_and_daytona_pending() {
+    fn egress_enforcement_never_oversells_a_provider_past_its_model() {
         let status = egress_enforcement_status();
-        let e2b = status
-            .iter()
-            .find(|row| row.provider == CodeExecutionProviderKind::E2b)
-            .expect("E2B enforcement is disclosed");
-        let daytona = status
-            .iter()
-            .find(|row| row.provider == CodeExecutionProviderKind::Daytona)
-            .expect("Daytona enforcement is disclosed");
+        let row = |provider| {
+            status
+                .iter()
+                .find(|row| row.provider == provider)
+                .unwrap_or_else(|| panic!("{provider} enforcement is disclosed"))
+        };
+        let e2b = row(CodeExecutionProviderKind::E2b);
+        let daytona = row(CodeExecutionProviderKind::Daytona);
+
+        // E2B is confirmed, but its own enforcement model says it is not a full
+        // boundary — domain rules cover only HTTP/HTTPS and DNS stays open — so
+        // the surface must report gaps, not a boundary. Reading it from the
+        // model is what keeps the two from ever disagreeing.
         assert!(
-            e2b.confirmed,
-            "E2B's per-sandbox egress semantics are confirmed"
+            !E2BExecutionProvider::egress_enforcement().is_credential_boundary(),
+            "the model itself does not treat E2B as a boundary"
         );
+        assert_eq!(e2b.status, EgressEnforcementStatus::AppliedWithGaps);
         assert!(
-            !daytona.confirmed,
-            "Daytona's deny-all semantics are pending live confirmation and must not be claimed as a boundary"
+            !e2b.gaps.is_empty(),
+            "the ports/DNS holes that make E2B not-a-boundary must be surfaced"
         );
+
+        // Daytona's wiring is unconfirmed against the live API; that dominates.
+        assert_eq!(daytona.status, EgressEnforcementStatus::Unconfirmed);
+        assert!(!daytona.gaps.is_empty());
+    }
+
+    #[test]
+    fn resolve_glue_applies_the_configured_policy_to_the_managed_providers() {
+        // The catastrophic-but-silent regression is the resolve path dropping
+        // the policy — a configured allowlist reverting to open egress. These
+        // assert the exact wiring resolve uses carries the policy through to the
+        // provider; the adapter tests then prove that policy compiles into the
+        // create body.
+        let timeout = Duration::from_millis(DEFAULT_TIMEOUT_MS);
+        let pool = RemoteSessionPool::default();
+        let allowlist = EgressConfig::Allowlist {
+            domains: vec!["*.pypi.org".to_owned()],
+            cidrs: vec!["140.82.112.0/20".to_owned()],
+        };
+        let expected = allowlist.to_policy().unwrap().unwrap();
+
+        let e2b = configured_e2b(
+            E2BCredential::parse("test-e2b-key").unwrap(),
+            timeout,
+            pool.clone(),
+            &allowlist,
+        )
+        .unwrap();
+        assert_eq!(e2b.egress_policy(), Some(&expected));
+
+        let daytona = configured_daytona(
+            DaytonaCredential::parse("test-daytona-key").unwrap(),
+            timeout,
+            pool.clone(),
+            &allowlist,
+        )
+        .unwrap();
+        assert_eq!(daytona.egress_policy(), Some(&expected));
+
+        // Open leaves both providers on today's open-internet creation: no
+        // policy is threaded in.
+        let open_e2b = configured_e2b(
+            E2BCredential::parse("test-e2b-key").unwrap(),
+            timeout,
+            pool.clone(),
+            &EgressConfig::Open,
+        )
+        .unwrap();
+        assert_eq!(open_e2b.egress_policy(), None);
+        let open_daytona = configured_daytona(
+            DaytonaCredential::parse("test-daytona-key").unwrap(),
+            timeout,
+            pool,
+            &EgressConfig::Open,
+        )
+        .unwrap();
+        assert_eq!(open_daytona.egress_policy(), None);
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -19,6 +19,7 @@ use openwave_code_execution::{
     E2B_CREDENTIAL_KEY,
 };
 use openwave_core::{Result, SecretProvider, Store};
+use openwave_egress::{CidrBlock, DomainPattern, EgressAllowlist, EgressError, EgressPolicy};
 use serde::{Deserialize, Serialize};
 
 use crate::error::ServerError;
@@ -36,6 +37,62 @@ const CREDENTIAL_PROVIDERS: [CodeExecutionProviderKind; 2] = [
     CodeExecutionProviderKind::Daytona,
 ];
 
+/// Host-owned, non-secret egress policy for the managed exec sandboxes.
+///
+/// The model never sets this (invariant 1): it is host configuration, carries
+/// no secret, and accepts no endpoint. `Open` is the default and preserves
+/// exec's out-of-the-box behavior — E2B and Daytona are created with open
+/// internet access, as they always have been. Egress restriction is opt-in:
+/// an `Allowlist` switches every managed sandbox created afterwards to
+/// deny-by-default and compiles the listed domain patterns and CIDR blocks
+/// into the vendor's per-sandbox network controls. An empty allowlist denies
+/// everything on both axes.
+///
+/// The strings are validated to the same [`DomainPattern`] and [`CidrBlock`]
+/// grammar the decision layer uses, so a malformed grant is rejected at
+/// `PUT` time rather than silently widening egress at sandbox creation.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, ts_rs::TS)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum EgressConfig {
+    /// Unrestricted egress — today's default. No policy is applied and the
+    /// managed adapters create open-internet sandboxes.
+    #[default]
+    Open,
+    /// Deny-by-default egress restricted to these domain patterns and CIDR
+    /// blocks. An empty allowlist blocks all egress.
+    Allowlist {
+        domains: Vec<String>,
+        cidrs: Vec<String>,
+    },
+}
+
+impl EgressConfig {
+    /// The egress policy to compile into a managed sandbox at creation, or
+    /// `None` to keep today's open-internet creation.
+    ///
+    /// Returns an error rather than silently opening egress when a stored
+    /// pattern does not parse, so an invalid grant fails closed at the network
+    /// boundary instead of degrading to unrestricted.
+    fn to_policy(&self) -> std::result::Result<Option<EgressPolicy>, EgressError> {
+        match self {
+            Self::Open => Ok(None),
+            Self::Allowlist { domains, cidrs } => {
+                let domains = domains
+                    .iter()
+                    .map(DomainPattern::parse)
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+                let cidrs = cidrs
+                    .iter()
+                    .map(CidrBlock::parse)
+                    .collect::<std::result::Result<Vec<_>, _>>()?;
+                Ok(Some(EgressPolicy::Allowlist(EgressAllowlist::new(
+                    domains, cidrs,
+                ))))
+            }
+        }
+    }
+}
+
 /// Non-secret host selection. Local is usable by default because its mandatory
 /// sandbox denies network and outside-workspace writes. `None` explicitly
 /// removes execution from service without changing the stable tool contract.
@@ -45,6 +102,11 @@ pub struct CodeExecutionConfig {
     pub provider: Option<CodeExecutionProviderKind>,
     #[serde(default = "default_timeout_ms")]
     pub timeout_ms: u64,
+    /// Egress policy for the managed adapters. Absent in configs written
+    /// before this field existed; those default to `Open`, preserving the
+    /// open-internet creation they already had.
+    #[serde(default)]
+    pub egress: EgressConfig,
 }
 
 impl Default for CodeExecutionConfig {
@@ -52,6 +114,7 @@ impl Default for CodeExecutionConfig {
         Self {
             provider: Some(CodeExecutionProviderKind::Local),
             timeout_ms: DEFAULT_TIMEOUT_MS,
+            egress: EgressConfig::Open,
         }
     }
 }
@@ -61,6 +124,7 @@ impl CodeExecutionConfig {
         Self {
             provider: None,
             timeout_ms: DEFAULT_TIMEOUT_MS,
+            egress: EgressConfig::Open,
         }
     }
 
@@ -70,12 +134,27 @@ impl CodeExecutionConfig {
                 "code execution timeout_ms must be between {MIN_TIMEOUT_MS} and {MAX_TIMEOUT_MS}"
             )));
         }
+        // A malformed allowlist is a bad request, not a silent open egress.
+        self.egress
+            .to_policy()
+            .map_err(|error| ServerError::bad_request(error.to_string()))?;
         Ok(())
     }
 }
 
 const fn default_timeout_ms() -> u64 {
     DEFAULT_TIMEOUT_MS
+}
+
+/// Compile the stored egress config into a policy at the last boundary before
+/// a managed sandbox is created. A malformed stored allowlist fails closed by
+/// refusing execution rather than degrading to open egress.
+fn resolve_egress_policy(
+    egress: &EgressConfig,
+) -> std::result::Result<Option<EgressPolicy>, CodeExecutionError> {
+    egress.to_policy().map_err(|error| {
+        CodeExecutionError::InvalidRequest(format!("invalid egress policy: {error}"))
+    })
 }
 
 /// Renderer-safe configuration and readiness.
@@ -87,6 +166,70 @@ pub struct CodeExecutionConfigInfo {
     pub timeout_ms: u64,
     pub available: bool,
     pub has_credential: bool,
+    /// The configured egress policy and each managed provider's enforcement
+    /// status, so the renderer can present the policy and disclose which
+    /// providers actually restrict egress today.
+    pub egress: CodeExecutionEgressInfo,
+}
+
+/// Renderer-safe egress policy plus per-provider enforcement disclosure.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
+pub struct CodeExecutionEgressInfo {
+    /// The configured host policy. `Open` is the default: managed sandboxes are
+    /// created with open internet access. An allowlist restricts every managed
+    /// sandbox created afterwards.
+    pub policy: EgressConfig,
+    /// One row per managed provider, stating whether its egress restriction is
+    /// confirmed against the live vendor API or still pending confirmation.
+    pub enforcement: Vec<CodeExecutionEgressEnforcement>,
+}
+
+/// A managed provider's egress-enforcement status, as host knowledge rather
+/// than a claim the backend makes about itself.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
+pub struct CodeExecutionEgressEnforcement {
+    pub provider: CodeExecutionProviderKind,
+    /// `true` once the vendor's per-sandbox network semantics are confirmed to
+    /// enforce the configured allowlist. E2B is confirmed; Daytona is not yet,
+    /// so a configured policy is applied but must not be relied on as a
+    /// boundary until its deny-all semantics are confirmed against the live API.
+    pub confirmed: bool,
+    /// Plain-language disclosure for the settings surface.
+    pub note: String,
+}
+
+/// The managed providers' egress-enforcement disclosure. This is host
+/// knowledge compiled into the build — E2B's per-sandbox `allowOut` semantics
+/// are documented and confirmed, while Daytona's empty-but-present allowlist
+/// "deny that axis" behavior is not yet confirmed against the live API.
+fn egress_enforcement_status() -> Vec<CodeExecutionEgressEnforcement> {
+    vec![
+        CodeExecutionEgressEnforcement {
+            provider: CodeExecutionProviderKind::E2b,
+            confirmed: true,
+            note: "E2B enforces the per-sandbox allowlist. DNS resolution and \
+                   non-HTTP/S ports stay reachable regardless of policy."
+                .to_owned(),
+        },
+        CodeExecutionEgressEnforcement {
+            provider: CodeExecutionProviderKind::Daytona,
+            confirmed: false,
+            note: "A configured policy is sent at creation, but whether an empty \
+                   allowlist denies that axis is not yet confirmed against the \
+                   live Daytona API, and Daytona keeps general-purpose services \
+                   reachable. Do not rely on it as a network boundary yet."
+                .to_owned(),
+        },
+    ]
+}
+
+impl CodeExecutionEgressInfo {
+    fn from_config(policy: EgressConfig) -> Self {
+        Self {
+            policy,
+            enforcement: egress_enforcement_status(),
+        }
+    }
 }
 
 /// Renderer-safe readiness for one managed provider's fixed credential slot.
@@ -112,6 +255,10 @@ pub struct CodeExecutionConfigUpdate {
     pub provider: Option<Option<CodeExecutionProviderKind>>,
     #[serde(default)]
     pub timeout_ms: Option<u64>,
+    /// Replace the egress policy. Absent leaves the current policy unchanged;
+    /// no secret or endpoint is accepted here — only domain patterns and CIDRs.
+    #[serde(default)]
+    pub egress: Option<EgressConfig>,
 }
 
 fn double_option<'de, D, T>(deserializer: D) -> std::result::Result<Option<Option<T>>, D::Error>
@@ -162,6 +309,7 @@ pub async fn config_info(
         timeout_ms: config.timeout_ms,
         available,
         has_credential,
+        egress: CodeExecutionEgressInfo::from_config(config.egress),
     })
 }
 
@@ -189,6 +337,9 @@ pub async fn update_config(
     }
     if let Some(timeout_ms) = update.timeout_ms {
         config.timeout_ms = timeout_ms;
+    }
+    if let Some(egress) = update.egress {
+        config.egress = egress;
     }
     config.validate()?;
     write_config(store, &config).await?;
@@ -308,21 +459,38 @@ impl ConfiguredCodeExecutionProvider {
                 let credential = E2BCredential::load(&*self.secrets)
                     .await?
                     .ok_or(CodeExecutionError::NotConfigured)?;
-                Ok(Box::new(E2BExecutionProvider::with_session_pool(
+                let provider = E2BExecutionProvider::with_session_pool(
                     credential,
                     Duration::from_millis(config.timeout_ms),
                     self.remote_sessions.clone(),
-                )?))
+                )?;
+                // A configured allowlist becomes E2B's per-sandbox network
+                // rules; `Open` leaves today's open-internet creation intact.
+                let provider = match resolve_egress_policy(&config.egress)? {
+                    Some(policy) => provider.with_egress_policy(policy),
+                    None => provider,
+                };
+                Ok(Box::new(provider))
             }
             CodeExecutionProviderKind::Daytona => {
                 let credential = DaytonaCredential::load(&*self.secrets)
                     .await?
                     .ok_or(CodeExecutionError::NotConfigured)?;
-                Ok(Box::new(DaytonaExecutionProvider::with_session_pool(
+                let provider = DaytonaExecutionProvider::with_session_pool(
                     credential,
                     Duration::from_millis(config.timeout_ms),
                     self.remote_sessions.clone(),
-                )?))
+                )?;
+                // The same policy compiles into Daytona's block-all switch and
+                // allowlists. Enforcement of the empty-present "deny that axis"
+                // case is still pending live confirmation (see the enforcement
+                // disclosure in `egress_enforcement_status`); the default
+                // (`Open` -> open egress) is unchanged.
+                let provider = match resolve_egress_policy(&config.egress)? {
+                    Some(policy) => provider.with_egress_policy(policy)?,
+                    None => provider,
+                };
+                Ok(Box::new(provider))
             }
             _ => Err(CodeExecutionError::Unavailable(
                 "selected provider is not supported by this build".into(),
@@ -476,6 +644,7 @@ mod tests {
         assert!(CodeExecutionConfig {
             provider: Some(CodeExecutionProviderKind::Local),
             timeout_ms: MIN_TIMEOUT_MS - 1,
+            egress: EgressConfig::Open,
         }
         .validate()
         .is_err());
@@ -489,6 +658,77 @@ mod tests {
         assert!(json.get("credential").is_none());
     }
 
+    #[test]
+    fn egress_defaults_to_open_and_compiles_no_policy() {
+        let config = CodeExecutionConfig::default();
+        assert_eq!(config.egress, EgressConfig::Open);
+        // Open must leave the managed adapters on today's open-internet
+        // creation: no policy is threaded into the create path.
+        assert_eq!(config.egress.to_policy().unwrap(), None);
+
+        // The egress config carries no secret or endpoint — only patterns.
+        let json = serde_json::to_value(&config.egress).unwrap();
+        assert_eq!(json, serde_json::json!({ "mode": "open" }));
+    }
+
+    #[test]
+    fn egress_allowlist_compiles_to_a_deny_by_default_decision_policy() {
+        let config = EgressConfig::Allowlist {
+            domains: vec!["*.pypi.org".to_owned(), "crates.io".to_owned()],
+            cidrs: vec!["140.82.112.0/20".to_owned()],
+        };
+        let Some(EgressPolicy::Allowlist(allowlist)) = config.to_policy().unwrap() else {
+            panic!("a non-empty allowlist compiles to an allowlist policy");
+        };
+        assert_eq!(allowlist.domains().len(), 2);
+        assert_eq!(allowlist.cidrs().len(), 1);
+
+        // An empty allowlist is a deny-all policy, not open egress.
+        let empty = EgressConfig::Allowlist {
+            domains: vec![],
+            cidrs: vec![],
+        };
+        let Some(EgressPolicy::Allowlist(empty_list)) = empty.to_policy().unwrap() else {
+            panic!("an empty allowlist still compiles to a policy");
+        };
+        assert!(empty_list.is_empty());
+
+        // A malformed grant fails closed at validation rather than widening.
+        let bad = EgressConfig::Allowlist {
+            domains: vec!["not a host".to_owned()],
+            cidrs: vec![],
+        };
+        assert!(bad.to_policy().is_err());
+        assert!(CodeExecutionConfig {
+            provider: Some(CodeExecutionProviderKind::E2b),
+            timeout_ms: DEFAULT_TIMEOUT_MS,
+            egress: bad,
+        }
+        .validate()
+        .is_err());
+    }
+
+    #[test]
+    fn egress_enforcement_reports_e2b_confirmed_and_daytona_pending() {
+        let status = egress_enforcement_status();
+        let e2b = status
+            .iter()
+            .find(|row| row.provider == CodeExecutionProviderKind::E2b)
+            .expect("E2B enforcement is disclosed");
+        let daytona = status
+            .iter()
+            .find(|row| row.provider == CodeExecutionProviderKind::Daytona)
+            .expect("Daytona enforcement is disclosed");
+        assert!(
+            e2b.confirmed,
+            "E2B's per-sandbox egress semantics are confirmed"
+        );
+        assert!(
+            !daytona.confirmed,
+            "Daytona's deny-all semantics are pending live confirmation and must not be claimed as a boundary"
+        );
+    }
+
     #[tokio::test]
     async fn configuration_can_disable_and_reenable_local_execution() {
         let (store, _dir) = test_store().await;
@@ -499,6 +739,7 @@ mod tests {
             CodeExecutionConfigUpdate {
                 provider: Some(None),
                 timeout_ms: Some(MIN_TIMEOUT_MS),
+                egress: None,
             },
         )
         .await;
@@ -515,6 +756,7 @@ mod tests {
             CodeExecutionConfigUpdate {
                 provider: Some(Some(CodeExecutionProviderKind::Local)),
                 timeout_ms: Some(MAX_TIMEOUT_MS),
+                egress: None,
             },
         )
         .await;

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -882,17 +882,20 @@ async fn code_execution_egress_policy_round_trips_and_rejects_secrets() {
     let initial: serde_json::Value = json_body(initial).await;
     assert_eq!(initial["egress"]["policy"]["mode"], "open");
     let enforcement = initial["egress"]["enforcement"].as_array().unwrap();
-    let confirmed = |provider: &str| {
+    let row = |provider: &str| {
         enforcement
             .iter()
             .find(|row| row["provider"] == provider)
-            .unwrap_or_else(|| panic!("{provider} enforcement is disclosed"))["confirmed"]
+            .unwrap_or_else(|| panic!("{provider} enforcement is disclosed"))
             .clone()
     };
-    assert_eq!(confirmed("e2b"), serde_json::json!(true));
+    // E2B is applied but honestly not a full boundary; Daytona is unconfirmed.
+    // Neither is ever shown as a plain boundary, and the gaps are surfaced.
+    assert_eq!(row("e2b")["status"], "applied_with_gaps");
+    assert!(!row("e2b")["gaps"].as_array().unwrap().is_empty());
     assert_eq!(
-        confirmed("daytona"),
-        serde_json::json!(false),
+        row("daytona")["status"],
+        "unconfirmed",
         "Daytona egress is applied but not yet a confirmed boundary"
     );
 

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -632,14 +632,17 @@ async fn code_execution_config_route_is_authenticated_and_preserves_explicit_dis
         .await
         .unwrap();
     assert_eq!(disabled.status(), StatusCode::OK);
-    assert_eq!(
-        json_body::<serde_json::Value>(disabled).await,
-        serde_json::json!({
-            "timeout_ms": crate::code_execution::MIN_TIMEOUT_MS,
-            "available": false,
-            "has_credential": false,
-        })
+    let disabled: serde_json::Value = json_body(disabled).await;
+    assert!(
+        disabled.get("provider").is_none(),
+        "an explicit disable omits the provider key"
     );
+    assert_eq!(
+        disabled["timeout_ms"],
+        crate::code_execution::MIN_TIMEOUT_MS
+    );
+    assert_eq!(disabled["available"], false);
+    assert_eq!(disabled["has_credential"], false);
 
     let e2b = router
         .clone()
@@ -661,15 +664,14 @@ async fn code_execution_config_route_is_authenticated_and_preserves_explicit_dis
         .await
         .unwrap();
     assert_eq!(e2b.status(), StatusCode::OK);
-    assert_eq!(
-        json_body::<serde_json::Value>(e2b).await,
-        serde_json::json!({
-            "provider": "e2b",
-            "timeout_ms": crate::code_execution::DEFAULT_TIMEOUT_MS,
-            "available": false,
-            "has_credential": false,
-        })
-    );
+    let e2b: serde_json::Value = json_body(e2b).await;
+    assert_eq!(e2b["provider"], "e2b");
+    assert_eq!(e2b["timeout_ms"], crate::code_execution::DEFAULT_TIMEOUT_MS);
+    assert_eq!(e2b["available"], false);
+    assert_eq!(e2b["has_credential"], false);
+    // Egress defaults to open and is disclosed on the same surface: managed
+    // sandboxes stay open-internet until a policy is configured.
+    assert_eq!(e2b["egress"]["policy"]["mode"], "open");
 
     let unknown_credential = router
         .clone()
@@ -838,6 +840,120 @@ async fn code_execution_config_route_is_authenticated_and_preserves_explicit_dis
     assert_eq!(ready["provider"], "daytona");
     assert_eq!(ready["available"], true);
     assert_eq!(ready["has_credential"], true);
+}
+
+#[tokio::test]
+async fn code_execution_egress_policy_round_trips_and_rejects_secrets() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+
+    let put_egress = |body: serde_json::Value| {
+        let router = router.clone();
+        let bearer = bearer.clone();
+        async move {
+            router
+                .oneshot(
+                    Request::builder()
+                        .method("PUT")
+                        .uri("/code-execution")
+                        .header(header::AUTHORIZATION, &bearer)
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(body.to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+        }
+    };
+
+    // The default surface discloses open egress plus each managed provider's
+    // enforcement status: E2B confirmed, Daytona pending live confirmation.
+    let initial = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/code-execution")
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let initial: serde_json::Value = json_body(initial).await;
+    assert_eq!(initial["egress"]["policy"]["mode"], "open");
+    let enforcement = initial["egress"]["enforcement"].as_array().unwrap();
+    let confirmed = |provider: &str| {
+        enforcement
+            .iter()
+            .find(|row| row["provider"] == provider)
+            .unwrap_or_else(|| panic!("{provider} enforcement is disclosed"))["confirmed"]
+            .clone()
+    };
+    assert_eq!(confirmed("e2b"), serde_json::json!(true));
+    assert_eq!(
+        confirmed("daytona"),
+        serde_json::json!(false),
+        "Daytona egress is applied but not yet a confirmed boundary"
+    );
+
+    // A configured allowlist round-trips through the store and back out.
+    let saved = put_egress(serde_json::json!({
+        "egress": {
+            "mode": "allowlist",
+            "domains": ["*.pypi.org", "crates.io"],
+            "cidrs": ["140.82.112.0/20"],
+        }
+    }))
+    .await;
+    assert_eq!(saved.status(), StatusCode::OK);
+    let saved: serde_json::Value = json_body(saved).await;
+    assert_eq!(saved["egress"]["policy"]["mode"], "allowlist");
+    assert_eq!(
+        saved["egress"]["policy"]["domains"],
+        serde_json::json!(["*.pypi.org", "crates.io"])
+    );
+    assert_eq!(
+        saved["egress"]["policy"]["cidrs"],
+        serde_json::json!(["140.82.112.0/20"])
+    );
+
+    // A malformed grant is a bad request, never a silent widening to open.
+    let malformed = put_egress(serde_json::json!({
+        "egress": { "mode": "allowlist", "domains": ["not a host"], "cidrs": [] }
+    }))
+    .await;
+    assert_eq!(malformed.status(), StatusCode::BAD_REQUEST);
+
+    // No secret or endpoint is accepted on this surface: an extra field is
+    // rejected rather than stored.
+    let with_endpoint = put_egress(serde_json::json!({
+        "egress": { "mode": "allowlist", "domains": [], "cidrs": [] },
+        "endpoint": "https://exfil.example",
+    }))
+    .await;
+    assert!(
+        with_endpoint.status().is_client_error(),
+        "an unknown field is rejected, never stored: {}",
+        with_endpoint.status()
+    );
+
+    // The last valid policy is still in place after the rejected writes.
+    let current = router
+        .oneshot(
+            Request::builder()
+                .uri("/code-execution")
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let current: serde_json::Value = json_body(current).await;
+    assert_eq!(current["egress"]["policy"]["mode"], "allowlist");
+    assert_eq!(
+        current["egress"]["policy"]["domains"],
+        serde_json::json!(["*.pypi.org", "crates.io"])
+    );
 }
 
 #[tokio::test]

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -15,8 +15,8 @@ The authenticated local API owns provider selection and timeout policy:
 
 | Route | Purpose |
 | --- | --- |
-| `GET /code-execution` | Return the selected provider, timeout, and host readiness |
-| `PUT /code-execution` | Select a fixed provider or disable execution, and update the bounded timeout |
+| `GET /code-execution` | Return the selected provider, timeout, egress policy, and host readiness |
+| `PUT /code-execution` | Select a fixed provider or disable execution, update the bounded timeout, and set the managed-sandbox egress policy |
 | `GET /code-execution/credentials` | Read readiness for the fixed E2B and Daytona key slots |
 | `PUT /code-execution/credentials/{e2b\|daytona}` | Store that provider's API key in its fixed host-secret slot |
 | `DELETE /code-execution/credentials/{e2b\|daytona}` | Remove only that provider's saved API key |
@@ -44,6 +44,51 @@ value, or secret reference is accepted by the non-secret settings surface.
 `GET /code-execution` reports `has_credential` for the selected provider only,
 while `GET /code-execution/credentials` reports readiness for both managed slots
 independently. Local execution needs no credential and has no slot to report.
+
+### Egress policy
+
+`GET`/`PUT /code-execution` also carry a host-owned, non-secret egress policy for
+the managed sandboxes, under the `egress` field. It is a store setting, not a
+keychain secret: it holds only an allowlist of domain patterns and CIDR blocks,
+or `open`, and the surface accepts no endpoint or secret. The model never sets
+it — it is host configuration, like provider selection and timeout.
+
+The `policy` is one of:
+
+```json
+{ "mode": "open" }
+{ "mode": "allowlist", "domains": ["*.pypi.org"], "cidrs": ["140.82.112.0/20"] }
+```
+
+Egress restriction is **opt-in, and the default is `open`**. Managed sandboxes
+have always been created with open internet access, and flipping the default to
+deny would break package installs and network fetches inside code execution, so
+`open` stays the out-of-the-box behavior and is disclosed as such in settings.
+Configuring an allowlist switches every managed sandbox created afterwards to
+deny-by-default: only the listed domains and address blocks are reachable, and
+an empty allowlist denies all egress. Domain and address rules are independent —
+a domain grant never opens a raw IP and an address block never opens a
+hostname — matching the decision layer in
+[sandbox providers](sandbox-providers.md). Each pattern is validated to that
+layer's grammar at `PUT` time, so a malformed grant is a bad request rather than
+a silent widening; a malformed *stored* policy fails closed by refusing
+execution, never by reverting to open egress. The local provider already denies
+all network and is unaffected.
+
+The `enforcement` field discloses, per managed provider, whether its egress
+restriction is confirmed against the live vendor API:
+
+- **E2B is confirmed.** A configured allowlist becomes E2B's per-sandbox
+  `allowOut` rules with `allow_internet_access: false`. DNS resolution and
+  non-HTTP/S ports stay reachable regardless of policy, as E2B's mechanism
+  allows.
+- **Daytona is pending.** A configured policy is sent at sandbox creation
+  (block-all switch or comma-separated allowlists), but whether an
+  empty-but-present allowlist denies that axis is not yet confirmed against the
+  live Daytona API, and Daytona keeps general-purpose services (package
+  registries, git hosting, container registries, AI APIs) reachable regardless
+  of policy. Daytona egress is therefore applied but must not be relied on as a
+  network boundary until confirmed.
 
 The `exec` tool remains registered with a stable schema while settings change.
 The host resolves the selected provider immediately before execution, so a
@@ -179,5 +224,7 @@ The provider adapters own only their control-plane and command transports:
 Managed credentials remain in the OS secret store and never enter configuration,
 tool arguments, logs, or renderer responses. Remote API endpoints are fixed by
 the build; Daytona toolbox URLs returned by the control plane are restricted to
-HTTPS Daytona origins. Both managed providers allow internet access inside the
-sandbox, unlike the local native provider.
+HTTPS Daytona origins. By default both managed providers allow internet access
+inside the sandbox, unlike the local native provider; a configured
+[egress policy](#egress-policy) restricts that access at sandbox creation, with
+E2B's enforcement confirmed and Daytona's pending live confirmation.

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -75,20 +75,31 @@ a silent widening; a malformed *stored* policy fails closed by refusing
 execution, never by reverting to open egress. The local provider already denies
 all network and is unaffected.
 
-The `enforcement` field discloses, per managed provider, whether its egress
-restriction is confirmed against the live vendor API:
+The `enforcement` field discloses, per managed provider, an honest `status`
+(`boundary`, `applied_with_gaps`, or `unconfirmed`) plus the `gaps` the vendor
+leaves reachable regardless of policy. The status is **derived from the shipped
+enforcement model** (`EgressEnforcement`), not asserted per provider, so the
+settings surface and the decision layer can never disagree — if the model says a
+vendor's mechanism leaves a general-purpose destination reachable, the surface
+cannot present it as a full boundary.
 
-- **E2B is confirmed.** A configured allowlist becomes E2B's per-sandbox
-  `allowOut` rules with `allow_internet_access: false`. DNS resolution and
-  non-HTTP/S ports stay reachable regardless of policy, as E2B's mechanism
-  allows.
-- **Daytona is pending.** A configured policy is sent at sandbox creation
+- **E2B — `applied_with_gaps`.** A configured allowlist becomes E2B's
+  per-sandbox `allowOut` rules with `allow_internet_access: false`, and this is
+  confirmed against the live API. It is **not a full boundary**: domain rules
+  are enforced only on ports 80/443 and DNS resolution stays open, so code in
+  the sandbox can still reach arbitrary hosts on other ports or tunnel over DNS.
+  The model's `is_credential_boundary()` returns false for exactly this reason,
+  and the projection reads that value rather than a hardcoded flag.
+- **Daytona — `unconfirmed`.** A configured policy is sent at sandbox creation
   (block-all switch or comma-separated allowlists), but whether an
   empty-but-present allowlist denies that axis is not yet confirmed against the
   live Daytona API, and Daytona keeps general-purpose services (package
   registries, git hosting, container registries, AI APIs) reachable regardless
   of policy. Daytona egress is therefore applied but must not be relied on as a
   network boundary until confirmed.
+
+The local sandbox is the only tier that denies all network outright — the actual
+boundary — and it does so unconditionally, independent of this policy.
 
 The `exec` tool remains registered with a stable schema while settings change.
 The host resolves the selected provider immediately before execution, so a


### PR DESCRIPTION
## Summary

The egress decision layer (#837) and its adapter builders shipped, but nothing
user-facing configured a policy or applied one — E2B and Daytona still created
open-internet sandboxes unconditionally. This wires the two ends together.

- **Config lives beside code-execution settings.** A new non-secret `egress`
  field on `GET`/`PUT /code-execution` holds an allowlist of domain patterns and
  CIDR blocks, or `open`. It is a **store setting, not a keychain secret** — it
  carries no secret and the surface accepts no endpoint. The model never sets it
  (invariant 1); it is host configuration like provider selection and timeout.
- **Applied at sandbox creation.** `ConfiguredCodeExecutionProvider::resolve`
  compiles the policy through the existing `with_egress_policy` builders into
  E2B's `allowOut` rules and Daytona's block-all switch / allowlists. Local
  already denies all network — unchanged. Patterns are validated to the decision
  layer's grammar at PUT time (malformed grant → bad request); a malformed
  *stored* policy fails closed by refusing execution, never by reverting to open.
- **Default stays open — restriction is opt-in.** Flipping the default to deny
  would break package installs and network fetches in code execution, so `open`
  remains the out-of-the-box behavior and is disclosed as such. A user who
  configures an allowlist gets deny-by-default egress with only the listed
  destinations reachable (empty allowlist = deny all).
- **E2B confirmed, Daytona pending.** The projection's `enforcement` field
  discloses per provider whether egress restriction is confirmed against the
  live vendor API. E2B's per-sandbox `allowOut` semantics are documented and
  confirmed. Daytona's are applied but **must not be relied on as a boundary
  yet** — see below.
- **Desktop UI.** The code-execution panel gains a "Network egress" section: an
  opt-in toggle, domain/CIDR entry, and the per-provider confirmed-vs-pending
  disclosure, consistent with the existing provider/credential config.

## What Daytona still needs before it is a boundary

Daytona is wired so a configured policy is sent at creation, but two things are
unconfirmed against the live API and are gated/commented as such:

1. **Empty-but-present allowlist semantics.** We emit both the CIDR and domain
   allowlist fields present-but-empty on the axis with no entries, intending
   "allow nothing on this axis" (mirroring E2B's explicit
   `allow_internet_access: false` baseline). Whether Daytona actually reads an
   empty-present list as deny-all — rather than "no restriction on that axis" —
   is **not confirmed against the live Daytona API** (flagged in #850).
2. **Vendor-curated always-reachable services.** Daytona keeps package
   registries, git hosting, container registries, and AI APIs reachable
   regardless of policy — each a general-purpose destination.

So the settings surface reports Daytona as `confirmed: false` and the docs say
its egress is applied but not a network boundary until confirmed. E2B is the
fully-supported path.

## Verification

- `cargo test -p openwave-server` (code_execution + config round-trip) and
  `-p openwave-code-execution`, `--locked`
- wire-types currency test green; regenerated `wire.ts` for the new `EgressConfig`
  and enforcement types
- `pnpm exec tsc --noEmit` + `pnpm test` (606 UI tests)
- clippy `--all-targets` clean, rustfmt clean
- `Cargo.lock` change is only the new `openwave-egress` dependency edge — no
  version drift

Not exercised: driving a live E2B/Daytona sandbox. E2B's create-body translation
is covered by the existing injected-HTTP adapter tests; this PR adds the
config→policy translation and round-trip coverage on top.

Closes #819