### PR TITLE
feat(desktop): show why a conflicting pairing link was refused

### DIFF
--- a/crates/openwave-desktop/src/deep_link.rs
+++ b/crates/openwave-desktop/src/deep_link.rs
@@ -199,7 +199,7 @@ fn spawn_pairing(app: tauri::AppHandle, link: ProvisionLink) {
             }
             Ok(None) => log_pairing(&app, &format!("pairing with {origin} declined")),
             Err(failure) => {
-                log_pairing(&app, &format!("pairing failed: {failure}"));
+                log_pairing(&app, &format!("pairing failed for {origin}: {failure}"));
                 show_pairing_failure(&app, &origin, &failure);
             }
         }
@@ -317,8 +317,8 @@ fn refusal_message(origin: &str, failure: &PairFailure) -> String {
              your administrator to change gateways."
         ),
         PairFailure::Other(_) => format!(
-            "OpenWave could not pair with {origin}. Nothing was changed; \
-             details are in pairing.log."
+            "OpenWave could not pair with {origin}. This device was not \
+             paired; details are in pairing.log."
         ),
     }
 }
@@ -404,7 +404,8 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::{
-        pair_after_confirmation, provision_link, refusal_message, PairFailure, ProvisionLink,
+        origin_of, pair_after_confirmation, provision_link, refusal_message, PairFailure,
+        ProvisionLink,
     };
 
     #[test]
@@ -539,5 +540,15 @@ mod tests {
         );
         assert!(other.contains("https://new.example"));
         assert!(!other.contains("token=shh"));
+    }
+
+    /// Pins the load-bearing reduction the conflict dialog's claim rests
+    /// on: scheme, host, and port — nothing else of the stored base URL.
+    #[test]
+    fn a_stored_base_url_reduces_to_its_origin() {
+        assert_eq!(
+            origin_of("https://gw.example:8443/base/path/"),
+            "https://gw.example:8443"
+        );
     }
 }

--- a/crates/openwave-desktop/src/deep_link.rs
+++ b/crates/openwave-desktop/src/deep_link.rs
@@ -27,7 +27,7 @@ use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use tokio::sync::watch;
 
-use openwave_server::PairingHandle;
+use openwave_server::{PairingError, PairingHandle};
 
 /// Where the pairing handler waits for the embedded server's pairing handle:
 /// filled once boot has bound the server. A provision link commonly
@@ -198,7 +198,10 @@ fn spawn_pairing(app: tauri::AppHandle, link: ProvisionLink) {
                 }
             }
             Ok(None) => log_pairing(&app, &format!("pairing with {origin} declined")),
-            Err(reason) => log_pairing(&app, &format!("pairing failed: {reason}")),
+            Err(failure) => {
+                log_pairing(&app, &format!("pairing failed: {failure}"));
+                show_pairing_failure(&app, &origin, &failure);
+            }
         }
         app.state::<PairingStore>()
             .in_flight
