### PR TITLE
feat(desktop): managed profiles pick from entitled models only

### DIFF
--- a/crates/openwave-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient, ModelInfo, ModelRoleInfo } from "../api";
 import { ModelsPanel } from "./ModelsPanel";
 
@@ -53,6 +53,11 @@ const roles: ModelRoleInfo[] = [
   { role: "chat", selection: "gpt-4o", resolved_key: "openai::gpt-4o" },
   { role: "utility", selection: null, resolved_key: "openai::gpt-4o-mini" },
 ];
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
 
 describe("ModelsPanel", () => {
   it("picks a model per role and names what automatic resolves to", async () => {
@@ -125,5 +130,130 @@ describe("ModelsPanel", () => {
     await waitFor(() =>
       expect(putModelRole).toHaveBeenCalledWith("utility", null),
     );
+  });
+});
+
+function gatewayModel(
+  id: string,
+  displayName: string,
+  contextWindow: number,
+): ModelInfo {
+  return {
+    key: `model_gateway::${id}`,
+    id,
+    display_name: displayName,
+    provider: "model_gateway",
+    available: true,
+    context_window: contextWindow,
+    max_output_tokens: 8_192,
+    input_modalities: ["text"],
+    supports_reasoning: false,
+    reasoning_efforts: [],
+    multimodal: false,
+  };
+}
+
+// A managed catalog: the locked-out BYOK registry row is still reported by
+// the server, and must not surface as a choice; the gateway rows are the
+// entitled list.
+const managedModels: ModelInfo[] = [
+  models[0],
+  gatewayModel("gw-flagship", "Gateway Flagship", 1_000_000),
+  gatewayModel("gw-haiku", "Gateway Haiku", 200_000),
+];
+
+// A BYOK chat pin carried in from before the profile was managed: the server
+// reports it stored but resolves the role to a gateway model.
+const managedRoles: ModelRoleInfo[] = [
+  {
+    role: "chat",
+    selection: "anthropic::claude-opus-4-8",
+    resolved_key: "model_gateway::gw-flagship",
+  },
+  { role: "utility", selection: null, resolved_key: "model_gateway::gw-haiku" },
+];
+
+describe("ModelsPanel under managed policy", () => {
+
+  it("offers one flat entitled list per role and reads a dead pin as automatic", async () => {
+    const listModels = vi
+      .fn()
+      .mockResolvedValue({ models: managedModels, roles: managedRoles });
+    const putModelRole = vi.fn().mockResolvedValue({
+      role: "utility",
+      selection: "model_gateway::gw-haiku",
+      resolved_key: "model_gateway::gw-haiku",
+    });
+    const client = { listModels, putModelRole } as unknown as ApiClient;
+    const user = userEvent.setup();
+
+    render(<ModelsPanel client={client} models={managedModels} managed />);
+
+    // No provider step: there is exactly one provider, so each role is a
+    // single flat picker.
+    const chatModel = await screen.findByRole("combobox", {
+      name: "Chat model",
+    });
+    expect(
+      screen.queryByRole("combobox", { name: "Chat provider" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("combobox", { name: "Background work provider" }),
+    ).toBeNull();
+
+    // The stored BYOK pin is not gateway-served, so the role reads as the
+    // automatic pick the server resolved it to — not a dead selection.
+    expect(chatModel).toHaveTextContent("Automatic — Gateway Flagship");
+
+    // The list is the entitled models, nothing else: no BYOK row, not even a
+    // disabled one, because the reader cannot fix its unavailability here.
+    await user.click(
+      screen.getByRole("combobox", { name: "Background work model" }),
+    );
+    expect(
+      screen.getByRole("option", { name: "Automatic — Gateway Haiku" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Gateway Flagship" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Claude Opus/ })).toBeNull();
+
+    await user.click(screen.getByRole("option", { name: "Gateway Haiku" }));
+    await waitFor(() =>
+      expect(putModelRole).toHaveBeenCalledWith(
+        "utility",
+        "model_gateway::gw-haiku",
+      ),
+    );
+  });
+
+  it("shows a completed model sync without a manual refresh", async () => {
+    const unsynced = {
+      models: [],
+      roles: [
+        { role: "chat", selection: null, resolved_key: null },
+        { role: "utility", selection: null, resolved_key: null },
+      ],
+    };
+    const listModels = vi
+      .fn()
+      .mockResolvedValueOnce(unsynced)
+      .mockResolvedValue({ models: managedModels, roles: managedRoles });
+    const client = { listModels } as unknown as ApiClient;
+
+    vi.useFakeTimers();
+    render(<ModelsPanel client={client} models={[]} managed />);
+    // Flush the initial load: nothing synced yet.
+    await act(async () => {});
+    expect(screen.getByText(/has not synced any models/)).toBeInTheDocument();
+
+    // The watch picks up the completed sync on its next tick.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_100);
+    });
+    expect(screen.queryByText(/has not synced any models/)).toBeNull();
+    expect(
+      screen.getByRole("combobox", { name: "Chat model" }),
+    ).toHaveTextContent("Automatic — Gateway Flagship");
   });
 });

--- a/crates/openwave-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
@@ -174,7 +174,6 @@ const managedRoles: ModelRoleInfo[] = [
 ];
 
 describe("ModelsPanel under managed policy", () => {
-
   it("offers one flat entitled list per role and reads a dead pin as automatic", async () => {
     const listModels = vi
       .fn()

--- a/crates/openwave-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ModelsPanel.dom.test.tsx
@@ -179,11 +179,13 @@ describe("ModelsPanel under managed policy", () => {
     const listModels = vi
       .fn()
       .mockResolvedValue({ models: managedModels, roles: managedRoles });
-    const putModelRole = vi.fn().mockResolvedValue({
-      role: "utility",
-      selection: "model_gateway::gw-haiku",
-      resolved_key: "model_gateway::gw-haiku",
-    });
+    const putModelRole = vi
+      .fn()
+      .mockImplementation(async (role: string, selection: string | null) => ({
+        role,
+        selection,
+        resolved_key: selection ?? "model_gateway::gw-flagship",
+      }));
     const client = { listModels, putModelRole } as unknown as ApiClient;
     const user = userEvent.setup();
 
@@ -202,8 +204,14 @@ describe("ModelsPanel under managed policy", () => {
     ).toBeNull();
 
     // The stored BYOK pin is not gateway-served, so the role reads as the
-    // automatic pick the server resolved it to — not a dead selection.
+    // automatic pick the server resolved it to — not a dead selection — and
+    // says the pin is kept for a return to the open experience.
     expect(chatModel).toHaveTextContent("Automatic — Gateway Flagship");
+    expect(
+      screen.getByText(
+        /Your previous Anthropic selection is kept and restored/,
+      ),
+    ).toBeInTheDocument();
 
     // The list is the entitled models, nothing else: no BYOK row, not even a
     // disabled one, because the reader cannot fix its unavailability here.
@@ -225,6 +233,24 @@ describe("ModelsPanel under managed policy", () => {
         "model_gateway::gw-haiku",
       ),
     );
+
+    // The automatic entry is a real choice while a dead pin exists: picking
+    // it persists null, so automatic-by-reroute can become genuinely
+    // automatic instead of the trigger already claiming the state.
+    await user.click(chatModel);
+    await user.click(
+      screen.getByRole("option", {
+        name: "Automatic — Gateway Flagship (clears your previous Claude Opus 4.8 pin)",
+      }),
+    );
+    await waitFor(() =>
+      expect(putModelRole).toHaveBeenCalledWith("chat", null),
+    );
+    // Cleared, the pin notice goes and automatic is simply the value.
+    expect(
+      screen.queryByText(/Your previous Anthropic selection is kept/),
+    ).toBeNull();
+    expect(chatModel).toHaveTextContent("Automatic — Gateway Flagship");
   });
 
   it("shows a completed model sync without a manual refresh", async () => {
@@ -249,7 +275,7 @@ describe("ModelsPanel under managed policy", () => {
 
     // The watch picks up the completed sync on its next tick.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(5_100);
+      await vi.advanceTimersByTimeAsync(15_100);
     });
     expect(screen.queryByText(/has not synced any models/)).toBeNull();
     expect(

--- a/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
@@ -284,21 +284,26 @@ function ManagedModelRoleRow({
     selected.provider === "model_gateway" &&
     selected.available;
   const deadPin = !gatewayServed && info.selection !== null;
+  // The kept-and-restored story belongs to a BYOK pin surviving managed mode.
+  // A gateway pin that is merely unavailable — signed out, say — has no such
+  // story, so it gets no notice.
+  const keptByokPin =
+    deadPin && selected !== null && selected.provider !== "model_gateway";
   const automatic = automaticLabel(models, info);
+  const selectValue =
+    gatewayServed && selected ? selected.key : deadPin ? "" : AUTOMATIC;
 
   return (
     <SettingsSection title={title}>
       <p className="text-sm text-muted-foreground">{hint}</p>
-      {deadPin && (
+      {keptByokPin && (
         <p className="text-sm text-muted-foreground">
-          {`Your previous ${
-            selected ? `${providerLabel(selected.provider)} ` : ""
-          }selection is kept and restored if this device leaves managed mode — picking a model here replaces it.`}
+          {`Your previous ${providerLabel(selected.provider)} selection is kept and restored if this device leaves managed mode — picking a model here replaces it.`}
         </p>
       )}
       <SettingsField label="Model">
         <Select
-          value={gatewayServed && selected ? selected.key : deadPin ? "" : AUTOMATIC}
+          value={selectValue}
           disabled={
             saving ||
             entitled.length === 0 ||

--- a/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
@@ -32,46 +32,78 @@ import {
 const AUTOMATIC = "__automatic__";
 
 /**
+ * How often a managed panel re-reads the catalog. Entitlements move under the
+ * gateway's feet — an admin-triggered model sync changes both the list and
+ * what automatic resolves to — so the page keeps itself current instead of
+ * asking the reader to refresh. Matches the session-watch cadence in
+ * `ManagedGate`.
+ */
+const MANAGED_SYNC_WATCH_MS = 5_000;
+
+/**
  * The roles a reader can choose a model for, in the order they matter to them:
  * the conversation first, then the work the app does on its own.
  *
- * A new role is an entry here, matching the server's role list.
+ * A new role is an entry here, matching the server's role list. `managedHint`
+ * is the same story told for a profile whose models all come from a gateway,
+ * where "your configured providers" would name a thing the reader cannot have.
  */
-const ROLES: { role: ModelRole; title: string; hint: string }[] = [
+const ROLES: {
+  role: ModelRole;
+  title: string;
+  hint: string;
+  managedHint: string;
+}[] = [
   {
     role: "chat",
     title: "Chat",
     hint: "New conversations start on this model, and each one can still override it.",
+    managedHint:
+      "New conversations start on this model, and each one can still override it.",
   },
   {
     role: "utility",
     title: "Background work",
     hint: "Work OpenWave does on its own — compacting a long conversation, for instance — runs here, so it is not billed at your conversation model. Left automatic, it picks the cheapest model your configured providers serve; with none available, that work is skipped rather than moved onto your chat model.",
+    managedHint:
+      "Work OpenWave does on its own — compacting a long conversation, for instance — runs here, so it is not billed at your conversation model. Left automatic, it picks the smallest model your gateway serves; with none available, that work is skipped rather than moved onto your chat model.",
   },
 ];
 
 export function ModelsPanel({
   client,
   models,
+  managed = false,
   onChanged,
 }: {
   client: ApiClient;
   models: ModelInfo[];
+  /** A managed profile's models all come from its gateway: there is no
+   * provider to choose, each role offers the entitled list flat, and a stored
+   * default the gateway does not serve reads as what automatic resolves to —
+   * the same re-route the server applies when resolving the role. */
+  managed?: boolean;
   onChanged?: () => void;
 }) {
   const [roles, setRoles] = useState<ModelRoleInfo[]>([]);
+  const [catalog, setCatalog] = useState<ModelInfo[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState<ModelRole | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // `managed` is a dependency on purpose: a policy flip mid-session re-reads
+  // the catalog, so the page reshapes without a manual refresh.
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setError(null);
     void (async () => {
       try {
-        const catalog = await client.listModels();
-        if (!cancelled) setRoles(catalog.roles);
+        const next = await client.listModels();
+        if (!cancelled) {
+          setRoles(next.roles);
+          setCatalog(next.models);
+        }
       } catch (err) {
         if (!cancelled) setError(String(err));
       } finally {
@@ -81,7 +113,32 @@ export function ModelsPanel({
     return () => {
       cancelled = true;
     };
-  }, [client]);
+  }, [client, managed]);
+
+  // The managed watch. A failed tick keeps the last answer — the next tick
+  // retries — and the poll only exists while the profile is managed, so the
+  // open experience keeps its read-once behavior untouched.
+  useEffect(() => {
+    if (!managed) return;
+    const timer = window.setInterval(() => {
+      void client
+        .listModels()
+        .then((next) => {
+          setRoles(next.roles);
+          setCatalog(next.models);
+        })
+        .catch(() => undefined);
+    }, MANAGED_SYNC_WATCH_MS);
+    return () => window.clearInterval(timer);
+  }, [client, managed]);
+
+  // Unmanaged renders from the shell's catalog exactly as it always has;
+  // managed renders from the panel's own fetch, which the watch keeps current.
+  const catalogModels = managed ? (catalog ?? models) : models;
+  const entitled = useMemo(
+    () => catalogModels.filter((model) => model.provider === "model_gateway"),
+    [catalogModels],
+  );
 
   async function save(role: ModelRole, selection: ModelSelectionKey | null) {
     setSaving(role);
@@ -104,7 +161,11 @@ export function ModelsPanel({
   return (
     <SettingsPanel
       title="Models"
-      description="Choose the provider first, then a model that provider is configured to serve. A role left automatic is resolved against whatever you have credentialed."
+      description={
+        managed
+          ? "Your organization's gateway decides which models are available here. A role left automatic resolves to one of them on its own."
+          : "Choose the provider first, then a model that provider is configured to serve. A role left automatic is resolved against whatever you have credentialed."
+      }
       busy={loading}
     >
       {loading ? (
@@ -114,7 +175,18 @@ export function ModelsPanel({
           {ROLES.map((entry) => {
             const info = roles.find((row) => row.role === entry.role);
             if (!info) return null;
-            return (
+            return managed ? (
+              <ManagedModelRoleRow
+                key={entry.role}
+                title={entry.title}
+                hint={entry.managedHint}
+                models={catalogModels}
+                entitled={entitled}
+                info={info}
+                saving={saving === entry.role}
+                onSelect={(selection) => void save(entry.role, selection)}
+              />
+            ) : (
               <ModelRoleRow
                 key={entry.role}
                 title={entry.title}
@@ -126,15 +198,88 @@ export function ModelsPanel({
               />
             );
           })}
-          {models.length === 0 && (
-            <p className="text-sm text-muted-foreground">
-              No models are registered yet. Configure a provider first.
-            </p>
-          )}
+          {managed
+            ? entitled.length === 0 && (
+                <p className="text-sm text-muted-foreground">
+                  The gateway has not synced any models yet. They appear here
+                  as soon as a sync completes.
+                </p>
+              )
+            : models.length === 0 && (
+                <p className="text-sm text-muted-foreground">
+                  No models are registered yet. Configure a provider first.
+                </p>
+              )}
         </>
       )}
       {error && <SettingsError>{error}</SettingsError>}
     </SettingsPanel>
+  );
+}
+
+/**
+ * One role under managed policy: no provider dropdown — there is exactly one
+ * provider — just the flat list of models the gateway is entitled to serve.
+ *
+ * A stored selection the gateway does not serve presents as the automatic
+ * choice rather than a dead pin, mirroring how the server resolves it. The pin
+ * itself stays stored, so a profile returned to the open experience gets its
+ * selection back.
+ */
+function ManagedModelRoleRow({
+  title,
+  hint,
+  models,
+  entitled,
+  info,
+  saving,
+  onSelect,
+}: {
+  title: string;
+  hint: string;
+  models: ModelInfo[];
+  entitled: ModelInfo[];
+  info: ModelRoleInfo;
+  saving: boolean;
+  onSelect: (selection: ModelSelectionKey | null) => void;
+}) {
+  const selected = modelForSelection(models, info.selection);
+  const gatewayServed =
+    selected !== null &&
+    selected.provider === "model_gateway" &&
+    selected.available;
+
+  return (
+    <SettingsSection title={title}>
+      <p className="text-sm text-muted-foreground">{hint}</p>
+      <SettingsField label="Model">
+        <Select
+          value={gatewayServed ? selected.key : AUTOMATIC}
+          disabled={saving || entitled.length === 0}
+          onValueChange={(value) => {
+            onSelect(value === AUTOMATIC ? null : (value as ModelSelectionKey));
+          }}
+        >
+          <SelectTrigger aria-label={`${title} model`}>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={AUTOMATIC}>
+              {automaticLabel(models, info)}
+            </SelectItem>
+            {entitled.map((model) => (
+              <SelectItem
+                key={model.key}
+                value={model.key}
+                disabled={!model.available}
+              >
+                {model.display_name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </SettingsField>
+    </SettingsSection>
   );
 }
 

--- a/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type {
   ApiClient,
   ModelInfo,
@@ -35,10 +35,11 @@ const AUTOMATIC = "__automatic__";
  * How often a managed panel re-reads the catalog. Entitlements move under the
  * gateway's feet — an admin-triggered model sync changes both the list and
  * what automatic resolves to — so the page keeps itself current instead of
- * asking the reader to refresh. Matches the session-watch cadence in
- * `ManagedGate`.
+ * asking the reader to refresh. Slower than the gate's session watch on
+ * purpose: entitlement changes are rare, and each tick is a full catalog
+ * read.
  */
-const MANAGED_SYNC_WATCH_MS = 5_000;
+const MANAGED_SYNC_WATCH_MS = 15_000;
 
 /**
  * The roles a reader can choose a model for, in the order they matter to them:
@@ -52,14 +53,15 @@ const ROLES: {
   role: ModelRole;
   title: string;
   hint: string;
-  managedHint: string;
+  /** Managed rewording, for roles whose open-experience copy names things a
+   * managed reader cannot have. Roles whose story is the same either way
+   * omit it. */
+  managedHint?: string;
 }[] = [
   {
     role: "chat",
     title: "Chat",
     hint: "New conversations start on this model, and each one can still override it.",
-    managedHint:
-      "New conversations start on this model, and each one can still override it.",
   },
   {
     role: "utility",
@@ -116,18 +118,26 @@ export function ModelsPanel({
   }, [client, managed]);
 
   // The managed watch. A failed tick keeps the last answer — the next tick
-  // retries — and the poll only exists while the profile is managed, so the
-  // open experience keeps its read-once behavior untouched.
+  // retries — a tick that finds the previous read still in flight skips
+  // rather than stacking requests behind a slow server, and the poll only
+  // exists while the profile is managed, so the open experience keeps its
+  // read-once behavior untouched.
+  const watchInFlight = useRef(false);
   useEffect(() => {
     if (!managed) return;
     const timer = window.setInterval(() => {
+      if (watchInFlight.current) return;
+      watchInFlight.current = true;
       void client
         .listModels()
         .then((next) => {
           setRoles(next.roles);
           setCatalog(next.models);
         })
-        .catch(() => undefined);
+        .catch(() => undefined)
+        .finally(() => {
+          watchInFlight.current = false;
+        });
     }, MANAGED_SYNC_WATCH_MS);
     return () => window.clearInterval(timer);
   }, [client, managed]);
@@ -179,7 +189,7 @@ export function ModelsPanel({
               <ManagedModelRoleRow
                 key={entry.role}
                 title={entry.title}
-                hint={entry.managedHint}
+                hint={entry.managedHint ?? entry.hint}
                 models={catalogModels}
                 entitled={entitled}
                 info={info}
@@ -198,18 +208,15 @@ export function ModelsPanel({
               />
             );
           })}
-          {managed
-            ? entitled.length === 0 && (
-                <p className="text-sm text-muted-foreground">
-                  The gateway has not synced any models yet. They appear here
-                  as soon as a sync completes.
-                </p>
-              )
-            : models.length === 0 && (
-                <p className="text-sm text-muted-foreground">
-                  No models are registered yet. Configure a provider first.
-                </p>
-              )}
+          {managed ? (
+            <ManagedCatalogNotice entitled={entitled} />
+          ) : (
+            models.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                No models are registered yet. Configure a provider first.
+              </p>
+            )
+          )}
         </>
       )}
       {error && <SettingsError>{error}</SettingsError>}
@@ -218,13 +225,41 @@ export function ModelsPanel({
 }
 
 /**
+ * What a managed reader is told when the entitled list cannot be picked from:
+ * nothing synced yet, or a gateway session that has lapsed. Both are states
+ * only the gateway side can fix, so the copy names the fix rather than
+ * offering rows that cannot be chosen.
+ */
+function ManagedCatalogNotice({ entitled }: { entitled: ModelInfo[] }) {
+  if (entitled.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        The gateway has not synced any models yet. They appear here as soon as
+        a sync completes.
+      </p>
+    );
+  }
+  if (!entitled.some((model) => model.available)) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Sign in to your gateway to choose models.
+      </p>
+    );
+  }
+  return null;
+}
+
+/**
  * One role under managed policy: no provider dropdown — there is exactly one
  * provider — just the flat list of models the gateway is entitled to serve.
  *
  * A stored selection the gateway does not serve presents as the automatic
- * choice rather than a dead pin, mirroring how the server resolves it. The pin
- * itself stays stored, so a profile returned to the open experience gets its
- * selection back.
+ * choice rather than a dead pin, mirroring how the server resolves it. The
+ * pin itself stays stored — a profile returned to the open experience gets
+ * its selection back — which the row says out loud, and the automatic entry
+ * doubles as the way to clear it: with a dead pin the trigger carries no
+ * value of its own (it shows the automatic label as placeholder), so choosing
+ * the automatic entry is a real change that persists `null`.
  */
 function ManagedModelRoleRow({
   title,
@@ -248,24 +283,41 @@ function ManagedModelRoleRow({
     selected !== null &&
     selected.provider === "model_gateway" &&
     selected.available;
+  const deadPin = !gatewayServed && info.selection !== null;
+  const automatic = automaticLabel(models, info);
 
   return (
     <SettingsSection title={title}>
       <p className="text-sm text-muted-foreground">{hint}</p>
+      {deadPin && (
+        <p className="text-sm text-muted-foreground">
+          {`Your previous ${
+            selected ? `${providerLabel(selected.provider)} ` : ""
+          }selection is kept and restored if this device leaves managed mode — picking a model here replaces it.`}
+        </p>
+      )}
       <SettingsField label="Model">
         <Select
-          value={gatewayServed ? selected.key : AUTOMATIC}
-          disabled={saving || entitled.length === 0}
+          value={gatewayServed && selected ? selected.key : deadPin ? "" : AUTOMATIC}
+          disabled={
+            saving ||
+            entitled.length === 0 ||
+            !entitled.some((model) => model.available)
+          }
           onValueChange={(value) => {
             onSelect(value === AUTOMATIC ? null : (value as ModelSelectionKey));
           }}
         >
           <SelectTrigger aria-label={`${title} model`}>
-            <SelectValue />
+            <SelectValue placeholder={automatic} />
           </SelectTrigger>
           <SelectContent>
             <SelectItem value={AUTOMATIC}>
-              {automaticLabel(models, info)}
+              {deadPin
+                ? `${automatic} (clears your previous ${
+                    selected?.display_name ?? info.selection
+                  } pin)`
+                : automatic}
             </SelectItem>
             {entitled.map((model) => (
               <SelectItem

--- a/crates/openwave-desktop/ui/src/settings/sections.tsx
+++ b/crates/openwave-desktop/ui/src/settings/sections.tsx
@@ -50,10 +50,12 @@ function GatewaySection() {
 
 function ModelsSection() {
   const { client, models, refreshCatalog } = useApp();
+  const { managed } = useManagedPolicy();
   return (
     <ModelsPanel
       client={client}
       models={models}
+      managed={managed}
       onChanged={() => void refreshCatalog()}
     />
   );

--- a/crates/openwave-server/src/model_roles.rs
+++ b/crates/openwave-server/src/model_roles.rs
@@ -197,12 +197,61 @@ async fn gateway_defaults(store: &dyn Store) -> Result<Vec<String>> {
         .await?
         .models;
     models.sort_by_key(|model| model.context_window);
-    Ok(models
+    Ok(selection_keys(&models))
+}
+
+/// The entitled models in the gateway's own listed order — the order the
+/// composer picker renders them, and therefore the chat role's fallback
+/// order. Contrast [`gateway_defaults`], which re-sorts the same list
+/// cheapest-first for background work.
+async fn gateway_listed(store: &dyn Store) -> Result<Vec<String>> {
+    Ok(selection_keys(
+        &providers::read_config(store, providers::ProviderKind::ModelGateway)
+            .await?
+            .models,
+    ))
+}
+
+fn selection_keys(models: &[providers::CustomModelConfig]) -> Vec<String> {
+    models
         .iter()
         .map(|model| {
             crate::model_registry::selection_key(providers::ProviderKind::ModelGateway, &model.id)
         })
-        .collect())
+        .collect()
+}
+
+/// The chat role's effective policy for `selection` under `managed`: the
+/// selection itself while its provider can serve it, else the first entitled
+/// gateway model.
+///
+/// This is one function on purpose. The roles read labels the default with it
+/// and the turn-accept seam freezes a model from it, so the model a client
+/// shows for "default" and the model the next turn actually runs cannot
+/// diverge. Unmanaged, the selection resolves as-is, dead or not: the open
+/// experience refuses loudly at send rather than silently moving a foreground
+/// turn to another provider.
+pub async fn effective_chat_policy(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+    managed: &crate::managed_policy::ManagedPolicy,
+    selection: &str,
+) -> Result<Option<ResolvedModelPolicy>> {
+    let resolved = providers::resolve_model_policy(store, selection, true).await?;
+    if !managed.managed {
+        return Ok(resolved);
+    }
+    if let Some(policy) = resolved {
+        if providers::provider_is_usable(store, secrets, policy.provider, managed).await? {
+            return Ok(Some(policy));
+        }
+    }
+    for key in gateway_listed(store).await? {
+        if let Some(policy) = usable_policy(store, secrets, managed, &key).await? {
+            return Ok(Some(policy));
+        }
+    }
+    Ok(None)
 }
 
 /// Resolve `selection` only if its provider is usable under `managed`.

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -908,6 +908,11 @@ pub async fn put_model_role(
 }
 
 /// The catalog key `role` resolves to right now, given its stored `selection`.
+///
+/// This is the server's one answer for "what does this role's default mean" —
+/// the settings page and the composer both label their automatic choice with
+/// it, which is why the managed re-route below lives here rather than in a
+/// client.
 async fn resolved_role_key(
     state: &AppState,
     role: ModelRole,
@@ -923,10 +928,49 @@ async fn resolved_role_key(
                 Some(selection) => selection.to_owned(),
                 None => chat_role_model(&*state.store, &state.agent_config.model).await?,
             };
+            let resolved = providers::resolve_model_policy(&*state.store, &fallback, true).await?;
+            let managed = crate::managed_policy::resolve(&*state.store, &*state.os_policy).await?;
+            if !managed.managed {
+                return Ok(resolved.map(|policy| policy.key));
+            }
+            // Managed: the stored selection — or the boot default behind it —
+            // may name a BYOK model the policy has locked out, typically a
+            // default carried in from before the profile was managed. That
+            // resolution names a model no turn can run, so the role lands on
+            // the first entitled gateway model instead: the row the composer
+            // picker offers first, in the gateway's own order. (The `utility`
+            // role re-routes inside `model_roles::resolve`, which walks the
+            // entitled list cheapest-first.)
+            if let Some(policy) = resolved {
+                if providers::provider_is_usable(
+                    &*state.store,
+                    &*state.secrets,
+                    policy.provider,
+                    &managed,
+                )
+                .await?
+                {
+                    return Ok(Some(policy.key));
+                }
+            }
+            if !providers::provider_is_usable(
+                &*state.store,
+                &*state.secrets,
+                ProviderKind::ModelGateway,
+                &managed,
+            )
+            .await?
+            {
+                return Ok(None);
+            }
             Ok(
-                providers::resolve_model_policy(&*state.store, &fallback, true)
+                providers::read_config(&*state.store, ProviderKind::ModelGateway)
                     .await?
-                    .map(|policy| policy.key),
+                    .models
+                    .first()
+                    .map(|model| {
+                        crate::model_registry::selection_key(ProviderKind::ModelGateway, &model.id)
+                    }),
             )
         }
         _ => Ok(

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -921,57 +921,24 @@ async fn resolved_role_key(
     match role {
         // The chat role goes through the same seam a new execution does, minus
         // the per-chat override there is no chat here to read — so the label a
-        // client shows for "default" is what the next turn actually gets. Its
-        // last resort is the boot default, which no role's list can name.
+        // client shows for "default" is what the next turn actually gets: the
+        // accept path below freezes its model through the same
+        // `effective_chat_policy`, managed re-route included. Its last resort
+        // is the boot default, which no role's list can name.
         ModelRole::Chat => {
             let fallback = match selection {
                 Some(selection) => selection.to_owned(),
                 None => chat_role_model(&*state.store, &state.agent_config.model).await?,
             };
-            let resolved = providers::resolve_model_policy(&*state.store, &fallback, true).await?;
             let managed = crate::managed_policy::resolve(&*state.store, &*state.os_policy).await?;
-            if !managed.managed {
-                return Ok(resolved.map(|policy| policy.key));
-            }
-            // Managed: the stored selection — or the boot default behind it —
-            // may name a BYOK model the policy has locked out, typically a
-            // default carried in from before the profile was managed. That
-            // resolution names a model no turn can run, so the role lands on
-            // the first entitled gateway model instead: the row the composer
-            // picker offers first, in the gateway's own order. (The `utility`
-            // role re-routes inside `model_roles::resolve`, which walks the
-            // entitled list cheapest-first.)
-            if let Some(policy) = resolved {
-                if providers::provider_is_usable(
-                    &*state.store,
-                    &*state.secrets,
-                    policy.provider,
-                    &managed,
-                )
-                .await?
-                {
-                    return Ok(Some(policy.key));
-                }
-            }
-            if !providers::provider_is_usable(
+            Ok(model_roles::effective_chat_policy(
                 &*state.store,
                 &*state.secrets,
-                ProviderKind::ModelGateway,
                 &managed,
+                &fallback,
             )
             .await?
-            {
-                return Ok(None);
-            }
-            Ok(
-                providers::read_config(&*state.store, ProviderKind::ModelGateway)
-                    .await?
-                    .models
-                    .first()
-                    .map(|model| {
-                        crate::model_registry::selection_key(ProviderKind::ModelGateway, &model.id)
-                    }),
-            )
+            .map(|policy| policy.key))
         }
         _ => Ok(
             model_roles::resolve(&*state.store, &*state.secrets, &*state.os_policy, role)
@@ -2078,6 +2045,15 @@ pub async fn post_message(
         existing.model
     } else {
         let selected = resolve_chat_model(&*state.store, &chat, &state.agent_config.model).await?;
+        // The same managed re-route the roles read applies, so the model a
+        // client labeled as the default is the model this freeze lands on. A
+        // managed profile with nothing entitled keeps the raw selection, and
+        // validation refuses it with the real reason.
+        let managed = crate::managed_policy::resolve(&*state.store, &*state.os_policy).await?;
+        let selected =
+            model_roles::effective_chat_policy(&*state.store, &*state.secrets, &managed, &selected)
+                .await?
+                .map_or(selected, |policy| policy.key);
         validate_model_selection(&state, &selected, true).await?
     };
     let images = resolve_message_attachments(&state, &body.attachments).await?;

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -2045,15 +2045,22 @@ pub async fn post_message(
         existing.model
     } else {
         let selected = resolve_chat_model(&*state.store, &chat, &state.agent_config.model).await?;
-        // The same managed re-route the roles read applies, so the model a
-        // client labeled as the default is the model this freeze lands on. A
-        // managed profile with nothing entitled keeps the raw selection, and
-        // validation refuses it with the real reason.
+        // The managed re-route the roles read applies, on exactly the domain
+        // that read labels: the role default, and only for a managed profile.
+        // Unmanaged sends pass through untouched — free-form ids included —
+        // and a per-chat override is the user's explicit pick, so a dead one
+        // gets the honest validation refusal below rather than a silent swap
+        // out from under the label the pill still shows; the picker offers
+        // only gateway models to fix it. A managed profile with nothing
+        // entitled also keeps the raw selection, refused with the real reason.
         let managed = crate::managed_policy::resolve(&*state.store, &*state.os_policy).await?;
-        let selected =
+        let selected = if managed.managed && chat.model.is_none() {
             model_roles::effective_chat_policy(&*state.store, &*state.secrets, &managed, &selected)
                 .await?
-                .map_or(selected, |policy| policy.key);
+                .map_or(selected, |policy| policy.key)
+        } else {
+            selected
+        };
         validate_model_selection(&state, &selected, true).await?
     };
     let images = resolve_message_attachments(&state, &body.attachments).await?;

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1403,7 +1403,8 @@ async fn configured_router_canonicalizes_typed_models_and_rejects_wrong_or_unava
 /// ordered defaults skip providers that cannot serve a request, a pin overrides
 /// them, and enabling a provider changes the answer without a restart. When the
 /// profile flips to managed, both roles' reads re-route to entitled gateway
-/// models rather than reporting selections no turn could serve.
+/// models rather than reporting selections no turn could serve — and a message
+/// sent against the stale default runs on the re-routed model.
 #[tokio::test]
 async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
     let dir = tempfile::tempdir().unwrap();
@@ -1581,6 +1582,14 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
         role_row(&role_rows().await, "utility")["resolved_key"],
         "gemini::gemini-3.5-flash-lite"
     );
+    // Unmanaged, the chat role reports even a dead default (OpenAI is now
+    // disabled) rather than re-routing it: the open experience refuses loudly
+    // at send instead of silently moving a foreground turn. This pins the
+    // unmanaged early return in `effective_chat_policy`.
+    assert_eq!(
+        role_row(&role_rows().await, "chat")["resolved_key"],
+        "openai::gpt-5.6-sol"
+    );
 
     // A managed flip with a BYOK chat pin carried in from before it: the pin
     // stays stored — a profile returned to the open experience gets it back —
@@ -1646,6 +1655,36 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
     assert_eq!(
         role_row(&roles, "utility")["resolved_key"],
         "model_gateway::gateway-haiku"
+    );
+
+    // The label is what the turn gets: a message sent against that stale BYOK
+    // default is accepted and frozen on the gateway model the roles read
+    // named, not refused with `model_provider_unavailable`. This is the
+    // field-reported failure — remove the re-route from the accept path and
+    // this send 409s.
+    let chat_response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/chats")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(chat_response.status(), StatusCode::CREATED);
+    let chat: Chat = json_body(chat_response).await;
+    let turn_id = TurnId::new();
+    assert_eq!(
+        send_message_with_id(&router, &bearer, chat.id, turn_id, "hello").await,
+        StatusCode::ACCEPTED
+    );
+    assert_eq!(
+        store.get_turn_run(turn_id).await.unwrap().unwrap().model,
+        "model_gateway::gateway-flagship"
     );
 }
 

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1401,7 +1401,9 @@ async fn configured_router_canonicalizes_typed_models_and_rejects_wrong_or_unava
 
 /// Roles resolve on read, against whatever the user has credentialed: the
 /// ordered defaults skip providers that cannot serve a request, a pin overrides
-/// them, and enabling a provider changes the answer without a restart.
+/// them, and enabling a provider changes the answer without a restart. When the
+/// profile flips to managed, both roles' reads re-route to entitled gateway
+/// models rather than reporting selections no turn could serve.
 #[tokio::test]
 async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
     let dir = tempfile::tempdir().unwrap();
@@ -1431,7 +1433,7 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
             ),
             Arc::new(crate::managed_policy::NoOsPolicy),
         )),
-        secrets,
+        secrets.clone(),
         Arc::new(ToolRegistry::new()),
         retrieval,
         AgentConfig {
@@ -1578,6 +1580,72 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
     assert_eq!(
         role_row(&role_rows().await, "utility")["resolved_key"],
         "gemini::gemini-3.5-flash-lite"
+    );
+
+    // A managed flip with a BYOK chat pin carried in from before it: the pin
+    // stays stored — a profile returned to the open experience gets it back —
+    // but both roles' effective resolutions move to entitled gateway models.
+    // Chat lands on the first model the gateway lists (the row the composer
+    // picker offers first); utility keeps #901's cheapest-first walk.
+    configure_provider("openai", serde_json::json!({"enabled": true})).await;
+    let pinned = put_role(
+        "chat",
+        serde_json::json!({"selection": "openai::gpt-5.6-sol"}),
+    )
+    .await;
+    assert_eq!(pinned.status(), StatusCode::OK);
+
+    crate::managed_policy::provision(&*store, "https://corp.gateway")
+        .await
+        .unwrap();
+    let credentials: openwave_connectors::GatewayCredentials =
+        serde_json::from_value(serde_json::json!({
+            "base_url": "https://corp.gateway/",
+            "installation_id": "install-1",
+            "user_id": "user-1",
+            "refresh_token": "mg_rt_seed",
+            "access_tokens": {}
+        }))
+        .unwrap();
+    openwave_connectors::CredentialVault::new(secrets)
+        .save(&credentials)
+        .await
+        .unwrap();
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::ModelGateway,
+        &providers::ProviderConfig {
+            enabled: true,
+            base_url: Some("https://corp.gateway/".to_string()),
+            vertex_location: None,
+            // Flagship-first, as a gateway well might list them: chat takes
+            // the gateway's first pick, utility must not.
+            models: vec![
+                providers::CustomModelConfig {
+                    id: "gateway-flagship".to_string(),
+                    display_name: Some("Gateway Flagship".to_string()),
+                    context_window: 1_000_000,
+                    max_output_tokens: 64_000,
+                },
+                providers::CustomModelConfig {
+                    id: "gateway-haiku".to_string(),
+                    display_name: Some("Gateway Haiku".to_string()),
+                    context_window: 200_000,
+                    max_output_tokens: 8_192,
+                },
+            ],
+        },
+    )
+    .await
+    .unwrap();
+
+    let roles = role_rows().await;
+    let chat = role_row(&roles, "chat");
+    assert_eq!(chat["selection"], "openai::gpt-5.6-sol");
+    assert_eq!(chat["resolved_key"], "model_gateway::gateway-flagship");
+    assert_eq!(
+        role_row(&roles, "utility")["resolved_key"],
+        "model_gateway::gateway-haiku"
     );
 }
 

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1603,6 +1603,25 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
     )
     .await;
     assert_eq!(pinned.status(), StatusCode::OK);
+    // A chat with its own explicit override, created while OpenAI could still
+    // serve it — the re-route must not cover it after the flip.
+    let overridden_response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/chats")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"model": "openai::gpt-5.6-sol"}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(overridden_response.status(), StatusCode::CREATED);
+    let overridden: Chat = json_body(overridden_response).await;
 
     crate::managed_policy::provision(&*store, "https://corp.gateway")
         .await
@@ -1685,6 +1704,15 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
     assert_eq!(
         store.get_turn_run(turn_id).await.unwrap().unwrap().model,
         "model_gateway::gateway-flagship"
+    );
+
+    // The re-route covers exactly what the roles read labels: the default. A
+    // per-chat override is the user's explicit pick, and its pill still names
+    // it — a dead one is refused honestly rather than silently swapped, and
+    // the picker offers only gateway models to fix it.
+    assert_eq!(
+        send_message_with_id(&router, &bearer, overridden.id, TurnId::new(), "hello").await,
+        StatusCode::CONFLICT
     );
 }
 


### PR DESCRIPTION
Under managed policy the Models/roles settings page rendered every BYOK provider as "<provider> — unavailable", and role defaults could point at providers the policy can never let serve them — Brandon's field report needed a refresh, new defaults, and a picker reset before the app worked.

## What changed

**Managed shape of the Models page.** Under a managed profile the page drops the provider dropdown entirely (there is exactly one provider) and offers each role one flat list of the gateway's entitled models. The "unavailable rows remain visible for clarity" rationale only holds when the reader can fix the unavailability; under managed they cannot, so locked-out BYOK rows no longer appear at all.

**Self-healing defaults, resolved server-side.** A stored default the gateway does not serve renders as — and resolves to — the automatic pick rather than a dead selection. The resolution locus is the server: `resolved_role_key` in `routes.rs` is the single answer for what a role's default means (the settings page and the composer both label "automatic" with it), so the re-route lives there rather than being reimplemented in a client. The `utility` role already walked the gateway's entitled models cheapest-first under managed (#901); the `chat` role now joins it, landing on the first entitled model in the gateway's own order — the row the composer picker offers first — when its stored or boot default is locked out. The stored pin is left in place, so a profile returned to the open experience gets its selection back.

**Live updates.** The panel re-reads the catalog when the managed policy flips and runs a modest 5s watch while managed, so a completed model sync appears without a manual refresh — the same cadence `ManagedGate` and the gateway panel already use. Unmanaged profiles keep the read-once behavior and render byte-for-byte unchanged.

## Tests

- `model_roles_resolve_at_read_time_and_honor_an_explicit_pin` (extended, `openwave-server`): after a managed flip with a BYOK chat pin carried in from before it, the roles read reports the pin as stored but resolves chat to the gateway's first listed model and utility to its cheapest — extending the existing #901 coverage rather than duplicating it.
- `ModelsPanel under managed policy > offers one flat entitled list per role and reads a dead pin as automatic` (DOM): no provider combobox, entitled-only options, dead pin shown as "Automatic — <resolved>", selecting an entitled model PUTs its key.
- `ModelsPanel under managed policy > shows a completed model sync without a manual refresh` (DOM): the empty "not synced yet" state is replaced by the entitled list on the watch's next tick.

Verified locally with `cargo check -p openwave-server --locked`, `cargo clippy -p openwave-server --all-targets --locked`, the model-roles server tests, `tsc`, and the touched vitest files.

Closes #946

🤖 Generated with [Claude Code](https://claude.com/claude-code)