### PR TITLE
feat(desktop): choose a chat's model and permissions before starting it

### DIFF
--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -6,6 +6,10 @@ import { ChatExplorer } from "./ChatExplorer";
 import { useChatListStore } from "./ChatListStore";
 import { Composer } from "./Composer";
 import { useFirstMessage } from "./FirstMessage";
+import { ModelMenu, ReasoningEffortMenu } from "./ModelMenu";
+import { modelForSelection } from "./ModelSelection";
+import { useNewChatSettings } from "./NewChatSettings";
+import { PermissionModeMenu } from "./PermissionModeMenu";
 import { RouteFrame } from "./RouteFrame";
 import { HomeSidebar } from "./sidebar/HomeSidebar";
 
@@ -25,11 +29,15 @@ const firstMessageActions = useFirstMessage.getState();
  */
 export function HomeRoute() {
   const navigate = useNavigate();
-  const { client } = useApp();
+  const { client, models, defaultModelKey } = useApp();
   const chatsLoaded = useChatListStore((state) => state.chatsLoaded);
   const creatingChat = useChatListStore((state) => state.creatingChat);
   const [draft, setDraft] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const newChat = useNewChatSettings();
+  // Only the levels the pending model accepts are offerable, the same rule the
+  // conversation composer follows.
+  const efforts = modelForSelection(models, newChat.model)?.reasoning_efforts ?? [];
 
   async function startChat() {
     const content = draft.trim();
@@ -37,7 +45,10 @@ export function HomeRoute() {
     chatListActions.setCreatingChat(true);
     setError(null);
     try {
-      const created = await client.createChat();
+      const created = await client.createChat(newChat.model ?? undefined, null, {
+        reasoningEffort: newChat.reasoningEffort,
+        permissionMode: newChat.permissionMode,
+      });
       chatListActions.prependChat(created);
       chatListActions.setChatsError(null);
       firstMessageActions.hold(created.id, content);
@@ -86,6 +97,30 @@ export function HomeRoute() {
             steerError={null}
             steerPending={false}
             steerStatus={null}
+            modelMenu={
+              <>
+                <ModelMenu
+                  models={models}
+                  value={newChat.model}
+                  defaultKey={defaultModelKey}
+                  disabled={creatingChat}
+                  onChange={newChat.setModel}
+                />
+                {efforts.length > 0 && (
+                  <ReasoningEffortMenu
+                    levels={efforts}
+                    value={newChat.reasoningEffort}
+                    disabled={creatingChat}
+                    onChange={newChat.setReasoningEffort}
+                  />
+                )}
+                <PermissionModeMenu
+                  value={newChat.permissionMode}
+                  disabled={creatingChat}
+                  onChange={newChat.setPermissionMode}
+                />
+              </>
+            }
             onDraftChange={setDraft}
             onSend={startChat}
             onSteer={async () => {}}

--- a/crates/openwave-desktop/ui/src/NewChatSettings.test.ts
+++ b/crates/openwave-desktop/ui/src/NewChatSettings.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The pre-chat choices are read back from storage a session later, so what is
+ * stored there is untrusted input: a value this build no longer knows must
+ * read as "unset" rather than reach chat creation, where it would be refused
+ * by the server or — worse for a permission mode — mean something other than
+ * what the reader chose.
+ */
+describe("new chat settings", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    window.localStorage.clear();
+  });
+
+  it("recovers stored choices and drops ones it no longer recognizes", async () => {
+    window.localStorage.setItem("openwave.new-chat-permission-mode", "auto");
+    window.localStorage.setItem("openwave.new-chat-reasoning-effort", "sideways");
+
+    const { useNewChatSettings } = await import("./NewChatSettings");
+    const state = useNewChatSettings.getState();
+
+    expect(state.permissionMode).toBe("auto");
+    expect(state.reasoningEffort).toBeNull();
+  });
+
+  it("persists a choice so it outlives the visit that made it", async () => {
+    const { useNewChatSettings } = await import("./NewChatSettings");
+
+    useNewChatSettings.getState().setPermissionMode("allow");
+
+    expect(useNewChatSettings.getState().permissionMode).toBe("allow");
+    expect(window.localStorage.getItem("openwave.new-chat-permission-mode")).toBe(
+      "allow",
+    );
+  });
+});

--- a/crates/openwave-desktop/ui/src/NewChatSettings.ts
+++ b/crates/openwave-desktop/ui/src/NewChatSettings.ts
@@ -1,0 +1,92 @@
+import { create } from "zustand";
+
+import type { ModelSelectionKey, PermissionMode, ReasoningEffort } from "./api";
+
+const MODEL_KEY = "openwave.new-chat-model";
+const REASONING_EFFORT_KEY = "openwave.new-chat-reasoning-effort";
+const PERMISSION_MODE_KEY = "openwave.new-chat-permission-mode";
+
+const REASONING_EFFORTS: readonly ReasoningEffort[] = [
+  "none",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+];
+
+const PERMISSION_MODES: readonly PermissionMode[] = ["ask", "auto", "allow"];
+
+function read(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function write(key: string, value: string | null): void {
+  try {
+    if (value === null) window.localStorage.removeItem(key);
+    else window.localStorage.setItem(key, value);
+  } catch {
+    // Persisting a pre-chat choice is best-effort; the session still holds it.
+  }
+}
+
+/**
+ * A stored value is only honored when this build still recognizes it. A model
+ * key is checked against the live catalog at the point of use rather than
+ * here — the catalog is not loaded yet when this store initializes, and a
+ * selection whose provider was since removed should read as "unavailable"
+ * exactly the way it does inside a chat.
+ */
+function readEnum<T extends string>(
+  key: string,
+  allowed: readonly T[],
+): T | null {
+  const stored = read(key);
+  return allowed.find((value) => value === stored) ?? null;
+}
+
+type NewChatSettings = {
+  model: ModelSelectionKey | null;
+  reasoningEffort: ReasoningEffort | null;
+  permissionMode: PermissionMode | null;
+  setModel: (model: ModelSelectionKey | null) => void;
+  setReasoningEffort: (effort: ReasoningEffort | null) => void;
+  setPermissionMode: (mode: PermissionMode) => void;
+};
+
+/**
+ * What the next chat will be created with, chosen before it exists.
+ *
+ * The home composer carries the same controls as a conversation's, but there
+ * is nothing to PATCH yet: the choices are held here and passed to `POST
+ * /chats`, so a chat starts the way it was set up rather than being created
+ * one way and corrected a moment later. That correcting PATCH is the failure
+ * this avoids — it races the first turn, which reads the chat as it was
+ * created.
+ *
+ * The choices persist, because "I work in Auto" is a standing preference, not
+ * a per-visit one. They are deliberately not a global default applied to
+ * chats created anywhere else: this is the state of one composer, and a chat
+ * created from a project or a deep link has its own.
+ */
+export const useNewChatSettings = create<NewChatSettings>((set) => ({
+  model: (read(MODEL_KEY) as ModelSelectionKey | null) ?? null,
+  reasoningEffort: readEnum(REASONING_EFFORT_KEY, REASONING_EFFORTS),
+  permissionMode: readEnum(PERMISSION_MODE_KEY, PERMISSION_MODES),
+  setModel: (model) => {
+    write(MODEL_KEY, model);
+    set({ model });
+  },
+  setReasoningEffort: (reasoningEffort) => {
+    write(REASONING_EFFORT_KEY, reasoningEffort);
+    set({ reasoningEffort });
+  },
+  setPermissionMode: (permissionMode) => {
+    write(PERMISSION_MODE_KEY, permissionMode);
+    set({ permissionMode });
+  },
+}));

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -599,6 +599,47 @@ describe("project-scoped conversation API", () => {
     );
   });
 
+  it("creates a chat already set up the way it will run", async () => {
+    // The home composer has nowhere to PATCH: its choices have to ride along
+    // with creation, or the first turn runs against a chat that was created
+    // before the reader's choices reached it.
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          id: "chat-1",
+          project_id: null,
+          title: null,
+          model: "anthropic::model-1",
+          reasoning_effort: "high",
+          permission_mode: "auto",
+          attachment_revision: 0,
+          root_attachments: [],
+          created_at: "2026-07-29T12:00:00Z",
+        }),
+        { status: 201 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = new ApiClient("http://127.0.0.1", "token");
+
+    await client.createChat("anthropic::model-1", null, {
+      reasoningEffort: "high",
+      permissionMode: "auto",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://127.0.0.1/chats",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          model: "anthropic::model-1",
+          reasoning_effort: "high",
+          permission_mode: "auto",
+        }),
+      }),
+    );
+  });
+
   it("keeps a loose chat explicitly outside project scope", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -832,13 +832,29 @@ export class ApiClient {
     });
   }
 
