### PR TITLE
feat(citations): embed citations inline as :cit directives

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -38,8 +38,8 @@ use crate::approval::{
 };
 use crate::cancel::CancelToken;
 use crate::citation::{
-    classify_source_reference_candidate, parse_assistant_citations, AssistantCitationReference,
-    SourceReferenceCandidate,
+    classify_source_reference_candidate, parse_assistant_citations, rebind_citation_ids,
+    AssistantCitationReference, SourceReferenceCandidate,
 };
 use crate::context;
 use crate::error::{AgentError, Result};
@@ -898,8 +898,34 @@ fn call_action_preview(call: &PendingCall) -> Option<ToolActionPreview> {
 }
 
 struct AssistantCandidate {
+    /// The message identity the content's citation ids were derived from.
+    message_id: MessageId,
     content: String,
     citations: Vec<AssistantCitationReference>,
+}
+
+impl AssistantCandidate {
+    /// This candidate as a durable message under `message_id`.
+    ///
+    /// A citation is identified by its message and its ordinal, so a candidate
+    /// persisted under an identity other than the one it was parsed for has its
+    /// embedded ids re-derived rather than left pointing at citations the stored
+    /// message does not own.
+    fn message(&self, message_id: MessageId, chat_id: ChatId, turn_id: TurnId) -> Message {
+        Message {
+            id: message_id,
+            chat_id,
+            turn_id,
+            role: Role::Assistant,
+            content: rebind_citation_ids(
+                &self.content,
+                self.message_id,
+                message_id,
+                self.citations.len(),
+            ),
+            created_at: Utc::now(),
+        }
+    }
 }
 
 enum AcceptedServerCall {
@@ -1372,8 +1398,19 @@ impl Agent {
                 calls.clear();
             }
 
-            let parsed = parse_assistant_citations(&text);
+            // Citation identities are derived from the message a citation
+            // belongs to, so the candidate's identity is settled before its text
+            // is parsed. A boundary steer can still turn a claimed turn's final
+            // candidate into an intermediate message; that path re-derives the
+            // ids for the identity it persists under.
+            let candidate_message_id = if calls.is_empty() && !publish_terminal {
+                output_message_id
+            } else {
+                MessageId::new()
+            };
+            let parsed = parse_assistant_citations(&text, candidate_message_id);
             let candidate = AssistantCandidate {
+                message_id: candidate_message_id,
                 content: parsed.content,
                 citations: parsed.references,
             };
@@ -1448,25 +1485,12 @@ impl Agent {
             }
 
             if calls.is_empty() {
-                // A boundary steer can turn this final candidate into an
-                // intermediate assistant message. Legacy turns persist each
-                // candidate immediately, so each needs its own identity. A
-                // claimed turn keeps the caller's stable completion identity:
-                // steered candidates are persisted separately by
-                // `apply_steers`, and only the actual final output uses it.
-                let candidate_message_id = if publish_terminal {
-                    MessageId::new()
-                } else {
-                    output_message_id
-                };
-                let output = Message {
-                    id: candidate_message_id,
-                    chat_id: chat.id,
-                    turn_id,
-                    role: Role::Assistant,
-                    content: text.clone(),
-                    created_at: Utc::now(),
-                };
+                // Legacy turns persist each candidate immediately, so each needs
+                // its own identity. A claimed turn keeps the caller's stable
+                // completion identity: steered candidates are persisted
+                // separately by `apply_steers`, and only the actual final output
+                // uses it.
+                let output = candidate.message(candidate.message_id, chat.id, turn_id);
                 if publish_terminal && !text.is_empty() {
                     self.append_assistant_exact_retry(&output, &candidate.citations)
                         .await?;
@@ -2096,14 +2120,9 @@ impl Agent {
         }
         let preceding = preceding_assistant
             .filter(|candidate| !candidate.content.is_empty() && !durable.is_empty())
-            .map(|candidate| Message {
-                id: MessageId::new(),
-                chat_id: chat.id,
-                turn_id,
-                role: Role::Assistant,
-                content: candidate.content.clone(),
-                created_at: Utc::now(),
-            });
+            // A steered candidate is not the turn's output, so it takes an
+            // identity of its own and its citation ids are re-derived for it.
+            .map(|candidate| candidate.message(MessageId::new(), chat.id, turn_id));
         let preceding_citations = preceding_assistant
             .filter(|candidate| !candidate.content.is_empty() && !durable.is_empty())
             .map_or(&[][..], |candidate| candidate.citations.as_slice());
@@ -2869,18 +2888,10 @@ impl Agent {
         turn_id: TurnId,
         candidate: &AssistantCandidate,
     ) -> Result<MessageId> {
-        let id = MessageId::new();
-        let message = Message {
-            id,
-            chat_id,
-            turn_id,
-            role: Role::Assistant,
-            content: candidate.content.clone(),
-            created_at: Utc::now(),
-        };
+        let message = candidate.message(candidate.message_id, chat_id, turn_id);
         self.append_assistant_exact_retry(&message, &candidate.citations)
             .await?;
-        Ok(id)
+        Ok(message.id)
     }
 
     async fn append_assistant_exact_retry(

--- a/crates/openwave-core/src/citation.rs
+++ b/crates/openwave-core/src/citation.rs
@@ -421,12 +421,16 @@ mod tests {
     fn rebinding_matches_parsing_for_the_other_message() {
         let parsed_for = MessageId::new();
         let stored_under = MessageId::new();
-        let reference = AssistantCitationReference {
+        let first = AssistantCitationReference {
+            source_token: uuid::Uuid::new_v4(),
+        };
+        let second = AssistantCitationReference {
             source_token: uuid::Uuid::new_v4(),
         };
         let text = format!(
-            "Grounded {}.",
-            format_citation_directive("claim", reference)
+            "Grounded {} and {}.",
+            format_citation_directive("claim", first),
+            format_citation_directive("other claim", second),
         );
 
         let parsed = parse_assistant_citations(&text, parsed_for);

--- a/crates/openwave-core/src/citation.rs
+++ b/crates/openwave-core/src/citation.rs
@@ -1,16 +1,28 @@
 //! Closed source-reference grammar for durable assistant citations.
 //!
-//! Search tools expose opaque references to the model. The agent removes those
-//! references from final text and hands only their typed identities to storage;
-//! renderer clients never see the grammar or its underlying call identity.
+//! Search tools expose opaque references to the model, which cites a passage by
+//! wrapping its own phrasing in a `:cit[…]{ref=…}` directive. The agent
+//! resolves those references and rewrites each directive to its durable
+//! identity — `:cit[…]{citation_id=…}` — so the cited phrase stays where the
+//! model put it. Renderer clients never see the opaque token or the call
+//! identity behind it.
 
-use std::collections::{BTreeSet, HashSet};
+use std::collections::BTreeSet;
 
 use crate::RetrievalEvidenceInput;
 use crate::{AssistantCitationId, DocumentId, MessageId, PageBounds, SourceLocation, SourceRegion};
 
 const SOURCE_REFERENCE_PREFIX: &str = "[[ow-source:";
 const SOURCE_REFERENCE_SUFFIX: &str = "]]";
+const SOURCE_TOKEN_LEN: usize = 32;
+
+/// Opens the inline citation directive, ahead of the cited phrase.
+const CITATION_DIRECTIVE_PREFIX: &str = ":cit[";
+/// Closes the cited phrase and opens the model-facing reference attribute.
+const CITATION_REFERENCE_ATTRIBUTE: &str = "]{ref=";
+/// Closes the cited phrase and opens the durable, renderer-facing attribute.
+const CITATION_ID_ATTRIBUTE: &str = "]{citation_id=";
+const CITATION_ATTRIBUTE_SUFFIX: &str = "}";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SourceReferenceCandidate {
@@ -144,28 +156,78 @@ pub fn format_source_reference(reference: AssistantCitationReference) -> String 
     )
 }
 
-/// Strip reserved references without interpreting Markdown.
-///
-/// Structurally complete reserved tokens are always removed from user-visible
-/// text. Exact lowercase-hex tokens become typed references; unknown tokens can
-/// be ignored by storage. Duplicates retain their first
-/// position and the result is bounded independently of provider output size.
+/// Produce the exact citation directive a search result asks the model to
+/// author around the phrasing that a passage supports.
 #[must_use]
-pub fn parse_assistant_citations(text: &str) -> ParsedAssistantCitations {
+pub fn format_citation_directive(phrase: &str, reference: AssistantCitationReference) -> String {
+    format!(
+        "{CITATION_DIRECTIVE_PREFIX}{phrase}{CITATION_REFERENCE_ATTRIBUTE}{}{CITATION_ATTRIBUTE_SUFFIX}",
+        reference.source_token.simple()
+    )
+}
+
+/// Resolve reserved references without interpreting Markdown.
+///
+/// A citation directive whose token is well formed keeps its cited phrase and
+/// is rewritten to the durable identity the phrase will be stored under; a bare
+/// reserved token is removed from user-visible text, as it always has been.
+/// Exact lowercase-hex tokens become typed references; unknown tokens can be
+/// ignored by storage. Duplicates retain their first position — and their first
+/// citation identity — and the result is bounded independently of provider
+/// output size.
+///
+/// `message_id` is the identity the parsed content will be stored under, since
+/// a citation's identity is derived from its message and its first-use ordinal.
+#[must_use]
+pub fn parse_assistant_citations(text: &str, message_id: MessageId) -> ParsedAssistantCitations {
     let mut content = String::with_capacity(text.len());
-    let mut references = Vec::new();
-    let mut seen = HashSet::new();
+    let mut references: Vec<AssistantCitationReference> = Vec::new();
     let mut remainder = text;
 
-    while let Some(start) = remainder.find(SOURCE_REFERENCE_PREFIX) {
+    loop {
+        // Whichever form opens first; the two openings cannot start at the same
+        // offset because their first bytes differ.
+        let (start, directive_first) = match (
+            remainder.find(SOURCE_REFERENCE_PREFIX),
+            remainder.find(CITATION_DIRECTIVE_PREFIX),
+        ) {
+            (Some(marker), Some(directive)) => (marker.min(directive), directive < marker),
+            (Some(marker), None) => (marker, false),
+            (None, Some(directive)) => (directive, true),
+            (None, None) => break,
+        };
         content.push_str(&remainder[..start]);
-        let token = &remainder[start + SOURCE_REFERENCE_PREFIX.len()..];
-        let Some(payload) = token.get(..32) else {
+        let candidate = &remainder[start..];
+        if directive_first {
+            let Some(directive) = split_citation_directive(candidate) else {
+                // Not a directive after all: release the opening and rescan from
+                // inside it, so directive-like prose is preserved and a bare
+                // reference embedded in the would-be phrase is still stripped.
+                content.push_str(CITATION_DIRECTIVE_PREFIX);
+                remainder = &candidate[CITATION_DIRECTIVE_PREFIX.len()..];
+                continue;
+            };
+            match first_use_ordinal(&mut references, directive.reference) {
+                // A directive with nothing to mark is just a bare marker.
+                Some(_) if directive.phrase.is_empty() => {}
+                Some(ordinal) => content.push_str(&format_bound_citation_directive(
+                    directive.phrase,
+                    AssistantCitationId::derive(message_id, ordinal),
+                )),
+                // Past the citation bound the prose is still the model's; only
+                // the citation is dropped.
+                None => content.push_str(directive.phrase),
+            }
+            remainder = directive.rest;
+            continue;
+        }
+        let token = &candidate[SOURCE_REFERENCE_PREFIX.len()..];
+        let Some(payload) = token.get(..SOURCE_TOKEN_LEN) else {
             content.push_str(SOURCE_REFERENCE_PREFIX);
             remainder = token;
             continue;
         };
-        let Some(after_payload) = token.get(32..) else {
+        let Some(after_payload) = token.get(SOURCE_TOKEN_LEN..) else {
             unreachable!("a 32-byte token prefix has a remainder")
         };
         let Some(reference) = after_payload
@@ -177,9 +239,8 @@ pub fn parse_assistant_citations(text: &str) -> ParsedAssistantCitations {
             remainder = token;
             continue;
         };
-        if references.len() < MAX_ASSISTANT_CITATIONS && seen.insert(reference) {
-            references.push(reference);
-        }
+        // A bare reference marks no phrase, so it is only recorded.
+        let _ = first_use_ordinal(&mut references, reference);
         remainder = &after_payload[SOURCE_REFERENCE_SUFFIX.len()..];
     }
     content.push_str(remainder);
@@ -188,6 +249,81 @@ pub fn parse_assistant_citations(text: &str) -> ParsedAssistantCitations {
         content,
         references,
     }
+}
+
+/// Re-derive the citation identities embedded in parsed content for a different
+/// message identity.
+///
+/// A citation is identified by its message and ordinal, so content persisted
+/// under an identity other than the one it was parsed for would otherwise carry
+/// ids the stored message does not own.
+pub(crate) fn rebind_citation_ids(
+    content: &str,
+    from: MessageId,
+    to: MessageId,
+    citations: usize,
+) -> String {
+    let mut rebound = content.to_owned();
+    if from == to {
+        return rebound;
+    }
+    for ordinal in 1..=citations.min(MAX_ASSISTANT_CITATIONS) {
+        let ordinal = u16::try_from(ordinal).expect("citation limit fits u16");
+        rebound = rebound.replace(
+            &AssistantCitationId::derive(from, ordinal).to_string(),
+            &AssistantCitationId::derive(to, ordinal).to_string(),
+        );
+    }
+    rebound
+}
+
+struct CitationDirective<'a> {
+    phrase: &'a str,
+    reference: AssistantCitationReference,
+    rest: &'a str,
+}
+
+/// Split a well-formed authoring directive off the front of `candidate`.
+///
+/// The first `]` closes the cited phrase: telling a bracket inside the phrase
+/// from the directive's own would take a Markdown parse, so a phrase carrying
+/// one degrades to literal prose instead of being guessed at.
+fn split_citation_directive(candidate: &str) -> Option<CitationDirective<'_>> {
+    let opened = candidate.strip_prefix(CITATION_DIRECTIVE_PREFIX)?;
+    let (phrase, closed) = opened.split_at(opened.find(']')?);
+    let attribute = closed.strip_prefix(CITATION_REFERENCE_ATTRIBUTE)?;
+    let payload = attribute.get(..SOURCE_TOKEN_LEN)?;
+    let rest = attribute
+        .get(SOURCE_TOKEN_LEN..)?
+        .strip_prefix(CITATION_ATTRIBUTE_SUFFIX)?;
+    Some(CitationDirective {
+        phrase,
+        reference: parse_reference_payload(payload)?,
+        rest,
+    })
+}
+
+fn format_bound_citation_directive(phrase: &str, id: AssistantCitationId) -> String {
+    format!(
+        "{CITATION_DIRECTIVE_PREFIX}{phrase}{CITATION_ID_ATTRIBUTE}{id}{CITATION_ATTRIBUTE_SUFFIX}"
+    )
+}
+
+/// The one-based position `reference` holds in first-use order, recording it if
+/// this is its first use and the citation bound leaves room for it.
+fn first_use_ordinal(
+    references: &mut Vec<AssistantCitationReference>,
+    reference: AssistantCitationReference,
+) -> Option<u16> {
+    let position = match references.iter().position(|seen| *seen == reference) {
+        Some(position) => position,
+        None if references.len() < MAX_ASSISTANT_CITATIONS => {
+            references.push(reference);
+            references.len() - 1
+        }
+        None => return None,
+    };
+    Some(u16::try_from(position + 1).expect("citation limit fits u16"))
 }
 
 pub(crate) fn classify_source_reference_candidate(candidate: &str) -> SourceReferenceCandidate {
@@ -238,6 +374,132 @@ fn parse_reference_payload(payload: &str) -> Option<AssistantCitationReference> 
 mod tests {
     use super::*;
 
+    /// The stored form of the citation a directive with `reference` becomes,
+    /// wrapping `phrase`, when it is the `ordinal`-th distinct citation of
+    /// `message_id`.
+    fn bound(phrase: &str, message_id: MessageId, ordinal: u16) -> String {
+        format!(
+            ":cit[{phrase}]{{citation_id={}}}",
+            AssistantCitationId::derive(message_id, ordinal)
+        )
+    }
+
+    #[test]
+    fn directives_keep_their_phrase_and_carry_one_identity_per_evidence() {
+        let message_id = MessageId::new();
+        let first = AssistantCitationReference {
+            source_token: uuid::Uuid::new_v4(),
+        };
+        let second = AssistantCitationReference {
+            source_token: uuid::Uuid::new_v4(),
+        };
+        let text = format!(
+            "{} and {}, plus {}.",
+            format_citation_directive("the sky is blue", first),
+            format_citation_directive("water is wet", second),
+            format_citation_directive("still blue", first),
+        );
+
+        let parsed = parse_assistant_citations(&text, message_id);
+
+        assert_eq!(
+            parsed.content,
+            format!(
+                "{} and {}, plus {}.",
+                bound("the sky is blue", message_id, 1),
+                bound("water is wet", message_id, 2),
+                bound("still blue", message_id, 1),
+            )
+        );
+        assert_eq!(parsed.references, [first, second]);
+        assert!(!parsed
+            .content
+            .contains(&first.source_token.simple().to_string()));
+    }
+
+    #[test]
+    fn rebinding_matches_parsing_for_the_other_message() {
+        let parsed_for = MessageId::new();
+        let stored_under = MessageId::new();
+        let reference = AssistantCitationReference {
+            source_token: uuid::Uuid::new_v4(),
+        };
+        let text = format!(
+            "Grounded {}.",
+            format_citation_directive("claim", reference)
+        );
+
+        let parsed = parse_assistant_citations(&text, parsed_for);
+        let rebound = rebind_citation_ids(
+            &parsed.content,
+            parsed_for,
+            stored_under,
+            parsed.references.len(),
+        );
+
+        assert_eq!(
+            rebound,
+            parse_assistant_citations(&text, stored_under).content
+        );
+    }
+
+    #[test]
+    fn malformed_directives_degrade_to_prose() {
+        let message_id = MessageId::new();
+        let reference = AssistantCitationReference {
+            source_token: uuid::Uuid::new_v4(),
+        };
+        let token = reference.source_token.simple().to_string();
+
+        // An unterminated phrase and an unparseable token are ordinary prose.
+        let unparseable = ":cit[unterminated and :cit[bad]{ref=nope} too";
+        let parsed = parse_assistant_citations(unparseable, message_id);
+        assert_eq!(parsed.content, unparseable);
+        assert!(parsed.references.is_empty());
+
+        // A bracket inside the phrase closes it early, so the directive
+        // degrades — and a bare marker caught inside it is still stripped.
+        let nested = format!(
+            ":cit[nested {} bracket]{{ref={token}}}",
+            format_source_reference(reference)
+        );
+        let parsed = parse_assistant_citations(&nested, message_id);
+        assert_eq!(
+            parsed.content,
+            format!(":cit[nested  bracket]{{ref={token}}}")
+        );
+        assert_eq!(parsed.references, [reference]);
+
+        // A directive with no phrase to mark resolves like a bare marker.
+        let empty = format!("Answer{}", format_citation_directive("", reference));
+        let parsed = parse_assistant_citations(&empty, message_id);
+        assert_eq!(parsed.content, "Answer");
+        assert_eq!(parsed.references, [reference]);
+    }
+
+    #[test]
+    fn directives_past_the_citation_bound_keep_only_their_phrase() {
+        let message_id = MessageId::new();
+        let references = (0..MAX_ASSISTANT_CITATIONS + 1)
+            .map(|_| AssistantCitationReference {
+                source_token: uuid::Uuid::new_v4(),
+            })
+            .collect::<Vec<_>>();
+        let text = references
+            .iter()
+            .map(|reference| format_citation_directive("phrase", *reference))
+            .collect::<String>();
+
+        let parsed = parse_assistant_citations(&text, message_id);
+
+        assert_eq!(parsed.references, references[..MAX_ASSISTANT_CITATIONS]);
+        assert!(parsed.content.ends_with("phrase"));
+        assert_eq!(
+            parsed.content.matches(":cit[").count(),
+            MAX_ASSISTANT_CITATIONS
+        );
+    }
+
     #[test]
     fn parser_strips_and_deduplicates_exact_references_without_markdown() {
         let first = AssistantCitationReference {
@@ -251,7 +513,7 @@ mod tests {
             first_ref = format_source_reference(first),
             second_ref = format_source_reference(second),
         );
-        let parsed = parse_assistant_citations(&text);
+        let parsed = parse_assistant_citations(&text, MessageId::new());
         assert_eq!(parsed.content, "Grounded  answer ");
         assert_eq!(parsed.references, [first, second]);
     }
@@ -262,6 +524,7 @@ mod tests {
             " before [[ow-source:not-a-token]] middle \
              [[ow-source:00000000000000000000000000000000]] after \
              [[ow-source:still-being-written ",
+            MessageId::new(),
         );
         assert_eq!(
             parsed.references,
@@ -288,7 +551,7 @@ mod tests {
              [[ow-source:short ordinary paragraph and a later ]] marker\n\
              {valid_marker} tail 🌊\n"
         );
-        let parsed = parse_assistant_citations(&text);
+        let parsed = parse_assistant_citations(&text, MessageId::new());
         assert_eq!(parsed.references, [valid]);
         assert_eq!(parsed.content, text.replace(&valid_marker, ""));
     }
@@ -333,7 +596,7 @@ mod tests {
             .iter()
             .map(|reference| format_source_reference(*reference))
             .collect::<String>();
-        let parsed = parse_assistant_citations(&text);
+        let parsed = parse_assistant_citations(&text, MessageId::new());
         assert!(parsed.content.is_empty());
         assert_eq!(parsed.references, references[..MAX_ASSISTANT_CITATIONS]);
     }

--- a/crates/openwave-core/src/db/ops/citation.rs
+++ b/crates/openwave-core/src/db/ops/citation.rs
@@ -69,7 +69,7 @@ pub(in crate::db) async fn append_assistant_message(
     .insert(&transaction)
     .await
     .map_err(store_err)?;
-    insert_for_message_on(&transaction, message, &evidence).await?;
+    insert_for_message_on(&transaction, message, references, &evidence).await?;
     transaction.commit().await.map_err(store_err)
 }
 
@@ -151,7 +151,7 @@ pub(in crate::db) async fn append_claimed_assistant_message(
     .insert(&transaction)
     .await
     .map_err(store_err)?;
-    insert_for_message_on(&transaction, message, &evidence).await?;
+    insert_for_message_on(&transaction, message, references, &evidence).await?;
     transaction.commit().await.map_err(store_err)?;
     Ok(AppendClaimedMessageOutcome::Appended)
 }
@@ -250,34 +250,48 @@ where
     Ok(evidence)
 }
 
+/// Record one citation per reference that resolved, numbered by where the model
+/// first used it.
+///
+/// The reference list is the only ordinal authority. A citation's identity is
+/// derived from its message and ordinal, and the message text embeds that same
+/// identity beside the phrase it backs, so numbering the surviving rows 1..n
+/// instead would hand a phrase whose reference resolved to nothing the identity
+/// of the next citation along — a reader would be shown another passage's
+/// evidence under it. A reference that resolves to no evidence leaves a gap
+/// instead: its embedded identity resolves to nothing, which renders as plain
+/// prose.
 pub(in crate::db) async fn insert_for_message_on<C>(
     conn: &C,
     message: &Message,
+    references: &[AssistantCitationReference],
     evidence: &[entities::retrieval_evidence::Model],
 ) -> Result<()>
 where
     C: ConnectionTrait,
 {
-    if evidence.is_empty() {
-        return Ok(());
-    }
-    let rows = evidence
+    let rows = references
         .iter()
         .enumerate()
-        .map(|(index, row)| entities::assistant_citation::ActiveModel {
-            id: Set(AssistantCitationId::derive(
-                message.id,
-                u16::try_from(index + 1).expect("citation limit fits u16"),
-            )
-            .0),
-            message_id: Set(message.id.0),
-            ordinal: Set(i32::try_from(index + 1).expect("citation limit fits i32")),
-            chat_id: Set(message.chat_id.0),
-            turn_id: Set(message.turn_id.0),
-            evidence_call_id: Set(row.call_id),
-            evidence_rank: Set(row.rank),
+        .filter_map(|(index, reference)| {
+            let row = evidence
+                .iter()
+                .find(|row| row.source_token == reference.source_token)?;
+            let ordinal = u16::try_from(index + 1).expect("citation limit fits u16");
+            Some(entities::assistant_citation::ActiveModel {
+                id: Set(AssistantCitationId::derive(message.id, ordinal).0),
+                message_id: Set(message.id.0),
+                ordinal: Set(i32::from(ordinal)),
+                chat_id: Set(message.chat_id.0),
+                turn_id: Set(message.turn_id.0),
+                evidence_call_id: Set(row.call_id),
+                evidence_rank: Set(row.rank),
+            })
         })
         .collect::<Vec<_>>();
+    if rows.is_empty() {
+        return Ok(());
+    }
     entities::assistant_citation::Entity::insert_many(rows)
         .exec(conn)
         .await
@@ -332,15 +346,18 @@ where
         .map_err(store_err)?;
     let mut snapshots = Vec::with_capacity(rows.len());
     let mut ordinal_owner = None;
-    let mut expected_ordinal = 1_i32;
+    // Ordinals ascend within a message but may skip: a reference the message
+    // cited and the store could not resolve holds its place rather than letting
+    // the citations after it inherit identities the text already spent.
+    let mut least_ordinal = 1_i32;
     for (row, evidence) in rows {
         let evidence = evidence
             .ok_or_else(|| AgentError::Store("assistant citation evidence disappeared".into()))?;
         if ordinal_owner != Some(row.message_id) {
             ordinal_owner = Some(row.message_id);
-            expected_ordinal = 1;
+            least_ordinal = 1;
         }
-        if row.ordinal != expected_ordinal
+        if row.ordinal < least_ordinal
             || !(1..=MAX_ASSISTANT_CITATIONS as i32).contains(&row.ordinal)
             || row.id
                 != AssistantCitationId::derive(
@@ -353,7 +370,7 @@ where
                 "assistant citation ordering or identity is corrupt".into(),
             ));
         }
-        expected_ordinal += 1;
+        least_ordinal = row.ordinal + 1;
         let evidence = super::client_execution::evidence_from_model(evidence)?;
         if evidence.chat_id != chat_id
             || evidence.turn_id.0 != row.turn_id

--- a/crates/openwave-core/src/db/ops/citation.rs
+++ b/crates/openwave-core/src/db/ops/citation.rs
@@ -210,7 +210,7 @@ pub(in crate::db) fn validate_assistant_message(
             "citations require a non-nil assistant message".into(),
         ));
     }
-    if parse_assistant_citations(&message.content).content != message.content {
+    if parse_assistant_citations(&message.content, message.id).content != message.content {
         return Err(AgentError::Store(
             "assistant message contains an unstripped source reference".into(),
         ));

--- a/crates/openwave-core/src/db/ops/turn/resolution.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution.rs
@@ -352,7 +352,8 @@ async fn complete_turn_run_inner(
         citations,
     )
     .await?;
-    super::super::citation::insert_for_message_on(&transaction, output, &evidence).await?;
+    super::super::citation::insert_for_message_on(&transaction, output, citations, &evidence)
+        .await?;
 
     let completed = entities::turn_run::Entity::update_many()
         .col_expr(

--- a/crates/openwave-core/src/db/ops/turn/steer.rs
+++ b/crates/openwave-core/src/db/ops/turn/steer.rs
@@ -456,7 +456,13 @@ pub(in crate::db) async fn apply_turn_steer(
             preceding_citations,
         )
         .await?;
-        super::super::citation::insert_for_message_on(&transaction, preceding, &evidence).await?;
+        super::super::citation::insert_for_message_on(
+            &transaction,
+            preceding,
+            preceding_citations,
+            &evidence,
+        )
+        .await?;
     }
 
     if !transfer_steer_message_identity_on(

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -11405,14 +11405,6 @@ async fn retrieval_evidence_is_atomic_generation_fenced_and_survives_source_chan
         .await
         .unwrap();
 
-    let assistant = Message {
-        id: MessageId::new(),
-        chat_id: chat.id,
-        turn_id: call.turn_id,
-        role: Role::Assistant,
-        content: "Grounded answer".into(),
-        created_at: resolved_at + chrono::Duration::seconds(1),
-    };
     let reference = crate::AssistantCitationReference {
         source_token: evidence.source_token,
     };
@@ -11421,6 +11413,30 @@ async fn retrieval_evidence_is_atomic_generation_fenced_and_survives_source_chan
     };
     let unknown_reference = crate::AssistantCitationReference {
         source_token: uuid::Uuid::new_v4(),
+    };
+    // The model cites a phantom between two real passages, so the citation the
+    // store cannot resolve sits ahead of ones it can.
+    let assistant_id = MessageId::new();
+    let cited = crate::parse_assistant_citations(
+        &format!(
+            "{} then {} then {}",
+            crate::format_citation_directive("phantom claim", unknown_reference),
+            crate::format_citation_directive("second claim", second_reference),
+            crate::format_citation_directive("first claim", reference),
+        ),
+        assistant_id,
+    );
+    assert_eq!(
+        cited.references,
+        [unknown_reference, second_reference, reference]
+    );
+    let assistant = Message {
+        id: assistant_id,
+        chat_id: chat.id,
+        turn_id: call.turn_id,
+        role: Role::Assistant,
+        content: cited.content.clone(),
+        created_at: resolved_at + chrono::Duration::seconds(1),
     };
     store
         .append_assistant_message_with_citations(
@@ -11453,8 +11469,32 @@ async fn retrieval_evidence_is_atomic_generation_fenced_and_survives_source_chan
     let snapshot = store.get_chat_transcript(chat.id).await.unwrap().unwrap();
     assert_eq!(snapshot.citations.len(), 2);
     assert_eq!(snapshot.citations[0].message_id, assistant.id);
-    assert_eq!(snapshot.citations[0].ordinal, 1);
-    assert_eq!(snapshot.citations[1].ordinal, 2);
+    // The unresolved citation holds ordinal 1 rather than letting the two that
+    // resolved slide onto identities the message text already spent: each
+    // embedded id resolves to the evidence its own phrase cited, and the
+    // phantom's resolves to nothing at all.
+    assert_eq!(snapshot.citations[0].ordinal, 2);
+    assert_eq!(snapshot.citations[1].ordinal, 3);
+    let cited_id = |phrase: &str| {
+        let opened = assistant
+            .content
+            .split_once(&format!(":cit[{phrase}]{{citation_id="))
+            .expect("the phrase is cited")
+            .1;
+        opened
+            .split_once('}')
+            .expect("the citation closes")
+            .0
+            .parse::<crate::AssistantCitationId>()
+            .expect("the citation carries an id")
+    };
+    assert_eq!(cited_id("second claim"), snapshot.citations[0].id);
+    assert_eq!(cited_id("first claim"), snapshot.citations[1].id);
+    let phantom = cited_id("phantom claim");
+    assert!(snapshot
+        .citations
+        .iter()
+        .all(|citation| citation.id != phantom));
     assert_eq!(snapshot.citations[0].excerpt.chars().count(), 600);
     assert!(!snapshot.citations[0].excerpt.contains(private_tail));
     assert_eq!(

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -80,10 +80,10 @@ pub use approval::{
 pub use blob::FsBlobStore;
 pub use cancel::{CancelToken, Cancelled};
 pub use citation::{
-    format_source_reference, parse_assistant_citations, AssistantCitationReference,
-    AssistantCitationSnapshot, CitationPageBounds, CitationSpan, ParsedAssistantCitations,
-    MAX_ASSISTANT_CITATIONS, MAX_CITATION_BOUNDS, MAX_CITATION_EXCERPT_CHARS,
-    MAX_CITATION_HEADING_CHARS, MAX_CITATION_PAGES,
+    format_citation_directive, format_source_reference, parse_assistant_citations,
+    AssistantCitationReference, AssistantCitationSnapshot, CitationPageBounds, CitationSpan,
+    ParsedAssistantCitations, MAX_ASSISTANT_CITATIONS, MAX_CITATION_BOUNDS,
+    MAX_CITATION_EXCERPT_CHARS, MAX_CITATION_HEADING_CHARS, MAX_CITATION_PAGES,
 };
 pub use client_tools::{
     import_connected_file_tool_spec, list_connected_folders_tool_spec, list_folder_tool_spec,

--- a/crates/openwave-desktop/ui/src/AssistantSourceMarkerStream.test.ts
+++ b/crates/openwave-desktop/ui/src/AssistantSourceMarkerStream.test.ts
@@ -2,8 +2,64 @@ import { describe, expect, it } from "vitest";
 import { AssistantSourceMarkerStreamScrubber } from "./AssistantSourceMarkerStream";
 
 const MARKER = "[[ow-source:0123456789abcdef0123456789abcdef]]";
+const DIRECTIVE = ":cit[the reef is large]{ref=0123456789abcdef0123456789abcdef}";
 
 describe("AssistantSourceMarkerStreamScrubber", () => {
+  it("keeps a directive's phrase and drops its reference at every delta boundary", () => {
+    const text = `Before ${DIRECTIVE} after.`;
+
+    for (let boundary = 0; boundary <= text.length; boundary += 1) {
+      const scrubber = new AssistantSourceMarkerStreamScrubber();
+      const first = scrubber.push(text.slice(0, boundary));
+      const second = scrubber.push(text.slice(boundary));
+      const finished = scrubber.finish();
+
+      expect(first).not.toContain("{ref=");
+      expect(first + second + finished, `boundary ${boundary}`).toBe(
+        "Before the reef is large after.",
+      );
+    }
+  });
+
+  it("does not flash a reference from a directive delivered one character at a time", () => {
+    const scrubber = new AssistantSourceMarkerStreamScrubber();
+    let visible = "";
+
+    for (const character of `Answer ${DIRECTIVE} continues`) {
+      visible += scrubber.push(character);
+      expect(visible).not.toContain(":cit[");
+      expect(visible).not.toContain("0123456789abcdef");
+    }
+
+    expect(visible + scrubber.finish()).toBe(
+      "Answer the reef is large continues",
+    );
+  });
+
+  it.each([
+    ":cit[phrase]{ref=0123456789abcdef0123456789abcdeG}",
+    ":cit[phrase]{ref=0123456789abcdef0123456789abcdef",
+    ":cit[phrase]{cite=0123456789abcdef0123456789abcdef}",
+    ":cit[phrase with ] bracket]{ref=0123456789abcdef0123456789abcdef}",
+    "ordinary :citation[prose]",
+  ])("preserves malformed directive-like prose: %s", (prose) => {
+    const scrubber = new AssistantSourceMarkerStreamScrubber();
+    const firstHalf = Math.floor(prose.length / 2);
+    const visible =
+      scrubber.push(prose.slice(0, firstHalf)) +
+      scrubber.push(prose.slice(firstHalf)) +
+      scrubber.finish();
+
+    expect(visible).toBe(prose);
+  });
+
+  it("releases an unclosed citation phrase rather than stalling the stream", () => {
+    const scrubber = new AssistantSourceMarkerStreamScrubber();
+    const prose = `:cit[${"long prose ".repeat(80)}`;
+
+    expect(scrubber.push(prose) + scrubber.finish()).toBe(prose);
+  });
+
   it("removes a marker split at every possible delta boundary", () => {
     const text = `Before ${MARKER} after.`;
 

--- a/crates/openwave-desktop/ui/src/AssistantSourceMarkerStream.ts
+++ b/crates/openwave-desktop/ui/src/AssistantSourceMarkerStream.ts
@@ -2,11 +2,23 @@ const MARKER_PREFIX = "[[ow-source:";
 const TOKEN_LENGTH = 32;
 const MARKER_LENGTH = MARKER_PREFIX.length + TOKEN_LENGTH + 2;
 
+const DIRECTIVE_PREFIX = ":cit[";
+const DIRECTIVE_ATTRIBUTE = "]{ref=";
 /**
- * Removes private source markers from streamed assistant text before it is
- * rendered. Only the short tail that could still become a valid marker is
- * retained between deltas; call finish when a stream ends or is interrupted
- * to recover an incomplete marker as literal prose.
+ * How much of an unclosed cited phrase is held before the opening is treated as
+ * ordinary prose. A citation wraps a clause the model just wrote, so anything
+ * longer is prose that happens to start like a directive — and holding it back
+ * would stall the visible stream for the rest of the message.
+ */
+const MAX_HELD_PHRASE = 512;
+
+/**
+ * Removes private source references from streamed assistant text before it is
+ * rendered: a bare marker disappears, and a citation directive is reduced to the
+ * phrase it wraps, which is what the durable text will read as until the
+ * transcript re-renders it as a real citation. Only the tail that could still
+ * become a valid reference is retained between deltas; call finish when a stream
+ * ends or is interrupted to recover an incomplete one as literal prose.
  */
 export class AssistantSourceMarkerStreamScrubber {
   private pending = "";
@@ -18,16 +30,33 @@ export class AssistantSourceMarkerStreamScrubber {
 
     while (input.length > 0) {
       const markerStart = input.indexOf(MARKER_PREFIX);
-      if (markerStart === -1) {
+      const directiveStart = input.indexOf(DIRECTIVE_PREFIX);
+      if (markerStart === -1 && directiveStart === -1) {
         const pendingLength = longestPrefixSuffix(input);
         output += input.slice(0, input.length - pendingLength);
         this.pending = input.slice(input.length - pendingLength);
         break;
       }
 
-      output += input.slice(0, markerStart);
-      const candidate = input.slice(markerStart);
-      if (candidate.length >= MARKER_LENGTH) {
+      const directiveFirst =
+        markerStart === -1 ||
+        (directiveStart !== -1 && directiveStart < markerStart);
+      const start = directiveFirst ? directiveStart : markerStart;
+      output += input.slice(0, start);
+      const candidate = input.slice(start);
+
+      if (directiveFirst) {
+        const directive = scanCitationDirective(candidate);
+        if (directive.kind === "complete") {
+          output += directive.phrase;
+          input = candidate.slice(directive.length);
+          continue;
+        }
+        if (directive.kind === "partial") {
+          this.pending = candidate;
+          break;
+        }
+      } else if (candidate.length >= MARKER_LENGTH) {
         const possibleMarker = candidate.slice(0, MARKER_LENGTH);
         if (isSourceMarker(possibleMarker)) {
           input = candidate.slice(MARKER_LENGTH);
@@ -38,9 +67,9 @@ export class AssistantSourceMarkerStreamScrubber {
         break;
       }
 
-      // This looked like a marker prefix but cannot become a valid marker.
-      // Release one character and rescan so malformed prose is preserved and
-      // a valid marker beginning later in the same input is still detected.
+      // This looked like a reference opening but cannot become a valid one.
+      // Release one character and rescan so malformed prose is preserved and a
+      // valid reference beginning later in the same input is still detected.
       output += candidate[0];
       input = candidate.slice(1);
     }
@@ -53,6 +82,55 @@ export class AssistantSourceMarkerStreamScrubber {
     this.pending = "";
     return literal;
   }
+}
+
+type CitationDirectiveScan =
+  | { kind: "complete"; phrase: string; length: number }
+  | { kind: "partial" }
+  | { kind: "invalid" };
+
+/**
+ * Classify text that starts with a citation-directive opening: a complete
+ * directive with the phrase it wraps, a prefix that could still become one, or
+ * prose that cannot.
+ *
+ * The first `]` closes the phrase, matching the parser that rewrites the durable
+ * text, so the two agree on what is a citation and what is prose.
+ */
+function scanCitationDirective(candidate: string): CitationDirectiveScan {
+  const opened = candidate.slice(DIRECTIVE_PREFIX.length);
+  const close = opened.indexOf("]");
+  if (close === -1) {
+    return opened.length > MAX_HELD_PHRASE
+      ? { kind: "invalid" }
+      : { kind: "partial" };
+  }
+  if (close > MAX_HELD_PHRASE) return { kind: "invalid" };
+
+  const phrase = opened.slice(0, close);
+  const closed = opened.slice(close);
+  if (!closed.startsWith(DIRECTIVE_ATTRIBUTE)) {
+    return DIRECTIVE_ATTRIBUTE.startsWith(closed)
+      ? { kind: "partial" }
+      : { kind: "invalid" };
+  }
+
+  const attribute = closed.slice(DIRECTIVE_ATTRIBUTE.length);
+  const token = attribute.slice(0, TOKEN_LENGTH);
+  if (!/^[0-9a-f]*$/.test(token)) return { kind: "invalid" };
+  if (attribute.length <= TOKEN_LENGTH) return { kind: "partial" };
+  if (attribute[TOKEN_LENGTH] !== "}") return { kind: "invalid" };
+
+  return {
+    kind: "complete",
+    phrase,
+    length:
+      DIRECTIVE_PREFIX.length +
+      close +
+      DIRECTIVE_ATTRIBUTE.length +
+      TOKEN_LENGTH +
+      1,
+  };
 }
 
 function isSourceMarker(value: string) {
@@ -89,10 +167,15 @@ function couldBecomeSourceMarker(value: string) {
   return closing === "" || closing === "]";
 }
 
+/** The longest tail of `value` that opens either reference form. */
 function longestPrefixSuffix(value: string) {
-  const maximum = Math.min(value.length, MARKER_PREFIX.length - 1);
+  const maximum = Math.min(
+    value.length,
+    Math.max(MARKER_PREFIX.length, DIRECTIVE_PREFIX.length) - 1,
+  );
   for (let length = maximum; length > 0; length -= 1) {
-    if (MARKER_PREFIX.startsWith(value.slice(-length))) {
+    const tail = value.slice(-length);
+    if (MARKER_PREFIX.startsWith(tail) || DIRECTIVE_PREFIX.startsWith(tail)) {
       return length;
     }
   }

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.test.tsx
@@ -5,6 +5,7 @@ import {
   preserveLineBreaks,
   rawCodeText,
   safeMarkdownUrl,
+  stripCitationDirectives,
 } from "./MessageMarkdown";
 
 describe("preserveLineBreaks", () => {
@@ -13,6 +14,28 @@ describe("preserveLineBreaks", () => {
     expect(preserveLineBreaks("para one\n\npara two")).toBe(
       "para one\n\npara two",
     );
+  });
+});
+
+describe("stripCitationDirectives", () => {
+  const id = "0b2b1f2c-9d3e-4a5b-8c7d-6e5f4a3b2c1d";
+
+  it("leaves the cited phrasing in place and the rest of the prose alone", () => {
+    expect(
+      stripCitationDirectives(
+        `The reef :cit[is the largest in the world]{citation_id=${id}}, and it grows.`,
+      ),
+    ).toBe("The reef is the largest in the world, and it grows.");
+  });
+
+  it("keeps directive-shaped prose that is not a stored citation", () => {
+    const prose = [
+      ":cit[unterminated",
+      `:cit[phrase]{ref=0123456789abcdef0123456789abcdef}`,
+      ":cit[phrase]{citation_id=not-a-uuid}",
+    ].join("\n");
+
+    expect(stripCitationDirectives(prose)).toBe(prose);
   });
 });
 

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
@@ -218,13 +218,30 @@ const rehypePlugins: NonNullable<Options["rehypePlugins"]> = [
 ];
 
 /**
- * Normalize raw model output before the parser sees it: rewrite LaTeX
- * delimiters into the dollar forms remark-math understands, then convert single
- * newlines into hard breaks so intended line breaks survive without leaking
- * source indentation.
+ * A stored citation, which wraps the phrase it backs: `:cit[phrase]{citation_id=…}`.
+ *
+ * The phrase cannot contain `]` — the parser that writes this form closes it at
+ * the first one — so a single non-greedy match is the whole grammar.
+ */
+const CITATION_DIRECTIVE =
+  /:cit\[([^\]]*)\]\{citation_id=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\}/gi;
+
+/**
+ * Reduce stored citations to the phrasing they wrap, which is what the message
+ * reads as until citations render as marks of their own.
+ */
+export function stripCitationDirectives(input: string): string {
+  return input.replace(CITATION_DIRECTIVE, "$1");
+}
+
+/**
+ * Normalize raw model output before the parser sees it: reduce citations to
+ * their phrasing, rewrite LaTeX delimiters into the dollar forms remark-math
+ * understands, then convert single newlines into hard breaks so intended line
+ * breaks survive without leaking source indentation.
  */
 export function processMarkdownContent(input: string): string {
-  return preserveLineBreaks(escapeLatexText(input));
+  return preserveLineBreaks(escapeLatexText(stripCitationDirectives(input)));
 }
 
 /**
@@ -284,6 +301,9 @@ function blockRehypePlugins(
 ): NonNullable<Options["rehypePlugins"]> {
   if (start == null || end == null || end <= start) return rehypePlugins;
   if (escapeLatexText(block) !== block) return rehypePlugins;
+  // A citation the block carries is removed from the text the parser reads, for
+  // the same reason: the offsets were measured against text that still had it.
+  if (stripCitationDirectives(block) !== block) return rehypePlugins;
   return [
     [
       rehypeHighlightRange,

--- a/crates/openwave-retrieval/src/search.rs
+++ b/crates/openwave-retrieval/src/search.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use openwave_core::{
-    format_source_reference, ApprovalClass, AssistantCitationReference, Result, ResultEntry,
+    format_citation_directive, ApprovalClass, AssistantCitationReference, Result, ResultEntry,
     ResultEntryKind, RetrievalEvidenceInput, RetrievalEvidenceSource, Tool, ToolCtx, ToolOutput,
     ToolSpec,
 };
@@ -82,15 +82,20 @@ fn render(citations: &[Citation], source_tokens: &[uuid::Uuid]) -> String {
     debug_assert_eq!(citations.len(), source_tokens.len());
     let plural = if citations.len() == 1 { "" } else { "s" };
     let mut out = format!(
-        "Found {} passage{plural}. To cite a passage, copy its opaque source reference exactly into the answer:",
+        "Found {} passage{plural}. To cite a passage, wrap the wording it supports in \
+         that passage's citation directive: your phrasing goes in the brackets and may \
+         paraphrase the passage, and the reference is copied exactly.",
         citations.len()
     );
     for (i, c) in citations.iter().enumerate() {
-        let reference = format_source_reference(AssistantCitationReference {
-            source_token: source_tokens[i],
-        });
+        let reference = format_citation_directive(
+            "your phrasing",
+            AssistantCitationReference {
+                source_token: source_tokens[i],
+            },
+        );
         out.push_str(&format!(
-            "\n\n{}. Source reference: {reference}\n[score {:.3}] document {} (bytes {}..{}){}{}\n{}",
+            "\n\n{}. Cite as: {reference}\n[score {:.3}] document {} (bytes {}..{}){}{}\n{}",
             i + 1,
             c.score,
             c.document_id,
@@ -139,7 +144,8 @@ impl Tool for SearchTool {
             name: "search".into(),
             description: "Search the indexed documents for passages relevant to a query. \
                           Returns ranked, grounded citations (document id, byte span, source \
-                          pages when available, and text)."
+                          pages when available, and text). Each result carries a citation \
+                          directive to wrap the wording it supports in."
                 .into(),
             input_schema: json!({
                 "type": "object",
@@ -635,11 +641,12 @@ mod tests {
         assert_eq!(out.private_evidence.len(), 1);
         assert!(out.private_evidence[0].snippet.contains("Jupiter"));
         assert_eq!(out.private_evidence[0].rank, 1);
-        assert!(out
-            .content
-            .contains(&format_source_reference(AssistantCitationReference {
+        assert!(out.content.contains(&format_citation_directive(
+            "your phrasing",
+            AssistantCitationReference {
                 source_token: out.private_evidence[0].source_token,
-            })));
+            }
+        )));
         assert_eq!(out.private_evidence[0].generation.content_revision, 1);
     }
 


### PR DESCRIPTION
Assistant citations were position-less. The search tool asked the model to paste an opaque `[[ow-source:<token>]]` marker, `parse_assistant_citations` deleted it, and all that survived was first-use reference order — so the renderer could show a detached sources row but never mark *which phrase* a citation backs.

The model now cites by wrapping its own phrasing:

- **Authoring** (`search.rs` `render()` + the tool description): each result is offered as `:cit[your phrasing]{ref=<32 hex token>}` — the same opaque per-turn token as before, bare inside the attribute.
- **Parsing**: a well-formed directive whose token resolves keeps its phrase and is rewritten in place to `:cit[phrase]{citation_id=<uuid>}`. The id is `AssistantCitationId::derive(message_id, ordinal)` — exactly the identity `insert_for_message_on` already writes to `assistant_citation.id` — so the text and the row agree without a second lookup. One id per distinct evidence: the same token cited twice carries the same `citation_id`, and the references list still records first-use order bounded by `MAX_ASSISTANT_CITATIONS`.
- **Legacy**: bare `[[ow-source:<token>]]` markers parse exactly as before (stripped, appended to reference order). Models emit slop and old prompts linger.
- The closed grammar is intact: an opaque token still never reaches storage or a renderer client, and `validate_assistant_message` now rejects a `{ref=…}` directive as well as a bare marker, because the parse it compares against would have rewritten one.

Because a citation's identity is derived from its message, the candidate's message identity is now settled *before* its text is parsed rather than at each persist site. One path persists a candidate under a different identity — a boundary steer turning a claimed turn's final candidate into an intermediate message — and it re-derives the embedded ids for the identity it stores under (`rebind_citation_ids`).

Two small desktop changes ship here so no intermediate state leaks a raw reference, both replaced by real inline rendering in #877:

- `AssistantSourceMarkerStream.ts` reduces a complete `:cit[phrase]{ref=…}` to `phrase` and holds a plausible partial directive as pending tail, mirroring the marker-holding it already did.
- `MessageMarkdown.tsx` preprocesses `:cit[phrase]{citation_id=<uuid>}` down to `phrase` before parsing. A block carrying one is excluded from citation-mark highlighting, for the same reason a LaTeX-rewritten block is: the offsets were measured against text the rewrite moves.

### Edge cases

- **A `]` in the phrase closes it.** Distinguishing a bracket inside the phrase from the directive's own would need a Markdown parse; instead the directive fails to match and degrades to literal prose. A bare marker caught inside the would-be phrase is still stripped, and the form we *write* can never contain a `]`, so the stored grammar stays trivially parseable (which is what lets the renderer preprocessor be one regex).
- **Malformed anything else** — unterminated `:cit[`, a non-hex token, a missing `}` — is left as literal prose, never stored as a raw token.
- **Past the citation bound**, the prose is still the model's: the phrase is kept and only the citation is dropped.
- **An empty phrase** (`:cit[]{ref=…}`) marks nothing, so it resolves exactly like a bare marker.
- **Code fences are not special.** The parser does not interpret Markdown — as the module has always said — so a directive inside a fence is rewritten like any other. Treating fences differently would mean parsing Markdown in the agent loop to decide what a citation is.
- **A directive whose token has no evidence row resolves to nothing, never to another passage.** See below.

### Citation ordinals are the order the model used them

The first version of this PR had the text and the rows numbering citations independently: content ids came from first-use order over every reference, while `insert_for_message_on` numbered 1..n over the references that *resolved*. A reference the store could not resolve — a token copied out of an earlier turn, or invented — shifted every citation after it, so a phrase would render under the next source along. Wrong attribution is the one failure this pathway must not ship, so it is fixed here rather than tracked.

The reference list is now the single ordinal authority: `insert_for_message_on` takes the references alongside the resolved evidence and gives each row the ordinal its token holds in that list. There is only one numbering, computed once at parse and echoed by the store from the same list it was handed, so the two cannot drift — a phantom reference holds its place and leaves a gap. Its embedded id resolves to no row, which the renderer treats as plain text.

I did not thread the resolvable tokens into the parser instead: making that safe means the agent building a set *exactly* equal to what `resolve_references_on` will match — same chat, same turn, including evidence written by an earlier attempt of a resumed turn — from a store method that does not exist yet. Two independently maintained definitions of "resolvable" is the disagreement this removes, not a second copy of it.

Consequences, both intended:

- Ordinals within a message ascend but need not be contiguous. `list_snapshots_on` still checks that each row's id is derived from the ordinal it claims — the anti-tamper property — and now allows a skip. Existing rows are contiguous, which is a special case, so nothing needs migrating.
- The sources row is numbered by ordinal, so a message whose model cited one phantom shows its real source as "2". That is honest — a citation we could not resolve did occupy that slot — and it keeps the badge in step with the inline marker #877 will render from the same field.

### Tests

Four new parse tests (directive round-trip incl. a repeated token reusing its id; rebinding equals parsing for the other message; malformed degradation; the citation bound keeping prose), a scrubber boundary sweep plus malformed cases, and the `stripCitationDirectives` preprocessor.

The existing store test that already appended a message citing `[phantom, real B, real A]` now carries those three as real directives and pins the invariant end to end: the id embedded beside each phrase resolves to that phrase's own snapshot, and the phantom's id matches no snapshot. Its two ordinal assertions moved from `1, 2` to `2, 3` — that is the misattribution being removed, not a test bent to fit.

The four existing parse tests keep their assertions verbatim; three gained a `MessageId::new()` argument and one gained it on its own line, all forced by the signature. The one changed assertion is in `search.rs`, where the tool output is now expected to advertise the directive instead of the bare marker — the behavior this PR replaces.

Not covered: `read_source` still hands the model a bare marker to copy. It keeps working through the legacy path; moving it is a separate slice.

Closes #876
