### PR TITLE
feat(desktop): align the composer control row and let a chat be set up before it starts

### DIFF
--- a/crates/openwave-desktop/ui/src/Composer.test.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.test.tsx
@@ -313,9 +313,10 @@ describe("Composer", () => {
       />,
     );
 
-    // One button for any file. Which of the two things it becomes is the
-    // host's decision from the bytes, not a choice put to the reader.
-    expect(markup).toContain('aria-label="Attach files"');
+    // One control for any file. Which of the two things it becomes is the
+    // host's decision from the bytes, not a choice put to the reader — the
+    // menu behind this trigger offers a single upload, never a per-kind pair.
+    expect(markup).toContain('aria-label="Add to this chat"');
     expect(markup).not.toContain('aria-label="Attach image"');
     expect(markup).toContain("brief.pdf");
     expect(markup).toContain("Added to this conversation");

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -12,8 +12,9 @@ import {
   ArrowUpRight,
   FileText,
   Image as ImageIcon,
-  Paperclip,
+  Plus,
   Square,
+  Upload,
   X,
 } from "lucide-react";
 import { MAX_STEER_CHARACTERS } from "./ActiveTurnSteer";
@@ -25,6 +26,13 @@ import {
   transferCarriesFiles,
   type ImageAttachment,
 } from "./ImageAttachments";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { WithTooltip } from "@/components/ui/tooltip";
 
 const MIN_COMPOSER_LINES = 1;
@@ -339,17 +347,30 @@ export function Composer({
         <div className="composer-actions">
           <div className="composer-actions-left">
             {canAttach && onAttach && (
-              <WithTooltip label={attaching ? "Attaching…" : "Attach files"}>
-                <button
-                  type="button"
-                  className="composer-attach"
-                  aria-label={attaching ? "Attaching" : "Attach files"}
-                  disabled={inputDisabled || attaching || busy}
-                  onClick={() => void onAttach()}
-                >
-                  <Paperclip size={15} aria-hidden="true" />
-                </button>
-              </WithTooltip>
+              <DropdownMenu>
+                <WithTooltip label={attaching ? "Attaching…" : "Add"}>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="icon-8"
+                      aria-label={attaching ? "Attaching" : "Add to this chat"}
+                      disabled={inputDisabled || attaching || busy}
+                    >
+                      <Plus aria-hidden="true" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                </WithTooltip>
+                {/* A menu rather than a bare button: attaching files is the
+                    first of the things a reader adds to a conversation, and
+                    the sources that follow it belong in the same place rather
+                    than as a second icon in the row. */}
+                <DropdownMenuContent align="start" side="top" className="w-56">
+                  <DropdownMenuItem onSelect={() => void onAttach()}>
+                    <Upload className="size-4" />
+                    Upload files
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             )}
             {modelMenu}
           </div>

--- a/crates/openwave-desktop/ui/src/ComposerAttachMenu.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerAttachMenu.dom.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, it, vi } from "vitest";
+import { Composer } from "./Composer";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const noop = async () => {};
+
+/**
+ * Uploading moved behind a menu, so the trigger is now the only way to reach
+ * it. A trigger that fails to open makes attachment unreachable without
+ * failing anything else — the static markup test still passes, because the
+ * button is right there.
+ */
+it("opens the add menu and runs the upload it offers", async () => {
+  const onAttach = vi.fn(async () => {});
+  render(
+    <Composer
+      activeTurnId={null}
+      busy={false}
+      cancelError={null}
+      cancelPending={false}
+      disabled={false}
+      draft=""
+      canAttach
+      attaching={false}
+      attachedSourceName={null}
+      attachError={null}
+      onAttach={onAttach}
+      onDraftChange={vi.fn()}
+      onSend={noop}
+      onSteer={noop}
+      onStop={noop}
+      resetKey="chat-1"
+      steerError={null}
+      steerPending={false}
+      steerStatus={null}
+    />,
+  );
+
+  // Nothing runs from the trigger itself: it opens the menu.
+  await userEvent.click(screen.getByRole("button", { name: "Add to this chat" }));
+  expect(onAttach).not.toHaveBeenCalled();
+
+  await userEvent.click(await screen.findByRole("menuitem", { name: /Upload files/ }));
+  await waitFor(() => expect(onAttach).toHaveBeenCalledTimes(1));
+});

--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import { Atom, Check, ChevronDown, Gauge, Info } from "lucide-react";
 import type { ModelInfo, ModelSelectionKey, ProviderKind, ReasoningEffort } from "./api";
 import { canonicalModelSelection, modelForSelection } from "./ModelSelection";
+import { Button } from "@/components/ui/button";
 import { ProviderIcon } from "./ProviderIcons";
 import {
   DropdownMenu,
@@ -172,12 +174,17 @@ export function ModelMenu({
   // the model was chosen here or inherited.
   const pillModel = known ?? (isDefault ? resolvedDefault : null);
 
+  // Controlled so every path that changes the chat's model closes the menu —
+  // including the Default switch, which is a selection like any row but is not
+  // a menu item Radix would close for us.
+  const [open, setOpen] = useState(false);
+
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className="model-menu-trigger"
+        <Button
+          variant="ghost"
+          className="h-8 max-w-56 gap-2"
           disabled={disabled}
           aria-label={triggerLabel}
           title={triggerLabel}
@@ -186,14 +193,14 @@ export function ModelMenu({
             <ProviderIcon
               provider={pillModel.provider}
               modelId={pillModel.id}
-              className="size-3.5"
+              className="size-4"
             />
           ) : (
-            <Atom className="size-3.5" />
+            <Atom className="size-4 text-muted-foreground" />
           )}
-          <span className="model-menu-label">{label}</span>
-          <ChevronDown className="size-3.5" />
-        </button>
+          <span className="truncate">{label}</span>
+          <ChevronDown className="size-4 opacity-50" />
+        </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="start"
@@ -211,13 +218,17 @@ export function ModelMenu({
             onToggle={(useDefault) => {
               if (useDefault) {
                 void onChange(null);
+                setOpen(false);
                 return;
               }
               // Turning the default off has to land on something; the first
               // model as the menu renders them, so the check appears at the
               // top of the list rather than mid-scroll.
               const first = firstAvailableModel(models, canonical);
-              if (first) void onChange(first.key);
+              if (first) {
+                void onChange(first.key);
+                setOpen(false);
+              }
             }}
           />
 
@@ -239,11 +250,12 @@ export function ModelMenu({
                   <DropdownMenuItem
                     key={model.key}
                     disabled={disabled || !model.available}
-                    // The menu stays open: the switch above and the rows here
-                    // are one control, and closing on a row would strand a
-                    // reader who meant to flip back to the default.
-                    onSelect={(event) => {
-                      event.preventDefault();
+                    // Picking a model is the whole point of opening this, so
+                    // the menu closes on it. Re-selecting what is already
+                    // chosen still closes: the reader asked for this model and
+                    // has it, and holding the menu open would read as a
+                    // dropped click.
+                    onSelect={() => {
                       if (selected || !model.available) return;
                       void onChange(model.key);
                     }}
@@ -337,20 +349,21 @@ export function ReasoningEffortMenu({
   const options = reasoningEffortOptions(levels);
   const isDefault = value === null;
   const label = isDefault ? "Default" : REASONING_EFFORT_LABELS[value];
+  const [open, setOpen] = useState(false);
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className="model-menu-trigger"
+        <Button
+          variant="ghost"
+          className="h-8 gap-1.5"
           disabled={disabled}
           aria-label={`Reasoning effort: ${label}`}
           title={`Reasoning effort: ${label}`}
         >
-          <Gauge className="size-3.5" />
-          <span className="model-menu-label">{label}</span>
-          <ChevronDown className="size-3.5" />
-        </button>
+          <Gauge className="size-4 text-muted-foreground" />
+          <span className="truncate">{label}</span>
+          <ChevronDown className="size-4 opacity-50" />
+        </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="start"
@@ -369,10 +382,14 @@ export function ReasoningEffortMenu({
             onToggle={(useDefault) => {
               if (useDefault) {
                 void onChange(null);
+                setOpen(false);
                 return;
               }
               const first = options[0];
-              if (first) void onChange(first.value);
+              if (first) {
+                void onChange(first.value);
+                setOpen(false);
+              }
             }}
           />
 
@@ -384,8 +401,7 @@ export function ReasoningEffortMenu({
               <DropdownMenuItem
                 key={option.value}
                 disabled={disabled}
-                onSelect={(event) => {
-                  event.preventDefault();
+                onSelect={() => {
                   if (selected) return;
                   void onChange(option.value);
                 }}

--- a/crates/openwave-desktop/ui/src/PermissionModeMenu.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/PermissionModeMenu.dom.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, it, vi } from "vitest";
+import { PermissionModeMenu } from "./PermissionModeMenu";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+/**
+ * The menu used to hold itself open after a choice, which reads as a dropped
+ * click on a control whose whole job is one decision.
+ */
+it("applies the chosen mode and closes", async () => {
+  const onChange = vi.fn();
+  render(<PermissionModeMenu value={null} onChange={onChange} />);
+
+  await userEvent.click(screen.getByRole("button", { name: "Permissions: Ask" }));
+  await userEvent.click(await screen.findByRole("menuitem", { name: /Allow all/ }));
+
+  expect(onChange).toHaveBeenCalledWith("allow");
+  await waitFor(() =>
+    expect(screen.queryByRole("menuitem", { name: /Allow all/ })).not.toBeInTheDocument(),
+  );
+});

--- a/crates/openwave-desktop/ui/src/PermissionModeMenu.tsx
+++ b/crates/openwave-desktop/ui/src/PermissionModeMenu.tsx
@@ -1,5 +1,6 @@
 import { Check, ChevronDown, ShieldCheck, Sparkles, Zap } from "lucide-react";
 import type { PermissionMode } from "./api";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -64,6 +65,11 @@ export function permissionModeOption(mode: PermissionMode | null) {
  * reads as Ask; selecting Ask stores the explicit token rather than clearing,
  * so a chat that was deliberately dialed back stays that way if the default
  * ever changes.
+ *
+ * An elevated mode accents the trigger's text and icon rather than its
+ * background: the row reads as one set of controls, and the one that has been
+ * dialed up should stand out within it without becoming a second kind of
+ * object.
  */
 export function PermissionModeMenu({
   value,
@@ -79,64 +85,56 @@ export function PermissionModeMenu({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className="model-menu-trigger"
+        <Button
+          variant="ghost"
+          className={cn("h-8 gap-1.5", current.elevated && "text-warning-foreground")}
           disabled={disabled}
           aria-label={`Permissions: ${current.label}`}
-          title={`Permissions: ${current.label}`}
         >
           <CurrentIcon
-            className={cn("size-3.5", current.elevated && "text-warning")}
-          />
-          <span
             className={cn(
-              "model-menu-label",
-              current.elevated && "text-warning",
+              "size-4",
+              current.elevated ? "text-warning-foreground" : "text-muted-foreground",
             )}
-          >
-            {current.label}
-          </span>
-          <ChevronDown className="size-3.5" />
-        </button>
+          />
+          {current.label}
+          <ChevronDown className="size-4 opacity-50" />
+        </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="start"
-        side="top"
-        className="model-menu-content w-80 overflow-y-auto p-0"
-      >
-        <div className="flex flex-col gap-1 p-1">
-          {PERMISSION_MODE_SCALE.map((option) => {
-            const selected = current.value === option.value;
-            const OptionIcon = option.icon;
-            return (
-              <DropdownMenuItem
-                key={option.value}
-                disabled={disabled}
-                onSelect={(event) => {
-                  event.preventDefault();
-                  if (selected) return;
-                  void onChange(option.value);
-                }}
-                className="flex items-start gap-2"
-              >
-                <OptionIcon
-                  className={cn(
-                    "mt-0.5 size-4 shrink-0",
-                    option.elevated && "text-warning",
-                  )}
-                />
-                <span className="flex min-w-0 flex-col">
-                  <span className="text-sm">{option.label}</span>
-                  <span className="text-muted-foreground text-xs">
-                    {option.description}
-                  </span>
+      <DropdownMenuContent align="end" side="top" className="w-72">
+        {PERMISSION_MODE_SCALE.map((option) => {
+          const selected = current.value === option.value;
+          const OptionIcon = option.icon;
+          return (
+            <DropdownMenuItem
+              key={option.value}
+              disabled={disabled}
+              onSelect={() => {
+                if (selected) return;
+                void onChange(option.value);
+              }}
+              className="flex flex-col items-start gap-0.5 py-3"
+            >
+              <div className="flex w-full items-center justify-between">
+                <span className="flex items-center gap-2 font-medium">
+                  <OptionIcon
+                    className={cn(
+                      "size-4",
+                      option.elevated
+                        ? "text-warning-foreground"
+                        : "text-muted-foreground",
+                    )}
+                  />
+                  {option.label}
                 </span>
-                {selected && <Check className="ml-auto size-4 shrink-0" />}
-              </DropdownMenuItem>
-            );
-          })}
-        </div>
+                {selected && <Check className="size-4" />}
+              </div>
+              <span className="text-muted-foreground pl-6 text-xs">
+                {option.description}
+              </span>
+            </DropdownMenuItem>
+          );
+        })}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/crates/openwave-desktop/ui/src/components/ui/button.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/button.tsx
@@ -26,6 +26,7 @@ const buttonVariants = cva(
         lg: "h-11 rounded-md px-8",
         icon: "size-10",
         "icon-sm": "size-9",
+        "icon-8": "size-8",
         xs: "h-7 px-2 rounded-md text-xs",
         "2xs": "h-5 px-1.5 rounded text-xs gap-1 [&_svg]:size-3",
         "icon-xs": "size-6 rounded-md [&_svg]:size-3.5",

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -1552,39 +1552,15 @@ body {
 .composer-actions-left {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 0.5rem;
   min-width: 0;
 }
 
 .composer-actions-right {
   display: flex;
   align-items: center;
-  gap: 0.45rem;
+  gap: 0.5rem;
   margin-left: auto;
-}
-
-.composer-attach {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  flex: 0 0 auto;
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  padding: 0;
-  color: var(--muted-foreground);
-  background: transparent;
-}
-
-.composer-attach:hover:not(:disabled) {
-  color: var(--ink);
-  background: var(--muted);
-}
-
-.composer-attach:disabled {
-  opacity: 0.45;
-  cursor: wait;
 }
 
 .composer-source {
@@ -1787,42 +1763,6 @@ body {
 }
 
 /* ---------- Model menu (composer) ---------- */
-
-.model-menu-trigger {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  max-width: 14rem;
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  padding: 0.25rem 0.6rem;
-  background: transparent;
-  color: var(--muted-foreground);
-  font-size: 0.8rem;
-  font-weight: 500;
-  transition: color 120ms ease, background-color 120ms ease,
-    border-color 120ms ease;
-}
-
-.model-menu-trigger:hover:not(:disabled) {
-  color: var(--ink);
-  background: var(--accent);
-}
-
-.model-menu-trigger:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.model-menu-trigger svg {
-  flex: 0 0 auto;
-}
-
-.model-menu-label {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
 
 .model-menu-content {
   /* Bounded by the space Radix measured between the trigger and the viewport


### PR DESCRIPTION
Three fixes to the composer's control row, all visible in one screenshot: the buttons were not the same size, uploading sat in the row as its own icon, and the menus stayed open after a choice.

## Sizing and shape

The attach square was 32px while the pills beside it computed to ~29px, so the row read as two sets of buttons rather than one. Everything is 32px now, and the labeled pills take the reference design's shape:

| | before | after |
|---|---|---|
| height | ~29px (padding-derived) | 32px |
| border | 1px | none (ghost) |
| text | 12.8px | 14px, same weight |
| horizontal padding | 9.6px | 16px |
| icon / chevron | 14px | 16px, chevron at 50% opacity |

The icon-only trigger keeps its outline treatment at a true 32×32 square (a new `icon-8` size on the Button primitive, matching the reference). The permission pill keeps its accent on **text and icon only** rather than gaining a background or border, so an elevated mode stands out within the row instead of becoming a different kind of object.

## Uploading moved into a menu

Attaching is now one item behind the trigger, rather than its own icon in the row — the place whatever we add to a conversation next belongs, instead of a second icon each time. The model and permission controls deliberately **stay outside**: they are read at a glance, and burying them would cost a click just to answer "what is this chat set to".

## Menus close on choice

All three menus held themselves open after a selection. For the model list that was deliberate — a comment argued that closing would strand a reader who meant to flip back to Default — but it reads as a dropped click on a control whose whole job is one decision. Model, reasoning effort, and permission mode all close now, including on the **Default switch**, which is a selection like any row but is not a menu item the primitive would close for us (so those two menus became controlled).

## Tests

The static composer test asserted the old aria-label; its invariant — one control for any file, never a per-kind pair — is unchanged and still asserted. Two DOM tests cover what moved behind a click, since a broken trigger would make uploading unreachable without failing anything else:

- the trigger opens the menu rather than uploading, and the item inside runs the upload;
- choosing a permission mode both applies it and closes the menu.

Also removes the three now-unused CSS rules (`.model-menu-trigger`, `.model-menu-label`, `.composer-attach`) and evens the row gaps to 8px.

Verified locally: `tsc`, 641 UI tests, `pnpm build`.

Follow-up, landing separately: the same controls on the home page before a chat exists.