### PR TITLE
fix(desktop): keep the settings visit to one history entry

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -381,6 +381,18 @@ describe("app shell", () => {
     await user.click(screen.getByText("Settings"));
     await screen.findByTestId("settings");
 
+    // Browsing sections must not bury the way out: section hops replace the
+    // history entry, so one "Back to app" still exits — not a hop back to the
+    // previously viewed section.
+    await user.click(screen.getByRole("button", { name: "Appearance" }));
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/settings/appearance"),
+    );
+    await user.click(screen.getByRole("button", { name: "Updates" }));
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/settings/updates"),
+    );
+
     await user.click(screen.getByRole("button", { name: "Back to app" }));
 
     await waitFor(() => expect(router.state.location.pathname).toBe("/c/chat-1"));

--- a/crates/openwave-desktop/ui/src/SettingsRoute.tsx
+++ b/crates/openwave-desktop/ui/src/SettingsRoute.tsx
@@ -19,7 +19,9 @@ import { SettingsSidebar } from "./sidebar/SettingsSidebar";
  * Going back is the previous history entry rather than a remembered chat id.
  * Settings is reachable from everywhere, so where the reader came from is the
  * only answer that is right from all of them — and it is one fewer place that
- * has to keep its own copy of which conversation is open.
+ * has to keep its own copy of which conversation is open. That entry is always
+ * the one before settings because navigation inside settings — the index
+ * redirect and the rail's section links — replaces rather than pushes.
  */
 export function SettingsRoute() {
   const navigate = useNavigate();

--- a/crates/openwave-desktop/ui/src/sidebar/SettingsSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/SettingsSidebar.tsx
@@ -47,7 +47,10 @@ export function SettingsSidebar({ onBack }: { onBack: () => void }) {
               aria-current={active ? "page" : undefined}
               data-active={active || undefined}
               className="data-[active]:bg-muted"
-              onClick={() => void navigate({ to })}
+              // Replace rather than push: the whole settings visit occupies one
+              // history entry, so "Back to app" is a single step out no matter
+              // how many sections were browsed.
+              onClick={() => void navigate({ to, replace: true })}
             >
               <Icon />
               <span>{section.label}</span>


### PR DESCRIPTION
Clicking through several settings sections pushed a history entry per hop, so **"Back to app"** — a single `router.history.back()` — could land on the previously viewed settings section instead of leaving settings.

Section links in the settings rail now navigate with `replace: true`, matching the bare `/settings` index redirect, so the whole settings visit occupies one history entry and "Back to app" is always a single step out to wherever the reader was before settings. The deep-link fallback to `/` is unchanged.

Extended the existing "returns from settings to the conversation that was open" DOM test to browse two sections before clicking "Back to app", which reproduces the bug on `main`.

Closes #963

🤖 Generated with [Claude Code](https://claude.com/claude-code)