### PR TITLE
feat(protocol): wire transport + in-container sandbox agent image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6627,6 +6627,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "openwave-sandbox-agent"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "openwave-core",
+ "openwave-sandbox-protocol",
+ "schemars 1.2.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+]
+
+[[package]]
 name = "openwave-sandbox-protocol"
 version = "0.0.0"
 dependencies = [

--- a/crates/openwave-sandbox-agent/Cargo.toml
+++ b/crates/openwave-sandbox-agent/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "openwave-sandbox-agent"
+description = "UNSTABLE: the in-container OpenWave sandbox agent — the sandbox-side transport server, a sandbox-resident tool registry, and an agent loop whose model inference is dialed back to the host over reverse RPC."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+publish = false
+
+# The container entrypoint is the `openwave-sandbox-agent` binary.
+[[bin]]
+name = "openwave-sandbox-agent"
+path = "src/main.rs"
+
+[dependencies]
+openwave-sandbox-protocol = { path = "../openwave-sandbox-protocol" }
+# Trait contracts only: the agent reuses OpenWave's `Tool`/`ToolRegistry` and the
+# provider vocabulary, not the host-side persistence stack. `default-features =
+# false` keeps sea-orm, the keychain, and the fs tools out of the container image.
+openwave-core = { path = "../openwave-core", default-features = false }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "sync"] }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+schemars = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time"] }
+
+[lints]
+workspace = true

--- a/crates/openwave-sandbox-agent/Dockerfile
+++ b/crates/openwave-sandbox-agent/Dockerfile
@@ -1,0 +1,53 @@
+# The OpenWave sandbox agent image.
+#
+# Packages the `openwave-sandbox-agent` binary: the sandbox-side transport
+# server plus the in-container agent loop. The container's entrypoint runs the
+# agent server on the listener port the host dials (default 8080, publishable by
+# the local container backend in issue #874).
+#
+# Build context is the WORKSPACE ROOT, so the whole Cargo workspace and the
+# committed Cargo.lock are visible to a `--locked` build:
+#
+#   docker build -f crates/openwave-sandbox-agent/Dockerfile -t openwave-sandbox-agent .
+#
+# The host verifies this image by digest before provisioning (a constraint from
+# issue #873); pinning-by-digest and host verification live on the host side in
+# #874, not in the image itself.
+#
+# Image build/verification for this slice is intentionally MANUAL, not a CI lane:
+# building it compiles the crate's slice of the workspace inside Docker, which is
+# far heavier than the cheap gates this foundational PR runs, and the container
+# runtime is a detected capability rather than a hard dependency. The command
+# above is the manual check.
+
+# ---- build stage -----------------------------------------------------------
+# Pinned to the workspace toolchain channel (stable) via the bookworm image; the
+# workspace's rust-toolchain.toml declares `stable`.
+FROM rust:1-bookworm AS build
+WORKDIR /src
+
+# Copy the whole workspace. A dependency-only pre-build cache layer is a later
+# optimization; correctness first.
+COPY . .
+
+# Build only the agent crate. Its dependency on openwave-core carries
+# `default-features = false`, so sea-orm, the OS keychain, and the filesystem
+# tools are never compiled into the image — no model or third-party credential
+# ships in it.
+RUN cargo build --release --locked -p openwave-sandbox-agent
+
+# ---- runtime stage ---------------------------------------------------------
+# distroless/cc provides glibc and libgcc for the dynamically-linked binary and
+# nothing else — no shell, no package manager — a minimal attack surface for a
+# container that runs untrusted model output. The binary uses rustls (no OpenSSL)
+# and opens no keychain, so cc is sufficient.
+FROM gcr.io/distroless/cc-debian12 AS runtime
+
+COPY --from=build /src/target/release/openwave-sandbox-agent /usr/local/bin/openwave-sandbox-agent
+
+# The listener address the supervisor binds; the host dials this port.
+ENV OPENWAVE_SANDBOX_LISTEN=0.0.0.0:8080
+EXPOSE 8080
+
+# distroless has no shell, so use the exec form.
+ENTRYPOINT ["/usr/local/bin/openwave-sandbox-agent"]

