### PR TITLE
feat(web-search): vendor page extraction through Exa and Tavily

### DIFF
--- a/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
@@ -171,7 +171,7 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
 
           <SettingsSection
             title="Active provider"
-            description="Agents search through this one provider. The others stay configured and idle."
+            description="Agents search and open pages through this one provider. The others stay configured and idle."
           >
             <ActiveProviderField
               value={provider}
@@ -206,6 +206,12 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
             Foreground and background agents can request configured search.
             Foreground requests ask for approval before the query leaves
             OpenWave.
+          </p>
+
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            {config.provider
+              ? `Agents also open single pages through ${providerLabel(config.provider)}. If a page comes back empty or ${providerLabel(config.provider)} is unavailable, OpenWave reads it directly instead.`
+              : "Agents can still open single pages without a provider: OpenWave reads them directly."}
           </p>
         </>
       )}

--- a/crates/openwave-web-search/src/exa.rs
+++ b/crates/openwave-web-search/src/exa.rs
@@ -1,4 +1,4 @@
-//! Exa's direct `/search` adapter.
+//! Exa's direct `/search` and `/contents` adapter.
 
 use std::collections::BTreeMap;
 
@@ -7,10 +7,30 @@ use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use serde_json::json;
 
+use crate::types::{count_words, same_page_url};
 use crate::{
-    HttpClient, HttpRequest, WebSearchCredential, WebSearchError, WebSearchProvider,
-    WebSearchProviderKind, WebSearchRequest, WebSearchResponse, WebSearchResult,
+    admit_fetch_url, ExtractionMethod, HttpClient, HttpRequest, WebExtractRequest,
+    WebExtractResponse, WebSearchCredential, WebSearchError, WebSearchProvider,
+    WebSearchProviderKind, WebSearchRequest, WebSearchResponse, WebSearchResult, MIN_EXTRACT_WORDS,
 };
+
+/// Upper bound Exa accepts for `text.maxCharacters`, and what this adapter
+/// always asks for.
+///
+/// Bounding the page at the source means the vendor never ships a whole book
+/// over the wire for us to throw away, and even all-4-byte characters at this
+/// length stay inside the serialized extraction budget — the trim ladder in
+/// [`WebExtractResponse`] is a backstop here, not the primary control.
+const EXTRACT_MAX_CHARACTERS: usize = 10_000;
+
+const _: () = assert!(EXTRACT_MAX_CHARACTERS * 4 <= crate::MAX_EXTRACT_OUTPUT_BYTES);
+
+/// How stale a cached crawl may be before Exa is asked to fetch the page live.
+///
+/// This is the supported replacement for the deprecated `livecrawl` mode
+/// selector. A day-old cache is fine for the pages an agent reads; anything
+/// older is re-crawled rather than quietly answered from an archive.
+const EXTRACT_MAX_AGE_HOURS: u32 = 24;
 
 /// Exa adapter backed by an injected HTTP client.
 ///
@@ -68,6 +88,49 @@ impl<C: HttpClient> WebSearchProvider for ExaProvider<C> {
             .filter_map(|result| normalize_result(result).ok())
             .collect();
         Ok(WebSearchResponse::new(self.kind(), results))
+    }
+
+    fn supports_extract(&self) -> bool {
+        true
+    }
+
+    async fn extract(
+        &self,
+        request: WebExtractRequest,
+    ) -> Result<WebExtractResponse, WebSearchError> {
+        // Revalidate at the egress boundary, exactly as `search` does: this
+        // request may have been deserialized rather than freshly admitted.
+        request.validate()?;
+        let response = self
+            .client
+            .post_json(HttpRequest {
+                // The authority is fixed by the provider kind and bound into
+                // the transport before the credential is attached here.
+                url: self.kind().extract_url().into(),
+                headers: vec![
+                    // `/contents` documents bearer auth; the legacy `x-api-key`
+                    // header the search path still uses is not the shape new
+                    // calls should be written against.
+                    (
+                        "authorization".into(),
+                        format!("Bearer {}", self.credential.api_key()),
+                    ),
+                    ("content-type".into(), "application/json".into()),
+                ],
+                body: extract_request_body(request.url()),
+            })
+            .await?;
+        response.ensure_bounded()?;
+        if !(200..300).contains(&response.status) {
+            return Err(extract_status_error(response.status));
+        }
+        let payload: ExaContentsResponse =
+            serde_json::from_slice(&response.body).map_err(|_| {
+                WebSearchError::InvalidResponse {
+                    provider: self.kind(),
+                }
+            })?;
+        normalize_extraction(request.url(), payload)
     }
 }
 
@@ -144,6 +207,130 @@ fn parse_provider_timestamp(value: &str) -> Option<DateTime<Utc>> {
         .map(|value| value.with_timezone(&Utc))
 }
 
