### PR TITLE
feat(web-search): native page fetch policy and readability extraction engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6800,6 +6800,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "dom_query 0.28.0",
  "dom_smoothie",
  "futures",
  "openwave-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,7 +1835,20 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
 dependencies = [
- "cssparser-macros",
+ "cssparser-macros 0.6.1",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros 0.7.0",
  "dtoa-short",
  "itoa",
  "phf 0.13.1",
@@ -1847,6 +1860,16 @@ name = "cssparser-macros"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -2857,12 +2880,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
- "cssparser",
+ "cssparser 0.36.0",
  "foldhash 0.2.0",
- "html5ever",
+ "html5ever 0.38.0",
  "precomputed-hash",
- "selectors",
+ "selectors 0.36.1",
  "tendril",
+]
+
+[[package]]
+name = "dom_query"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac5fca71e65e94cc718a6e2af65d6e0f9c6027751c2aa562fbb5087fda639bc"
+dependencies = [
+ "bit-set",
+ "cssparser 0.37.0",
+ "foldhash 0.2.0",
+ "html5ever 0.39.0",
+ "nom",
+ "precomputed-hash",
+ "selectors 0.38.0",
+ "tendril",
+]
+
+[[package]]
+name = "dom_smoothie"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8b9b294aabb8010b37c49a07d6f82175152f4927855d534979a38737721875"
+dependencies = [
+ "dom_query 0.28.0",
+ "flagset",
+ "foldhash 0.2.0",
+ "gjson",
+ "html-escape",
+ "once_cell",
+ "phf 0.13.1",
+ "tendril",
+ "thiserror 2.0.19",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -3169,6 +3226,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flatbuffers"
@@ -3660,6 +3723,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gjson"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43503cc176394dd30a6525f5f36e838339b8b5619be33ed9a7783841580a97b6"
+
+[[package]]
 name = "glib"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3923,13 +3992,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "html-escape"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c1ff2d1cbf39efe5af0900ced8a069b5e61557a17544eb0c4a50239937389e"
+
+[[package]]
 name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
- "markup5ever",
+ "markup5ever 0.38.0",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
 ]
 
 [[package]]
@@ -5755,6 +5840,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6704,8 +6800,10 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "dom_smoothie",
  "futures",
  "openwave-core",
+ "openwave-egress",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -8558,7 +8656,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
  "bitflags 2.13.0",
- "cssparser",
+ "cssparser 0.36.0",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
+name = "selectors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cssparser 0.37.0",
  "derive_more",
  "log",
  "new_debug_unreachable",
