### PR TITLE
feat(retrieval): structured-path citations for JSON, XML, and HTML

### DIFF
--- a/crates/openwave-core/src/citation.rs
+++ b/crates/openwave-core/src/citation.rs
@@ -184,7 +184,12 @@ pub(crate) fn project_citation_pages(
     // that start at the same point.
     let mut rects = BTreeSet::new();
     for region in regions {
-        let SourceLocation::Page { number, bounds } = region.location;
+        // A region that names something other than a page has no page to
+        // paint; document-content evidence never carries one, and a location
+        // this projection does not recognize is left out rather than guessed at.
+        let SourceLocation::Page { number, bounds } = region.location else {
+            continue;
+        };
         let page = number.get();
         if pages.len() < MAX_CITATION_PAGES && !pages.contains(&page) {
             pages.push(page);

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -104,6 +104,29 @@ pub enum SourceLocation {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         bounds: Option<PageBounds>,
     },
+    /// One node of a structured source — a JSON value, an XML or HTML element.
+    ///
+    /// A structured source has no pages: its canonical text is the file itself,
+    /// and the position a reader opens is a node of the tree the file parses
+    /// into. The path is recorded alongside the span rather than instead of it,
+    /// because the span is still what addresses the extracted text.
+    StructuredPath {
+        /// The path itself, interpreted according to `path_type`.
+        path: String,
+        /// How to read the path.
+        path_type: StructuredPathType,
+    },
+}
+
+impl SourceLocation {
+    /// The structured path this location names, where it names one.
+    #[must_use]
+    pub fn structured_path(&self) -> Option<(&str, StructuredPathType)> {
+        match self {
+            Self::StructuredPath { path, path_type } => Some((path.as_str(), *path_type)),
+            _ => None,
+        }
+    }
 }
 
 /// Mapping from canonical text back to a location in the original source.
@@ -137,9 +160,20 @@ pub fn validate_source_regions(
         if region.span.start < previous_end {
             return Err("source regions must be ordered and nonoverlapping");
         }
-        let SourceLocation::Page { bounds, .. } = &region.location;
-        if bounds.is_some_and(|bounds| !bounds.is_valid()) {
-            return Err("source region bounds must be nonempty and within the page");
+        match &region.location {
+            SourceLocation::Page { bounds, .. } => {
+                if bounds.is_some_and(|bounds| !bounds.is_valid()) {
+                    return Err("source region bounds must be nonempty and within the page");
+                }
+            }
+            SourceLocation::StructuredPath { path, .. } => {
+                if path.is_empty()
+                    || path.len() > EvidenceLocation::MAX_STRUCTURED_PATH_BYTES
+                    || path.contains('\0')
+                {
+                    return Err("structured source region paths must be nonempty and bounded");
+                }
+            }
         }
         previous_end = region.span.end;
     }
@@ -883,6 +917,48 @@ impl EvidenceLocation {
             }
         }
     }
+
+    /// The location a passage occupies, given the parser regions its span maps
+    /// to and the headings above it.
+    ///
+    /// The regions decide the kind. A parser that resolved a structured source
+    /// hands back node paths, and a passage covering several of them is at the
+    /// node that contains them all — the enclosing record of three quoted
+    /// fields, not the first of the three. When the passage covers so much of
+    /// the tree that the only common node is the root, which has no path, the
+    /// first node it touches is where a reader is sent instead. Anything else
+    /// is document content, which is what pages, headings, and geometry
+    /// describe.
+    #[must_use]
+    pub fn for_source_regions(
+        heading_path: Vec<String>,
+        source_regions: Vec<SourceRegion>,
+    ) -> Self {
+        let Some((first, path_type)) = source_regions
+            .first()
+            .and_then(|region| region.location.structured_path())
+        else {
+            return Self::DocumentContent {
+                heading_path,
+                source_regions,
+            };
+        };
+        let mut common = first;
+        for region in &source_regions[1..] {
+            let Some((path, kind)) = region.location.structured_path() else {
+                continue;
+            };
+            if kind != path_type {
+                continue;
+            }
+            common = path_type.common_ancestor(common, path);
+        }
+        let path = if common.is_empty() { first } else { common };
+        Self::StructuredPath {
+            path: path.to_owned(),
+            path_type,
+        }
+    }
 }
 
 /// How the `path` of a structured-path evidence location is written.
@@ -895,6 +971,44 @@ pub enum StructuredPathType {
     JsonDotNotation,
     /// An XPath expression into an XML or HTML document.
     XmlXpath,
+}
+
+impl StructuredPathType {
+    /// The character that separates one step of a path of this kind.
+    #[must_use]
+    pub const fn separator(self) -> char {
+        match self {
+            Self::JsonDotNotation => '.',
+            Self::XmlXpath => '/',
+        }
+    }
+
+    /// The deepest node both paths lie under, as a path of the same kind.
+    ///
+    /// Empty when the two share no addressable node: two JSON paths under
+    /// different top-level keys, or two XPaths whose only common step is the
+    /// document itself. The root of a tree has no path, so an empty answer is
+    /// the honest one rather than a path that addresses everything.
+    #[must_use]
+    pub fn common_ancestor<'a>(self, left: &'a str, right: &str) -> &'a str {
+        let separator = self.separator();
+        let matched: usize = left
+            .split(separator)
+            .zip(right.split(separator))
+            .take_while(|(left_step, right_step)| left_step == right_step)
+            .map(|(left_step, _)| left_step.len())
+            .sum::<usize>();
+        let steps = left
+            .split(separator)
+            .zip(right.split(separator))
+            .take_while(|(left_step, right_step)| left_step == right_step)
+            .count();
+        // The shared steps are rejoined by the separator they were split on, so
+        // the prefix is their bytes plus one separator between each pair. An
+        // XPath's leading step is empty, which leaves the root as the empty
+        // path it is.
+        &left[..matched + steps.saturating_sub(1)]
+    }
 }
 
 /// Whether `cell` is an A1-notation reference: a column of letters followed by

--- a/crates/openwave-desktop/ui/src/AssistantSources.tsx
+++ b/crates/openwave-desktop/ui/src/AssistantSources.tsx
@@ -1,6 +1,6 @@
 import { ChevronRight } from "lucide-react";
 
