### PR TITLE
feat(approvals): list and revoke standing grants

### DIFF
--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -314,7 +314,7 @@ pub struct StandingGrant {
 /// scope is stated in the grant itself rather than inferred from the tool. The
 /// narrower variants exist because "don't ask me about commands again" is a
 /// much larger thing to agree to than "don't ask me about `cargo` again".
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, TS)]
 #[serde(tag = "scope", rename_all = "snake_case")]
 pub enum GrantScope {
     /// Exactly the action the card showed, and nothing else.
@@ -482,6 +482,16 @@ impl StandingGrant {
             && kind.is_approvable()
             && self.scope.covers_call(tool_name, arguments)
     }
+}
+
+/// A durable standing grant as the revocation surface reads it: the grant
+/// itself plus the approval decision that created it, which is also the row's
+/// identity and therefore the handle a revocation names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StandingGrantRecord {
+    /// The call whose approval created this grant (primary key).
+    pub source_call_id: CallId,
+    pub grant: StandingGrant,
 }
 
 /// Explicit in-memory grants for isolated, non-durable callers such as the

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -2700,6 +2700,14 @@ impl Store for DbStore {
         ops::approval::list_pending(self, chat_id, limit).await
     }
 
+    async fn list_standing_tool_grants(&self) -> Result<Vec<crate::approval::StandingGrantRecord>> {
+        ops::approval::list_standing_grants(self).await
+    }
+
+    async fn revoke_standing_tool_grant(&self, source_call_id: CallId) -> Result<bool> {
+        ops::approval::revoke_standing_grant(self, source_call_id).await
+    }
+
     async fn claim_client_tool_call(
         &self,
         id: CallId,

--- a/crates/openwave-core/src/db/ops/approval.rs
+++ b/crates/openwave-core/src/db/ops/approval.rs
@@ -74,6 +74,50 @@ where
     Ok(None)
 }
 
+/// Every durable standing grant, newest first, hydrated on the same terms as
+/// [`matching_standing_grant`]: a row whose kind, scope, or grantability no
+/// longer parses is skipped rather than surfaced or widened.
+pub(in crate::db) async fn list_standing_grants(
+    store: &DbStore,
+) -> Result<Vec<crate::approval::StandingGrantRecord>> {
+    let rows = entities::standing_tool_grant::Entity::find()
+        .order_by_desc(entities::standing_tool_grant::Column::GrantedAt)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| {
+            let stored_kind = ToolApprovalKind::from_standing_grant_key(&row.approval_kind)?;
+            let scope = serde_json::from_value::<GrantScope>(row.scope).ok()?;
+            let grant = StandingGrant::scoped(
+                ChatId(row.chat_id),
+                row.tool_name,
+                stored_kind,
+                scope,
+                row.granted_at,
+            )?;
+            Some(crate::approval::StandingGrantRecord {
+                source_call_id: CallId(row.source_call_id),
+                grant,
+            })
+        })
+        .collect())
+}
+
+/// Delete one standing grant by its source approval. Idempotent: deleting a
+/// grant that is already gone reports `false` rather than erroring.
+pub(in crate::db) async fn revoke_standing_grant(
+    store: &DbStore,
+    source_call_id: CallId,
+) -> Result<bool> {
+    let result = entities::standing_tool_grant::Entity::delete_by_id(source_call_id.0)
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(result.rows_affected == 1)
+}
+
 /// The `approval_class` column spelling for a gated call.
 ///
 /// Existing databases constrain the column to `"sensitive"`, from before

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -78,8 +78,8 @@ pub use agent_tools::{
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalJournalIdentity, ApprovalRegistration,
     ApprovalRegistrationFuture, ApprovalRequest, ApprovalRequiredPublication, AutoApproveGate,
-    GrantScope, RefuseGate, StandingGrant, StandingGrants, ToolApproval, ToolApprovalKind,
-    ToolApprovalStatus,
+    GrantScope, RefuseGate, StandingGrant, StandingGrantRecord, StandingGrants, ToolApproval,
+    ToolApprovalKind, ToolApprovalStatus,
 };
 #[cfg(feature = "blob-fs")]
 pub use blob::FsBlobStore;

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -2649,6 +2649,26 @@ pub trait Store: Send + Sync {
         ))
     }
 