--- a/crates/openwave-sandbox-agent/src/agent.rs
+++ b/crates/openwave-sandbox-agent/src/agent.rs
@@ -1,0 +1,146 @@
+//! The in-container agent loop.
+//!
+//! This is the sandbox-resident consumer of the transport: on attach it drives a
+//! bounded agent loop that reuses OpenWave's [`Tool`](openwave_core::Tool)
+//! registry, dials each model step back to the host over reverse RPC, emits the
+//! event stream as it goes, and submits a final result.
+//!
+//! # Scope: the loop's shape, not the host-side `Agent`
+//!
+//! OpenWave's full host-side [`Agent`](openwave_core::Agent) drives its turn from
+//! a durable [`Store`](openwave_core::storage) — messages, turns, checkpoints,
+//! approval brokering — which is host-side persistence machinery, not something
+//! the container stands up. This slice therefore reuses the *plain-Rust seams*
+//! the design says the sandbox loop shares — the `Tool` trait and registry, the
+//! `ToolCtx`/`ToolOutput` vocabulary, and host-proxied model inference — and runs
+//! a minimal loop over them to demonstrate the sandbox-resident path end to end.
+//! Swapping this minimal driver for `Agent::run_turn` behind a sandbox-resident
+//! `Store` is the productionization step, and it plugs in exactly here.
+//!
+//! # The demo tool protocol
+//!
+//! To keep the loop model-driven without a full tool-calling transcript, a model
+//! completion is read as a directive: a completion of the form
+//! `use-tool:<name>:<json-args>` runs that tool locally and feeds its result
+//! back for the next step; any other completion is the final answer. The host
+//! (or, in tests, a mock host model) is what decides the directive, so the loop
+//! is genuinely driven from the model over the reverse channel.
+
+use openwave_core::{ChatId, ToolCtx, ToolRegistry};
+use openwave_sandbox_protocol::{ids::OperationId, SandboxRun};
+
+use crate::model::{HostModel, ModelError};
+use crate::tools::sandbox_tool_registry;
+
+/// The prefix a model completion uses to request a local tool call.
+const TOOL_DIRECTIVE: &str = "use-tool:";
+
+/// Bound on model steps, so a model that never finishes cannot loop forever.
+const MAX_STEPS: usize = 8;
+
+/// Why an in-container agent run did not complete.
+#[derive(Debug, thiserror::Error)]
+pub enum AgentRunError {
+    /// A model step failed (the host refused it, or the connection dropped).
+    #[error("model step failed: {0}")]
+    Model(#[from] ModelError),
+    /// The loop hit its step bound without the model submitting a final answer.
+    #[error("the agent loop exceeded {MAX_STEPS} model steps without a result")]
+    StepLimit,
+}
+
+/// Run the sandbox-resident agent loop for one `task`, driving it through `run`.
+///
+/// Emits progress events as it works and submits the final answer as the run's
+/// terminal [`Result`](openwave_sandbox_protocol::events::EventPayload::Result)
+/// event. Returns the final answer text.
+///
+/// # Errors
+/// [`AgentRunError::Model`] if a model step fails, or [`AgentRunError::StepLimit`]
+/// if the model never submits a final answer within the step bound.
+pub async fn run_agent(run: SandboxRun, task: impl Into<String>) -> Result<String, AgentRunError> {
+    let task = task.into();
+    let tools = sandbox_tool_registry();
+    let model = HostModel::new(run.clone());
+    // The sandbox loop has no host chat identity or filesystem scratch; a fresh
+    // chat id and no private scratch keep the tool context self-contained.
+    let ctx = ToolCtx::without_private_scratch(ChatId::new(), None);
+
+    let _ = run
+        .emit_progress("sandbox agent attached; starting run")
+        .await;
+
+    let mut transcript = format!("Task: {task}\n");
+    for _step in 0..MAX_STEPS {
+        // Each model step is its own durable operation, so a re-issue after a
+        // reconnect is answered from the host's recorded outcome.
+        let completion = model
+            .complete(OperationId::new(), transcript.clone())
+            .await?;
+
+        let Some(directive) = parse_tool_directive(&completion) else {
+            // Any non-directive completion is the final answer.
+            let _ = run.emit_result(completion.clone()).await;
+            return Ok(completion);
+        };
+
+        let _ = run
+            .emit_progress(format!("calling tool {}", directive.name))
+            .await;
+        let output = run_tool(&tools, &ctx, directive.name, directive.args).await;
+        let _ = run
+            .emit_progress(format!("tool {} -> {}", directive.name, output))
+            .await;
+        transcript.push_str(&format!("Tool {} result: {output}\n", directive.name));
+    }
+
+    Err(AgentRunError::StepLimit)
+}
+
+/// A parsed `use-tool:<name>:<json-args>` directive.
+struct ToolDirective<'a> {
+    name: &'a str,
+    args: &'a str,
+}
+
+/// Read a completion as a tool directive, or `None` if it is a final answer.
+fn parse_tool_directive(completion: &str) -> Option<ToolDirective<'_>> {
+    let rest = completion.strip_prefix(TOOL_DIRECTIVE)?;
+    let (name, args) = rest.split_once(':')?;
+    (!name.is_empty()).then_some(ToolDirective { name, args })
+}
+
+/// Execute one local tool by name, returning its model-readable result text.
+///
+/// A missing tool or a malformed argument string is reported back to the model
+/// as text rather than aborting the run — the loop treats them the way the model
+/// would treat any tool failure.
+async fn run_tool(tools: &ToolRegistry, ctx: &ToolCtx, name: &str, args: &str) -> String {
+    let Some(tool) = tools.get(name) else {
+        return format!("error: no tool named {name}");
+    };
+    let args = match serde_json::from_str(args) {
+        Ok(args) => args,
+        Err(error) => return format!("error: tool arguments were not valid JSON: {error}"),
+    };
+    match tool.execute(ctx, args).await {
+        Ok(output) => output.content,
+        Err(error) => format!("error: {error}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_tool_directive_and_ignores_a_final_answer() {
+        let directive = parse_tool_directive("use-tool:word_count:{\"text\":\"a b\"}").unwrap();
+        assert_eq!(directive.name, "word_count");
+        assert_eq!(directive.args, "{\"text\":\"a b\"}");
+
+        assert!(parse_tool_directive("the final answer is 2").is_none());
+        // An empty tool name is not a directive.
+        assert!(parse_tool_directive("use-tool::{}").is_none());
+    }
+}

--- a/crates/openwave-sandbox-agent/src/lib.rs
+++ b/crates/openwave-sandbox-agent/src/lib.rs
@@ -1,0 +1,32 @@
+//! The in-container OpenWave sandbox agent.
+//!
+//! This crate is the sandbox-resident side of the sandbox-provider design's step
+//! 7.1: a container image running OpenWave's agent loop with a closed,
+//! sandbox-resident tool registry, behind the versioned
+//! [`openwave_sandbox_protocol`] wire contract. It is the primary consumer of
+//! that protocol's sandbox-side transport.
+//!
+//! Three components, and their separation is the point:
+//!
+//! - the [`supervisor`] owns the transport listener (and, as a documented stub,
+//!   the credential/egress boundary) — the non-agent component;
+//! - the [`agent`] loop drives the run: model inference dialed back to the host
+//!   over reverse RPC, a sandbox-resident [`tools`] registry, the event stream,
+//!   and a final result;
+//! - the [`model`] client turns each model step into a host-proxied reverse call,
+//!   so **no model credential ever lives in the container**.
+//!
+//! # UNSTABLE
+//!
+//! Like the protocol it speaks, this crate is unstable and unversioned until a
+//! named release.
+
+pub mod agent;
+pub mod model;
+pub mod supervisor;
+pub mod tools;
+
+pub use agent::{run_agent, AgentRunError};
+pub use model::{HostModel, ModelError};
+pub use supervisor::{CredentialProxy, Supervisor};
+pub use tools::{sandbox_tool_registry, WordCount, WORD_COUNT_TOOL};

--- a/crates/openwave-sandbox-agent/src/main.rs
+++ b/crates/openwave-sandbox-agent/src/main.rs
@@ -1,0 +1,60 @@
+//! Container entrypoint for the OpenWave sandbox agent.
+//!
+//! Binds the supervisor's transport listener and starts the agent loop. The
+//! agent blocks until the host dials in and completes the attach handshake — an
+//! attached-only run cannot take a model step without its host, which is the
+//! model proxy — then runs to a submitted result over the reverse channel. The
+//! process keeps serving after the result is submitted so the host holds the
+//! connection and drains the event stream; teardown is host-driven.
+//!
+//! Configuration is by environment, so the image needs no arguments:
+//!
+//! - `OPENWAVE_SANDBOX_LISTEN` — the address the listener binds (default
+//!   `0.0.0.0:8080`, the port the container publishes).
+//! - `OPENWAVE_SANDBOX_TASK` — the delegated task. In the full design the host
+//!   delivers the task in the run-init payload after the handle commits; until
+//!   that init frame is wired, the entrypoint reads it from the environment.
+
+use std::env;
+
+use openwave_sandbox_agent::{run_agent, Supervisor};
+use openwave_sandbox_protocol::{reverse::Capability, SandboxRun};
+
+/// Default listener address; the container publishes this port.
+const DEFAULT_LISTEN: &str = "0.0.0.0:8080";
+
+#[tokio::main]
+async fn main() {
+    if let Err(error) = run().await {
+        eprintln!("openwave-sandbox-agent: {error}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let listen = env::var("OPENWAVE_SANDBOX_LISTEN").unwrap_or_else(|_| DEFAULT_LISTEN.to_owned());
+    let task = env::var("OPENWAVE_SANDBOX_TASK")
+        .unwrap_or_else(|_| "Summarize what this sandbox agent can do.".to_owned());
+
+    // Attached-only: the only granted reverse capability is host-proxied model
+    // inference. No model credential lives in the container.
+    let run = SandboxRun::new([Capability::ModelInference]);
+    let supervisor = Supervisor::bind(&listen, run.clone()).await?;
+    eprintln!(
+        "openwave-sandbox-agent listening on {}",
+        supervisor.local_addr()?
+    );
+
+    // The agent loop is a separate future from the supervisor's listener: it
+    // waits for the host to attach, then runs to a submitted result.
+    tokio::spawn(async move {
+        match run_agent(run, task).await {
+            Ok(answer) => eprintln!("openwave-sandbox-agent: submitted result: {answer}"),
+            Err(error) => eprintln!("openwave-sandbox-agent: run failed: {error}"),
+        }
+    });
+
+    // Keep serving so the host can drain the event stream and drive teardown.
+    supervisor.serve().await;
+    Ok(())
+}

--- a/crates/openwave-sandbox-agent/src/model.rs
+++ b/crates/openwave-sandbox-agent/src/model.rs
@@ -1,0 +1,78 @@
+//! Host-proxied model inference over the reverse channel.
+//!
+//! An attached-only sandbox run carries no model credential (see
+//! [credential separation](../../docs/sandbox-providers.md)); the host is the
+//! model proxy. This module dials one model completion back to the host over the
+//! reverse-RPC lane the transport carries, keyed by a durable
+//! [`OperationId`](openwave_sandbox_protocol::ids::OperationId) so a completion
+//! re-issued after a reconnect is answered from the host's recorded outcome
+//! rather than executed twice.
+
+use openwave_sandbox_protocol::{
+    ids::OperationId,
+    protocol::Response,
+    reverse::{ModelInferenceParams, ReverseRequest, ReverseResult},
+    ReverseOutcome, SandboxRun,
+};
+
+/// Why a host-proxied model completion did not return text.
+#[derive(Debug, thiserror::Error)]
+pub enum ModelError {
+    /// The host answered with a transport-stable error (denied, cancelled,
+    /// version, too large, or an operation-log refusal).
+    #[error("the host refused the model completion: {code:?}: {message}")]
+    Host {
+        /// The stable failure class.
+        code: openwave_sandbox_protocol::protocol::ErrorCode,
+        /// The transport-safe detail.
+        message: String,
+    },
+    /// The connection dropped before the completion arrived. Re-issuing the same
+    /// operation identity after the host reattaches returns the recorded outcome.
+    #[error("the reverse connection dropped before the completion arrived")]
+    Disconnected,
+    /// The host answered a model-inference call with a non-inference result.
+    #[error("the host answered with an unexpected reverse result")]
+    UnexpectedResult,
+}
+
+/// The sandbox's model client: every completion is a reverse call to the host.
+#[derive(Clone)]
+pub struct HostModel {
+    run: SandboxRun,
+}
+
+impl HostModel {
+    /// Build a model client that dials completions back over `run`'s reverse lane.
+    #[must_use]
+    pub fn new(run: SandboxRun) -> Self {
+        Self { run }
+    }
+
+    /// Complete `prompt` through the host under the durable `operation_id`.
+    ///
+    /// # Errors
+    /// [`ModelError::Host`] on a transport-stable refusal, [`ModelError::Disconnected`]
+    /// if the connection drops mid-flight, or [`ModelError::UnexpectedResult`] if
+    /// the host answers with a non-inference result.
+    pub async fn complete(
+        &self,
+        operation_id: OperationId,
+        prompt: impl Into<String>,
+    ) -> Result<String, ModelError> {
+        let request = ReverseRequest::ModelInference(ModelInferenceParams {
+            prompt: prompt.into(),
+        });
+        match self.run.call(operation_id, request).await {
+            ReverseOutcome::Settled(Response::Ok(ReverseResult::ModelInference(result))) => {
+                Ok(result.completion)
+            }
+            ReverseOutcome::Settled(Response::Ok(_)) => Err(ModelError::UnexpectedResult),
+            ReverseOutcome::Settled(Response::Error(error)) => Err(ModelError::Host {
+                code: error.code,
+                message: error.message,
+            }),
+            ReverseOutcome::Disconnected => Err(ModelError::Disconnected),
+        }
+    }
+}

--- a/crates/openwave-sandbox-agent/src/supervisor.rs
+++ b/crates/openwave-sandbox-agent/src/supervisor.rs
@@ -1,0 +1,99 @@
+//! The sandbox supervisor: the non-agent component that owns the transport
+//! listener and (eventually) holds credentials and fronts egress.
+//!
+//! The supervisor is deliberately **distinct from the agent process**. Per the
+//! [credential separation](../../docs/sandbox-providers.md) invariant, the
+//! non-agent component owns the transport listener, holds credentials, and
+//! substitutes them at its own egress boundary so a third-party credential never
+//! enters the agent's address space. This slice ships the listener half of that
+//! separation and leaves the credential/egress boundary as a **documented stub**
+//! ([`CredentialProxy`]) marking exactly where it plugs in — the full egress
+//! proxy is its own step and is not built here.
+//!
+//! In this crate the split is structural: [`Supervisor`] binds the listener and
+//! serves each host connection against the run's transport ([`SandboxRun`]),
+//! while the agent loop ([`crate::agent::run_agent`]) is a separate future that
+//! only ever touches the same `SandboxRun` handle — never the listener, never a
+//! credential. A tool that shells out would run under the supervisor's egress
+//! boundary with a cleared environment and, where the platform allows, a
+//! different UID; this slice has no subprocess tools, so that obligation is
+//! recorded here rather than exercised.
+
+use std::io;
+
+use openwave_sandbox_protocol::{serve_connection, SandboxRun};
+use tokio::net::TcpListener;
+
+/// The credential and egress boundary the supervisor owns — a documented stub.
+///
+/// In the full design the agent addresses a connected service with an opaque
+/// placeholder and this boundary substitutes the real credential and strips
+/// agent-supplied authentication, terminating TLS at the supervisor. None of
+/// that is built in this slice: an attached-only run carries no credential (the
+/// host is the model proxy, reached over reverse RPC), so there is nothing to
+/// substitute yet. This type exists to name the seam the egress step wires in.
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct CredentialProxy;
+
+impl CredentialProxy {
+    /// A credential/egress boundary that holds and substitutes nothing.
+    ///
+    /// The real proxy replaces this: it holds the run's scoped credentials, is
+    /// the only component that ever sees them, and applies the egress policy
+    /// snapshot the host delivered at admission.
+    #[must_use]
+    pub fn stub() -> Self {
+        Self
+    }
+}
+
+/// The sandbox supervisor. Owns the transport listener; the agent loop does not.
+pub struct Supervisor {
+    listener: TcpListener,
+    run: SandboxRun,
+    #[allow(dead_code)]
+    credentials: CredentialProxy,
+}
+
+impl Supervisor {
+    /// Bind the transport listener on `addr` for the run behind `run`.
+    ///
+    /// The host dials this listener; the per-run transport secret authenticating
+    /// the dial is delivered out of band through the provider control plane and
+    /// is a follow-up on this listener (see the crate docs).
+    ///
+    /// # Errors
+    /// Propagates the bind failure if the address cannot be listened on.
+    pub async fn bind(addr: &str, run: SandboxRun) -> io::Result<Self> {
+        let listener = TcpListener::bind(addr).await?;
+        Ok(Self {
+            listener,
+            run,
+            credentials: CredentialProxy::stub(),
+        })
+    }
+
+    /// The address the listener actually bound, so a caller that passed port 0
+    /// can learn the assigned port.
+    ///
+    /// # Errors
+    /// Propagates the failure if the local address cannot be read.
+    pub fn local_addr(&self) -> io::Result<std::net::SocketAddr> {
+        self.listener.local_addr()
+    }
+
+    /// Accept host connections forever, serving each against the run's transport.
+    ///
+    /// Each connection is served on its own task, so a reconnect after a
+    /// disconnect reattaches to the same [`SandboxRun`] — its event buffer and
+    /// operation identities outlive any single connection.
+    pub async fn serve(self) {
+        while let Ok((stream, _peer)) = self.listener.accept().await {
+            let run = self.run.clone();
+            tokio::spawn(async move {
+                let _ = serve_connection(stream, run).await;
+            });
+        }
+    }
+}

--- a/crates/openwave-sandbox-agent/src/tools.rs
+++ b/crates/openwave-sandbox-agent/src/tools.rs
@@ -1,0 +1,74 @@
+//! The sandbox-resident tool registry.
+//!
+//! Running the agent loop inside a sandbox is "the same code with a different
+//! tool registry and transport" (see
+//! [sandbox-providers.md](../../docs/sandbox-providers.md)). This module builds
+//! that registry from OpenWave's own [`Tool`] trait, so the tools the sandbox
+//! loop invokes are ordinary [`openwave_core`] tools — not a parallel
+//! abstraction.
+//!
+//! The set is deliberately **closed and minimal** for this slice: model
+//! inference is dialed back to the host over reverse RPC (the first host-mediated
+//! capability), and the only sandbox-local tool is a trivial, dependency-free,
+//! read-only computation that demonstrates the loop actually invoking a tool.
+//! Widening the sandbox-resident registry is a separate design, gated on the
+//! entry conditions the delivery sequence names; nothing here reaches the network
+//! or the filesystem, so no credential or egress boundary is engaged yet.
+
+use async_trait::async_trait;
+use openwave_core::{ApprovalClass, Result, Tool, ToolCtx, ToolOutput, ToolSpec};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+
+/// The name the model uses to invoke the word-count tool.
+pub const WORD_COUNT_TOOL: &str = "word_count";
+
+/// Arguments for [`WordCount`].
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct WordCountArgs {
+    /// The text whose words to count.
+    text: String,
+}
+
+/// A trivial, read-only local tool: count the whitespace-separated words in a
+/// piece of text.
+///
+/// It exists to prove the sandbox loop can invoke a real [`Tool`] locally, not to
+/// be useful. It touches no filesystem, network, or credential, so it needs no
+/// approval beyond the auto-approving [`ApprovalClass::ReadOnly`] class.
+pub struct WordCount;
+
+#[async_trait]
+impl Tool for WordCount {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec::for_args::<WordCountArgs>(
+            WORD_COUNT_TOOL,
+            "Count the whitespace-separated words in a piece of text.",
+        )
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        // Arguments are untrusted input; a malformed call is a tool failure the
+        // model sees and can correct, not a process error.
+        let args: WordCountArgs = match serde_json::from_value(args) {
+            Ok(args) => args,
+            Err(error) => return Ok(ToolOutput::error(format!("invalid arguments: {error}"))),
+        };
+        let count = args.text.split_whitespace().count();
+        Ok(ToolOutput::text(count.to_string()))
+    }
+}
+
+/// Build the closed sandbox-resident tool registry for this slice.
+#[must_use]
+pub fn sandbox_tool_registry() -> openwave_core::ToolRegistry {
+    let mut registry = openwave_core::ToolRegistry::new();
+    registry.register(Box::new(WordCount));
+    registry
+}

--- a/crates/openwave-sandbox-agent/tests/agent_run.rs
+++ b/crates/openwave-sandbox-agent/tests/agent_run.rs
@@ -1,0 +1,162 @@
+//! End-to-end: the in-container agent, driven over a real socket against a mock
+//! host model.
+//!
+//! This runs the agent server in-process — the sandbox-side transport server and
+//! the agent loop — with the host side dialing in over a TCP loopback and
+//! answering model steps from a scripted mock model. It exercises the whole
+//! sandbox-resident path the image packages: attach handshake, model inference
+//! dialed back over reverse RPC, a local tool call, the event stream, and a
+//! submitted result — and asserts exactly-once against the host's operation-log
+//! seam (each model step runs once, one record per operation).
+//!
+//! The whole scenario runs under a wall-clock [`timeout`](tokio::time::timeout),
+//! so a transport regression fails the test fast instead of hanging the suite.
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+use tokio::{net::TcpStream, time::Duration};
+
+use openwave_sandbox_agent::run_agent;
+use openwave_sandbox_protocol::{
+    events::EventPayload,
+    ids::RunId,
+    oplog::{InMemoryOperationStore, OperationStore},
+    protocol::{AttachRequest, Response, PROTOCOL_VERSION},
+    reverse::{
+        Capability, CapabilityResponder, GrantSet, ModelInferenceResult, ReverseRequest,
+        ReverseResult, RunProvenance,
+    },
+    serve_connection, CapabilityHost, EventCursor, SandboxRun, WireClient,
+};
+
+/// A mock host model that scripts the loop: it asks for the word-count tool on
+/// the first step, then — once the transcript shows the tool's result — returns a
+/// final answer. It counts executions so a test can assert exactly-once.
+struct ScriptedModel {
+    executions: Arc<AtomicUsize>,
+}
+
+const FINAL_ANSWER: &str = "counted the words in the sample";
+
+#[async_trait::async_trait]
+impl CapabilityResponder for ScriptedModel {
+    async fn respond(&self, request: ReverseRequest) -> Response<ReverseResult> {
+        self.executions.fetch_add(1, Ordering::SeqCst);
+        let prompt = match request {
+            ReverseRequest::ModelInference(params) => params.prompt,
+            _ => unreachable!("only model inference is exercised"),
+        };
+        let completion = if prompt.contains("Tool word_count result") {
+            FINAL_ANSWER.to_owned()
+        } else {
+            // Drive a real local tool call over the loop's directive protocol.
+            "use-tool:word_count:{\"text\":\"alpha beta gamma delta\"}".to_owned()
+        };
+        Response::Ok(ReverseResult::ModelInference(ModelInferenceResult {
+            completion,
+        }))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn attach_infer_tool_and_submit_result_runs_exactly_once() {
+    // Bound the whole scenario so a transport deadlock fails fast rather than
+    // hanging the test runner.
+    tokio::time::timeout(Duration::from_secs(20), scenario())
+        .await
+        .expect("agent scenario completed within its time bound");
+}
+
+async fn scenario() {
+    // Sandbox side: the run and its transport server on a loopback port.
+    let run = SandboxRun::new([Capability::ModelInference]);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback");
+    let addr = listener.local_addr().expect("addr");
+    {
+        let run = run.clone();
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                let run = run.clone();
+                tokio::spawn(async move {
+                    let _ = serve_connection(stream, run).await;
+                });
+            }
+        });
+    }
+
+    // Host side: the operation-log-backed capability host, wired to the mock
+    // model, that answers reverse calls over the connection.
+    let executions = Arc::new(AtomicUsize::new(0));
+    let store = InMemoryOperationStore::new();
+    let host = CapabilityHost::new(
+        GrantSet::new(
+            RunProvenance {
+                run_id: RunId::new(),
+                provider: "agent-run-test".to_owned(),
+            },
+            [Capability::ModelInference],
+        ),
+        Arc::new(ScriptedModel {
+            executions: Arc::clone(&executions),
+        }),
+        Arc::new(store.clone()),
+    );
+
+    let stream = TcpStream::connect(addr).await.expect("dial");
+    let mut conn = WireClient::connect(
+        stream,
+        AttachRequest {
+            protocol_version: PROTOCOL_VERSION,
+            run_id: RunId::new(),
+            resume_from: EventCursor::START,
+        },
+        host,
+    )
+    .await
+    .expect("attach accepted");
+
+    // Drive the agent loop; it dials its model steps back over the connection.
+    let agent = tokio::spawn(async move { run_agent(run, "count the words in the sample").await });
+
+    // Drain the event stream until the terminal result arrives.
+    let mut progress = Vec::new();
+    let result = loop {
+        let event = conn
+            .next_event()
+            .await
+            .expect("stream stays open until result");
+        match event.payload {
+            EventPayload::Progress(text) => progress.push(text),
+            EventPayload::Result(text) => break text,
+            _ => {}
+        }
+    };
+
+    assert_eq!(result, FINAL_ANSWER, "the run submitted its final answer");
+    // The loop actually ran the local tool: word_count("alpha beta gamma delta")
+    // is 4, surfaced on a progress event.
+    assert!(
+        progress.iter().any(|line| line.contains("word_count -> 4")),
+        "the sandbox-resident tool ran locally: {progress:?}"
+    );
+
+    let answer = agent
+        .await
+        .expect("agent task joins")
+        .expect("agent run succeeds");
+    assert_eq!(answer, FINAL_ANSWER);
+
+    // Exactly-once seam: two model steps, two distinct operations, each recorded
+    // once and executed once.
+    assert_eq!(
+        executions.load(Ordering::SeqCst),
+        2,
+        "each model step executed exactly once"
+    );
+    assert_eq!(store.len(), 2, "one operation-log record per model step");
+}

--- a/crates/openwave-sandbox-protocol/Cargo.toml
+++ b/crates/openwave-sandbox-protocol/Cargo.toml
@@ -17,10 +17,10 @@ uuid = { workspace = true }
 base64 = { workspace = true }
 sha2 = { workspace = true }
 async-trait = { workspace = true }
-tokio = { workspace = true, features = ["rt", "sync", "macros", "time"] }
+tokio = { workspace = true, features = ["rt", "sync", "macros", "time", "io-util"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "macros", "time"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "macros", "time", "io-util", "net"] }
 
 [lints]
 workspace = true

--- a/crates/openwave-sandbox-protocol/src/lib.rs
+++ b/crates/openwave-sandbox-protocol/src/lib.rs
@@ -64,6 +64,7 @@ pub mod protocol;
 pub mod provisioning;
 pub mod reference;
 pub mod reverse;
+pub mod wire;
 
 pub use host::{CapabilityHost, ReverseWaiter};
 pub use ids::{EventCursor, OperationId, RequestId, RunId, SandboxTag, Sequence};
@@ -81,4 +82,9 @@ pub use reverse::{
     Capability, CapabilityResponder, ControlFrame, GrantSet, ModelInferenceParams,
     ModelInferenceResult, RequestFrame, ReverseEnvelope, ReverseRequest, ReverseResponseEnvelope,
     ReverseResult, RunProvenance,
+};
+pub use wire::sandbox::serve_connection;
+pub use wire::{
+    host::ConnectError, read_frame, write_frame, FrameError, HostConnection, ReverseOutcome,
+    SandboxRun, WireClient, WireFrame,
 };

--- a/crates/openwave-sandbox-protocol/src/wire/host.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/host.rs
@@ -1,0 +1,250 @@
+//! The host-side transport client: dial a sandbox, do the version handshake,
+//! then service the connection.
+//!
+//! The host dials the sandbox and holds the connection; "reverse" names only
+//! which side originates requests over it (the sandbox does). Once the handshake
+//! is accepted, the client runs the connection: it answers reverse requests
+//! against the run-scoped [`CapabilityHost`] — the same operation-log seam that
+//! fences idempotent replay in-process — forwards the sandbox's event stream to
+//! the caller, and answers liveness pings. Reverse-RPC exactly-once is the
+//! `CapabilityHost`'s job, not the transport's; the transport only carries the
+//! frames.
+//!
+//! This client is what the local container backend (issue #874) connects to a
+//! provisioned container with: dial the container's loopback address into any
+//! [`AsyncRead`]`+`[`AsyncWrite`] stream (a [`TcpStream`](tokio::net::TcpStream)
+//! there), hand it the [`AttachRequest`] and the run's `CapabilityHost`, and
+//! drive the returned [`HostConnection`].
+
+use tokio::{
+    io::{split, AsyncRead, AsyncWrite, BufReader},
+    sync::mpsc,
+    task::JoinHandle,
+};
+
+use crate::{
+    events::SandboxEvent,
+    host::CapabilityHost,
+    ids::EventCursor,
+    protocol::{AttachAccepted, AttachRefused, AttachRequest, HandshakeResponse},
+    reverse::{ControlFrame, RequestFrame, ReverseResponseEnvelope},
+    wire::{read_frame, write_frame, write_prioritized, FrameError, WireFrame},
+};
+
+/// Why dialing and attaching to a sandbox over the wire failed.
+#[derive(Debug, thiserror::Error)]
+pub enum ConnectError {
+    /// The sandbox refused the version; it answered with an on-wire
+    /// [`AttachRefused`] carrying its own version, and the connection is not
+    /// established.
+    #[error("attach refused: sandbox speaks protocol version {}", .0.protocol_version)]
+    VersionRefused(AttachRefused),
+    /// The handshake did not complete: the sandbox closed the connection or sent
+    /// something other than a handshake frame first.
+    #[error("the sandbox did not complete the attach handshake: {0}")]
+    Handshake(String),
+    /// The transport failed before the handshake completed.
+    #[error("transport failed during attach: {0}")]
+    Transport(#[from] FrameError),
+}
+
+/// The host's live connection to a sandbox.
+///
+/// Holds the accepted handshake, a receiver for the sandbox's event stream, and
+/// a handle to send control frames. Dropping it aborts the service tasks and so
+/// drops the connection — the sandbox observes a disconnect and, for an
+/// attached-only run, checkpoints and waits.
+pub struct HostConnection {
+    accepted: AttachAccepted,
+    events: mpsc::Receiver<SandboxEvent>,
+    outbound: Outbound,
+    tasks: Vec<JoinHandle<()>>,
+}
+
+/// Prioritized outbound queues shared with the writer task: control frames drain
+/// ahead of the request/ack lane.
+#[derive(Clone)]
+struct Outbound {
+    control: mpsc::Sender<WireFrame>,
+    data: mpsc::Sender<WireFrame>,
+}
+
+/// The host-side transport client. Its one job is to dial and attach; the live
+/// connection it returns is a [`HostConnection`].
+pub struct WireClient;
+
+impl WireClient {
+    /// Attach to a sandbox over `stream`: send the [`AttachRequest`], read the
+    /// handshake, and — on acceptance — spawn the connection's service tasks
+    /// wired to `host`.
+    ///
+    /// # Errors
+    /// [`ConnectError::VersionRefused`] on a version mismatch (the connection is
+    /// not established), [`ConnectError::Handshake`] if the sandbox closes or
+    /// answers with a non-handshake frame, or [`ConnectError::Transport`] on a
+    /// transport failure during attach.
+    pub async fn connect<S>(
+        stream: S,
+        attach: AttachRequest,
+        host: CapabilityHost,
+    ) -> Result<HostConnection, ConnectError>
+    where
+        S: AsyncRead + AsyncWrite + Send + 'static,
+    {
+        let (read_half, write_half) = split(stream);
+        let mut reader = BufReader::new(read_half);
+
+        // The control queue is depth-1 and drained first; the data queue carries
+        // reverse responses and event acks.
+        let (control_tx, control_rx) = mpsc::channel::<WireFrame>(8);
+        let (data_tx, data_rx) = mpsc::channel::<WireFrame>(crate::protocol::MAX_INFLIGHT_REQUESTS);
+        let outbound = Outbound {
+            control: control_tx,
+            data: data_tx,
+        };
+
+        // Send the handshake request, then await the answer, before spawning the
+        // writer task — the handshake is a strict request/response prelude.
+        {
+            let mut write_half = write_half;
+            write_frame(&mut write_half, &WireFrame::Attach(attach))
+                .await
+                .map_err(ConnectError::Transport)?;
+
+            let accepted = match read_frame(&mut reader).await {
+                Ok(WireFrame::Handshake(HandshakeResponse::Accepted(accepted))) => accepted,
+                Ok(WireFrame::Handshake(HandshakeResponse::Refused(refused))) => {
+                    return Err(ConnectError::VersionRefused(refused));
+                }
+                Ok(_) => {
+                    return Err(ConnectError::Handshake(
+                        "sandbox sent a non-handshake frame first".to_owned(),
+                    ));
+                }
+                Err(FrameError::Closed) => {
+                    return Err(ConnectError::Handshake(
+                        "sandbox closed before answering the handshake".to_owned(),
+                    ));
+                }
+                Err(error) => return Err(ConnectError::Transport(error)),
+            };
+
+            let (event_tx, event_rx) =
+                mpsc::channel::<SandboxEvent>(crate::protocol::MAX_INFLIGHT_REQUESTS);
+            let writer = tokio::spawn(write_prioritized(write_half, control_rx, data_rx));
+            let reader_task = tokio::spawn(read_loop(reader, host, outbound.clone(), event_tx));
+
+            Ok(HostConnection {
+                accepted,
+                events: event_rx,
+                outbound,
+                tasks: vec![writer, reader_task],
+            })
+        }
+    }
+}
+
+impl HostConnection {
+    /// The accepted handshake: the sandbox's version, the granted capabilities,
+    /// and the highest sequence it held at attach.
+    #[must_use]
+    pub fn accepted(&self) -> &AttachAccepted {
+        &self.accepted
+    }
+
+    /// Await the next event on the sandbox's stream, or `None` once the
+    /// connection has drained and closed.
+    pub async fn next_event(&mut self) -> Option<SandboxEvent> {
+        self.events.recv().await
+    }
+
+    /// Acknowledge the event stream through `cursor`, letting the sandbox advance
+    /// its un-acknowledged buffer. Best-effort: a closed connection drops it.
+    pub async fn acknowledge(&self, cursor: EventCursor) {
+        let _ = self
+            .outbound
+            .data
+            .send(WireFrame::EventAck { cursor })
+            .await;
+    }
+
+    /// Send a liveness ping over the reserved control lane. Best-effort.
+    pub async fn ping(&self, nonce: u64) {
+        let _ = self
+            .outbound
+            .control
+            .send(WireFrame::Control(ControlFrame::Ping { nonce }))
+            .await;
+    }
+}
+
+impl Drop for HostConnection {
+    fn drop(&mut self) {
+        for task in &self.tasks {
+            task.abort();
+        }
+    }
+}
+
+/// Service inbound frames: answer reverse requests against `host`, forward events
+/// to `events`, and answer pings.
+async fn read_loop<R>(
+    mut reader: BufReader<R>,
+    host: CapabilityHost,
+    outbound: Outbound,
+    events: mpsc::Sender<SandboxEvent>,
+) where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    // Per-request forwarders are detached: each awaits its operation's outcome
+    // and writes the response frame. The execution behind an operation lives in
+    // the CapabilityHost, decoupled from this connection, so a disconnect tears
+    // down the forwarders but not the executions — the disconnect asymmetry the
+    // reverse-RPC design requires.
+    loop {
+        let frame = match read_frame(&mut reader).await {
+            Ok(frame) => frame,
+            Err(_) => break,
+        };
+        match frame {
+            WireFrame::Request(RequestFrame::Request(envelope)) => {
+                let request_id = envelope.request_id;
+                let operation_id = envelope.operation_id;
+                let protocol_version = envelope.protocol_version;
+                let waiter = host.dispatch(envelope);
+                let data = outbound.data.clone();
+                tokio::spawn(async move {
+                    let response = waiter.wait().await;
+                    let frame =
+                        WireFrame::Request(RequestFrame::Response(ReverseResponseEnvelope {
+                            protocol_version,
+                            request_id,
+                            operation_id,
+                            response,
+                        }));
+                    let _ = data.send(frame).await;
+                });
+            }
+            WireFrame::Control(ControlFrame::Cancel { operation_id }) => host.cancel(operation_id),
+            WireFrame::Control(ControlFrame::Ping { nonce }) => {
+                let _ = outbound
+                    .control
+                    .send(WireFrame::Control(ControlFrame::Pong { nonce }))
+                    .await;
+            }
+            WireFrame::Control(ControlFrame::Pong { .. }) => {}
+            WireFrame::Event(event) => {
+                if events.send(event).await.is_err() {
+                    // The caller dropped the connection; stop forwarding.
+                    break;
+                }
+            }
+            // The host answers requests; it never receives responses or another
+            // handshake mid-connection. Ignore rather than trust peer input.
+            WireFrame::Request(RequestFrame::Response(_))
+            | WireFrame::Attach(_)
+            | WireFrame::Handshake(_)
+            | WireFrame::EventAck { .. } => {}
+        }
+    }
+}

--- a/crates/openwave-sandbox-protocol/src/wire/host.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/host.rs
@@ -56,7 +56,7 @@ pub enum ConnectError {
 /// attached-only run, checkpoints and waits.
 pub struct HostConnection {
     accepted: AttachAccepted,
-    events: mpsc::UnboundedReceiver<SandboxEvent>,
+    events: mpsc::Receiver<SandboxEvent>,
     outbound: Outbound,
     tasks: Vec<JoinHandle<()>>,
 }
@@ -87,6 +87,24 @@ impl WireClient {
         stream: S,
         attach: AttachRequest,
         host: CapabilityHost,
+    ) -> Result<HostConnection, ConnectError>
+    where
+        S: AsyncRead + AsyncWrite + Send + 'static,
+    {
+        // The host caps its inbound event buffer at MAX_BUFFERED_EVENTS — the same
+        // ceiling a conforming sandbox self-limits its un-acknowledged events to,
+        // so a conforming peer never fills it, but a misbehaving one is torn down
+        // rather than allowed to grow host memory without bound.
+        Self::connect_with(stream, attach, host, crate::protocol::MAX_BUFFERED_EVENTS).await
+    }
+
+    /// [`connect`](Self::connect) with an explicit inbound event-buffer bound,
+    /// for exercising the host's ceiling at a small, cheap scale.
+    pub(crate) async fn connect_with<S>(
+        stream: S,
+        attach: AttachRequest,
+        host: CapabilityHost,
+        event_capacity: usize,
     ) -> Result<HostConnection, ConnectError>
     where
         S: AsyncRead + AsyncWrite + Send + 'static,
@@ -129,13 +147,13 @@ impl WireClient {
                 Err(error) => return Err(ConnectError::Transport(error)),
             };
 
-            // The event channel is unbounded so forwarding an event never blocks
-            // the read loop that also dispatches reverse requests and answers
-            // pings — a slow `next_event` consumer must not stall the reverse
-            // lane. A conforming sandbox bounds the backlog for us: it stops
-            // producing once MAX_BUFFERED_EVENTS go un-acknowledged, and
-            // [`HostConnection::acknowledge`] is how the host advances that.
-            let (event_tx, event_rx) = mpsc::unbounded_channel::<SandboxEvent>();
+            // The event channel is BOUNDED at the host's ceiling. The read loop
+            // forwards events with a non-blocking `try_send`, so a slow
+            // `next_event` consumer never stalls reverse-request dispatch or ping
+            // handling (the decoupling this design needs); but the bound caps host
+            // memory, and a peer that overruns it is torn down as a protocol
+            // violation rather than buffered without limit.
+            let (event_tx, event_rx) = mpsc::channel::<SandboxEvent>(event_capacity.max(1));
             let writer = tokio::spawn(write_prioritized(write_half, control_rx, data_rx));
             let reader_task = tokio::spawn(read_loop(reader, host, outbound.clone(), event_tx));
 
@@ -160,12 +178,15 @@ impl HostConnection {
     /// Await the next event on the sandbox's stream, or `None` once the
     /// connection has drained and closed.
     ///
-    /// The owner MUST keep draining this: forwarded events are buffered off the
-    /// read loop's path so a slow consumer cannot stall reverse-request dispatch
-    /// or liveness, and the only thing that bounds that buffer is the sandbox's
-    /// own flow control — it stops producing once MAX_BUFFERED_EVENTS go
-    /// un-acknowledged. Draining (and [`acknowledge`](Self::acknowledge)ing) keeps
-    /// that backlog from parking the run.
+    /// Forwarded events are buffered off the read loop's path (a non-blocking
+    /// hand-off) so a slow consumer cannot stall reverse-request dispatch or
+    /// liveness. That buffer is bounded at the host's own ceiling
+    /// (MAX_BUFFERED_EVENTS): a conforming sandbox self-limits below it and never
+    /// trips it, but a peer that overruns it — buggy or hostile — has its
+    /// connection torn down (this stream then returns `None`) rather than being
+    /// allowed to grow host memory without bound. Draining, and
+    /// [`acknowledge`](Self::acknowledge)ing, keeps the backlog from parking the
+    /// run.
     pub async fn next_event(&mut self) -> Option<SandboxEvent> {
         self.events.recv().await
     }
@@ -204,10 +225,11 @@ async fn read_loop<R>(
     mut reader: BufReader<R>,
     host: CapabilityHost,
     outbound: Outbound,
-    events: mpsc::UnboundedSender<SandboxEvent>,
+    events: mpsc::Sender<SandboxEvent>,
 ) where
     R: AsyncRead + Unpin + Send + 'static,
 {
+    use tokio::sync::mpsc::error::TrySendError;
     // Per-request forwarders are detached: each awaits its operation's outcome
     // and writes the response frame. The execution behind an operation lives in
     // the CapabilityHost, decoupled from this connection, so a disconnect tears
@@ -246,11 +268,22 @@ async fn read_loop<R>(
             }
             WireFrame::Control(ControlFrame::Pong { .. }) => {}
             WireFrame::Event(event) => {
-                // Non-blocking: forwarding an event must never stall this loop's
-                // reverse-request dispatch or ping handling. An error means the
-                // caller dropped the connection, so stop forwarding.
-                if events.send(event).is_err() {
+                // An inbound event is untrusted input. `read_frame` bounds a frame
+                // at MAX_FRAME_BYTES; re-enforce the smaller per-event payload cap
+                // here, and refuse an over-bound event as a protocol violation
+                // rather than forward it.
+                if !event.payload.within_bounds() {
                     break;
+                }
+                // Non-blocking: forwarding an event must never stall this loop's
+                // reverse-request dispatch or ping handling. A `Full` channel means
+                // the peer overran the host's event ceiling — impossible for a
+                // conforming sandbox, which self-limits below it — so tear the
+                // connection down instead of blocking or buffering without bound.
+                // `Closed` means the owner dropped the connection.
+                match events.try_send(event) {
+                    Ok(()) => {}
+                    Err(TrySendError::Full(_) | TrySendError::Closed(_)) => break,
                 }
             }
             // The host answers requests; it never receives responses or another
@@ -260,5 +293,151 @@ async fn read_loop<R>(
             | WireFrame::Handshake(_)
             | WireFrame::EventAck { .. } => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+
+    use super::*;
+    use crate::{
+        events::EventPayload,
+        ids::{RunId, Sequence},
+        oplog::InMemoryOperationStore,
+        protocol::{Response, MAX_EVENT_PAYLOAD_BYTES, PROTOCOL_VERSION},
+        reverse::{CapabilityResponder, GrantSet, ReverseRequest, ReverseResult, RunProvenance},
+    };
+
+    /// A responder that is never invoked: these tests drive only the event lane.
+    struct NoopResponder;
+
+    #[async_trait::async_trait]
+    impl CapabilityResponder for NoopResponder {
+        async fn respond(&self, _request: ReverseRequest) -> Response<ReverseResult> {
+            unreachable!("the ceiling tests never issue a reverse request")
+        }
+    }
+
+    fn events_only_host() -> CapabilityHost {
+        CapabilityHost::new(
+            GrantSet::none(RunProvenance {
+                run_id: RunId::new(),
+                provider: "wire-host-test".to_owned(),
+            }),
+            Arc::new(NoopResponder),
+            Arc::new(InMemoryOperationStore::new()),
+        )
+    }
+
+    fn attach() -> AttachRequest {
+        AttachRequest {
+            protocol_version: PROTOCOL_VERSION,
+            run_id: RunId::new(),
+            resume_from: EventCursor::START,
+        }
+    }
+
+    /// Answer the attach handshake on a raw sandbox side, then hand back the write
+    /// half so the caller can flood frames directly.
+    async fn accept_handshake<S>(
+        sandbox: S,
+    ) -> (BufReader<tokio::io::ReadHalf<S>>, tokio::io::WriteHalf<S>)
+    where
+        S: AsyncRead + AsyncWrite,
+    {
+        let (read_half, mut write_half) = split(sandbox);
+        let mut reader = BufReader::new(read_half);
+        let _ = read_frame(&mut reader).await;
+        let accepted = WireFrame::Handshake(HandshakeResponse::Accepted(AttachAccepted {
+            protocol_version: PROTOCOL_VERSION,
+            granted_capabilities: Vec::new(),
+            latest_sequence: None,
+        }));
+        let _ = write_frame(&mut write_half, &accepted).await;
+        (reader, write_half)
+    }
+
+    /// A peer that floods more un-acknowledged events than the host's ceiling is
+    /// torn down — the host buffers at most its ceiling and then closes the
+    /// stream, rather than growing memory without bound or stalling.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_peer_that_overruns_the_event_ceiling_is_torn_down() {
+        tokio::time::timeout(Duration::from_secs(10), async {
+            let capacity = 4usize;
+            let (host_side, sandbox_side) = tokio::io::duplex(64 * 1024);
+
+            let flood = tokio::spawn(async move {
+                let (_reader, mut write_half) = accept_handshake(sandbox_side).await;
+                // Flood well past the host's ceiling, never reading an ack.
+                for seq in 1..=(capacity as u64 + 50) {
+                    let event = WireFrame::Event(SandboxEvent {
+                        sequence: Sequence::new(seq),
+                        payload: EventPayload::Progress(format!("e{seq}")),
+                    });
+                    if write_frame(&mut write_half, &event).await.is_err() {
+                        break;
+                    }
+                }
+            });
+
+            let mut conn =
+                WireClient::connect_with(host_side, attach(), events_only_host(), capacity)
+                    .await
+                    .expect("attach accepted");
+
+            // Let the read loop fill the bounded channel and tear down on overrun.
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            // The stream yields at most the ceiling, then closes (teardown) — it
+            // does not hang (the outer timeout would catch that) or buffer without
+            // bound (the count would exceed the ceiling).
+            let mut count = 0usize;
+            while conn.next_event().await.is_some() {
+                count += 1;
+                assert!(count <= capacity, "host buffered past its ceiling");
+            }
+            assert!(
+                count <= capacity,
+                "host tore down after buffering at most its ceiling, got {count}"
+            );
+
+            let _ = flood.await;
+        })
+        .await
+        .expect("test completed within its time bound");
+    }
+
+    /// A single over-bound event (within the 1 MiB frame cap but past the 64 KiB
+    /// per-event payload cap) is refused at the host as a protocol violation.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn an_over_bound_event_payload_is_refused_at_the_host() {
+        tokio::time::timeout(Duration::from_secs(10), async {
+            let (host_side, sandbox_side) = tokio::io::duplex(4 * 1024 * 1024);
+
+            let peer = tokio::spawn(async move {
+                let (_reader, mut write_half) = accept_handshake(sandbox_side).await;
+                let event = WireFrame::Event(SandboxEvent {
+                    sequence: Sequence::new(1),
+                    payload: EventPayload::Progress("x".repeat(MAX_EVENT_PAYLOAD_BYTES + 1)),
+                });
+                let _ = write_frame(&mut write_half, &event).await;
+            });
+
+            let mut conn = WireClient::connect_with(host_side, attach(), events_only_host(), 16)
+                .await
+                .expect("attach accepted");
+
+            // The over-bound event is dropped and the connection torn down, so the
+            // stream closes without ever yielding it.
+            assert!(
+                conn.next_event().await.is_none(),
+                "an over-bound event must be refused, not forwarded"
+            );
+
+            let _ = peer.await;
+        })
+        .await
+        .expect("test completed within its time bound");
     }
 }

--- a/crates/openwave-sandbox-protocol/src/wire/host.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/host.rs
@@ -56,7 +56,7 @@ pub enum ConnectError {
 /// attached-only run, checkpoints and waits.
 pub struct HostConnection {
     accepted: AttachAccepted,
-    events: mpsc::Receiver<SandboxEvent>,
+    events: mpsc::UnboundedReceiver<SandboxEvent>,
     outbound: Outbound,
     tasks: Vec<JoinHandle<()>>,
 }
@@ -129,8 +129,13 @@ impl WireClient {
                 Err(error) => return Err(ConnectError::Transport(error)),
             };
 
-            let (event_tx, event_rx) =
-                mpsc::channel::<SandboxEvent>(crate::protocol::MAX_INFLIGHT_REQUESTS);
+            // The event channel is unbounded so forwarding an event never blocks
+            // the read loop that also dispatches reverse requests and answers
+            // pings — a slow `next_event` consumer must not stall the reverse
+            // lane. A conforming sandbox bounds the backlog for us: it stops
+            // producing once MAX_BUFFERED_EVENTS go un-acknowledged, and
+            // [`HostConnection::acknowledge`] is how the host advances that.
+            let (event_tx, event_rx) = mpsc::unbounded_channel::<SandboxEvent>();
             let writer = tokio::spawn(write_prioritized(write_half, control_rx, data_rx));
             let reader_task = tokio::spawn(read_loop(reader, host, outbound.clone(), event_tx));
 
@@ -154,6 +159,13 @@ impl HostConnection {
 
     /// Await the next event on the sandbox's stream, or `None` once the
     /// connection has drained and closed.
+    ///
+    /// The owner MUST keep draining this: forwarded events are buffered off the
+    /// read loop's path so a slow consumer cannot stall reverse-request dispatch
+    /// or liveness, and the only thing that bounds that buffer is the sandbox's
+    /// own flow control — it stops producing once MAX_BUFFERED_EVENTS go
+    /// un-acknowledged. Draining (and [`acknowledge`](Self::acknowledge)ing) keeps
+    /// that backlog from parking the run.
     pub async fn next_event(&mut self) -> Option<SandboxEvent> {
         self.events.recv().await
     }
@@ -192,7 +204,7 @@ async fn read_loop<R>(
     mut reader: BufReader<R>,
     host: CapabilityHost,
     outbound: Outbound,
-    events: mpsc::Sender<SandboxEvent>,
+    events: mpsc::UnboundedSender<SandboxEvent>,
 ) where
     R: AsyncRead + Unpin + Send + 'static,
 {
@@ -234,8 +246,10 @@ async fn read_loop<R>(
             }
             WireFrame::Control(ControlFrame::Pong { .. }) => {}
             WireFrame::Event(event) => {
-                if events.send(event).await.is_err() {
-                    // The caller dropped the connection; stop forwarding.
+                // Non-blocking: forwarding an event must never stall this loop's
+                // reverse-request dispatch or ping handling. An error means the
+                // caller dropped the connection, so stop forwarding.
+                if events.send(event).is_err() {
                     break;
                 }
             }

--- a/crates/openwave-sandbox-protocol/src/wire/mod.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/mod.rs
@@ -1,0 +1,262 @@
+//! The concrete byte transport: newline-delimited JSON framing plus a host-side
+//! client and a sandbox-side server that carry the protocol's existing frame
+//! types over a real socket.
+//!
+//! The crate's core (see the [crate docs](crate)) pins the wire *types and their
+//! semantics* against an in-process [reference backend](crate::reference); it
+//! deliberately left the *byte transport* — how a frame is delimited on a socket
+//! and how the request and control lanes share one connection — to a concrete
+//! backend. This module is that transport, and it is what the local container
+//! backend and its host connect over.
+//!
+//! # Framing: newline-delimited JSON
+//!
+//! One frame is one line of compact JSON terminated by `\n`. This mirrors the
+//! shipped `openwave-host-broker` sidecar's hand-rolled newline protocol and the
+//! reverse-RPC spike, and it was chosen over a length prefix for three reasons:
+//! it is trivially debuggable (a frame is a readable JSON line), `read_until`
+//! over a [`BufReader`](tokio::io::BufReader) reassembles a frame that spans
+//! several reads and retains any bytes past the newline for the next frame, and
+//! it needs no codec dependency. `serde_json` emits compact single-line JSON, so
+//! the delimiter is unambiguous; a frame is bounded by [`MAX_FRAME_BYTES`] so a
+//! peer cannot force unbounded buffering with one enormous line.
+//!
+//! # Lanes over one connection
+//!
+//! Every unit on the wire is a [`WireFrame`], an adjacently-tagged envelope that
+//! names which lane a frame belongs to and carries one of the protocol's
+//! existing types unchanged — the reverse-RPC [`RequestFrame`], the reserved
+//! [`ControlFrame`], a [`SandboxEvent`], or the [handshake](AttachRequest) pair.
+//! The envelope is the only new wire type; the payloads are the same ones the
+//! [wire-format spec](../tests/wire_format.rs) pins.
+//!
+//! The [reserved control lane](crate::reverse::ControlFrame) is realized as a
+//! separate outbound queue that the writer drains with priority over the request
+//! lane, so a [`ControlFrame::Cancel`] is never stuck behind a saturated request
+//! backlog. On the sandbox side the request lane also applies backpressure at a
+//! bounded in-flight semaphore before a request frame is even enqueued, so a
+//! saturated request lane blocks new requests rather than the writer — and a
+//! cancel, which acquires no permit and rides the control queue, still lands.
+
+pub mod host;
+pub mod sandbox;
+
+use serde::{Deserialize, Serialize};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader},
+    sync::mpsc,
+};
+
+use crate::{
+    events::SandboxEvent,
+    ids::EventCursor,
+    protocol::{AttachRequest, HandshakeResponse},
+    reverse::{ControlFrame, RequestFrame},
+};
+
+pub use host::{HostConnection, WireClient};
+pub use sandbox::{serve_connection, ReverseOutcome, SandboxRun};
+
+/// Largest single frame a conforming transport reads or writes, re-exported from
+/// the protocol's [`MAX_FRAME_BYTES`](crate::protocol::MAX_FRAME_BYTES) so the
+/// byte transport and the semantic bound stay one number.
+pub const MAX_FRAME_BYTES: usize = crate::protocol::MAX_FRAME_BYTES;
+
+/// One framed unit on the wire.
+///
+/// The variants name the four lanes the connection multiplexes plus the two
+/// handshake frames that open it. Each carries one of the protocol's existing
+/// types verbatim; this envelope does not fork their shapes, it only tags which
+/// lane the payload belongs to.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(
+    tag = "lane",
+    content = "body",
+    rename_all = "snake_case",
+    deny_unknown_fields
+)]
+pub enum WireFrame {
+    /// Host -> sandbox: the attach handshake request. Always the first frame the
+    /// host sends on a fresh connection.
+    Attach(AttachRequest),
+    /// Sandbox -> host: the handshake answer. Always the first frame the sandbox
+    /// sends, before any event or reverse response.
+    Handshake(HandshakeResponse),
+    /// The reverse-RPC request lane: a request sandbox -> host, or the host's
+    /// correlated response host -> sandbox.
+    Request(RequestFrame),
+    /// The reserved control lane: cancel (sandbox -> host) and liveness (either
+    /// direction). Never subject to request backpressure.
+    Control(ControlFrame),
+    /// Sandbox -> host: one event on the resumable, monotonically sequenced
+    /// event stream.
+    Event(SandboxEvent),
+    /// Host -> sandbox: acknowledge the event stream through a committed cursor,
+    /// so the sandbox may advance its un-acknowledged buffer.
+    EventAck {
+        /// The host's committed cursor.
+        cursor: EventCursor,
+    },
+}
+
+/// Why a framed read or write stopped.
+#[derive(Debug, thiserror::Error)]
+pub enum FrameError {
+    /// The peer closed the connection (EOF at a frame boundary).
+    #[error("the connection closed")]
+    Closed,
+    /// A frame exceeded [`MAX_FRAME_BYTES`]; the peer is refused rather than
+    /// buffered without bound.
+    #[error("a frame exceeded {MAX_FRAME_BYTES} bytes")]
+    TooLarge,
+    /// A frame was not valid protocol JSON.
+    #[error("a frame was not valid protocol JSON")]
+    Malformed,
+    /// The underlying transport failed.
+    #[error("transport i/o failed: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Read the next [`WireFrame`] from a buffered reader, or report why none came.
+///
+/// `read_until` reassembles a frame that spans several underlying reads and the
+/// [`BufReader`] retains any bytes past the newline for the next call — the
+/// framing behavior a real socket forces, which an in-process channel would not
+/// have exercised.
+///
+/// # Errors
+/// [`FrameError::Closed`] at EOF, [`FrameError::TooLarge`] past
+/// [`MAX_FRAME_BYTES`], [`FrameError::Malformed`] on invalid JSON, or
+/// [`FrameError::Io`] on a transport failure.
+pub async fn read_frame<R>(reader: &mut BufReader<R>) -> Result<WireFrame, FrameError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut line = Vec::new();
+    let read = reader.read_until(b'\n', &mut line).await?;
+    if read == 0 {
+        return Err(FrameError::Closed);
+    }
+    if line.len() > MAX_FRAME_BYTES {
+        return Err(FrameError::TooLarge);
+    }
+    if line.last() == Some(&b'\n') {
+        line.pop();
+    }
+    serde_json::from_slice(&line).map_err(|_| FrameError::Malformed)
+}
+
+/// Write one [`WireFrame`] followed by its newline delimiter and flush it.
+///
+/// # Errors
+/// [`FrameError::TooLarge`] if the encoded frame exceeds [`MAX_FRAME_BYTES`],
+/// [`FrameError::Malformed`] if it cannot serialize, or [`FrameError::Io`] on a
+/// transport failure.
+pub async fn write_frame<W>(writer: &mut W, frame: &WireFrame) -> Result<(), FrameError>
+where
+    W: AsyncWrite + Unpin,
+{
+    let mut encoded = serde_json::to_vec(frame).map_err(|_| FrameError::Malformed)?;
+    if encoded.len() >= MAX_FRAME_BYTES {
+        return Err(FrameError::TooLarge);
+    }
+    encoded.push(b'\n');
+    writer.write_all(&encoded).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Drain two outbound queues onto one write half, control frames first.
+///
+/// Both the host and sandbox sides split their outbound frames into a reserved
+/// control queue and a request/data queue; this `biased` select drains any
+/// pending control frame before the data lane, realizing the reserved control
+/// lane at the writer so a cancel or a pong is never stuck behind a data
+/// backlog. Returns when both queues close or a write fails.
+pub(crate) async fn write_prioritized<W>(
+    mut write_half: W,
+    mut control_rx: mpsc::Receiver<WireFrame>,
+    mut data_rx: mpsc::Receiver<WireFrame>,
+) where
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    loop {
+        // `Some(..) =` disables a closed queue rather than treating its `None` as
+        // a frame, so a closed control lane does not starve a still-open data
+        // lane; `else` fires only once both queues have closed.
+        let frame = tokio::select! {
+            biased;
+            Some(frame) = control_rx.recv() => frame,
+            Some(frame) = data_rx.recv() => frame,
+            else => break,
+        };
+        if write_frame(&mut write_half, &frame).await.is_err() {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        ids::{OperationId, RequestId, RunId},
+        protocol::PROTOCOL_VERSION,
+        reverse::{ModelInferenceParams, ReverseEnvelope, ReverseRequest},
+    };
+
+    #[test]
+    fn wire_frame_tags_its_lane() {
+        let frame = WireFrame::Control(ControlFrame::Cancel {
+            operation_id: OperationId::new(),
+        });
+        let encoded = serde_json::to_value(&frame).unwrap();
+        assert_eq!(encoded["lane"], "control");
+        assert_eq!(encoded["body"]["control"], "cancel");
+        assert_eq!(serde_json::from_value::<WireFrame>(encoded).unwrap(), frame);
+    }
+
+    #[tokio::test]
+    async fn frames_survive_being_split_and_batched_across_reads() {
+        // Encode two frames back to back, then feed them through a duplex a few
+        // bytes at a time so a frame spans reads and two frames share a read —
+        // the two properties newline framing must handle.
+        let attach = WireFrame::Attach(AttachRequest {
+            protocol_version: PROTOCOL_VERSION,
+            run_id: RunId::new(),
+            resume_from: EventCursor::START,
+        });
+        let request = WireFrame::Request(RequestFrame::Request(ReverseEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: RequestId::new(),
+            operation_id: OperationId::new(),
+            request: ReverseRequest::ModelInference(ModelInferenceParams {
+                prompt: "hello".to_owned(),
+            }),
+        }));
+
+        let mut bytes = serde_json::to_vec(&attach).unwrap();
+        bytes.push(b'\n');
+        bytes.extend(serde_json::to_vec(&request).unwrap());
+        bytes.push(b'\n');
+
+        let (mut writer, reader) = tokio::io::duplex(8);
+        let feed = tokio::spawn(async move {
+            use tokio::io::AsyncWriteExt as _;
+            for chunk in bytes.chunks(3) {
+                writer.write_all(chunk).await.unwrap();
+                writer.flush().await.unwrap();
+            }
+            // Drop closes the write half so the reader eventually sees EOF.
+        });
+
+        let mut reader = BufReader::new(reader);
+        assert_eq!(read_frame(&mut reader).await.unwrap(), attach);
+        assert_eq!(read_frame(&mut reader).await.unwrap(), request);
+        assert!(matches!(
+            read_frame(&mut reader).await,
+            Err(FrameError::Closed)
+        ));
+        feed.await.unwrap();
+    }
+}

--- a/crates/openwave-sandbox-protocol/src/wire/mod.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/mod.rs
@@ -43,7 +43,7 @@ pub mod sandbox;
 
 use serde::{Deserialize, Serialize};
 use tokio::{
-    io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader},
+    io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader},
     sync::mpsc,
 };
 
@@ -119,29 +119,48 @@ pub enum FrameError {
 
 /// Read the next [`WireFrame`] from a buffered reader, or report why none came.
 ///
-/// `read_until` reassembles a frame that spans several underlying reads and the
-/// [`BufReader`] retains any bytes past the newline for the next call — the
-/// framing behavior a real socket forces, which an in-process channel would not
-/// have exercised.
+/// The read is bounded to [`MAX_FRAME_BYTES`] `+ 1` bytes by an
+/// [`AsyncReadExt::take`] before it looks for the delimiter, so the *buffering
+/// itself* is capped, not just checked after the fact: a peer that streams bytes
+/// without ever sending `\n` cannot grow the frame buffer without limit and OOM
+/// this side. Within that budget, `read_until` reassembles a frame that spans
+/// several underlying reads and the [`BufReader`] retains any bytes past the
+/// newline for the next call — the framing behavior a real socket forces.
 ///
 /// # Errors
-/// [`FrameError::Closed`] at EOF, [`FrameError::TooLarge`] past
-/// [`MAX_FRAME_BYTES`], [`FrameError::Malformed`] on invalid JSON, or
-/// [`FrameError::Io`] on a transport failure.
+/// [`FrameError::Closed`] at EOF on a frame boundary, [`FrameError::TooLarge`]
+/// once the byte budget is exhausted before a delimiter, [`FrameError::Malformed`]
+/// on invalid JSON, or [`FrameError::Io`] on a transport failure.
 pub async fn read_frame<R>(reader: &mut BufReader<R>) -> Result<WireFrame, FrameError>
 where
     R: AsyncRead + Unpin,
 {
+    // One byte past the cap: a maximal frame (MAX_FRAME_BYTES of content plus its
+    // delimiter) still fits, and anything larger trips the budget before a
+    // delimiter is seen.
+    let budget = MAX_FRAME_BYTES as u64 + 1;
     let mut line = Vec::new();
-    let read = reader.read_until(b'\n', &mut line).await?;
+    let read = (&mut *reader)
+        .take(budget)
+        .read_until(b'\n', &mut line)
+        .await?;
     if read == 0 {
         return Err(FrameError::Closed);
     }
-    if line.len() > MAX_FRAME_BYTES {
-        return Err(FrameError::TooLarge);
-    }
     if line.last() == Some(&b'\n') {
         line.pop();
+    } else {
+        // No delimiter within the budget. Either the peer exhausted the byte cap
+        // without a newline (a flood, or an over-bound frame) or the stream ended
+        // mid-frame; the buffer never exceeded the cap either way.
+        return if line.len() as u64 >= budget {
+            Err(FrameError::TooLarge)
+        } else {
+            Err(FrameError::Closed)
+        };
+    }
+    if line.len() > MAX_FRAME_BYTES {
+        return Err(FrameError::TooLarge);
     }
     serde_json::from_slice(&line).map_err(|_| FrameError::Malformed)
 }
@@ -258,5 +277,20 @@ mod tests {
             Err(FrameError::Closed)
         ));
         feed.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_no_newline_flood_is_refused_as_too_large_without_unbounded_buffering() {
+        // An endless stream of non-delimiter bytes must be refused once the byte
+        // budget is spent, not buffered without bound. `repeat` never yields a
+        // newline and never ends, so a correct `read_frame` returns after reading
+        // the bounded budget; a regression that buffers unboundedly would run the
+        // machine out of memory instead of returning here.
+        let flood = tokio::io::repeat(b'x');
+        let mut reader = BufReader::new(flood);
+        match read_frame(&mut reader).await {
+            Err(FrameError::TooLarge) => {}
+            other => panic!("a no-newline flood must be refused as TooLarge, got {other:?}"),
+        }
     }
 }