@@ -210,16 +213,17 @@ fn spawn_pairing(app: tauri::AppHandle, link: ProvisionLink) {
 /// decision path is testable without a GUI: `confirm` sees only the gateway
 /// origin, and nothing runs `pair` but a confirming answer. What a confirmed
 /// pairing yields flows back to the caller — today, whether this pairing
-/// newly provisioned the profile, which decides the restart prompt.
-async fn pair_after_confirmation<C, P, F, T>(
+/// newly provisioned the profile, which decides the restart prompt — and so
+/// does what a failed one raised, which decides the refusal dialog.
+async fn pair_after_confirmation<C, P, F, T, E>(
     link: ProvisionLink,
     confirm: C,
     pair: P,
-) -> Result<Option<T>, String>
+) -> Result<Option<T>, E>
 where
     C: FnOnce(&str) -> bool,
     P: FnOnce(String) -> F,
-    F: std::future::Future<Output = Result<T, String>>,
+    F: std::future::Future<Output = Result<T, E>>,
 {
     if !confirm(&link.origin) {
         return Ok(None);
@@ -247,16 +251,89 @@ fn confirm_pairing(app: &tauri::AppHandle, origin: &str) -> bool {
         .blocking_show()
 }
 
+/// A pairing failure, split the way the user-facing surface needs it: the
+/// conflict refusal is a product state with its own explanation, everything
+/// else a generic fault whose details belong in the log, not the dialog.
+enum PairFailure {
+    /// This device is provisioned to a different gateway. Refuse-forever is
+    /// the recorded decision, so the dialog names that gateway's origin and
+    /// points at the administrator instead of offering a retry.
+    Conflict { provisioned_origin: String },
+    /// Anything else: unreachable gateway, invalid manifest, the embedded
+    /// server not starting.
+    Other(String),
+}
+
+impl std::fmt::Display for PairFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Conflict { provisioned_origin } => write!(
+                f,
+                "refused: this device is already provisioned to {provisioned_origin}"
+            ),
+            Self::Other(reason) => f.write_str(reason),
+        }
+    }
+}
+
 /// Validate, probe, and provision — all server-side. The sign-in gate is a
 /// separate surface: once policy flips to managed it presents itself on its
 /// next poll, so pairing does not drive the renderer. Reports whether this
