### PR TITLE
feat(ui): consolidate file upload and citations into a tools menu

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -47,8 +47,9 @@ import {
 } from "./ImageAttachments";
 import { useImageAttachments } from "./useImageAttachments";
 import { modelForSelection } from "./ModelSelection";
-import { CitationFormatMenu, ModelMenu, ReasoningEffortMenu } from "./ModelMenu";
+import { ModelMenu, ReasoningEffortMenu } from "./ModelMenu";
 import { PermissionModeMenu } from "./PermissionModeMenu";
+import { ToolsMenu } from "./ToolsMenu";
 import {
   PICKER_BUSY_MESSAGE,
   PICKER_HOLDERS,
@@ -380,7 +381,6 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             deletingChat={deletingChatId !== null}
             draft={draft}
             draftRef={draftRef}
-            attaching={attaching}
             attachedSourceName={recentSource?.displayName ?? null}
             attachError={attachError}
             composerImages={{
@@ -393,6 +393,14 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             }}
             composerModelMenu={
               <>
+                <ToolsMenu
+                  disabled={deletingChatId !== null}
+                  onAttach={hasNativeHost() ? onAttach : undefined}
+                  attaching={attaching}
+                  citationFormat={chat!.citation_format}
+                  defaultCitationFormat={defaultCitationFormat}
+                  onCitationFormatChange={onCitationFormatChange}
+                />
                 <ModelMenu
                   models={models}
                   value={chat!.model}
@@ -413,16 +421,9 @@ export function ChatRoute({ chatId }: { chatId: string }) {
                   disabled={deletingChatId !== null}
                   onChange={onPermissionModeChange}
                 />
-                <CitationFormatMenu
-                  value={chat!.citation_format}
-                  defaultFormat={defaultCitationFormat}
-                  disabled={deletingChatId !== null}
-                  onChange={onCitationFormatChange}
-                />
               </>
             }
             onDraftChange={setComposerDraft}
-            onAttach={onAttach}
             onDismissAttachedSource={() => setRecentSource(null)}
             onSelectPrompt={setComposerDraft}
             onSend={onSend}

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -58,14 +58,12 @@ function DraftingChatView(overrides: Partial<ChatViewProps> = {}) {
       draftRef={draftRef}
       composerModelMenu={null}
       composerImages={noImages()}
-      attaching={false}
       attachedSourceName={null}
       attachError={null}
       onDraftChange={(value) => {
         draftRef.current = value;
         setDraft(value);
       }}
-      onAttach={vi.fn(async () => {})}
       onDismissAttachedSource={vi.fn()}
       onSelectPrompt={vi.fn()}
       onSend={vi.fn(async () => {})}
@@ -85,11 +83,9 @@ function renderChatView(overrides: Partial<ChatViewProps> = {}) {
     draftRef: { current: "" },
     composerModelMenu: null,
     composerImages: noImages(),
-    attaching: false,
     attachedSourceName: null,
     attachError: null,
     onDraftChange: vi.fn(),
-    onAttach: vi.fn(async () => {}),
     onDismissAttachedSource: vi.fn(),
     onSelectPrompt: vi.fn(),
     onSend: vi.fn(async () => {}),

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -32,11 +32,9 @@ export type ChatViewProps = {
   draftRef: RefObject<string>;
   composerModelMenu: ReactNode;
   composerImages: ComposerImages;
-  attaching: boolean;
   attachedSourceName: string | null;
   attachError: string | null;
   onDraftChange: (value: string) => void;
-  onAttach: () => Promise<void>;
   onDismissAttachedSource: () => void;
   onSelectPrompt: (prompt: string) => void;
   onSend: () => Promise<void>;
@@ -59,11 +57,9 @@ export function ChatView({
   draftRef,
   composerModelMenu,
   composerImages,
-  attaching,
   attachedSourceName,
   attachError,
   onDraftChange,
-  onAttach,
   onDismissAttachedSource,
   onSelectPrompt,
   onSend,
@@ -313,11 +309,8 @@ export function ChatView({
         draft={draft}
         modelMenu={composerModelMenu}
         images={composerImages}
-        canAttach={nativeHost}
-        attaching={attaching}
         attachedSourceName={attachedSourceName}
         attachError={attachError}
-        onAttach={onAttach}
         onDismissAttachedSource={onDismissAttachedSource}
         // Typing retires the verdict on the last piece of guidance. Accepted
         // guidance clears the draft through the raw callback instead, so

--- a/crates/openwave-desktop/ui/src/Composer.test.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.test.tsx
@@ -287,7 +287,7 @@ describe("Composer", () => {
     expect(markup).toContain('disabled=""');
   });
 
-  it("offers one attach control, and reports what it added", () => {
+  it("reports what source was added", () => {
     const markup = renderToStaticMarkup(
       <Composer
         activeTurnId={null}
@@ -296,11 +296,8 @@ describe("Composer", () => {
         cancelPending={false}
         disabled={false}
         draft="Summarize this"
-        canAttach
-        attaching={false}
         attachedSourceName="brief.pdf"
         attachError={null}
-        onAttach={noop}
         onDismissAttachedSource={vi.fn()}
         onDraftChange={vi.fn()}
         onSend={noop}
@@ -313,11 +310,6 @@ describe("Composer", () => {
       />,
     );
 
-    // One control for any file. Which of the two things it becomes is the
-    // host's decision from the bytes, not a choice put to the reader — the
-    // menu behind this trigger offers a single upload, never a per-kind pair.
-    expect(markup).toContain('aria-label="Add to this chat"');
-    expect(markup).not.toContain('aria-label="Attach image"');
     expect(markup).toContain("brief.pdf");
     expect(markup).toContain("Added to this conversation");
     expect(markup).toContain('aria-label="Dismiss brief.pdf"');

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -12,9 +12,7 @@ import {
   ArrowUpRight,
   FileText,
   Image as ImageIcon,
-  Plus,
   Square,
-  Upload,
   X,
 } from "lucide-react";
 import { MAX_STEER_CHARACTERS } from "./ActiveTurnSteer";
@@ -26,13 +24,6 @@ import {
   transferCarriesFiles,
   type ImageAttachment,
 } from "./ImageAttachments";
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { WithTooltip } from "@/components/ui/tooltip";
 
 const MIN_COMPOSER_LINES = 1;
@@ -139,12 +130,8 @@ export type ComposerProps = {
   draft: string;
   modelMenu?: ReactNode;
   images?: ComposerImages;
-  /** Whether the host can open a picker; drop and paste work regardless. */
-  canAttach?: boolean;
-  attaching?: boolean;
   attachedSourceName?: string | null;
   attachError?: string | null;
-  onAttach?: () => Promise<void>;
   onDismissAttachedSource?: () => void;
   onDraftChange: (draft: string) => void;
   onSend: () => Promise<void>;
@@ -165,11 +152,8 @@ export function Composer({
   draft,
   modelMenu,
   images,
-  canAttach = false,
-  attaching = false,
   attachedSourceName = null,
   attachError = null,
-  onAttach,
   onDismissAttachedSource,
   onDraftChange,
   onSend,
@@ -346,32 +330,6 @@ export function Composer({
         />
         <div className="composer-actions">
           <div className="composer-actions-left">
-            {canAttach && onAttach && (
-              <DropdownMenu>
-                <WithTooltip label={attaching ? "Attaching…" : "Add"}>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="icon-8"
-                      aria-label={attaching ? "Attaching" : "Add to this chat"}
-                      disabled={inputDisabled || attaching || busy}
-                    >
-                      <Plus aria-hidden="true" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                </WithTooltip>
-                {/* A menu rather than a bare button: attaching files is the
-                    first of the things a reader adds to a conversation, and
-                    the sources that follow it belong in the same place rather
-                    than as a second icon in the row. */}
-                <DropdownMenuContent align="start" side="top" className="w-56">
-                  <DropdownMenuItem onSelect={() => void onAttach()}>
-                    <Upload className="size-4" />
-                    Upload files
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
             {modelMenu}
           </div>
           <div className="composer-actions-right">

--- a/crates/openwave-desktop/ui/src/ComposerAttachMenu.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerAttachMenu.dom.test.tsx
@@ -2,51 +2,41 @@
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, expect, it, vi } from "vitest";
-import { Composer } from "./Composer";
+import { ToolsMenu } from "./ToolsMenu";
 
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
 });
 
-const noop = async () => {};
-
-/**
- * Uploading moved behind a menu, so the trigger is now the only way to reach
- * it. A trigger that fails to open makes attachment unreachable without
- * failing anything else — the static markup test still passes, because the
- * button is right there.
- */
 it("opens the add menu and runs the upload it offers", async () => {
   const onAttach = vi.fn(async () => {});
   render(
-    <Composer
-      activeTurnId={null}
-      busy={false}
-      cancelError={null}
-      cancelPending={false}
-      disabled={false}
-      draft=""
-      canAttach
-      attaching={false}
-      attachedSourceName={null}
-      attachError={null}
+    <ToolsMenu
       onAttach={onAttach}
-      onDraftChange={vi.fn()}
-      onSend={noop}
-      onSteer={noop}
-      onStop={noop}
-      resetKey="chat-1"
-      steerError={null}
-      steerPending={false}
-      steerStatus={null}
+      citationFormat={null}
+      defaultCitationFormat="inline"
+      onCitationFormatChange={vi.fn()}
     />,
   );
 
-  // Nothing runs from the trigger itself: it opens the menu.
-  await userEvent.click(screen.getByRole("button", { name: "Add to this chat" }));
+  await userEvent.click(screen.getByRole("button", { name: "Add" }));
   expect(onAttach).not.toHaveBeenCalled();
 
   await userEvent.click(await screen.findByRole("menuitem", { name: /Upload files/ }));
   await waitFor(() => expect(onAttach).toHaveBeenCalledTimes(1));
+});
+
+it("shows citations but hides upload when onAttach is not provided", async () => {
+  render(
+    <ToolsMenu
+      citationFormat={null}
+      defaultCitationFormat="inline"
+      onCitationFormatChange={vi.fn()}
+    />,
+  );
+
+  await userEvent.click(screen.getByRole("button", { name: "Add" }));
+  expect(screen.queryByRole("menuitem", { name: /Upload files/ })).toBeNull();
+  expect(screen.getByRole("menuitem", { name: /Citations/ })).toBeInTheDocument();
 });

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -6,12 +6,13 @@ import { ChatExplorer } from "./ChatExplorer";
 import { useChatListStore } from "./ChatListStore";
 import { Composer } from "./Composer";
 import { useFirstMessage } from "./FirstMessage";
-import { CitationFormatMenu, ModelMenu, ReasoningEffortMenu } from "./ModelMenu";
+import { ModelMenu, ReasoningEffortMenu } from "./ModelMenu";
 import { modelForSelection } from "./ModelSelection";
 import { useNewChatSettings } from "./NewChatSettings";
 import { PermissionModeMenu } from "./PermissionModeMenu";
 import { RouteFrame } from "./RouteFrame";
 import { HomeSidebar } from "./sidebar/HomeSidebar";
+import { ToolsMenu } from "./ToolsMenu";
 
 const chatListActions = useChatListStore.getState();
 const firstMessageActions = useFirstMessage.getState();
@@ -100,6 +101,12 @@ export function HomeRoute() {
             steerStatus={null}
             modelMenu={
               <>
+                <ToolsMenu
+                  disabled={creatingChat}
+                  citationFormat={newChat.citationFormat}
+                  defaultCitationFormat={defaultCitationFormat}
+                  onCitationFormatChange={newChat.setCitationFormat}
+                />
                 <ModelMenu
                   models={models}
                   value={newChat.model}
@@ -119,12 +126,6 @@ export function HomeRoute() {
                   value={newChat.permissionMode}
                   disabled={creatingChat}
                   onChange={newChat.setPermissionMode}
-                />
-                <CitationFormatMenu
-                  value={newChat.citationFormat}
-                  defaultFormat={defaultCitationFormat}
-                  disabled={creatingChat}
-                  onChange={newChat.setCitationFormat}
                 />
               </>
             }

--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -1,13 +1,11 @@
 import { useState } from "react";
-import { Atom, Check, ChevronDown, Gauge, Info, Quote } from "lucide-react";
+import { Atom, Check, ChevronDown, Gauge, Info } from "lucide-react";
 import type {
-  CitationFormat,
   ModelInfo,
   ModelSelectionKey,
   ProviderKind,
   ReasoningEffort,
 } from "./api";
-import { CITATION_FORMAT_LABELS, CITATION_FORMAT_OPTIONS } from "./CitationFormats";
 import { canonicalModelSelection, modelForSelection } from "./ModelSelection";
 import { Button } from "@/components/ui/button";
 import { ProviderIcon } from "./ProviderIcons";
@@ -100,7 +98,7 @@ export function firstAvailableModel(
  * and the tooltip names the model the default currently lands on, which is the
  * only thing the reader actually wanted to know.
  */
-function DefaultRow({
+export function DefaultRow({
   isDefault,
   tooltip,
   disabled,
@@ -428,89 +426,3 @@ export function ReasoningEffortMenu({
   );
 }
 
-/**
- * Per-chat citation-format selector, shown beside the model picker. `null`
- * means "follow the global default", which is what a chat starts on.
- *
- * `defaultFormat` is the format that default currently resolves to, so the
- * Default row can name it rather than describe it — the same reason the model
- * picker names the model behind its own default.
- */
-export function CitationFormatMenu({
-  value,
-  defaultFormat,
-  disabled,
-  onChange,
-}: {
-  value: CitationFormat | null;
-  defaultFormat: CitationFormat;
-  disabled?: boolean;
-  onChange: (format: CitationFormat | null) => void | Promise<void>;
-}) {
-  const isDefault = value === null;
-  const label = isDefault ? "Default" : CITATION_FORMAT_LABELS[value];
-  const triggerLabel = isDefault
-    ? `Citations: Default (${CITATION_FORMAT_LABELS[defaultFormat]})`
-    : `Citations: ${label}`;
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className="model-menu-trigger"
-          disabled={disabled}
-          aria-label={triggerLabel}
-          title={triggerLabel}
-        >
-          <Quote className="size-3.5" />
-          <span className="model-menu-label">{label}</span>
-          <ChevronDown className="size-3.5" />
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="start"
-        side="top"
-        className="model-menu-content w-80 overflow-y-auto p-0"
-      >
-        <div className="flex flex-col gap-1 p-1">
-          <DefaultRow
-            isDefault={isDefault}
-            tooltip={
-              isDefault
-                ? `New turns cite the way Settings says. Currently: ${CITATION_FORMAT_LABELS[defaultFormat]}.`
-                : "Override active. Toggle Default to follow the setting again."
-            }
-            disabled={Boolean(disabled)}
-            onToggle={(useDefault) => {
-              void onChange(useDefault ? null : defaultFormat);
-            }}
-          />
-
-          <DropdownMenuSeparator />
-
-          {CITATION_FORMAT_OPTIONS.map((option) => {
-            const selected = !isDefault && value === option.value;
-            return (
-              <DropdownMenuItem
-                key={option.value}
-                disabled={disabled}
-                onSelect={(event) => {
-                  event.preventDefault();
-                  if (selected) return;
-                  void onChange(option.value);
-                }}
-                className={cn(
-                  "flex items-center gap-2",
-                  isDefault && "opacity-60",
-                )}
-              >
-                <span className="text-sm">{option.label}</span>
-                {selected && <Check className="ml-auto size-4" />}
-              </DropdownMenuItem>
-            );
-          })}
-        </div>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}

--- a/crates/openwave-desktop/ui/src/ToolsMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ToolsMenu.tsx
@@ -1,0 +1,118 @@
+import { Check, Plus, Quote, Upload } from "lucide-react";
+import type { CitationFormat } from "./api";
+import { CITATION_FORMAT_LABELS, CITATION_FORMAT_OPTIONS } from "./CitationFormats";
+import { DefaultRow } from "./ModelMenu";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { WithTooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+type ToolsMenuProps = {
+  disabled?: boolean;
+  onAttach?: () => Promise<void>;
+  attaching?: boolean;
+  citationFormat: CitationFormat | null;
+  defaultCitationFormat: CitationFormat;
+  onCitationFormatChange: (format: CitationFormat | null) => void | Promise<void>;
+};
+
+export function ToolsMenu({
+  disabled,
+  onAttach,
+  attaching,
+  citationFormat,
+  defaultCitationFormat,
+  onCitationFormatChange,
+}: ToolsMenuProps) {
+  const isDefault = citationFormat === null;
+  const citationLabel = isDefault
+    ? "Default"
+    : CITATION_FORMAT_LABELS[citationFormat];
+
+  return (
+    <DropdownMenu>
+      <WithTooltip label={attaching ? "Attaching…" : "Add"}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="icon-8"
+            aria-label={attaching ? "Attaching" : "Add"}
+            disabled={disabled || attaching}
+          >
+            <Plus aria-hidden="true" />
+          </Button>
+        </DropdownMenuTrigger>
+      </WithTooltip>
+      <DropdownMenuContent align="start" side="top" className="w-56">
+        {onAttach && (
+          <>
+            <DropdownMenuItem
+              disabled={disabled || attaching}
+              onSelect={() => void onAttach()}
+            >
+              <Upload className="size-4" />
+              Upload files
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        )}
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger disabled={disabled}>
+            <Quote className="size-4" />
+            <span>Citations</span>
+            <span className="text-muted-foreground flex-1 text-right text-xs">
+              {citationLabel}
+            </span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-72 p-0">
+            <div className="flex flex-col gap-1 p-1">
+              <DefaultRow
+                isDefault={isDefault}
+                tooltip={
+                  isDefault
+                    ? `New turns cite the way Settings says. Currently: ${CITATION_FORMAT_LABELS[defaultCitationFormat]}.`
+                    : "Override active. Toggle Default to follow the setting again."
+                }
+                disabled={Boolean(disabled)}
+                onToggle={(useDefault) => {
+                  void onCitationFormatChange(
+                    useDefault ? null : defaultCitationFormat,
+                  );
+                }}
+              />
+              <DropdownMenuSeparator />
+              {CITATION_FORMAT_OPTIONS.map((option) => {
+                const selected = !isDefault && citationFormat === option.value;
+                return (
+                  <DropdownMenuItem
+                    key={option.value}
+                    disabled={disabled}
+                    onSelect={(event) => {
+                      event.preventDefault();
+                      if (selected) return;
+                      void onCitationFormatChange(option.value);
+                    }}
+                    className={cn(isDefault && "opacity-60")}
+                  >
+                    <span className="text-sm">{option.label}</span>
+                    {selected && <Check className="ml-auto size-4" />}
+                  </DropdownMenuItem>
+                );
+              })}
+            </div>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/crates/openwave-desktop/ui/src/components/ui/dropdown-menu.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/dropdown-menu.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { ChevronRight } from "lucide-react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
@@ -7,6 +8,7 @@ const DropdownMenu = DropdownMenuPrimitive.Root;
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
 const DropdownMenuGroup = DropdownMenuPrimitive.Group;
 const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 
 const DropdownMenuContent = React.forwardRef<
   React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
@@ -67,6 +69,44 @@ const DropdownMenuSeparator = React.forwardRef<
 ));
 DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
 
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "focus:bg-accent data-[state=open]:bg-accent flex cursor-default items-center gap-4 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none [&_svg]:size-4 [&_svg]:shrink-0",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto" />
+  </DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.SubContent
+      ref={ref}
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-lg",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
+
 export {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -75,4 +115,7 @@ export {
   DropdownMenuSeparator,
   DropdownMenuGroup,
   DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
 };


### PR DESCRIPTION
## Summary

- Introduces a **ToolsMenu** component — a "+" dropdown that consolidates file upload and the citation format selector into a single BW-style menu, replacing the unstyled `CitationFormatMenu` button and the Composer's inline "+" button.
- Adds **DropdownMenuSub/SubTrigger/SubContent** primitives to the UI library (Radix native sub-menu support with chevron indicators and animation).
- The "+" menu now appears on the **home page** (with citations; upload files follows once home-page attachment infrastructure lands) and in **conversations** (with both upload files and citations).
- Removes `canAttach`/`attaching`/`onAttach` from Composer props — the ToolsMenu in the `modelMenu` slot handles the trigger now.
- Deletes the dead `CitationFormatMenu` and cleans up related imports.

## Test plan

- [ ] Verify the "+" button appears on the home page composer with a "Citations" sub-menu
- [ ] Verify the "+" button appears in a conversation composer with both "Upload files" and "Citations"
- [ ] Click "Upload files" in a conversation — native file picker should open
- [ ] Open Citations sub-menu — toggle Default, pick Inline or Sources only — confirm it persists
- [ ] Confirm the model, reasoning, and permission menus still work as separate buttons beside the "+"
- [ ] `pnpm build` passes (verified locally)
- [ ] `pnpm test` passes — all 653 tests green (verified locally)