### PR TITLE
feat(server): drive a sandbox-resident agent run on a local container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,6 +454,59 @@ jobs:
           cargo test -p openwave-core --no-default-features --features postgres
           --test postgres_turn_state --locked
 
+  sandbox-container:
+    name: sandbox-resident container e2e
+    needs: changes
+    # Builds the sandbox-agent image (compiling the agent crate's slice of the
+    # workspace inside Docker) and drives a real container end to end. That is
+    # expensive, and the container runtime is a detected capability rather than a
+    # hard dependency, so — like the durable vector lane — pay for it once per
+    # merge instead of once per push to every open PR. The rest of the stack is
+    # covered on every PR by the loopback tests, which drive the same driver
+    # against the real agent over a socket.
+    if: ${{ needs.changes.outputs.workspace == 'true' && github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: READ_ONLY
+      RUSTC_WRAPPER: sccache
+      RUSTFLAGS: -C link-arg=-fuse-ld=mold
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install toolchain (honors rust-toolchain.toml)
+        run: rustup show
+      - name: Set up compiler cache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          version: v0.16.0
+      - name: Install headless system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends mold
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: cargo-registry-v3-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          cache-targets: false
+          save-if: false
+      # The runner ships a working Docker daemon; assert it rather than letting
+      # the test skip silently and report a green lane that exercised nothing.
+      - name: The container runtime must be present
+        run: docker version --format '{{.Server.Version}}'
+      # `--ignored` runs exactly the gated end-to-end test, which builds the
+      # agent image itself from the workspace root.
+      - name: Drive a sandbox-resident run on a real container
+        run: >-
+          cargo test -p openwave-server --locked
+          sandbox_container_run::tests::docker_end_to_end_drives_a_real_container
+          -- --ignored --exact --nocapture
+
   ui:
     name: desktop UI test · build
     needs: changes
@@ -496,6 +549,7 @@ jobs:
         test,
         vectors,
         postgres,
+        sandbox-container,
         ui,
       ]
     runs-on: ubuntu-latest
@@ -508,6 +562,7 @@ jobs:
           TEST_RESULT: ${{ needs.test.result }}
           VECTORS_RESULT: ${{ needs.vectors.result }}
           POSTGRES_RESULT: ${{ needs.postgres.result }}
+          SANDBOX_CONTAINER_RESULT: ${{ needs.sandbox-container.result }}
           UI_RESULT: ${{ needs.ui.result }}
           PR_TITLE_RESULT: ${{ needs.pr-title.result }}
           RELEASE_POLICY_RESULT: ${{ needs.release-policy.result }}
@@ -585,5 +640,17 @@ jobs:
             case "$WORKSPACE_CHANGED" in
               true) test "$VECTORS_RESULT" = success ;;
               false) test "$VECTORS_RESULT" = skipped ;;
