### PR TITLE
feat(desktop): mount gateway endpoints from the MCP servers page

### DIFF
--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
@@ -31,8 +31,6 @@ function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
     gatewaySignOut: vi.fn().mockResolvedValue(signedOut),
     syncGatewayModels: vi.fn().mockResolvedValue(signedIn),
     getGatewayApps: vi.fn().mockResolvedValue({ supported: true, apps: [] }),
-    listMcpServers: vi.fn().mockResolvedValue({ servers: [] }),
-    putMcpServers: vi.fn().mockResolvedValue({ servers: [] }),
     putProvider: vi.fn().mockResolvedValue({}),
     ...overrides,
   } as unknown as ApiClient;
@@ -208,6 +206,10 @@ describe("GatewayPanel", () => {
     );
     expect(await screen.findByText("Signed in")).toBeInTheDocument();
     expect(screen.queryByText("Connected apps")).not.toBeInTheDocument();
+    // The route to mounting still shows: older gateways mount by slug too.
+    expect(
+      screen.getByRole("button", { name: /Mount endpoints in MCP servers/ }),
+    ).toBeInTheDocument();
   });
 
   it("keeps connected apps informational and sends mounting to the MCP page", async () => {
@@ -222,28 +224,6 @@ describe("GatewayPanel", () => {
             app_kind: "rest_api",
             enabled: true,
             mcp_endpoint_slugs: ["example-security-tools"],
-          },
-        ],
-      }),
-      // A configured mount for that endpoint exists; this panel still shows
-      // no toggle for it — mounting lives on the MCP servers page now.
-      listMcpServers: vi.fn().mockResolvedValue({
-        servers: [
-          {
-            name: "example-security-tools",
-            command: null,
-            args: [],
-            env: {},
-            env_from: [],
-            cwd: null,
-            url: null,
-            bearer_token_env: null,
-            gateway_endpoint: "example-security-tools",
-            request_timeout_ms: 60_000,
-            enabled: true,
-            health: "healthy",
-            tool_count: 3,
-            diagnostic: null,
           },
         ],
       }),

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
@@ -22,40 +22,6 @@ const signedIn: GatewayStatus = {
   model_count: 2,
 };
 
-/** A configured gateway mount as `listMcpServers` reports it. */
-function gatewayMount(slug: string, overrides: Record<string, unknown> = {}) {
-  return {
-    name: slug,
-    command: null,
-    args: [],
-    env: {},
-    env_from: [],
-    cwd: null,
-    url: null,
-    bearer_token_env: null,
-    gateway_endpoint: slug,
-    request_timeout_ms: 60_000,
-    enabled: true,
-    health: "healthy",
-    tool_count: 3,
-    diagnostic: null,
-    ...overrides,
-  };
-}
-
-const incidentApps = {
-  supported: true,
-  apps: [
-    {
-      id: "app-1",
-      name: "Incident API",
-      app_kind: "rest_api",
-      enabled: true,
-      mcp_endpoint_slugs: ["example-security-tools"],
-    },
-  ],
-};
-
 function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
   return {
     getGatewayStatus: vi.fn().mockResolvedValue(signedOut),
@@ -84,7 +50,13 @@ describe("GatewayPanel", () => {
     const open = vi.fn();
     vi.stubGlobal("open", open);
     const user = userEvent.setup();
-    render(<GatewayPanel client={client} onChanged={() => undefined} />);
+    render(
+      <GatewayPanel
+        client={client}
+        onChanged={() => undefined}
+        onOpenMcpSettings={() => undefined}
+      />,
+    );
 
     expect(await screen.findByText("Not signed in")).toBeInTheDocument();
     expect(screen.queryByPlaceholderText(/API key/i)).not.toBeInTheDocument();
@@ -105,7 +77,13 @@ describe("GatewayPanel", () => {
     });
     const onChanged = vi.fn();
     const user = userEvent.setup();
-    render(<GatewayPanel client={client} onChanged={onChanged} />);
+    render(
+      <GatewayPanel
+        client={client}
+        onChanged={onChanged}
+        onOpenMcpSettings={() => undefined}
+      />,
+    );
 
     expect(await screen.findByText("Signed in")).toBeInTheDocument();
     expect(screen.getByText(/abaas@example\.test/)).toBeInTheDocument();
@@ -127,7 +105,13 @@ describe("GatewayPanel", () => {
         .mockResolvedValue({ ...signedOut, configured: false, base_url: undefined }),
     });
     const user = userEvent.setup();
-    render(<GatewayPanel client={client} onChanged={() => undefined} />);
+    render(
+      <GatewayPanel
+        client={client}
+        onChanged={() => undefined}
+        onOpenMcpSettings={() => undefined}
+      />,
+    );
 
     await screen.findByText("Not signed in");
     // Unconfigured, the connect affordance stays off.
@@ -157,7 +141,13 @@ describe("GatewayPanel", () => {
     const client = api({ getGatewayStatus });
     const onChanged = vi.fn();
     vi.useFakeTimers();
-    render(<GatewayPanel client={client} onChanged={onChanged} />);
+    render(
+      <GatewayPanel
+        client={client}
+        onChanged={onChanged}
+        onOpenMcpSettings={() => undefined}
+      />,
+    );
     // Flush the initial status load.
     await act(async () => {});
 
@@ -190,7 +180,13 @@ describe("GatewayPanel", () => {
         ],
       }),
     });
-    render(<GatewayPanel client={client} onChanged={() => undefined} />);
+    render(
+      <GatewayPanel
+        client={client}
+        onChanged={() => undefined}
+        onOpenMcpSettings={() => undefined}
+      />,
+    );
 
     expect(await screen.findByText("Incident API")).toBeInTheDocument();
     expect(screen.getByText(/via example-security-tools/)).toBeInTheDocument();
@@ -203,32 +199,18 @@ describe("GatewayPanel", () => {
         .fn()
         .mockResolvedValue({ supported: false, apps: [] }),
     });
-    render(<GatewayPanel client={older} onChanged={() => undefined} />);
+    render(
+      <GatewayPanel
+        client={older}
+        onChanged={() => undefined}
+        onOpenMcpSettings={() => undefined}
+      />,
+    );
     expect(await screen.findByText("Signed in")).toBeInTheDocument();
     expect(screen.queryByText("Connected apps")).not.toBeInTheDocument();
   });
 
-  it("mounts a gateway endpoint with a session-bound definition", async () => {
-    const putMcpServers = vi.fn().mockResolvedValue({
-      servers: [
-        {
-          name: "example-security-tools",
-          command: null,
-          args: [],
-          env: {},
-          env_from: [],
-          cwd: null,
-          url: null,
-          bearer_token_env: null,
-          gateway_endpoint: "example-security-tools",
-          request_timeout_ms: 60_000,
-          enabled: true,
-          health: "healthy",
-          tool_count: 3,
-          diagnostic: null,
-        },
-      ],
-    });
+  it("keeps connected apps informational and sends mounting to the MCP page", async () => {
     const client = api({
       getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
       getGatewayApps: vi.fn().mockResolvedValue({
@@ -243,188 +225,48 @@ describe("GatewayPanel", () => {
           },
         ],
       }),
-      putMcpServers,
-    });
-    const user = userEvent.setup();
-    render(<GatewayPanel client={client} onChanged={() => undefined} />);
-
-    await user.click(
-      await screen.findByRole("switch", {
-        name: "Mount example-security-tools",
-      }),
-    );
-    await waitFor(() =>
-      expect(putMcpServers).toHaveBeenCalledWith([
-        expect.objectContaining({
-          name: "example-security-tools",
-          gateway_endpoint: "example-security-tools",
-          url: null,
-          bearer_token_env: null,
-        }),
-      ]),
-    );
-    // The saved mount reports its health inline.
-    expect(await screen.findByText(/3 tools available/)).toBeInTheDocument();
-  });
-
-  it("derives a mount name that fits the namespace limit for long slugs", async () => {
-    const longSlug = "a-very-long-endpoint-slug-that-exceeds-the-name-limit";
-    const putMcpServers = vi.fn().mockResolvedValue({ servers: [] });
-    const client = api({
-      getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
-      getGatewayApps: vi.fn().mockResolvedValue({
-        supported: true,
-        apps: [
+      // A configured mount for that endpoint exists; this panel still shows
+      // no toggle for it — mounting lives on the MCP servers page now.
+      listMcpServers: vi.fn().mockResolvedValue({
+        servers: [
           {
-            id: "app-1",
-            name: "Incident API",
-            app_kind: "rest_api",
+            name: "example-security-tools",
+            command: null,
+            args: [],
+            env: {},
+            env_from: [],
+            cwd: null,
+            url: null,
+            bearer_token_env: null,
+            gateway_endpoint: "example-security-tools",
+            request_timeout_ms: 60_000,
             enabled: true,
-            mcp_endpoint_slugs: [longSlug],
+            health: "healthy",
+            tool_count: 3,
+            diagnostic: null,
           },
         ],
       }),
-      putMcpServers,
     });
+    const openMcpSettings = vi.fn();
     const user = userEvent.setup();
-    render(<GatewayPanel client={client} onChanged={() => undefined} />);
-
-    await user.click(
-      await screen.findByRole("switch", { name: `Mount ${longSlug}` }),
+    render(
+      <GatewayPanel
+        client={client}
+        onChanged={() => undefined}
+        onOpenMcpSettings={openMcpSettings}
+      />,
     );
-    await waitFor(() =>
-      expect(putMcpServers).toHaveBeenCalledWith([
-        expect.objectContaining({
-          name: longSlug.slice(0, 32),
-          gateway_endpoint: longSlug,
-        }),
-      ]),
-    );
-  });
 
-  it("keeps a row and unmount toggle for a mount whose entitlement was revoked", async () => {
-    const revokedMount = gatewayMount("revoked-tools", {
-      health: "reconnecting",
-      tool_count: 0,
-    });
-    const putMcpServers = vi.fn().mockResolvedValue({ servers: [] });
-    const client = api({
-      getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
-      // No entitled app references the mounted slug any more.
-      getGatewayApps: vi.fn().mockResolvedValue({ supported: true, apps: [] }),
-      listMcpServers: vi.fn().mockResolvedValue({ servers: [revokedMount] }),
-      putMcpServers,
-    });
-    const user = userEvent.setup();
-    render(<GatewayPanel client={client} onChanged={() => undefined} />);
-
-    // The configured mount keeps its row, with an explanation instead of a
-    // health line.
-    expect(await screen.findByText("revoked-tools")).toBeInTheDocument();
+    expect(await screen.findByText("Incident API")).toBeInTheDocument();
     expect(
-      screen.getByText(/No longer granted to your teams/),
-    ).toBeInTheDocument();
-    // The explanation replaces the health line, and the apps section's empty
-    // copy doesn't sit above a populated mount list.
-    expect(screen.queryByText(/Connecting/)).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(/No connected apps are granted/),
+      screen.queryByRole("switch", { name: /^Mount / }),
     ).not.toBeInTheDocument();
 
-    // And the toggle still unmounts it.
-    const toggle = screen.getByRole("switch", { name: "Mount revoked-tools" });
-    expect(toggle).toBeChecked();
-    await user.click(toggle);
-    await waitFor(() => expect(putMcpServers).toHaveBeenCalledWith([]));
-  });
-
-  it("surfaces a failed server-list fetch as a retryable error, not dead toggles", async () => {
-    const listMcpServers = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("mcp backend unavailable"))
-      .mockResolvedValue({ servers: [] });
-    const client = api({
-      getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
-      getGatewayApps: vi.fn().mockResolvedValue(incidentApps),
-      listMcpServers,
-    });
-    const user = userEvent.setup();
-    render(<GatewayPanel client={client} onChanged={() => undefined} />);
-
-    // The failure is visible and named, and the disabled toggle is explained
-    // rather than passing unknown off as unmounted.
-    expect(
-      await screen.findByText(/mcp backend unavailable/),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("switch", { name: "Mount example-security-tools" }),
-    ).toBeDisabled();
-    expect(screen.getByText(/Mount state unknown/)).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: /Retry/ }));
-    await waitFor(() =>
-      expect(
-        screen.queryByText(/mcp backend unavailable/),
-      ).not.toBeInTheDocument(),
+    await user.click(
+      screen.getByRole("button", { name: /Mount endpoints in MCP servers/ }),
     );
-    expect(
-      screen.getByRole("switch", { name: "Mount example-security-tools" }),
-    ).toBeEnabled();
-  });
-
-  it("keeps last-known rows and live toggles when a later refresh fails", async () => {
-    const listMcpServers = vi
-      .fn()
-      .mockResolvedValueOnce({ servers: [gatewayMount("example-security-tools")] })
-      .mockRejectedValue(new Error("mcp backend unavailable"));
-    const client = api({
-      getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
-      getGatewayApps: vi.fn().mockResolvedValue(incidentApps),
-      listMcpServers,
-    });
-    vi.useFakeTimers();
-    render(<GatewayPanel client={client} onChanged={() => undefined} />);
-    await act(async () => {});
-    expect(screen.getByText(/3 tools available/)).toBeInTheDocument();
-
-    // The 15s refresh fails: the error appears, but the last-known row keeps
-    // its health line and a usable toggle instead of resetting to unknown.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(15_100);
-    });
-    expect(screen.getByText(/mcp backend unavailable/)).toBeInTheDocument();
-    expect(screen.getByText(/3 tools available/)).toBeInTheDocument();
-    const toggle = screen.getByRole("switch", {
-      name: "Mount example-security-tools",
-    });
-    expect(toggle).toBeChecked();
-    expect(toggle).toBeEnabled();
-  });
-
-  it("still shows configured mounts when entitlements cannot be read", async () => {
-    const client = api({
-      getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
-      getGatewayApps: vi
-        .fn()
-        .mockRejectedValue(new Error("gateway unreachable")),
-      listMcpServers: vi.fn().mockResolvedValue({
-        servers: [gatewayMount("example-security-tools")],
-      }),
-    });
-    render(<GatewayPanel client={client} onChanged={() => undefined} />);
-
-    // The row survives the apps failure, labeled unknown-entitlements — never
-    // misreported as revoked.
-    expect(
-      await screen.findByText("example-security-tools"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Couldn't read your entitlements/),
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/No longer granted/)).not.toBeInTheDocument();
-    expect(
-      screen.getByRole("switch", { name: "Mount example-security-tools" }),
-    ).toBeChecked();
+    expect(openMcpSettings).toHaveBeenCalled();
   });
 
   it("surfaces a failed sign-in with its bounded message", async () => {
@@ -434,7 +276,13 @@ describe("GatewayPanel", () => {
         sign_in: { state: "failed", message: "browser authorization timed out" },
       }),
     });