-  createChat(model?: ModelSelectionKey, projectId?: string | null): Promise<Chat> {
+  /**
+   * Create a chat, optionally already set up the way it will run.
+   *
+   * The turn inputs are sent at creation rather than PATCHed afterwards: a
+   * correcting PATCH races the first turn, which reads the chat as it was
+   * created.
+   */
+  createChat(
+    model?: ModelSelectionKey,
+    projectId?: string | null,
+    settings?: {
+      reasoningEffort?: ReasoningEffort | null;
+      permissionMode?: PermissionMode | null;
+    },
+  ): Promise<Chat> {
     return this.json("/chats", {
       method: "POST",
       headers: this.headers(true),
       body: JSON.stringify({
         model: model || undefined,
         project_id: projectId || undefined,
+        reasoning_effort: settings?.reasoningEffort ?? undefined,
+        permission_mode: settings?.permissionMode ?? undefined,
       }),
     });
   }


### PR DESCRIPTION
Follows #926, which fixed the composer control row inside a conversation. The home composer had none of those controls at all.

## The problem

The only way to start a chat in Auto — or on anything but the default model — was to start it, notice it was wrong, and change it. **That correcting PATCH races the first turn**, which reads the chat as it was created. So the choice had to be made before creation or not at all.

## The change

The same three controls now sit on the home composer, and their choices are held in a small store until there is a chat to give them to. They ride along with `POST /chats`, which has accepted `model`, `reasoning_effort` and `permission_mode` since permission modes landed — **no server change was needed**.

They persist across sessions, because "I work in Auto" is a standing preference rather than a per-visit one. A stored value this build no longer recognizes reads as unset rather than reaching creation: for a permission mode in particular, a value we cannot interpret must never become one we guess at.

Deliberately scoped to the home composer rather than becoming a global default: this is the state of one composer, and a chat created from a project or a deep link has its own.

## Uploading is not included

The picker is a host command that imports straight into a chat — the renderer never sees the bytes, so unlike a model choice there is nothing to hold onto and hand over after creation. Doing it needs either a chat created earlier than send (which strands an empty chat if the picker is cancelled) or a host-side change. Filed as #927 with both options rather than guessed at here.

## Tests

- Creation carries the pre-chat choices — if that broke, a reader sets Auto and silently gets an Ask chat.
- A stored value this build doesn't recognize is dropped rather than sent.

I deliberately did **not** add a rendered HomeRoute test: it would need the router, app context, sidebar and explorer all mocked to assert a three-line pass-through — the setup-heavy-with-a-trivial-assertion shape `CLAUDE.md` says to leave out.

Verified locally: `tsc`, 644 UI tests, `pnpm build`.