### PR TITLE
feat(protocol): authenticated attach for the sandbox-resident transport

### DIFF
--- a/crates/openwave-sandbox-agent/src/main.rs
+++ b/crates/openwave-sandbox-agent/src/main.rs
@@ -11,6 +11,11 @@
 //!
 //! - `OPENWAVE_SANDBOX_LISTEN` — the address the listener binds (default
 //!   `0.0.0.0:8080`, the port the container publishes).
+//! - `OPENWAVE_TRANSPORT_SECRET` — the per-run transport secret the host minted
+//!   and injected. The supervisor requires an inbound attach to present it before
+//!   it installs the connection. If it is absent the sandbox fails closed: it
+//!   still binds and answers, but refuses every attach rather than serving one
+//!   unauthenticated.
 //! - `OPENWAVE_SANDBOX_TASK` — the delegated task. In the full design the host
 //!   delivers the task in the run-init payload after the handle commits; until
 //!   that init frame is wired, the entrypoint reads it from the environment.
@@ -18,10 +23,14 @@
 use std::env;
 
 use openwave_sandbox_agent::{run_agent, Supervisor};
-use openwave_sandbox_protocol::{reverse::Capability, SandboxRun};
+use openwave_sandbox_protocol::{reverse::Capability, SandboxRun, TransportSecret};
 
 /// Default listener address; the container publishes this port.
 const DEFAULT_LISTEN: &str = "0.0.0.0:8080";
+/// Environment variable carrying the per-run transport secret into the container.
+/// Must match the name the backend injects (see `sandbox_docker`'s
+/// `TRANSPORT_SECRET_ENV`).
+const TRANSPORT_SECRET_ENV: &str = "OPENWAVE_TRANSPORT_SECRET";
 
 #[tokio::main]
 async fn main() {
@@ -36,9 +45,23 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let task = env::var("OPENWAVE_SANDBOX_TASK")
         .unwrap_or_else(|_| "Summarize what this sandbox agent can do.".to_owned());
 
+    // The per-run secret the host must present to attach. Fail closed: with none
+    // configured the run holds `None`, so every attach is refused rather than
+    // served unauthenticated. A supervisor with no secret must not serve.
+    let expected_secret = match env::var(TRANSPORT_SECRET_ENV) {
+        Ok(secret) if !secret.is_empty() => Some(TransportSecret::new(secret)),
+        _ => {
+            eprintln!(
+                "openwave-sandbox-agent: no {TRANSPORT_SECRET_ENV} configured; \
+                 refusing every attach (fail closed)"
+            );
+            None
+        }
+    };
+
     // Attached-only: the only granted reverse capability is host-proxied model
     // inference. No model credential lives in the container.
-    let run = SandboxRun::new([Capability::ModelInference]);
+    let run = SandboxRun::new([Capability::ModelInference], expected_secret);
     let supervisor = Supervisor::bind(&listen, run.clone()).await?;
     eprintln!(
         "openwave-sandbox-agent listening on {}",

--- a/crates/openwave-sandbox-agent/src/supervisor.rs
+++ b/crates/openwave-sandbox-agent/src/supervisor.rs
@@ -59,9 +59,10 @@ pub struct Supervisor {
 impl Supervisor {
     /// Bind the transport listener on `addr` for the run behind `run`.
     ///
-    /// The host dials this listener; the per-run transport secret authenticating
-    /// the dial is delivered out of band through the provider control plane and
-    /// is a follow-up on this listener (see the crate docs).
+    /// The host dials this listener and authenticates the dial with the per-run
+    /// transport secret the backend injected; the run behind `run` holds the
+    /// expected secret and [`serve_connection`] refuses an attach that does not
+    /// present it, before installing the connection.
     ///
     /// # Errors
     /// Propagates the bind failure if the address cannot be listened on.

--- a/crates/openwave-sandbox-agent/tests/agent_run.rs
+++ b/crates/openwave-sandbox-agent/tests/agent_run.rs
@@ -29,8 +29,11 @@ use openwave_sandbox_protocol::{
         Capability, CapabilityResponder, GrantSet, ModelInferenceResult, ReverseRequest,
         ReverseResult, RunProvenance,
     },
-    serve_connection, CapabilityHost, EventCursor, SandboxRun, WireClient,
+    serve_connection, CapabilityHost, EventCursor, SandboxRun, TransportSecret, WireClient,
 };
+
+/// The per-run transport secret the sandbox expects and the host presents.
+const SECRET: &str = "agent-run-transport-secret";
 
 /// A mock host model that scripts the loop: it asks for the word-count tool on
 /// the first step, then — once the transcript shows the tool's result — returns a
@@ -72,7 +75,10 @@ async fn attach_infer_tool_and_submit_result_runs_exactly_once() {
 
 async fn scenario() {
     // Sandbox side: the run and its transport server on a loopback port.
-    let run = SandboxRun::new([Capability::ModelInference]);
+    let run = SandboxRun::new(
+        [Capability::ModelInference],
+        Some(TransportSecret::new(SECRET)),
+    );
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind loopback");
@@ -114,6 +120,7 @@ async fn scenario() {
             protocol_version: PROTOCOL_VERSION,
             run_id: RunId::new(),
             resume_from: EventCursor::START,
+            transport_secret: TransportSecret::new(SECRET),
         },
         host,
     )

--- a/crates/openwave-sandbox-protocol/src/conformance.rs
+++ b/crates/openwave-sandbox-protocol/src/conformance.rs
@@ -8,9 +8,10 @@
 //! own fixture and panics on a contract violation, so `tests/conformance.rs` can
 //! surface them as individual CI checks.
 //!
-//! The four contract areas the suite must cover, and where:
+//! The contract areas the suite must cover, and where:
 //!
 //! - **version-mismatch refusal** — [`version_mismatch_is_refused`];
+//! - **authenticated attach** — [`unauthenticated_attach_is_refused`];
 //! - **deny-by-default** — [`deny_by_default_refuses_ungranted_capability`];
 //! - **the event-stream resumable-cursor contract** —
 //!   [`event_stream_resumes_from_committed_cursor`] and
@@ -130,10 +131,17 @@ fn provision_request() -> ProvisionRequest {
 }
 
 fn attach_request() -> AttachRequest {
+    attach_presenting(secret())
+}
+
+/// An attach presenting `secret`, so the backend's authenticated handshake
+/// accepts it (or, with a mismatched secret, refuses it).
+fn attach_presenting(secret: TransportSecret) -> AttachRequest {
     AttachRequest {
         protocol_version: PROTOCOL_VERSION,
         run_id: RunId::new(),
         resume_from: EventCursor::START,
+        transport_secret: secret,
     }
 }
 
@@ -155,6 +163,7 @@ async fn attach(
                 protocol_version: PROTOCOL_VERSION,
                 run_id: RunId::new(),
                 resume_from,
+                transport_secret: secret(),
             },
             host,
         )
@@ -181,6 +190,35 @@ pub async fn version_mismatch_is_refused() {
         }
         Err(other) => panic!("expected a version-mismatch refusal, got {other:?}"),
         Ok(_) => panic!("a version mismatch must refuse the connection"),
+    }
+}
+
+/// An attach presenting a wrong (or absent) transport secret is refused, and no
+/// session is established — the version gate passes, so the refusal is auth. This
+/// pins the authenticated attach on the reference-backend code path, distinct
+/// from the wire suite's socket path.
+pub async fn unauthenticated_attach_is_refused() {
+    let sandbox = ReferenceSandbox::new();
+    let backend = ReferenceBackend::self_hosted("inproc://authn", secret(), sandbox);
+    let handle = backend
+        .provision(provision_request())
+        .await
+        .expect("provision");
+    let address = backend.address(&handle).await.expect("address");
+
+    for bad in [
+        TransportSecret::new("not-the-secret"),
+        TransportSecret::default(),
+    ] {
+        let (host, _store) = host_with(vec![Capability::ModelInference], echo().0);
+        match backend.connect(&address, attach_presenting(bad), host) {
+            Err(crate::reference::ConnectError::Unauthenticated(refused)) => {
+                assert_eq!(refused.protocol_version, PROTOCOL_VERSION);
+                assert_eq!(refused.code, ErrorCode::Unauthenticated);
+            }
+            Err(other) => panic!("expected an authentication refusal, got {other:?}"),
+            Ok(_) => panic!("a wrong transport secret must refuse the connection"),
+        }
     }
 }
 
@@ -467,6 +505,7 @@ async fn drive_one_run(backend: &ReferenceBackend, endpoint: Option<&str>) {
                 protocol_version: PROTOCOL_VERSION,
                 run_id: RunId::new(),
                 resume_from: EventCursor::START,
+                transport_secret: secret(),
             },
             host,
         )
