### PR TITLE
fix(server): restore the container-run test's Chat literal

### DIFF
--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -257,6 +257,7 @@ async fn store() -> (tempfile::TempDir, Arc<dyn Store>, Chat) {
         model: Some("host-model".into()),
         permission_mode: None,
         reasoning_effort: None,
+        citation_format: None,
         attachment_revision: 0,
         root_attachments: Vec::new(),
         created_at: chrono::Utc::now(),


### PR DESCRIPTION
`main` does not currently compile under `--all-targets`:

```
error[E0063]: missing field `citation_format` in initializer of `openwave_core::Chat`
   --> crates/openwave-server/src/sandbox_container_run/tests.rs:253:16
```

A semantic conflict rather than anyone's mistake: #917 added `Chat::citation_format` and #894 added `sandbox_container_run/tests.rs` in the same window. Each was green against the base it branched from, and neither diff touched the other's file, so nothing flagged it until both were on `main` together.

The fix sets the field to the same `None` every other test literal uses. No behavior change.

Verified: `cargo check -p openwave-server --locked --all-targets` is clean with this applied, and reproduces the failure without it.