### PR TITLE
fix(execution): correct Daytona egress enforcement — strict per-sandbox boundary (tier 3+)

### DIFF
--- a/crates/openwave-code-execution/src/daytona.rs
+++ b/crates/openwave-code-execution/src/daytona.rs
@@ -3,9 +3,7 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use openwave_core::SecretProvider;
-use openwave_egress::{
-    EgressEnforcement, EgressPolicy, EnforcementException, ExceptionReach, ExceptionScope,
-};
+use openwave_egress::{EgressEnforcement, EgressPolicy};
 use reqwest::{Client, Response, StatusCode, Url};
 use serde::{Deserialize, Serialize};
 
@@ -175,24 +173,31 @@ impl DaytonaExecutionProvider {
     }
 
     /// Host knowledge about Daytona's per-sandbox network enforcement,
-    /// declared as what it actually blocks. Daytona keeps a vendor-curated
-    /// "essential services" list reachable regardless of policy — package
-    /// registries, public git hosting, container registries, and AI APIs —
-    /// each a general-purpose destination, so this surface does not qualify
-    /// as a boundary for third-party-credential-bearing work.
+    /// declared as what it actually blocks.
+    ///
+    /// A live test against a real Daytona account (issue #888) established that
+    /// a per-sandbox policy is a *strict*, externally-enforced allowlist: only
+    /// listed domains are reachable, raw-IP egress and unlisted-domain DNS are
+    /// blocked, and there is no "essential services" carve-out — package
+    /// registries, public git hosting, container registries, and AI APIs are
+    /// all blocked under a per-sandbox policy, contrary to the earlier
+    /// assumption this code encoded. So the surface has the external tier with
+    /// no general-purpose holes and qualifies as a credential boundary; in fact
+    /// it is stronger than E2B, which limits domain rules to HTTP/HTTPS ports
+    /// and leaves DNS open.
+    ///
+    /// The one caveat left is a precondition the adapter cannot verify
+    /// statically, so it is *not* encoded here (this declares what the
+    /// mechanism blocks, not account state): the per-sandbox egress override
+    /// requires Daytona org tier 3+. On tier 1–2 the override is refused and the
+    /// org default applies, so the boundary is not guaranteed. The host
+    /// projection surfaces that requirement inline as a conditional boundary
+    /// rather than an unconditional one.
     #[must_use]
     pub fn egress_enforcement() -> EgressEnforcement {
-        let curated = |purpose: &'static str| EnforcementException {
-            scope: ExceptionScope::VendorCurated,
-            reach: ExceptionReach::GeneralPurpose,
-            purpose,
-        };
-        EgressEnforcement::external(vec![
-            curated("package registries"),
-            curated("git hosting"),
-            curated("container registries"),
-            curated("AI APIs"),
-        ])
+        // No general-purpose exceptions: a per-sandbox policy blocks every
+        // unlisted destination, confirmed live in #888.
+        EgressEnforcement::external(Vec::new())
     }
 
     async fn create_sandbox(
@@ -713,12 +718,15 @@ struct DaytonaNetworkSettings {
 /// one. This mirrors E2B's explicit `allow_internet_access: false` baseline:
 /// a domain-only policy must still deny raw-IP egress, and an omitted CIDR
 /// field could read as "no restriction on that axis" and leave IP egress
-/// fully open — defeating deny-by-default. Present-but-empty is intended to
-/// mean "allow nothing on this axis."
+/// fully open — defeating deny-by-default. Present-but-empty means "allow
+/// nothing on this axis."
 ///
-/// Vendor semantics of an empty-but-present allowlist need live confirmation
-/// against Daytona before this surface is trusted as an enforcement boundary;
-/// the default (no policy → open egress) is not changed here.
+/// A live test against a real Daytona account (issue #888) confirmed that
+/// empty-but-present *is* read as deny-all on that axis: under a domain-only
+/// policy (`domainAllowList` set, `networkAllowList` present but empty) raw-IP
+/// egress was blocked at connect and forbidden by the proxy. The
+/// present-but-empty deny-all shape is therefore relied on, not assumed. The
+/// default (no policy → open egress) is unchanged.
 fn daytona_network_settings(policy: Option<&EgressPolicy>) -> DaytonaNetworkSettings {
     let open = DaytonaNetworkSettings {
         network_block_all: false,

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -318,7 +318,15 @@ export type CodeExecutionEgressEnforcement = { provider: CodeExecutionProviderKi
  * enforcement model, so the settings surface can show the caveat inline
  * instead of burying it in prose the user skims past.
  */
-gaps: Array<string>, };
+gaps: Array<string>, 
+/**
+ * A precondition the boundary is gated on that the host cannot verify
+ * statically ("Daytona org tier 3+"). Present only for a
+ * [`EgressEnforcementStatus::ConditionalBoundary`], so the surface can
+ * state the condition inline rather than implying an unconditional
+ * boundary.
+ */
+requirement?: string, };
 
 /**
  * Renderer-safe egress policy plus per-provider enforcement disclosure.
@@ -397,7 +405,7 @@ export type EgressConfig = { "mode": "open" } | { "mode": "allowlist", domains: 
  * says a vendor's mechanism leaves a general-purpose destination reachable,
  * the surface must not present it as a full boundary.
  */
-export type EgressEnforcementStatus = "boundary" | "applied_with_gaps" | "unconfirmed";
+export type EgressEnforcementStatus = "boundary" | "conditional_boundary" | "applied_with_gaps" | "unconfirmed";
 
 /**
  * One entitled connected app, with the slugs of the MCP endpoints that

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
@@ -15,7 +15,10 @@ import type {
 } from "../api";
 import { CodeExecutionPanel } from "./CodeExecutionPanel";
 
-/** The default egress projection: open policy, E2B applied-with-gaps, Daytona unconfirmed. */
+/**
+ * The default egress projection: open policy, E2B applied-with-gaps, Daytona a
+ * strict per-sandbox boundary conditional on org tier 3+ (no phantom gaps).
+ */
 const OPEN_EGRESS: CodeExecutionConfigInfo["egress"] = {
   policy: { mode: "open" },
   enforcement: [
@@ -26,8 +29,9 @@ const OPEN_EGRESS: CodeExecutionConfigInfo["egress"] = {
     },
     {
       provider: "daytona",
-      status: "unconfirmed",
-      gaps: ["package registries", "git hosting"],
+      status: "conditional_boundary",
+      gaps: [],
+      requirement: "Daytona org tier 3+",
     },
   ],
 };
@@ -192,6 +196,26 @@ describe("CodeExecutionPanel", () => {
     expect(
       screen.getByText(/domain filtering covers HTTP and HTTPS ports only/i),
     ).toBeInTheDocument();
+  });
+
+  it("presents Daytona as a conditional boundary requiring org tier 3+, never an unconditional boundary", async () => {
+    const { client } = clientFor({
+      provider: "daytona",
+      timeout_ms: 20_000,
+      available: true,
+      has_credential: true,
+      egress: OPEN_EGRESS,
+    });
+
+    render(<CodeExecutionPanel client={client} />);
+
+    // The tier-3+ requirement is surfaced inline, and the badge reads
+    // conditional — never a plain green "Boundary".
+    await screen.findByText(/Requires Daytona org tier 3\+/i);
+    expect(screen.getByText(/Boundary — conditional/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Boundary$/)).toBeNull();
+    // The phantom curated-service exceptions are gone from the disclosure.
+    expect(screen.queryByText(/git hosting/i)).toBeNull();
   });
 
   it("rejects a timeout outside the bounds before touching the server", async () => {

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
@@ -351,12 +351,20 @@ type EgressEnforcementRow =
  */
 const EGRESS_STATUS_PRESENTATION: Record<
   EgressEnforcementRow["status"],
-  { badge: "success" | "warning" | "critical"; label: string; lead: string }
+  { badge: "success" | "info" | "warning" | "critical"; label: string; lead: string }
 > = {
   boundary: {
     badge: "success",
     label: "Boundary",
     lead: "Enforced as a full network boundary.",
+  },
+  // A real boundary, but gated on a precondition the host can't verify. Shown
+  // in the informational tone rather than plain green, with the requirement
+  // rendered inline below, so it never reads as an unconditional boundary.
+  conditional_boundary: {
+    badge: "info",
+    label: "Boundary — conditional",
+    lead: "A strict per-sandbox boundary when enforced: unlisted domains, raw IPs, and unlisted-domain DNS are all blocked — stronger than E2B. Not guaranteed on every account:",
   },
   applied_with_gaps: {
     badge: "warning",
@@ -395,6 +403,13 @@ function EgressEnforcementDisclosure({
               </span>{" "}
               — {presentation.lead}
               {row.gaps.length > 0 && ` ${row.gaps.join("; ")}.`}
+              {row.requirement && (
+                <span className="font-medium text-foreground">
+                  {" "}
+                  Requires {row.requirement}. On a lower tier the per-sandbox
+                  override is refused and the account default applies.
+                </span>
+              )}
             </span>
           </div>
         );

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -230,9 +230,18 @@ pub struct CodeExecutionEgressInfo {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum EgressEnforcementStatus {
-    /// External enforcement with no general-purpose holes: a full network
-    /// boundary. No managed provider reaches this today.
+    /// External enforcement with no general-purpose holes and no unmet
+    /// precondition: a full network boundary the host can rely on
+    /// unconditionally. No managed provider reaches this today — the only
+    /// unconditional boundary is the local sandbox, outside this list.
     Boundary,
+    /// A full boundary *when enforced*, gated on a precondition the host cannot
+    /// verify statically. Daytona's per-sandbox egress is a strict, externally
+    /// enforced allowlist, but the per-sandbox override requires Daytona org
+    /// tier 3+; on tier 1–2 the org default applies and the boundary is not
+    /// guaranteed. Disclosed with the requirement inline so it never reads as an
+    /// unconditional green boundary.
+    ConditionalBoundary,
     /// External enforcement is applied, but the vendor's mechanism leaves
     /// general-purpose destinations reachable, so a configured allowlist is
     /// not a full boundary and must not be presented as one.
@@ -253,7 +262,22 @@ pub struct CodeExecutionEgressEnforcement {
     /// enforcement model, so the settings surface can show the caveat inline
     /// instead of burying it in prose the user skims past.
     pub gaps: Vec<String>,
+    /// A precondition the boundary is gated on that the host cannot verify
+    /// statically ("Daytona org tier 3+"). Present only for a
+    /// [`EgressEnforcementStatus::ConditionalBoundary`], so the surface can
+    /// state the condition inline rather than implying an unconditional
+    /// boundary.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub requirement: Option<String>,
 }
+
+/// The precondition Daytona's per-sandbox egress boundary is gated on. The
+/// per-sandbox network override requires Daytona org tier 3+; on tier 1–2 the
+/// override is refused and the org default applies, so the boundary is not
+/// guaranteed. The host cannot read the account's tier statically, so the
+/// requirement is surfaced inline rather than assumed met.
+const DAYTONA_TIER_REQUIREMENT: &str = "Daytona org tier 3+";
 
 /// The managed providers' egress-enforcement disclosure, derived from the
 /// shipped [`EgressEnforcement`] declarations.
@@ -261,20 +285,25 @@ pub struct CodeExecutionEgressEnforcement {
 /// E2B's enforcement is confirmed against the live API, so its status is
 /// whatever the model reports — and the model reports *not a boundary*, because
 /// its domain rules cover only HTTP/HTTPS ports and DNS stays open. Daytona's
-/// wiring is not yet confirmed against the live API (its empty-but-present
-/// "deny that axis" semantics are unverified), which dominates the display
-/// regardless of tier.
+/// per-sandbox enforcement is now confirmed live (issue #888): it is a strict,
+/// externally enforced allowlist with no general-purpose carve-out, so the
+/// model reports it as a credential boundary. The one thing the host cannot
+/// establish statically is the account tier the per-sandbox override needs, so
+/// Daytona is disclosed as a *conditional* boundary with that requirement
+/// inline, never an unconditional green one.
 fn egress_enforcement_status() -> Vec<CodeExecutionEgressEnforcement> {
     vec![
         enforcement_row(
             CodeExecutionProviderKind::E2b,
             &E2BExecutionProvider::egress_enforcement(),
             true,
+            None,
         ),
         enforcement_row(
             CodeExecutionProviderKind::Daytona,
             &DaytonaExecutionProvider::egress_enforcement(),
-            false,
+            true,
+            Some(DAYTONA_TIER_REQUIREMENT),
         ),
     ]
 }
@@ -283,18 +312,26 @@ fn egress_enforcement_status() -> Vec<CodeExecutionEgressEnforcement> {
 ///
 /// The status reads straight from the model: an unconfirmed vendor is
 /// `Unconfirmed`; otherwise `is_credential_boundary()` — external tier with no
-/// general-purpose holes — decides `Boundary` versus `AppliedWithGaps`. Every
-/// declared exception is surfaced as a gap so nothing the vendor leaves open is
-/// hidden from the user.
+/// general-purpose holes — decides boundary versus `AppliedWithGaps`. A
+/// `requirement` is a precondition the host cannot verify statically: when the
+/// model backs a boundary but such a precondition exists, the row is a
+/// `ConditionalBoundary` carrying the requirement, so the surface can never
+/// present it as an unconditional boundary. Every declared exception is
+/// surfaced as a gap so nothing the vendor leaves open is hidden from the user.
 fn enforcement_row(
     provider: CodeExecutionProviderKind,
     enforcement: &EgressEnforcement,
     confirmed: bool,
+    requirement: Option<&'static str>,
 ) -> CodeExecutionEgressEnforcement {
     let status = if !confirmed {
         EgressEnforcementStatus::Unconfirmed
     } else if enforcement.is_credential_boundary() {
-        EgressEnforcementStatus::Boundary
+        if requirement.is_some() {
+            EgressEnforcementStatus::ConditionalBoundary
+        } else {
+            EgressEnforcementStatus::Boundary
+        }
     } else {
         EgressEnforcementStatus::AppliedWithGaps
     };
@@ -307,6 +344,7 @@ fn enforcement_row(
         provider,
         status,
         gaps,
+        requirement: requirement.map(str::to_owned),
     }
 }
 
@@ -806,9 +844,35 @@ mod tests {
             "the ports/DNS holes that make E2B not-a-boundary must be surfaced"
         );
 
-        // Daytona's wiring is unconfirmed against the live API; that dominates.
-        assert_eq!(daytona.status, EgressEnforcementStatus::Unconfirmed);
-        assert!(!daytona.gaps.is_empty());
+        // Daytona's per-sandbox policy is a strict, externally enforced
+        // boundary — confirmed live in #888 — so the corrected model treats it
+        // as a credential boundary with no phantom curated-service exceptions.
+        assert!(
+            DaytonaExecutionProvider::egress_enforcement().is_credential_boundary(),
+            "the corrected Daytona model is a credential boundary"
+        );
+        assert!(
+            daytona.gaps.is_empty(),
+            "the phantom curated-service exceptions must be gone from the disclosure"
+        );
+        // But it stays honest about the one thing the host can't verify
+        // statically: the per-sandbox override needs Daytona org tier 3+. So it
+        // is a conditional boundary carrying that requirement inline, never an
+        // unconditional green boundary.
+        assert_eq!(
+            daytona.status,
+            EgressEnforcementStatus::ConditionalBoundary,
+            "Daytona over-claims as an unconditional boundary"
+        );
+        assert_eq!(
+            daytona.requirement.as_deref(),
+            Some(DAYTONA_TIER_REQUIREMENT)
+        );
+        assert_ne!(
+            daytona.status,
+            EgressEnforcementStatus::Boundary,
+            "the tier caveat must keep Daytona off the unconditional boundary status"
+        );
     }
 
     #[test]

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -867,7 +867,8 @@ async fn code_execution_egress_policy_round_trips_and_rejects_secrets() {
     };
 
     // The default surface discloses open egress plus each managed provider's
-    // enforcement status: E2B confirmed, Daytona pending live confirmation.
+    // enforcement status: E2B applied-with-gaps, Daytona a boundary conditional
+    // on its org tier.
     let initial = router
         .clone()
         .oneshot(
@@ -889,14 +890,21 @@ async fn code_execution_egress_policy_round_trips_and_rejects_secrets() {
             .unwrap_or_else(|| panic!("{provider} enforcement is disclosed"))
             .clone()
     };
-    // E2B is applied but honestly not a full boundary; Daytona is unconfirmed.
-    // Neither is ever shown as a plain boundary, and the gaps are surfaced.
+    // E2B is applied but honestly not a full boundary. Daytona's per-sandbox
+    // policy is a strict, live-confirmed boundary, but gated on org tier 3+, so
+    // it surfaces as a conditional boundary with the requirement inline — never
+    // an unconditional boundary, and with no phantom curated-service gaps.
     assert_eq!(row("e2b")["status"], "applied_with_gaps");
     assert!(!row("e2b")["gaps"].as_array().unwrap().is_empty());
     assert_eq!(
         row("daytona")["status"],
-        "unconfirmed",
-        "Daytona egress is applied but not yet a confirmed boundary"
+        "conditional_boundary",
+        "Daytona is a strict per-sandbox boundary, conditional on org tier 3+"
+    );
+    assert_eq!(row("daytona")["requirement"], "Daytona org tier 3+");
+    assert!(
+        row("daytona")["gaps"].as_array().unwrap().is_empty(),
+        "the phantom curated-service exceptions must be gone"
     );
 
     // A configured allowlist round-trips through the store and back out.

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -76,12 +76,13 @@ execution, never by reverting to open egress. The local provider already denies
 all network and is unaffected.
 
 The `enforcement` field discloses, per managed provider, an honest `status`
-(`boundary`, `applied_with_gaps`, or `unconfirmed`) plus the `gaps` the vendor
-leaves reachable regardless of policy. The status is **derived from the shipped
-enforcement model** (`EgressEnforcement`), not asserted per provider, so the
-settings surface and the decision layer can never disagree — if the model says a
-vendor's mechanism leaves a general-purpose destination reachable, the surface
-cannot present it as a full boundary.
+(`boundary`, `conditional_boundary`, `applied_with_gaps`, or `unconfirmed`),
+plus the `gaps` the vendor leaves reachable regardless of policy and an optional
+`requirement` when a boundary is gated on a precondition. The status is
+**derived from the shipped enforcement model** (`EgressEnforcement`), not
+asserted per provider, so the settings surface and the decision layer can never
+disagree — if the model says a vendor's mechanism leaves a general-purpose
+destination reachable, the surface cannot present it as a full boundary.
 
 - **E2B — `applied_with_gaps`.** A configured allowlist becomes E2B's
   per-sandbox `allowOut` rules with `allow_internet_access: false`, and this is
@@ -90,13 +91,20 @@ cannot present it as a full boundary.
   the sandbox can still reach arbitrary hosts on other ports or tunnel over DNS.
   The model's `is_credential_boundary()` returns false for exactly this reason,
   and the projection reads that value rather than a hardcoded flag.
-- **Daytona — `unconfirmed`.** A configured policy is sent at sandbox creation
-  (block-all switch or comma-separated allowlists), but whether an
-  empty-but-present allowlist denies that axis is not yet confirmed against the
-  live Daytona API, and Daytona keeps general-purpose services (package
-  registries, git hosting, container registries, AI APIs) reachable regardless
-  of policy. Daytona egress is therefore applied but must not be relied on as a
-  network boundary until confirmed.
+- **Daytona — `conditional_boundary`, requiring org tier 3+.** A configured
+  policy is sent at sandbox creation (block-all switch or comma-separated
+  allowlists). A live test against a real Daytona account confirmed that a
+  per-sandbox policy is a *strict*, externally enforced allowlist: only listed
+  domains are reachable, and raw IPs, unlisted domains, unlisted-domain DNS, and
+  the package registries / git hosting / container registries / AI APIs that
+  were once assumed always-reachable are **all blocked**. There is no
+  general-purpose carve-out, so `is_credential_boundary()` returns true and
+  Daytona is in fact a stronger boundary than E2B. The one caveat is a
+  precondition the host cannot read statically: the per-sandbox egress override
+  requires **Daytona org tier 3+**. On tier 1–2 the override is refused and the
+  org default applies, so the boundary is not guaranteed — the projection
+  therefore reports it as a *conditional* boundary with that requirement inline,
+  never an unconditional green one.
 
 The local sandbox is the only tier that denies all network outright — the actual
 boundary — and it does so unconditionally, independent of this policy.
@@ -237,5 +245,6 @@ tool arguments, logs, or renderer responses. Remote API endpoints are fixed by
 the build; Daytona toolbox URLs returned by the control plane are restricted to
 HTTPS Daytona origins. By default both managed providers allow internet access
 inside the sandbox, unlike the local native provider; a configured
-[egress policy](#egress-policy) restricts that access at sandbox creation, with
-E2B's enforcement confirmed and Daytona's pending live confirmation.
+[egress policy](#egress-policy) restricts that access at sandbox creation. E2B's
+enforcement is confirmed but applied-with-gaps; Daytona's per-sandbox policy is a
+strict, live-confirmed boundary conditional on org tier 3+.

--- a/docs/sandbox-providers.md
+++ b/docs/sandbox-providers.md
@@ -463,6 +463,20 @@ Three honesty rules keep this from becoming a label:
   against the honest declaration, exceptions included, never the feature
   name.
 
+Concretely, the two managed vendors land on different points of this model,
+and live measurement has refined it. E2B's per-sandbox allowlist is confirmed
+but *applied-with-gaps* — domain rules cover only ports 80/443 and DNS stays
+open — so its declaration carries those holes and it is not a boundary.
+Daytona's per-sandbox policy, by contrast, is a confirmed *strict* boundary: a
+live test against a real account showed it blocks raw IPs, unlisted domains,
+unlisted-domain DNS, and the package registries and public git hosting once
+assumed always-reachable, with no general-purpose carve-out — so it clears the
+external-tier bar and is in fact stronger than E2B. Its one caveat is plan-tier
+gating: the per-sandbox override requires Daytona org tier 3+, which the host
+cannot read statically, so settings disclose Daytona as a boundary *conditional*
+on that tier rather than an unconditional one. The local adapter stays the only
+unconditional boundary.
+
 For an unattached run, policy is the snapshot delivered at admission.
 Revoking a grant while its run is unattached takes effect at reattachment
 or next admission, not instantly — revocation semantics follow host


### PR DESCRIPTION
## Summary

A live test against a real Daytona account (see #888) established that a per-sandbox Daytona egress policy is a **strict, externally enforced allowlist**, not the leaky surface this code assumed:

- Only listed domains are reachable. Raw IPs, unlisted domains, and unlisted-domain DNS are all blocked.
- The package registries, public git hosting, container registries, and AI APIs that the code declared as always-reachable general-purpose exceptions are **all blocked** under a per-sandbox policy — there is no such carve-out.
- An empty-but-present `networkAllowList` is read as **deny-all** on the IP axis (previously flagged NEEDS-LIVE-CONFIRMATION; now confirmed).

So Daytona per-sandbox egress is a genuine boundary, in fact **stronger than E2B** (which limits domain rules to HTTP/HTTPS ports and leaves DNS open). The prior model wrongly declared phantom curated-service exceptions, forcing `is_credential_boundary()` to `false`.

## Changes

- **`DaytonaExecutionProvider::egress_enforcement()`** — removed the phantom general-purpose curated-service exceptions. With no general-purpose holes, `is_credential_boundary()` now returns `true` for Daytona.
- **Adapter comments** — the empty-present `networkAllowList` = deny-all behavior is marked live-confirmed.
- **Enforcement reporting** — added an `EgressEnforcementStatus::ConditionalBoundary` plus an optional `requirement` note on the row. Daytona now reports as a boundary **conditional on org tier 3+** with the requirement surfaced inline, never an unconditional green boundary.
- **UI** (`CodeExecutionPanel.tsx`) — Daytona renders with an informational-tone badge (`Boundary — conditional`) and an inline `Requires Daytona org tier 3+` line explaining that on a lower tier the per-sandbox override is refused and the account default applies.
- **Docs** — `code-execution.md` and `sandbox-providers.md` describe Daytona as a strict boundary conditional on tier 3+, E2B as applied-with-gaps, and local as the only unconditional boundary.

## How the tier-3+ conditionality is modeled

**Static conditional note, not a runtime signal.** The enforcement disclosure is computed statically in `config_info` without any live Daytona call, and it renders before any sandbox is ever created — so a runtime echo from sandbox creation cannot honestly flow into it without a stateful, drift-prone tier cache. The account tier cannot be known statically, so the honest, fail-safe representation is a distinct `ConditionalBoundary` status carrying the `Daytona org tier 3+` requirement. This neither over-claims (not an unconditional boundary) nor under-claims (no longer buried as `Unconfirmed` now that #888 confirmed the mechanism), and the distinct status token prevents the UI from rendering a plain green boundary.

The #879 invariant holds: status is derived from the model (`is_credential_boundary()` + the exception set); the tier requirement is an additional host-known precondition passed into the projection alongside `confirmed`, exactly like `confirmed` itself.

**No egress-applying behavior changed** — the #879 create-body wiring is untouched; this is about the enforcement model/reporting being accurate.

## Verification

- `cargo test -p openwave-server -p openwave-code-execution --locked` — pass (regression test updated: Daytona is `ConditionalBoundary`, no phantom gaps, requirement surfaced; the route integration test updated to match).
- Wire types regenerated (`UPDATE_WIRE_TYPES=1`); `requirement?: string` and the new status member land in `wire.ts`.
- `tsc --noEmit` clean; `pnpm test` (vitest) 627 pass, including a new panel test asserting Daytona reads as conditional-with-tier-3+ and never as an unconditional boundary.
- `clippy --all-targets -D warnings` clean; `fmt` clean.

Closes #892