### PR TITLE
feat(desktop): one-click inline citations with brand highlight anchors

### DIFF
--- a/crates/openwave-desktop/ui/src/InlineCitation.tsx
+++ b/crates/openwave-desktop/ui/src/InlineCitation.tsx
@@ -1,9 +1,9 @@
+import { Quote } from "lucide-react";
 import { createContext, useContext, type ReactNode } from "react";
 
 import { CitationEvidence, type AssistantSource } from "./AssistantSources";
 import {
   Popover,
-  PopoverClose,
   PopoverContent,
   PopoverTrigger,
 } from "./components/ui/popover";
@@ -41,13 +41,21 @@ const CITATION_ID =
  * A cited phrase, in the prose where the model wrote it.
  *
  * The phrase stays prose — it inherits the surrounding type and reads as part of
- * the sentence — with the citation's ordinal beside it and its evidence a click
- * away. The ordinal comes from the snapshot rather than from the order spans
- * happen to appear in: a citation dropped past the message's bound leaves a gap,
- * and a badge counted off the rendering would silently renumber the rest.
+ * the sentence — marked by a highlight that grows in under it on hover and a
+ * small quote chip after it. It carries no ordinal: the sources row at the foot
+ * of the message is where a citation is numbered, and a number in the middle of
+ * a sentence only interrupts it.
+ *
+ * The document is the destination. A citation that names one opens it at the
+ * cited passage on a single click, which is what a reader wants from an anchor
+ * over a phrase; the popover is what is left when there is no document to open
+ * into, and shows the evidence in place instead.
  *
  * An id that matches no snapshot is a normal state, not an error to show: the