+/// One URL, text always requested explicitly.
+///
+/// `text` is sent as an object on every call rather than relying on the
+/// endpoint's default: the default decides both whether text comes back at all
+/// and how much of it, and neither is something this adapter should inherit
+/// from a vendor release note. `includeHtmlTags` stays off so the payload is
+/// the markdown the extraction contract promises.
+fn extract_request_body(url: &str) -> serde_json::Value {
+    json!({
+        "urls": [url],
+        "text": {
+            "maxCharacters": EXTRACT_MAX_CHARACTERS,
+            "includeHtmlTags": false,
+        },
+        "maxAgeHours": EXTRACT_MAX_AGE_HOURS,
+    })
+}
+
+/// Project a request-level status onto the crate's typed errors.
+///
+/// Only the statuses that change what a caller should do are named. Everything
+/// else — validation, server faults — stays a plain [`WebSearchError::HttpStatus`],
+/// which the extraction tool treats as "this vendor call failed, try native".
+fn extract_status_error(status: u16) -> WebSearchError {
+    let provider = WebSearchProviderKind::Exa;
+    match status {
+        401 => WebSearchError::CredentialRejected(provider),
+        // Exa reports an exhausted balance as Payment Required.
+        402 => WebSearchError::QuotaExhausted(provider),
+        429 => WebSearchError::RateLimited(provider),
+        status => WebSearchError::HttpStatus { provider, status },
+    }
+}
+
+#[derive(Deserialize)]
+struct ExaContentsResponse {
+    #[serde(default)]
+    results: Vec<ExaContentResult>,
+    /// Per-URL outcome, parallel to but not positionally aligned with
+    /// `results`: a URL that failed appears here only.
+    #[serde(default)]
+    statuses: Vec<ExaContentStatus>,
+}
+
+#[derive(Deserialize)]
+struct ExaContentResult {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    text: Option<String>,
+}
+
+/// The `error` object carries a closed vendor tag (`CRAWL_NOT_FOUND`,
+/// `CRAWL_TIMEOUT`, …). It is deliberately not read: the tag would only ever be
+/// forwarded, and no vendor string belongs in a model context. `source` used to
+/// appear here and no longer does, which unknown-field tolerance already covers.
+#[derive(Deserialize)]
+struct ExaContentStatus {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    status: String,
+}
+
+/// Turn one `/contents` payload into a bounded extraction, or a typed failure.
+///
+/// A failed URL comes back inside an HTTP 200 with an empty `results`, so the
+/// per-URL status is consulted first and the result is then matched by key. An
+/// absent or too-thin result is a failure, never an empty-content success.
+fn normalize_extraction(
+    requested: &str,
+    payload: ExaContentsResponse,
+) -> Result<WebExtractResponse, WebSearchError> {
+    let provider = WebSearchProviderKind::Exa;
+    let failed = || WebSearchError::PageNotExtracted { provider };
+    if payload
+        .statuses
+        .iter()
+        .any(|entry| same_page_url(&entry.id, requested) && entry.status != "success")
+    {
+        return Err(failed());
+    }
+    let result = payload
+        .results
+        .into_iter()
+        .find(|result| {
+            [result.id.as_deref(), result.url.as_deref()]
+                .into_iter()
+                .flatten()
+                .any(|candidate| same_page_url(candidate, requested))
+        })
+        .ok_or_else(failed)?;
+    let text = result.text.unwrap_or_default();
+    let text = text.trim();
+    let word_count = count_words(text);
+    if word_count < MIN_EXTRACT_WORDS {
+        return Err(failed());
+    }
+    // Exa bounds the text but does not say when it hit the bound. Content
+    // sitting exactly on the cap is reported as truncated rather than passed
+    // off as a whole page.
+    let truncated = text.chars().count() >= EXTRACT_MAX_CHARACTERS;
+    // The vendor may echo a resolved URL. Accept it only if it clears the same
+    // admission policy every native redirect hop clears; otherwise keep the URL
+    // the caller asked for.
+    let url = result
+        .url
+        .as_deref()
+        .and_then(|url| admit_fetch_url(url).ok())
+        .map_or_else(|| requested.to_owned(), String::from);
+    WebExtractResponse::new(
+        ExtractionMethod::Provider(provider),
+        url,
+        result.title.unwrap_or_default(),
+        text,
+        word_count,
+        truncated,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::{Arc, Mutex};
@@ -213,5 +400,157 @@ mod tests {
         assert_eq!(sent[0].body["numResults"], 2);
         assert_eq!(sent[0].body["includeDomains"][0], "docs.example.com");
         assert_eq!(sent[0].headers[0], ("x-api-key".into(), "exa-key".into()));
+    }
+
+    const EXTRACT_URL: &str = "https://example.com/article";
+
+    async fn extract(
+        status: u16,
+        body: serde_json::Value,
+    ) -> (Result<WebExtractResponse, WebSearchError>, Vec<HttpRequest>) {
+        let credential = WebSearchCredentials::load(&StaticSecrets, WebSearchProviderKind::Exa)
+            .await
+            .unwrap()
+            .unwrap();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let provider = ExaProvider::new(
+            FakeHttpClient {
+                seen: Arc::clone(&seen),
+                response: HttpResponse {
+                    status,
+                    body: serde_json::to_vec(&body).unwrap(),
+                },
+            },
+            credential,
+        )
+        .unwrap();
+        let result = provider
+            .extract(WebExtractRequest::new(EXTRACT_URL).unwrap())
+            .await;
+        let sent = seen.lock().unwrap().clone();
+        (result, sent)
+    }
+
+    #[tokio::test]
+    async fn extract_asks_for_bounded_text_and_normalizes_the_page_within_budget() {
+        // A page far larger than either bound, so both the vendor-side cap and
+        // the serialized output budget have to do their jobs.
+        let text = "openwave ".repeat(8_000);
+        let (result, sent) = extract(
+            200,
+            serde_json::json!({
+                "requestId": "request-fixture",
+                "results": [{
+                    "id": EXTRACT_URL,
+                    "url": EXTRACT_URL,
+                    "title": "Example article",
+                    "text": text,
+                    "publishedDate": "2026-01-01T00:00:00Z",
+                    "author": "Example",
+                }],
+                "statuses": [{ "id": EXTRACT_URL, "status": "success" }],
+                "costDollars": { "total": 0.001 },
+            }),
+        )
+        .await;
+
+        let response = result.unwrap();
+        assert_eq!(
+            response.extraction_method,
+            ExtractionMethod::Provider(WebSearchProviderKind::Exa)
+        );
+        assert_eq!(response.url, EXTRACT_URL);
+        assert_eq!(response.title, "Example article");
+        // Words are counted over the whole extraction, before either trim.
+        assert_eq!(response.word_count, 8_000);
+        assert!(response.truncated);
+        assert!(
+            serde_json::to_vec(&response).unwrap().len() <= crate::MAX_EXTRACT_OUTPUT_BYTES,
+            "extraction exceeded its serialized output budget"
+        );
+
+        assert_eq!(sent[0].url, WebSearchProviderKind::Exa.extract_url());
+        assert_eq!(sent[0].body["urls"], serde_json::json!([EXTRACT_URL]));
+        // Text is always requested explicitly and always bounded at the source,
+        // and freshness is expressed through the supported knob.
+        assert_eq!(
+            sent[0].body["text"]["maxCharacters"],
+            EXTRACT_MAX_CHARACTERS
+        );
+        assert_eq!(sent[0].body["maxAgeHours"], EXTRACT_MAX_AGE_HOURS);
+        assert!(sent[0].body.get("livecrawl").is_none());
+        assert_eq!(
+            sent[0].headers[0],
+            ("authorization".into(), "Bearer exa-key".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn extract_maps_per_url_failure_and_distinctive_statuses_to_typed_errors() {
+        let other = "https://example.com/other";
+        let page = "openwave ".repeat(40);
+        let cases = [
+            // The whole point: a failed URL comes back inside an HTTP 200 with
+            // an empty `results` and the reason in `statuses`.
+            (
+                serde_json::json!({
+                    "results": [],
+                    "statuses": [{
+                        "id": EXTRACT_URL,
+                        "status": "error",
+                        "error": { "tag": "CRAWL_NOT_FOUND", "httpStatusCode": 404 },
+                    }],
+                }),
+                "per-URL failure inside HTTP 200",
+            ),
+            // A success for some other URL must not be adopted by position.
+            (
+                serde_json::json!({
+                    "results": [{ "id": other, "url": other, "title": "Other", "text": page }],
+                    "statuses": [{ "id": other, "status": "success" }],
+                }),
+                "result for a different URL",
+            ),
+            // A result too thin to be a page is nothing, not a blank success.
+            (
+                serde_json::json!({
+                    "results": [{ "id": EXTRACT_URL, "url": EXTRACT_URL, "text": "Enable JavaScript." }],
+                    "statuses": [{ "id": EXTRACT_URL, "status": "success" }],
+                }),
+                "content below the readable floor",
+            ),
+        ];
+        for (body, case) in cases {
+            let (result, _) = extract(200, body).await;
+            assert!(
+                matches!(
+                    result,
+                    Err(WebSearchError::PageNotExtracted {
+                        provider: WebSearchProviderKind::Exa
+                    })
+                ),
+                "{case} did not produce a typed per-URL failure"
+            );
+        }
+
+        let empty = || serde_json::json!({});
+        assert!(matches!(
+            extract(401, empty()).await.0,
+            Err(WebSearchError::CredentialRejected(_))
+        ));
+        // Exa signals an exhausted balance as Payment Required, which no amount
+        // of backing off resolves.
+        assert!(matches!(
+            extract(402, empty()).await.0,
+            Err(WebSearchError::QuotaExhausted(_))
+        ));
+        assert!(matches!(
+            extract(429, empty()).await.0,
+            Err(WebSearchError::RateLimited(_))
+        ));
+        assert!(matches!(
+            extract(503, empty()).await.0,
+            Err(WebSearchError::HttpStatus { status: 503, .. })
+        ));
     }
 }

--- a/crates/openwave-web-search/src/http.rs
+++ b/crates/openwave-web-search/src/http.rs
@@ -301,9 +301,12 @@ mod tests {
             crate::WebSearchProviderKind::Exa,
             crate::WebSearchProviderKind::Tavily,
         ] {
-            assert!(
-                validate_outbound_url(provider.search_url(), provider.outbound_domain()).is_ok()
-            );
+            for endpoint in [provider.search_url(), provider.extract_url()] {
+                assert!(
+                    validate_outbound_url(endpoint, provider.outbound_domain()).is_ok(),
+                    "{endpoint} is not on {provider}'s fixed outbound domain"
+                );
+            }
         }
     }
 

--- a/crates/openwave-web-search/src/lib.rs
+++ b/crates/openwave-web-search/src/lib.rs
@@ -10,7 +10,10 @@
 //! The Exa and Tavily adapters use their public HTTP APIs through the small
 //! [`HttpClient`] seam; no vendor SDK is required. `ReqwestHttpClient` is opt-in
 //! behind the `http` feature. Requests and normalized output are bounded before
-//! egress and before they can reach a model context.
+//! egress and before they can reach a model context. Both adapters implement
+//! page extraction as well as search, on the same fixed authority; a per-URL
+//! vendor failure is a typed error rather than an empty success, so extraction
+//! can fall back to the native engine instead of returning a blank page.
 //!
 //! The `extract-native` feature adds a self-contained extraction engine:
 //! [`NativeExtractor`] fetches one admitted URL — every redirect hop re-vetted
@@ -41,7 +44,7 @@ pub use http::{HttpClient, HttpRequest, HttpResponse, MAX_HTTP_RESPONSE_BYTES};
 pub use native::{
     HostAddressResolver, NativeExtractError, NativeExtraction, NativeExtractor, PageFetchResponse,
     PageFetchTransport, ReqwestPageFetcher, TokioHostResolver, MAX_EXTRACT_CONTENT_CHARS,
-    MAX_FETCH_REDIRECT_HOPS, MAX_FETCH_RESPONSE_BYTES, MIN_EXTRACT_WORDS, NATIVE_FETCH_USER_AGENT,
+    MAX_FETCH_REDIRECT_HOPS, MAX_FETCH_RESPONSE_BYTES, NATIVE_FETCH_USER_AGENT,
 };
 pub use tavily::TavilyProvider;
 pub use tool::{
@@ -53,5 +56,5 @@ pub use types::{
     WebSearchError, WebSearchProvider, WebSearchProviderKind, WebSearchRequest, WebSearchResponse,
     WebSearchResult, MAX_DOMAINS, MAX_EXTRACT_OUTPUT_BYTES, MAX_OUTPUT_BYTES, MAX_OUTPUT_CHARS,
     MAX_QUERY_CHARS, MAX_RESULTS, MAX_RESULT_CONTENT_CHARS, MAX_RESULT_SNIPPET_CHARS,
-    MAX_RESULT_TITLE_CHARS, MAX_RESULT_URL_BYTES,
+    MAX_RESULT_TITLE_CHARS, MAX_RESULT_URL_BYTES, MIN_EXTRACT_WORDS,
 };

--- a/crates/openwave-web-search/src/native.rs
+++ b/crates/openwave-web-search/src/native.rs
@@ -32,6 +32,8 @@ use thiserror::Error;
 use url::{Host, Url};
 
 use crate::fetch_policy::{admit_fetch_address, admit_fetch_url, FetchPolicyViolation};
+use crate::types::count_words;
+use crate::MIN_EXTRACT_WORDS;
 
 /// Largest response body retained for one native page fetch.
 pub const MAX_FETCH_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
@@ -40,8 +42,6 @@ pub const MAX_FETCH_REDIRECT_HOPS: usize = 5;
 /// Maximum Unicode scalar values of extracted content returned to a caller,
 /// including the truncation marker when one is inserted.
 pub const MAX_EXTRACT_CONTENT_CHARS: usize = 24_000;
-/// Below this many extracted words a page has no readable content.
-pub const MIN_EXTRACT_WORDS: usize = 20;
 /// The honest, distinct user agent every native page fetch announces.
 pub const NATIVE_FETCH_USER_AGENT: &str =
     "OpenWavePageExtractor/1.0 (+https://github.com/brightwave-inc/openwave)";
@@ -547,13 +547,6 @@ fn sanitized_title(value: &str) -> String {
 
 /// Words that carry content: whitespace-separated tokens with at least one
 /// alphanumeric character, so markdown punctuation does not inflate the count.
-fn count_words(value: &str) -> usize {
-    value
-        .split_whitespace()
-        .filter(|token| token.chars().any(char::is_alphanumeric))
-        .count()
-}
-
 /// Keep the head and tail of over-budget content with an explicit marker in
 /// between; the result never exceeds `budget` characters.
 fn truncate_head_tail(value: &str, budget: usize) -> (String, bool) {

--- a/crates/openwave-web-search/src/tavily.rs
+++ b/crates/openwave-web-search/src/tavily.rs
@@ -1,4 +1,4 @@
-//! Tavily's direct `/search` adapter.
+//! Tavily's direct `/search` and `/extract` adapter.
 
 use std::collections::BTreeMap;
 
@@ -7,9 +7,11 @@ use chrono::{DateTime, NaiveDate, Utc};
 use serde::Deserialize;
 use serde_json::json;
 
+use crate::types::{count_words, same_page_url};
 use crate::{
-    HttpClient, HttpRequest, WebSearchCredential, WebSearchError, WebSearchProvider,
-    WebSearchProviderKind, WebSearchRequest, WebSearchResponse, WebSearchResult,
+    admit_fetch_url, ExtractionMethod, HttpClient, HttpRequest, WebExtractRequest,
+    WebExtractResponse, WebSearchCredential, WebSearchError, WebSearchProvider,
+    WebSearchProviderKind, WebSearchRequest, WebSearchResponse, WebSearchResult, MIN_EXTRACT_WORDS,
 };
 
 /// Tavily adapter backed by an injected HTTP client.
@@ -63,6 +65,45 @@ impl<C: HttpClient> WebSearchProvider for TavilyProvider<C> {
             .filter_map(|result| normalize_result(result).ok())
             .collect();
         Ok(WebSearchResponse::new(self.kind(), results))
+    }
+
+    fn supports_extract(&self) -> bool {
+        true
+    }
+
+    async fn extract(
+        &self,
+        request: WebExtractRequest,
+    ) -> Result<WebExtractResponse, WebSearchError> {
+        request.validate()?;
+        let response = self
+            .client
+            .post_json(HttpRequest {
+                url: self.kind().extract_url().into(),
+                headers: vec![
+                    // `/extract` takes the key as a bearer token only; the body
+                    // `api_key` field the search path still sends is not part
+                    // of this endpoint's contract.
+                    (
+                        "authorization".into(),
+                        format!("Bearer {}", self.credential.api_key()),
+                    ),
+                    ("content-type".into(), "application/json".into()),
+                ],
+                body: extract_request_body(request.url()),
+            })
+            .await?;
+        response.ensure_bounded()?;
+        if !(200..300).contains(&response.status) {
+            return Err(extract_status_error(response.status));
+        }
+        let payload: TavilyExtractResponse =
+            serde_json::from_slice(&response.body).map_err(|_| {
+                WebSearchError::InvalidResponse {
+                    provider: self.kind(),
+                }
+            })?;
+        normalize_extraction(request.url(), payload)
     }
 }
 
@@ -126,6 +167,112 @@ fn normalize_result(result: TavilyResult) -> Result<WebSearchResult, WebSearchEr
     )
 }
 
+/// One URL, whole page, markdown.
+///
+/// `query` is deliberately absent. Supplying one switches `raw_content` from
+/// the page to reranked chunks joined by a literal `"[...]"` marker, which is a
+/// different product from the extraction contract this adapter implements.
+/// `basic` depth is the whole-page read; `advanced` doubles the cost for table
+/// and dynamic-content recovery that the native engine already backstops. No
+/// body `timeout` is sent either — the host's clamped transport timeout is the
+/// single deadline, and a second one in the payload could only disagree with it.
+fn extract_request_body(url: &str) -> serde_json::Value {
+    json!({
+        "urls": [url],
+        "extract_depth": "basic",
+        "format": "markdown",
+        "include_images": false,
+    })
+}
+
+/// Project a request-level status onto the crate's typed errors.
+fn extract_status_error(status: u16) -> WebSearchError {
+    let provider = WebSearchProviderKind::Tavily;
+    match status {
+        401 => WebSearchError::CredentialRejected(provider),
+        // Tavily splits "you are going too fast" from "you are out of credit"
+        // across nonstandard statuses: 432 is the plan allowance, 433 the
+        // pay-as-you-go balance. Neither is fixed by backing off, so they must
+        // not be folded into 429.
+        432 | 433 => WebSearchError::QuotaExhausted(provider),
+        429 => WebSearchError::RateLimited(provider),
+        status => WebSearchError::HttpStatus { provider, status },
+    }
+}
+
+#[derive(Deserialize)]
+struct TavilyExtractResponse {
+    #[serde(default)]
+    results: Vec<TavilyExtractResult>,
+    /// URLs the vendor could not read. Its per-entry `error` prose is
+    /// deliberately not deserialized: it would only ever be forwarded, and no
+    /// vendor string belongs in a model context.
+    #[serde(default)]
+    failed_results: Vec<TavilyFailedResult>,
+}
+
+#[derive(Deserialize)]
+struct TavilyExtractResult {
+    #[serde(default)]
+    url: String,
+    #[serde(default)]
+    raw_content: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct TavilyFailedResult {
+    #[serde(default)]
+    url: String,
+}
+
+/// Turn one `/extract` payload into a bounded extraction, or a typed failure.
+///
+/// The endpoint answers HTTP 200 even when every URL failed, splitting the
+/// outcome across `results` and `failed_results`, so the requested URL is
+/// looked up by key in both. A missing or too-thin page is a failure rather
+/// than an extraction with nothing in it.
+fn normalize_extraction(
+    requested: &str,
+    payload: TavilyExtractResponse,
+) -> Result<WebExtractResponse, WebSearchError> {
+    let provider = WebSearchProviderKind::Tavily;
+    let failed = || WebSearchError::PageNotExtracted { provider };
+    if payload
+        .failed_results
+        .iter()
+        .any(|entry| same_page_url(&entry.url, requested))
+    {
+        return Err(failed());
+    }
+    let result = payload
+        .results
+        .into_iter()
+        .find(|result| same_page_url(&result.url, requested))
+        .ok_or_else(failed)?;
+    let content = result.raw_content.unwrap_or_default();
+    let content = content.trim();
+    let word_count = count_words(content);
+    if word_count < MIN_EXTRACT_WORDS {
+        return Err(failed());
+    }
+    let url = admit_fetch_url(&result.url).map_or_else(|_| requested.to_owned(), String::from);
+    WebExtractResponse::new(
+        ExtractionMethod::Provider(provider),
+        url,
+        // `/extract` returns no title field, so there is none to report. An
+        // empty title is what the contract already means by "the page did not
+        // provide one"; inventing one from the first markdown heading would put
+        // a guess where a fact belongs, and the result card falls back to the
+        // page host on its own.
+        "",
+        content,
+        word_count,
+        // Tavily applies no length cap of its own, so anything shortened here
+        // is shortened by the output budget, which sets this itself.
+        false,
+    )
+}
+
 fn parse_provider_timestamp(value: &str) -> Option<DateTime<Utc>> {
     DateTime::parse_from_rfc3339(value)
         .ok()
@@ -149,6 +296,7 @@ mod tests {
     #[derive(Clone)]
     struct FakeHttpClient {
         request: Arc<Mutex<Option<HttpRequest>>>,
+        response: HttpResponse,
     }
 
     struct StaticSecrets;
@@ -175,10 +323,7 @@ mod tests {
     impl HttpClient for FakeHttpClient {
         async fn post_json(&self, request: HttpRequest) -> Result<HttpResponse, WebSearchError> {
             *self.request.lock().unwrap() = Some(request);
-            Ok(HttpResponse {
-                status: 200,
-                body: br#"{"results":[{"url":"https://example.com/t","title":"Tavily","content":"bounded content","score":0.5,"published_date":"2026-01-01"}]}"#.to_vec(),
-            })
+            Ok(self.response.clone())
         }
     }
 
@@ -192,6 +337,10 @@ mod tests {
         let provider = TavilyProvider::new(
             FakeHttpClient {
                 request: Arc::clone(&request),
+                response: HttpResponse {
+                    status: 200,
+                    body: br#"{"results":[{"url":"https://example.com/t","title":"Tavily","content":"bounded content","score":0.5,"published_date":"2026-01-01"}]}"#.to_vec(),
+                },
             },
             credential,
         )
@@ -210,5 +359,150 @@ mod tests {
         assert_eq!(sent.url, WebSearchProviderKind::Tavily.search_url());
         assert_eq!(sent.body["api_key"], "tavily-key");
         assert!(sent.headers.iter().all(|(_, value)| value != "tavily-key"));
+    }
+
+    const EXTRACT_URL: &str = "https://example.com/article";
+
+    async fn extract(
+        status: u16,
+        body: serde_json::Value,
+    ) -> (
+        Result<WebExtractResponse, WebSearchError>,
+        Option<HttpRequest>,
+    ) {
+        let credential = WebSearchCredentials::load(&StaticSecrets, WebSearchProviderKind::Tavily)
+            .await
+            .unwrap()
+            .unwrap();
+        let request = Arc::new(Mutex::new(None));
+        let provider = TavilyProvider::new(
+            FakeHttpClient {
+                request: Arc::clone(&request),
+                response: HttpResponse {
+                    status,
+                    body: serde_json::to_vec(&body).unwrap(),
+                },
+            },
+            credential,
+        )
+        .unwrap();
+        let result = provider
+            .extract(WebExtractRequest::new(EXTRACT_URL).unwrap())
+            .await;
+        let sent = request.lock().unwrap().clone();
+        (result, sent)
+    }
+
+    #[tokio::test]
+    async fn extract_requests_the_whole_page_and_normalizes_it_within_budget() {
+        let raw_content = "openwave ".repeat(8_000);
+        let (result, sent) = extract(
+            200,
+            serde_json::json!({
+                "results": [{ "url": EXTRACT_URL, "raw_content": raw_content }],
+                "failed_results": [],
+                "response_time": 1.23,
+                "usage": { "credits": 1 },
+            }),
+        )
+        .await;
+
+        let response = result.unwrap();
+        assert_eq!(
+            response.extraction_method,
+            ExtractionMethod::Provider(WebSearchProviderKind::Tavily)
+        );
+        assert_eq!(response.url, EXTRACT_URL);
+        // `/extract` returns no title, and none is invented for it.
+        assert!(response.title.is_empty());
+        assert_eq!(response.word_count, 8_000);
+        // Tavily caps nothing itself, so the output budget is what shortened
+        // this page, and it says so.
+        assert!(response.truncated);
+        assert!(
+            serde_json::to_vec(&response).unwrap().len() <= crate::MAX_EXTRACT_OUTPUT_BYTES,
+            "extraction exceeded its serialized output budget"
+        );
+
+        let sent = sent.unwrap();
+        assert_eq!(sent.url, WebSearchProviderKind::Tavily.extract_url());
+        assert_eq!(sent.body["urls"], serde_json::json!([EXTRACT_URL]));
+        assert_eq!(sent.body["format"], "markdown");
+        // A query would turn `raw_content` into reranked chunks instead of the
+        // page, so it must never be sent from the extraction path.
+        assert!(sent.body.get("query").is_none());
+        assert_eq!(
+            sent.headers[0],
+            ("authorization".into(), "Bearer tavily-key".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn extract_maps_per_url_failure_and_distinctive_statuses_to_typed_errors() {
+        let other = "https://example.com/other";
+        let page = "openwave ".repeat(40);
+        let cases = [
+            // The whole point: a wholly failed batch is still HTTP 200, with
+            // the reason parked in `failed_results`.
+            (
+                serde_json::json!({
+                    "results": [],
+                    "failed_results": [{ "url": EXTRACT_URL, "error": "unreachable host" }],
+                }),
+                "per-URL failure inside HTTP 200",
+            ),
+            // A success for some other URL must not be adopted by position.
+            (
+                serde_json::json!({
+                    "results": [{ "url": other, "raw_content": page }],
+                    "failed_results": [],
+                }),
+                "result for a different URL",
+            ),
+            (
+                serde_json::json!({
+                    "results": [{ "url": EXTRACT_URL, "raw_content": "Enable JavaScript." }],
+                    "failed_results": [],
+                }),
+                "content below the readable floor",
+            ),
+        ];
+        for (body, case) in cases {
+            let (result, _) = extract(200, body).await;
+            assert!(
+                matches!(
+                    result,
+                    Err(WebSearchError::PageNotExtracted {
+                        provider: WebSearchProviderKind::Tavily
+                    })
+                ),
+                "{case} did not produce a typed per-URL failure"
+            );
+        }
+
+        let empty = || serde_json::json!({});
+        assert!(matches!(
+            extract(401, empty()).await.0,
+            Err(WebSearchError::CredentialRejected(_))
+        ));
+        // 432 (plan allowance) and 433 (pay-as-you-go balance) are Tavily's own
+        // statuses and are not rate limits: retrying cannot clear either.
+        for status in [432, 433] {
+            assert!(
+                matches!(
+                    extract(status, empty()).await.0,
+                    Err(WebSearchError::QuotaExhausted(_))
+                ),
+                "HTTP {status} was not mapped to an exhausted quota"
+            );
+        }
+        assert!(matches!(
+            extract(429, empty()).await.0,
+            Err(WebSearchError::RateLimited(_))
+        ));
+        assert!(matches!(
+            extract(503, empty()).await.0,
+            Err(WebSearchError::HttpStatus { status: 503, .. })
+        ));
     }
 }

--- a/crates/openwave-web-search/src/tool.rs
+++ b/crates/openwave-web-search/src/tool.rs
@@ -136,9 +136,10 @@ pub fn extract_request_from_tool_arguments(
 /// Routing is deterministic and derived from the configured provider: an
 /// extract-capable provider receives the request, and a search-only or absent
 /// provider routes to the native engine. A vendor failure falls back to the
-/// native engine for that request; a native failure returns a closed,
-/// actionable reason. Nothing degrades silently — every success is stamped
-/// with its extraction method.
+/// native engine for that request, except a rejected credential, which is host
+/// configuration and surfaces; a native failure returns a closed, actionable
+/// reason. Nothing degrades silently — every success is stamped with its
+/// extraction method.
 pub struct WebExtractTool {
     resolver: Arc<dyn WebSearchResolver>,
     native: Option<Arc<dyn PageExtractor>>,
@@ -186,11 +187,25 @@ impl Tool for WebExtractTool {
         };
         // Deterministic routing: the configured provider takes the request
         // exactly when it implements the extract contract. A vendor failure
-        // (quota, timeout, provider error) falls back to the native engine for
-        // this request; no vendor diagnostic crosses either way.
+        // (quota, rate limit, timeout, an unreadable page) falls back to the
+        // native engine for this request; no vendor diagnostic crosses either
+        // way.
         if let Some(provider) = provider.filter(|provider| provider.supports_extract()) {
-            if let Ok(response) = provider.extract(request.clone()).await {
-                return Ok(extraction_output(&response));
+            match provider.extract(request.clone()).await {
+                Ok(response) => return Ok(extraction_output(&response)),
+                // A rejected key is the one vendor failure that is about the
+                // host and not about this page. It will reject the next call
+                // and every call after it, and the same key is what web search
+                // uses, so falling back would hide a broken configuration
+                // behind quietly degraded extraction forever. Surface it as the
+                // typed configuration failure the settings card repairs.
+                Err(WebSearchError::CredentialRejected(_)) => {
+                    return Ok(ToolOutput::failed(
+                        ToolErrorCategory::ConfigurationRequired,
+                        "The configured web-search provider rejected its API key.",
+                    ))
+                }
+                Err(_) => {}
             }
         }
         let Some(native) = &self.native else {
@@ -453,6 +468,36 @@ mod tests {
         fail_extract: bool,
     }
 
+    /// A provider whose key the vendor rejects.
+    struct KeyRejectingProvider;
+
+    #[async_trait]
+    impl WebSearchProvider for KeyRejectingProvider {
+        fn kind(&self) -> WebSearchProviderKind {
+            WebSearchProviderKind::Tavily
+        }
+
+        fn supports_extract(&self) -> bool {
+            true
+        }
+
+        async fn search(
+            &self,
+            _request: WebSearchRequest,
+        ) -> Result<WebSearchResponse, WebSearchError> {
+            unreachable!("extraction must never call search")
+        }
+
+        async fn extract(
+            &self,
+            _request: WebExtractRequest,
+        ) -> Result<WebExtractResponse, WebSearchError> {
+            Err(WebSearchError::CredentialRejected(
+                WebSearchProviderKind::Tavily,
+            ))
+        }
+    }
+
     #[async_trait]
     impl WebSearchProvider for ExtractCapableProvider {
         fn kind(&self) -> WebSearchProviderKind {
@@ -553,6 +598,19 @@ mod tests {
         assert_eq!(body["extraction_method"], "native");
         assert_eq!(*native.calls.lock().unwrap(), 1);
         assert!(!output.content.contains("private vendor"));
+
+        // A rejected key is the exception: it is host configuration, so it
+        // surfaces for repair instead of degrading quietly on every future
+        // call. The native engine is not consulted.
+        let native = StubNative::new();
+        let tool = extract_tool(Some(Arc::new(KeyRejectingProvider)), Some(native.clone()));
+        let output = tool.execute(&context(), EXTRACT_ARGS()).await.unwrap();
+        assert!(output.is_error);
+        assert_eq!(
+            output.error_category,
+            Some(ToolErrorCategory::ConfigurationRequired)
+        );
+        assert_eq!(*native.calls.lock().unwrap(), 0);
     }
 
     #[tokio::test]

--- a/crates/openwave-web-search/src/types.rs
+++ b/crates/openwave-web-search/src/types.rs
@@ -29,6 +29,12 @@ pub const MAX_OUTPUT_BYTES: usize = 16_000;
 /// content budget as single-byte text; a page dense in multi-byte script is
 /// trimmed to fit and says so through `truncated`.
 pub const MAX_EXTRACT_OUTPUT_BYTES: usize = 64_000;
+/// Below this many extracted words a page has no readable content.
+///
+/// The floor is engine-neutral on purpose: a vendor that answers with a cookie
+/// banner is exactly as unhelpful as a native fetch that lands on a script
+/// shell, and both should resolve "nothing there" rather than a thin success.
+pub const MIN_EXTRACT_WORDS: usize = 20;
 /// Legacy name for the serialized response output budget.
 pub const MAX_OUTPUT_CHARS: usize = MAX_OUTPUT_BYTES;
 const MAX_DOMAIN_CHARS: usize = 253;
@@ -67,6 +73,15 @@ impl WebSearchProviderKind {
         match self {
             Self::Exa => "https://api.exa.ai/search",
             Self::Tavily => "https://api.tavily.com/search",
+        }
+    }
+
+    /// Fixed page-extraction endpoint, on the same authority as
+    /// [`Self::search_url`] so one transport binding covers both calls.
+    pub(crate) const fn extract_url(self) -> &'static str {
+        match self {
+            Self::Exa => "https://api.exa.ai/contents",
+            Self::Tavily => "https://api.tavily.com/extract",
         }
     }
 
@@ -625,6 +640,22 @@ pub enum WebSearchError {
         provider: WebSearchProviderKind,
         status: u16,
     },
+    /// The provider refused the configured key. This is host configuration
+    /// rather than a property of the request, so it is worth distinguishing
+    /// from every other provider failure: it will recur on the next call.
+    #[error("web search provider {0} rejected the configured API key")]
+    CredentialRejected(WebSearchProviderKind),
+    /// The account's plan or prepaid balance is spent. Distinct from
+    /// [`Self::RateLimited`] because waiting does not clear it.
+    #[error("web search provider {0} has no remaining quota")]
+    QuotaExhausted(WebSearchProviderKind),
+    #[error("web search provider {0} rate limited the request")]
+    RateLimited(WebSearchProviderKind),
+    /// The provider accepted the request and reported that this one page could
+    /// not be extracted. Both vendors answer HTTP 200 in that case, so this is
+    /// what stops a per-URL failure becoming an empty-content success.
+    #[error("web search provider {provider} could not extract the page")]
+    PageNotExtracted { provider: WebSearchProviderKind },
     #[error("web search provider {provider} returned an invalid response")]
     InvalidResponse { provider: WebSearchProviderKind },
     #[error("web search provider returned an invalid result URL")]
@@ -646,6 +677,38 @@ fn canonical_http_url(value: &str) -> Result<String, WebSearchError> {
 
 pub(crate) fn truncate(value: &str, max_chars: usize) -> String {
     value.chars().take(max_chars).collect()
+}
+
+/// Words carrying at least one alphanumeric character.
+///
+/// Punctuation-only tokens are not words, so a page of navigation glyphs
+/// cannot clear [`MIN_EXTRACT_WORDS`] on separators alone.
+pub(crate) fn count_words(value: &str) -> usize {
+    value
+        .split_whitespace()
+        .filter(|token| token.chars().any(char::is_alphanumeric))
+        .count()
+}
+
+/// Whether a URL a provider echoed back names the page that was requested.
+///
+/// Both extract endpoints answer HTTP 200 on a partial failure and report the
+/// per-URL outcome in a side array, so a response must be matched by URL key
+/// and never by array position. Providers may normalize what they echo — host
+/// case, an added root path — so parsed forms are compared, with exact bytes as
+/// the fallback for an identifier that is not a URL at all.
+pub(crate) fn same_page_url(candidate: &str, requested: &str) -> bool {
+    if candidate == requested {
+        return true;
+    }
+    match (Url::parse(candidate), Url::parse(requested)) {
+        (Ok(mut candidate), Ok(mut requested)) => {
+            candidate.set_fragment(None);
+            requested.set_fragment(None);
+            candidate == requested
+        }
+        _ => false,
+    }
 }
 
 fn contains_control(value: &str) -> bool {

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -21,7 +21,7 @@ The current foreground agent surface contains nineteen tools:
 | `read_source` | Read a bounded canonical-text range from one source and create citable evidence | Server, read-only |
 | `read_tool_result` | Read past the point a large tool result was cut short for the turn | Server, read-only |
 | `web_search` | Search the public web through the configured Exa or Tavily provider | Server, sensitive approval |
-| `web_extract` | Fetch one exact public page URL and return its readable content | Server, sensitive approval |
+| `web_extract` | Fetch one exact public page URL and return its readable content, through the configured provider or the built-in engine | Server, sensitive approval |
 | `request_folder_access` | Ask the trusted desktop host to connect another folder | Client continuation |
 | `list_connected_folders` | List roots already attached to this chat | Native client continuation |
 | `list_folder` | List one directory below an attached root | Native client continuation |
@@ -301,7 +301,10 @@ only then resolves current host policy and credentials. `web_extract` sits
 beside it on the same terms: Sensitive, with the exact page URL on the
 approval card, and routed deterministically to the configured provider when it
 implements the extract contract or to the built-in native extraction engine
-otherwise — see [Web search](web-search.md) for the routing and fetch-policy
+otherwise. Exa and Tavily both implement it, so a configured host extracts
+through the vendor and falls back to native — except on a rejected key, which
+surfaces for repair rather than degrading silently. See
+[Web search](web-search.md) for the routing, wire shapes, and fetch-policy
 details. Turn cancellation drops
 an in-flight tool future, aborting its HTTP request. The sandbox path remains a
 separate checkpoint executor: it attaches host policy only after claiming and

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -82,8 +82,34 @@ capability split (`supports_search` / `supports_extract`); extraction goes to
 the configured provider exactly when it implements the extract contract, and to
 the built-in native engine otherwise — including when the provider is
 search-only or when no provider is configured at all. Extraction therefore
-works with zero web-search configuration. Neither Exa nor Tavily implements
-the extract contract yet, so every extraction currently routes native.
+works with zero web-search configuration.
+
+Exa and Tavily both implement the extract contract, so a host with either
+selected extracts through the vendor and falls back to native. They reach
+`https://api.exa.ai/contents` and `https://api.tavily.com/extract`, on the same
+fixed authority their search calls use, with the key as a bearer token.
+
+| | Exa | Tavily |
+| --- | --- | --- |
+| Request | one URL, `text` always sent explicitly, bounded at the source with `text.maxCharacters` (10,000) | one URL, `extract_depth: basic`, `format: markdown` |
+| Freshness | `maxAgeHours: 24`, the supported replacement for the deprecated `livecrawl` selector | vendor default |
+| Title | taken from the response | none in the response; reported empty rather than invented |
+| Per-URL failure | HTTP 200 with the URL absent from `results` and an error in `statuses` | HTTP 200 with the URL in `failed_results` |
+
+Both endpoints answer HTTP 200 when the single requested URL failed, so the
+adapters read the per-URL outcome first and match results by URL key rather
+than array position. A missing, failed, or too-thin result is a typed
+`PageNotExtracted`, never an extraction with nothing in it. The vendor's own
+error tag or prose is not deserialized at all: it would only ever be forwarded,
+and no vendor string belongs in a model context.
+
+Request-level statuses are mapped to typed errors so the routing can act on
+them: `401` is a rejected credential, Exa's `402` and Tavily's nonstandard `432`
+(plan allowance) and `433` (pay-as-you-go balance) are an exhausted quota,
+`429` is a rate limit, and everything else stays a plain HTTP status. The
+timeout is the host's clamped `timeout_ms` for both search and extraction;
+neither adapter takes a timeout of its own and no extract call carries one in
+its payload.
 
 The native engine (the crate's `extract-native` feature) admits a URL through
 a strict fetch policy — https only, no userinfo, default port, and a denied
@@ -94,13 +120,19 @@ addresses. Fetches carry no cookies or ambient credentials, stream under a hard
 byte cap, gate on a textual content-type allowlist, and reduce the page with a
 readability pass to bounded markdown.
 
-Failure is layered and never silent. A vendor extract failure falls back to
-the native engine for that request. A native failure returns a closed,
-actionable reason ("the page returned HTTP 404", "no readable content could be
-extracted from the page") with no transport or vendor diagnostics attached.
-When no extraction path exists at all, the tool returns the same typed
-configuration-required failure web search uses, which the desktop renders as a
-settings card. Every successful extraction is stamped with its
+Failure is layered and never silent. A vendor extract failure — quota, rate
+limit, timeout, a page the vendor could not read — falls back to the native
+engine for that request, with no vendor diagnostic crossing either way. The one
+exception is a rejected API key: that is host configuration rather than a
+property of the page, it will reject every later call, and it is the same key
+web search uses, so falling back would hide a broken configuration behind
+quietly degraded extraction forever. It surfaces as the typed
+configuration-required failure instead, which the desktop renders as the
+settings card that repairs it. A native failure returns a closed, actionable
+reason ("the page returned HTTP 404", "no readable content could be extracted
+from the page") with no transport or vendor diagnostics attached. When no
+extraction path exists at all, the tool returns that same typed
+configuration-required failure. Every successful extraction is stamped with its
 `extraction_method` (`native` or the provider name) so degraded extraction
 stays visible downstream.
 


### PR DESCRIPTION
Stacked on #934. Both providers now declare extract support and
implement it, so a configured provider does the extraction and the
native engine becomes the fallback rather than the only path. This
completes the capability: search finds a page, extraction opens it, and
which engine did the work is recorded on the result.

## The partial-failure trap

Neither vendor reports a failed page as a failed request. Both answer
`200` with the page's failure in a side channel — Exa in a `statuses`
array parallel to `results`, Tavily in a `failed_results` array beside
them — so a client that reads `results[0]` turns a refusal into an empty
success and hands the model a blank page it believes is real. Responses
are matched back to the requested URL by key rather than by position,
and a page that came back empty, unmatched, or under the readable-word
floor is a typed failure that falls through to native. Both cases are
tested, for both vendors; they are the subtle ones.

A URL a vendor echoes back is adopted only if it passes the same
admission policy the native path applies to every redirect hop — a
vendor is a less hostile source than an open redirect, but it is still
not a reason to skip the check.

## Failure mapping

| Condition | Outcome |
| --- | --- |
| 401 | surfaces as a configuration failure |
| Exa 402, Tavily 432/433 (quota) | falls back to native |
| 429 | falls back to native |
| 4xx/5xx, transport, timeout | falls back to native |
| 200 with per-URL failure, no match, or too few words | falls back to native |

**Auth does not fall back.** A rejected key describes the host's
configuration rather than the page, it will reject every later call
identically, and it is the same key web search uses — so falling back
would hide a broken setup behind extraction that quietly got worse,
which is the failure mode the method stamp exists to make visible. It
returns the configuration failure that renders the settings card
repairing both tools. Quota is different and does fall back: it clears
on its own, native is an adequate substitute, and the stamp records that
the result was degraded.

## Notes

Tavily's extract response has no title field, so the title is left
empty — the field is already documented as empty when a page provides
none, and deriving one from the first heading would put a guess where a
fact belongs. Exa's response is bounded at the source with
`maxCharacters` rather than relying on the output ladder, with a
compile-time assert keeping the two consistent. No `query` is sent to
Tavily: it would replace the page with reranked chunks.

No new dependencies, no lockfile movement. Coverage is fixture-driven
through the injected HTTP client — the wire shapes come from each
vendor's published contract, not from a live response, so first contact
with a real endpoint is still ahead of us.