### PR TITLE
feat(desktop): draw citation highlights on PDF pages

### DIFF
--- a/crates/openwave-desktop/ui/src/AssistantSources.test.tsx
+++ b/crates/openwave-desktop/ui/src/AssistantSources.test.tsx
@@ -11,6 +11,7 @@ function source(overrides: Partial<AssistantSource> = {}): AssistantSource {
     excerpt: "A short supporting excerpt.",
     heading: "Project notes",
     pages: [2, 3],
+    bounds: [],
     ...overrides,
   };
 }

--- a/crates/openwave-desktop/ui/src/AssistantSources.tsx
+++ b/crates/openwave-desktop/ui/src/AssistantSources.tsx
@@ -1,5 +1,7 @@
 import { ChevronRight } from "lucide-react";
 
+import type { CitationPageBounds } from "@/api";
+
 export type AssistantSource = Readonly<{
   id: string;
   ordinal: number;
@@ -13,6 +15,13 @@ export type AssistantSource = Readonly<{
   excerpt: string;
   heading: string | null;
   pages: number[];
+  /**
+   * Where on those pages the passage sits, for a source whose parser resolved
+   * it that finely. Empty for page-granular sources, which is every source
+   * imported before regions were recorded; `pages` is the complete answer
+   * either way.
+   */
+  bounds: readonly CitationPageBounds[];
 }>;
 
 type AssistantSourcesProps = {

--- a/crates/openwave-desktop/ui/src/AssistantWorkingIndicator.test.tsx
+++ b/crates/openwave-desktop/ui/src/AssistantWorkingIndicator.test.tsx
@@ -67,6 +67,7 @@ describe("AssistantWorkingIndicator", () => {
                 excerpt: "Visible evidence",
                 heading: null,
                 pages: [],
+                bounds: [],
               },
             ],
           },

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -107,6 +107,7 @@ describe("terminal transcript presentation", () => {
             excerpt: "Bounded source excerpt",
             heading: null,
             pages: [],
+            bounds: [],
           },
         ],
       },
