### PR TITLE
feat(desktop): honest gateway mount rows — revoked, stale, and failed states

### DIFF
--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
@@ -268,6 +268,91 @@ describe("GatewayPanel", () => {
     );
   });
 
+  it("keeps a row and unmount toggle for a mount whose entitlement was revoked", async () => {
+    const revokedMount = {
+      name: "revoked-tools",
+      command: null,
+      args: [],
+      env: {},
+      env_from: [],
+      cwd: null,
+      url: null,
+      bearer_token_env: null,
+      gateway_endpoint: "revoked-tools",
+      request_timeout_ms: 60_000,
+      enabled: true,
+      health: "reconnecting",
+      tool_count: 0,
+      diagnostic: null,
+    };
+    const putMcpServers = vi.fn().mockResolvedValue({ servers: [] });
+    const client = api({
+      getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+      // No entitled app references the mounted slug any more.
+      getGatewayApps: vi.fn().mockResolvedValue({ supported: true, apps: [] }),
+      listMcpServers: vi.fn().mockResolvedValue({ servers: [revokedMount] }),
+      putMcpServers,
+    });
+    const user = userEvent.setup();
+    render(<GatewayPanel client={client} onChanged={() => undefined} />);
+
+    // The configured mount keeps its row, with an explanation instead of a
+    // health line.
+    expect(await screen.findByText("revoked-tools")).toBeInTheDocument();
+    expect(
+      screen.getByText(/No longer granted to your teams/),
+    ).toBeInTheDocument();
+
+    // And the toggle still unmounts it.
+    const toggle = screen.getByRole("switch", { name: "Mount revoked-tools" });
+    expect(toggle).toBeChecked();
+    await user.click(toggle);
+    await waitFor(() => expect(putMcpServers).toHaveBeenCalledWith([]));
+  });
+
+  it("surfaces a failed server-list fetch as a retryable error, not dead toggles", async () => {
+    const listMcpServers = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("mcp backend unavailable"))
+      .mockResolvedValue({ servers: [] });
+    const client = api({
+      getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+      getGatewayApps: vi.fn().mockResolvedValue({
+        supported: true,
+        apps: [
+          {
+            id: "app-1",
+            name: "Incident API",
+            app_kind: "rest_api",
+            enabled: true,
+            mcp_endpoint_slugs: ["example-security-tools"],
+          },
+        ],
+      }),
+      listMcpServers,
+    });
+    const user = userEvent.setup();
+    render(<GatewayPanel client={client} onChanged={() => undefined} />);
+
+    // The failure is visible and named, and the retry succeeds in place.
+    expect(
+      await screen.findByText(/mcp backend unavailable/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "Mount example-security-tools" }),
+    ).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: /Retry/ }));
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/mcp backend unavailable/),
+      ).not.toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("switch", { name: "Mount example-security-tools" }),
+    ).toBeEnabled();
+  });
+
   it("surfaces a failed sign-in with its bounded message", async () => {
     const client = api({
       getGatewayStatus: vi.fn().mockResolvedValue({

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
@@ -22,6 +22,40 @@ const signedIn: GatewayStatus = {
   model_count: 2,
 };
 
+/** A configured gateway mount as `listMcpServers` reports it. */
+function gatewayMount(slug: string, overrides: Record<string, unknown> = {}) {
+  return {
+    name: slug,
+    command: null,
+    args: [],
+    env: {},
+    env_from: [],
+    cwd: null,
+    url: null,
+    bearer_token_env: null,
+    gateway_endpoint: slug,
+    request_timeout_ms: 60_000,
+    enabled: true,
+    health: "healthy",
+    tool_count: 3,
+    diagnostic: null,
+    ...overrides,
+  };
+}
+
+const incidentApps = {
+  supported: true,
+  apps: [
+    {
+      id: "app-1",
+      name: "Incident API",
+      app_kind: "rest_api",
+      enabled: true,
+      mcp_endpoint_slugs: ["example-security-tools"],
+    },
+  ],
+};
+
 function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
   return {
     getGatewayStatus: vi.fn().mockResolvedValue(signedOut),
@@ -269,22 +303,10 @@ describe("GatewayPanel", () => {
   });
 
   it("keeps a row and unmount toggle for a mount whose entitlement was revoked", async () => {
-    const revokedMount = {
-      name: "revoked-tools",
-      command: null,
-      args: [],
-      env: {},
-      env_from: [],
-      cwd: null,
-      url: null,
-      bearer_token_env: null,
-      gateway_endpoint: "revoked-tools",
-      request_timeout_ms: 60_000,
-      enabled: true,
+    const revokedMount = gatewayMount("revoked-tools", {
       health: "reconnecting",
       tool_count: 0,
-      diagnostic: null,
-    };
+    });
     const putMcpServers = vi.fn().mockResolvedValue({ servers: [] });
     const client = api({
       getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
@@ -302,6 +324,12 @@ describe("GatewayPanel", () => {
     expect(
       screen.getByText(/No longer granted to your teams/),
     ).toBeInTheDocument();
+    // The explanation replaces the health line, and the apps section's empty
+    // copy doesn't sit above a populated mount list.
+    expect(screen.queryByText(/Connecting/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/No connected apps are granted/),
+    ).not.toBeInTheDocument();
 
     // And the toggle still unmounts it.
     const toggle = screen.getByRole("switch", { name: "Mount revoked-tools" });
@@ -317,30 +345,21 @@ describe("GatewayPanel", () => {
       .mockResolvedValue({ servers: [] });
     const client = api({
       getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
-      getGatewayApps: vi.fn().mockResolvedValue({
-        supported: true,
-        apps: [
-          {
-            id: "app-1",
-            name: "Incident API",
-            app_kind: "rest_api",
-            enabled: true,
-            mcp_endpoint_slugs: ["example-security-tools"],
-          },
-        ],
-      }),
+      getGatewayApps: vi.fn().mockResolvedValue(incidentApps),
       listMcpServers,
     });
     const user = userEvent.setup();
     render(<GatewayPanel client={client} onChanged={() => undefined} />);
 
-    // The failure is visible and named, and the retry succeeds in place.
+    // The failure is visible and named, and the disabled toggle is explained
+    // rather than passing unknown off as unmounted.
     expect(
       await screen.findByText(/mcp backend unavailable/),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("switch", { name: "Mount example-security-tools" }),
     ).toBeDisabled();
+    expect(screen.getByText(/Mount state unknown/)).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /Retry/ }));
     await waitFor(() =>
@@ -351,6 +370,61 @@ describe("GatewayPanel", () => {
     expect(
       screen.getByRole("switch", { name: "Mount example-security-tools" }),
     ).toBeEnabled();
+  });
+
+  it("keeps last-known rows and live toggles when a later refresh fails", async () => {
+    const listMcpServers = vi
+      .fn()
+      .mockResolvedValueOnce({ servers: [gatewayMount("example-security-tools")] })
+      .mockRejectedValue(new Error("mcp backend unavailable"));
+    const client = api({
+      getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+      getGatewayApps: vi.fn().mockResolvedValue(incidentApps),
+      listMcpServers,
+    });
+    vi.useFakeTimers();
+    render(<GatewayPanel client={client} onChanged={() => undefined} />);
+    await act(async () => {});
+    expect(screen.getByText(/3 tools available/)).toBeInTheDocument();
+
+    // The 15s refresh fails: the error appears, but the last-known row keeps
+    // its health line and a usable toggle instead of resetting to unknown.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_100);
+    });
+    expect(screen.getByText(/mcp backend unavailable/)).toBeInTheDocument();
+    expect(screen.getByText(/3 tools available/)).toBeInTheDocument();
+    const toggle = screen.getByRole("switch", {
+      name: "Mount example-security-tools",
+    });
+    expect(toggle).toBeChecked();
+    expect(toggle).toBeEnabled();
+  });
+
+  it("still shows configured mounts when entitlements cannot be read", async () => {
+    const client = api({
+      getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+      getGatewayApps: vi
+        .fn()
+        .mockRejectedValue(new Error("gateway unreachable")),
+      listMcpServers: vi.fn().mockResolvedValue({
+        servers: [gatewayMount("example-security-tools")],
+      }),
+    });
+    render(<GatewayPanel client={client} onChanged={() => undefined} />);
+
+    // The row survives the apps failure, labeled unknown-entitlements — never
+    // misreported as revoked.
+    expect(
+      await screen.findByText("example-security-tools"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Couldn't read your entitlements/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/No longer granted/)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "Mount example-security-tools" }),
+    ).toBeChecked();
   });
 
   it("surfaces a failed sign-in with its bounded message", async () => {

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
@@ -65,6 +65,12 @@ function mountStatus(mounted: McpServerInfo): string {
   }
 }
 
+/** A message that can sit mid-sentence: `String(err)` would keep the error
+ * class prefix ("HttpError: ...") in front of it. */
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 /** A fresh gateway mount: everything comes from the session except the name,
  * which doubles as the tool namespace. */
 function mountDefinition(slug: string, name: string): McpServerDefinition {
@@ -101,6 +107,9 @@ export function GatewayPanel({
 }) {
   const [status, setStatus] = useState<GatewayStatus | null>(null);
   const [apps, setApps] = useState<GatewayApps | null>(null);
+  // Distinguishes "the apps read failed" from "no apps granted": a failure
+  // must not make configured mounts masquerade as revoked, nor hide them.
+  const [appsFailed, setAppsFailed] = useState(false);
   const [mcpServers, setMcpServers] = useState<McpServerInfo[] | null>(null);
   const [mcpError, setMcpError] = useState<string | null>(null);
   // Bumped by the Retry affordance; re-runs the mount-list effect immediately
@@ -115,6 +124,9 @@ export function GatewayPanel({
   // them), and the poll must not refill a field the user is editing.
   const signedInRef = useRef(false);
   const dirtyRef = useRef(false);
+  // Monotonic id for mount-list reads: a slow in-flight read must not clobber
+  // the fresher list a toggle write (or a newer read) has since installed.
+  const mountsRequestRef = useRef(0);
 
   const reload = useCallback(async () => {
     const next = await client.getGatewayStatus();
@@ -134,20 +146,28 @@ export function GatewayPanel({
 
   // Entitled apps are never cached server-side (a revoked grant disappears on
   // the next request), so fetch them fresh whenever the signed-in state turns
-  // on. A fetch failure only hides the section; models keep working.
+  // on. A fetch failure hides the apps list but is remembered, so mount rows
+  // can say entitlements are unknown instead of claiming anything.
   useEffect(() => {
     if (!status?.signed_in) {
       setApps(null);
+      setAppsFailed(false);
       return;
     }
     let cancelled = false;
     client
       .getGatewayApps()
       .then((next) => {
-        if (!cancelled) setApps(next);
+        if (!cancelled) {
+          setApps(next);
+          setAppsFailed(false);
+        }
       })
       .catch(() => {
-        if (!cancelled) setApps(null);
+        if (!cancelled) {
+          setApps(null);
+          setAppsFailed(true);
+        }
       });
     return () => {
       cancelled = true;
@@ -166,22 +186,23 @@ export function GatewayPanel({
       setMcpError(null);
       return;
     }
-    let cancelled = false;
     const refresh = async () => {
+      const request = ++mountsRequestRef.current;
       try {
         const next = await client.listMcpServers();
-        if (!cancelled) {
-          setMcpServers(next.servers);
-          setMcpError(null);
-        }
+        if (request !== mountsRequestRef.current) return;
+        setMcpServers(next.servers);
+        setMcpError(null);
       } catch (err) {
-        if (!cancelled) setMcpError(String(err));
+        if (request !== mountsRequestRef.current) return;
+        setMcpError(errorMessage(err));
       }
     };
     void refresh();
     const timer = window.setInterval(() => void refresh(), MOUNT_REFRESH_MS);
     return () => {
-      cancelled = true;
+      // Invalidate any in-flight read; a re-run issues fresh ids above this.
+      mountsRequestRef.current += 1;
       window.clearInterval(timer);
     };
   }, [client, status?.signed_in, mountsRefreshNonce]);
@@ -221,6 +242,8 @@ export function GatewayPanel({
         ? [...without, mountDefinition(slug, mountName(slug, taken))]
         : without;
       const result = await client.putMcpServers(next);
+      // Supersede any in-flight background read; this list is fresher.
+      mountsRequestRef.current += 1;
       setMcpServers(result.servers);
       setMcpError(null);
       toast.success(mounted ? `Mounted ${slug}` : `Unmounted ${slug}`);
@@ -265,6 +288,17 @@ export function GatewayPanel({
         .filter((slug): slug is string => slug !== null),
     ]),
   ];
+  // "Revoked" is only a claim we can make after actually reading the
+  // entitlements; a failed or unsupported apps read leaves them unknown.
+  const entitlementsKnown = apps?.supported === true;
+  /** The one line under a mount row: unknown beats revoked beats health. */
+  const rowNote = (slug: string, mounted: McpServerInfo | undefined) => {
+    if (mcpServers === null) return "Mount state unknown.";
+    if (entitlementsKnown && !entitledSlugs.has(slug)) {
+      return "No longer granted to your teams. Switch off to unmount it.";
+    }
+    return mounted ? mountStatus(mounted) : null;
+  };
 
   return (
     <SettingsPanel
@@ -418,100 +452,104 @@ export function GatewayPanel({
         )}
       </SettingsSection>
 
-      {status.signed_in && apps?.supported && (
-        <SettingsSection title="Connected apps">
-          {apps.apps.length === 0 ? (
-            <p className="text-muted-foreground text-sm">
-              No connected apps are granted to your teams yet.
-            </p>
-          ) : (
-            <ul className="flex flex-col gap-2">
-              {apps.apps.map((app) => (
-                <li key={app.id} className="rounded-md border px-3 py-2 text-sm">
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium">{app.name}</span>
-                    <span className="text-muted-foreground text-xs">
-                      {app.app_kind}
-                    </span>
-                    {!app.enabled && (
-                      <span className="text-muted-foreground text-xs">
-                        disabled
-                      </span>
-                    )}
-                  </div>
-                  {app.mcp_endpoint_slugs.length > 0 && (
-                    <p className="text-muted-foreground text-xs">
-                      via {app.mcp_endpoint_slugs.join(", ")}
-                    </p>
-                  )}
-                </li>
-              ))}
-            </ul>
-          )}
-
-          {(endpointSlugs.length > 0 || mcpError !== null) && (
-            <div className="flex flex-col gap-2">
-              <div>
-                <p className="text-sm font-bold">MCP endpoints</p>
-                <p className="text-xs text-muted-foreground">
-                  Mounted endpoints connect with your gateway session — no
-                  tokens to copy, and they reconnect after you sign back in.
-                </p>
-              </div>
-              {mcpError !== null && (
-                <div className="flex items-center justify-between gap-4">
-                  <SettingsError>
-                    Couldn't read the MCP server list: {mcpError}
-                  </SettingsError>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    disabled={working}
-                    onClick={() => setMountsRefreshNonce((nonce) => nonce + 1)}
-                  >
-                    <RefreshCw size={14} />
-                    Retry
-                  </Button>
-                </div>
-              )}
+      {status.signed_in &&
+        apps?.supported &&
+        (apps.apps.length > 0 || endpointSlugs.length === 0) && (
+          <SettingsSection title="Connected apps">
+            {apps.apps.length === 0 ? (
+              <p className="text-muted-foreground text-sm">
+                No connected apps are granted to your teams yet.
+              </p>
+            ) : (
               <ul className="flex flex-col gap-2">
-                {endpointSlugs.map((slug) => {
-                  const mounted = mcpServers?.find(
-                    (server) => server.gateway_endpoint === slug,
-                  );
-                  return (
-                    <li
-                      key={slug}
-                      className="flex items-center justify-between gap-4 rounded-md border px-3 py-2 text-sm"
-                    >
-                      <div className="min-w-0 flex-1">
-                        <code className="font-medium">{slug}</code>
-                        {!entitledSlugs.has(slug) ? (
-                          <p className="text-muted-foreground text-xs">
-                            No longer granted to your teams. Switch off to
-                            unmount it.
-                          </p>
-                        ) : (
-                          mounted && (
-                            <p className="text-muted-foreground text-xs">
-                              {mountStatus(mounted)}
-                            </p>
-                          )
-                        )}
-                      </div>
-                      <Switch
-                        aria-label={`Mount ${slug}`}
-                        checked={mounted !== undefined}
-                        disabled={working || mcpServers === null}
-                        onCheckedChange={(checked) =>
-                          void setMounted(slug, checked)
-                        }
-                      />
-                    </li>
-                  );
-                })}
+                {apps.apps.map((app) => (
+                  <li
+                    key={app.id}
+                    className="rounded-md border px-3 py-2 text-sm"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium">{app.name}</span>
+                      <span className="text-muted-foreground text-xs">
+                        {app.app_kind}
+                      </span>
+                      {!app.enabled && (
+                        <span className="text-muted-foreground text-xs">
+                          disabled
+                        </span>
+                      )}
+                    </div>
+                    {app.mcp_endpoint_slugs.length > 0 && (
+                      <p className="text-muted-foreground text-xs">
+                        via {app.mcp_endpoint_slugs.join(", ")}
+                      </p>
+                    )}
+                  </li>
+                ))}
               </ul>
+            )}
+          </SettingsSection>
+        )}
+
+      {/* Deliberately NOT gated on the apps read: a configured mount keeps
+          its row — and a mount-list failure its Retry — even when the
+          entitlements can't be read at all. */}
+      {status.signed_in && (endpointSlugs.length > 0 || mcpError !== null) && (
+        <SettingsSection
+          title="MCP endpoints"
+          description="Mounted endpoints connect with your gateway session — no tokens to copy, and they reconnect after you sign back in."
+        >
+          {appsFailed && (
+            <p className="text-muted-foreground text-xs">
+              Couldn't read your entitlements from the gateway; these are the
+              configured mounts.
+            </p>
+          )}
+          {mcpError !== null && (
+            <div className="flex items-center justify-between gap-4">
+              <SettingsError>
+                Couldn't read the MCP server list: {mcpError}
+              </SettingsError>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={working}
+                onClick={() => setMountsRefreshNonce((nonce) => nonce + 1)}
+              >
+                <RefreshCw size={14} />
+                Retry
+              </Button>
             </div>
+          )}
+          {endpointSlugs.length > 0 && (
+            <ul className="flex flex-col gap-2">
+              {endpointSlugs.map((slug) => {
+                const mounted = mcpServers?.find(
+                  (server) => server.gateway_endpoint === slug,
+                );
+                const note = rowNote(slug, mounted);
+                return (
+                  <li
+                    key={slug}
+                    className="flex items-center justify-between gap-4 rounded-md border px-3 py-2 text-sm"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <code className="font-medium">{slug}</code>
+                      {note && (
+                        <p className="text-muted-foreground text-xs">{note}</p>
+                      )}
+                    </div>
+                    <Switch
+                      aria-label={`Mount ${slug}`}
+                      checked={mounted !== undefined}
+                      disabled={working || mcpServers === null}
+                      onCheckedChange={(checked) =>
+                        void setMounted(slug, checked)
+                      }
+                    />
+                  </li>
+                );
+              })}
+            </ul>
           )}
         </SettingsSection>
       )}

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
@@ -21,6 +21,9 @@ import {
 } from "./primitives";
 
 const SIGN_IN_POLL_MS = 2_000;
+/** Mount health lives in the local MCP supervisor, so a modest refresh while
+ * the panel is visible keeps the health lines honest without gateway load. */
+const MOUNT_REFRESH_MS = 15_000;
 const DEFAULT_MOUNT_TIMEOUT_MS = 60_000;
 /** Server names cap at 32 bytes (the MCP tool namespace); endpoint slugs go
  * to 127, so the mount name is derived, not the slug itself. Mount identity
@@ -99,6 +102,10 @@ export function GatewayPanel({
   const [status, setStatus] = useState<GatewayStatus | null>(null);
   const [apps, setApps] = useState<GatewayApps | null>(null);
   const [mcpServers, setMcpServers] = useState<McpServerInfo[] | null>(null);
+  const [mcpError, setMcpError] = useState<string | null>(null);
+  // Bumped by the Retry affordance; re-runs the mount-list effect immediately
+  // and restarts its cadence.
+  const [mountsRefreshNonce, setMountsRefreshNonce] = useState(0);
   const [baseUrl, setBaseUrl] = useState("");
   const [dirty, setDirty] = useState(false);
   const [working, setWorking] = useState(false);
@@ -148,25 +155,36 @@ export function GatewayPanel({
   }, [client, status?.signed_in]);
 
   // Mount state lives in the MCP configuration; load it alongside the apps so
-  // each endpoint's toggle reflects what is actually configured.
+  // each endpoint's toggle reflects what is actually configured — and keep
+  // re-reading it while the panel is visible, so a mount that degrades after
+  // the first read doesn't keep a stale healthy line. A failed read keeps the
+  // last-known rows and surfaces a retryable error instead of silently
+  // disabling every toggle.
   useEffect(() => {
     if (!status?.signed_in) {
       setMcpServers(null);
+      setMcpError(null);
       return;
     }
     let cancelled = false;
-    client
-      .listMcpServers()
-      .then((next) => {
-        if (!cancelled) setMcpServers(next.servers);
-      })
-      .catch(() => {
-        if (!cancelled) setMcpServers(null);
-      });
+    const refresh = async () => {
+      try {
+        const next = await client.listMcpServers();
+        if (!cancelled) {
+          setMcpServers(next.servers);
+          setMcpError(null);
+        }
+      } catch (err) {
+        if (!cancelled) setMcpError(String(err));
+      }
+    };
+    void refresh();
+    const timer = window.setInterval(() => void refresh(), MOUNT_REFRESH_MS);
     return () => {
       cancelled = true;
+      window.clearInterval(timer);
     };
-  }, [client, status?.signed_in]);
+  }, [client, status?.signed_in, mountsRefreshNonce]);
 
   // While the browser flow is pending, watch for its outcome.
   useEffect(() => {
@@ -204,6 +222,7 @@ export function GatewayPanel({
         : without;
       const result = await client.putMcpServers(next);
       setMcpServers(result.servers);
+      setMcpError(null);
       toast.success(mounted ? `Mounted ${slug}` : `Unmounted ${slug}`);
     });
   }
@@ -231,8 +250,20 @@ export function GatewayPanel({
 
   const pendingUrl =
     status.sign_in.state === "pending" ? status.sign_in.authorization_url : null;
+  const entitledSlugs = new Set(
+    apps?.apps.flatMap((app) => app.mcp_endpoint_slugs) ?? [],
+  );
+  // Rows are the union of what's entitled and what's configured: a mount
+  // whose grant was revoked must keep its row (and unmount toggle) here,
+  // not silently drop to being visible only in the MCP panel while
+  // supervision retries it.
   const endpointSlugs = [
-    ...new Set(apps?.apps.flatMap((app) => app.mcp_endpoint_slugs) ?? []),
+    ...new Set([
+      ...entitledSlugs,
+      ...(mcpServers ?? [])
+        .map((server) => server.gateway_endpoint)
+        .filter((slug): slug is string => slug !== null),
+    ]),
   ];
 
   return (
@@ -418,7 +449,7 @@ export function GatewayPanel({
             </ul>
           )}
 
-          {endpointSlugs.length > 0 && (
+          {(endpointSlugs.length > 0 || mcpError !== null) && (
             <div className="flex flex-col gap-2">
               <div>
                 <p className="text-sm font-bold">MCP endpoints</p>
@@ -427,6 +458,22 @@ export function GatewayPanel({
                   tokens to copy, and they reconnect after you sign back in.
                 </p>
               </div>
+              {mcpError !== null && (
+                <div className="flex items-center justify-between gap-4">
+                  <SettingsError>
+                    Couldn't read the MCP server list: {mcpError}
+                  </SettingsError>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={working}
+                    onClick={() => setMountsRefreshNonce((nonce) => nonce + 1)}
+                  >
+                    <RefreshCw size={14} />
+                    Retry
+                  </Button>
+                </div>
+              )}
               <ul className="flex flex-col gap-2">
                 {endpointSlugs.map((slug) => {
                   const mounted = mcpServers?.find(
@@ -439,10 +486,17 @@ export function GatewayPanel({
                     >
                       <div className="min-w-0 flex-1">
                         <code className="font-medium">{slug}</code>
-                        {mounted && (
+                        {!entitledSlugs.has(slug) ? (
                           <p className="text-muted-foreground text-xs">
-                            {mountStatus(mounted)}
+                            No longer granted to your teams. Switch off to
+                            unmount it.
                           </p>
+                        ) : (
+                          mounted && (
+                            <p className="text-muted-foreground text-xs">
+                              {mountStatus(mounted)}
+                            </p>
+                          )
                         )}
                       </div>
                       <Switch


### PR DESCRIPTION
The gateway panel's MCP endpoint list derived only from currently entitled apps, so a mount whose entitlement was revoked lost its row and toggle here while supervision kept retrying it — it stayed visible only in the MCP servers panel. The mount list was also fetched once per sign-in transition: later degradation kept a stale healthy line, and a fetch failure set the list to null, silently disabling every toggle with no error and no way to retry.

## What changed

- **Union rows.** Endpoint rows are now the union of the entitled apps' slugs and the configured gateway mounts. A configured-but-no-longer-entitled mount keeps its row, rendered with an explanatory line ("No longer granted to your teams. Switch off to unmount it.") in place of the health line, and its unmount toggle keeps working.
- **Refresh cadence.** The mount list re-reads every 15s while the panel is visible. It is a local supervisor read (`listMcpServers`), not gateway traffic, so the cadence is cheap; health lines no longer rot at whatever they said on first load.
- **Honest failure.** A failed list read keeps the last-known rows and surfaces a named error with a Retry button inside the MCP endpoints block. Retry refetches immediately and restarts the cadence. Toggles are only disabled while the configured state is genuinely unknown (nothing loaded yet), and that state is now visible rather than silent.

Managed/unmanaged neutrality: no policy logic touched; the panel behaves identically in both modes.

## Tests

Extended `GatewayPanel.dom.test.tsx`:

- `keeps a row and unmount toggle for a mount whose entitlement was revoked` — no entitled apps, one configured gateway mount; asserts the row, the explanatory line, the checked toggle, and that toggling off puts an empty server list.
- `surfaces a failed server-list fetch as a retryable error, not dead toggles` — first `listMcpServers` rejects; asserts the named error and disabled toggle, then that Retry clears the error and re-enables the toggle.

Gates run locally: `pnpm install --frozen-lockfile`, `tsc`, full vitest suite (643 passing), production build. UI-only change; no Rust touched.

Closes #899

🤖 Generated with [Claude Code](https://claude.com/claude-code)