- * phrase was authored as prose and renders as prose, without a badge to press.
+ * phrase was authored as prose and renders as prose, without a control to press.
+ * That is also why nothing here guards against a half-streamed citation — a
+ * streaming message's directives are reduced to their phrasing before they reach
+ * the renderer, and its snapshots arrive with the settled turn.
  */
 export function InlineCitation({
   citationId,
@@ -66,39 +74,44 @@ export function InlineCitation({
 
   if (!source) return <>{children}</>;
 
+  const openDocument =
+    onOpenSource && source.documentId ? () => onOpenSource(source) : undefined;
+
+  const anchor = (
+    // Named by the phrase it wraps, not by a label that would replace it: what
+    // the citation backs is the sentence, and the ordinal only says which
+    // citation backs it.
+    <button type="button" className="inline-citation" onClick={openDocument}>
+      <span className="inline-citation-phrase">{children}</span>
+      <span className="sr-only">, citation {source.ordinal}</span>
+      <span className="inline-citation-mark" aria-hidden="true">
+        <Quote className="inline-citation-glyph" />
+      </span>
+    </button>
+  );
+
+  if (openDocument) return anchor;
+
   return (
     <Popover>
-      <PopoverTrigger asChild>
-        {/* Named by the phrase it wraps, not by a label that would replace it:
-            what the citation backs is the sentence, and the badge only says
-            which citation backs it. */}
-        <button type="button" className="inline-citation">
-          {children}
-          <sup className="inline-citation-ordinal">
-            <span className="sr-only">, citation {source.ordinal}</span>
-            <span aria-hidden="true">{source.ordinal}</span>
-          </sup>
-        </button>
-      </PopoverTrigger>
+      <PopoverTrigger asChild>{anchor}</PopoverTrigger>
       <PopoverContent
-        className="inline-citation-popover w-80"
+        className="inline-citation-popover"
         align="start"
         side="bottom"
+        collisionPadding={10}
+        // Wide enough to read an excerpt as prose rather than as a column, and
+        // held inside whatever the popover was given to open into.
+        style={{
+          width:
+            "min(36rem, calc(var(--radix-popover-content-available-width) - 20px))",
+          maxWidth: "calc(100vw - 20px)",
+          maxHeight: "calc(var(--radix-popover-content-available-height) - 1em)",
+        }}
       >
         <div className="assistant-source-copy">
           <CitationEvidence source={source} />
         </div>
-        {onOpenSource && source.documentId ? (
-          <PopoverClose asChild>
-            <button
-              type="button"
-              className="inline-citation-open"
-              onClick={() => onOpenSource(source)}
-            >
-              Open source
-            </button>
-          </PopoverClose>
-        ) : null}
       </PopoverContent>
     </Popover>
   );

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -814,7 +814,6 @@ describe("citation anchors", () => {
     );
 
     await user.click(screen.getByRole("button", { name: /citation 1$/ }));
-    await user.click(screen.getByRole("button", { name: "Open source" }));
     await user.click(screen.getByRole("button", { name: "Open source 1" }));
 
     expect(openCitation).toHaveBeenCalledTimes(2);

--- a/crates/openwave-desktop/ui/src/MessageMarkdown.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageMarkdown.dom.test.tsx
@@ -63,7 +63,7 @@ describe("inline citations", () => {
     return { ...view, onOpenSource };
   }
 
-  it("anchors each citation on the phrase it backs, badged by its ordinal", async () => {
+  it("anchors each citation on the phrase it backs and opens its document on one click", async () => {
     const user = userEvent.setup();
     const { container, onOpenSource } = renderCited(
       `The reef :cit[is the largest in the world]{citation_id=${REEF}}, ` +
@@ -81,15 +81,33 @@ describe("inline citations", () => {
     expect(container.textContent).not.toContain(":cit");
     expect(container.textContent).not.toContain("citation_id");
 
-    // Each span carries its own evidence, and opening it hands back the
-    // snapshot the phrase was anchored to.
+    // The document is the destination: one click gets there, with no popover in
+    // the way, and hands back the snapshot the phrase was anchored to.
     await user.click(cited[1]!);
-    const popover = await screen.findByText("Tides");
-    expect(popover.parentElement).toHaveTextContent("Tides run to four metres.");
-    expect(popover.parentElement).toHaveTextContent("Pages 11, 12");
-
-    await user.click(screen.getByRole("button", { name: "Open source" }));
     expect(onOpenSource).toHaveBeenCalledWith(sources[1]);
+    expect(screen.queryByText("Tides run to four metres.")).toBeNull();
+  });
+
+  it("shows the evidence in place when there is no document to open", async () => {
+    const user = userEvent.setup();
+    const onOpenSource = vi.fn();
+    render(
+      <MessageCitationsProvider
+        value={{ sources: [source({ documentId: "" })], onOpenSource }}
+      >
+        <MessageMarkdown>
+          {`The reef :cit[is the largest in the world]{citation_id=${REEF}}.`}
+        </MessageMarkdown>
+      </MessageCitationsProvider>,
+    );
+
+    await user.click(screen.getByRole("button"));
+    const popover = await screen.findByText("Extent");
+    expect(popover.parentElement).toHaveTextContent(
+      "The reef spans 2,300 kilometres.",
+    );
+    expect(popover.parentElement).toHaveTextContent("Page 4");
+    expect(onOpenSource).not.toHaveBeenCalled();
   });
 
   it("reads as prose when the citation is not one the message carries", () => {

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -60,6 +60,11 @@
   --info-background: oklch(0.951 0.026 236.824);
   --info-border: oklch(0.391 0.09 240.876);
 
+  /* Brand highlight — the band a cited phrase carries and the chip beside it. */
+  --brightwave: oklch(0.87 0.2 102);
+  --citation-mark: var(--color-neutral-300);
+  --citation-mark-active-ink: var(--foreground);
+
   --radius: 0.5rem;
 
   /* The app chrome is the page background; every content region is a card
@@ -159,6 +164,12 @@
   --info-background: oklch(0.391 0.09 240.876);
   --info-border: oklch(0.746 0.16 232.661);
 
+  /* The band keeps its brand chroma on a dark page; only the chip and the glyph
+     it sits on have to swap so the mark stays legible either way. */
+  --brightwave: oklch(0.87 0.2 102);
+  --citation-mark: var(--color-neutral-700);
+  --citation-mark-active-ink: var(--background);
+
   --shadow-sm: 0 0px 8px 0px oklch(0 0 0 / 0.24);
   --shadow: 0 0px 8px 0px oklch(0 0 0 / 0.28);
   --shadow-lg: 0 0px 12px 0px oklch(0 0 0 / 0.32);
@@ -221,6 +232,8 @@
   --color-info-foreground-muted: var(--info-foreground-muted);
   --color-info-background: var(--info-background);
   --color-info-border: var(--info-border);
+
+  --color-brightwave: var(--brightwave);
 
   --shadow-2xs: var(--shadow-sm);
   --shadow-xs: var(--shadow-sm);
@@ -1063,8 +1076,8 @@ body {
 
 /* ---------- Inline citations ---------- */
 
-/* The cited phrase is prose first: it inherits the type around it and carries
-   the same underline a link does, so a sentence still reads as a sentence. */
+/* The cited phrase is prose first: it inherits the type around it, so a sentence
+   still reads as a sentence and nothing is marked until it is pointed at. */
 .inline-citation {
   display: inline;
   margin: 0;
@@ -1075,54 +1088,71 @@ body {
   background: none;
   font: inherit;
   text-align: inherit;
-  text-decoration: underline;
-  text-decoration-color: color-mix(in srgb, currentColor 30%, transparent);
-  text-decoration-style: dotted;
-  text-underline-offset: 0.16em;
 }
 
-.inline-citation:hover,
-.inline-citation:focus-visible,
-.inline-citation[data-state="open"] {
-  text-decoration-color: currentColor;
+/* The band is painted as a background rather than an underline so it can grow
+   from nothing to the full phrase — an underline's thickness is animatable, its
+   length is not. */
+.inline-citation-phrase {
+  background-image: linear-gradient(var(--brightwave), var(--brightwave));
+  background-position: left bottom;
+  background-repeat: no-repeat;
+  background-size: 0% 35%;
+  transition: background-size 160ms ease-out;
 }
 
-.inline-citation-ordinal {
-  margin-left: 0.12em;
-  color: var(--muted-foreground);
-  font-size: 0.68em;
-  font-weight: 600;
-  text-decoration: none;
+.inline-citation:hover .inline-citation-phrase,
+.inline-citation:focus-visible .inline-citation-phrase,
+.inline-citation[data-state="open"] .inline-citation-phrase {
+  background-size: 100% 35%;
 }
 
-.inline-citation:hover .inline-citation-ordinal,
-.inline-citation:focus-visible .inline-citation-ordinal,
-.inline-citation[data-state="open"] .inline-citation-ordinal {
-  color: var(--ink);
+.inline-citation-mark {
+  display: inline-block;
+  margin-left: 0.25rem;
+  border-radius: 4px;
+  padding: 0 0.375rem;
+  background: var(--citation-mark);
+  transition: background-color 160ms ease-out;
+}
+
+.inline-citation:hover .inline-citation-mark,
+.inline-citation:focus-visible .inline-citation-mark,
+.inline-citation[data-state="open"] .inline-citation-mark {
+  background: var(--brightwave);
+}
+
+/* Mirrored to read as a closing quote, and filled rather than stroked because a
+   stroked glyph this small renders as a smudge. */
+.inline-citation-glyph {
+  display: inline-block;
+  width: 0.625rem;
+  height: 0.625rem;
+  transform: translateY(-2px) scale(-1);
+  fill: var(--foreground);
+  stroke: none;
+  transition: fill 160ms ease-out;
+}
+
+.inline-citation:hover .inline-citation-glyph,
+.inline-citation:focus-visible .inline-citation-glyph,
+.inline-citation[data-state="open"] .inline-citation-glyph {
+  fill: var(--citation-mark-active-ink);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .inline-citation-phrase,
+  .inline-citation-mark,
+  .inline-citation-glyph {
+    transition: none;
+  }
 }
 
 .inline-citation-popover {
   display: grid;
   gap: 0.5rem;
+  overflow-y: auto;
   font-size: 0.78rem;
-}
-
-.inline-citation-open {
-  justify-self: start;
-  border: 0;
-  border-radius: 6px;
-  padding: 0.2rem 0.4rem;
-  margin: 0 -0.4rem -0.2rem;
-  cursor: pointer;
-  color: var(--ink);
-  background: none;
-  font: inherit;
-  font-weight: 600;
-}
-
-.inline-citation-open:hover,
-.inline-citation-open:focus-visible {
-  background: color-mix(in srgb, var(--accent) 58%, transparent);
 }
 
 /* ---------- Notices ---------- */


### PR DESCRIPTION
Closes #902

An inline citation anchor rendered as a dotted-underline phrase with an ordinal superscript, and every click opened a popover; reaching the cited document took a second click on "Open source". The document is the thing a reader wants from an anchor over a phrase, so it becomes the destination.

## Behaviour

- **One click opens the document.** An anchor whose citation names a document calls the same `onOpenSource` path the sources row uses, navigating the document panel to the citation's highlight. No popover on that path — it is not rendered at all, rather than rendered and left closed.
- **The popover is the fallback.** It opens only for a citation with no document to navigate to (or read outside a `SourceNav` provider, where there is no panel). It is wide now — `min(36rem, available width)`, bottom/start, collision padding 10 — and shows the excerpt with its heading and page references. The "Open source" button is gone: on the fallback path there is nothing to open.
- **An id matching no snapshot still renders as plain prose**, unchanged.

## Styling

- The phrase carries a brand-yellow band aligned to the bottom of the line, painted as a background so it can grow from `0%` to full width on hover, focus and open. An underline's thickness is animatable; its length is not.
- After the phrase sits a small rounded chip holding a mirrored, filled quote glyph. The chip is neutral at rest and turns brand-yellow with the band; on a dark page the glyph flips to the page colour so it stays legible against the yellow.
- The ordinal superscript is gone from the anchor. The sources row keeps its ordinals, and the anchor keeps an `sr-only` "citation N" so its accessible name still names which citation backs the phrase.
- Adds the `brightwave` brand token in light and dark, plus the chip's own neutral/ink pair, alongside the existing oklch tokens. Nothing defined a brand colour before.
- Both transitions are dropped under `prefers-reduced-motion: reduce`.

## No streaming guard

The reference blocks navigation mid-stream because its anchors render while the citation is still being fetched. Ours cannot reach that state: `AssistantSourceMarkerStreamScrubber` reduces a citation directive to the phrase it wraps before the streamed text is rendered, and a streaming assistant message carries `sources: []`. Directives and their snapshots both arrive together when the settled turn is hydrated from durable state, so an anchor never exists before its evidence does. A "wait for the response to complete" affordance would be unreachable code, so there isn't one.

Similarly there is no loading or error state in the popover: snapshots ship with the message rather than being fetched per citation.

## Verified

`pnpm exec tsc --noEmit`, `pnpm test` (628 passing), `pnpm build` — all clean. Not driven in the running app.

Tests updated rather than added: the anchor test now asserts one click navigates with no popover in the way, a new case covers the documentless fallback showing evidence in place, and the transcript test drops the intermediate "Open source" click that no longer exists.