### PR TITLE
feat(desktop): render inline citations in message markdown

### DIFF
--- a/crates/openwave-desktop/ui/src/AssistantSources.tsx
+++ b/crates/openwave-desktop/ui/src/AssistantSources.tsx
@@ -122,14 +122,7 @@ function SourceCopy({
   source: AssistantSource;
   onOpen?: (source: AssistantSource) => void;
 }) {
-  const heading = boundedText(source.heading, MAX_HEADING_CHARACTERS);
-  const body = (
-    <>
-      {heading ? <strong>{heading}</strong> : null}
-      <p>{boundedText(source.excerpt, MAX_EXCERPT_CHARACTERS)}</p>
-      <PageReferences pages={source.pages} />
-    </>
-  );
+  const body = <CitationEvidence source={source} />;
 
   if (!onOpen || !source.documentId) {
     return <div className="assistant-source-copy">{body}</div>;
@@ -144,6 +137,23 @@ function SourceCopy({
     >
       {body}
     </button>
+  );
+}
+
+/**
+ * What one citation says for itself: where it came from and what it quoted,
+ * bounded so an unexpected payload cannot grow the DOM. Shared with the popover
+ * an inline citation opens, so the summary row and the phrase in the prose read
+ * the same evidence the same way.
+ */
+export function CitationEvidence({ source }: { source: AssistantSource }) {
+  const heading = boundedText(source.heading, MAX_HEADING_CHARACTERS);
+  return (
+    <>
+      {heading ? <strong>{heading}</strong> : null}
+      <p>{boundedText(source.excerpt, MAX_EXCERPT_CHARACTERS)}</p>
+      <PageReferences pages={source.pages} />
+    </>
   );
 }
 

--- a/crates/openwave-desktop/ui/src/InlineCitation.tsx
+++ b/crates/openwave-desktop/ui/src/InlineCitation.tsx
@@ -1,0 +1,105 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+import { CitationEvidence, type AssistantSource } from "./AssistantSources";
+import {
+  Popover,
+  PopoverClose,
+  PopoverContent,
+  PopoverTrigger,
+} from "./components/ui/popover";
+
+/**
+ * The citations one message carries, and how to open one.
+ *
+ * A cited phrase is rendered several components below the message that owns the
+ * evidence — inside the Markdown pipeline, which is memoized per block so that a
+ * streaming message re-parses only its tail. Threading the snapshots through
+ * that as props would change the identity of every block on every token and
+ * defeat exactly the memoization it exists for, so they are read where the
+ * citation is instead. Outside a provider a citation reads as plain prose.
+ */
+export type MessageCitations = {
+  sources: readonly AssistantSource[];
+  /** Open the cited place in the source panel — the sources row's own path. */
+  onOpenSource?: (source: AssistantSource) => void;
+};
+
+const MessageCitationsContext = createContext<MessageCitations>({
+  sources: [],
+});
+
+export const MessageCitationsProvider = MessageCitationsContext.Provider;
+
+export function useMessageCitations(): MessageCitations {
+  return useContext(MessageCitationsContext);
+}
+
+const CITATION_ID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * A cited phrase, in the prose where the model wrote it.
+ *
+ * The phrase stays prose — it inherits the surrounding type and reads as part of
+ * the sentence — with the citation's ordinal beside it and its evidence a click
+ * away. The ordinal comes from the snapshot rather than from the order spans
+ * happen to appear in: a citation dropped past the message's bound leaves a gap,
+ * and a badge counted off the rendering would silently renumber the rest.
+ *
+ * An id that matches no snapshot is a normal state, not an error to show: the
+ * phrase was authored as prose and renders as prose, without a badge to press.
+ */
+export function InlineCitation({
+  citationId,
+  children,
+}: {
+  citationId: string;
+  children?: ReactNode;
+}) {
+  const { sources, onOpenSource } = useMessageCitations();
+  const source = CITATION_ID.test(citationId)
+    ? sources.find(
+        (candidate) =>
+          candidate.id.toLowerCase() === citationId.toLowerCase(),
+      )
+    : undefined;
+
+  if (!source) return <>{children}</>;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="inline-citation"
+          aria-label={`Citation ${source.ordinal}`}
+        >
+          {children}
+          <sup className="inline-citation-ordinal" aria-hidden="true">
+            {source.ordinal}
+          </sup>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="inline-citation-popover w-80"
+        align="start"
+        side="bottom"
+      >
+        <div className="assistant-source-copy">
+          <CitationEvidence source={source} />
+        </div>
+        {onOpenSource && source.documentId ? (
+          <PopoverClose asChild>
+            <button
+              type="button"
+              className="inline-citation-open"
+              onClick={() => onOpenSource(source)}
+            >
+              Open source
+            </button>
+          </PopoverClose>
+        ) : null}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/crates/openwave-desktop/ui/src/InlineCitation.tsx
+++ b/crates/openwave-desktop/ui/src/InlineCitation.tsx
@@ -69,14 +69,14 @@ export function InlineCitation({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <button
-          type="button"
-          className="inline-citation"
-          aria-label={`Citation ${source.ordinal}`}
-        >
+        {/* Named by the phrase it wraps, not by a label that would replace it:
+            what the citation backs is the sentence, and the badge only says
+            which citation backs it. */}
+        <button type="button" className="inline-citation">
           {children}
-          <sup className="inline-citation-ordinal" aria-hidden="true">
-            {source.ordinal}
+          <sup className="inline-citation-ordinal">
+            <span className="sr-only">, citation {source.ordinal}</span>
+            <span aria-hidden="true">{source.ordinal}</span>
           </sup>
         </button>
       </PopoverTrigger>

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -6,6 +6,7 @@ import { ApprovalCard } from "./ApprovalCard";
 import { AppContextProvider, type AppContextValue } from "./AppContext";
 import type { ApiClient } from "./api";
 import { MessageBubble, MessageList, type ChatMessage } from "./MessageList";
+import { SourceNavProvider } from "./panel/SourceNav";
 import { renderWithRouter } from "./test/router";
 
 const noop = () => undefined;
@@ -779,5 +780,58 @@ describe("actionable tool results", () => {
     await waitFor(() => {
       expect(router.state.location.pathname).toBe("/settings/web-search");
     });
+  });
+});
+
+describe("citation anchors", () => {
+  const CITATION = "0b2b1f2c-9d3e-4a5b-8c7d-6e5f4a3b2c1d";
+
+  const message: ChatMessage = {
+    id: "assistant-1",
+    role: "assistant",
+    text: `The reef :cit[is the largest in the world]{citation_id=${CITATION}}.`,
+    sources: [
+      {
+        id: CITATION,
+        ordinal: 1,
+        documentId: "document-1",
+        span: { start: 0, end: 26 },
+        excerpt: "A short supporting excerpt.",
+        heading: "Project notes",
+        pages: [2],
+        bounds: [],
+      },
+    ],
+  };
+
+  it("opens the same place from the phrase and from the sources row", async () => {
+    const user = userEvent.setup();
+    const openCitation = vi.fn();
+    render(
+      <SourceNavProvider value={{ openCitation }}>
+        <MessageBubble message={message} busy={false} />
+      </SourceNavProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Citation 1" }));
+    await user.click(screen.getByRole("button", { name: "Open source" }));
+    await user.click(screen.getByRole("button", { name: "Open source 1" }));
+
+    expect(openCitation).toHaveBeenCalledTimes(2);
+    expect(openCitation.mock.calls[0]).toEqual(openCitation.mock.calls[1]);
+    expect(openCitation).toHaveBeenLastCalledWith({
+      documentId: "document-1",
+      citationId: CITATION,
+    });
+  });
+
+  it("copies what the message reads as, not how a citation is stored", async () => {
+    const user = userEvent.setup();
+    render(<MessageBubble message={message} busy={false} />);
+
+    await user.click(screen.getByRole("button", { name: "Copy" }));
+    expect(await window.navigator.clipboard.readText()).toBe(
+      "The reef is the largest in the world.",
+    );
   });
 });

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -813,7 +813,7 @@ describe("citation anchors", () => {
       </SourceNavProvider>,
     );
 
-    await user.click(screen.getByRole("button", { name: "Citation 1" }));
+    await user.click(screen.getByRole("button", { name: /citation 1$/ }));
     await user.click(screen.getByRole("button", { name: "Open source" }));
     await user.click(screen.getByRole("button", { name: "Open source 1" }));
 

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -22,6 +22,8 @@ import { OutputWritebackCard } from "./OutputWritebackCard";
 import { MessageMarkdown } from "./MessageMarkdown";
 import { MessageFooter } from "./MessageFooter";
 import { AssistantSources, type AssistantSource } from "./AssistantSources";
+import { stripCitationDirectives } from "./citationDirectives";
+import { MessageCitationsProvider } from "./InlineCitation";
 import { McpAppCard } from "./McpAppCard";
 import { ToolCommandCard, type ToolCallStatus } from "./ToolCallCard";
 import { ToolEntriesCard } from "./ToolEntriesCard";
@@ -621,6 +623,9 @@ function AssistantMessageBody({
  */
 export const MessageBubble = memo(MessageBubbleImpl);
 
+/** A stable stand-in for the roles that carry no citations. */
+const EMPTY_SOURCES: readonly AssistantSource[] = [];
+
 /**
  * One conversational turn. Tool calls and approvals are not turns — they belong
  * to an activity phase, which owns both the rail and the cards below it.
@@ -637,6 +642,24 @@ function MessageBubbleImpl({
   chatId?: string;
 }) {
   const sourceNav = useSourceNav();
+  // One way into the source panel for both anchors a citation has: the phrase
+  // in the prose and the row at the foot of the message open the same place.
+  const openSource = useMemo(
+    () =>
+      sourceNav
+        ? (source: AssistantSource) =>
+            sourceNav.openCitation({
+              documentId: source.documentId,
+              citationId: source.id,
+            })
+        : undefined,
+    [sourceNav],
+  );
+  const sources = message.role === "assistant" ? message.sources : EMPTY_SOURCES;
+  const citations = useMemo(
+    () => ({ sources, onOpenSource: openSource }),
+    [sources, openSource],
+  );
 
   if (message.role === "assistant") {
     if (!message.text && message.sources.length === 0) return null;
@@ -653,29 +676,25 @@ function MessageBubbleImpl({
     }
 
     return (
-      <article className="message message-assistant" aria-label="Assistant">
-        {message.text && (
-          <AssistantMessageBody text={message.text} streaming={busy} />
-        )}
-        <AssistantSources
-          sources={message.sources}
-          onOpenSource={
-            sourceNav
-              ? (source) =>
-                  sourceNav.openCitation({
-                    documentId: source.documentId,
-                    citationId: source.id,
-                  })
-              : undefined
-          }
-        />
-        <MessageFooter
-          role="assistant"
-          text={message.text}
-          createdAt={message.createdAt}
-          settled={!busy}
-        />
-      </article>
+      <MessageCitationsProvider value={citations}>
+        <article className="message message-assistant" aria-label="Assistant">
+          {message.text && (
+            <AssistantMessageBody text={message.text} streaming={busy} />
+          )}
+          <AssistantSources
+            sources={message.sources}
+            onOpenSource={openSource}
+          />
+          <MessageFooter
+            role="assistant"
+            // The clipboard yields what the message reads as, not how a
+            // citation is stored.
+            text={stripCitationDirectives(message.text)}
+            createdAt={message.createdAt}
+            settled={!busy}
+          />
+        </article>
+      </MessageCitationsProvider>
     );
   }
 

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.dom.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AssistantSource } from "./AssistantSources";
+import { MessageCitationsProvider } from "./InlineCitation";
 import { MessageMarkdown } from "./MessageMarkdown";
 
 afterEach(cleanup);
@@ -16,5 +18,87 @@ describe("code block copy", () => {
     expect(await window.navigator.clipboard.readText()).toBe(
       "const x: number = 1;\n",
     );
+  });
+});
+
+const REEF = "0b2b1f2c-9d3e-4a5b-8c7d-6e5f4a3b2c1d";
+const TIDE = "3f7c8a91-2b4d-4e6f-9a1b-5c7d8e9f0a1b";
+const DANGLING = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+
+function source(overrides: Partial<AssistantSource> = {}): AssistantSource {
+  return {
+    id: REEF,
+    ordinal: 2,
+    documentId: "doc-reef",
+    span: { start: 10, end: 40 },
+    excerpt: "The reef spans 2,300 kilometres.",
+    heading: "Extent",
+    pages: [4],
+    bounds: [],
+    ...overrides,
+  };
+}
+
+describe("inline citations", () => {
+  // Ordinals skip: a citation dropped past the message's bound leaves a gap, so
+  // a badge counted off the rendering would renumber every citation after it.
+  const sources = [
+    source(),
+    source({
+      id: TIDE,
+      ordinal: 4,
+      documentId: "doc-tide",
+      excerpt: "Tides run to four metres.",
+      heading: "Tides",
+      pages: [11, 12],
+    }),
+  ];
+
+  function renderCited(text: string, onOpenSource = vi.fn()) {
+    const view = render(
+      <MessageCitationsProvider value={{ sources, onOpenSource }}>
+        <MessageMarkdown>{text}</MessageMarkdown>
+      </MessageCitationsProvider>,
+    );
+    return { ...view, onOpenSource };
+  }
+
+  it("anchors each citation on the phrase it backs, badged by its ordinal", async () => {
+    const user = userEvent.setup();
+    const { container, onOpenSource } = renderCited(
+      `The reef :cit[is the largest in the world]{citation_id=${REEF}}, ` +
+        `and :cit[its tides are extreme]{citation_id=${TIDE}}.`,
+    );
+
+    const cited = screen.getAllByRole("button");
+    expect(cited.map((button) => button.getAttribute("aria-label"))).toEqual([
+      "Citation 2",
+      "Citation 4",
+    ]);
+    expect(cited[0]).toHaveTextContent("is the largest in the world");
+    expect(cited[1]).toHaveTextContent("its tides are extreme");
+    expect(container.textContent).toContain("The reef is the largest");
+    expect(container.textContent).not.toContain(":cit");
+    expect(container.textContent).not.toContain("citation_id");
+
+    // Each span carries its own evidence, and opening it hands back the
+    // snapshot the phrase was anchored to.
+    await user.click(cited[1]!);
+    const popover = await screen.findByText("Tides");
+    expect(popover.parentElement).toHaveTextContent("Tides run to four metres.");
+    expect(popover.parentElement).toHaveTextContent("Pages 11, 12");
+
+    await user.click(screen.getByRole("button", { name: "Open source" }));
+    expect(onOpenSource).toHaveBeenCalledWith(sources[1]);
+  });
+
+  it("reads as prose when the citation is not one the message carries", () => {
+    const { container } = renderCited(
+      `Reefs :cit[grow slowly]{citation_id=${DANGLING}} and ` +
+        ":cit[tides turn]{citation_id=not-a-uuid}.",
+    );
+
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+    expect(container.textContent).toBe("Reefs grow slowly and tides turn.");
   });
 });

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.dom.test.tsx
@@ -71,12 +71,12 @@ describe("inline citations", () => {
     );
 
     const cited = screen.getAllByRole("button");
-    expect(cited.map((button) => button.getAttribute("aria-label"))).toEqual([
-      "Citation 2",
-      "Citation 4",
-    ]);
-    expect(cited[0]).toHaveTextContent("is the largest in the world");
-    expect(cited[1]).toHaveTextContent("its tides are extreme");
+    expect(cited).toHaveLength(2);
+    // The phrase names the control; the ordinal is the snapshot's own.
+    expect(cited[0]).toHaveAccessibleName(
+      "is the largest in the world, citation 2",
+    );
+    expect(cited[1]).toHaveAccessibleName("its tides are extreme, citation 4");
     expect(container.textContent).toContain("The reef is the largest");
     expect(container.textContent).not.toContain(":cit");
     expect(container.textContent).not.toContain("citation_id");

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.test.tsx
@@ -1,11 +1,11 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+import { stripCitationDirectives } from "./citationDirectives";
 import {
   MessageMarkdown,
   preserveLineBreaks,
   rawCodeText,
   safeMarkdownUrl,
-  stripCitationDirectives,
 } from "./MessageMarkdown";
 
 describe("preserveLineBreaks", () => {
@@ -17,25 +17,42 @@ describe("preserveLineBreaks", () => {
   });
 });
 
-describe("stripCitationDirectives", () => {
+describe("citation directives", () => {
   const id = "0b2b1f2c-9d3e-4a5b-8c7d-6e5f4a3b2c1d";
 
-  it("leaves the cited phrasing in place and the rest of the prose alone", () => {
+  it("renders the cited phrasing, with its Markdown, and never the syntax", () => {
+    const markup = renderToStaticMarkup(
+      <MessageMarkdown>
+        {`The reef :cit[is the *largest* in the world]{citation_id=${id}}, and it grows.`}
+      </MessageMarkdown>,
+    );
+
+    expect(markup).toContain("The reef ");
+    expect(markup).toContain("is the <em>largest</em> in the world");
+    expect(markup).toContain(", and it grows.");
+    expect(markup).not.toContain(":cit");
+    expect(markup).not.toContain("citation_id");
+  });
+
+  it("keeps directive-shaped prose that never closes into a citation", () => {
+    const prose = [
+      ":cit[unterminated",
+      ":cit[phrase]{ref=0123456789abcdef0123456789abcdef}",
+    ].join("\n");
+    const markup = renderToStaticMarkup(
+      <MessageMarkdown>{prose}</MessageMarkdown>,
+    );
+
+    expect(markup).toContain(":cit[unterminated");
+    expect(markup).toContain(":cit[phrase]{ref=0123456789abcdef0123456789abcdef}");
+  });
+
+  it("strips citations from the text the clipboard is handed", () => {
     expect(
       stripCitationDirectives(
         `The reef :cit[is the largest in the world]{citation_id=${id}}, and it grows.`,
       ),
     ).toBe("The reef is the largest in the world, and it grows.");
-  });
-
-  it("keeps directive-shaped prose that is not a stored citation", () => {
-    const prose = [
-      ":cit[unterminated",
-      `:cit[phrase]{ref=0123456789abcdef0123456789abcdef}`,
-      ":cit[phrase]{citation_id=not-a-uuid}",
-    ].join("\n");
-
-    expect(stripCitationDirectives(prose)).toBe(prose);
   });
 });
 

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.tsx
@@ -9,11 +9,17 @@ import rehypeHighlight from "rehype-highlight";
 import rehypeKatex from "rehype-katex";
 import { ClipboardCopyButton } from "./ClipboardCopyButton";
 import {
+  CITATION_ID_PROPERTY,
+  hasCitationDirective,
+  rehypeCitationDirectives,
+} from "./citationDirectives";
+import {
   pieceStartOffsets,
   rangeWithinPiece,
   rehypeHighlightRange,
   type HighlightRange,
 } from "./components/document/citationMark";
+import { InlineCitation } from "./InlineCitation";
 import { splitMarkdownBlocks } from "./markdownBlocks";
 import { escapeLatexText } from "./markdownLatex";
 import { slugify } from "./markdownHeadings";
@@ -168,6 +174,16 @@ const components: Components = {
     );
   },
   blockquote: ({ children }) => <blockquote>{children}</blockquote>,
+  // Most spans in a rendered message are syntax-highlighting tokens and pass
+  // straight through; the ones {@link rehypeCitationDirectives} built carry the
+  // citation they cite and become the phrase a reader can open.
+  span: ({ children, node, ...props }) => {
+    const citationId = node?.properties?.[CITATION_ID_PROPERTY];
+    if (typeof citationId !== "string") {
+      return <span {...props}>{children}</span>;
+    }
+    return <InlineCitation citationId={citationId}>{children}</InlineCitation>;
+  },
 };
 
 /**
@@ -211,6 +227,9 @@ const remarkPlugins: Options["remarkPlugins"] = [
 ];
 
 const rehypePlugins: NonNullable<Options["rehypePlugins"]> = [
+  // Before anything rewrites the tree: the citations are read out of text nodes
+  // as the parser left them, which highlighting and math no longer are.
+  rehypeCitationDirectives,
   // Highlight only fence-tagged languages; auto-detection on unlabeled blocks
   // guesses wrong too often to be worth it.
   [rehypeHighlight, { detect: false }],
@@ -218,30 +237,18 @@ const rehypePlugins: NonNullable<Options["rehypePlugins"]> = [
 ];
 
 /**
- * A stored citation, which wraps the phrase it backs: `:cit[phrase]{citation_id=…}`.
+ * Normalize raw model output before the parser sees it: rewrite LaTeX
+ * delimiters into the dollar forms remark-math understands, then convert single
+ * newlines into hard breaks so intended line breaks survive without leaking
+ * source indentation.
  *
- * The phrase cannot contain `]` — the parser that writes this form closes it at
- * the first one — so a single non-greedy match is the whole grammar.
- */
-const CITATION_DIRECTIVE =
-  /:cit\[([^\]]*)\]\{citation_id=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\}/gi;
-
-/**
- * Reduce stored citations to the phrasing they wrap, which is what the message
- * reads as until citations render as marks of their own.
- */
-export function stripCitationDirectives(input: string): string {
-  return input.replace(CITATION_DIRECTIVE, "$1");
-}
-
-/**
- * Normalize raw model output before the parser sees it: reduce citations to
- * their phrasing, rewrite LaTeX delimiters into the dollar forms remark-math
- * understands, then convert single newlines into hard breaks so intended line
- * breaks survive without leaking source indentation.
+ * Citations are deliberately not touched here. They are read off the parsed
+ * tree, where the phrase they wrap is already the inline nodes it was written
+ * as, rather than off the source, where taking them apart would mean parsing
+ * Markdown twice.
  */
 export function processMarkdownContent(input: string): string {
-  return preserveLineBreaks(escapeLatexText(stripCitationDirectives(input)));
+  return preserveLineBreaks(escapeLatexText(input));
 }
 
 /**
@@ -301,9 +308,10 @@ function blockRehypePlugins(
 ): NonNullable<Options["rehypePlugins"]> {
   if (start == null || end == null || end <= start) return rehypePlugins;
   if (escapeLatexText(block) !== block) return rehypePlugins;
-  // A citation the block carries is removed from the text the parser reads, for
-  // the same reason: the offsets were measured against text that still had it.
-  if (stripCitationDirectives(block) !== block) return rehypePlugins;
+  // A block carrying a citation is left alone too: the mark would split the
+  // text the citation is read out of, leaving the two passes to argue over the
+  // same nodes for a passage that is already marked by the citation itself.
+  if (hasCitationDirective(block)) return rehypePlugins;
   return [
     [
       rehypeHighlightRange,

--- a/crates/openwave-desktop/ui/src/citationDirectives.ts
+++ b/crates/openwave-desktop/ui/src/citationDirectives.ts
@@ -1,0 +1,202 @@
+import type { Element, ElementContent, Root, RootContent } from "hast";
+
+/**
+ * How a stored citation wraps the phrase it backs: `:cit[phrase]{citation_id=…}`.
+ *
+ * The grammar is closed on the writing side — the parser that produces this form
+ * closes the phrase at its first `]`, so no `]` can occur inside one — which is
+ * what makes reading it back a scan rather than a parse, and is why this is a
+ * few dozen lines here instead of a Markdown directive extension over every
+ * message the model writes.
+ */
+const OPENING = ":cit[";
+
+/**
+ * The closing, anchored at the `]` that ended the phrase. The id is taken as
+ * written and validated by the renderer: an id that is not a citation this
+ * message carries still had its phrase authored as prose, and prose is what it
+ * reads as.
+ */
+const CLOSING = /^\]\{citation_id=([^}\s]*)\}/;
+
+/**
+ * How far a phrase is followed before the opening is read as ordinary prose.
+ * A citation wraps a clause the model just wrote; anything longer is text that
+ * happens to begin like one. Mirrors the streaming scrubber's own bound.
+ */
+const MAX_PHRASE_CHARACTERS = 512;
+
+/** Where the citation's id is carried from the tree to the component. */
+export const CITATION_ID_PROPERTY = "dataCitationId";
+
+/**
+ * The stored form, matched whole, for a caller that means to remove citations
+ * rather than render them — the clipboard, which yields prose and not markup.
+ */
+const STORED_CITATION =
+  /:cit\[([^\]]*)\]\{citation_id=[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\}/gi;
+
+/** Reduce stored citations to the phrasing they wrap. */
+export function stripCitationDirectives(input: string): string {
+  return input.replace(STORED_CITATION, "$1");
+}
+
+/** Whether text could carry a citation at all — a cheap conservative test. */
+export function hasCitationDirective(input: string): boolean {
+  return input.includes(OPENING);
+}
+
+/**
+ * Turn stored citations into spans carrying the id they cite, leaving the cited
+ * phrase where the model wrote it.
+ *
+ * This runs over the parsed tree rather than the source so that a phrase with
+ * Markdown in it — `:cit[the *largest* reef]{citation_id=…}` — keeps its
+ * emphasis: the phrase is whatever inline nodes stand between the opening and
+ * the closing, which is why the scan follows siblings rather than matching one
+ * text node. Anything that does not close is left exactly as it was read, so
+ * directive-shaped prose survives as prose.
+ *
+ * Code and math are skipped. Their text is source that is either displayed
+ * verbatim or handed to another renderer, and rewriting nodes inside them would
+ * corrupt what those render.
+ */
+export function rehypeCitationDirectives() {
+  return (tree: Root) => {
+    tree.children = convertContent(elementContent(tree.children));
+  };
+}
+
+function convertContent(nodes: ElementContent[]): ElementContent[] {
+  const converted: ElementContent[] = [];
+  let index = 0;
+  // Text left over from a citation just closed, or from an opening that turned
+  // out to be prose, which has to be rescanned rather than emitted.
+  let carry: string | null = null;
+
+  while (index < nodes.length || carry !== null) {
+    let value: string;
+    if (carry !== null) {
+      value = carry;
+      carry = null;
+    } else {
+      const node = nodes[index]!;
+      index += 1;
+      if (node.type === "element") {
+        if (!isOpaque(node)) node.children = convertContent(node.children);
+        converted.push(node);
+        continue;
+      }
+      if (node.type !== "text") {
+        converted.push(node);
+        continue;
+      }
+      value = node.value;
+    }
+
+    const opening = value.indexOf(OPENING);
+    if (opening === -1) {
+      pushText(converted, value);
+      continue;
+    }
+
+    pushText(converted, value.slice(0, opening));
+    const phrase = value.slice(opening + OPENING.length);
+    const citation = scanCitation(phrase, nodes.slice(index));
+    if (!citation) {
+      // Not a citation after all. Release the opening as the prose it is and
+      // rescan the rest, so a real citation later in the same text is still
+      // found — and so the nodes a failed scan looked at stay untouched.
+      pushText(converted, OPENING);
+      carry = phrase;
+      continue;
+    }
+
+    index += citation.consumed;
+    converted.push({
+      type: "element",
+      tagName: "span",
+      properties: { [CITATION_ID_PROPERTY]: citation.citationId },
+      children: citation.children,
+    });
+    carry = citation.trailing;
+  }
+
+  return converted;
+}
+
+type ScannedCitation = {
+  /** The phrase, as the inline nodes it was written as. */
+  children: ElementContent[];
+  citationId: string;
+  /** How many following siblings the phrase spanned. */
+  consumed: number;
+  /** What was left of the text node the citation closed in. */
+  trailing: string;
+};
+
+/**
+ * Read a citation that begins where `head` begins, following siblings until the
+ * phrase closes, or `null` for an opening that never closes into one.
+ */
+function scanCitation(
+  head: string,
+  following: readonly ElementContent[],
+): ScannedCitation | null {
+  const children: ElementContent[] = [];
+  let text = head;
+  let consumed = 0;
+  let length = 0;
+
+  for (;;) {
+    const close = text.indexOf("]");
+    if (close !== -1) {
+      const closing = CLOSING.exec(text.slice(close));
+      if (!closing) return null;
+      pushText(children, text.slice(0, close));
+      return {
+        children,
+        citationId: closing[1] ?? "",
+        consumed,
+        trailing: text.slice(close + closing[0].length),
+      };
+    }
+
+    length += text.length;
+    if (length > MAX_PHRASE_CHARACTERS) return null;
+    pushText(children, text);
+
+    const next = following[consumed];
+    if (!next) return null;
+    consumed += 1;
+    if (next.type === "text") {
+      text = next.value;
+      continue;
+    }
+    // A comment cannot be part of a phrase; an element — emphasis, code, a
+    // line break — is carried into it whole.
+    if (next.type !== "element") return null;
+    children.push(next);
+    text = "";
+  }
+}
+
+const OPAQUE_TAGS = new Set(["code", "pre"]);
+
+/** Whether an element's text is source rather than prose. */
+function isOpaque(node: Element): boolean {
+  if (OPAQUE_TAGS.has(node.tagName)) return true;
+  // remark-math parks a formula's source in a span for rehype-katex to render.
+  const className = node.properties?.className;
+  return Array.isArray(className) && className.includes("math");
+}
+
+function elementContent(nodes: RootContent[]): ElementContent[] {
+  return nodes.filter(
+    (node): node is ElementContent => node.type !== "doctype",
+  );
+}
+
+function pushText(nodes: ElementContent[], value: string): void {
+  if (value) nodes.push({ type: "text", value });
+}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -1061,6 +1061,70 @@ body {
   font-weight: 550;
 }
 
+/* ---------- Inline citations ---------- */
+
+/* The cited phrase is prose first: it inherits the type around it and carries
+   the same underline a link does, so a sentence still reads as a sentence. */
+.inline-citation {
+  display: inline;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+  background: none;
+  font: inherit;
+  text-align: inherit;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, currentColor 30%, transparent);
+  text-decoration-style: dotted;
+  text-underline-offset: 0.16em;
+}
+
+.inline-citation:hover,
+.inline-citation:focus-visible,
+.inline-citation[data-state="open"] {
+  text-decoration-color: currentColor;
+}
+
+.inline-citation-ordinal {
+  margin-left: 0.12em;
+  color: var(--muted-foreground);
+  font-size: 0.68em;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.inline-citation:hover .inline-citation-ordinal,
+.inline-citation:focus-visible .inline-citation-ordinal,
+.inline-citation[data-state="open"] .inline-citation-ordinal {
+  color: var(--ink);
+}
+
+.inline-citation-popover {
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.78rem;
+}
+
+.inline-citation-open {
+  justify-self: start;
+  border: 0;
+  border-radius: 6px;
+  padding: 0.2rem 0.4rem;
+  margin: 0 -0.4rem -0.2rem;
+  cursor: pointer;
+  color: var(--ink);
+  background: none;
+  font: inherit;
+  font-weight: 600;
+}
+
+.inline-citation-open:hover,
+.inline-citation-open:focus-visible {
+  background: color-mix(in srgb, var(--accent) 58%, transparent);
+}
+
 /* ---------- Notices ---------- */
 
 .message-notice {


### PR DESCRIPTION
Stored assistant content carries its citations inline — `:cit[phrase]{citation_id=…}` around the phrasing each one backs — and the renderer was throwing that position away. A preprocessor reduced every directive to its bare phrase, so the only evidence a reader could reach was the summary row at the foot of the message.

The cited phrase is now the anchor:

- It stays prose (inherits the surrounding type, dotted underline in the link idiom) with the citation's ordinal as a superscript badge. The trigger is a real button, so it is keyboard reachable, and the popover is the repo's Radix one.
- The popover shows the heading, excerpt and pages the snapshot already ships with — no fetch — through the same `CitationEvidence` body the sources row renders.
- Its "Open source" link and the sources row now call one handler in `MessageBubble`, so the phrase and the row open the same place; #887's plumbing takes it from there. The row stays as the summary view.
- The badge is the snapshot's `ordinal`, never an index: ordinals skip when a citation falls past the message's bound, and counting off the rendering would silently renumber the rest.

### Reading them back without a new dependency

Citations are read off the parsed tree (`rehypeCitationDirectives`) rather than off the source, which is what lets a phrase keep its own Markdown — `:cit[the *largest* reef]{…}` renders emphasized. The scan follows sibling inline nodes to find the closing, since the phrase may have been parsed into several of them.

remark-directive would have parsed the label content for us, but it also turns every `:name[…]`, `::leaf` and `:::container` appearing in model prose into a directive node. The at-rest grammar is closed enough that reading it back is a scan: the writing parser closes the phrase at its first `]`, so no `]` can occur inside one. Roughly 60 lines of tokenizer against a permanent widening of the Markdown grammar over every message — the tokenizer wins.

Fail-safes, all of which render as ordinary prose:

- an opening that never closes into a citation is emitted verbatim and the rest rescanned, so directive-shaped prose survives and a real citation later in the same text is still found;
- an id that is not a UUID, or that names no snapshot the message carries, renders as the phrase with no badge and no popover — a dangling id is a normal state (a phantom slot), not an error to surface;
- code and math are skipped, so a directive inside a fence stays literal source rather than being rewritten inside a block another renderer owns.

The clipboard copy now strips citations from `message.text`; it had been yielding the stored form while the prose beside it read plainly.

### Tests

`stripCitationDirectives`'s tests are re-pointed rather than dropped — the invariant they defend (raw syntax never reaches the reader) is now the renderer's, and one of them still covers the clipboard path that still strips. Added: two citations render as two interactive spans badged 2 and 4 with the right evidence in each popover and no syntax anywhere in the DOM; dangling and malformed ids read as plain prose; and one in `MessageList` asserting the phrase and the sources row hand `openCitation` the same target.

Verified with `pnpm test` and `pnpm build` (plus `tsc`). No Rust changes, and no lockfile movement — nothing was added to `package.json`. I could not drive the running app, so the visual treatment of the span, badge and popover is unverified beyond the DOM.

Closes #877