### PR TITLE
feat(desktop): prompt a restart after pairing completes managed enforcement

### DIFF
--- a/crates/openwave-desktop/src/deep_link.rs
+++ b/crates/openwave-desktop/src/deep_link.rs
@@ -191,7 +191,12 @@ fn spawn_pairing(app: tauri::AppHandle, link: ProvisionLink) {
         )
         .await;
         match outcome {
-            Ok(Some(())) => log_pairing(&app, &format!("provisioned to {origin}")),
+            Ok(Some(newly_managed)) => {
+                log_pairing(&app, &format!("provisioned to {origin}"));
+                if newly_managed {
+                    prompt_restart(&app);
+                }
+            }
             Ok(None) => log_pairing(&app, &format!("pairing with {origin} declined")),
             Err(reason) => log_pairing(&app, &format!("pairing failed: {reason}")),
         }
@@ -203,16 +208,18 @@ fn spawn_pairing(app: tauri::AppHandle, link: ProvisionLink) {
 
 /// The confirmation gate, separated from the dialog and the store so the
 /// decision path is testable without a GUI: `confirm` sees only the gateway
-/// origin, and nothing runs `pair` but a confirming answer.
-async fn pair_after_confirmation<C, P, F>(
+/// origin, and nothing runs `pair` but a confirming answer. What a confirmed
+/// pairing yields flows back to the caller — today, whether the profile
+/// newly became managed, which decides the restart prompt.
+async fn pair_after_confirmation<C, P, F, T>(
     link: ProvisionLink,
     confirm: C,
     pair: P,
-) -> Result<Option<()>, String>
+) -> Result<Option<T>, String>
 where
     C: FnOnce(&str) -> bool,
     P: FnOnce(String) -> F,
-    F: std::future::Future<Output = Result<(), String>>,
+    F: std::future::Future<Output = Result<T, String>>,
 {
     if !confirm(&link.origin) {
         return Ok(None);
@@ -242,13 +249,45 @@ fn confirm_pairing(app: &tauri::AppHandle, origin: &str) -> bool {
 
 /// Validate, probe, and provision — all server-side. The sign-in gate is a
 /// separate surface: once policy flips to managed it presents itself on its
-/// next poll, so pairing does not drive the renderer.
-async fn pair(app: tauri::AppHandle, gateway_url: String) -> Result<(), String> {
+/// next poll, so pairing does not drive the renderer. Reports whether this
+/// pairing newly managed the profile — the restart-prompt signal.
+async fn pair(app: tauri::AppHandle, gateway_url: String) -> Result<bool, String> {
     let handle = wait_pairing_handle(&app).await?;
     openwave_server::pair_with_gateway(&handle, &gateway_url)
         .await
-        .map(|_| ())
+        .map(|outcome| outcome.newly_managed)
         .map_err(|error| error.to_string())
+}
+
+/// Offer the restart that completes enforcement, after a pairing that newly
+/// managed this profile. The embeddings client is boot-scoped (the vector
+/// index is dimension-bound to it — see `resolve_embedder` in
+/// `openwave-server`), so a BYOK embedder resolved at launch keeps serving
+/// until the next start; an idempotent re-pair changes nothing and never
+/// reaches here. Declining is honored without nagging, but not silently: one
+/// log line records that enforcement completes at the next launch.
+fn prompt_restart(app: &tauri::AppHandle) {
+    let restart = app
+        .dialog()
+        .message(
+            "Pairing complete — restart OpenWave to finish applying managed \
+             enforcement.\n\nUntil the next launch, document embeddings keep \
+             the configuration the app started with.",
+        )
+        .title("Pairing complete")
+        .kind(MessageDialogKind::Info)
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Restart Now".to_string(),
+            "Later".to_string(),
+        ))
+        .blocking_show();
+    if restart {
+        app.restart();
+    }
+    log_pairing(
+        app,
+        "restart deferred; managed enforcement completes at the next launch",
+    );
 }
 
 async fn wait_pairing_handle(app: &tauri::AppHandle) -> Result<PairingHandle, String> {
@@ -371,14 +410,16 @@ mod tests {
             |_| false,
             |_| {
                 paired.store(true, Ordering::SeqCst);
-                async { Ok(()) }
+                async { Ok(true) }
             },
         )
         .await;
         assert_eq!(outcome, Ok(None));
         assert!(!paired.load(Ordering::SeqCst));
 
-        // Confirmed: the dialog sees the origin, the pairing action the URL.
+        // Confirmed: the dialog sees the origin, the pairing action the URL,
+        // and what the pairing yielded (the restart-prompt signal) comes
+        // back to the caller.
         let outcome = pair_after_confirmation(
             link(),
             |origin| {
@@ -387,10 +428,10 @@ mod tests {
             },
             |gateway_url| async move {
                 assert_eq!(gateway_url, "https://gw.example");
-                Ok(())
+                Ok(true)
             },
         )
         .await;
-        assert_eq!(outcome, Ok(Some(())));
+        assert_eq!(outcome, Ok(Some(true)));
     }
 }

--- a/crates/openwave-desktop/src/deep_link.rs
+++ b/crates/openwave-desktop/src/deep_link.rs
@@ -191,9 +191,9 @@ fn spawn_pairing(app: tauri::AppHandle, link: ProvisionLink) {
         )
         .await;
         match outcome {
-            Ok(Some(newly_managed)) => {
+            Ok(Some(newly_provisioned)) => {
                 log_pairing(&app, &format!("provisioned to {origin}"));
-                if newly_managed {
+                if newly_provisioned {
                     prompt_restart(&app);
                 }
             }
@@ -209,8 +209,8 @@ fn spawn_pairing(app: tauri::AppHandle, link: ProvisionLink) {
 /// The confirmation gate, separated from the dialog and the store so the
 /// decision path is testable without a GUI: `confirm` sees only the gateway
 /// origin, and nothing runs `pair` but a confirming answer. What a confirmed
-/// pairing yields flows back to the caller — today, whether the profile
-/// newly became managed, which decides the restart prompt.
+/// pairing yields flows back to the caller — today, whether this pairing
+/// newly provisioned the profile, which decides the restart prompt.
 async fn pair_after_confirmation<C, P, F, T>(
     link: ProvisionLink,
     confirm: C,
@@ -250,22 +250,24 @@ fn confirm_pairing(app: &tauri::AppHandle, origin: &str) -> bool {
 /// Validate, probe, and provision — all server-side. The sign-in gate is a
 /// separate surface: once policy flips to managed it presents itself on its
 /// next poll, so pairing does not drive the renderer. Reports whether this
-/// pairing newly managed the profile — the restart-prompt signal.
+/// pairing newly provisioned the profile — the restart-prompt signal.
 async fn pair(app: tauri::AppHandle, gateway_url: String) -> Result<bool, String> {
     let handle = wait_pairing_handle(&app).await?;
     openwave_server::pair_with_gateway(&handle, &gateway_url)
         .await
-        .map(|outcome| outcome.newly_managed)
+        .map(|outcome| outcome.newly_provisioned)
         .map_err(|error| error.to_string())
 }
 
-/// Offer the restart that completes enforcement, after a pairing that newly
-/// managed this profile. The embeddings client is boot-scoped (the vector
-/// index is dimension-bound to it — see `resolve_embedder` in
+/// Offer the restart that completes enforcement, after the pairing that
+/// provisioned this profile. The embeddings client is boot-scoped (the
+/// vector index is dimension-bound to it — see `resolve_embedder` in
 /// `openwave-server`), so a BYOK embedder resolved at launch keeps serving
-/// until the next start; an idempotent re-pair changes nothing and never
-/// reaches here. Declining is honored without nagging, but not silently: one
-/// log line records that enforcement completes at the next launch.
+/// until the next start. An idempotent re-pair never reaches here; the
+/// first pairing of a profile already OS-managed at boot does, and for it
+/// the offered restart simply changes nothing. Declining is honored without
+/// nagging, but not silently: one log line records that enforcement
+/// completes at the next launch.
 fn prompt_restart(app: &tauri::AppHandle) {
     let restart = app
         .dialog()
@@ -419,7 +421,8 @@ mod tests {
 
         // Confirmed: the dialog sees the origin, the pairing action the URL,
         // and what the pairing yielded (the restart-prompt signal) comes
-        // back to the caller.
+        // back to the caller — yielding `false` here, against the declined
+        // arm's `true`, pins that the value is read rather than assumed.
         let outcome = pair_after_confirmation(
             link(),
             |origin| {
@@ -428,10 +431,10 @@ mod tests {
             },
             |gateway_url| async move {
                 assert_eq!(gateway_url, "https://gw.example");
-                Ok(true)
+                Ok(false)
             },
         )
         .await;
-        assert_eq!(outcome, Ok(Some(true)));
+        assert_eq!(outcome, Ok(Some(false)));
     }
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -938,9 +938,9 @@ const EMBED_DIMS: usize = 1536;
 /// Because the embedder is boot-scoped (the vector index is dimension-bound
 /// to it), a profile provisioned managed at runtime keeps a live BYOK
 /// embedder until the next app start. The desktop deep-link pairing flow
-/// therefore prompts for a restart when a pairing newly manages the profile
-/// (keyed off `PairingOutcome::newly_managed` — #898); either way this gate
-/// closes at the next boot.
+/// therefore prompts for a restart when a pairing newly provisions the
+/// profile (keyed off `PairingOutcome::newly_provisioned` — #898); either
+/// way this gate closes at the next boot.
 async fn resolve_embedder(
     store: &dyn Store,
     secrets: &dyn SecretProvider,

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -91,7 +91,7 @@ use resolver::KeyedResolver;
 
 pub use durable_oplog::DurableOperationStore;
 pub use error::ServerError;
-pub use pairing::{pair_with_gateway, PairingHandle};
+pub use pairing::{pair_with_gateway, PairingHandle, PairingOutcome};
 pub use state::AppState;
 
 const MAX_RAW_DOCUMENT_BYTES: usize = 16 * 1024 * 1024;
@@ -937,9 +937,10 @@ const EMBED_DIMS: usize = 1536;
 ///
 /// Because the embedder is boot-scoped (the vector index is dimension-bound
 /// to it), a profile provisioned managed at runtime keeps a live BYOK
-/// embedder until the next app start: the pairing flow must prompt or
-/// trigger a restart (or index rebuild) to complete enforcement — tracked
-/// in #763.
+/// embedder until the next app start. The desktop deep-link pairing flow
+/// therefore prompts for a restart when a pairing newly manages the profile
+/// (keyed off `PairingOutcome::newly_managed` — #898); either way this gate
+/// closes at the next boot.
 async fn resolve_embedder(
     store: &dyn Store,
     secrets: &dyn SecretProvider,

--- a/crates/openwave-server/src/pairing.rs
+++ b/crates/openwave-server/src/pairing.rs
@@ -52,11 +52,26 @@ impl PairingHandle {
     }
 }
 
+/// What a successful pairing did, beyond the writes themselves.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PairingOutcome {
+    /// The normalized gateway base URL now on record.
+    pub base_url: String,
+    /// True when this pairing transitioned the profile from unprovisioned to
+    /// provisioned (managed); false for an idempotent re-pair of the gateway
+    /// already on record, which changed no policy. The desktop shell keys
+    /// its restart prompt off this: enforcement that only a fresh boot can
+    /// apply (the boot-scoped embedder) is outstanding exactly when the
+    /// transition happened here.
+    pub newly_managed: bool,
+}
+
 /// Validate `gateway_url`, probe the gateway, and provision this profile.
 ///
-/// Returns the normalized gateway base URL on success. Nothing is written
-/// unless the URL passes the gateway contract and the deployment answers
-/// `GET /api/v1/meta`; a conflicting re-provision is refused inside
+/// Returns a [`PairingOutcome`] on success — the normalized gateway base URL
+/// plus whether this call is the one that made the profile managed. Nothing
+/// is written unless the URL passes the gateway contract and the deployment
+/// answers `GET /api/v1/meta`; a conflicting re-provision is refused inside
 /// [`managed_policy::provision`] and leaves both the policy and the provider
 /// configuration untouched. Success also points the ModelGateway provider at
 /// the gateway and enables it, dropping any model snapshot synced from a
@@ -66,7 +81,10 @@ impl PairingHandle {
 /// servers running under the previously open profile are taken down here
 /// rather than at the supervisor's next sweep, so no locked child keeps
 /// serving tools across the window in between.
-pub async fn pair_with_gateway(handle: &PairingHandle, gateway_url: &str) -> Result<String> {
+pub async fn pair_with_gateway(
+    handle: &PairingHandle,
+    gateway_url: &str,
+) -> Result<PairingOutcome> {
     let store = &*handle.store;
     let config = GatewayAuthConfig::new(gateway_url)?;
     let base_url = config.base_url().to_string();
@@ -78,13 +96,14 @@ pub async fn pair_with_gateway(handle: &PairingHandle, gateway_url: &str) -> Res
     // provider-first fails into a still-unmanaged profile recoverable from
     // settings, while policy-first could strand a permanently managed
     // profile with no configured provider.
-    if let Some(existing) = managed_policy::provisioned_url(store).await? {
-        if existing != base_url {
+    let already_provisioned = match managed_policy::provisioned_url(store).await? {
+        Some(existing) if existing != base_url => {
             return Err(AgentError::config(
                 "this profile is already provisioned to a different gateway",
             ));
         }
-    }
+        existing => existing.is_some(),
+    };
     let mut provider = providers::read_config(store, ProviderKind::ModelGateway).await?;
     if provider.base_url.as_deref() != Some(base_url.as_str()) {
         // A model snapshot synced from a previously configured gateway does
@@ -96,7 +115,10 @@ pub async fn pair_with_gateway(handle: &PairingHandle, gateway_url: &str) -> Res
     providers::write_config(store, ProviderKind::ModelGateway, &provider).await?;
     managed_policy::provision(store, &base_url).await?;
     handle.mcp.enforce_manual_lockdown().await;
-    Ok(base_url)
+    Ok(PairingOutcome {
+        base_url,
+        newly_managed: !already_provisioned,
+    })
 }
 
 #[cfg(test)]
@@ -248,9 +270,14 @@ mod tests {
         .await
         .unwrap();
 
-        let normalized = pair_with_gateway(&test_handle(&store), &base)
+        let outcome = pair_with_gateway(&test_handle(&store), &base)
             .await
             .unwrap();
+        assert!(
+            outcome.newly_managed,
+            "the first pairing is the unmanaged-to-managed transition"
+        );
+        let normalized = outcome.base_url;
         assert_eq!(normalized, format!("{base}/"));
 
         let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
@@ -264,10 +291,13 @@ mod tests {
         assert_eq!(provider.base_url.as_deref(), Some(normalized.as_str()));
         assert!(provider.models.is_empty());
 
-        // Re-pairing the same gateway is idempotent.
-        pair_with_gateway(&test_handle(&store), &base)
+        // Re-pairing the same gateway is idempotent, and reports that no
+        // transition happened — the desktop shell keys its restart prompt
+        // off this distinction.
+        let repaired = pair_with_gateway(&test_handle(&store), &base)
             .await
             .unwrap();
+        assert!(!repaired.newly_managed);
     }
 
     /// Pairing applies the policy it writes, not just persists it: a manual
@@ -338,7 +368,8 @@ mod tests {
         let second = serve_meta().await;
         let normalized = pair_with_gateway(&test_handle(&store), &first)
             .await
-            .unwrap();
+            .unwrap()
+            .base_url;
         let error = pair_with_gateway(&test_handle(&store), &second)
             .await
             .err()

--- a/crates/openwave-server/src/pairing.rs
+++ b/crates/openwave-server/src/pairing.rs
@@ -53,23 +53,26 @@ impl PairingHandle {
 }
 
 /// What a successful pairing did, beyond the writes themselves.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct PairingOutcome {
     /// The normalized gateway base URL now on record.
     pub base_url: String,
-    /// True when this pairing transitioned the profile from unprovisioned to
-    /// provisioned (managed); false for an idempotent re-pair of the gateway
-    /// already on record, which changed no policy. The desktop shell keys
-    /// its restart prompt off this: enforcement that only a fresh boot can
-    /// apply (the boot-scoped embedder) is outstanding exactly when the
-    /// transition happened here.
-    pub newly_managed: bool,
+    /// True when this call is the one that provisioned the profile; false
+    /// for an idempotent re-pair of the gateway already on record, which
+    /// changed no policy. The desktop shell keys its restart prompt off
+    /// this, and the claim is one-directional: enforcement that only a
+    /// fresh boot can apply (the boot-scoped embedder) is outstanding only
+    /// if this call did the provisioning. A profile already managed by OS
+    /// policy was gated at boot and first-pairs with nothing outstanding,
+    /// and a deferred restart stays outstanding through later re-pairs
+    /// that report false.
+    pub newly_provisioned: bool,
 }
 
 /// Validate `gateway_url`, probe the gateway, and provision this profile.
 ///
 /// Returns a [`PairingOutcome`] on success — the normalized gateway base URL
-/// plus whether this call is the one that made the profile managed. Nothing
+/// plus whether this call is the one that provisioned the profile. Nothing
 /// is written unless the URL passes the gateway contract and the deployment
 /// answers `GET /api/v1/meta`; a conflicting re-provision is refused inside
 /// [`managed_policy::provision`] and leaves both the policy and the provider
@@ -102,7 +105,7 @@ pub async fn pair_with_gateway(
                 "this profile is already provisioned to a different gateway",
             ));
         }
-        existing => existing.is_some(),
+        other => other.is_some(),
     };
     let mut provider = providers::read_config(store, ProviderKind::ModelGateway).await?;
     if provider.base_url.as_deref() != Some(base_url.as_str()) {
@@ -117,7 +120,7 @@ pub async fn pair_with_gateway(
     handle.mcp.enforce_manual_lockdown().await;
     Ok(PairingOutcome {
         base_url,
-        newly_managed: !already_provisioned,
+        newly_provisioned: !already_provisioned,
     })
 }
 
@@ -274,8 +277,8 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            outcome.newly_managed,
-            "the first pairing is the unmanaged-to-managed transition"
+            outcome.newly_provisioned,
+            "the first pairing is the one that provisions"
         );
         let normalized = outcome.base_url;
         assert_eq!(normalized, format!("{base}/"));
@@ -297,7 +300,7 @@ mod tests {
         let repaired = pair_with_gateway(&test_handle(&store), &base)
             .await
             .unwrap();
-        assert!(!repaired.newly_managed);
+        assert!(!repaired.newly_provisioned);
     }
 
     /// Pairing applies the policy it writes, not just persists it: a manual


### PR DESCRIPTION
Deep-link pairing applies managed enforcement inline except for one piece: the embeddings client is boot-scoped (the vector index is dimension-bound to the embedder), so a profile provisioned managed at runtime keeps a live BYOK OpenAI embedder until the next app start. This surfaces that gap the moment it opens.

## What changed

- `pair_with_gateway` now returns a `PairingOutcome { base_url, newly_managed }`. `newly_managed` is true only when the call transitioned the profile from unprovisioned to provisioned, computed from the existing `provisioned_url` pre-check under the pairing mutex; an idempotent re-pair of the already-provisioned gateway reports false, since it changes no policy.
- After a successful pairing in the deep-link flow, the desktop shell shows a follow-up native dialog — "Pairing complete — restart OpenWave to finish applying managed enforcement." — with **Restart Now** (`AppHandle::restart`) and **Later**. It is keyed off `newly_managed`, so a re-pair never raises it.
- Declining is honored without nagging, but not silently: one bounded `pairing.log` line records that enforcement completes at the next launch.
- The `resolve_embedder` doc comment now points at the prompt (and #898) instead of calling the restart trigger future work; the structural constraint text is unchanged.

## Tests

- Extended `pairing_provisions_policy_and_points_the_provider` to assert the transition signal both ways: the first pairing reports `newly_managed`, the idempotent re-pair reports it false. No new test walks the pair/re-pair path a second time.
- `only_a_confirmed_pairing_reaches_the_write_path` now checks the pairing's yielded value (the restart-prompt signal) flows back through the GUI-free confirmation gate; the dialog itself stays untested GUI.
- `a_failed_pairing_changes_nothing` adjusted for the new return type only.

Verified locally: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace`, `cargo check --workspace --locked` (no lock diff). UI untouched.

Closes #898

🤖 Generated with [Claude Code](https://claude.com/claude-code)