### PR TITLE
feat(execution): mirror private scratch into remote sandboxes around exec

### DIFF
--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -18,6 +18,7 @@ mod local;
 mod output;
 mod receipt;
 mod remote;
+pub mod sync;
 mod tool;
 mod types;
 

--- a/crates/openwave-code-execution/src/output.rs
+++ b/crates/openwave-code-execution/src/output.rs
@@ -65,6 +65,7 @@ impl Capture {
             timed_out,
             output_truncated: self.truncated,
             duration_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+            sync_notes: Vec::new(),
         }
     }
 }

--- a/crates/openwave-code-execution/src/sync.rs
+++ b/crates/openwave-code-execution/src/sync.rs
@@ -1,0 +1,421 @@
+//! Mirror a host directory into a durable workspace and back.
+//!
+//! Remote sandboxes have their own filesystem, but the model is shown one
+//! path vocabulary: the file tools and `exec` both speak private-scratch
+//! relative paths. The host keeps that story true by pushing the chat's
+//! scratch into the workspace before a command runs and pulling the workspace
+//! back afterwards, so a file written by either side is visible to the other.
+//!
+//! The mirror is additive in both directions: a file deleted on one side is
+//! not deleted on the other. Everything a sync leaves behind — oversized
+//! files, dependency trees, truncated listings — is reported in the
+//! [`SyncReport`], never skipped silently.
+
+use std::path::{Path, PathBuf};
+
+use crate::{
+    CodeExecutionError, ExecutionWorkspaceId, WorkspaceFilePath, WorkspaceLifecycle,
+    MAX_WORKSPACE_FILE_BYTES,
+};
+
+/// The most files one direction of a sync will transfer before stopping and
+/// saying so. A workspace that grows a dependency tree past the skip list
+/// should degrade into a bounded transfer plus a note, not an unbounded copy.
+pub const MAX_SYNC_FILES: usize = 256;
+
+/// Directory names never mirrored in either direction: version control and
+/// dependency trees that are large, regenerable, and meaningless to copy
+/// between the host and a sandbox.
+const SKIPPED_DIRS: &[&str] = &[".git", ".venv", "__pycache__", "node_modules"];
+
+/// What one direction of a sync transferred, and everything it left behind.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct SyncReport {
+    pub transferred: usize,
+    pub notes: Vec<String>,
+}
+
+impl SyncReport {
+    fn skip(&mut self, note: impl Into<String>) {
+        self.notes.push(note.into());
+    }
+}
+
+/// Push every eligible file under `host_dir` into the workspace.
+///
+/// A missing `host_dir` pushes nothing: the chat simply has no scratch yet.
+pub async fn push_host_dir(
+    lifecycle: &dyn WorkspaceLifecycle,
+    workspace: &ExecutionWorkspaceId,
+    host_dir: &Path,
+) -> Result<SyncReport, CodeExecutionError> {
+    let mut report = SyncReport::default();
+    if tokio::fs::symlink_metadata(host_dir).await.is_err() {
+        return Ok(report);
+    }
+    let mut stack: Vec<(PathBuf, String)> = vec![(host_dir.to_path_buf(), String::new())];
+    let mut files: Vec<(WorkspaceFilePath, PathBuf)> = Vec::new();
+    while let Some((dir, prefix)) = stack.pop() {
+        let mut entries = tokio::fs::read_dir(&dir)
+            .await
+            .map_err(|_| unreadable(&prefix))?;
+        while let Some(entry) = entries
+            .next_entry()
+            .await
+            .map_err(|_| unreadable(&prefix))?
+        {
+            let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+                report.skip(format!(
+                    "not pushed: an entry under '{prefix}/' has a non-UTF-8 name"
+                ));
+                continue;
+            };
+            let relative = if prefix.is_empty() {
+                name.clone()
+            } else {
+                format!("{prefix}/{name}")
+            };
+            let metadata = tokio::fs::symlink_metadata(entry.path())
+                .await
+                .map_err(|_| unreadable(&relative))?;
+            if metadata.is_symlink() {
+                report.skip(format!("not pushed: {relative} is a symlink"));
+                continue;
+            }
+            if metadata.is_dir() {
+                if SKIPPED_DIRS.contains(&name.as_str()) {
+                    report.skip(format!("not pushed: {relative}/ (dependency or VCS tree)"));
+                } else {
+                    stack.push((entry.path(), relative));
+                }
+                continue;
+            }
+            if !metadata.is_file() {
+                continue;
+            }
+            if metadata.len() > MAX_WORKSPACE_FILE_BYTES as u64 {
+                report.skip(format!(
+                    "not pushed: {relative} exceeds the {MAX_WORKSPACE_FILE_BYTES}-byte file limit"
+                ));
+                continue;
+            }
+            let Ok(path) = WorkspaceFilePath::parse(&relative) else {
+                report.skip(format!(
+                    "not pushed: {relative} is not a valid workspace path"
+                ));
+                continue;
+            };
+            files.push((path, entry.path()));
+        }
+    }
+    files.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
+    let overflow = files.len().saturating_sub(MAX_SYNC_FILES);
+    if overflow > 0 {
+        report.skip(format!(
+            "not pushed: {overflow} more file(s) beyond the {MAX_SYNC_FILES}-file sync limit"
+        ));
+    }
+    for (path, host_path) in files.into_iter().take(MAX_SYNC_FILES) {
+        let content = tokio::fs::read(&host_path)
+            .await
+            .map_err(|_| unreadable(path.as_str()))?;
+        lifecycle
+            .put_workspace_file(workspace, &path, &content)
+            .await?;
+        report.transferred += 1;
+    }
+    Ok(report)
+}
+
+/// Pull every eligible workspace file into `host_dir`, writing only files
+/// whose content actually differs from the host copy.
+pub async fn pull_into_host_dir(
+    lifecycle: &dyn WorkspaceLifecycle,
+    workspace: &ExecutionWorkspaceId,
+    host_dir: &Path,
+) -> Result<SyncReport, CodeExecutionError> {
+    let mut report = SyncReport::default();
+    let mut stack: Vec<Option<WorkspaceFilePath>> = vec![None];
+    let mut files: Vec<WorkspaceFilePath> = Vec::new();
+    while let Some(dir) = stack.pop() {
+        let listing = lifecycle
+            .list_workspace_files(workspace, dir.as_ref())
+            .await?;
+        if listing.truncated {
+            let shown = dir
+                .as_ref()
+                .map_or("the workspace root", WorkspaceFilePath::as_str);
+            report.skip(format!(
+                "not fully pulled: the listing of {shown} was truncated"
+            ));
+        }
+        for entry in listing.entries {
+            // The path comes back from the sandbox; re-validate it so a
+            // hostile or confused backend cannot steer a write outside the
+            // chat's scratch directory.
+            let Ok(path) = WorkspaceFilePath::parse(&entry.path) else {
+                report.skip(format!(
+                    "not pulled: '{}' is not a valid workspace path",
+                    entry.path
+                ));
+                continue;
+            };
+            if entry.directory {
+                if SKIPPED_DIRS.contains(&path.file_name()) {
+                    report.skip(format!(
+                        "not pulled: {}/ (dependency or VCS tree)",
+                        path.as_str()
+                    ));
+                } else {
+                    stack.push(Some(path));
+                }
+                continue;
+            }
+            if entry
+                .size_bytes
+                .is_some_and(|size| size > MAX_WORKSPACE_FILE_BYTES as u64)
+            {
+                report.skip(format!(
+                    "not pulled: {} exceeds the {MAX_WORKSPACE_FILE_BYTES}-byte file limit",
+                    path.as_str()
+                ));
+                continue;
+            }
+            files.push(path);
+        }
+    }
+    files.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+    let overflow = files.len().saturating_sub(MAX_SYNC_FILES);
+    if overflow > 0 {
+        report.skip(format!(
+            "not pulled: {overflow} more file(s) beyond the {MAX_SYNC_FILES}-file sync limit"
+        ));
+    }
+    for path in files.into_iter().take(MAX_SYNC_FILES) {
+        let content = lifecycle.get_workspace_file(workspace, &path).await?;
+        let host_path = host_dir.join(path.as_str());
+        if let Ok(existing) = tokio::fs::read(&host_path).await {
+            if existing == content {
+                continue;
+            }
+        }
+        if tokio::fs::symlink_metadata(&host_path)
+            .await
+            .is_ok_and(|metadata| metadata.is_symlink())
+        {
+            report.skip(format!(
+                "not pulled: {} is a symlink on the host",
+                path.as_str()
+            ));
+            continue;
+        }
+        if let Some(parent) = host_path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|_| unwritable(path.as_str()))?;
+        }
+        tokio::fs::write(&host_path, &content)
+            .await
+            .map_err(|_| unwritable(path.as_str()))?;
+        report.transferred += 1;
+    }
+    Ok(report)
+}
+
+fn unreadable(path: &str) -> CodeExecutionError {
+    CodeExecutionError::Sandbox(format!("private scratch entry '{path}' is unreadable"))
+}
+
+fn unwritable(path: &str) -> CodeExecutionError {
+    CodeExecutionError::Sandbox(format!("private scratch entry '{path}' is unwritable"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{WorkspaceFileEntry, WorkspaceListing};
+    use async_trait::async_trait;
+    use std::collections::BTreeMap;
+    use std::sync::Mutex;
+
+    /// In-memory workspace: a flat map of normalized relative paths to bytes,
+    /// listing direct children per directory the way real backends do.
+    #[derive(Default)]
+    struct FakeWorkspace {
+        files: Mutex<BTreeMap<String, Vec<u8>>>,
+        /// Extra listing rows returned verbatim, for hostile-backend cases.
+        planted: Mutex<Vec<WorkspaceFileEntry>>,
+    }
+
+    impl FakeWorkspace {
+        fn insert(&self, path: &str, content: &[u8]) {
+            self.files
+                .lock()
+                .unwrap()
+                .insert(path.into(), content.to_vec());
+        }
+
+        fn get(&self, path: &str) -> Option<Vec<u8>> {
+            self.files.lock().unwrap().get(path).cloned()
+        }
+    }
+
+    #[async_trait]
+    impl WorkspaceLifecycle for FakeWorkspace {
+        async fn create_workspace(
+            &self,
+            _workspace: &ExecutionWorkspaceId,
+        ) -> Result<(), CodeExecutionError> {
+            Ok(())
+        }
+
+        async fn connect_workspace(
+            &self,
+            _workspace: &ExecutionWorkspaceId,
+        ) -> Result<bool, CodeExecutionError> {
+            Ok(true)
+        }
+
+        async fn destroy_workspace(
+            &self,
+            _workspace: &ExecutionWorkspaceId,
+        ) -> Result<(), CodeExecutionError> {
+            Ok(())
+        }
+
+        async fn put_workspace_file(
+            &self,
+            _workspace: &ExecutionWorkspaceId,
+            path: &WorkspaceFilePath,
+            content: &[u8],
+        ) -> Result<(), CodeExecutionError> {
+            self.insert(path.as_str(), content);
+            Ok(())
+        }
+
+        async fn get_workspace_file(
+            &self,
+            _workspace: &ExecutionWorkspaceId,
+            path: &WorkspaceFilePath,
+        ) -> Result<Vec<u8>, CodeExecutionError> {
+            self.get(path.as_str())
+                .ok_or_else(|| CodeExecutionError::Sandbox("missing file".into()))
+        }
+
+        async fn list_workspace_files(
+            &self,
+            _workspace: &ExecutionWorkspaceId,
+            path: Option<&WorkspaceFilePath>,
+        ) -> Result<WorkspaceListing, CodeExecutionError> {
+            let prefix = path.map_or(String::new(), |dir| format!("{}/", dir.as_str()));
+            let mut entries: Vec<WorkspaceFileEntry> = Vec::new();
+            let mut seen_dirs: Vec<String> = Vec::new();
+            for (file, content) in self.files.lock().unwrap().iter() {
+                let Some(rest) = file.strip_prefix(&prefix) else {
+                    continue;
+                };
+                match rest.split_once('/') {
+                    None => entries.push(WorkspaceFileEntry {
+                        path: file.clone(),
+                        directory: false,
+                        size_bytes: Some(content.len() as u64),
+                    }),
+                    Some((child, _)) => {
+                        let child_path = format!("{prefix}{child}");
+                        if !seen_dirs.contains(&child_path) {
+                            seen_dirs.push(child_path.clone());
+                            entries.push(WorkspaceFileEntry {
+                                path: child_path,
+                                directory: true,
+                                size_bytes: None,
+                            });
+                        }
+                    }
+                }
+            }
+            if path.is_none() {
+                entries.extend(self.planted.lock().unwrap().drain(..));
+            }
+            Ok(WorkspaceListing {
+                entries,
+                truncated: false,
+            })
+        }
+    }
+
+    fn workspace_id() -> ExecutionWorkspaceId {
+        ExecutionWorkspaceId::parse("chat-1".to_owned()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn round_trips_host_scratch_through_the_workspace() {
+        let host = tempfile::tempdir().unwrap();
+        std::fs::write(host.path().join("a.txt"), "host a").unwrap();
+        std::fs::create_dir_all(host.path().join("sub")).unwrap();
+        std::fs::write(host.path().join("sub/b.txt"), "host b").unwrap();
+        std::fs::create_dir_all(host.path().join(".git")).unwrap();
+        std::fs::write(host.path().join(".git/config"), "never").unwrap();
+
+        let fake = FakeWorkspace::default();
+        let pushed = push_host_dir(&fake, &workspace_id(), host.path())
+            .await
+            .unwrap();
+        assert_eq!(pushed.transferred, 2);
+        assert_eq!(fake.get("a.txt").unwrap(), b"host a");
+        assert_eq!(fake.get("sub/b.txt").unwrap(), b"host b");
+        assert!(fake.get(".git/config").is_none());
+        assert_eq!(
+            pushed.notes,
+            vec!["not pushed: .git/ (dependency or VCS tree)"]
+        );
+
+        // The sandbox edits one file and creates another; the pull mirrors
+        // both back and leaves the unchanged file alone.
+        fake.insert("a.txt", b"sandbox a");
+        fake.insert("out/c.txt", b"sandbox c");
+        let pulled = pull_into_host_dir(&fake, &workspace_id(), host.path())
+            .await
+            .unwrap();
+        assert_eq!(pulled.transferred, 2, "{:?}", pulled.notes);
+        assert_eq!(
+            std::fs::read(host.path().join("a.txt")).unwrap(),
+            b"sandbox a"
+        );
+        assert_eq!(
+            std::fs::read(host.path().join("out/c.txt")).unwrap(),
+            b"sandbox c"
+        );
+        assert_eq!(
+            std::fs::read(host.path().join("sub/b.txt")).unwrap(),
+            b"host b"
+        );
+    }
+
+    #[tokio::test]
+    async fn pull_rejects_paths_that_escape_the_host_directory() {
+        let parent = tempfile::tempdir().unwrap();
+        let host = parent.path().join("scratch");
+        std::fs::create_dir_all(&host).unwrap();
+
+        let fake = FakeWorkspace::default();
+        fake.planted.lock().unwrap().push(WorkspaceFileEntry {
+            path: "../escape.txt".into(),
+            directory: false,
+            size_bytes: Some(4),
+        });
+        fake.planted.lock().unwrap().push(WorkspaceFileEntry {
+            path: "big.bin".into(),
+            directory: false,
+            size_bytes: Some(MAX_WORKSPACE_FILE_BYTES as u64 + 1),
+        });
+
+        let pulled = pull_into_host_dir(&fake, &workspace_id(), &host)
+            .await
+            .unwrap();
+        assert_eq!(pulled.transferred, 0);
+        assert!(!parent.path().join("escape.txt").exists());
+        assert_eq!(pulled.notes.len(), 2, "{:?}", pulled.notes);
+        assert!(pulled.notes[0].contains("not a valid workspace path"));
+        assert!(pulled.notes[1].contains("file limit"));
+    }
+}

--- a/crates/openwave-code-execution/src/tool.rs
+++ b/crates/openwave-code-execution/src/tool.rs
@@ -46,8 +46,11 @@ impl Tool for ExecTool {
             description: "Run one executable with an argument vector in the configured isolated \
                           execution provider. No shell parses the arguments unless you explicitly \
                           invoke a shell. The local provider blocks network and user-data access \
-                          outside private chat scratch; E2B runs in a managed cloud sandbox. Every \
-                          provider returns bounded stdout/stderr."
+                          outside private chat scratch; managed cloud sandboxes (E2B, Daytona) \
+                          have the chat's private scratch mirrored in before the command runs and \
+                          mirrored back after, so files from write_file are visible here and \
+                          files this command writes are visible to read_file. Every provider \
+                          returns bounded stdout/stderr."
                 .into(),
             input_schema: json!({
                 "type": "object",
@@ -131,6 +134,13 @@ impl Tool for ExecTool {
         if response.output_truncated {
             content.push_str("\noutput_truncated: true");
         }
+        if !response.sync_notes.is_empty() {
+            content.push_str("\n\nworkspace sync:");
+            for note in &response.sync_notes {
+                content.push('\n');
+                content.push_str(note);
+            }
+        }
         if !response.stdout.is_empty() {
             content.push_str("\n\nstdout:\n");
             content.push_str(&response.stdout);
@@ -151,6 +161,7 @@ impl Tool for ExecTool {
             "duration_ms": response.duration_ms,
             "stdout": response.stdout,
             "stderr": response.stderr,
+            "sync_notes": response.sync_notes,
         }));
         output.is_error = failed;
         Ok(output)
@@ -185,6 +196,7 @@ mod tests {
                 timed_out: false,
                 output_truncated: false,
                 duration_ms: 3,
+                sync_notes: Vec::new(),
             })
         }
     }

--- a/crates/openwave-code-execution/src/types.rs
+++ b/crates/openwave-code-execution/src/types.rs
@@ -315,6 +315,11 @@ pub struct CodeExecutionResponse {
     pub timed_out: bool,
     pub output_truncated: bool,
     pub duration_ms: u64,
+    /// What the scratch↔workspace mirror around this execution left behind
+    /// (oversized files, truncated listings, a failed pull). Empty when the
+    /// provider shares the host filesystem or the mirror was complete.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sync_notes: Vec<String>,
 }
 
 /// A configured execution provider. Implementations must treat

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -12,11 +12,11 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use openwave_code_execution::{
-    CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest,
-    CodeExecutionResponse, DaytonaCredential, DaytonaExecutionProvider, E2BCredential,
-    E2BExecutionProvider, ExecutionWorkspaceId, LocalExecutionProvider, RemoteSessionPool,
-    WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, DAYTONA_CREDENTIAL_KEY,
-    E2B_CREDENTIAL_KEY,
+    sync, CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind,
+    CodeExecutionRequest, CodeExecutionResponse, DaytonaCredential, DaytonaExecutionProvider,
+    E2BCredential, E2BExecutionProvider, ExecutionWorkspaceId, LocalExecutionProvider,
+    RemoteSessionPool, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing,
+    DAYTONA_CREDENTIAL_KEY, E2B_CREDENTIAL_KEY,
 };
 use openwave_core::{Result, SecretProvider, Store};
 use openwave_egress::{
@@ -568,44 +568,50 @@ impl ConfiguredCodeExecutionProvider {
     /// Resolve the currently selected adapter at the last boundary before use.
     async fn resolve(
         &self,
-    ) -> std::result::Result<Box<dyn CodeExecutionProvider>, CodeExecutionError> {
+    ) -> std::result::Result<
+        (CodeExecutionProviderKind, Box<dyn CodeExecutionProvider>),
+        CodeExecutionError,
+    > {
         let config = read_config(&*self.store).await.map_err(|_| {
             CodeExecutionError::Unavailable("configuration storage is unavailable".into())
         })?;
         let Some(provider) = config.provider else {
             return Err(CodeExecutionError::NotConfigured);
         };
-        match provider {
-            CodeExecutionProviderKind::Local => Ok(Box::new(LocalExecutionProvider::new(
+        let resolved: Box<dyn CodeExecutionProvider> = match provider {
+            CodeExecutionProviderKind::Local => Box::new(LocalExecutionProvider::new(
                 &self.scratch_root,
                 Duration::from_millis(config.timeout_ms),
-            )?)),
+            )?),
             CodeExecutionProviderKind::E2b => {
                 let credential = E2BCredential::load(&*self.secrets)
                     .await?
                     .ok_or(CodeExecutionError::NotConfigured)?;
-                Ok(Box::new(configured_e2b(
+                Box::new(configured_e2b(
                     credential,
                     Duration::from_millis(config.timeout_ms),
                     self.remote_sessions.clone(),
                     &config.egress,
-                )?))
+                )?)
             }
             CodeExecutionProviderKind::Daytona => {
                 let credential = DaytonaCredential::load(&*self.secrets)
                     .await?
                     .ok_or(CodeExecutionError::NotConfigured)?;
-                Ok(Box::new(configured_daytona(
+                Box::new(configured_daytona(
                     credential,
                     Duration::from_millis(config.timeout_ms),
                     self.remote_sessions.clone(),
                     &config.egress,
-                )?))
+                )?)
             }
-            _ => Err(CodeExecutionError::Unavailable(
-                "selected provider is not supported by this build".into(),
-            )),
-        }
+            _ => {
+                return Err(CodeExecutionError::Unavailable(
+                    "selected provider is not supported by this build".into(),
+                ))
+            }
+        };
+        Ok((provider, resolved))
     }
 
     /// The configured provider's optional durable-workspace surface.
@@ -618,7 +624,7 @@ impl ConfiguredCodeExecutionProvider {
         &self,
     ) -> std::result::Result<Option<ConfiguredWorkspace>, CodeExecutionError> {
         let provider = match self.resolve().await {
-            Ok(provider) => provider,
+            Ok((_, provider)) => provider,
             Err(CodeExecutionError::NotConfigured) => return Ok(None),
             Err(error) => return Err(error),
         };
@@ -635,7 +641,37 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
         &self,
         request: CodeExecutionRequest,
     ) -> std::result::Result<CodeExecutionResponse, CodeExecutionError> {
-        self.resolve().await?.execute(request).await
+        let (kind, provider) = self.resolve().await?;
+        // A remote sandbox has its own filesystem, but the model is shown one
+        // path vocabulary across the file tools and exec. Mirror the chat's
+        // private scratch into the workspace before the command and back out
+        // after it, so a file written by either side is visible to the other.
+        // The local provider already runs inside scratch; mirroring there
+        // would only copy the directory onto itself.
+        let lifecycle = match kind {
+            CodeExecutionProviderKind::Local => None,
+            _ => provider.workspace_lifecycle(),
+        };
+        let Some(lifecycle) = lifecycle else {
+            return provider.execute(request).await;
+        };
+        let host_dir = self.scratch_root.join(request.workspace_id.as_str());
+        // A failed push fails the execution: running against files the model
+        // believes are present would answer with misleading not-found errors.
+        let mut notes = sync::push_host_dir(lifecycle, &request.workspace_id, &host_dir)
+            .await?
+            .notes;
+        let mut response = provider.execute(request.clone()).await?;
+        // A failed pull keeps the execution's output — the command did run —
+        // and says the host copies are stale instead of failing the call.
+        match sync::pull_into_host_dir(lifecycle, &request.workspace_id, &host_dir).await {
+            Ok(pulled) => notes.extend(pulled.notes),
+            Err(error) => notes.push(format!(
+                "workspace files were not copied back to private scratch: {error}"
+            )),
+        }
+        response.sync_notes.extend(notes);
+        Ok(response)
     }
 
     // `workspace_lifecycle` stays `None` here on purpose: the capability of

--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -257,6 +257,7 @@ async fn store() -> (tempfile::TempDir, Arc<dyn Store>, Chat) {
         model: Some("host-model".into()),
         permission_mode: None,
         reasoning_effort: None,
+        citation_format: None,
         attachment_revision: 0,
         root_attachments: Vec::new(),
         created_at: chrono::Utc::now(),


### PR DESCRIPTION
Closes #908.

Observed live on E2B: `write_file` wrote `test/hello.txt`, then `exec` failed with `FileNotFoundError: 'test/hello.txt'`. The file tools and `exec` present one path vocabulary — "private-scratch-relative" — but only the Local provider actually runs inside the host scratch directory. E2B and Daytona execute in the sandbox's own filesystem and nothing bridged the two, even though both providers already implement the workspace file surface (#820).

## What changes

A new `sync` module in `openwave-code-execution` mirrors a host directory through the `WorkspaceLifecycle` trait:

- **Push before the command** — every eligible file under the chat's scratch is uploaded to the same workspace-relative path. A push failure fails the execution: running against files the model believes are present would answer with misleading not-found errors.
- **Pull after the command** — the workspace is listed recursively and files are downloaded back, writing only content that actually differs. A pull failure keeps the execution's output (the command did run) and reports that host copies are stale.

`ConfiguredCodeExecutionProvider::execute` wires this around remote kinds only; the Local provider already runs inside scratch, so mirroring there would copy the directory onto itself.

Bounds, all surfaced rather than silent via a new `sync_notes` field on `CodeExecutionResponse` (rendered into the tool output and the closed-result data): per-file cap at the existing `MAX_WORKSPACE_FILE_BYTES`, 256 files per direction, `.git`/`.venv`/`__pycache__`/`node_modules` never mirrored, symlinks skipped, truncated listings reported. Paths returned by the sandbox are re-validated through `WorkspaceFilePath::parse` before any host write, so a hostile or confused backend cannot steer a write outside the chat's scratch. The mirror is additive: deletions do not propagate.

The exec tool description now tells the model the two surfaces compose.

## Tests

Two in `sync::tests` against an in-memory workspace fake: a round trip (push skips VCS trees; pull mirrors a sandbox-created and a sandbox-modified file while leaving the unchanged one alone) and the boundary case (an escaping path from the backend is rejected with a note and writes nothing outside the scratch dir; an oversized file is skipped with a note).

Verified locally: `cargo test -p openwave-code-execution` (22 passed), `cargo test -p openwave-server --lib code_execution` (11 passed), clippy clean on both, `cargo fmt`.

Not verified against live E2B/Daytona — the mock-server suites cover the transport, but a real-sandbox smoke run (write_file → exec → read_file) is worth doing when convenient.