-/// pairing newly provisioned the profile — the restart-prompt signal.
-async fn pair(app: tauri::AppHandle, gateway_url: String) -> Result<bool, String> {
-    let handle = wait_pairing_handle(&app).await?;
-    openwave_server::pair_with_gateway(&handle, &gateway_url)
+/// pairing newly provisioned the profile — the restart-prompt signal — and
+/// keeps the server's typed conflict refusal distinct from other failures,
+/// reduced to the provisioned gateway's origin.
+async fn pair(app: tauri::AppHandle, gateway_url: String) -> Result<bool, PairFailure> {
+    let handle = wait_pairing_handle(&app)
         .await
-        .map(|outcome| outcome.newly_provisioned)
-        .map_err(|error| error.to_string())
+        .map_err(PairFailure::Other)?;
+    match openwave_server::pair_with_gateway(&handle, &gateway_url).await {
+        Ok(outcome) => Ok(outcome.newly_provisioned),
+        Err(PairingError::Conflict { provisioned_url }) => Err(PairFailure::Conflict {
+            provisioned_origin: origin_of(&provisioned_url),
+        }),
+        Err(error) => Err(PairFailure::Other(error.to_string())),
+    }
+}
+
+/// Reduce a stored gateway base URL to its origin — the only form
+/// user-facing text and logs carry. The stored URL passed the gateway
+/// contract at provisioning, so this parse does not fail in practice; the
+/// fallback keeps the dialog honest rather than empty if it ever does.
+fn origin_of(url: &str) -> String {
+    tauri::Url::parse(url)
+        .map(|url| url.origin().ascii_serialization())
+        .unwrap_or_else(|_| "another gateway".to_string())
+}
+
+/// The one user-facing line per failure class, pure so the choice of what a
+/// refusal says is testable without a GUI. The conflict names the gateway
+/// that actually manages this device and points at the administrator; any
+/// other failure names only the origin the user just confirmed — the raw
+/// reason stays in `pairing.log`.
+fn refusal_message(origin: &str, failure: &PairFailure) -> String {
+    match failure {
+        PairFailure::Conflict { provisioned_origin } => format!(
+            "This device is already managed by {provisioned_origin}. Contact \
+             your administrator to change gateways."
+        ),
+        PairFailure::Other(_) => format!(
+            "OpenWave could not pair with {origin}. Nothing was changed; \
+             details are in pairing.log."
+        ),
+    }
+}
+
+/// One bounded error dialog per failed attempt, for both failure classes:
+/// the user just confirmed a pairing in a dialog, so a refusal that reaches
+/// only the log reads as success — the exact silent confusion the
+/// confirmation flow exists to avoid. No retry affordance, no loop: the
+/// dialog closes and the attempt is over.
+fn show_pairing_failure(app: &tauri::AppHandle, origin: &str, failure: &PairFailure) {
+    app.dialog()
+        .message(refusal_message(origin, failure))
+        .title("Pairing failed")
+        .kind(MessageDialogKind::Error)
+        .blocking_show();
 }
 
 /// Offer the restart that completes enforcement, after the pairing that
@@ -326,7 +403,9 @@ fn log_pairing(app: &tauri::AppHandle, message: &str) {
 mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
 
-    use super::{pair_after_confirmation, provision_link, ProvisionLink};
+    use super::{
+        pair_after_confirmation, provision_link, refusal_message, PairFailure, ProvisionLink,
+    };
 
     #[test]
     fn provision_links_are_held_to_the_contract() {
@@ -412,7 +491,7 @@ mod tests {
             |_| false,
             |_| {
                 paired.store(true, Ordering::SeqCst);
-                async { Ok(true) }
+                async { Ok::<_, String>(true) }
             },
         )
         .await;
@@ -431,10 +510,34 @@ mod tests {
             },
             |gateway_url| async move {
                 assert_eq!(gateway_url, "https://gw.example");
-                Ok(false)
+                Ok::<_, String>(false)
             },
         )
         .await;
         assert_eq!(outcome, Ok(Some(false)));
+    }
+
+    /// The refusal dialog's one line per failure class: the conflict names
+    /// the gateway that actually manages this device (never the link's) and
+    /// points at the administrator; a generic failure names only the origin
+    /// the user confirmed, keeping the raw reason out of the dialog.
+    #[test]
+    fn the_refusal_dialog_names_the_right_gateway() {
+        let conflict = refusal_message(
+            "https://new.example",
+            &PairFailure::Conflict {
+                provisioned_origin: "https://old.example".to_string(),
+            },
+        );
+        assert!(conflict.contains("already managed by https://old.example"));
+        assert!(conflict.contains("administrator"));
+        assert!(!conflict.contains("new.example"));
+
+        let other = refusal_message(
+            "https://new.example",
+            &PairFailure::Other("probe failed: token=shh".to_string()),
+        );
+        assert!(other.contains("https://new.example"));
+        assert!(!other.contains("token=shh"));
     }
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -91,7 +91,7 @@ use resolver::KeyedResolver;
 
 pub use durable_oplog::DurableOperationStore;
 pub use error::ServerError;
-pub use pairing::{pair_with_gateway, PairingHandle, PairingOutcome};
+pub use pairing::{pair_with_gateway, PairingError, PairingHandle, PairingOutcome};
 pub use state::AppState;
 
 const MAX_RAW_DOCUMENT_BYTES: usize = 16 * 1024 * 1024;

--- a/crates/openwave-server/src/pairing.rs
+++ b/crates/openwave-server/src/pairing.rs
@@ -79,6 +79,7 @@ pub struct PairingOutcome {
 /// Every other failure — invalid URL, unreachable gateway, bad manifest,
 /// store errors — stays the [`AgentError`] it was.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum PairingError {
     /// The link named a different gateway than the one this profile is
     /// provisioned to. Carries the provisioned base URL — normalized and
@@ -88,7 +89,11 @@ pub enum PairingError {
         /// The normalized base URL this profile is provisioned to.
         provisioned_url: String,
     },
-    /// Any other failure. Nothing durable changed.
+    /// Any other failure. No policy was written — though the provider
+    /// configuration may already be repointed: it is deliberately written
+    /// first, so a failure between the writes fails into a still-unmanaged
+    /// profile recoverable from settings (see the ordering comment in
+    /// [`pair_with_gateway`]).
     Other(AgentError),
 }
 

--- a/crates/openwave-server/src/pairing.rs
+++ b/crates/openwave-server/src/pairing.rs
@@ -69,14 +69,66 @@ pub struct PairingOutcome {
     pub newly_provisioned: bool,
 }
 
+/// Why a pairing did not provision this profile.
+///
+/// The conflict is its own variant because it is a product refusal, not a
+/// fault: the recorded decision is refuse-forever (gateway migration is the
+/// MDM tier's job — OS-asserted policy already outranks provisioned state —
+/// or a profile reset), and the shell owes the user an explanation naming
+/// the gateway that actually manages this device rather than a log line.
+/// Every other failure — invalid URL, unreachable gateway, bad manifest,
+/// store errors — stays the [`AgentError`] it was.
+#[derive(Debug)]
+pub enum PairingError {
+    /// The link named a different gateway than the one this profile is
+    /// provisioned to. Carries the provisioned base URL — normalized and
+    /// secret-free by the gateway-URL contract — so callers can name it;
+    /// user-facing surfaces should reduce it to the origin.
+    Conflict {
+        /// The normalized base URL this profile is provisioned to.
+        provisioned_url: String,
+    },
+    /// Any other failure. Nothing durable changed.
+    Other(AgentError),
+}
+
+impl std::fmt::Display for PairingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Conflict { .. } => write!(
+                f,
+                "this profile is already provisioned to a different gateway"
+            ),
+            Self::Other(error) => error.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for PairingError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Conflict { .. } => None,
+            Self::Other(error) => Some(error),
+        }
+    }
+}
+
+impl From<AgentError> for PairingError {
+    fn from(error: AgentError) -> Self {
+        Self::Other(error)
+    }
+}
+
 /// Validate `gateway_url`, probe the gateway, and provision this profile.
 ///
 /// Returns a [`PairingOutcome`] on success — the normalized gateway base URL
 /// plus whether this call is the one that provisioned the profile. Nothing
 /// is written unless the URL passes the gateway contract and the deployment
