### PR TITLE
fix(desktop): retire completed output writebacks

### DIFF
--- a/crates/openwave-desktop/src/client_execution/output_writeback.rs
+++ b/crates/openwave-desktop/src/client_execution/output_writeback.rs
@@ -440,7 +440,8 @@ async fn publish_resolution(
     receipt: &OutputWritebackReceipt,
     resolution: &StoredResolution,
 ) -> Result<(), String> {
-    control_plane(state)?
+    let client = control_plane(state)?;
+    match client
         .resolve(
             receipt.chat_id,
             receipt.call_id,
@@ -448,7 +449,29 @@ async fn publish_resolution(
             resolution,
         )
         .await
-        .map_err(control_plane_error)
+    {
+        Ok(()) => state
+            .receipts
+            .remove_output_writeback(receipt.call_id)
+            .map_err(private_receipt_error),
+        Err(error) if error.is_conflict() => {
+            let pending = client
+                .pending(receipt.chat_id)
+                .await
+                .map_err(control_plane_error)?
+                .into_iter()
+                .any(|call| call.id == receipt.call_id);
+            if pending {
+                Err("output write-back result no longer owns the pending request".to_owned())
+            } else {
+                state
+                    .receipts
+                    .remove_output_writeback(receipt.call_id)
+                    .map_err(private_receipt_error)
+            }
+        }
+        Err(error) => Err(control_plane_error(error)),
+    }
 }
 
 fn canonical_arguments(

--- a/crates/openwave-desktop/src/client_execution/receipt_store.rs
+++ b/crates/openwave-desktop/src/client_execution/receipt_store.rs
@@ -957,6 +957,14 @@ impl ReceiptStore {
         }
     }
 
+    pub(super) fn remove_output_writeback(&self, call_id: CallId) -> io::Result<()> {
+        match fs::remove_file(self.output_writeback_receipt_path(call_id)) {
+            Ok(()) => sync_directory(&self.directory),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
     pub(super) fn remove_manual_connect(
         &self,
         change_id: RootAttachmentChangeId,


### PR DESCRIPTION
## Summary

- remove durable output write-back receipts after the control plane accepts their terminal result
- retire receipts after a conflicting resolve only when the call is confirmed no longer pending
- preserve receipts for retryable transport and ownership failures

## Why

Completed output write-backs left their recovery receipt behind, so the desktop retried the same terminal resolution and logged deferred work every two seconds. Retiring the receipt closes that recovery loop without repeating the broker write.

## Verification

- `cargo fmt -p openwave-desktop -- --check`
- `cargo check -p openwave-desktop --locked`