### PR TITLE
fix(server): add citation_format to the container-run test chat literal

### DIFF
--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -257,6 +257,7 @@ async fn store() -> (tempfile::TempDir, Arc<dyn Store>, Chat) {
         model: Some("host-model".into()),
         permission_mode: None,
         reasoning_effort: None,
+        citation_format: None,
         attachment_revision: 0,
         root_attachments: Vec::new(),
         created_at: chrono::Utc::now(),


### PR DESCRIPTION
## Unblocks a red main

`main` currently fails clippy + test (compile error): #919's `sandbox_container_run/tests.rs` builds a `Chat` literal that predates the required `citation_format` field #917 added to `Chat`. #919 merged against a base that didn't yet have the field (a green-in-isolation / red-when-merged semantic conflict), so main no longer compiles — blocking every in-flight PR.

One-line fix: add `citation_format: None` to the test literal, matching the other `Chat` literals in the tree.

## Verification
- `cargo test -p openwave-server --no-run --locked` compiles clean (was the failing target).