--- a/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
@@ -352,6 +352,14 @@ where
         closed: Arc::clone(&closed),
     };
 
+    // Spawn the writer BEFORE pushing anything onto the outbound queues. The
+    // resume replay below can enqueue far more events than the request-lane queue
+    // depth (up to MAX_BUFFERED_EVENTS), and if the writer that drains `data_rx`
+    // is not already running, the replay loop wedges on a full channel and the
+    // connection never starts serving. With the writer live, `data_rx` drains as
+    // the replay fills it.
+    let writer = tokio::spawn(write_prioritized(write_half, control_rx, data_rx));
+
     // Publish this connection as the run's live connection, then replay buffered
     // events strictly newer than the host's resume cursor. `send_replace`, not
     // `send`: the run holds no long-lived receiver, so `send` would be rejected
@@ -363,8 +371,6 @@ where
             break;
         }
     }
-
-    let writer = tokio::spawn(write_prioritized(write_half, control_rx, data_rx));
 
     // Serve inbound frames: correlate reverse responses, answer pings, and take
     // event acknowledgements.

--- a/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
@@ -1,0 +1,417 @@
+//! The sandbox-side transport server: accept a host connection, answer the
+//! version handshake, and serve the run over the wire.
+//!
+//! [`SandboxRun`] is the run-scoped state that outlives any single connection:
+//! the resumable event buffer and the reverse-RPC lane the in-container agent
+//! calls into. A connection is transient plumbing. When the host reconnects, it
+//! reattaches to the *same* `SandboxRun`, so buffered events replay from the
+//! host's committed cursor and reverse calls resume with the same
+//! [`OperationId`](crate::ids::OperationId).
+//!
+//! The agent drives the run through the cloneable [`SandboxRun`] handle: it
+//! [`emit_progress`](SandboxRun::emit_progress)es events, submits a final result
+//! with [`emit_result`](SandboxRun::emit_result), and dials the host for a model
+//! completion with [`call`](SandboxRun::call). Reverse-RPC availability is keyed
+//! to attachment: a `call` with no attached host waits for the host to attach.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+};
+
+use tokio::{
+    io::{split, AsyncRead, AsyncWrite, BufReader},
+    sync::{mpsc, oneshot, watch, Semaphore},
+};
+
+use crate::{
+    events::{EventPayload, SandboxEvent},
+    ids::{EventCursor, OperationId, RequestId, Sequence},
+    protocol::{
+        handshake, AttachAccepted, HandshakeResponse, Response, MAX_BUFFERED_EVENTS,
+        MAX_INFLIGHT_REQUESTS, PROTOCOL_VERSION,
+    },
+    reference::EmitError,
+    reverse::{
+        Capability, ControlFrame, RequestFrame, ReverseEnvelope, ReverseRequest, ReverseResult,
+    },
+    wire::{read_frame, write_frame, write_prioritized, FrameError, WireFrame},
+};
+
+/// The outcome of one sandbox-originated reverse call over the current
+/// connection.
+#[derive(Debug, Clone)]
+pub enum ReverseOutcome {
+    /// The host settled the call (a success or a transport-stable error).
+    Settled(Response<ReverseResult>),
+    /// The connection dropped before a response arrived. The host's execution
+    /// keeps running and records, so re-issuing the same `OperationId` after the
+    /// host reattaches returns the recorded outcome.
+    Disconnected,
+}
+
+/// In-flight reverse requests awaiting their correlated response, keyed by the
+/// per-attempt [`RequestId`].
+type PendingResponses = Arc<Mutex<HashMap<RequestId, oneshot::Sender<Response<ReverseResult>>>>>;
+
+/// The live connection's outbound handle, shared between the agent (which sends
+/// reverse requests and events) and the serve loop (which completes responses).
+#[derive(Clone)]
+struct ConnHandle {
+    /// Request and event frames; subject to the request-lane bound.
+    data: mpsc::Sender<WireFrame>,
+    /// The reserved control lane; drained ahead of `data`.
+    control: mpsc::Sender<WireFrame>,
+    /// In-flight reverse requests awaiting a correlated response.
+    pending: PendingResponses,
+    /// The request lane's in-flight bound. A reverse call acquires a permit
+    /// before enqueuing; a cancel on the control lane acquires none.
+    permits: Arc<Semaphore>,
+    /// Set once this connection has dropped, so a late `call` fails fast.
+    closed: Arc<AtomicBool>,
+}
+
+struct EventBuffer {
+    events: Vec<SandboxEvent>,
+    next_seq: u64,
+    acked_through: u64,
+    buffer_cap: usize,
+    overflowed: bool,
+}
+
+struct RunInner {
+    protocol_version: u32,
+    granted: Vec<Capability>,
+    request_lane_capacity: usize,
+    events: Mutex<EventBuffer>,
+    conn: watch::Sender<Option<ConnHandle>>,
+}
+
+/// One run-scoped, cloneable sandbox. Every clone shares one event buffer and one
+/// live-connection slot.
+#[derive(Clone)]
+pub struct SandboxRun {
+    inner: Arc<RunInner>,
+}
+
+impl SandboxRun {
+    /// A run speaking the current [`PROTOCOL_VERSION`], granting `capabilities`
+    /// deny-by-default, with the default event-buffer and request-lane bounds.
+    #[must_use]
+    pub fn new(capabilities: impl IntoIterator<Item = Capability>) -> Self {
+        Self::with_config(
+            PROTOCOL_VERSION,
+            MAX_BUFFERED_EVENTS,
+            MAX_INFLIGHT_REQUESTS,
+            capabilities,
+        )
+    }
+
+    /// A run with an explicit protocol version, event-buffer bound, and
+    /// request-lane capacity, for exercising version refusal and backpressure at
+    /// a small, cheap scale.
+    #[must_use]
+    pub fn with_config(
+        protocol_version: u32,
+        buffer_cap: usize,
+        request_lane_capacity: usize,
+        capabilities: impl IntoIterator<Item = Capability>,
+    ) -> Self {
+        let (conn, _) = watch::channel(None);
+        Self {
+            inner: Arc::new(RunInner {
+                protocol_version,
+                granted: capabilities.into_iter().collect(),
+                request_lane_capacity: request_lane_capacity.max(1),
+                events: Mutex::new(EventBuffer {
+                    events: Vec::new(),
+                    next_seq: Sequence::FIRST.get(),
+                    acked_through: EventCursor::START.get(),
+                    buffer_cap: buffer_cap.max(1),
+                    overflowed: false,
+                }),
+                conn,
+            }),
+        }
+    }
+
+    /// Emit a bounded progress line, returning its assigned sequence.
+    ///
+    /// The event is buffered for resume and, if a host is attached, delivered
+    /// live over the connection. Emitting does not require attachment: an event
+    /// emitted while unattached is buffered and replays when the host attaches.
+    ///
+    /// # Errors
+    /// [`EmitError::TooLarge`] past the per-event bound, or [`EmitError::Overflow`]
+    /// when the un-acknowledged buffer is full.
+    pub async fn emit_progress(&self, text: impl Into<String>) -> Result<Sequence, EmitError> {
+        self.emit(EventPayload::Progress(text.into())).await
+    }
+
+    /// Emit the run's terminal result submission, returning its sequence.
+    ///
+    /// # Errors
+    /// [`EmitError::TooLarge`] past the per-event bound, or [`EmitError::Overflow`]
+    /// when the un-acknowledged buffer is full.
+    pub async fn emit_result(&self, text: impl Into<String>) -> Result<Sequence, EmitError> {
+        self.emit(EventPayload::Result(text.into())).await
+    }
+
+    async fn emit(&self, payload: EventPayload) -> Result<Sequence, EmitError> {
+        let event = self.buffer_event(payload)?;
+        let sequence = event.sequence;
+        if let Some(conn) = self.current_conn() {
+            // Live delivery on the current connection. A send failure only means
+            // the connection dropped; the event stays buffered for replay.
+            let _ = conn.data.send(WireFrame::Event(event)).await;
+        }
+        Ok(sequence)
+    }
+
+    fn buffer_event(&self, payload: EventPayload) -> Result<SandboxEvent, EmitError> {
+        if !payload.within_bounds() {
+            return Err(EmitError::TooLarge);
+        }
+        let mut buffer = self.inner.events.lock().expect("event buffer lock");
+        let unacked = (buffer.next_seq - 1).saturating_sub(buffer.acked_through);
+        if unacked >= buffer.buffer_cap as u64 {
+            buffer.overflowed = true;
+            return Err(EmitError::Overflow);
+        }
+        let sequence = Sequence::new(buffer.next_seq);
+        let event = SandboxEvent { sequence, payload };
+        buffer.events.push(event.clone());
+        buffer.next_seq += 1;
+        Ok(event)
+    }
+
+    /// Dial the host for one host-proxied capability under the durable
+    /// `operation_id`, awaiting the host's answer.
+    ///
+    /// Waits for a host to be attached (reverse RPC is keyed to attachment), then
+    /// acquires a request-lane permit — the backpressure point — before enqueuing
+    /// the request frame. A disconnect mid-flight yields
+    /// [`ReverseOutcome::Disconnected`]; re-issue the same `operation_id` after
+    /// the host reattaches to receive the recorded outcome.
+    pub async fn call(&self, operation_id: OperationId, request: ReverseRequest) -> ReverseOutcome {
+        let Some(conn) = self.attached().await else {
+            return ReverseOutcome::Disconnected;
+        };
+        let Ok(_permit) = Arc::clone(&conn.permits).acquire_owned().await else {
+            return ReverseOutcome::Disconnected;
+        };
+        if conn.closed.load(Ordering::SeqCst) {
+            return ReverseOutcome::Disconnected;
+        }
+
+        let request_id = RequestId::new();
+        let (tx, rx) = oneshot::channel();
+        conn.pending
+            .lock()
+            .expect("pending lock")
+            .insert(request_id, tx);
+
+        let envelope = ReverseEnvelope {
+            protocol_version: self.inner.protocol_version,
+            request_id,
+            operation_id,
+            request,
+        };
+        if conn
+            .data
+            .send(WireFrame::Request(RequestFrame::Request(envelope)))
+            .await
+            .is_err()
+        {
+            conn.pending
+                .lock()
+                .expect("pending lock")
+                .remove(&request_id);
+            return ReverseOutcome::Disconnected;
+        }
+
+        match rx.await {
+            Ok(response) => ReverseOutcome::Settled(response),
+            Err(_) => ReverseOutcome::Disconnected,
+        }
+    }
+
+    /// Cancel an in-flight reverse operation over the reserved control lane.
+    ///
+    /// The cancel acquires no request-lane permit and rides the control queue,
+    /// which the writer drains ahead of the request lane, so it lands even while
+    /// the request lane is saturated.
+    pub fn cancel(&self, operation_id: OperationId) {
+        if let Some(conn) = self.current_conn() {
+            let _ = conn
+                .control
+                .try_send(WireFrame::Control(ControlFrame::Cancel { operation_id }));
+        }
+    }
+
+    fn current_conn(&self) -> Option<ConnHandle> {
+        self.inner.conn.borrow().clone()
+    }
+
+    /// Wait until a host is attached, returning that connection.
+    async fn attached(&self) -> Option<ConnHandle> {
+        let mut rx = self.inner.conn.subscribe();
+        loop {
+            if let Some(conn) = rx.borrow_and_update().clone() {
+                if !conn.closed.load(Ordering::SeqCst) {
+                    return Some(conn);
+                }
+            }
+            if rx.changed().await.is_err() {
+                return None;
+            }
+        }
+    }
+
+    fn latest_sequence(&self) -> Option<Sequence> {
+        let buffer = self.inner.events.lock().expect("event buffer lock");
+        (buffer.next_seq > Sequence::FIRST.get()).then(|| Sequence::new(buffer.next_seq - 1))
+    }
+
+    /// Buffered events strictly newer than `cursor`, for a resume replay.
+    fn events_since(&self, cursor: EventCursor) -> Vec<SandboxEvent> {
+        self.inner
+            .events
+            .lock()
+            .expect("event buffer lock")
+            .events
+            .iter()
+            .filter(|event| cursor.precedes(event.sequence))
+            .cloned()
+            .collect()
+    }
+
+    /// Advance the un-acknowledged buffer to the host's committed cursor.
+    fn acknowledge(&self, cursor: EventCursor) {
+        let mut buffer = self.inner.events.lock().expect("event buffer lock");
+        buffer.acked_through = buffer.acked_through.max(cursor.get());
+        let unacked = (buffer.next_seq - 1).saturating_sub(buffer.acked_through);
+        if unacked < buffer.buffer_cap as u64 {
+            buffer.overflowed = false;
+        }
+    }
+}
+
+/// Serve one host connection against `run` until the host closes it.
+///
+/// Reads the [`AttachRequest`](crate::protocol::AttachRequest), answers the
+/// handshake with the canonical [`handshake`] function (a version skew yields an
+/// on-wire refusal and the connection is not established), and on acceptance
+/// runs the connection: replays buffered events past the host's resume cursor,
+/// carries the agent's reverse requests and events out, and correlates the host's
+/// responses back. Returns when the connection drops; the `run` survives for the
+/// host to reattach to.
+///
+/// # Errors
+/// [`FrameError`] if the transport fails before or during the handshake.
+pub async fn serve_connection<S>(stream: S, run: SandboxRun) -> Result<(), FrameError>
+where
+    S: AsyncRead + AsyncWrite + Send + 'static,
+{
+    let (read_half, write_half) = split(stream);
+    let mut reader = BufReader::new(read_half);
+    let mut write_half = write_half;
+
+    // The first frame must be the attach handshake.
+    let attach = match read_frame(&mut reader).await? {
+        WireFrame::Attach(attach) => attach,
+        // A peer that opens with anything else is not speaking the protocol.
+        _ => return Ok(()),
+    };
+
+    let response = handshake(
+        &attach,
+        run.inner.protocol_version,
+        run.inner.granted.clone(),
+        run.latest_sequence(),
+    );
+    write_frame(&mut write_half, &WireFrame::Handshake(response.clone())).await?;
+    let _accepted: AttachAccepted = match response {
+        HandshakeResponse::Accepted(accepted) => accepted,
+        // The connection is refused and left unusable; the run stands.
+        HandshakeResponse::Refused(_) => return Ok(()),
+    };
+
+    let (control_tx, control_rx) = mpsc::channel::<WireFrame>(8);
+    let (data_tx, data_rx) = mpsc::channel::<WireFrame>(MAX_INFLIGHT_REQUESTS);
+    let pending = Arc::new(Mutex::new(HashMap::new()));
+    let closed = Arc::new(AtomicBool::new(false));
+    let conn = ConnHandle {
+        data: data_tx,
+        control: control_tx,
+        pending: Arc::clone(&pending),
+        permits: Arc::new(Semaphore::new(run.inner.request_lane_capacity)),
+        closed: Arc::clone(&closed),
+    };
+
+    // Publish this connection as the run's live connection, then replay buffered
+    // events strictly newer than the host's resume cursor. `send_replace`, not
+    // `send`: the run holds no long-lived receiver, so `send` would be rejected
+    // for want of one and leave the slot empty — `send_replace` updates the value
+    // unconditionally, and a `call` that subscribes afterward still sees it.
+    run.inner.conn.send_replace(Some(conn.clone()));
+    for event in run.events_since(attach.resume_from) {
+        if conn.data.send(WireFrame::Event(event)).await.is_err() {
+            break;
+        }
+    }
+
+    let writer = tokio::spawn(write_prioritized(write_half, control_rx, data_rx));
+
+    // Serve inbound frames: correlate reverse responses, answer pings, and take
+    // event acknowledgements.
+    loop {
+        let frame = match read_frame(&mut reader).await {
+            Ok(frame) => frame,
+            Err(_) => break,
+        };
+        match frame {
+            WireFrame::Request(RequestFrame::Response(envelope)) => {
+                if let Some(tx) = pending
+                    .lock()
+                    .expect("pending lock")
+                    .remove(&envelope.request_id)
+                {
+                    let _ = tx.send(envelope.response);
+                }
+            }
+            WireFrame::Control(ControlFrame::Ping { nonce }) => {
+                let _ = conn
+                    .control
+                    .send(WireFrame::Control(ControlFrame::Pong { nonce }))
+                    .await;
+            }
+            WireFrame::EventAck { cursor } => run.acknowledge(cursor),
+            // The sandbox originates cancels and requests; it never receives
+            // them. Pong is liveness only. Ignore rather than trust peer input.
+            WireFrame::Control(ControlFrame::Pong { .. } | ControlFrame::Cancel { .. })
+            | WireFrame::Request(RequestFrame::Request(_))
+            | WireFrame::Attach(_)
+            | WireFrame::Handshake(_)
+            | WireFrame::Event(_) => {}
+        }
+    }
+
+    // Disconnect: fail every in-flight reverse call and retire this connection.
+    closed.store(true, Ordering::SeqCst);
+    pending.lock().expect("pending lock").clear();
+    // Clear the live slot only if it is still this connection — a reconnect may
+    // already have installed a newer one.
+    run.inner.conn.send_if_modified(|slot| match slot {
+        Some(current) if Arc::ptr_eq(&current.closed, &closed) => {
+            *slot = None;
+            true
+        }
+        _ => false,
+    });
+    writer.abort();
+    Ok(())
+}

