### PR TITLE
feat(approvals): widen a standing grant to the project it was made in

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -2496,8 +2496,13 @@ impl Agent {
         let action = call_action_preview(call);
         let bypass_by_explicit_grant = durable_approval.is_none()
             && serde_json::from_str::<Value>(&call.args).is_ok_and(|arguments| {
-                self.standing_grants
-                    .covers(chat.id, &call.name, kind_for_call, &arguments)
+                self.standing_grants.covers(
+                    chat.id,
+                    chat.project_id,
+                    &call.name,
+                    kind_for_call,
+                    &arguments,
+                )
             });
         // A recovered call re-enters the gate whatever the mode now says: its
         // durable approval may already hold a rejection the mode must not
@@ -6430,12 +6435,12 @@ mod tests {
 
     #[tokio::test]
     async fn standing_grant_runs_sensitive_tool_without_parking() {
-        use crate::approval::{StandingGrant, StandingGrants};
+        use crate::approval::{GrantLevel, StandingGrant, StandingGrants};
 
         let store = search_grant_store().await;
         let chat = search_grant_chat(&store).await;
         let grants = Arc::new(StandingGrants::from_grants(vec![StandingGrant::new(
-            chat.id,
+            GrantLevel::Chat { chat_id: chat.id },
             "search",
             ToolApprovalKind::for_tool_name("search"),
             Utc::now(),
@@ -6466,13 +6471,15 @@ mod tests {
 
     #[tokio::test]
     async fn standing_grant_for_another_chat_does_not_bypass_the_gate() {
-        use crate::approval::{StandingGrant, StandingGrants};
+        use crate::approval::{GrantLevel, StandingGrant, StandingGrants};
 
         let store = search_grant_store().await;
         let chat = search_grant_chat(&store).await;
         // A grant scoped to a different chat must not cover this chat's call.
         let grants = Arc::new(StandingGrants::from_grants(vec![StandingGrant::new(
-            ChatId::new(),
+            GrantLevel::Chat {
+                chat_id: ChatId::new(),
+            },
             "search",
             ToolApprovalKind::for_tool_name("search"),
             Utc::now(),
@@ -6759,12 +6766,12 @@ mod tests {
 
     #[tokio::test]
     async fn standing_grant_runs_escaping_exec_without_parking() {
-        use crate::approval::{StandingGrant, StandingGrants};
+        use crate::approval::{GrantLevel, StandingGrant, StandingGrants};
 
         let store = search_grant_store().await;
         let chat = search_grant_chat(&store).await;
         let grants = Arc::new(StandingGrants::from_grants(vec![StandingGrant::new(
-            chat.id,
+            GrantLevel::Chat { chat_id: chat.id },
             "exec",
             ToolApprovalKind::for_tool_name("exec"),
             Utc::now(),

--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -14,7 +14,7 @@ use std::pin::Pin;
 use std::sync::RwLock;
 
 use crate::event::SequencedEvent;
-use crate::id::{CallId, ChatId, TurnId};
+use crate::id::{CallId, ChatId, ProjectId, TurnId};
 use crate::preview::ToolActionPreview;
 use crate::tool::ApprovalClass;
 use chrono::{DateTime, Utc};
@@ -350,6 +350,49 @@ impl ToolApproval {
     }
 }
 
+/// How far a standing grant reaches.
+///
+/// A grant used to cover exactly one chat, so "always allow `cargo`" was
+/// re-asked in the next conversation and the one after it — the single
+/// biggest source of prompting in the model. The level is chosen from where
+/// the chat lives rather than put to the reader as a question: a chat in a
+/// project grants across that project, and a loose chat has nothing wider to
+/// mean, so it grants for itself. The card states which one it is about to
+/// write; a grant nobody expected is the failure the ladder exists to prevent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, TS)]
+#[serde(tag = "level", rename_all = "snake_case")]
+pub enum GrantLevel {
+    /// Every later matching call in one chat.
+    Chat { chat_id: ChatId },
+    /// Every later matching call in any chat filed under one project.
+    Project { project_id: ProjectId },
+}
+
+impl GrantLevel {
+    /// The level a grant made from this chat should be written at.
+    #[must_use]
+    pub const fn for_chat(chat_id: ChatId, project_id: Option<ProjectId>) -> Self {
+        match project_id {
+            Some(project_id) => Self::Project { project_id },
+            None => Self::Chat { chat_id },
+        }
+    }
+
+    /// Whether this level reaches a call made in `chat_id` under
+    /// `project_id`.
+    #[must_use]
+    pub fn reaches(self, chat_id: ChatId, project_id: Option<ProjectId>) -> bool {
+        match self {
+            Self::Chat { chat_id: granted } => granted == chat_id,
+            // A project grant covers the project it names, and only a chat
+            // that is actually filed under it.
+            Self::Project {
+                project_id: granted,
+            } => project_id == Some(granted),
+        }
+    }
+}
+
 /// A remembered approval that lets a repeated in-scope Sensitive action run
 /// without re-prompting.
 ///
@@ -360,7 +403,7 @@ impl ToolApproval {
 /// capability-model issue.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StandingGrant {
-    chat_id: ChatId,
+    level: GrantLevel,
     tool_name: String,
     kind: ToolApprovalKind,
     scope: GrantScope,
@@ -465,12 +508,12 @@ impl StandingGrant {
     /// the gate every call.
     #[must_use]
     pub fn new(
-        chat_id: ChatId,
+        level: GrantLevel,
         tool_name: impl Into<String>,
         kind: ToolApprovalKind,
         granted_at: DateTime<Utc>,
     ) -> Option<Self> {
-        Self::scoped(chat_id, tool_name, kind, GrantScope::WholeTool, granted_at)
+        Self::scoped(level, tool_name, kind, GrantScope::WholeTool, granted_at)
     }
 
     /// Record consent limited to `scope`.
@@ -478,7 +521,7 @@ impl StandingGrant {
     /// Returns `None` on the same terms as [`StandingGrant::new`].
     #[must_use]
     pub fn scoped(
-        chat_id: ChatId,
+        level: GrantLevel,
         tool_name: impl Into<String>,
         kind: ToolApprovalKind,
         scope: GrantScope,
@@ -488,7 +531,7 @@ impl StandingGrant {
             return None;
         }
         Some(Self {
-            chat_id,
+            level,
             tool_name: tool_name.into(),
             kind,
             scope,
@@ -502,10 +545,10 @@ impl StandingGrant {
         &self.scope
     }
 
-    /// Chat the standing consent belongs to.
+    /// How far this standing consent reaches.
     #[must_use]
-    pub const fn chat_id(&self) -> ChatId {
-        self.chat_id
+    pub const fn level(&self) -> GrantLevel {
+        self.level
     }
 
     /// Tool name the consent covers.
@@ -531,11 +574,12 @@ impl StandingGrant {
     pub(crate) fn covers(
         &self,
         chat_id: ChatId,
+        project_id: Option<ProjectId>,
         tool_name: &str,
         kind: ToolApprovalKind,
         arguments: &serde_json::Value,
     ) -> bool {
-        self.chat_id == chat_id
+        self.level.reaches(chat_id, project_id)
             && self.tool_name == tool_name
             && self.kind == kind
             && kind.is_approvable()
@@ -578,7 +622,7 @@ impl StandingGrants {
     pub fn record(&self, grant: StandingGrant) {
         let mut grants = self.write();
         if !grants.iter().any(|existing| {
-            existing.chat_id == grant.chat_id
+            existing.level == grant.level
                 && existing.tool_name == grant.tool_name
                 && existing.kind == grant.kind
                 && existing.scope == grant.scope
@@ -591,13 +635,14 @@ impl StandingGrants {
     pub fn covers(
         &self,
         chat_id: ChatId,
+        project_id: Option<ProjectId>,
         tool_name: &str,
         kind: ToolApprovalKind,
         arguments: &serde_json::Value,
     ) -> bool {
         self.read()
             .iter()
-            .any(|grant| grant.covers(chat_id, tool_name, kind, arguments))
+            .any(|grant| grant.covers(chat_id, project_id, tool_name, kind, arguments))
     }
 
     pub fn clear(&self) {
@@ -762,7 +807,7 @@ mod standing_grant_tests {
 
     fn grant(chat_id: ChatId, tool: &str) -> StandingGrant {
         StandingGrant::new(
-            chat_id,
+            GrantLevel::Chat { chat_id },
             tool,
             ToolApprovalKind::for_tool_name(tool),
             Utc::now(),
@@ -801,9 +846,9 @@ mod standing_grant_tests {
         let chat = ChatId::new();
         let grants = StandingGrants::from_grants(vec![grant(chat, "exec")]);
         let kind = ToolApprovalKind::for_tool_name("exec");
-        assert!(grants.covers(chat, "exec", kind, &no_args()));
+        assert!(grants.covers(chat, None, "exec", kind, &no_args()));
         // Deny-by-default still holds for a different chat.
-        assert!(!grants.covers(ChatId::new(), "exec", kind, &no_args()));
+        assert!(!grants.covers(ChatId::new(), None, "exec", kind, &no_args()));
     }
 
     #[test]
@@ -812,16 +857,23 @@ mod standing_grant_tests {
         assert_eq!(kind, ToolApprovalKind::ExternalMcpMayCallServer);
         assert!(kind.is_approvable());
         assert!(!kind.is_standing_grantable());
-        assert!(
-            StandingGrant::new(ChatId::new(), "mcp__documents__search", kind, Utc::now(),)
-                .is_none()
-        );
+        assert!(StandingGrant::new(
+            GrantLevel::Chat {
+                chat_id: ChatId::new()
+            },
+            "mcp__documents__search",
+            kind,
+            Utc::now(),
+        )
+        .is_none());
     }
 
     #[test]
     fn non_approvable_tools_cannot_be_granted() {
         assert!(StandingGrant::new(
-            ChatId::new(),
+            GrantLevel::Chat {
+                chat_id: ChatId::new()
+            },
             "third_party_sensitive",
             ToolApprovalKind::for_tool_name("third_party_sensitive"),
             Utc::now(),
@@ -835,6 +887,7 @@ mod standing_grant_tests {
         let grants = StandingGrants::new();
         assert!(!grants.covers(
             chat,
+            None,
             "search",
             ToolApprovalKind::for_tool_name("search"),
             &no_args()
@@ -848,10 +901,11 @@ mod standing_grant_tests {
         let grants = StandingGrants::from_grants(vec![grant(chat, "search")]);
         let kind = ToolApprovalKind::for_tool_name("search");
 
-        assert!(grants.covers(chat, "search", kind, &no_args()));
-        assert!(!grants.covers(other_chat, "search", kind, &no_args()));
+        assert!(grants.covers(chat, None, "search", kind, &no_args()));
+        assert!(!grants.covers(other_chat, None, "search", kind, &no_args()));
         assert!(!grants.covers(
             chat,
+            None,
             "third_party_sensitive",
             ToolApprovalKind::for_tool_name("third_party_sensitive"),
             &no_args(),
@@ -895,7 +949,7 @@ mod standing_grant_tests {
         let grants = StandingGrants::new();
         grants.record(
             StandingGrant::scoped(
-                chat,
+                GrantLevel::Chat { chat_id: chat },
                 "exec",
                 kind,
                 exact_command("cargo", &["test"]),
@@ -904,11 +958,11 @@ mod standing_grant_tests {
             .unwrap(),
         );
 
-        assert!(grants.covers(chat, "exec", kind, &exec_args("cargo", &["test"])));
-        assert!(!grants.covers(chat, "exec", kind, &exec_args("cargo", &["publish"])));
-        assert!(!grants.covers(chat, "exec", kind, &exec_args("rm", &["test"])));
+        assert!(grants.covers(chat, None, "exec", kind, &exec_args("cargo", &["test"])));
+        assert!(!grants.covers(chat, None, "exec", kind, &exec_args("cargo", &["publish"])));
+        assert!(!grants.covers(chat, None, "exec", kind, &exec_args("rm", &["test"])));
         // An action the renderer could not describe was never the one granted.
-        assert!(!grants.covers(chat, "exec", kind, &no_args()));
+        assert!(!grants.covers(chat, None, "exec", kind, &no_args()));
     }
 
     #[test]
@@ -919,7 +973,7 @@ mod standing_grant_tests {
         let grants = StandingGrants::new();
         grants.record(
             StandingGrant::scoped(
-                chat,
+                GrantLevel::Chat { chat_id: chat },
                 "exec",
                 kind,
                 exact_command("bash", &["-c", &long]),
@@ -931,10 +985,16 @@ mod standing_grant_tests {
         // Truncation: a longer script sharing the granted prefix projects to
         // the same preview. Keying on the projection would run it unprompted.
         let appended = format!("{long}; rm -rf ~");
-        assert!(!grants.covers(chat, "exec", kind, &exec_args("bash", &["-c", &appended])));
+        assert!(!grants.covers(
+            chat,
+            None,
+            "exec",
+            kind,
+            &exec_args("bash", &["-c", &appended])
+        ));
         // A value exactly at the bound is not truncated, so it stays faithful
         // and the grant still covers the command it was actually given for.
-        assert!(grants.covers(chat, "exec", kind, &exec_args("bash", &["-c", &long])));
+        assert!(grants.covers(chat, None, "exec", kind, &exec_args("bash", &["-c", &long])));
         // Nothing at or past the bound can be turned into a narrow grant.
         assert_eq!(
             GrantScope::ladder_for("exec", &exec_args("bash", &["-c", &appended])),
@@ -949,7 +1009,7 @@ mod standing_grant_tests {
         let grants = StandingGrants::new();
         grants.record(
             StandingGrant::scoped(
-                chat,
+                GrantLevel::Chat { chat_id: chat },
                 "exec",
                 kind,
                 exact_command("foo", &["bar"]),
@@ -958,15 +1018,16 @@ mod standing_grant_tests {
             .unwrap(),
         );
 
-        assert!(grants.covers(chat, "exec", kind, &exec_args("foo", &["bar"])));
+        assert!(grants.covers(chat, None, "exec", kind, &exec_args("foo", &["bar"])));
         // An empty argument used to clamp away entirely, making these two
         // different calls indistinguishable.
-        assert!(!grants.covers(chat, "exec", kind, &exec_args("foo", &["", "bar"])));
+        assert!(!grants.covers(chat, None, "exec", kind, &exec_args("foo", &["", "bar"])));
         // A control character used to be stripped, so these collapsed too.
-        assert!(!grants.covers(chat, "exec", kind, &exec_args("foo", &["b\u{0}ar"])));
+        assert!(!grants.covers(chat, None, "exec", kind, &exec_args("foo", &["b\u{0}ar"])));
         // A non-string argument used to be dropped, changing the call's arity.
         assert!(!grants.covers(
             chat,
+            None,
             "exec",
             kind,
             &serde_json::json!({ "command": "foo", "args": ["bar", 7] })
@@ -978,6 +1039,7 @@ mod standing_grant_tests {
             .collect();
         assert!(!grants.covers(
             chat,
+            None,
             "exec",
             kind,
             &serde_json::json!({ "command": "foo", "args": many })
@@ -991,7 +1053,7 @@ mod standing_grant_tests {
         let grants = StandingGrants::new();
         grants.record(
             StandingGrant::scoped(
-                chat,
+                GrantLevel::Chat { chat_id: chat },
                 "exec",
                 kind,
                 GrantScope::ExactAction(ToolActionPreview::Exec {
@@ -1006,9 +1068,9 @@ mod standing_grant_tests {
 
         let in_dir =
             |cwd: &str| serde_json::json!({ "command": "npm", "args": ["install"], "cwd": cwd });
-        assert!(grants.covers(chat, "exec", kind, &in_dir("./sandbox")));
+        assert!(grants.covers(chat, None, "exec", kind, &in_dir("./sandbox")));
         // The card showed the directory, so the grant is about that directory.
-        assert!(!grants.covers(chat, "exec", kind, &in_dir("/")));
+        assert!(!grants.covers(chat, None, "exec", kind, &in_dir("/")));
     }
 
     #[test]
@@ -1018,7 +1080,7 @@ mod standing_grant_tests {
         let grants = StandingGrants::new();
         grants.record(
             StandingGrant::scoped(
-                chat,
+                GrantLevel::Chat { chat_id: chat },
                 "exec",
                 kind,
                 GrantScope::AnyArgsFor {
@@ -1029,9 +1091,9 @@ mod standing_grant_tests {
             .unwrap(),
         );
 
-        assert!(grants.covers(chat, "exec", kind, &exec_args("cargo", &["test"])));
-        assert!(grants.covers(chat, "exec", kind, &exec_args("cargo", &["publish"])));
-        assert!(!grants.covers(chat, "exec", kind, &exec_args("rm", &["-rf"])));
+        assert!(grants.covers(chat, None, "exec", kind, &exec_args("cargo", &["test"])));
+        assert!(grants.covers(chat, None, "exec", kind, &exec_args("cargo", &["publish"])));
+        assert!(!grants.covers(chat, None, "exec", kind, &exec_args("rm", &["-rf"])));
     }
 
     #[test]
@@ -1041,8 +1103,8 @@ mod standing_grant_tests {
         let grants = StandingGrants::new();
         grants.record(grant(chat, "exec"));
 
-        assert!(grants.covers(chat, "exec", kind, &exec_args("rm", &["-rf"])));
-        assert!(grants.covers(chat, "exec", kind, &no_args()));
+        assert!(grants.covers(chat, None, "exec", kind, &exec_args("rm", &["-rf"])));
+        assert!(grants.covers(chat, None, "exec", kind, &no_args()));
     }
 
     #[test]
@@ -1103,7 +1165,7 @@ mod standing_grant_tests {
         let grants = StandingGrants::new();
         grants.record(
             StandingGrant::scoped(
-                chat,
+                GrantLevel::Chat { chat_id: chat },
                 "web_search",
                 kind,
                 exact_web_search("quarterly filings"),
@@ -1113,14 +1175,21 @@ mod standing_grant_tests {
         );
 
         let query = |query: &str| serde_json::json!({ "query": query });
-        assert!(grants.covers(chat, "web_search", kind, &query("quarterly filings")));
+        assert!(grants.covers(chat, None, "web_search", kind, &query("quarterly filings")));
         // The tool trims before searching, so padding is not a different search.
-        assert!(grants.covers(chat, "web_search", kind, &query("  quarterly filings ")));
-        assert!(!grants.covers(chat, "web_search", kind, &query("payroll")));
+        assert!(grants.covers(
+            chat,
+            None,
+            "web_search",
+            kind,
+            &query("  quarterly filings ")
+        ));
+        assert!(!grants.covers(chat, None, "web_search", kind, &query("payroll")));
         // Same query, different tool: a grant is scoped to the tool it was
         // given for, and a private-source search is not a public web search.
         assert!(!grants.covers(
             chat,
+            None,
             "search",
             ToolApprovalKind::for_tool_name("search"),
             &query("quarterly filings"),
@@ -1129,6 +1198,7 @@ mod standing_grant_tests {
         // filter is a different disclosure and was never the one granted.
         assert!(!grants.covers(
             chat,
+            None,
             "web_search",
             kind,
             &serde_json::json!({ "query": "quarterly filings", "domains": ["sec.gov"] }),
@@ -1136,6 +1206,7 @@ mod standing_grant_tests {
         // Bounding the response is not part of what leaves the machine.
         assert!(grants.covers(
             chat,
+            None,
             "web_search",
             kind,
             &serde_json::json!({ "query": "quarterly filings", "max_results": 10 }),
@@ -1150,7 +1221,7 @@ mod standing_grant_tests {
         for command in ["cargo", "git"] {
             grants.record(
                 StandingGrant::scoped(
-                    chat,
+                    GrantLevel::Chat { chat_id: chat },
                     "exec",
                     kind,
                     GrantScope::AnyArgsFor {
@@ -1162,8 +1233,8 @@ mod standing_grant_tests {
             );
         }
         assert_eq!(grants.read().len(), 2);
-        assert!(grants.covers(chat, "exec", kind, &exec_args("git", &["log"])));
-        assert!(!grants.covers(chat, "exec", kind, &exec_args("npm", &["i"])));
+        assert!(grants.covers(chat, None, "exec", kind, &exec_args("git", &["log"])));
+        assert!(!grants.covers(chat, None, "exec", kind, &exec_args("npm", &["i"])));
     }
 
     #[test]
@@ -1174,9 +1245,9 @@ mod standing_grant_tests {
         grants.record(grant(chat, "search"));
         grants.record(grant(chat, "search"));
         assert_eq!(grants.read().len(), 1);
-        assert!(grants.covers(chat, "search", kind, &no_args()));
+        assert!(grants.covers(chat, None, "search", kind, &no_args()));
 
         grants.clear();
-        assert!(!grants.covers(chat, "search", kind, &no_args()));
+        assert!(!grants.covers(chat, None, "search", kind, &no_args()));
     }
 }

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -1095,7 +1095,8 @@ pub mod standing_tool_grant {
     pub struct Model {
         #[sea_orm(primary_key, auto_increment = false)]
         pub source_call_id: Uuid,
-        pub chat_id: Uuid,
+        pub chat_id: Option<Uuid>,
+        pub project_id: Option<Uuid>,
         pub tool_name: String,
         pub approval_kind: String,
         #[sea_orm(column_type = "JsonBinary")]

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -42,6 +42,7 @@ impl MigratorTrait for Migrator {
             Box::new(AddChatCitationFormat),
             Box::new(AddEvidenceLocation),
             Box::new(AllowContainerExecutionLocation),
+            Box::new(WidenStandingGrantScope),
         ]
     }
 }
@@ -6939,6 +6940,211 @@ impl MigrationTrait for AddClaimedTurnEffectLeases {
     }
 }
 
+/// Widens a standing grant from one chat to the level it was granted at
+/// (issue #937): `chat_id` becomes nullable and `project_id` joins it, with
+/// exactly one of the two set. A grant made in a chat that belongs to a
+/// project now covers that project, so "always allow" survives into the next
+/// conversation instead of being re-asked.
+///
+/// Existing rows are chat grants and stay chat grants — widening someone's
+/// past decision without asking is the one thing this must not do.
+///
+/// SQLite cannot drop a NOT NULL or add a CHECK in place, so it rebuilds the
+/// table and copies every row across; PostgreSQL alters in place. The `down`
+/// deletes project-level rows first, because they have no representation in
+/// the narrower shape and silently rewriting them to a chat would invent a
+/// scope nobody chose.
+struct WidenStandingGrantScope;
+
+impl MigrationName for WidenStandingGrantScope {
+    fn name(&self) -> &str {
+        "m20260729_000028_widen_standing_grant_scope"
+    }
+}
+
+const STANDING_GRANT_REBUILD: &str = "standing_tool_grant_rebuild";
+
+/// Exactly one of `chat_id` / `project_id` names the level.
+fn standing_grant_level_check(widened: bool) -> SimpleExpr {
+    if widened {
+        Expr::col(StandingToolGrant::ChatId)
+            .is_not_null()
+            .and(Expr::col(StandingToolGrant::ProjectId).is_null())
+            .or(Expr::col(StandingToolGrant::ChatId)
+                .is_null()
+                .and(Expr::col(StandingToolGrant::ProjectId).is_not_null()))
+    } else {
+        Expr::col(StandingToolGrant::ChatId).is_not_null()
+    }
+}
+
+fn standing_grant_rebuild_table(widened: bool) -> TableCreateStatement {
+    let mut table = Table::create();
+    table
+        .table(Alias::new(STANDING_GRANT_REBUILD))
+        .col(
+            ColumnDef::new(StandingToolGrant::SourceCallId)
+                .uuid()
+                .not_null()
+                .primary_key(),
+        )
+        .col({
+            let mut column = ColumnDef::new(StandingToolGrant::ChatId);
+            column.uuid();
+            if !widened {
+                column.not_null();
+            }
+            column
+        })
+        .col(
+            ColumnDef::new(StandingToolGrant::ToolName)
+                .text()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(StandingToolGrant::ApprovalKind)
+                .string_len(64)
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(StandingToolGrant::Scope)
+                .json_binary()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(StandingToolGrant::GrantedAt)
+                .timestamp_with_time_zone()
+                .not_null(),
+        )
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_standing_tool_grant_chat")
+                .from(
+                    Alias::new(STANDING_GRANT_REBUILD),
+                    StandingToolGrant::ChatId,
+                )
+                .to(Chat::Table, Chat::Id)
+                .on_delete(ForeignKeyAction::Cascade),
+        )
+        .check(
+            Func::char_length(Expr::col(StandingToolGrant::ToolName))
+                .between(1, crate::model::ToolCallRecord::MAX_LABEL_LEN as i32),
+        )
+        .check(Expr::col(StandingToolGrant::ApprovalKind).is_in([
+            crate::ToolApprovalKind::SearchMayShareQueryAndExcerpts.standing_grant_key(),
+            crate::ToolApprovalKind::WebSearchMayShareQuery.standing_grant_key(),
+            crate::ToolApprovalKind::ExecMayRunNetworkedCommand.standing_grant_key(),
+        ]));
+    if widened {
+        table
+            .col(ColumnDef::new(StandingToolGrant::ProjectId).uuid())
+            .foreign_key(
+                ForeignKey::create()
+                    .name("fk_standing_tool_grant_project")
+                    .from(
+                        Alias::new(STANDING_GRANT_REBUILD),
+                        StandingToolGrant::ProjectId,
+                    )
+                    .to(Project::Table, Project::Id)
+                    .on_delete(ForeignKeyAction::Cascade),
+            );
+    }
+    table.check(standing_grant_level_check(widened));
+    table.to_owned()
+}
+
+fn standing_grant_rebuild_index() -> IndexCreateStatement {
+    Index::create()
+        .name("idx_standing_tool_grant_lookup")
+        .table(StandingToolGrant::Table)
+        .col(StandingToolGrant::ChatId)
+        .col(StandingToolGrant::ToolName)
+        .col(StandingToolGrant::ApprovalKind)
+        .col(StandingToolGrant::GrantedAt)
+        .to_owned()
+}
+
+async fn rebuild_standing_grant_sqlite(
+    manager: &SchemaManager<'_>,
+    widened: bool,
+) -> Result<(), DbErr> {
+    let shared = "source_call_id, chat_id, tool_name, approval_kind, scope, granted_at";
+    let copy = if widened {
+        format!(
+            "INSERT INTO {STANDING_GRANT_REBUILD} ({shared}, project_id) \
+             SELECT {shared}, NULL FROM standing_tool_grant"
+        )
+    } else {
+        // Project grants cannot be narrowed to a chat without inventing one.
+        format!(
+            "INSERT INTO {STANDING_GRANT_REBUILD} ({shared}) \
+             SELECT {shared} FROM standing_tool_grant WHERE chat_id IS NOT NULL"
+        )
+    };
+    let statements = vec![
+        "PRAGMA foreign_keys=OFF".to_owned(),
+        "BEGIN IMMEDIATE".to_owned(),
+        standing_grant_rebuild_table(widened).to_string(SqliteQueryBuilder),
+        copy,
+        "DROP TABLE standing_tool_grant".to_owned(),
+        format!("ALTER TABLE {STANDING_GRANT_REBUILD} RENAME TO standing_tool_grant"),
+        standing_grant_rebuild_index().to_string(SqliteQueryBuilder),
+        "COMMIT".to_owned(),
+        "PRAGMA foreign_keys=ON".to_owned(),
+    ];
+    manager
+        .get_connection()
+        .execute_unprepared(&format!("{};", statements.join(";\n")))
+        .await?;
+    Ok(())
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for WidenStandingGrantScope {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() == DatabaseBackend::Sqlite {
+            return rebuild_standing_grant_sqlite(manager, true).await;
+        }
+        let level = render_postgres_check(standing_grant_level_check(true));
+        let statements = [
+            "ALTER TABLE standing_tool_grant ADD COLUMN project_id uuid".to_owned(),
+            "ALTER TABLE standing_tool_grant ADD CONSTRAINT fk_standing_tool_grant_project \
+             FOREIGN KEY (project_id) REFERENCES project(id) ON DELETE CASCADE"
+                .to_owned(),
+            "ALTER TABLE standing_tool_grant ALTER COLUMN chat_id DROP NOT NULL".to_owned(),
+            format!(
+                "ALTER TABLE standing_tool_grant ADD CONSTRAINT chk_standing_tool_grant_level \
+                 CHECK ({level})"
+            ),
+        ];
+        manager
+            .get_connection()
+            .execute_unprepared(&format!("{};", statements.join(";\n")))
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() == DatabaseBackend::Sqlite {
+            return rebuild_standing_grant_sqlite(manager, false).await;
+        }
+        let statements = [
+            "DELETE FROM standing_tool_grant WHERE project_id IS NOT NULL".to_owned(),
+            "ALTER TABLE standing_tool_grant DROP CONSTRAINT chk_standing_tool_grant_level"
+                .to_owned(),
+            "ALTER TABLE standing_tool_grant ALTER COLUMN chat_id SET NOT NULL".to_owned(),
+            "ALTER TABLE standing_tool_grant DROP CONSTRAINT fk_standing_tool_grant_project"
+                .to_owned(),
+            "ALTER TABLE standing_tool_grant DROP COLUMN project_id".to_owned(),
+        ];
+        manager
+            .get_connection()
+            .execute_unprepared(&format!("{};", statements.join(";\n")))
+            .await?;
+        Ok(())
+    }
+}
+
 /// Adds `tool_call.auto_judge_status` (issue #756): where the Auto-mode judge
 /// stands on a parked approval (`judging` / `approved` / `declined`, `NULL`
 /// when no judge was engaged). Values are code-enforced; the column carries no
@@ -7812,6 +8018,7 @@ enum StandingToolGrant {
     Table,
     SourceCallId,
     ChatId,
+    ProjectId,
     ToolName,
     ApprovalKind,
     Scope,

--- a/crates/openwave-core/src/db/ops/approval.rs
+++ b/crates/openwave-core/src/db/ops/approval.rs
@@ -31,6 +31,7 @@ use super::{acquire_chat_write_lock, acquire_tool_call_write_lock, acquire_turn_
 async fn matching_standing_grant<C>(
     conn: &C,
     chat_id: ChatId,
+    project_id: Option<crate::id::ProjectId>,
     tool_name: &str,
     kind: ToolApprovalKind,
     arguments: &serde_json::Value,
@@ -41,8 +42,17 @@ where
     if !kind.is_standing_grantable() {
         return Ok(None);
     }
+    // Either level can authorize this call, so both are read and the decision
+    // is made per grant by `covers`. A projectless chat can only ever be
+    // covered by its own grants.
+    let mut reachable =
+        sea_orm::Condition::any().add(entities::standing_tool_grant::Column::ChatId.eq(chat_id.0));
+    if let Some(project_id) = project_id {
+        reachable =
+            reachable.add(entities::standing_tool_grant::Column::ProjectId.eq(project_id.0));
+    }
     let grants = entities::standing_tool_grant::Entity::find()
-        .filter(entities::standing_tool_grant::Column::ChatId.eq(chat_id.0))
+        .filter(reachable)
         .filter(entities::standing_tool_grant::Column::ToolName.eq(tool_name))
         .filter(entities::standing_tool_grant::Column::ApprovalKind.eq(kind.standing_grant_key()))
         .order_by_desc(entities::standing_tool_grant::Column::GrantedAt)
@@ -58,20 +68,53 @@ where
         let Ok(scope) = serde_json::from_value::<GrantScope>(row.scope) else {
             continue;
         };
-        let Some(grant) = StandingGrant::scoped(
-            ChatId(row.chat_id),
-            row.tool_name,
-            stored_kind,
-            scope,
-            row.granted_at,
-        ) else {
+        let Some(level) = grant_level_from_row(row.chat_id, row.project_id) else {
             continue;
         };
-        if grant.covers(chat_id, tool_name, kind, arguments) {
+        let Some(grant) =
+            StandingGrant::scoped(level, row.tool_name, stored_kind, scope, row.granted_at)
+        else {
+            continue;
+        };
+        if grant.covers(chat_id, project_id, tool_name, kind, arguments) {
             return Ok(Some(source_call_id));
         }
     }
     Ok(None)
+}
+
+/// The project a chat is filed under, read inside the caller's transaction so
+/// a grant is matched against the same membership the write will see.
+async fn chat_project_id<C>(conn: &C, chat_id: ChatId) -> Result<Option<crate::id::ProjectId>>
+where
+    C: ConnectionTrait,
+{
+    Ok(entities::chat::Entity::find_by_id(chat_id.0)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .and_then(|chat| chat.project_id)
+        .map(crate::id::ProjectId))
+}
+
+/// Recover the level a stored grant was written at.
+///
+/// A row that names neither a chat nor a project — or both — is not a level
+/// this build can honor, so it is skipped rather than guessed at, on the same
+/// terms as an unparseable scope.
+fn grant_level_from_row(
+    chat_id: Option<uuid::Uuid>,
+    project_id: Option<uuid::Uuid>,
+) -> Option<crate::approval::GrantLevel> {
+    match (chat_id, project_id) {
+        (Some(chat_id), None) => Some(crate::approval::GrantLevel::Chat {
+            chat_id: ChatId(chat_id),
+        }),
+        (None, Some(project_id)) => Some(crate::approval::GrantLevel::Project {
+            project_id: crate::id::ProjectId(project_id),
+        }),
+        _ => None,
+    }
 }
 
 /// Every durable standing grant, newest first, hydrated on the same terms as
@@ -90,13 +133,9 @@ pub(in crate::db) async fn list_standing_grants(
         .filter_map(|row| {
             let stored_kind = ToolApprovalKind::from_standing_grant_key(&row.approval_kind)?;
             let scope = serde_json::from_value::<GrantScope>(row.scope).ok()?;
-            let grant = StandingGrant::scoped(
-                ChatId(row.chat_id),
-                row.tool_name,
-                stored_kind,
-                scope,
-                row.granted_at,
-            )?;
+            let level = grant_level_from_row(row.chat_id, row.project_id)?;
+            let grant =
+                StandingGrant::scoped(level, row.tool_name, stored_kind, scope, row.granted_at)?;
             Some(crate::approval::StandingGrantRecord {
                 source_call_id: CallId(row.source_call_id),
                 grant,
@@ -244,6 +283,7 @@ pub(in crate::db) async fn request_and_append_event(
     if let Some(source_call_id) = matching_standing_grant(
         &transaction,
         request.chat_id,
+        chat_project_id(&transaction, request.chat_id).await?,
         &call.name,
         request.kind,
         &call.arguments,
@@ -447,6 +487,7 @@ pub(in crate::db) async fn request(
     if let Some(source_call_id) = matching_standing_grant(
         &transaction,
         request.chat_id,
+        chat_project_id(&transaction, request.chat_id).await?,
         &existing.name,
         request.kind,
         &existing.arguments,
@@ -596,7 +637,13 @@ pub(in crate::db) async fn decide_with_grant(
     }
     if existing.status != ToolCallStatus::Pending.as_str()
         || existing.execution != ToolCallExecution::Server.as_str()
-        || !grant.covers(chat_id, &existing.name, current.kind, &existing.arguments)
+        || !grant.covers(
+            chat_id,
+            chat_project_id(&transaction, chat_id).await?,
+            &existing.name,
+            current.kind,
+            &existing.arguments,
+        )
     {
         transaction.commit().await.map_err(store_err)?;
         return Ok(DecideToolApprovalOutcome::Unavailable);
@@ -635,7 +682,14 @@ where
         .map_err(|error| AgentError::Store(format!("invalid standing grant scope: {error}")))?;
     entities::standing_tool_grant::Entity::insert(entities::standing_tool_grant::ActiveModel {
         source_call_id: Set(source_call_id.0),
-        chat_id: Set(grant.chat_id().0),
+        chat_id: Set(match grant.level() {
+            crate::approval::GrantLevel::Chat { chat_id } => Some(chat_id.0),
+            crate::approval::GrantLevel::Project { .. } => None,
+        }),
+        project_id: Set(match grant.level() {
+            crate::approval::GrantLevel::Chat { .. } => None,
+            crate::approval::GrantLevel::Project { project_id } => Some(project_id.0),
+        }),
         tool_name: Set(grant.tool_name().to_owned()),
         approval_kind: Set(grant.kind().standing_grant_key().into()),
         scope: Set(scope),
@@ -664,10 +718,12 @@ where
     };
     let scope = serde_json::to_value(grant.scope())
         .map_err(|error| AgentError::Store(format!("invalid standing grant scope: {error}")))?;
-    Ok(stored.chat_id == grant.chat_id().0
-        && stored.tool_name == grant.tool_name()
-        && stored.approval_kind == grant.kind().standing_grant_key()
-        && stored.scope == scope)
+    Ok(
+        grant_level_from_row(stored.chat_id, stored.project_id) == Some(grant.level())
+            && stored.tool_name == grant.tool_name()
+            && stored.approval_kind == grant.kind().standing_grant_key()
+            && stored.scope == scope,
+    )
 }
 
 pub(in crate::db) async fn get(store: &DbStore, call_id: CallId) -> Result<Option<ToolApproval>> {

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -5344,6 +5344,21 @@ async fn m0006_upgrades_an_existing_store_without_losing_records() {
     assert_eq!(stored, document);
 }
 
+/// How many migrations were registered strictly after `name`.
+///
+/// A test that wants to roll back one specific migration has to get past
+/// whatever was appended after it. Deriving that keeps every new migration
+/// from having to find and bump a literal count in an unrelated test.
+pub(super) fn migrations_added_after(name: &str) -> u32 {
+    use sea_orm_migration::MigratorTrait;
+    let all = migration::Migrator::migrations();
+    let index = all
+        .iter()
+        .position(|migration| migration.name() == name)
+        .expect("the migration under test is registered");
+    u32::try_from(all.len() - index - 1).expect("migration count fits in u32")
+}
+
 #[tokio::test]
 async fn m0024_widens_and_narrows_the_execution_location_domain() {
     // Guards the container-location migration's bespoke SQLite table rebuild in
@@ -5382,6 +5397,15 @@ async fn m0024_widens_and_narrows_the_execution_location_domain() {
         insert_container(conn.clone()).await.is_ok(),
         "container must be accepted after the widening migration"
     );
+
+    // Roll back anything appended after this migration, so the `down(1)` calls
+    // below exercise *its* rollback rather than whatever landed most recently.
+    let appended = migrations_added_after("m20260729_000027_allow_container_execution_location");
+    if appended > 0 {
+        migration::Migrator::down(&conn, Some(appended))
+            .await
+            .unwrap();
+    }
 
     // A rollback with a container row still present is refused up front, and
     // leaves the schema untouched — rather than failing partway through the

--- a/crates/openwave-core/src/db/tests/operation_log.rs
+++ b/crates/openwave-core/src/db/tests/operation_log.rs
@@ -233,6 +233,21 @@ async fn eviction_leaves_a_marker_that_never_re_executes() {
     );
 }
 
+/// The name of the migration this test covers.
+const OPERATION_LOG_MIGRATION: &str = "m20260728_000022_add_operation_log";
+
+/// How many migrations were added at or after `name`, so a rollback can be
+/// expressed as "undo everything since" rather than as a literal count that
+/// every later migration has to remember to bump.
+fn migrations_after(name: &str) -> u32 {
+    let all = Migrator::migrations();
+    let index = all
+        .iter()
+        .position(|migration| migration.name() == name)
+        .expect("the migration under test is registered");
+    u32::try_from(all.len() - index).expect("migration count fits in u32")
+}
+
 #[tokio::test]
 async fn the_operation_log_migration_is_reversible() {
     let (_dir, store) = temp_store().await;
@@ -245,12 +260,13 @@ async fn the_operation_log_migration_is_reversible() {
         .await
         .unwrap();
 
-    // Rolling back the seven most recent additive migrations (the container
-    // execution location, the evidence location column, the per-chat citation
-    // format, the tool-call judge status, the chat permission mode, the
-    // output-revision binary/producing-run
-    // extension, then this one) drops the table symmetrically...
-    Migrator::down(&store.conn, Some(7)).await.unwrap();
+    // Rolling back every migration added after this one drops the table
+    // symmetrically. The count is derived rather than written down: this test
+    // is about the operation log's own reversibility, and having every new
+    // migration edit the number here made it a tripwire for unrelated work.
+    Migrator::down(&store.conn, Some(migrations_after(OPERATION_LOG_MIGRATION)))
+        .await
+        .unwrap();
     assert!(
         store
             .claim_operation(run, Uuid::new_v4(), b"fp", true, Uuid::new_v4())

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -79,8 +79,8 @@ pub use agent_tools::{
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalJournalIdentity, ApprovalRegistration,
     ApprovalRegistrationFuture, ApprovalRequest, ApprovalRequiredPublication, AutoApproveGate,
-    AutoJudgeStatus, GrantScope, RefuseGate, StandingGrant, StandingGrantRecord, StandingGrants,
-    ToolApproval, ToolApprovalKind, ToolApprovalStatus,
+    AutoJudgeStatus, GrantLevel, GrantScope, RefuseGate, StandingGrant, StandingGrantRecord,
+    StandingGrants, ToolApproval, ToolApprovalKind, ToolApprovalStatus,
 };
 #[cfg(feature = "blob-fs")]
 pub use blob::FsBlobStore;

--- a/crates/openwave-desktop/ui/src/ApprovalCard.tsx
+++ b/crates/openwave-desktop/ui/src/ApprovalCard.tsx
@@ -26,6 +26,8 @@ type ApprovalCardProps = {
   preview: ToolActionPreview | null;
   canApprove: boolean;
   canRemember: boolean;
+  /** How far a remembered answer will reach, for the option labels. */
+  grantScope?: GrantScopeName;
   /** The Auto-mode judge is deciding. Advisory only: the card stays live. */
   autoJudging?: boolean;
   deciding: boolean;
@@ -55,13 +57,14 @@ export function ApprovalCard({
   preview,
   canApprove,
   canRemember,
+  grantScope = "chat",
   autoJudging,
   deciding,
   error,
   onDecide,
 }: ApprovalCardProps) {
   const [expanded, setExpanded] = useState(false);
-  const options = approvalOptions(preview, canApprove, canRemember, expanded);
+  const options = approvalOptions(preview, canApprove, canRemember, expanded, grantScope);
   const [highlight, setHighlight] = useState(0);
   const rowRefs = useRef<Array<HTMLDivElement | null>>([]);
   const hasAutoFocused = useRef(false);
@@ -191,6 +194,12 @@ export function ApprovalCard({
           </div>
         ))}
       </div>
+      {canRemember && grantScope === "project" && (
+        <p className="text-muted-foreground text-xs">
+          Saved answers apply to every chat in this project. Review them under
+          Settings → Permissions.
+        </p>
+      )}
       <div className="flex items-center justify-between gap-2 text-xs">
         <span className="text-muted-foreground">
           ↑↓ choose · 1–{Math.min(options.length, 9)} jump · ↵ submit
@@ -243,11 +252,15 @@ const INLINE_GRANTS = 1;
  * A kind the server will not let the renderer approve offers only the decline,
  * so an unpresentable action can never be waved through from here.
  */
+/** How far a remembered answer reaches, as the label says it. */
+export type GrantScopeName = "chat" | "project";
+
 export function approvalOptions(
   preview: ToolActionPreview | null,
   canApprove: boolean,
   canRemember: boolean,
   expanded = false,
+  scope: GrantScopeName = "chat",
 ): ApprovalOption[] {
   if (!canApprove) return [declineOption()];
 
@@ -264,7 +277,7 @@ export function approvalOptions(
     },
   ];
 
-  const grants = canRemember ? grantLadder(preview) : [];
+  const grants = canRemember ? grantLadder(preview, scope) : [];
   const visible = expanded ? grants : grants.slice(0, INLINE_GRANTS);
   options.push(...visible);
   if (grants.length > visible.length) {
@@ -292,14 +305,21 @@ function declineOption(): ApprovalOption {
  * "allow every web search in this chat". A tool with nothing to describe can
  * only be granted wholesale, because there is no narrower thing to name.
  */
-export function grantLadder(preview: ToolActionPreview | null): ApprovalOption[] {
+export function grantLadder(
+  preview: ToolActionPreview | null,
+  scope: GrantScopeName = "chat",
+): ApprovalOption[] {
+  // The label names the level the server will actually write. A chat filed
+  // under a project grants across it, and saying "this chat" while writing
+  // something wider is the one thing a consent label must never do.
+  const where = scope === "project" ? "in this project" : "in this chat";
   const wholeTool: ApprovalOption = {
     kind: "decide",
     key: "whole-tool",
     label:
       preview?.tool === "exec"
-        ? "Yes, and don't ask again about commands in this chat"
-        : "Yes, and don't ask again in this chat",
+        ? `Yes, and don't ask again about commands ${where}`
+        : `Yes, and don't ask again ${where}`,
     decision: "approve",
     grant: "whole_tool",
   };

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -265,6 +265,7 @@ export function ChatView({
           userQuestionErrors={userQuestions.errors}
           decidingApprovalCalls={approvals.deciding}
           approvalErrors={approvals.errors}
+          grantScope={chat.project_id ? "project" : "chat"}
           backgroundAgentRuns={agentRuns.runs}
           backgroundAgentRunsLoading={agentRuns.loading}
           backgroundAgentRunsError={agentRuns.error}

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -28,6 +28,13 @@ function card(overrides: Partial<Parameters<typeof ApprovalCard>[0]> = {}) {
 
 const ONCE = "1.Yes, allow it once";
 const REMEMBER = "2.Yes, and don't ask again in this chat";
+
+/**
+ * A grant made in a project chat reaches every chat in it, so the widest rung
+ * has to say so — a label that says "this chat" while the server writes
+ * something wider is the failure the ladder exists to prevent.
+ */
+const REMEMBER_IN_PROJECT = "2.Yes, and don't ask again in this project";
 const MORE = "More options";
 
 afterEach(cleanup);
@@ -180,6 +187,17 @@ describe("approval card interactions", () => {
       "5.No, don't allow this",
     ]);
     expect(onDecide).not.toHaveBeenCalled();
+  });
+
+  it("names the project when a remembered answer will reach past this chat", async () => {
+    render(card({ grantScope: "project" }));
+
+    expect(
+      screen.getAllByRole("option").map((row) => row.textContent),
+    ).toEqual([ONCE, REMEMBER_IN_PROJECT, "3.No, don't allow this"]);
+    // And says once, in full, what the rows cannot say without becoming
+    // three long lines.
+    screen.getByText(/Saved answers apply to every chat in this project/);
   });
 
   it("returns the highlight to the narrowest grant when it widens the list", async () => {

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -11,7 +11,7 @@ import type {
   ToolResultPreview,
   UserQuestionAnswer,
 } from "./api";
-import { ApprovalCard } from "./ApprovalCard";
+import { ApprovalCard, type GrantScopeName } from "./ApprovalCard";
 import { AssistantWorkingIndicator } from "./AssistantWorkingIndicator";
 import { FolderAccessCard } from "./FolderAccessCard";
 import type {
@@ -109,6 +109,8 @@ type MessageListProps = {
   userQuestionErrors?: Record<string, string>;
   decidingApprovalCalls: Set<string>;
   approvalErrors: Record<string, string>;
+  /** How far a remembered approval reaches, for the card's labels. */
+  grantScope?: GrantScopeName;
   backgroundAgentRuns?: AgentRun[];
   backgroundAgentRunsLoading?: boolean;
   backgroundAgentRunsError?: string | null;
@@ -165,6 +167,7 @@ export function MessageList({
   userQuestionErrors = {},
   decidingApprovalCalls,
   approvalErrors,
+  grantScope,
   backgroundAgentRuns = [],
   backgroundAgentRunsLoading = false,
   backgroundAgentRunsError = null,
@@ -190,8 +193,8 @@ export function MessageList({
   // Stable identity between renders so memoized rows only re-render when the
   // approval state itself changes, not on every streamed token.
   const approvalState = useMemo(
-    () => ({ decidingApprovalCalls, approvalErrors }),
-    [decidingApprovalCalls, approvalErrors],
+    () => ({ decidingApprovalCalls, approvalErrors, grantScope }),
+    [decidingApprovalCalls, approvalErrors, grantScope],
   );
   const { items: messageItems, lastTurnStart } = groupMessageItems(
     messages,
@@ -363,6 +366,7 @@ export function groupMessageItems(
   approvalState?: {
     decidingApprovalCalls: Set<string>;
     approvalErrors: Record<string, string>;
+    grantScope?: GrantScopeName;
   },
   imageClient?: Pick<ApiClient, "getChatImageAttachment">,
   chatId?: string,
@@ -502,6 +506,7 @@ function surfacedCards(
   approvalState?: {
     decidingApprovalCalls: Set<string>;
     approvalErrors: Record<string, string>;
+    grantScope?: GrantScopeName;
   },
   chatId?: string,
 ): ReactNode[] {
@@ -519,6 +524,7 @@ function surfacedCards(
           preview={entry.preview ?? null}
           canApprove={entry.canApprove}
           canRemember={entry.canRemember}
+          grantScope={approvalState?.grantScope ?? "chat"}
           autoJudging={entry.autoJudging ?? false}
           deciding={
             approvalState?.decidingApprovalCalls.has(entry.callId) ?? false

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -22,6 +22,7 @@ import {
   type GatewayStatus as WireGatewayStatus,
   type SignInProgress,
   type StandingGrantSnapshot,
+  type GrantLevel,
   type GrantScope,
   type McpServerInfo as WireMcpServerInfo,
   type ManagedPolicy as WireManagedPolicy,
@@ -65,6 +66,7 @@ import type { DocumentProcessingStatus } from "./documents";
 
 export type {
   ApprovalClass,
+  GrantLevel,
   GrantScope,
   StandingGrantSnapshot,
   ChatToolActivityStatus,

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -478,6 +478,19 @@ supported: boolean, apps: Array<GatewayAppInfo>, };
 export type GatewayStatus = { configured: boolean, enabled: boolean, base_url?: string, signed_in: boolean, account_hint?: string, installation_id?: string, model_count: number, sign_in: SignInProgress, };
 
 /**
+ * How far a standing grant reaches.
+ *
+ * A grant used to cover exactly one chat, so "always allow `cargo`" was
+ * re-asked in the next conversation and the one after it — the single
+ * biggest source of prompting in the model. The level is chosen from where
+ * the chat lives rather than put to the reader as a question: a chat in a
+ * project grants across that project, and a loose chat has nothing wider to
+ * mean, so it grants for itself. The card states which one it is about to
+ * write; a grant nobody expected is the failure the ladder exists to prevent.
+ */
+export type GrantLevel = { "level": "chat", chat_id: ChatId, } | { "level": "project", project_id: ProjectId, };
+
+/**
  * How much a standing grant covers.
  *
  * A grant is easy to widen by accident and hard to notice afterwards, so the
@@ -1046,11 +1059,16 @@ export type StandingGrantSnapshot = {
  * The approval decision that created the grant — also the handle a
  * revocation names.
  */
-source_call_id: CallId, chat_id: ChatId, 
+source_call_id: CallId, 
 /**
- * Chat title for provenance; `None` when the chat is untitled.
+ * How far the grant reaches — one chat, or every chat in a project.
  */
-chat_title: string | null, action: RendererToolName, approval: ToolApprovalKind, scope: GrantScope, granted_at: string, };
+level: GrantLevel, 
+/**
+ * The name of whatever the level points at, for provenance. `None` when
+ * that chat or project is untitled.
+ */
+level_title: string | null, action: RendererToolName, approval: ToolApprovalKind, scope: GrantScope, granted_at: string, };
 
 /**
  * How the `path` of a structured-path evidence location is written.

--- a/crates/openwave-desktop/ui/src/settings/PermissionsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/PermissionsPanel.dom.test.tsx
@@ -7,8 +7,8 @@ import { PermissionsPanel } from "./PermissionsPanel";
 
 const execGrant: StandingGrantSnapshot = {
   source_call_id: "11111111-1111-1111-1111-111111111111",
-  chat_id: "22222222-2222-2222-2222-222222222222",
-  chat_title: "Quarterly filings",
+  level: { level: "chat", chat_id: "22222222-2222-2222-2222-222222222222" },
+  level_title: "Quarterly filings",
   action: "exec",
   approval: "exec_may_run_networked_command",
   scope: { scope: "any_args_for", command: "cargo" },
@@ -51,6 +51,22 @@ describe("PermissionsPanel", () => {
     await waitFor(() =>
       expect(screen.queryByText("cargo …")).not.toBeInTheDocument(),
     );
+  });
+
+  it("names a project grant as reaching past the chat that made it", async () => {
+    const projectGrant: StandingGrantSnapshot = {
+      ...execGrant,
+      level: { level: "project", project_id: "33333333-3333-3333-3333-333333333333" },
+      level_title: "Filings",
+    };
+    const client = api({
+      listStandingGrants: vi.fn().mockResolvedValue([projectGrant]),
+    });
+    render(<PermissionsPanel client={client} />);
+
+    // Not "Filings" alone: the reader has to be able to tell a grant that
+    // covers conversations they have not started yet.
+    await screen.findByText("Everything in Filings");
   });
 
   it("says so when nothing is saved", async () => {

--- a/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
@@ -69,9 +69,27 @@ export function shortOpaqueId(id: string): string {
   return id.length <= 10 ? id : `${id.slice(0, 6)}…${id.slice(-4)}`;
 }
 
-export function chatLabel(grant: StandingGrantSnapshot): string {
-  const title = grant.chat_title?.trim();
-  return title || `Chat ${shortOpaqueId(grant.chat_id)}`;
+/** The identity of whatever a grant reaches, for grouping. */
+export function levelKey(grant: StandingGrantSnapshot): string {
+  return grant.level.level === "chat"
+    ? `chat:${grant.level.chat_id}`
+    : `project:${grant.level.project_id}`;
+}
+
+/**
+ * What a group of grants applies to, named the way the reader chose it. A
+ * project grant says so out loud: it reaches conversations that have not been
+ * started yet, which is the whole point and also the thing worth being able
+ * to see.
+ */
+export function levelLabel(grant: StandingGrantSnapshot): string {
+  const title = grant.level_title?.trim();
+  if (grant.level.level === "project") {
+    return title
+      ? `Everything in ${title}`
+      : `Everything in project ${shortOpaqueId(grant.level.project_id)}`;
+  }
+  return title || `Chat ${shortOpaqueId(grant.level.chat_id)}`;
 }
 
 function grantedAtLabel(grantedAt: string): string {
@@ -84,23 +102,19 @@ function grantedAtLabel(grantedAt: string): string {
   })}`;
 }
 
-/** Grants in listing order, bucketed by chat without reordering across rows. */
-export function groupByChat(
+/** Grants in listing order, bucketed by what they reach, order preserved. */
+export function groupByLevel(
   grants: readonly StandingGrantSnapshot[],
-): { chatId: string; label: string; grants: StandingGrantSnapshot[] }[] {
+): { key: string; label: string; grants: StandingGrantSnapshot[] }[] {
   const groups = new Map<
     string,
-    { chatId: string; label: string; grants: StandingGrantSnapshot[] }
+    { key: string; label: string; grants: StandingGrantSnapshot[] }
   >();
   for (const grant of grants) {
-    const group = groups.get(grant.chat_id);
+    const key = levelKey(grant);
+    const group = groups.get(key);
     if (group) group.grants.push(grant);
-    else
-      groups.set(grant.chat_id, {
-        chatId: grant.chat_id,
-        label: chatLabel(grant),
-        grants: [grant],
-      });
+    else groups.set(key, { key, label: levelLabel(grant), grants: [grant] });
   }
   return [...groups.values()];
 }
@@ -164,7 +178,7 @@ export function PermissionsPanel({ client }: { client: ApiClient }) {
       ).toLowerCase()} covered by “${grantScopeLabel(
         grant.scope,
         grant.action,
-      )}” in ${chatLabel(grant)}.`,
+      )}” in ${levelLabel(grant).toLowerCase()}.`,
       confirmLabel: "Revoke",
       destructive: true,
     });
@@ -200,8 +214,8 @@ export function PermissionsPanel({ client }: { client: ApiClient }) {
         </p>
       )}
       {grants !== null &&
-        groupByChat(grants).map((group) => (
-          <SettingsSection key={group.chatId} title={group.label}>
+        groupByLevel(grants).map((group) => (
+          <SettingsSection key={group.key} title={group.label}>
             <div className="flex flex-col gap-4">
               {group.grants.map((grant) => (
                 <GrantRow

--- a/crates/openwave-mcp/src/server.rs
+++ b/crates/openwave-mcp/src/server.rs
@@ -72,7 +72,12 @@ impl ApprovalBridge {
         let action = ToolActionPreview::build(tool_name, arguments);
         // The canonical arguments decide authority; `action` beside it only
         // describes them for the card.
-        if self.grants.covers(chat_id, tool_name, kind, arguments) {
+        // The MCP face carries no project membership, so a grant reaches it
+        // only at chat level.
+        if self
+            .grants
+            .covers(chat_id, None, tool_name, kind, arguments)
+        {
             return None;
         }
         let request = ApprovalRequest {
@@ -365,7 +370,8 @@ mod tests {
     use async_trait::async_trait;
     use chrono::Utc;
     use openwave_core::{
-        ApprovalClass, AutoApproveGate, RefuseGate, StandingGrant, Tool, ToolOutput, ToolSpec,
+        ApprovalClass, AutoApproveGate, GrantLevel, RefuseGate, StandingGrant, Tool, ToolOutput,
+        ToolSpec,
     };
     use serde_json::json;
 
@@ -796,7 +802,7 @@ mod tests {
             ran: Arc::clone(&ran),
         }));
         let grant = StandingGrant::new(
-            chat_id,
+            GrantLevel::Chat { chat_id },
             "search",
             ToolApprovalKind::for_tool_name("search"),
             Utc::now(),

--- a/crates/openwave-server/src/approvals.rs
+++ b/crates/openwave-server/src/approvals.rs
@@ -14,8 +14,8 @@ use tokio::sync::Notify;
 use openwave_core::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalJournalIdentity, ApprovalRegistration,
     ApprovalRegistrationFuture, ApprovalRequest, ApprovalRequiredPublication, CallId, ChatId,
-    DecideToolApprovalOutcome, GrantScope, RequestToolApprovalOutcome, Result, StandingGrant,
-    StandingGrants, Store,
+    DecideToolApprovalOutcome, GrantLevel, GrantScope, RequestToolApprovalOutcome, Result,
+    StandingGrant, StandingGrants, Store,
 };
 
 /// Coordinates durable approval state with local low-latency waiters.
@@ -86,9 +86,23 @@ impl ApprovalBroker {
                 }
             }
         };
+        // Read before the decision so the grant is written at the level the
+        // chat actually has, not one inferred after the fact.
+        let chat_project_id = match rung {
+            None => None,
+            Some(_) => self
+                .store
+                .get_chat(chat_id)
+                .await?
+                .and_then(|chat| chat.project_id),
+        };
         let grant = match scope {
             Some(scope) => match StandingGrant::scoped(
-                current.chat_id,
+                // The level follows where the chat lives rather than being
+                // put to the reader: a chat in a project grants across it, a
+                // loose chat has nothing wider to mean. The card's label is
+                // what states which one this is.
+                GrantLevel::for_chat(current.chat_id, chat_project_id),
                 current.tool_name.clone(),
                 current.kind,
                 scope,
@@ -571,6 +585,118 @@ mod tests {
         );
     }
 
+    /// Create a chat filed under a fresh project, plus a parked exec request.
+    async fn setup_in_project(
+        arguments: serde_json::Value,
+    ) -> (Arc<dyn Store>, openwave_core::ProjectId, ApprovalRequest) {
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("approval.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        std::mem::forget(db);
+        let project = openwave_core::Project {
+            id: openwave_core::ProjectId::new(),
+            title: Some("Filings".into()),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_project(&project).await.unwrap();
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: Some(project.id),
+            title: Some("First".into()),
+            model: None,
+            reasoning_effort: None,
+            permission_mode: None,
+            citation_format: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let request = request_for(&store, chat.id, "exec", arguments).await;
+        (store, project.id, request)
+    }
+
+    /// The whole point of the widening: a grant made in one conversation is
+    /// still in force in the next one, instead of being re-asked forever.
+    #[tokio::test]
+    async fn a_grant_made_in_a_project_covers_the_next_chat_in_it() {
+        let exec_args = json!({ "command": "cargo", "args": ["test"], "cwd": "." });
+        let (store, project_id, request) = setup_in_project(exec_args.clone()).await;
+        let broker = ApprovalBroker::new(store.clone());
+        let pending = broker.register(request.clone(), None).await;
+        drop(pending.decision);
+        assert_eq!(
+            broker
+                .resolve_with_grant(
+                    request.chat_id,
+                    request.call_id,
+                    ApprovalDecision::Approve,
+                    Some(crate::routes::ApprovalGrantRung::WholeTool),
+                )
+                .await
+                .unwrap(),
+            ResolveApprovalOutcome::Resolved
+        );
+        // The grant was written at the level the chat lives at, not at the
+        // chat that happened to ask.
+        let listed = store.list_standing_tool_grants().await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].grant.level(), GrantLevel::Project { project_id });
+
+        // A different chat in the same project is covered without asking.
+        let sibling = Chat {
+            id: ChatId::new(),
+            project_id: Some(project_id),
+            title: Some("Second".into()),
+            model: None,
+            reasoning_effort: None,
+            permission_mode: None,
+            citation_format: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&sibling).await.unwrap();
+        let covered = request_for(&store, sibling.id, "exec", exec_args.clone()).await;
+        let registration = broker.register(covered, None).await;
+        assert!(matches!(
+            registration.publication,
+            openwave_core::ApprovalRequiredPublication::StandingGrant
+        ));
+        assert_eq!(registration.decision.await, ApprovalDecision::Approve);
+
+        // A chat outside the project is not. A project grant must widen to
+        // its project and no further.
+        let outsider = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: Some("Loose".into()),
+            model: None,
+            reasoning_effort: None,
+            permission_mode: None,
+            citation_format: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&outsider).await.unwrap();
+        let uncovered = request_for(&store, outsider.id, "exec", exec_args).await;
+        let registration = broker.register(uncovered, None).await;
+        assert!(!matches!(
+            registration.publication,
+            openwave_core::ApprovalRequiredPublication::StandingGrant
+        ));
+        drop(registration.decision);
+    }
+
     #[tokio::test]
     async fn a_revoked_grant_leaves_the_list_and_stops_covering() {
         let exec_args = json!({ "command": "cargo", "args": ["test"], "cwd": "." });
@@ -595,7 +721,12 @@ mod tests {
         let listed = store.list_standing_tool_grants().await.unwrap();
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].source_call_id, request.call_id);
-        assert_eq!(listed[0].grant.chat_id(), request.chat_id);
+        assert_eq!(
+            listed[0].grant.level(),
+            GrantLevel::Chat {
+                chat_id: request.chat_id
+            }
+        );
         assert_eq!(listed[0].grant.tool_name(), "exec");
 
         // A matching later call is auto-granted while the grant stands…
@@ -738,6 +869,7 @@ mod tests {
         );
         assert!(broker.standing_grants().covers(
             request.chat_id,
+            None,
             &request.tool_name,
             request.kind,
             &json!({})
@@ -887,6 +1019,7 @@ mod tests {
             |command: &str, args: &[&str]| json!({ "command": command, "args": args, "cwd": "." });
         assert!(grants.covers(
             request.chat_id,
+            None,
             "exec",
             request.kind,
             &exec("cargo", &["test"]),
@@ -895,11 +1028,12 @@ mod tests {
         // cannot stretch to a command the human never saw.
         assert!(!grants.covers(
             request.chat_id,
+            None,
             "exec",
             request.kind,
             &exec("cargo", &["publish"]),
         ));
-        assert!(!grants.covers(request.chat_id, "exec", request.kind, &json!({})));
+        assert!(!grants.covers(request.chat_id, None, "exec", request.kind, &json!({})));
     }
 
     #[tokio::test]
@@ -929,6 +1063,7 @@ mod tests {
         let query = |query: &str| json!({ "query": query });
         assert!(grants.covers(
             request.chat_id,
+            None,
             "web_search",
             request.kind,
             &query("quarterly filings"),
@@ -937,6 +1072,7 @@ mod tests {
         // asks.
         assert!(!grants.covers(
             request.chat_id,
+            None,
             "web_search",
             request.kind,
             &query("payroll")
@@ -984,6 +1120,7 @@ mod tests {
         );
         assert!(!broker.standing_grants().covers(
             request.chat_id,
+            None,
             "exec",
             request.kind,
             &json!({})
@@ -1013,6 +1150,7 @@ mod tests {
         );
         assert!(broker.standing_grants().covers(
             request.chat_id,
+            None,
             &request.tool_name,
             request.kind,
             &json!({})

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -2365,9 +2365,11 @@ pub(crate) struct StandingGrantSnapshot {
     /// The approval decision that created the grant — also the handle a
     /// revocation names.
     pub source_call_id: CallId,
-    pub chat_id: ChatId,
-    /// Chat title for provenance; `None` when the chat is untitled.
-    pub chat_title: Option<String>,
+    /// How far the grant reaches — one chat, or every chat in a project.
+    pub level: openwave_core::GrantLevel,
+    /// The name of whatever the level points at, for provenance. `None` when
+    /// that chat or project is untitled.
+    pub level_title: Option<String>,
     pub action: openwave_core::RendererToolName,
     pub approval: openwave_core::ToolApprovalKind,
     pub scope: openwave_core::GrantScope,
@@ -2382,24 +2384,42 @@ pub(crate) async fn list_standing_grants(
     State(state): State<AppState>,
 ) -> Result<Json<Vec<StandingGrantSnapshot>>, ServerError> {
     let grants = state.store.list_standing_tool_grants().await?;
-    let titles: std::collections::HashMap<ChatId, Option<String>> = state
+    let chat_titles: std::collections::HashMap<ChatId, Option<String>> = state
         .store
         .list_chats()
         .await?
         .into_iter()
         .map(|chat| (chat.id, chat.title))
         .collect();
+    let project_titles: std::collections::HashMap<ProjectId, Option<String>> = state
+        .store
+        .list_projects()
+        .await?
+        .into_iter()
+        .map(|project| (project.id, project.title))
+        .collect();
     Ok(Json(
         grants
             .into_iter()
-            .map(|record| StandingGrantSnapshot {
-                source_call_id: record.source_call_id,
-                chat_id: record.grant.chat_id(),
-                chat_title: titles.get(&record.grant.chat_id()).cloned().flatten(),
-                action: openwave_core::RendererToolName::from(record.grant.tool_name()),
-                approval: record.grant.kind(),
-                scope: record.grant.scope().clone(),
-                granted_at: record.grant.granted_at(),
+            .map(|record| {
+                let level = record.grant.level();
+                let level_title = match level {
+                    openwave_core::GrantLevel::Chat { chat_id } => {
+                        chat_titles.get(&chat_id).cloned().flatten()
+                    }
+                    openwave_core::GrantLevel::Project { project_id } => {
+                        project_titles.get(&project_id).cloned().flatten()
+                    }
+                };
+                StandingGrantSnapshot {
+                    source_call_id: record.source_call_id,
+                    level,
+                    level_title,
+                    action: openwave_core::RendererToolName::from(record.grant.tool_name()),
+                    approval: record.grant.kind(),
+                    scope: record.grant.scope().clone(),
+                    granted_at: record.grant.granted_at(),
+                }
             })
             .collect(),
     ))


### PR DESCRIPTION
Closes #937. The first of the four changes from the approval-model comparison, and the one that actually reduces prompting.

## The problem

`StandingGrant` was `(chat_id, tool_name, kind, scope)`, and the row cascaded on chat delete. So "always allow `cargo`" was asked again in the next conversation, forever. The tools we are modelling after make a remembered shell approval **permanent and per repository** — that single property is most of why they are not exhausting to use.

## The change

A grant now carries a **level**:

```rust
enum GrantLevel {
    Chat { chat_id: ChatId },
    Project { project_id: ProjectId },
}
```

The level follows where the chat lives rather than being put to the reader as a question — a chat filed under a project grants across that project, a loose chat has nothing wider to mean. **One answer, no scope picker, no new row on the card.** Matching widens from `chat_id = ?` to "the grant's chat is this chat, or its project is this chat's project", and a project grant reaches its project and no further.

## Not a silent widening

The card names the reach it is about to write — "don't ask again **in this project**" — and states once, under the options, that saved answers apply to every chat in the project.

I initially put the scope on all three rungs and the tests caught why that is wrong: the exact-action rung has a character budget for a single row, and three long rows say the same thing worse than one line does. So the widest rung names the reach (as it always did) and one sentence carries it for the rest.

The Permissions panel now groups by **what a grant reaches** rather than by chat, so a project grant reads as "Everything in Filings" and is findable and revocable as the wider thing it is.

## Migration

Existing rows are chat grants and stay chat grants — widening a decision someone already made, without asking, is the one thing this must not do.

`chat_id` becomes nullable and `project_id` joins it, with a CHECK that exactly one is set. SQLite cannot drop a NOT NULL or add a CHECK in place, so it rebuilds the table and copies every row across, following the existing `rebuild_agent_run_sqlite` pattern; PostgreSQL alters in place. The `down` **deletes project-level rows first**, because they have no representation in the narrower shape and rewriting them to a chat would invent a scope nobody chose.

## Tests

- The point of the feature, end to end: a grant made in a project chat covers a *different* chat in that project without asking, and does **not** cover a loose chat outside it.
- The card names the project when a remembered answer will reach past this chat, and shows the one-line explanation.
- The panel names a project grant as reaching past the chat that made it.

Two existing migration tests counted "roll back N migrations" literally and broke on any new migration. They derive the count from the registry now, so the next migration does not have to find and bump a number in an unrelated test — that tripwire has fired on nearly every migration I have added this week.

Verified locally: fmt, clippy (workspace, all targets), 572 core + 462 server + 47 MCP tests, `tsc`, 651 UI tests, build.

Depends on #944 (a one-line fix for a `main` that does not currently compile under `--all-targets`); that fix is carried here so this branch builds, and will disappear from the diff once #944 lands.

Next, per the plan: #938 (pattern rung), then #941 (read-only mode), then #939 (one vocabulary).