### PR TITLE
feat(retrieval): search card names matched documents (title, media type)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6582,6 +6582,7 @@ dependencies = [
  "arrow-schema 58.4.0",
  "arrow-select 58.4.0",
  "async-trait",
+ "chrono",
  "futures",
  "lancedb",
  "liteparse",

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -191,6 +191,15 @@ pub struct ResultEntry {
     pub detail: Option<String>,
     /// Trailing meta — a size, a count, a status word.
     pub meta: Option<String>,
+    /// The document's media type, when the row is a document with one.
+    ///
+    /// Data rather than display text: the renderer maps it to a type-specific
+    /// icon (a PDF mark, a spreadsheet mark) and never prints it. Still not a
+    /// glyph name — the vocabulary is media types, and the renderer keeps its
+    /// own closed mapping with a generic fallback. `default` because retained
+    /// projections predate the field.
+    #[serde(default)]
+    pub media_type: Option<String>,
 }
 
 impl ResultEntry {
@@ -202,6 +211,7 @@ impl ResultEntry {
             label: label.into(),
             detail: None,
             meta: None,
+            media_type: None,
         }
     }
 
@@ -216,6 +226,13 @@ impl ResultEntry {
     #[must_use]
     pub fn with_meta(mut self, meta: impl Into<String>) -> Self {
         self.meta = Some(meta.into());
+        self
+    }
+
+    /// Name the document's media type.
+    #[must_use]
+    pub fn with_media_type(mut self, media_type: impl Into<String>) -> Self {
+        self.media_type = Some(media_type.into());
         self
     }
 }
@@ -513,6 +530,7 @@ fn result_entry(value: &Value) -> Option<ResultEntry> {
         label: clamp(value.get("label")?.as_str()?, MAX_RESULT_ENTRY_CHARS)?,
         detail: entry_field(value.get("detail")),
         meta: entry_field(value.get("meta")),
+        media_type: entry_field(value.get("media_type")),
     })
 }
 

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -646,8 +646,8 @@ describe("mcp app views", () => {
               tool: "entries",
               elided: 3,
               entries: [
-                { kind: "file", label: "notes.md", detail: null, meta: "1.2 KB" },
-                { kind: "folder", label: "reports", detail: null, meta: null },
+                { kind: "file", label: "notes.md", detail: null, meta: "1.2 KB", mediaType: null },
+                { kind: "folder", label: "reports", detail: null, meta: null, mediaType: null },
               ],
               failures: [],
             },
@@ -699,7 +699,7 @@ describe("mcp app views", () => {
               tool: "entries",
               elided: 0,
               entries: [
-                { kind: "file", label: "q3.md", detail: null, meta: null },
+                { kind: "file", label: "q3.md", detail: null, meta: null, mediaType: null },
               ],
               failures: [
                 { label: "q4.md", error: "file is not valid UTF-8" },

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -814,7 +814,13 @@ describe("parseToolResultPreview closed results", () => {
         tool: "entries",
         elided: 2,
         entries: [
-          { kind: "file", label: "notes.md", detail: "scratch", meta: "1.2 KB" },
+          {
+            kind: "file",
+            label: "notes.md",
+            detail: "scratch",
+            meta: "1.2 KB",
+            media_type: "text/markdown",
+          },
           { kind: "sabotage", label: "notes.md" },
           { kind: "file", label: "" },
           { kind: "folder", label: "reports" },
@@ -829,8 +835,14 @@ describe("parseToolResultPreview closed results", () => {
       tool: "entries",
       elided: 5,
       entries: [
-        { kind: "file", label: "notes.md", detail: "scratch", meta: "1.2 KB" },
-        { kind: "folder", label: "reports", detail: null, meta: null },
+        {
+          kind: "file",
+          label: "notes.md",
+          detail: "scratch",
+          meta: "1.2 KB",
+          mediaType: "text/markdown",
+        },
+        { kind: "folder", label: "reports", detail: null, meta: null, mediaType: null },
       ],
       failures: [{ label: "q4.md", error: "unreadable" }],
     });

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -315,6 +315,8 @@ export type ResultEntry = {
   label: string;
   detail: string | null;
   meta: string | null;
+  /** The document's media type, when the row is a document with one. */
+  mediaType: string | null;
 };
 
 /** One thing a listed call could not do. */
@@ -1625,16 +1627,18 @@ function parseResultEntry(value: unknown): ResultEntry | null {
   // wrong type would be a reason to distrust the row, and it drops that field.
   const detail = value.detail ?? null;
   const meta = value.meta ?? null;
+  const mediaType = value.media_type ?? null;
   if (
     typeof label !== "string" ||
     label.length === 0 ||
     !(RESULT_ENTRY_KINDS as readonly unknown[]).includes(kind) ||
     !isOptionalString(detail) ||
-    !isOptionalString(meta)
+    !isOptionalString(meta) ||
+    !isOptionalString(mediaType)
   ) {
     return null;
   }
-  return { kind: kind as ResultEntryKind, label, detail, meta };
+  return { kind: kind as ResultEntryKind, label, detail, meta, mediaType };
 }
 
 /**

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -868,7 +868,17 @@ detail: string | null,
 /**
  * Trailing meta — a size, a count, a status word.
  */
-meta: string | null, };
+meta: string | null, 
+/**
+ * The document's media type, when the row is a document with one.
+ *
+ * Data rather than display text: the renderer maps it to a type-specific
+ * icon (a PDF mark, a spreadsheet mark) and never prints it. Still not a
+ * glyph name — the vocabulary is media types, and the renderer keeps its
+ * own closed mapping with a generic fallback. `default` because retained
+ * projections predate the field.
+ */
+media_type: string | null, };
 
 /**
  * What one row of a listed result is, which is what picks its icon.

--- a/crates/openwave-retrieval/Cargo.toml
+++ b/crates/openwave-retrieval/Cargo.toml
@@ -84,3 +84,5 @@ liteparse-pdfium-sys = { version = "=1.4.0", optional = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tempfile = "=3.27.0"
+# Only to construct DocumentSummaryRecord fixtures for the search-card join.
+chrono = { workspace = true }

--- a/crates/openwave-retrieval/src/lance_store.rs
+++ b/crates/openwave-retrieval/src/lance_store.rs
@@ -1644,7 +1644,7 @@ mod tests {
         assert_eq!(
             hits[0].chunk.source_regions[0].location,
             SourceLocation::Page {
-                number: std::num::NonZeroU32::new(7).unwrap()
+                number: std::num::NonZeroU32::new(7).unwrap(),
                 bounds: None,
             }
         );

--- a/crates/openwave-retrieval/src/lib.rs
+++ b/crates/openwave-retrieval/src/lib.rs
@@ -116,7 +116,7 @@ pub use parse::{DocumentParser, FallbackParser, ParsedDocument, ParserRegistry, 
 pub use rerank::Reranker;
 pub use retriever::{GenerationIndexOutcome, IngestOutcome, Retriever};
 #[cfg(feature = "tool")]
-pub use search::SearchTool;
+pub use search::{SearchTool, SourceCatalog};
 pub use selection::MAX_SEARCH_RESULTS;
 pub use vector::{
     DocumentGenerationState, GenerationStageOutcome, InMemoryVectorStore, SearchOptions,

--- a/crates/openwave-retrieval/src/search.rs
+++ b/crates/openwave-retrieval/src/search.rs
@@ -16,13 +16,14 @@
 //!
 //! Enabled by the `tool` feature.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use openwave_core::{
-    format_citation_directive, ApprovalClass, AssistantCitationReference, Result, ResultEntry,
-    ResultEntryKind, RetrievalEvidenceInput, RetrievalEvidenceSource, Tool, ToolCtx, ToolOutput,
-    ToolSpec,
+    format_citation_directive, ApprovalClass, AssistantCitationReference, ChatId, DocumentId,
+    DocumentScope, DocumentSummaryRecord, Result, ResultEntry, ResultEntryKind,
+    RetrievalEvidenceInput, RetrievalEvidenceSource, Store, Tool, ToolCtx, ToolOutput, ToolSpec,
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -33,11 +34,35 @@ use crate::rerank::{rerank_candidates, Reranker};
 use crate::selection::{candidate_limit, select};
 use crate::vector::{SearchScope, VectorStore};
 
+/// The one catalog question the search card asks: which documents exist in a
+/// chat, by title and media type.
+///
+/// A narrow seam rather than the full [`Store`] so the join stays testable and
+/// the tool cannot grow ambient storage powers. Best-effort by contract: a
+/// catalog that cannot answer returns empty, and the card degrades to untitled
+/// rows rather than failing a search that already happened.
+#[async_trait]
+pub trait SourceCatalog: Send + Sync {
+    /// The chat's document summaries, newest first, at most `limit`.
+    async fn document_summaries(&self, chat_id: ChatId, limit: u64) -> Vec<DocumentSummaryRecord>;
+}
+
+/// The server hands its document store straight in.
+#[async_trait]
+impl SourceCatalog for Arc<dyn Store> {
+    async fn document_summaries(&self, chat_id: ChatId, limit: u64) -> Vec<DocumentSummaryRecord> {
+        self.list_document_summaries(DocumentScope::Chat(chat_id), None, limit)
+            .await
+            .unwrap_or_default()
+    }
+}
+
 /// A `Tool` that searches an embedded index and returns grounded citations.
 pub struct SearchTool {
     embedder: Arc<dyn Embedder>,
     store: Arc<dyn VectorStore>,
     reranker: Option<Arc<dyn Reranker>>,
+    source_catalog: Option<Box<dyn SourceCatalog>>,
 }
 
 impl SearchTool {
@@ -51,6 +76,7 @@ impl SearchTool {
             embedder,
             store,
             reranker: None,
+            source_catalog: None,
         }
     }
 
@@ -58,6 +84,19 @@ impl SearchTool {
     #[must_use]
     pub fn with_reranker(mut self, reranker: Arc<dyn Reranker>) -> Self {
         self.reranker = Some(reranker);
+        self
+    }
+
+    /// Let result rows name the documents they matched.
+    ///
+    /// The vector index knows spans, not titles. With a catalog the tool's
+    /// projection lists the matched *documents* — title and media type joined
+    /// from their summaries, the way `list_sources` names them — instead of one
+    /// anonymous row per passage. Without one it falls back to passage rows, so
+    /// the library stays usable with no document catalog at all.
+    #[must_use]
+    pub fn with_source_catalog(mut self, catalog: impl SourceCatalog + 'static) -> Self {
+        self.source_catalog = Some(Box::new(catalog));
         self
     }
 }
@@ -264,12 +303,110 @@ impl Tool for SearchTool {
                 })
             })
             .collect::<std::result::Result<Vec<_>, _>>();
+        let entries = match self.source_catalog.as_deref() {
+            Some(catalog) => document_entries(catalog, ctx.chat_id, &citations).await,
+            None => citations.iter().map(passage_entry).collect(),
+        };
         match evidence {
             Ok(evidence) => Ok(ToolOutput::text(content)
-                .with_entries(citations.iter().map(passage_entry).collect())
+                .with_entries(entries)
                 .with_private_evidence(evidence)),
             Err(output) => Ok(output),
         }
+    }
+}
+
+/// How many document summaries the projection join will read.
+///
+/// The join is per-chat and one page: a conversation with more sources than
+/// this still searches all of them — the documents past the limit just lose
+/// their title and type on the card and render as untitled source rows.
+const SUMMARY_JOIN_LIMIT: u64 = 500;
+
+/// The matched documents as card rows, one per document.
+///
+/// The card answers "what did the search find" the way a reader thinks about
+/// it: which sources matched, and how hard. One row per matched passage says
+/// the same document three times by three heading paths, which reads as three
+/// findings when it is one. So passages fold into their document — title and
+/// media type joined from the summary store, pages gathered across the
+/// document's matches, and the match count as the row's tally.
+///
+/// The join is best-effort on purpose: summaries failing to load, or a
+/// document missing from them, degrades that row's naming — never the search
+/// result itself, which already happened.
+async fn document_entries(
+    catalog: &dyn SourceCatalog,
+    chat_id: ChatId,
+    citations: &[Citation],
+) -> Vec<ResultEntry> {
+    let summaries = catalog
+        .document_summaries(chat_id, SUMMARY_JOIN_LIMIT)
+        .await;
+    let by_id: HashMap<DocumentId, _> = summaries
+        .iter()
+        .map(|summary| (summary.id, summary))
+        .collect();
+
+    let mut order: Vec<DocumentId> = Vec::new();
+    let mut matches: HashMap<DocumentId, Vec<&Citation>> = HashMap::new();
+    for citation in citations {
+        let group = matches.entry(citation.document_id).or_default();
+        if group.is_empty() {
+            order.push(citation.document_id);
+        }
+        group.push(citation);
+    }
+
+    order
+        .into_iter()
+        .map(|document_id| {
+            let group = &matches[&document_id];
+            let count = group.len();
+            let title = by_id
+                .get(&document_id)
+                .and_then(|summary| summary.title.as_deref())
+                .filter(|title| !title.trim().is_empty())
+                .unwrap_or("Untitled source");
+            let mut entry = ResultEntry::new(ResultEntryKind::Source, title).with_meta(format!(
+                "{count} {}",
+                if count == 1 { "match" } else { "matches" }
+            ));
+            if let Some(summary) = by_id.get(&document_id) {
+                entry = entry.with_media_type(summary.media_type.clone());
+            }
+            if let Some(pages) = pages_detail(group) {
+                entry = entry.with_detail(pages);
+            }
+            entry
+        })
+        .collect()
+}
+
+/// The pages a document matched on, in match order and deduplicated.
+fn pages_detail(citations: &[&Citation]) -> Option<String> {
+    let mut pages: Vec<u32> = Vec::new();
+    for citation in citations {
+        for region in &citation.source_regions {
+            if let SourceLocation::Page { number, .. } = &region.location {
+                let page = number.get();
+                if !pages.contains(&page) {
+                    pages.push(page);
+                }
+            }
+        }
+    }
+    match pages.as_slice() {
+        [] => None,
+        [page] => Some(format!("Page {page}")),
+        pages => Some(format!(
+            "Pages {}",
+            pages
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
     }
 }
 
@@ -311,7 +448,7 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Mutex;
 
-    use openwave_core::{ChatId, DocumentGeneration, ProjectId};
+    use openwave_core::{ChatId, DocumentGeneration, DocumentProcessingStatus, ProjectId};
 
     use crate::chunk::{Chunker, TextChunker};
     use crate::document::{
@@ -648,6 +785,99 @@ mod tests {
             }
         )));
         assert_eq!(out.private_evidence[0].generation.content_revision, 1);
+    }
+
+    /// A document catalog that answers from a fixed summary list.
+    struct SummaryCatalog(Vec<DocumentSummaryRecord>);
+
+    #[async_trait]
+    impl SourceCatalog for SummaryCatalog {
+        async fn document_summaries(
+            &self,
+            _chat_id: ChatId,
+            _limit: u64,
+        ) -> Vec<DocumentSummaryRecord> {
+            self.0.clone()
+        }
+    }
+
+    fn summary(id: DocumentId, title: &str, media_type: &str) -> DocumentSummaryRecord {
+        DocumentSummaryRecord {
+            id,
+            chat_id: Some(test_chat_id()),
+            project_id: None,
+            source_uri: None,
+            media_type: media_type.into(),
+            title: Some(title.into()),
+            source_byte_len: None,
+            content_revision: 1,
+            processing_status: DocumentProcessingStatus::Ready,
+            searchable: true,
+            indexed_revision: Some(1),
+            index_fingerprint: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            indexed_at: None,
+        }
+    }
+
+    /// With a document store attached, the card names matched documents — one
+    /// row per document with its title, media type, pages, and match tally —
+    /// and a document the join cannot name degrades to an untitled row rather
+    /// than losing the result.
+    #[tokio::test]
+    async fn search_card_folds_passages_into_named_documents() {
+        let titled = DocumentId::new();
+        let untitled = DocumentId::new();
+        let page = |start, end, number| SourceRegion {
+            span: ByteSpan::new(start, end),
+            location: SourceLocation::Page {
+                number: std::num::NonZeroU32::new(number).unwrap(),
+                bounds: None,
+            },
+        };
+        let mut first = scored(titled, 0, 0, 40, "annual revenue grew");
+        first.chunk.source_regions = vec![page(0, 40, 3)];
+        let mut second = scored(titled, 1, 100, 140, "cash position");
+        second.chunk.source_regions = vec![page(100, 140, 7)];
+        let third = scored(untitled, 2, 0, 40, "unrelated aside");
+        let tool = SearchTool::new(
+            Arc::new(HashEmbedder::new(DIMS)),
+            Arc::new(SpyVectorStore {
+                candidates: vec![first, second, third],
+                calls: Mutex::new(Vec::new()),
+            }),
+        )
+        .with_source_catalog(SummaryCatalog(vec![summary(
+            titled,
+            "Q3 Report",
+            "application/pdf",
+        )]));
+
+        let output = tool
+            .execute(&ctx(), json!({"query": "revenue", "k": 3}))
+            .await
+            .unwrap();
+
+        assert!(!output.is_error);
+        assert_eq!(
+            openwave_core::ToolResultPreview::build("search", &output),
+            Some(openwave_core::ToolResultPreview::Entries {
+                entries: vec![
+                    ResultEntry::new(ResultEntryKind::Source, "Q3 Report")
+                        .with_media_type("application/pdf")
+                        .with_detail("Pages 3, 7")
+                        .with_meta("2 matches"),
+                    ResultEntry::new(ResultEntryKind::Source, "Untitled source")
+                        .with_meta("1 match"),
+                ],
+                failures: Vec::new(),
+                elided: 0,
+            })
+        );
+        // The model-facing content and durable evidence stay passage-shaped;
+        // only the card folds.
+        assert_eq!(output.private_evidence.len(), 3);
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -835,6 +835,9 @@ fn agent_deps(
     source_store: Arc<dyn Store>,
 ) -> (Arc<Retriever>, ToolRegistry, AgentConfig) {
     let (retrieval, search) = build_retrieval(embedder, store);
+    // The document store lets the search card name matched documents (title,
+    // media type) instead of listing anonymous passages.
+    let search = Box::new(search.with_source_catalog(source_store.clone()));
     let mut tools = ToolRegistry::new()
         .with(Box::new(ReadFile))
         .with(Box::new(ListDir))

--- a/crates/openwave-server/src/source_tools.rs
+++ b/crates/openwave-server/src/source_tools.rs
@@ -156,6 +156,7 @@ impl Tool for ListSourcesTool {
                     openwave_core::ResultEntryKind::Source,
                     record.title.as_deref().unwrap_or("Untitled source"),
                 )
+                .with_media_type(record.media_type.clone())
                 .with_meta(readiness_label(record.readiness().as_str()))
             })
             .collect();
@@ -341,6 +342,7 @@ impl Tool for ReadSourceTool {
                 openwave_core::ResultEntryKind::Source,
                 title,
             )
+            .with_media_type(document.media_type.clone())
             // Which slice of the source was read, because a source read in
             // twelve-thousand-character windows produces twelve identical rail
             // lines and the range is the only thing telling them apart.


### PR DESCRIPTION
The search tool's transcript card listed one anonymous row per matched passage — a heading path or a snippet line, with no document title and no type — so several matches in one document read as several findings, and the renderer had nothing to drive a document icon with. BW's equivalent card lists the matched *documents*, each typed.

This slice makes the projection document-shaped:

- **`search` folds passages into the documents they matched.** One row per document: title and media type joined from the chat's document summaries, pages gathered across that document's matches (`Pages 3, 7`), and the match tally as the row's meta (`2 matches`). A document the join cannot name degrades to an untitled row; the model-facing content and durable evidence stay passage-shaped.
- **The join is a narrow seam.** `SourceCatalog` (one method: a chat's document summaries) rather than the full `Store`, backed by the server's store at registration. Best-effort by contract — a catalog that cannot answer returns empty and the card loses naming, never the search.
- **`ResultEntry` gains an optional `media_type`**, carried through the projection clamp, persisted previews (`serde(default)`, so retained rows still parse), and the generated wire types; the desktop API layer validates it. `list_sources` and `read_source` rows now carry it too.

Rendering the icons and the BW-style card layout is #905.

Verified locally: `cargo test -p openwave-core --lib`, `cargo test -p openwave-retrieval` (including `--features vec-lance`, since that lane doesn't run on PRs), clippy on the three touched crates, `pnpm test` + `tsc`. The `Cargo.lock` diff is only the new `chrono` dev-dep edge for the retrieval fixture; no version changes.

Closes #904

---

**Also carried here: a one-line fix to the `vec-lance` lane, which is red on `main`.** #863 landed a missing comma in a vec-lance-only test (`lance_store.rs`); the durable-vector-store lane doesn't run on PRs, so it slipped through and has failed the lane on every merge to `main` since. Running the lane locally for this PR (required when touching `openwave-retrieval`) caught it. With the fix, all 175 vec-lance tests pass locally.