### PR TITLE
feat(web-search): Brave and self-hosted SearXNG backends

### DIFF
--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -678,6 +678,9 @@ export class ApiClient {
   putWebSearchConfig(body: {
     provider?: WebSearchProviderKind | null;
     timeout_ms?: number;
+    // Explicit null clears the configured instance URL; omitting the field
+    // leaves it as it is.
+    searxng_base_url?: string | null;
   }): Promise<WebSearchConfigInfo> {
     return this.json("/web-search", {
       method: "PUT",

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1212,10 +1212,27 @@ export type UserQuestionOption = { id: string, label: string, description: strin
 
 /**
  * Public state returned by the local API. It intentionally reports only
- * selection and credential presence — key material never crosses the secret
- * boundary.
+ * selection, credential presence, and the configured instance URL — key
+ * material never crosses the secret boundary.
  */
-export type WebSearchConfigInfo = { provider?: WebSearchProviderKind, timeout_ms: number, has_credential: boolean, };
+export type WebSearchConfigInfo = { provider?: WebSearchProviderKind, timeout_ms: number, 
+/**
+ * Whether a key is stored for the selected provider. Always false for a
+ * credential-free provider, which has no key slot at all — read
+ * [`Self::available`] to know whether search will actually run.
+ */
+has_credential: boolean, 
+/**
+ * Whether the selected provider has everything it needs to be invoked.
+ *
+ * A key for the credentialed providers, an instance URL for SearXNG.
+ */
+available: boolean, 
+/**
+ * The configured SearXNG instance URL, in the canonical form the host
+ * stored. It is safe to return: validation forbids embedded credentials.
+ */
+searxng_base_url?: string, };
 
 /**
  * Credential readiness for one fixed web-search provider. This public shape
@@ -1227,7 +1244,7 @@ export type WebSearchCredentialReadiness = { provider: WebSearchProviderKind, ha
  * A configured web-search backend. The stable string also selects its secret
  * reference; it is intentionally not a model-controlled argument.
  */
-export type WebSearchProviderKind = "exa" | "tavily" | "brave";
+export type WebSearchProviderKind = "exa" | "tavily" | "brave" | "searxng";
 
 /**
  * Every tool name the renderer will accept, at runtime.

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1227,7 +1227,7 @@ export type WebSearchCredentialReadiness = { provider: WebSearchProviderKind, ha
  * A configured web-search backend. The stable string also selects its secret
  * reference; it is intentionally not a model-controlled argument.
  */
-export type WebSearchProviderKind = "exa" | "tavily";
+export type WebSearchProviderKind = "exa" | "tavily" | "brave";
 
 /**
  * Every tool name the renderer will accept, at runtime.

--- a/crates/openwave-desktop/ui/src/settings/WebSearchPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/WebSearchPanel.dom.test.tsx
@@ -54,6 +54,7 @@ describe("WebSearchPanel", () => {
     const { client, putWebSearchConfig, putWebSearchCredential } = clientFor({
       provider: "exa",
       has_credential: false,
+      available: false,
       timeout_ms: 20_000,
     });
 
@@ -80,6 +81,7 @@ describe("WebSearchPanel", () => {
     expect(putWebSearchConfig).toHaveBeenCalledWith({
       provider: "exa",
       timeout_ms: 30_000,
+      searxng_base_url: null,
     });
     // A provider must not go active in a pass that failed to store its key.
     expect(putWebSearchCredential.mock.invocationCallOrder[0]).toBeLessThan(
@@ -89,7 +91,12 @@ describe("WebSearchPanel", () => {
 
   it("removes one provider's saved key without touching the other", async () => {
     const { client, deleteWebSearchCredential } = clientFor(
-      { provider: "exa", has_credential: true, timeout_ms: 20_000 },
+      {
+        provider: "exa",
+        has_credential: true,
+        available: true,
+        timeout_ms: 20_000,
+      },
       [
         { provider: "exa", has_credential: true },
         { provider: "tavily", has_credential: true },
@@ -108,10 +115,40 @@ describe("WebSearchPanel", () => {
     expect(deleteWebSearchCredential).toHaveBeenCalledTimes(1);
   });
 
+  // The self-hosted provider is configured by address, not by key: it has no
+  // credential field, and losing the address field would leave it selected and
+  // unusable with nothing on screen to repair it.
+  it("saves the self-hosted instance URL and offers it no key field", async () => {
+    const { client, putWebSearchConfig, putWebSearchCredential } = clientFor({
+      provider: "searxng",
+      has_credential: false,
+      available: false,
+      timeout_ms: 20_000,
+    });
+
+    render(<WebSearchPanel client={client} />);
+
+    fireEvent.change(await screen.findByLabelText(/SearXNG instance URL/), {
+      target: { value: "  http://localhost:8888  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+
+    await waitFor(() =>
+      expect(putWebSearchConfig).toHaveBeenCalledWith({
+        provider: "searxng",
+        timeout_ms: 20_000,
+        searxng_base_url: "http://localhost:8888",
+      }),
+    );
+    expect(putWebSearchCredential).not.toHaveBeenCalled();
+    expect(screen.queryByLabelText(/SearXNG API key/)).toBeNull();
+  });
+
   it("rejects a timeout outside the bounds before touching the server", async () => {
     const { client, putWebSearchConfig } = clientFor({
       provider: "exa",
       has_credential: true,
+      available: true,
       timeout_ms: 20_000,
     });
 

--- a/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
@@ -13,8 +13,10 @@ import {
   TimeoutSecondsField,
   timeoutMsFromSeconds,
 } from "./ProviderFields";
+import { Input } from "@/components/ui/input";
 import {
   SettingsError,
+  SettingsField,
   SettingsPanel,
   SettingsSection,
   SettingsStatus,
@@ -23,11 +25,18 @@ import {
 const MIN_WEB_SEARCH_TIMEOUT_SECONDS = 1;
 const MAX_WEB_SEARCH_TIMEOUT_SECONDS = 60;
 
+/**
+ * SearXNG is self-hosted: the operator runs the instance, so it needs an
+ * address instead of a key and never appears in the credential list.
+ */
+const SEARXNG_PROVIDER: WebSearchProviderKind = "searxng";
+
 export function WebSearchPanel({ client }: { client: ApiClient }) {
   const [config, setConfig] = useState<WebSearchConfigInfo | null>(null);
   const [credentials, setCredentials] = useState<WebSearchCredentialReadiness[]>([]);
   const [provider, setProvider] = useState<WebSearchProviderKind | "">("");
   const [timeoutSeconds, setTimeoutSeconds] = useState("");
+  const [searxngBaseUrl, setSearxngBaseUrl] = useState("");
   // One draft key per provider: a pass can add Exa's key and Tavily's key
   // together, and switching the active provider must not discard either.
   const [apiKeys, setApiKeys] = useState<
@@ -53,6 +62,7 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
         setCredentials(nextCredentials.credentials);
         setProvider(nextConfig.provider ?? "");
         setTimeoutSeconds(String(nextConfig.timeout_ms / 1000));
+        setSearxngBaseUrl(nextConfig.searxng_base_url ?? "");
       } catch (err) {
         if (!cancelled) setError(String(err));
       } finally {
@@ -92,11 +102,15 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
       const nextConfig = await client.putWebSearchConfig({
         provider: provider || null,
         timeout_ms: timeout.timeoutMs,
+        // An empty field clears the stored address rather than leaving a
+        // stale one behind an emptied box.
+        searxng_base_url: searxngBaseUrl.trim() || null,
       });
       const nextCredentials = await client.listWebSearchCredentials();
       setConfig(nextConfig);
       setCredentials(nextCredentials.credentials);
       setTimeoutSeconds(String(nextConfig.timeout_ms / 1000));
+      setSearxngBaseUrl(nextConfig.searxng_base_url ?? "");
       toast.success("Saved web-search settings");
     } catch (err) {
       setError(String(err));
@@ -170,6 +184,25 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
           </SettingsSection>
 
           <SettingsSection
+            title="Self-hosted instance"
+            description="SearXNG needs no key — it needs the address of the instance you run. Enable the JSON output format on that instance, which is off by default."
+          >
+            <SettingsField
+              label="SearXNG instance URL"
+              hint="For example http://localhost:8888. A loopback or private address is expected here; leave blank to take SearXNG out of service."
+            >
+              <Input
+                type="url"
+                inputMode="url"
+                placeholder="http://localhost:8888"
+                value={searxngBaseUrl}
+                disabled={working}
+                onChange={(event) => setSearxngBaseUrl(event.target.value)}
+              />
+            </SettingsField>
+          </SettingsSection>
+
+          <SettingsSection
             title="Active provider"
             description="Agents search and open pages through this one provider. The others stay configured and idle."
           >
@@ -177,10 +210,16 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
               value={provider}
               disabled={working}
               onChange={setProvider}
-              options={credentials.map((credential) => ({
-                kind: credential.provider,
-                label: providerLabel(credential.provider),
-              }))}
+              options={[
+                ...credentials.map((credential) => ({
+                  kind: credential.provider,
+                  label: providerLabel(credential.provider),
+                })),
+                {
+                  kind: SEARXNG_PROVIDER,
+                  label: providerLabel(SEARXNG_PROVIDER),
+                },
+              ]}
             />
 
             <TimeoutSecondsField
@@ -228,6 +267,8 @@ function providerLabel(provider: WebSearchProviderKind): string {
       return "Tavily";
     case "brave":
       return "Brave Search";
+    case "searxng":
+      return "SearXNG";
     default:
       return provider;
   }
@@ -245,16 +286,22 @@ function webSearchState(config: WebSearchConfigInfo | null): {
       description: "No web-search provider is selected.",
     };
   }
-  if (config.has_credential) {
+  if (config.available) {
     return {
       kind: "ready",
       label: "Ready",
-      description: `${providerLabel(config.provider)} is selected and has a saved key.`,
+      description:
+        config.provider === SEARXNG_PROVIDER
+          ? `${providerLabel(config.provider)} is selected and pointed at ${config.searxng_base_url}.`
+          : `${providerLabel(config.provider)} is selected and has a saved key.`,
     };
   }
   return {
     kind: "not-configured",
     label: "Not configured",
-    description: `${providerLabel(config.provider)} is selected but needs an API key.`,
+    description:
+      config.provider === SEARXNG_PROVIDER
+        ? `${providerLabel(config.provider)} is selected but needs an instance URL.`
+        : `${providerLabel(config.provider)} is selected but needs an API key.`,
   };
 }

--- a/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/WebSearchPanel.tsx
@@ -148,7 +148,7 @@ export function WebSearchPanel({ client }: { client: ApiClient }) {
 
           <SettingsSection
             title="Providers"
-            description="Give a key to every provider you want available. Each key is stored in the system keychain and never shown again."
+            description="Give a key to every provider you want available. Brave Search has a free tier; Exa and Tavily are paid. Each key is stored in the system keychain and never shown again."
           >
             {credentials.map((credential) => (
               <ProviderCredentialField
@@ -226,6 +226,8 @@ function providerLabel(provider: WebSearchProviderKind): string {
       return "Exa";
     case "tavily":
       return "Tavily";
+    case "brave":
+      return "Brave Search";
     default:
       return provider;
   }

--- a/crates/openwave-server/src/secret_rehome.rs
+++ b/crates/openwave-server/src/secret_rehome.rs
@@ -24,10 +24,21 @@ use crate::providers::{ProviderKind, LEGACY_ANTHROPIC_API_KEY};
 /// Credential keys for the web-search providers. `credential_key` is a `const
 /// fn`, so the keys resolve here rather than being spelled out again.
 const WEB_SEARCH_CREDENTIAL_KEYS: &[&str] = &[
-    WebSearchProviderKind::Exa.credential_key(),
-    WebSearchProviderKind::Tavily.credential_key(),
-    WebSearchProviderKind::Brave.credential_key(),
+    web_search_credential_key(WebSearchProviderKind::Exa),
+    web_search_credential_key(WebSearchProviderKind::Tavily),
+    web_search_credential_key(WebSearchProviderKind::Brave),
 ];
+
+/// One provider's fixed credential key, in const context.
+///
+/// A credential-free provider (a self-hosted instance) stores nothing and has
+/// nothing to re-home, so listing one above is a compile-time error.
+const fn web_search_credential_key(kind: WebSearchProviderKind) -> &'static str {
+    match kind.credential_key() {
+        Some(key) => key,
+        None => panic!("web-search provider stores no credential"),
+    }
+}
 
 /// Credential keys for the code-execution providers that take one (`Local`
 /// runs in the host sandbox and has none).
@@ -204,10 +215,11 @@ mod tests {
             assert!(keys.contains(&kind.credential_key()), "{kind:?}");
         }
         for kind in WebSearchProviderKind::ALL {
-            assert!(
-                keys.iter().any(|key| key == kind.credential_key()),
-                "{kind:?}"
-            );
+            // A credential-free provider stores nothing to re-home.
+            let Some(expected) = kind.credential_key() else {
+                continue;
+            };
+            assert!(keys.iter().any(|key| key == expected), "{kind:?}");
         }
         // `CodeExecutionProviderKind` is `#[non_exhaustive]`, so a match here
         // cannot stand in for coverage; assert the credentialed kinds' keys

--- a/crates/openwave-server/src/secret_rehome.rs
+++ b/crates/openwave-server/src/secret_rehome.rs
@@ -26,6 +26,7 @@ use crate::providers::{ProviderKind, LEGACY_ANTHROPIC_API_KEY};
 const WEB_SEARCH_CREDENTIAL_KEYS: &[&str] = &[
     WebSearchProviderKind::Exa.credential_key(),
     WebSearchProviderKind::Tavily.credential_key(),
+    WebSearchProviderKind::Brave.credential_key(),
 ];
 
 /// Credential keys for the code-execution providers that take one (`Local`
@@ -192,8 +193,9 @@ mod tests {
     }
 
     /// A provider whose credential key is missing here would keep prompting
-    /// with no way to repair it. The matches are exhaustive, so adding a kind
-    /// fails to compile until its key is listed.
+    /// with no way to repair it. `ProviderKind::ALL` and
+    /// `WebSearchProviderKind::ALL` cover every variant, so adding a kind fails
+    /// this test until its key is listed.
     #[test]
     fn every_credentialed_provider_kind_is_covered() {
         let keys = stored_secret_keys();
@@ -201,10 +203,7 @@ mod tests {
         for kind in ProviderKind::ALL {
             assert!(keys.contains(&kind.credential_key()), "{kind:?}");
         }
-        for kind in [WebSearchProviderKind::Exa, WebSearchProviderKind::Tavily] {
-            match kind {
-                WebSearchProviderKind::Exa | WebSearchProviderKind::Tavily => {}
-            }
+        for kind in WebSearchProviderKind::ALL {
             assert!(
                 keys.iter().any(|key| key == kind.credential_key()),
                 "{kind:?}"

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -427,7 +427,8 @@ async fn web_search_credential_routes_are_authenticated_and_never_return_keys() 
         serde_json::json!({
             "credentials": [
                 {"provider": "exa", "has_credential": false},
-                {"provider": "tavily", "has_credential": false}
+                {"provider": "tavily", "has_credential": false},
+                {"provider": "brave", "has_credential": false}
             ]
         })
     );

--- a/crates/openwave-server/src/web_search.rs
+++ b/crates/openwave-server/src/web_search.rs
@@ -11,10 +11,10 @@ use std::time::Duration;
 use async_trait::async_trait;
 use openwave_core::{Result, SecretProvider, Store};
 use openwave_web_search::{
-    ExaProvider, NativeExtractor, PageExtractor, ReqwestHttpClient, ReqwestPageFetcher,
-    TavilyProvider, TokioHostResolver, WebExtractFailure, WebExtractRequest, WebExtractResponse,
-    WebExtractTool, WebSearchCredentials, WebSearchProvider, WebSearchProviderKind,
-    WebSearchResolver, WebSearchResolverError, WebSearchTool,
+    BraveProvider, ExaProvider, NativeExtractor, PageExtractor, ReqwestHttpClient,
+    ReqwestPageFetcher, TavilyProvider, TokioHostResolver, WebExtractFailure, WebExtractRequest,
+    WebExtractResponse, WebExtractTool, WebSearchCredentials, WebSearchProvider,
+    WebSearchProviderKind, WebSearchResolver, WebSearchResolverError, WebSearchTool,
 };
 use serde::{Deserialize, Serialize};
 
@@ -34,8 +34,11 @@ pub const MAX_TIMEOUT_MS: u64 = 60_000;
 /// The fixed providers this host can hold a credential for. Keeping this
 /// allow-list here means a local API route can never turn an arbitrary path
 /// segment into a keychain key.
-const CREDENTIAL_PROVIDERS: [WebSearchProviderKind; 2] =
-    [WebSearchProviderKind::Exa, WebSearchProviderKind::Tavily];
+const CREDENTIAL_PROVIDERS: [WebSearchProviderKind; 3] = [
+    WebSearchProviderKind::Exa,
+    WebSearchProviderKind::Tavily,
+    WebSearchProviderKind::Brave,
+];
 
 /// Non-secret host configuration. `provider: None` is the safe default: no
 /// credential lookup and no possible outbound request.
@@ -268,6 +271,10 @@ pub async fn resolve_provider(
         ),
         WebSearchProviderKind::Tavily => Arc::new(
             TavilyProvider::new(client, credential)
+                .map_err(|_| ServerError::internal("web search configuration is unavailable"))?,
+        ),
+        WebSearchProviderKind::Brave => Arc::new(
+            BraveProvider::new(client, credential)
                 .map_err(|_| ServerError::internal("web search configuration is unavailable"))?,
         ),
     };

--- a/crates/openwave-server/src/web_search.rs
+++ b/crates/openwave-server/src/web_search.rs
@@ -11,10 +11,11 @@ use std::time::Duration;
 use async_trait::async_trait;
 use openwave_core::{Result, SecretProvider, Store};
 use openwave_web_search::{
-    BraveProvider, ExaProvider, NativeExtractor, PageExtractor, ReqwestHttpClient,
-    ReqwestPageFetcher, TavilyProvider, TokioHostResolver, WebExtractFailure, WebExtractRequest,
-    WebExtractResponse, WebExtractTool, WebSearchCredentials, WebSearchProvider,
-    WebSearchProviderKind, WebSearchResolver, WebSearchResolverError, WebSearchTool,
+    BraveProvider, ExaProvider, NativeExtractor, OutboundOrigin, PageExtractor, ReqwestHttpClient,
+    ReqwestPageFetcher, SearxngBaseUrl, SearxngProvider, TavilyProvider, TokioHostResolver,
+    WebExtractFailure, WebExtractRequest, WebExtractResponse, WebExtractTool, WebSearchCredential,
+    WebSearchCredentialState, WebSearchCredentials, WebSearchProvider, WebSearchProviderKind,
+    WebSearchResolver, WebSearchResolverError, WebSearchTool,
 };
 use serde::{Deserialize, Serialize};
 
@@ -31,9 +32,10 @@ pub const MIN_TIMEOUT_MS: u64 = 1_000;
 /// durable worker state rather than an unbounded HTTP call.
 pub const MAX_TIMEOUT_MS: u64 = 60_000;
 
-/// The fixed providers this host can hold a credential for. Keeping this
-/// allow-list here means a local API route can never turn an arbitrary path
-/// segment into a keychain key.
+/// The fixed providers this host can hold a credential for. SearXNG is
+/// self-hosted and holds none, so it is absent here. Keeping this allow-list
+/// here means a local API route can never turn an arbitrary path segment into
+/// a keychain key.
 const CREDENTIAL_PROVIDERS: [WebSearchProviderKind; 3] = [
     WebSearchProviderKind::Exa,
     WebSearchProviderKind::Tavily,
@@ -48,6 +50,16 @@ pub struct WebSearchConfig {
     pub provider: Option<WebSearchProviderKind>,
     #[serde(default = "default_timeout_ms")]
     pub timeout_ms: u64,
+    /// Base URL of the operator's self-hosted SearXNG instance.
+    ///
+    /// This is the one address in the whole surface that is configuration
+    /// rather than a constant, because a self-hosted instance has none to pin.
+    /// It is host configuration only: it is never a model argument and nothing
+    /// in a tool call can reach it. It is validated here at `PUT` time, exactly
+    /// as the egress allowlist is, so a malformed value is rejected rather than
+    /// silently widening where the transport may dial.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub searxng_base_url: Option<String>,
 }
 
 impl Default for WebSearchConfig {
@@ -55,6 +67,7 @@ impl Default for WebSearchConfig {
         Self {
             provider: None,
             timeout_ms: DEFAULT_TIMEOUT_MS,
+            searxng_base_url: None,
         }
     }
 }
@@ -66,7 +79,27 @@ impl WebSearchConfig {
                 "web search timeout_ms must be between {MIN_TIMEOUT_MS} and {MAX_TIMEOUT_MS}"
             )));
         }
+        if self
+            .searxng_base_url
+            .as_deref()
+            .map(SearxngBaseUrl::parse)
+            .is_some_and(|parsed| parsed.is_err())
+        {
+            return Err(ServerError::bad_request(
+                "web search searxng_base_url must be an http or https instance URL with no credentials, query, or fragment",
+            ));
+        }
         Ok(())
+    }
+
+    /// The configured instance URL in canonical form, if it is usable.
+    ///
+    /// `validate` has already rejected a malformed value, so this reads as a
+    /// straightforward "is one configured" without a second error path.
+    fn searxng_base_url(&self) -> Option<SearxngBaseUrl> {
+        self.searxng_base_url
+            .as_deref()
+            .and_then(|value| SearxngBaseUrl::parse(value).ok())
     }
 }
 
@@ -75,15 +108,27 @@ const fn default_timeout_ms() -> u64 {
 }
 
 /// Public state returned by the local API. It intentionally reports only
-/// selection and credential presence — key material never crosses the secret
-/// boundary.
+/// selection, credential presence, and the configured instance URL — key
+/// material never crosses the secret boundary.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub struct WebSearchConfigInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub provider: Option<WebSearchProviderKind>,
     pub timeout_ms: u64,
+    /// Whether a key is stored for the selected provider. Always false for a
+    /// credential-free provider, which has no key slot at all — read
+    /// [`Self::available`] to know whether search will actually run.
     pub has_credential: bool,
+    /// Whether the selected provider has everything it needs to be invoked.
+    ///
+    /// A key for the credentialed providers, an instance URL for SearXNG.
+    pub available: bool,
+    /// The configured SearXNG instance URL, in the canonical form the host
+    /// stored. It is safe to return: validation forbids embedded credentials.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub searxng_base_url: Option<String>,
 }
 
 /// Credential readiness for one fixed web-search provider. This public shape
@@ -108,6 +153,11 @@ pub struct WebSearchConfigUpdate {
     pub provider: Option<Option<WebSearchProviderKind>>,
     #[serde(default)]
     pub timeout_ms: Option<u64>,
+    /// An omitted value leaves the instance URL unchanged; an explicit `null`
+    /// clears it, which takes SearXNG out of service without discarding the
+    /// other providers' keys.
+    #[serde(default, deserialize_with = "double_option")]
+    pub searxng_base_url: Option<Option<String>>,
 }
 
 fn double_option<'de, D, T>(deserializer: D) -> std::result::Result<Option<Option<T>>, D::Error>
@@ -146,17 +196,26 @@ pub async fn config_info(
 ) -> Result<WebSearchConfigInfo> {
     let config = read_config(store).await?;
     let has_credential = match config.provider {
-        Some(provider) => WebSearchCredentials::load(secrets, provider)
-            .await
-            .ok()
-            .flatten()
-            .is_some(),
+        Some(provider) => matches!(
+            WebSearchCredentials::resolve(secrets, provider).await,
+            Ok(WebSearchCredentialState::Present(_))
+        ),
+        None => false,
+    };
+    let available = match config.provider {
+        // Nothing to authenticate with; the instance URL is what it needs.
+        Some(WebSearchProviderKind::Searxng) => config.searxng_base_url().is_some(),
+        Some(_) => has_credential,
         None => false,
     };
     Ok(WebSearchConfigInfo {
         provider: config.provider,
         timeout_ms: config.timeout_ms,
         has_credential,
+        available,
+        searxng_base_url: config
+            .searxng_base_url()
+            .map(|base| base.as_str().to_owned()),
     })
 }
 
@@ -168,10 +227,14 @@ pub async fn credentials_info(
 ) -> std::result::Result<WebSearchCredentialsInfo, ServerError> {
     let mut credentials = Vec::with_capacity(CREDENTIAL_PROVIDERS.len());
     for provider in CREDENTIAL_PROVIDERS {
-        let has_credential = WebSearchCredentials::load(secrets, provider)
-            .await
-            .map_err(|_| ServerError::internal("web search credential storage is unavailable"))?
-            .is_some();
+        let has_credential = matches!(
+            WebSearchCredentials::resolve(secrets, provider)
+                .await
+                .map_err(|_| ServerError::internal(
+                    "web search credential storage is unavailable"
+                ))?,
+            WebSearchCredentialState::Present(_)
+        );
         credentials.push(WebSearchCredentialReadiness {
             provider,
             has_credential,
@@ -190,6 +253,21 @@ pub fn credential_provider(value: &str) -> std::result::Result<WebSearchProvider
         .ok_or_else(|| ServerError::not_found(format!("unknown web search provider kind: {value}")))
 }
 
+/// The fixed keychain name for a provider that takes a key.
+///
+/// A credential-free provider has no slot to address, and asking for one is a
+/// routing mistake rather than a storage failure — [`credential_provider`]
+/// already refuses to resolve one from a path segment.
+fn credential_key(
+    provider: WebSearchProviderKind,
+) -> std::result::Result<&'static str, ServerError> {
+    provider.credential_key().ok_or_else(|| {
+        ServerError::not_found(format!(
+            "web search provider {provider} stores no credential"
+        ))
+    })
+}
+
 /// Store a non-empty, already validated credential under the provider's fixed
 /// key. The provider kind is an enum rather than caller-controlled storage
 /// input, so this cannot address other application secrets.
@@ -199,7 +277,7 @@ pub async fn write_credential(
     api_key: &str,
 ) -> std::result::Result<WebSearchCredentialReadiness, ServerError> {
     secrets
-        .set_secret(provider.credential_key(), api_key)
+        .set_secret(credential_key(provider)?, api_key)
         .await
         .map_err(|_| ServerError::internal("web search credential storage is unavailable"))?;
     Ok(WebSearchCredentialReadiness {
@@ -214,7 +292,7 @@ pub async fn delete_credential(
     provider: WebSearchProviderKind,
 ) -> std::result::Result<WebSearchCredentialReadiness, ServerError> {
     secrets
-        .delete_secret(provider.credential_key())
+        .delete_secret(credential_key(provider)?)
         .await
         .map_err(|_| ServerError::internal("web search credential storage is unavailable"))?;
     Ok(WebSearchCredentialReadiness {
@@ -236,17 +314,67 @@ pub async fn update_config(
     if let Some(timeout_ms) = update.timeout_ms {
         config.timeout_ms = timeout_ms;
     }
+    if let Some(searxng_base_url) = update.searxng_base_url {
+        // Store the canonical form the crate produced, not the raw text, so
+        // there is one spelling of an instance URL in the store and in every
+        // later comparison.
+        config.searxng_base_url = match searxng_base_url {
+            Some(value) => Some(
+                SearxngBaseUrl::parse(value)
+                    .map_err(|_| {
+                        ServerError::bad_request(
+                            "web search searxng_base_url must be an http or https instance URL with no credentials, query, or fragment",
+                        )
+                    })?
+                    .as_str()
+                    .to_owned(),
+            ),
+            None => None,
+        };
+    }
     config.validate()?;
     write_config(store, &config).await?;
     config_info(store, secrets).await.map_err(Into::into)
 }
 
-/// Resolve the explicitly selected, credentialed provider for host execution.
-/// The returned provider is inert until its `search` method is called.
+/// One opaque failure for everything about resolving host configuration, so
+/// keychain and transport details cannot escape through logs or local API
+/// responses.
+fn unavailable() -> ServerError {
+    ServerError::internal("web search configuration is unavailable")
+}
+
+/// A transport bound to exactly one origin under the current timeout policy.
+fn bound_client(
+    origin: OutboundOrigin,
+    timeout_ms: u64,
+) -> std::result::Result<ReqwestHttpClient, ServerError> {
+    ReqwestHttpClient::with_timeout(origin, Duration::from_millis(timeout_ms))
+        .map_err(|_| unavailable())
+}
+
+/// The stored key for a provider that requires one, or `None` to fail closed.
 ///
-/// Secret resolution failures are intentionally projected to one generic
-/// message so keychain implementation details cannot escape through logs or
-/// local API responses. A missing key fails closed as `Ok(None)`.
+/// Only providers that take a key reach this. A credential-free provider is
+/// routed before it, so `NotRequired` here would mean a routing mistake, and
+/// answering `None` keeps that mistake a refusal rather than an unauthenticated
+/// request.
+async fn required_credential(
+    secrets: &dyn SecretProvider,
+    kind: WebSearchProviderKind,
+) -> std::result::Result<Option<WebSearchCredential>, ServerError> {
+    match WebSearchCredentials::resolve(secrets, kind).await {
+        Ok(WebSearchCredentialState::Present(credential)) => Ok(Some(credential)),
+        Ok(WebSearchCredentialState::Missing | WebSearchCredentialState::NotRequired) => Ok(None),
+        Err(_) => Err(unavailable()),
+    }
+}
+
+/// Resolve the explicitly selected provider for host execution. The returned
+/// provider is inert until its `search` method is called.
+///
+/// Every path fails closed as `Ok(None)`: a missing key for the providers that
+/// need one, and a missing instance URL for the one that does not.
 pub async fn resolve_provider(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
@@ -256,27 +384,38 @@ pub async fn resolve_provider(
     let Some(kind) = config.provider else {
         return Ok(None);
     };
-    let credential = WebSearchCredentials::load(secrets, kind)
-        .await
-        .map_err(|_| ServerError::internal("web search configuration is unavailable"))?;
-    let Some(credential) = credential else {
-        return Ok(None);
-    };
-    let client = ReqwestHttpClient::with_timeout(kind, Duration::from_millis(config.timeout_ms))
-        .map_err(|_| ServerError::internal("web search configuration is unavailable"))?;
     let provider: Arc<dyn WebSearchProvider> = match kind {
-        WebSearchProviderKind::Exa => Arc::new(
-            ExaProvider::new(client, credential)
-                .map_err(|_| ServerError::internal("web search configuration is unavailable"))?,
-        ),
-        WebSearchProviderKind::Tavily => Arc::new(
-            TavilyProvider::new(client, credential)
-                .map_err(|_| ServerError::internal("web search configuration is unavailable"))?,
-        ),
-        WebSearchProviderKind::Brave => Arc::new(
-            BraveProvider::new(client, credential)
-                .map_err(|_| ServerError::internal("web search configuration is unavailable"))?,
-        ),
+        WebSearchProviderKind::Searxng => {
+            // The self-hosted case: no credential to resolve, and the address
+            // comes from validated host configuration rather than a constant.
+            // Without one there is nowhere to dial, which fails closed exactly
+            // as a missing key does for the others.
+            let Some(base_url) = config.searxng_base_url() else {
+                return Ok(None);
+            };
+            let client = bound_client(base_url.origin(), config.timeout_ms)?;
+            Arc::new(SearxngProvider::new(client, base_url))
+        }
+        kind => {
+            let Some(credential) = required_credential(secrets, kind).await? else {
+                return Ok(None);
+            };
+            let origin = OutboundOrigin::fixed(kind).ok_or_else(unavailable)?;
+            let client = bound_client(origin, config.timeout_ms)?;
+            match kind {
+                WebSearchProviderKind::Exa => {
+                    Arc::new(ExaProvider::new(client, credential).map_err(|_| unavailable())?)
+                }
+                WebSearchProviderKind::Tavily => {
+                    Arc::new(TavilyProvider::new(client, credential).map_err(|_| unavailable())?)
+                }
+                WebSearchProviderKind::Brave => {
+                    Arc::new(BraveProvider::new(client, credential).map_err(|_| unavailable())?)
+                }
+                // Handled above; `OutboundOrigin::fixed` has already refused it.
+                WebSearchProviderKind::Searxng => return Ok(None),
+            }
+        }
     };
     Ok(Some(provider))
 }
@@ -410,14 +549,16 @@ mod tests {
         assert_eq!(config.timeout_ms, DEFAULT_TIMEOUT_MS);
         assert!(config.validate().is_ok());
         assert!(WebSearchConfig {
-            provider: Some(WebSearchProviderKind::Exa),
             timeout_ms: MIN_TIMEOUT_MS - 1,
+            provider: Some(WebSearchProviderKind::Exa),
+            ..WebSearchConfig::default()
         }
         .validate()
         .is_err());
         assert!(WebSearchConfig {
-            provider: Some(WebSearchProviderKind::Tavily),
             timeout_ms: MAX_TIMEOUT_MS + 1,
+            provider: Some(WebSearchProviderKind::Tavily),
+            ..WebSearchConfig::default()
         }
         .validate()
         .is_err());
@@ -427,7 +568,7 @@ mod tests {
     fn selection_has_no_endpoint_or_secret_reference_field() {
         let json = serde_json::to_value(WebSearchConfig {
             provider: Some(WebSearchProviderKind::Exa),
-            timeout_ms: DEFAULT_TIMEOUT_MS,
+            ..WebSearchConfig::default()
         })
         .unwrap();
         assert_eq!(json["provider"], "exa");
@@ -454,6 +595,7 @@ mod tests {
             WebSearchConfigUpdate {
                 provider: Some(Some(WebSearchProviderKind::Exa)),
                 timeout_ms: Some(MIN_TIMEOUT_MS),
+                searxng_base_url: None,
             },
         )
         .await;
@@ -464,8 +606,64 @@ mod tests {
 
         assert_eq!(info.provider, Some(WebSearchProviderKind::Exa));
         assert!(!info.has_credential);
+        assert!(!info.available);
         assert!(matches!(resolve_provider(&store, &secrets).await, Ok(None)));
         assert!(secrets.0.lock().unwrap().is_empty());
+    }
+
+    /// The credential-free provider: selection alone is not enough, an
+    /// instance URL is, and no key is ever read or written for it.
+    #[tokio::test]
+    async fn a_credential_free_provider_turns_on_with_an_instance_url_and_no_key() {
+        let (store, _dir) = test_store().await;
+        let secrets = TestSecrets::default();
+        let select = |base: Option<Option<String>>| WebSearchConfigUpdate {
+            provider: Some(Some(WebSearchProviderKind::Searxng)),
+            timeout_ms: None,
+            searxng_base_url: base,
+        };
+
+        // Selected but with nowhere to dial: fails closed exactly as a
+        // credentialed provider without its key does.
+        let info = update_config(&store, &secrets, select(None)).await.unwrap();
+        assert_eq!(info.provider, Some(WebSearchProviderKind::Searxng));
+        assert!(!info.available);
+        assert!(matches!(resolve_provider(&store, &secrets).await, Ok(None)));
+
+        // A malformed instance URL is rejected at PUT time rather than
+        // silently widening where the transport may dial.
+        for invalid in ["not a url", "ftp://localhost:8888", "http://user:pw@host"] {
+            assert!(
+                update_config(&store, &secrets, select(Some(Some(invalid.into()))))
+                    .await
+                    .is_err(),
+                "{invalid} was accepted as an instance URL"
+            );
+        }
+
+        // A valid one stores canonically and makes the provider usable, with
+        // `has_credential` still false because there is no key slot at all.
+        let info = update_config(
+            &store,
+            &secrets,
+            select(Some(Some("http://localhost:8888/".into()))),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            info.searxng_base_url.as_deref(),
+            Some("http://localhost:8888")
+        );
+        assert!(!info.has_credential);
+        assert!(info.available);
+        assert!(matches!(
+            resolve_provider(&store, &secrets).await,
+            Ok(Some(_))
+        ));
+        // Nothing about a credential-free provider touches the keychain, and
+        // it is not addressable as a credential slot either.
+        assert!(secrets.0.lock().unwrap().is_empty());
+        assert!(credential_provider("searxng").is_err());
     }
 
     #[tokio::test]
@@ -492,26 +690,34 @@ mod tests {
         let info = config_info(&store, &secrets).await.unwrap();
         assert_eq!(info.provider, None);
         assert!(!info.has_credential);
+        assert!(!info.available);
         assert!(matches!(resolve_provider(&store, &secrets).await, Ok(None)));
     }
 
+    /// Persisted policy may be hand-edited or left by an interrupted build.
+    /// Neither an out-of-range timeout nor an instance URL that would widen
+    /// egress may leave a selected provider usable.
     #[tokio::test]
-    async fn invalid_persisted_timeout_reverts_to_disabled_policy() {
-        let (store, _dir) = test_store().await;
-        store
-            .set_setting(
-                WEB_SEARCH_SETTING,
-                &serde_json::json!({
-                    "provider": "tavily",
-                    "timeout_ms": MAX_TIMEOUT_MS + 1,
-                }),
-            )
-            .await
-            .unwrap();
+    async fn invalid_persisted_policy_reverts_to_disabled() {
+        for invalid in [
+            serde_json::json!({ "provider": "tavily", "timeout_ms": MAX_TIMEOUT_MS + 1 }),
+            serde_json::json!({
+                "provider": "searxng",
+                "timeout_ms": DEFAULT_TIMEOUT_MS,
+                "searxng_base_url": "http://operator:secret@localhost:8888",
+            }),
+        ] {
+            let (store, _dir) = test_store().await;
+            store
+                .set_setting(WEB_SEARCH_SETTING, &invalid)
+                .await
+                .unwrap();
 
-        assert_eq!(
-            read_config(&store).await.unwrap(),
-            WebSearchConfig::default()
-        );
+            assert_eq!(
+                read_config(&store).await.unwrap(),
+                WebSearchConfig::default(),
+                "{invalid} did not fail closed"
+            );
+        }
     }
 }

--- a/crates/openwave-web-search/src/brave.rs
+++ b/crates/openwave-web-search/src/brave.rs
@@ -8,10 +8,12 @@
 use std::collections::BTreeMap;
 
 use async_trait::async_trait;
-use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use serde::Deserialize;
 
-use crate::types::{domain_scoped_query, result_within_domains};
+use crate::types::{
+    domain_scoped_query, parse_iso8601_instant, result_within_domains,
+    result_within_published_window,
+};
 use crate::{
     HttpClient, HttpGetRequest, WebSearchCredential, WebSearchError, WebSearchProvider,
     WebSearchProviderKind, WebSearchRequest, WebSearchResponse, WebSearchResult,
@@ -60,7 +62,11 @@ impl<C: HttpClient> WebSearchProvider for BraveProvider<C> {
         let response = self
             .client
             .get(HttpGetRequest {
-                url: self.kind().search_url().into(),
+                url: self
+                    .kind()
+                    .search_url()
+                    .ok_or(WebSearchError::NotConfigured(self.kind()))?
+                    .into(),
                 query: search_query(&request),
                 headers: vec![
                     (
@@ -92,6 +98,16 @@ impl<C: HttpClient> WebSearchProvider for BraveProvider<C> {
             // domain-restricted call can never return an off-domain page,
             // whatever the upstream ranker did with the operator.
             .filter(|result| result_within_domains(&result.url, &request.domains))
+            // `freshness` only carries a fully closed window, so a half-open
+            // request has nothing sent for it; the window is applied here so it
+            // is honoured either way.
+            .filter(|result| {
+                result_within_published_window(
+                    result.published_at,
+                    request.start_published_at,
+                    request.end_published_at,
+                )
+            })
             .collect();
         Ok(WebSearchResponse::new(self.kind(), results))
     }
@@ -174,7 +190,7 @@ struct BraveResult {
 /// score is reported: the response carries no relevance number, and a
 /// synthesized one would read as vendor data that does not exist.
 fn normalize_result(result: BraveResult) -> Result<WebSearchResult, WebSearchError> {
-    let published_at = result.page_age.as_deref().and_then(parse_page_age);
+    let published_at = result.page_age.as_deref().and_then(parse_iso8601_instant);
     WebSearchResult::new(
         result.url,
         result.title,
@@ -187,30 +203,15 @@ fn normalize_result(result: BraveResult) -> Result<WebSearchResult, WebSearchErr
     )
 }
 
-/// `page_age` is ISO 8601, usually without a zone offset.
-fn parse_page_age(value: &str) -> Option<DateTime<Utc>> {
-    DateTime::parse_from_rfc3339(value)
-        .ok()
-        .map(|value| value.with_timezone(&Utc))
-        .or_else(|| {
-            NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S")
-                .ok()
-                .map(|value| value.and_utc())
-        })
-        .or_else(|| {
-            NaiveDate::parse_from_str(value, "%Y-%m-%d")
-                .ok()
-                .and_then(|date| date.and_hms_opt(0, 0, 0))
-                .map(|value| value.and_utc())
-        })
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::{Arc, Mutex};
 
     use super::*;
-    use crate::{HttpRequest, HttpResponse, SearchDomain, WebExtractRequest, WebSearchCredentials};
+    use crate::{
+        HttpRequest, HttpResponse, SearchDomain, WebExtractRequest, WebSearchCredentialState,
+        WebSearchCredentials,
+    };
     use openwave_core::{AgentError, SecretProvider};
 
     struct StaticSecrets;
@@ -218,7 +219,8 @@ mod tests {
     #[async_trait]
     impl SecretProvider for StaticSecrets {
         async fn get_secret(&self, key: &str) -> openwave_core::Result<Option<String>> {
-            Ok((key == WebSearchProviderKind::Brave.credential_key()).then(|| "brave-key".into()))
+            Ok((Some(key) == WebSearchProviderKind::Brave.credential_key())
+                .then(|| "brave-key".into()))
         }
 
         async fn set_secret(&self, _key: &str, _value: &str) -> openwave_core::Result<()> {
@@ -227,6 +229,15 @@ mod tests {
 
         async fn delete_secret(&self, _key: &str) -> openwave_core::Result<()> {
             Err(AgentError::Secret("read only test secrets".into()))
+        }
+    }
+
+    /// The stored key as a usable credential, failing the test by name if any
+    /// other credential state comes back.
+    async fn test_credential() -> WebSearchCredential {
+        match WebSearchCredentials::resolve(&StaticSecrets, WebSearchProviderKind::Brave).await {
+            Ok(WebSearchCredentialState::Present(credential)) => credential,
+            other => panic!("expected a stored Brave key, got {other:?}"),
         }
     }
 
@@ -249,10 +260,7 @@ mod tests {
     }
 
     async fn provider(status: u16, body: &[u8]) -> BraveProvider<FakeHttpClient> {
-        let credential = WebSearchCredentials::load(&StaticSecrets, WebSearchProviderKind::Brave)
-            .await
-            .unwrap()
-            .unwrap();
+        let credential = test_credential().await;
         BraveProvider::new(
             FakeHttpClient {
                 request: Arc::new(Mutex::new(None)),
@@ -326,7 +334,10 @@ mod tests {
 
         let sent = sent.lock().unwrap();
         let sent = sent.as_ref().unwrap();
-        assert_eq!(sent.url, WebSearchProviderKind::Brave.search_url());
+        assert_eq!(
+            Some(sent.url.as_str()),
+            WebSearchProviderKind::Brave.search_url()
+        );
         let pairs: BTreeMap<&str, &str> = sent
             .query
             .iter()

--- a/crates/openwave-web-search/src/brave.rs
+++ b/crates/openwave-web-search/src/brave.rs
@@ -1,0 +1,426 @@
+//! Brave Search's `/res/v1/web/search` adapter.
+//!
+//! Brave is the search-only backend with a free tier, so it is the one a host
+//! can turn on without a paid plan. It publishes no page-extraction endpoint;
+//! [`WebSearchProvider::supports_extract`] therefore stays false and
+//! `web_extract` routes to the native engine, which needs no configuration.
+
+use std::collections::BTreeMap;
+
+use async_trait::async_trait;
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+use serde::Deserialize;
+
+use crate::types::{domain_scoped_query, result_within_domains};
+use crate::{
+    HttpClient, HttpGetRequest, WebSearchCredential, WebSearchError, WebSearchProvider,
+    WebSearchProviderKind, WebSearchRequest, WebSearchResponse, WebSearchResult,
+};
+
+/// Largest `count` the web-search endpoint accepts on one call.
+const MAX_COUNT: usize = 20;
+
+/// The crate never asks for more results than Brave will return, so `count`
+/// can carry `max_results` unclamped.
+const _: () = assert!(crate::MAX_RESULTS <= MAX_COUNT);
+
+/// Longest query Brave accepts in `q`.
+///
+/// It happens to equal this crate's own query bound, which is why appending
+/// `site:` operators can overflow it and why [`domain_scoped_query`] is given
+/// the limit rather than assuming the operators always fit.
+const MAX_QUERY_CHARS: usize = 400;
+
+const _: () = assert!(crate::MAX_QUERY_CHARS <= MAX_QUERY_CHARS);
+
+/// Brave adapter backed by an injected HTTP client.
+#[derive(Clone, Debug)]
+pub struct BraveProvider<C> {
+    client: C,
+    credential: WebSearchCredential,
+}
+
+impl<C> BraveProvider<C> {
+    pub fn new(client: C, credential: WebSearchCredential) -> Result<Self, WebSearchError> {
+        if credential.kind() != WebSearchProviderKind::Brave {
+            return Err(WebSearchError::NotConfigured(WebSearchProviderKind::Brave));
+        }
+        Ok(Self { client, credential })
+    }
+}
+
+#[async_trait]
+impl<C: HttpClient> WebSearchProvider for BraveProvider<C> {
+    fn kind(&self) -> WebSearchProviderKind {
+        WebSearchProviderKind::Brave
+    }
+
+    async fn search(&self, request: WebSearchRequest) -> Result<WebSearchResponse, WebSearchError> {
+        request.validate()?;
+        let response = self
+            .client
+            .get(HttpGetRequest {
+                url: self.kind().search_url().into(),
+                query: search_query(&request),
+                headers: vec![
+                    (
+                        "x-subscription-token".into(),
+                        self.credential.api_key().into(),
+                    ),
+                    ("accept".into(), "application/json".into()),
+                ],
+            })
+            .await?;
+        response.ensure_bounded()?;
+        if !(200..300).contains(&response.status) {
+            return Err(status_error(response.status));
+        }
+        let payload: BraveSearchResponse =
+            serde_json::from_slice(&response.body).map_err(|_| {
+                WebSearchError::InvalidResponse {
+                    provider: self.kind(),
+                }
+            })?;
+        let results = payload
+            .web
+            .map(|web| web.results)
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|result| normalize_result(result).ok())
+            // Brave has no include-domains parameter, so the operators in `q`
+            // are a hint and this is the filter. Enforcing it here means a
+            // domain-restricted call can never return an off-domain page,
+            // whatever the upstream ranker did with the operator.
+            .filter(|result| result_within_domains(&result.url, &request.domains))
+            .collect();
+        Ok(WebSearchResponse::new(self.kind(), results))
+    }
+}
+
+/// The documented query parameters for one bounded web search.
+///
+/// `text_decorations` is switched off so `description` arrives as plain text:
+/// with the default on, Brave wraps matched terms in `<strong>` markup, and
+/// asking the vendor not to send markup beats stripping it afterwards.
+/// `result_filter` keeps the response to the web cluster — the news, video,
+/// discussion, and infobox clusters are not part of this crate's contract and
+/// would only cost payload against the response byte cap.
+fn search_query(request: &WebSearchRequest) -> Vec<(String, String)> {
+    let mut query = vec![
+        (
+            "q".into(),
+            domain_scoped_query(&request.query, &request.domains, MAX_QUERY_CHARS),
+        ),
+        ("count".into(), request.max_results.to_string()),
+        ("result_filter".into(), "web".into()),
+        ("text_decorations".into(), "false".into()),
+    ];
+    // Brave expresses a custom window as one `freshness` range and requires
+    // both ends, so a half-open request cannot be sent. The unsent end is not
+    // silently dropped either: the normalized results still carry
+    // `published_at`, which is what a caller filters on.
+    if let (Some(start), Some(end)) = (request.start_published_at, request.end_published_at) {
+        query.push((
+            "freshness".into(),
+            format!("{}to{}", start.date_naive(), end.date_naive()),
+        ));
+    }
+    query
+}
+
+/// Project a request-level status onto the crate's typed errors.
+///
+/// Brave documents no distinct quota status: a spent monthly allowance and a
+/// burst overrun both answer `429`, so [`WebSearchError::QuotaExhausted`] has
+/// no code to map from here and inventing one would be a guess about billing.
+fn status_error(status: u16) -> WebSearchError {
+    let provider = WebSearchProviderKind::Brave;
+    match status {
+        401 => WebSearchError::CredentialRejected(provider),
+        429 => WebSearchError::RateLimited(provider),
+        status => WebSearchError::HttpStatus { provider, status },
+    }
+}
+
+#[derive(Deserialize)]
+struct BraveSearchResponse {
+    /// Absent when the query produced no web cluster at all, which is a valid
+    /// empty answer rather than a malformed response.
+    #[serde(default)]
+    web: Option<BraveWebResults>,
+}
+
+#[derive(Deserialize)]
+struct BraveWebResults {
+    #[serde(default)]
+    results: Vec<BraveResult>,
+}
+
+#[derive(Deserialize)]
+struct BraveResult {
+    url: String,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    description: String,
+    /// ISO 8601 publication timestamp. The sibling `age` field holds a
+    /// human-readable relative string ("2 days ago") that carries no instant,
+    /// so it is deliberately not read.
+    #[serde(default)]
+    page_age: Option<String>,
+}
+
+/// Brave returns a snippet and no page text, so `content` stays empty and no
+/// score is reported: the response carries no relevance number, and a
+/// synthesized one would read as vendor data that does not exist.
+fn normalize_result(result: BraveResult) -> Result<WebSearchResult, WebSearchError> {
+    let published_at = result.page_age.as_deref().and_then(parse_page_age);
+    WebSearchResult::new(
+        result.url,
+        result.title,
+        result.description,
+        None,
+        None,
+        published_at,
+        None,
+        BTreeMap::new(),
+    )
+}
+
+/// `page_age` is ISO 8601, usually without a zone offset.
+fn parse_page_age(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|value| value.with_timezone(&Utc))
+        .or_else(|| {
+            NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S")
+                .ok()
+                .map(|value| value.and_utc())
+        })
+        .or_else(|| {
+            NaiveDate::parse_from_str(value, "%Y-%m-%d")
+                .ok()
+                .and_then(|date| date.and_hms_opt(0, 0, 0))
+                .map(|value| value.and_utc())
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+    use crate::{HttpRequest, HttpResponse, SearchDomain, WebExtractRequest, WebSearchCredentials};
+    use openwave_core::{AgentError, SecretProvider};
+
+    struct StaticSecrets;
+
+    #[async_trait]
+    impl SecretProvider for StaticSecrets {
+        async fn get_secret(&self, key: &str) -> openwave_core::Result<Option<String>> {
+            Ok((key == WebSearchProviderKind::Brave.credential_key()).then(|| "brave-key".into()))
+        }
+
+        async fn set_secret(&self, _key: &str, _value: &str) -> openwave_core::Result<()> {
+            Err(AgentError::Secret("read only test secrets".into()))
+        }
+
+        async fn delete_secret(&self, _key: &str) -> openwave_core::Result<()> {
+            Err(AgentError::Secret("read only test secrets".into()))
+        }
+    }
+
+    #[derive(Clone)]
+    struct FakeHttpClient {
+        request: Arc<Mutex<Option<HttpGetRequest>>>,
+        response: HttpResponse,
+    }
+
+    #[async_trait]
+    impl HttpClient for FakeHttpClient {
+        async fn post_json(&self, _request: HttpRequest) -> Result<HttpResponse, WebSearchError> {
+            unreachable!("the Brave adapter is a GET-only backend")
+        }
+
+        async fn get(&self, request: HttpGetRequest) -> Result<HttpResponse, WebSearchError> {
+            *self.request.lock().unwrap() = Some(request);
+            Ok(self.response.clone())
+        }
+    }
+
+    async fn provider(status: u16, body: &[u8]) -> BraveProvider<FakeHttpClient> {
+        let credential = WebSearchCredentials::load(&StaticSecrets, WebSearchProviderKind::Brave)
+            .await
+            .unwrap()
+            .unwrap();
+        BraveProvider::new(
+            FakeHttpClient {
+                request: Arc::new(Mutex::new(None)),
+                response: HttpResponse {
+                    status,
+                    body: body.to_vec(),
+                },
+            },
+            credential,
+        )
+        .unwrap()
+    }
+
+    /// A response shaped like the documented payload, including the sibling
+    /// clusters and per-result fields this adapter deliberately ignores.
+    const RESPONSE: &[u8] = br#"{
+      "type": "search",
+      "query": { "original": "openwave", "more_results_available": true },
+      "mixed": { "type": "mixed", "main": [{ "type": "web", "index": 0, "all": false }] },
+      "web": {
+        "type": "search",
+        "family_friendly": true,
+        "results": [
+          {
+            "type": "search_result",
+            "url": "https://example.com/release",
+            "title": "OpenWave release notes",
+            "description": "Everything that shipped this month.",
+            "age": "3 days ago",
+            "page_age": "2026-07-01T09:30:00",
+            "language": "en",
+            "family_friendly": true,
+            "meta_url": { "scheme": "https", "netloc": "example.com", "hostname": "example.com", "path": "/release" },
+            "thumbnail": { "src": "https://imgs.example.com/thumb", "original": "https://example.com/hero.png" },
+            "profile": { "name": "Example", "long_name": "example.com" }
+          },
+          {
+            "type": "search_result",
+            "url": "https://other.invalid/page",
+            "title": "Unrelated",
+            "description": "Off-domain result.",
+            "page_age": "2026-06-01"
+          }
+        ]
+      }
+    }"#;
+
+    #[tokio::test]
+    async fn maps_the_web_cluster_and_sends_the_documented_query() {
+        let provider = provider(200, RESPONSE).await;
+        let sent = provider.client.request.clone();
+        let response = provider
+            .search(WebSearchRequest::new("openwave", 3).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.provider, WebSearchProviderKind::Brave);
+        assert_eq!(response.results.len(), 2);
+        let first = &response.results[0];
+        assert_eq!(first.url, "https://example.com/release");
+        assert_eq!(first.title, "OpenWave release notes");
+        assert_eq!(first.snippet, "Everything that shipped this month.");
+        // Brave returns a snippet, not page text, and no relevance number.
+        assert_eq!(first.content, None);
+        assert_eq!(first.score, None);
+        assert_eq!(
+            first.published_at.unwrap().to_rfc3339(),
+            "2026-07-01T09:30:00+00:00"
+        );
+        assert!(serde_json::to_vec(&response).unwrap().len() <= crate::MAX_OUTPUT_BYTES);
+
+        let sent = sent.lock().unwrap();
+        let sent = sent.as_ref().unwrap();
+        assert_eq!(sent.url, WebSearchProviderKind::Brave.search_url());
+        let pairs: BTreeMap<&str, &str> = sent
+            .query
+            .iter()
+            .map(|(name, value)| (name.as_str(), value.as_str()))
+            .collect();
+        assert_eq!(pairs["q"], "openwave");
+        assert_eq!(pairs["count"], "3");
+        assert_eq!(pairs["result_filter"], "web");
+        // Markup in `description` is refused at the source rather than
+        // stripped after the fact.
+        assert_eq!(pairs["text_decorations"], "false");
+        assert!(!pairs.contains_key("freshness"));
+        assert_eq!(
+            sent.headers[0],
+            ("x-subscription-token".into(), "brave-key".into())
+        );
+        // The key rides in a header, never in the query string, which is the
+        // part of a GET that lands in proxy and server logs.
+        assert!(sent.query.iter().all(|(_, value)| value != "brave-key"));
+    }
+
+    #[tokio::test]
+    async fn domain_filters_become_operators_and_a_hard_result_filter() {
+        let provider = provider(200, RESPONSE).await;
+        let sent = provider.client.request.clone();
+        let response = provider
+            .search(
+                WebSearchRequest::new("openwave", 3)
+                    .unwrap()
+                    .with_domains(vec![SearchDomain::parse("example.com").unwrap()])
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // The off-domain result Brave returned anyway does not survive.
+        assert_eq!(response.results.len(), 1);
+        assert_eq!(response.results[0].url, "https://example.com/release");
+
+        let sent = sent.lock().unwrap();
+        let query = sent
+            .as_ref()
+            .unwrap()
+            .query
+            .iter()
+            .find(|(name, _)| name == "q")
+            .unwrap()
+            .1
+            .clone();
+        assert_eq!(query, "openwave site:example.com");
+    }
+
+    async fn search_status(status: u16) -> WebSearchError {
+        provider(status, b"{}")
+            .await
+            .search(WebSearchRequest::new("openwave", 1).unwrap())
+            .await
+            .unwrap_err()
+    }
+
+    #[tokio::test]
+    async fn maps_distinctive_statuses_to_typed_errors() {
+        assert!(matches!(
+            search_status(401).await,
+            WebSearchError::CredentialRejected(WebSearchProviderKind::Brave)
+        ));
+        // A spent monthly allowance answers 429 as well, so this one code
+        // covers both and no quota status is invented for Brave.
+        assert!(matches!(
+            search_status(429).await,
+            WebSearchError::RateLimited(WebSearchProviderKind::Brave)
+        ));
+        for status in [422, 503] {
+            assert!(
+                matches!(
+                    search_status(status).await,
+                    WebSearchError::HttpStatus { status: seen, .. } if seen == status
+                ),
+                "HTTP {status} did not stay a plain status"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn is_search_only_so_extraction_routes_to_the_native_engine() {
+        let provider = provider(200, RESPONSE).await;
+        assert!(!provider.supports_extract());
+        assert!(matches!(
+            provider
+                .extract(WebExtractRequest::new("https://example.com/article").unwrap())
+                .await,
+            Err(WebSearchError::ExtractNotSupported(
+                WebSearchProviderKind::Brave
+            ))
+        ));
+    }
+}

--- a/crates/openwave-web-search/src/credentials.rs
+++ b/crates/openwave-web-search/src/credentials.rs
@@ -32,23 +32,47 @@ impl WebSearchCredential {
     }
 }
 
+/// Whether one provider's credential requirement is satisfied.
+///
+/// "No key stored" and "no key needed" are separate states on purpose. Folding
+/// them into one `Option` would make a provider that *requires* a key look
+/// usable the moment a credential-free one existed, and failing closed on a
+/// missing key is the whole point of resolving credentials at all.
+#[derive(Debug)]
+pub enum WebSearchCredentialState {
+    /// The provider's fixed key is stored and non-empty.
+    Present(WebSearchCredential),
+    /// The provider requires a key and none is stored. Callers must fail
+    /// closed and make no request.
+    Missing,
+    /// The provider takes no credential — a self-hosted instance the operator
+    /// runs. There is nothing here to fail closed on.
+    NotRequired,
+}
+
 /// Reads provider keys from the application's existing secret boundary.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct WebSearchCredentials;
 
 impl WebSearchCredentials {
-    /// Resolve one provider's key. Missing or whitespace-only entries mean the
-    /// provider is disabled; callers must fail closed and make no request.
-    pub async fn load(
+    /// Resolve one provider's credential state. Missing or whitespace-only
+    /// entries are [`WebSearchCredentialState::Missing`], never a usable
+    /// credential.
+    pub async fn resolve(
         secrets: &dyn SecretProvider,
         kind: WebSearchProviderKind,
-    ) -> Result<Option<WebSearchCredential>, WebSearchError> {
+    ) -> Result<WebSearchCredentialState, WebSearchError> {
+        let Some(key) = kind.credential_key() else {
+            return Ok(WebSearchCredentialState::NotRequired);
+        };
         let value = secrets
-            .get_secret(kind.credential_key())
+            .get_secret(key)
             .await
             .map_err(|error| WebSearchError::Transport(error.to_string()))?;
         Ok(value
             .filter(|value| !value.trim().is_empty())
-            .map(|api_key| WebSearchCredential { kind, api_key }))
+            .map_or(WebSearchCredentialState::Missing, |api_key| {
+                WebSearchCredentialState::Present(WebSearchCredential { kind, api_key })
+            }))
     }
 }

--- a/crates/openwave-web-search/src/exa.rs
+++ b/crates/openwave-web-search/src/exa.rs
@@ -62,7 +62,11 @@ impl<C: HttpClient> WebSearchProvider for ExaProvider<C> {
         let response = self
             .client
             .post_json(HttpRequest {
-                url: self.kind().search_url().into(),
+                url: self
+                    .kind()
+                    .search_url()
+                    .ok_or(WebSearchError::NotConfigured(self.kind()))?
+                    .into(),
                 headers: vec![
                     ("x-api-key".into(), self.credential.api_key().into()),
                     ("content-type".into(), "application/json".into()),
@@ -340,7 +344,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use super::*;
-    use crate::{HttpResponse, WebSearchCredentials};
+    use crate::{HttpResponse, WebSearchCredentialState, WebSearchCredentials};
     use openwave_core::{AgentError, SecretProvider};
 
     #[derive(Clone)]
@@ -354,7 +358,10 @@ mod tests {
     #[async_trait]
     impl SecretProvider for StaticSecrets {
         async fn get_secret(&self, key: &str) -> openwave_core::Result<Option<String>> {
-            Ok((key == WebSearchProviderKind::Exa.credential_key()).then(|| "exa-key".into()))
+            Ok(
+                (Some(key) == WebSearchProviderKind::Exa.credential_key())
+                    .then(|| "exa-key".into()),
+            )
         }
 
         async fn set_secret(&self, _key: &str, _value: &str) -> openwave_core::Result<()> {
@@ -363,6 +370,15 @@ mod tests {
 
         async fn delete_secret(&self, _key: &str) -> openwave_core::Result<()> {
             Err(AgentError::Secret("read only test secrets".into()))
+        }
+    }
+
+    /// The stored key as a usable credential, failing the test by name if any
+    /// other credential state comes back.
+    async fn test_credential() -> WebSearchCredential {
+        match WebSearchCredentials::resolve(&StaticSecrets, WebSearchProviderKind::Exa).await {
+            Ok(WebSearchCredentialState::Present(credential)) => credential,
+            other => panic!("expected a stored Exa key, got {other:?}"),
         }
     }
 
@@ -383,10 +399,7 @@ mod tests {
 
     #[tokio::test]
     async fn maps_exa_response_and_sends_bounded_direct_request() {
-        let credential = WebSearchCredentials::load(&StaticSecrets, WebSearchProviderKind::Exa)
-            .await
-            .unwrap()
-            .unwrap();
+        let credential = test_credential().await;
         let seen = Arc::new(Mutex::new(Vec::new()));
         let client = FakeHttpClient {
             seen: Arc::clone(&seen),
@@ -407,7 +420,10 @@ mod tests {
         assert_eq!(response.results[0].snippet, "short summary");
         let sent = seen.lock().unwrap();
         assert_eq!(sent.len(), 1);
-        assert_eq!(sent[0].url, WebSearchProviderKind::Exa.search_url());
+        assert_eq!(
+            Some(sent[0].url.as_str()),
+            WebSearchProviderKind::Exa.search_url()
+        );
         assert_eq!(sent[0].body["numResults"], 2);
         assert_eq!(sent[0].body["includeDomains"][0], "docs.example.com");
         assert_eq!(sent[0].headers[0], ("x-api-key".into(), "exa-key".into()));
@@ -419,10 +435,7 @@ mod tests {
         status: u16,
         body: serde_json::Value,
     ) -> (Result<WebExtractResponse, WebSearchError>, Vec<HttpRequest>) {
-        let credential = WebSearchCredentials::load(&StaticSecrets, WebSearchProviderKind::Exa)
-            .await
-            .unwrap()
-            .unwrap();
+        let credential = test_credential().await;
         let seen = Arc::new(Mutex::new(Vec::new()));
         let provider = ExaProvider::new(
             FakeHttpClient {

--- a/crates/openwave-web-search/src/exa.rs
+++ b/crates/openwave-web-search/src/exa.rs
@@ -106,7 +106,11 @@ impl<C: HttpClient> WebSearchProvider for ExaProvider<C> {
             .post_json(HttpRequest {
                 // The authority is fixed by the provider kind and bound into
                 // the transport before the credential is attached here.
-                url: self.kind().extract_url().into(),
+                url: self
+                    .kind()
+                    .extract_url()
+                    .ok_or(WebSearchError::ExtractNotSupported(self.kind()))?
+                    .into(),
                 headers: vec![
                     // `/contents` documents bearer auth; the legacy `x-api-key`
                     // header the search path still uses is not the shape new
@@ -368,6 +372,13 @@ mod tests {
             self.seen.lock().unwrap().push(request);
             Ok(self.response.clone())
         }
+
+        async fn get(
+            &self,
+            _request: crate::HttpGetRequest,
+        ) -> Result<HttpResponse, WebSearchError> {
+            unreachable!("the Exa adapter posts JSON on both endpoints")
+        }
     }
 
     #[tokio::test]
@@ -469,7 +480,10 @@ mod tests {
             "extraction exceeded its serialized output budget"
         );
 
-        assert_eq!(sent[0].url, WebSearchProviderKind::Exa.extract_url());
+        assert_eq!(
+            Some(sent[0].url.as_str()),
+            WebSearchProviderKind::Exa.extract_url()
+        );
         assert_eq!(sent[0].body["urls"], serde_json::json!([EXTRACT_URL]));
         // Text is always requested explicitly and always bounded at the source,
         // and freshness is expressed through the supported knob.

--- a/crates/openwave-web-search/src/http.rs
+++ b/crates/openwave-web-search/src/http.rs
@@ -18,25 +18,52 @@ pub struct HttpRequest {
 
 impl fmt::Debug for HttpRequest {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let headers: Vec<(&str, &str)> = self
-            .headers
-            .iter()
-            .map(|(name, value)| {
-                (
-                    name.as_str(),
-                    if is_sensitive_name(name) {
-                        "***"
-                    } else {
-                        value
-                    },
-                )
-            })
-            .collect();
         formatter
             .debug_struct("HttpRequest")
             .field("url", &redacted_url(&self.url))
-            .field("headers", &headers)
+            .field("headers", &redacted_pairs(&self.headers))
             .field("body", &redacted_json(&self.body))
+            .finish()
+    }
+}
+
+/// Header or query pairs with every credential-shaped name masked.
+fn redacted_pairs(pairs: &[(String, String)]) -> Vec<(&str, &str)> {
+    pairs
+        .iter()
+        .map(|(name, value)| {
+            (
+                name.as_str(),
+                if is_sensitive_name(name) {
+                    "***"
+                } else {
+                    value.as_str()
+                },
+            )
+        })
+        .collect()
+}
+
+/// One outbound `GET` with its query string supplied as decoded pairs.
+///
+/// The pairs are kept apart from `url` on purpose: the concrete client binds
+/// the request to its provider's authority by inspecting `url` alone, and a
+/// caller that had to pre-encode its own query string could otherwise smuggle
+/// an authority past that check.
+#[derive(Clone, PartialEq)]
+pub struct HttpGetRequest {
+    pub url: String,
+    pub query: Vec<(String, String)>,
+    pub headers: Vec<(String, String)>,
+}
+
+impl fmt::Debug for HttpGetRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("HttpGetRequest")
+            .field("url", &redacted_url(&self.url))
+            .field("query", &redacted_pairs(&self.query))
+            .field("headers", &redacted_pairs(&self.headers))
             .finish()
     }
 }
@@ -62,9 +89,18 @@ impl HttpResponse {
 
 /// Minimal outbound HTTP seam. A host can provide proxy, allow-list, test, or
 /// auditing policy here without exposing that machinery to a model tool.
+///
+/// Both verbs are required rather than defaulted. Vendors split evenly between
+/// JSON bodies and query strings, so a seam that could only `POST` would push
+/// the difference into the adapters; and a defaulted `get` that failed at
+/// runtime would let a host look implemented while half the backends could not
+/// egress through it.
 #[async_trait]
 pub trait HttpClient: Send + Sync {
     async fn post_json(&self, request: HttpRequest) -> Result<HttpResponse, WebSearchError>;
+
+    /// Dispatch one `GET`, appending `query` to `url` as a query string.
+    async fn get(&self, request: HttpGetRequest) -> Result<HttpResponse, WebSearchError>;
 }
 
 fn is_sensitive_name(name: &str) -> bool {
@@ -176,16 +212,12 @@ impl ReqwestHttpClient {
 }
 
 #[cfg(feature = "http")]
-#[async_trait]
-impl HttpClient for ReqwestHttpClient {
-    async fn post_json(&self, request: HttpRequest) -> Result<HttpResponse, WebSearchError> {
+impl ReqwestHttpClient {
+    /// Send one already authority-checked request and read its body under the
+    /// hard byte cap.
+    async fn dispatch(builder: reqwest::RequestBuilder) -> Result<HttpResponse, WebSearchError> {
         use futures::StreamExt;
 
-        validate_outbound_url(&request.url, self.allowed_domain)?;
-        let mut builder = self.client.post(request.url).json(&request.body);
-        for (name, value) in request.headers {
-            builder = builder.header(name, value);
-        }
         let response = builder
             .send()
             .await
@@ -203,6 +235,30 @@ impl HttpClient for ReqwestHttpClient {
             body.extend_from_slice(&chunk);
         }
         Ok(HttpResponse { status, body })
+    }
+}
+
+#[cfg(feature = "http")]
+#[async_trait]
+impl HttpClient for ReqwestHttpClient {
+    async fn post_json(&self, request: HttpRequest) -> Result<HttpResponse, WebSearchError> {
+        validate_outbound_url(&request.url, self.allowed_domain)?;
+        let mut builder = self.client.post(request.url).json(&request.body);
+        for (name, value) in request.headers {
+            builder = builder.header(name, value);
+        }
+        Self::dispatch(builder).await
+    }
+
+    async fn get(&self, request: HttpGetRequest) -> Result<HttpResponse, WebSearchError> {
+        // The authority is decided by `url` alone, and `query` is appended by
+        // the client afterwards, so no query pair can move the destination.
+        validate_outbound_url(&request.url, self.allowed_domain)?;
+        let mut builder = self.client.get(request.url).query(&request.query);
+        for (name, value) in request.headers {
+            builder = builder.header(name, value);
+        }
+        Self::dispatch(builder).await
     }
 }
 
@@ -249,7 +305,16 @@ mod tests {
             }),
         };
 
-        let debug = format!("{request:?}");
+        let get = HttpGetRequest {
+            url: "https://url-user:url-password@example.com/search?api_key=url-secret".into(),
+            query: vec![
+                ("q".into(), "public".into()),
+                ("subscription_token".into(), "query-secret".into()),
+            ],
+            headers: vec![("X-Subscription-Token".into(), "brave-secret".into())],
+        };
+
+        let debug = format!("{request:?}{get:?}");
         for secret in [
             "url-secret",
             "url-user",
@@ -260,6 +325,8 @@ mod tests {
             "tavily-secret",
             "nested-secret",
             "credential-secret",
+            "query-secret",
+            "brave-secret",
         ] {
             assert!(!debug.contains(secret), "debug leaked {secret}: {debug}");
         }
@@ -289,7 +356,22 @@ mod tests {
                 .unwrap_err();
             assert!(
                 matches!(error, WebSearchError::OutboundNotAllowed),
-                "unexpected result for {url}: {error}"
+                "unexpected POST result for {url}: {error}"
+            );
+
+            // The GET verb is bound by exactly the same rule; a seam that
+            // checked only one of them would be no boundary at all.
+            let error = client
+                .get(HttpGetRequest {
+                    url: url.into(),
+                    query: vec![("q".into(), "openwave".into())],
+                    headers: vec![("x-subscription-token".into(), "must-not-egress".into())],
+                })
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(error, WebSearchError::OutboundNotAllowed),
+                "unexpected GET result for {url}: {error}"
             );
         }
     }
@@ -297,11 +379,8 @@ mod tests {
     #[cfg(feature = "http")]
     #[test]
     fn provider_endpoints_satisfy_their_fixed_domain_policy() {
-        for provider in [
-            crate::WebSearchProviderKind::Exa,
-            crate::WebSearchProviderKind::Tavily,
-        ] {
-            for endpoint in [provider.search_url(), provider.extract_url()] {
+        for provider in crate::WebSearchProviderKind::ALL {
+            for endpoint in std::iter::once(provider.search_url()).chain(provider.extract_url()) {
                 assert!(
                     validate_outbound_url(endpoint, provider.outbound_domain()).is_ok(),
                     "{endpoint} is not on {provider}'s fixed outbound domain"

--- a/crates/openwave-web-search/src/http.rs
+++ b/crates/openwave-web-search/src/http.rs
@@ -168,22 +168,88 @@ fn redacted_json(value: &Value) -> Value {
     }
 }
 
+/// The exact origin one transport is bound to: scheme, host, and explicit port.
+///
+/// Every hosted provider pins a fixed HTTPS domain through
+/// [`Self::fixed`]. A self-hosted instance has no single address to pin, so its
+/// origin comes from validated host configuration through [`Self::parse`]. The
+/// binding is the same either way — one origin, decided before the client
+/// exists, never reachable from a model argument or a tool input.
+///
+/// [`Self::parse`] is also the one place a non-HTTPS or private destination
+/// becomes reachable, and only because the operator typed the address into
+/// their own settings. That is a different trust class from the URLs the native
+/// extractor fetches, which the model or a fetched page chose; `fetch_policy`
+/// governs those and is deliberately untouched by this.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OutboundOrigin {
+    /// Exactly `scheme://host[:port]`, as it must appear at the start of every
+    /// request URL this client dispatches.
+    origin: String,
+    scheme: String,
+    host: String,
+    port: Option<u16>,
+}
+
+impl OutboundOrigin {
+    /// The fixed HTTPS domain a provider's endpoints live on.
+    ///
+    /// `None` for a provider whose address is host configuration.
+    #[must_use]
+    pub fn fixed(provider: crate::WebSearchProviderKind) -> Option<Self> {
+        provider.outbound_domain().map(|domain| Self {
+            origin: format!("https://{domain}"),
+            scheme: "https".into(),
+            host: domain.into(),
+            port: None,
+        })
+    }
+
+    /// The origin of an already validated `http`/`https` base URL.
+    pub fn parse(value: &str) -> Result<Self, WebSearchError> {
+        let parsed = Url::parse(value).map_err(|_| WebSearchError::OutboundNotAllowed)?;
+        let (Some(host), scheme @ ("http" | "https")) = (parsed.host_str(), parsed.scheme()) else {
+            return Err(WebSearchError::OutboundNotAllowed);
+        };
+        if !parsed.username().is_empty() || parsed.password().is_some() {
+            return Err(WebSearchError::OutboundNotAllowed);
+        }
+        let host = host.to_ascii_lowercase();
+        let port = parsed.port();
+        let authority = match port {
+            Some(port) => format!("{host}:{port}"),
+            None => host.clone(),
+        };
+        Ok(Self {
+            origin: format!("{scheme}://{authority}"),
+            scheme: scheme.to_owned(),
+            host,
+            port,
+        })
+    }
+
+    /// The `scheme://host[:port]` prefix every request URL must start with.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.origin
+    }
+}
+
 #[cfg(feature = "http")]
 #[derive(Clone, Debug)]
 pub struct ReqwestHttpClient {
     client: reqwest::Client,
-    allowed_domain: &'static str,
+    origin: OutboundOrigin,
 }
 
 #[cfg(feature = "http")]
 impl ReqwestHttpClient {
-    /// Build a client for one provider with a bounded end-to-end timeout.
+    /// Build a client bound to one origin with a bounded end-to-end timeout.
     ///
-    /// The selected provider fixes the only HTTPS domain this client may
-    /// contact. Redirects stay disabled so credentials are never replayed to
-    /// another origin.
+    /// That origin is the only place this client may dial. Redirects stay
+    /// disabled so credentials are never replayed to another origin.
     pub fn with_timeout(
-        provider: crate::WebSearchProviderKind,
+        origin: OutboundOrigin,
         timeout: std::time::Duration,
     ) -> Result<Self, WebSearchError> {
         if timeout.is_zero() {
@@ -200,14 +266,11 @@ impl ReqwestHttpClient {
             .timeout(timeout)
             .build()
             .map_err(|error| WebSearchError::Transport(error.to_string()))?;
-        Ok(Self {
-            client,
-            allowed_domain: provider.outbound_domain(),
-        })
+        Ok(Self { client, origin })
     }
 
-    pub fn new(provider: crate::WebSearchProviderKind) -> Result<Self, WebSearchError> {
-        Self::with_timeout(provider, std::time::Duration::from_secs(20))
+    pub fn new(origin: OutboundOrigin) -> Result<Self, WebSearchError> {
+        Self::with_timeout(origin, std::time::Duration::from_secs(20))
     }
 }
 
@@ -242,7 +305,7 @@ impl ReqwestHttpClient {
 #[async_trait]
 impl HttpClient for ReqwestHttpClient {
     async fn post_json(&self, request: HttpRequest) -> Result<HttpResponse, WebSearchError> {
-        validate_outbound_url(&request.url, self.allowed_domain)?;
+        validate_outbound_url(&request.url, &self.origin)?;
         let mut builder = self.client.post(request.url).json(&request.body);
         for (name, value) in request.headers {
             builder = builder.header(name, value);
@@ -253,7 +316,7 @@ impl HttpClient for ReqwestHttpClient {
     async fn get(&self, request: HttpGetRequest) -> Result<HttpResponse, WebSearchError> {
         // The authority is decided by `url` alone, and `query` is appended by
         // the client afterwards, so no query pair can move the destination.
-        validate_outbound_url(&request.url, self.allowed_domain)?;
+        validate_outbound_url(&request.url, &self.origin)?;
         let mut builder = self.client.get(request.url).query(&request.query);
         for (name, value) in request.headers {
             builder = builder.header(name, value);
@@ -262,18 +325,24 @@ impl HttpClient for ReqwestHttpClient {
     }
 }
 
+/// Refuse any request URL that does not sit exactly on the bound origin.
+///
+/// The check is deliberately made twice over. The raw prefix comparison rejects
+/// anything the parser might normalize away — an added default port, a trailing
+/// dot on the host, userinfo, a look-alike suffix — and the parsed comparison
+/// rejects anything the raw form could disguise.
 #[cfg(feature = "http")]
-fn validate_outbound_url(value: &str, allowed_domain: &str) -> Result<(), WebSearchError> {
+fn validate_outbound_url(value: &str, origin: &OutboundOrigin) -> Result<(), WebSearchError> {
     let parsed = Url::parse(value).map_err(|_| WebSearchError::OutboundNotAllowed)?;
-    let authority = value
-        .strip_prefix("https://")
-        .and_then(|remainder| remainder.split(['/', '?', '#']).next());
-    if authority != Some(allowed_domain)
-        || parsed.scheme() != "https"
-        || parsed.host_str() != Some(allowed_domain)
+    let boundary_is_clean = value
+        .strip_prefix(&origin.origin)
+        .is_some_and(|rest| rest.is_empty() || rest.starts_with(['/', '?', '#']));
+    if !boundary_is_clean
+        || parsed.scheme() != origin.scheme
+        || parsed.host_str() != Some(origin.host.as_str())
+        || parsed.port() != origin.port
         || !parsed.username().is_empty()
         || parsed.password().is_some()
-        || parsed.port().is_some()
     {
         return Err(WebSearchError::OutboundNotAllowed);
     }
@@ -337,7 +406,10 @@ mod tests {
     #[cfg(feature = "http")]
     #[tokio::test]
     async fn reqwest_client_rejects_requests_outside_its_provider_domain() {
-        let client = ReqwestHttpClient::new(crate::WebSearchProviderKind::Exa).unwrap();
+        let client = ReqwestHttpClient::new(
+            OutboundOrigin::fixed(crate::WebSearchProviderKind::Exa).unwrap(),
+        )
+        .unwrap();
         for url in [
             "http://api.exa.ai/search",
             "https://api.tavily.com/search",
@@ -380,13 +452,53 @@ mod tests {
     #[test]
     fn provider_endpoints_satisfy_their_fixed_domain_policy() {
         for provider in crate::WebSearchProviderKind::ALL {
-            for endpoint in std::iter::once(provider.search_url()).chain(provider.extract_url()) {
+            let Some(origin) = OutboundOrigin::fixed(provider) else {
+                // A self-hosted provider has no fixed domain to check; its
+                // origin is validated where the operator configures it.
+                continue;
+            };
+            for endpoint in provider
+                .search_url()
+                .into_iter()
+                .chain(provider.extract_url())
+            {
                 assert!(
-                    validate_outbound_url(endpoint, provider.outbound_domain()).is_ok(),
+                    validate_outbound_url(endpoint, &origin).is_ok(),
                     "{endpoint} is not on {provider}'s fixed outbound domain"
                 );
             }
         }
+    }
+
+    /// A configured origin is still exactly one origin. Loopback and an
+    /// explicit port are reachable — that is the point of a self-hosted
+    /// instance — but nothing else on the host is.
+    #[cfg(feature = "http")]
+    #[test]
+    fn a_configured_origin_binds_as_tightly_as_a_fixed_one() {
+        let origin = OutboundOrigin::parse("http://localhost:8888").unwrap();
+        assert!(validate_outbound_url("http://localhost:8888/search", &origin).is_ok());
+        for url in [
+            "https://localhost:8888/search",
+            "http://localhost:8889/search",
+            "http://localhost/search",
+            "http://localhost.evil.example:8888/search",
+            "http://user:password@localhost:8888/search",
+            "http://127.0.0.1:8888/search",
+        ] {
+            assert!(
+                matches!(
+                    validate_outbound_url(url, &origin),
+                    Err(WebSearchError::OutboundNotAllowed)
+                ),
+                "{url} was accepted against {}",
+                origin.as_str()
+            );
+        }
+
+        // Userinfo never survives into an origin in the first place.
+        assert!(OutboundOrigin::parse("http://user:password@localhost:8888").is_err());
+        assert!(OutboundOrigin::parse("ftp://localhost").is_err());
     }
 
     #[cfg(feature = "http")]
@@ -415,7 +527,10 @@ mod tests {
                 .unwrap();
         });
 
-        let client = ReqwestHttpClient::new(crate::WebSearchProviderKind::Exa).unwrap();
+        let client = ReqwestHttpClient::new(
+            OutboundOrigin::fixed(crate::WebSearchProviderKind::Exa).unwrap(),
+        )
+        .unwrap();
         let response = client
             .client
             .post(format!("http://{source_address}/search"))

--- a/crates/openwave-web-search/src/lib.rs
+++ b/crates/openwave-web-search/src/lib.rs
@@ -19,9 +19,15 @@
 //! Exa and Tavily implement page extraction as well as search, on the same
 //! fixed authority; a per-URL vendor failure is a typed error rather than an
 //! empty success, so extraction can fall back to the native engine instead of
-//! returning a blank page. Brave is search-only and says so through
+//! returning a blank page. Brave and SearXNG are search-only and say so through
 //! [`WebSearchProvider::supports_extract`], which sends extraction to the
 //! native engine.
+//!
+//! SearXNG is self-hosted, which makes it the one provider that carries no
+//! credential and the one whose address is host configuration rather than a
+//! fixed constant. Both departures are contained in [`searxng`]; the
+//! credentialed providers still fail closed on a missing key, and the transport
+//! is still bound to exactly one [`OutboundOrigin`] before any request exists.
 //!
 //! The `extract-native` feature adds a self-contained extraction engine:
 //! [`NativeExtractor`] fetches one admitted URL — every redirect hop re-vetted
@@ -37,25 +43,29 @@ mod fetch_policy;
 mod http;
 #[cfg(feature = "extract-native")]
 mod native;
+pub mod searxng;
 pub mod tavily;
 mod tool;
 mod types;
 
 pub use brave::BraveProvider;
-pub use credentials::{WebSearchCredential, WebSearchCredentials};
+pub use credentials::{WebSearchCredential, WebSearchCredentialState, WebSearchCredentials};
 pub use exa::ExaProvider;
 pub use fetch_policy::{
     admit_fetch_address, admit_fetch_url, FetchPolicyViolation, MAX_FETCH_URL_BYTES,
 };
 #[cfg(feature = "http")]
 pub use http::ReqwestHttpClient;
-pub use http::{HttpClient, HttpGetRequest, HttpRequest, HttpResponse, MAX_HTTP_RESPONSE_BYTES};
+pub use http::{
+    HttpClient, HttpGetRequest, HttpRequest, HttpResponse, OutboundOrigin, MAX_HTTP_RESPONSE_BYTES,
+};
 #[cfg(feature = "extract-native")]
 pub use native::{
     HostAddressResolver, NativeExtractError, NativeExtraction, NativeExtractor, PageFetchResponse,
     PageFetchTransport, ReqwestPageFetcher, TokioHostResolver, MAX_EXTRACT_CONTENT_CHARS,
     MAX_FETCH_REDIRECT_HOPS, MAX_FETCH_RESPONSE_BYTES, NATIVE_FETCH_USER_AGENT,
 };
+pub use searxng::{SearxngBaseUrl, SearxngProvider};
 pub use tavily::TavilyProvider;
 pub use tool::{
     extract_request_from_tool_arguments, request_from_tool_arguments, PageExtractor,

--- a/crates/openwave-web-search/src/lib.rs
+++ b/crates/openwave-web-search/src/lib.rs
@@ -7,13 +7,21 @@
 //! adapter to its provider's exact HTTPS domain before any tool or worker can
 //! use it.
 //!
-//! The Exa and Tavily adapters use their public HTTP APIs through the small
-//! [`HttpClient`] seam; no vendor SDK is required. `ReqwestHttpClient` is opt-in
-//! behind the `http` feature. Requests and normalized output are bounded before
-//! egress and before they can reach a model context. Both adapters implement
-//! page extraction as well as search, on the same fixed authority; a per-URL
-//! vendor failure is a typed error rather than an empty success, so extraction
-//! can fall back to the native engine instead of returning a blank page.
+//! Every adapter talks to its backend over plain HTTP through the small
+//! [`HttpClient`] seam; no vendor SDK is used, and none should be added. Cargo
+//! features are resolved at compile time, so an SDK for a backend most users
+//! never configure would still ship in every binary, while an HTTP adapter
+//! reuses the client that is already there and costs essentially nothing per
+//! backend. `ReqwestHttpClient` is opt-in behind the `http` feature. Requests
+//! and normalized output are bounded before egress and before they can reach a
+//! model context.
+//!
+//! Exa and Tavily implement page extraction as well as search, on the same
+//! fixed authority; a per-URL vendor failure is a typed error rather than an
+//! empty success, so extraction can fall back to the native engine instead of
+//! returning a blank page. Brave is search-only and says so through
+//! [`WebSearchProvider::supports_extract`], which sends extraction to the
+//! native engine.
 //!
 //! The `extract-native` feature adds a self-contained extraction engine:
 //! [`NativeExtractor`] fetches one admitted URL — every redirect hop re-vetted
@@ -22,6 +30,7 @@
 //! The admission policy itself is always compiled because it is pure and
 //! dependency-light; only the parser and transport stack is feature-gated.
 
+pub mod brave;
 mod credentials;
 pub mod exa;
 mod fetch_policy;
@@ -32,6 +41,7 @@ pub mod tavily;
 mod tool;
 mod types;
 
+pub use brave::BraveProvider;
 pub use credentials::{WebSearchCredential, WebSearchCredentials};
 pub use exa::ExaProvider;
 pub use fetch_policy::{
@@ -39,7 +49,7 @@ pub use fetch_policy::{
 };
 #[cfg(feature = "http")]
 pub use http::ReqwestHttpClient;
-pub use http::{HttpClient, HttpRequest, HttpResponse, MAX_HTTP_RESPONSE_BYTES};
+pub use http::{HttpClient, HttpGetRequest, HttpRequest, HttpResponse, MAX_HTTP_RESPONSE_BYTES};
 #[cfg(feature = "extract-native")]
 pub use native::{
     HostAddressResolver, NativeExtractError, NativeExtraction, NativeExtractor, PageFetchResponse,

--- a/crates/openwave-web-search/src/searxng.rs
+++ b/crates/openwave-web-search/src/searxng.rs
@@ -1,0 +1,485 @@
+//! SearXNG's JSON search API adapter, for a self-hosted instance.
+//!
+//! SearXNG is the backend that needs no vendor account at all: the operator
+//! runs the instance. That makes it the one provider that departs from two of
+//! this crate's standing rules, and both departures are deliberate and narrow.
+//!
+//! **It carries no credential.** Every other provider holds an API key in the
+//! host's secret store and is unusable until that key is present. SearXNG has
+//! nothing to hold, which is a third state rather than an optional key — see
+//! [`WebSearchCredentialState`](crate::WebSearchCredentialState). The
+//! credentialed providers still fail closed exactly as before.
+//!
+//! **Its address is configuration.** Every other provider pins a fixed
+//! `outbound_domain` so neither host settings nor a model argument can redirect
+//! egress. A self-hosted instance has no fixed address to pin, so the base URL
+//! is host configuration — validated by [`SearxngBaseUrl`] when it is stored,
+//! and turned into exactly one [`OutboundOrigin`](crate::OutboundOrigin) the
+//! transport is bound to before any request exists. It is never a model
+//! argument and is not derivable from tool input.
+//!
+//! Instances commonly run on `http://localhost:8888` or a private LAN address,
+//! so loopback and private destinations are reachable here. That is a different
+//! trust class from the URLs `web_extract` fetches: the operator typed this one
+//! into their own settings, whereas `fetch_policy` governs addresses the model
+//! or a fetched page chose. `fetch_policy` is not relaxed by any of this.
+
+use std::collections::BTreeMap;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use url::Url;
+
+use crate::types::{
+    domain_scoped_query, parse_iso8601_instant, result_within_domains,
+    result_within_published_window,
+};
+use crate::{
+    HttpClient, HttpGetRequest, OutboundOrigin, WebSearchError, WebSearchProvider,
+    WebSearchProviderKind, WebSearchRequest, WebSearchResponse, WebSearchResult,
+};
+
+/// Longest base URL accepted for an instance.
+const MAX_BASE_URL_BYTES: usize = 512;
+
+/// Longest query this adapter will build.
+///
+/// SearXNG imposes no bound of its own — it forwards the query to upstream
+/// engines — so this is the crate's own bound plus room for the `site:`
+/// operators it may append.
+const MAX_QUERY_CHARS: usize = 1_000;
+
+/// A validated base URL for a self-hosted SearXNG instance.
+///
+/// Parsing happens once, where the value is configured, and the canonical form
+/// is what gets stored and dialed. Everything a base URL has no business
+/// carrying is rejected rather than normalized away: a non-HTTP scheme, embedded
+/// credentials, a query string, or a fragment. The search endpoint is derived
+/// from the result, never supplied alongside it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SearxngBaseUrl(String);
+
+impl SearxngBaseUrl {
+    pub fn parse(value: impl AsRef<str>) -> Result<Self, WebSearchError> {
+        let value = value.as_ref().trim();
+        let invalid = || WebSearchError::InvalidRequest("invalid SearXNG instance URL".into());
+        if value.is_empty() || value.len() > MAX_BASE_URL_BYTES {
+            return Err(invalid());
+        }
+        let parsed = Url::parse(value).map_err(|_| invalid())?;
+        if !matches!(parsed.scheme(), "http" | "https")
+            || parsed.cannot_be_a_base()
+            || parsed.host_str().is_none_or(str::is_empty)
+            || !parsed.username().is_empty()
+            || parsed.password().is_some()
+            || parsed.query().is_some()
+            || parsed.fragment().is_some()
+        {
+            return Err(invalid());
+        }
+        // An instance may live under a path prefix, but a relative segment
+        // means the value did not come from a settings field describing one.
+        // The check reads the raw text because `Url::parse` resolves `..` and
+        // `.` away, and quietly rewriting what the operator typed is worse
+        // than saying no. Query and fragment are already refused above, so
+        // everything after the authority is the path.
+        let raw_path = value
+            .split_once("://")
+            .map_or("", |(_, rest)| rest)
+            .split_once('/')
+            .map_or("", |(_, path)| path);
+        if raw_path
+            .split('/')
+            .any(|segment| matches!(segment, ".." | "."))
+        {
+            return Err(invalid());
+        }
+        let path = parsed.path().trim_end_matches('/');
+        let origin = OutboundOrigin::parse(parsed.as_str())?;
+        Ok(Self(format!("{}{path}", origin.as_str())))
+    }
+
+    /// The canonical base URL, with no trailing slash.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// The one origin a transport for this instance may dial.
+    #[must_use]
+    pub fn origin(&self) -> OutboundOrigin {
+        // The canonical form was built from a parsed origin, so this cannot
+        // fail; falling back to re-parsing keeps the type total rather than
+        // introducing a panic on host configuration.
+        OutboundOrigin::parse(&self.0).unwrap_or_else(|_| unreachable!("canonical base URL"))
+    }
+
+    fn search_url(&self) -> String {
+        format!("{}/search", self.0)
+    }
+}
+
+/// SearXNG adapter backed by an injected HTTP client.
+///
+/// It takes no credential, because there is none to take.
+#[derive(Clone, Debug)]
+pub struct SearxngProvider<C> {
+    client: C,
+    base_url: SearxngBaseUrl,
+}
+
+impl<C> SearxngProvider<C> {
+    pub fn new(client: C, base_url: SearxngBaseUrl) -> Self {
+        Self { client, base_url }
+    }
+}
+
+#[async_trait]
+impl<C: HttpClient> WebSearchProvider for SearxngProvider<C> {
+    fn kind(&self) -> WebSearchProviderKind {
+        WebSearchProviderKind::Searxng
+    }
+
+    async fn search(&self, request: WebSearchRequest) -> Result<WebSearchResponse, WebSearchError> {
+        request.validate()?;
+        let response = self
+            .client
+            .get(HttpGetRequest {
+                url: self.base_url.search_url(),
+                query: search_query(&request),
+                headers: vec![("accept".into(), "application/json".into())],
+            })
+            .await?;
+        response.ensure_bounded()?;
+        if !(200..300).contains(&response.status) {
+            return Err(status_error(response.status));
+        }
+        let payload: SearxngSearchResponse = serde_json::from_slice(&response.body)
+            // An instance without the JSON format enabled does not always
+            // refuse: some deployments answer 200 with the HTML results page.
+            // Naming the configuration is more actionable than "invalid
+            // response", and it is the same repair either way.
+            .map_err(|_| WebSearchError::JsonApiUnavailable(self.kind()))?;
+        let results = payload
+            .results
+            .into_iter()
+            .filter_map(|result| normalize_result(result).ok())
+            // SearXNG passes the query through to upstream engines, so the
+            // `site:` operators are only as good as whichever engine served
+            // the result. These two filters are what hold the request's
+            // contract regardless.
+            .filter(|result| result_within_domains(&result.url, &request.domains))
+            .filter(|result| {
+                result_within_published_window(
+                    result.published_at,
+                    request.start_published_at,
+                    request.end_published_at,
+                )
+            })
+            // The API returns a whole page of results and takes no count, so
+            // the requested bound is applied here.
+            .take(request.max_results)
+            .collect();
+        Ok(WebSearchResponse::new(self.kind(), results))
+    }
+}
+
+/// The documented search parameters.
+///
+/// `time_range` is not sent: its vocabulary is `day`/`month`/`year`, which
+/// cannot express the request's window, and a coarser filter than was asked for
+/// would quietly change the question. The window is applied to the results
+/// instead.
+fn search_query(request: &WebSearchRequest) -> Vec<(String, String)> {
+    vec![
+        (
+            "q".into(),
+            domain_scoped_query(&request.query, &request.domains, MAX_QUERY_CHARS),
+        ),
+        ("format".into(), "json".into()),
+        ("pageno".into(), "1".into()),
+    ]
+}
+
+/// Project a request-level status onto the crate's typed errors.
+fn status_error(status: u16) -> WebSearchError {
+    let provider = WebSearchProviderKind::Searxng;
+    match status {
+        // The documented answer to a format that is not enabled in the
+        // instance's `settings.yml`. It is off by default in many deployments,
+        // so this is the failure a new operator is most likely to hit.
+        403 => WebSearchError::JsonApiUnavailable(provider),
+        // SearXNG ships a request limiter that answers 429.
+        429 => WebSearchError::RateLimited(provider),
+        status => WebSearchError::HttpStatus { provider, status },
+    }
+}
+
+#[derive(Deserialize)]
+struct SearxngSearchResponse {
+    #[serde(default)]
+    results: Vec<SearxngResult>,
+}
+
+#[derive(Deserialize)]
+struct SearxngResult {
+    /// Absent on the non-web result templates an instance may mix into the
+    /// list; those are skipped rather than guessed at.
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    content: String,
+    #[serde(default)]
+    score: Option<f64>,
+    /// ISO 8601, and usually without a zone offset because the value is
+    /// serialized straight from a naive datetime.
+    #[serde(default, rename = "publishedDate")]
+    published_date: Option<String>,
+}
+
+/// `content` is a snippet, not page text, so it becomes the snippet and nothing
+/// else. The `engine`/`engines` provenance fields are deliberately not carried:
+/// they would spend the output budget on an upstream engine name a model cannot
+/// act on.
+fn normalize_result(result: SearxngResult) -> Result<WebSearchResult, WebSearchError> {
+    let url = result.url.ok_or(WebSearchError::InvalidResultUrl)?;
+    let published_at = result
+        .published_date
+        .as_deref()
+        .and_then(parse_iso8601_instant);
+    WebSearchResult::new(
+        url,
+        result.title,
+        result.content,
+        None,
+        result.score,
+        published_at,
+        None,
+        BTreeMap::new(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+    use crate::{HttpRequest, HttpResponse, SearchDomain, WebExtractRequest};
+
+    #[derive(Clone)]
+    struct FakeHttpClient {
+        request: Arc<Mutex<Option<HttpGetRequest>>>,
+        response: HttpResponse,
+    }
+
+    #[async_trait]
+    impl HttpClient for FakeHttpClient {
+        async fn post_json(&self, _request: HttpRequest) -> Result<HttpResponse, WebSearchError> {
+            unreachable!("the SearXNG adapter is a GET-only backend")
+        }
+
+        async fn get(&self, request: HttpGetRequest) -> Result<HttpResponse, WebSearchError> {
+            *self.request.lock().unwrap() = Some(request);
+            Ok(self.response.clone())
+        }
+    }
+
+    const BASE_URL: &str = "http://localhost:8888";
+
+    fn provider(status: u16, body: &[u8]) -> SearxngProvider<FakeHttpClient> {
+        SearxngProvider::new(
+            FakeHttpClient {
+                request: Arc::new(Mutex::new(None)),
+                response: HttpResponse {
+                    status,
+                    body: body.to_vec(),
+                },
+            },
+            SearxngBaseUrl::parse(BASE_URL).unwrap(),
+        )
+    }
+
+    /// A response shaped like the JSON API's own output, including the
+    /// sibling arrays and per-result fields this adapter ignores.
+    const RESPONSE: &[u8] = br#"{
+      "query": "openwave",
+      "number_of_results": 0,
+      "results": [
+        {
+          "url": "https://example.com/release",
+          "title": "OpenWave release notes",
+          "content": "Everything that shipped this month.",
+          "engine": "duckduckgo",
+          "parsed_url": ["https", "example.com", "/release", "", "", ""],
+          "template": "default.html",
+          "engines": ["duckduckgo", "brave"],
+          "positions": [1, 2],
+          "publishedDate": "2026-07-01T09:30:00",
+          "score": 3.5,
+          "category": "general"
+        },
+        {
+          "url": "https://other.invalid/page",
+          "title": "Unrelated",
+          "content": "Off-domain result.",
+          "engine": "duckduckgo",
+          "score": 1.0
+        }
+      ],
+      "answers": [],
+      "corrections": [],
+      "infoboxes": [],
+      "suggestions": [],
+      "unresponsive_engines": []
+    }"#;
+
+    #[tokio::test]
+    async fn maps_the_json_api_and_sends_the_documented_query() {
+        let provider = provider(200, RESPONSE);
+        let sent = provider.client.request.clone();
+        let response = provider
+            .search(WebSearchRequest::new("openwave", 3).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.provider, WebSearchProviderKind::Searxng);
+        assert_eq!(response.results.len(), 2);
+        let first = &response.results[0];
+        assert_eq!(first.url, "https://example.com/release");
+        assert_eq!(first.title, "OpenWave release notes");
+        assert_eq!(first.snippet, "Everything that shipped this month.");
+        assert_eq!(first.score, Some(3.5));
+        // A naive `publishedDate` is read as UTC rather than dropped.
+        assert_eq!(
+            first.published_at.unwrap().to_rfc3339(),
+            "2026-07-01T09:30:00+00:00"
+        );
+        assert!(serde_json::to_vec(&response).unwrap().len() <= crate::MAX_OUTPUT_BYTES);
+
+        let sent = sent.lock().unwrap();
+        let sent = sent.as_ref().unwrap();
+        assert_eq!(sent.url, "http://localhost:8888/search");
+        let pairs: BTreeMap<&str, &str> = sent
+            .query
+            .iter()
+            .map(|(name, value)| (name.as_str(), value.as_str()))
+            .collect();
+        assert_eq!(pairs["q"], "openwave");
+        assert_eq!(pairs["format"], "json");
+        assert!(sent.headers.iter().all(|(name, _)| name != "authorization"));
+    }
+
+    #[tokio::test]
+    async fn honours_domain_and_publication_filters_the_api_cannot_express() {
+        let provider = provider(200, RESPONSE);
+        let sent = provider.client.request.clone();
+        let response = provider
+            .search(
+                WebSearchRequest::new("openwave", 3)
+                    .unwrap()
+                    .with_domains(vec![SearchDomain::parse("example.com").unwrap()])
+                    .unwrap()
+                    .with_published_between(
+                        Some(parse_iso8601_instant("2026-07-01").unwrap()),
+                        None,
+                    )
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // The off-domain result the instance returned anyway does not survive.
+        assert_eq!(response.results.len(), 1);
+        assert_eq!(response.results[0].url, "https://example.com/release");
+
+        let sent = sent.lock().unwrap();
+        let sent = sent.as_ref().unwrap();
+        let query = &sent.query.iter().find(|(name, _)| name == "q").unwrap().1;
+        assert_eq!(query, "openwave site:example.com");
+        // The window has no faithful parameter, so none is sent and the filter
+        // is applied to the results instead.
+        assert!(sent.query.iter().all(|(name, _)| name != "time_range"));
+    }
+
+    async fn search_status(status: u16, body: &[u8]) -> WebSearchError {
+        provider(status, body)
+            .search(WebSearchRequest::new("openwave", 1).unwrap())
+            .await
+            .unwrap_err()
+    }
+
+    #[tokio::test]
+    async fn an_instance_without_the_json_format_is_a_named_configuration_failure() {
+        // The documented refusal for a format that is not enabled.
+        assert!(matches!(
+            search_status(403, b"").await,
+            WebSearchError::JsonApiUnavailable(WebSearchProviderKind::Searxng)
+        ));
+        // And the deployments that answer the HTML page at 200 instead.
+        assert!(matches!(
+            search_status(200, b"<!DOCTYPE html><html><body>results</body></html>").await,
+            WebSearchError::JsonApiUnavailable(WebSearchProviderKind::Searxng)
+        ));
+        assert!(matches!(
+            search_status(429, b"").await,
+            WebSearchError::RateLimited(WebSearchProviderKind::Searxng)
+        ));
+        assert!(matches!(
+            search_status(502, b"").await,
+            WebSearchError::HttpStatus { status: 502, .. }
+        ));
+    }
+
+    #[test]
+    fn base_url_validation_rejects_everything_that_is_not_an_origin() {
+        assert_eq!(
+            SearxngBaseUrl::parse("http://localhost:8888/")
+                .unwrap()
+                .as_str(),
+            "http://localhost:8888"
+        );
+        // A private LAN address and a path prefix are both ordinary
+        // self-hosted deployments.
+        assert_eq!(
+            SearxngBaseUrl::parse("https://Search.Lan/searxng/")
+                .unwrap()
+                .as_str(),
+            "https://search.lan/searxng"
+        );
+
+        for invalid in [
+            "",
+            "not a url",
+            "localhost:8888",
+            "ftp://localhost:8888",
+            "file:///etc/passwd",
+            "javascript:alert(1)",
+            "http://user:password@localhost:8888",
+            "http://localhost:8888/search?q=leak",
+            "http://localhost:8888/#fragment",
+            "http://localhost:8888/../admin",
+            "http://",
+        ] {
+            assert!(
+                SearxngBaseUrl::parse(invalid).is_err(),
+                "{invalid} was accepted as an instance URL"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn is_search_only_so_extraction_routes_to_the_native_engine() {
+        let provider = provider(200, RESPONSE);
+        assert!(!provider.supports_extract());
+        assert!(matches!(
+            provider
+                .extract(WebExtractRequest::new("https://example.com/article").unwrap())
+                .await,
+            Err(WebSearchError::ExtractNotSupported(
+                WebSearchProviderKind::Searxng
+            ))
+        ));
+    }
+}

--- a/crates/openwave-web-search/src/tavily.rs
+++ b/crates/openwave-web-search/src/tavily.rs
@@ -79,7 +79,11 @@ impl<C: HttpClient> WebSearchProvider for TavilyProvider<C> {
         let response = self
             .client
             .post_json(HttpRequest {
-                url: self.kind().extract_url().into(),
+                url: self
+                    .kind()
+                    .extract_url()
+                    .ok_or(WebSearchError::ExtractNotSupported(self.kind()))?
+                    .into(),
                 headers: vec![
                     // `/extract` takes the key as a bearer token only; the body
                     // `api_key` field the search path still sends is not part
@@ -331,6 +335,13 @@ mod tests {
             *self.request.lock().unwrap() = Some(request);
             Ok(self.response.clone())
         }
+
+        async fn get(
+            &self,
+            _request: crate::HttpGetRequest,
+        ) -> Result<HttpResponse, WebSearchError> {
+            unreachable!("the Tavily adapter posts JSON on both endpoints")
+        }
     }
 
     #[tokio::test]
@@ -436,7 +447,10 @@ mod tests {
         );
 
         let sent = sent.unwrap();
-        assert_eq!(sent.url, WebSearchProviderKind::Tavily.extract_url());
+        assert_eq!(
+            Some(sent.url.as_str()),
+            WebSearchProviderKind::Tavily.extract_url()
+        );
         assert_eq!(sent.body["urls"], serde_json::json!([EXTRACT_URL]));
         assert_eq!(sent.body["format"], "markdown");
         // A query would turn `raw_content` into reranked chunks instead of the

--- a/crates/openwave-web-search/src/tavily.rs
+++ b/crates/openwave-web-search/src/tavily.rs
@@ -41,7 +41,11 @@ impl<C: HttpClient> WebSearchProvider for TavilyProvider<C> {
         let response = self
             .client
             .post_json(HttpRequest {
-                url: self.kind().search_url().into(),
+                url: self
+                    .kind()
+                    .search_url()
+                    .ok_or(WebSearchError::NotConfigured(self.kind()))?
+                    .into(),
                 headers: vec![("content-type".into(), "application/json".into())],
                 body: request_body(&request, self.credential.api_key()),
             })
@@ -300,7 +304,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use super::*;
-    use crate::{HttpResponse, WebSearchCredentials};
+    use crate::{HttpResponse, WebSearchCredentialState, WebSearchCredentials};
     use openwave_core::{AgentError, SecretProvider};
 
     #[derive(Clone)]
@@ -315,7 +319,7 @@ mod tests {
     impl SecretProvider for StaticSecrets {
         async fn get_secret(&self, key: &str) -> openwave_core::Result<Option<String>> {
             Ok(
-                (key == WebSearchProviderKind::Tavily.credential_key())
+                (Some(key) == WebSearchProviderKind::Tavily.credential_key())
                     .then(|| "tavily-key".into()),
             )
         }
@@ -326,6 +330,15 @@ mod tests {
 
         async fn delete_secret(&self, _key: &str) -> openwave_core::Result<()> {
             Err(AgentError::Secret("read only test secrets".into()))
+        }
+    }
+
+    /// The stored key as a usable credential, failing the test by name if any
+    /// other credential state comes back.
+    async fn test_credential() -> WebSearchCredential {
+        match WebSearchCredentials::resolve(&StaticSecrets, WebSearchProviderKind::Tavily).await {
+            Ok(WebSearchCredentialState::Present(credential)) => credential,
+            other => panic!("expected a stored Tavily key, got {other:?}"),
         }
     }
 
@@ -346,10 +359,7 @@ mod tests {
 
     #[tokio::test]
     async fn maps_tavily_response_and_keeps_credential_out_of_headers() {
-        let credential = WebSearchCredentials::load(&StaticSecrets, WebSearchProviderKind::Tavily)
-            .await
-            .unwrap()
-            .unwrap();
+        let credential = test_credential().await;
         let request = Arc::new(Mutex::new(None));
         let provider = TavilyProvider::new(
             FakeHttpClient {
@@ -373,7 +383,10 @@ mod tests {
         );
         let sent = request.lock().unwrap();
         let sent = sent.as_ref().unwrap();
-        assert_eq!(sent.url, WebSearchProviderKind::Tavily.search_url());
+        assert_eq!(
+            Some(sent.url.as_str()),
+            WebSearchProviderKind::Tavily.search_url()
+        );
         assert_eq!(sent.body["api_key"], "tavily-key");
         assert!(sent.headers.iter().all(|(_, value)| value != "tavily-key"));
     }
@@ -387,10 +400,7 @@ mod tests {
         Result<WebExtractResponse, WebSearchError>,
         Option<HttpRequest>,
     ) {
-        let credential = WebSearchCredentials::load(&StaticSecrets, WebSearchProviderKind::Tavily)
-            .await
-            .unwrap()
-            .unwrap();
+        let credential = test_credential().await;
         let request = Arc::new(Mutex::new(None));
         let provider = TavilyProvider::new(
             FakeHttpClient {

--- a/crates/openwave-web-search/src/types.rs
+++ b/crates/openwave-web-search/src/types.rs
@@ -49,14 +49,22 @@ const MAX_METADATA_VALUE_CHARS: usize = 256;
 pub enum WebSearchProviderKind {
     Exa,
     Tavily,
+    Brave,
 }
 
 impl WebSearchProviderKind {
+    /// Every backend this crate implements.
+    ///
+    /// Anything that has to enumerate providers reads this rather than
+    /// spelling out a list that a new variant would silently fall out of.
+    pub const ALL: [Self; 3] = [Self::Exa, Self::Tavily, Self::Brave];
+
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Exa => "exa",
             Self::Tavily => "tavily",
+            Self::Brave => "brave",
         }
     }
 
@@ -66,6 +74,7 @@ impl WebSearchProviderKind {
         match self {
             Self::Exa => "web_search.exa.api_key",
             Self::Tavily => "web_search.tavily.api_key",
+            Self::Brave => "web_search.brave.api_key",
         }
     }
 
@@ -73,15 +82,21 @@ impl WebSearchProviderKind {
         match self {
             Self::Exa => "https://api.exa.ai/search",
             Self::Tavily => "https://api.tavily.com/search",
+            Self::Brave => "https://api.search.brave.com/res/v1/web/search",
         }
     }
 
     /// Fixed page-extraction endpoint, on the same authority as
     /// [`Self::search_url`] so one transport binding covers both calls.
-    pub(crate) const fn extract_url(self) -> &'static str {
+    ///
+    /// `None` for a search-only backend. Extraction routing reads
+    /// [`WebSearchProvider::supports_extract`], so a provider without an
+    /// endpoint here simply never receives an extraction request.
+    pub(crate) const fn extract_url(self) -> Option<&'static str> {
         match self {
-            Self::Exa => "https://api.exa.ai/contents",
-            Self::Tavily => "https://api.tavily.com/extract",
+            Self::Exa => Some("https://api.exa.ai/contents"),
+            Self::Tavily => Some("https://api.tavily.com/extract"),
+            Self::Brave => None,
         }
     }
 
@@ -95,6 +110,7 @@ impl WebSearchProviderKind {
         match self {
             Self::Exa => "api.exa.ai",
             Self::Tavily => "api.tavily.com",
+            Self::Brave => "api.search.brave.com",
         }
     }
 }
@@ -484,7 +500,7 @@ impl<'de> Deserialize<'de> for ExtractionMethod {
         if value == "native" {
             return Ok(Self::Native);
         }
-        [WebSearchProviderKind::Exa, WebSearchProviderKind::Tavily]
+        WebSearchProviderKind::ALL
             .into_iter()
             .find(|kind| kind.as_str() == value)
             .map(Self::Provider)
@@ -688,6 +704,60 @@ pub(crate) fn count_words(value: &str) -> usize {
         .split_whitespace()
         .filter(|token| token.chars().any(char::is_alphanumeric))
         .count()
+}
+
+/// Fold domain filters into the query string as `site:` operators.
+///
+/// Some backends have no domain-filter parameter and instead pass search
+/// operators through in the query. The operators are best effort: whether an
+/// upstream engine honours `site:` is not something this crate can promise, so
+/// [`result_within_domains`] is what actually holds the contract. That also
+/// makes it safe to leave the query alone when the operators would not fit the
+/// engine's query bound — the filter is still enforced, just later.
+pub(crate) fn domain_scoped_query(
+    query: &str,
+    domains: &[SearchDomain],
+    max_chars: usize,
+) -> String {
+    if domains.is_empty() {
+        return query.to_owned();
+    }
+    let operators = domains
+        .iter()
+        .map(|domain| format!("site:{}", domain.as_str()))
+        .collect::<Vec<_>>()
+        .join(" OR ");
+    let scoped = if domains.len() == 1 {
+        format!("{query} {operators}")
+    } else {
+        format!("{query} ({operators})")
+    };
+    if scoped.chars().count() > max_chars {
+        return query.to_owned();
+    }
+    scoped
+}
+
+/// Whether one result URL falls inside the requested domain filters.
+///
+/// This is what makes a domain filter real for a backend that only understands
+/// operators: a result the engine returned anyway is dropped here. A filter
+/// matches the host itself or any subdomain of it, which is the meaning the
+/// backends that filter natively already give it.
+pub(crate) fn result_within_domains(url: &str, domains: &[SearchDomain]) -> bool {
+    if domains.is_empty() {
+        return true;
+    }
+    let Some(host) = Url::parse(url)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_ascii_lowercase))
+    else {
+        return false;
+    };
+    domains.iter().any(|domain| {
+        let domain = domain.as_str();
+        host == domain || host.ends_with(&format!(".{domain}"))
+    })
 }
 
 /// Whether a URL a provider echoed back names the page that was requested.

--- a/crates/openwave-web-search/src/types.rs
+++ b/crates/openwave-web-search/src/types.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
@@ -50,6 +50,7 @@ pub enum WebSearchProviderKind {
     Exa,
     Tavily,
     Brave,
+    Searxng,
 }
 
 impl WebSearchProviderKind {
@@ -57,7 +58,7 @@ impl WebSearchProviderKind {
     ///
     /// Anything that has to enumerate providers reads this rather than
     /// spelling out a list that a new variant would silently fall out of.
-    pub const ALL: [Self; 3] = [Self::Exa, Self::Tavily, Self::Brave];
+    pub const ALL: [Self; 4] = [Self::Exa, Self::Tavily, Self::Brave, Self::Searxng];
 
     #[must_use]
     pub const fn as_str(self) -> &'static str {
@@ -65,24 +66,37 @@ impl WebSearchProviderKind {
             Self::Exa => "exa",
             Self::Tavily => "tavily",
             Self::Brave => "brave",
+            Self::Searxng => "searxng",
         }
     }
 
     /// Stable key in the application [`SecretProvider`](openwave_core::SecretProvider).
+    ///
+    /// `None` for a provider that authenticates with nothing at all. That is
+    /// not the same as a key being optional: a provider named here is unusable
+    /// until its key is stored, which is what
+    /// [`WebSearchCredentialState`](crate::WebSearchCredentialState) keeps
+    /// distinguishable.
     #[must_use]
-    pub const fn credential_key(self) -> &'static str {
+    pub const fn credential_key(self) -> Option<&'static str> {
         match self {
-            Self::Exa => "web_search.exa.api_key",
-            Self::Tavily => "web_search.tavily.api_key",
-            Self::Brave => "web_search.brave.api_key",
+            Self::Exa => Some("web_search.exa.api_key"),
+            Self::Tavily => Some("web_search.tavily.api_key"),
+            Self::Brave => Some("web_search.brave.api_key"),
+            // A self-hosted instance the operator runs. There is no vendor
+            // account behind it and so no key.
+            Self::Searxng => None,
         }
     }
 
-    pub(crate) const fn search_url(self) -> &'static str {
+    /// Fixed search endpoint, or `None` for a provider whose address is host
+    /// configuration because it has no single hosted address to pin.
+    pub(crate) const fn search_url(self) -> Option<&'static str> {
         match self {
-            Self::Exa => "https://api.exa.ai/search",
-            Self::Tavily => "https://api.tavily.com/search",
-            Self::Brave => "https://api.search.brave.com/res/v1/web/search",
+            Self::Exa => Some("https://api.exa.ai/search"),
+            Self::Tavily => Some("https://api.tavily.com/search"),
+            Self::Brave => Some("https://api.search.brave.com/res/v1/web/search"),
+            Self::Searxng => None,
         }
     }
 
@@ -96,7 +110,7 @@ impl WebSearchProviderKind {
         match self {
             Self::Exa => Some("https://api.exa.ai/contents"),
             Self::Tavily => Some("https://api.tavily.com/extract"),
-            Self::Brave => None,
+            Self::Brave | Self::Searxng => None,
         }
     }
 
@@ -105,12 +119,19 @@ impl WebSearchProviderKind {
     /// Keeping this mapping beside the fixed credential key and endpoint
     /// prevents host configuration or model arguments from selecting an
     /// outbound target.
+    ///
+    /// `None` for a self-hosted provider, whose address the operator supplies.
+    /// The transport is still bound to exactly one origin — see
+    /// [`OutboundOrigin`](crate::OutboundOrigin) — it is just an origin fixed
+    /// at construction from validated host configuration rather than a
+    /// constant.
     #[must_use]
-    pub const fn outbound_domain(self) -> &'static str {
+    pub const fn outbound_domain(self) -> Option<&'static str> {
         match self {
-            Self::Exa => "api.exa.ai",
-            Self::Tavily => "api.tavily.com",
-            Self::Brave => "api.search.brave.com",
+            Self::Exa => Some("api.exa.ai"),
+            Self::Tavily => Some("api.tavily.com"),
+            Self::Brave => Some("api.search.brave.com"),
+            Self::Searxng => None,
         }
     }
 }
@@ -674,6 +695,12 @@ pub enum WebSearchError {
     PageNotExtracted { provider: WebSearchProviderKind },
     #[error("web search provider {provider} returned an invalid response")]
     InvalidResponse { provider: WebSearchProviderKind },
+    /// A self-hosted instance answered, but not with its JSON API. The JSON
+    /// output format is off by default in many deployments, which makes this a
+    /// configuration problem on the instance rather than a bad response — and
+    /// far more actionable to say so.
+    #[error("web search provider {0} did not return its JSON API")]
+    JsonApiUnavailable(WebSearchProviderKind),
     #[error("web search provider returned an invalid result URL")]
     InvalidResultUrl,
 }
@@ -758,6 +785,46 @@ pub(crate) fn result_within_domains(url: &str, domains: &[SearchDomain]) -> bool
         let domain = domain.as_str();
         host == domain || host.ends_with(&format!(".{domain}"))
     })
+}
+
+/// Whether one result falls inside the requested publication window.
+///
+/// Backends that cannot express the window natively still have to honour it.
+/// A result carrying a date outside the window is dropped; an undated result is
+/// kept, because most engines report no date at all and dropping those would
+/// empty an answer rather than narrow it.
+pub(crate) fn result_within_published_window(
+    published_at: Option<DateTime<Utc>>,
+    start: Option<DateTime<Utc>>,
+    end: Option<DateTime<Utc>>,
+) -> bool {
+    let Some(published_at) = published_at else {
+        return true;
+    };
+    start.is_none_or(|start| published_at >= start) && end.is_none_or(|end| published_at <= end)
+}
+
+/// Parse an ISO 8601 instant, with or without a zone offset.
+///
+/// Several backends report a naive local-looking timestamp
+/// (`2026-07-01T09:30:00`) or a bare date. Both are read as UTC, which is what
+/// they mean in practice and what keeps a missing offset from becoming a
+/// dropped date.
+pub(crate) fn parse_iso8601_instant(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|value| value.with_timezone(&Utc))
+        .or_else(|| {
+            NaiveDateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S%.f")
+                .ok()
+                .map(|value| value.and_utc())
+        })
+        .or_else(|| {
+            NaiveDate::parse_from_str(value, "%Y-%m-%d")
+                .ok()
+                .and_then(|date| date.and_hms_opt(0, 0, 0))
+                .map(|value| value.and_utc())
+        })
 }
 
 /// Whether a URL a provider echoed back names the page that was requested.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -20,7 +20,7 @@ The current foreground agent surface contains nineteen tools:
 | `list_sources` | List bounded metadata for sources in this exact conversation | Server, read-only |
 | `read_source` | Read a bounded canonical-text range from one source and create citable evidence | Server, read-only |
 | `read_tool_result` | Read past the point a large tool result was cut short for the turn | Server, read-only |
-| `web_search` | Search the public web through the configured provider (Exa, Tavily, or Brave) | Server, sensitive approval |
+| `web_search` | Search the public web through the configured provider (Exa, Tavily, Brave, or a self-hosted SearXNG) | Server, sensitive approval |
 | `web_extract` | Fetch one exact public page URL and return its readable content, through the configured provider or the built-in engine | Server, sensitive approval |
 | `request_folder_access` | Ask the trusted desktop host to connect another folder | Client continuation |
 | `list_connected_folders` | List roots already attached to this chat | Native client continuation |
@@ -273,7 +273,8 @@ HTTP code embedded in the core loop:
 WebSearchProvider
 ├── ExaProvider
 ├── TavilyProvider
-└── BraveProvider
+├── BraveProvider
+└── SearxngProvider
 
 WebSearchService
 ├── timeout and retry policy
@@ -292,9 +293,11 @@ The crate supplies the normalized bounded contract, fixed secret keys, direct
 vendor adapters over plain HTTP through an injected seam, strict tool-argument
 decoding, and the foreground `WebSearchTool`. The server owns a
 disabled-by-default provider selection and a 1–60 second request timeout at
-`GET`/`PUT /web-search`. That setting has no endpoint or credential reference,
-returns only whether the selected fixed key is present, and does not construct
-or call a provider.
+`GET`/`PUT /web-search`. That setting carries no credential reference and does
+not construct or call a provider. The one address it accepts is the base URL of
+a self-hosted SearXNG instance, which is validated at `PUT` time and is the only
+provider address that is not a constant; see [Web search](web-search.md) for why
+that stays safe.
 
 The foreground registry advertises `web_search` as Sensitive. A call is
 persisted, durably approved for sharing the query and explicit filters, and
@@ -304,8 +307,8 @@ approval card, and routed deterministically to the configured provider when it
 implements the extract contract or to the built-in native extraction engine
 otherwise. Exa and Tavily both implement it, so a configured host extracts
 through the vendor and falls back to native — except on a rejected key, which
-surfaces for repair rather than degrading silently. Brave is search-only, so a
-host on it extracts natively. See
+surfaces for repair rather than degrading silently. Brave and SearXNG are
+search-only, so a host on either extracts natively. See
 [Web search](web-search.md) for the routing, wire shapes, and fetch-policy
 details. Turn cancellation drops
 an in-flight tool future, aborting its HTTP request. The sandbox path remains a

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -20,7 +20,7 @@ The current foreground agent surface contains nineteen tools:
 | `list_sources` | List bounded metadata for sources in this exact conversation | Server, read-only |
 | `read_source` | Read a bounded canonical-text range from one source and create citable evidence | Server, read-only |
 | `read_tool_result` | Read past the point a large tool result was cut short for the turn | Server, read-only |
-| `web_search` | Search the public web through the configured Exa or Tavily provider | Server, sensitive approval |
+| `web_search` | Search the public web through the configured provider (Exa, Tavily, or Brave) | Server, sensitive approval |
 | `web_extract` | Fetch one exact public page URL and return its readable content, through the configured provider or the built-in engine | Server, sensitive approval |
 | `request_folder_access` | Ask the trusted desktop host to connect another folder | Client continuation |
 | `list_connected_folders` | List roots already attached to this chat | Native client continuation |
@@ -272,7 +272,8 @@ HTTP code embedded in the core loop:
 ```text
 WebSearchProvider
 ├── ExaProvider
-└── TavilyProvider
+├── TavilyProvider
+└── BraveProvider
 
 WebSearchService
 ├── timeout and retry policy
@@ -288,7 +289,7 @@ WebSearchTool
 ```
 
 The crate supplies the normalized bounded contract, fixed secret keys, direct
-Exa/Tavily adapters through an injected HTTP seam, strict tool-argument
+vendor adapters over plain HTTP through an injected seam, strict tool-argument
 decoding, and the foreground `WebSearchTool`. The server owns a
 disabled-by-default provider selection and a 1–60 second request timeout at
 `GET`/`PUT /web-search`. That setting has no endpoint or credential reference,
@@ -303,7 +304,8 @@ approval card, and routed deterministically to the configured provider when it
 implements the extract contract or to the built-in native extraction engine
 otherwise. Exa and Tavily both implement it, so a configured host extracts
 through the vendor and falls back to native — except on a rejected key, which
-surfaces for repair rather than degrading silently. See
+surfaces for repair rather than degrading silently. Brave is search-only, so a
+host on it extracts natively. See
 [Web search](web-search.md) for the routing, wire shapes, and fetch-policy
 details. Turn cancellation drops
 an in-flight tool future, aborting its HTTP request. The sandbox path remains a

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -1,10 +1,19 @@
 # Web search configuration
 
-OpenWave has a bounded `openwave-web-search` library for direct Exa and Tavily
-search and for single-page extraction. The crate owns the provider-neutral
-request/result contracts, HTTP adapters, and the foreground `WebSearchTool` and
-`WebExtractTool`; the server supplies current host policy and credentials
-through a resolver. Configuration alone performs no outbound request.
+OpenWave has a bounded `openwave-web-search` library for direct Exa, Tavily, and
+Brave search and for single-page extraction. The crate owns the
+provider-neutral request/result contracts, HTTP adapters, and the foreground
+`WebSearchTool` and `WebExtractTool`; the server supplies current host policy
+and credentials through a resolver. Configuration alone performs no outbound
+request.
+
+## Backends
+
+| Backend | Needs | Search | Extract |
+| --- | --- | --- | --- |
+| Exa | paid API key | yes | yes |
+| Tavily | paid API key | yes | yes |
+| Brave | API key, free tier available | yes | no — routes to the native engine |
 
 ## Local API
 
@@ -13,9 +22,9 @@ The loopback API exposes a bearer-protected host policy at `/web-search`.
 | Endpoint | Purpose |
 | --- | --- |
 | `GET /web-search` | Read the selected provider, timeout, and whether its fixed key is available. |
-| `PUT /web-search` | Select `exa`, `tavily`, or `null` to disable; optionally set the timeout. |
-| `GET /web-search/credentials` | Read readiness for the fixed Exa and Tavily key slots. |
-| `PUT /web-search/credentials/{provider}` | Store a key for `exa` or `tavily`; returns readiness only. |
+| `PUT /web-search` | Select `exa`, `tavily`, `brave`, or `null` to disable; optionally set the timeout. |
+| `GET /web-search/credentials` | Read readiness for the fixed Exa, Tavily, and Brave key slots. |
+| `PUT /web-search/credentials/{provider}` | Store a key for one of those slots; returns readiness only. |
 | `DELETE /web-search/credentials/{provider}` | Delete that fixed provider key; returns readiness only. |
 
 Example:
@@ -28,28 +37,65 @@ Example:
 ```
 
 Timeouts must be between 1,000 and 60,000 milliseconds. There is no endpoint,
-proxy URL, arbitrary secret reference, or API-key field in this API. The Exa
-and Tavily adapters own their fixed HTTPS endpoints, disable redirects, and
-bound request input and retained response output. The host constructs the
-concrete HTTP client for the selected provider only; that client rejects any
-request whose scheme or exact authority differs from the provider's fixed API
-domain before dispatch.
+proxy URL, arbitrary secret reference, or API-key field in this API. Every
+adapter owns its fixed HTTPS endpoints, disables redirects, and bounds request
+input and retained response output. The host constructs the concrete HTTP
+client for the selected provider only; that client rejects any request whose
+scheme or exact authority differs from the provider's fixed API domain before
+dispatch, on both the `POST` and `GET` verbs of the transport seam.
 
 No response contains a credential. `/web-search` reports only
 `has_credential` for the currently selected provider, while
-`/web-search/credentials` reports readiness for both fixed slots. Keys are read
+`/web-search/credentials` reports readiness for every fixed slot. Keys are read
 from and written to the OS keychain through
-`SecretProvider` under the fixed names `web_search.exa.api_key` and
-`web_search.tavily.api_key`. Credential writes reject empty values and values
-over 8 KiB. They never alter selection or timeout policy. A missing key or
-disabled selection fails closed: there is no provider to invoke.
+`SecretProvider` under the fixed names `web_search.exa.api_key`,
+`web_search.tavily.api_key`, and `web_search.brave.api_key`. Credential writes
+reject empty values and values over 8 KiB. They never alter selection or
+timeout policy. A missing key or disabled selection fails closed: there is no
+provider to invoke.
+
+## Brave Search
+
+Brave is the search-only backend with a free tier, so it is the one a host can
+turn on without a paid plan. It is a `GET` against the fixed
+`https://api.search.brave.com/res/v1/web/search` with the key in the
+`X-Subscription-Token` header — never in the query string, which is the part of
+a `GET` that lands in proxy and server logs — and `Accept: application/json`.
+
+| | Brave |
+| --- | --- |
+| Query | `q`, `count` (the request's `max_results`; the endpoint's own cap is 20) |
+| Snippet markup | `text_decorations=false`, so `description` arrives as plain text instead of `<strong>`-wrapped matches that would have to be stripped |
+| Response scope | `result_filter=web`, keeping the news, video, discussion, and infobox clusters out of the payload |
+| Dates | `freshness=YYYY-MM-DDtoYYYY-MM-DD`, sent only when the request carries both ends, which is what a custom range requires |
+| Domains | no include-domains parameter; `site:` operators are folded into `q` and returned results are then filtered by host |
+| Result mapping | `url`, `title`, `description` → snippet, `page_age` → `published_at`. The sibling `age` is a relative phrase ("2 days ago") and carries no instant, so it is not read. There is no page text or relevance score in the response, so `content` and `score` stay empty rather than being synthesized. |
+
+The domain filter is worth spelling out because it is the one place a backend
+cannot express the request natively. The `site:` operators are a hint — whether
+an upstream ranker honours them is not something this crate can promise — so
+the filter is *also* applied to the returned results by host, matching the
+domain itself or any subdomain of it. That is what actually holds the contract:
+a domain-restricted call cannot return an off-domain page. When the operators
+would push `q` past the endpoint's 400-character limit they are left off and the
+result filter alone does the work.
+
+Statuses map to the crate's typed errors: `401` is a rejected credential and
+`429` is a rate limit. Brave documents no separate quota code — a spent monthly
+allowance answers `429` as well — so `QuotaExhausted` has nothing to map from
+here and no billing status is invented for it. Everything else stays a plain
+HTTP status.
+
+Brave publishes no page-extraction endpoint, so it does not implement the
+extract contract and `web_extract` routes to the native engine (see
+[Page extraction](#page-extraction)).
 
 ## Desktop setup
 
 The desktop sidebar has a **Web search** panel for this same local API. It
 shows whether the saved configuration is disabled, ready, or missing the
-selected provider's key; offers a key field per fixed slot, so Exa and Tavily
-can both hold a key and switching between them needs no retyping; and lets the
+selected provider's key; offers a key field per fixed slot, so every backend
+can hold a key at once and switching between them needs no retyping; and lets the
 user pick which provider is active (or disable search) and set the bounded
 timeout. Existing keys are never displayed or read into the renderer. Saving
 writes every key the user typed before it writes selection, so a provider cannot
@@ -85,7 +131,8 @@ search-only or when no provider is configured at all. Extraction therefore
 works with zero web-search configuration.
 
 Exa and Tavily both implement the extract contract, so a host with either
-selected extracts through the vendor and falls back to native. They reach
+selected extracts through the vendor and falls back to native. Brave is
+search-only and never receives an extraction request. They reach
 `https://api.exa.ai/contents` and `https://api.tavily.com/extract`, on the same
 fixed authority their search calls use, with the key as a bearer token.
 
@@ -153,5 +200,5 @@ egress; when the receipt resolves, its next claim rebuilds the same
 not cross into the foreground registry: that path uses the ordinary durable
 tool-call and approval state machine, while recursive agents remain impossible.
 The concrete transport enforces an exact HTTPS
-outbound-domain policy (`api.exa.ai` for Exa and `api.tavily.com` for Tavily)
-outside model-controlled arguments.
+outbound-domain policy (`api.exa.ai` for Exa, `api.tavily.com` for Tavily, and
+`api.search.brave.com` for Brave) outside model-controlled arguments.

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -1,11 +1,10 @@
 # Web search configuration
 
-OpenWave has a bounded `openwave-web-search` library for direct Exa, Tavily, and
-Brave search and for single-page extraction. The crate owns the
-provider-neutral request/result contracts, HTTP adapters, and the foreground
-`WebSearchTool` and `WebExtractTool`; the server supplies current host policy
-and credentials through a resolver. Configuration alone performs no outbound
-request.
+OpenWave has a bounded `openwave-web-search` library for direct search and for
+single-page extraction. The crate owns the provider-neutral request/result
+contracts, HTTP adapters, and the foreground `WebSearchTool` and
+`WebExtractTool`; the server supplies current host policy and credentials
+through a resolver. Configuration alone performs no outbound request.
 
 ## Backends
 
@@ -14,6 +13,30 @@ request.
 | Exa | paid API key | yes | yes |
 | Tavily | paid API key | yes | yes |
 | Brave | API key, free tier available | yes | no — routes to the native engine |
+| SearXNG | a self-hosted instance URL, no key | yes | no — routes to the native engine |
+
+Two of the four therefore work without paying anyone: Brave on its free tier,
+and SearXNG on an instance the operator runs.
+
+## Adapters are plain HTTP, and stay that way
+
+Every adapter talks to its backend over plain HTTP through the crate's small
+`HttpClient` seam. **No vendor SDK or client library is used, and none should be
+added.**
+
+The reason is that cargo features are resolved at compile time. An SDK for a
+backend that most users never configure would still be compiled into every
+shipped binary — its dependency tree, its own transport, its update cadence —
+paid for by everyone who does not use it. An HTTP adapter reuses the client that
+is already present and costs essentially nothing per backend. It also keeps
+every backend under the same discipline: one bound origin, one timeout, no
+redirects, no vendor-native JSON escaping into a normalized response.
+
+If an SDK ever turns out to be genuinely unavoidable for a backend, it must sit
+behind an off-by-default cargo feature so the default binary does not carry it,
+and any UI-side equivalent must be a dynamic import so the default bundle does
+not either. Adding one is a design decision to argue for in review, not a
+convenience.
 
 ## Local API
 
@@ -21,8 +44,8 @@ The loopback API exposes a bearer-protected host policy at `/web-search`.
 
 | Endpoint | Purpose |
 | --- | --- |
-| `GET /web-search` | Read the selected provider, timeout, and whether its fixed key is available. |
-| `PUT /web-search` | Select `exa`, `tavily`, `brave`, or `null` to disable; optionally set the timeout. |
+| `GET /web-search` | Read the selected provider, timeout, the SearXNG instance URL, and whether the selection is usable. |
+| `PUT /web-search` | Select `exa`, `tavily`, `brave`, `searxng`, or `null` to disable; optionally set the timeout and the SearXNG instance URL. |
 | `GET /web-search/credentials` | Read readiness for the fixed Exa, Tavily, and Brave key slots. |
 | `PUT /web-search/credentials/{provider}` | Store a key for one of those slots; returns readiness only. |
 | `DELETE /web-search/credentials/{provider}` | Delete that fixed provider key; returns readiness only. |
@@ -36,17 +59,24 @@ Example:
 }
 ```
 
-Timeouts must be between 1,000 and 60,000 milliseconds. There is no endpoint,
-proxy URL, arbitrary secret reference, or API-key field in this API. Every
-adapter owns its fixed HTTPS endpoints, disables redirects, and bounds request
-input and retained response output. The host constructs the concrete HTTP
-client for the selected provider only; that client rejects any request whose
-scheme or exact authority differs from the provider's fixed API domain before
-dispatch, on both the `POST` and `GET` verbs of the transport seam.
+Timeouts must be between 1,000 and 60,000 milliseconds. There is no proxy URL,
+arbitrary secret reference, or API-key field in this API, and the one address it
+does accept — `searxng_base_url` — is described under
+[SearXNG](#searxng-self-hosted). Every hosted adapter owns its fixed HTTPS
+endpoints, disables redirects, and bounds request input and retained response
+output. The host constructs the concrete HTTP client for the selected provider
+only; that client is bound to exactly one origin and rejects any request whose
+scheme or exact authority differs from it before dispatch, on both the `POST`
+and `GET` verbs of the transport seam.
 
-No response contains a credential. `/web-search` reports only
-`has_credential` for the currently selected provider, while
-`/web-search/credentials` reports readiness for every fixed slot. Keys are read
+`GET /web-search` reports `has_credential` (a key is stored for the selected
+provider) and `available` (the selected provider has everything it needs). The
+two differ only for SearXNG, which has no key slot at all: `has_credential` is
+always false there and `available` follows the instance URL.
+
+No response contains a credential. `/web-search/credentials` reports readiness
+for every fixed key slot; SearXNG is absent from it, exactly as local execution
+is absent from the code-execution credential list. Keys are read
 from and written to the OS keychain through
 `SecretProvider` under the fixed names `web_search.exa.api_key`,
 `web_search.tavily.api_key`, and `web_search.brave.api_key`. Credential writes
@@ -90,17 +120,94 @@ Brave publishes no page-extraction endpoint, so it does not implement the
 extract contract and `web_extract` routes to the native engine (see
 [Page extraction](#page-extraction)).
 
+## SearXNG (self-hosted)
+
+SearXNG is a metasearch engine the operator runs themselves. It is the backend
+that needs no vendor account at all, and it is the only one that departs from
+two of this crate's standing rules. Both departures are narrow and neither
+loosens anything for the other providers.
+
+### It carries no credential
+
+Every other provider holds an API key in the OS keychain and is unusable until
+that key is present. SearXNG has nothing to hold. Rather than making the key
+optional — which would quietly turn "no key stored" into "usable" for providers
+that do need one — credential resolution answers with three states:
+
+- **Present** — the provider's fixed key is stored and non-empty.
+- **Missing** — the provider requires a key and none is stored. The host fails
+  closed and makes no request. This is unchanged for Exa, Tavily, and Brave.
+- **Not required** — the provider takes no credential. Only SearXNG reaches it.
+
+SearXNG has no keychain slot, does not appear in `/web-search/credentials`, and
+cannot be addressed by `PUT`/`DELETE /web-search/credentials/{provider}` — the
+same shape local execution already has in the code-execution surface.
+
+### Its address is configuration
+
+Every other provider pins a fixed `outbound_domain` so neither host settings nor
+a model argument can redirect egress. A self-hosted instance has no fixed
+address to pin, so `searxng_base_url` is the one address this surface accepts.
+What keeps that safe:
+
+- **It is host configuration only.** It is never a model argument, is not
+  derivable from tool input, and no tool schema mentions it. The only way to set
+  it is the authenticated local `PUT /web-search`.
+- **It is validated where it is stored,** the same way the code-execution egress
+  allowlist is: `http` or `https`, a real host, no userinfo, no query, no
+  fragment, no relative path segments, bounded length. A malformed value is
+  rejected at `PUT` time rather than silently widening where the transport may
+  dial, and a malformed value already in the store makes the whole configuration
+  fail closed to disabled on read. The canonical form is what gets stored, so
+  there is one spelling of an instance URL everywhere.
+- **The search endpoint is derived from it,** never supplied beside it: the base
+  URL plus `/search`.
+- **The transport is still bound to exactly one origin.** A configured origin
+  goes through the same scheme/host/port check a fixed one does, so an instance
+  at `http://localhost:8888` cannot reach `:8889`, another host, or the same
+  host over a different scheme.
+
+Loopback and private addresses are permitted here, because that is where
+self-hosted instances live. This is a deliberately different trust class from
+the URLs `web_extract` fetches: the operator typed this address into their own
+settings, whereas `fetch_policy` governs addresses the model or a fetched page
+chose. **`fetch_policy` itself is unchanged** — it still denies loopback,
+private, link-local, metadata, CGNAT, and ULA space for model-supplied URLs, in
+every IP encoding.
+
+### Request and response
+
+| | SearXNG |
+| --- | --- |
+| Request | `GET {base}/search` with `q`, `format=json`, `pageno=1`, and `Accept: application/json`. No credential header of any kind. |
+| Domains | no domain-filter parameter; `site:` operators are folded into `q` and returned results are then filtered by host, exactly as for Brave |
+| Dates | `time_range` is `day`/`month`/`year` only and cannot express the request's window, so none is sent and the window is applied to results that carry a date; undated results are kept, because most upstream engines report none and dropping them would empty an answer rather than narrow it |
+| Result count | the API takes no count, so the request's `max_results` bound is applied to the results |
+| Result mapping | `url`, `title`, `content` → snippet, `score`, `publishedDate` → `published_at` (read as UTC when it carries no offset). The `engine`/`engines` provenance fields are not carried: they would spend the output budget on a name a model cannot act on. |
+
+The JSON output format is **off by default** in many deployments, and a public
+instance usually leaves it off. That is why an instance that does not answer
+with JSON gets its own typed failure rather than a generic invalid response: a
+documented `403`, or a `200` carrying the HTML results page, both resolve to
+"the instance did not return its JSON API", which names the repair. `429` is
+the instance's own request limiter; everything else stays a plain HTTP status.
+
+SearXNG is search-only, so `web_extract` routes to the native engine.
+
 ## Desktop setup
 
 The desktop sidebar has a **Web search** panel for this same local API. It
-shows whether the saved configuration is disabled, ready, or missing the
-selected provider's key; offers a key field per fixed slot, so every backend
-can hold a key at once and switching between them needs no retyping; and lets the
-user pick which provider is active (or disable search) and set the bounded
-timeout. Existing keys are never displayed or read into the renderer. Saving
-writes every key the user typed before it writes selection, so a provider cannot
-become active in a pass that failed to store its key. Removing a key stays a
-separate action against a single slot.
+shows whether the saved configuration is disabled, ready, or still missing what
+the selected provider needs; offers a key field per fixed slot, so every
+credentialed backend can hold a key at once and switching between them needs no
+retyping; offers the SearXNG instance URL as its own field, with no key field
+because there is no key; and lets the user pick which provider is active (or
+disable search) and set the bounded timeout. Existing keys are never displayed
+or read into the renderer. Saving writes every key the user typed before it
+writes selection, so a provider cannot become active in a pass that failed to
+store its key. Removing a key stays a separate action against a single slot;
+clearing the instance URL field takes SearXNG out of service without touching
+anything else.
 
 ## Current boundary
 
@@ -199,6 +306,7 @@ egress; when the receipt resolves, its next claim rebuilds the same
 `ToolUse`/`ToolResult` pair and may finalize. Sandbox checkpoint authority does
 not cross into the foreground registry: that path uses the ordinary durable
 tool-call and approval state machine, while recursive agents remain impossible.
-The concrete transport enforces an exact HTTPS
-outbound-domain policy (`api.exa.ai` for Exa, `api.tavily.com` for Tavily, and
-`api.search.brave.com` for Brave) outside model-controlled arguments.
+The concrete transport is bound to exactly one origin outside model-controlled
+arguments: the fixed HTTPS domain for the hosted providers (`api.exa.ai`,
+`api.tavily.com`, `api.search.brave.com`) and the validated configured origin
+for a self-hosted SearXNG instance.


### PR DESCRIPTION
Web search currently requires a paid key. These two backends let it work
on a free tier or entirely self-hosted, which matters for a local-first
product: the capability should not be gated behind someone else's
billing relationship.

Both are search-only. Neither declares extract support, so extraction
falls through to the native engine that already ships — meaning a
keyless setup gets working search *and* working page extraction.

Two commits: Brave, then SearXNG with the plain-HTTP rule for future
backends.

## Brave

`GET /res/v1/web/search` with `X-Subscription-Token`, normalized from
`web.results[]`. Two details found in the documentation rather than
assumed: `text_decorations=false` is the documented way to stop `<strong>`
markup appearing inside `description`, which is better than stripping
tags afterwards; and Brave documents **no** distinct quota status — a
spent monthly allowance returns `429` exactly like a burst overrun. So
the adapter maps 401 to a rejected credential, 429 to rate limiting, and
leaves the quota variant unreachable with a comment saying why, rather
than inventing a 402 that the API never sends.

## SearXNG

Self-hosted, and it breaks two invariants the crate holds deliberately.
Both are handled rather than waived:

**No credential.** Credential resolution was `Option`-shaped, and making
the key optional would have turned "no key stored" into "usable" for
every provider. It is now three-state — present, missing, not required —
so a missing key stays fatal for the providers that need one. SearXNG
has no keychain slot and its credential endpoints refuse, the same shape
local execution already has.

**No fixed endpoint.** Each provider is pinned to a fixed outbound
domain so neither host config nor a model argument can redirect egress.
A self-hosted instance has no fixed address, so its base URL is
configuration — settable only through the authenticated config endpoint,
validated on the way in (http/https, real host, no userinfo, no query or
fragment) and stored canonically. The transport's binding moved from a
fixed domain string to an origin value, so a configured origin gets the
identical scheme/host/port check a fixed one always got.

Loopback and private addresses are reachable **only** through that
configured origin, because a self-hosted instance is normally exactly
that. This is a different trust class from the addresses the page
extractor fetches: here an operator typed the address into their own
settings, whereas the fetch policy governs addresses a model or a
fetched page chose. `fetch_policy` is untouched.

## Filtering honesty

Neither backend has an include-domains parameter. Domain restrictions go
into the query as `site:` operators *and* results are filtered by host
afterwards — the operator is a hint to the engine, the host filter is
what actually holds the contract. SearXNG's date window cannot be sent
at all (its API takes only day/month/year ranges), so it is applied to
results that carry a date and undated results are kept; that judgement
is documented in the code and the docs rather than left implicit.

## Dependencies

No new dependencies, and none should be needed for a backend again.
`docs/web-search.md` now states the rule: adapters talk to vendors over
plain HTTP through the injected client seam, never a vendor SDK. In a
single shipped binary a cargo feature is compile-time, so an SDK for a
vendor most users never configure still ships to all of them, while an
HTTP adapter reuses the client already present. If one is ever genuinely
unavoidable it must sit behind an off-by-default feature, and any
UI-side equivalent must be a dynamic import.

## Note

The search client still inherits ambient proxy configuration, unlike the
page extractor which disables it. That is pre-existing and, I think,
correct for this case: the extractor disables proxies because address
pinning is its security control and a proxy silently voids it, whereas
these adapters authenticate over TLS to a fixed authority with redirects
disabled. Flagging it so the difference is a decision on the record
rather than an inconsistency someone finds later.