--- a/crates/openwave-sandbox-protocol/tests/wire_conformance.rs
+++ b/crates/openwave-sandbox-protocol/tests/wire_conformance.rs
@@ -1,0 +1,358 @@
+//! On-the-wire conformance for the sandbox-agent transport.
+//!
+//! Every scenario runs the host-side client and the sandbox-side server against
+//! each other over a real TCP loopback connection — not the in-process channels
+//! the [reference backend](openwave_sandbox_protocol::reference) uses — so the
+//! version handshake, the newline framing, the reverse-RPC correlation, the
+//! resumable event stream, and the reserved control lane are all exercised as
+//! bytes on a socket. This closes the interop gap the protocol crate deferred to
+//! the concrete-transport step: the reference suite pins semantics, this suite
+//! pins that the same semantics survive a real socket.
+//!
+//! The four contract areas required of the wire transport, and where:
+//!
+//! - version-mismatch refusal on the wire — [`version_mismatch_is_refused_on_the_wire`];
+//! - a model-inference reverse call round-trip (with exactly-once replay) —
+//!   [`model_inference_round_trips_and_replays_exactly_once`];
+//! - event-stream delivery and resume-by-sequence — [`event_stream_delivers_then_resumes_by_sequence`];
+//! - control-lane cancel preempting a saturated request lane —
+//!   [`control_lane_cancel_preempts_a_saturated_request_lane`].
+//!
+//! Each test body runs under a wall-clock [`timeout`](tokio::time::timeout), so a
+//! transport regression — including a spin-loop that never observes its
+//! condition — fails fast rather than hanging the suite.
+
+use std::{
+    future::Future,
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::Semaphore,
+    time::timeout,
+};
+
+use openwave_sandbox_protocol::{
+    ids::{EventCursor, OperationId, RunId, Sequence},
+    oplog::{InMemoryOperationStore, OperationStore},
+    protocol::{AttachRequest, ErrorCode, Response, PROTOCOL_VERSION},
+    reverse::{
+        Capability, CapabilityResponder, GrantSet, ModelInferenceParams, ModelInferenceResult,
+        ReverseRequest, ReverseResult, RunProvenance,
+    },
+    serve_connection, CapabilityHost, ConnectError, HostConnection, ReverseOutcome, SandboxRun,
+    WireClient,
+};
+
+/// Run one scenario under a wall-clock bound so nothing can hang the suite.
+async fn bounded<F: Future<Output = ()>>(scenario: F) {
+    timeout(Duration::from_secs(15), scenario)
+        .await
+        .expect("scenario completed within its time bound");
+}
+
+/// A responder that answers instantly and counts how many times it ran — the
+/// exactly-once witness for idempotent replay over the wire.
+struct EchoResponder {
+    executions: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl CapabilityResponder for EchoResponder {
+    async fn respond(&self, request: ReverseRequest) -> Response<ReverseResult> {
+        self.executions.fetch_add(1, Ordering::SeqCst);
+        let prompt = match request {
+            ReverseRequest::ModelInference(params) => params.prompt,
+            _ => unreachable!("only model inference is exercised"),
+        };
+        Response::Ok(ReverseResult::ModelInference(ModelInferenceResult {
+            completion: format!("echo:{prompt}"),
+        }))
+    }
+}
+
+/// A responder that blocks until the test releases a gate, so a cancel can be
+/// observed while the request is genuinely in flight on the host.
+struct GateResponder {
+    gate: Arc<Semaphore>,
+    started: Arc<AtomicUsize>,
+    finished: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl CapabilityResponder for GateResponder {
+    async fn respond(&self, request: ReverseRequest) -> Response<ReverseResult> {
+        self.started.fetch_add(1, Ordering::SeqCst);
+        let permit = self.gate.acquire().await.expect("gate open");
+        permit.forget();
+        self.finished.fetch_add(1, Ordering::SeqCst);
+        let prompt = match request {
+            ReverseRequest::ModelInference(params) => params.prompt,
+            _ => unreachable!("only model inference is exercised"),
+        };
+        Response::Ok(ReverseResult::ModelInference(ModelInferenceResult {
+            completion: format!("done:{prompt}"),
+        }))
+    }
+}
+
+fn infer(prompt: &str) -> ReverseRequest {
+    ReverseRequest::ModelInference(ModelInferenceParams {
+        prompt: prompt.to_owned(),
+    })
+}
+
+fn completion(result: &ReverseResult) -> String {
+    match result {
+        ReverseResult::ModelInference(result) => result.completion.clone(),
+        _ => unreachable!("only model inference is exercised"),
+    }
+}
+
+fn host_with(
+    grants: Vec<Capability>,
+    responder: Arc<dyn CapabilityResponder>,
+) -> (CapabilityHost, InMemoryOperationStore) {
+    let store = InMemoryOperationStore::new();
+    let provenance = RunProvenance {
+        run_id: RunId::new(),
+        provider: "wire-conformance".to_owned(),
+    };
+    let host = CapabilityHost::new(
+        GrantSet::new(provenance, grants),
+        responder,
+        Arc::new(store.clone()),
+    );
+    (host, store)
+}
+
+fn attach(resume_from: EventCursor) -> AttachRequest {
+    AttachRequest {
+        protocol_version: PROTOCOL_VERSION,
+        run_id: RunId::new(),
+        resume_from,
+    }
+}
+
+/// Accept host connections and serve them against `run` on a loopback port.
+async fn spawn_sandbox(run: SandboxRun) -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            let run = run.clone();
+            tokio::spawn(async move {
+                let _ = serve_connection(stream, run).await;
+            });
+        }
+    });
+    addr
+}
+
+/// Dial the sandbox at `addr` and complete the attach handshake.
+async fn connect(
+    addr: SocketAddr,
+    host: CapabilityHost,
+    resume_from: EventCursor,
+) -> Result<HostConnection, ConnectError> {
+    let stream = TcpStream::connect(addr).await.expect("dial loopback");
+    WireClient::connect(stream, attach(resume_from), host).await
+}
+
+/// A version-skewed peer is refused on the wire, and no session is established.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn version_mismatch_is_refused_on_the_wire() {
+    bounded(async {
+        // The sandbox speaks a version the host does not.
+        let run =
+            SandboxRun::with_config(PROTOCOL_VERSION + 1, 16, 4, [Capability::ModelInference]);
+        let addr = spawn_sandbox(run).await;
+        let (host, _store) = host_with(vec![Capability::ModelInference], echo().0);
+
+        match connect(addr, host, EventCursor::START).await {
+            Err(ConnectError::VersionRefused(refused)) => {
+                // The refusal frame carried the sandbox's own version over the socket.
+                assert_eq!(refused.protocol_version, PROTOCOL_VERSION + 1);
+                assert_eq!(refused.code, ErrorCode::ProtocolVersion);
+            }
+            Err(other) => panic!("expected a version-mismatch refusal, got {other:?}"),
+            Ok(_) => panic!("a version mismatch must refuse the connection on the wire"),
+        }
+    })
+    .await;
+}
+
+/// A model-inference reverse call round-trips over the socket, and re-issuing the
+/// same operation identity replays the recorded answer without re-executing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn model_inference_round_trips_and_replays_exactly_once() {
+    bounded(async {
+        let run = SandboxRun::new([Capability::ModelInference]);
+        let addr = spawn_sandbox(run.clone()).await;
+        let (responder, executions) = echo();
+        let (host, store) = host_with(vec![Capability::ModelInference], responder);
+
+        // Keep the connection alive for the duration of the calls.
+        let _conn = connect(addr, host, EventCursor::START)
+            .await
+            .expect("attach accepted");
+
+        let operation = OperationId::new();
+        match run.call(operation, infer("forecast")).await {
+            ReverseOutcome::Settled(Response::Ok(result)) => {
+                assert_eq!(completion(&result), "echo:forecast");
+            }
+            other => panic!("expected a settled success, got {other:?}"),
+        }
+        assert_eq!(executions.load(Ordering::SeqCst), 1);
+
+        // Re-issue the same operation identity: the host replays the recorded
+        // outcome from its operation log and does not execute the model again.
+        match run.call(operation, infer("forecast")).await {
+            ReverseOutcome::Settled(Response::Ok(result)) => {
+                assert_eq!(completion(&result), "echo:forecast");
+            }
+            other => panic!("expected a recorded replay, got {other:?}"),
+        }
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            1,
+            "a replay must not execute the model again"
+        );
+        assert_eq!(store.len(), 1, "one distinct operation was recorded");
+    })
+    .await;
+}
+
+/// The event stream is delivered in order over the socket, and a fresh
+/// connection resuming from a committed cursor receives only newer events.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn event_stream_delivers_then_resumes_by_sequence() {
+    bounded(async {
+        let run = SandboxRun::new([]);
+        // Emit before any host attaches: the events buffer for replay.
+        for letter in ["a", "b", "c", "d", "e"] {
+            run.emit_progress(letter).await.expect("emit");
+        }
+        let addr = spawn_sandbox(run.clone()).await;
+
+        // First attach from the start replays all five, in order.
+        let (host, _store) = host_with(Vec::new(), echo().0);
+        let mut first = connect(addr, host, EventCursor::START)
+            .await
+            .expect("attach accepted");
+        let mut sequences = Vec::new();
+        for _ in 0..5 {
+            let event = first.next_event().await.expect("stream open");
+            sequences.push(event.sequence.get());
+        }
+        assert_eq!(sequences, vec![1, 2, 3, 4, 5], "monotonic and gapless");
+        drop(first);
+
+        // A second connection resuming from a committed cursor gets only what is
+        // strictly newer than it.
+        let (host, _store) = host_with(Vec::new(), echo().0);
+        let mut resumed = connect(addr, host, EventCursor::committed(Sequence::new(3)))
+            .await
+            .expect("reattach accepted");
+        let mut resumed_sequences = Vec::new();
+        for _ in 0..2 {
+            let event = resumed.next_event().await.expect("stream open");
+            resumed_sequences.push(event.sequence.get());
+        }
+        assert_eq!(
+            resumed_sequences,
+            vec![4, 5],
+            "resume delivers only events past the committed cursor"
+        );
+    })
+    .await;
+}
+
+/// A cancel on the reserved control lane lands even while the request lane is
+/// saturated, aborting the in-flight execution; the saturated calls never reach
+/// the host, and the cancelled effect never finishes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn control_lane_cancel_preempts_a_saturated_request_lane() {
+    bounded(async {
+        // A request lane with exactly two in-flight permits.
+        let run = SandboxRun::with_config(PROTOCOL_VERSION, 16, 2, [Capability::ModelInference]);
+        let addr = spawn_sandbox(run.clone()).await;
+
+        let gate = Arc::new(Semaphore::new(0));
+        let started = Arc::new(AtomicUsize::new(0));
+        let finished = Arc::new(AtomicUsize::new(0));
+        let responder = Arc::new(GateResponder {
+            gate: Arc::clone(&gate),
+            started: Arc::clone(&started),
+            finished: Arc::clone(&finished),
+        });
+        let (host, _store) = host_with(vec![Capability::ModelInference], responder);
+        let _conn = connect(addr, host, EventCursor::START)
+            .await
+            .expect("attach accepted");
+
+        // Saturate the request lane: two gated calls hold both permits and block
+        // in the host's responder.
+        let target = OperationId::new();
+        let call_a = {
+            let run = run.clone();
+            tokio::spawn(async move { run.call(target, infer("a")).await })
+        };
+        let call_b = {
+            let run = run.clone();
+            tokio::spawn(async move { run.call(OperationId::new(), infer("b")).await })
+        };
+        while started.load(Ordering::SeqCst) < 2 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        // A third call cannot even acquire a permit, so it never reaches the host.
+        let call_c = {
+            let run = run.clone();
+            tokio::spawn(async move { run.call(OperationId::new(), infer("c")).await })
+        };
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            started.load(Ordering::SeqCst),
+            2,
+            "a third request is blocked behind request backpressure"
+        );
+
+        // The cancel rides the reserved control lane, acquires no request permit,
+        // and lands despite the saturated request lane.
+        run.cancel(target);
+        match call_a.await.expect("join") {
+            ReverseOutcome::Settled(Response::Error(error)) => {
+                assert_eq!(error.code, ErrorCode::Cancelled);
+            }
+            other => panic!("expected the cancel to land, got {other:?}"),
+        }
+        assert_eq!(
+            finished.load(Ordering::SeqCst),
+            0,
+            "the cancelled effect never finished"
+        );
+
+        // Cleanup: the still-blocked calls are abandoned with the test.
+        call_b.abort();
+        call_c.abort();
+    })
+    .await;
+}
+
+fn echo() -> (Arc<dyn CapabilityResponder>, Arc<AtomicUsize>) {
+    let executions = Arc::new(AtomicUsize::new(0));
+    let responder = Arc::new(EchoResponder {
+        executions: Arc::clone(&executions),
+    });
+    (responder, executions)
+}

