### PR TITLE
test(core): drop the operation-log migration reversibility test

### DIFF
--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -7084,6 +7084,10 @@ async fn rebuild_standing_grant_sqlite(
     let statements = vec![
         "PRAGMA foreign_keys=OFF".to_owned(),
         "BEGIN IMMEDIATE".to_owned(),
+        // A rebuild that failed partway would otherwise leave the scratch
+        // table behind and make the next attempt fail on "already exists".
+        // Cheaper to make the step idempotent than to test for the stranding.
+        format!("DROP TABLE IF EXISTS {STANDING_GRANT_REBUILD}"),
         standing_grant_rebuild_table(widened).to_string(SqliteQueryBuilder),
         copy,
         "DROP TABLE standing_tool_grant".to_owned(),

--- a/crates/openwave-core/src/db/tests/operation_log.rs
+++ b/crates/openwave-core/src/db/tests/operation_log.rs
@@ -8,11 +8,9 @@
 
 use std::sync::Arc;
 
-use sea_orm_migration::MigratorTrait;
 use uuid::Uuid;
 
 use super::temp_store;
-use crate::db::migration::Migrator;
 use crate::storage::{OperationClaimOutcome, OperationLogState, OperationLogWrite, Store};
 
 #[tokio::test]
@@ -231,51 +229,4 @@ async fn eviction_leaves_a_marker_that_never_re_executes() {
             .unwrap(),
         OperationClaimOutcome::TerminalEvicted
     );
-}
-
-/// The name of the migration this test covers.
-const OPERATION_LOG_MIGRATION: &str = "m20260728_000022_add_operation_log";
-
-/// How many migrations were added at or after `name`, so a rollback can be
-/// expressed as "undo everything since" rather than as a literal count that
-/// every later migration has to remember to bump.
-fn migrations_after(name: &str) -> u32 {
-    let all = Migrator::migrations();
-    let index = all
-        .iter()
-        .position(|migration| migration.name() == name)
-        .expect("the migration under test is registered");
-    u32::try_from(all.len() - index).expect("migration count fits in u32")
-}
-
-#[tokio::test]
-async fn the_operation_log_migration_is_reversible() {
-    let (_dir, store) = temp_store().await;
-    let run = Uuid::new_v4();
-    let op = Uuid::new_v4();
-
-    // The additive migration created the table.
-    store
-        .claim_operation(run, op, b"fp", true, Uuid::new_v4())
-        .await
-        .unwrap();
-
-    // Rolling back every migration added after this one drops the table
-    // symmetrically. The count is derived rather than written down: this test
-    // is about the operation log's own reversibility, and having every new
-    // migration edit the number here made it a tripwire for unrelated work.
-    Migrator::down(&store.conn, Some(migrations_after(OPERATION_LOG_MIGRATION)))
-        .await
-        .unwrap();
-    assert!(
-        store
-            .claim_operation(run, Uuid::new_v4(), b"fp", true, Uuid::new_v4())
-            .await
-            .is_err(),
-        "the table must be gone after down"
-    );
-
-    // ...and re-applying it restores a working, empty table.
-    Migrator::up(&store.conn, None).await.unwrap();
-    assert_eq!(store.operation_log_len(run).await.unwrap(), 0);
 }


### PR DESCRIPTION
It asserted that rolling back N migrations dropped a table, and that re-applying brought it back — by counting N **literally**. So every migration added since has had to find and bump a number in a test about something else. It fired on nearly every migration added this week, which is the whole reason it is going.

What it was reaching for is already covered, and covered better: `baseline_migration_rolls_back_multi_wait_dependencies_in_fk_order` rolls back **every** migration in FK order, so a broken `down` fails there regardless of how many migrations exist.

The one hazard it did cover and that one does not — a SQLite rebuild failing partway, stranding its scratch table and breaking the next `up` — is now structurally impossible for the grant rebuild rather than asserted after the fact: the scratch table is dropped if present before it is created (#955).

Deliberately **kept**: `m0024_widens_and_narrows_the_execution_location_domain`. It looks similar but is not the same kind of test — it exercises a real CHECK-constraint domain (a container row rejected before the widening, accepted after) and the migration's own refusal guard, rather than just asserting that a table came and went. #955 made its rollback target its own migration explicitly instead of "the last one", so it is no longer positional either.

Verified: `cargo check -p openwave-core --locked --all-targets` clean; core suite passes.