+            esac
+          fi
+
+          # The sandbox-resident container e2e is post-merge only for the same
+          # reason (see the job's own comment): it builds the agent image. Assert
+          # the exemption rather than dropping the lane from the gate.
+          if test "$EVENT_NAME" = pull_request; then
+            test "$SANDBOX_CONTAINER_RESULT" = skipped
+          else
+            case "$WORKSPACE_CHANGED" in
+              true) test "$SANDBOX_CONTAINER_RESULT" = success ;;
+              false) test "$SANDBOX_CONTAINER_RESULT" = skipped ;;
             esac
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6769,6 +6769,7 @@ dependencies = [
  "openwave-mcp",
  "openwave-retrieval",
  "openwave-router",
+ "openwave-sandbox-agent",
  "openwave-sandbox-protocol",
  "openwave-web-search",
  "plist",

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -409,8 +409,10 @@ impl MigrationTrait for AllowContainerExecutionLocation {
 async fn reject_down_with_container_rows(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
     let conn = manager.get_connection();
     let backend = manager.get_database_backend();
+    // sea-orm 2.0: `query_one` takes a `StatementBuilder`; a prepared raw
+    // `Statement` goes through `query_one_raw`.
     let remaining = conn
-        .query_one(sea_orm::Statement::from_string(
+        .query_one_raw(sea_orm::Statement::from_string(
             backend,
             "SELECT COUNT(*) AS remaining FROM agent_run WHERE execution_location = 'container'",
         ))

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -41,6 +41,7 @@ impl MigratorTrait for Migrator {
             Box::new(AddToolCallAutoJudgeStatus),
             Box::new(AddChatCitationFormat),
             Box::new(AddEvidenceLocation),
+            Box::new(AllowContainerExecutionLocation),
         ]
     }
 }
@@ -324,6 +325,143 @@ async fn rebuild_agent_run_sqlite(manager: &SchemaManager<'_>, split: bool) -> R
     Ok(())
 }
 
+/// Widens `agent_run.execution_location` from `in_process` only to
+/// `in_process | container`, so a background run can be admitted to run inside a
+/// sandbox-resident container (issue #874). Purely a domain widening: no row
+/// changes, and the in-process scheduler already selects only `in_process` runs,
+/// so nothing it advances is affected. The `down` narrows the domain back, which
+/// is safe only while no `container` rows exist.
+///
+/// SQLite cannot alter a CHECK constraint, so it rebuilds the table with the two
+/// post-split columns copied straight across (the split already retired the old
+/// `execution` column) under the widened location check; PostgreSQL drops and
+/// re-adds the named constraint in place.
+struct AllowContainerExecutionLocation;
+
+impl MigrationName for AllowContainerExecutionLocation {
+    fn name(&self) -> &str {
+        "m20260729_000027_allow_container_execution_location"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AllowContainerExecutionLocation {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() == DatabaseBackend::Sqlite {
+            return rebuild_agent_run_sqlite_relocate(manager, true).await;
+        }
+        let location = render_postgres_check(agent_run_location_check_container());
+        for statement in [
+            "ALTER TABLE agent_run DROP CONSTRAINT chk_agent_run_execution_location".to_owned(),
+            format!(
+                "ALTER TABLE agent_run ADD CONSTRAINT chk_agent_run_execution_location \
+                 CHECK ({location})"
+            ),
+        ] {
+            manager
+                .get_connection()
+                .execute_unprepared(&statement)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Narrowing the domain is only meaningful with no `container` rows left.
+        // Refuse up front with a clear error rather than failing partway through
+        // — on SQLite a mid-rebuild failure would strand the scratch table and
+        // break the next `up`, and on PostgreSQL it would leave the location
+        // column with no constraint at all.
+        reject_down_with_container_rows(manager).await?;
+        if manager.get_database_backend() == DatabaseBackend::Sqlite {
+            return rebuild_agent_run_sqlite_relocate(manager, false).await;
+        }
+        // Re-add before dropping, under a distinct name, so no window exists in
+        // which the location column is unconstrained: if either statement fails,
+        // the migration's transaction rolls back with a constraint still in
+        // place. The narrow constraint then takes the canonical name.
+        let location = render_postgres_check(agent_run_location_check());
+        for statement in [
+            format!(
+                "ALTER TABLE agent_run ADD CONSTRAINT chk_agent_run_execution_location_narrow \
+                 CHECK ({location})"
+            ),
+            "ALTER TABLE agent_run DROP CONSTRAINT chk_agent_run_execution_location".to_owned(),
+            "ALTER TABLE agent_run RENAME CONSTRAINT chk_agent_run_execution_location_narrow \
+             TO chk_agent_run_execution_location"
+                .to_owned(),
+        ] {
+            manager
+                .get_connection()
+                .execute_unprepared(&statement)
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+/// Refuse a rollback of the container-location widening while any `container`
+/// row remains, on either backend.
+///
+/// Without this the narrowing fails deep inside the rebuild (SQLite) or the
+/// constraint validation (PostgreSQL), leaving a half-migrated schema. Failing
+/// here instead names the actual problem and leaves the schema untouched.
+async fn reject_down_with_container_rows(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let conn = manager.get_connection();
+    let backend = manager.get_database_backend();
+    let remaining = conn
+        .query_one(sea_orm::Statement::from_string(
+            backend,
+            "SELECT COUNT(*) AS remaining FROM agent_run WHERE execution_location = 'container'",
+        ))
+        .await?;
+    let remaining = match remaining {
+        // The count comes back as i64 on both backends.
+        Some(row) => row.try_get::<i64>("", "remaining")?,
+        None => 0,
+    };
+    if remaining > 0 {
+        return Err(DbErr::Custom(format!(
+            "cannot narrow agent_run.execution_location: {remaining} container run(s) remain; \
+             terminalize or delete them before rolling this migration back"
+        )));
+    }
+    Ok(())
+}
+
+/// Rebuild the post-split `agent_run` table under a chosen execution-location
+/// domain, copying the two split columns straight across (unlike
+/// [`rebuild_agent_run_sqlite`], which maps the retired `execution` column).
+async fn rebuild_agent_run_sqlite_relocate(
+    manager: &SchemaManager<'_>,
+    allow_container: bool,
+) -> Result<(), DbErr> {
+    let columns = "id, chat_id, parent_id, parent_depth, spawn_call_id, tier, \
+         execution_location, depth, status, input, model, attempt_count, max_attempts, \
+         claim_count, available_at, deadline_at, lease_token, lease_expires_at, started_at, \
+         finished_at, last_error_code, last_error_detail, created_at, updated_at";
+    let mut statements = vec![
+        "PRAGMA foreign_keys=OFF".to_owned(),
+        "BEGIN IMMEDIATE".to_owned(),
+        agent_run_rebuild_table_with_location(true, allow_container).to_string(SqliteQueryBuilder),
+        format!("INSERT INTO {AGENT_RUN_REBUILD} ({columns}) SELECT {columns} FROM agent_run"),
+        "DROP TABLE agent_run".to_owned(),
+        format!("ALTER TABLE {AGENT_RUN_REBUILD} RENAME TO agent_run"),
+    ];
+    statements.extend(
+        agent_run_rebuild_indexes(true)
+            .iter()
+            .map(|index| index.to_string(SqliteQueryBuilder)),
+    );
+    statements.push("COMMIT".to_owned());
+    statements.push("PRAGMA foreign_keys=ON".to_owned());
+    manager
+        .get_connection()
+        .execute_unprepared(&format!("{};", statements.join(";\n")))
+        .await?;
+    Ok(())
+}
+
 fn agent_run_rebuild_copy_sql(split: bool) -> String {
     let (new_columns, mapped) = if split {
         (
@@ -351,6 +489,16 @@ fn agent_run_rebuild_copy_sql(split: bool) -> String {
 }
 
 fn agent_run_rebuild_table(split: bool) -> TableCreateStatement {
+    agent_run_rebuild_table_with_location(split, false)
+}
+
+/// [`agent_run_rebuild_table`] with an explicit choice of location-domain check,
+/// so the container-location migration can rebuild the table with the widened
+/// domain while every historical caller keeps the strict one.
+fn agent_run_rebuild_table_with_location(
+    split: bool,
+    allow_container: bool,
+) -> TableCreateStatement {
     let rebuild = Alias::new(AGENT_RUN_REBUILD);
     let mut statement = Table::create();
     statement
@@ -470,7 +618,11 @@ fn agent_run_rebuild_table(split: bool) -> TableCreateStatement {
         )
         .check(Expr::col(AgentRun::UpdatedAt).gte(Expr::col(AgentRun::CreatedAt)));
     if split {
-        statement.check(agent_run_location_check());
+        statement.check(if allow_container {
+            agent_run_location_check_container()
+        } else {
+            agent_run_location_check()
+        });
     }
     statement.to_owned()
 }
@@ -615,6 +767,12 @@ fn agent_run_shape_check(split: bool) -> SimpleExpr {
 
 fn agent_run_location_check() -> SimpleExpr {
     Expr::col(AgentRun::ExecutionLocation).eq("in_process")
+}
+
+/// The widened execution-location domain: in-process, or resident in a
+/// container the sandbox-resident driver provisions and drives.
+fn agent_run_location_check_container() -> SimpleExpr {
+    Expr::col(AgentRun::ExecutionLocation).is_in(["in_process", "container"])
 }
 
 fn agent_run_lease_check() -> SimpleExpr {

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1961,6 +1961,39 @@ impl Store for DbStore {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
+    async fn admit_sandbox_container_agent_run(
+        &self,
+        origin_turn_id: TurnId,
+        spawn_call_id: CallId,
+        input: &str,
+        lease_token: uuid::Uuid,
+        expected_steer_revision: i64,
+        max_outstanding_children: u32,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<Option<AdmitSandboxAgentRunOutcome>> {
+        ops::agent_run::admit_sandbox_container_agent_run(
+            self,
+            origin_turn_id,
+            spawn_call_id,
+            input,
+            lease_token,
+            expected_steer_revision,
+            max_outstanding_children,
+            now,
+        )
+        .await
+    }
+
+    async fn claim_container_agent_run(
+        &self,
+        id: AgentRunId,
+        lease_token: uuid::Uuid,
+        lease_duration: chrono::Duration,
+    ) -> Result<Option<AgentRun>> {
+        ops::agent_run::claim_container_agent_run(self, id, lease_token, lease_duration).await
+    }
+
     async fn checkpoint_sandbox_spawn(
         &self,
         request: &crate::model::SandboxSpawnCheckpointRequest,

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -2329,6 +2329,17 @@ where
 {
     entities::agent_run::Entity::find()
         .filter(entities::agent_run::Column::Tier.eq(AgentRunTier::Background.as_str()))
+        // Lease expiry means "the in-process worker that held this run died".
+        // A sandbox-resident run holds no in-process worker: its driver keeps
+        // the lease live by heartbeat while the container works, and a driver
+        // that dies is recovered by reconciling the existing container, not by
+        // reaping the run out from under a container that is still spending.
+        // Its absolute deadline (checked by the deadline scan above, which has
+        // no such exemption) remains the backstop.
+        .filter(
+            entities::agent_run::Column::ExecutionLocation
+                .eq(AgentRunExecutionLocation::InProcess.as_str()),
+        )
         .filter(entities::agent_run::Column::Id.in_subquery(admitted_child_id_subquery()))
         .filter(
             sea_orm::Condition::any()

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -260,6 +260,62 @@ pub(in crate::db) async fn admit_sandbox_agent_run(
     max_outstanding_children: u32,
     now: chrono::DateTime<Utc>,
 ) -> Result<Option<AdmitSandboxAgentRunOutcome>> {
+    admit_sandbox_agent_run_at(
+        store,
+        origin_turn_id,
+        spawn_call_id,
+        input,
+        AgentRunExecutionLocation::InProcess,
+        lease_token,
+        expected_steer_revision,
+        max_outstanding_children,
+        now,
+    )
+    .await
+}
+
+/// Admit a depth-one sandbox child that runs inside a sandbox-resident
+/// container, host-driven over the wire protocol. Identical to
+/// [`admit_sandbox_agent_run`] except the child's execution location is
+/// [`AgentRunExecutionLocation::Container`], so the in-process scheduler leaves
+/// it for the sandbox-resident driver to claim, provision, attach, and drive.
+#[allow(clippy::too_many_arguments)]
+pub(in crate::db) async fn admit_sandbox_container_agent_run(
+    store: &DbStore,
+    origin_turn_id: TurnId,
+    spawn_call_id: CallId,
+    input: &str,
+    lease_token: uuid::Uuid,
+    expected_steer_revision: i64,
+    max_outstanding_children: u32,
+    now: chrono::DateTime<Utc>,
+) -> Result<Option<AdmitSandboxAgentRunOutcome>> {
+    admit_sandbox_agent_run_at(
+        store,
+        origin_turn_id,
+        spawn_call_id,
+        input,
+        AgentRunExecutionLocation::Container,
+        lease_token,
+        expected_steer_revision,
+        max_outstanding_children,
+        now,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn admit_sandbox_agent_run_at(
+    store: &DbStore,
+    origin_turn_id: TurnId,
+    spawn_call_id: CallId,
+    input: &str,
+    execution_location: AgentRunExecutionLocation,
+    lease_token: uuid::Uuid,
+    expected_steer_revision: i64,
+    max_outstanding_children: u32,
+    now: chrono::DateTime<Utc>,
+) -> Result<Option<AdmitSandboxAgentRunOutcome>> {
     validate_admission_request(
         origin_turn_id,
         spawn_call_id,
@@ -300,6 +356,7 @@ pub(in crate::db) async fn admit_sandbox_agent_run(
         spawn_call_id,
         input,
         None,
+        execution_location,
         lease_token,
         expected_steer_revision,
         max_outstanding_children,
@@ -354,6 +411,7 @@ pub(in crate::db) async fn admit_sandbox_agent_run_on<C>(
     spawn_call_id: CallId,
     input: &str,
     resource: Option<&SandboxAgentFileResource>,
+    execution_location: AgentRunExecutionLocation,
     lease_token: uuid::Uuid,
     expected_steer_revision: i64,
     max_outstanding_children: u32,
@@ -455,7 +513,7 @@ where
         parent_depth: Set(Some(0)),
         spawn_call_id: Set(Some(spawn_call_id.0)),
         tier: Set(AgentRunTier::Background.as_str().into()),
-        execution_location: Set(AgentRunExecutionLocation::InProcess.as_str().into()),
+        execution_location: Set(execution_location.as_str().into()),
         depth: Set(i16::from(AgentRun::MAX_DEPTH)),
         status: Set(AgentRunStatus::Queued.as_str().into()),
         input: Set(Some(input.into())),
@@ -465,7 +523,15 @@ where
         // the row records what it ran against.
         model: Set(Some(turn.model.clone())),
         attempt_count: Set(0),
-        max_attempts: Set(AgentRun::DEFAULT_MAX_ATTEMPTS),
+        // A sandbox-resident (container) run has exactly one execution attempt:
+        // an external effect (model spend) cannot be proven unexecuted after a
+        // loss, so a lost run fails terminally and is never re-claimed into a
+        // second attempt. Only in-process runs use the multi-attempt retry
+        // machinery.
+        max_attempts: Set(match execution_location {
+            AgentRunExecutionLocation::Container => 1,
+            _ => AgentRun::DEFAULT_MAX_ATTEMPTS,
+        }),
         claim_count: Set(0),
         available_at: Set(created_at),
         deadline_at: Set(Some(created_at + AgentRun::DEFAULT_MAX_DURATION)),
@@ -614,6 +680,7 @@ pub(in crate::db) async fn accept_sandbox_agent_run_and_park_turn(
         spawn_call_id,
         input,
         None,
+        AgentRunExecutionLocation::InProcess,
         lease_token,
         expected_steer_revision,
         AgentRun::DEFAULT_MAX_OUTSTANDING_CHILDREN,
@@ -988,6 +1055,170 @@ pub(in crate::db) async fn claim_agent_run(
         transaction.commit().await.map_err(store_err)?;
         return Ok(Some(claimed));
     }
+}
+
+/// Claim one specific queued sandbox-resident container run by id under an exact
+/// bounded lease, so the sandbox-resident driver can drive it and commit its
+/// result through the same fenced result path as an in-process run.
+///
+/// Unlike [`claim_agent_run`] — which the in-process scheduler uses to select
+/// the oldest due `in_process` run under global and per-chat concurrency limits
+/// — this claims exactly the named `container` run, because the driver has
+/// already decided which run it is provisioning a container for. Reusing
+/// `lease_token` recovers only its original still-live claim (the same
+/// ambiguous-commit recovery `claim_agent_run` gives) and never claims different
+/// work. A container run has exactly one execution attempt, so this only
+/// transitions a fresh `queued` run to `running`; it never reclaims an expired
+/// lease into a second attempt.
+pub(in crate::db) async fn claim_container_agent_run(
+    store: &DbStore,
+    id: AgentRunId,
+    lease_token: uuid::Uuid,
+    lease_duration: chrono::Duration,
+) -> Result<Option<AgentRun>> {
+    if lease_token.is_nil() || lease_duration <= chrono::Duration::zero() {
+        return Err(AgentError::Store(
+            "container agent-run claim requires a non-nil token and positive duration".into(),
+        ));
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    acquire_agent_run_claim_lock(&transaction).await?;
+    let now = database_now(&transaction).await?;
+    let lease_expires_at = now.checked_add_signed(lease_duration).ok_or_else(|| {
+        AgentError::Store("agent-run lease duration overflows the database timestamp range".into())
+    })?;
+
+    // Idempotent re-claim: a prior commit may have been lost after it wrote the
+    // claim receipt. Recover only the exact still-live claim this token owns.
+    if let Some(receipt) = entities::agent_run_claim::Entity::find_by_id(lease_token)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    {
+        let Some(agent_run_id) = receipt.agent_run_id else {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(None);
+        };
+        let existing = find_by_id_on(&transaction, AgentRunId(agent_run_id))
+            .await?
+            .filter(|run| {
+                run.tier == AgentRunTier::Background.as_str()
+                    && run.execution_location == AgentRunExecutionLocation::Container.as_str()
+                    && matches!(run.status.as_str(), "running" | "cancelling")
+                    && Some(run.attempt_count) == receipt.attempt_count
+                    && Some(run.claim_count) == receipt.claim_count
+                    && run.lease_token == Some(lease_token)
+                    && run.lease_expires_at.is_some_and(|expiry| expiry > now)
+                    && run.deadline_at.is_some_and(|deadline| deadline > now)
+            })
+            .map(agent_run_from_model)
+            .transpose()?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(existing);
+    }
+
+    let Some(candidate) = find_by_id_on(&transaction, id).await? else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    let admitted = entities::sandbox_agent_admission::Entity::find_by_id(candidate.id)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .is_some();
+    let claimable = admitted
+        && candidate.tier == AgentRunTier::Background.as_str()
+        && candidate.execution_location == AgentRunExecutionLocation::Container.as_str()
+        && candidate.status == AgentRunStatus::Queued.as_str()
+        && candidate.available_at <= now
+        && candidate.deadline_at.is_some_and(|deadline| deadline > now)
+        && candidate.updated_at <= now;
+    if !claimable {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+
+    let attempt_count = candidate.attempt_count.checked_add(1).ok_or_else(|| {
+        AgentError::Store(format!("agent run {} attempt count overflow", candidate.id))
+    })?;
+    let claim_count = candidate.claim_count.checked_add(1).ok_or_else(|| {
+        AgentError::Store(format!("agent run {} claim count overflow", candidate.id))
+    })?;
+    let deadline_at = candidate
+        .deadline_at
+        .ok_or_else(|| AgentError::Store("container agent run is missing its deadline".into()))?;
+    let effective_lease_expires_at = Ord::min(deadline_at, lease_expires_at);
+    entities::agent_run_claim::ActiveModel {
+        token: Set(lease_token),
+        agent_run_id: Set(Some(candidate.id)),
+        attempt_count: Set(Some(attempt_count)),
+        claim_count: Set(Some(claim_count)),
+        claimed_at: Set(now),
+        lease_expires_at: Set(Some(effective_lease_expires_at)),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+
+    let claimed = entities::agent_run::Entity::update_many()
+        .col_expr(
+            entities::agent_run::Column::Status,
+            sea_orm::sea_query::Expr::value(AgentRunStatus::Running.as_str()),
+        )
+        .col_expr(
+            entities::agent_run::Column::AttemptCount,
+            sea_orm::sea_query::Expr::value(attempt_count),
+        )
+        .col_expr(
+            entities::agent_run::Column::ClaimCount,
+            sea_orm::sea_query::Expr::value(claim_count),
+        )
+        .col_expr(
+            entities::agent_run::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Some(lease_token)),
+        )
+        .col_expr(
+            entities::agent_run::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Some(effective_lease_expires_at)),
+        )
+        .col_expr(
+            entities::agent_run::Column::StartedAt,
+            sea_orm::sea_query::Expr::value(Some(candidate.started_at.unwrap_or(now))),
+        )
+        .col_expr(
+            entities::agent_run::Column::LastErrorCode,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::agent_run::Column::LastErrorDetail,
+            sea_orm::sea_query::Expr::value(Option::<String>::None),
+        )
+        .col_expr(
+            entities::agent_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::agent_run::Column::Id.eq(candidate.id))
+        .filter(entities::agent_run::Column::Status.eq(AgentRunStatus::Queued.as_str()))
+        .filter(entities::agent_run::Column::AttemptCount.eq(candidate.attempt_count))
+        .filter(entities::agent_run::Column::ClaimCount.eq(candidate.claim_count))
+        .filter(entities::agent_run::Column::UpdatedAt.eq(candidate.updated_at))
+        .filter(entities::agent_run::Column::LeaseToken.is_null())
+        .filter(entities::agent_run::Column::LeaseExpiresAt.is_null())
+        .filter(entities::agent_run::Column::AvailableAt.lte(now))
+        .filter(entities::agent_run::Column::DeadlineAt.gt(now))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if claimed.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let claimed = find_by_id_on(&transaction, id)
+        .await?
+        .ok_or_else(|| AgentError::Store("claimed container agent run disappeared".into()))?;
+    let claimed = agent_run_from_model(claimed)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(claimed))
 }
 
 async fn record_empty_claim_scan_on<C>(
@@ -2424,6 +2655,7 @@ pub(in crate::db) fn agent_run_from_model(model: entities::agent_run::Model) -> 
     };
     let execution_location = match model.execution_location.as_str() {
         "in_process" => AgentRunExecutionLocation::InProcess,
+        "container" => AgentRunExecutionLocation::Container,
         value => {
             return Err(AgentError::Store(format!(
                 "invalid agent-run execution location {value}"

--- a/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
+++ b/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
@@ -11,8 +11,9 @@ use crate::agent_tools::{
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::model::{
-    AgentRun, SandboxSpawnCheckpoint, SandboxSpawnCheckpointRequest, ToolCallExecution,
-    ToolCallRecord, ToolCallStatus, TurnCheckpointProgress, TurnRunStatus, TurnSteerStatus,
+    AgentRun, AgentRunExecutionLocation, SandboxSpawnCheckpoint, SandboxSpawnCheckpointRequest,
+    ToolCallExecution, ToolCallRecord, ToolCallStatus, TurnCheckpointProgress, TurnRunStatus,
+    TurnSteerStatus,
 };
 use crate::storage::{AdmitSandboxAgentRunOutcome, CheckpointSandboxSpawnOutcome};
 use crate::{AgentRunId, ChatId, ToolOutput};
@@ -175,6 +176,7 @@ where
         request.call_id,
         &arguments.task,
         arguments.resource.as_ref(),
+        AgentRunExecutionLocation::InProcess,
         request.lease_token,
         request.expected_steer_revision,
         AgentRun::DEFAULT_MAX_OUTSTANDING_CHILDREN,

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -5345,6 +5345,84 @@ async fn m0006_upgrades_an_existing_store_without_losing_records() {
 }
 
 #[tokio::test]
+async fn m0024_widens_and_narrows_the_execution_location_domain() {
+    // Guards the container-location migration's bespoke SQLite table rebuild in
+    // both directions: after `up` a `container` execution location is accepted,
+    // after `down` it is rejected again, and re-applying `up` restores it — so a
+    // regression in the hand-written rebuild SQL fails here rather than silently.
+    let dir = tempfile::tempdir().unwrap();
+    let url = format!(
+        "sqlite://{}?mode=rwc",
+        dir.path().join("relocate.db").display()
+    );
+    let conn = Database::connect(&url).await.unwrap();
+    migration::Migrator::up(&conn, None).await.unwrap();
+
+    // A foreground-shaped row is the cheapest row that satisfies the unrelated
+    // shape/lease/finished checks; only its execution location is under test.
+    // Foreign keys are off so no chat row is needed.
+    conn.execute_unprepared("PRAGMA foreign_keys=OFF")
+        .await
+        .unwrap();
+    let insert_container = |conn: DatabaseConnection| async move {
+        let id = uuid::Uuid::new_v4().simple().to_string();
+        let chat = uuid::Uuid::new_v4().simple().to_string();
+        conn.execute_unprepared(&format!(
+            "INSERT INTO agent_run \
+             (id, chat_id, tier, execution_location, depth, status, attempt_count, \
+              max_attempts, claim_count, available_at, created_at, updated_at) \
+             VALUES (X'{id}', X'{chat}', 'foreground', 'container', 0, 'active', 0, 0, 0, \
+              '2026-07-29 00:00:00+00:00', '2026-07-29 00:00:00+00:00', \
+              '2026-07-29 00:00:00+00:00')"
+        ))
+        .await
+    };
+
+    assert!(
+        insert_container(conn.clone()).await.is_ok(),
+        "container must be accepted after the widening migration"
+    );
+
+    // A rollback with a container row still present is refused up front, and
+    // leaves the schema untouched — rather than failing partway through the
+    // rebuild and stranding the scratch table, which would break the next `up`.
+    let refused = migration::Migrator::down(&conn, Some(1)).await;
+    assert!(
+        refused.is_err(),
+        "narrowing must be refused while a container row remains"
+    );
+    conn.execute_unprepared("PRAGMA foreign_keys=OFF")
+        .await
+        .unwrap();
+    assert!(
+        insert_container(conn.clone()).await.is_ok(),
+        "a refused rollback must leave the widened schema intact"
+    );
+
+    // With the container rows cleared, the rollback proceeds.
+    conn.execute_unprepared("DELETE FROM agent_run")
+        .await
+        .unwrap();
+    migration::Migrator::down(&conn, Some(1)).await.unwrap();
+    conn.execute_unprepared("PRAGMA foreign_keys=OFF")
+        .await
+        .unwrap();
+    assert!(
+        insert_container(conn.clone()).await.is_err(),
+        "container must be rejected once the domain is narrowed back"
+    );
+
+    migration::Migrator::up(&conn, None).await.unwrap();
+    conn.execute_unprepared("PRAGMA foreign_keys=OFF")
+        .await
+        .unwrap();
+    assert!(
+        insert_container(conn.clone()).await.is_ok(),
+        "re-applying the migration restores the widened domain"
+    );
+}
+
+#[tokio::test]
 async fn m0011_preserves_legacy_documents_as_conversationless() {
     let dir = tempfile::tempdir().unwrap();
     let url = format!(

--- a/crates/openwave-core/src/db/tests/operation_log.rs
+++ b/crates/openwave-core/src/db/tests/operation_log.rs
@@ -245,11 +245,12 @@ async fn the_operation_log_migration_is_reversible() {
         .await
         .unwrap();
 
-    // Rolling back the six most recent additive migrations (the evidence
-    // location column, the per-chat citation format, the judge status, the
-    // chat permission mode, the output-revision binary/producing-run
+    // Rolling back the seven most recent additive migrations (the container
+    // execution location, the evidence location column, the per-chat citation
+    // format, the tool-call judge status, the chat permission mode, the
+    // output-revision binary/producing-run
     // extension, then this one) drops the table symmetrically...
-    Migrator::down(&store.conn, Some(6)).await.unwrap();
+    Migrator::down(&store.conn, Some(7)).await.unwrap();
     assert!(
         store
             .claim_operation(run, Uuid::new_v4(), b"fp", true, Uuid::new_v4())

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1914,6 +1914,12 @@ impl AgentRunTier {
 pub enum AgentRunExecutionLocation {
     /// The loop runs inside the OpenWave server process.
     InProcess,
+    /// The loop runs inside a sandbox-resident container, host-driven over the
+    /// versioned sandbox-agent wire protocol. The in-process scheduler does not
+    /// advance these runs; the sandbox-resident driver provisions the container,
+    /// attaches, proxies model inference back over the reverse channel, and
+    /// commits the result through the same fenced result path.
+    Container,
 }
 
 impl AgentRunExecutionLocation {
@@ -1922,6 +1928,7 @@ impl AgentRunExecutionLocation {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::InProcess => "in_process",
+            Self::Container => "container",
         }
     }
 }

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1749,6 +1749,49 @@ pub trait Store: Send + Sync {
         agent_run_storage_unavailable()
     }
 
+    /// Admit one depth-one sandbox child that executes inside a sandbox-resident
+    /// container rather than in process.
+    ///
+    /// Identical to [`Store::admit_sandbox_agent_run`] except the child's
+    /// [`AgentRunExecutionLocation`](crate::model::AgentRunExecutionLocation) is
+    /// `Container`, so the in-process scheduler leaves it and the
+    /// sandbox-resident driver claims it with
+    /// [`Store::claim_container_agent_run`], provisions a container, attaches,
+    /// proxies model inference back over the reverse channel, and commits the
+    /// result through the same fenced result path.
+    #[allow(clippy::too_many_arguments)]
+    async fn admit_sandbox_container_agent_run(
+        &self,
+        _origin_turn_id: TurnId,
+        _spawn_call_id: CallId,
+        _input: &str,
+        _lease_token: uuid::Uuid,
+        _expected_steer_revision: i64,
+        _max_outstanding_children: u32,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<AdmitSandboxAgentRunOutcome>> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Claim one specific queued sandbox-resident container run by id under an
+    /// exact bounded lease.
+    ///
+    /// The sandbox-resident driver calls this for the exact run it is
+    /// provisioning a container for; unlike [`Store::claim_agent_run`], which the
+    /// in-process scheduler uses to select the oldest due in-process run, this
+    /// only transitions a fresh `queued` `container` run to `running`. Reusing
+    /// `lease_token` recovers its original still-live claim and never claims
+    /// different work. The returned lease fences the run's result commit exactly
+    /// as an in-process claim does.
+    async fn claim_container_agent_run(
+        &self,
+        _id: AgentRunId,
+        _lease_token: uuid::Uuid,
+        _lease_duration: chrono::Duration,
+    ) -> Result<Option<AgentRun>> {
+        agent_run_storage_unavailable()
+    }
+
     /// Atomically admit one depth-one sandbox child and yield the foreground
     /// turn at a non-blocking spawn boundary.
     ///

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -43,7 +43,7 @@ export type AgentRunCancellationStatus = "cancelling" | "cancelled";
  * executing inside an execution provider's boundary adds a variant here
  * rather than a second meaning to [`AgentRunTier`].
  */
-export type AgentRunExecutionLocation = "in_process";
+export type AgentRunExecutionLocation = "in_process" | "container";
 
 /**
  * Identifies one durable foreground or sandboxed background agent run.

--- a/crates/openwave-sandbox-agent/src/agent.rs
+++ b/crates/openwave-sandbox-agent/src/agent.rs
@@ -59,7 +59,19 @@ pub enum AgentRunError {
 /// [`AgentRunError::Model`] if a model step fails, or [`AgentRunError::StepLimit`]
 /// if the model never submits a final answer within the step bound.
 pub async fn run_agent(run: SandboxRun, task: impl Into<String>) -> Result<String, AgentRunError> {
-    let task = task.into();
+    let outcome = run_loop(run.clone(), task.into()).await;
+    // Every exit from the loop must put a terminal event on the stream. The
+    // supervisor keeps serving the connection after this returns, so a host that
+    // saw neither a result nor a failure would wait on an open socket forever
+    // and leak the sandbox. `run_loop` emits the result on the success path; a
+    // failure is signalled here, once, on every other path.
+    if let Err(error) = &outcome {
+        let _ = run.emit_failed(error.to_string()).await;
+    }
+    outcome
+}
+
+async fn run_loop(run: SandboxRun, task: String) -> Result<String, AgentRunError> {
     let tools = sandbox_tool_registry();
     let model = HostModel::new(run.clone());
     // The sandbox loop has no host chat identity or filesystem scratch; a fresh

--- a/crates/openwave-sandbox-protocol/src/conformance.rs
+++ b/crates/openwave-sandbox-protocol/src/conformance.rs
@@ -125,6 +125,7 @@ fn provision_request() -> ProvisionRequest {
         run_id: RunId::new(),
         tag: crate::ids::SandboxTag::new(),
         lifetime_cap_secs: None,
+        task: Some("the delegated task".to_owned()),
     }
 }
 

--- a/crates/openwave-sandbox-protocol/src/events.rs
+++ b/crates/openwave-sandbox-protocol/src/events.rs
@@ -37,6 +37,16 @@ pub enum EventPayload {
     Progress(String),
     /// The run's terminal result submission.
     Result(String),
+    /// The run's loop ended without producing a result — it exhausted its step
+    /// budget, or a model step failed unrecoverably. Terminal, like
+    /// [`Result`](EventPayload::Result): a conforming sandbox emits exactly one
+    /// of the two and then stops producing.
+    ///
+    /// Without this the host cannot tell "still working" from "finished with
+    /// nothing", because the supervisor keeps serving the connection after the
+    /// agent loop returns. A host that only watched for a result would wait on
+    /// the open socket forever and leak the sandbox.
+    Failed(String),
 }
 
 impl EventPayload {
@@ -44,9 +54,19 @@ impl EventPayload {
     #[must_use]
     pub fn within_bounds(&self) -> bool {
         let len = match self {
-            EventPayload::Progress(text) | EventPayload::Result(text) => text.len(),
+            EventPayload::Progress(text)
+            | EventPayload::Result(text)
+            | EventPayload::Failed(text) => text.len(),
         };
         len <= MAX_EVENT_PAYLOAD_BYTES
+    }
+
+    /// Whether this payload terminates the run's event stream — a submitted
+    /// result or a loop that ended without one. The host stops draining and
+    /// terminalizes on either.
+    #[must_use]
+    pub const fn is_terminal(&self) -> bool {
+        matches!(self, EventPayload::Result(_) | EventPayload::Failed(_))
     }
 }
 

--- a/crates/openwave-sandbox-protocol/src/provisioning.rs
+++ b/crates/openwave-sandbox-protocol/src/provisioning.rs
@@ -49,6 +49,19 @@ pub struct ProvisionRequest {
     /// outside the sandbox. `None` means the backend cannot cap lifetime, which
     /// (per the design) makes the run attached-only.
     pub lifetime_cap_secs: Option<u64>,
+    /// The delegated task, as bounded UTF-8.
+    ///
+    /// **Interim.** The design delivers the task in the [run
+    /// init](crate::init::RunInit) *after* the handle commits, so a sandbox
+    /// reclaimed before that point never executed anything. No init frame exists
+    /// on the transport yet, so the task rides the provisioning request and the
+    /// backend delivers it through whatever its control plane is (for a local
+    /// container, the container's environment — the same path that already
+    /// carries the per-run transport secret). This field goes away when the init
+    /// frame lands; a backend that cannot carry a task ignores it, and `None`
+    /// leaves the sandbox on its own default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task: Option<String>,
 }
 
 /// An opaque, backend-specific handle to a provisioned sandbox.

--- a/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
@@ -160,6 +160,20 @@ impl SandboxRun {
         self.emit(EventPayload::Result(text.into())).await
     }
 
+    /// Emit the run's terminal loop-end failure, returning its sequence.
+    ///
+    /// A conforming sandbox emits exactly one terminal event — this or
+    /// [`emit_result`](Self::emit_result) — when its loop ends, so the host can
+    /// terminalize and tear down instead of waiting on a connection the
+    /// supervisor keeps serving after the agent is done.
+    ///
+    /// # Errors
+    /// [`EmitError::TooLarge`] past the per-event bound, or [`EmitError::Overflow`]
+    /// when the un-acknowledged buffer is full.
+    pub async fn emit_failed(&self, text: impl Into<String>) -> Result<Sequence, EmitError> {
+        self.emit(EventPayload::Failed(text.into())).await
+    }
+
     async fn emit(&self, payload: EventPayload) -> Result<Sequence, EmitError> {
         let event = self.buffer_event(payload)?;
         let sequence = event.sequence;

--- a/crates/openwave-sandbox-protocol/tests/wire_format.rs
+++ b/crates/openwave-sandbox-protocol/tests/wire_format.rs
@@ -249,6 +249,22 @@ fn event_stream_wire_shapes() {
     roundtrip(&result);
     golden(&result, &[("/payload/kind", json!("result"))]);
 
+    // The other terminal event: the loop ended without a result.
+    let failed = SandboxEvent {
+        sequence: Sequence::new(3),
+        payload: EventPayload::Failed("step budget exhausted".to_owned()),
+    };
+    roundtrip(&failed);
+    golden(
+        &failed,
+        &[
+            ("/payload/kind", json!("failed")),
+            ("/payload/body", json!("step budget exhausted")),
+        ],
+    );
+    assert!(failed.payload.is_terminal() && result.payload.is_terminal());
+    assert!(!progress.payload.is_terminal());
+
     let batch = EventBatch {
         events: vec![progress],
         overflowed: false,
@@ -296,9 +312,25 @@ fn provisioning_wire_shapes() {
         run_id: RunId::new(),
         tag: SandboxTag::new(),
         lifetime_cap_secs: Some(3600),
+        task: Some("summarize the corpus".to_owned()),
     };
     roundtrip(&request);
-    golden(&request, &[("/lifetime_cap_secs", json!(3600))]);
+    golden(
+        &request,
+        &[
+            ("/lifetime_cap_secs", json!(3600)),
+            ("/task", json!("summarize the corpus")),
+        ],
+    );
+
+    // An absent task is omitted entirely, so a backend that carries no task and
+    // an older encoding both decode.
+    let taskless = ProvisionRequest {
+        task: None,
+        ..request
+    };
+    roundtrip(&taskless);
+    assert!(serde_json::to_value(&taskless).unwrap().get("task").is_none());
 
     let handle = SandboxHandle {
         reference: "container-abc".to_owned(),

--- a/crates/openwave-sandbox-protocol/tests/wire_format.rs
+++ b/crates/openwave-sandbox-protocol/tests/wire_format.rs
@@ -330,7 +330,10 @@ fn provisioning_wire_shapes() {
         ..request
     };
     roundtrip(&taskless);
-    assert!(serde_json::to_value(&taskless).unwrap().get("task").is_none());
+    assert!(serde_json::to_value(&taskless)
+        .unwrap()
+        .get("task")
+        .is_none());
 
     let handle = SandboxHandle {
         reference: "container-abc".to_owned(),

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -88,6 +88,10 @@ windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
 winreg = "=0.55.0"
 
 [dev-dependencies]
+# The real in-container agent (loop, supervisor, word_count tool) so the
+# sandbox-resident driver tests can drive the actual sandbox side over a
+# loopback socket, with only Docker and the host model mocked.
+openwave-sandbox-agent = { path = "../openwave-sandbox-agent" }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
 tower = { version = "=0.5.3", features = ["util"] }
 reqwest = { workspace = true }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -42,6 +42,7 @@ mod providers;
 mod resolver;
 mod routes;
 mod sandbox_agent_run_worker;
+pub mod sandbox_container_run;
 /// A [`SandboxBackend`](openwave_sandbox_protocol::SandboxBackend) over the Docker
 /// CLI: container provision, loopback addressing, idempotent teardown, and a
 /// correlation-tag orphan sweep.

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -40,8 +40,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use futures::StreamExt;
 use openwave_core::{
-    AgentError, AgentRun, AgentRunExecutionLocation, AgentRunId, AgentRunStatus, ChatMessage,
-    ChatRequest, ProviderEvent, Result, Role, Store, SubmitAgentRunResultOutcome,
+    AgentConfig, AgentError, AgentRun, AgentRunExecutionLocation, AgentRunId, AgentRunStatus,
+    ChatMessage, ChatRequest, ProviderEvent, Result, Role, Store, SubmitAgentRunResultOutcome,
 };
 use openwave_sandbox_protocol::{
     events::EventPayload,
@@ -71,10 +71,14 @@ pub struct SandboxContainerRunConfig {
     /// The bounded lease the driver claims the run under; the same lease fences
     /// the result commit.
     pub lease: Duration,
+    /// How often the driver extends that lease while the container works.
+    ///
+    /// A container run outlives one lease period, and the in-process reaper
+    /// terminalizes a background run whose lease expires. Must be well under
+    /// [`lease`](Self::lease).
+    pub heartbeat: Duration,
     /// How long to wait for one TCP dial of the container's loopback address.
     pub dial_timeout: Duration,
-    /// Upper bound on tokens the host requests per proxied model completion.
-    pub max_tokens: u32,
     /// How many times the driver re-dials after an unplanned disconnect before
     /// giving up on an attached-only run. Reattachment resumes the event stream
     /// from the committed cursor and replays any recorded reverse answer.
@@ -87,8 +91,8 @@ impl Default for SandboxContainerRunConfig {
     fn default() -> Self {
         Self {
             lease: Duration::from_secs(60),
+            heartbeat: Duration::from_secs(15),
             dial_timeout: Duration::from_secs(10),
-            max_tokens: 4_096,
             reattach_attempts: 5,
             reattach_backoff: Duration::from_millis(250),
         }
@@ -121,8 +125,12 @@ pub enum SandboxContainerRunOutcome {
 /// reconnect replays that record rather than spending a second time.
 struct HostModelProxy {
     resolver: Arc<dyn ProviderResolver>,
-    model: String,
-    max_tokens: u32,
+    /// The run's model selection already resolved through the host's model
+    /// registry (provider route, reasoning shape, token and effort bounds), so
+    /// every proxied completion egresses under exactly the policy an in-process
+    /// run would. Resolved once at attach and failed closed there, never
+    /// re-derived per request from an untrusted prompt.
+    config: AgentConfig,
 }
 
 #[async_trait]
@@ -139,10 +147,16 @@ impl CapabilityResponder for HostModelProxy {
             ));
         };
         let provider = self.resolver.resolve().await;
+        // The sandbox names no model, provider, or endpoint: it supplies only a
+        // prompt, and the host's policy-resolved config decides where it goes.
         let request = ChatRequest {
-            model: self.model.clone(),
+            provider: self.config.provider.clone(),
+            model: self.config.model.clone(),
+            reasoning_model: self.config.reasoning_model,
             messages: vec![ChatMessage::text(Role::User, params.prompt)],
-            max_tokens: Some(self.max_tokens),
+            max_tokens: self.config.max_tokens,
+            temperature: self.config.temperature,
+            reasoning_effort: self.config.reasoning_effort,
             ..Default::default()
         };
         let mut stream = match provider.stream(request).await {
@@ -273,7 +287,23 @@ impl SandboxContainerRunner {
                     .await;
             }
         };
-        let model = run.model.clone().unwrap_or_default();
+        // Resolve the run's model through the host's registry BEFORE any
+        // container exists, and fail closed if it does not resolve: the in-process
+        // worker gates every egress on the registry, and a container run must
+        // egress under the same policy rather than a looser one.
+        let config = match self.resolve_model_config(&run).await {
+            Ok(config) => config,
+            Err(error) => {
+                return self
+                    .fail(
+                        run_id,
+                        lease_token,
+                        "model_policy_refused",
+                        &error.to_string(),
+                    )
+                    .await;
+            }
+        };
 
         // Provisioning intent and correlation tag before the create call: the
         // host mints the tag, and the backend stamps it into the container's
@@ -290,6 +320,8 @@ impl SandboxContainerRunner {
                 // A local container has no external lifetime cap, which is why
                 // the run is attached-only.
                 lifetime_cap_secs: None,
+                // The delegated task. Interim delivery: see `ProvisionRequest::task`.
+                task: Some(task),
             })
             .await
         {
@@ -304,20 +336,53 @@ impl SandboxContainerRunner {
         // From here on a container exists, so every terminal path must drive its
         // teardown obligation.
         let outcome = self
-            .attach_and_drive(&run, lease_token, protocol_run_id, task, model, &handle)
+            .attach_and_drive(&run, lease_token, protocol_run_id, config, &handle)
             .await;
         self.teardown(&handle).await;
         outcome
     }
 
-    #[allow(clippy::too_many_arguments)]
+    /// Resolve the run's frozen model selection into an egress config under the
+    /// host's model-registry policy, exactly as the in-process worker does.
+    ///
+    /// Fails closed: an absent or unregistered model refuses the run rather than
+    /// egressing on an empty or unvetted selection.
+    async fn resolve_model_config(&self, run: &AgentRun) -> Result<AgentConfig> {
+        let Some(model) = run.model.clone().filter(|model| !model.is_empty()) else {
+            return Err(AgentError::config(
+                "container agent run has no frozen model selection",
+            ));
+        };
+        let chat = self
+            .store
+            .get_chat(run.chat_id)
+            .await?
+            .ok_or_else(|| AgentError::msg("container agent run has no chat"))?;
+        let mut config = AgentConfig::default();
+        if self.resolver.enforces_model_registry() {
+            let Some(policy) =
+                crate::providers::resolve_model_policy(&*self.store, &model, true).await?
+            else {
+                return Err(AgentError::config(
+                    "container sandbox model is not registered for its provider",
+                ));
+            };
+            crate::providers::apply_model_policy(&mut config, &policy, chat.reasoning_effort)?;
+        } else {
+            // A test or custom embedder that injects one provider keeps its
+            // free-form model contract, as elsewhere in the server.
+            config.model = model;
+            config.reasoning_effort = chat.reasoning_effort;
+        }
+        Ok(config)
+    }
+
     async fn attach_and_drive(
         &self,
         run: &AgentRun,
         lease_token: Uuid,
         protocol_run_id: RunId,
-        task: String,
-        model: String,
+        config: AgentConfig,
         handle: &SandboxHandle,
     ) -> Result<SandboxContainerRunOutcome> {
         let run_id = run.id;
@@ -333,53 +398,127 @@ impl SandboxContainerRunner {
             GrantSet::new(provenance, [Capability::ModelInference]),
             Arc::new(HostModelProxy {
                 resolver: Arc::clone(&self.resolver),
-                model,
-                max_tokens: self.config.max_tokens,
+                config,
             }),
             Arc::new(DurableOperationStore::new(
                 Arc::clone(&self.store),
                 protocol_run_id,
             )),
         );
-        // The task is delivered out of band into the container (its environment
-        // today); the run-init frame is a protocol follow-up. Retained here so
-        // the driver is the single place that would deliver it once the frame
-        // lands.
-        let _ = task;
 
+        // Drive the container while holding the lease live. A container run
+        // routinely outlives one lease period, and the in-process reaper
+        // terminalizes a background run whose lease expires — so without this
+        // heartbeat the run is failed out from under a container that is still
+        // working and still spending. The whole drive is additionally bounded by
+        // the run's absolute deadline, so no path can wait forever.
+        let drive = self.drive_events(protocol_run_id, handle, &host);
+        tokio::pin!(drive);
+        let mut heartbeat = tokio::time::interval(self.config.heartbeat);
+        heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        heartbeat.tick().await;
+        let deadline = self.deadline_sleep(run);
+        tokio::pin!(deadline);
+
+        let end = loop {
+            tokio::select! {
+                end = &mut drive => break end,
+                () = &mut deadline => break DriveEnd::DeadlineExceeded,
+                _ = heartbeat.tick() => {
+                    if !self
+                        .store
+                        .heartbeat_agent_run(
+                            run_id,
+                            lease_token,
+                            chrono_duration(self.config.lease)?,
+                        )
+                        .await?
+                    {
+                        // The lease is gone (cancelled, or reaped): stop driving
+                        // rather than keep a container working for a run this
+                        // host no longer owns. Teardown still runs.
+                        break DriveEnd::LeaseLost;
+                    }
+                }
+            }
+        };
+
+        match end {
+            DriveEnd::Result(text) => self.commit_result(run_id, lease_token, &text).await,
+            DriveEnd::AgentFailed(detail) => {
+                self.fail(run_id, lease_token, "sandbox_agent_failed", &detail)
+                    .await
+            }
+            DriveEnd::TransportFailed(detail) => {
+                self.fail(run_id, lease_token, "sandbox_transport_failed", &detail)
+                    .await
+            }
+            DriveEnd::Unreachable => {
+                self.fail(
+                    run_id,
+                    lease_token,
+                    "sandbox_unreachable",
+                    "container did not deliver a terminal event before its reattach budget",
+                )
+                .await
+            }
+            DriveEnd::DeadlineExceeded => {
+                self.fail(
+                    run_id,
+                    lease_token,
+                    "deadline_exceeded",
+                    "container run exceeded its absolute deadline",
+                )
+                .await
+            }
+            DriveEnd::LeaseLost => Ok(SandboxContainerRunOutcome::LeaseLost(run_id)),
+        }
+    }
+
+    /// A sleep that fires at the run's absolute deadline. A run with no deadline
+    /// (which the schema forbids for a background run) never fires, and the
+    /// reattach budget still bounds the drive.
+    async fn deadline_sleep(&self, run: &AgentRun) {
+        let Some(deadline_at) = run.deadline_at else {
+            return std::future::pending().await;
+        };
+        let remaining = deadline_at.signed_duration_since(chrono::Utc::now());
+        // A negative remaining duration means the deadline already passed, and
+        // `to_std` refuses it — fire immediately in that case.
+        if let Ok(remaining) = remaining.to_std() {
+            tokio::time::sleep(remaining).await;
+        }
+    }
+
+    /// Attach and drain the container's event stream until it reports a terminal
+    /// event, reattaching across unplanned disconnects within the budget.
+    async fn drive_events(
+        &self,
+        protocol_run_id: RunId,
+        handle: &SandboxHandle,
+        host: &CapabilityHost,
+    ) -> DriveEnd {
         let mut cursor = EventCursor::START;
         let mut attempt = 0u32;
         loop {
             match self
-                .drain_connection(protocol_run_id, handle, &host, &mut cursor)
+                .drain_connection(protocol_run_id, handle, host, &mut cursor)
                 .await
             {
-                DrainOutcome::Result(text) => {
-                    return self.commit_result(run_id, lease_token, &text).await;
-                }
+                DrainOutcome::Result(text) => return DriveEnd::Result(text),
+                DrainOutcome::AgentFailed(detail) => return DriveEnd::AgentFailed(detail),
                 DrainOutcome::Disconnected => {
                     // An attached-only run that lost its host takes no new model
                     // step; reattachment resumes the stream from the committed
                     // cursor. Bound the retries so a container that never comes
                     // back is failed rather than driven forever.
                     if attempt >= self.config.reattach_attempts {
-                        return self
-                            .fail(
-                                run_id,
-                                lease_token,
-                                "sandbox_unreachable",
-                                "container did not deliver a result before its reattach budget",
-                            )
-                            .await;
+                        return DriveEnd::Unreachable;
                     }
                     attempt += 1;
                     tokio::time::sleep(self.config.reattach_backoff).await;
                 }
-                DrainOutcome::Failed(detail) => {
-                    return self
-                        .fail(run_id, lease_token, "sandbox_transport_failed", &detail)
-                        .await;
-                }
+                DrainOutcome::Failed(detail) => return DriveEnd::TransportFailed(detail),
             }
         }
     }
@@ -425,14 +564,19 @@ impl SandboxContainerRunner {
                 };
             }
         };
-        // Drain events, committing the cursor by acknowledging each, until the
-        // result arrives or the connection closes.
+        // Drain events, committing the cursor by acknowledging each, until a
+        // terminal event arrives or the connection closes. Both terminal events
+        // end the drive: the supervisor keeps serving after its agent loop
+        // returns, so waiting only for a result would hang on an open socket and
+        // leak the container.
         while let Some(event) = conn.next_event().await {
             let payload = event.payload.clone();
             *cursor = EventCursor::committed(event.sequence);
             conn.acknowledge(*cursor).await;
-            if let EventPayload::Result(text) = payload {
-                return DrainOutcome::Result(text);
+            match payload {
+                EventPayload::Result(text) => return DrainOutcome::Result(text),
+                EventPayload::Failed(detail) => return DrainOutcome::AgentFailed(detail),
+                _ => {}
             }
         }
         DrainOutcome::Disconnected
@@ -531,11 +675,32 @@ impl SandboxContainerRunner {
 enum DrainOutcome {
     /// The container delivered its terminal result.
     Result(String),
-    /// The connection dropped (or could not be established) with no result; an
-    /// attached-only run reattaches and resumes from the committed cursor.
+    /// The container's agent loop ended without a result — it exhausted its step
+    /// budget or a model step failed. Terminal, and distinct from a transport
+    /// failure: the container worked and reported an outcome.
+    AgentFailed(String),
+    /// The connection dropped (or could not be established) with no terminal
+    /// event; an attached-only run reattaches and resumes from the committed
+    /// cursor.
     Disconnected,
     /// A terminal transport condition (version refusal, vanished container).
     Failed(String),
+}
+
+/// How the whole drive ended, across every connection to the container.
+enum DriveEnd {
+    /// The container submitted a result to commit.
+    Result(String),
+    /// The container's agent loop ended without a result.
+    AgentFailed(String),
+    /// A terminal transport condition.
+    TransportFailed(String),
+    /// The container never came back within the reattach budget.
+    Unreachable,
+    /// The run's absolute deadline passed while the container worked.
+    DeadlineExceeded,
+    /// The lease was lost mid-drive; this host no longer owns the run.
+    LeaseLost,
 }
 
 fn chrono_duration(duration: Duration) -> Result<chrono::Duration> {

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -1,0 +1,547 @@
+//! Driving a sandbox-resident agent run inside a local container, host-driven
+//! and attached-only (issue #874).
+//!
+//! This is the host side of the sandbox-resident execution location. Where the
+//! [in-process worker](crate::sandbox_agent_run_worker) advances a background run
+//! by streaming the model itself, this driver hands the loop to a container and
+//! becomes the container's model proxy over the reverse channel. Concretely, for
+//! one admitted `container`-located run it:
+//!
+//! 1. **claims** the run under a bounded lease
+//!    ([`Store::claim_container_agent_run`]) — the same lease that fences the
+//!    result commit at the end;
+//! 2. **provisions** a container from the agent image through the
+//!    [`SandboxBackend`], stamping a host-minted correlation tag so the backend's
+//!    orphan sweep can reclaim a container whose run never committed a handle;
+//! 3. **connects** to the container's mapped loopback address with
+//!    [`WireClient::connect`], doing the version handshake;
+//! 4. **drives** the run: it backs the protocol host's operation log with the
+//!    crash-safe [`DurableOperationStore`], answers the sandbox's reverse-RPC
+//!    model-inference calls with the host's own [`ProviderResolver`] (the same
+//!    resolver the in-process worker uses — no model credential lives in the
+//!    container), drains the event stream committing its cursor, and commits the
+//!    agent's final result through the run tier's fenced result path;
+//! 5. **tears down** the container idempotently on the run's terminal state.
+//!
+//! Attached-only: a local container runtime has no lifetime cap it can enforce
+//! from outside the container, so the run may not work while unattached and this
+//! driver is the container's only model path.
+//!
+//! # Multi-thread precondition
+//!
+//! [`DurableOperationStore`]'s synchronous [`OperationStore`] bridge drives the
+//! async store through [`tokio::task::block_in_place`], which requires a
+//! multi-thread runtime. The host runs on one; every test here uses the
+//! multi-thread flavor.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::StreamExt;
+use openwave_core::{
+    AgentError, AgentRun, AgentRunExecutionLocation, AgentRunId, AgentRunStatus, ChatMessage,
+    ChatRequest, ProviderEvent, Result, Role, Store, SubmitAgentRunResultOutcome,
+};
+use openwave_sandbox_protocol::{
+    events::EventPayload,
+    ids::{EventCursor, RunId},
+    protocol::{ErrorCode, ErrorResponse, Response, PROTOCOL_VERSION},
+    reverse::{
+        Capability, CapabilityResponder, GrantSet, ModelInferenceResult, ReverseRequest,
+        ReverseResult, RunProvenance,
+    },
+    AttachRequest, BackendError, CapabilityHost, ConnectError, ProvisionRequest, SandboxAddress,
+    SandboxBackend, SandboxHandle, SandboxTag, WireClient,
+};
+use tokio::net::TcpStream;
+use uuid::Uuid;
+
+use crate::durable_oplog::DurableOperationStore;
+use crate::resolver::ProviderResolver;
+
+/// The provider attribution stamped on reverse operations from a local
+/// container. Untrusted attribution rendered on consent prompts, never a claim
+/// the container makes about itself.
+const CONTAINER_PROVENANCE_PROVIDER: &str = "local-container";
+
+/// Tunables for driving one sandbox-resident container run.
+#[derive(Debug, Clone, Copy)]
+pub struct SandboxContainerRunConfig {
+    /// The bounded lease the driver claims the run under; the same lease fences
+    /// the result commit.
+    pub lease: Duration,
+    /// How long to wait for one TCP dial of the container's loopback address.
+    pub dial_timeout: Duration,
+    /// Upper bound on tokens the host requests per proxied model completion.
+    pub max_tokens: u32,
+    /// How many times the driver re-dials after an unplanned disconnect before
+    /// giving up on an attached-only run. Reattachment resumes the event stream
+    /// from the committed cursor and replays any recorded reverse answer.
+    pub reattach_attempts: u32,
+    /// Backoff between re-dials.
+    pub reattach_backoff: Duration,
+}
+
+impl Default for SandboxContainerRunConfig {
+    fn default() -> Self {
+        Self {
+            lease: Duration::from_secs(60),
+            dial_timeout: Duration::from_secs(10),
+            max_tokens: 4_096,
+            reattach_attempts: 5,
+            reattach_backoff: Duration::from_millis(250),
+        }
+    }
+}
+
+/// How a driven sandbox-resident container run finished.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SandboxContainerRunOutcome {
+    /// The container submitted a final result and the host committed it.
+    Completed(AgentRunId),
+    /// The result was already committed by this attempt; the redelivery was
+    /// acknowledged with the original receipt.
+    AlreadyCompleted(AgentRunId),
+    /// The run failed terminally (no result within its bounds); a sandbox-
+    /// resident run is never re-executed.
+    Failed(AgentRunId),
+    /// The lease was lost or the run was already terminal when the driver tried
+    /// to commit — nothing was committed by this attempt.
+    LeaseLost(AgentRunId),
+}
+
+/// The host's model proxy for an attached-only sandbox run.
+///
+/// It answers each reverse [`ReverseRequest::ModelInference`] with the host's own
+/// configured model access — the same [`ProviderResolver`] the in-process worker
+/// resolves — so no model credential ever enters the container. The
+/// [`CapabilityHost`] calls this at most once per [`OperationId`], recording the
+/// bounded completion in the [`DurableOperationStore`]; a re-issue after a
+/// reconnect replays that record rather than spending a second time.
+struct HostModelProxy {
+    resolver: Arc<dyn ProviderResolver>,
+    model: String,
+    max_tokens: u32,
+}
+
+#[async_trait]
+impl CapabilityResponder for HostModelProxy {
+    async fn respond(&self, request: ReverseRequest) -> Response<ReverseResult> {
+        let ReverseRequest::ModelInference(params) = request else {
+            // The grant set only authorizes model inference, so a well-behaved
+            // sandbox never reaches this; refuse an unknown capability rather
+            // than trust it.
+            return Response::Error(ErrorResponse::new(
+                ErrorCode::InvalidRequest,
+                "unsupported reverse capability",
+                false,
+            ));
+        };
+        let provider = self.resolver.resolve().await;
+        let request = ChatRequest {
+            model: self.model.clone(),
+            messages: vec![ChatMessage::text(Role::User, params.prompt)],
+            max_tokens: Some(self.max_tokens),
+            ..Default::default()
+        };
+        let mut stream = match provider.stream(request).await {
+            Ok(stream) => stream,
+            Err(error) => {
+                // A transport-safe, retryable refusal: re-issuing the same
+                // operation identity may succeed once the provider is reachable.
+                eprintln!("openwave: host model proxy could not start inference: {error}");
+                return Response::Error(ErrorResponse::new(
+                    ErrorCode::Internal,
+                    "host model inference could not start",
+                    true,
+                ));
+            }
+        };
+        let mut completion = String::new();
+        while let Some(event) = stream.next().await {
+            match event {
+                ProviderEvent::TextDelta { text } => completion.push_str(&text),
+                ProviderEvent::Failed { message } => {
+                    eprintln!("openwave: host model proxy inference failed: {message}");
+                    return Response::Error(ErrorResponse::new(
+                        ErrorCode::Internal,
+                        "host model inference failed",
+                        true,
+                    ));
+                }
+                // Reasoning, usage, tool-call, and stop events do not contribute
+                // to the completion text the sandbox loop reads back.
+                _ => {}
+            }
+        }
+        Response::Ok(ReverseResult::ModelInference(ModelInferenceResult {
+            completion,
+        }))
+    }
+}
+
+/// Drives one admitted `container`-located agent run through a local container.
+pub struct SandboxContainerRunner {
+    store: Arc<dyn Store>,
+    backend: Arc<dyn SandboxBackend>,
+    resolver: Arc<dyn ProviderResolver>,
+    config: SandboxContainerRunConfig,
+}
+
+impl SandboxContainerRunner {
+    /// A runner over `store`, provisioning through `backend` and proxying model
+    /// inference with `resolver`.
+    #[must_use]
+    pub fn new(
+        store: Arc<dyn Store>,
+        backend: Arc<dyn SandboxBackend>,
+        resolver: Arc<dyn ProviderResolver>,
+        config: SandboxContainerRunConfig,
+    ) -> Self {
+        Self {
+            store,
+            backend,
+            resolver,
+            config,
+        }
+    }
+
+    /// Claim and drive the container-located run `run_id` to a terminal state.
+    ///
+    /// Returns `Ok(None)` if the run could not be claimed (it is not a queued
+    /// container run, or another driver holds it). Otherwise it provisions,
+    /// attaches, drives, commits, and — always, on any terminal path — drives the
+    /// container's teardown obligation to completion before returning.
+    ///
+    /// # Errors
+    /// Propagates a durable-store failure. A provisioning or transport failure is
+    /// recorded as a terminal run failure rather than surfaced, because a
+    /// sandbox-resident run has exactly one attempt and is never re-executed.
+    pub async fn drive(&self, run_id: AgentRunId) -> Result<Option<SandboxContainerRunOutcome>> {
+        let lease_token = Uuid::new_v4();
+        let Some(run) = self
+            .store
+            .claim_container_agent_run(run_id, lease_token, chrono_duration(self.config.lease)?)
+            .await?
+        else {
+            return Ok(None);
+        };
+        if run.status != AgentRunStatus::Running
+            || run.lease_token != Some(lease_token)
+            || run.execution_location != AgentRunExecutionLocation::Container
+        {
+            return Err(AgentError::msg(format!(
+                "claimed container agent run {run_id} has an invalid execution identity"
+            )));
+        }
+        Ok(Some(self.drive_claimed(run, lease_token).await?))
+    }
+
+    async fn drive_claimed(
+        &self,
+        run: AgentRun,
+        lease_token: Uuid,
+    ) -> Result<SandboxContainerRunOutcome> {
+        let run_id = run.id;
+        // The run's durable identity is the protocol run identity: the operation
+        // log, event cursor, and grant provenance are all scoped to it and
+        // outlive any single connection to the container.
+        let protocol_run_id = match RunId::from_uuid(*run_id.as_uuid()) {
+            Ok(id) => id,
+            Err(error) => {
+                return self
+                    .fail(
+                        run_id,
+                        lease_token,
+                        "invalid_run_identity",
+                        &error.to_string(),
+                    )
+                    .await;
+            }
+        };
+        let task = match run.input.clone() {
+            Some(task) => task,
+            None => {
+                return self
+                    .fail(
+                        run_id,
+                        lease_token,
+                        "missing_task",
+                        "container agent run has no delegated task",
+                    )
+                    .await;
+            }
+        };
+        let model = run.model.clone().unwrap_or_default();
+
+        // Provisioning intent and correlation tag before the create call: the
+        // host mints the tag, and the backend stamps it into the container's
+        // metadata so an orphan sweep can reclaim a container whose run never
+        // committed a handle. (The durable intent row and the host-side sweep it
+        // drives are a follow-up; the tag discipline and the backend's sweep are
+        // here.)
+        let tag = SandboxTag::new();
+        let handle = match self
+            .backend
+            .provision(ProvisionRequest {
+                run_id: protocol_run_id,
+                tag,
+                // A local container has no external lifetime cap, which is why
+                // the run is attached-only.
+                lifetime_cap_secs: None,
+            })
+            .await
+        {
+            Ok(handle) => handle,
+            Err(error) => {
+                return self
+                    .fail(run_id, lease_token, "provision_failed", &error.to_string())
+                    .await;
+            }
+        };
+
+        // From here on a container exists, so every terminal path must drive its
+        // teardown obligation.
+        let outcome = self
+            .attach_and_drive(&run, lease_token, protocol_run_id, task, model, &handle)
+            .await;
+        self.teardown(&handle).await;
+        outcome
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn attach_and_drive(
+        &self,
+        run: &AgentRun,
+        lease_token: Uuid,
+        protocol_run_id: RunId,
+        task: String,
+        model: String,
+        handle: &SandboxHandle,
+    ) -> Result<SandboxContainerRunOutcome> {
+        let run_id = run.id;
+        // One capability host per run, shared across every connection: it holds
+        // the grant set, the model proxy, and the crash-safe operation log, and a
+        // reattachment reuses it so a re-issued reverse call replays its recorded
+        // answer rather than spending twice.
+        let provenance = RunProvenance {
+            run_id: protocol_run_id,
+            provider: CONTAINER_PROVENANCE_PROVIDER.to_owned(),
+        };
+        let host = CapabilityHost::new(
+            GrantSet::new(provenance, [Capability::ModelInference]),
+            Arc::new(HostModelProxy {
+                resolver: Arc::clone(&self.resolver),
+                model,
+                max_tokens: self.config.max_tokens,
+            }),
+            Arc::new(DurableOperationStore::new(
+                Arc::clone(&self.store),
+                protocol_run_id,
+            )),
+        );
+        // The task is delivered out of band into the container (its environment
+        // today); the run-init frame is a protocol follow-up. Retained here so
+        // the driver is the single place that would deliver it once the frame
+        // lands.
+        let _ = task;
+
+        let mut cursor = EventCursor::START;
+        let mut attempt = 0u32;
+        loop {
+            match self
+                .drain_connection(protocol_run_id, handle, &host, &mut cursor)
+                .await
+            {
+                DrainOutcome::Result(text) => {
+                    return self.commit_result(run_id, lease_token, &text).await;
+                }
+                DrainOutcome::Disconnected => {
+                    // An attached-only run that lost its host takes no new model
+                    // step; reattachment resumes the stream from the committed
+                    // cursor. Bound the retries so a container that never comes
+                    // back is failed rather than driven forever.
+                    if attempt >= self.config.reattach_attempts {
+                        return self
+                            .fail(
+                                run_id,
+                                lease_token,
+                                "sandbox_unreachable",
+                                "container did not deliver a result before its reattach budget",
+                            )
+                            .await;
+                    }
+                    attempt += 1;
+                    tokio::time::sleep(self.config.reattach_backoff).await;
+                }
+                DrainOutcome::Failed(detail) => {
+                    return self
+                        .fail(run_id, lease_token, "sandbox_transport_failed", &detail)
+                        .await;
+                }
+            }
+        }
+    }
+
+    /// Dial the container, attach, and drain its event stream over one
+    /// connection until it delivers a result or drops.
+    async fn drain_connection(
+        &self,
+        protocol_run_id: RunId,
+        handle: &SandboxHandle,
+        host: &CapabilityHost,
+        cursor: &mut EventCursor,
+    ) -> DrainOutcome {
+        let address = match self.backend.address(handle).await {
+            Ok(address) => address,
+            Err(BackendError::UnknownHandle) => {
+                return DrainOutcome::Failed("container no longer exists".to_owned());
+            }
+            Err(error) => {
+                eprintln!("openwave: container address unavailable, will reattach: {error}");
+                return DrainOutcome::Disconnected;
+            }
+        };
+        let stream = match self.dial(&address).await {
+            Ok(stream) => stream,
+            Err(_) => return DrainOutcome::Disconnected,
+        };
+        let attach = AttachRequest {
+            protocol_version: PROTOCOL_VERSION,
+            run_id: protocol_run_id,
+            resume_from: *cursor,
+        };
+        let mut conn = match WireClient::connect(stream, attach, host.clone()).await {
+            Ok(conn) => conn,
+            Err(error) => {
+                // A version refusal is terminal; a transport failure during
+                // attach is a disconnect the driver retries.
+                return match error {
+                    ConnectError::VersionRefused(_) => {
+                        DrainOutcome::Failed("container speaks an incompatible protocol".to_owned())
+                    }
+                    _ => DrainOutcome::Disconnected,
+                };
+            }
+        };
+        // Drain events, committing the cursor by acknowledging each, until the
+        // result arrives or the connection closes.
+        while let Some(event) = conn.next_event().await {
+            let payload = event.payload.clone();
+            *cursor = EventCursor::committed(event.sequence);
+            conn.acknowledge(*cursor).await;
+            if let EventPayload::Result(text) = payload {
+                return DrainOutcome::Result(text);
+            }
+        }
+        DrainOutcome::Disconnected
+    }
+
+    /// Connect a TCP stream to the container's loopback address.
+    async fn dial(&self, address: &SandboxAddress) -> Result<TcpStream> {
+        let authority = address
+            .base_url
+            .trim_start_matches("http://")
+            .trim_start_matches("https://");
+        let connect = TcpStream::connect(authority);
+        match tokio::time::timeout(self.config.dial_timeout, connect).await {
+            Ok(Ok(stream)) => Ok(stream),
+            Ok(Err(error)) => Err(AgentError::msg(format!("container dial failed: {error}"))),
+            Err(_) => Err(AgentError::msg("container dial timed out")),
+        }
+    }
+
+    async fn commit_result(
+        &self,
+        run_id: AgentRunId,
+        lease_token: Uuid,
+        text: &str,
+    ) -> Result<SandboxContainerRunOutcome> {
+        match self
+            .store
+            .submit_agent_run_result(run_id, lease_token, text)
+            .await?
+        {
+            Some(SubmitAgentRunResultOutcome::Completed(_)) => {
+                Ok(SandboxContainerRunOutcome::Completed(run_id))
+            }
+            Some(SubmitAgentRunResultOutcome::Existing(_)) => {
+                Ok(SandboxContainerRunOutcome::AlreadyCompleted(run_id))
+            }
+            None => Ok(SandboxContainerRunOutcome::LeaseLost(run_id)),
+        }
+    }
+
+    async fn fail(
+        &self,
+        run_id: AgentRunId,
+        lease_token: Uuid,
+        code: &str,
+        detail: &str,
+    ) -> Result<SandboxContainerRunOutcome> {
+        let detail = detail
+            .chars()
+            .take(AgentRun::MAX_ERROR_DETAIL_LEN)
+            .collect::<String>();
+        // A sandbox-resident run is admitted with a single attempt, so this
+        // exhausts the attempt budget and terminalizes rather than scheduling a
+        // retry. The delay is required to be positive but is never waited on
+        // here — a container run is never re-claimed.
+        match self
+            .store
+            .fail_agent_run(
+                run_id,
+                lease_token,
+                code,
+                &detail,
+                chrono::Duration::seconds(1),
+            )
+            .await?
+        {
+            Some(_) => Ok(SandboxContainerRunOutcome::Failed(run_id)),
+            None => Ok(SandboxContainerRunOutcome::LeaseLost(run_id)),
+        }
+    }
+
+    /// Drive the container's teardown obligation to completion, idempotently. A
+    /// container that outlives its run is a bounded exposure the destroy exists
+    /// to end, so an unconfirmed destroy is retried within a small budget rather
+    /// than abandoned.
+    async fn teardown(&self, handle: &SandboxHandle) {
+        for attempt in 0..3u32 {
+            match self.backend.destroy(handle).await {
+                Ok(()) => return,
+                Err(error) => {
+                    eprintln!(
+                        "openwave: container teardown attempt {attempt} unconfirmed: {error}"
+                    );
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+        eprintln!(
+            "openwave: container teardown for {} left unconfirmed; a sweep must re-drive it",
+            handle.reference
+        );
+    }
+}
+
+/// The result of draining one connection to the container.
+enum DrainOutcome {
+    /// The container delivered its terminal result.
+    Result(String),
+    /// The connection dropped (or could not be established) with no result; an
+    /// attached-only run reattaches and resumes from the committed cursor.
+    Disconnected,
+    /// A terminal transport condition (version refusal, vanished container).
+    Failed(String),
+}
+
+fn chrono_duration(duration: Duration) -> Result<chrono::Duration> {
+    chrono::Duration::from_std(duration)
+        .map_err(|error| AgentError::msg(format!("invalid container-run duration: {error}")))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -1,0 +1,570 @@
+//! Tests for the sandbox-resident container driver.
+//!
+//! The non-Docker tests drive the **real** in-container agent loop
+//! (`openwave_sandbox_agent::run_agent` plus its `word_count` tool and the
+//! sandbox transport server) over a real loopback TCP socket, with only Docker
+//! (the [`SandboxBackend`]) and the host model (the [`ProviderResolver`]) mocked.
+//! That exercises the whole stack — provision, attach, reverse-RPC model
+//! inference answered by the host proxy through the durable op-log, event drain,
+//! fenced result commit, teardown — without a container runtime. The Docker
+//! end-to-end test at the bottom re-points the same driver at a real container
+//! and is skipped cleanly when no daemon is present.
+//!
+//! Every socket test is wrapped in a timeout so a regression fails loudly rather
+//! than hanging CI, and every test uses the multi-thread runtime the durable
+//! operation store's `block_in_place` bridge requires.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::stream::{self, BoxStream};
+use futures::StreamExt;
+use openwave_core::{
+    AdmitSandboxAgentRunOutcome, AgentRun, AgentRunExecutionLocation, AgentRunId, AgentRunStatus,
+    CallId, Chat, ChatId, ChatRequest, DbStore, ModelProvider, ProviderEvent, ProviderId, Result,
+    StopReason, Store,
+};
+use openwave_sandbox_agent::run_agent;
+use openwave_sandbox_protocol::{
+    ids::{OperationId, RunId},
+    protocol::{Response, PROTOCOL_VERSION},
+    reverse::{
+        Capability, GrantSet, ModelInferenceParams, ReverseEnvelope, ReverseRequest, ReverseResult,
+        RunProvenance,
+    },
+    serve_connection, BackendError, CapabilityHost, ProvisionRequest, SandboxAddress,
+    SandboxBackend, SandboxHandle, SandboxRun, TransportSecret,
+};
+use tokio::net::TcpListener;
+use uuid::Uuid;
+
+use super::{
+    HostModelProxy, SandboxContainerRunConfig, SandboxContainerRunOutcome, SandboxContainerRunner,
+};
+use crate::durable_oplog::DurableOperationStore;
+use crate::resolver::ProviderResolver;
+
+// --- Mock host model (the resolver the driver proxies inference through) ------
+
+/// A provider that scripts one directive step then a final answer, counting how
+/// many completions it is asked for. Drives the real in-container loop: the first
+/// completion tells the sandbox to run `word_count`, the second is the final
+/// result the sandbox submits.
+struct ScriptedProvider {
+    completions: Mutex<Vec<String>>,
+    calls: AtomicUsize,
+}
+
+impl ScriptedProvider {
+    fn new(completions: Vec<String>) -> Self {
+        Self {
+            completions: Mutex::new(completions),
+            calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl ModelProvider for ScriptedProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("scripted-host-model")
+    }
+
+    async fn stream(&self, _request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        let index = self.calls.fetch_add(1, Ordering::SeqCst);
+        let text = self
+            .completions
+            .lock()
+            .unwrap()
+            .get(index)
+            .cloned()
+            .unwrap_or_else(|| "the final answer".to_owned());
+        Ok(stream::iter(vec![
+            ProviderEvent::TextDelta { text },
+            ProviderEvent::Stop {
+                reason: StopReason::EndTurn,
+            },
+        ])
+        .boxed())
+    }
+}
+
+/// A resolver that always hands back the same scripted provider, so completion
+/// counts are observable and the op-log's exactly-once holds across a re-issue.
+struct FixedResolver(Arc<ScriptedProvider>);
+
+#[async_trait]
+impl ProviderResolver for FixedResolver {
+    async fn resolve(&self) -> Arc<dyn ModelProvider> {
+        self.0.clone()
+    }
+}
+
+// --- Mock Docker backend ------------------------------------------------------
+
+/// A [`SandboxBackend`] that stands in for Docker: `provision` and `destroy`
+/// only record, and `address` returns a fixed loopback address the test's own
+/// sandbox listener is bound to (or an unreachable one, to exercise failure).
+struct MockBackend {
+    address: Mutex<Option<String>>,
+    provisions: AtomicUsize,
+    destroys: AtomicUsize,
+}
+
+impl MockBackend {
+    fn reachable(base_url: String) -> Arc<Self> {
+        Arc::new(Self {
+            address: Mutex::new(Some(base_url)),
+            provisions: AtomicUsize::new(0),
+            destroys: AtomicUsize::new(0),
+        })
+    }
+}
+
+#[async_trait]
+impl SandboxBackend for MockBackend {
+    async fn provision(
+        &self,
+        request: ProvisionRequest,
+    ) -> std::result::Result<SandboxHandle, BackendError> {
+        self.provisions.fetch_add(1, Ordering::SeqCst);
+        Ok(SandboxHandle {
+            reference: format!("mock-{}", request.run_id),
+            tag: request.tag,
+        })
+    }
+
+    async fn address(
+        &self,
+        _handle: &SandboxHandle,
+    ) -> std::result::Result<SandboxAddress, BackendError> {
+        let Some(base_url) = self.address.lock().unwrap().clone() else {
+            return Err(BackendError::Unaddressable("no address".to_owned()));
+        };
+        Ok(SandboxAddress {
+            base_url,
+            transport_secret: TransportSecret::new("test-secret"),
+        })
+    }
+
+    async fn destroy(&self, _handle: &SandboxHandle) -> std::result::Result<(), BackendError> {
+        self.destroys.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+// --- Store / admission fixture ------------------------------------------------
+
+async fn store() -> (tempfile::TempDir, Arc<dyn Store>, Chat) {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let chat = Chat {
+        id: ChatId::new(),
+        project_id: None,
+        title: Some("container".into()),
+        model: Some("host-model".into()),
+        reasoning_effort: None,
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
+        created_at: chrono::Utc::now(),
+    };
+    store.create_chat(&chat).await.unwrap();
+    (dir, store, chat)
+}
+
+/// Admit one container-located sandbox child under the chat's running turn,
+/// mirroring how a foreground turn admits a sandbox child — but at the container
+/// execution location.
+async fn admit_container_run(store: &Arc<dyn Store>, chat_id: ChatId, task: &str) -> AgentRunId {
+    let turn_id = openwave_core::TurnId::new();
+    store
+        .accept_turn(turn_id, chat_id, "host-model", "delegate a container run")
+        .await
+        .unwrap();
+    let lease = Uuid::new_v4();
+    let now = chrono::Utc::now();
+    let turn = store
+        .claim_turn_run(lease, now, now + chrono::Duration::hours(1))
+        .await
+        .unwrap()
+        .turn
+        .expect("test turn should claim");
+    let call = CallId::new();
+    match store
+        .admit_sandbox_container_agent_run(
+            turn.id,
+            call,
+            task,
+            lease,
+            turn.steer_revision,
+            AgentRun::MAX_CONCURRENCY_LIMIT,
+            chrono::Utc::now(),
+        )
+        .await
+        .unwrap()
+        .expect("container admission should resolve")
+    {
+        AdmitSandboxAgentRunOutcome::Accepted { child, .. }
+        | AdmitSandboxAgentRunOutcome::Existing { child, .. } => child.id,
+        outcome => panic!("unexpected container admission: {outcome:?}"),
+    }
+}
+
+/// Bind a loopback listener and serve the real in-container agent behind it: the
+/// transport server against a fresh [`SandboxRun`], plus the agent loop that
+/// dials model completions back over the reverse channel. Returns the bound
+/// `http://` base URL.
+async fn spawn_sandbox_agent(task: &str) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    let run = SandboxRun::new([Capability::ModelInference]);
+    let agent_run = run.clone();
+    let task = task.to_owned();
+    tokio::spawn(async move {
+        let _ = run_agent(agent_run, task).await;
+    });
+    tokio::spawn(async move {
+        while let Ok((stream, _peer)) = listener.accept().await {
+            let run = run.clone();
+            tokio::spawn(async move {
+                let _ = serve_connection(stream, run).await;
+            });
+        }
+    });
+    base_url
+}
+
+fn fast_config() -> SandboxContainerRunConfig {
+    SandboxContainerRunConfig {
+        lease: Duration::from_secs(30),
+        dial_timeout: Duration::from_secs(2),
+        max_tokens: 256,
+        reattach_attempts: 2,
+        reattach_backoff: Duration::from_millis(10),
+    }
+}
+
+// --- Tests --------------------------------------------------------------------
+
+/// The whole stack over loopback: admit a container run, drive it with the real
+/// in-container agent loop answering `word_count` and dialing the host for model
+/// inference, and assert the host committed the result exactly once, proxied
+/// each model step through the resolver, and tore the container down.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn drives_a_container_run_end_to_end_over_loopback() {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        let (_dir, store, chat) = store().await;
+        let run_id = admit_container_run(&store, chat.id, "count some words").await;
+
+        let base_url = spawn_sandbox_agent("count some words").await;
+        let backend = MockBackend::reachable(base_url);
+        // Step 1: run word_count on three words. Step 2: the final answer.
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            "use-tool:word_count:{\"text\":\"one two three\"}".to_owned(),
+            "the text has three words".to_owned(),
+        ]));
+        let resolver = Arc::new(FixedResolver(provider.clone()));
+
+        let runner =
+            SandboxContainerRunner::new(store.clone(), backend.clone(), resolver, fast_config());
+        let outcome = runner
+            .drive(run_id)
+            .await
+            .expect("driving succeeds")
+            .expect("the container run is claimable");
+        assert_eq!(outcome, SandboxContainerRunOutcome::Completed(run_id));
+
+        // The host committed the container's final result exactly once, through
+        // the fenced result path.
+        let committed = store.get_agent_run(run_id).await.unwrap().unwrap();
+        assert_eq!(committed.status, AgentRunStatus::Completed);
+
+        // Both model steps were proxied through the host resolver (no model
+        // credential in the container), and the op-log recorded each exactly once.
+        assert_eq!(
+            provider.calls.load(Ordering::SeqCst),
+            2,
+            "each model step should proxy through the host exactly once"
+        );
+
+        // The container was provisioned once and torn down.
+        assert_eq!(backend.provisions.load(Ordering::SeqCst), 1);
+        assert_eq!(backend.destroys.load(Ordering::SeqCst), 1);
+    })
+    .await
+    .expect("test completed within its time bound");
+}
+
+/// A model-inference call re-issued after a reconnect is answered from the
+/// durable op-log, not executed a second time: the host proxy runs once and the
+/// re-issue replays its recorded completion. This is the reverse-RPC exactly-once
+/// guarantee the reattachment path depends on, at the seam this slice adds
+/// (the host proxy over the durable operation store).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn host_model_proxy_answers_a_reissued_inference_from_the_op_log() {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        let (_dir, store, _chat) = store().await;
+        let run_id = RunId::new();
+        let provider = Arc::new(ScriptedProvider::new(vec!["the-answer".to_owned()]));
+        let host = CapabilityHost::new(
+            GrantSet::new(
+                RunProvenance {
+                    run_id,
+                    provider: "test".to_owned(),
+                },
+                [Capability::ModelInference],
+            ),
+            Arc::new(HostModelProxy {
+                resolver: Arc::new(FixedResolver(provider.clone())),
+                model: "host-model".to_owned(),
+                max_tokens: 256,
+            }),
+            Arc::new(DurableOperationStore::new(store.clone(), run_id)),
+        );
+
+        let operation_id = OperationId::new();
+        let request = ReverseRequest::ModelInference(ModelInferenceParams {
+            prompt: "one step".to_owned(),
+        });
+        let envelope = || ReverseEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: openwave_sandbox_protocol::ids::RequestId::new(),
+            operation_id,
+            request: request.clone(),
+        };
+
+        let first = host.dispatch(envelope()).wait().await;
+        // A re-issue with the same operation identity (a reconnect) — a fresh
+        // RequestId, the same OperationId.
+        let replay = host.dispatch(envelope()).wait().await;
+
+        let expect = Response::Ok(ReverseResult::ModelInference(
+            openwave_sandbox_protocol::reverse::ModelInferenceResult {
+                completion: "the-answer".to_owned(),
+            },
+        ));
+        assert_eq!(first, expect);
+        assert_eq!(
+            replay, expect,
+            "the re-issue must replay the recorded answer"
+        );
+        assert_eq!(
+            provider.calls.load(Ordering::SeqCst),
+            1,
+            "a re-issued inference must not spend a second model call"
+        );
+    })
+    .await
+    .expect("test completed within its time bound");
+}
+
+/// A container that never becomes reachable is failed terminally after the
+/// reattach budget, and its teardown obligation is still driven to completion —
+/// a sandbox-resident run has exactly one attempt and is never re-executed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fails_terminally_and_tears_down_when_the_container_is_unreachable() {
+    tokio::time::timeout(Duration::from_secs(15), async {
+        let (_dir, store, chat) = store().await;
+        let run_id = admit_container_run(&store, chat.id, "unreachable").await;
+
+        // A loopback port with nothing listening: every dial fails, so the driver
+        // exhausts its reattach budget and fails the run.
+        let dead = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let dead_addr = dead.local_addr().unwrap();
+        drop(dead);
+        let backend = MockBackend::reachable(format!("http://{dead_addr}"));
+        let resolver = Arc::new(FixedResolver(Arc::new(ScriptedProvider::new(vec![]))));
+
+        let runner =
+            SandboxContainerRunner::new(store.clone(), backend.clone(), resolver, fast_config());
+        let outcome = runner
+            .drive(run_id)
+            .await
+            .expect("driving succeeds")
+            .expect("the container run is claimable");
+        assert_eq!(outcome, SandboxContainerRunOutcome::Failed(run_id));
+
+        let failed = store.get_agent_run(run_id).await.unwrap().unwrap();
+        assert_eq!(failed.status, AgentRunStatus::Failed);
+        // The teardown obligation was driven even though the run failed.
+        assert_eq!(backend.destroys.load(Ordering::SeqCst), 1);
+    })
+    .await
+    .expect("test completed within its time bound");
+}
+
+/// Admission routes a container run to the container execution location: the
+/// in-process scheduler leaves it, and only the container claim picks it up.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn admission_routes_to_the_container_location_not_the_in_process_scheduler() {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        let (_dir, store, chat) = store().await;
+        let run_id = admit_container_run(&store, chat.id, "routed").await;
+
+        let admitted = store.get_agent_run(run_id).await.unwrap().unwrap();
+        assert_eq!(
+            admitted.execution_location,
+            AgentRunExecutionLocation::Container
+        );
+        assert_eq!(admitted.status, AgentRunStatus::Queued);
+        // One attempt only: the run tier's retry machinery does not apply.
+        assert_eq!(admitted.max_attempts, 1);
+
+        // The in-process scheduler must not claim a container run.
+        assert!(
+            store
+                .claim_agent_run(Uuid::new_v4(), chrono::Duration::minutes(5), 4, 4)
+                .await
+                .unwrap()
+                .is_none(),
+            "the in-process scheduler must leave a container run for the driver"
+        );
+
+        // The container claim transitions it to running under a lease.
+        let lease = Uuid::new_v4();
+        let claimed = store
+            .claim_container_agent_run(run_id, lease, chrono::Duration::minutes(5))
+            .await
+            .unwrap()
+            .expect("the container claim should pick up the queued run");
+        assert_eq!(claimed.id, run_id);
+        assert_eq!(claimed.status, AgentRunStatus::Running);
+        assert_eq!(claimed.lease_token, Some(lease));
+
+        // Re-claiming with the same token recovers the same live claim, never a
+        // second attempt.
+        let reclaimed = store
+            .claim_container_agent_run(run_id, lease, chrono::Duration::minutes(5))
+            .await
+            .unwrap()
+            .expect("reusing the token recovers the live claim");
+        assert_eq!(reclaimed.id, run_id);
+        assert_eq!(reclaimed.attempt_count, claimed.attempt_count);
+    })
+    .await
+    .expect("test completed within its time bound");
+}
+
+// --- Docker end-to-end (gated on a container runtime + the agent image) -------
+
+/// The full stack on a real Docker container: build the `openwave-sandbox-agent`
+/// image, admit a container run, and drive it end to end — provision a container
+/// from the image, attach over its published loopback port, answer its
+/// `word_count`-then-final model steps from a mock host model, and assert the
+/// result committed exactly once and the container was torn down.
+///
+/// Skipped cleanly when no container runtime or daemon is present (there is none
+/// in the unit-test sandbox); CI runners have Docker. Building the image is heavy
+/// (it compiles the agent crate's slice of the workspace inside Docker), so this
+/// is the one place that pays for it, guarded behind daemon detection and a long
+/// timeout.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires a Docker daemon and builds the agent image; run explicitly or in the Docker CI lane"]
+async fn docker_end_to_end_drives_a_real_container() {
+    use crate::sandbox_docker::{DockerConfig, DockerSandboxBackend, RUN_TAG_LABEL};
+
+    let backend_probe = DockerSandboxBackend::with_defaults();
+    if !backend_probe.is_available() {
+        eprintln!("skipping: no container runtime on PATH");
+        return;
+    }
+
+    // Build the agent image from the workspace root (the Dockerfile's build
+    // context is the whole workspace, so Cargo.lock is visible to `--locked`).
+    let image = "openwave-sandbox-agent:it";
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .unwrap();
+    let build = tokio::time::timeout(
+        Duration::from_secs(1800),
+        tokio::process::Command::new("docker")
+            .current_dir(&workspace_root)
+            .args([
+                "build",
+                "-f",
+                "crates/openwave-sandbox-agent/Dockerfile",
+                "-t",
+                image,
+                ".",
+            ])
+            .output(),
+    )
+    .await;
+    match build {
+        Ok(Ok(output)) if output.status.success() => {}
+        Ok(Ok(output)) => {
+            panic!(
+                "building the agent image failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        Ok(Err(error)) => {
+            eprintln!("skipping: could not invoke docker build: {error}");
+            return;
+        }
+        Err(_) => panic!("building the agent image timed out"),
+    }
+
+    let (_dir, store, chat) = store().await;
+    let run_id = admit_container_run(&store, chat.id, "count these four words now").await;
+
+    let backend = Arc::new(DockerSandboxBackend::new(DockerConfig {
+        image: image.to_owned(),
+        ..DockerConfig::default()
+    }));
+    let provider = Arc::new(ScriptedProvider::new(vec![
+        "use-tool:word_count:{\"text\":\"count these four words\"}".to_owned(),
+        "the count is four".to_owned(),
+    ]));
+    let resolver = Arc::new(FixedResolver(provider.clone()));
+
+    let runner = SandboxContainerRunner::new(
+        store.clone(),
+        backend,
+        resolver,
+        SandboxContainerRunConfig {
+            dial_timeout: Duration::from_secs(30),
+            ..SandboxContainerRunConfig::default()
+        },
+    );
+    let outcome = tokio::time::timeout(Duration::from_secs(120), runner.drive(run_id))
+        .await
+        .expect("driving a real container completes within its bound")
+        .expect("driving succeeds")
+        .expect("the container run is claimable");
+    assert_eq!(outcome, SandboxContainerRunOutcome::Completed(run_id));
+
+    let committed = store.get_agent_run(run_id).await.unwrap().unwrap();
+    assert_eq!(committed.status, AgentRunStatus::Completed);
+    assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
+
+    // The container was torn down: no container carrying this run's tag remains.
+    let listed = tokio::process::Command::new("docker")
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            &format!("label={RUN_TAG_LABEL}"),
+            "--filter",
+            &format!("label=openwave.run-id={run_id}"),
+            "--format",
+            "{{.ID}}",
+        ])
+        .output()
+        .await
+        .unwrap();
+    assert!(
+        String::from_utf8_lossy(&listed.stdout).trim().is_empty(),
+        "the container should have been torn down"
+    );
+}

--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -22,9 +22,9 @@ use async_trait::async_trait;
 use futures::stream::{self, BoxStream};
 use futures::StreamExt;
 use openwave_core::{
-    AdmitSandboxAgentRunOutcome, AgentRun, AgentRunExecutionLocation, AgentRunId, AgentRunStatus,
-    CallId, Chat, ChatId, ChatRequest, DbStore, ModelProvider, ProviderEvent, ProviderId, Result,
-    StopReason, Store,
+    AdmitSandboxAgentRunOutcome, AgentConfig, AgentRun, AgentRunExecutionLocation, AgentRunId,
+    AgentRunStatus, CallId, Chat, ChatId, ChatRequest, DbStore, ModelProvider, ProviderEvent,
+    ProviderId, Result, StopReason, Store,
 };
 use openwave_sandbox_agent::run_agent;
 use openwave_sandbox_protocol::{
@@ -55,6 +55,13 @@ use crate::resolver::ProviderResolver;
 struct ScriptedProvider {
     completions: Mutex<Vec<String>>,
     calls: AtomicUsize,
+    /// Every prompt the sandbox asked the host to complete. The sandbox's
+    /// transcript opens with `Task: <task>`, so this is where a test reads back
+    /// which task the container actually received.
+    prompts: Mutex<Vec<String>>,
+    /// How long each completion stalls, so a test can hold a drive open across
+    /// several lease periods.
+    delay: Duration,
 }
 
 impl ScriptedProvider {
@@ -62,7 +69,27 @@ impl ScriptedProvider {
         Self {
             completions: Mutex::new(completions),
             calls: AtomicUsize::new(0),
+            prompts: Mutex::new(Vec::new()),
+            delay: Duration::ZERO,
         }
+    }
+
+    /// The same provider, but stalling `delay` before answering each completion,
+    /// so a drive spans several lease periods.
+    fn slow(completions: Vec<String>, delay: Duration) -> Self {
+        Self {
+            delay,
+            ..Self::new(completions)
+        }
+    }
+
+    fn first_prompt(&self) -> String {
+        self.prompts
+            .lock()
+            .unwrap()
+            .first()
+            .cloned()
+            .unwrap_or_default()
     }
 }
 
@@ -72,8 +99,15 @@ impl ModelProvider for ScriptedProvider {
         ProviderId::new("scripted-host-model")
     }
 
-    async fn stream(&self, _request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+    async fn stream(&self, request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
         let index = self.calls.fetch_add(1, Ordering::SeqCst);
+        for message in &request.messages {
+            for block in &message.content {
+                if let openwave_core::ContentBlock::Text { text } = block {
+                    self.prompts.lock().unwrap().push(text.clone());
+                }
+            }
+        }
         let text = self
             .completions
             .lock()
@@ -81,6 +115,9 @@ impl ModelProvider for ScriptedProvider {
             .get(index)
             .cloned()
             .unwrap_or_else(|| "the final answer".to_owned());
+        if !self.delay.is_zero() {
+            tokio::time::sleep(self.delay).await;
+        }
         Ok(stream::iter(vec![
             ProviderEvent::TextDelta { text },
             ProviderEvent::Stop {
@@ -104,22 +141,51 @@ impl ProviderResolver for FixedResolver {
 
 // --- Mock Docker backend ------------------------------------------------------
 
-/// A [`SandboxBackend`] that stands in for Docker: `provision` and `destroy`
-/// only record, and `address` returns a fixed loopback address the test's own
-/// sandbox listener is bound to (or an unreachable one, to exercise failure).
+/// A [`SandboxBackend`] that stands in for Docker.
+///
+/// `provision` starts the real in-container agent on a loopback listener with
+/// **the task the driver asked to be delivered** — the same relationship Docker
+/// has to the container's `OPENWAVE_SANDBOX_TASK` environment. That is what makes
+/// task delivery genuinely testable here: if the driver failed to pass the run's
+/// task, the sandbox would run the image's default task and the committed result
+/// would answer the wrong question.
 struct MockBackend {
+    /// When set, `address` resolves here instead of the provisioned sandbox —
+    /// used to point the driver at an unreachable port.
+    address_override: Option<String>,
+    /// The loopback address of the sandbox started at provision.
     address: Mutex<Option<String>>,
     provisions: AtomicUsize,
     destroys: AtomicUsize,
+    delivered_task: Mutex<Option<String>>,
 }
 
 impl MockBackend {
-    fn reachable(base_url: String) -> Arc<Self> {
+    /// A backend that starts the real agent on provision, carrying whatever task
+    /// the driver delivered.
+    fn spawning() -> Arc<Self> {
         Arc::new(Self {
-            address: Mutex::new(Some(base_url)),
+            address_override: None,
+            address: Mutex::new(None),
             provisions: AtomicUsize::new(0),
             destroys: AtomicUsize::new(0),
+            delivered_task: Mutex::new(None),
         })
+    }
+
+    /// A backend whose containers are never reachable at `base_url`.
+    fn unreachable(base_url: String) -> Arc<Self> {
+        Arc::new(Self {
+            address_override: Some(base_url),
+            address: Mutex::new(None),
+            provisions: AtomicUsize::new(0),
+            destroys: AtomicUsize::new(0),
+            delivered_task: Mutex::new(None),
+        })
+    }
+
+    fn task_delivered(&self) -> Option<String> {
+        self.delivered_task.lock().unwrap().clone()
     }
 }
 
@@ -130,6 +196,17 @@ impl SandboxBackend for MockBackend {
         request: ProvisionRequest,
     ) -> std::result::Result<SandboxHandle, BackendError> {
         self.provisions.fetch_add(1, Ordering::SeqCst);
+        *self.delivered_task.lock().unwrap() = request.task.clone();
+        if self.address_override.is_none() {
+            // Start the sandbox on the delivered task, exactly as the image does
+            // from its environment. A driver that delivered nothing gets the
+            // image's default task, which is the failure this models.
+            let task = request
+                .task
+                .clone()
+                .unwrap_or_else(|| "Summarize what this sandbox agent can do.".to_owned());
+            *self.address.lock().unwrap() = Some(spawn_sandbox_agent(&task).await);
+        }
         Ok(SandboxHandle {
             reference: format!("mock-{}", request.run_id),
             tag: request.tag,
@@ -140,8 +217,14 @@ impl SandboxBackend for MockBackend {
         &self,
         _handle: &SandboxHandle,
     ) -> std::result::Result<SandboxAddress, BackendError> {
-        let Some(base_url) = self.address.lock().unwrap().clone() else {
-            return Err(BackendError::Unaddressable("no address".to_owned()));
+        let base_url = match &self.address_override {
+            Some(base_url) => base_url.clone(),
+            None => self
+                .address
+                .lock()
+                .unwrap()
+                .clone()
+                .ok_or_else(|| BackendError::Unaddressable("not provisioned".to_owned()))?,
         };
         Ok(SandboxAddress {
             base_url,
@@ -172,6 +255,7 @@ async fn store() -> (tempfile::TempDir, Arc<dyn Store>, Chat) {
         project_id: None,
         title: Some("container".into()),
         model: Some("host-model".into()),
+        permission_mode: None,
         reasoning_effort: None,
         attachment_revision: 0,
         root_attachments: Vec::new(),
@@ -246,8 +330,8 @@ async fn spawn_sandbox_agent(task: &str) -> String {
 fn fast_config() -> SandboxContainerRunConfig {
     SandboxContainerRunConfig {
         lease: Duration::from_secs(30),
+        heartbeat: Duration::from_secs(5),
         dial_timeout: Duration::from_secs(2),
-        max_tokens: 256,
         reattach_attempts: 2,
         reattach_backoff: Duration::from_millis(10),
     }
@@ -258,15 +342,18 @@ fn fast_config() -> SandboxContainerRunConfig {
 /// The whole stack over loopback: admit a container run, drive it with the real
 /// in-container agent loop answering `word_count` and dialing the host for model
 /// inference, and assert the host committed the result exactly once, proxied
-/// each model step through the resolver, and tore the container down.
+/// each model step through the resolver, delivered the run's ACTUAL task, and
+/// tore the container down.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn drives_a_container_run_end_to_end_over_loopback() {
     tokio::time::timeout(Duration::from_secs(30), async {
         let (_dir, store, chat) = store().await;
-        let run_id = admit_container_run(&store, chat.id, "count some words").await;
+        let task = "count the words in this delegated sentence";
+        let run_id = admit_container_run(&store, chat.id, task).await;
 
-        let base_url = spawn_sandbox_agent("count some words").await;
-        let backend = MockBackend::reachable(base_url);
+        // The backend starts the sandbox on whatever task the driver delivered,
+        // exactly as Docker starts the container from its environment.
+        let backend = MockBackend::spawning();
         // Step 1: run word_count on three words. Step 2: the final answer.
         let provider = Arc::new(ScriptedProvider::new(vec![
             "use-tool:word_count:{\"text\":\"one two three\"}".to_owned(),
@@ -296,9 +383,176 @@ async fn drives_a_container_run_end_to_end_over_loopback() {
             "each model step should proxy through the host exactly once"
         );
 
+        // The run's ACTUAL delegated task reached the container — not the image's
+        // default — and is what the container asked the host to reason about.
+        assert_eq!(backend.task_delivered().as_deref(), Some(task));
+        assert!(
+            provider.first_prompt().contains(task),
+            "the container must work on the delegated task, got prompt: {}",
+            provider.first_prompt()
+        );
+
         // The container was provisioned once and torn down.
         assert_eq!(backend.provisions.load(Ordering::SeqCst), 1);
         assert_eq!(backend.destroys.load(Ordering::SeqCst), 1);
+    })
+    .await
+    .expect("test completed within its time bound");
+}
+
+/// An agent loop that ends WITHOUT submitting a result — it exhausts its step
+/// budget — still terminalizes the run and tears the container down.
+///
+/// This is the container-leak case a reachable-but-resultless container creates:
+/// the supervisor keeps serving after the agent loop returns, so a driver that
+/// only watched for a result would wait on the open socket forever, never tear
+/// down, and leave the run to be reaped. The agent's terminal failure event is
+/// what closes it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn terminalizes_and_tears_down_when_the_agent_loop_ends_without_a_result() {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        let (_dir, store, chat) = store().await;
+        let run_id = admit_container_run(&store, chat.id, "never finishes").await;
+
+        let backend = MockBackend::spawning();
+        // Every completion is another tool directive, so the loop never submits a
+        // final answer and exhausts MAX_STEPS.
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            "use-tool:word_count:{\"text\":\"a\"}".to_owned();
+            16
+        ]));
+        let resolver = Arc::new(FixedResolver(provider.clone()));
+
+        let runner =
+            SandboxContainerRunner::new(store.clone(), backend.clone(), resolver, fast_config());
+        let outcome = runner
+            .drive(run_id)
+            .await
+            .expect("driving succeeds")
+            .expect("the container run is claimable");
+        assert_eq!(outcome, SandboxContainerRunOutcome::Failed(run_id));
+
+        let failed = store.get_agent_run(run_id).await.unwrap().unwrap();
+        assert_eq!(failed.status, AgentRunStatus::Failed);
+        assert_eq!(
+            failed.last_error_code.as_deref(),
+            Some("sandbox_agent_failed"),
+            "a loop that ended without a result is an agent failure, not a transport one"
+        );
+        // The container did not leak: teardown ran even though no result arrived.
+        assert_eq!(backend.destroys.load(Ordering::SeqCst), 1);
+    })
+    .await
+    .expect("test completed within its time bound");
+}
+
+/// The driver keeps the run's lease live while the container works, so a run that
+/// outlives one lease period is not reaped mid-flight.
+///
+/// The lease here is deliberately short and the heartbeat shorter: the drive is
+/// held open past several lease periods, and the run must still be `running` with
+/// a lease extended beyond its original expiry rather than terminalized.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn heartbeats_the_lease_so_a_long_run_is_not_reaped() {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        let (_dir, store, chat) = store().await;
+        let run_id = admit_container_run(&store, chat.id, "takes a while").await;
+
+        let backend = MockBackend::spawning();
+        // A provider that stalls each completion keeps the container working, so
+        // the drive stays open across several lease periods.
+        let provider = Arc::new(ScriptedProvider::slow(
+            vec![
+                "use-tool:word_count:{\"text\":\"a b\"}".to_owned(),
+                "done".to_owned(),
+            ],
+            Duration::from_millis(700),
+        ));
+        let resolver = Arc::new(FixedResolver(provider.clone()));
+
+        let runner = SandboxContainerRunner::new(
+            store.clone(),
+            backend.clone(),
+            resolver,
+            SandboxContainerRunConfig {
+                lease: Duration::from_secs(2),
+                heartbeat: Duration::from_millis(100),
+                ..fast_config()
+            },
+        );
+
+        // Observe the lease while the drive runs: it must be extended past the
+        // original 2s expiry rather than left to lapse.
+        let observer = {
+            let store = store.clone();
+            tokio::spawn(async move {
+                let mut seen: Vec<chrono::DateTime<chrono::Utc>> = Vec::new();
+                for _ in 0..30 {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    if let Ok(Some(run)) = store.get_agent_run(run_id).await {
+                        if let Some(expiry) = run.lease_expires_at {
+                            seen.push(expiry);
+                        }
+                        if run.status != AgentRunStatus::Running {
+                            break;
+                        }
+                    }
+                }
+                seen
+            })
+        };
+
+        let outcome = runner
+            .drive(run_id)
+            .await
+            .expect("driving succeeds")
+            .expect("the container run is claimable");
+        // The run completed normally rather than being reaped out from under the
+        // still-working container.
+        assert_eq!(outcome, SandboxContainerRunOutcome::Completed(run_id));
+
+        let seen = observer.await.unwrap();
+        assert!(
+            seen.windows(2).any(|pair| pair[1] > pair[0]),
+            "the lease must be extended while the container works, saw: {seen:?}"
+        );
+    })
+    .await
+    .expect("test completed within its time bound");
+}
+
+/// A container run is exempt from the in-process lease reaper: its lease
+/// expiring does not terminalize it, because no in-process worker holds it and
+/// the container may still be working and spending.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_in_process_reaper_leaves_an_expired_container_lease_alone() {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        let (_dir, store, chat) = store().await;
+        let run_id = admit_container_run(&store, chat.id, "reaper bait").await;
+
+        // Claim with a lease that expires immediately, then let the in-process
+        // scheduler scan. Its lease reaper would otherwise fail this run (a
+        // container run has max_attempts = 1, so attempt_count >= max_attempts
+        // the moment it is claimed).
+        let lease = Uuid::new_v4();
+        store
+            .claim_container_agent_run(run_id, lease, chrono::Duration::milliseconds(1))
+            .await
+            .unwrap()
+            .expect("the container claim should pick up the queued run");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let _ = store
+            .claim_agent_run(Uuid::new_v4(), chrono::Duration::minutes(5), 4, 4)
+            .await
+            .unwrap();
+
+        let after = store.get_agent_run(run_id).await.unwrap().unwrap();
+        assert_eq!(
+            after.status,
+            AgentRunStatus::Running,
+            "the in-process reaper must not terminalize a container run on lease expiry"
+        );
     })
     .await
     .expect("test completed within its time bound");
@@ -325,8 +579,10 @@ async fn host_model_proxy_answers_a_reissued_inference_from_the_op_log() {
             ),
             Arc::new(HostModelProxy {
                 resolver: Arc::new(FixedResolver(provider.clone())),
-                model: "host-model".to_owned(),
-                max_tokens: 256,
+                config: AgentConfig {
+                    model: "host-model".to_owned(),
+                    ..AgentConfig::default()
+                },
             }),
             Arc::new(DurableOperationStore::new(store.clone(), run_id)),
         );
@@ -381,7 +637,7 @@ async fn fails_terminally_and_tears_down_when_the_container_is_unreachable() {
         let dead = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let dead_addr = dead.local_addr().unwrap();
         drop(dead);
-        let backend = MockBackend::reachable(format!("http://{dead_addr}"));
+        let backend = MockBackend::unreachable(format!("http://{dead_addr}"));
         let resolver = Arc::new(FixedResolver(Arc::new(ScriptedProvider::new(vec![]))));
 
         let runner =

--- a/crates/openwave-server/src/sandbox_docker.rs
+++ b/crates/openwave-server/src/sandbox_docker.rs
@@ -57,6 +57,10 @@ pub const RUN_TAG_LABEL: &str = "openwave.run-tag";
 pub const RUN_ID_LABEL: &str = "openwave.run-id";
 /// Environment variable carrying the per-run transport secret into the container.
 const TRANSPORT_SECRET_ENV: &str = "OPENWAVE_TRANSPORT_SECRET";
+/// Environment variable carrying the delegated task into the container. The
+/// agent image reads its task from here; see [`ProvisionRequest::task`] for why
+/// this rides provisioning rather than a run-init frame today.
+const TASK_ENV: &str = "OPENWAVE_SANDBOX_TASK";
 /// Go-template that lists a tagged container's id and correlation tag, tab-separated.
 /// Kept in sync with [`RUN_TAG_LABEL`] by a unit test.
 const TAG_LIST_FORMAT: &str = "{{.ID}}\t{{.Label \"openwave.run-tag\"}}";
@@ -250,10 +254,20 @@ impl SandboxBackend for DockerSandboxBackend {
         // `lifetime_cap_secs` is not enforceable here and is intentionally ignored.
         let secret = Uuid::new_v4().to_string();
         let mut command = self.command();
-        command.args(run_args(&self.config, request.tag, request.run_id));
+        command.args(run_args(
+            &self.config,
+            request.tag,
+            request.run_id,
+            request.task.is_some(),
+        ));
         // Set the secret on the runtime CLI's own environment and pass it through with
         // a valueless `--env`, so it never appears in this process's argv.
         command.env(TRANSPORT_SECRET_ENV, &secret);
+        // The delegated task travels the same way: by name only, so task text
+        // never lands in this process's argv or in `ps` output.
+        if let Some(task) = &request.task {
+            command.env(TASK_ENV, task);
+        }
         let output = command
             .output()
             .await
@@ -315,7 +329,7 @@ impl SandboxBackend for DockerSandboxBackend {
 
 /// The `docker run` argument vector for one provisioning. Factored out so the
 /// label, publish, and env-passthrough composition is testable without a runtime.
-fn run_args(config: &DockerConfig, tag: SandboxTag, run_id: RunId) -> Vec<String> {
+fn run_args(config: &DockerConfig, tag: SandboxTag, run_id: RunId, with_task: bool) -> Vec<String> {
     let mut args = vec![
         "run".to_owned(),
         "-d".to_owned(),
@@ -325,10 +339,16 @@ fn run_args(config: &DockerConfig, tag: SandboxTag, run_id: RunId) -> Vec<String
         format!("{RUN_ID_LABEL}={run_id}"),
         "--env".to_owned(),
         TRANSPORT_SECRET_ENV.to_owned(),
+    ];
+    if with_task {
+        args.push("--env".to_owned());
+        args.push(TASK_ENV.to_owned());
+    }
+    args.extend([
         "--publish".to_owned(),
         format!("127.0.0.1::{}", config.listener_port),
         config.image.clone(),
-    ];
+    ]);
     args.extend(config.command.iter().cloned());
     args
 }
@@ -472,6 +492,7 @@ mod tests {
             run_id: RunId::new(),
             tag: SandboxTag::new(),
             lifetime_cap_secs: None,
+            task: None,
         };
         assert!(matches!(
             backend.provision(request).await,
@@ -510,7 +531,7 @@ mod tests {
             command: vec!["sleep".to_owned(), "infinity".to_owned()],
             ..DockerConfig::default()
         };
-        let args = run_args(&config, tag, run_id);
+        let args = run_args(&config, tag, run_id, true);
 
         assert_eq!(args[0], "run");
         assert!(args.contains(&"-d".to_owned()));
@@ -522,6 +543,12 @@ mod tests {
         assert!(args
             .iter()
             .all(|arg| !arg.contains(TRANSPORT_SECRET_ENV) || arg == TRANSPORT_SECRET_ENV));
+        // The delegated task is passed by name only too, so task text never
+        // reaches this process's argv.
+        assert!(args.contains(&TASK_ENV.to_owned()));
+        assert!(args
+            .iter()
+            .all(|arg| !arg.contains(TASK_ENV) || arg == TASK_ENV));
         assert!(args.contains(&"127.0.0.1::9000".to_owned()));
         // The image precedes the container command.
         let image_at = args
@@ -531,6 +558,11 @@ mod tests {
         let command_at = args.iter().position(|arg| arg == "sleep").unwrap();
         assert!(image_at < command_at);
         assert_eq!(args.last().unwrap(), "infinity");
+
+        // With no task to deliver the passthrough is omitted entirely, leaving
+        // the image on its own default.
+        let taskless = run_args(&config, tag, run_id, false);
+        assert!(!taskless.contains(&TASK_ENV.to_owned()));
     }
 
     #[test]
@@ -695,6 +727,7 @@ mod tests {
                 run_id: RunId::new(),
                 tag: live_tag,
                 lifetime_cap_secs: None,
+                task: None,
             })
             .await
             .expect("provision live container");
@@ -706,6 +739,7 @@ mod tests {
                 run_id: RunId::new(),
                 tag: orphan_tag,
                 lifetime_cap_secs: None,
+                task: None,
             })
             .await
             .expect("provision orphan container");


### PR DESCRIPTION
The integrative slice for sandbox-resident runs: get one background agent run to execute **inside a container**, host-driven and attached-only.

> **Not production-wired.** Nothing routes background children to the `container` execution location yet — only this PR's own tests admit there. Routing is **gated on #920**, specifically the two blockers named there: the local-container transport is currently **unauthenticated** (any local process can connect to the published loopback port, complete the version-only handshake, and hijack the run's model channel), and there is **no host-side cap on the number of inference operations** a run may request (`MAX_STEPS` is enforced inside the untrusted container). Both need their own slices; neither is a regression of anything shipped, because nothing routes here.

## What the host does

1. **Admits** a background run at a new `container` execution location. `AgentRunExecutionLocation::Container` joins the tier/location split; `admit_sandbox_container_agent_run` writes it, and a widening migration relaxes the execution-location CHECK on both SQLite and PostgreSQL. The in-process scheduler's claim already filters to `in_process`, so it leaves container runs alone; `claim_container_agent_run` picks the exact run up under a bounded lease. Container runs admit with a **single attempt**.
2. **Provisions** a container through the `SandboxBackend`, committing a host-minted correlation tag before the create so the backend's orphan sweep can reclaim a container whose run never committed a handle. The run's delegated task rides the provisioning request and is delivered into the container by environment name (interim, until the run-init frame lands — the field says so).
3. **Connects** to the container's mapped loopback address with `WireClient::connect`, doing the version handshake.
4. **Drives** the run: backs the protocol host's operation log with the crash-safe `DurableOperationStore`; answers the sandbox's reverse-RPC **model-inference** calls with the host's own `ProviderResolver`, under the **same model-registry policy** the in-process worker applies (resolved once before any container exists, failed closed for an absent or unregistered model) — so no model credential lives in the container and the sandbox names no model, provider, or endpoint; drains the event stream, acknowledging by cursor; and commits the result through the run tier's **fenced** result path. It **heartbeats the lease** for the life of the drive and is **bounded by the run's absolute deadline**.
5. **Tears down** the container idempotently on every terminal path.

## Correctness details worth reviewing

- **Lease liveness.** A container run routinely outlives one lease period. The driver heartbeats (~15s against a 60s lease), and the in-process **lease reaper now skips container runs** — lease expiry means "the in-process worker died", and a sandbox-resident run has none. The deadline scan (no such exemption) remains the backstop. Without both, a run was failed out from under a container that was still working and still spending.
- **Terminating without a result.** The in-container agent ends without a `Result` on ordinary paths (step limit, failed model step) and the supervisor keeps serving afterwards — so a driver watching only for a result would wait on the open socket forever, never tear down, and leak the container. The event stream now carries a terminal `Failed` payload beside `Result`; the agent emits one on every non-result exit and the driver terminalizes on either.
- **Migration rollback** refuses up front while any `container` row remains, rather than failing partway through the SQLite rebuild (stranding the scratch table) or dropping the PostgreSQL constraint without re-adding it.

## Tests and CI

The non-Docker tests drive the **real** in-container agent loop (`openwave-sandbox-agent`) over a real loopback TCP socket, with only Docker and the host model mocked. The mock backend starts the agent on **the task the driver delivered**, the same relationship Docker has to the container's environment — so a driver that failed to deliver the task would run the image's default and fail the assertion. Coverage: end-to-end result committed exactly once with each model step proxied exactly once (op-log exactly-once) and the real task reaching the container; loop-ends-without-a-result terminalizing and tearing down; the lease heartbeat observed across several lease periods; the reaper exemption; admission routing; unreachable-container terminal failure with teardown. All timeout-wrapped, multi-thread runtime.

**CI:** a new post-merge `sandbox-resident container e2e` lane builds the agent image and drives a real container via `--ignored`, and **asserts the Docker daemon is present** rather than skipping silently into a green result. It is in the required aggregate gate, with its post-merge-only exemption asserted there (same treatment as the durable vector lane, and for the same reason — it is expensive). On pull requests the loopback tests are the coverage.

## Exit criteria: landed vs deferred

**Landed:** admission routing; reverse-RPC model inference recorded exactly once with a re-issue replaying the recorded response; teardown on every terminal path including loop-end-without-result; one-attempt terminal failure; duplicate-event discard by cursor; tag-sweep-reclaim (at the backend, whose tag the driver stamps); lease liveness and deadline bounding.

**Deferred to #920** (which now gates routing): transport authentication; per-run inference spend budget; durable provisioning-intent/handle + host-restart reconciliation; durable teardown obligation and the sweep that drives it (`reclaim_orphans` has no caller yet); the deadline reaper for a container whose driver died; late-result-as-evidence; cancellation (attached + cascade); the no-worker-lease persisted shape; the run-init frame; concurrency limits for container runs.

## Verified

`cargo test --locked` on openwave-core (567), openwave-server (456 + 5), openwave-sandbox-protocol, openwave-sandbox-agent; `clippy --all-targets` clean on all four; `fmt`; `cargo check -p openwave-core --no-default-features --features postgres --locked`; wire-types currency (`wire.ts` regenerated for the new location variant); `cargo check --workspace --locked` with no lockfile drift. The Docker e2e runs in the new CI lane post-merge.

Part of #874.