### PR TITLE
fix(desktop): square the sidebar logo's box

### DIFF
--- a/crates/openwave-desktop/ui/src/Logomark.tsx
+++ b/crates/openwave-desktop/ui/src/Logomark.tsx
@@ -1,6 +1,13 @@
 import type { ComponentPropsWithoutRef } from "react";
 
-/** OpenWave mark geometry, shared with the packaged desktop app icon. */
+/**
+ * OpenWave mark geometry, shared with the packaged desktop app icon.
+ *
+ * The box is tight to the drawing, unlike the packaged icon's square canvas:
+ * call sites that size the mark with `height: auto` derive their height from
+ * this ratio, so squaring it here would pad every one of them. A caller that
+ * wants a square footprint asks for one by passing equal width and height.
+ */
 const LOGOMARK_VIEWBOX = "127 217 757 407";
 const LOGOMARK_PATH = `
   M1736 3851l-179-178 4-9c2-5 306-309 675-676l671-668h723v18l-1 17-832 838-832 838-25-1-25-1-179-178z

--- a/crates/openwave-desktop/ui/src/sidebar/SidebarFrame.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/SidebarFrame.tsx
@@ -50,7 +50,9 @@ export function SidebarFrame({ children }: { children: ReactNode }) {
           aria-label="Home"
           onClick={() => void navigate({ to: "/" })}
         >
-          <Logomark width="28" height="15" />
+          {/* Square box around the wide mark, so the home button lines up with
+              the column of square rail buttons under it. */}
+          <Logomark width="28" height="28" />
         </button>
         <span className="grow" />
         {!isCompact && (


### PR DESCRIPTION
The home button in the sidebar header drew the mark in a 28x15 box, so it sat as a short wide sliver against the column of square rail buttons under it. It now gets a square box.

The drawing is untouched. With the default `preserveAspectRatio`, the wide viewBox fits by width in a square box, so the glyph renders at exactly the size it did before — rendering both at 10x gives an identical 266x136 mark — and is centred vertically instead of filling the box.

The shared `LOGOMARK_VIEWBOX` deliberately stays tight to the drawing, with a comment saying why: the boot screens, the welcome state, and the working indicator size the mark with `width: <n>; height: auto` and derive their height from that ratio. Squaring it there would pad all six of those call sites — the welcome mark would go from 36x19 to 36x36 and push the copy below it down. A caller that wants a square footprint asks for one, as the header now does.

No tests: this is an attribute value on one element, with no behaviour behind it to regress.

I have not seen this in the running app, so whether the extra vertical air reads better than the sliver is worth a look before merging.