@@ -9908,7 +10025,7 @@ dependencies = [
  "brotli",
  "cargo_metadata",
  "ctor",
- "dom_query",
+ "dom_query 0.27.0",
  "dunce",
  "glob",
  "http",
@@ -11662,7 +11779,7 @@ dependencies = [
  "cookie",
  "crossbeam-channel",
  "dirs",
- "dom_query",
+ "dom_query 0.27.0",
  "dpi",
  "dunce",
  "gdkx11",

--- a/crates/openwave-web-search/Cargo.toml
+++ b/crates/openwave-web-search/Cargo.toml
@@ -19,7 +19,7 @@ http = ["dep:reqwest", "dep:futures"]
 # pass. Opt-in so the HTML parser stack stays out of consumers that only need
 # the search contracts; it implies `http` because the concrete transport and
 # resolver live behind that seam's dependencies.
-extract-native = ["http", "dep:dom_smoothie", "dep:tokio"]
+extract-native = ["http", "dep:dom_smoothie", "dep:dom_query", "dep:tokio"]
 
 [dependencies]
 async-trait = { workspace = true }
@@ -34,7 +34,12 @@ url = "=2.5.8"
 reqwest = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 dom_smoothie = { version = "=0.18.0", optional = true }
-tokio = { workspace = true, features = ["net", "rt"], optional = true }
+# The parser `dom_smoothie` builds on. It is a direct dependency so the fetched
+# document can be parsed once, bounded, and then handed to the readability pass
+# via `Readability::with_document`. That handoff only typechecks against the
+# exact version `dom_smoothie` uses, so the two pins move together.
+dom_query = { version = "=0.28.0", optional = true }
+tokio = { workspace = true, features = ["net", "rt", "time"], optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util", "time"] }

--- a/crates/openwave-web-search/Cargo.toml
+++ b/crates/openwave-web-search/Cargo.toml
@@ -15,11 +15,17 @@ default = []
 # A small reqwest implementation of the HTTP seam. It is opt-in so consumers
 # that only need the contract do not pull a network client into their process.
 http = ["dep:reqwest", "dep:futures"]
+# Native page extraction: safe manual-redirect fetching plus a readability
+# pass. Opt-in so the HTML parser stack stays out of consumers that only need
+# the search contracts; it implies `http` because the concrete transport and
+# resolver live behind that seam's dependencies.
+extract-native = ["http", "dep:dom_smoothie", "dep:tokio"]
 
 [dependencies]
 async-trait = { workspace = true }
 chrono = { workspace = true }
 openwave-core = { path = "../openwave-core", default-features = false }
+openwave-egress = { path = "../openwave-egress" }
 serde = { workspace = true }
 ts-rs = { workspace = true }
 serde_json = { workspace = true }
@@ -27,6 +33,8 @@ thiserror = { workspace = true }
 url = "=2.5.8"
 reqwest = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
+dom_smoothie = { version = "=0.18.0", optional = true }
+tokio = { workspace = true, features = ["net", "rt"], optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "net", "io-util", "time"] }

--- a/crates/openwave-web-search/src/fetch_policy.rs
+++ b/crates/openwave-web-search/src/fetch_policy.rs
@@ -1,0 +1,253 @@
+//! Admission policy for native page fetches.
+//!
+//! The search adapters talk to one fixed vendor authority, so their transport
+//! can pin an exact domain. Native extraction fetches model-chosen URLs, which
+//! makes admission the security boundary: every URL — the initial one and each
+//! redirect hop — must pass these checks before any connection is opened, and
+//! every address a host resolves to must clear the denied-network list before
+//! it may be dialed. The policy is pure and synchronous so callers can re-run
+//! it on every hop and every freshly resolved address without a transport in
+//! hand.
+
+use std::net::{IpAddr, Ipv4Addr};
+use std::sync::LazyLock;
+
+use openwave_egress::CidrBlock;
+use thiserror::Error;
+use url::{Host, Url};
+
+/// Longest URL accepted for a native page fetch, in bytes.
+pub const MAX_FETCH_URL_BYTES: usize = crate::MAX_RESULT_URL_BYTES;
+
+/// Why a URL or resolved address may not be fetched.
+///
+/// The enum is closed and carries no attacker-controlled text beyond the
+/// denied address itself, so a reason can surface in diagnostics without
+/// echoing an arbitrary URL.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum FetchPolicyViolation {
+    #[error("page URL is not valid")]
+    InvalidUrl,
+    #[error("page URL exceeds the byte limit")]
+    UrlTooLong,
+    #[error("page URL scheme must be https")]
+    SchemeNotHttps,
+    #[error("page URL must not carry userinfo")]
+    HasUserinfo,
+    #[error("page URL has no host")]
+    MissingHost,
+    #[error("page URL must use the default https port")]
+    ForbiddenPort,
+    #[error("page address {0} is in a denied network range")]
+    DeniedAddress(IpAddr),
+}
+
+/// Admit a model-supplied URL for fetching, or say precisely why not.
+///
+/// Admission requires `https`, an empty userinfo, a present host, and the
+/// default port; the fragment is stripped from the returned URL because it is
+/// never sent on the wire. An IP-literal host — in any encoding the URL parser
+/// dials as an address, including decimal, hex, and octal forms — is vetted
+/// against the denied-network list here. A DNS-named host is *not* resolved
+/// here: the fetcher must pass every freshly resolved address through
+/// [`admit_fetch_address`] before connecting, on every redirect hop.
+pub fn admit_fetch_url(value: &str) -> Result<Url, FetchPolicyViolation> {
+    if value.len() > MAX_FETCH_URL_BYTES {
+        return Err(FetchPolicyViolation::UrlTooLong);
+    }
+    let mut parsed = Url::parse(value).map_err(|_| FetchPolicyViolation::InvalidUrl)?;
+    if parsed.scheme() != "https" {
+        return Err(FetchPolicyViolation::SchemeNotHttps);
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(FetchPolicyViolation::HasUserinfo);
+    }
+    match parsed.host() {
+        None => return Err(FetchPolicyViolation::MissingHost),
+        Some(Host::Domain("")) => return Err(FetchPolicyViolation::MissingHost),
+        Some(Host::Ipv4(address)) => admit_fetch_address(IpAddr::V4(address))?,
+        Some(Host::Ipv6(address)) => admit_fetch_address(IpAddr::V6(address))?,
+        Some(Host::Domain(_)) => {}
+    }
+    // The URL parser normalizes an explicit `:443` away for https, so any
+    // remaining port is a non-default one.
+    if parsed.port().is_some() {
+        return Err(FetchPolicyViolation::ForbiddenPort);
+    }
+    parsed.set_fragment(None);
+    Ok(parsed)
+}
+
+/// Admit one resolved (or literal) address, or name it as denied.
+///
+/// The denied list covers loopback, unspecified, RFC 1918, link-local (which
+/// includes cloud metadata services), CGNAT, IPv6 unique-local, and
+/// multicast/broadcast/reserved space. An IPv6 address that embeds an IPv4
+/// address — the mapped `::ffff:a.b.c.d` form and the NAT64 `64:ff9b::/96`
+/// prefix — is judged by the embedded IPv4 address, so `::ffff:10.0.0.1` is
+/// exactly as denied as `10.0.0.1`.
+pub fn admit_fetch_address(address: IpAddr) -> Result<(), FetchPolicyViolation> {
+    let denied = match address {
+        IpAddr::V4(v4) => is_denied_v4(v4),
+        IpAddr::V6(v6) => {
+            if let Some(mapped) = v6.to_ipv4_mapped() {
+                is_denied_v4(mapped)
+            } else if let Some(embedded) = nat64_embedded_v4(u128::from(v6)) {
+                is_denied_v4(embedded)
+            } else {
+                DENIED_V6_BLOCKS.iter().any(|block| block.contains(address))
+            }
+        }
+    };
+    if denied {
+        return Err(FetchPolicyViolation::DeniedAddress(address));
+    }
+    Ok(())
+}
+
+fn is_denied_v4(address: Ipv4Addr) -> bool {
+    DENIED_V4_BLOCKS
+        .iter()
+        .any(|block| block.contains(IpAddr::V4(address)))
+}
+
+/// The IPv4 address a NAT64 (`64:ff9b::/96`) IPv6 address translates to.
+fn nat64_embedded_v4(bits: u128) -> Option<Ipv4Addr> {
+    const NAT64_PREFIX: u128 = 0x0064_ff9b_0000_0000_0000_0000_0000_0000;
+    (bits >> 32 == NAT64_PREFIX >> 32).then(|| Ipv4Addr::from((bits & 0xffff_ffff) as u32))
+}
+
+static DENIED_V4_BLOCKS: LazyLock<[CidrBlock; 9]> = LazyLock::new(|| {
+    [
+        "0.0.0.0/8",      // unspecified and "this network"
+        "10.0.0.0/8",     // RFC 1918
+        "100.64.0.0/10",  // CGNAT shared address space
+        "127.0.0.0/8",    // loopback
+        "169.254.0.0/16", // link-local, including cloud metadata endpoints
+        "172.16.0.0/12",  // RFC 1918
+        "192.168.0.0/16", // RFC 1918
+        "224.0.0.0/4",    // multicast
+        "240.0.0.0/4",    // reserved, including the broadcast address
+    ]
+    .map(|block| CidrBlock::parse(block).expect("static deny CIDR must parse"))
+});
+
+static DENIED_V6_BLOCKS: LazyLock<[CidrBlock; 4]> = LazyLock::new(|| {
+    [
+        "::/96",     // unspecified, loopback, and deprecated IPv4-compatible space
+        "fc00::/7",  // unique local addresses
+        "fe80::/10", // link-local
+        "ff00::/8",  // multicast
+    ]
+    .map(|block| CidrBlock::parse(block).expect("static deny CIDR must parse"))
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn admission_rejects_unsafe_urls_and_denied_hosts_in_every_encoding() {
+        let cases: &[(&str, FetchPolicyViolation)] = &[
+            ("http://example.com/", FetchPolicyViolation::SchemeNotHttps),
+            ("ftp://example.com/", FetchPolicyViolation::SchemeNotHttps),
+            (
+                "https://user:pw@example.com/",
+                FetchPolicyViolation::HasUserinfo,
+            ),
+            (
+                "https://user@example.com/",
+                FetchPolicyViolation::HasUserinfo,
+            ),
+            (
+                "https://example.com:8443/",
+                FetchPolicyViolation::ForbiddenPort,
+            ),
+            (
+                "https://example.com:80/",
+                FetchPolicyViolation::ForbiddenPort,
+            ),
+            ("data:text/html,hello", FetchPolicyViolation::SchemeNotHttps),
+        ];
+        for (url, expected) in cases {
+            assert_eq!(admit_fetch_url(url).unwrap_err(), *expected, "{url}");
+        }
+        assert_eq!(
+            admit_fetch_url(&format!(
+                "https://example.com/{}",
+                "a".repeat(MAX_FETCH_URL_BYTES)
+            ))
+            .unwrap_err(),
+            FetchPolicyViolation::UrlTooLong
+        );
+
+        // IP-literal hosts in the ranges the fetcher must never dial, in the
+        // alternate numeric encodings the URL parser resolves to addresses.
+        for url in [
+            "https://127.0.0.1/",
+            "https://0x7f000001/", // hex encoding of 127.0.0.1
+            "https://2130706433/", // decimal encoding of 127.0.0.1
+            "https://0177.0.0.1/", // octal encoding of 127.0.0.1
+            "https://127.1/",      // dotted-short encoding of 127.0.0.1
+            "https://0.0.0.0/",
+            "https://10.0.0.1/",
+            "https://172.16.5.5/",
+            "https://192.168.0.10/",
+            "https://169.254.169.254/latest/meta-data/", // IMDS
+            "https://100.64.0.1/",
+            "https://224.0.0.1/",
+            "https://255.255.255.255/",
+            "https://[::1]/",
+            "https://[::]/",
+            "https://[fe80::1]/",
+            "https://[fd00::1]/",
+            "https://[ff02::1]/",
+            "https://[::ffff:10.0.0.1]/", // IPv4-mapped RFC 1918
+            "https://[64:ff9b::a00:1]/",  // NAT64-embedded 10.0.0.1
+        ] {
+            assert!(
+                matches!(
+                    admit_fetch_url(url),
+                    Err(FetchPolicyViolation::DeniedAddress(_))
+                ),
+                "{url} was admitted"
+            );
+        }
+
+        // Resolved addresses go through the same denial, mapped forms judged
+        // by the embedded IPv4 address.
+        for address in [
+            "127.0.0.1",
+            "10.255.255.255",
+            "169.254.169.254",
+            "::ffff:127.0.0.1",
+            "::ffff:169.254.169.254",
+            "::ffff:192.168.1.1",
+            "fc00::1234",
+            "64:ff9b::7f00:1",
+        ] {
+            let address: IpAddr = address.parse().unwrap();
+            assert!(admit_fetch_address(address).is_err(), "{address} admitted");
+        }
+    }
+
+    #[test]
+    fn admission_accepts_public_destinations_and_strips_fragments() {
+        let admitted = admit_fetch_url("https://example.com/a%20page?q=1#section").unwrap();
+        assert_eq!(admitted.as_str(), "https://example.com/a%20page?q=1");
+        // An explicit default port normalizes away rather than rejecting.
+        assert!(admit_fetch_url("https://example.com:443/x").is_ok());
+        assert!(admit_fetch_url("https://93.184.216.34/").is_ok());
+
+        for address in [
+            "93.184.216.34",
+            "2606:2800:220:1:248:1893:25c8:1946",
+            // Public IPv4 carried in mapped and NAT64 forms stays admissible.
+            "::ffff:93.184.216.34",
+            "64:ff9b::5db8:d822",
+        ] {
+            let address: IpAddr = address.parse().unwrap();
+            assert!(admit_fetch_address(address).is_ok(), "{address} denied");
+        }
+    }
+}

--- a/crates/openwave-web-search/src/fetch_policy.rs
+++ b/crates/openwave-web-search/src/fetch_policy.rs
@@ -9,7 +9,7 @@
 //! it on every hop and every freshly resolved address without a transport in
 //! hand.
 
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::LazyLock;
 
 use openwave_egress::CidrBlock;
@@ -21,9 +21,12 @@ pub const MAX_FETCH_URL_BYTES: usize = crate::MAX_RESULT_URL_BYTES;
 
 /// Why a URL or resolved address may not be fetched.
 ///
-/// The enum is closed and carries no attacker-controlled text beyond the
-/// denied address itself, so a reason can surface in diagnostics without
-/// echoing an arbitrary URL.
+/// The enum is closed and carries no attacker-controlled text and, in
+/// particular, no address. Which address a host resolved to *is* the sensitive
+/// datum: it is an internal DNS answer for a name that a model — or a page
+/// that redirected us — chose, so repeating it back would turn a refusal into
+/// an internal-topology oracle. The address stays inside the check that made
+/// it.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum FetchPolicyViolation {
     #[error("page URL is not valid")]
@@ -38,8 +41,8 @@ pub enum FetchPolicyViolation {
     MissingHost,
     #[error("page URL must use the default https port")]
     ForbiddenPort,
-    #[error("page address {0} is in a denied network range")]
-    DeniedAddress(IpAddr),
+    #[error("page address is not an allowed destination")]
+    DeniedAddress,
 }
 
 /// Admit a model-supplied URL for fetching, or say precisely why not.
@@ -78,29 +81,29 @@ pub fn admit_fetch_url(value: &str) -> Result<Url, FetchPolicyViolation> {
     Ok(parsed)
 }
 
-/// Admit one resolved (or literal) address, or name it as denied.
+/// Admit one resolved (or literal) address, or refuse it as a destination.
 ///
 /// The denied list covers loopback, unspecified, RFC 1918, link-local (which
-/// includes cloud metadata services), CGNAT, IPv6 unique-local, and
-/// multicast/broadcast/reserved space. An IPv6 address that embeds an IPv4
-/// address — the mapped `::ffff:a.b.c.d` form and the NAT64 `64:ff9b::/96`
-/// prefix — is judged by the embedded IPv4 address, so `::ffff:10.0.0.1` is
-/// exactly as denied as `10.0.0.1`.
+/// includes cloud metadata services), CGNAT, benchmarking, documentation and
+/// TEST-NET ranges, IPv6 unique-local and site-local, and
+/// multicast/broadcast/reserved space.
+///
+/// An IPv6 address that embeds an IPv4 address is *also* judged by every IPv4
+/// address it embeds, because the host stack will route it back onto the IPv4
+/// internet: the mapped `::ffff:a.b.c.d` form, the NAT64 `64:ff9b::/96`
+/// prefix, 6to4 `2002::/16`, and Teredo `2001::/32` (both the relay's address
+/// and the obfuscated client address). So `2002:7f00:1::` is exactly as denied
+/// as `127.0.0.1`.
 pub fn admit_fetch_address(address: IpAddr) -> Result<(), FetchPolicyViolation> {
     let denied = match address {
         IpAddr::V4(v4) => is_denied_v4(v4),
         IpAddr::V6(v6) => {
-            if let Some(mapped) = v6.to_ipv4_mapped() {
-                is_denied_v4(mapped)
-            } else if let Some(embedded) = nat64_embedded_v4(u128::from(v6)) {
-                is_denied_v4(embedded)
-            } else {
-                DENIED_V6_BLOCKS.iter().any(|block| block.contains(address))
-            }
+            DENIED_V6_BLOCKS.iter().any(|block| block.contains(address))
+                || embedded_v4_addresses(v6).into_iter().any(is_denied_v4)
         }
     };
     if denied {
-        return Err(FetchPolicyViolation::DeniedAddress(address));
+        return Err(FetchPolicyViolation::DeniedAddress);
     }
     Ok(())
 }
@@ -111,33 +114,71 @@ fn is_denied_v4(address: Ipv4Addr) -> bool {
         .any(|block| block.contains(IpAddr::V4(address)))
 }
 
-/// The IPv4 address a NAT64 (`64:ff9b::/96`) IPv6 address translates to.
-fn nat64_embedded_v4(bits: u128) -> Option<Ipv4Addr> {
-    const NAT64_PREFIX: u128 = 0x0064_ff9b_0000_0000_0000_0000_0000_0000;
-    (bits >> 32 == NAT64_PREFIX >> 32).then(|| Ipv4Addr::from((bits & 0xffff_ffff) as u32))
+/// Every IPv4 address an IPv6 address embeds, across the transition formats a
+/// host stack translates back to IPv4.
+///
+/// A format is only recognized by its prefix, so an address may yield no
+/// embedded IPv4 at all; each one that is found is judged by the IPv4 list.
+fn embedded_v4_addresses(address: Ipv6Addr) -> Vec<Ipv4Addr> {
+    /// `64:ff9b::/96`, the well-known NAT64 prefix (RFC 6052). The local-use
+    /// `64:ff9b:1::/48` prefix carries the IPv4 address at a position that
+    /// varies with the prefix length, so it is denied wholesale instead.
+    const NAT64_WELL_KNOWN: u128 = 0x0064_ff9b_0000_0000_0000_0000_0000_0000;
+
+    let bits = u128::from(address);
+    let embedded_at = |shift: u32| Ipv4Addr::from(((bits >> shift) & 0xffff_ffff) as u32);
+    let mut addresses = Vec::new();
+    if let Some(mapped) = address.to_ipv4_mapped() {
+        addresses.push(mapped);
+    }
+    if bits >> 32 == NAT64_WELL_KNOWN >> 32 {
+        addresses.push(embedded_at(0));
+    }
+    // 6to4 (RFC 3056): the 32 bits after the `2002::/16` prefix are the IPv4
+    // tunnel endpoint, so `2002:7f00:1::` reaches 127.0.0.1.
+    if bits >> 112 == 0x2002 {
+        addresses.push(embedded_at(80));
+    }
+    // Teredo (RFC 4380): the 32 bits after the `2001::/32` prefix are the
+    // server, and the last 32 bits are the client's IPv4 address stored as its
+    // bitwise complement. Traffic can reach either, so both are judged.
+    if bits >> 96 == 0x2001_0000 {
+        addresses.push(embedded_at(64));
+        addresses.push(Ipv4Addr::from(!((bits & 0xffff_ffff) as u32)));
+    }
+    addresses
 }
 
-static DENIED_V4_BLOCKS: LazyLock<[CidrBlock; 9]> = LazyLock::new(|| {
+static DENIED_V4_BLOCKS: LazyLock<[CidrBlock; 15]> = LazyLock::new(|| {
     [
-        "0.0.0.0/8",      // unspecified and "this network"
-        "10.0.0.0/8",     // RFC 1918
-        "100.64.0.0/10",  // CGNAT shared address space
-        "127.0.0.0/8",    // loopback
-        "169.254.0.0/16", // link-local, including cloud metadata endpoints
-        "172.16.0.0/12",  // RFC 1918
-        "192.168.0.0/16", // RFC 1918
-        "224.0.0.0/4",    // multicast
-        "240.0.0.0/4",    // reserved, including the broadcast address
+        "0.0.0.0/8",       // unspecified and "this network"
+        "10.0.0.0/8",      // RFC 1918
+        "100.64.0.0/10",   // CGNAT shared address space
+        "127.0.0.0/8",     // loopback
+        "169.254.0.0/16",  // link-local, including cloud metadata endpoints
+        "172.16.0.0/12",   // RFC 1918
+        "192.0.0.0/24",    // IETF protocol assignments
+        "192.0.2.0/24",    // TEST-NET-1
+        "192.88.99.0/24",  // 6to4 relay anycast
+        "192.168.0.0/16",  // RFC 1918
+        "198.18.0.0/15",   // benchmarking, routed by some SD-WAN and VPN clients
+        "198.51.100.0/24", // TEST-NET-2
+        "203.0.113.0/24",  // TEST-NET-3
+        "224.0.0.0/4",     // multicast
+        "240.0.0.0/4",     // reserved, including the broadcast address
     ]
     .map(|block| CidrBlock::parse(block).expect("static deny CIDR must parse"))
 });
 
-static DENIED_V6_BLOCKS: LazyLock<[CidrBlock; 4]> = LazyLock::new(|| {
+static DENIED_V6_BLOCKS: LazyLock<[CidrBlock; 7]> = LazyLock::new(|| {
     [
-        "::/96",     // unspecified, loopback, and deprecated IPv4-compatible space
-        "fc00::/7",  // unique local addresses
-        "fe80::/10", // link-local
-        "ff00::/8",  // multicast
+        "::/96",          // unspecified, loopback, and deprecated IPv4-compatible space
+        "64:ff9b:1::/48", // local-use NAT64 (RFC 8215)
+        "2001:db8::/32",  // documentation
+        "fc00::/7",       // unique local addresses
+        "fe80::/10",      // link-local
+        "fec0::/10",      // deprecated site-local, still configured on some networks
+        "ff00::/8",       // multicast
     ]
     .map(|block| CidrBlock::parse(block).expect("static deny CIDR must parse"))
 });
@@ -204,11 +245,17 @@ mod tests {
             "https://[ff02::1]/",
             "https://[::ffff:10.0.0.1]/", // IPv4-mapped RFC 1918
             "https://[64:ff9b::a00:1]/",  // NAT64-embedded 10.0.0.1
+            "https://[2002:7f00:1::]/",   // 6to4-embedded 127.0.0.1
+            "https://[2001:0:7f00:1::]/", // Teredo server 127.0.0.1
+            "https://198.18.0.1/",
+            "https://192.0.2.1/",
+            "https://[fec0::1]/",
+            "https://[2001:db8::1]/",
         ] {
             assert!(
                 matches!(
                     admit_fetch_url(url),
-                    Err(FetchPolicyViolation::DeniedAddress(_))
+                    Err(FetchPolicyViolation::DeniedAddress)
                 ),
                 "{url} was admitted"
             );
@@ -225,6 +272,13 @@ mod tests {
             "::ffff:192.168.1.1",
             "fc00::1234",
             "64:ff9b::7f00:1",
+            "64:ff9b:1::1",
+            // Teredo relayed through a public server, but tunnelled to a
+            // loopback client: the client address is the complement of
+            // 127.0.0.1.
+            "2001:0:5db8:d822::80ff:fffe",
+            "192.88.99.1",
+            "203.0.113.9",
         ] {
             let address: IpAddr = address.parse().unwrap();
             assert!(admit_fetch_address(address).is_err(), "{address} admitted");
@@ -242,9 +296,11 @@ mod tests {
         for address in [
             "93.184.216.34",
             "2606:2800:220:1:248:1893:25c8:1946",
-            // Public IPv4 carried in mapped and NAT64 forms stays admissible.
+            // Public IPv4 carried in mapped, NAT64, and 6to4 forms stays
+            // admissible.
             "::ffff:93.184.216.34",
             "64:ff9b::5db8:d822",
+            "2002:5db8:d822::1",
         ] {
             let address: IpAddr = address.parse().unwrap();
             assert!(admit_fetch_address(address).is_ok(), "{address} denied");

--- a/crates/openwave-web-search/src/lib.rs
+++ b/crates/openwave-web-search/src/lib.rs
@@ -11,19 +11,38 @@
 //! [`HttpClient`] seam; no vendor SDK is required. `ReqwestHttpClient` is opt-in
 //! behind the `http` feature. Requests and normalized output are bounded before
 //! egress and before they can reach a model context.
+//!
+//! The `extract-native` feature adds a self-contained extraction engine:
+//! [`NativeExtractor`] fetches one admitted URL — every redirect hop re-vetted
+//! against the [`fetch_policy`](admit_fetch_url) admission rules with fresh,
+//! pinned DNS resolution — and reduces the page to bounded readable markdown.
+//! The admission policy itself is always compiled because it is pure and
+//! dependency-light; only the parser and transport stack is feature-gated.
 
 mod credentials;
 pub mod exa;
+mod fetch_policy;
 mod http;
+#[cfg(feature = "extract-native")]
+mod native;
 pub mod tavily;
 mod tool;
 mod types;
 
 pub use credentials::{WebSearchCredential, WebSearchCredentials};
 pub use exa::ExaProvider;
+pub use fetch_policy::{
+    admit_fetch_address, admit_fetch_url, FetchPolicyViolation, MAX_FETCH_URL_BYTES,
+};
 #[cfg(feature = "http")]
 pub use http::ReqwestHttpClient;
 pub use http::{HttpClient, HttpRequest, HttpResponse, MAX_HTTP_RESPONSE_BYTES};
+#[cfg(feature = "extract-native")]
+pub use native::{
+    HostAddressResolver, NativeExtractError, NativeExtraction, NativeExtractor, PageFetchResponse,
+    PageFetchTransport, ReqwestPageFetcher, TokioHostResolver, MAX_EXTRACT_CONTENT_CHARS,
+    MAX_FETCH_REDIRECT_HOPS, MAX_FETCH_RESPONSE_BYTES, MIN_EXTRACT_WORDS, NATIVE_FETCH_USER_AGENT,
+};
 pub use tavily::TavilyProvider;
 pub use tool::{
     request_from_tool_arguments, WebSearchResolver, WebSearchResolverError, WebSearchTool,

--- a/crates/openwave-web-search/src/native.rs
+++ b/crates/openwave-web-search/src/native.rs
@@ -7,18 +7,25 @@
 //! that were vetted. That re-vetting is the defense against DNS rebinding and
 //! redirect-based server-side request forgery: a page may not launder a fetch
 //! toward loopback, private, link-local, or metadata address space through a
-//! redirect or a second DNS answer. Fetches carry no cookies and no ambient
-//! credentials, announce a distinct honest user agent, and retain a bounded
-//! body of an allow-listed textual content type only.
+//! redirect or a second DNS answer. Fetches carry no cookies, no proxy, and no
+//! ambient credentials, announce a distinct honest user agent, and retain a
+//! bounded body of an allow-listed textual content type only.
+//!
+//! One deadline covers the whole extraction — every DNS resolution, every hop,
+//! and the parse — because the individually bounded steps multiply: a host that
+//! black-holes its DNS answers can otherwise stall a caller for minutes out of
+//! a single tool call.
 //!
 //! Extraction itself never returns junk to a caller: a page whose readable
 //! content falls below a small word floor — including script-only shells that
 //! ask the visitor to enable JavaScript — resolves the typed
 //! [`NativeExtractError::NoReadableContent`] so a caller can distinguish
-//! "extracted" from "nothing there".
+//! "extracted" from "nothing there". Adversarial markup is bounded *before* it
+//! is serialized rather than after, and extracted text is stripped of the
+//! control and bidirectional characters that let a page lie to a renderer.
 
 use std::net::IpAddr;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use thiserror::Error;
@@ -42,7 +49,27 @@ pub const NATIVE_FETCH_USER_AGENT: &str =
 /// Marker inserted between the head and tail of over-budget content.
 const TRUNCATION_MARKER: &str = "\n\n[... content truncated ...]\n\n";
 /// Most document elements the readability pass will parse.
-const MAX_PARSE_ELEMENTS: usize = 200_000;
+///
+/// With [`MAX_PARSE_DEPTH`] this bounds the markdown serializer's worst case:
+/// it indents each list item by four spaces per nesting level, so hostile
+/// markup costs at most `MAX_PARSE_ELEMENTS * MAX_PARSE_DEPTH * 4` bytes of
+/// output — tens of megabytes, not the gigabytes an unbounded document yields
+/// from a few hundred kilobytes of source.
+const MAX_PARSE_ELEMENTS: usize = 50_000;
+/// Deepest element nesting the readability pass will accept.
+///
+/// This is a stack bound, not a taste bound. The markdown serializer recurses
+/// once per nested list level, and a stack overflow is not a catchable Rust
+/// error — it aborts the process, taking the whole host down. Real pages nest
+/// a few dozen levels at most; this sits far above them and far below the
+/// depth at which the serializer runs out of stack.
+const MAX_PARSE_DEPTH: usize = 100;
+/// Longest any single host resolution may take out of the extraction budget.
+///
+/// The OS resolver's own timeout is tens of seconds and a hostile nameserver
+/// can hold every one of them, so the deadline — not `getaddrinfo` — decides
+/// when to give up.
+const MAX_DNS_RESOLUTION_TIME: Duration = Duration::from_secs(5);
 /// Longest content-type echoed back in an error.
 const MAX_CONTENT_TYPE_ECHO_CHARS: usize = 100;
 /// Word ceiling under which JavaScript-shell boilerplate disqualifies a page.
@@ -70,9 +97,16 @@ pub struct NativeExtraction {
 #[derive(Debug, Error)]
 pub enum NativeExtractError {
     #[error("page fetch violates the URL admission policy: {0}")]
-    PolicyViolation(#[from] FetchPolicyViolation),
-    #[error("page host did not resolve: {0}")]
-    DnsResolution(String),
+    PolicyViolation(FetchPolicyViolation),
+    /// The host could not be reached, and deliberately does not say why.
+    ///
+    /// A name that does not resolve, a name that resolves into denied address
+    /// space, and an address literal in denied space all end here. Told apart,
+    /// they answer "does this internal name exist, and what does it point at?"
+    /// for any name a model or a fetched page can name — which is a scanner.
+    /// Told together, they answer nothing.
+    #[error("page host is not a reachable destination")]
+    UnreachableHost,
     #[error("page fetch failed: {0}")]
     Fetch(String),
     #[error("page returned HTTP {0}")]
@@ -83,10 +117,27 @@ pub enum NativeExtractError {
     InvalidRedirect,
     #[error("page response exceeded the byte limit")]
     ResponseTooLarge,
+    #[error("page fetch exceeded its time budget")]
+    Timeout,
     #[error("page content type {0:?} is not extractable")]
     UnsupportedContentType(String),
+    #[error("page markup is too large or too deeply nested to extract")]
+    DocumentTooComplex,
     #[error("page has no readable content")]
     NoReadableContent,
+}
+
+impl From<FetchPolicyViolation> for NativeExtractError {
+    fn from(violation: FetchPolicyViolation) -> Self {
+        match violation {
+            // A denied address is the one violation that describes the network
+            // rather than the caller's own URL string, so it collapses into the
+            // opaque refusal. The rest name a defect in the requested URL, which
+            // the caller can act on and which reveals nothing it did not supply.
+            FetchPolicyViolation::DeniedAddress => Self::UnreachableHost,
+            other => Self::PolicyViolation(other),
+        }
+    }
 }
 
 /// One vetted response from the page transport.
@@ -111,9 +162,10 @@ impl PageFetchResponse {
 }
 
 /// One admitted GET. Implementations must connect only to `addresses` (the
-/// vetted resolution of the URL's host), never follow redirects themselves,
-/// send no cookies or ambient credentials, and cap the retained body at
-/// [`MAX_FETCH_RESPONSE_BYTES`].
+/// vetted resolution of the URL's host) — which rules out an ambient proxy,
+/// since a proxied connection dials the proxy and not the vetted address —
+/// never follow redirects themselves, send no cookies or ambient credentials,
+/// and cap the retained body at [`MAX_FETCH_RESPONSE_BYTES`].
 #[async_trait]
 pub trait PageFetchTransport: Send + Sync {
     async fn get(
@@ -134,7 +186,7 @@ pub trait HostAddressResolver: Send + Sync {
 /// The native extraction engine, backed by an injected transport and resolver.
 ///
 /// It has no default constructor because the host must explicitly decide the
-/// transport policy and the request timeout.
+/// transport policy and the time budget.
 #[derive(Clone, Debug)]
 pub struct NativeExtractor<T, R> {
     transport: T,
@@ -143,6 +195,9 @@ pub struct NativeExtractor<T, R> {
 }
 
 impl<T, R> NativeExtractor<T, R> {
+    /// Build an extractor whose `timeout` is the budget for one whole
+    /// [`extract`](NativeExtractor::extract) call — every DNS resolution, every
+    /// redirect hop, and the parse together, not per request.
     pub fn new(transport: T, resolver: R, timeout: Duration) -> Result<Self, NativeExtractError> {
         if timeout.is_zero() {
             return Err(NativeExtractError::Fetch(
@@ -158,15 +213,19 @@ impl<T, R> NativeExtractor<T, R> {
 }
 
 impl<T: PageFetchTransport, R: HostAddressResolver> NativeExtractor<T, R> {
-    /// Fetch `url` safely and extract its readable content.
+    /// Fetch `url` safely and extract its readable content, within one budget.
     pub async fn extract(&self, url: &str) -> Result<NativeExtraction, NativeExtractError> {
-        let (final_url, response) = self.fetch_vetted(url).await?;
+        let deadline = Instant::now() + self.timeout;
+        let (final_url, response) = self.fetch_vetted(url, deadline).await?;
         let media_type = extractable_media_type(response.content_type.as_deref())?;
-        let body = String::from_utf8_lossy(&response.body);
+        let body = String::from_utf8_lossy(&response.body).into_owned();
         let (title, content) = match media_type {
-            PageMediaType::Html => readable_article(&body, &final_url)?,
+            PageMediaType::Html => {
+                readable_article(body, final_url.clone(), remaining(deadline)?).await?
+            }
             PageMediaType::Text => (String::new(), body.trim().to_owned()),
         };
+        let content = sanitized_content(&content);
         let word_count = count_words(&content);
         if word_count < MIN_EXTRACT_WORDS {
             return Err(NativeExtractError::NoReadableContent);
@@ -174,7 +233,7 @@ impl<T: PageFetchTransport, R: HostAddressResolver> NativeExtractor<T, R> {
         let (content, truncated) = truncate_head_tail(&content, MAX_EXTRACT_CONTENT_CHARS);
         Ok(NativeExtraction {
             url: final_url.into(),
-            title: crate::types::truncate(title.trim(), crate::MAX_RESULT_TITLE_CHARS),
+            title: crate::types::truncate(&sanitized_title(&title), crate::MAX_RESULT_TITLE_CHARS),
             content,
             word_count,
             truncated,
@@ -183,18 +242,30 @@ impl<T: PageFetchTransport, R: HostAddressResolver> NativeExtractor<T, R> {
 
     /// Follow redirects manually, re-admitting every hop's URL and freshly
     /// resolved addresses, until a non-redirect response arrives.
+    ///
+    /// Every hop draws from the same `deadline`, so a chain of slow hops cannot
+    /// buy itself more time than one slow hop would.
     async fn fetch_vetted(
         &self,
         url: &str,
+        deadline: Instant,
     ) -> Result<(Url, PageFetchResponse), NativeExtractError> {
         let mut current = admit_fetch_url(url)?;
         for _ in 0..=MAX_FETCH_REDIRECT_HOPS {
-            let addresses = self.vetted_addresses(&current).await?;
-            let response = self
-                .transport
-                .get(&current, &addresses, self.timeout)
-                .await?;
-            if matches!(response.status, 301 | 302 | 303 | 307 | 308) {
+            let addresses = self.vetted_addresses(&current, deadline).await?;
+            let budget = remaining(deadline)?;
+            // The timeout is also passed to the transport, which is expected to
+            // apply it; wrapping the call keeps a transport that ignores it —
+            // this trait is a seam a host implements — inside the deadline.
+            let response =
+                tokio::time::timeout(budget, self.transport.get(&current, &addresses, budget))
+                    .await
+                    .map_err(|_| NativeExtractError::Timeout)??;
+            // Bound the body before anything reads it, on every hop: this is
+            // the check that holds a custom transport to its contract, and a
+            // redirect response is as much a transport response as the last one.
+            response.ensure_bounded()?;
+            if is_redirect_status(response.status) {
                 let location = response
                     .location
                     .as_deref()
@@ -208,7 +279,6 @@ impl<T: PageFetchTransport, R: HostAddressResolver> NativeExtractor<T, R> {
             if !(200..300).contains(&response.status) {
                 return Err(NativeExtractError::HttpStatus(response.status));
             }
-            response.ensure_bounded()?;
             return Ok((current, response));
         }
         Err(NativeExtractError::TooManyRedirects)
@@ -216,25 +286,47 @@ impl<T: PageFetchTransport, R: HostAddressResolver> NativeExtractor<T, R> {
 
     /// Resolve the URL's host and admit every address, so the transport can
     /// pin its connection to exactly what was vetted.
-    async fn vetted_addresses(&self, url: &Url) -> Result<Vec<IpAddr>, NativeExtractError> {
+    async fn vetted_addresses(
+        &self,
+        url: &Url,
+        deadline: Instant,
+    ) -> Result<Vec<IpAddr>, NativeExtractError> {
         let addresses = match url.host() {
             // `admit_fetch_url` already vetted a literal, but hops are cheap
             // to re-check and the policy is the boundary.
             Some(Host::Ipv4(address)) => vec![IpAddr::V4(address)],
             Some(Host::Ipv6(address)) => vec![IpAddr::V6(address)],
-            Some(Host::Domain(host)) => self.resolver.resolve(host).await?,
+            Some(Host::Domain(host)) => {
+                let budget = remaining(deadline)?.min(MAX_DNS_RESOLUTION_TIME);
+                tokio::time::timeout(budget, self.resolver.resolve(host))
+                    .await
+                    .map_err(|_| NativeExtractError::Timeout)??
+            }
             None => return Err(FetchPolicyViolation::MissingHost.into()),
         };
         if addresses.is_empty() {
-            return Err(NativeExtractError::DnsResolution(
-                "host resolved to no addresses".into(),
-            ));
+            return Err(NativeExtractError::UnreachableHost);
         }
         for address in &addresses {
             admit_fetch_address(*address)?;
         }
         Ok(addresses)
     }
+}
+
+/// What is left of the extraction budget, or the refusal to start another step.
+fn remaining(deadline: Instant) -> Result<Duration, NativeExtractError> {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if remaining.is_zero() {
+        return Err(NativeExtractError::Timeout);
+    }
+    Ok(remaining)
+}
+
+/// Statuses the extractor follows itself, and whose bodies it therefore never
+/// needs to read.
+fn is_redirect_status(status: u16) -> bool {
+    matches!(status, 301 | 302 | 303 | 307 | 308)
 }
 
 enum PageMediaType {
@@ -262,20 +354,85 @@ fn extractable_media_type(value: Option<&str>) -> Result<PageMediaType, NativeEx
 }
 
 /// Run the readability pass over fetched HTML and return `(title, markdown)`.
-fn readable_article(html: &str, url: &Url) -> Result<(String, String), NativeExtractError> {
+///
+/// Parsing and serializing a page is CPU-bound and can run for seconds on a
+/// large document, so it goes to the blocking pool rather than stalling a
+/// runtime worker for the whole turn.
+async fn readable_article(
+    html: String,
+    url: Url,
+    budget: Duration,
+) -> Result<(String, String), NativeExtractError> {
+    let parse = tokio::task::spawn_blocking(move || readable_article_blocking(&html, &url));
+    match tokio::time::timeout(budget, parse).await {
+        Ok(Ok(article)) => article,
+        Ok(Err(_)) => Err(NativeExtractError::Fetch("page extraction failed".into())),
+        // A blocking task cannot be cancelled, so this abandons the parse
+        // rather than stopping it. That is bounded work — `MAX_PARSE_ELEMENTS`
+        // and `MAX_PARSE_DEPTH` are checked before serialization — and the
+        // caller gets its deadline back either way.
+        Err(_) => Err(NativeExtractError::Timeout),
+    }
+}
+
+fn readable_article_blocking(
+    html: &str,
+    url: &Url,
+) -> Result<(String, String), NativeExtractError> {
+    // The document is parsed here rather than inside `Readability::new` so its
+    // shape can be bounded before the readability pass serializes it. This
+    // requires the exact `dom_query` version `dom_smoothie` builds against; a
+    // mismatch is a type error at `with_document`, not a silent fallback.
+    let document = dom_query::Document::from(html);
+    if exceeds_element_depth(document.root(), MAX_PARSE_DEPTH) {
+        return Err(NativeExtractError::DocumentTooComplex);
+    }
     let config = dom_smoothie::Config {
         max_elements_to_parse: MAX_PARSE_ELEMENTS,
         text_mode: dom_smoothie::TextMode::Markdown,
         ..dom_smoothie::Config::default()
     };
-    let article = dom_smoothie::Readability::new(html, Some(url.as_str()), Some(config))
-        .and_then(|mut readability| readability.parse())
-        .map_err(|_| NativeExtractError::NoReadableContent)?;
+    let article =
+        dom_smoothie::Readability::with_document(document, Some(url.as_str()), Some(config))
+            // One attempt under the strict policy, rather than `parse`'s sieve
+            // of four: the sieve clones the whole document per attempt and
+            // retains the best one, which is the memory cost this page budget
+            // cannot afford on hostile input. A page the strict policy cannot
+            // grab resolves as `NoReadableContent`.
+            .and_then(|mut readability| {
+                readability.parse_with_policy(dom_smoothie::ParsePolicy::Strict)
+            })
+            .map_err(|error| match error {
+                dom_smoothie::ReadabilityError::TooManyElements(..) => {
+                    NativeExtractError::DocumentTooComplex
+                }
+                _ => NativeExtractError::NoReadableContent,
+            })?;
     let content = article.text_content.trim().to_owned();
     if looks_like_script_shell(&content) {
         return Err(NativeExtractError::NoReadableContent);
     }
     Ok((article.title, content))
+}
+
+/// Whether any element in the tree nests deeper than `cap`.
+///
+/// The walk is iterative on purpose: the thing it protects against is
+/// unbounded recursion, and it would be absurd to measure that recursively.
+fn exceeds_element_depth(root: dom_query::NodeRef<'_>, cap: usize) -> bool {
+    let mut pending = vec![(root, 0_usize)];
+    while let Some((node, depth)) = pending.pop() {
+        let depth = depth + usize::from(node.is_element());
+        if depth > cap {
+            return true;
+        }
+        let mut child = node.first_child();
+        while let Some(current) = child {
+            child = current.next_sibling();
+            pending.push((current, depth));
+        }
+    }
+    false
 }
 
 /// A near-empty page that asks the visitor to enable JavaScript is an
@@ -294,6 +451,47 @@ fn looks_like_script_shell(extracted: &str) -> bool {
     ]
     .iter()
     .any(|tell| lower.contains(tell))
+}
+
+/// Characters extracted text must never carry to a renderer: the C0/C1
+/// controls that carry ANSI escape sequences, and the Unicode bidirectional
+/// and zero-width formatting characters that let a page display something
+/// other than what it says.
+///
+/// Line breaks and tabs are structure in markdown, not hazard, so they stay.
+fn is_display_hazard(value: char) -> bool {
+    (value.is_control() && value != '\n' && value != '\t')
+        || matches!(value,
+            '\u{200b}'..='\u{200f}'   // zero-width and directional marks
+            | '\u{202a}'..='\u{202e}' // bidirectional embedding and override
+            | '\u{2066}'..='\u{2069}' // bidirectional isolates
+            | '\u{feff}') // zero-width no-break space
+}
+
+/// Strip display hazards from extracted content.
+///
+/// The sibling search-result path rejects a whole result that carries a
+/// control character. Extraction sanitizes instead: it holds one page that
+/// cost a fetch and a parse, and a single stray control character somewhere in
+/// a long article is not a reason to return nothing. The characters that could
+/// mislead a reader are removed; the article survives.
+fn sanitized_content(value: &str) -> String {
+    value
+        .chars()
+        .filter(|value| !is_display_hazard(*value))
+        .collect()
+}
+
+/// Reduce an extracted title to one clean line.
+///
+/// A title is a single-line field, so every hazard becomes a space and runs of
+/// whitespace collapse — a title cannot smuggle line breaks into a list.
+fn sanitized_title(value: &str) -> String {
+    let cleaned: String = value
+        .chars()
+        .map(|value| if is_display_hazard(value) { ' ' } else { value })
+        .collect();
+    cleaned.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 /// Words that carry content: whitespace-separated tokens with at least one
@@ -347,15 +545,25 @@ impl PageFetchTransport for ReqwestPageFetcher {
             ));
         }
         let mut builder = reqwest::Client::builder()
+            // Load-bearing, not tidiness: reqwest defaults to discovering a
+            // proxy from `HTTPS_PROXY`/`ALL_PROXY` and system configuration,
+            // and a proxied connection dials the *proxy* — the pinned
+            // addresses below are never consulted, so the deny list and the
+            // per-hop re-vetting silently become advisory, a loopback proxy
+            // becomes reachable, and proxy userinfo would be turned into a
+            // `Proxy-Authorization` header on a model-chosen request. Removing
+            // this line removes the address pinning.
+            .no_proxy()
             .redirect(reqwest::redirect::Policy::none())
             .https_only(true)
             .user_agent(NATIVE_FETCH_USER_AGENT)
             .connect_timeout(timeout.min(Duration::from_secs(10)))
             .timeout(timeout);
         if let Some(Host::Domain(host)) = url.host() {
+            let port = url.port_or_known_default().unwrap_or(443);
             let pinned: Vec<std::net::SocketAddr> = addresses
                 .iter()
-                .map(|address| std::net::SocketAddr::new(*address, 443))
+                .map(|address| std::net::SocketAddr::new(*address, port))
                 .collect();
             builder = builder.resolve_to_addrs(host, &pinned);
         }
@@ -381,14 +589,17 @@ impl PageFetchTransport for ReqwestPageFetcher {
         };
         let content_type = header(reqwest::header::CONTENT_TYPE);
         let location = header(reqwest::header::LOCATION);
-        let mut stream = response.bytes_stream();
         let mut body = Vec::new();
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk.map_err(|error| NativeExtractError::Fetch(error.to_string()))?;
-            if body.len().saturating_add(chunk.len()) > MAX_FETCH_RESPONSE_BYTES {
-                return Err(NativeExtractError::ResponseTooLarge);
+        // A redirect's body is never read: the extractor only wants the
+        // `Location` header, and downloading up to the cap on every hop would
+        // move megabytes per extract to throw them away. Dropping the response
+        // here ends the transfer.
+        if !is_redirect_status(status) {
+            let mut stream = response.bytes_stream();
+            while let Some(chunk) = stream.next().await {
+                let chunk = chunk.map_err(|error| NativeExtractError::Fetch(error.to_string()))?;
+                push_bounded(&mut body, &chunk)?;
             }
-            body.extend_from_slice(&chunk);
         }
         Ok(PageFetchResponse {
             status,
@@ -399,6 +610,17 @@ impl PageFetchTransport for ReqwestPageFetcher {
     }
 }
 
+/// Retain one streamed chunk, refusing the response the moment it would cross
+/// [`MAX_FETCH_RESPONSE_BYTES`] — before the bytes are kept, so an unbounded
+/// or lying `Content-Length` never turns into an unbounded allocation.
+fn push_bounded(body: &mut Vec<u8>, chunk: &[u8]) -> Result<(), NativeExtractError> {
+    if body.len().saturating_add(chunk.len()) > MAX_FETCH_RESPONSE_BYTES {
+        return Err(NativeExtractError::ResponseTooLarge);
+    }
+    body.extend_from_slice(chunk);
+    Ok(())
+}
+
 /// Host resolver backed by the operating system's resolver.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct TokioHostResolver;
@@ -406,9 +628,13 @@ pub struct TokioHostResolver;
 #[async_trait]
 impl HostAddressResolver for TokioHostResolver {
     async fn resolve(&self, host: &str) -> Result<Vec<IpAddr>, NativeExtractError> {
+        // `lookup_host` runs `getaddrinfo` on the blocking pool, whose own
+        // timeout is the OS resolver's — tens of seconds. The extractor caps
+        // how long it *waits*; abandoning the wait does not stop the syscall,
+        // which is why the cap matters and why nothing here retries.
         let resolved = tokio::net::lookup_host((host, 443))
             .await
-            .map_err(|error| NativeExtractError::DnsResolution(error.to_string()))?;
+            .map_err(|_| NativeExtractError::UnreachableHost)?;
         let mut addresses = Vec::new();
         for address in resolved.map(|socket| socket.ip()) {
             if !addresses.contains(&address) {
@@ -428,6 +654,16 @@ mod tests {
 
     const PUBLIC_V4: IpAddr = IpAddr::V4(std::net::Ipv4Addr::new(93, 184, 216, 34));
     const PRIVATE_V4: IpAddr = IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 5));
+
+    /// A title an attacker would like a renderer to obey rather than print:
+    /// a right-to-left override and an ANSI escape introducer.
+    const HOSTILE_TITLE: &str = "Rust\u{202e} Ownership\u{1b} Explained";
+
+    /// [`ARTICLE_HTML`] with the hostile title in both the `<title>` and the
+    /// `<h1>`, so the assertion holds whichever one the readability pass picks.
+    fn hostile_title_html() -> String {
+        ARTICLE_HTML.replace("Rust Ownership Explained", HOSTILE_TITLE)
+    }
 
     const ARTICLE_HTML: &str = r#"<!doctype html>
 <html><head><title>Rust Ownership Explained</title>
@@ -498,7 +734,7 @@ relationships between references are ambiguous.</p>
             self.0
                 .get(host)
                 .cloned()
-                .ok_or_else(|| NativeExtractError::DnsResolution(format!("unknown host {host}")))
+                .ok_or(NativeExtractError::UnreachableHost)
         }
     }
 
@@ -537,7 +773,7 @@ relationships between references are ambiguous.</p>
         let extractor = build_extractor(
             vec![
                 redirect_response("/articles/ownership"),
-                html_response(200, ARTICLE_HTML),
+                html_response(200, &hostile_title_html()),
             ],
             &[("example.com", vec![PUBLIC_V4])],
         );
@@ -547,7 +783,6 @@ relationships between references are ambiguous.</p>
             .unwrap();
 
         assert_eq!(extraction.url, "https://example.com/articles/ownership");
-        assert_eq!(extraction.title, "Rust Ownership Explained");
         assert!(extraction.content.contains("single owner"));
         assert!(extraction.content.contains("Lifetimes"));
         assert!(!extraction.content.contains("do-not-extract-this-token"));
@@ -555,12 +790,19 @@ relationships between references are ambiguous.</p>
         assert!(extraction.word_count >= MIN_EXTRACT_WORDS);
         assert!(!extraction.truncated);
 
-        // Both hops were dialed with the vetted address, fragment stripped.
+        // The page's control and directional characters do not survive into
+        // either field a renderer will show.
+        assert_eq!(extraction.title, "Rust Ownership Explained");
+        assert!(!extraction.content.contains('\u{202e}'));
+        assert!(!extraction.content.contains('\u{1b}'));
+
+        // Every hop was dialed with the vetted address, fragment stripped.
         let seen = extractor.transport.seen.lock().unwrap();
         assert_eq!(seen.len(), 2);
         assert_eq!(seen[0].0, "https://example.com/start");
         assert_eq!(seen[0].1, vec![PUBLIC_V4]);
         assert_eq!(seen[1].0, "https://example.com/articles/ownership");
+        assert_eq!(seen[1].1, vec![PUBLIC_V4]);
     }
 
     #[tokio::test]
@@ -581,10 +823,10 @@ relationships between references are ambiguous.</p>
             .extract("https://example.com/start")
             .await
             .unwrap_err();
-        assert!(matches!(
-            error,
-            NativeExtractError::PolicyViolation(FetchPolicyViolation::DeniedAddress(_))
-        ));
+        // The refusal does not say which address the host resolved to, or that
+        // it resolved at all.
+        assert!(matches!(error, NativeExtractError::UnreachableHost));
+        assert!(!error.to_string().contains("10.0.0.5"));
         assert_eq!(extractor.transport.seen.lock().unwrap().len(), 1);
 
         // A redirect straight to a denied IP literal is refused by URL
@@ -594,10 +836,7 @@ relationships between references are ambiguous.</p>
             .extract("https://example.com/start")
             .await
             .unwrap_err();
-        assert!(matches!(
-            error,
-            NativeExtractError::PolicyViolation(FetchPolicyViolation::DeniedAddress(_))
-        ));
+        assert!(matches!(error, NativeExtractError::UnreachableHost));
         assert_eq!(extractor.transport.seen.lock().unwrap().len(), 1);
     }
 
@@ -659,6 +898,93 @@ relationships between references are ambiguous.</p>
                 .unwrap_err(),
             NativeExtractError::NoReadableContent
         ));
+    }
+
+    #[tokio::test]
+    async fn deeply_nested_markup_is_refused_before_it_is_serialized() {
+        // The markdown serializer recurses once per nested list level and
+        // indents by four spaces per level, so this shape is both a stack bomb
+        // and a quadratic output bomb. It has to be refused on the parsed
+        // document, before anything walks it.
+        let depth = MAX_PARSE_DEPTH + 20;
+        let html = format!(
+            "<!doctype html><html><body>{}<p>nested</p>{}</body></html>",
+            "<ul><li>".repeat(depth),
+            "</li></ul>".repeat(depth)
+        );
+        let extractor = build_extractor(
+            vec![html_response(200, &html)],
+            &[("example.com", vec![PUBLIC_V4])],
+        );
+        assert!(matches!(
+            extractor
+                .extract("https://example.com/deep")
+                .await
+                .unwrap_err(),
+            NativeExtractError::DocumentTooComplex
+        ));
+    }
+
+    #[tokio::test]
+    async fn oversized_transport_bodies_are_refused_on_every_hop() {
+        // A transport is contractually capped, so this only bites when a host
+        // supplies its own — which is exactly when the extractor has to check.
+        let oversized = vec![b'a'; MAX_FETCH_RESPONSE_BYTES + 1];
+        let mut terminal = html_response(200, "");
+        terminal.body = oversized.clone();
+        let extractor = build_extractor(vec![terminal], &[("example.com", vec![PUBLIC_V4])]);
+        assert!(matches!(
+            extractor
+                .extract("https://example.com/big")
+                .await
+                .unwrap_err(),
+            NativeExtractError::ResponseTooLarge
+        ));
+
+        // Including a redirect's body, which is read before the hop is taken.
+        let mut redirect = redirect_response("/next");
+        redirect.body = oversized;
+        let extractor = build_extractor(
+            vec![redirect, html_response(200, ARTICLE_HTML)],
+            &[("example.com", vec![PUBLIC_V4])],
+        );
+        assert!(matches!(
+            extractor
+                .extract("https://example.com/start")
+                .await
+                .unwrap_err(),
+            NativeExtractError::ResponseTooLarge
+        ));
+        assert_eq!(extractor.transport.seen.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_black_holed_resolver_cannot_outlive_the_extraction_budget() {
+        struct SlowResolver;
+
+        #[async_trait]
+        impl HostAddressResolver for SlowResolver {
+            async fn resolve(&self, _host: &str) -> Result<Vec<IpAddr>, NativeExtractError> {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                Ok(vec![PUBLIC_V4])
+            }
+        }
+
+        let extractor = NativeExtractor::new(
+            ScriptedTransport::new(vec![html_response(200, ARTICLE_HTML)]),
+            SlowResolver,
+            Duration::from_millis(100),
+        )
+        .unwrap();
+        let started = Instant::now();
+        let error = extractor
+            .extract("https://example.com/slow")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, NativeExtractError::Timeout));
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(extractor.transport.seen.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/openwave-web-search/src/native.rs
+++ b/crates/openwave-web-search/src/native.rs
@@ -1,0 +1,688 @@
+//! Native page extraction: fetch one admitted URL and reduce the page to
+//! bounded, readable text.
+//!
+//! The extractor follows redirects manually so that every hop — not just the
+//! first URL — passes the full [`crate::fetch_policy`] admission check with a
+//! fresh DNS resolution, and each connection is pinned to the exact addresses
+//! that were vetted. That re-vetting is the defense against DNS rebinding and
+//! redirect-based server-side request forgery: a page may not launder a fetch
+//! toward loopback, private, link-local, or metadata address space through a
+//! redirect or a second DNS answer. Fetches carry no cookies and no ambient
+//! credentials, announce a distinct honest user agent, and retain a bounded
+//! body of an allow-listed textual content type only.
+//!
+//! Extraction itself never returns junk to a caller: a page whose readable
+//! content falls below a small word floor — including script-only shells that
+//! ask the visitor to enable JavaScript — resolves the typed
+//! [`NativeExtractError::NoReadableContent`] so a caller can distinguish
+//! "extracted" from "nothing there".
+
+use std::net::IpAddr;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use thiserror::Error;
+use url::{Host, Url};
+
+use crate::fetch_policy::{admit_fetch_address, admit_fetch_url, FetchPolicyViolation};
+
+/// Largest response body retained for one native page fetch.
+pub const MAX_FETCH_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
+/// Redirect hops followed before a fetch is refused.
+pub const MAX_FETCH_REDIRECT_HOPS: usize = 5;
+/// Maximum Unicode scalar values of extracted content returned to a caller,
+/// including the truncation marker when one is inserted.
+pub const MAX_EXTRACT_CONTENT_CHARS: usize = 24_000;
+/// Below this many extracted words a page has no readable content.
+pub const MIN_EXTRACT_WORDS: usize = 20;
+/// The honest, distinct user agent every native page fetch announces.
+pub const NATIVE_FETCH_USER_AGENT: &str =
+    "OpenWavePageExtractor/1.0 (+https://github.com/brightwave-inc/openwave)";
+
+/// Marker inserted between the head and tail of over-budget content.
+const TRUNCATION_MARKER: &str = "\n\n[... content truncated ...]\n\n";
+/// Most document elements the readability pass will parse.
+const MAX_PARSE_ELEMENTS: usize = 200_000;
+/// Longest content-type echoed back in an error.
+const MAX_CONTENT_TYPE_ECHO_CHARS: usize = 100;
+/// Word ceiling under which JavaScript-shell boilerplate disqualifies a page.
+const MAX_SHELL_BOILERPLATE_WORDS: usize = 150;
+
+/// Readable content extracted from one fetched page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NativeExtraction {
+    /// Final fetched URL after redirects, fragment stripped.
+    pub url: String,
+    /// Page title; empty when the page did not provide one.
+    pub title: String,
+    /// Main content as markdown (plain text for a `text/*` page), bounded by
+    /// [`MAX_EXTRACT_CONTENT_CHARS`] with head-and-tail truncation.
+    pub content: String,
+    /// Words in the full extraction, counted before any truncation.
+    pub word_count: usize,
+    /// Whether `content` was truncated to fit the character budget.
+    pub truncated: bool,
+}
+
+/// Why a native extraction failed. Closed and typed so a caller can act on
+/// the reason without parsing prose, and so no vendor or transport payload
+/// leaks through it.
+#[derive(Debug, Error)]
+pub enum NativeExtractError {
+    #[error("page fetch violates the URL admission policy: {0}")]
+    PolicyViolation(#[from] FetchPolicyViolation),
+    #[error("page host did not resolve: {0}")]
+    DnsResolution(String),
+    #[error("page fetch failed: {0}")]
+    Fetch(String),
+    #[error("page returned HTTP {0}")]
+    HttpStatus(u16),
+    #[error("page redirected more than {MAX_FETCH_REDIRECT_HOPS} times")]
+    TooManyRedirects,
+    #[error("page redirect location is missing or invalid")]
+    InvalidRedirect,
+    #[error("page response exceeded the byte limit")]
+    ResponseTooLarge,
+    #[error("page content type {0:?} is not extractable")]
+    UnsupportedContentType(String),
+    #[error("page has no readable content")]
+    NoReadableContent,
+}
+
+/// One vetted response from the page transport.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PageFetchResponse {
+    pub status: u16,
+    /// Raw `Content-Type` header value, when present.
+    pub content_type: Option<String>,
+    /// Raw `Location` header value, when present.
+    pub location: Option<String>,
+    pub body: Vec<u8>,
+}
+
+impl PageFetchResponse {
+    /// Reject a custom transport's oversized body before it is parsed.
+    pub fn ensure_bounded(&self) -> Result<(), NativeExtractError> {
+        if self.body.len() > MAX_FETCH_RESPONSE_BYTES {
+            return Err(NativeExtractError::ResponseTooLarge);
+        }
+        Ok(())
+    }
+}
+
+/// One admitted GET. Implementations must connect only to `addresses` (the
+/// vetted resolution of the URL's host), never follow redirects themselves,
+/// send no cookies or ambient credentials, and cap the retained body at
+/// [`MAX_FETCH_RESPONSE_BYTES`].
+#[async_trait]
+pub trait PageFetchTransport: Send + Sync {
+    async fn get(
+        &self,
+        url: &Url,
+        addresses: &[IpAddr],
+        timeout: Duration,
+    ) -> Result<PageFetchResponse, NativeExtractError>;
+}
+
+/// Fresh DNS resolution for one host. The extractor calls this on every
+/// redirect hop and vets every returned address before any connection.
+#[async_trait]
+pub trait HostAddressResolver: Send + Sync {
+    async fn resolve(&self, host: &str) -> Result<Vec<IpAddr>, NativeExtractError>;
+}
+
+/// The native extraction engine, backed by an injected transport and resolver.
+///
+/// It has no default constructor because the host must explicitly decide the
+/// transport policy and the request timeout.
+#[derive(Clone, Debug)]
+pub struct NativeExtractor<T, R> {
+    transport: T,
+    resolver: R,
+    timeout: Duration,
+}
+
+impl<T, R> NativeExtractor<T, R> {
+    pub fn new(transport: T, resolver: R, timeout: Duration) -> Result<Self, NativeExtractError> {
+        if timeout.is_zero() {
+            return Err(NativeExtractError::Fetch(
+                "page fetch timeout must be greater than zero".into(),
+            ));
+        }
+        Ok(Self {
+            transport,
+            resolver,
+            timeout,
+        })
+    }
+}
+
+impl<T: PageFetchTransport, R: HostAddressResolver> NativeExtractor<T, R> {
+    /// Fetch `url` safely and extract its readable content.
+    pub async fn extract(&self, url: &str) -> Result<NativeExtraction, NativeExtractError> {
+        let (final_url, response) = self.fetch_vetted(url).await?;
+        let media_type = extractable_media_type(response.content_type.as_deref())?;
+        let body = String::from_utf8_lossy(&response.body);
+        let (title, content) = match media_type {
+            PageMediaType::Html => readable_article(&body, &final_url)?,
+            PageMediaType::Text => (String::new(), body.trim().to_owned()),
+        };
+        let word_count = count_words(&content);
+        if word_count < MIN_EXTRACT_WORDS {
+            return Err(NativeExtractError::NoReadableContent);
+        }
+        let (content, truncated) = truncate_head_tail(&content, MAX_EXTRACT_CONTENT_CHARS);
+        Ok(NativeExtraction {
+            url: final_url.into(),
+            title: crate::types::truncate(title.trim(), crate::MAX_RESULT_TITLE_CHARS),
+            content,
+            word_count,
+            truncated,
+        })
+    }
+
+    /// Follow redirects manually, re-admitting every hop's URL and freshly
+    /// resolved addresses, until a non-redirect response arrives.
+    async fn fetch_vetted(
+        &self,
+        url: &str,
+    ) -> Result<(Url, PageFetchResponse), NativeExtractError> {
+        let mut current = admit_fetch_url(url)?;
+        for _ in 0..=MAX_FETCH_REDIRECT_HOPS {
+            let addresses = self.vetted_addresses(&current).await?;
+            let response = self
+                .transport
+                .get(&current, &addresses, self.timeout)
+                .await?;
+            if matches!(response.status, 301 | 302 | 303 | 307 | 308) {
+                let location = response
+                    .location
+                    .as_deref()
+                    .ok_or(NativeExtractError::InvalidRedirect)?;
+                let next = current
+                    .join(location)
+                    .map_err(|_| NativeExtractError::InvalidRedirect)?;
+                current = admit_fetch_url(next.as_str())?;
+                continue;
+            }
+            if !(200..300).contains(&response.status) {
+                return Err(NativeExtractError::HttpStatus(response.status));
+            }
+            response.ensure_bounded()?;
+            return Ok((current, response));
+        }
+        Err(NativeExtractError::TooManyRedirects)
+    }
+
+    /// Resolve the URL's host and admit every address, so the transport can
+    /// pin its connection to exactly what was vetted.
+    async fn vetted_addresses(&self, url: &Url) -> Result<Vec<IpAddr>, NativeExtractError> {
+        let addresses = match url.host() {
+            // `admit_fetch_url` already vetted a literal, but hops are cheap
+            // to re-check and the policy is the boundary.
+            Some(Host::Ipv4(address)) => vec![IpAddr::V4(address)],
+            Some(Host::Ipv6(address)) => vec![IpAddr::V6(address)],
+            Some(Host::Domain(host)) => self.resolver.resolve(host).await?,
+            None => return Err(FetchPolicyViolation::MissingHost.into()),
+        };
+        if addresses.is_empty() {
+            return Err(NativeExtractError::DnsResolution(
+                "host resolved to no addresses".into(),
+            ));
+        }
+        for address in &addresses {
+            admit_fetch_address(*address)?;
+        }
+        Ok(addresses)
+    }
+}
+
+enum PageMediaType {
+    Html,
+    Text,
+}
+
+/// Allow-list the response content type; anything else is a typed refusal,
+/// never a guess.
+fn extractable_media_type(value: Option<&str>) -> Result<PageMediaType, NativeExtractError> {
+    let raw = value.unwrap_or("");
+    let essence = raw
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    match essence.as_str() {
+        "text/html" | "application/xhtml+xml" => Ok(PageMediaType::Html),
+        "text/plain" | "text/markdown" => Ok(PageMediaType::Text),
+        _ => Err(NativeExtractError::UnsupportedContentType(
+            crate::types::truncate(&essence, MAX_CONTENT_TYPE_ECHO_CHARS),
+        )),
+    }
+}
+
+/// Run the readability pass over fetched HTML and return `(title, markdown)`.
+fn readable_article(html: &str, url: &Url) -> Result<(String, String), NativeExtractError> {
+    let config = dom_smoothie::Config {
+        max_elements_to_parse: MAX_PARSE_ELEMENTS,
+        text_mode: dom_smoothie::TextMode::Markdown,
+        ..dom_smoothie::Config::default()
+    };
+    let article = dom_smoothie::Readability::new(html, Some(url.as_str()), Some(config))
+        .and_then(|mut readability| readability.parse())
+        .map_err(|_| NativeExtractError::NoReadableContent)?;
+    let content = article.text_content.trim().to_owned();
+    if looks_like_script_shell(&content) {
+        return Err(NativeExtractError::NoReadableContent);
+    }
+    Ok((article.title, content))
+}
+
+/// A near-empty page that asks the visitor to enable JavaScript is an
+/// application shell, not content.
+fn looks_like_script_shell(extracted: &str) -> bool {
+    if count_words(extracted) > MAX_SHELL_BOILERPLATE_WORDS {
+        return false;
+    }
+    let lower = extracted.to_lowercase();
+    [
+        "enable javascript",
+        "javascript is required",
+        "javascript is disabled",
+        "turn on javascript",
+        "javascript to run this app",
+    ]
+    .iter()
+    .any(|tell| lower.contains(tell))
+}
+
+/// Words that carry content: whitespace-separated tokens with at least one
+/// alphanumeric character, so markdown punctuation does not inflate the count.
+fn count_words(value: &str) -> usize {
+    value
+        .split_whitespace()
+        .filter(|token| token.chars().any(char::is_alphanumeric))
+        .count()
+}
+
+/// Keep the head and tail of over-budget content with an explicit marker in
+/// between; the result never exceeds `budget` characters.
+fn truncate_head_tail(value: &str, budget: usize) -> (String, bool) {
+    let total = value.chars().count();
+    if total <= budget {
+        return (value.to_owned(), false);
+    }
+    let marker_chars = TRUNCATION_MARKER.chars().count();
+    let keep = budget.saturating_sub(marker_chars);
+    let head_chars = keep * 2 / 3;
+    let tail_chars = keep - head_chars;
+    let head: String = value.chars().take(head_chars).collect();
+    let tail: String = value.chars().skip(total - tail_chars).collect();
+    (format!("{head}{TRUNCATION_MARKER}{tail}"), true)
+}
+
+/// Page transport that builds one pinned `reqwest` client per request.
+///
+/// Building per request is what lets the connection be pinned: the vetted
+/// addresses are installed as the host's only resolution, so the connect
+/// cannot re-resolve to something the policy never saw. Redirects stay
+/// disabled — the extractor's loop is the only redirect follower — and the
+/// client holds no cookie store and attaches no credentials.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ReqwestPageFetcher;
+
+#[async_trait]
+impl PageFetchTransport for ReqwestPageFetcher {
+    async fn get(
+        &self,
+        url: &Url,
+        addresses: &[IpAddr],
+        timeout: Duration,
+    ) -> Result<PageFetchResponse, NativeExtractError> {
+        use futures::StreamExt;
+
+        if timeout.is_zero() {
+            return Err(NativeExtractError::Fetch(
+                "page fetch timeout must be greater than zero".into(),
+            ));
+        }
+        let mut builder = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .https_only(true)
+            .user_agent(NATIVE_FETCH_USER_AGENT)
+            .connect_timeout(timeout.min(Duration::from_secs(10)))
+            .timeout(timeout);
+        if let Some(Host::Domain(host)) = url.host() {
+            let pinned: Vec<std::net::SocketAddr> = addresses
+                .iter()
+                .map(|address| std::net::SocketAddr::new(*address, 443))
+                .collect();
+            builder = builder.resolve_to_addrs(host, &pinned);
+        }
+        let client = builder
+            .build()
+            .map_err(|error| NativeExtractError::Fetch(error.to_string()))?;
+        let response = client
+            .get(url.as_str())
+            .header(
+                reqwest::header::ACCEPT,
+                "text/html, application/xhtml+xml, text/plain;q=0.9, text/markdown;q=0.9",
+            )
+            .send()
+            .await
+            .map_err(|error| NativeExtractError::Fetch(error.to_string()))?;
+        let status = response.status().as_u16();
+        let header = |name: reqwest::header::HeaderName| {
+            response
+                .headers()
+                .get(name)
+                .and_then(|value| value.to_str().ok())
+                .map(ToOwned::to_owned)
+        };
+        let content_type = header(reqwest::header::CONTENT_TYPE);
+        let location = header(reqwest::header::LOCATION);
+        let mut stream = response.bytes_stream();
+        let mut body = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|error| NativeExtractError::Fetch(error.to_string()))?;
+            if body.len().saturating_add(chunk.len()) > MAX_FETCH_RESPONSE_BYTES {
+                return Err(NativeExtractError::ResponseTooLarge);
+            }
+            body.extend_from_slice(&chunk);
+        }
+        Ok(PageFetchResponse {
+            status,
+            content_type,
+            location,
+            body,
+        })
+    }
+}
+
+/// Host resolver backed by the operating system's resolver.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TokioHostResolver;
+
+#[async_trait]
+impl HostAddressResolver for TokioHostResolver {
+    async fn resolve(&self, host: &str) -> Result<Vec<IpAddr>, NativeExtractError> {
+        let resolved = tokio::net::lookup_host((host, 443))
+            .await
+            .map_err(|error| NativeExtractError::DnsResolution(error.to_string()))?;
+        let mut addresses = Vec::new();
+        for address in resolved.map(|socket| socket.ip()) {
+            if !addresses.contains(&address) {
+                addresses.push(address);
+            }
+        }
+        Ok(addresses)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, VecDeque};
+    use std::sync::Mutex;
+
+    use super::*;
+
+    const PUBLIC_V4: IpAddr = IpAddr::V4(std::net::Ipv4Addr::new(93, 184, 216, 34));
+    const PRIVATE_V4: IpAddr = IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 5));
+
+    const ARTICLE_HTML: &str = r#"<!doctype html>
+<html><head><title>Rust Ownership Explained</title>
+<style>body { color: red; }</style>
+<script>window.telemetry = "do-not-extract-this-token";</script>
+</head><body>
+<article>
+<h1>Rust Ownership Explained</h1>
+<p>Ownership is the discipline that lets Rust manage memory without a garbage
+collector. Every value has a single owner, and when the owner goes out of
+scope the value is dropped deterministically.</p>
+<p>Borrowing lets other code read or mutate a value without taking ownership.
+The compiler enforces that mutable borrows are exclusive, which rules out data
+races at compile time rather than at runtime.</p>
+<p>Lifetimes describe how long references remain valid. Most of the time the
+compiler infers them, and explicit annotations only appear where the
+relationships between references are ambiguous.</p>
+</article>
+</body></html>"#;
+
+    const SHELL_HTML: &str = r#"<!doctype html>
+<html><head><title>App</title>
+<script src="/static/bundle.js"></script>
+<script>window.__STATE__ = {"a":1,"b":2,"c":3,"d":4,"e":5,"f":6,"g":7};</script>
+</head><body>
+<div id="root"><p>You need to enable JavaScript to run this app.</p></div>
+</body></html>"#;
+
+    struct ScriptedTransport {
+        responses: Mutex<VecDeque<PageFetchResponse>>,
+        seen: Mutex<Vec<(String, Vec<IpAddr>)>>,
+    }
+
+    impl ScriptedTransport {
+        fn new(responses: Vec<PageFetchResponse>) -> Self {
+            Self {
+                responses: Mutex::new(responses.into()),
+                seen: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl PageFetchTransport for ScriptedTransport {
+        async fn get(
+            &self,
+            url: &Url,
+            addresses: &[IpAddr],
+            _timeout: Duration,
+        ) -> Result<PageFetchResponse, NativeExtractError> {
+            self.seen
+                .lock()
+                .unwrap()
+                .push((url.to_string(), addresses.to_vec()));
+            self.responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or_else(|| NativeExtractError::Fetch("no scripted response".into()))
+        }
+    }
+
+    struct StaticResolver(HashMap<&'static str, Vec<IpAddr>>);
+
+    #[async_trait]
+    impl HostAddressResolver for StaticResolver {
+        async fn resolve(&self, host: &str) -> Result<Vec<IpAddr>, NativeExtractError> {
+            self.0
+                .get(host)
+                .cloned()
+                .ok_or_else(|| NativeExtractError::DnsResolution(format!("unknown host {host}")))
+        }
+    }
+
+    fn html_response(status: u16, body: &str) -> PageFetchResponse {
+        PageFetchResponse {
+            status,
+            content_type: Some("text/html; charset=utf-8".into()),
+            location: None,
+            body: body.as_bytes().to_vec(),
+        }
+    }
+
+    fn redirect_response(location: &str) -> PageFetchResponse {
+        PageFetchResponse {
+            status: 302,
+            content_type: None,
+            location: Some(location.into()),
+            body: Vec::new(),
+        }
+    }
+
+    fn build_extractor(
+        responses: Vec<PageFetchResponse>,
+        hosts: &[(&'static str, Vec<IpAddr>)],
+    ) -> NativeExtractor<ScriptedTransport, StaticResolver> {
+        NativeExtractor::new(
+            ScriptedTransport::new(responses),
+            StaticResolver(hosts.iter().cloned().collect()),
+            Duration::from_secs(5),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn extracts_readable_markdown_through_a_vetted_redirect() {
+        let extractor = build_extractor(
+            vec![
+                redirect_response("/articles/ownership"),
+                html_response(200, ARTICLE_HTML),
+            ],
+            &[("example.com", vec![PUBLIC_V4])],
+        );
+        let extraction = extractor
+            .extract("https://example.com/start#fragment")
+            .await
+            .unwrap();
+
+        assert_eq!(extraction.url, "https://example.com/articles/ownership");
+        assert_eq!(extraction.title, "Rust Ownership Explained");
+        assert!(extraction.content.contains("single owner"));
+        assert!(extraction.content.contains("Lifetimes"));
+        assert!(!extraction.content.contains("do-not-extract-this-token"));
+        assert!(!extraction.content.contains("color: red"));
+        assert!(extraction.word_count >= MIN_EXTRACT_WORDS);
+        assert!(!extraction.truncated);
+
+        // Both hops were dialed with the vetted address, fragment stripped.
+        let seen = extractor.transport.seen.lock().unwrap();
+        assert_eq!(seen.len(), 2);
+        assert_eq!(seen[0].0, "https://example.com/start");
+        assert_eq!(seen[0].1, vec![PUBLIC_V4]);
+        assert_eq!(seen[1].0, "https://example.com/articles/ownership");
+    }
+
+    #[tokio::test]
+    async fn redirect_hops_toward_denied_space_are_refused_before_any_fetch() {
+        // A redirect to a host that resolves to RFC 1918 space must fail the
+        // hop's fresh resolution vetting without a second transport call.
+        let extractor = build_extractor(
+            vec![
+                redirect_response("https://internal.example/admin"),
+                html_response(200, ARTICLE_HTML),
+            ],
+            &[
+                ("example.com", vec![PUBLIC_V4]),
+                ("internal.example", vec![PRIVATE_V4]),
+            ],
+        );
+        let error = extractor
+            .extract("https://example.com/start")
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            NativeExtractError::PolicyViolation(FetchPolicyViolation::DeniedAddress(_))
+        ));
+        assert_eq!(extractor.transport.seen.lock().unwrap().len(), 1);
+
+        // A redirect straight to a denied IP literal is refused by URL
+        // admission alone.
+        let extractor = extractor_with_imds_redirect();
+        let error = extractor
+            .extract("https://example.com/start")
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            NativeExtractError::PolicyViolation(FetchPolicyViolation::DeniedAddress(_))
+        ));
+        assert_eq!(extractor.transport.seen.lock().unwrap().len(), 1);
+    }
+
+    fn extractor_with_imds_redirect() -> NativeExtractor<ScriptedTransport, StaticResolver> {
+        build_extractor(
+            vec![redirect_response(
+                "https://169.254.169.254/latest/meta-data/",
+            )],
+            &[("example.com", vec![PUBLIC_V4])],
+        )
+    }
+
+    #[tokio::test]
+    async fn refuses_endless_redirects_and_non_success_statuses() {
+        let hops = (0..=MAX_FETCH_REDIRECT_HOPS + 1)
+            .map(|hop| redirect_response(&format!("/hop/{hop}")))
+            .collect();
+        let extractor = build_extractor(hops, &[("example.com", vec![PUBLIC_V4])]);
+        let error = extractor
+            .extract("https://example.com/start")
+            .await
+            .unwrap_err();
+        assert!(matches!(error, NativeExtractError::TooManyRedirects));
+
+        let extractor = build_extractor(
+            vec![html_response(404, "missing")],
+            &[("example.com", vec![PUBLIC_V4])],
+        );
+        assert!(matches!(
+            extractor
+                .extract("https://example.com/gone")
+                .await
+                .unwrap_err(),
+            NativeExtractError::HttpStatus(404)
+        ));
+    }
+
+    #[tokio::test]
+    async fn refuses_unsupported_content_types_and_javascript_shells() {
+        let mut response = html_response(200, "{\"not\": \"extractable\"}");
+        response.content_type = Some("application/json".into());
+        let extractor = build_extractor(vec![response], &[("example.com", vec![PUBLIC_V4])]);
+        assert!(matches!(
+            extractor
+                .extract("https://example.com/api")
+                .await
+                .unwrap_err(),
+            NativeExtractError::UnsupportedContentType(essence) if essence == "application/json"
+        ));
+
+        let extractor = build_extractor(
+            vec![html_response(200, SHELL_HTML)],
+            &[("example.com", vec![PUBLIC_V4])],
+        );
+        assert!(matches!(
+            extractor
+                .extract("https://example.com/app")
+                .await
+                .unwrap_err(),
+            NativeExtractError::NoReadableContent
+        ));
+    }
+
+    #[tokio::test]
+    async fn over_budget_content_keeps_head_and_tail_with_a_marker() {
+        let head_words = "alpha ".repeat(6_000);
+        let tail_words = "omega ".repeat(6_000);
+        let body = format!("{head_words}{tail_words}");
+        let response = PageFetchResponse {
+            status: 200,
+            content_type: Some("text/plain".into()),
+            location: None,
+            body: body.into_bytes(),
+        };
+        let extractor = build_extractor(vec![response], &[("example.com", vec![PUBLIC_V4])]);
+        let extraction = extractor
+            .extract("https://example.com/big.txt")
+            .await
+            .unwrap();
+
+        assert!(extraction.truncated);
+        assert!(extraction.content.chars().count() <= MAX_EXTRACT_CONTENT_CHARS);
+        assert!(extraction.content.contains(TRUNCATION_MARKER.trim()));
+        assert!(extraction.content.starts_with("alpha"));
+        assert!(extraction.content.ends_with("omega") || extraction.content.ends_with("omega "));
+        assert_eq!(extraction.word_count, 12_000);
+    }
+}

--- a/crates/openwave-web-search/src/types.rs
+++ b/crates/openwave-web-search/src/types.rs
@@ -419,7 +419,7 @@ fn canonical_http_url(value: &str) -> Result<String, WebSearchError> {
     Ok(canonical)
 }
 
-fn truncate(value: &str, max_chars: usize) -> String {
+pub(crate) fn truncate(value: &str, max_chars: usize) -> String {
     value.chars().take(max_chars).collect()
 }
 

--- a/crates/openwave-web-search/tests/pinned_page_transport.rs
+++ b/crates/openwave-web-search/tests/pinned_page_transport.rs
@@ -1,0 +1,71 @@
+//! Socket-level proof that the shipped page transport dials exactly the
+//! address the admission policy vetted — and nothing else.
+//!
+//! It lives in its own test binary because it sets proxy environment
+//! variables. `reqwest` reads those when a client is built, so keeping them in
+//! a process of their own is what stops them from reaching another test.
+
+#![cfg(feature = "extract-native")]
+
+use std::net::IpAddr;
+use std::time::Duration;
+
+use openwave_web_search::{PageFetchTransport, ReqwestPageFetcher};
+use tokio::net::TcpListener;
+use url::Url;
+
+/// The transport is handed one vetted address and must use it, no matter what
+/// the environment would rather it did.
+///
+/// Two things make this fail if either defense is removed. Without
+/// `resolve_to_addrs`, `pinned.invalid` is a name that cannot resolve, so no
+/// socket is ever reached and the pinned listener never accepts. Without
+/// `no_proxy`, the ambient proxy wins over the pinned address: the proxy
+/// listener accepts and the pinned one does not.
+#[tokio::test]
+async fn dials_the_pinned_address_and_never_an_ambient_proxy() {
+    let pinned = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let pinned_address = pinned.local_addr().unwrap();
+    let proxy = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_address = proxy.local_addr().unwrap();
+
+    std::env::set_var("HTTPS_PROXY", format!("http://{proxy_address}"));
+    std::env::set_var("ALL_PROXY", format!("http://{proxy_address}"));
+
+    let url = Url::parse(&format!(
+        "https://pinned.invalid:{}/page",
+        pinned_address.port()
+    ))
+    .unwrap();
+    let fetch = tokio::spawn(async move {
+        // The listener speaks no TLS, so this fetch always ends in an error.
+        // Which socket it reached on the way is the whole question.
+        let _ = ReqwestPageFetcher
+            .get(
+                &url,
+                &[IpAddr::from([127, 0, 0, 1])],
+                Duration::from_secs(2),
+            )
+            .await;
+    });
+
+    // Accepting and immediately closing ends the handshake the fetcher is
+    // waiting on, so the fetch resolves without burning its whole timeout.
+    let dialed = tokio::time::timeout(Duration::from_secs(5), pinned.accept())
+        .await
+        .is_ok();
+    std::env::remove_var("HTTPS_PROXY");
+    std::env::remove_var("ALL_PROXY");
+    assert!(
+        dialed,
+        "the transport never dialed the address it was pinned to"
+    );
+
+    let _ = fetch.await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), proxy.accept())
+            .await
+            .is_err(),
+        "the transport dialed the ambient proxy instead of the vetted address"
+    );
+}


### PR DESCRIPTION
The agent can search the web but cannot open any result it finds. This is
the first of three slices that close that gap; it adds the engine only —
no tool, no trait change, no server wiring, so nothing is model-reachable
yet.

## What's here

**`fetch_policy.rs`** — a pure, always-compiled admission policy for
model-supplied URLs. HTTPS only, no userinfo, port 443 only, fragments
stripped, 2 KiB URL cap. Every IP literal and every DNS-resolved address
is checked against a deny list built on `openwave-egress`'s `CidrBlock`:
loopback, unspecified, RFC1918, link-local v4 (which covers the cloud
metadata endpoint) and v6, CGNAT, ULA, multicast, broadcast, reserved.
IPv4-mapped IPv6 and NAT64 addresses are judged by their embedded v4, so
`::ffff:10.0.0.1` cannot walk through the v6 path.

**`native.rs`** — the fetcher and readability engine, behind a new
`extract-native` feature. Redirects are followed manually, up to five
hops, and every hop re-enters the full policy with fresh DNS resolution;
connections are pinned to the vetted addresses so a second DNS answer
cannot land somewhere else. No cookies, no ambient credentials, an
honest User-Agent, a 4 MiB streamed response cap, and a content-type
allowlist. Extraction runs dom_smoothie in markdown mode under a
24k-character head-and-tail budget, and returns a typed
`NoReadableContent` rather than a plausible-looking fragment when a page
is a JavaScript shell or consent wall — callers must be able to tell
"extracted" from "nothing there".

## Why the policy is this paranoid

Every existing egress path in this crate is bound to one vendor's HTTPS
authority before credentials attach. This is the first code that fetches
an arbitrary URL chosen by the model, from the host process, so the
address-space and redirect checks are the boundary rather than a
belt-and-braces layer.

## Tests

Six of the twenty-one cover the invariants that are easy to reverse by
accident: denied address space including the IPv4-mapped and metadata
forms, redirect hops toward private space refused mid-chain, scheme and
userinfo and port rejects, budget truncation, and the JS-shell case. The
end-to-end extraction test drives a fixture page through the injected
transport; no test touches the network.

## Notes for review

- New transitive deps `cssparser` and `selectors` are MPL-2.0. That's
  file-level copyleft and link-compatible with our Apache-2.0, but it is
  the first MPL code in the workspace, so flagging it deliberately.
- Nothing enables `extract-native` yet, so its gated tests do not run in
  CI until the next slice wires the tool up — the same gap `http` had
  before it had a consumer. Worth landing that slice promptly.