-/// answers `GET /api/v1/meta`; a conflicting re-provision is refused inside
-/// [`managed_policy::provision`] and leaves both the policy and the provider
-/// configuration untouched. Success also points the ModelGateway provider at
+/// answers `GET /api/v1/meta`; a conflicting re-provision is refused as the
+/// typed [`PairingError::Conflict`] before either write, leaving both the
+/// policy and the provider configuration untouched — the desktop shell
+/// surfaces that refusal instead of treating it as a generic fault. Success
+/// also points the ModelGateway provider at
 /// the gateway and enables it, dropping any model snapshot synced from a
 /// previously configured base URL — sign-in resyncs the entitled set.
 ///
@@ -87,7 +139,7 @@ pub struct PairingOutcome {
 pub async fn pair_with_gateway(
     handle: &PairingHandle,
     gateway_url: &str,
-) -> Result<PairingOutcome> {
+) -> Result<PairingOutcome, PairingError> {
     let store = &*handle.store;
     let config = GatewayAuthConfig::new(gateway_url)?;
     let base_url = config.base_url().to_string();
@@ -101,9 +153,9 @@ pub async fn pair_with_gateway(
     // profile with no configured provider.
     let already_provisioned = match managed_policy::provisioned_url(store).await? {
         Some(existing) if existing != base_url => {
-            return Err(AgentError::config(
-                "this profile is already provisioned to a different gateway",
-            ));
+            return Err(PairingError::Conflict {
+                provisioned_url: existing,
+            });
         }
         other => other.is_some(),
     };
@@ -353,11 +405,14 @@ mod tests {
     async fn a_failed_pairing_changes_nothing() {
         let (store, _directory) = test_store().await;
 
-        // Unreachable gateway: the probe fails before any write.
+        // Unreachable gateway: the probe fails before any write, and the
+        // failure is a fault, not the typed conflict refusal.
         let dead = unreachable_base().await;
-        assert!(pair_with_gateway(&test_handle(&store), &dead)
+        let error = pair_with_gateway(&test_handle(&store), &dead)
             .await
-            .is_err());
+            .err()
+            .unwrap();
+        assert!(matches!(error, PairingError::Other(_)));
         assert!(!resolve(&*store, &NoOsPolicy).await.unwrap().managed);
         let provider = providers::read_config(&*store, ProviderKind::ModelGateway)
             .await
@@ -373,10 +428,18 @@ mod tests {
             .await
             .unwrap()
             .base_url;
+        // The refusal is typed — the desktop dialog keys off the variant,
+        // not the message — and names the gateway actually on record.
         let error = pair_with_gateway(&test_handle(&store), &second)
             .await
             .err()
             .unwrap();
+        match &error {
+            PairingError::Conflict { provisioned_url } => {
+                assert_eq!(provisioned_url, &normalized)
+            }
+            other => panic!("expected the typed conflict, got {other:?}"),
+        }
         assert!(error.to_string().contains("already provisioned"));
         let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
         assert_eq!(policy.gateway_url.as_deref(), Some(normalized.as_str()));


### PR DESCRIPTION
Today a provision deep link naming a different gateway than the one this profile is provisioned to is refused correctly but silently: the user confirms the "Pair with <B>?" dialog and the refusal goes only to `pairing.log`. Per the recorded decision on #742 (Option A), refuse-forever stays — this makes the refusal visible.

## Design

- **Typed conflict signal, no string-matching.** `pair_with_gateway` now returns `Result<PairingOutcome, PairingError>`. `PairingError::Conflict { provisioned_url }` carries the normalized base URL on record (secret-free by the gateway-URL contract); every other failure — invalid URL, unreachable gateway, bad manifest, store errors — flows through `PairingError::Other(AgentError)` via a `From` impl, so the function body's `?` plumbing is unchanged. The enum is `#[non_exhaustive]`, matching `AgentError`'s rationale. Other-class log lines are byte-identical to before; the conflict log line changed shape deliberately (old: `configuration error: this profile is already provisioned to a different gateway`; new: `refused: this device is already provisioned to <origin>` — origin-named, still secret-free).
- **Conflict dialog.** The deep-link flow reduces the carried URL to its origin and shows: "This device is already managed by `<origin>`. Contact your administrator to change gateways." No retry affordance — the dialog closes and the attempt is over.
- **Other failures also get a dialog** (the decision the issue asked to be documented): the user just confirmed a pairing in a native dialog, so a failure that reaches only the log reads as success — the same silent-confusion rationale as the conflict. It is one bounded, generic line naming only the origin the user confirmed ("OpenWave could not pair with `<origin>`. This device was not paired; details are in pairing.log."); the copy claims only what is always true — the provider config is deliberately written before the sticky policy, so a failure between the writes can leave it repointed while the profile stays unmanaged and recoverable from settings. Raw error text stays in the log, which already strips URLs and token material. One dialog per attempt, no loops.
- The message choice lives in a pure `refusal_message(origin, &PairFailure)` so the decision is testable without a GUI, mirroring the #924 pattern; `pair_after_confirmation` generalizes its error type so the typed failure flows through the existing GUI-free gate.

## Tests

- `pairing::tests::a_failed_pairing_changes_nothing` (extended, no new server test): the unreachable-gateway failure is asserted to be `PairingError::Other` and the conflicting re-pair to be `PairingError::Conflict` carrying exactly the provisioned URL — conflict vs other-failure distinguishable by variant, plus the existing `Display` pin.
- `deep_link::tests::the_refusal_dialog_names_the_right_gateway` (new): the conflict message names the provisioned origin (never the link's) and points at the administrator; the generic message names only the confirmed origin and leaks no raw error text.
- `deep_link::tests::a_stored_base_url_reduces_to_its_origin` (new): pins the URL-to-origin reduction the conflict dialog's claim rests on.

Verified locally: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace`, `cargo check --workspace --locked` (no lock diff). UI untouched.

Closes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)