@@ -221,6 +222,7 @@ describe("terminal transcript presentation", () => {
             excerpt: "Bounded source excerpt",
             heading: null,
             pages: [],
+            bounds: [],
           },
           {
             id: "citation-second",
@@ -230,6 +232,7 @@ describe("terminal transcript presentation", () => {
             excerpt: "Second bounded excerpt",
             heading: "Heading",
             pages: [4],
+            bounds: [],
           },
         ],
       },

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -273,6 +273,7 @@ describe("MessageBubble", () => {
             excerpt: "First source excerpt",
             heading: "First source",
             pages: [4],
+            bounds: [],
           },
         ],
       },

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -62,7 +62,16 @@ export function hydrateTranscriptHistory(
       sources:
         message.role === "assistant"
           ? (message.citations ?? []).map(
-              ({ id, ordinal, document_id, span, excerpt, heading, pages }) => ({
+              ({
+                id,
+                ordinal,
+                document_id,
+                span,
+                excerpt,
+                heading,
+                pages,
+                bounds,
+              }) => ({
                 id,
                 ordinal,
                 documentId: document_id,
@@ -70,6 +79,7 @@ export function hydrateTranscriptHistory(
                 excerpt,
                 heading,
                 pages,
+                bounds,
               }),
             )
           : [],

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -42,6 +42,7 @@ import {
   type UserQuestionOption as WireUserQuestionOption,
   type ChatToolActivitySnapshot,
   type ChatToolActivityStatus,
+  type CitationPageBounds as WireCitationPageBounds,
   type RendererAgentEvent,
   type RendererChatFrame,
   type RendererChatMetadata,
@@ -212,6 +213,14 @@ export type ChatMessage = Omit<
  * deliberately skips `message_id` on the wire. Do not reintroduce it.
  */
 export type ChatMessageCitation = AssistantCitationSnapshot;
+
+/**
+ * One rectangle of a cited passage, on the page it falls on.
+ *
+ * The rectangle is normalized to the page box in ten-thousandths, so a viewer
+ * places it as a fraction of whatever size the page was rendered at.
+ */
+export type CitationPageBounds = WireCitationPageBounds;
 
 /** One durable image identity in a historical user message. */
 export type ChatMessageImageAttachment = WireTranscriptImageAttachment;

--- a/crates/openwave-desktop/ui/src/components/document/document-details.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/document-details.tsx
@@ -11,7 +11,7 @@
 import { Loader2Icon } from "lucide-react";
 import { lazy, Suspense, useEffect, useMemo, useRef } from "react";
 
-import type { DocumentDetail } from "@/api";
+import type { CitationPageBounds, DocumentDetail } from "@/api";
 import { useApp } from "@/AppContext";
 import {
   DocumentViewer,
@@ -101,6 +101,12 @@ type DocumentDetailsProps = {
   citationSpan?: CitationSpan;
   /** Page of a paginated original to open on, when opened from a citation. */
   targetPage?: number;
+  /**
+   * Where the cited passage sits on those pages, for a source parsed that
+   * finely. Drawn over the rendered page; empty for a page-granular citation,
+   * which opens on its page with nothing marked on it.
+   */
+  citationBounds?: readonly CitationPageBounds[];
 };
 
 /**
@@ -121,6 +127,7 @@ export function DocumentDetails({
   highlightPath,
   citationSpan,
   targetPage,
+  citationBounds,
 }: DocumentDetailsProps) {
   const { client } = useApp();
   const type = baseMediaType(info.media_type);
@@ -137,6 +144,7 @@ export function DocumentDetails({
               documentId={info.document_id}
               mediaType={type}
               targetPage={targetPage}
+              citationBounds={citationBounds}
               className="bg-page-background grow p-4 pt-2"
             />
           ) : type.startsWith("image/") ? (

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
@@ -3,26 +3,35 @@ import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { HttpError, type ApiClient, type DocumentDetail } from "@/api";
+import {
+  HttpError,
+  type ApiClient,
+  type CitationPageBounds,
+  type DocumentDetail,
+} from "@/api";
 import { AppContextProvider, type AppContextValue } from "@/AppContext";
 import type { AssistantSource } from "@/AssistantSources";
 import { useChatSessionStore } from "@/ChatSessionStore";
+import { CITATION_MARK_CLASS } from "@/components/document/citationMark";
 import { clearFileDownloadCache } from "@/document/useFileDownload";
 import { renderWithRouter } from "../test/router";
 import { DocumentDetailRoot } from "./DocumentDetailRoot";
 
 // pdf.js draws to a canvas and runs a worker, neither of which jsdom has, so
 // the page targeting is observed through a stand-in that keeps the real page
-// state hook — the part the panel actually drives.
+// state hook and the real highlight overlay — the parts the panel drives.
 vi.mock("@/document/PdfViewer", async () => {
   const { usePdfPageState } = await import("@/document/usePdfPageState");
+  const { PdfPageHighlights } = await import("@/document/PdfPageHighlights");
   return {
     PdfViewer: ({
       documentId,
       targetPage,
+      highlights,
     }: {
       documentId: string;
       targetPage?: number;
+      highlights?: readonly CitationPageBounds[];
     }) => {
       const { currentPage, setCurrentPage } = usePdfPageState(documentId, {
         numPages: 20,
@@ -34,11 +43,21 @@ vi.mock("@/document/PdfViewer", async () => {
           <button type="button" onClick={() => setCurrentPage(currentPage + 1)}>
             Next page
           </button>
+          <PdfPageHighlights
+            page={currentPage}
+            highlights={highlights ?? []}
+            onNavigate={setCurrentPage}
+          />
         </div>
       );
     },
   };
 });
+
+/** The boxes drawn over the page on screen, however many pages carry them. */
+function drawnHighlights(): Element[] {
+  return [...document.querySelectorAll(`.${CITATION_MARK_CLASS}`)];
+}
 
 const scrolledTo: Element[] = [];
 
@@ -136,6 +155,7 @@ function seedTranscript(source: Partial<AssistantSource> & { id: string }) {
             excerpt: "",
             heading: null,
             pages: [],
+            bounds: [],
             ...source,
           },
         ],
@@ -167,6 +187,11 @@ async function openCitation(
     </AppContextProvider>,
     { initialUrl: `/c/chat-1?left=sources.doc-1.${citationId}&right=chat` },
   );
+}
+
+/** One rectangle of a citation, in the ten-thousandths the wire carries. */
+function rect(page: number, bounds: CitationPageBounds["bounds"]): CitationPageBounds {
+  return { page, bounds };
 }
 
 /** Byte offsets of a passage, which is how a citation reports its span. */
@@ -384,6 +409,37 @@ describe("DocumentDetailRoot", () => {
     // re-resolved with it. The page it asked for must not be applied twice.
     seedTranscript({ id: "cite-2", pages: [4, 5], span: { start: 10, end: 20 } });
     expect(await screen.findByText("Page 5")).toBeVisible();
+
+    // A citation that knows only which pages it came from marks none of them,
+    // which is every source imported before regions were recorded.
+    expect(drawnHighlights()).toHaveLength(0);
+  });
+
+  it("marks where a citation sits on the page it is open at, and only there", async () => {
+    const user = userEvent.setup();
+    seedTranscript({
+      id: "cite-5",
+      pages: [4, 5],
+      bounds: [
+        rect(4, { left: 1_000, top: 2_000, width: 8_000, height: 400 }),
+        rect(4, { left: 1_000, top: 2_500, width: 6_000, height: 400 }),
+        rect(5, { left: 1_000, top: 500, width: 3_000, height: 400 }),
+      ],
+    });
+    await openCitation(
+      detail({ media_type: "application/pdf", title: "Report.pdf", content: "text" }),
+      "cite-5",
+    );
+
+    expect(await screen.findByText("Page 4")).toBeVisible();
+    await waitFor(() => expect(drawnHighlights()).toHaveLength(2));
+    // Placed as a fraction of the page rather than in pixels, so the boxes
+    // survive zooming and resizing without being recomputed.
+    expect(drawnHighlights()[0]).toHaveStyle({ top: "calc(20% - 2px)" });
+
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+    expect(await screen.findByText("Page 5")).toBeVisible();
+    await waitFor(() => expect(drawnHighlights()).toHaveLength(1));
   });
 
   // The panel unmounts the viewer whenever the reader switches views, so

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
@@ -80,9 +80,15 @@ export function DocumentDetailRoot({
   const [view, setView] = useState<DocumentView>("original_doc");
 
   const placement = useCitationPlacement(documentID, citationId);
+  const paginated = info != null && isPaginatedOriginalViewer(info.media_type);
   const citationPage =
-    placement?.page != null && info != null && isPaginatedOriginalViewer(info.media_type)
-      ? placement.page
+    placement?.page != null && paginated ? placement.page : undefined;
+  // Rectangles are only worth carrying where there is a page to draw them on;
+  // a citation into an unpaginated source has none, and most citations carry
+  // none at all.
+  const citationBounds =
+    citationPage != null && placement != null && placement.bounds.length > 0
+      ? placement.bounds
       : undefined;
 
   // Arriving from a citation, land on whichever view can show where it points:
@@ -161,6 +167,7 @@ export function DocumentDetailRoot({
           hasOriginalDocumentTab={hasOriginalDocumentTab}
           citationSpan={placement?.span}
           targetPage={citationPage}
+          citationBounds={citationBounds}
         />
       ) : (
         <p className="p-6 text-sm text-muted-foreground" role="status">

--- a/crates/openwave-desktop/ui/src/document-detail/citationPlacement.ts
+++ b/crates/openwave-desktop/ui/src/document-detail/citationPlacement.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 
+import type { CitationPageBounds } from "@/api";
 import { useChatSessionStore } from "@/ChatSessionStore";
 import type { CitationSpan } from "@/components/document/citationSpan";
 import type { ChatMessage } from "@/MessageList";
@@ -10,6 +11,12 @@ export type CitationPlacement = {
   span: CitationSpan;
   /** The page the passage was recorded on, for a paginated source. */
   page?: number;
+  /**
+   * Where on the pages the passage sits, for a source parsed that finely.
+   * Empty for a page-granular source, which opens on its page with nothing
+   * drawn on it.
+   */
+  bounds: readonly CitationPageBounds[];
 };
 
 /**
@@ -33,7 +40,8 @@ export function findCitationPlacement(
       if (source.id !== citationId || source.documentId !== documentId) continue;
       return {
         span: { start: source.span.start, end: source.span.end },
-        page: earliestPage(source.pages),
+        page: earliestPage(source.pages, source.bounds),
+        bounds: source.bounds,
       };
     }
   }
@@ -44,8 +52,17 @@ export function findCitationPlacement(
  * The first page the passage was recorded on, where any was.
  *
  * A span can cross a page break, and the place to open is where it starts.
+ * A page carrying a rectangle wins over one that only appears in `pages`:
+ * that is the page where the reader will actually see the passage marked.
  */
-function earliestPage(pages: readonly number[]): number | undefined {
+function earliestPage(
+  pages: readonly number[],
+  bounds: readonly CitationPageBounds[],
+): number | undefined {
+  return lowestPage(bounds.map((rect) => rect.page)) ?? lowestPage(pages);
+}
+
+function lowestPage(pages: readonly number[]): number | undefined {
   const numbered = pages.filter((page) => Number.isSafeInteger(page) && page > 0);
   return numbered.length > 0 ? Math.min(...numbered) : undefined;
 }

--- a/crates/openwave-desktop/ui/src/document/DocumentViewer.tsx
+++ b/crates/openwave-desktop/ui/src/document/DocumentViewer.tsx
@@ -12,7 +12,7 @@
 import { lazy, Suspense } from "react";
 import { Loader2Icon } from "lucide-react";
 
-import type { ApiClient } from "@/api";
+import type { ApiClient, CitationPageBounds } from "@/api";
 
 // pdf.js is a large dependency and most sessions never open a PDF, so it is
 // fetched from the app bundle on first use rather than at startup.
@@ -79,6 +79,11 @@ interface DocumentViewerProps {
   mediaType: string;
   /** Open on this page the first time it is requested for this document. */
   targetPage?: number;
+  /**
+   * Rectangles of a cited passage to mark on the page it was recorded on.
+   * Only a paginated viewer has anywhere to draw them.
+   */
+  citationBounds?: readonly CitationPageBounds[];
   className?: string;
 }
 
@@ -88,6 +93,7 @@ export function DocumentViewer({
   documentId,
   mediaType,
   targetPage,
+  citationBounds,
   className,
 }: DocumentViewerProps) {
   const type = normalizeMediaType(mediaType);
@@ -100,6 +106,7 @@ export function DocumentViewer({
           chatId={chatId}
           documentId={documentId}
           targetPage={targetPage}
+          highlights={citationBounds}
           className={className}
         />
       </ViewerBoundary>

--- a/crates/openwave-desktop/ui/src/document/PdfPageHighlights.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/document/PdfPageHighlights.dom.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { CitationPageBounds } from "@/api";
+import { highlightBoxStyle, PdfPageHighlights } from "./PdfPageHighlights";
+
+afterEach(cleanup);
+
+beforeAll(() => {
+  // jsdom does not scroll, and the overlay reveals its first box on mount.
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+function rect(page: number, top: number): CitationPageBounds {
+  return { page, bounds: { left: 1_000, top, width: 5_000, height: 400 } };
+}
+
+describe("PdfPageHighlights", () => {
+  it("offers the rest of a passage that runs onto a later page", async () => {
+    const user = userEvent.setup();
+    const onNavigate = vi.fn();
+    render(
+      <PdfPageHighlights
+        page={4}
+        // The passage resumes on 6, not on the page immediately after this one.
+        highlights={[rect(4, 8_000), rect(6, 500)]}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Continues on next page/ }));
+    expect(onNavigate).toHaveBeenCalledWith(6);
+  });
+
+  it("says nothing about continuing where the passage ends on this page", () => {
+    render(
+      <PdfPageHighlights page={4} highlights={[rect(4, 8_000)]} onNavigate={vi.fn()} />,
+    );
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});
+
+describe("highlightBoxStyle", () => {
+  // Ten-thousandths of the page box, drawn as a fraction of the rendered page.
+  it("places a rectangle as a percentage of the page it was measured against", () => {
+    expect(
+      highlightBoxStyle({ left: 1_250, top: 2_500, width: 5_000, height: 400 }),
+    ).toEqual({
+      left: "calc(12.5% - 2px)",
+      top: "calc(25% - 2px)",
+      width: "calc(50% + 7px)",
+      height: "calc(4% + 7px)",
+    });
+  });
+});

--- a/crates/openwave-desktop/ui/src/document/PdfPageHighlights.tsx
+++ b/crates/openwave-desktop/ui/src/document/PdfPageHighlights.tsx
@@ -1,0 +1,136 @@
+import type { CSSProperties } from "react";
+import { useEffect, useRef } from "react";
+
+import type { CitationPageBounds } from "@/api";
+import {
+  CITATION_MARK_CLASS,
+  CITATION_MARK_STYLE,
+} from "@/components/document/citationMark";
+import { cn } from "@/lib/utils";
+
+/**
+ * The fixed-point scale page bounds arrive in: coordinates are ten-thousandths
+ * of the page box, so a rectangle divided by this is the fraction of the page
+ * it covers. Mirrors `PAGE_BOUNDS_SCALE` on the server.
+ */
+const PAGE_BOUNDS_SCALE = 10_000;
+
+/**
+ * A box over the page reads as the cited passage does everywhere else, which is
+ * why it takes the shared mark style rather than a colour of its own. What it
+ * adds is the blend: the fill is multiplied into the page so the words beneath
+ * it stay legible instead of being painted over, and it takes no pointer events
+ * so selecting and following links on the page carries on underneath.
+ */
+const HIGHLIGHT_STYLE = "pointer-events-none absolute mix-blend-multiply";
+
+type Props = {
+  /** The page currently on screen. Rectangles on any other page are not drawn. */
+  page: number;
+  /** Every rectangle of the citation, across all the pages it covers. */
+  highlights: readonly CitationPageBounds[];
+  /** Follow the passage onto the next page that carries part of it. */
+  onNavigate: (page: number) => void;
+};
+
+/**
+ * A citation's rectangles, drawn over the page they were recorded on.
+ *
+ * Positioned in percentages of the page container rather than in pixels, so
+ * zooming or resizing the panel moves the boxes with the page for free — the
+ * rectangles are fractions of the page box and never needed the rendered size.
+ *
+ * Mount this only once the page itself has rendered: the first box is scrolled
+ * to on mount, and against pdf.js's loading placeholder that would centre on a
+ * position the page does not have yet.
+ */
+export function PdfPageHighlights({ page, highlights, onNavigate }: Props) {
+  const onThisPage = highlights.filter((rect) => rect.page === page);
+  const firstRef = useRef<HTMLDivElement | null>(null);
+
+  // Reveal the passage once for the page it starts on. Keyed on the page and
+  // the box rather than on the element, so re-rendering the page at a new zoom
+  // does not yank the reader back to the citation mid-gesture.
+  const anchor = onThisPage[0];
+  const anchorKey = anchor
+    ? `${page}:${anchor.bounds.top}:${anchor.bounds.left}`
+    : null;
+  useEffect(() => {
+    if (anchorKey === null) return;
+    firstRef.current?.scrollIntoView({ block: "center", inline: "center" });
+  }, [anchorKey]);
+
+  if (onThisPage.length === 0) return null;
+
+  const continuesOn = nextPageWithBounds(highlights, page);
+  const last = onThisPage[onThisPage.length - 1]!;
+
+  return (
+    <>
+      {onThisPage.map((rect, index) => (
+        <div
+          key={`${rect.page}:${index}`}
+          ref={index === 0 ? firstRef : undefined}
+          // Decoration over a canvas: the passage itself is in the page's text
+          // layer, and announcing an empty box beside it says nothing.
+          aria-hidden="true"
+          className={cn(CITATION_MARK_CLASS, CITATION_MARK_STYLE, HIGHLIGHT_STYLE)}
+          style={highlightBoxStyle(rect.bounds)}
+        />
+      ))}
+      {continuesOn != null && (
+        <button
+          type="button"
+          onClick={() => onNavigate(continuesOn)}
+          className="absolute z-10 -translate-x-full rounded-md border bg-popover px-2 py-1 text-xs font-medium whitespace-nowrap text-popover-foreground shadow-sm"
+          style={continuationStyle(last.bounds)}
+        >
+          Continues on next page →
+        </button>
+      )}
+    </>
+  );
+}
+
+/**
+ * Where one rectangle sits on the page, as percentages of the page container.
+ *
+ * The couple of pixels of slack around each box is deliberate: a rectangle
+ * fitted tightly to a line of text clips its descenders, and the highlight then
+ * reads as cutting through the words it is meant to mark.
+ */
+export function highlightBoxStyle(bounds: CitationPageBounds["bounds"]): CSSProperties {
+  return {
+    left: `calc(${percent(bounds.left)}% - 2px)`,
+    top: `calc(${percent(bounds.top)}% - 2px)`,
+    width: `calc(${percent(bounds.width)}% + 7px)`,
+    height: `calc(${percent(bounds.height)}% + 7px)`,
+  };
+}
+
+/** The affordance hangs off the bottom-right corner of the last box drawn. */
+function continuationStyle(bounds: CitationPageBounds["bounds"]): CSSProperties {
+  return {
+    left: `${percent(bounds.left + bounds.width)}%`,
+    top: `calc(${percent(bounds.top + bounds.height)}% + 4px)`,
+  };
+}
+
+/**
+ * The next page carrying part of this citation, or null where the passage ends
+ * on the page on screen. Not simply the following page: what the reader is
+ * being offered is the rest of the passage, wherever it resumes.
+ */
+function nextPageWithBounds(
+  highlights: readonly CitationPageBounds[],
+  page: number,
+): number | null {
+  const later = highlights
+    .map((rect) => rect.page)
+    .filter((candidate) => candidate > page);
+  return later.length > 0 ? Math.min(...later) : null;
+}
+
+function percent(fixedPoint: number): number {
+  return (fixedPoint / PAGE_BOUNDS_SCALE) * 100;
+}

--- a/crates/openwave-desktop/ui/src/document/PdfViewer.tsx
+++ b/crates/openwave-desktop/ui/src/document/PdfViewer.tsx
@@ -14,10 +14,11 @@ import { Document, Page, pdfjs } from "react-pdf";
 // security policy. Vite emits the file and rewrites this to its final URL.
 import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
 
-import type { ApiClient } from "@/api";
+import type { ApiClient, CitationPageBounds } from "@/api";
 import { FileDownloadProgressIndicator } from "@/components/document/FileDownloadProgress";
 import { Button } from "@/components/ui/button";
 import { useRegisterPdfControls } from "@/document/PdfControlsContext";
+import { PdfPageHighlights } from "@/document/PdfPageHighlights";
 import { useFileDownload } from "@/document/useFileDownload";
 import { usePdfPageState } from "@/document/usePdfPageState";
 import { useWheelPageNavigation } from "@/document/useWheelPageNavigation";
@@ -27,12 +28,20 @@ import { cn } from "@/lib/utils";
 
 pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
 
+/** Shared so a viewer opened without a citation does not remount the overlay. */
+const EMPTY_HIGHLIGHTS: readonly CitationPageBounds[] = [];
+
 interface Props extends HTMLAttributes<HTMLDivElement> {
   client: Pick<ApiClient, "getChatDocumentFile">;
   chatId: string;
   documentId: string;
   /** Open on this page the first time it is requested for this document. */
   targetPage?: number;
+  /**
+   * Rectangles of a cited passage to mark on the pages they were recorded on.
+   * Empty, or absent, for a citation that only knows which pages it came from.
+   */
+  highlights?: readonly CitationPageBounds[];
   /** Render the toolbar at a smaller scale. */
   compact?: boolean;
 }
@@ -40,17 +49,32 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
 interface PdfPageProps {
   pageNumber: number;
   width: number;
+  highlights: readonly CitationPageBounds[];
+  onNavigate: (page: number) => void;
 }
 
-function PdfPage({ pageNumber, width }: PdfPageProps) {
+function PdfPage({ pageNumber, width, highlights, onNavigate }: PdfPageProps) {
+  // The overlay is placed as a fraction of this container, so it can only be
+  // drawn once the page has laid the container out at its real aspect — until
+  // then the container is the loading placeholder, which is a different shape.
+  const [pageRendered, setPageRendered] = useState(false);
+
   return (
     <div style={{ position: "relative", width, display: "inline-block" }}>
       <Page
         pageNumber={pageNumber}
         width={width}
         className="shadow"
+        onRenderSuccess={() => setPageRendered(true)}
         loading={<div className="aspect-4/3 bg-background" style={{ width }} />}
       />
+      {pageRendered && (
+        <PdfPageHighlights
+          page={pageNumber}
+          highlights={highlights}
+          onNavigate={onNavigate}
+        />
+      )}
     </div>
   );
 }
@@ -65,6 +89,7 @@ export function PdfViewer({
   chatId,
   documentId,
   targetPage,
+  highlights,
   compact,
   className,
   ...restProps
@@ -325,6 +350,8 @@ export function PdfViewer({
               key={`page_${currentPage}`}
               pageNumber={currentPage}
               width={pageWidth}
+              highlights={highlights ?? EMPTY_HIGHLIGHTS}
+              onNavigate={setCurrentPage}
             />
           )}
         </Document>


### PR DESCRIPTION
Part of #812.

Opening a citation into a PDF has landed on the recorded page since #674, but nothing on the page said where the passage was. Citation snapshots carry page rectangles as of #878, so the viewer can now mark them.

## What changed

- `AssistantSource` carries the snapshot's `bounds`, and `TranscriptHistory` maps them through — one construction site, so nothing else had to learn about them.
- `CitationPlacement` carries the rectangles beside the span and the page. The page it opens at now prefers the first page that has a rectangle, falling back to `pages` exactly as before.
- `DocumentDetailRoot` passes them on only where there is a page to draw them on, through `DocumentDetails` and the media-type dispatcher, to `PdfViewer`'s new `highlights` prop.
- `PdfPageHighlights` draws the rectangles for the page on screen. Rectangles on any other page are never rendered, and navigating re-derives the visible set.

Boxes are positioned as percentages of the page container, so zoom and resize move them with the page without any JS reflow work; they take no pointer events, so selecting text and following links underneath carries on. The overlay mounts only once pdf.js has rendered the page — against the loading placeholder the container is a different shape, and the reveal scroll would centre on a position the page does not have yet. That scroll runs once per page the passage is opened at, not on every zoom tick.

A passage that runs past the bottom of the page offers "Continues on next page →", which jumps to the next page carrying part of it rather than blindly to the following one.

Colour is the shared `CITATION_MARK_STYLE` — the same yellow the cited passage gets in the extracted text and in text-shaped originals, which is already tuned for both themes — plus `mix-blend-multiply` so the words underneath stay legible instead of being painted over. Boxes also carry `CITATION_MARK_CLASS`, the hook the other viewers already scroll to.

A citation with no rectangles behaves exactly as it does today: it opens at its page with nothing drawn. That is every source imported before regions were recorded, so it stays first-class.

Nothing on the Rust side changed. The Markdown and tree-viewer halves of #812 are untouched, which is why this does not close it.

## Tests

- `DocumentDetailRoot.dom.test.tsx`: a citation with rectangles on pages 4 and 5 draws two boxes on the page it opens at and one after paging forward. The PDF stand-in the file already uses now renders the real overlay, so this exercises placement → panel → viewer prop → boxes rather than a shape assertion.
- The existing page-only citation case asserts nothing is drawn, which is the pre-reparse floor.
- `PdfPageHighlights.dom.test.tsx`: the continuation affordance appears only when the passage resumes later and navigates to the page it resumes on, plus one pure test of the percent math against a fixed-point rectangle.

## Verification

`pnpm test` (609 passing) and `pnpm build` both green locally. I did not drive the running app, so the rendered appearance of the overlay over a real page — the blend, the box slack against real line boxes, the reveal scroll landing — is unverified beyond the DOM.