-    render(<GatewayPanel client={client} onChanged={() => undefined} />);
+    render(
+      <GatewayPanel
+        client={client}
+        onChanged={() => undefined}
+        onOpenMcpSettings={() => undefined}
+      />,
+    );
 
     expect(
       await screen.findByText(/browser authorization timed out/),

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
@@ -133,6 +133,19 @@ export function GatewayPanel({
 
   const pendingUrl =
     status.sign_in.state === "pending" ? status.sign_in.authorization_url : null;
+  // The one route to mounting, shown whenever signed in: a gateway without
+  // the apps surface still mounts endpoints by slug on the MCP servers page.
+  const mountSignpost = (
+    <Button
+      type="button"
+      variant="outline"
+      className="self-start"
+      onClick={onOpenMcpSettings}
+    >
+      <PlugZap size={14} />
+      Mount endpoints in MCP servers
+    </Button>
+  );
 
   return (
     <SettingsPanel
@@ -286,54 +299,48 @@ export function GatewayPanel({
         )}
       </SettingsSection>
 
-      {status.signed_in && (
-        <>
-          {apps?.supported && (
-            <SettingsSection
-              title="Connected apps"
-              description="The apps your teams have granted this deployment. Mounting their MCP endpoints happens under MCP servers, beside the health of what is mounted."
-            >
-              {apps.apps.length === 0 ? (
-                <p className="text-muted-foreground text-sm">
-                  No connected apps are granted to your teams yet.
-                </p>
-              ) : (
-                <ul className="flex flex-col gap-2">
-                  {apps.apps.map((app) => (
-                    <li key={app.id} className="rounded-md border px-3 py-2 text-sm">
-                      <div className="flex items-center gap-2">
-                        <span className="font-medium">{app.name}</span>
-                        <span className="text-muted-foreground text-xs">
-                          {app.app_kind}
-                        </span>
-                        {!app.enabled && (
-                          <span className="text-muted-foreground text-xs">
-                            disabled
-                          </span>
-                        )}
-                      </div>
-                      {app.mcp_endpoint_slugs.length > 0 && (
-                        <p className="text-muted-foreground text-xs">
-                          via {app.mcp_endpoint_slugs.join(", ")}
-                        </p>
-                      )}
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </SettingsSection>
-          )}
-          <Button
-            type="button"
-            variant="outline"
-            className="self-start"
-            onClick={onOpenMcpSettings}
+      {status.signed_in &&
+        (apps?.supported ? (
+          <SettingsSection
+            title="Connected apps"
+            description="The apps your teams have granted this deployment. Mounting their MCP endpoints happens under MCP servers, beside the health of what is mounted."
           >
-            <PlugZap size={14} />
-            Mount endpoints in MCP servers
-          </Button>
-        </>
-      )}
+            {apps.apps.length === 0 ? (
+              <p className="text-muted-foreground text-sm">
+                No connected apps are granted to your teams yet.
+              </p>
+            ) : (
+              <ul className="flex flex-col gap-2">
+                {apps.apps.map((app) => (
+                  <li
+                    key={app.id}
+                    className="rounded-md border px-3 py-2 text-sm"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium">{app.name}</span>
+                      <span className="text-muted-foreground text-xs">
+                        {app.app_kind}
+                      </span>
+                      {!app.enabled && (
+                        <span className="text-muted-foreground text-xs">
+                          disabled
+                        </span>
+                      )}
+                    </div>
+                    {app.mcp_endpoint_slugs.length > 0 && (
+                      <p className="text-muted-foreground text-xs">
+                        via {app.mcp_endpoint_slugs.join(", ")}
+                      </p>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+            {mountSignpost}
+          </SettingsSection>
+        ) : (
+          <SettingsSection>{mountSignpost}</SettingsSection>
+        ))}
 
       <p className="text-sm leading-relaxed text-muted-foreground">
         Sign-in happens in your browser against the gateway itself; OpenWave

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
@@ -286,38 +286,42 @@ export function GatewayPanel({
         )}
       </SettingsSection>
 
-      {status.signed_in && apps?.supported && (
-        <SettingsSection
-          title="Connected apps"
-          description="The apps your teams have granted this deployment. Mounting their MCP endpoints happens under MCP servers, beside the health of what is mounted."
-        >
-          {apps.apps.length === 0 ? (
-            <p className="text-muted-foreground text-sm">
-              No connected apps are granted to your teams yet.
-            </p>
-          ) : (
-            <ul className="flex flex-col gap-2">
-              {apps.apps.map((app) => (
-                <li key={app.id} className="rounded-md border px-3 py-2 text-sm">
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium">{app.name}</span>
-                    <span className="text-muted-foreground text-xs">
-                      {app.app_kind}
-                    </span>
-                    {!app.enabled && (
-                      <span className="text-muted-foreground text-xs">
-                        disabled
-                      </span>
-                    )}
-                  </div>
-                  {app.mcp_endpoint_slugs.length > 0 && (
-                    <p className="text-muted-foreground text-xs">
-                      via {app.mcp_endpoint_slugs.join(", ")}
-                    </p>
-                  )}
-                </li>
-              ))}
-            </ul>
+      {status.signed_in && (
+        <>
+          {apps?.supported && (
+            <SettingsSection
+              title="Connected apps"
+              description="The apps your teams have granted this deployment. Mounting their MCP endpoints happens under MCP servers, beside the health of what is mounted."
+            >
+              {apps.apps.length === 0 ? (
+                <p className="text-muted-foreground text-sm">
+                  No connected apps are granted to your teams yet.
+                </p>
+              ) : (
+                <ul className="flex flex-col gap-2">
+                  {apps.apps.map((app) => (
+                    <li key={app.id} className="rounded-md border px-3 py-2 text-sm">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium">{app.name}</span>
+                        <span className="text-muted-foreground text-xs">
+                          {app.app_kind}
+                        </span>
+                        {!app.enabled && (
+                          <span className="text-muted-foreground text-xs">
+                            disabled
+                          </span>
+                        )}
+                      </div>
+                      {app.mcp_endpoint_slugs.length > 0 && (
+                        <p className="text-muted-foreground text-xs">
+                          via {app.mcp_endpoint_slugs.join(", ")}
+                        </p>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </SettingsSection>
           )}
           <Button
             type="button"
@@ -328,7 +332,7 @@ export function GatewayPanel({
             <PlugZap size={14} />
             Mount endpoints in MCP servers
           </Button>
-        </SettingsSection>
+        </>
       )}
 
       <p className="text-sm leading-relaxed text-muted-foreground">

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
@@ -1,13 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
-import { ExternalLink, LogOut, RefreshCw } from "lucide-react";
-import type {
-  ApiClient,
-  GatewayApps,
-  GatewayStatus,
-  McpServerDefinition,
-  McpServerInfo,
-} from "../api";
+import { ExternalLink, LogOut, PlugZap, RefreshCw } from "lucide-react";
+import type { ApiClient, GatewayApps, GatewayStatus } from "../api";
 import { openSignInPage } from "../openSignInPage";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -21,73 +15,6 @@ import {
 } from "./primitives";
 
 const SIGN_IN_POLL_MS = 2_000;
-/** Mount health lives in the local MCP supervisor, so a modest refresh while
- * the panel is visible keeps the health lines honest without gateway load. */
-const MOUNT_REFRESH_MS = 15_000;
-const DEFAULT_MOUNT_TIMEOUT_MS = 60_000;
-/** Server names cap at 32 bytes (the MCP tool namespace); endpoint slugs go
- * to 127, so the mount name is derived, not the slug itself. Mount identity
- * is always the `gateway_endpoint` field, never the name. */
-const MAX_NAMESPACE_BYTES = 32;
-
-function definitionOf(server: McpServerInfo): McpServerDefinition {
-  const { health: _, tool_count: __, diagnostic: ___, ...value } = server;
-  return value;
-}
-
-/** A valid, unused namespace for a mount: the slug, truncated to the name
- * limit and de-duplicated against every configured server. */
-function mountName(slug: string, taken: ReadonlySet<string>): string {
-  const base = slug.slice(0, MAX_NAMESPACE_BYTES);
-  if (!taken.has(base)) return base;
-  for (let n = 2; ; n += 1) {
-    const suffix = `_${n}`;
-    const candidate =
-      base.slice(0, MAX_NAMESPACE_BYTES - suffix.length) + suffix;
-    if (!taken.has(candidate)) return candidate;
-  }
-}
-
-/** Sentence-shaped status for a mount row; diagnostics already are one. */
-function mountStatus(mounted: McpServerInfo): string {
-  if (mounted.health === "healthy") {
-    return `${mounted.tool_count} tool${mounted.tool_count === 1 ? "" : "s"} available to new turns.`;
-  }
-  if (mounted.diagnostic) return mounted.diagnostic;
-  switch (mounted.health) {
-    case "initializing":
-    case "reconnecting":
-      return "Connecting…";
-    case "disabled":
-      return "Disabled in MCP servers settings.";
-    default:
-      return "Needs attention. See MCP servers settings.";
-  }
-}
-
-/** A message that can sit mid-sentence: `String(err)` would keep the error
- * class prefix ("HttpError: ...") in front of it. */
-function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}
-
-/** A fresh gateway mount: everything comes from the session except the name,
- * which doubles as the tool namespace. */
-function mountDefinition(slug: string, name: string): McpServerDefinition {
-  return {
-    name,
-    command: null,
-    args: [],
-    env: {},
-    env_from: [],
-    cwd: null,
-    url: null,
-    bearer_token_env: null,
-    gateway_endpoint: slug,
-    request_timeout_ms: DEFAULT_MOUNT_TIMEOUT_MS,
-    enabled: true,
-  };
-}
 
 /**
  * The Model Gateway connection: one toggle, one URL, one sign-in.
@@ -101,20 +28,17 @@ function mountDefinition(slug: string, name: string): McpServerDefinition {
 export function GatewayPanel({
   client,
   onChanged,
+  onOpenMcpSettings,
 }: {
   client: ApiClient;
   onChanged: () => void;
+  /** Navigates to the MCP servers section, where entitled endpoints are
+   * mounted. Mounting lives beside the health of what is mounted, so this
+   * panel points at it rather than carrying its own toggles. */
+  onOpenMcpSettings: () => void;
 }) {
   const [status, setStatus] = useState<GatewayStatus | null>(null);
   const [apps, setApps] = useState<GatewayApps | null>(null);
-  // Distinguishes "the apps read failed" from "no apps granted": a failure
-  // must not make configured mounts masquerade as revoked, nor hide them.
-  const [appsFailed, setAppsFailed] = useState(false);
-  const [mcpServers, setMcpServers] = useState<McpServerInfo[] | null>(null);
-  const [mcpError, setMcpError] = useState<string | null>(null);
-  // Bumped by the Retry affordance; re-runs the mount-list effect immediately
-  // and restarts its cadence.
-  const [mountsRefreshNonce, setMountsRefreshNonce] = useState(0);
   const [baseUrl, setBaseUrl] = useState("");
   const [dirty, setDirty] = useState(false);
   const [working, setWorking] = useState(false);
@@ -124,9 +48,6 @@ export function GatewayPanel({
   // them), and the poll must not refill a field the user is editing.
   const signedInRef = useRef(false);
   const dirtyRef = useRef(false);
-  // Monotonic id for mount-list reads: a slow in-flight read must not clobber
-  // the fresher list a toggle write (or a newer read) has since installed.
-  const mountsRequestRef = useRef(0);
 
   const reload = useCallback(async () => {
     const next = await client.getGatewayStatus();
@@ -146,66 +67,26 @@ export function GatewayPanel({
 
   // Entitled apps are never cached server-side (a revoked grant disappears on
   // the next request), so fetch them fresh whenever the signed-in state turns
-  // on. A fetch failure hides the apps list but is remembered, so mount rows
-  // can say entitlements are unknown instead of claiming anything.
+  // on. A failure leaves the list absent rather than asserting anything about
+  // what is granted.
   useEffect(() => {
     if (!status?.signed_in) {
       setApps(null);
-      setAppsFailed(false);
       return;
     }
     let cancelled = false;
     client
       .getGatewayApps()
       .then((next) => {
-        if (!cancelled) {
-          setApps(next);
-          setAppsFailed(false);
-        }
+        if (!cancelled) setApps(next);
       })
       .catch(() => {
-        if (!cancelled) {
-          setApps(null);
-          setAppsFailed(true);
-        }
+        if (!cancelled) setApps(null);
       });
     return () => {
       cancelled = true;
     };
   }, [client, status?.signed_in]);
-
-  // Mount state lives in the MCP configuration; load it alongside the apps so
-  // each endpoint's toggle reflects what is actually configured — and keep
-  // re-reading it while the panel is visible, so a mount that degrades after
-  // the first read doesn't keep a stale healthy line. A failed read keeps the
-  // last-known rows and surfaces a retryable error instead of silently
-  // disabling every toggle.
-  useEffect(() => {
-    if (!status?.signed_in) {
-      setMcpServers(null);
-      setMcpError(null);
-      return;
-    }
-    const refresh = async () => {
-      const request = ++mountsRequestRef.current;
-      try {
-        const next = await client.listMcpServers();
-        if (request !== mountsRequestRef.current) return;
-        setMcpServers(next.servers);
-        setMcpError(null);
-      } catch (err) {
-        if (request !== mountsRequestRef.current) return;
-        setMcpError(errorMessage(err));
-      }
-    };
-    void refresh();
-    const timer = window.setInterval(() => void refresh(), MOUNT_REFRESH_MS);
-    return () => {
-      // Invalidate any in-flight read; a re-run issues fresh ids above this.
-      mountsRequestRef.current += 1;
-      window.clearInterval(timer);
-    };
-  }, [client, status?.signed_in, mountsRefreshNonce]);
 
   // While the browser flow is pending, watch for its outcome.
   useEffect(() => {
@@ -227,27 +108,6 @@ export function GatewayPanel({
     } finally {
       setWorking(false);
     }
-  }
-
-  async function setMounted(slug: string, mounted: boolean) {
-    await run(async () => {
-      // Rebuild from the live configuration, not the panel cache, so a mount
-      // toggled here never drops a server edited elsewhere in the meantime.
-      const current = (await client.listMcpServers()).servers.map(definitionOf);
-      const without = current.filter(
-        (server) => server.gateway_endpoint !== slug,
-      );
-      const taken = new Set(without.map((server) => server.name));
-      const next = mounted
-        ? [...without, mountDefinition(slug, mountName(slug, taken))]
-        : without;
-      const result = await client.putMcpServers(next);
-      // Supersede any in-flight background read; this list is fresher.
-      mountsRequestRef.current += 1;
-      setMcpServers(result.servers);
-      setMcpError(null);
-      toast.success(mounted ? `Mounted ${slug}` : `Unmounted ${slug}`);
-    });
   }
 
   async function save(enabled: boolean) {
@@ -273,32 +133,6 @@ export function GatewayPanel({
 
   const pendingUrl =
     status.sign_in.state === "pending" ? status.sign_in.authorization_url : null;
-  const entitledSlugs = new Set(
-    apps?.apps.flatMap((app) => app.mcp_endpoint_slugs) ?? [],
-  );
-  // Rows are the union of what's entitled and what's configured: a mount
-  // whose grant was revoked must keep its row (and unmount toggle) here,
-  // not silently drop to being visible only in the MCP panel while
-  // supervision retries it.
-  const endpointSlugs = [
-    ...new Set([
-      ...entitledSlugs,
-      ...(mcpServers ?? [])
-        .map((server) => server.gateway_endpoint)
-        .filter((slug): slug is string => slug !== null),
-    ]),
-  ];
-  // "Revoked" is only a claim we can make after actually reading the
-  // entitlements; a failed or unsupported apps read leaves them unknown.
-  const entitlementsKnown = apps?.supported === true;
-  /** The one line under a mount row: unknown beats revoked beats health. */
-  const rowNote = (slug: string, mounted: McpServerInfo | undefined) => {
-    if (mcpServers === null) return "Mount state unknown.";
-    if (entitlementsKnown && !entitledSlugs.has(slug)) {
-      return "No longer granted to your teams. Switch off to unmount it.";
-    }
-    return mounted ? mountStatus(mounted) : null;
-  };
 
   return (
     <SettingsPanel
@@ -452,105 +286,48 @@ export function GatewayPanel({
         )}
       </SettingsSection>
 
-      {status.signed_in &&
-        apps?.supported &&
-        (apps.apps.length > 0 || endpointSlugs.length === 0) && (
-          <SettingsSection title="Connected apps">
-            {apps.apps.length === 0 ? (
-              <p className="text-muted-foreground text-sm">
-                No connected apps are granted to your teams yet.
-              </p>
-            ) : (
-              <ul className="flex flex-col gap-2">
-                {apps.apps.map((app) => (
-                  <li
-                    key={app.id}
-                    className="rounded-md border px-3 py-2 text-sm"
-                  >
-                    <div className="flex items-center gap-2">
-                      <span className="font-medium">{app.name}</span>
-                      <span className="text-muted-foreground text-xs">
-                        {app.app_kind}
-                      </span>
-                      {!app.enabled && (
-                        <span className="text-muted-foreground text-xs">
-                          disabled
-                        </span>
-                      )}
-                    </div>
-                    {app.mcp_endpoint_slugs.length > 0 && (
-                      <p className="text-muted-foreground text-xs">
-                        via {app.mcp_endpoint_slugs.join(", ")}
-                      </p>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </SettingsSection>
-        )}
-
-      {/* Deliberately NOT gated on the apps read: a configured mount keeps
-          its row — and a mount-list failure its Retry — even when the
-          entitlements can't be read at all. */}
-      {status.signed_in && (endpointSlugs.length > 0 || mcpError !== null) && (
+      {status.signed_in && apps?.supported && (
         <SettingsSection
-          title="MCP endpoints"
-          description="Mounted endpoints connect with your gateway session — no tokens to copy, and they reconnect after you sign back in."
+          title="Connected apps"
+          description="The apps your teams have granted this deployment. Mounting their MCP endpoints happens under MCP servers, beside the health of what is mounted."
         >
-          {appsFailed && (
-            <p className="text-muted-foreground text-xs">
-              Couldn't read your entitlements from the gateway; these are the
-              configured mounts.
+          {apps.apps.length === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              No connected apps are granted to your teams yet.
             </p>
-          )}
-          {mcpError !== null && (
-            <div className="flex items-center justify-between gap-4">
-              <SettingsError>
-                Couldn't read the MCP server list: {mcpError}
-              </SettingsError>
-              <Button
-                type="button"
-                variant="outline"
-                disabled={working}
-                onClick={() => setMountsRefreshNonce((nonce) => nonce + 1)}
-              >
-                <RefreshCw size={14} />
-                Retry
-              </Button>
-            </div>
-          )}
-          {endpointSlugs.length > 0 && (
+          ) : (
             <ul className="flex flex-col gap-2">
-              {endpointSlugs.map((slug) => {
-                const mounted = mcpServers?.find(
-                  (server) => server.gateway_endpoint === slug,
-                );
-                const note = rowNote(slug, mounted);
-                return (
-                  <li
-                    key={slug}
-                    className="flex items-center justify-between gap-4 rounded-md border px-3 py-2 text-sm"
-                  >
-                    <div className="min-w-0 flex-1">
-                      <code className="font-medium">{slug}</code>
-                      {note && (
-                        <p className="text-muted-foreground text-xs">{note}</p>
-                      )}
-                    </div>
-                    <Switch
-                      aria-label={`Mount ${slug}`}
-                      checked={mounted !== undefined}
-                      disabled={working || mcpServers === null}
-                      onCheckedChange={(checked) =>
-                        void setMounted(slug, checked)
-                      }
-                    />
-                  </li>
-                );
-              })}
+              {apps.apps.map((app) => (
+                <li key={app.id} className="rounded-md border px-3 py-2 text-sm">
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{app.name}</span>
+                    <span className="text-muted-foreground text-xs">
+                      {app.app_kind}
+                    </span>
+                    {!app.enabled && (
+                      <span className="text-muted-foreground text-xs">
+                        disabled
+                      </span>
+                    )}
+                  </div>
+                  {app.mcp_endpoint_slugs.length > 0 && (
+                    <p className="text-muted-foreground text-xs">
+                      via {app.mcp_endpoint_slugs.join(", ")}
+                    </p>
+                  )}
+                </li>
+              ))}
             </ul>
           )}
+          <Button
+            type="button"
+            variant="outline"
+            className="self-start"
+            onClick={onOpenMcpSettings}
+          >
+            <PlugZap size={14} />
+            Mount endpoints in MCP servers
+          </Button>
         </SettingsSection>
       )}
 

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
@@ -669,6 +669,50 @@ describe("McpPanel", () => {
     );
   });
 
+  it("a background refresh landing mid-edit keeps the unsaved draft", async () => {
+    // The mount write disables the form while it flies, so the in-flight
+    // completion a reader can actually race against is the background list
+    // read. It captures a render from before the edit; only the dirty ref —
+    // not that render's `dirty` — can tell it the draft must survive.
+    const listMcpServers = vi.fn().mockResolvedValue(healthy);
+    const client = api(healthy, {
+      listMcpServers,
+      getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+    });
+    // Real time may pass (userEvent needs it); only the 15s cadence is
+    // driven explicitly.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup();
+    render(<McpPanel client={client} />);
+    await act(async () => {});
+    expect(
+      screen.getByPlaceholderText("/absolute/path/to/server"),
+    ).toHaveValue("/opt/mcp/docs");
+
+    // The next cadence read hangs; the reader edits while it is in flight.
+    let resolveRead!: (value: McpServersInfo) => void;
+    listMcpServers.mockImplementationOnce(
+      () =>
+        new Promise<McpServersInfo>((resolve) => {
+          resolveRead = resolve;
+        }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_100);
+    });
+    await user.type(
+      screen.getByPlaceholderText("/absolute/path/to/server"),
+      "-edited",
+    );
+
+    // The read's snapshot predates the edit; landing, it must not undo it.
+    resolveRead(healthy);
+    await act(async () => {});
+    expect(
+      screen.getByPlaceholderText("/absolute/path/to/server"),
+    ).toHaveValue("/opt/mcp/docs-edited");
+  });
+
   it("keeps a mount made during unsaved edits through the next save", async () => {
     const mount = gatewayMount("example-security-tools");
     const putMcpServers = vi

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
@@ -1,8 +1,20 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ApiClient, McpServersInfo } from "../api";
+import type {
+  ApiClient,
+  GatewayStatus,
+  McpServerInfo,
+  McpServersInfo,
+} from "../api";
 import { McpPanel } from "./McpPanel";
 
 const healthy: McpServersInfo = {
@@ -26,17 +38,84 @@ const healthy: McpServersInfo = {
   ],
 };
 
-function api(result = healthy) {
+const signedOut: GatewayStatus = {
+  configured: true,
+  enabled: true,
+  base_url: "http://127.0.0.1:28081",
+  signed_in: false,
+  model_count: 0,
+  sign_in: { state: "idle" },
+};
+
+const signedIn: GatewayStatus = { ...signedOut, signed_in: true, model_count: 2 };
+
+/** A configured gateway mount as `listMcpServers` reports it. */
+function gatewayMount(
+  slug: string,
+  overrides: Partial<McpServerInfo> = {},
+): McpServerInfo {
+  return {
+    name: slug,
+    command: null,
+    args: [],
+    env: {},
+    env_from: [],
+    cwd: null,
+    url: null,
+    bearer_token_env: null,
+    gateway_endpoint: slug,
+    request_timeout_ms: 60_000,
+    enabled: true,
+    health: "healthy",
+    tool_count: 3,
+    diagnostic: null,
+    ...overrides,
+  };
+}
+
+const incidentApps = {
+  supported: true,
+  apps: [
+    {
+      id: "app-1",
+      name: "Incident API",
+      app_kind: "rest_api",
+      enabled: true,
+      mcp_endpoint_slugs: ["example-security-tools"],
+    },
+  ],
+};
+
+/** No gateway session unless a test signs one in, so the gateway endpoints
+ * section is absent by default — as it is on an unpaired profile. */
+function api(
+  result = healthy,
+  overrides: Partial<Record<keyof ApiClient, unknown>> = {},
+) {
   return {
     listMcpServers: vi.fn().mockResolvedValue(result),
     putMcpServers: vi.fn().mockResolvedValue(result),
     reconnectMcpServer: vi.fn().mockResolvedValue(result),
+    getGatewayStatus: vi.fn().mockResolvedValue(signedOut),
+    getGatewayApps: vi.fn().mockResolvedValue({ supported: true, apps: [] }),
+    ...overrides,
   } as unknown as ApiClient;
+}
+
+/** The row a mount toggle belongs to, for assertions that would otherwise
+ * also match the same server's card further down the page. */
+function mountRow(slug: string): HTMLElement {
+  const row = screen
+    .getByRole("switch", { name: `Mount ${slug}` })
+    .closest("li");
+  if (!row) throw new Error(`no mount row for ${slug}`);
+  return row;
 }
 
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  vi.useRealTimers();
 });
 
 describe("McpPanel", () => {
@@ -292,5 +371,246 @@ describe("McpPanel", () => {
     expect(
       screen.queryByRole("button", { name: "Save and verify" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows no gateway endpoints section without a gateway session", async () => {
+    render(
+      <McpPanel
+        client={api({ servers: [gatewayMount("example-security-tools")] })}
+      />,
+    );
+
+    await screen.findByText("Healthy");
+    expect(screen.queryByText("Gateway endpoints")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("switch", { name: /^Mount / }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("mounts a gateway endpoint with a session-bound definition", async () => {
+    const putMcpServers = vi.fn().mockResolvedValue({
+      servers: [gatewayMount("example-security-tools")],
+    });
+    const client = api(
+      { servers: [] },
+      {
+        getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+        getGatewayApps: vi.fn().mockResolvedValue(incidentApps),
+        putMcpServers,
+      },
+    );
+    const user = userEvent.setup();
+    render(<McpPanel client={client} />);
+
+    await user.click(
+      await screen.findByRole("switch", {
+        name: "Mount example-security-tools",
+      }),
+    );
+    await waitFor(() =>
+      expect(putMcpServers).toHaveBeenCalledWith([
+        expect.objectContaining({
+          name: "example-security-tools",
+          gateway_endpoint: "example-security-tools",
+          url: null,
+          bearer_token_env: null,
+        }),
+      ]),
+    );
+    // The saved mount reports its health inline, on its own row.
+    await waitFor(() =>
+      expect(
+        within(mountRow("example-security-tools")).getByText(
+          /3 tools available/,
+        ),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("derives a mount name that fits the namespace limit for long slugs", async () => {
+    const longSlug = "a-very-long-endpoint-slug-that-exceeds-the-name-limit";
+    const putMcpServers = vi.fn().mockResolvedValue({ servers: [] });
+    const client = api(
+      { servers: [] },
+      {
+        getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+        getGatewayApps: vi.fn().mockResolvedValue({
+          supported: true,
+          apps: [{ ...incidentApps.apps[0], mcp_endpoint_slugs: [longSlug] }],
+        }),
+        putMcpServers,
+      },
+    );
+    const user = userEvent.setup();
+    render(<McpPanel client={client} />);
+
+    await user.click(
+      await screen.findByRole("switch", { name: `Mount ${longSlug}` }),
+    );
+    await waitFor(() =>
+      expect(putMcpServers).toHaveBeenCalledWith([
+        expect.objectContaining({
+          name: longSlug.slice(0, 32),
+          gateway_endpoint: longSlug,
+        }),
+      ]),
+    );
+  });
+
+  it("keeps a row and unmount toggle for a mount whose entitlement was revoked", async () => {
+    const revoked = gatewayMount("revoked-tools", {
+      health: "reconnecting",
+      tool_count: 0,
+    });
+    const putMcpServers = vi.fn().mockResolvedValue({ servers: [] });
+    const client = api(
+      { servers: [revoked] },
+      {
+        getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+        // No entitled app references the mounted slug any more.
+        getGatewayApps: vi.fn().mockResolvedValue({ supported: true, apps: [] }),
+        putMcpServers,
+      },
+    );
+    const user = userEvent.setup();
+    render(<McpPanel client={client} />);
+
+    // The configured mount keeps its row, with an explanation instead of a
+    // health line.
+    const row = await waitFor(() => mountRow("revoked-tools"));
+    expect(
+      within(row).getByText(/No longer granted to your teams/),
+    ).toBeInTheDocument();
+    expect(within(row).queryByText(/Connecting/)).not.toBeInTheDocument();
+
+    // And the toggle still unmounts it.
+    const toggle = within(row).getByRole("switch");
+    expect(toggle).toBeChecked();
+    await user.click(toggle);
+    await waitFor(() => expect(putMcpServers).toHaveBeenCalledWith([]));
+  });
+
+  it("surfaces a failed server-list fetch as a retryable error, not dead toggles", async () => {
+    const listMcpServers = vi
+      .fn()
+      .mockRejectedValue(new Error("mcp backend unavailable"));
+    const client = api(
+      { servers: [] },
+      {
+        getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+        getGatewayApps: vi.fn().mockResolvedValue(incidentApps),
+        listMcpServers,
+      },
+    );
+    const user = userEvent.setup();
+    render(<McpPanel client={client} />);
+
+    // The failure is visible and named, and the disabled toggle is explained
+    // rather than passing unknown off as unmounted.
+    expect(
+      await screen.findByText(/Couldn't read the MCP server list/),
+    ).toBeInTheDocument();
+    const row = mountRow("example-security-tools");
+    expect(within(row).getByRole("switch")).toBeDisabled();
+    expect(within(row).getByText(/Mount state unknown/)).toBeInTheDocument();
+
+    listMcpServers.mockResolvedValue({ servers: [] });
+    await user.click(screen.getByRole("button", { name: /Retry/ }));
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/Couldn't read the MCP server list/),
+      ).not.toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("switch", { name: "Mount example-security-tools" }),
+    ).toBeEnabled();
+  });
+
+  it("keeps last-known rows and live toggles when a later refresh fails", async () => {
+    const listMcpServers = vi
+      .fn()
+      .mockResolvedValue({ servers: [gatewayMount("example-security-tools")] });
+    const client = api(
+      { servers: [] },
+      {
+        getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+        getGatewayApps: vi.fn().mockResolvedValue(incidentApps),
+        listMcpServers,
+      },
+    );
+    vi.useFakeTimers();
+    render(<McpPanel client={client} />);
+    await act(async () => {});
+    expect(
+      within(mountRow("example-security-tools")).getByText(/3 tools available/),
+    ).toBeInTheDocument();
+
+    // The 15s refresh fails: the error appears, but the last-known row keeps
+    // its health line and a usable toggle instead of resetting to unknown.
+    listMcpServers.mockRejectedValue(new Error("mcp backend unavailable"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_100);
+    });
+    expect(
+      screen.getByText(/Couldn't read the MCP server list/),
+    ).toBeInTheDocument();
+    const row = mountRow("example-security-tools");
+    expect(within(row).getByText(/3 tools available/)).toBeInTheDocument();
+    const toggle = within(row).getByRole("switch");
+    expect(toggle).toBeChecked();
+    expect(toggle).toBeEnabled();
+  });
+
+  it("still shows configured mounts when entitlements cannot be read", async () => {
+    const client = api(
+      { servers: [gatewayMount("example-security-tools")] },
+      {
+        getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+        getGatewayApps: vi
+          .fn()
+          .mockRejectedValue(new Error("gateway unreachable")),
+      },
+    );
+    render(<McpPanel client={client} />);
+
+    // The row survives the apps failure, labeled unknown-entitlements — never
+    // misreported as revoked.
+    const row = await waitFor(() => mountRow("example-security-tools"));
+    expect(
+      screen.getByText(/Couldn't read your entitlements/),
+    ).toBeInTheDocument();
+    expect(within(row).queryByText(/No longer granted/)).not.toBeInTheDocument();
+    expect(within(row).getByRole("switch")).toBeChecked();
+  });
+
+  it("keeps the gateway endpoint toggles live on a managed profile", async () => {
+    const putMcpServers = vi.fn().mockResolvedValue({
+      servers: [gatewayMount("example-security-tools")],
+    });
+    const client = api(
+      { servers: [] },
+      {
+        getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+        getGatewayApps: vi.fn().mockResolvedValue(incidentApps),
+        putMcpServers,
+      },
+    );
+    const user = userEvent.setup();
+    render(<McpPanel client={client} managed />);
+
+    // Manual servers are read-only under managed policy, but a gateway mount
+    // is exactly the write the server admits — so this toggle still writes.
+    const toggle = await screen.findByRole("switch", {
+      name: "Mount example-security-tools",
+    });
+    expect(toggle).toBeEnabled();
+    await user.click(toggle);
+    await waitFor(() =>
+      expect(putMcpServers).toHaveBeenCalledWith([
+        expect.objectContaining({
+          gateway_endpoint: "example-security-tools",
+        }),
+      ]),
+    );
   });
 });

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
@@ -360,7 +360,9 @@ describe("McpPanel", () => {
     // The gateway mount and its health stay visible; the locked manual server
     // stays listed with the server's own reason rather than disappearing.
     expect(await screen.findByText("Healthy")).toBeInTheDocument();
-    expect(screen.getByText("3 tools available to new turns.")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("3 tools available to new turns.").length,
+    ).toBeGreaterThan(0);
     expect(screen.getByText(/Disabled by managed policy/)).toBeInTheDocument();
 
     // Nothing manual is editable: no fields, and no way to add or save one.
@@ -373,18 +375,33 @@ describe("McpPanel", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows no gateway endpoints section without a gateway session", async () => {
-    render(
-      <McpPanel
-        client={api({ servers: [gatewayMount("example-security-tools")] })}
-      />,
-    );
+  it("shows no gateway endpoints section on an unpaired profile", async () => {
+    render(<McpPanel client={api()} />);
 
     await screen.findByText("Healthy");
     expect(screen.queryByText("Gateway endpoints")).not.toBeInTheDocument();
     expect(
       screen.queryByRole("switch", { name: /^Mount / }),
     ).not.toBeInTheDocument();
+  });
+
+  it("lists configured mounts signed out, toggles off, pointing at sign-in", async () => {
+    render(
+      <McpPanel
+        client={api({ servers: [gatewayMount("example-security-tools")] })}
+      />,
+    );
+
+    const toggle = await screen.findByRole("switch", {
+      name: "Mount example-security-tools",
+    });
+    expect(toggle).toBeChecked();
+    expect(toggle).toBeDisabled();
+    expect(
+      screen.getByText(/Sign in to the Model Gateway to mount or unmount/),
+    ).toBeInTheDocument();
+    // Signed out, no entitlements were read, so nothing claims a revocation.
+    expect(screen.queryByText(/No longer granted/)).not.toBeInTheDocument();
   });
 
   it("mounts a gateway endpoint with a session-bound definition", async () => {
@@ -476,11 +493,15 @@ describe("McpPanel", () => {
     render(<McpPanel client={client} />);
 
     // The configured mount keeps its row, with an explanation instead of a
-    // health line.
-    const row = await waitFor(() => mountRow("revoked-tools"));
-    expect(
-      within(row).getByText(/No longer granted to your teams/),
-    ).toBeInTheDocument();
+    // health line once the entitlements land.
+    await waitFor(() =>
+      expect(
+        within(mountRow("revoked-tools")).getByText(
+          /No longer granted to your teams/,
+        ),
+      ).toBeInTheDocument(),
+    );
+    const row = mountRow("revoked-tools");
     expect(within(row).queryByText(/Connecting/)).not.toBeInTheDocument();
 
     // And the toggle still unmounts it.
@@ -505,20 +526,30 @@ describe("McpPanel", () => {
     const user = userEvent.setup();
     render(<McpPanel client={client} />);
 
-    // The failure is visible and named, and the disabled toggle is explained
-    // rather than passing unknown off as unmounted.
+    // The failure is visible and carries the underlying message, and the
+    // disabled toggle is explained rather than passing unknown off as
+    // unmounted.
     expect(
-      await screen.findByText(/Couldn't read the MCP server list/),
+      await screen.findByText(
+        /Couldn't read the MCP server list: mcp backend unavailable/,
+      ),
     ).toBeInTheDocument();
-    const row = mountRow("example-security-tools");
-    expect(within(row).getByRole("switch")).toBeDisabled();
-    expect(within(row).getByText(/Mount state unknown/)).toBeInTheDocument();
+    expect(
+      await screen.findByRole("switch", {
+        name: "Mount example-security-tools",
+      }),
+    ).toBeDisabled();
+    expect(
+      within(mountRow("example-security-tools")).getByText(
+        /Mount state unknown/,
+      ),
+    ).toBeInTheDocument();
 
     listMcpServers.mockResolvedValue({ servers: [] });
     await user.click(screen.getByRole("button", { name: /Retry/ }));
     await waitFor(() =>
       expect(
-        screen.queryByText(/Couldn't read the MCP server list/),
+        screen.queryByText(/mcp backend unavailable/),
       ).not.toBeInTheDocument(),
     );
     expect(
@@ -552,7 +583,9 @@ describe("McpPanel", () => {
       await vi.advanceTimersByTimeAsync(15_100);
     });
     expect(
-      screen.getByText(/Couldn't read the MCP server list/),
+      screen.getByText(
+        /Couldn't read the MCP server list: mcp backend unavailable/,
+      ),
     ).toBeInTheDocument();
     const row = mountRow("example-security-tools");
     expect(within(row).getByText(/3 tools available/)).toBeInTheDocument();
@@ -575,20 +608,28 @@ describe("McpPanel", () => {
 
     // The row survives the apps failure, labeled unknown-entitlements — never
     // misreported as revoked.
-    const row = await waitFor(() => mountRow("example-security-tools"));
     expect(
-      screen.getByText(/Couldn't read your entitlements/),
+      await screen.findByText(/Couldn't read your entitlements/),
     ).toBeInTheDocument();
+    const row = mountRow("example-security-tools");
     expect(within(row).queryByText(/No longer granted/)).not.toBeInTheDocument();
     expect(within(row).getByRole("switch")).toBeChecked();
   });
 
-  it("keeps the gateway endpoint toggles live on a managed profile", async () => {
+  it("mounts on a managed profile, round-tripping a manual server unchanged", async () => {
+    const legacy: McpServerInfo = {
+      ...healthy.servers[0],
+      name: "legacy_docs",
+      health: "disabled",
+      tool_count: 0,
+      diagnostic:
+        "Disabled by managed policy. Gateway-managed MCP endpoints remain available.",
+    };
     const putMcpServers = vi.fn().mockResolvedValue({
-      servers: [gatewayMount("example-security-tools")],
+      servers: [legacy, gatewayMount("example-security-tools")],
     });
     const client = api(
-      { servers: [] },
+      { servers: [legacy] },
       {
         getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
         getGatewayApps: vi.fn().mockResolvedValue(incidentApps),
@@ -599,7 +640,8 @@ describe("McpPanel", () => {
     render(<McpPanel client={client} managed />);
 
     // Manual servers are read-only under managed policy, but a gateway mount
-    // is exactly the write the server admits — so this toggle still writes.
+    // is exactly the write the server admits — and admission depends on the
+    // inert manual definition arriving unchanged, so pin it exactly.
     const toggle = await screen.findByRole("switch", {
       name: "Mount example-security-tools",
     });
@@ -607,10 +649,69 @@ describe("McpPanel", () => {
     await user.click(toggle);
     await waitFor(() =>
       expect(putMcpServers).toHaveBeenCalledWith([
+        {
+          name: "legacy_docs",
+          command: "/opt/mcp/docs",
+          args: ["--stdio"],
+          env: { LOG_LEVEL: "info" },
+          env_from: ["PRIVATE_DOCS_TOKEN"],
+          cwd: "/tmp/docs",
+          url: null,
+          bearer_token_env: null,
+          gateway_endpoint: null,
+          request_timeout_ms: 60_000,
+          enabled: true,
+        },
         expect.objectContaining({
           gateway_endpoint: "example-security-tools",
         }),
       ]),
     );
+  });
+
+  it("keeps a mount made during unsaved edits through the next save", async () => {
+    const mount = gatewayMount("example-security-tools");
+    const putMcpServers = vi
+      .fn()
+      .mockResolvedValue({ servers: [...healthy.servers, mount] });
+    const client = api(healthy, {
+      getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+      getGatewayApps: vi.fn().mockResolvedValue(incidentApps),
+      putMcpServers,
+    });
+    const user = userEvent.setup();
+    render(<McpPanel client={client} />);
+
+    // An unsaved manual edit first, so the draft is dirty when the mount lands.
+    await user.type(
+      await screen.findByPlaceholderText("/absolute/path/to/server"),
+      "-edited",
+    );
+    await user.click(
+      await screen.findByRole("switch", {
+        name: "Mount example-security-tools",
+      }),
+    );
+    // The mount write is rebuilt from the saved configuration: nobody's
+    // toggle persists an unsaved edit.
+    await waitFor(() =>
+      expect(putMcpServers).toHaveBeenCalledWith([
+        expect.objectContaining({ command: "/opt/mcp/docs" }),
+        expect.objectContaining({
+          gateway_endpoint: "example-security-tools",
+        }),
+      ]),
+    );
+
+    // Saving the dirty draft carries the mount instead of silently
+    // reverting it.
+    await user.click(screen.getByRole("button", { name: "Save and verify" }));
+    await waitFor(() => expect(putMcpServers).toHaveBeenCalledTimes(2));
+    expect(putMcpServers).toHaveBeenLastCalledWith([
+      expect.objectContaining({ command: "/opt/mcp/docs-edited" }),
+      expect.objectContaining({
+        gateway_endpoint: "example-security-tools",
+      }),
+    ]);
   });
 });

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 import { Plus, RefreshCw, Trash2 } from "lucide-react";
 import type {
   ApiClient,
+  GatewayApps,
   McpServerDefinition,
   McpServerInfo,
 } from "../api";
@@ -19,6 +20,13 @@ import {
 
 const DEFAULT_TIMEOUT_MS = 60_000;
 const MAX_TIMEOUT_MS = 3_600_000;
+/** Mount health lives in the local MCP supervisor, so a modest refresh while
+ * the section is visible keeps the health lines honest without gateway load. */
+const MOUNT_REFRESH_MS = 15_000;
+/** Server names cap at 32 bytes (the MCP tool namespace); endpoint slugs go
+ * to 127, so the mount name is derived, not the slug itself. Mount identity
+ * is always the `gateway_endpoint` field, never the name. */
+const MAX_NAMESPACE_BYTES = 32;
 
 function emptyServer(index: number): McpServerInfo {
   return {
@@ -78,10 +86,10 @@ export function McpPanel({
   managed = false,
 }: {
   client: ApiClient;
-  /** On a managed profile the server refuses manual server writes, so this
-   * panel becomes a read-only view of what is mounted. Gateway mounts and
-   * their health stay visible; they are added and removed from the Model
-   * Gateway panel, which is where they come from. */
+  /** On a managed profile the server refuses manual server writes, so the
+   * manual half of this panel becomes a read-only view of what is mounted.
+   * The gateway endpoints section keeps its toggles: a `gateway_endpoint`
+   * definition is exactly the write managed policy admits. */
   managed?: boolean;
 }) {
   const [servers, setServers] = useState<McpServerInfo[]>([]);
@@ -138,6 +146,13 @@ export function McpPanel({
     }
   }
 
+  /** A mount toggled in the gateway section rewrites the same configuration
+   * this list edits, so adopt its result — unless the reader has unsaved
+   * edits here, which must never be replaced underneath them. */
+  function adoptMounts(next: McpServerInfo[]) {
+    if (!dirty) setServers(next);
+  }
+
   async function reconnect(name: string) {
     setReconnecting(name);
     setError(null);
@@ -173,6 +188,7 @@ export function McpPanel({
         description="Tool servers provided by your organization's model gateway."
         busy={loading}
       >
+        <GatewayEndpoints client={client} onMountsChanged={adoptMounts} />
         {loading ? (
           <p className="text-sm text-muted-foreground">Loading MCP servers…</p>
         ) : (
@@ -189,6 +205,7 @@ export function McpPanel({
       description="Connect local stdio tool servers or remote HTTP endpoints without a shell or a desktop restart."
       busy={loading || working}
     >
+      <GatewayEndpoints client={client} onMountsChanged={adoptMounts} />
       {loading ? (
         <p className="text-sm text-muted-foreground">
           Loading MCP servers…
@@ -257,7 +274,7 @@ export function McpPanel({
                   Managed by the Model Gateway (endpoint{" "}
                   <code>{server.gateway_endpoint}</code>). Its URL and
                   short-lived credentials come from the signed-in gateway
-                  session; mount or unmount it from the Model Gateway panel.
+                  session; mount or unmount it under Gateway endpoints above.
                 </p>
               )}
 
@@ -483,6 +500,298 @@ export function McpPanel({
   );
 }
 
+/** A valid, unused namespace for a mount: the slug, truncated to the name
+ * limit and de-duplicated against every configured server. */
+function mountName(slug: string, taken: ReadonlySet<string>): string {
+  const base = slug.slice(0, MAX_NAMESPACE_BYTES);
+  if (!taken.has(base)) return base;
+  for (let n = 2; ; n += 1) {
+    const suffix = `_${n}`;
+    const candidate =
+      base.slice(0, MAX_NAMESPACE_BYTES - suffix.length) + suffix;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
+
+/** Sentence-shaped status for a mount row; diagnostics already are one. */
+function mountStatus(mounted: McpServerInfo): string {
+  if (mounted.health === "healthy") {
+    return `${mounted.tool_count} tool${mounted.tool_count === 1 ? "" : "s"} available to new turns.`;
+  }
+  if (mounted.diagnostic) return mounted.diagnostic;
+  switch (mounted.health) {
+    case "initializing":
+    case "reconnecting":
+      return "Connecting…";
+    case "disabled":
+      return "Disabled below.";
+    default:
+      return "Needs attention. See its entry below.";
+  }
+}
+
+/** A message that can sit mid-sentence: `String(err)` would keep the error
+ * class prefix ("HttpError: ...") in front of it. */
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** A fresh gateway mount: everything comes from the session except the name,
+ * which doubles as the tool namespace. */
+function mountDefinition(slug: string, name: string): McpServerDefinition {
+  return {
+    name,
+    command: null,
+    args: [],
+    env: {},
+    env_from: [],
+    cwd: null,
+    url: null,
+    bearer_token_env: null,
+    gateway_endpoint: slug,
+    request_timeout_ms: DEFAULT_TIMEOUT_MS,
+    enabled: true,
+  };
+}
+
+/**
+ * The gateway's MCP endpoints, and the toggle that mounts each one.
+ *
+ * Mounting belongs beside the health of what is mounted, so it lives here
+ * rather than in the Model Gateway panel, which keeps the connected apps as
+ * an informational list. A `gateway_endpoint` definition is the one write
+ * managed policy admits, so these toggles stay live on a managed profile
+ * where every manual server below is read-only.
+ *
+ * The section carries its own view of the configured servers, separate from
+ * the editable list around it, so a background refresh can keep the health
+ * lines honest without touching a form the reader is part-way through.
+ * Nothing renders at all until a gateway session exists.
+ */
+function GatewayEndpoints({
+  client,
+  onMountsChanged,
+}: {
+  client: ApiClient;
+  /** The fresh server list a mount write returns, so the page around this
+   * section reflects the mount it just made. */
+  onMountsChanged: (servers: McpServerInfo[]) => void;
+}) {
+  const [signedIn, setSignedIn] = useState(false);
+  const [apps, setApps] = useState<GatewayApps | null>(null);
+  // Distinguishes "the apps read failed" from "no apps granted": a failure
+  // must not make configured mounts masquerade as revoked, nor hide them.
+  const [appsFailed, setAppsFailed] = useState(false);
+  const [servers, setServers] = useState<McpServerInfo[] | null>(null);
+  const [listError, setListError] = useState<string | null>(null);
+  // Bumped by the Retry affordance; re-runs the mount-list effect immediately
+  // and restarts its cadence.
+  const [refreshNonce, setRefreshNonce] = useState(0);
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Monotonic id for mount-list reads: a slow in-flight read must not clobber
+  // the fresher list a toggle write (or a newer read) has since installed.
+  const requestRef = useRef(0);
+
+  // An unreachable or unpaired gateway is simply no section, not an error on
+  // a page whose subject is the local MCP configuration.
+  useEffect(() => {
+    let cancelled = false;
+    client
+      .getGatewayStatus()
+      .then((status) => {
+        if (!cancelled) setSignedIn(status.signed_in);
+      })
+      .catch(() => {
+        if (!cancelled) setSignedIn(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  // Entitled apps are never cached server-side (a revoked grant disappears on
+  // the next request), so fetch them fresh whenever the signed-in state turns
+  // on. A fetch failure hides the apps list but is remembered, so mount rows
+  // can say entitlements are unknown instead of claiming anything.
+  useEffect(() => {
+    if (!signedIn) {
+      setApps(null);
+      setAppsFailed(false);
+      return;
+    }
+    let cancelled = false;
+    client
+      .getGatewayApps()
+      .then((next) => {
+        if (!cancelled) {
+          setApps(next);
+          setAppsFailed(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setApps(null);
+          setAppsFailed(true);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client, signedIn]);
+
+  // Keep re-reading the configuration while the section is visible, so a
+  // mount that degrades after the first read doesn't keep a stale healthy
+  // line. A failed read keeps the last-known rows and surfaces a retryable
+  // error instead of silently disabling every toggle.
+  useEffect(() => {
+    if (!signedIn) {
+      setServers(null);
+      setListError(null);
+      return;
+    }
+    const refresh = async () => {
+      const request = ++requestRef.current;
+      try {
+        const next = await client.listMcpServers();
+        if (request !== requestRef.current) return;
+        setServers(next.servers);
+        setListError(null);
+      } catch (err) {
+        if (request !== requestRef.current) return;
+        setListError(errorMessage(err));
+      }
+    };
+    void refresh();
+    const timer = window.setInterval(() => void refresh(), MOUNT_REFRESH_MS);
+    return () => {
+      // Invalidate any in-flight read; a re-run issues fresh ids above this.
+      requestRef.current += 1;
+      window.clearInterval(timer);
+    };
+  }, [client, signedIn, refreshNonce]);
+
+  async function setMounted(slug: string, mounted: boolean) {
+    setWorking(true);
+    setError(null);
+    try {
+      // Rebuild from the live configuration, not this section's cache, so a
+      // mount toggled here never drops a server edited elsewhere meanwhile.
+      const current = (await client.listMcpServers()).servers.map(definition);
+      const without = current.filter(
+        (server) => server.gateway_endpoint !== slug,
+      );
+      const taken = new Set(without.map((server) => server.name));
+      const next = mounted
+        ? [...without, mountDefinition(slug, mountName(slug, taken))]
+        : without;
+      const result = await client.putMcpServers(next);
+      // Supersede any in-flight background read; this list is fresher.
+      requestRef.current += 1;
+      setServers(result.servers);
+      setListError(null);
+      onMountsChanged(result.servers);
+      toast.success(mounted ? `Mounted ${slug}` : `Unmounted ${slug}`);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  const entitledSlugs = new Set(
+    apps?.apps.flatMap((app) => app.mcp_endpoint_slugs) ?? [],
+  );
+  // Rows are the union of what's entitled and what's configured: a mount
+  // whose grant was revoked must keep its row (and unmount toggle), not drop
+  // to being visible only as a failing server further down the page.
+  const endpointSlugs = [
+    ...new Set([
+      ...entitledSlugs,
+      ...(servers ?? [])
+        .map((server) => server.gateway_endpoint)
+        .filter((slug): slug is string => slug !== null),
+    ]),
+  ];
+  // "Revoked" is only a claim we can make after actually reading the
+  // entitlements; a failed or unsupported apps read leaves them unknown.
+  const entitlementsKnown = apps?.supported === true;
+  /** The one line under a mount row: unknown beats revoked beats health. */
+  const rowNote = (slug: string, mounted: McpServerInfo | undefined) => {
+    if (servers === null) return "Mount state unknown.";
+    if (entitlementsKnown && !entitledSlugs.has(slug)) {
+      return "No longer granted to your teams. Switch off to unmount it.";
+    }
+    return mounted ? mountStatus(mounted) : null;
+  };
+
+  // Deliberately NOT gated on the apps read: a configured mount keeps its row
+  // — and a list failure its Retry — even when entitlements can't be read.
+  if (!signedIn || (endpointSlugs.length === 0 && listError === null)) {
+    return null;
+  }
+
+  return (
+    <SettingsSection
+      title="Gateway endpoints"
+      description="Mounted endpoints connect with your gateway session — no tokens to copy, and they reconnect after you sign back in."
+    >
+      {appsFailed && (
+        <p className="text-muted-foreground text-xs">
+          Couldn't read your entitlements from the gateway; these are the
+          configured mounts.
+        </p>
+      )}
+      {listError !== null && (
+        <div className="flex items-center justify-between gap-4">
+          <SettingsError>
+            Couldn't read the MCP server list: {listError}
+          </SettingsError>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={working}
+            onClick={() => setRefreshNonce((nonce) => nonce + 1)}
+          >
+            <RefreshCw size={14} />
+            Retry
+          </Button>
+        </div>
+      )}
+      {endpointSlugs.length > 0 && (
+        <ul className="flex flex-col gap-2">
+          {endpointSlugs.map((slug) => {
+            const mounted = servers?.find(
+              (server) => server.gateway_endpoint === slug,
+            );
+            const note = rowNote(slug, mounted);
+            return (
+              <li
+                key={slug}
+                className="flex items-center justify-between gap-4 rounded-md border px-3 py-2 text-sm"
+              >
+                <div className="min-w-0 flex-1">
+                  <code className="font-medium">{slug}</code>
+                  {note && (
+                    <p className="text-muted-foreground text-xs">{note}</p>
+                  )}
+                </div>
+                <Switch
+                  aria-label={`Mount ${slug}`}
+                  checked={mounted !== undefined}
+                  disabled={working || servers === null}
+                  onCheckedChange={(checked) => void setMounted(slug, checked)}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      {error && <SettingsError>{error}</SettingsError>}
+    </SettingsSection>
+  );
+}
+
 /**
  * The managed read-only view: what is mounted and whether it is working.
  *
@@ -498,7 +807,7 @@ function ManagedServerList({ servers }: { servers: McpServerInfo[] }) {
         <SettingsSection>
           <p className="text-sm text-muted-foreground">
             No MCP servers are mounted. Mount the endpoints you are entitled to
-            from the Model Gateway section.
+            under Gateway endpoints above.
           </p>
         </SettingsSection>
       )}
@@ -521,8 +830,8 @@ function ManagedServerList({ servers }: { servers: McpServerInfo[] }) {
           {transportOf(server) === "gateway" ? (
             <p className="text-sm text-muted-foreground">
               Managed by the Model Gateway (endpoint{" "}
-              <code>{server.gateway_endpoint}</code>). Mount or unmount it from
-              the Model Gateway section.
+              <code>{server.gateway_endpoint}</code>). Mount or unmount it under
+              Gateway endpoints above.
             </p>
           ) : (
             <p className="text-sm text-muted-foreground">

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
@@ -134,6 +134,9 @@ export function McpPanel({
    * their health. */
   function adoptServers(fresh: McpServerInfo[]) {
     setServers((current) => {
+      // Reading the ref inside the updater is sound where a transition
+      // detector would not be: it only reads, so a StrictMode double-invoke
+      // computes the same list twice.
       if (!dirtyRef.current) return fresh;
       const freshMounts = new Map<string, McpServerInfo>();
       for (const server of fresh) {
@@ -221,10 +224,10 @@ export function McpPanel({
         adoptServers(result.servers);
         setServersKnown(true);
         setListError(null);
+        setLoading(false);
       } catch (err) {
         if (request !== requestRef.current) return;
         setListError(errorMessage(err));
-      } finally {
         setLoading(false);
       }
     };
@@ -263,7 +266,7 @@ export function McpPanel({
       markDirty(false);
       toast.success("Saved MCP servers");
     } catch (err) {
-      setError(String(err));
+      setError(errorMessage(err));
     } finally {
       setSaving(false);
     }
@@ -314,7 +317,7 @@ export function McpPanel({
       requestRef.current += 1;
       setServers(result.servers);
     } catch (err) {
-      setError(String(err));
+      setError(errorMessage(err));
       try {
         const result = await client.listMcpServers();
         requestRef.current += 1;
@@ -635,20 +638,39 @@ export function McpPanel({
                       : "Reconnect and refresh tools"}
                   </Button>
                 )}
-                <Button
-                  type="button"
-                  variant="destructive"
-                  disabled={working}
-                  onClick={() => {
-                    markDirty(true);
-                    setServers((current) =>
-                      current.filter((_, itemIndex) => itemIndex !== index),
-                    );
-                  }}
-                >
-                  <Trash2 size={14} />
-                  Remove
-                </Button>
+                {/* Mounts are owned by the mount write, not the draft: a
+                    draft deletion would be undone by the next reconcile,
+                    which re-adds every configured mount. Unmounting writes
+                    immediately, like the section's toggle. */}
+                {transportOf(server) === "gateway" ? (
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    disabled={working}
+                    onClick={() => {
+                      const slug = server.gateway_endpoint;
+                      if (slug !== null) void setMounted(slug, false);
+                    }}
+                  >
+                    <Trash2 size={14} />
+                    Unmount
+                  </Button>
+                ) : (
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    disabled={working}
+                    onClick={() => {
+                      markDirty(true);
+                      setServers((current) =>
+                        current.filter((_, itemIndex) => itemIndex !== index),
+                      );
+                    }}
+                  >
+                    <Trash2 size={14} />
+                    Remove
+                  </Button>
+                )}
               </div>
             </SettingsSection>
           ))}

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
@@ -98,32 +98,151 @@ export function McpPanel({
   const [reconnecting, setReconnecting] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Gateway session state, held here because the gateway endpoints section
+  // shares this panel's one server list instead of owning a second copy.
+  const [signedIn, setSignedIn] = useState(false);
+  const [apps, setApps] = useState<GatewayApps | null>(null);
+  // Distinguishes "the apps read failed" from "no apps granted": a failure
+  // must not make configured mounts masquerade as revoked, nor hide them.
+  const [appsFailed, setAppsFailed] = useState(false);
+  // Whether any server-list read has succeeded: before one has, a mount
+  // toggle would be a write against unknown state, so the rows say so.
+  const [serversKnown, setServersKnown] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
+  // Bumped by the Retry affordance; re-runs the list effect immediately and
+  // restarts its cadence.
+  const [refreshNonce, setRefreshNonce] = useState(0);
+  const [mounting, setMounting] = useState(false);
+  // `dirty`, mirrored for the async work below: a background read or a slow
+  // mount write resolves against a render whose captured `dirty` may predate
+  // the edit it must not clobber.
+  const dirtyRef = useRef(false);
+  // Monotonic id for server-list reads: a slow in-flight read must not
+  // clobber the fresher list a write (or a newer read) has since installed.
+  const requestRef = useRef(0);
 
+  function markDirty(value: boolean) {
+    dirtyRef.current = value;
+    setDirty(value);
+  }
+
+  /** Install a fresh, authoritative server list: wholesale when nothing is
+   * unsaved; otherwise reconciled around the draft. Gateway mounts follow
+   * the saved configuration — their toggle writes immediately, and the next
+   * Save must carry the result instead of reverting it — while manual rows
+   * keep the reader's unsaved edits, and edited mount rows refresh only
+   * their health. */
+  function adoptServers(fresh: McpServerInfo[]) {
+    setServers((current) => {
+      if (!dirtyRef.current) return fresh;
+      const freshMounts = new Map<string, McpServerInfo>();
+      for (const server of fresh) {
+        if (server.gateway_endpoint !== null) {
+          freshMounts.set(server.gateway_endpoint, server);
+        }
+      }
+      const kept = current.flatMap((server) => {
+        if (server.gateway_endpoint === null) return [server];
+        const mount = freshMounts.get(server.gateway_endpoint);
+        if (mount === undefined) return [];
+        freshMounts.delete(server.gateway_endpoint);
+        return [
+          {
+            ...server,
+            health: mount.health,
+            tool_count: mount.tool_count,
+            diagnostic: mount.diagnostic,
+          },
+        ];
+      });
+      return [...kept, ...freshMounts.values()];
+    });
+  }
+
+  // An unreachable gateway reads as signed out: the endpoints section then
+  // treats entitlements as unknown rather than failing a page whose subject
+  // is the local MCP configuration.
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
-    setError(null);
-    void client
-      .listMcpServers()
-      .then((result) => {
-        if (!cancelled) {
-          setServers(result.servers);
-          setDirty(false);
-        }
+    client
+      .getGatewayStatus()
+      .then((status) => {
+        if (!cancelled) setSignedIn(status.signed_in);
       })
-      .catch((err) => {
-        if (!cancelled) setError(String(err));
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
+      .catch(() => {
+        if (!cancelled) setSignedIn(false);
       });
     return () => {
       cancelled = true;
     };
   }, [client]);
 
+  // Entitled apps are never cached server-side (a revoked grant disappears on
+  // the next request), so fetch them fresh whenever the signed-in state turns
+  // on. A fetch failure is remembered, so mount rows can say entitlements are
+  // unknown instead of claiming anything.
+  useEffect(() => {
+    if (!signedIn) {
+      setApps(null);
+      setAppsFailed(false);
+      return;
+    }
+    let cancelled = false;
+    client
+      .getGatewayApps()
+      .then((next) => {
+        if (!cancelled) {
+          setApps(next);
+          setAppsFailed(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setApps(null);
+          setAppsFailed(true);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client, signedIn]);
+
+  // The one reader of the server list: the initial load, the Retry
+  // affordance, and — while a gateway session exists — a steady cadence, so
+  // a mount that degrades after the first read doesn't keep a stale healthy
+  // line. A failed read keeps the last-known rows and surfaces a retryable
+  // error instead of silently disabling every toggle.
+  useEffect(() => {
+    const read = async () => {
+      const request = ++requestRef.current;
+      try {
+        const result = await client.listMcpServers();
+        if (request !== requestRef.current) return;
+        adoptServers(result.servers);
+        setServersKnown(true);
+        setListError(null);
+      } catch (err) {
+        if (request !== requestRef.current) return;
+        setListError(errorMessage(err));
+      } finally {
+        setLoading(false);
+      }
+    };
+    void read();
+    const timer = signedIn
+      ? window.setInterval(() => void read(), MOUNT_REFRESH_MS)
+      : null;
+    return () => {
+      // Invalidate any in-flight read; a re-run issues fresh ids above this.
+      requestRef.current += 1;
+      if (timer !== null) window.clearInterval(timer);
+    };
+    // adoptServers touches only refs and state setters, so the effect only
+    // re-runs when a read would actually change: client, session, retry.
+  }, [client, signedIn, refreshNonce]);
+
   function update(index: number, change: Partial<McpServerInfo>) {
-    setDirty(true);
+    markDirty(true);
     setServers((current) =>
       current.map((server, itemIndex) =>
         itemIndex === index ? { ...server, ...change } : server,
@@ -136,8 +255,12 @@ export function McpPanel({
     setError(null);
     try {
       const result = await client.putMcpServers(servers.map(definition));
+      // Supersede any in-flight background read; this list is fresher.
+      requestRef.current += 1;
       setServers(result.servers);
-      setDirty(false);
+      setServersKnown(true);
+      setListError(null);
+      markDirty(false);
       toast.success("Saved MCP servers");
     } catch (err) {
       setError(String(err));
@@ -146,11 +269,34 @@ export function McpPanel({
     }
   }
 
-  /** A mount toggled in the gateway section rewrites the same configuration
-   * this list edits, so adopt its result — unless the reader has unsaved
-   * edits here, which must never be replaced underneath them. */
-  function adoptMounts(next: McpServerInfo[]) {
-    if (!dirty) setServers(next);
+  /** Mount or unmount one endpoint: an immediate, complete configuration
+   * write, rebuilt from the live configuration rather than the draft above
+   * so it never persists an unsaved edit — nor drops a server saved from
+   * elsewhere in the meantime. */
+  async function setMounted(slug: string, mounted: boolean) {
+    setMounting(true);
+    setError(null);
+    try {
+      const current = (await client.listMcpServers()).servers.map(definition);
+      const without = current.filter(
+        (server) => server.gateway_endpoint !== slug,
+      );
+      const taken = new Set(without.map((server) => server.name));
+      const next = mounted
+        ? [...without, mountDefinition(slug, mountName(slug, taken))]
+        : without;
+      const result = await client.putMcpServers(next);
+      // Supersede any in-flight background read; this list is fresher.
+      requestRef.current += 1;
+      adoptServers(result.servers);
+      setServersKnown(true);
+      setListError(null);
+      toast.success(mounted ? `Mounted ${slug}` : `Unmounted ${slug}`);
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setMounting(false);
+    }
   }
 
   async function reconnect(name: string) {
@@ -165,11 +311,13 @@ export function McpPanel({
     );
     try {
       const result = await client.reconnectMcpServer(name);
+      requestRef.current += 1;
       setServers(result.servers);
     } catch (err) {
       setError(String(err));
       try {
         const result = await client.listMcpServers();
+        requestRef.current += 1;
         setServers(result.servers);
       } catch {
         // Preserve the reconnect error; reopening Settings performs a full load.
@@ -179,21 +327,68 @@ export function McpPanel({
     }
   }
 
-  const working = saving || reconnecting !== null;
+  const working = saving || reconnecting !== null || mounting;
+
+  const entitledSlugs = new Set(
+    apps?.apps.flatMap((app) => app.mcp_endpoint_slugs) ?? [],
+  );
+  // Rows are the union of what's entitled and what's configured: a mount
+  // whose grant was revoked — or whose session signed out — must keep its
+  // row rather than dropping to a bare failing server in the list.
+  const endpointSlugs = [
+    ...new Set([
+      ...entitledSlugs,
+      ...servers
+        .map((server) => server.gateway_endpoint)
+        .filter((slug): slug is string => slug !== null),
+    ]),
+  ];
+  // Signed out, the section still lists configured mounts (toggles off,
+  // pointing at sign-in); it disappears only when there is nothing to show —
+  // an unpaired profile with no gateway mounts.
+  const endpointsVisible =
+    endpointSlugs.length > 0 || (signedIn && listError !== null);
+  const endpointsSection = endpointsVisible && (
+    <GatewayEndpoints
+      signedIn={signedIn}
+      slugs={endpointSlugs}
+      servers={servers}
+      serversKnown={serversKnown}
+      entitledSlugs={apps?.supported === true ? entitledSlugs : null}
+      appsFailed={appsFailed}
+      listError={listError}
+      working={working}
+      onRetry={() => {
+        // One error surface: a retry that recovers the list must not leave a
+        // stale action error standing beside fresh rows.
+        setError(null);
+        setRefreshNonce((nonce) => nonce + 1);
+      }}
+      onToggle={(slug, mounted) => void setMounted(slug, mounted)}
+    />
+  );
+  // A failed list read still surfaces (without the section's Retry) when the
+  // section that normally carries it has nothing else to show.
+  const fallbackListError = !endpointsVisible && listError !== null && (
+    <SettingsError>
+      Couldn't read the MCP server list: {listError}
+    </SettingsError>
+  );
 
   if (managed) {
     return (
       <SettingsPanel
         title="MCP servers"
         description="Tool servers provided by your organization's model gateway."
-        busy={loading}
+        busy={loading || working}
       >
-        <GatewayEndpoints client={client} onMountsChanged={adoptMounts} />
+        {endpointsSection}
         {loading ? (
           <p className="text-sm text-muted-foreground">Loading MCP servers…</p>
         ) : (
           <ManagedServerList servers={servers} />
         )}
+        {fallbackListError}
         {error && <SettingsError>{error}</SettingsError>}
       </SettingsPanel>
     );
@@ -205,7 +400,7 @@ export function McpPanel({
       description="Connect local stdio tool servers or remote HTTP endpoints without a shell or a desktop restart."
       busy={loading || working}
     >
-      <GatewayEndpoints client={client} onMountsChanged={adoptMounts} />
+      {endpointsSection}
       {loading ? (
         <p className="text-sm text-muted-foreground">
           Loading MCP servers…
@@ -444,14 +639,12 @@ export function McpPanel({
                   type="button"
                   variant="destructive"
                   disabled={working}
-                  onClick={() =>
-                    setServers((current) => {
-                      setDirty(true);
-                      return current.filter(
-                        (_, itemIndex) => itemIndex !== index,
-                      );
-                    })
-                  }
+                  onClick={() => {
+                    markDirty(true);
+                    setServers((current) =>
+                      current.filter((_, itemIndex) => itemIndex !== index),
+                    );
+                  }}
                 >
                   <Trash2 size={14} />
                   Remove
@@ -465,12 +658,13 @@ export function McpPanel({
               type="button"
               variant="outline"
               disabled={working}
-              onClick={() =>
-                setServers((current) => {
-                  setDirty(true);
-                  return [...current, emptyServer(current.length)];
-                })
-              }
+              onClick={() => {
+                markDirty(true);
+                setServers((current) => [
+                  ...current,
+                  emptyServer(current.length),
+                ]);
+              }}
             >
               <Plus size={14} />
               Add server
@@ -495,6 +689,7 @@ export function McpPanel({
           </p>
         </>
       )}
+      {fallbackListError}
       {error && <SettingsError>{error}</SettingsError>}
     </SettingsPanel>
   );
@@ -524,9 +719,9 @@ function mountStatus(mounted: McpServerInfo): string {
     case "reconnecting":
       return "Connecting…";
     case "disabled":
-      return "Disabled below.";
+      return "Disabled in its server entry.";
     default:
-      return "Needs attention. See its entry below.";
+      return "Needs attention. See its server entry.";
   }
 }
 
@@ -561,181 +756,59 @@ function mountDefinition(slug: string, name: string): McpServerDefinition {
  * rather than in the Model Gateway panel, which keeps the connected apps as
  * an informational list. A `gateway_endpoint` definition is the one write
  * managed policy admits, so these toggles stay live on a managed profile
- * where every manual server below is read-only.
+ * where every manual server on this page is read-only.
  *
- * The section carries its own view of the configured servers, separate from
- * the editable list around it, so a background refresh can keep the health
- * lines honest without touching a form the reader is part-way through.
- * Nothing renders at all until a gateway session exists.
+ * Purely presentational: the panel owns the single server list this section
+ * reads, its refresh cadence, and the mount writes, so there is no second
+ * copy of the configuration to fall out of step with the editor beside it.
  */
 function GatewayEndpoints({
-  client,
-  onMountsChanged,
+  signedIn,
+  slugs,
+  servers,
+  serversKnown,
+  entitledSlugs,
+  appsFailed,
+  listError,
+  working,
+  onRetry,
+  onToggle,
 }: {
-  client: ApiClient;
-  /** The fresh server list a mount write returns, so the page around this
-   * section reflects the mount it just made. */
-  onMountsChanged: (servers: McpServerInfo[]) => void;
+  signedIn: boolean;
+  slugs: string[];
+  servers: McpServerInfo[];
+  /** Whether any server-list read has succeeded yet; before one has, mount
+   * state is unknown and the rows say so instead of writing blind. */
+  serversKnown: boolean;
+  /** null while entitlements are unknown — signed out, an older gateway, or
+   * a failed apps read — so no row ever claims a revocation it can't know. */
+  entitledSlugs: ReadonlySet<string> | null;
+  appsFailed: boolean;
+  listError: string | null;
+  working: boolean;
+  onRetry: () => void;
+  onToggle: (slug: string, mounted: boolean) => void;
 }) {
-  const [signedIn, setSignedIn] = useState(false);
-  const [apps, setApps] = useState<GatewayApps | null>(null);
-  // Distinguishes "the apps read failed" from "no apps granted": a failure
-  // must not make configured mounts masquerade as revoked, nor hide them.
-  const [appsFailed, setAppsFailed] = useState(false);
-  const [servers, setServers] = useState<McpServerInfo[] | null>(null);
-  const [listError, setListError] = useState<string | null>(null);
-  // Bumped by the Retry affordance; re-runs the mount-list effect immediately
-  // and restarts its cadence.
-  const [refreshNonce, setRefreshNonce] = useState(0);
-  const [working, setWorking] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  // Monotonic id for mount-list reads: a slow in-flight read must not clobber
-  // the fresher list a toggle write (or a newer read) has since installed.
-  const requestRef = useRef(0);
-
-  // An unreachable or unpaired gateway is simply no section, not an error on
-  // a page whose subject is the local MCP configuration.
-  useEffect(() => {
-    let cancelled = false;
-    client
-      .getGatewayStatus()
-      .then((status) => {
-        if (!cancelled) setSignedIn(status.signed_in);
-      })
-      .catch(() => {
-        if (!cancelled) setSignedIn(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [client]);
-
-  // Entitled apps are never cached server-side (a revoked grant disappears on
-  // the next request), so fetch them fresh whenever the signed-in state turns
-  // on. A fetch failure hides the apps list but is remembered, so mount rows
-  // can say entitlements are unknown instead of claiming anything.
-  useEffect(() => {
-    if (!signedIn) {
-      setApps(null);
-      setAppsFailed(false);
-      return;
-    }
-    let cancelled = false;
-    client
-      .getGatewayApps()
-      .then((next) => {
-        if (!cancelled) {
-          setApps(next);
-          setAppsFailed(false);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setApps(null);
-          setAppsFailed(true);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [client, signedIn]);
-
-  // Keep re-reading the configuration while the section is visible, so a
-  // mount that degrades after the first read doesn't keep a stale healthy
-  // line. A failed read keeps the last-known rows and surfaces a retryable
-  // error instead of silently disabling every toggle.
-  useEffect(() => {
-    if (!signedIn) {
-      setServers(null);
-      setListError(null);
-      return;
-    }
-    const refresh = async () => {
-      const request = ++requestRef.current;
-      try {
-        const next = await client.listMcpServers();
-        if (request !== requestRef.current) return;
-        setServers(next.servers);
-        setListError(null);
-      } catch (err) {
-        if (request !== requestRef.current) return;
-        setListError(errorMessage(err));
-      }
-    };
-    void refresh();
-    const timer = window.setInterval(() => void refresh(), MOUNT_REFRESH_MS);
-    return () => {
-      // Invalidate any in-flight read; a re-run issues fresh ids above this.
-      requestRef.current += 1;
-      window.clearInterval(timer);
-    };
-  }, [client, signedIn, refreshNonce]);
-
-  async function setMounted(slug: string, mounted: boolean) {
-    setWorking(true);
-    setError(null);
-    try {
-      // Rebuild from the live configuration, not this section's cache, so a
-      // mount toggled here never drops a server edited elsewhere meanwhile.
-      const current = (await client.listMcpServers()).servers.map(definition);
-      const without = current.filter(
-        (server) => server.gateway_endpoint !== slug,
-      );
-      const taken = new Set(without.map((server) => server.name));
-      const next = mounted
-        ? [...without, mountDefinition(slug, mountName(slug, taken))]
-        : without;
-      const result = await client.putMcpServers(next);
-      // Supersede any in-flight background read; this list is fresher.
-      requestRef.current += 1;
-      setServers(result.servers);
-      setListError(null);
-      onMountsChanged(result.servers);
-      toast.success(mounted ? `Mounted ${slug}` : `Unmounted ${slug}`);
-    } catch (err) {
-      setError(String(err));
-    } finally {
-      setWorking(false);
-    }
-  }
-
-  const entitledSlugs = new Set(
-    apps?.apps.flatMap((app) => app.mcp_endpoint_slugs) ?? [],
-  );
-  // Rows are the union of what's entitled and what's configured: a mount
-  // whose grant was revoked must keep its row (and unmount toggle), not drop
-  // to being visible only as a failing server further down the page.
-  const endpointSlugs = [
-    ...new Set([
-      ...entitledSlugs,
-      ...(servers ?? [])
-        .map((server) => server.gateway_endpoint)
-        .filter((slug): slug is string => slug !== null),
-    ]),
-  ];
-  // "Revoked" is only a claim we can make after actually reading the
-  // entitlements; a failed or unsupported apps read leaves them unknown.
-  const entitlementsKnown = apps?.supported === true;
   /** The one line under a mount row: unknown beats revoked beats health. */
   const rowNote = (slug: string, mounted: McpServerInfo | undefined) => {
-    if (servers === null) return "Mount state unknown.";
-    if (entitlementsKnown && !entitledSlugs.has(slug)) {
+    if (!serversKnown) return "Mount state unknown.";
+    if (entitledSlugs !== null && !entitledSlugs.has(slug)) {
       return "No longer granted to your teams. Switch off to unmount it.";
     }
     return mounted ? mountStatus(mounted) : null;
   };
-
-  // Deliberately NOT gated on the apps read: a configured mount keeps its row
-  // — and a list failure its Retry — even when entitlements can't be read.
-  if (!signedIn || (endpointSlugs.length === 0 && listError === null)) {
-    return null;
-  }
 
   return (
     <SettingsSection
       title="Gateway endpoints"
       description="Mounted endpoints connect with your gateway session — no tokens to copy, and they reconnect after you sign back in."
     >
+      {!signedIn && (
+        <p className="text-muted-foreground text-xs">
+          Sign in to the Model Gateway to mount or unmount endpoints. The
+          configured mounts stay listed meanwhile.
+        </p>
+      )}
       {appsFailed && (
         <p className="text-muted-foreground text-xs">
           Couldn't read your entitlements from the gateway; these are the
@@ -751,17 +824,17 @@ function GatewayEndpoints({
             type="button"
             variant="outline"
             disabled={working}
-            onClick={() => setRefreshNonce((nonce) => nonce + 1)}
+            onClick={onRetry}
           >
             <RefreshCw size={14} />
             Retry
           </Button>
         </div>
       )}
-      {endpointSlugs.length > 0 && (
+      {slugs.length > 0 && (
         <ul className="flex flex-col gap-2">
-          {endpointSlugs.map((slug) => {
-            const mounted = servers?.find(
+          {slugs.map((slug) => {
+            const mounted = servers.find(
               (server) => server.gateway_endpoint === slug,
             );
             const note = rowNote(slug, mounted);
@@ -779,15 +852,14 @@ function GatewayEndpoints({
                 <Switch
                   aria-label={`Mount ${slug}`}
                   checked={mounted !== undefined}
-                  disabled={working || servers === null}
-                  onCheckedChange={(checked) => void setMounted(slug, checked)}
+                  disabled={!signedIn || working || !serversKnown}
+                  onCheckedChange={(checked) => onToggle(slug, checked)}
                 />
               </li>
             );
           })}
         </ul>
       )}
-      {error && <SettingsError>{error}</SettingsError>}
     </SettingsSection>
   );
 }
@@ -806,8 +878,8 @@ function ManagedServerList({ servers }: { servers: McpServerInfo[] }) {
       {servers.length === 0 && (
         <SettingsSection>
           <p className="text-sm text-muted-foreground">
-            No MCP servers are mounted. Mount the endpoints you are entitled to
-            under Gateway endpoints above.
+            No MCP servers are mounted. Any endpoints your teams are granted
+            appear under Gateway endpoints above.
           </p>
         </SettingsSection>
       )}

--- a/crates/openwave-desktop/ui/src/settings/sections.tsx
+++ b/crates/openwave-desktop/ui/src/settings/sections.tsx
@@ -1,4 +1,5 @@
 import type { ComponentType, FunctionComponent } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import {
   Cpu,
   Globe,
@@ -45,7 +46,17 @@ function ProvidersSection() {
 
 function GatewaySection() {
   const { client, refreshCatalog } = useApp();
-  return <GatewayPanel client={client} onChanged={() => void refreshCatalog()} />;
+  const navigate = useNavigate();
+  // Settings sections are registered from a runtime table, so TanStack's
+  // generated route union contains `/settings` but not each literal child.
+  const mcpPath: string = "/settings/mcp";
+  return (
+    <GatewayPanel
+      client={client}
+      onChanged={() => void refreshCatalog()}
+      onOpenMcpSettings={() => void navigate({ to: mcpPath })}
+    />
+  );
 }
 
 function ModelsSection() {
@@ -151,8 +162,8 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
  *
  * A managed profile has no bring-your-own credentials to manage, so the
  * Providers section is dropped and the Model Gateway — the one place its
- * models, session, and MCP mounts come from — becomes the first section, and
- * therefore where settings opens.
+ * models and session come from — becomes the first section, and therefore
+ * where settings opens.
  */
 export function settingsSectionsFor(managed: boolean): SettingsSectionDef[] {
   return managed

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -431,8 +431,8 @@ impl McpRuntime {
     ///
     /// Managed lockdown refuses these rather than every manual definition in
     /// the body: a profile that carried manual servers before it was managed
-    /// keeps them (inert, see [`MANAGED_DISABLED_DIAGNOSTIC`]), and the
-    /// gateway panel — which saves the complete server list to mount an
+    /// keeps them (inert, see [`MANAGED_DISABLED_DIAGNOSTIC`]), and the MCP
+    /// servers page — which saves the complete server list to mount a gateway
     /// endpoint — is not blocked by their presence. Removing one is a
     /// candidate without it, so nothing is trapped in the configuration.
     ///

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -23,7 +23,7 @@ Each server has:
     (`gateway_endpoint`). The endpoint URL and a short-lived `mcp:<slug>`
     bearer are resolved from the signed-in gateway session at every
     connection; nothing is copied, selected by name, or stored. Mount these
-    from **Settings → Model Gateway → Connected apps** with a toggle. Signed
+    from **Settings → MCP servers → Gateway endpoints** with a toggle. Signed
     out, the mount degrades to a "sign in to reconnect" diagnostic and
     recovers on the next reconnect after sign-in;
 - a request timeout from 1 to 3,600,000 milliseconds; and


### PR DESCRIPTION
Mount toggles for entitled gateway endpoints lived in the Model Gateway panel, while the health of what they mounted lived on the MCP servers page. Deciding whether a mount was worth keeping meant reading two sections, and mounting had no view of what mounting had already produced.

The toggles move to a **Gateway endpoints** section at the top of the MCP servers page. The row logic transfers as it was: the union of entitled slugs and configured `gateway_endpoint` servers, the revoked-grant row that keeps its unmount toggle, the 15s health refresh, the retryable list failure that keeps last-known rows instead of dead toggles, the request-id guard against a slow read clobbering a fresher list, and the derived mount name that fits the 32-byte namespace.

The section reads the gateway status and the entitled apps itself (same supported/failure handling as the panel had) and renders nothing at all without a signed-in session, so an unpaired profile sees no gateway surface on either page. It keeps its own view of the configured servers, separate from the editable list around it, so a background refresh never replaces a form part-way through an edit; the list a mount write returns is adopted into that editable list only when nothing is unsaved.

Under managed policy the toggles stay live while every manual server above is read-only. No server change was needed: `manual_additions` refuses manual definitions that are *added or changed*, and a mount write sends the existing manual definitions unchanged alongside the new `gateway_endpoint` one, so it is admitted from this page exactly as it was from the gateway panel. Its doc comment, which named the gateway panel as the caller, now names this page.

The Model Gateway panel keeps **Connected apps** as an informational list — name, kind, and endpoint slugs, no toggles — with a button that opens the MCP servers section. The panel takes an `onOpenMcpSettings` callback rather than reaching for the router itself, matching how the other settings panels take their effects as props.

### Tests

Moved from `GatewayPanel.dom.test.tsx` to `McpPanel.test.tsx`, adapted to the new host (six tests): mount with a session-bound definition, derived mount name for a long slug, revoked-entitlement row with a working unmount toggle, retryable server-list failure, keep-last-known rows when a later refresh fails, and configured mounts surviving an unreadable entitlements read. Assertions that could now match the same server twice — the mount row and that server's own card further down the page — are scoped to the row via a `mountRow` helper, which localizes a regression better than the bare page query did.

Added: the gateway panel no longer renders mount toggles (asserted against a client that reports a configured mount) and its button routes to the MCP servers page; the endpoints section is absent without a gateway session even when a gateway mount is configured; and the section's toggle still writes on a managed profile.

Two assertions did not survive the move and are not worth reconstructing:

- `expect(screen.queryByText(/No connected apps are granted/)).not.toBeInTheDocument()` in the revoked-row test asserted that the gateway panel's empty apps copy did not sit above a populated mount list. Those two lists are no longer on the same page, so it now asserts nothing about the code.
- `expect(screen.findByText("revoked-tools"))` and the equivalent slug lookups were replaced by the row-scoped queries above; matching the bare slug on the MCP page is ambiguous — it is also the server's name in the list below — and a passing match would no longer tell us which surface rendered it.

Verified locally: `tsc`, the full vitest suite (652 tests), and a production `vite build`.

Closes #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)