--- a/crates/openwave-sandbox-protocol/tests/wire_conformance.rs
+++ b/crates/openwave-sandbox-protocol/tests/wire_conformance.rs
@@ -349,6 +349,108 @@ async fn control_lane_cancel_preempts_a_saturated_request_lane() {
     .await;
 }
 
+/// A resume that replays more buffered events than the outbound request-lane
+/// queue depth still delivers every event: the writer drains the queue while the
+/// replay fills it, rather than the replay wedging on a full channel.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn resume_replays_more_events_than_the_request_lane_depth() {
+    bounded(async {
+        let run = SandboxRun::new([]);
+        // Buffer far more events than the outbound `data` queue depth
+        // (MAX_INFLIGHT_REQUESTS = 16), the earlier deadlock's trigger.
+        const COUNT: u64 = 40;
+        for index in 0..COUNT {
+            run.emit_progress(format!("event-{index}"))
+                .await
+                .expect("emit");
+        }
+        let addr = spawn_sandbox(run).await;
+
+        let (host, _store) = host_with(Vec::new(), echo().0);
+        let mut conn = connect(addr, host, EventCursor::START)
+            .await
+            .expect("attach accepted");
+        let mut sequences = Vec::new();
+        for _ in 0..COUNT {
+            let event = conn.next_event().await.expect("stream open");
+            sequences.push(event.sequence.get());
+        }
+        assert_eq!(
+            sequences,
+            (1..=COUNT).collect::<Vec<_>>(),
+            "every buffered event replays past the queue depth, in order"
+        );
+    })
+    .await;
+}
+
+/// Run-scoped state outlives the connection over the real wire: a reverse call
+/// whose connection drops fails to the sandbox, its host-side execution keeps
+/// running and records, and re-issuing the same operation identity on a fresh
+/// connection replays the recorded outcome with the model still run exactly once.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reverse_call_survives_a_disconnect_and_reissue_replays_exactly_once() {
+    bounded(async {
+        let run = SandboxRun::new([Capability::ModelInference]);
+        let addr = spawn_sandbox(run.clone()).await;
+
+        // A gated host model, shared run-scoped across both connections.
+        let gate = Arc::new(Semaphore::new(0));
+        let started = Arc::new(AtomicUsize::new(0));
+        let finished = Arc::new(AtomicUsize::new(0));
+        let responder = Arc::new(GateResponder {
+            gate: Arc::clone(&gate),
+            started: Arc::clone(&started),
+            finished: Arc::clone(&finished),
+        });
+        let (host, store) = host_with(vec![Capability::ModelInference], responder);
+
+        let operation = OperationId::new();
+
+        // Connection 1: issue a call, let the host start executing, then drop the
+        // connection with the call still in flight.
+        let conn1 = connect(addr, host.clone(), EventCursor::START)
+            .await
+            .expect("attach accepted");
+        let inflight = {
+            let run = run.clone();
+            tokio::spawn(async move { run.call(operation, infer("job")).await })
+        };
+        while started.load(Ordering::SeqCst) < 1 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        drop(conn1);
+        match inflight.await.expect("join") {
+            ReverseOutcome::Disconnected => {}
+            other => panic!("a dropped connection must fail the in-flight call, got {other:?}"),
+        }
+
+        // The detached host-side execution outlives the connection; release it so
+        // it runs to completion and records.
+        gate.add_permits(1);
+
+        // Connection 2 over a fresh stream, same run-scoped host: re-issue the same
+        // operation identity. Whether the record has landed or the execution is
+        // still live, the host answers once — never a second execution.
+        let _conn2 = connect(addr, host.clone(), EventCursor::START)
+            .await
+            .expect("reattach accepted");
+        match run.call(operation, infer("job")).await {
+            ReverseOutcome::Settled(Response::Ok(result)) => {
+                assert_eq!(completion(&result), "done:job");
+            }
+            other => panic!("expected the recorded outcome to replay, got {other:?}"),
+        }
+        assert_eq!(
+            finished.load(Ordering::SeqCst),
+            1,
+            "the model executed exactly once across the disconnect and re-issue"
+        );
+        assert_eq!(store.len(), 1, "one operation-log record");
+    })
+    .await;
+}
+
 fn echo() -> (Arc<dyn CapabilityResponder>, Arc<AtomicUsize>) {
     let executions = Arc::new(AtomicUsize::new(0));
     let responder = Arc::new(EchoResponder {


### PR DESCRIPTION
Adds the over-the-wire byte transport that `openwave-sandbox-protocol` deferred to its concrete-backend step (the #860 review flagged byte framing as step 7 — this is step 7), and the in-container agent image that is the transport's first consumer. The two parts belong together: the agent is the primary consumer of the sandbox-side transport.

## Part A — the wire transport (`openwave-sandbox-protocol::wire`)

**Framing: newline-delimited JSON.** One frame is one line of compact JSON terminated by `\n`. Chosen over a length prefix because it is trivially debuggable (a frame is a readable line), `read_until` over a `BufReader` reassembles a frame that spans several reads and retains the remainder for the next, and it needs no codec dependency — the same choice the shipped `openwave-host-broker` sidecar and the reverse-RPC spike made. Frames are bounded by `MAX_FRAME_BYTES`. Every unit is a lane-tagged `WireFrame` envelope wrapping the protocol's existing `RequestFrame` / `ControlFrame` / `SandboxEvent` / handshake types unchanged — the envelope is the only new wire type, the payloads are the ones the wire-format spec already pins.

**Host client** — the API #874 will consume:
```
WireClient::connect(stream, AttachRequest, CapabilityHost) -> Result<HostConnection, ConnectError>
```
Dials any `AsyncRead + AsyncWrite` stream (a `TcpStream` for a local container), performs the exact-equality version handshake, then services the connection: it answers reverse requests against the run-scoped `CapabilityHost` — the same operation-log seam that fences idempotent replay in-process — and forwards the resumable event stream. `HostConnection` exposes `accepted()`, `next_event()`, `acknowledge(cursor)`, and `ping(nonce)`; dropping it drops the connection. Reverse-RPC exactly-once stays the `CapabilityHost`'s job; the transport only carries frames.

**Sandbox server** (`serve_connection(stream, SandboxRun)`): the run-scoped `SandboxRun` outlives connections. `serve_connection` answers the handshake, replays buffered events past the host's resume cursor, and carries the agent's reverse calls (`SandboxRun::call`) and events (`emit_progress` / `emit_result`). The reserved control lane is a separate outbound queue the writer drains ahead of the request lane, and a reverse call takes a bounded in-flight permit *before* enqueuing, so a cancel — which takes no permit — preempts a saturated request backlog.

**Real-socket conformance** (`tests/wire_conformance.rs`, host client ↔ sandbox server over TCP loopback, not in-process channels): version-mismatch refusal on the wire, a model-inference reverse round-trip with exactly-once replay, event-stream delivery + resume-by-sequence, and control-lane cancel preempting a saturated request lane. This closes the interop gap #864/#860 noted. Each body runs under a wall-clock `timeout` so a transport regression fails fast instead of hanging the suite.

## Part B — the in-container agent (`openwave-sandbox-agent`)

A binary crate with three deliberately separated components:

- **supervisor** — the non-agent component that owns the transport listener. The credential/egress proxy is a documented stub (`CredentialProxy`) marking where the egress step wires in; an attached-only run carries no credential, so there is nothing to substitute yet.
- **agent loop** — reuses openwave-core's `Tool` / `ToolRegistry`, dials every model step back to the host over reverse RPC (**no model credential in the container**), emits the event stream, and submits a final result. The sandbox-resident registry is a single trivial, read-only `word_count` tool for this slice — enough to demonstrate the loop invoking a real tool locally; widening it is a separate design.
- **model client** — turns each model step into a host-proxied `ModelInference` reverse call.

It reuses openwave-core's plain-Rust seams (the `Tool` trait, the provider vocabulary) rather than the host-side stateful `Agent`, which drives from a durable `Store` the container does not stand up; a note in `agent.rs` says exactly where `Agent::run_turn` plugs in.

**Image:** a distroless (`gcr.io/distroless/cc-debian12`) Dockerfile packages the binary — glibc + libgcc for the rustls binary, no shell or package manager. The entrypoint runs the agent server on the listener port #872 publishes. Building it is a **documented manual step** (`docker build -f crates/openwave-sandbox-agent/Dockerfile .` from the repo root), not a CI lane: the build compiles the crate's workspace slice inside Docker, far heavier than the cheap gates this foundational PR runs, and the container runtime is a detected capability, not a hard dependency. Host-side digest pinning and verification before provisioning are #874's job.

**Integration test** (`tests/agent_run.rs`) runs the agent server in-process and drives attach → one model-inference reverse call → tool call → event → submit-result over a real socket against a mock host model, asserting exactly-once through the operation-log seam (two model steps, two records, each executed once).

## Review fixes (second commit)

A review of the first commit found three issues the tests missed; the second commit fixes them:

- **A second deadlock in the attach/resume path.** `serve_connection` replayed buffered events into the request-lane queue (depth `MAX_INFLIGHT_REQUESTS`) *before* spawning the writer that drains it, so any resume of more than that many events wedged on a full channel — the normal reattach-drain path, since `MAX_BUFFERED_EVENTS` is 4096. Fixed by spawning the writer before the replay; covered by a new resume test that buffers 40 events.
- **Unbounded buffering in `read_frame`.** It appended bytes up to the delimiter and checked the size only afterward, so a peer streaming without a `\n` could OOM this side. Fixed by bounding the read to `MAX_FRAME_BYTES + 1` with a `take()` before scanning; covered by a no-newline flood test.
- **Event forwarding coupled to request dispatch** in the host read loop. Fixed by forwarding events on an unbounded channel (bounded in practice by the sandbox's own event flow control) so a slow `next_event` consumer can't stall the reverse lane; the drain obligation is documented on `next_event`.

Also added a socket-level test that drops a reverse call's connection in flight, reconnects over a fresh stream, and re-issues the same `OperationId` — proving run-scoped state and exactly-once execution survive a real disconnect on the wire.

## Notes

- Does not touch `openwave-core`.
- `Cargo.lock` change is +14/-0: it only adds the new crate.
- Foundational; wants a strong review of the on-wire handshake/framing and the exactly-once reverse RPC over a real socket. No auto-merge.

Closes #873