@@ -626,6 +665,7 @@ pub async fn control_lane_cancel_preempts_saturated_request_lane() {
 /// Run every conformance scenario in sequence.
 pub async fn run_all() {
     version_mismatch_is_refused().await;
+    unauthenticated_attach_is_refused().await;
     deny_by_default_refuses_ungranted_capability().await;
     over_bound_request_is_refused().await;
     over_bound_event_is_refused().await;

--- a/crates/openwave-sandbox-protocol/src/protocol.rs
+++ b/crates/openwave-sandbox-protocol/src/protocol.rs
@@ -10,6 +10,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::ids::{EventCursor, RunId};
+use crate::provisioning::TransportSecret;
 
 /// Current sandbox-agent wire protocol.
 ///
@@ -17,7 +18,10 @@ use crate::ids::{EventCursor, RunId};
 /// equality and refuses a differing peer, exactly as the host broker does; the
 /// protocol is [UNSTABLE](crate) until a named release and offers no
 /// negotiation window across versions.
-pub const PROTOCOL_VERSION: u32 = 1;
+///
+/// Version 2 added the authenticated attach: [`AttachRequest`] carries a per-run
+/// [`TransportSecret`] the sandbox verifies before it installs the connection.
+pub const PROTOCOL_VERSION: u32 = 2;
 
 /// Largest single reverse-RPC or event frame a conforming transport accepts,
 /// so a peer cannot force unbounded buffering with one enormous frame.
@@ -53,7 +57,7 @@ pub const MAX_INFLIGHT_REQUESTS: usize = 16;
 /// `resume_from` is the host's last committed [`EventCursor`]; a fresh run
 /// attaches at [`EventCursor::START`]. The handshake is the first thing that
 /// crosses a new connection, before any event or reverse request.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AttachRequest {
     /// The version the host speaks. The sandbox refuses a value it does not
@@ -63,6 +67,18 @@ pub struct AttachRequest {
     pub run_id: RunId,
     /// Where to resume the event stream from.
     pub resume_from: EventCursor,
+    /// The per-run transport secret the host presents to authenticate the dial.
+    ///
+    /// The sandbox verifies it against the secret it was configured with —
+    /// [after](handshake) the version check and *before* it installs the
+    /// connection or serves any capability — and refuses a mismatch with
+    /// [`ErrorCode::Unauthenticated`]. It is an opaque bearer token carried within
+    /// the frame bound; it is never logged (its [`Debug`] is redacting). An
+    /// omitted token decodes, via `#[serde(default)]`, to the empty secret, which
+    /// authenticates against nothing and is refused — a naive or older peer that
+    /// sends no token gets a clean auth refusal rather than a frame-parse drop.
+    #[serde(default)]
+    pub transport_secret: TransportSecret,
 }
 
 /// The sandbox supervisor's answer to an [`AttachRequest`], as an on-wire frame.
@@ -104,37 +120,59 @@ pub struct AttachAccepted {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AttachRefused {
-    /// The version the sandbox speaks, different from the host's.
+    /// The version the sandbox speaks (equal to the host's on an authentication
+    /// refusal, different on a version refusal).
     pub protocol_version: u32,
-    /// Always [`ErrorCode::ProtocolVersion`] today; carried for symmetry with
-    /// other refusals.
+    /// Why the attach was refused: [`ErrorCode::ProtocolVersion`] on a version
+    /// skew, or [`ErrorCode::Unauthenticated`] when the presented transport secret
+    /// did not match.
     pub code: ErrorCode,
 }
 
 /// Compute the sandbox's handshake answer for one attach — the canonical answer
 /// a backend returns, so a third-party implementation has an exact example.
 ///
-/// Exact-equality on the version, mirroring the host broker: equal versions
-/// accept; anything else refuses and returns the sandbox's version.
+/// Two gates, in this order:
+///
+/// 1. **Version**, exact-equality, mirroring the host broker: a skew refuses with
+///    [`ErrorCode::ProtocolVersion`] and returns the sandbox's version, before
+///    authentication is even considered — so neither gate leaks signal about the
+///    other.
+/// 2. **Authentication**: the presented [`AttachRequest::transport_secret`] is
+///    compared, in constant time, against `expected_secret`. A mismatch — or a
+///    sandbox with no configured secret (`expected_secret` is `None`), which
+///    authenticates nothing and so **fails closed** — refuses with
+///    [`ErrorCode::Unauthenticated`]. The refusal carries no secret.
+///
+/// Only when both gates pass is the connection accepted. A caller installs the
+/// connection or serves a capability *only* on [`HandshakeResponse::Accepted`].
 #[must_use]
 pub fn handshake(
     request: &AttachRequest,
     sandbox_version: u32,
+    expected_secret: Option<&TransportSecret>,
     granted_capabilities: Vec<crate::reverse::Capability>,
     latest_sequence: Option<crate::ids::Sequence>,
 ) -> HandshakeResponse {
-    if request.protocol_version == sandbox_version {
-        HandshakeResponse::Accepted(AttachAccepted {
-            protocol_version: sandbox_version,
-            granted_capabilities,
-            latest_sequence,
-        })
-    } else {
-        HandshakeResponse::Refused(AttachRefused {
+    if request.protocol_version != sandbox_version {
+        return HandshakeResponse::Refused(AttachRefused {
             protocol_version: sandbox_version,
             code: ErrorCode::ProtocolVersion,
-        })
+        });
     }
+    let authenticated =
+        expected_secret.is_some_and(|secret| secret.verify(&request.transport_secret));
+    if !authenticated {
+        return HandshakeResponse::Refused(AttachRefused {
+            protocol_version: sandbox_version,
+            code: ErrorCode::Unauthenticated,
+        });
+    }
+    HandshakeResponse::Accepted(AttachAccepted {
+        protocol_version: sandbox_version,
+        granted_capabilities,
+        latest_sequence,
+    })
 }
 
 /// Stable failure classes carried across the sandbox-agent boundary.
@@ -147,6 +185,10 @@ pub fn handshake(
 pub enum ErrorCode {
     /// The request did not match the host's exact [`PROTOCOL_VERSION`].
     ProtocolVersion,
+    /// The presented per-run transport secret did not match the sandbox's, or no
+    /// token was presented. The attach is refused before the connection is
+    /// installed or any capability is served.
+    Unauthenticated,
     /// The requested capability was not granted to this run.
     Denied,
     /// The operation identity was reused for a different request.
@@ -249,6 +291,7 @@ mod tests {
             protocol_version: PROTOCOL_VERSION,
             run_id: RunId::new(),
             resume_from: EventCursor::committed(Sequence::new(7)),
+            transport_secret: TransportSecret::new("per-run-secret"),
         };
         let encoded = serde_json::to_string(&request).unwrap();
         assert_eq!(
@@ -278,14 +321,17 @@ mod tests {
 
     #[test]
     fn handshake_accepts_on_match_and_refuses_on_skew() {
+        let secret = TransportSecret::new("the-run-secret");
         let request = AttachRequest {
             protocol_version: PROTOCOL_VERSION,
             run_id: RunId::new(),
             resume_from: EventCursor::START,
+            transport_secret: secret.clone(),
         };
         match handshake(
             &request,
             PROTOCOL_VERSION,
+            Some(&secret),
             vec![Capability::ModelInference],
             None,
         ) {
@@ -296,12 +342,18 @@ mod tests {
                     vec![Capability::ModelInference]
                 );
             }
-            HandshakeResponse::Refused(_) => panic!("matching versions must accept"),
+            HandshakeResponse::Refused(_) => panic!("a matching version and secret must accept"),
         }
 
         // A skewed attach is answered with an on-wire refusal carrying the
         // sandbox's own version, not a blank error.
-        let skewed = handshake(&request, PROTOCOL_VERSION + 1, Vec::new(), None);
+        let skewed = handshake(
+            &request,
+            PROTOCOL_VERSION + 1,
+            Some(&secret),
+            Vec::new(),
+            None,
+        );
         match skewed {
             HandshakeResponse::Refused(refused) => {
                 assert_eq!(refused.protocol_version, PROTOCOL_VERSION + 1);
@@ -317,6 +369,63 @@ mod tests {
             serde_json::from_value::<HandshakeResponse>(encoded).unwrap(),
             skewed
         );
+    }
+
+    #[test]
+    fn handshake_refuses_a_bad_secret_after_the_version_gate() {
+        let expected = TransportSecret::new("the-run-secret");
+        let attach_with = |secret: TransportSecret| AttachRequest {
+            protocol_version: PROTOCOL_VERSION,
+            run_id: RunId::new(),
+            resume_from: EventCursor::START,
+            transport_secret: secret,
+        };
+
+        // Right version, wrong secret: refused as Unauthenticated (not accepted,
+        // and not a version refusal).
+        let wrong = handshake(
+            &attach_with(TransportSecret::new("not-the-secret")),
+            PROTOCOL_VERSION,
+            Some(&expected),
+            vec![Capability::ModelInference],
+            None,
+        );
+        match wrong {
+            HandshakeResponse::Refused(refused) => {
+                assert_eq!(refused.code, ErrorCode::Unauthenticated)
+            }
+            HandshakeResponse::Accepted(_) => panic!("a wrong secret must be refused"),
+        }
+
+        // The version gate comes first: a skew with a *correct* secret is still a
+        // version refusal, so auth never bypasses the version check.
+        let skewed_but_authed = handshake(
+            &attach_with(expected.clone()),
+            PROTOCOL_VERSION + 1,
+            Some(&expected),
+            Vec::new(),
+            None,
+        );
+        match skewed_but_authed {
+            HandshakeResponse::Refused(refused) => {
+                assert_eq!(refused.code, ErrorCode::ProtocolVersion)
+            }
+            HandshakeResponse::Accepted(_) => panic!("a version skew must refuse even when authed"),
+        }
+
+        // No configured secret fails closed: every attach is Unauthenticated even
+        // with a matching version.
+        let unconfigured = handshake(
+            &attach_with(expected.clone()),
+            PROTOCOL_VERSION,
+            None,
+            Vec::new(),
+            None,
+        );
+        assert!(matches!(
+            unconfigured,
+            HandshakeResponse::Refused(refused) if refused.code == ErrorCode::Unauthenticated
+        ));
     }
 
     #[test]

--- a/crates/openwave-sandbox-protocol/src/provisioning.rs
+++ b/crates/openwave-sandbox-protocol/src/provisioning.rs
@@ -86,6 +86,10 @@ pub struct SandboxHandle {
 /// It is a bearer secret and a deduplication aid, not proof of sandbox
 /// authenticity: whoever carries it can impersonate the run to the host, which
 /// is a trust-model fact, not fine print. It is never logged or `Debug`-printed.
+///
+/// The sandbox supervisor holds the expected secret and checks a presented token
+/// against it with [`verify`](Self::verify) — a constant-time comparison — before
+/// it installs a connection or serves any capability.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct TransportSecret(String);
@@ -102,12 +106,50 @@ impl TransportSecret {
     pub fn expose(&self) -> &str {
         &self.0
     }
+
+    /// Whether a `presented` token equals this expected secret.
+    ///
+    /// The comparison runs in time independent of *where* the two tokens diverge:
+    /// it never returns on the first differing byte, so a caller cannot learn a
+    /// correct prefix from how long the check took. A length difference — the
+    /// length of a bearer token is not itself the secret — is the only early exit.
+    /// Neither operand is logged or `Debug`-printed.
+    #[must_use]
+    pub fn verify(&self, presented: &TransportSecret) -> bool {
+        constant_time_eq(self.0.as_bytes(), presented.0.as_bytes())
+    }
+}
+
+impl Default for TransportSecret {
+    /// The empty token: it authenticates against no configured secret. It stands
+    /// for "no secret presented" so an attach that omits one deserializes to this
+    /// and is refused, rather than being silently accepted.
+    fn default() -> Self {
+        Self(String::new())
+    }
 }
 
 impl std::fmt::Debug for TransportSecret {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str("TransportSecret([redacted])")
     }
+}
+
+/// Byte equality in time independent of where the inputs differ.
+///
+/// The difference is accumulated across every byte rather than returned on the
+/// first mismatch, so two equal-length inputs are always compared in full; only a
+/// length difference short-circuits. [`std::hint::black_box`] keeps the optimizer
+/// from reintroducing an early exit over the accumulator.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut difference: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        difference |= x ^ y;
+    }
+    std::hint::black_box(difference) == 0
 }
 
 /// A reachable base URL plus the per-run credential the host presents.
@@ -151,4 +193,45 @@ pub trait SandboxBackend: Send + Sync {
     /// [`BackendError::Teardown`] if teardown could not be confirmed; the caller
     /// re-drives the obligation on the next sweep.
     async fn destroy(&self, handle: &SandboxHandle) -> Result<(), BackendError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_redacts_the_secret() {
+        let secret = TransportSecret::new("super-secret-token");
+        let rendered = format!("{secret:?}");
+        assert!(
+            !rendered.contains("super-secret-token"),
+            "Debug leaked the secret"
+        );
+        assert!(rendered.contains("redacted"));
+    }
+
+    #[test]
+    fn verify_accepts_the_matching_secret_and_rejects_others() {
+        let expected = TransportSecret::new("correct-horse-battery-staple");
+        assert!(expected.verify(&TransportSecret::new("correct-horse-battery-staple")));
+        // A wrong token of the SAME length is refused: the comparison examines
+        // every byte, so a shared prefix does not pass.
+        assert!(!expected.verify(&TransportSecret::new("Xorrect-horse-battery-staple")));
+        assert!(!expected.verify(&TransportSecret::new("correct-horse-battery-staplX")));
+        // A different length, and the empty (absent) token, are refused too.
+        assert!(!expected.verify(&TransportSecret::new("short")));
+        assert!(!expected.verify(&TransportSecret::default()));
+    }
+
+    #[test]
+    fn constant_time_eq_examines_every_byte() {
+        assert!(constant_time_eq(b"abcdef", b"abcdef"));
+        // A difference at the first byte is caught.
+        assert!(!constant_time_eq(b"Xbcdef", b"abcdef"));
+        // A difference only at the LAST byte is the short-circuit trap: a compare
+        // that returned `true` after the matching prefix would wrongly accept it.
+        assert!(!constant_time_eq(b"abcdeX", b"abcdef"));
+        // A length mismatch is refused.
+        assert!(!constant_time_eq(b"abc", b"abcdef"));
+    }
 }

--- a/crates/openwave-sandbox-protocol/src/reference.rs
+++ b/crates/openwave-sandbox-protocol/src/reference.rs
@@ -53,6 +53,11 @@ pub enum ConnectError {
     /// established.
     #[error("attach refused: sandbox speaks protocol version {}", .0.protocol_version)]
     VersionRefused(AttachRefused),
+    /// The presented transport secret did not match; the sandbox answered with an
+    /// on-wire [`AttachRefused`], and no session was established or served. The
+    /// error text carries no secret.
+    #[error("attach refused: the sandbox rejected the transport secret")]
+    Unauthenticated(AttachRefused),
     /// The address resolves to no reachable sandbox.
     #[error("sandbox address is not reachable: {0}")]
     Unreachable(String),
@@ -473,9 +478,10 @@ impl ReferenceBackend {
     /// [`AttachRefused`] rather than an out-of-band decision.
     ///
     /// # Errors
-    /// [`ConnectError::VersionRefused`] on a version mismatch (carrying the
-    /// sandbox's on-wire refusal; the connection is not established), or
-    /// [`ConnectError::Unreachable`] if the address resolves to no sandbox.
+    /// [`ConnectError::VersionRefused`] on a version mismatch or
+    /// [`ConnectError::Unauthenticated`] on a rejected transport secret (each
+    /// carrying the sandbox's on-wire refusal; the connection is not established),
+    /// or [`ConnectError::Unreachable`] if the address resolves to no sandbox.
     pub fn connect(
         &self,
         address: &SandboxAddress,
@@ -493,12 +499,16 @@ impl ReferenceBackend {
         let accepted = match handshake(
             &attach,
             sandbox.protocol_version(),
+            Some(&self.secret),
             host.granted_capabilities(),
             sandbox.latest_sequence(),
         ) {
             HandshakeResponse::Accepted(accepted) => accepted,
             HandshakeResponse::Refused(refused) => {
-                return Err(ConnectError::VersionRefused(refused))
+                return Err(match refused.code {
+                    ErrorCode::Unauthenticated => ConnectError::Unauthenticated(refused),
+                    _ => ConnectError::VersionRefused(refused),
+                });
             }
         };
 

--- a/crates/openwave-sandbox-protocol/src/wire/host.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/host.rs
@@ -26,7 +26,7 @@ use crate::{
     events::SandboxEvent,
     host::CapabilityHost,
     ids::EventCursor,
-    protocol::{AttachAccepted, AttachRefused, AttachRequest, HandshakeResponse},
+    protocol::{AttachAccepted, AttachRefused, AttachRequest, ErrorCode, HandshakeResponse},
     reverse::{ControlFrame, RequestFrame, ReverseResponseEnvelope},
     wire::{read_frame, write_frame, write_prioritized, FrameError, WireFrame},
 };
@@ -39,6 +39,10 @@ pub enum ConnectError {
     /// established.
     #[error("attach refused: sandbox speaks protocol version {}", .0.protocol_version)]
     VersionRefused(AttachRefused),
+    /// The sandbox refused the presented transport secret; the connection is not
+    /// established and no capability was served. The error text carries no secret.
+    #[error("attach refused: the sandbox rejected the transport secret")]
+    Unauthenticated(AttachRefused),
     /// The handshake did not complete: the sandbox closed the connection or sent
     /// something other than a handshake frame first.
     #[error("the sandbox did not complete the attach handshake: {0}")]
@@ -79,10 +83,11 @@ impl WireClient {
     /// wired to `host`.
     ///
     /// # Errors
-    /// [`ConnectError::VersionRefused`] on a version mismatch (the connection is
-    /// not established), [`ConnectError::Handshake`] if the sandbox closes or
-    /// answers with a non-handshake frame, or [`ConnectError::Transport`] on a
-    /// transport failure during attach.
+    /// [`ConnectError::VersionRefused`] on a version mismatch or
+    /// [`ConnectError::Unauthenticated`] on a rejected transport secret (in either
+    /// case the connection is not established), [`ConnectError::Handshake`] if the
+    /// sandbox closes or answers with a non-handshake frame, or
+    /// [`ConnectError::Transport`] on a transport failure during attach.
     pub async fn connect<S>(
         stream: S,
         attach: AttachRequest,
@@ -132,7 +137,10 @@ impl WireClient {
             let accepted = match read_frame(&mut reader).await {
                 Ok(WireFrame::Handshake(HandshakeResponse::Accepted(accepted))) => accepted,
                 Ok(WireFrame::Handshake(HandshakeResponse::Refused(refused))) => {
-                    return Err(ConnectError::VersionRefused(refused));
+                    return Err(match refused.code {
+                        ErrorCode::Unauthenticated => ConnectError::Unauthenticated(refused),
+                        _ => ConnectError::VersionRefused(refused),
+                    });
                 }
                 Ok(_) => {
                     return Err(ConnectError::Handshake(
@@ -335,6 +343,7 @@ mod tests {
             protocol_version: PROTOCOL_VERSION,
             run_id: RunId::new(),
             resume_from: EventCursor::START,
+            transport_secret: crate::provisioning::TransportSecret::new("event-lane-test"),
         }
     }
 

--- a/crates/openwave-sandbox-protocol/src/wire/mod.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/mod.rs
@@ -244,6 +244,7 @@ mod tests {
             protocol_version: PROTOCOL_VERSION,
             run_id: RunId::new(),
             resume_from: EventCursor::START,
+            transport_secret: crate::provisioning::TransportSecret::new("frame-split-test"),
         });
         let request = WireFrame::Request(RequestFrame::Request(ReverseEnvelope {
             protocol_version: PROTOCOL_VERSION,

--- a/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
@@ -34,6 +34,7 @@ use crate::{
         handshake, AttachAccepted, HandshakeResponse, Response, MAX_BUFFERED_EVENTS,
         MAX_INFLIGHT_REQUESTS, PROTOCOL_VERSION,
     },
+    provisioning::TransportSecret,
     reference::EmitError,
     reverse::{
         Capability, ControlFrame, RequestFrame, ReverseEnvelope, ReverseRequest, ReverseResult,
@@ -84,6 +85,11 @@ struct EventBuffer {
 
 struct RunInner {
     protocol_version: u32,
+    /// The per-run transport secret the supervisor was configured with. An attach
+    /// is authenticated against it before its connection is installed. `None`
+    /// means no secret was configured, and the run fails closed — every attach is
+    /// refused rather than served unauthenticated.
+    expected_secret: Option<TransportSecret>,
     granted: Vec<Capability>,
     request_lane_capacity: usize,
     events: Mutex<EventBuffer>,
@@ -99,14 +105,22 @@ pub struct SandboxRun {
 
 impl SandboxRun {
     /// A run speaking the current [`PROTOCOL_VERSION`], granting `capabilities`
-    /// deny-by-default, with the default event-buffer and request-lane bounds.
+    /// deny-by-default, authenticating attaches against `expected_secret`, with
+    /// the default event-buffer and request-lane bounds.
+    ///
+    /// `expected_secret` is `None` only when no per-run secret was configured, in
+    /// which case the run fails closed and refuses every attach.
     #[must_use]
-    pub fn new(capabilities: impl IntoIterator<Item = Capability>) -> Self {
+    pub fn new(
+        capabilities: impl IntoIterator<Item = Capability>,
+        expected_secret: Option<TransportSecret>,
+    ) -> Self {
         Self::with_config(
             PROTOCOL_VERSION,
             MAX_BUFFERED_EVENTS,
             MAX_INFLIGHT_REQUESTS,
             capabilities,
+            expected_secret,
         )
     }
 
@@ -119,11 +133,13 @@ impl SandboxRun {
         buffer_cap: usize,
         request_lane_capacity: usize,
         capabilities: impl IntoIterator<Item = Capability>,
+        expected_secret: Option<TransportSecret>,
     ) -> Self {
         let (conn, _) = watch::channel(None);
         Self {
             inner: Arc::new(RunInner {
                 protocol_version,
+                expected_secret,
                 granted: capabilities.into_iter().collect(),
                 request_lane_capacity: request_lane_capacity.max(1),
                 events: Mutex::new(EventBuffer {
@@ -317,9 +333,10 @@ impl SandboxRun {
 /// Serve one host connection against `run` until the host closes it.
 ///
 /// Reads the [`AttachRequest`](crate::protocol::AttachRequest), answers the
-/// handshake with the canonical [`handshake`] function (a version skew yields an
-/// on-wire refusal and the connection is not established), and on acceptance
-/// runs the connection: replays buffered events past the host's resume cursor,
+/// handshake with the canonical [`handshake`] function (a version skew or a
+/// failed transport-secret authentication yields an on-wire refusal and the
+/// connection is neither installed nor served), and on acceptance runs the
+/// connection: replays buffered events past the host's resume cursor,
 /// carries the agent's reverse requests and events out, and correlates the host's
 /// responses back. Returns when the connection drops; the `run` survives for the
 /// host to reattach to.
@@ -344,13 +361,18 @@ where
     let response = handshake(
         &attach,
         run.inner.protocol_version,
+        run.inner.expected_secret.as_ref(),
         run.inner.granted.clone(),
         run.latest_sequence(),
     );
     write_frame(&mut write_half, &WireFrame::Handshake(response.clone())).await?;
     let _accepted: AttachAccepted = match response {
         HandshakeResponse::Accepted(accepted) => accepted,
-        // The connection is refused and left unusable; the run stands.
+        // Refused — a version skew or a failed authentication. The connection is
+        // left unusable and is NOT installed as the run's live peer: the code
+        // below that publishes this connection via `send_replace` is never
+        // reached, so an unauthenticated dial cannot hijack the channel from the
+        // authenticated one. The run stands for a legitimate host to attach.
         HandshakeResponse::Refused(_) => return Ok(()),
     };
 

--- a/crates/openwave-sandbox-protocol/tests/conformance.rs
+++ b/crates/openwave-sandbox-protocol/tests/conformance.rs
@@ -13,6 +13,11 @@ async fn version_mismatch_is_refused() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unauthenticated_attach_is_refused() {
+    conformance::unauthenticated_attach_is_refused().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn deny_by_default_refuses_ungranted_capability() {
     conformance::deny_by_default_refuses_ungranted_capability().await;
 }

--- a/crates/openwave-sandbox-protocol/tests/wire_conformance.rs
+++ b/crates/openwave-sandbox-protocol/tests/wire_conformance.rs
@@ -9,9 +9,15 @@
 //! the concrete-transport step: the reference suite pins semantics, this suite
 //! pins that the same semantics survive a real socket.
 //!
-//! The four contract areas required of the wire transport, and where:
+//! The contract areas required of the wire transport, and where:
 //!
 //! - version-mismatch refusal on the wire — [`version_mismatch_is_refused_on_the_wire`];
+//! - authenticated attach: the correct transport secret is accepted and serves a
+//!   capability ([`correct_secret_attaches_and_serves_a_capability`]), a wrong or
+//!   absent secret is refused and serves nothing
+//!   ([`wrong_or_absent_secret_is_refused_and_serves_nothing`]), and a refused
+//!   second connection cannot hijack the live one
+//!   ([`a_refused_second_connection_cannot_hijack_the_live_one`]);
 //! - a model-inference reverse call round-trip (with exactly-once replay) —
 //!   [`model_inference_round_trips_and_replays_exactly_once`];
 //! - event-stream delivery and resume-by-sequence — [`event_stream_delivers_then_resumes_by_sequence`];
@@ -47,8 +53,18 @@ use openwave_sandbox_protocol::{
         ReverseRequest, ReverseResult, RunProvenance,
     },
     serve_connection, CapabilityHost, ConnectError, HostConnection, ReverseOutcome, SandboxRun,
-    WireClient,
+    TransportSecret, WireClient,
 };
+
+/// The per-run transport secret both sides of these tests share. A run expects
+/// it; the [`attach`] helper presents it; the authentication tests present a
+/// wrong or empty token instead.
+const SECRET: &str = "wire-conformance-transport-secret";
+
+/// The expected secret a run authenticates attaches against.
+fn expected_secret() -> Option<TransportSecret> {
+    Some(TransportSecret::new(SECRET))
+}
 
 /// Run one scenario under a wall-clock bound so nothing can hang the suite.
 async fn bounded<F: Future<Output = ()>>(scenario: F) {
@@ -133,10 +149,17 @@ fn host_with(
 }
 
 fn attach(resume_from: EventCursor) -> AttachRequest {
+    attach_with(resume_from, SECRET)
+}
+
+/// An attach presenting an explicit transport secret, for the authentication
+/// tests that dial with a wrong or empty token.
+fn attach_with(resume_from: EventCursor, secret: &str) -> AttachRequest {
     AttachRequest {
         protocol_version: PROTOCOL_VERSION,
         run_id: RunId::new(),
         resume_from,
+        transport_secret: TransportSecret::new(secret),
     }
 }
 
@@ -167,16 +190,25 @@ async fn connect(
     WireClient::connect(stream, attach(resume_from), host).await
 }
 
-/// A version-skewed peer is refused on the wire, and no session is established.
+/// A version-skewed peer is refused on the wire, and no session is established —
+/// even though it presents the *correct* transport secret. This pins the ordering
+/// invariant: authentication never bypasses the version gate.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn version_mismatch_is_refused_on_the_wire() {
     bounded(async {
-        // The sandbox speaks a version the host does not.
-        let run =
-            SandboxRun::with_config(PROTOCOL_VERSION + 1, 16, 4, [Capability::ModelInference]);
+        // The sandbox speaks a version the host does not, but shares the secret.
+        let run = SandboxRun::with_config(
+            PROTOCOL_VERSION + 1,
+            16,
+            4,
+            [Capability::ModelInference],
+            expected_secret(),
+        );
         let addr = spawn_sandbox(run).await;
         let (host, _store) = host_with(vec![Capability::ModelInference], echo().0);
 
+        // `connect` presents the correct secret via `attach`; the refusal is still
+        // a version refusal, so a matching secret does not slip past the skew.
         match connect(addr, host, EventCursor::START).await {
             Err(ConnectError::VersionRefused(refused)) => {
                 // The refusal frame carried the sandbox's own version over the socket.
@@ -190,12 +222,130 @@ async fn version_mismatch_is_refused_on_the_wire() {
     .await;
 }
 
+/// The correct transport secret is accepted and the connection serves a
+/// capability: an authenticated attach round-trips a model-inference reverse call.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn correct_secret_attaches_and_serves_a_capability() {
+    bounded(async {
+        let run = SandboxRun::new([Capability::ModelInference], expected_secret());
+        let addr = spawn_sandbox(run.clone()).await;
+        let (responder, executions) = echo();
+        let (host, _store) = host_with(vec![Capability::ModelInference], responder);
+
+        // Keep the authenticated connection open for the call.
+        let _conn = connect(addr, host, EventCursor::START)
+            .await
+            .expect("the correct secret is accepted");
+        match run.call(OperationId::new(), infer("hi")).await {
+            ReverseOutcome::Settled(Response::Ok(result)) => {
+                assert_eq!(completion(&result), "echo:hi");
+            }
+            other => panic!("an authenticated attach must serve a capability, got {other:?}"),
+        }
+        assert_eq!(executions.load(Ordering::SeqCst), 1);
+    })
+    .await;
+}
+
+/// A wrong secret, and an absent (empty) one, are each refused as
+/// `Unauthenticated` after the version gate — and because the attach never
+/// completes, no capability is ever served over that connection.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wrong_or_absent_secret_is_refused_and_serves_nothing() {
+    bounded(async {
+        let run = SandboxRun::new([Capability::ModelInference], expected_secret());
+        let addr = spawn_sandbox(run).await;
+
+        for bad in ["a-totally-wrong-secret", ""] {
+            let (host, _store) = host_with(vec![Capability::ModelInference], echo().0);
+            let stream = TcpStream::connect(addr).await.expect("dial loopback");
+            let kind = if bad.is_empty() {
+                "an absent"
+            } else {
+                "a wrong"
+            };
+            match WireClient::connect(stream, attach_with(EventCursor::START, bad), host).await {
+                Err(ConnectError::Unauthenticated(refused)) => {
+                    // Versions matched — the refusal is authentication, not skew.
+                    assert_eq!(refused.protocol_version, PROTOCOL_VERSION);
+                    assert_eq!(refused.code, ErrorCode::Unauthenticated);
+                }
+                Err(other) => {
+                    panic!("{kind} secret must be refused as Unauthenticated, got {other:?}");
+                }
+                Ok(_) => panic!("{kind} secret must be refused, but a session was established"),
+            }
+            // The `Err` is the whole point: there is no `HostConnection`, so the
+            // attacker holds nothing it could serve or drive a reverse call over.
+        }
+    })
+    .await;
+}
+
+/// The hijack scenario: a first, authenticated connection is live and is the
+/// run's reverse-RPC peer; a second connection presenting a wrong (then absent)
+/// secret is refused and must NOT displace the live one. The sandbox installs the
+/// newest *accepted* connection via `send_replace`, so a refused attach that never
+/// reaches that install cannot steal the channel.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_refused_second_connection_cannot_hijack_the_live_one() {
+    bounded(async {
+        let run = SandboxRun::new([Capability::ModelInference], expected_secret());
+        let addr = spawn_sandbox(run.clone()).await;
+
+        // Host 1 attaches with the correct secret and becomes the live peer.
+        let (responder, executions) = echo();
+        let (host1, _store) = host_with(vec![Capability::ModelInference], responder);
+        let _conn1 = connect(addr, host1, EventCursor::START)
+            .await
+            .expect("the authenticated attach is accepted");
+        match run.call(OperationId::new(), infer("one")).await {
+            ReverseOutcome::Settled(Response::Ok(result)) => {
+                assert_eq!(completion(&result), "echo:one");
+            }
+            other => panic!("the authenticated peer must answer, got {other:?}"),
+        }
+        assert_eq!(executions.load(Ordering::SeqCst), 1);
+
+        // An attacker dials the same port with a wrong secret, then with none.
+        for bad in ["stolen-guess", ""] {
+            let (attacker, _s) = host_with(vec![Capability::ModelInference], echo().0);
+            let stream = TcpStream::connect(addr).await.expect("dial loopback");
+            match WireClient::connect(stream, attach_with(EventCursor::START, bad), attacker).await
+            {
+                Err(ConnectError::Unauthenticated(_)) => {}
+                Err(other) => panic!("a {bad:?} secret must be refused, got {other:?}"),
+                Ok(_) => panic!("a {bad:?} secret must not establish a session"),
+            }
+
+            // The live peer is unchanged: a fresh reverse call still routes to
+            // host 1, whose responder count advances — the attacker never became
+            // the run's connection, so it could not answer, read events, or drive
+            // the agent.
+            match run.call(OperationId::new(), infer("again")).await {
+                ReverseOutcome::Settled(Response::Ok(result)) => {
+                    assert_eq!(completion(&result), "echo:again");
+                }
+                other => {
+                    panic!("the live connection must survive the refused hijack, got {other:?}")
+                }
+            }
+        }
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            3,
+            "every call was served by the authenticated peer, never the attacker"
+        );
+    })
+    .await;
+}
+
 /// A model-inference reverse call round-trips over the socket, and re-issuing the
 /// same operation identity replays the recorded answer without re-executing.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn model_inference_round_trips_and_replays_exactly_once() {
     bounded(async {
-        let run = SandboxRun::new([Capability::ModelInference]);
+        let run = SandboxRun::new([Capability::ModelInference], expected_secret());
         let addr = spawn_sandbox(run.clone()).await;
         let (responder, executions) = echo();
         let (host, store) = host_with(vec![Capability::ModelInference], responder);
@@ -237,7 +387,7 @@ async fn model_inference_round_trips_and_replays_exactly_once() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn event_stream_delivers_then_resumes_by_sequence() {
     bounded(async {
-        let run = SandboxRun::new([]);
+        let run = SandboxRun::new([], expected_secret());
         // Emit before any host attaches: the events buffer for replay.
         for letter in ["a", "b", "c", "d", "e"] {
             run.emit_progress(letter).await.expect("emit");
@@ -284,7 +434,13 @@ async fn event_stream_delivers_then_resumes_by_sequence() {
 async fn control_lane_cancel_preempts_a_saturated_request_lane() {
     bounded(async {
         // A request lane with exactly two in-flight permits.
-        let run = SandboxRun::with_config(PROTOCOL_VERSION, 16, 2, [Capability::ModelInference]);
+        let run = SandboxRun::with_config(
+            PROTOCOL_VERSION,
+            16,
+            2,
+            [Capability::ModelInference],
+            expected_secret(),
+        );
         let addr = spawn_sandbox(run.clone()).await;
 
         let gate = Arc::new(Semaphore::new(0));
@@ -355,7 +511,7 @@ async fn control_lane_cancel_preempts_a_saturated_request_lane() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn resume_replays_more_events_than_the_request_lane_depth() {
     bounded(async {
-        let run = SandboxRun::new([]);
+        let run = SandboxRun::new([], expected_secret());
         // Buffer far more events than the outbound `data` queue depth
         // (MAX_INFLIGHT_REQUESTS = 16), the earlier deadlock's trigger.
         const COUNT: u64 = 40;
@@ -391,7 +547,7 @@ async fn resume_replays_more_events_than_the_request_lane_depth() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn reverse_call_survives_a_disconnect_and_reissue_replays_exactly_once() {
     bounded(async {
-        let run = SandboxRun::new([Capability::ModelInference]);
+        let run = SandboxRun::new([Capability::ModelInference], expected_secret());
         let addr = spawn_sandbox(run.clone()).await;
 
         // A gated host model, shared run-scoped across both connections.

--- a/crates/openwave-sandbox-protocol/tests/wire_format.rs
+++ b/crates/openwave-sandbox-protocol/tests/wire_format.rs
@@ -54,6 +54,7 @@ fn attach_handshake_wire_shapes() {
         protocol_version: PROTOCOL_VERSION,
         run_id: RunId::new(),
         resume_from: EventCursor::committed(Sequence::new(3)),
+        transport_secret: TransportSecret::new("per-run-secret"),
     };
     roundtrip(&request);
     golden(
@@ -61,8 +62,19 @@ fn attach_handshake_wire_shapes() {
         &[
             ("/protocol_version", json!(PROTOCOL_VERSION)),
             ("/resume_from", json!(3)),
+            // The secret is transparent on the wire (a bearer token), so a
+            // self-hoster's host presents it as a plain string field.
+            ("/transport_secret", json!("per-run-secret")),
         ],
     );
+
+    // An attach that omits the secret decodes to the empty token (serde default),
+    // which the sandbox refuses — a naive peer gets a clean auth refusal.
+    let omitted: AttachRequest = serde_json::from_value(
+        json!({"protocol_version": PROTOCOL_VERSION, "run_id": RunId::new(), "resume_from": 0}),
+    )
+    .expect("an attach without a secret still decodes");
+    assert_eq!(omitted.transport_secret, TransportSecret::default());
 
     let accepted = HandshakeResponse::Accepted(AttachAccepted {
         protocol_version: PROTOCOL_VERSION,

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -550,16 +550,25 @@ impl SandboxContainerRunner {
             protocol_version: PROTOCOL_VERSION,
             run_id: protocol_run_id,
             resume_from: *cursor,
+            // Present the per-run secret the backend minted and injected into the
+            // container; the supervisor verifies it before installing this
+            // connection. Cloned from the resolved address rather than discarded.
+            transport_secret: address.transport_secret.clone(),
         };
         let mut conn = match WireClient::connect(stream, attach, host.clone()).await {
             Ok(conn) => conn,
             Err(error) => {
-                // A version refusal is terminal; a transport failure during
-                // attach is a disconnect the driver retries.
+                // A version or authentication refusal is terminal — retrying the
+                // same secret against the same container cannot succeed; a
+                // transport failure during attach is a disconnect the driver
+                // retries.
                 return match error {
                     ConnectError::VersionRefused(_) => {
                         DrainOutcome::Failed("container speaks an incompatible protocol".to_owned())
                     }
+                    ConnectError::Unauthenticated(_) => DrainOutcome::Failed(
+                        "container rejected the run's transport secret".to_owned(),
+                    ),
                     _ => DrainOutcome::Disconnected,
                 };
             }

--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -311,7 +311,12 @@ async fn admit_container_run(store: &Arc<dyn Store>, chat_id: ChatId, task: &str
 async fn spawn_sandbox_agent(task: &str) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let base_url = format!("http://{}", listener.local_addr().unwrap());
-    let run = SandboxRun::new([Capability::ModelInference]);
+    // The supervisor expects the same per-run secret the MockBackend hands the
+    // driver from `address()`, so the driver's authenticated attach is accepted.
+    let run = SandboxRun::new(
+        [Capability::ModelInference],
+        Some(TransportSecret::new("test-secret")),
+    );
     let agent_run = run.clone();
     let task = task.to_owned();
     tokio::spawn(async move {


### PR DESCRIPTION
## The gap

The sandbox-resident transport handshake checked only the protocol version. The Docker backend mints a per-run `TransportSecret` and injects it into the container, but the driver **discarded** it and `AttachRequest` had no auth field. So any local process could connect to the container's published `127.0.0.1:<port>`, complete the version-only handshake, and **hijack** the run's channel: the sandbox installs the newest connection as its live reverse-RPC peer via `send_replace`, so an attacker becomes the run's model-inference responder — answering completions, driving the agent, reading its events. Low-impact against today's toy tool surface, a local privilege/exfil hole the moment a sandbox agent gets a real shell. This is blocker #1 on #920 (routing to the `container` location is gated on it).

## What this does

An **authenticated attach**, version first then auth, across the three layers the fix is cross-cutting over:

**Protocol (`openwave-sandbox-protocol`).** `AttachRequest` gains a per-run `transport_secret` (the existing opaque, redacting-`Debug` `TransportSecret`). `handshake()` now takes the expected secret and runs two ordered gates: the existing exact-equality `PROTOCOL_VERSION` check, then a **constant-time** comparison of the presented token against the configured one. A mismatch — or a sandbox with no secret configured (fails closed) — refuses with a new `ErrorCode::Unauthenticated`; the sandbox server returns *before* the `send_replace` that would install the peer, so a refused dial can never displace the live one or serve a capability. `ConnectError::Unauthenticated` is surfaced on both the wire client and the reference backend. This is a wire change, so `PROTOCOL_VERSION` bumps to 2. No new dependency: the constant-time compare is a small XOR-accumulate helper (no early exit on the first differing byte, `black_box` guards the accumulator).

**Supervisor (`openwave-sandbox-agent`).** The entrypoint reads the expected secret from `OPENWAVE_TRANSPORT_SECRET` — the exact name `sandbox_docker` injects — and hands it to the `SandboxRun`. **Fail closed:** with none configured the run still binds and answers but refuses every attach rather than serving one unauthenticated.

**Driver (`openwave-server`).** Presents `address().transport_secret` in the `AttachRequest` instead of discarding it, and treats an authentication refusal as terminal (retrying the same secret cannot succeed).

`openwave-core` is untouched (Postgres lane unaffected); the container path stays unwired; deps stay exact-pinned and `Cargo.lock` is unchanged.

## Tests

All socket tests are timeout-wrapped. Over a real loopback socket (`wire_conformance.rs`): correct secret → accepted + a capability round-trips; wrong **and** absent secret → `Unauthenticated`, nothing served; the **hijack** scenario — a live authenticated connection is not displaced by a refused second one; version mismatch still refused even when the secret is correct (auth never bypasses the version gate). Plus a constant-time comparison unit test (a wrong secret of the right length, differing only in the last byte, is refused), a reference-backend auth scenario in the conformance suite, and the golden wire-format shape for the new field.

I verified the hijack test is a genuine regression witness: with the auth gate neutered (old behavior) it fails ("a wrong secret must not establish a session"); with the gate in place it passes. `cargo test` on the three touched crates, `clippy --all-targets -D warnings`, and `fmt` are all green.

Security-critical — please review closely. Not set to auto-merge.

Part of #920