-import type { CitationPageBounds } from "@/api";
+import type { CitationPageBounds, StructuredPathType } from "@/api";
 
 export type AssistantSource = Readonly<{
   id: string;
@@ -22,6 +22,13 @@ export type AssistantSource = Readonly<{
    * either way.
    */
   bounds: readonly CitationPageBounds[];
+  /**
+   * The node of a structured source the passage came from, for a source that
+   * is a tree rather than a run of pages: a dot path into JSON, an XPath into
+   * XML or HTML. Absent for every other kind of source, which is addressed by
+   * its span and its pages.
+   */
+  structuredPath?: Readonly<{ path: string; pathType: StructuredPathType }>;
 }>;
 
 type AssistantSourcesProps = {

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -85,6 +85,13 @@ export function hydrateTranscriptHistory(
                   location.kind === "document_content" ? location.pages : [],
                 bounds:
                   location.kind === "document_content" ? location.bounds : [],
+                // A structured source is opened at a node instead: the tree
+                // viewers navigate by path, and the span alone names nothing
+                // they can expand or scroll to.
+                structuredPath:
+                  location.kind === "structured_path"
+                    ? { path: location.path, pathType: location.path_type }
+                    : undefined,
               }),
             )
           : [],

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -48,6 +48,7 @@ import {
   type ChatToolActivityStatus,
   type CitationFormat as WireCitationFormat,
   type CitationPageBounds as WireCitationPageBounds,
+  type StructuredPathType as WireStructuredPathType,
   type RendererAgentEvent,
   type RendererChatFrame,
   type RendererChatMetadata,
@@ -240,6 +241,12 @@ export type ChatMessageCitation = AssistantCitationSnapshot;
  * places it as a fraction of whatever size the page was rendered at.
  */
 export type CitationPageBounds = WireCitationPageBounds;
+
+/**
+ * How a citation's node path is written: dotted keys and indices for JSON, an
+ * XPath expression for XML and HTML.
+ */
+export type StructuredPathType = WireStructuredPathType;
 
 /** One durable image identity in a historical user message. */
 export type ChatMessageImageAttachment = WireTranscriptImageAttachment;

--- a/crates/openwave-desktop/ui/src/components/document/document-details.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/document-details.tsx
@@ -70,7 +70,7 @@ export function isDocumentRenderable(mediaType: string): boolean {
  * source sniffed as `image/svg+xml` or `application/ld+json` is that tree
  * shape, and a reader opening one wants the tree rather than a wall of text.
  */
-function structuredKind(type: string): "json" | "xml" | null {
+export function structuredKind(type: string): "json" | "xml" | null {
   if (type === "application/json" || type.endsWith("+json")) return "json";
   if (type === "application/xml" || type === "text/xml" || type.endsWith("+xml")) {
     return "xml";
@@ -87,10 +87,10 @@ type DocumentDetailsProps = {
    * Node to reveal in a tree viewer, when opened from a citation: a
    * dot-notation path for JSON, an XPath expression for XML.
    *
-   * Uncalled, and not derivable from a citation: a citation addresses a byte
-   * range of the text read out of the file, and which node of the parsed tree
-   * that range came from is not recorded anywhere. The viewers honour the prop,
-   * so a producer of node paths would only have to reach this far.
+   * Recorded when the source was parsed and carried on the citation beside its
+   * span, so a citation into a tree opens at the node it quoted rather than at
+   * the top of the file. Absent for a citation into a source with no tree, and
+   * for one made before its source's paths were recorded.
    */
   highlightPath?: string;
   /**

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
@@ -299,6 +299,51 @@ describe("DocumentDetailRoot", () => {
     expect(screen.queryByText(body)).toBeNull();
   });
 
+  // A tree is navigated by node, so a citation into one carries the path of the
+  // node it quoted beside its span. Everything below the root opens collapsed,
+  // which is why the quoted value is only on screen when the path arrived: it
+  // is what expands the record holding it.
+  const INVOICES_JSON = '{"invoices":[{"number":"A-1"},{"number":"B-2"}]}';
+  const INVOICES_XML =
+    "<invoices><invoice><number>A-1</number></invoice><invoice><number>B-2</number></invoice></invoices>";
+
+  it.each([
+    [
+      "application/json",
+      INVOICES_JSON,
+      { path: "invoices.1.number", pathType: "json_dot_notation" as const },
+    ],
+    [
+      "application/xml",
+      INVOICES_XML,
+      { path: "/invoices[1]/invoice[2]/number[1]", pathType: "xml_xpath" as const },
+    ],
+  ])(
+    "opens a citation into a %s tree at the node it quoted",
+    async (mediaType, body, structuredPath) => {
+      seedTranscript({ id: "cite-tree", structuredPath });
+      await openCitation(
+        detail({ media_type: mediaType, title: "Invoices", content: body }),
+        "cite-tree",
+        body,
+      );
+
+      const cited = await screen.findByText(/B-2/);
+      expect(scrolledTo).toContain(cited.closest("div"));
+    },
+  );
+
+  it("opens a tree collapsed when nothing pointed into it", async () => {
+    await openPanel(
+      detail({ media_type: "application/json", title: "Invoices" }),
+      vi.fn(),
+      INVOICES_JSON,
+    );
+
+    expect(await screen.findByRole("button", { name: "Collapse all" })).toBeVisible();
+    expect(screen.queryByText(/B-2/)).toBeNull();
+  });
+
   // The outline slugs the raw markdown and the renderer slugs the rendered
   // heading, independently. This is the only test that puts the two together,
   // so it is what would catch them drifting apart.

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
 
-import { HttpError, type DocumentDetail } from "@/api";
+import { HttpError, type DocumentDetail, type StructuredPathType } from "@/api";
 import { useApp } from "@/AppContext";
 import {
+  baseMediaType,
   DocumentDetails,
   isDocumentRenderable,
+  structuredKind,
   type DocumentView,
 } from "@/components/document/document-details";
 import { DocumentError } from "@/components/document/error";
@@ -91,6 +93,20 @@ export function DocumentDetailRoot({
       ? placement.bounds
       : undefined;
 
+  // A node path only opens a source the panel draws as a tree, and only in the
+  // notation that tree is addressed by. A JSON path handed to the XML viewer
+  // resolves to nothing, so a mismatch is treated as no path at all rather than
+  // as a highlight that silently never appears.
+  const treeKind = info ? structuredKind(baseMediaType(info.media_type)) : null;
+  const pathKind = treeViewerForPath(placement?.structuredPath?.pathType);
+  const citationPath =
+    placement?.structuredPath != null &&
+    hasOriginalDocumentTab &&
+    pathKind != null &&
+    pathKind === treeKind
+      ? placement.structuredPath.path
+      : undefined;
+
   // Arriving from a citation, land on whichever view can show where it points:
   // the recorded page of a paginated original, or else the extracted text,
   // where the passage itself is highlighted. A citation the transcript cannot
@@ -102,7 +118,7 @@ export function DocumentDetailRoot({
   // showing nothing at all rather than saying what went wrong.
   const citationView: DocumentView | null = !placement
     ? null
-    : citationPage != null && hasOriginalDocumentTab
+    : (citationPage != null || citationPath != null) && hasOriginalDocumentTab
       ? "original_doc"
       : "extracted_text";
 
@@ -179,6 +195,7 @@ export function DocumentDetailRoot({
           view={view}
           hasOriginalDocumentTab={hasOriginalDocumentTab}
           citationSpan={placement?.span}
+          highlightPath={citationPath}
           targetPage={citationPage}
           citationBounds={citationBounds}
         />
@@ -194,6 +211,26 @@ export function DocumentDetailRoot({
       )}
     </PanelFrame>
   );
+}
+
+/**
+ * Which tree viewer reads a path of this notation, where one does.
+ *
+ * A notation this build does not know resolves to nothing rather than to a
+ * guess, so a citation written by a newer server opens the source normally
+ * instead of highlighting the wrong node.
+ */
+function treeViewerForPath(
+  pathType: StructuredPathType | undefined,
+): "json" | "xml" | null {
+  switch (pathType) {
+    case "json_dot_notation":
+      return "json";
+    case "xml_xpath":
+      return "xml";
+    default:
+      return null;
+  }
 }
 
 /** Why the source did not load, and whether asking again could help. */

--- a/crates/openwave-desktop/ui/src/document-detail/citationPlacement.ts
+++ b/crates/openwave-desktop/ui/src/document-detail/citationPlacement.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 
-import type { CitationPageBounds } from "@/api";
+import type { CitationPageBounds, StructuredPathType } from "@/api";
 import { useChatSessionStore } from "@/ChatSessionStore";
 import type { CitationSpan } from "@/components/document/citationSpan";
 import type { ChatMessage } from "@/MessageList";
@@ -17,6 +17,12 @@ export type CitationPlacement = {
    * drawn on it.
    */
   bounds: readonly CitationPageBounds[];
+  /**
+   * The node the passage came from, for a source read as a tree. It is carried
+   * beside the span rather than instead of it: the span still addresses the
+   * extracted text, and the path is what the original view opens at.
+   */
+  structuredPath?: Readonly<{ path: string; pathType: StructuredPathType }>;
 };
 
 /**
@@ -42,6 +48,7 @@ export function findCitationPlacement(
         span: { start: source.span.start, end: source.span.end },
         page: earliestPage(source.pages, source.bounds),
         bounds: source.bounds,
+        structuredPath: source.structuredPath,
       };
     }
   }

--- a/crates/openwave-retrieval/src/document.rs
+++ b/crates/openwave-retrieval/src/document.rs
@@ -182,6 +182,10 @@ impl Document {
     /// that happens the regions are coalesced by page: the page a passage came
     /// from is the part worth keeping, and the geometry within it is the part
     /// worth losing.
+    ///
+    /// A structured source coalesces the same way one level up the tree: a
+    /// passage crossing four hundred cells of a table is at the table, and the
+    /// enclosing node is what survives when the individual ones cannot.
     #[must_use]
     pub fn source_regions_for(&self, span: ByteSpan) -> Vec<SourceRegion> {
         let clipped: Vec<SourceRegion> = self
@@ -199,8 +203,52 @@ impl Document {
         if clipped.len() <= RetrievalEvidenceInput::MAX_SOURCE_REGIONS {
             return clipped;
         }
+        if clipped
+            .iter()
+            .all(|region| region.location.structured_path().is_some())
+        {
+            return coalesce_by_ancestor(clipped);
+        }
         coalesce_by_page(clipped)
     }
+}
+
+/// Fold a run of structured-path regions into at most the number of regions
+/// evidence carries, naming each group by the deepest node its members share.
+///
+/// Regions arrive ordered, so a group is a contiguous stretch of the passage
+/// and the node above them all is a true description of it. A group whose
+/// members share no node at all — spanning two top-level keys, say — keeps the
+/// first node it touches, which is at least somewhere the reader can be sent.
+fn coalesce_by_ancestor(regions: Vec<SourceRegion>) -> Vec<SourceRegion> {
+    let limit = RetrievalEvidenceInput::MAX_SOURCE_REGIONS;
+    let group_size = regions.len().div_ceil(limit).max(1);
+    regions
+        .chunks(group_size)
+        .filter_map(|group| {
+            let first = group.first()?;
+            let (first_path, path_type) = first.location.structured_path()?;
+            let common = group
+                .iter()
+                .filter_map(|region| region.location.structured_path())
+                .filter(|(_, kind)| *kind == path_type)
+                .fold(first_path, |common, (path, _)| {
+                    path_type.common_ancestor(common, path)
+                });
+            let path = if common.is_empty() {
+                first_path
+            } else {
+                common
+            };
+            Some(SourceRegion {
+                span: ByteSpan::new(first.span.start, group.last()?.span.end),
+                location: SourceLocation::StructuredPath {
+                    path: path.to_owned(),
+                    path_type,
+                },
+            })
+        })
+        .collect()
 }
 
 /// Merge consecutive regions that name the same page into one region for that

--- a/crates/openwave-retrieval/src/lib.rs
+++ b/crates/openwave-retrieval/src/lib.rs
@@ -91,6 +91,7 @@ mod retriever;
 #[cfg(feature = "tool")]
 mod search;
 mod selection;
+mod structure;
 mod vector;
 
 pub use chunk::{Chunker, TextChunker};
@@ -112,7 +113,10 @@ pub use liteparse_parser::LiteParsePdfParser;
 #[cfg(feature = "embed-openai")]
 pub use openai_embed::OpenAiEmbedder;
 pub use openwave_core::{DocumentGeneration, ProjectId};
-pub use parse::{DocumentParser, FallbackParser, ParsedDocument, ParserRegistry, PlainTextParser};
+pub use parse::{
+    DocumentParser, FallbackParser, ParsedDocument, ParserRegistry, PlainTextParser,
+    StructuredTextParser,
+};
 pub use rerank::Reranker;
 pub use retriever::{GenerationIndexOutcome, IngestOutcome, Retriever};
 #[cfg(feature = "tool")]

--- a/crates/openwave-retrieval/src/parse.rs
+++ b/crates/openwave-retrieval/src/parse.rs
@@ -187,6 +187,52 @@ impl DocumentParser for PlainTextParser {
     }
 }
 
+/// The parser for tree-shaped text: JSON, XML, and HTML.
+///
+/// Canonical text is the file itself, exactly as [`PlainTextParser`] would have
+/// produced it — nothing is extracted, converted, or reordered, so spans keep
+/// addressing the bytes a reader downloads. What this parser adds is the map
+/// from those spans to the nodes they came from, which is what lets a citation
+/// open the document as a tree rather than as a wall of characters.
+///
+/// A file that does not parse is still indexed: it yields the same text with an
+/// empty map, which is indistinguishable downstream from a format that has no
+/// structure to record.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct StructuredTextParser;
+
+impl StructuredTextParser {
+    /// Construct the parser.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait::async_trait]
+impl DocumentParser for StructuredTextParser {
+    fn fingerprint_for(&self, media_type: &str) -> Option<String> {
+        crate::structure::structured_format(media_type).map(crate::structure::structure_fingerprint)
+    }
+
+    fn supports(&self, media_type: &str) -> bool {
+        crate::structure::structured_format(media_type).is_some()
+    }
+
+    async fn parse(&self, raw: &[u8], media_type: &str) -> Result<ParsedDocument> {
+        let format = crate::structure::structured_format(media_type).ok_or_else(|| {
+            RetrievalError::parse(format!(
+                "StructuredTextParser does not support media type `{media_type}`"
+            ))
+        })?;
+        // Lossy for the same reason plain text is: one bad byte in a large
+        // export should cost that byte, not the document.
+        let text = String::from_utf8_lossy(raw).into_owned();
+        let regions = crate::structure::structured_regions(&text, format);
+        Ok(ParsedDocument::from_text(text).with_source_regions(regions))
+    }
+}
+
 /// A last-resort parser that accepts **any** media type so no upload is rejected
 /// for its format alone.
 ///

--- a/crates/openwave-retrieval/src/search.rs
+++ b/crates/openwave-retrieval/src/search.rs
@@ -293,10 +293,10 @@ impl Tool for SearchTool {
                     chunk_id: citation.chunk_id,
                     span: citation.span,
                     snippet: citation.snippet.clone(),
-                    location: EvidenceLocation::DocumentContent {
-                        heading_path: citation.heading_path.clone(),
-                        source_regions: citation.source_regions.clone(),
-                    },
+                    location: EvidenceLocation::for_source_regions(
+                        citation.heading_path.clone(),
+                        citation.source_regions.clone(),
+                    ),
                     source: match &citation.source {
                         crate::DocumentSource::Uri { uri } => {
                             RetrievalEvidenceSource::Uri { uri: uri.clone() }

--- a/crates/openwave-retrieval/src/structure.rs
+++ b/crates/openwave-retrieval/src/structure.rs
@@ -1,0 +1,777 @@
+//! Node paths for structured sources: which part of the tree a byte span came
+//! from.
+//!
+//! JSON, XML, and HTML are indexed as their own text — nothing is extracted out
+//! of them, so a chunk's byte span already addresses the file verbatim. That is
+//! enough to highlight a passage in the extracted text and not enough to open
+//! the file as the tree it is, because "bytes 4100–5300" names no node. This
+//! module walks the source once and records, for each run of leaf content, the
+//! path of the node it belongs to. Those become [`SourceRegion`]s beside the
+//! spans they describe, so a passage retrieved later resolves to a node without
+//! reparsing the document.
+//!
+//! Paths are written in the notation each tree is addressed by: dotted keys and
+//! indices for JSON (`items.0.invoice_number`), an XPath for XML and HTML
+//! (`/invoices[1]/invoice[3]/total[1]`).
+//!
+//! Both scanners are lenient about what they cannot read: a document that does
+//! not parse yields no regions at all, which costs the node view and leaves
+//! everything else — text, chunks, spans, citations — exactly as it was.
+
+use std::collections::HashMap;
+
+use openwave_core::{ByteSpan, EvidenceLocation, SourceLocation, SourceRegion, StructuredPathType};
+
+/// Deepest nesting either scanner follows.
+///
+/// Past this the paths are longer than anything a reader navigates by, and the
+/// documents that reach it are generated rather than written. Exceeding it
+/// abandons the walk rather than truncating paths, because a truncated path
+/// addresses the wrong node.
+const MAX_DEPTH: usize = 128;
+
+/// Most regions one document's structure map holds.
+///
+/// A structure map is stored with the document and read back on every search
+/// that touches it, so a machine-generated file with a million leaves must not
+/// turn into a million rows. Past the limit the document keeps its text, spans,
+/// and citations and loses only the node view.
+const MAX_REGIONS: usize = 50_000;
+
+/// Which tree shape a source parses into.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StructuredFormat {
+    Json,
+    Xml,
+}
+
+impl StructuredFormat {
+    const fn path_type(self) -> StructuredPathType {
+        match self {
+            Self::Json => StructuredPathType::JsonDotNotation,
+            Self::Xml => StructuredPathType::XmlXpath,
+        }
+    }
+
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Json => "json",
+            Self::Xml => "xml",
+        }
+    }
+}
+
+/// The tree shape a media type declares, if it declares one.
+///
+/// The `+json` and `+xml` suffixes are matched as well as the base types, so a
+/// source typed `application/ld+json` or `application/xhtml+xml` is read as the
+/// tree it is. Images are excluded even when they carry an XML syntax: an SVG
+/// is opened as a picture, and a path into one addresses nothing a reader sees.
+pub(crate) fn structured_format(media_type: &str) -> Option<StructuredFormat> {
+    let base = media_type
+        .split(';')
+        .next()
+        .unwrap_or(media_type)
+        .trim()
+        .to_ascii_lowercase();
+    if base.starts_with("image/") {
+        return None;
+    }
+    if base == "application/json" || base.ends_with("+json") {
+        return Some(StructuredFormat::Json);
+    }
+    if base == "application/xml"
+        || base == "text/xml"
+        || base == "text/html"
+        || base.ends_with("+xml")
+    {
+        return Some(StructuredFormat::Xml);
+    }
+    None
+}
+
+/// Map `text` to the node each of its leaf runs belongs to.
+///
+/// Returns an empty map for a document that does not parse, which is the same
+/// answer as "this format carries no structure" and is handled identically
+/// everywhere downstream.
+pub(crate) fn structured_regions(text: &str, format: StructuredFormat) -> Vec<SourceRegion> {
+    let regions = match format {
+        StructuredFormat::Json => JsonScanner::new(text).run(),
+        StructuredFormat::Xml => scan_markup(text),
+    };
+    match regions {
+        Some(regions) if regions.len() <= MAX_REGIONS => regions
+            .into_iter()
+            .map(|(span, path)| SourceRegion {
+                span,
+                location: SourceLocation::StructuredPath {
+                    path,
+                    path_type: format.path_type(),
+                },
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// A stable identity for this module's path-building behavior, per format.
+///
+/// Part of the parser fingerprint: changing how a path is written changes what
+/// a stored region means, and stored regions are only rebuilt when the
+/// fingerprint moves.
+pub(crate) fn structure_fingerprint(format: StructuredFormat) -> String {
+    format!("structure-v1:{}", format.name())
+}
+
+/// One recorded run of leaf content: the bytes it covers and the node it is in.
+type PathRegion = (ByteSpan, String);
+
+/// Record `span` under `path`, unless the path addresses nothing a reader can
+/// open: the root of a tree has no path, and one longer than evidence carries
+/// would be dropped later anyway.
+fn record(regions: &mut Vec<PathRegion>, span: ByteSpan, path: &str) {
+    if span.is_empty()
+        || path.is_empty()
+        || path.len() > EvidenceLocation::MAX_STRUCTURED_PATH_BYTES
+    {
+        return;
+    }
+    regions.push((span, path.to_owned()));
+}
+
+// ---------------------------------------------------------------------------
+// JSON
+// ---------------------------------------------------------------------------
+
+/// What a JSON value turned out to be, which decides whether its siblings can
+/// be addressed together.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Shape {
+    Scalar,
+    Container,
+}
+
+struct JsonScanner<'a> {
+    text: &'a str,
+    bytes: &'a [u8],
+    pos: usize,
+    path: String,
+    regions: Vec<PathRegion>,
+}
+
+impl<'a> JsonScanner<'a> {
+    fn new(text: &'a str) -> Self {
+        Self {
+            text,
+            bytes: text.as_bytes(),
+            pos: 0,
+            path: String::new(),
+            regions: Vec::new(),
+        }
+    }
+
+    fn run(mut self) -> Option<Vec<PathRegion>> {
+        self.value(0, 0)?;
+        self.skip_whitespace();
+        (self.pos == self.bytes.len()).then_some(self.regions)
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    fn skip_whitespace(&mut self) {
+        while matches!(self.peek(), Some(b' ' | b'\t' | b'\n' | b'\r')) {
+            self.pos += 1;
+        }
+    }
+
+    /// Parse one value, recording it under the path currently in scope.
+    ///
+    /// `start` is where a region for this value begins, which for an object
+    /// member is its key: a reader whose passage starts at `"total":` is at the
+    /// total, not in the gap before it.
+    fn value(&mut self, start: usize, depth: usize) -> Option<Shape> {
+        if depth > MAX_DEPTH || self.regions.len() > MAX_REGIONS {
+            return None;
+        }
+        self.skip_whitespace();
+        match self.peek()? {
+            b'{' => self.object(start, depth),
+            b'[' => self.array(start, depth),
+            b'"' => {
+                self.string()?;
+                record(
+                    &mut self.regions,
+                    ByteSpan::new(start, self.pos),
+                    &self.path,
+                );
+                Some(Shape::Scalar)
+            }
+            _ => {
+                self.literal()?;
+                record(
+                    &mut self.regions,
+                    ByteSpan::new(start, self.pos),
+                    &self.path,
+                );
+                Some(Shape::Scalar)
+            }
+        }
+    }
+
+    fn object(&mut self, start: usize, depth: usize) -> Option<Shape> {
+        self.pos += 1;
+        let mut members = 0_usize;
+        loop {
+            self.skip_whitespace();
+            match self.peek()? {
+                b'}' => {
+                    self.pos += 1;
+                    break;
+                }
+                b'"' => {
+                    let key_start = self.pos;
+                    let key = self.string()?;
+                    self.skip_whitespace();
+                    if self.peek()? != b':' {
+                        return None;
+                    }
+                    self.pos += 1;
+                    let scope = self.path.len();
+                    self.push_step(&key);
+                    self.value(key_start, depth + 1)?;
+                    self.path.truncate(scope);
+                    members += 1;
+                    self.skip_whitespace();
+                    match self.peek()? {
+                        b',' => self.pos += 1,
+                        b'}' => {
+                            self.pos += 1;
+                            break;
+                        }
+                        _ => return None,
+                    }
+                }
+                _ => return None,
+            }
+        }
+        if members == 0 {
+            record(
+                &mut self.regions,
+                ByteSpan::new(start, self.pos),
+                &self.path,
+            );
+        }
+        Some(Shape::Container)
+    }
+
+    fn array(&mut self, start: usize, depth: usize) -> Option<Shape> {
+        self.pos += 1;
+        let mark = self.regions.len();
+        let mut elements = 0_usize;
+        let mut all_scalar = true;
+        loop {
+            self.skip_whitespace();
+            if self.peek()? == b']' {
+                self.pos += 1;
+                break;
+            }
+            let scope = self.path.len();
+            self.push_step(&elements.to_string());
+            let element_start = self.pos;
+            all_scalar &= self.value(element_start, depth + 1)? == Shape::Scalar;
+            self.path.truncate(scope);
+            elements += 1;
+            self.skip_whitespace();
+            match self.peek()? {
+                b',' => self.pos += 1,
+                b']' => {
+                    self.pos += 1;
+                    break;
+                }
+                _ => return None,
+            }
+        }
+        // A list of plain values is one thing a reader looks at, not a hundred:
+        // `readings.417` is a number on its own, while `readings` is the series
+        // it belongs to. Lists holding objects keep their elements addressable,
+        // because those are the records the document is about.
+        if elements == 0 || (all_scalar && elements > 1) {
+            self.regions.truncate(mark);
+            record(
+                &mut self.regions,
+                ByteSpan::new(start, self.pos),
+                &self.path,
+            );
+        }
+        Some(Shape::Container)
+    }
+
+    fn push_step(&mut self, step: &str) {
+        if !self.path.is_empty() {
+            self.path.push('.');
+        }
+        self.path.push_str(step);
+    }
+
+    /// Consume a quoted string, returning it with its escapes resolved.
+    fn string(&mut self) -> Option<String> {
+        if self.peek()? != b'"' {
+            return None;
+        }
+        self.pos += 1;
+        let mut out = String::new();
+        loop {
+            match self.peek()? {
+                b'"' => {
+                    self.pos += 1;
+                    return Some(out);
+                }
+                b'\\' => {
+                    self.pos += 1;
+                    match self.peek()? {
+                        b'"' => out.push('"'),
+                        b'\\' => out.push('\\'),
+                        b'/' => out.push('/'),
+                        b'b' => out.push('\u{8}'),
+                        b'f' => out.push('\u{c}'),
+                        b'n' => out.push('\n'),
+                        b'r' => out.push('\r'),
+                        b't' => out.push('\t'),
+                        b'u' => {
+                            let hex = self.text.get(self.pos + 1..self.pos + 5)?;
+                            let code = u32::from_str_radix(hex, 16).ok()?;
+                            // Lone surrogates and pairs alike become the
+                            // replacement character: a key spelled with one is
+                            // not a key anybody navigates by, and the walk must
+                            // still reach the values after it.
+                            out.push(char::from_u32(code).unwrap_or(char::REPLACEMENT_CHARACTER));
+                            self.pos += 4;
+                        }
+                        _ => return None,
+                    }
+                    self.pos += 1;
+                }
+                _ => {
+                    // Advance by whole characters so a multi-byte value cannot
+                    // leave the cursor inside one.
+                    let rest = self.text.get(self.pos..)?;
+                    let next = rest.chars().next()?;
+                    out.push(next);
+                    self.pos += next.len_utf8();
+                }
+            }
+        }
+    }
+
+    /// Consume a number, `true`, `false`, or `null`.
+    fn literal(&mut self) -> Option<()> {
+        let start = self.pos;
+        while let Some(byte) = self.peek() {
+            if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'+' | b'.') {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        (self.pos > start).then_some(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// XML and HTML
+// ---------------------------------------------------------------------------
+
+/// HTML elements that never have a closing tag. Treated as self-closing so an
+/// `<img>` in the middle of a page does not swallow everything after it.
+const VOID_ELEMENTS: &[&str] = &[
+    "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source",
+    "track", "wbr",
+];
+
+/// One element the scanner is inside.
+struct OpenElement {
+    name: String,
+    /// Length of the path string before this element's own step, for unwinding.
+    path_scope: usize,
+    /// Byte offset of this element's `<`.
+    start: usize,
+    /// How many children of each tag name have been opened so far, which is
+    /// what makes an XPath position predicate.
+    children: HashMap<String, usize>,
+    /// Whether anything recorded inside this element belongs to a child rather
+    /// than to the element itself.
+    has_element_child: bool,
+    /// Region count when this element opened, for collapsing a leaf element's
+    /// text into the element.
+    mark: usize,
+}
+
+/// Walk markup once, recording each run of text under the element that owns it
+/// and each leaf element under itself.
+///
+/// Leniency is deliberate and matches what a reader's browser does with the
+/// same file: unmatched close tags are ignored, an element closed out of order
+/// closes what it contains, and anything still open at the end of the file
+/// contributes nothing. HTML is read by the same walk as XML — the difference
+/// that matters here is the void elements, which are listed above.
+fn scan_markup(text: &str) -> Option<Vec<PathRegion>> {
+    let bytes = text.as_bytes();
+    let mut regions: Vec<PathRegion> = Vec::new();
+    let mut stack: Vec<OpenElement> = Vec::new();
+    let mut path = String::new();
+    let mut pos = 0;
+    let mut text_start = 0;
+
+    while pos < bytes.len() {
+        if bytes[pos] != b'<' {
+            pos += 1;
+            continue;
+        }
+        flush_text(&mut regions, text, text_start, pos, &path);
+        let tag_start = pos;
+        let rest = text.get(pos..)?;
+        if rest.starts_with("<!--") {
+            pos = find_after(text, pos + 4, "-->").unwrap_or(bytes.len());
+        } else if rest.starts_with("<![CDATA[") {
+            let end = find_after(text, pos + 9, "]]>").unwrap_or(bytes.len());
+            flush_text(&mut regions, text, pos + 9, end.saturating_sub(3), &path);
+            pos = end;
+        } else if rest.starts_with("<!") || rest.starts_with("<?") {
+            pos = find_after(text, pos + 2, ">").unwrap_or(bytes.len());
+        } else if rest.starts_with("</") {
+            let (name, end) = read_tag(text, pos + 2)?;
+            pos = end;
+            close_element(&mut regions, &mut stack, &mut path, &name, tag_start, pos);
+        } else {
+            let (name, end) = read_tag(text, pos + 1)?;
+            if name.is_empty() {
+                // A bare `<` in text is not a tag; step over it and keep the
+                // character as content.
+                pos += 1;
+                text_start = tag_start;
+                continue;
+            }
+            pos = end;
+            let self_closing = (pos >= 2 && bytes[pos - 1] == b'>' && bytes[pos - 2] == b'/')
+                || VOID_ELEMENTS.contains(&name.to_ascii_lowercase().as_str());
+            if stack.len() >= MAX_DEPTH {
+                return None;
+            }
+            open_element(&mut stack, &mut path, name, tag_start, regions.len());
+            if self_closing {
+                let element = stack.pop().expect("just opened");
+                finish_element(&mut regions, element, &mut path, pos);
+            }
+        }
+        text_start = pos;
+        if regions.len() > MAX_REGIONS {
+            return None;
+        }
+    }
+    flush_text(&mut regions, text, text_start, bytes.len(), &path);
+    Some(regions)
+}
+
+fn open_element(
+    stack: &mut Vec<OpenElement>,
+    path: &mut String,
+    name: String,
+    start: usize,
+    mark: usize,
+) {
+    let index = match stack.last_mut() {
+        Some(parent) => {
+            parent.has_element_child = true;
+            let count = parent.children.entry(name.clone()).or_insert(0);
+            *count += 1;
+            *count
+        }
+        None => 1,
+    };
+    let path_scope = path.len();
+    path.push('/');
+    path.push_str(&name);
+    path.push('[');
+    path.push_str(&index.to_string());
+    path.push(']');
+    stack.push(OpenElement {
+        name,
+        path_scope,
+        start,
+        children: HashMap::new(),
+        has_element_child: false,
+        mark,
+    });
+}
+
+/// Close `name`, and with it anything left open inside it.
+fn close_element(
+    regions: &mut Vec<PathRegion>,
+    stack: &mut Vec<OpenElement>,
+    path: &mut String,
+    name: &str,
+    tag_start: usize,
+    tag_end: usize,
+) {
+    let Some(depth) = stack
+        .iter()
+        .rposition(|element| element.name.eq_ignore_ascii_case(name))
+    else {
+        return;
+    };
+    while stack.len() > depth + 1 {
+        let element = stack.pop().expect("checked depth");
+        finish_element(regions, element, path, tag_start);
+    }
+    let element = stack.pop().expect("checked depth");
+    finish_element(regions, element, path, tag_end);
+}
+
+/// Retire an element: an element with no element children *is* the leaf its
+/// text belongs to, so its text runs collapse into one region covering the
+/// element itself — markup included, so a passage starting at the tag still
+/// resolves.
+fn finish_element(
+    regions: &mut Vec<PathRegion>,
+    element: OpenElement,
+    path: &mut String,
+    end: usize,
+) {
+    if !element.has_element_child {
+        regions.truncate(element.mark);
+        record(regions, ByteSpan::new(element.start, end), path);
+    }
+    path.truncate(element.path_scope);
+}
+
+/// Record the text between two tags under the element that owns it, trimmed of
+/// the whitespace that only formats the markup.
+fn flush_text(regions: &mut Vec<PathRegion>, text: &str, start: usize, end: usize, path: &str) {
+    let Some(slice) = text.get(start..end) else {
+        return;
+    };
+    let leading = slice.len() - slice.trim_start().len();
+    let trimmed = slice.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    record(
+        regions,
+        ByteSpan::new(start + leading, start + leading + trimmed.len()),
+        path,
+    );
+}
+
+/// Read a tag's name from `start`, returning it with the offset just past the
+/// tag's `>`. Quoted attribute values are honoured so a `>` inside one does not
+/// end the tag early.
+fn read_tag(text: &str, start: usize) -> Option<(String, usize)> {
+    let bytes = text.as_bytes();
+    let mut pos = start;
+    while pos < bytes.len()
+        && (bytes[pos].is_ascii_alphanumeric() || matches!(bytes[pos], b':' | b'-' | b'_' | b'.'))
+    {
+        pos += 1;
+    }
+    let name = text.get(start..pos)?.to_owned();
+    let mut quote: Option<u8> = None;
+    while pos < bytes.len() {
+        let byte = bytes[pos];
+        match quote {
+            Some(open) if byte == open => quote = None,
+            Some(_) => {}
+            None if byte == b'"' || byte == b'\'' => quote = Some(byte),
+            None if byte == b'>' => return Some((name, pos + 1)),
+            None => {}
+        }
+        pos += 1;
+    }
+    Some((name, bytes.len()))
+}
+
+/// The offset just past the next `needle` at or after `from`.
+fn find_after(text: &str, from: usize, needle: &str) -> Option<usize> {
+    let rest = text.get(from..)?;
+    rest.find(needle).map(|at| from + at + needle.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::chunk::{Chunker, TextChunker};
+    use crate::document::{Document, DocumentSource};
+    use crate::parse::DocumentParser;
+
+    const INVOICES_JSON: &str = r#"{
+  "invoices": [
+    {"number": "A-1", "customer": "Acme", "total": 42, "tags": ["paid", "eu"]},
+    {"number": "B-2", "customer": "Globex", "total": 7, "tags": []}
+  ],
+  "count": 2
+}"#;
+
+    const INVOICES_XML: &str = r#"<?xml version="1.0"?>
+<!-- exported nightly -->
+<invoices>
+  <invoice id="A-1"><customer>Acme</customer><total>42</total></invoice>
+  <invoice id="B-2"><customer>Globex</customer><total>7</total></invoice>
+  <note>Totals are <em>net</em> of tax</note>
+</invoices>"#;
+
+    /// The paths recorded for `text`, paired with the source they address.
+    fn located(text: &str, format: StructuredFormat) -> Vec<(String, &str)> {
+        structured_regions(text, format)
+            .into_iter()
+            .map(|region| {
+                let (path, _) = region
+                    .location
+                    .structured_path()
+                    .expect("structured sources record structured paths");
+                (path.to_owned(), &text[region.span.start..region.span.end])
+            })
+            .collect()
+    }
+
+    #[test]
+    fn json_paths_address_the_value_a_span_covers() {
+        assert_eq!(
+            located(INVOICES_JSON, StructuredFormat::Json),
+            vec![
+                ("invoices.0.number".into(), "\"number\": \"A-1\""),
+                ("invoices.0.customer".into(), "\"customer\": \"Acme\""),
+                ("invoices.0.total".into(), "\"total\": 42"),
+                // A list of plain values is one thing to look at, so the list
+                // is the node rather than each of its elements.
+                ("invoices.0.tags".into(), "\"tags\": [\"paid\", \"eu\"]"),
+                ("invoices.1.number".into(), "\"number\": \"B-2\""),
+                ("invoices.1.customer".into(), "\"customer\": \"Globex\""),
+                ("invoices.1.total".into(), "\"total\": 7"),
+                ("invoices.1.tags".into(), "\"tags\": []"),
+                ("count".into(), "\"count\": 2"),
+            ]
+        );
+    }
+
+    #[test]
+    fn markup_paths_are_xpaths_into_the_element_a_span_sits_in() {
+        assert_eq!(
+            located(INVOICES_XML, StructuredFormat::Xml),
+            vec![
+                (
+                    "/invoices[1]/invoice[1]/customer[1]".into(),
+                    "<customer>Acme</customer>"
+                ),
+                (
+                    "/invoices[1]/invoice[1]/total[1]".into(),
+                    "<total>42</total>"
+                ),
+                (
+                    "/invoices[1]/invoice[2]/customer[1]".into(),
+                    "<customer>Globex</customer>"
+                ),
+                (
+                    "/invoices[1]/invoice[2]/total[1]".into(),
+                    "<total>7</total>"
+                ),
+                // Text an element owns directly belongs to that element; the
+                // child between the two runs is addressed on its own.
+                ("/invoices[1]/note[1]".into(), "Totals are"),
+                ("/invoices[1]/note[1]/em[1]".into(), "<em>net</em>"),
+                ("/invoices[1]/note[1]".into(), "of tax"),
+            ]
+        );
+    }
+
+    #[test]
+    fn html_is_read_leniently_and_void_elements_do_not_swallow_the_page() {
+        let html = "<html><body><h1>Q4</h1><p>Revenue <b>rose</b><br>sharply</body></html>";
+        assert_eq!(
+            located(html, StructuredFormat::Xml),
+            vec![
+                ("/html[1]/body[1]/h1[1]".into(), "<h1>Q4</h1>"),
+                ("/html[1]/body[1]/p[1]".into(), "Revenue"),
+                ("/html[1]/body[1]/p[1]/b[1]".into(), "<b>rose</b>"),
+                ("/html[1]/body[1]/p[1]/br[1]".into(), "<br>"),
+                ("/html[1]/body[1]/p[1]".into(), "sharply"),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn a_chunk_of_a_structured_source_is_located_at_the_node_it_covers() {
+        let parsed = crate::parse::StructuredTextParser::new()
+            .parse(INVOICES_JSON.as_bytes(), "application/json")
+            .await
+            .unwrap();
+        assert_eq!(parsed.text, INVOICES_JSON);
+        let document = Document::new(DocumentSource::Inline, "application/json", &parsed.text)
+            .with_source_regions(parsed.source_regions);
+        // A window small enough to fall inside one invoice, so the passage has
+        // an enclosing record rather than the whole file.
+        let chunks = TextChunker::new(60, 0)
+            .chunk(&document, "application/json")
+            .unwrap();
+        let located: Vec<_> = chunks
+            .iter()
+            .map(|chunk| {
+                EvidenceLocation::for_source_regions(
+                    chunk.heading_path.clone(),
+                    chunk.source_regions.clone(),
+                )
+            })
+            .collect();
+        assert!(
+            located.contains(&EvidenceLocation::StructuredPath {
+                path: "invoices.0".into(),
+                path_type: StructuredPathType::JsonDotNotation,
+            }),
+            "a passage across one invoice's fields is at that invoice: {located:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_source_that_does_not_parse_keeps_its_text_and_gains_no_paths() {
+        let broken = b"{\"invoices\": [ truncated";
+        let parsed = crate::parse::StructuredTextParser::new()
+            .parse(broken, "application/json")
+            .await
+            .unwrap();
+        assert_eq!(parsed.text, String::from_utf8_lossy(broken));
+        assert!(parsed.source_regions.is_empty());
+    }
+
+    #[test]
+    fn a_passage_crossing_more_nodes_than_evidence_carries_stays_valid() {
+        let mut json = String::from("{\"rows\":[");
+        for row in 0..600 {
+            if row > 0 {
+                json.push(',');
+            }
+            json.push_str(&format!("{{\"a\":{row},\"b\":{row}}}"));
+        }
+        json.push_str("]}");
+        let document = Document::new(DocumentSource::Inline, "application/json", &json)
+            .with_source_regions(structured_regions(&json, StructuredFormat::Json));
+        let chunks = TextChunker::default()
+            .chunk(&document, "application/json")
+            .unwrap();
+        for chunk in &chunks {
+            chunk
+                .validate_source_regions()
+                .expect("a dense structured passage must still be valid evidence");
+            let located = EvidenceLocation::for_source_regions(
+                chunk.heading_path.clone(),
+                chunk.source_regions.clone(),
+            );
+            assert!(
+                matches!(located, EvidenceLocation::StructuredPath { .. })
+                    && located.is_well_formed(),
+                "every chunk of a structured source is at a node: {located:?}"
+            );
+        }
+    }
+}

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -1009,10 +1009,13 @@ fn build_retrieval(
 /// Office parser claims Word/Excel/PowerPoint/OpenDocument types (converting via
 /// LibreOffice when present, storing without searchable text when not); with
 /// `parse-image`, the image parser claims common raster types (PNG/JPEG/WebP/GIF/
-/// TIFF/BMP), stored without searchable text until OCR lands; `PlainTextParser`
-/// claims `text/*`; the `FallbackParser` claims everything else so **any** upload
-/// is accepted — text-like unknown types stay searchable and binary ones are
-/// stored without polluting the index.
+/// TIFF/BMP), stored without searchable text until OCR lands; the
+/// `StructuredTextParser` claims the tree-shaped text types (JSON, XML, HTML),
+/// whose text it passes through unchanged while recording which node each part
+/// of it came from; `PlainTextParser` claims the rest of `text/*`; the
+/// `FallbackParser` claims everything else so **any** upload is accepted —
+/// text-like unknown types stay searchable and binary ones are stored without
+/// polluting the index.
 fn document_parser_registry() -> ParserRegistry {
     let registry = ParserRegistry::new();
     #[cfg(feature = "parse-liteparse")]
@@ -1022,6 +1025,7 @@ fn document_parser_registry() -> ParserRegistry {
     #[cfg(feature = "parse-image")]
     let registry = registry.with_parser(openwave_retrieval::LiteParseImageParser::new());
     registry
+        .with_parser(openwave_retrieval::StructuredTextParser::new())
         .with_parser(PlainTextParser::new())
         .with_parser(FallbackParser::new())
 }

--- a/crates/openwave-server/src/source_tools.rs
+++ b/crates/openwave-server/src/source_tools.rs
@@ -338,10 +338,7 @@ impl Tool for ReadSourceTool {
             chunk_id: ChunkId::derive(document_id, span.start, span.end),
             span,
             snippet: window.text.to_owned(),
-            location: EvidenceLocation::DocumentContent {
-                heading_path: Vec::new(),
-                source_regions,
-            },
+            location: EvidenceLocation::for_source_regions(Vec::new(), source_regions),
             source,
         };
         Ok(ToolOutput::text(content)


### PR DESCRIPTION
A citation into a JSON or XML source now carries the node it quoted, and
clicking it opens the source's tree at that node instead of at the top of the
file. `EvidenceLocation::StructuredPath` has existed and validated since the
evidence taxonomy landed; nothing produced or rendered one. This fills it in end
to end.

## Producing the path

JSON, XML, and HTML are indexed as their own text — nothing is extracted out of
them — so a chunk's byte span already addresses the bytes a reader downloads.
What was missing is the map from those spans to the nodes they came from.

A new `StructuredTextParser` claims the tree-shaped text types
(`application/json`, `application/xml`, `text/xml`, `text/html`, and the
`+json`/`+xml` suffixes; images are excluded so an SVG stays a picture). Its
canonical text is byte-for-byte what `PlainTextParser` produced, so spans,
chunks, and the extracted-text view are unchanged. What it adds is a structure
map: a walk of the source recording, for each run of leaf content, the path of
the node holding it. Those travel as `SourceRegion`s — the same channel page maps
already use — so a passage retrieved later resolves to a node without reparsing
the document, and no storage schema changes.

- **JSON** → dot paths, e.g. `invoices.0.number`. Each object member is recorded
  from its key through its value, so a passage starting at `"total":` is at the
  total. A list whose elements are all plain values is recorded as the list:
  `readings.417` is a number on its own, `readings` is the series it belongs to.
- **XML/HTML** → XPath with position predicates, e.g.
  `/invoices[1]/invoice[2]/number[1]`. An element with no element children is
  recorded whole, markup included; text directly owned by a mixed-content
  element is recorded under that element, so the runs either side of an `<em>`
  resolve to the paragraph.

Both walks are hand-rolled over the source bytes — no new dependencies. HTML is
read by the same walk with the void-element list applied, and leniently: an
unmatched close tag is ignored, an element closed out of order closes what it
contains, and anything still open at end of file contributes nothing.

**What the parser cannot resolve, and does not fake:**

- A document that does not parse yields no paths at all. It keeps its text,
  spans, and citations and loses only the node view.
- The root of a tree has no path, so a passage covering the whole file falls
  back to the first node it touches.
- A JSON key containing a `.` produces a path the dot-notation reader cannot
  split. The path is still descriptive; the viewer finds no node and highlights
  nothing.
- A namespace-prefixed XML element keeps its qualified name in the XPath, which
  the viewer evaluates without a namespace resolver, so it will not resolve.
- Machine-generated files past 50k leaf regions, or nested past 128 levels, are
  indexed with no structure map rather than with a truncated one.

## Carrying it through

`EvidenceLocation::for_source_regions` picks the kind from the regions a passage
maps to: structured regions become `StructuredPath`, everything else stays
`DocumentContent`. A passage covering several nodes is located at the node
containing them all — the enclosing invoice of three quoted fields, not the
first of the three. Both evidence producers (the search tool and `read_source`)
go through it. The projection to `CitationLocation::StructuredPath` was already
written and needed no change; persistence already stores any location the
evidence columns cannot express as its own payload, so there is no migration.

`Document::source_regions_for` gained the structured counterpart of its
coalesce-by-page fallback: a passage crossing more nodes than evidence carries
folds into groups named by the node above each group. Without it a passage over
a dense table produced evidence that failed validation.

## Rendering it

`JsonViewer` and `XmlViewer` already implemented `highlightPath` fully — exact
highlight, ancestor expansion, scroll — and had no caller, which is the half of
#812 that was left. The path now reaches them:

`CitationLocation` → `AssistantSource.structuredPath` → `CitationPlacement` →
`DocumentDetailRoot` → `DocumentDetails.highlightPath`, following the landing
structure #909 established. A citation carrying a path lands on the original
view the way a paginated citation lands on its page; one without keeps today's
behavior exactly. The notation is checked against the viewer the media type gets
— a dot path handed to the XML viewer resolves to nothing — and a notation this
build does not know is treated as no path rather than as a wrong node.

**HTML is produced but not yet rendered.** `text/html` gets XPaths in its
evidence and citations, but the panel draws an HTML original with the text
viewer rather than a tree, so nothing consumes the path yet. Routing HTML to the
XML viewer is not a one-line change: the browser's HTML parser inserts implied
`<html>`, `<head>`, and `<tbody>` elements that a lenient tag walk does not, so
the two would disagree about positions. Left as it stands rather than shipped
half-working.

Existing JSON/XML/HTML sources are re-parsed by the document auditor, which
enqueues a parse job whenever a document's stored parser fingerprint differs
from the active one — a source imported before this change picks up its paths
provided its original bytes were retained. A source stored without them keeps
its text and gains no paths.

## Tests

- The paths produced for a realistic JSON document and a realistic XML document,
  asserted against the source each addresses — including the scalar-list rule
  and mixed content.
- HTML read leniently, with a void element not swallowing the rest of the page.
- A chunk of a parsed JSON source is located at the record it covers, driven
  through the real parser and chunker.
- A source that does not parse keeps its text and gains no paths.
- A passage crossing more nodes than evidence carries still validates as
  evidence and is still located at a node.
- The panel, in the DOM: a citation carrying a path opens a JSON tree and an XML
  tree at the quoted node — the quoted value is only on screen because the path
  expanded the record holding it, and the same tree opened without a citation is
  asserted collapsed so that claim is not vacuous.

No tests deleted. Persistence and projection of a location the evidence columns
cannot express already have a round-trip test from the taxonomy slice; adding a
second variant of it would be duplicate coverage.

Not verified by driving the app: the tree landing is covered by the DOM test
rather than by opening a real conversation.

Closes #886
