### PR TITLE
fix(server): set the chat citation format in container run tests

### DIFF
--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -257,6 +257,7 @@ async fn store() -> (tempfile::TempDir, Arc<dyn Store>, Chat) {
         model: Some("host-model".into()),
         permission_mode: None,
         reasoning_effort: None,
+        citation_format: None,
         attachment_revision: 0,
         root_attachments: Vec::new(),
         created_at: chrono::Utc::now(),


### PR DESCRIPTION
The test build is broken on `main` right now:

```
error[E0063]: missing field `citation_format` in initializer of `openwave_core::Chat`
   --> crates/openwave-server/src/sandbox_container_run/tests.rs:253:16
```

Two changes landed independently — one gave a chat a citation format,
the other added container-run tests that build a chat. Each compiled
against the `main` it was written on, so both went green, and the merge
of the two does not compile. Neither PR did anything wrong; this is the
gap a per-PR build cannot see.

One field, matching every other test chat in the crate.