+    /// Every durable standing grant, newest first, across all chats.
+    ///
+    /// A malformed row is skipped, never surfaced: what cannot be described
+    /// cannot be knowingly kept, and it already fails to authorize anything
+    /// at match time for the same reason.
+    async fn list_standing_tool_grants(&self) -> Result<Vec<crate::approval::StandingGrantRecord>> {
+        Err(AgentError::Store(
+            "durable standing-grant storage is not implemented by this Store".into(),
+        ))
+    }
+
+    /// Withdraw one standing grant by the approval that created it. Later
+    /// matching calls park on the gate again. Returns `false` when no such
+    /// grant exists (already revoked, or never granted).
+    async fn revoke_standing_tool_grant(&self, _source_call_id: CallId) -> Result<bool> {
+        Err(AgentError::Store(
+            "durable standing-grant storage is not implemented by this Store".into(),
+        ))
+    }
+
     /// List a bounded page of pending approvals for one chat.
     async fn list_pending_tool_call_approvals(
         &self,

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -21,6 +21,8 @@ import {
   type GatewayAppInfo as WireGatewayAppInfo,
   type GatewayStatus as WireGatewayStatus,
   type SignInProgress,
+  type StandingGrantSnapshot,
+  type GrantScope,
   type McpServerInfo as WireMcpServerInfo,
   type ManagedPolicy as WireManagedPolicy,
   type ManagedPolicySource as WireManagedPolicySource,
@@ -62,6 +64,8 @@ import type { DocumentProcessingStatus } from "./documents";
 
 export type {
   ApprovalClass,
+  GrantScope,
+  StandingGrantSnapshot,
   ChatToolActivityStatus,
   TranscriptRole,
   RendererToolName,
@@ -1136,6 +1140,19 @@ export class ApiClient {
       approvals.set(approval.callId, approval);
     }
     return [...approvals.values()];
+  }
+
+  /** Every standing "don't ask again", newest first, across all chats. */
+  listStandingGrants(): Promise<StandingGrantSnapshot[]> {
+    return this.json(`/grants`, { headers: this.headers() });
+  }
+
+  /** Withdraw a standing grant; later matching calls ask again. */
+  revokeStandingGrant(sourceCallId: string): Promise<void> {
+    return this.json(`/grants/${sourceCallId}`, {
+      method: "DELETE",
+      headers: this.headers(),
+    });
   }
 
   async listPendingFolderAccessRequests(

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -437,6 +437,16 @@ supported: boolean, apps: Array<GatewayAppInfo>, };
 export type GatewayStatus = { configured: boolean, enabled: boolean, base_url?: string, signed_in: boolean, account_hint?: string, installation_id?: string, model_count: number, sign_in: SignInProgress, };
 
 /**
+ * How much a standing grant covers.
+ *
+ * A grant is easy to widen by accident and hard to notice afterwards, so the
+ * scope is stated in the grant itself rather than inferred from the tool. The
+ * narrower variants exist because "don't ask me about commands again" is a
+ * much larger thing to agree to than "don't ask me about `cargo` again".
+ */
+export type GrantScope = { "scope": "exact_action" } & ToolActionPreview | { "scope": "any_args_for", command: string, } | { "scope": "whole_tool" };
+
+/**
  * Opaque identifier for a folder registered with a host broker.
  *
  * This is product projection data, not authority: possession of an id never
@@ -968,6 +978,22 @@ has_api_key: boolean, };
  * Renderer-safe progress of the current sign-in attempt.
  */
 export type SignInProgress = { "state": "idle" } | { "state": "pending", authorization_url: string, } | { "state": "failed", message: string, };
+
+/**
+ * One durable "don't ask again" the reader has made, with enough provenance
+ * to recognize it later and withdraw it. Grant scopes are already closed
+ * renderer-safe projections, so the snapshot carries them verbatim.
+ */
+export type StandingGrantSnapshot = { 
+/**
+ * The approval decision that created the grant — also the handle a
+ * revocation names.
+ */
+source_call_id: CallId, chat_id: ChatId, 
+/**
+ * Chat title for provenance; `None` when the chat is untitled.
+ */
+chat_title: string | null, action: RendererToolName, approval: ToolApprovalKind, scope: GrantScope, granted_at: string, };
 
 /**
  * The action a call will take, in a form a human can inspect.

--- a/crates/openwave-desktop/ui/src/settings/PermissionsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/PermissionsPanel.dom.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient, StandingGrantSnapshot } from "../api";
+import { PermissionsPanel } from "./PermissionsPanel";
+
+const execGrant: StandingGrantSnapshot = {
+  source_call_id: "11111111-1111-1111-1111-111111111111",
+  chat_id: "22222222-2222-2222-2222-222222222222",
+  chat_title: "Quarterly filings",
+  action: "exec",
+  approval: "exec_may_run_networked_command",
+  scope: { scope: "any_args_for", command: "cargo" },
+  granted_at: "2026-07-29T12:00:00Z",
+};
+
+function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
+  return {
+    listStandingGrants: vi.fn().mockResolvedValue([execGrant]),
+    revokeStandingGrant: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as ApiClient;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("PermissionsPanel", () => {
+  it("revokes a grant after confirmation and drops the row", async () => {
+    const client = api();
+    render(<PermissionsPanel client={client} />);
+
+    // The grant renders under its chat, worded as the width of the consent.
+    await screen.findByText("Quarterly filings");
+    screen.getByText("cargo …");
+
+    await userEvent.click(screen.getByRole("button", { name: "Revoke" }));
+    // The confirmation names what will start asking again before it acts.
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Revoke", hidden: false }),
+    );
+
+    await waitFor(() =>
+      expect(client.revokeStandingGrant).toHaveBeenCalledWith(
+        execGrant.source_call_id,
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("cargo …")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("says so when nothing is saved", async () => {
+    const client = api({ listStandingGrants: vi.fn().mockResolvedValue([]) });
+    render(<PermissionsPanel client={client} />);
+    await screen.findByText(/Nothing saved yet/);
+    expect(client.listStandingGrants).toHaveBeenCalled();
+  });
+});

--- a/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
@@ -1,0 +1,212 @@
+import { useCallback, useEffect, useState } from "react";
+
+import type {
+  ApiClient,
+  GrantScope,
+  RendererToolName,
+  StandingGrantSnapshot,
+} from "../api";
+import { useConfirm } from "../components/ConfirmDialog";
+import { Button } from "@/components/ui/button";
+import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
+
+// The "what the agent can do without asking" surface: every standing grant,
+// grouped by the chat it applies to, each revocable back to being asked.
+// A grant the reader cannot find is a one-way door; this page is where it is
+// found.
+
+const TOOL_LABELS: Partial<Record<RendererToolName, string>> = {
+  exec: "Commands",
+  search: "Document search",
+  web_search: "Web search",
+};
+
+export function toolGrantLabel(action: RendererToolName): string {
+  return TOOL_LABELS[action] ?? action;
+}
+
+/**
+ * The scope line, worded as the width of what was agreed to. Mirrors the
+ * approval card's rungs: the exact action, an executable with any arguments,
+ * or the whole tool.
+ */
+export function grantScopeLabel(
+  scope: GrantScope,
+  action: RendererToolName,
+): string {
+  switch (scope.scope) {
+    case "exact_action": {
+      if (scope.tool === "exec") {
+        return [scope.command, ...scope.args].join(" ");
+      }
+      return `“${scope.query}”`;
+    }
+    case "any_args_for":
+      return `${scope.command} …`;
+    case "whole_tool":
+      switch (action) {
+        case "exec":
+          return "Any command";
+        case "search":
+          return "Every document search";
+        case "web_search":
+          return "Every web search";
+        default:
+          return `Every ${toolGrantLabel(action)} call`;
+      }
+  }
+}
+
+export function shortOpaqueId(id: string): string {
+  return id.length <= 10 ? id : `${id.slice(0, 6)}…${id.slice(-4)}`;
+}
+
+export function chatLabel(grant: StandingGrantSnapshot): string {
+  const title = grant.chat_title?.trim();
+  return title || `Chat ${shortOpaqueId(grant.chat_id)}`;
+}
+
+function grantedAtLabel(grantedAt: string): string {
+  const when = new Date(grantedAt);
+  if (Number.isNaN(when.getTime())) return "";
+  return `Added ${when.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })}`;
+}
+
+/** Grants in listing order, bucketed by chat without reordering across rows. */
+export function groupByChat(
+  grants: readonly StandingGrantSnapshot[],
+): { chatId: string; label: string; grants: StandingGrantSnapshot[] }[] {
+  const groups = new Map<
+    string,
+    { chatId: string; label: string; grants: StandingGrantSnapshot[] }
+  >();
+  for (const grant of grants) {
+    const group = groups.get(grant.chat_id);
+    if (group) group.grants.push(grant);
+    else
+      groups.set(grant.chat_id, {
+        chatId: grant.chat_id,
+        label: chatLabel(grant),
+        grants: [grant],
+      });
+  }
+  return [...groups.values()];
+}
+
+function GrantRow({
+  grant,
+  busy,
+  onRevoke,
+}: {
+  grant: StandingGrantSnapshot;
+  busy: boolean;
+  onRevoke: () => void;
+}) {
+  const metadata = grantedAtLabel(grant.granted_at);
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">
+          {grantScopeLabel(grant.scope, grant.action)}
+        </p>
+        <p className="text-muted-foreground mt-0.5 truncate text-sm">
+          {toolGrantLabel(grant.action)}
+        </p>
+        {metadata && (
+          <p className="text-muted-foreground mt-1 truncate text-xs">
+            {metadata}
+          </p>
+        )}
+      </div>
+      <Button variant="ghost" size="sm" disabled={busy} onClick={onRevoke}>
+        Revoke
+      </Button>
+    </div>
+  );
+}
+
+export function PermissionsPanel({ client }: { client: ApiClient }) {
+  const [grants, setGrants] = useState<StandingGrantSnapshot[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const { confirm, dialog } = useConfirm();
+
+  const reload = useCallback(async () => {
+    try {
+      setGrants(await client.listStandingGrants());
+      setError(null);
+    } catch {
+      setError("Saved approvals could not be loaded.");
+    }
+  }, [client]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  async function revoke(grant: StandingGrantSnapshot) {
+    const confirmed = await confirm({
+      title: "Revoke this approval?",
+      description: `The agent will ask again before ${toolGrantLabel(
+        grant.action,
+      ).toLowerCase()} covered by “${grantScopeLabel(
+        grant.scope,
+        grant.action,
+      )}” in ${chatLabel(grant)}.`,
+      confirmLabel: "Revoke",
+      destructive: true,
+    });
+    if (!confirmed) return;
+    setBusyId(grant.source_call_id);
+    try {
+      await client.revokeStandingGrant(grant.source_call_id);
+      setGrants(
+        (current) =>
+          current?.filter(
+            (existing) => existing.source_call_id !== grant.source_call_id,
+          ) ?? null,
+      );
+      setError(null);
+    } catch {
+      setError("The approval could not be revoked. Try again.");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <SettingsPanel
+      title="Permissions"
+      description="What the agent can do without asking. Revoke anything to be asked again."
+      busy={grants === null}
+    >
+      {error && <SettingsError>{error}</SettingsError>}
+      {grants !== null && grants.length === 0 && !error && (
+        <p className="text-sm text-muted-foreground">
+          Nothing saved yet. When you answer an approval with “always allow”,
+          it appears here.
+        </p>
+      )}
+      {grants !== null &&
+        groupByChat(grants).map((group) => (
+          <SettingsSection key={group.chatId} title={group.label}>
+            <div className="flex flex-col gap-4">
+              {group.grants.map((grant) => (
+                <GrantRow
+                  key={grant.source_call_id}
+                  grant={grant}
+                  busy={busyId === grant.source_call_id}
+                  onRevoke={() => void revoke(grant)}
+                />
+              ))}
+            </div>
+          </SettingsSection>
+        ))}
+      {dialog}
+    </SettingsPanel>
+  );
+}

--- a/crates/openwave-desktop/ui/src/settings/sections.tsx
+++ b/crates/openwave-desktop/ui/src/settings/sections.tsx
@@ -6,6 +6,7 @@ import {
   Palette,
   PlugZap,
   RefreshCw,
+  ShieldCheck,
   SquareTerminal,
   Waypoints,
 } from "lucide-react";
@@ -16,6 +17,7 @@ import { AppearancePanel } from "./AppearancePanel";
 import { CodeExecutionPanel } from "./CodeExecutionPanel";
 import { GatewayPanel } from "./GatewayPanel";
 import { McpPanel } from "./McpPanel";
+import { PermissionsPanel } from "./PermissionsPanel";
 import { ModelsPanel } from "./ModelsPanel";
 import { ProvidersPanel } from "./ProvidersPanel";
 import { UpdatesPanel } from "./UpdatesPanel";
@@ -71,6 +73,11 @@ function McpSection() {
   return <McpPanel client={client} managed={managed} />;
 }
 
+function PermissionsSection() {
+  const { client } = useApp();
+  return <PermissionsPanel client={client} />;
+}
+
 function AppearanceSection() {
   const { themeMode, setThemeMode } = useApp();
   return <AppearancePanel mode={themeMode} onChange={setThemeMode} />;
@@ -121,6 +128,12 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     Component: CodeExecutionSection,
   },
   { path: "mcp", label: "MCP servers", icon: PlugZap, Component: McpSection },
+  {
+    path: "permissions",
+    label: "Permissions",
+    icon: ShieldCheck,
+    Component: PermissionsSection,
+  },
   { path: "appearance", label: "Appearance", icon: Palette, Component: AppearanceSection },
   { path: "updates", label: "Updates", icon: RefreshCw, Component: UpdatesSection },
 ];

--- a/crates/openwave-server/src/approvals.rs
+++ b/crates/openwave-server/src/approvals.rs
@@ -449,6 +449,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_revoked_grant_leaves_the_list_and_stops_covering() {
+        let exec_args = json!({ "command": "cargo", "args": ["test"], "cwd": "." });
+        let (store, request) = setup_with_arguments("exec", exec_args.clone()).await;
+        let broker = ApprovalBroker::new(store.clone());
+        let pending = broker.register(request.clone(), None).await;
+        drop(pending.decision);
+        assert_eq!(
+            broker
+                .resolve_with_grant(
+                    request.chat_id,
+                    request.call_id,
+                    ApprovalDecision::Approve,
+                    Some(crate::routes::ApprovalGrantRung::WholeTool),
+                )
+                .await
+                .unwrap(),
+            ResolveApprovalOutcome::Resolved
+        );
+
+        // The grant is findable, carrying the identity a revocation names.
+        let listed = store.list_standing_tool_grants().await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].source_call_id, request.call_id);
+        assert_eq!(listed[0].grant.chat_id(), request.chat_id);
+        assert_eq!(listed[0].grant.tool_name(), "exec");
+
+        // A matching later call is auto-granted while the grant stands…
+        let covered = request_for(&store, request.chat_id, "exec", exec_args.clone()).await;
+        let registration = broker.register(covered, None).await;
+        assert!(matches!(
+            registration.publication,
+            openwave_core::ApprovalRequiredPublication::StandingGrant
+        ));
+        assert_eq!(registration.decision.await, ApprovalDecision::Approve);
+
+        // …and parks on the gate again once it is revoked.
+        assert!(store
+            .revoke_standing_tool_grant(request.call_id)
+            .await
+            .unwrap());
+        assert!(store.list_standing_tool_grants().await.unwrap().is_empty());
+        assert!(!store
+            .revoke_standing_tool_grant(request.call_id)
+            .await
+            .unwrap());
+        let uncovered = request_for(&store, request.chat_id, "exec", exec_args).await;
+        let registration = broker.register(uncovered, None).await;
+        assert!(!matches!(
+            registration.publication,
+            openwave_core::ApprovalRequiredPublication::StandingGrant
+        ));
+        drop(registration.decision);
+    }
+
+    #[tokio::test]
     async fn decision_survives_broker_recreation() {
         let (store, request) = setup("search").await;
         let first = ApprovalBroker::new(store.clone());

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -407,6 +407,11 @@ pub fn app(state: AppState) -> Router {
             "/chats/{id}/approvals/{call_id}",
             post(routes::post_approval),
         )
+        .route("/grants", get(routes::list_standing_grants))
+        .route(
+            "/grants/{call_id}",
+            axum::routing::delete(routes::delete_standing_grant),
+        )
         .route("/chats/{id}/events", get(routes::chat_events))
         .merge(client_executor_api)
         .route_layer(axum::middleware::from_fn_with_state(

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -2327,6 +2327,70 @@ pub(crate) async fn list_pending_approvals(
     ))
 }
 
+/// One durable "don't ask again" the reader has made, with enough provenance
+/// to recognize it later and withdraw it. Grant scopes are already closed
+/// renderer-safe projections, so the snapshot carries them verbatim.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub(crate) struct StandingGrantSnapshot {
+    /// The approval decision that created the grant — also the handle a
+    /// revocation names.
+    pub source_call_id: CallId,
+    pub chat_id: ChatId,
+    /// Chat title for provenance; `None` when the chat is untitled.
+    pub chat_title: Option<String>,
+    pub action: openwave_core::RendererToolName,
+    pub approval: openwave_core::ToolApprovalKind,
+    pub scope: openwave_core::GrantScope,
+    pub granted_at: chrono::DateTime<Utc>,
+}
+
+/// `GET /grants` — every standing grant, newest first, across all chats.
+///
+/// The settings surface for "what the agent can do without asking": a grant
+/// the reader cannot find is a one-way door, and this is where it is found.
+pub(crate) async fn list_standing_grants(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<StandingGrantSnapshot>>, ServerError> {
+    let grants = state.store.list_standing_tool_grants().await?;
+    let titles: std::collections::HashMap<ChatId, Option<String>> = state
+        .store
+        .list_chats()
+        .await?
+        .into_iter()
+        .map(|chat| (chat.id, chat.title))
+        .collect();
+    Ok(Json(
+        grants
+            .into_iter()
+            .map(|record| StandingGrantSnapshot {
+                source_call_id: record.source_call_id,
+                chat_id: record.grant.chat_id(),
+                chat_title: titles.get(&record.grant.chat_id()).cloned().flatten(),
+                action: openwave_core::RendererToolName::from(record.grant.tool_name()),
+                approval: record.grant.kind(),
+                scope: record.grant.scope().clone(),
+                granted_at: record.grant.granted_at(),
+            })
+            .collect(),
+    ))
+}
+
+/// `DELETE /grants/{call_id}` — withdraw a standing grant. Later matching
+/// calls park on the approval card again. `204` on success, `404` when the
+/// grant does not exist (already revoked, or never granted).
+pub(crate) async fn delete_standing_grant(
+    State(state): State<AppState>,
+    Path(call_id): Path<CallId>,
+) -> Result<StatusCode, ServerError> {
+    if state.store.revoke_standing_tool_grant(call_id).await? {
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(ServerError::not_found(format!(
+            "standing grant {call_id} not found"
+        )))
+    }
+}
+
 /// `POST /chats/{id}/approvals/{call_id}` — decide a parked Sensitive tool call.
 ///
 /// `204` on success. `404` if the chat or call isn't pending. The turn stays

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -319,6 +319,7 @@ mod tests {
         // output rather than the wire, so the generated types are what the
         // validators narrow *from* — see the aliases in api.ts.
         generate::collect_from::<crate::routes::PendingApprovalSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::StandingGrantSnapshot>(&cfg, &mut out);
         generate::collect_from::<openwave_core::PendingUserQuestions>(&cfg, &mut out);
         generate::collect_from::<crate::routes::client_execution::PendingFolderAccessRequest>(
             &cfg, &mut out,


### PR DESCRIPTION
The read-and-revoke surface for standing grants, closing the last gap #756 named after #914: grants have been durable all along, but there was nowhere to see what a chat runs without asking or to withdraw a decision. A grant the reader cannot find is a one-way door, and that is what made widening one risky rather than convenient.

## What changed

- **Store**: `list_standing_tool_grants()` (all chats, newest first, hydrated on the same skip-malformed terms as grant matching) and `revoke_standing_tool_grant(source_call_id)` (idempotent delete keyed by the approval that created the grant). Default-erroring trait methods, implemented by `DbStore`.
- **Server**: `GET /grants` returns renderer-safe snapshots — grant scope verbatim (`GrantScope` is already a closed projection, now TS-exported), tool name through the `RendererToolName` allowlist, chat title for provenance. `DELETE /grants/{call_id}` withdraws one (204/404).
- **UI**: a **Permissions** settings section — "what the agent can do without asking" — grouping grants by chat, each row worded as the width of the consent (`cargo …`, a quoted query, "Any command"), with a confirmation that names exactly what will start asking again before anything is deleted. Ported from the reference design's grant-row/actions-without-asking shape.

Revocation is a durable delete only: foreground authorization already reads the store inside the approval transaction (the broker's in-memory mirror is test-only), so there is no in-process state to invalidate — the next matching call simply parks.

## Tests

- One end-to-end broker test: grant created via the card rung → listed with the identity a revocation needs → covers a later matching call → revoked → gone from the list, second revoke reports false, and the next matching call parks again.
- Two DOM tests: the revoke flow (confirm → DELETE → row drops) and the empty state.

Verified locally: fmt, clippy (workspace, all targets), server suite, `tsc`, vitest, after rebasing onto main.

Part of #756. Still deferred: the Auto-mode judge for uncovered Sensitive calls, and managed-policy lockdown of the permission mode.