### PR TITLE
feat(deliverables): accept binary workspace artifacts into conversation outputs

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -1247,6 +1247,7 @@ pub mod output_revision {
         pub byte_len: i64,
         pub sha256: Vec<u8>,
         pub turn_id: Option<Uuid>,
+        pub producing_run_id: Option<Uuid>,
         pub created_at: DateTimeUtc,
     }
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -36,6 +36,7 @@ impl MigratorTrait for Migrator {
             Box::new(AddToolResultPreviews),
             Box::new(SplitAgentRunExecution),
             Box::new(AddOperationLog),
+            Box::new(ExtendOutputRevisionsForBinary),
         ]
     }
 }
@@ -1394,6 +1395,231 @@ impl MigrationTrait for AddOutputRevisionCitations {
             )
             .await
     }
+}
+
+/// Extends the output-revision shape so the record can hold host-accepted binary
+/// workspace artifacts and can attribute a revision to a producing background
+/// run.
+///
+/// Two additive changes to `output_revision`:
+///
+/// - `producing_run_id` (nullable) records the background run that produced a
+///   revision, alongside the existing `turn_id`. A revision names at most one
+///   producer, enforced by a check; existing rows keep only their `turn_id`.
+/// - the coarse `byte_len` upper bound is raised from the 512 KiB text cap to
+///   the 16 MiB binary cap. The tight per-kind ceiling (text stays 512 KiB) is
+///   enforced in application validation; the database bound is the outer limit
+///   that admits a binary artifact at all.
+///
+/// SQLite cannot alter a check constraint in place, so it rebuilds the table
+/// under foreign-key suppression the same way the agent-run split does; the
+/// `output_revision_citation` foreign key resolves to the rebuilt table once it
+/// is renamed. PostgreSQL alters the column and constraints directly. The `down`
+/// is symmetric and restores the original shape.
+struct ExtendOutputRevisionsForBinary;
+
+impl MigrationName for ExtendOutputRevisionsForBinary {
+    fn name(&self) -> &str {
+        "m20260729_000023_extend_output_revisions_for_binary"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for ExtendOutputRevisionsForBinary {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() == DatabaseBackend::Sqlite {
+            return rebuild_output_revision_sqlite(manager, true).await;
+        }
+        let statements = [
+            "ALTER TABLE output_revision ADD COLUMN producing_run_id uuid".to_owned(),
+            // The baseline's byte_len checks are unnamed; drop both by the column
+            // they constrain, then re-add named ones so a re-up after down is
+            // idempotent.
+            "DO $$
+             DECLARE name text;
+             BEGIN
+                 FOR name IN
+                     SELECT conname FROM pg_constraint
+                     WHERE conrelid = 'output_revision'::regclass
+                       AND contype = 'c'
+                       AND pg_get_constraintdef(oid) LIKE '%byte_len%'
+                 LOOP
+                     EXECUTE format('ALTER TABLE output_revision DROP CONSTRAINT %I', name);
+                 END LOOP;
+             END $$"
+                .to_owned(),
+            "ALTER TABLE output_revision ADD CONSTRAINT chk_output_revision_byte_len_nonneg \
+             CHECK (byte_len >= 0)"
+                .to_owned(),
+            format!(
+                "ALTER TABLE output_revision ADD CONSTRAINT chk_output_revision_byte_len_max \
+                 CHECK (byte_len <= {})",
+                crate::deliverable::MAX_BINARY_DELIVERABLE_BYTES as i64
+            ),
+            "ALTER TABLE output_revision ADD CONSTRAINT chk_output_revision_producer \
+             CHECK (turn_id IS NULL OR producing_run_id IS NULL)"
+                .to_owned(),
+        ];
+        for statement in statements {
+            manager
+                .get_connection()
+                .execute_unprepared(&statement)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() == DatabaseBackend::Sqlite {
+            return rebuild_output_revision_sqlite(manager, false).await;
+        }
+        let statements = [
+            "ALTER TABLE output_revision DROP CONSTRAINT chk_output_revision_producer".to_owned(),
+            "DO $$
+             DECLARE name text;
+             BEGIN
+                 FOR name IN
+                     SELECT conname FROM pg_constraint
+                     WHERE conrelid = 'output_revision'::regclass
+                       AND contype = 'c'
+                       AND pg_get_constraintdef(oid) LIKE '%byte_len%'
+                 LOOP
+                     EXECUTE format('ALTER TABLE output_revision DROP CONSTRAINT %I', name);
+                 END LOOP;
+             END $$"
+                .to_owned(),
+            "ALTER TABLE output_revision ADD CONSTRAINT chk_output_revision_byte_len_nonneg \
+             CHECK (byte_len >= 0)"
+                .to_owned(),
+            format!(
+                "ALTER TABLE output_revision ADD CONSTRAINT chk_output_revision_byte_len_max \
+                 CHECK (byte_len <= {})",
+                crate::deliverable::MAX_DELIVERABLE_BYTES as i64
+            ),
+            "ALTER TABLE output_revision DROP COLUMN producing_run_id".to_owned(),
+        ];
+        for statement in statements {
+            manager
+                .get_connection()
+                .execute_unprepared(&statement)
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+/// The table name used while rebuilding `output_revision` on SQLite.
+const OUTPUT_REVISION_REBUILD: &str = "output_revision_rebuild";
+
+async fn rebuild_output_revision_sqlite(
+    manager: &SchemaManager<'_>,
+    binary: bool,
+) -> Result<(), DbErr> {
+    let statements = vec![
+        "PRAGMA foreign_keys=OFF".to_owned(),
+        "BEGIN IMMEDIATE".to_owned(),
+        output_revision_rebuild_table(binary).to_string(SqliteQueryBuilder),
+        output_revision_rebuild_copy_sql(binary),
+        "DROP TABLE output_revision".to_owned(),
+        format!("ALTER TABLE {OUTPUT_REVISION_REBUILD} RENAME TO output_revision"),
+        output_revision_ordinal_index().to_string(SqliteQueryBuilder),
+        "COMMIT".to_owned(),
+        "PRAGMA foreign_keys=ON".to_owned(),
+    ];
+    manager
+        .get_connection()
+        .execute_unprepared(&format!("{};", statements.join(";\n")))
+        .await?;
+    Ok(())
+}
+
+fn output_revision_rebuild_table(binary: bool) -> TableCreateStatement {
+    let rebuild = Alias::new(OUTPUT_REVISION_REBUILD);
+    let byte_ceiling = if binary {
+        crate::deliverable::MAX_BINARY_DELIVERABLE_BYTES as i64
+    } else {
+        crate::deliverable::MAX_DELIVERABLE_BYTES as i64
+    };
+    let mut statement = Table::create();
+    statement
+        .table(rebuild.clone())
+        .col(
+            ColumnDef::new(OutputRevision::Id)
+                .uuid()
+                .not_null()
+                .primary_key(),
+        )
+        .col(ColumnDef::new(OutputRevision::OutputId).uuid().not_null())
+        .col(ColumnDef::new(OutputRevision::Ordinal).integer().not_null())
+        .col(
+            ColumnDef::new(OutputRevision::ByteLen)
+                .big_integer()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(OutputRevision::Sha256)
+                .binary_len(32)
+                .not_null(),
+        )
+        .col(ColumnDef::new(OutputRevision::TurnId).uuid());
+    if binary {
+        statement.col(ColumnDef::new(OutputRevision::ProducingRunId).uuid());
+    }
+    statement
+        .col(
+            ColumnDef::new(OutputRevision::CreatedAt)
+                .timestamp_with_time_zone()
+                .not_null(),
+        )
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_output_revision_output")
+                .from(rebuild, OutputRevision::OutputId)
+                .to(Output::Table, Output::Id)
+                .on_delete(ForeignKeyAction::Cascade),
+        )
+        .check(
+            Expr::col(OutputRevision::Ordinal)
+                .between(1, crate::deliverable::MAX_OUTPUT_REVISIONS as i32),
+        )
+        .check(Expr::col(OutputRevision::ByteLen).gte(0))
+        .check(Expr::col(OutputRevision::ByteLen).lte(byte_ceiling));
+    if binary {
+        statement.check(
+            Expr::col(OutputRevision::TurnId)
+                .is_null()
+                .or(Expr::col(OutputRevision::ProducingRunId).is_null()),
+        );
+    }
+    statement.to_owned()
+}
+
+fn output_revision_rebuild_copy_sql(binary: bool) -> String {
+    if binary {
+        format!(
+            "INSERT INTO {OUTPUT_REVISION_REBUILD} \
+             (id, output_id, ordinal, byte_len, sha256, turn_id, producing_run_id, created_at) \
+             SELECT id, output_id, ordinal, byte_len, sha256, turn_id, NULL, created_at \
+             FROM output_revision"
+        )
+    } else {
+        format!(
+            "INSERT INTO {OUTPUT_REVISION_REBUILD} \
+             (id, output_id, ordinal, byte_len, sha256, turn_id, created_at) \
+             SELECT id, output_id, ordinal, byte_len, sha256, turn_id, created_at \
+             FROM output_revision"
+        )
+    }
+}
+
+fn output_revision_ordinal_index() -> IndexCreateStatement {
+    Index::create()
+        .name("idx_output_revision_ordinal")
+        .table(OutputRevision::Table)
+        .col(OutputRevision::OutputId)
+        .col(OutputRevision::Ordinal)
+        .unique()
+        .to_owned()
 }
 
 /// Records the images a message was submitted with, so a reloaded conversation
@@ -6728,6 +6954,7 @@ enum OutputRevision {
     ByteLen,
     Sha256,
     TurnId,
+    ProducingRunId,
     CreatedAt,
 }
 

--- a/crates/openwave-core/src/db/ops/output.rs
+++ b/crates/openwave-core/src/db/ops/output.rs
@@ -17,9 +17,10 @@ use crate::citation::{
     MAX_CITATION_HEADING_CHARS,
 };
 use crate::deliverable::{
-    deliverable_media_type, validate_deliverable_name, CreateOutput, NewOutputRevision,
-    OutputCitationSnapshot, OutputRecord, OutputRevision, MAX_DELIVERABLE_BYTES,
-    MAX_OUTPUT_CITATIONS, MAX_OUTPUT_REVISIONS,
+    deliverable_media_type, revision_byte_ceiling, validate_binary_deliverable,
+    validate_deliverable_name, CreateOutput, DeliverableKind, NewOutputRevision,
+    OutputCitationSnapshot, OutputRecord, OutputRevision, MAX_OUTPUT_CITATIONS,
+    MAX_OUTPUT_REVISIONS,
 };
 use crate::error::{AgentError, Result};
 use crate::id::{ChatId, OutputCitationId, OutputId, OutputRevisionId};
@@ -46,7 +47,7 @@ pub(in crate::db) async fn create_output(
         // An exact retry must return the original record rather than fail. A
         // reused id that describes different content is a caller bug.
         let exact =
-            exact_output_on(&transaction, &existing, request, media_type, created_at).await?;
+            exact_output_on(&transaction, &existing, request, &media_type, created_at).await?;
         transaction.rollback().await.map_err(store_err)?;
         return if exact {
             Ok(existing)
@@ -63,7 +64,7 @@ pub(in crate::db) async fn create_output(
         id: Set(request.id.0),
         chat_id: Set(request.chat_id.0),
         filename: Set(request.filename.clone()),
-        media_type: Set(media_type.to_owned()),
+        media_type: Set(media_type.clone()),
         current_revision_id: Set(request.revision.id.0),
         revision_count: Set(1),
         created_at: Set(created_at),
@@ -86,13 +87,18 @@ pub(in crate::db) async fn append_output_revision(
     output_id: OutputId,
     revision: &NewOutputRevision,
 ) -> Result<OutputRecord> {
-    validate_revision(revision)?;
     let created_at = canonical_db_timestamp(revision.created_at)?;
     let transaction = store.conn.begin().await.map_err(store_err)?;
     let Some(existing) = find_output_on(&transaction, output_id).await? else {
         transaction.rollback().await.map_err(store_err)?;
         return Err(AgentError::Store(format!("output {output_id} not found")));
     };
+    // The output's fixed media type fixes the revision size ceiling: a binary
+    // output accepts binary-sized revisions, a text output only text-sized ones.
+    if let Err(error) = validate_revision(revision, revision_byte_ceiling(&existing.media_type)) {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(error);
+    }
     // Take the owning chat's write lock so two concurrent revisions cannot
     // both read the same ordinal and race to publish a current revision.
     if !acquire_chat_write_lock(&transaction, existing.chat_id).await? {
@@ -290,20 +296,41 @@ pub(in crate::db) async fn delete_output(
     Ok(true)
 }
 
-fn validate_new_output(request: &CreateOutput) -> Result<&'static str> {
-    validate_deliverable_name(&request.filename)
-        .map_err(|message| AgentError::Store(format!("invalid output filename: {message}")))?;
-    let media_type = deliverable_media_type(&request.filename)
-        .ok_or_else(|| AgentError::Store("output filename has no supported media type".into()))?;
-    validate_revision(&request.revision)?;
+fn validate_new_output(request: &CreateOutput) -> Result<String> {
+    let media_type = match &request.kind {
+        DeliverableKind::Text => {
+            validate_deliverable_name(&request.filename).map_err(|message| {
+                AgentError::Store(format!("invalid output filename: {message}"))
+            })?;
+            deliverable_media_type(&request.filename)
+                .ok_or_else(|| {
+                    AgentError::Store("output filename has no supported media type".into())
+                })?
+                .to_owned()
+        }
+        DeliverableKind::Binary { media_type } => {
+            validate_binary_deliverable(&request.filename, media_type).map_err(|message| {
+                AgentError::Store(format!("invalid binary output: {message}"))
+            })?;
+            media_type.clone()
+        }
+    };
+    validate_revision(&request.revision, revision_byte_ceiling(&media_type))?;
     Ok(media_type)
 }
 
-fn validate_revision(revision: &NewOutputRevision) -> Result<()> {
-    if revision.byte_len > MAX_DELIVERABLE_BYTES as u64 {
+fn validate_revision(revision: &NewOutputRevision, byte_ceiling: usize) -> Result<()> {
+    if revision.byte_len > byte_ceiling as u64 {
         return Err(AgentError::Store(format!(
-            "output revision is too large (maximum {MAX_DELIVERABLE_BYTES} bytes)"
+            "output revision is too large (maximum {byte_ceiling} bytes)"
         )));
+    }
+    // A revision records the foreground turn or the background run that produced
+    // it, never both.
+    if revision.turn_id.is_some() && revision.producing_run_id.is_some() {
+        return Err(AgentError::Store(
+            "output revision names both a producing turn and a producing run".into(),
+        ));
     }
     if revision.citations.len() > MAX_OUTPUT_CITATIONS
         || revision
@@ -343,6 +370,7 @@ where
         })?),
         sha256: Set(revision.sha256.to_vec()),
         turn_id: Set(revision.turn_id.map(|turn_id| turn_id.0)),
+        producing_run_id: Set(revision.producing_run_id.map(|run_id| run_id.0)),
         created_at: Set(created_at),
     }
     .insert(conn)
@@ -494,6 +522,7 @@ fn revision_matches(
         && stored.byte_len == request.byte_len
         && stored.sha256 == request.sha256
         && stored.turn_id == request.turn_id
+        && stored.producing_run_id == request.producing_run_id
         && stored.created_at == created_at
 }
 
@@ -563,6 +592,7 @@ fn revision_from_model(model: entities::output_revision::Model) -> Result<Output
             .map_err(|_| AgentError::Store("stored output revision length is negative".into()))?,
         sha256,
         turn_id: model.turn_id.map(crate::id::TurnId),
+        producing_run_id: model.producing_run_id.map(crate::id::AgentRunId),
         created_at: model.created_at,
     })
 }

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -5372,11 +5372,13 @@ async fn m0013_adds_outputs_to_an_existing_conversation_store() {
         id: crate::id::OutputId::new(),
         chat_id: chat.id,
         filename: "brief.md".into(),
+        kind: crate::deliverable::DeliverableKind::Text,
         revision: crate::deliverable::NewOutputRevision {
             id: crate::id::OutputRevisionId::new(),
             byte_len: 7,
             sha256: [3; 32],
             turn_id: None,
+            producing_run_id: None,
             citations: Vec::new(),
             created_at: DateTime::<Utc>::from_timestamp(1_710_000_000, 0).unwrap(),
         },
@@ -5400,26 +5402,47 @@ async fn m0015_adds_output_citations_without_changing_existing_outputs() {
     let store = DbStore { conn: conn.clone() };
     let chat = sample_chat();
     create_chat_before_agent_run_split(&store, &chat).await;
-    let request = crate::deliverable::CreateOutput {
-        id: crate::id::OutputId::new(),
-        chat_id: chat.id,
-        filename: "brief.md".into(),
-        revision: crate::deliverable::NewOutputRevision {
-            id: crate::id::OutputRevisionId::new(),
-            byte_len: 7,
-            sha256: [3; 32],
-            turn_id: None,
-            citations: Vec::new(),
-            created_at: DateTime::<Utc>::from_timestamp(1_710_000_000, 0).unwrap(),
-        },
-    };
-    let created = store.create_output(&request).await.unwrap();
+    // Seed the output at the pre-producing-run schema via raw SQL, the way
+    // intermediate-schema upgrade tests write against a partially migrated store
+    // (the ORM entity now carries `producing_run_id`, absent before m0023).
+    let output_id = crate::id::OutputId::new();
+    let revision_id = crate::id::OutputRevisionId::new();
+    conn.execute_unprepared(&format!(
+        "INSERT INTO output \
+         (id, chat_id, filename, media_type, current_revision_id, revision_count, \
+          created_at, updated_at, deleted_at) \
+         VALUES (X'{output}', X'{chat}', 'brief.md', 'text/markdown', X'{revision}', 1, \
+          '2024-03-09 16:00:00+00:00', '2024-03-09 16:00:00+00:00', NULL); \
+         INSERT INTO output_revision \
+         (id, output_id, ordinal, byte_len, sha256, turn_id, created_at) \
+         VALUES (X'{revision}', X'{output}', 1, 7, X'{sha}', NULL, \
+          '2024-03-09 16:00:00+00:00')",
+        output = output_id.0.simple(),
+        chat = chat.id.0.simple(),
+        revision = revision_id.0.simple(),
+        sha = "03".repeat(32),
+    ))
+    .await
+    .unwrap();
 
     migration::Migrator::up(&conn, None).await.unwrap();
 
-    assert_eq!(store.get_output(created.id).await.unwrap(), Some(created));
+    // Both the citations migration and the binary/producing-run migration
+    // preserve the pre-existing output and its revision unchanged.
+    let output = store.get_output(output_id).await.unwrap().unwrap();
+    assert_eq!(output.filename, "brief.md");
+    assert_eq!(output.media_type, "text/markdown");
+    assert_eq!(output.revision_count, 1);
+    let revision = store
+        .get_output_revision(revision_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(revision.byte_len, 7);
+    assert_eq!(revision.turn_id, None);
+    assert_eq!(revision.producing_run_id, None);
     assert!(store
-        .list_output_revision_citations(request.revision.id)
+        .list_output_revision_citations(revision_id)
         .await
         .unwrap()
         .is_empty());

--- a/crates/openwave-core/src/db/tests/operation_log.rs
+++ b/crates/openwave-core/src/db/tests/operation_log.rs
@@ -245,8 +245,10 @@ async fn the_operation_log_migration_is_reversible() {
         .await
         .unwrap();
 
-    // Rolling back the last migration drops it symmetrically...
-    Migrator::down(&store.conn, Some(1)).await.unwrap();
+    // Rolling back the two most recent additive migrations (the output-revision
+    // binary/producing-run extension, then this one) drops the table
+    // symmetrically...
+    Migrator::down(&store.conn, Some(2)).await.unwrap();
     assert!(
         store
             .claim_operation(run, Uuid::new_v4(), b"fp", true, Uuid::new_v4())

--- a/crates/openwave-core/src/db/tests/output.rs
+++ b/crates/openwave-core/src/db/tests/output.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::citation::AssistantCitationReference;
 use crate::deliverable::{
-    CreateOutput, NewOutputRevision, OutputRecord, MAX_DELIVERABLE_BYTES, MAX_OUTPUT_REVISIONS,
+    CreateOutput, DeliverableKind, NewOutputRevision, OutputRecord, MAX_DELIVERABLE_BYTES,
+    MAX_OUTPUT_REVISIONS,
 };
 use crate::id::{CallId, DocumentId, OutputId, OutputRevisionId};
 use crate::model::{
@@ -24,6 +25,7 @@ fn revision(seed: u8, second: i64) -> NewOutputRevision {
         byte_len: u64::from(seed) + 1,
         sha256: digest(seed),
         turn_id: None,
+        producing_run_id: None,
         citations: Vec::new(),
         created_at: at(second),
     }
@@ -34,6 +36,7 @@ fn create_request(chat_id: ChatId, filename: &str, seed: u8) -> CreateOutput {
         id: OutputId::new(),
         chat_id,
         filename: filename.to_owned(),
+        kind: DeliverableKind::Text,
         revision: revision(seed, 0),
     }
 }
@@ -513,4 +516,151 @@ async fn output_citations_cannot_cross_turn_or_conversation_boundaries() {
         .await
         .unwrap()
         .is_empty());
+}
+
+#[cfg(feature = "tools")]
+fn open_scratch(path: &std::path::Path) -> cap_std::fs::Dir {
+    cap_std::fs::Dir::open_ambient_dir(path, cap_std::ambient_authority()).unwrap()
+}
+
+#[tokio::test]
+async fn a_revision_records_a_producing_run_and_rejects_two_producers() {
+    use crate::id::AgentRunId;
+
+    let (_dir, store, chat) = store_with_chat().await;
+    let request = create_request(chat.id, "brief.md", 1);
+    let created = store.create_output(&request).await.unwrap();
+
+    // A later revision can be attributed to a producing background run.
+    let run_id = AgentRunId::new();
+    let mut run_revision = revision(2, 10);
+    run_revision.producing_run_id = Some(run_id);
+    let updated = store
+        .append_output_revision(created.id, &run_revision)
+        .await
+        .unwrap();
+    let stored = store
+        .get_output_revision(updated.current_revision)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.producing_run_id, Some(run_id));
+    assert_eq!(stored.turn_id, None);
+
+    // A revision may not name both a producing turn and a producing run.
+    let mut both = revision(3, 20);
+    both.turn_id = Some(TurnId::new());
+    both.producing_run_id = Some(AgentRunId::new());
+    assert!(store
+        .append_output_revision(created.id, &both)
+        .await
+        .is_err());
+}
+
+#[cfg(feature = "tools")]
+#[tokio::test]
+async fn a_binary_workspace_artifact_is_accepted_published_and_attributed_to_its_run() {
+    use crate::deliverable::{output_revision_relative_path, RevisionProducer};
+    use crate::deliverable_acceptance::{accept_workspace_artifact, WorkspaceArtifactProposal};
+    use crate::id::AgentRunId;
+
+    let (_dir, store, chat) = store_with_chat().await;
+    let scratch = tempfile::tempdir().unwrap();
+    let dir = open_scratch(scratch.path());
+
+    // A binary artifact larger than the 512 KiB text cap, which the text path
+    // would reject, and carrying a real binary media type.
+    let mut content = b"\x89PNG\r\n\x1a\n".to_vec();
+    content.resize(700 * 1024, 7);
+    let run_id = AgentRunId::new();
+    let output_id = OutputId::new();
+    let revision_id = OutputRevisionId::new();
+
+    let record = accept_workspace_artifact(
+        &store,
+        &dir,
+        &WorkspaceArtifactProposal {
+            output_id,
+            chat_id: chat.id,
+            filename: "chart.png".into(),
+            media_type: "image/png".into(),
+            revision_id,
+            producer: RevisionProducer::Run(run_id),
+            revise: false,
+            content: content.clone(),
+            created_at: at(0),
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(record.media_type, "image/png");
+    assert_eq!(record.revision_count, 1);
+
+    // The bytes landed at the exact write-once revision path the desktop export
+    // reads, unchanged and content-addressed.
+    let published = scratch
+        .path()
+        .join(output_revision_relative_path(output_id, revision_id));
+    assert_eq!(std::fs::read(&published).unwrap(), content);
+
+    // The revision records the producing run, not a turn.
+    let revision = store
+        .get_output_revision(revision_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(revision.producing_run_id, Some(run_id));
+    assert_eq!(revision.turn_id, None);
+    assert_eq!(revision.byte_len, content.len() as u64);
+    use sha2::Digest as _;
+    assert_eq!(
+        revision.sha256,
+        <[u8; 32]>::from(sha2::Sha256::digest(&content))
+    );
+}
+
+#[cfg(feature = "tools")]
+#[tokio::test]
+async fn acceptance_enforces_the_binary_cap_and_rejects_empty_artifacts() {
+    use crate::deliverable::{RevisionProducer, MAX_BINARY_DELIVERABLE_BYTES};
+    use crate::deliverable_acceptance::{accept_workspace_artifact, WorkspaceArtifactProposal};
+    use crate::id::AgentRunId;
+
+    let (_dir, store, chat) = store_with_chat().await;
+    let scratch = tempfile::tempdir().unwrap();
+    let dir = open_scratch(scratch.path());
+
+    let proposal = |content: Vec<u8>| WorkspaceArtifactProposal {
+        output_id: OutputId::new(),
+        chat_id: chat.id,
+        filename: "blob.bin".into(),
+        media_type: "application/octet-stream".into(),
+        revision_id: OutputRevisionId::new(),
+        producer: RevisionProducer::Run(AgentRunId::new()),
+        revise: false,
+        content,
+        created_at: at(0),
+    };
+
+    assert!(
+        accept_workspace_artifact(&store, &dir, &proposal(Vec::new()))
+            .await
+            .is_err()
+    );
+    assert!(accept_workspace_artifact(
+        &store,
+        &dir,
+        &proposal(vec![0u8; MAX_BINARY_DELIVERABLE_BYTES + 1])
+    )
+    .await
+    .is_err());
+    // Exactly at the cap is accepted.
+    assert!(accept_workspace_artifact(
+        &store,
+        &dir,
+        &proposal(vec![0u8; MAX_BINARY_DELIVERABLE_BYTES])
+    )
+    .await
+    .is_ok());
 }

--- a/crates/openwave-core/src/deliverable.rs
+++ b/crates/openwave-core/src/deliverable.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use chrono::{DateTime, Utc};
 
 use crate::citation::{AssistantCitationReference, CitationPageBounds};
-use crate::id::{ChatId, OutputCitationId, OutputId, OutputRevisionId, TurnId};
+use crate::id::{AgentRunId, ChatId, OutputCitationId, OutputId, OutputRevisionId, TurnId};
 
 /// Private-scratch directory holding legacy filename-addressed output files.
 ///
@@ -31,8 +31,21 @@ pub const DELIVERABLES_DIRECTORY: &str = "artifacts";
 pub const OUTPUTS_DIRECTORY: &str = "outputs";
 /// Largest text artifact the foreground agent may create.
 pub const MAX_DELIVERABLE_BYTES: usize = 512 * 1024;
+/// Largest binary workspace artifact the host may accept into an output.
+///
+/// A binary artifact only enters the record through host acceptance of a file
+/// pulled back with `WorkspaceLifecycle::get_workspace_file`, which itself
+/// bounds a single transfer at 16 MiB. Matching that transfer ceiling keeps the
+/// acceptance invariant simple: every file the workspace is willing to hand
+/// back fits, so acceptance never has to reject a well-formed artifact a
+/// provider already produced. It is 32x the text cap yet still small enough to
+/// buffer one revision in memory while publishing it to private scratch and
+/// exporting it.
+pub const MAX_BINARY_DELIVERABLE_BYTES: usize = 16 * 1024 * 1024;
 /// Largest filename accepted by the model-facing and native boundaries.
 pub const MAX_DELIVERABLE_NAME_CHARS: usize = 120;
+/// Largest declared media type accepted for a binary workspace artifact.
+pub const MAX_DELIVERABLE_MEDIA_TYPE_CHARS: usize = 127;
 /// Largest number of revisions one output retains.
 ///
 /// Reaching the bound is a product decision rather than a storage failure: the
@@ -68,7 +81,9 @@ pub struct OutputRecord {
     pub chat_id: ChatId,
     /// Display filename. Not identity, and not unique within a chat.
     pub filename: String,
-    /// Fixed media type derived from `filename` when the output was created.
+    /// Fixed media type set when the output was created: derived from `filename`
+    /// for a text deliverable, or the explicit type of an accepted binary
+    /// artifact.
     pub media_type: String,
     /// Revision currently presented as the output's content.
     pub current_revision: OutputRevisionId,
@@ -96,10 +111,55 @@ pub struct OutputRevision {
     pub byte_len: u64,
     /// SHA-256 of the revision's content, used to recognize an exact retry.
     pub sha256: [u8; 32],
-    /// Turn that produced the revision, when it came from an agent turn.
+    /// Turn that produced the revision, when it came from a foreground turn.
+    ///
+    /// Mutually exclusive with [`OutputRevision::producing_run_id`]: a revision
+    /// records the foreground turn or the background run that produced it, never
+    /// both.
     pub turn_id: Option<TurnId>,
+    /// Background run that produced the revision, when it came from a background
+    /// run rather than a foreground turn.
+    ///
+    /// Added alongside `turn_id` rather than replacing it: existing readers of
+    /// `turn_id` are unchanged, and a revision that predates background-run
+    /// production continues to carry only its turn.
+    pub producing_run_id: Option<AgentRunId>,
     /// Host-stamped creation time.
     pub created_at: DateTime<Utc>,
+}
+
+/// The foreground turn or background run that produced an output revision.
+///
+/// Callers that mint a revision name exactly one producer through this enum; the
+/// store records it into the mutually exclusive `turn_id` / `producing_run_id`
+/// columns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RevisionProducer {
+    /// A foreground turn produced the revision. Only a turn producer may carry
+    /// retrieval citations, which resolve against the turn's evidence.
+    Turn(TurnId),
+    /// A background run produced the revision.
+    Run(AgentRunId),
+}
+
+impl RevisionProducer {
+    /// The producing turn, when the producer is a foreground turn.
+    #[must_use]
+    pub fn turn_id(self) -> Option<TurnId> {
+        match self {
+            Self::Turn(turn_id) => Some(turn_id),
+            Self::Run(_) => None,
+        }
+    }
+
+    /// The producing run, when the producer is a background run.
+    #[must_use]
+    pub fn producing_run_id(self) -> Option<AgentRunId> {
+        match self {
+            Self::Run(run_id) => Some(run_id),
+            Self::Turn(_) => None,
+        }
+    }
 }
 
 /// Renderer-safe historical citation projected from immutable output evidence.
@@ -127,8 +187,12 @@ pub struct NewOutputRevision {
     pub byte_len: u64,
     /// SHA-256 of that content.
     pub sha256: [u8; 32],
-    /// Turn that produced the revision, when it came from an agent turn.
+    /// Foreground turn that produced the revision, when one did. Mutually
+    /// exclusive with `producing_run_id`.
     pub turn_id: Option<TurnId>,
+    /// Background run that produced the revision, when one did. Mutually
+    /// exclusive with `turn_id`.
+    pub producing_run_id: Option<AgentRunId>,
     /// Ordered evidence references selected while producing this revision.
     ///
     /// References only resolve against the revision's chat and producing turn;
@@ -138,6 +202,31 @@ pub struct NewOutputRevision {
     pub created_at: DateTime<Utc>,
 }
 
+impl NewOutputRevision {
+    /// Record the producer that minted this revision into its turn/run fields.
+    #[must_use]
+    pub fn with_producer(mut self, producer: RevisionProducer) -> Self {
+        self.turn_id = producer.turn_id();
+        self.producing_run_id = producer.producing_run_id();
+        self
+    }
+}
+
+/// Whether an output holds model-authored text or a host-accepted binary
+/// artifact. The kind fixes the output's media type and its size ceiling.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeliverableKind {
+    /// Model-authored UTF-8 text. The media type is derived from the filename
+    /// extension and the size ceiling is [`MAX_DELIVERABLE_BYTES`].
+    Text,
+    /// A host-accepted binary workspace artifact carrying an explicit media
+    /// type. The size ceiling is [`MAX_BINARY_DELIVERABLE_BYTES`].
+    Binary {
+        /// Declared media type, validated by [`validate_binary_deliverable`].
+        media_type: String,
+    },
+}
+
 /// Request to create an output together with its first revision.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CreateOutput {
@@ -145,8 +234,12 @@ pub struct CreateOutput {
     pub id: OutputId,
     /// Conversation that will own the output.
     pub chat_id: ChatId,
-    /// Display filename, validated by [`validate_deliverable_name`].
+    /// Display filename, validated by [`validate_deliverable_name`] for text
+    /// and [`validate_binary_deliverable`] for binary artifacts.
     pub filename: String,
+    /// Whether the output is model-authored text or a host-accepted binary
+    /// artifact. Fixes the media type and the revision size ceiling.
+    pub kind: DeliverableKind,
     /// The output's first revision.
     pub revision: NewOutputRevision,
 }
@@ -157,6 +250,21 @@ pub struct CreateOutput {
 /// arbitrary scratch-relative path. This keeps the catalog and native export
 /// boundary closed and makes names portable across desktop platforms.
 pub fn validate_deliverable_name(name: &str) -> Result<(), &'static str> {
+    validate_portable_filename(name)?;
+    if deliverable_media_type(name).is_none() {
+        return Err("filename must end in .md, .txt, .csv, .json, or .html");
+    }
+    Ok(())
+}
+
+/// Validate one portable, renderer-safe filename without constraining its
+/// extension.
+///
+/// This is the shared name contract for both text deliverables and binary
+/// workspace artifacts. Text names additionally require a supported extension
+/// ([`validate_deliverable_name`]); a binary artifact carries its media type
+/// explicitly, so its extension is unconstrained beyond these portability rules.
+pub fn validate_portable_filename(name: &str) -> Result<(), &'static str> {
     if name.is_empty() || name.chars().count() > MAX_DELIVERABLE_NAME_CHARS {
         return Err("filename must contain between 1 and 120 characters");
     }
@@ -179,10 +287,66 @@ pub fn validate_deliverable_name(name: &str) -> Result<(), &'static str> {
             "filename may contain only letters, numbers, spaces, dashes, underscores, and parentheses",
         );
     }
-    if deliverable_media_type(name).is_none() {
-        return Err("filename must end in .md, .txt, .csv, .json, or .html");
+    Ok(())
+}
+
+/// Validate a host-accepted binary artifact's filename and declared media type.
+///
+/// The filename obeys the portable rules; the media type is a well-formed,
+/// bounded `type/subtype` token that is not one of the curated text types (those
+/// belong to the model-authored text path, which derives the type from the
+/// name).
+pub fn validate_binary_deliverable(name: &str, media_type: &str) -> Result<(), &'static str> {
+    validate_portable_filename(name)?;
+    validate_deliverable_media_type(media_type)?;
+    if media_type_is_text(media_type) {
+        return Err("binary artifacts must not declare a curated text media type");
     }
     Ok(())
+}
+
+/// Validate a declared media type is a bounded, well-formed `type/subtype`
+/// token with no parameters.
+pub fn validate_deliverable_media_type(media_type: &str) -> Result<(), &'static str> {
+    if media_type.is_empty() || media_type.chars().count() > MAX_DELIVERABLE_MEDIA_TYPE_CHARS {
+        return Err("media type must contain between 1 and 127 characters");
+    }
+    let Some((kind, subtype)) = media_type.split_once('/') else {
+        return Err("media type must be in type/subtype form");
+    };
+    if !is_media_type_token(kind) || !is_media_type_token(subtype) {
+        return Err("media type contains invalid characters");
+    }
+    Ok(())
+}
+
+fn is_media_type_token(token: &str) -> bool {
+    !token.is_empty()
+        && token
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "!#$&-^_.+".contains(character))
+}
+
+/// Whether a media type is one of the curated text types whose outputs use the
+/// text size ceiling.
+#[must_use]
+pub fn media_type_is_text(media_type: &str) -> bool {
+    matches!(
+        media_type,
+        "text/markdown" | "text/plain" | "text/csv" | "application/json" | "text/html"
+    )
+}
+
+/// The revision size ceiling that applies to an output with this media type:
+/// [`MAX_DELIVERABLE_BYTES`] for curated text, [`MAX_BINARY_DELIVERABLE_BYTES`]
+/// otherwise.
+#[must_use]
+pub fn revision_byte_ceiling(media_type: &str) -> usize {
+    if media_type_is_text(media_type) {
+        MAX_DELIVERABLE_BYTES
+    } else {
+        MAX_BINARY_DELIVERABLE_BYTES
+    }
 }
 
 /// Return the fixed media type for one supported deliverable filename.
@@ -262,5 +426,70 @@ mod tests {
         assert_eq!(deliverable_media_type("brief.MD"), Some("text/markdown"));
         assert_eq!(deliverable_media_type("table.csv"), Some("text/csv"));
         assert_eq!(deliverable_media_type("archive.zip"), None);
+    }
+
+    #[test]
+    fn binary_artifacts_accept_portable_names_and_well_formed_media_types() {
+        for (name, media_type) in [
+            ("chart.png", "image/png"),
+            ("report.pdf", "application/pdf"),
+            ("model.bin", "application/octet-stream"),
+            (
+                "sheet.xlsx",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            ),
+        ] {
+            assert!(
+                validate_binary_deliverable(name, media_type).is_ok(),
+                "{name} {media_type}"
+            );
+        }
+        // A binary artifact may not masquerade as a curated text type.
+        assert!(validate_binary_deliverable("notes.png", "text/plain").is_err());
+        // Malformed media types are rejected.
+        for media_type in [
+            "",
+            "image",
+            "image/",
+            "/png",
+            "image/png; charset",
+            "im age/png",
+        ] {
+            assert!(
+                validate_deliverable_media_type(media_type).is_err(),
+                "{media_type}"
+            );
+        }
+        // Traversal and non-portable names are rejected before the media type.
+        assert!(validate_binary_deliverable("../chart.png", "image/png").is_err());
+    }
+
+    #[test]
+    fn revision_ceiling_tracks_the_content_kind() {
+        assert_eq!(
+            revision_byte_ceiling("text/markdown"),
+            MAX_DELIVERABLE_BYTES
+        );
+        assert_eq!(
+            revision_byte_ceiling("application/json"),
+            MAX_DELIVERABLE_BYTES
+        );
+        assert_eq!(
+            revision_byte_ceiling("image/png"),
+            MAX_BINARY_DELIVERABLE_BYTES
+        );
+        const {
+            assert!(MAX_BINARY_DELIVERABLE_BYTES > MAX_DELIVERABLE_BYTES);
+        }
+    }
+
+    #[test]
+    fn a_revision_producer_is_exactly_one_of_turn_or_run() {
+        let turn = TurnId::new();
+        let run = AgentRunId::new();
+        assert_eq!(RevisionProducer::Turn(turn).turn_id(), Some(turn));
+        assert_eq!(RevisionProducer::Turn(turn).producing_run_id(), None);
+        assert_eq!(RevisionProducer::Run(run).producing_run_id(), Some(run));
+        assert_eq!(RevisionProducer::Run(run).turn_id(), None);
     }
 }

--- a/crates/openwave-core/src/deliverable_acceptance.rs
+++ b/crates/openwave-core/src/deliverable_acceptance.rs
@@ -1,0 +1,122 @@
+//! Host-side acceptance of workspace artifacts into the conversation output
+//! record.
+//!
+//! A file produced inside an execution provider's durable workspace is only a
+//! *proposal* until the host accepts it. Acceptance is a host operation under
+//! the live-consent invariant — the model never self-accepts — and it is what
+//! turns bytes pulled back with `WorkspaceLifecycle::get_workspace_file` into a
+//! durable, exportable output revision. The bytes land in the exact
+//! conversation's private scratch under the same write-once revision path as a
+//! text deliverable, so every downstream surface (the desktop catalog, preview,
+//! and Save As… export) treats an accepted binary artifact exactly like any
+//! other output.
+
+use cap_std::fs::Dir;
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+
+use crate::deliverable::{
+    output_revision_relative_path, CreateOutput, DeliverableKind, NewOutputRevision,
+    RevisionProducer, MAX_BINARY_DELIVERABLE_BYTES,
+};
+use crate::error::{AgentError, Result};
+use crate::id::{ChatId, OutputId, OutputRevisionId};
+use crate::storage::Store;
+use crate::OutputRecord;
+
+/// A workspace artifact the host proposes to accept into an output record.
+///
+/// The bytes are already in hand — pulled from the provider workspace by
+/// `WorkspaceLifecycle::get_workspace_file` — so acceptance is decoupled from
+/// any particular provider.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceArtifactProposal {
+    /// Caller-minted output identity. A fresh id creates a new output; an
+    /// existing id (with `revise` set) appends a revision, so an ambiguous
+    /// acceptance can be retried without forking the record.
+    pub output_id: OutputId,
+    /// Conversation that will own the accepted output.
+    pub chat_id: ChatId,
+    /// Portable display filename shown in the catalog and save dialog.
+    pub filename: String,
+    /// Declared media type of the artifact, validated as binary.
+    pub media_type: String,
+    /// Caller-minted revision identity, also the private-scratch filename.
+    pub revision_id: OutputRevisionId,
+    /// The turn or background run that produced the artifact.
+    pub producer: RevisionProducer,
+    /// Append a revision to an existing output rather than create a new one.
+    pub revise: bool,
+    /// Artifact bytes pulled from the workspace.
+    pub content: Vec<u8>,
+    /// Host-stamped acceptance time.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Accept a workspace artifact into the conversation output record.
+///
+/// `scratch` is the exact owning conversation's private scratch directory. The
+/// bytes are published once at the derived revision path and then recorded, so a
+/// display filename can never steer where they are written and a retry with the
+/// same identity and bytes is idempotent.
+pub async fn accept_workspace_artifact(
+    store: &dyn Store,
+    scratch: &Dir,
+    proposal: &WorkspaceArtifactProposal,
+) -> Result<OutputRecord> {
+    if proposal.content.is_empty() {
+        return Err(AgentError::Store("workspace artifact is empty".into()));
+    }
+    if proposal.content.len() > MAX_BINARY_DELIVERABLE_BYTES {
+        return Err(AgentError::Store(format!(
+            "workspace artifact is too large (maximum {MAX_BINARY_DELIVERABLE_BYTES} bytes)"
+        )));
+    }
+
+    let byte_len = proposal.content.len() as u64;
+    let sha256: [u8; 32] = Sha256::digest(&proposal.content).into();
+    let relative_path = output_revision_relative_path(proposal.output_id, proposal.revision_id);
+
+    // Publishing is blocking capability I/O; keep it off the async runtime.
+    let scratch = scratch
+        .try_clone()
+        .map_err(|error| AgentError::Store(format!("could not open private scratch: {error}")))?;
+    let content = proposal.content.clone();
+    tokio::task::spawn_blocking(move || {
+        crate::tools::private_scratch::publish_immutable_file(&scratch, &relative_path, &content)
+    })
+    .await
+    .map_err(|error| AgentError::Store(format!("artifact publication task failed: {error}")))?
+    .map_err(|error| AgentError::Store(format!("could not publish accepted artifact: {error}")))?;
+
+    let revision = NewOutputRevision {
+        id: proposal.revision_id,
+        byte_len,
+        sha256,
+        // A binary artifact carries no retrieval citations: it is host-accepted
+        // bytes, not a turn's cited text.
+        turn_id: None,
+        producing_run_id: None,
+        citations: Vec::new(),
+        created_at: proposal.created_at,
+    }
+    .with_producer(proposal.producer);
+
+    if proposal.revise {
+        store
+            .append_output_revision(proposal.output_id, &revision)
+            .await
+    } else {
+        store
+            .create_output(&CreateOutput {
+                id: proposal.output_id,
+                chat_id: proposal.chat_id,
+                filename: proposal.filename.clone(),
+                kind: DeliverableKind::Binary {
+                    media_type: proposal.media_type.clone(),
+                },
+                revision,
+            })
+            .await
+    }
+}

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -36,6 +36,11 @@ pub mod context;
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub mod db;
 pub mod deliverable;
+// Host-side acceptance writes bytes into private scratch, so it depends on the
+// capability filesystem and async runtime that only the `tools` feature pulls
+// in. The persisted contract and migration below stay available without it.
+#[cfg(feature = "tools")]
+pub mod deliverable_acceptance;
 pub mod error;
 pub mod event;
 pub mod id;
@@ -104,11 +109,16 @@ pub use config::{Config, Profile};
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub use db::DbStore;
 pub use deliverable::{
-    deliverable_media_type, output_revision_relative_path, validate_deliverable_name, CreateOutput,
-    NewOutputRevision, OutputCitationSnapshot, OutputRecord, OutputRevision,
-    DELIVERABLES_DIRECTORY, MAX_DELIVERABLE_BYTES, MAX_DELIVERABLE_NAME_CHARS,
-    MAX_OUTPUT_CITATIONS, MAX_OUTPUT_REVISIONS, OUTPUTS_DIRECTORY,
+    deliverable_media_type, media_type_is_text, output_revision_relative_path,
+    revision_byte_ceiling, validate_binary_deliverable, validate_deliverable_media_type,
+    validate_deliverable_name, validate_portable_filename, CreateOutput, DeliverableKind,
+    NewOutputRevision, OutputCitationSnapshot, OutputRecord, OutputRevision, RevisionProducer,
+    DELIVERABLES_DIRECTORY, MAX_BINARY_DELIVERABLE_BYTES, MAX_DELIVERABLE_BYTES,
+    MAX_DELIVERABLE_MEDIA_TYPE_CHARS, MAX_DELIVERABLE_NAME_CHARS, MAX_OUTPUT_CITATIONS,
+    MAX_OUTPUT_REVISIONS, OUTPUTS_DIRECTORY,
 };
+#[cfg(feature = "tools")]
+pub use deliverable_acceptance::{accept_workspace_artifact, WorkspaceArtifactProposal};
 pub use error::{AgentError, AgentErrorInfo, Result};
 pub use event::{AgentEvent, SequencedEvent};
 pub use id::{

--- a/crates/openwave-core/src/tools/create_deliverable.rs
+++ b/crates/openwave-core/src/tools/create_deliverable.rs
@@ -9,8 +9,8 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
 use crate::deliverable::{
-    output_revision_relative_path, validate_deliverable_name, CreateOutput, NewOutputRevision,
-    DELIVERABLES_DIRECTORY, MAX_DELIVERABLE_BYTES, MAX_DELIVERABLE_NAME_CHARS,
+    output_revision_relative_path, validate_deliverable_name, CreateOutput, DeliverableKind,
+    NewOutputRevision, DELIVERABLES_DIRECTORY, MAX_DELIVERABLE_BYTES, MAX_DELIVERABLE_NAME_CHARS,
 };
 use crate::error::Result;
 use crate::id::{OutputId, OutputRevisionId};
@@ -184,6 +184,7 @@ impl Tool for CreateDeliverable {
             byte_len: content_len as u64,
             sha256: Sha256::digest(&published).into(),
             turn_id: Some(call.turn_id),
+            producing_run_id: None,
             citations: Vec::new(),
             created_at: call.created_at,
         };
@@ -196,6 +197,7 @@ impl Tool for CreateDeliverable {
                         id: output_id,
                         chat_id: ctx.chat_id,
                         filename,
+                        kind: DeliverableKind::Text,
                         revision,
                     })
                     .await

--- a/crates/openwave-core/src/tools/mod.rs
+++ b/crates/openwave-core/src/tools/mod.rs
@@ -8,7 +8,7 @@ mod arguments;
 mod create_deliverable;
 mod definitions;
 mod list_dir;
-mod private_scratch;
+pub(crate) mod private_scratch;
 mod read_file;
 mod write_file;
 

--- a/crates/openwave-core/src/tools/private_scratch.rs
+++ b/crates/openwave-core/src/tools/private_scratch.rs
@@ -176,7 +176,7 @@ pub(super) fn write_utf8_file(workspace: &Dir, path: &Path, content: &[u8]) -> s
 /// A hard link gives the temporary file an atomic, no-replace final name. If a
 /// previous attempt already published that name, accepting it only when its
 /// exact bytes match makes an interrupted store response safe to retry.
-pub(super) fn publish_immutable_file(
+pub(crate) fn publish_immutable_file(
     workspace: &Dir,
     path: &Path,
     content: &[u8],

--- a/crates/openwave-desktop/src/deliverables.rs
+++ b/crates/openwave-desktop/src/deliverables.rs
@@ -13,8 +13,9 @@ use cap_fs_ext::{DirExt as _, FollowSymlinks, OpenOptionsFollowExt};
 use cap_std::ambient_authority;
 use cap_std::fs::{Dir, OpenOptions};
 use openwave_core::{
-    deliverable_media_type, ChatId, OutputId, OutputRecord, OutputRevision, OutputRevisionId,
-    Store, MAX_DELIVERABLE_BYTES, OUTPUTS_DIRECTORY,
+    deliverable_media_type, media_type_is_text, revision_byte_ceiling, ChatId, OutputId,
+    OutputRecord, OutputRevision, OutputRevisionId, Store, MAX_BINARY_DELIVERABLE_BYTES,
+    OUTPUTS_DIRECTORY,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -343,12 +344,16 @@ fn summary_from_record(
     output: &OutputRecord,
     revision: &OutputRevision,
 ) -> Result<DeliverableSummary, String> {
+    // Text outputs derive their media type from the filename; binary artifacts
+    // carry an explicit media type with an arbitrary extension, so only text is
+    // held to the filename-derived type. Each kind keeps its own size ceiling.
     if output.deleted_at.is_some()
         || output.current_revision != revision.id
         || output.id != revision.output_id
         || output.revision_count == 0
-        || revision.byte_len > MAX_DELIVERABLE_BYTES as u64
-        || deliverable_media_type(&output.filename) != Some(output.media_type.as_str())
+        || revision.byte_len > revision_byte_ceiling(&output.media_type) as u64
+        || (media_type_is_text(&output.media_type)
+            && deliverable_media_type(&output.filename) != Some(output.media_type.as_str()))
     {
         return Err("Could not load this conversation's outputs".to_owned());
     }
@@ -368,10 +373,11 @@ pub(crate) fn read_output_revision_bytes(
     output: &OutputRecord,
     revision: &OutputRevision,
 ) -> Result<Vec<u8>, String> {
+    let ceiling = revision_byte_ceiling(&output.media_type);
     if output.chat_id != chat_id
         || output.deleted_at.is_some()
         || revision.output_id != output.id
-        || revision.byte_len > MAX_DELIVERABLE_BYTES as u64
+        || revision.byte_len > ceiling as u64
     {
         return Err("Output not found in this conversation".to_owned());
     }
@@ -410,11 +416,11 @@ pub(crate) fn read_output_revision_bytes(
         return Err("Output content is unavailable".to_owned());
     }
     let mut bytes = Vec::with_capacity(metadata.len() as usize);
-    file.take((MAX_DELIVERABLE_BYTES + 1) as u64)
+    file.take((ceiling + 1) as u64)
         .read_to_end(&mut bytes)
         .map_err(|_| "Output content is unavailable".to_owned())?;
     if bytes.len() as u64 != revision.byte_len
-        || bytes.len() > MAX_DELIVERABLE_BYTES
+        || bytes.len() > ceiling
         || <[u8; 32]>::from(Sha256::digest(&bytes)) != revision.sha256
     {
         return Err("Output content is unavailable".to_owned());
@@ -505,7 +511,7 @@ fn destination_matches_revision(destination: &Path, revision: &OutputRevision) -
 }
 
 fn destination_matches(destination: &Path, byte_len: u64, sha256: [u8; 32]) -> bool {
-    if !destination.is_absolute() || byte_len > MAX_DELIVERABLE_BYTES as u64 {
+    if !destination.is_absolute() || byte_len > MAX_BINARY_DELIVERABLE_BYTES as u64 {
         return false;
     }
     let Some(parent) = destination.parent() else {
@@ -530,7 +536,7 @@ fn destination_matches(destination: &Path, byte_len: u64, sha256: [u8; 32]) -> b
     };
     let mut bytes = Vec::with_capacity(byte_len as usize);
     if file
-        .take((MAX_DELIVERABLE_BYTES + 1) as u64)
+        .take((MAX_BINARY_DELIVERABLE_BYTES + 1) as u64)
         .read_to_end(&mut bytes)
         .is_err()
     {
@@ -595,7 +601,7 @@ async fn pick_export_path(app: &AppHandle, filename: &str) -> Result<Option<Path
 }
 
 fn write_exported_deliverable(destination: &Path, content: &[u8]) -> Result<(), String> {
-    if !destination.is_absolute() || content.len() > MAX_DELIVERABLE_BYTES {
+    if !destination.is_absolute() || content.len() > MAX_BINARY_DELIVERABLE_BYTES {
         return Err("The save destination is invalid".to_owned());
     }
     let parent = destination
@@ -681,6 +687,7 @@ mod tests {
                 byte_len: content.len() as u64,
                 sha256: Sha256::digest(content).into(),
                 turn_id: None,
+                producing_run_id: None,
                 created_at,
             },
         )
@@ -718,6 +725,72 @@ mod tests {
         for forbidden in ["path", "scratch", "chatId", "token", "sha256"] {
             assert!(!serialized.to_string().contains(forbidden));
         }
+    }
+
+    fn binary_output_record(
+        chat_id: ChatId,
+        filename: &str,
+        media_type: &str,
+        content: &[u8],
+    ) -> (OutputRecord, OutputRevision) {
+        let output_id = OutputId::new();
+        let revision_id = OutputRevisionId::new();
+        let created_at = Utc.timestamp_opt(1_800_000_000, 0).unwrap();
+        (
+            OutputRecord {
+                id: output_id,
+                chat_id,
+                filename: filename.to_owned(),
+                media_type: media_type.to_owned(),
+                current_revision: revision_id,
+                revision_count: 1,
+                created_at,
+                updated_at: created_at,
+                deleted_at: None,
+            },
+            OutputRevision {
+                id: revision_id,
+                output_id,
+                ordinal: 1,
+                byte_len: content.len() as u64,
+                sha256: Sha256::digest(content).into(),
+                turn_id: None,
+                producing_run_id: None,
+                created_at,
+            },
+        )
+    }
+
+    #[test]
+    fn binary_artifacts_beyond_the_text_cap_are_cataloged_read_and_exported() {
+        let scratch = tempfile::tempdir().unwrap();
+        // A binary artifact larger than the 512 KiB text cap.
+        let mut content = b"\x89PNG\r\n\x1a\n".to_vec();
+        content.resize(700 * 1024, 9);
+        let (output, revision) =
+            binary_output_record(ChatId::new(), "chart.png", "image/png", &content);
+
+        // It is a valid catalog entry despite its non-text media type and its
+        // size exceeding the text ceiling.
+        let summary = summary_from_record(&output, &revision).unwrap();
+        assert_eq!(summary.media_type, "image/png");
+        assert_eq!(summary.size_bytes, content.len() as u64);
+
+        // Its bytes round-trip out of private scratch unchanged.
+        let path = revision_path(scratch.path(), &output, &revision);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, &content).unwrap();
+        assert_eq!(
+            read_output_revision_bytes(scratch.path(), output.chat_id, &output, &revision).unwrap(),
+            content
+        );
+
+        // And they export to a chosen destination as raw bytes.
+        let destination_root = tempfile::tempdir().unwrap();
+        let destination = destination_root.path().join("chart.png");
+        write_exported_deliverable(&destination, &content).unwrap();
+        assert_eq!(std::fs::read(&destination).unwrap(), content);
+        assert!(destination_matches_revision(&destination, &revision));
     }
 
     #[test]

--- a/docs/deliverables.md
+++ b/docs/deliverables.md
@@ -52,8 +52,12 @@ The product store therefore owns an output record whose identity is an opaque
 - An output has an opaque id, an owning conversation, a display filename, a
   fixed media type, a current revision, and a revision count.
 - A revision has its own opaque id, a one-based ordinal, an exact byte length,
-  a SHA-256 digest, and the turn that produced it. Revision rows are
-  insert-only.
+  a SHA-256 digest, and the producer that created it. A producer is either a
+  foreground turn or a background run, never both — recorded in two mutually
+  exclusive nullable references so existing turn-produced revisions are
+  unchanged and a background run can now be attributed just as precisely. Only a
+  turn producer may carry retrieval citations, which resolve against the turn's
+  evidence. Revision rows are insert-only.
 - Updating an output appends a revision and republishes the current one. The
   replaced revision keeps its own id and stays readable, so an update can no
   longer destroy the bytes it supersedes.
@@ -80,12 +84,42 @@ is not yet wired to `create_deliverable`, which still writes a filename into
 adopted into it: they stay on disk and remain listed by the current catalog
 until that surface moves to the record.
 
+## Accepting binary workspace artifacts
+
+An execution provider with a durable workspace (see
+[sandbox providers](sandbox-providers.md)) can produce a file the conversation
+should keep — a rendered chart, a generated PDF, a spreadsheet. Such a file is a
+*proposal*, not an output: it enters the record only when the host **accepts**
+it, and acceptance is a host-side operation the model cannot perform for itself.
+
+- The host pulls the bytes back with the workspace capability's bounded file
+  read, then accepts them into an output. Acceptance publishes the bytes at the
+  same write-once revision path a text deliverable uses, so an accepted binary
+  artifact is cataloged, addressed, and exported exactly like any other output.
+- A binary artifact carries an **explicit media type** rather than one derived
+  from its filename, and its filename obeys the same portable-ASCII rules with
+  no text-extension requirement. The declared media type is a bounded,
+  well-formed `type/subtype` token and may not masquerade as one of the curated
+  text types.
+- Binary artifacts are bounded at 16 MiB — the same ceiling the workspace file
+  read enforces, so every file the workspace is willing to hand back is
+  acceptable and acceptance never has to reject a well-formed artifact. The text
+  path keeps its 512 KiB cap; each output's media type fixes which ceiling its
+  revisions use.
+- The producing background run is recorded on the accepted revision, so a
+  workspace artifact's provenance is a run rather than a foreground turn.
+
+Acceptance changes nothing about export: a person still chooses the destination
+through **Save As…**, and the bytes never leave private app data until then.
+
 ## Deliberate limits
 
 An export is a synchronous user action, so it is not automatically retried and
-does not yet have a durable export receipt. Binary formats, Office document
-generation, transcript-inline artifact cards, per-revision source references,
-and writing directly into connected folders remain later slices. Those
-additions should preserve the same rule: the model names a logical output,
-while a person or narrowly scoped capability chooses where host data is
-written.
+does not yet have a durable export receipt. Binary artifacts enter the record
+only through host acceptance of a workspace file, described above;
+`create_deliverable` itself still authors text only, so model-authored binary
+generation is not part of this contract. Office document generation,
+transcript-inline artifact cards, per-revision source references, and writing
+directly into connected folders remain later slices. Those additions should
+preserve the same rule: the model names a logical output, while a person or
+narrowly scoped capability chooses where host data is written.


### PR DESCRIPTION
Extends the conversation-outputs contract (docs/deliverables.md, "Conversation outputs") from model-authored UTF-8 text to host-accepted binary workspace artifacts, and lets an output revision record a producing background run rather than only a foreground turn. This is step 4 of the delivery sequence in docs/sandbox-providers.md; it does not touch the deferred sandbox-resident-agent direction.

## New bound and media type

- `MAX_BINARY_DELIVERABLE_BYTES` = 16 MiB, chosen to match the workspace file-transfer bound (`get_workspace_file` caps a single read at 16 MiB). Matching that ceiling keeps the acceptance invariant simple: every file the workspace is willing to hand back fits, so acceptance never has to reject a well-formed artifact a provider already produced. It is 32x the 512 KiB text cap yet small enough to buffer one revision in memory while publishing and exporting it.
- A binary output carries an **explicit media type** (validated as a bounded, well-formed `type/subtype` token that may not be one of the curated text types) rather than one derived from its filename. Binary filenames obey the same portable-ASCII rules with no text-extension requirement.
- Each output's media type fixes the ceiling its revisions use — text stays 512 KiB, binary gets 16 MiB. The text `create_deliverable` path is unchanged.

## Host acceptance path

- `accept_workspace_artifact` takes the bytes already pulled from a workspace via `WorkspaceLifecycle::get_workspace_file` plus a proposal, publishes the bytes at the same write-once revision path a text deliverable uses, and records the output. Acceptance is a host-side operation — the model does not self-accept.
- Because the bytes land in the same per-chat private scratch and output record, the accepted artifact is cataloged, addressed, and exported through the existing desktop catalog / read / Save As… surfaces. Those surfaces were widened to carry binary media types and the larger ceiling.

## Producing-run recording

- The revision producer is recorded additively: a nullable `producing_run_id` column sits alongside the existing `turn_id`, and the two are mutually exclusive (enforced in validation and by a DB check). Existing readers of `turn_id` are untouched, and existing rows keep only their turn — that is what makes it backward-compatible. Only a turn producer may carry citations.

## Migration

Additive `m20260729_000022_extend_output_revisions_for_binary` on `output_revision`: adds `producing_run_id`, raises the coarse `byte_len` upper bound from the 512 KiB text cap to the 16 MiB binary cap (the tight per-kind cap is enforced in application validation), and adds the producer-exclusivity check. SQLite rebuilds the table under foreign-key suppression the same way the shipped agent-run split does; PostgreSQL alters the column and constraints directly. The `down` is symmetric on both backends.

## Verification

- `cargo check --workspace --locked` (no lockfile drift)
- `cargo test -p openwave-core --locked --lib -- db::tests` (287 passed), including a binary artifact round-tripping through acceptance into the record and read back from its published path, the binary cap and empty-artifact rejection, producing-run recording + two-producer rejection, and the m0022 up/down reversibility exercised through the existing full-rollback and intermediate-schema upgrade tests.
- `cargo test -p openwave-desktop --locked --lib -- deliverables` (binary artifact beyond the text cap cataloged, read from scratch, and exported)
- `cargo clippy --all-targets --locked` clean on both crates; `cargo fmt`.

No ts-rs wire types were added or changed, so no UI regen. Not driving the running app to confirm export UX is out of scope here.

Closes #820