### PR TITLE
fix(desktop): land citation clicks on the highlighted passage in every document view

### DIFF
--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import {
@@ -139,7 +140,7 @@ async function openFailingPanel(rejection: unknown) {
  * The transcript beside the panel, holding the citation the panel is opened
  * from. This is where the panel resolves it: no request is made for it.
  */
-function seedTranscript(source: Partial<AssistantSource> & { id: string }) {
+function seedTranscript(...sources: (Partial<AssistantSource> & { id: string })[]) {
   useChatSessionStore.getState().update((session) => ({
     ...session,
     messages: [
@@ -147,18 +148,16 @@ function seedTranscript(source: Partial<AssistantSource> & { id: string }) {
         id: "m1",
         role: "assistant",
         text: "Revenue rose in the second quarter.",
-        sources: [
-          {
-            ordinal: 1,
-            documentId: "doc-1",
-            span: { start: 0, end: 0 },
-            excerpt: "",
-            heading: null,
-            pages: [],
-            bounds: [],
-            ...source,
-          },
-        ],
+        sources: sources.map((source, index) => ({
+          ordinal: index + 1,
+          documentId: "doc-1",
+          span: { start: 0, end: 0 },
+          excerpt: "",
+          heading: null,
+          pages: [],
+          bounds: [],
+          ...source,
+        })),
       },
     ],
   }));
@@ -187,6 +186,44 @@ async function openCitation(
     </AppContextProvider>,
     { initialUrl: `/c/chat-1?left=sources.doc-1.${citationId}&right=chat` },
   );
+}
+
+/**
+ * The panel opened at one citation, with a control that moves it to another —
+ * which is what a second click in the transcript does to the panel already open
+ * beside it.
+ */
+async function openCitationThenAnother(
+  info: DocumentDetail,
+  first: string,
+  second: string,
+) {
+  const client = {
+    getChatDocument: vi.fn().mockResolvedValue(info),
+    getChatDocumentFile: vi.fn().mockResolvedValue({
+      bytes: new TextEncoder().encode("bytes"),
+      contentType: info.media_type,
+    }),
+  };
+  function Harness() {
+    const [citationId, setCitationId] = useState(first);
+    return (
+      <AppContextProvider value={{ client } as unknown as AppContextValue}>
+        <button type="button" onClick={() => setCitationId(second)}>
+          Click the second citation
+        </button>
+        <DocumentDetailRoot
+          chatId="chat-1"
+          documentID="doc-1"
+          citationId={citationId}
+          position="left"
+        />
+      </AppContextProvider>
+    );
+  }
+  return renderWithRouter(<Harness />, {
+    initialUrl: `/c/chat-1?left=sources.doc-1.${first}&right=chat`,
+  });
 }
 
 /** One rectangle of a citation, in the ten-thousandths the wire carries. */
@@ -440,6 +477,53 @@ describe("DocumentDetailRoot", () => {
     await user.click(screen.getByRole("button", { name: "Next page" }));
     expect(await screen.findByText("Page 5")).toBeVisible();
     await waitFor(() => expect(drawnHighlights()).toHaveLength(1));
+  });
+
+  // The panel is already open at a citation when the next one is clicked, and
+  // two citations into one source usually want the same view — so the view a
+  // citation asks for cannot tell the second click from the first. A reader who
+  // had switched views in between used to stay where they were, and the second
+  // citation landed nowhere.
+  it("lands a second citation into a source the reader had switched views on", async () => {
+    const user = userEvent.setup();
+    seedTranscript(
+      { id: "cite-6", pages: [2], span: { start: 0, end: 4 } },
+      { id: "cite-7", pages: [7], span: { start: 5, end: 9 } },
+    );
+    await openCitationThenAnother(
+      detail({ media_type: "application/pdf", title: "Report.pdf", content: "text" }),
+      "cite-6",
+      "cite-7",
+    );
+
+    expect(await screen.findByText("Page 2")).toBeVisible();
+    await user.click(screen.getByRole("tab", { name: "Extracted text" }));
+
+    await user.click(screen.getByRole("button", { name: "Click the second citation" }));
+
+    expect(
+      await screen.findByRole("tab", { name: "Original document", selected: true }),
+    ).toBeVisible();
+    expect(await screen.findByText("Page 7")).toBeVisible();
+  });
+
+  // A citation can outlive the reading of the source it points into — the file
+  // is re-read on import and the parse fails the second time. There is no
+  // original view behind the tab then, and sending the reader to it left the
+  // panel drawing nothing at all.
+  it("says a source failed rather than opening a citation on an empty panel", async () => {
+    seedTranscript({ id: "cite-8", pages: [3], span: { start: 0, end: 4 } });
+    await openCitation(
+      detail({
+        media_type: "application/pdf",
+        title: "Report.pdf",
+        processing_status: "failed",
+        content: "",
+      }),
+      "cite-8",
+    );
+
+    expect(await screen.findByText("Failed to process document")).toBeVisible();
   });
 
   // The panel unmounts the viewer whenever the reader switches views, so

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
@@ -95,17 +95,30 @@ export function DocumentDetailRoot({
   // the recorded page of a paginated original, or else the extracted text,
   // where the passage itself is highlighted. A citation the transcript cannot
   // resolve opens the document the same way the source list does.
+  //
+  // The original view is only worth landing on where there is one: a source
+  // whose processing failed has no viewer behind that tab, however precisely
+  // the citation addresses it, and sending the reader there left the panel
+  // showing nothing at all rather than saying what went wrong.
   const citationView: DocumentView | null = !placement
     ? null
-    : citationPage != null
+    : citationPage != null && hasOriginalDocumentTab
       ? "original_doc"
       : "extracted_text";
 
   // Reset the view when the document changes. A format with no viewer has only
   // the extracted text to land on.
+  //
+  // Landing is per citation rather than per resolution. Two citations into one
+  // source often want the same view, so the view alone cannot tell the second
+  // click from the first: without the citation in the dependencies, a reader who
+  // had since switched views stayed on the view they were on and the second
+  // citation landed nowhere. The citation only changes when the reader clicks
+  // one, so the transcript re-resolving the citation the panel is already open
+  // at still leaves a deliberate view switch alone.
   useEffect(() => {
     setView(citationView ?? (hasOriginalDocumentTab ? "original_doc" : "extracted_text"));
-  }, [documentID, hasOriginalDocumentTab, citationView]);
+  }, [documentID, hasOriginalDocumentTab, citationView, citationId]);
 
   const documentName = info ? documentTitle(info) : undefined;
 

--- a/crates/openwave-desktop/ui/src/panel/usePanelNav.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/panel/usePanelNav.dom.test.tsx
@@ -4,16 +4,25 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { renderWithRouter } from "../test/router";
+import { useStableSourceNav } from "./SourceNav";
 import { usePanelNav } from "./usePanelNav";
 
 afterEach(cleanup);
 
 function Harness() {
   const { openPanel, closePanel, toggleFullscreen } = usePanelNav();
+  const sourceNav = useStableSourceNav(openPanel);
   return (
     <div>
       <button onClick={() => openPanel({ type: "sources" })}>open sources</button>
       <button onClick={() => openPanel({ type: "outputs" })}>open outputs</button>
+      <button
+        onClick={() =>
+          sourceNav.openCitation({ documentId: "doc-2", citationId: "cite-1" })
+        }
+      >
+        open citation
+      </button>
       <button onClick={() => closePanel("left")}>close left</button>
       <button onClick={() => closePanel("right")}>close right</button>
       <button onClick={() => toggleFullscreen("left")}>fullscreen left</button>
@@ -45,6 +54,27 @@ describe("usePanelNav", () => {
 
     await waitFor(() =>
       expect(router.state.location.search).toEqual({ left: "outputs", right: "chat" }),
+    );
+  });
+
+  // A citation is clicked in the transcript, which in a split layout is one of
+  // the two slots. The document has to arrive beside it: replacing the
+  // conversation with the source it cites takes away the thing being read.
+  it("opens a citation beside the conversation rather than over it", async () => {
+    const user = userEvent.setup();
+    // Another source is already open, and the conversation is fullscreen — the
+    // reader is reading it, and the citation they clicked is in it.
+    const { router } = await mount(
+      "/c/chat-1?left=sources.doc-1&right=chat&fullscreen=right",
+    );
+
+    await user.click(screen.getByText("open citation"));
+
+    await waitFor(() =>
+      expect(router.state.location.search).toEqual({
+        left: "sources.doc-2.cite-1",
+        right: "chat",
+      }),
     );
   });
 


### PR DESCRIPTION
With one-click citation navigation becoming the primary interaction, landing
quality is the product. This audits every path a citation takes into the
document panel and closes the two that fell short.

## Per-view audit

| View | Worked already | Fixed here | Blocked |
| --- | --- | --- | --- |
| Extracted text | Mark drawn and scrolled to for a citation opened from the transcript. The byte span is converted against the text of record, so a passage behind an accent still lands on the right words. The run is split in three around the passage rather than reduced to it, which is what keeps the offsets meaning something. | — | — |
| Markdown / plain-text original | The mark is drawn, not just positioned: the range is carried into whichever blocks it covers and placed against the offsets the parser recorded, so a passage spanning an emphasized word is marked in each place it stands. The viewer picks the chunk the passage begins in and scrolls to the mark once per passage. A passage straddling a chunk boundary is marked on both sides — verified against a file with no break for the splitter to prefer. | — | A passage inside a code fence or a formula goes unmarked: those passes rewrite their subtrees and drop the positions the mark is placed by. Existing, deliberate. |
| PDF | The recorded page opens, the rectangles are overlaid on it as marks in page fractions, and the first is scrolled into view. Only the page on screen is marked, with an affordance onto the next page carrying part of the passage. A citation with no rectangles still lands on its recorded page with nothing drawn — every source imported before regions were recorded. | A citation into a source whose processing failed opened an **empty panel**: the page sent the panel to the original view, which for a failed source has no viewer behind it and no tab to leave by. It lands on the extracted text now, where the failure is reported. | — |
| Split layout | A citation opens the document beside the conversation, never over it: the slot holding the transcript is preserved, and a fullscreen conversation is restored to the split rather than replaced. Verified across every reachable layout — single, document already open, output panel open, either side fullscreen. This had no test; it does now. | — | — |
| Any view, second citation | — | A second citation into the source the panel is **already open at** could land nowhere. Two citations usually want the same view, so the view alone cannot tell the second click from the first, and a reader who had switched views in between stayed where they were while the panel re-resolved the citation behind them. Landing now keys on the citation itself. | — |
| JSON / XML tree | The citation still lands: it opens on the extracted text with the passage marked. | — | The tree view stays dead. A citation addresses a byte range of the text read out of the file; which node it came from is not recorded. `JsonViewer` and `XmlViewer` implement `highlightPath` fully and have no producer — #886, and #846 for the viewer half. |
| Spreadsheet | Same: lands on the extracted text with the passage marked. | — | The sheet view stays dead. `UniverSpreadsheetViewer` honours a cell range and no citation carries one — #885. |

Neither blocked view was worked around.

## Changes

- `DocumentDetailRoot` picks the landing view per citation rather than per
  resolution, and only sends a citation to the original view where there is one.

## Tests

Three added, each guarding something that just broke or that nothing else
watches. None deleted.

- A second citation into a source the reader had switched views on. Fails
  before the change with the panel still on the view the reader chose.
- A citation into a failed source, which drew nothing at all before.
- A citation opened from a split layout, asserting the conversation survives in
  its slot and fullscreen is dropped. Nothing guarded this and the panel wiring
  is shared.

## Not covered

Clicking the *same* citation a second time after scrolling away in the document
does nothing: the address is unchanged, so there is nothing to navigate to, and
every viewer's reveal is guarded against firing twice for one passage. Putting
the reader back would need a re-reveal signal threaded past those guards, which
is its own slice. Filed as a follow-up.

Verified: `pnpm exec tsc --noEmit`, `pnpm test` (630 tests, 87 files), and
`pnpm build`, all from `crates/openwave-desktop/ui`. Not driven in the running
app.

Closes #903
