### PR TITLE
feat: bash and filesystem tools for the sandbox-resident agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6899,11 +6899,13 @@ name = "openwave-sandbox-agent"
 version = "0.0.0"
 dependencies = [
  "async-trait",
+ "libc",
  "openwave-core",
  "openwave-sandbox-protocol",
  "schemars 1.2.2",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.19",
  "tokio",
 ]

--- a/crates/openwave-sandbox-agent/Cargo.toml
+++ b/crates/openwave-sandbox-agent/Cargo.toml
@@ -20,15 +20,21 @@ openwave-sandbox-protocol = { path = "../openwave-sandbox-protocol" }
 # provider vocabulary, not the host-side persistence stack. `default-features =
 # false` keeps sea-orm, the keychain, and the fs tools out of the container image.
 openwave-core = { path = "../openwave-core", default-features = false }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "sync"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "process", "time"] }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 schemars = { workspace = true }
 thiserror = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+# The in-container `exec` tool bounds its child the way the local exec adapter
+# does: own process group, wall-time kill of the group, and rlimit ceilings.
+libc = { workspace = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time"] }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/openwave-sandbox-agent/Dockerfile
+++ b/crates/openwave-sandbox-agent/Dockerfile
@@ -43,12 +43,23 @@ RUN cargo build --release --locked -p openwave-sandbox-agent
 # applets) and the workspace root the tools are scoped to, then copy just those
 # into the runtime. busybox is a deliberate, bounded surface for running the
 # model's commands, not a general package manager.
+#
+# The applet symlinks must resolve in the RUNTIME image, where this staging tree
+# lands at `/`. `busybox --install -s` would bake in the *build-time* absolute
+# path (`/rootfs/bin/busybox`), which does not exist after the copy — every
+# symlink would dangle and `/bin/sh -c` would fail for every exec. So create each
+# applet as a RELATIVE symlink to `busybox`: at runtime `/bin/sh -> busybox`
+# resolves to `/bin/busybox`, which is there. Correct by construction regardless
+# of where the staging tree was assembled.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends busybox-static \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /rootfs/bin /rootfs/workspace \
     && cp /bin/busybox /rootfs/bin/busybox \
-    && /rootfs/bin/busybox --install -s /rootfs/bin
+    && for applet in $(/rootfs/bin/busybox --list); do \
+         [ "$applet" = busybox ] || ln -s busybox /rootfs/bin/"$applet"; \
+       done \
+    && test "$(readlink /rootfs/bin/sh)" = busybox
 
 # ---- runtime stage ---------------------------------------------------------
 # distroless/cc provides glibc and libgcc for the dynamically-linked binary; the

--- a/crates/openwave-sandbox-agent/Dockerfile
+++ b/crates/openwave-sandbox-agent/Dockerfile
@@ -31,23 +31,41 @@ WORKDIR /src
 COPY . .
 
 # Build only the agent crate. Its dependency on openwave-core carries
-# `default-features = false`, so sea-orm, the OS keychain, and the filesystem
-# tools are never compiled into the image — no model or third-party credential
-# ships in it.
+# `default-features = false`, so sea-orm, the OS keychain, and openwave-core's
+# own feature-gated filesystem tools are never compiled into the image — no model
+# or third-party credential ships in it. (The sandbox-resident `exec`/filesystem
+# tools live in this crate and are the point of the image.)
 RUN cargo build --release --locked -p openwave-sandbox-agent
 
+# The sandbox-resident `exec` tool runs model-authored commands through /bin/sh
+# inside the container — in-container execution IS the containment. distroless/cc
+# ships no shell, so stage a static busybox (a shell plus the common coreutils
+# applets) and the workspace root the tools are scoped to, then copy just those
+# into the runtime. busybox is a deliberate, bounded surface for running the
+# model's commands, not a general package manager.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends busybox-static \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /rootfs/bin /rootfs/workspace \
+    && cp /bin/busybox /rootfs/bin/busybox \
+    && /rootfs/bin/busybox --install -s /rootfs/bin
+
 # ---- runtime stage ---------------------------------------------------------
-# distroless/cc provides glibc and libgcc for the dynamically-linked binary and
-# nothing else — no shell, no package manager — a minimal attack surface for a
-# container that runs untrusted model output. The binary uses rustls (no OpenSSL)
-# and opens no keychain, so cc is sufficient.
+# distroless/cc provides glibc and libgcc for the dynamically-linked binary; the
+# binary uses rustls (no OpenSSL) and opens no keychain, so cc is sufficient. It
+# ships no package manager — the only added surface is the staged busybox the
+# exec tool shells out to, in a container that runs untrusted model output.
 FROM gcr.io/distroless/cc-debian12 AS runtime
 
 COPY --from=build /src/target/release/openwave-sandbox-agent /usr/local/bin/openwave-sandbox-agent
+# busybox (/bin/sh + coreutils applets) and the /workspace tool root.
+COPY --from=build /rootfs /
 
 # The listener address the supervisor binds; the host dials this port.
 ENV OPENWAVE_SANDBOX_LISTEN=0.0.0.0:8080
+# The in-container workspace root the exec and filesystem tools are scoped to.
+ENV OPENWAVE_SANDBOX_WORKSPACE=/workspace
 EXPOSE 8080
 
-# distroless has no shell, so use the exec form.
+# distroless has no shell for a RUN, so use the exec form for the entrypoint.
 ENTRYPOINT ["/usr/local/bin/openwave-sandbox-agent"]

--- a/crates/openwave-sandbox-agent/src/agent.rs
+++ b/crates/openwave-sandbox-agent/src/agent.rs
@@ -26,6 +26,8 @@
 //! (or, in tests, a mock host model) is what decides the directive, so the loop
 //! is genuinely driven from the model over the reverse channel.
 
+use std::path::PathBuf;
+
 use openwave_core::{ChatId, ToolCtx, ToolRegistry};
 use openwave_sandbox_protocol::{ids::OperationId, SandboxRun};
 
@@ -47,19 +49,30 @@ pub enum AgentRunError {
     /// The loop hit its step bound without the model submitting a final answer.
     #[error("the agent loop exceeded {MAX_STEPS} model steps without a result")]
     StepLimit,
+    /// The agent's workspace directory could not be prepared.
+    #[error("the sandbox workspace directory is unavailable")]
+    Workspace,
 }
 
 /// Run the sandbox-resident agent loop for one `task`, driving it through `run`.
 ///
-/// Emits progress events as it works and submits the final answer as the run's
-/// terminal [`Result`](openwave_sandbox_protocol::events::EventPayload::Result)
-/// event. Returns the final answer text.
+/// `workspace` is the agent's in-container workspace directory; it is created if
+/// absent and canonicalized, and the sandbox-resident tool registry (`exec`, the
+/// filesystem tools) is scoped to it. Emits progress events as it works and
+/// submits the final answer as the run's terminal
+/// [`Result`](openwave_sandbox_protocol::events::EventPayload::Result) event.
+/// Returns the final answer text.
 ///
 /// # Errors
+/// [`AgentRunError::Workspace`] if the workspace cannot be prepared,
 /// [`AgentRunError::Model`] if a model step fails, or [`AgentRunError::StepLimit`]
 /// if the model never submits a final answer within the step bound.
-pub async fn run_agent(run: SandboxRun, task: impl Into<String>) -> Result<String, AgentRunError> {
-    let outcome = run_loop(run.clone(), task.into()).await;
+pub async fn run_agent(
+    run: SandboxRun,
+    task: impl Into<String>,
+    workspace: impl Into<PathBuf>,
+) -> Result<String, AgentRunError> {
+    let outcome = run_loop(run.clone(), task.into(), workspace.into()).await;
     // Every exit from the loop must put a terminal event on the stream. The
     // supervisor keeps serving the connection after this returns, so a host that
     // saw neither a result nor a failure would wait on an open socket forever
@@ -71,8 +84,16 @@ pub async fn run_agent(run: SandboxRun, task: impl Into<String>) -> Result<Strin
     outcome
 }
 
-async fn run_loop(run: SandboxRun, task: String) -> Result<String, AgentRunError> {
-    let tools = sandbox_tool_registry();
+async fn run_loop(
+    run: SandboxRun,
+    task: String,
+    workspace: PathBuf,
+) -> Result<String, AgentRunError> {
+    // The workspace is the tools' root: create it if the host has not, then
+    // canonicalize so path validation compares against the real directory.
+    std::fs::create_dir_all(&workspace).map_err(|_| AgentRunError::Workspace)?;
+    let workspace = std::fs::canonicalize(&workspace).map_err(|_| AgentRunError::Workspace)?;
+    let tools = sandbox_tool_registry(workspace);
     let model = HostModel::new(run.clone());
     // The sandbox loop has no host chat identity or filesystem scratch; a fresh
     // chat id and no private scratch keep the tool context self-contained.
@@ -147,9 +168,9 @@ mod tests {
 
     #[test]
     fn parses_a_tool_directive_and_ignores_a_final_answer() {
-        let directive = parse_tool_directive("use-tool:word_count:{\"text\":\"a b\"}").unwrap();
-        assert_eq!(directive.name, "word_count");
-        assert_eq!(directive.args, "{\"text\":\"a b\"}");
+        let directive = parse_tool_directive("use-tool:read_file:{\"path\":\"a.txt\"}").unwrap();
+        assert_eq!(directive.name, "read_file");
+        assert_eq!(directive.args, "{\"path\":\"a.txt\"}");
 
         assert!(parse_tool_directive("the final answer is 2").is_none());
         // An empty tool name is not a directive.

--- a/crates/openwave-sandbox-agent/src/exec.rs
+++ b/crates/openwave-sandbox-agent/src/exec.rs
@@ -24,7 +24,7 @@
 //! until externally-enforced egress (the run's egress policy applied to the
 //! container's network) and the transport-auth gate land. See the crate docs.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -203,7 +203,7 @@ mod capture {
 }
 
 #[cfg(unix)]
-async fn run_bounded(command: &str, workspace: &PathBuf, timeout: Duration) -> ExecOutcome {
+async fn run_bounded(command: &str, workspace: &Path, timeout: Duration) -> ExecOutcome {
     use std::os::unix::process::CommandExt;
     use std::process::Stdio;
     use std::sync::{Arc, Mutex};
@@ -326,7 +326,7 @@ async fn run_bounded(command: &str, workspace: &PathBuf, timeout: Duration) -> E
 }
 
 #[cfg(not(unix))]
-async fn run_bounded(_command: &str, _workspace: &PathBuf, _timeout: Duration) -> ExecOutcome {
+async fn run_bounded(_command: &str, _workspace: &Path, _timeout: Duration) -> ExecOutcome {
     ExecOutcome {
         stderr: "in-container exec is only supported on unix".to_owned(),
         ..ExecOutcome::default()
@@ -367,10 +367,14 @@ mod tests {
     async fn echoes_and_runs_in_the_workspace() {
         let dir = workspace();
         let tool = ExecTool::new(dir.path(), DEFAULT_EXEC_TIMEOUT);
-        let out = tool
-            .execute(&ctx(), serde_json::json!({ "command": "printf hi; pwd" }))
-            .await
-            .unwrap();
+        // Bound the whole call so a wedged /bin/sh fails fast instead of hanging.
+        let out = tokio::time::timeout(
+            Duration::from_secs(10),
+            tool.execute(&ctx(), serde_json::json!({ "command": "printf hi; pwd" })),
+        )
+        .await
+        .expect("exec returned within the outer bound")
+        .unwrap();
         assert!(!out.is_error, "{out:?}");
         assert!(out.content.contains("exit code: 0"), "{}", out.content);
         assert!(out.content.contains("hi"), "{}", out.content);

--- a/crates/openwave-sandbox-agent/src/exec.rs
+++ b/crates/openwave-sandbox-agent/src/exec.rs
@@ -1,0 +1,432 @@
+//! The sandbox-resident `exec` tool: a model-authored command run *inside* the
+//! container.
+//!
+//! In-container execution is the containment (see
+//! [sandbox-providers.md](../../docs/sandbox-providers.md)). The container's
+//! OS/VM boundary is what makes model-authored execution admissible at all:
+//! model output can only move the sandbox, and the host consumes the run's
+//! bounded event stream and result as untrusted input. So this tool does **not**
+//! try to re-sandbox inside the container — that boundary already holds. What it
+//! does is bound the invocation exactly the way the shipped foreground exec
+//! adapter bounds its confined child (`openwave-code-execution`'s local
+//! provider): a cleared environment with a fixed `HOME`/`TMPDIR`/`PATH`, stdin
+//! wired to `/dev/null`, its own process group, a wall-time timeout that kills
+//! that whole group, a captured-output cap, and rlimit ceilings — so a
+//! runaway or wedged command is contained by resource bounds, not left to run.
+//!
+//! # NOT YET FOR CREDENTIAL-BEARING WORK
+//!
+//! A command run here can make network calls. The design routes egress through
+//! the sandbox supervisor (credential separation + an egress proxy), which is a
+//! **stub** in this crate. Nothing here reaches host authority — the containment
+//! above holds — but egress *from the container* is not yet externally enforced.
+//! This tool surface must not be routed to production credential-bearing work
+//! until externally-enforced egress (the run's egress policy applied to the
+//! container's network) and the transport-auth gate land. See the crate docs.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use openwave_core::{ApprovalClass, Result, Tool, ToolCtx, ToolOutput, ToolSpec};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+
+/// The name the model uses to invoke the in-container exec tool.
+pub const EXEC_TOOL: &str = "exec";
+
+/// Default wall-time bound for one command; a command that outlives it has its
+/// process group killed and the result is reported as timed out.
+pub const DEFAULT_EXEC_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Maximum UTF-8 bytes in one model-authored command string.
+pub const MAX_COMMAND_BYTES: usize = 64 * 1_024;
+
+/// Maximum bytes captured from stdout and stderr together; beyond it the output
+/// is truncated rather than buffered without bound.
+pub const MAX_CAPTURE_BYTES: usize = 40_000;
+
+/// The shell the command runs under. The container is the isolation boundary, so
+/// a shell is admissible; `-c <command>` runs the model's text as one command.
+const SHELL: &str = "/bin/sh";
+
+/// A fixed, minimal search path handed to the command, so lookup does not depend
+/// on an inherited environment (which is cleared).
+const FIXED_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
+/// Arguments for [`ExecTool`].
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ExecArgs {
+    /// The shell command to run inside the container's workspace directory.
+    command: String,
+}
+
+/// Run a model-authored shell command inside the container, bounded.
+///
+/// The tool is rooted at the agent's in-container workspace directory: the
+/// command runs with that directory as its working directory, `HOME`, and
+/// `TMPDIR`. It holds a per-invocation wall-time bound.
+pub struct ExecTool {
+    workspace: PathBuf,
+    timeout: Duration,
+}
+
+impl ExecTool {
+    /// Build an exec tool rooted at `workspace`, bounding each command by
+    /// `timeout`.
+    #[must_use]
+    pub fn new(workspace: impl Into<PathBuf>, timeout: Duration) -> Self {
+        Self {
+            workspace: workspace.into(),
+            timeout,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for ExecTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec::for_args::<ExecArgs>(
+            EXEC_TOOL,
+            "Run a shell command inside the sandbox workspace and return its \
+             output. The command runs with the workspace as its working \
+             directory; it is bounded by a wall-time limit and a captured-output \
+             cap.",
+        )
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        // A command can escape the workspace and reach the network from inside
+        // the container, so it is the most privileged class the sandbox surface
+        // declares.
+        ApprovalClass::Sensitive
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        // Arguments are untrusted: a malformed call is a tool failure the model
+        // sees and can correct, not a process error.
+        let args: ExecArgs = match serde_json::from_value(args) {
+            Ok(args) => args,
+            Err(error) => return Ok(ToolOutput::error(format!("invalid arguments: {error}"))),
+        };
+        if args.command.is_empty() || args.command.len() > MAX_COMMAND_BYTES {
+            return Ok(ToolOutput::error(format!(
+                "command must be between 1 and {MAX_COMMAND_BYTES} bytes"
+            )));
+        }
+        if args.command.as_bytes().contains(&0) {
+            return Ok(ToolOutput::error(
+                "command must not contain a NUL byte".to_owned(),
+            ));
+        }
+
+        let outcome = run_bounded(&args.command, &self.workspace, self.timeout).await;
+        Ok(ToolOutput::text(outcome.render()))
+    }
+}
+
+/// The normalized, bounded result of one in-container command.
+#[derive(Debug, Default)]
+pub(crate) struct ExecOutcome {
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) stdout: String,
+    pub(crate) stderr: String,
+    pub(crate) timed_out: bool,
+    pub(crate) truncated: bool,
+}
+
+impl ExecOutcome {
+    fn render(&self) -> String {
+        let mut out = String::new();
+        match (self.timed_out, self.exit_code) {
+            (true, _) => out.push_str("command timed out and was killed\n"),
+            (false, Some(code)) => out.push_str(&format!("exit code: {code}\n")),
+            (false, None) => out.push_str("command was terminated by a signal\n"),
+        }
+        if self.truncated {
+            out.push_str("(output truncated at the capture cap)\n");
+        }
+        out.push_str("stdout:\n");
+        out.push_str(&self.stdout);
+        if !self.stdout.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str("stderr:\n");
+        out.push_str(&self.stderr);
+        out
+    }
+}
+
+#[cfg(unix)]
+mod capture {
+    use super::MAX_CAPTURE_BYTES;
+
+    #[derive(Clone, Copy)]
+    pub(super) enum StreamKind {
+        Stdout,
+        Stderr,
+    }
+
+    /// A bounded stdout/stderr accumulator: once the shared cap is reached,
+    /// further bytes are dropped and the capture is marked truncated.
+    #[derive(Default)]
+    pub(super) struct Capture {
+        stdout: Vec<u8>,
+        stderr: Vec<u8>,
+        total: usize,
+        pub(super) truncated: bool,
+    }
+
+    impl Capture {
+        pub(super) fn append(&mut self, bytes: &[u8], kind: StreamKind) {
+            let available = MAX_CAPTURE_BYTES.saturating_sub(self.total);
+            let kept = available.min(bytes.len());
+            let target = match kind {
+                StreamKind::Stdout => &mut self.stdout,
+                StreamKind::Stderr => &mut self.stderr,
+            };
+            target.extend_from_slice(&bytes[..kept]);
+            self.total += kept;
+            self.truncated |= kept < bytes.len();
+        }
+
+        pub(super) fn stdout(&self) -> String {
+            String::from_utf8_lossy(&self.stdout).into_owned()
+        }
+
+        pub(super) fn stderr(&self) -> String {
+            String::from_utf8_lossy(&self.stderr).into_owned()
+        }
+    }
+}
+
+#[cfg(unix)]
+async fn run_bounded(command: &str, workspace: &PathBuf, timeout: Duration) -> ExecOutcome {
+    use std::os::unix::process::CommandExt;
+    use std::process::Stdio;
+    use std::sync::{Arc, Mutex};
+
+    use capture::{Capture, StreamKind};
+    use tokio::io::{AsyncRead, AsyncReadExt};
+    use tokio::process::Command;
+
+    /// Grace between the SIGTERM and SIGKILL sent to a timed-out group.
+    const TERMINATE_GRACE: Duration = Duration::from_millis(250);
+    /// How long to wait for the output readers to drain after the child exits.
+    const OUTPUT_DRAIN_GRACE: Duration = Duration::from_secs(1);
+    /// Ceiling on files the command may open, as defense in depth.
+    const MAX_OPEN_FILES: u64 = 256;
+
+    let cpu_seconds = timeout.as_secs().saturating_add(1).max(1);
+    let mut cmd = Command::new(SHELL);
+    cmd.arg("-c")
+        .arg(command)
+        .current_dir(workspace)
+        .env_clear()
+        .env("HOME", workspace)
+        .env("TMPDIR", workspace)
+        .env("PATH", FIXED_PATH)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    // SAFETY: `pre_exec` runs after fork and before exec. The closure performs
+    // only async-signal-safe `setrlimit` calls with copied scalar values.
+    unsafe {
+        cmd.as_std_mut().pre_exec(move || {
+            set_limit(libc::RLIMIT_CPU, cpu_seconds)?;
+            set_limit(libc::RLIMIT_NOFILE, MAX_OPEN_FILES)?;
+            Ok(())
+        });
+    }
+    // Its own process group, so a wall-time kill reaps the whole tree, not just
+    // the shell leader.
+    cmd.as_std_mut().process_group(0);
+
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(error) => {
+            return ExecOutcome {
+                stderr: format!("could not start the command: {error}"),
+                ..ExecOutcome::default()
+            };
+        }
+    };
+    let group = child.id().map(|id| id as i32);
+    let Some(stdout) = child.stdout.take() else {
+        return ExecOutcome {
+            stderr: "stdout capture is unavailable".to_owned(),
+            ..ExecOutcome::default()
+        };
+    };
+    let Some(stderr) = child.stderr.take() else {
+        return ExecOutcome {
+            stderr: "stderr capture is unavailable".to_owned(),
+            ..ExecOutcome::default()
+        };
+    };
+
+    async fn drain<R: AsyncRead + Unpin>(
+        mut reader: R,
+        capture: Arc<Mutex<Capture>>,
+        kind: StreamKind,
+    ) {
+        let mut chunk = [0_u8; 8 * 1_024];
+        loop {
+            match reader.read(&mut chunk).await {
+                Ok(0) | Err(_) => return,
+                Ok(read) => capture.lock().unwrap().append(&chunk[..read], kind),
+            }
+        }
+    }
+
+    let capture = Arc::new(Mutex::new(Capture::default()));
+    let stdout_reader = tokio::spawn(drain(stdout, capture.clone(), StreamKind::Stdout));
+    let stderr_reader = tokio::spawn(drain(stderr, capture.clone(), StreamKind::Stderr));
+
+    let (status, timed_out) = match tokio::time::timeout(timeout, child.wait()).await {
+        Ok(waited) => (waited.ok(), false),
+        Err(_) => {
+            if let Some(group) = group {
+                signal_group(group, libc::SIGTERM);
+                tokio::time::sleep(TERMINATE_GRACE).await;
+                signal_group(group, libc::SIGKILL);
+            } else {
+                let _ = child.kill().await;
+            }
+            (child.wait().await.ok(), true)
+        }
+    };
+    if let Some(group) = group {
+        // A command that daemonized must not outlive the invocation; sweep any
+        // survivors after the leader is reaped.
+        signal_group(group, libc::SIGKILL);
+    }
+
+    for reader in [stdout_reader, stderr_reader] {
+        let mut reader = reader;
+        if tokio::time::timeout(OUTPUT_DRAIN_GRACE, &mut reader)
+            .await
+            .is_err()
+        {
+            reader.abort();
+        }
+    }
+
+    let capture = capture.lock().unwrap();
+    ExecOutcome {
+        exit_code: status.and_then(|status| status.code()),
+        stdout: capture.stdout(),
+        stderr: capture.stderr(),
+        timed_out,
+        truncated: capture.truncated,
+    }
+}
+
+#[cfg(not(unix))]
+async fn run_bounded(_command: &str, _workspace: &PathBuf, _timeout: Duration) -> ExecOutcome {
+    ExecOutcome {
+        stderr: "in-container exec is only supported on unix".to_owned(),
+        ..ExecOutcome::default()
+    }
+}
+
+#[cfg(unix)]
+fn set_limit(resource: libc::c_int, value: u64) -> std::io::Result<()> {
+    let limit = libc::rlimit {
+        rlim_cur: value as libc::rlim_t,
+        rlim_max: value as libc::rlim_t,
+    };
+    // SAFETY: `limit` is a valid initialized value and the resource constant is
+    // supplied by libc for this target.
+    if unsafe { libc::setrlimit(resource, &limit) } == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+fn signal_group(group: i32, signal: i32) {
+    // SAFETY: a negative pid addresses the child-owned process group. Failure
+    // (normally ESRCH after a clean exit) is intentionally harmless.
+    let _ = unsafe { libc::kill(-group, signal) };
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    fn workspace() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    #[tokio::test]
+    async fn echoes_and_runs_in_the_workspace() {
+        let dir = workspace();
+        let tool = ExecTool::new(dir.path(), DEFAULT_EXEC_TIMEOUT);
+        let out = tool
+            .execute(&ctx(), serde_json::json!({ "command": "printf hi; pwd" }))
+            .await
+            .unwrap();
+        assert!(!out.is_error, "{out:?}");
+        assert!(out.content.contains("exit code: 0"), "{}", out.content);
+        assert!(out.content.contains("hi"), "{}", out.content);
+        // `pwd` resolves through the canonicalized workspace root.
+        let canonical = std::fs::canonicalize(dir.path()).unwrap();
+        assert!(
+            out.content.contains(canonical.to_str().unwrap()),
+            "ran in the workspace: {}",
+            out.content
+        );
+    }
+
+    #[tokio::test]
+    async fn a_timeout_kills_the_process_group() {
+        let dir = workspace();
+        let tool = ExecTool::new(dir.path(), Duration::from_millis(200));
+        // Bound the whole assertion so a kill regression fails fast.
+        let out = tokio::time::timeout(
+            Duration::from_secs(10),
+            tool.execute(&ctx(), serde_json::json!({ "command": "sleep 30" })),
+        )
+        .await
+        .expect("exec returned within the outer bound")
+        .unwrap();
+        assert!(out.content.contains("timed out"), "{}", out.content);
+    }
+
+    #[tokio::test]
+    async fn output_past_the_cap_is_truncated() {
+        let dir = workspace();
+        let tool = ExecTool::new(dir.path(), DEFAULT_EXEC_TIMEOUT);
+        // Emit well past the capture cap.
+        let command = format!("yes x | head -c {}", MAX_CAPTURE_BYTES * 2);
+        let out = tokio::time::timeout(
+            Duration::from_secs(10),
+            tool.execute(&ctx(), serde_json::json!({ "command": command })),
+        )
+        .await
+        .expect("exec returned within the outer bound")
+        .unwrap();
+        assert!(out.content.contains("truncated"), "{}", &out.content[..200]);
+        assert!(out.content.len() < MAX_CAPTURE_BYTES * 2);
+    }
+
+    #[tokio::test]
+    async fn an_empty_command_is_a_tool_failure() {
+        let dir = workspace();
+        let tool = ExecTool::new(dir.path(), DEFAULT_EXEC_TIMEOUT);
+        let out = tool
+            .execute(&ctx(), serde_json::json!({ "command": "" }))
+            .await
+            .unwrap();
+        assert!(out.is_error);
+    }
+
+    fn ctx() -> ToolCtx {
+        ToolCtx::without_private_scratch(openwave_core::ChatId::new(), None)
+    }
+}

--- a/crates/openwave-sandbox-agent/src/fs.rs
+++ b/crates/openwave-sandbox-agent/src/fs.rs
@@ -1,0 +1,537 @@
+//! Sandbox-resident filesystem tools: read, write, and list files within the
+//! agent's in-container workspace directory.
+//!
+//! These tools are scoped to a single workspace root. Every model-supplied path
+//! goes through [`WorkspacePath`], which mirrors the `WorkspaceFilePath`
+//! validation the shipped foreground provider uses: relative paths only, no
+//! traversal (`..`), no absolute or prefix components, no control characters or
+//! backslashes, and a bounded length, normalized to a `a/b/c` form. Resolution
+//! then canonicalizes against the workspace root and refuses anything that
+//! escapes it, so a symlinked intermediate directory cannot redirect a read or
+//! write outside the workspace. Transfers and listings are bounded.
+//!
+//! The container is the isolation boundary; this path validation is what keeps a
+//! model-authored path from wandering *within* the container's filesystem, not a
+//! substitute for that boundary.
+
+use std::path::{Component, Path, PathBuf};
+
+use async_trait::async_trait;
+use openwave_core::{ApprovalClass, Result, Tool, ToolCtx, ToolOutput, ToolSpec};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+
+/// The name the model uses to read a workspace file.
+pub const READ_FILE_TOOL: &str = "read_file";
+/// The name the model uses to write a workspace file.
+pub const WRITE_FILE_TOOL: &str = "write_file";
+/// The name the model uses to list a workspace directory.
+pub const LIST_DIR_TOOL: &str = "list_dir";
+
+/// Maximum UTF-8 bytes in a workspace-relative path.
+pub const MAX_PATH_BYTES: usize = 1_024;
+/// Maximum bytes returned by one read.
+pub const MAX_READ_BYTES: usize = 256 * 1_024;
+/// Maximum bytes accepted by one write.
+pub const MAX_WRITE_BYTES: usize = 1_024 * 1_024;
+/// Maximum entries returned by one directory listing.
+pub const MAX_LIST_ENTRIES: usize = 256;
+
+/// A validated workspace-relative path.
+///
+/// Relative, normal components only (no `.`, `..`, root, or prefix), bounded
+/// length, no control characters or backslashes, normalized to `a/b/c`. Absolute
+/// host paths and traversal never cross this type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspacePath(String);
+
+impl WorkspacePath {
+    /// Parse and normalize a workspace-relative path, or return why it is
+    /// invalid.
+    pub fn parse(value: impl Into<String>) -> std::result::Result<Self, String> {
+        let value = value.into();
+        let invalid = || "invalid workspace path".to_owned();
+        if value.is_empty()
+            || value.len() > MAX_PATH_BYTES
+            || value.chars().any(char::is_control)
+            || value.contains('\\')
+        {
+            return Err(invalid());
+        }
+        let path = Path::new(&value);
+        if path.is_absolute() {
+            return Err(invalid());
+        }
+        let mut parts = Vec::new();
+        for component in path.components() {
+            let Component::Normal(part) = component else {
+                return Err(invalid());
+            };
+            parts.push(part.to_str().ok_or_else(invalid)?);
+        }
+        if parts.is_empty() {
+            return Err(invalid());
+        }
+        Ok(Self(parts.join("/")))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// The final path component.
+    #[must_use]
+    fn file_name(&self) -> &str {
+        self.0.rsplit('/').next().unwrap_or(&self.0)
+    }
+}
+
+/// Canonicalize the workspace root so the `starts_with` containment checks
+/// compare against the real directory, falling back to the given path when it
+/// does not yet exist (the agent loop creates and canonicalizes it before use).
+fn canonical_root(workspace: PathBuf) -> PathBuf {
+    std::fs::canonicalize(&workspace).unwrap_or(workspace)
+}
+
+/// Resolve an existing path within `root`, refusing anything that escapes it.
+///
+/// Returns `Ok(None)` when the path does not exist. Canonicalization collapses
+/// any symlinked intermediate directory, and the `starts_with` check is what
+/// refuses an escape.
+fn resolve_existing(
+    root: &Path,
+    rel: &WorkspacePath,
+) -> std::result::Result<Option<PathBuf>, String> {
+    let candidate = root.join(rel.as_str());
+    match std::fs::canonicalize(&candidate) {
+        Ok(resolved) if resolved.starts_with(root) => Ok(Some(resolved)),
+        Ok(_) => Err("path escapes the workspace".to_owned()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(_) => Err("could not resolve the path".to_owned()),
+    }
+}
+
+/// Resolve a write target within `root`, creating parent directories inside the
+/// workspace. The canonicalized parent must stay within the workspace; the final
+/// component is rejoined so a not-yet-existing file resolves.
+fn resolve_write_target(root: &Path, rel: &WorkspacePath) -> std::result::Result<PathBuf, String> {
+    let target = root.join(rel.as_str());
+    let parent = target
+        .parent()
+        .ok_or_else(|| "path has no parent".to_owned())?;
+    std::fs::create_dir_all(parent)
+        .map_err(|_| "could not create workspace directories".to_owned())?;
+    let parent = std::fs::canonicalize(parent)
+        .map_err(|_| "could not resolve the workspace directory".to_owned())?;
+    if !parent.starts_with(root) {
+        return Err("path escapes the workspace".to_owned());
+    }
+    Ok(parent.join(rel.file_name()))
+}
+
+/// Arguments naming one workspace file.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ReadArgs {
+    /// Workspace-relative path of the file to read.
+    path: String,
+}
+
+/// Read one bounded file from the workspace.
+pub struct ReadFileTool {
+    workspace: PathBuf,
+}
+
+impl ReadFileTool {
+    #[must_use]
+    pub fn new(workspace: impl Into<PathBuf>) -> Self {
+        Self {
+            workspace: canonical_root(workspace.into()),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for ReadFileTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec::for_args::<ReadArgs>(
+            READ_FILE_TOOL,
+            "Read a UTF-8 text file from the sandbox workspace by its \
+             workspace-relative path.",
+        )
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let args: ReadArgs = match serde_json::from_value(args) {
+            Ok(args) => args,
+            Err(error) => return Ok(ToolOutput::error(format!("invalid arguments: {error}"))),
+        };
+        let path = match WorkspacePath::parse(args.path) {
+            Ok(path) => path,
+            Err(error) => return Ok(ToolOutput::error(error)),
+        };
+        let resolved = match resolve_existing(&self.workspace, &path) {
+            Ok(Some(resolved)) => resolved,
+            Ok(None) => return Ok(ToolOutput::error("no such file".to_owned())),
+            Err(error) => return Ok(ToolOutput::error(error)),
+        };
+        let bytes = match read_bounded(&resolved) {
+            Ok(bytes) => bytes,
+            Err(error) => return Ok(ToolOutput::error(error)),
+        };
+        let truncated = bytes.len() > MAX_READ_BYTES;
+        let kept = &bytes[..bytes.len().min(MAX_READ_BYTES)];
+        let mut content = String::from_utf8_lossy(kept).into_owned();
+        if truncated {
+            content.push_str("\n(truncated at the read cap)");
+        }
+        Ok(ToolOutput::text(content))
+    }
+}
+
+/// Read a regular file, refusing a symlinked final component and capping the
+/// bytes read so an oversized file cannot exhaust memory.
+fn read_bounded(path: &Path) -> std::result::Result<Vec<u8>, String> {
+    use std::io::Read;
+
+    let mut open = std::fs::OpenOptions::new();
+    open.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        open.custom_flags(libc::O_NOFOLLOW);
+    }
+    let file = open
+        .open(path)
+        .map_err(|_| "could not read the file".to_owned())?;
+    let metadata = file
+        .metadata()
+        .map_err(|_| "could not read the file".to_owned())?;
+    if !metadata.is_file() {
+        return Err("path is not a regular file".to_owned());
+    }
+    let mut content = Vec::new();
+    file.take(MAX_READ_BYTES as u64 + 1)
+        .read_to_end(&mut content)
+        .map_err(|_| "could not read the file".to_owned())?;
+    Ok(content)
+}
+
+/// Arguments for one workspace write.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct WriteArgs {
+    /// Workspace-relative path of the file to write.
+    path: String,
+    /// The UTF-8 content to write, replacing any existing file.
+    content: String,
+}
+
+/// Write one bounded file within the workspace.
+pub struct WriteFileTool {
+    workspace: PathBuf,
+}
+
+impl WriteFileTool {
+    #[must_use]
+    pub fn new(workspace: impl Into<PathBuf>) -> Self {
+        Self {
+            workspace: canonical_root(workspace.into()),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for WriteFileTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec::for_args::<WriteArgs>(
+            WRITE_FILE_TOOL,
+            "Write a UTF-8 text file into the sandbox workspace at a \
+             workspace-relative path, creating parent directories as needed and \
+             replacing any existing file.",
+        )
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        // A write stays inside the workspace, so it is a workspace mutation
+        // rather than an escape.
+        ApprovalClass::Workspace
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let args: WriteArgs = match serde_json::from_value(args) {
+            Ok(args) => args,
+            Err(error) => return Ok(ToolOutput::error(format!("invalid arguments: {error}"))),
+        };
+        if args.content.len() > MAX_WRITE_BYTES {
+            return Ok(ToolOutput::error(format!(
+                "content exceeds the {MAX_WRITE_BYTES}-byte write cap"
+            )));
+        }
+        let path = match WorkspacePath::parse(args.path) {
+            Ok(path) => path,
+            Err(error) => return Ok(ToolOutput::error(error)),
+        };
+        let target = match resolve_write_target(&self.workspace, &path) {
+            Ok(target) => target,
+            Err(error) => return Ok(ToolOutput::error(error)),
+        };
+        match write_no_follow(&target, args.content.as_bytes()) {
+            Ok(()) => Ok(ToolOutput::text(format!(
+                "wrote {} bytes to {}",
+                args.content.len(),
+                path.as_str()
+            ))),
+            Err(error) => Ok(ToolOutput::error(error)),
+        }
+    }
+}
+
+/// Write `content` to `path`, refusing to follow a symlink already at the final
+/// component so a planted link cannot redirect the write.
+fn write_no_follow(path: &Path, content: &[u8]) -> std::result::Result<(), String> {
+    use std::io::Write;
+
+    let mut open = std::fs::OpenOptions::new();
+    open.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        open.custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut file = open
+        .open(path)
+        .map_err(|_| "could not write the file".to_owned())?;
+    file.write_all(content)
+        .map_err(|_| "could not write the file".to_owned())
+}
+
+/// Arguments for one directory listing.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ListArgs {
+    /// Workspace-relative directory to list; omit to list the workspace root.
+    #[serde(default)]
+    path: Option<String>,
+}
+
+/// List one workspace directory, bounded.
+pub struct ListDirTool {
+    workspace: PathBuf,
+}
+
+impl ListDirTool {
+    #[must_use]
+    pub fn new(workspace: impl Into<PathBuf>) -> Self {
+        Self {
+            workspace: canonical_root(workspace.into()),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for ListDirTool {
+    fn spec(&self) -> ToolSpec {
+        ToolSpec::for_args::<ListArgs>(
+            LIST_DIR_TOOL,
+            "List the entries of a directory in the sandbox workspace \
+             (the workspace root when no path is given).",
+        )
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        ApprovalClass::ReadOnly
+    }
+
+    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let args: ListArgs = match serde_json::from_value(args) {
+            Ok(args) => args,
+            Err(error) => return Ok(ToolOutput::error(format!("invalid arguments: {error}"))),
+        };
+        let (base, prefix) = match args.path {
+            None => (self.workspace.clone(), None),
+            Some(raw) => {
+                let path = match WorkspacePath::parse(raw) {
+                    Ok(path) => path,
+                    Err(error) => return Ok(ToolOutput::error(error)),
+                };
+                match resolve_existing(&self.workspace, &path) {
+                    Ok(Some(resolved)) => (resolved, Some(path.as_str().to_owned())),
+                    Ok(None) => return Ok(ToolOutput::error("no such directory".to_owned())),
+                    Err(error) => return Ok(ToolOutput::error(error)),
+                }
+            }
+        };
+        if !base.is_dir() {
+            return Ok(ToolOutput::error("path is not a directory".to_owned()));
+        }
+        match list_bounded(&base, prefix.as_deref()) {
+            Ok(listing) => Ok(ToolOutput::text(listing)),
+            Err(error) => Ok(ToolOutput::error(error)),
+        }
+    }
+}
+
+/// List a directory into sorted, bounded text, skipping symlinks and special
+/// files so a listing describes only regular files and directories.
+fn list_bounded(base: &Path, prefix: Option<&str>) -> std::result::Result<String, String> {
+    let reader = std::fs::read_dir(base).map_err(|_| "could not list the directory".to_owned())?;
+    let mut entries = Vec::new();
+    for entry in reader {
+        let entry = entry.map_err(|_| "could not list the directory".to_owned())?;
+        let Ok(name) = entry.file_name().into_string() else {
+            continue;
+        };
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        if metadata.file_type().is_symlink() || (!metadata.is_dir() && !metadata.is_file()) {
+            continue;
+        }
+        let relative = match prefix {
+            None => name,
+            Some(prefix) => format!("{prefix}/{name}"),
+        };
+        let line = if metadata.is_dir() {
+            format!("{relative}/")
+        } else {
+            format!("{relative} ({} bytes)", metadata.len())
+        };
+        entries.push(line);
+    }
+    entries.sort();
+    let truncated = entries.len() > MAX_LIST_ENTRIES;
+    entries.truncate(MAX_LIST_ENTRIES);
+    if truncated {
+        entries.push(format!("(truncated at {MAX_LIST_ENTRIES} entries)"));
+    }
+    if entries.is_empty() {
+        return Ok("(empty)".to_owned());
+    }
+    Ok(entries.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> ToolCtx {
+        ToolCtx::without_private_scratch(openwave_core::ChatId::new(), None)
+    }
+
+    #[test]
+    fn path_validation_rejects_traversal_and_absolute_and_control() {
+        assert_eq!(
+            WorkspacePath::parse("reports//2026/summary.txt")
+                .unwrap()
+                .as_str(),
+            "reports/2026/summary.txt"
+        );
+        for rejected in [
+            "",
+            "/etc/passwd",
+            "../outside",
+            "a/../b",
+            "./a",
+            "a\\b",
+            "a\u{0}b",
+        ] {
+            assert!(
+                WorkspacePath::parse(rejected).is_err(),
+                "{rejected:?} must be rejected"
+            );
+        }
+        assert!(WorkspacePath::parse("x".repeat(MAX_PATH_BYTES + 1)).is_err());
+    }
+
+    #[tokio::test]
+    async fn write_then_read_round_trips_within_the_workspace() {
+        let dir = tempfile::tempdir().unwrap();
+        let write = WriteFileTool::new(dir.path());
+        let read = ReadFileTool::new(dir.path());
+
+        let wrote = write
+            .execute(
+                &ctx(),
+                serde_json::json!({ "path": "notes/hello.txt", "content": "hi there" }),
+            )
+            .await
+            .unwrap();
+        assert!(!wrote.is_error, "{wrote:?}");
+
+        let got = read
+            .execute(&ctx(), serde_json::json!({ "path": "notes/hello.txt" }))
+            .await
+            .unwrap();
+        assert_eq!(got.content, "hi there");
+    }
+
+    #[tokio::test]
+    async fn a_traversal_path_is_rejected_by_the_tool() {
+        let dir = tempfile::tempdir().unwrap();
+        let read = ReadFileTool::new(dir.path());
+        let out = read
+            .execute(&ctx(), serde_json::json!({ "path": "../secret" }))
+            .await
+            .unwrap();
+        assert!(out.is_error, "traversal must be refused: {out:?}");
+    }
+
+    #[tokio::test]
+    async fn an_oversized_write_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let write = WriteFileTool::new(dir.path());
+        let content = "x".repeat(MAX_WRITE_BYTES + 1);
+        let out = write
+            .execute(
+                &ctx(),
+                serde_json::json!({ "path": "big.txt", "content": content }),
+            )
+            .await
+            .unwrap();
+        assert!(out.is_error, "oversized write must be refused");
+        assert!(!dir.path().join("big.txt").exists(), "nothing was written");
+    }
+
+    #[tokio::test]
+    async fn list_reflects_written_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let write = WriteFileTool::new(dir.path());
+        write
+            .execute(
+                &ctx(),
+                serde_json::json!({ "path": "a.txt", "content": "1" }),
+            )
+            .await
+            .unwrap();
+        let list = ListDirTool::new(dir.path());
+        let out = list.execute(&ctx(), serde_json::json!({})).await.unwrap();
+        assert!(out.content.contains("a.txt"), "{}", out.content);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_symlink_escape_is_refused_on_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret.txt"), "secret").unwrap();
+        // A symlink planted inside the workspace pointing outside it.
+        std::os::unix::fs::symlink(outside.path().join("secret.txt"), dir.path().join("leak"))
+            .unwrap();
+        let read = ReadFileTool::new(dir.path());
+        let out = read
+            .execute(&ctx(), serde_json::json!({ "path": "leak" }))
+            .await
+            .unwrap();
+        assert!(
+            out.is_error,
+            "a symlink escaping the workspace must be refused"
+        );
+    }
+}

--- a/crates/openwave-sandbox-agent/src/lib.rs
+++ b/crates/openwave-sandbox-agent/src/lib.rs
@@ -16,17 +16,31 @@
 //! - the [`model`] client turns each model step into a host-proxied reverse call,
 //!   so **no model credential ever lives in the container**.
 //!
+//! The sandbox-resident tool surface — [`exec`], [`fs`], and the closed
+//! [`tools`] registry that pins them — runs *inside* the container. That
+//! in-container execution is the containment: model output can only move the
+//! sandbox. Egress from the container is not yet externally enforced (the
+//! supervisor's egress proxy is a stub), so this surface must not be routed to
+//! production credential-bearing work until that enforcement and the
+//! transport-auth gate land.
+//!
 //! # UNSTABLE
 //!
 //! Like the protocol it speaks, this crate is unstable and unversioned until a
 //! named release.
 
 pub mod agent;
+pub mod exec;
+pub mod fs;
 pub mod model;
 pub mod supervisor;
 pub mod tools;
 
 pub use agent::{run_agent, AgentRunError};
+pub use exec::{ExecTool, EXEC_TOOL};
+pub use fs::{
+    ListDirTool, ReadFileTool, WriteFileTool, LIST_DIR_TOOL, READ_FILE_TOOL, WRITE_FILE_TOOL,
+};
 pub use model::{HostModel, ModelError};
 pub use supervisor::{CredentialProxy, Supervisor};
-pub use tools::{sandbox_tool_registry, WordCount, WORD_COUNT_TOOL};
+pub use tools::{sandbox_tool_registry, SANDBOX_REGISTRY_TOOL_NAMES};

--- a/crates/openwave-sandbox-agent/src/main.rs
+++ b/crates/openwave-sandbox-agent/src/main.rs
@@ -19,6 +19,9 @@
 //! - `OPENWAVE_SANDBOX_TASK` — the delegated task. In the full design the host
 //!   delivers the task in the run-init payload after the handle commits; until
 //!   that init frame is wired, the entrypoint reads it from the environment.
+//! - `OPENWAVE_SANDBOX_WORKSPACE` — the agent's in-container workspace directory,
+//!   the root the `exec` and filesystem tools are scoped to (default
+//!   `/workspace`, provisioned in the container image).
 
 use std::env;
 
@@ -32,6 +35,9 @@ const DEFAULT_LISTEN: &str = "0.0.0.0:8080";
 /// `TRANSPORT_SECRET_ENV`).
 const TRANSPORT_SECRET_ENV: &str = "OPENWAVE_TRANSPORT_SECRET";
 
+/// Default in-container workspace root for the sandbox-resident tool surface.
+const DEFAULT_WORKSPACE: &str = "/workspace";
+
 #[tokio::main]
 async fn main() {
     if let Err(error) = run().await {
@@ -44,6 +50,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let listen = env::var("OPENWAVE_SANDBOX_LISTEN").unwrap_or_else(|_| DEFAULT_LISTEN.to_owned());
     let task = env::var("OPENWAVE_SANDBOX_TASK")
         .unwrap_or_else(|_| "Summarize what this sandbox agent can do.".to_owned());
+    let workspace =
+        env::var("OPENWAVE_SANDBOX_WORKSPACE").unwrap_or_else(|_| DEFAULT_WORKSPACE.to_owned());
 
     // The per-run secret the host must present to attach. Fail closed: with none
     // configured the run holds `None`, so every attach is refused rather than
@@ -71,7 +79,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // The agent loop is a separate future from the supervisor's listener: it
     // waits for the host to attach, then runs to a submitted result.
     tokio::spawn(async move {
-        match run_agent(run, task).await {
+        match run_agent(run, task, workspace).await {
             Ok(answer) => eprintln!("openwave-sandbox-agent: submitted result: {answer}"),
             Err(error) => eprintln!("openwave-sandbox-agent: run failed: {error}"),
         }

--- a/crates/openwave-sandbox-agent/src/tools.rs
+++ b/crates/openwave-sandbox-agent/src/tools.rs
@@ -1,74 +1,101 @@
-//! The sandbox-resident tool registry.
+//! The sandbox-resident tool registry — a closed, test-pinned set.
 //!
 //! Running the agent loop inside a sandbox is "the same code with a different
 //! tool registry and transport" (see
 //! [sandbox-providers.md](../../docs/sandbox-providers.md)). This module builds
-//! that registry from OpenWave's own [`Tool`] trait, so the tools the sandbox
-//! loop invokes are ordinary [`openwave_core`] tools — not a parallel
-//! abstraction.
+//! that registry from OpenWave's own [`Tool`](openwave_core::Tool) trait, so the
+//! tools the sandbox loop invokes are ordinary [`openwave_core`] tools — not a
+//! parallel abstraction.
 //!
-//! The set is deliberately **closed and minimal** for this slice: model
-//! inference is dialed back to the host over reverse RPC (the first host-mediated
-//! capability), and the only sandbox-local tool is a trivial, dependency-free,
-//! read-only computation that demonstrates the loop actually invoking a tool.
-//! Widening the sandbox-resident registry is a separate design, gated on the
-//! entry conditions the delivery sequence names; nothing here reaches the network
-//! or the filesystem, so no credential or egress boundary is engaged yet.
+//! # The closed set is the design gate
+//!
+//! The design makes widening the sandbox-resident surface a deliberate, reviewed
+//! change: "a sandbox-resident run gets its own pinned tool registry, and
+//! widening that registry is a separate design gated on this document." The gate
+//! is mechanical — [`SANDBOX_REGISTRY_TOOL_NAMES`] names the exact set and a
+//! test asserts the built registry matches it. Adding a tool that is not a
+//! drive-by change means editing that named invariant, which review sees.
+//!
+//! For this slice the surface is:
+//!
+//! - **model inference** — dialed back to the host over reverse RPC (not a
+//!   registered [`Tool`]; the run's granted reverse capability, so no model
+//!   credential lives in the container);
+//! - **[`exec`](crate::exec)** — a bounded, model-authored command run *inside*
+//!   the container (the container is the containment);
+//! - **[`read_file`](crate::fs), [`write_file`](crate::fs),
+//!   [`list_dir`](crate::fs)** — path-validated filesystem access within the
+//!   agent's workspace directory.
+//!
+//! # NOT YET FOR CREDENTIAL-BEARING WORK
+//!
+//! `exec` can make network calls. Egress is meant to be routed through the
+//! sandbox supervisor (credential separation + an egress proxy), which is a
+//! **stub** in this crate. In-container execution keeps model output from
+//! reaching host authority, but egress *from the container* is not yet
+//! externally enforced, so this surface must not be routed to production
+//! credential-bearing work until externally-enforced egress and the
+//! transport-auth gate land.
 
-use async_trait::async_trait;
-use openwave_core::{ApprovalClass, Result, Tool, ToolCtx, ToolOutput, ToolSpec};
-use schemars::JsonSchema;
-use serde::Deserialize;
-use serde_json::Value;
+use std::path::PathBuf;
 
-/// The name the model uses to invoke the word-count tool.
-pub const WORD_COUNT_TOOL: &str = "word_count";
+use openwave_core::ToolRegistry;
 
-/// Arguments for [`WordCount`].
-#[derive(Debug, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
-struct WordCountArgs {
-    /// The text whose words to count.
-    text: String,
-}
+use crate::exec::{ExecTool, DEFAULT_EXEC_TIMEOUT, EXEC_TOOL};
+use crate::fs::{
+    ListDirTool, ReadFileTool, WriteFileTool, LIST_DIR_TOOL, READ_FILE_TOOL, WRITE_FILE_TOOL,
+};
 
-/// A trivial, read-only local tool: count the whitespace-separated words in a
-/// piece of text.
+/// The exact, closed set of tool names the sandbox-resident registry registers.
 ///
-/// It exists to prove the sandbox loop can invoke a real [`Tool`] locally, not to
-/// be useful. It touches no filesystem, network, or credential, so it needs no
-/// approval beyond the auto-approving [`ApprovalClass::ReadOnly`] class.
-pub struct WordCount;
+/// This is the named invariant the design gate rides on: the reverse-RPC model
+/// inference capability is granted separately (it is not a registered tool), and
+/// every *local* tool the sandbox loop can invoke is one of these. Widening it is
+/// a deliberate edit here, seen in review.
+pub const SANDBOX_REGISTRY_TOOL_NAMES: [&str; 4] =
+    [EXEC_TOOL, READ_FILE_TOOL, WRITE_FILE_TOOL, LIST_DIR_TOOL];
 
-#[async_trait]
-impl Tool for WordCount {
-    fn spec(&self) -> ToolSpec {
-        ToolSpec::for_args::<WordCountArgs>(
-            WORD_COUNT_TOOL,
-            "Count the whitespace-separated words in a piece of text.",
-        )
-    }
-
-    fn approval_class(&self) -> ApprovalClass {
-        ApprovalClass::ReadOnly
-    }
-
-    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
-        // Arguments are untrusted input; a malformed call is a tool failure the
-        // model sees and can correct, not a process error.
-        let args: WordCountArgs = match serde_json::from_value(args) {
-            Ok(args) => args,
-            Err(error) => return Ok(ToolOutput::error(format!("invalid arguments: {error}"))),
-        };
-        let count = args.text.split_whitespace().count();
-        Ok(ToolOutput::text(count.to_string()))
-    }
+/// Build the closed sandbox-resident tool registry rooted at `workspace`.
+///
+/// `workspace` is the agent's in-container workspace directory; the filesystem
+/// tools are scoped to it and `exec` runs commands inside it. The exec tool is
+/// bounded by [`DEFAULT_EXEC_TIMEOUT`].
+#[must_use]
+pub fn sandbox_tool_registry(workspace: impl Into<PathBuf>) -> ToolRegistry {
+    let workspace = workspace.into();
+    let mut registry = ToolRegistry::new();
+    registry.register(Box::new(ExecTool::new(
+        workspace.clone(),
+        DEFAULT_EXEC_TIMEOUT,
+    )));
+    registry.register(Box::new(ReadFileTool::new(workspace.clone())));
+    registry.register(Box::new(WriteFileTool::new(workspace.clone())));
+    registry.register(Box::new(ListDirTool::new(workspace)));
+    registry
 }
 
-/// Build the closed sandbox-resident tool registry for this slice.
-#[must_use]
-pub fn sandbox_tool_registry() -> openwave_core::ToolRegistry {
-    let mut registry = openwave_core::ToolRegistry::new();
-    registry.register(Box::new(WordCount));
-    registry
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The design gate: the built registry advertises exactly the pinned closed
+    /// set — no more, no fewer. A new tool must edit
+    /// [`SANDBOX_REGISTRY_TOOL_NAMES`] to pass, which is the reviewed change the
+    /// design requires.
+    #[test]
+    fn the_registry_is_the_pinned_closed_set() {
+        let registry = sandbox_tool_registry(std::env::temp_dir());
+        let mut built: Vec<String> = registry.specs().into_iter().map(|spec| spec.name).collect();
+        built.sort();
+        let mut pinned: Vec<String> = SANDBOX_REGISTRY_TOOL_NAMES
+            .iter()
+            .map(|name| (*name).to_owned())
+            .collect();
+        pinned.sort();
+        assert_eq!(
+            built, pinned,
+            "the sandbox-resident registry must match its pinned closed set; \
+             widening it is a deliberate edit to SANDBOX_REGISTRY_TOOL_NAMES"
+        );
+    }
 }

--- a/crates/openwave-sandbox-agent/tests/agent_run.rs
+++ b/crates/openwave-sandbox-agent/tests/agent_run.rs
@@ -5,9 +5,10 @@
 //! the agent loop — with the host side dialing in over a TCP loopback and
 //! answering model steps from a scripted mock model. It exercises the whole
 //! sandbox-resident path the image packages: attach handshake, model inference
-//! dialed back over reverse RPC, a local tool call, the event stream, and a
-//! submitted result — and asserts exactly-once against the host's operation-log
-//! seam (each model step runs once, one record per operation).
+//! dialed back over reverse RPC, real filesystem tool calls (write a file, then
+//! read it back), the event stream, and a submitted result — and asserts
+//! exactly-once against the host's operation-log seam (each model step runs
+//! once, one record per operation).
 //!
 //! The whole scenario runs under a wall-clock [`timeout`](tokio::time::timeout),
 //! so a transport regression fails the test fast instead of hanging the suite.
@@ -35,14 +36,15 @@ use openwave_sandbox_protocol::{
 /// The per-run transport secret the sandbox expects and the host presents.
 const SECRET: &str = "agent-run-transport-secret";
 
-/// A mock host model that scripts the loop: it asks for the word-count tool on
-/// the first step, then — once the transcript shows the tool's result — returns a
-/// final answer. It counts executions so a test can assert exactly-once.
+/// A mock host model that scripts the loop through the real sandbox tools: write
+/// a file, then read it back, then return a final answer. It counts executions
+/// so a test can assert exactly-once.
 struct ScriptedModel {
     executions: Arc<AtomicUsize>,
 }
 
-const FINAL_ANSWER: &str = "counted the words in the sample";
+const FINAL_ANSWER: &str = "wrote the note and read it back";
+const NOTE_CONTENT: &str = "hello from the sandbox";
 
 #[async_trait::async_trait]
 impl CapabilityResponder for ScriptedModel {
@@ -52,11 +54,14 @@ impl CapabilityResponder for ScriptedModel {
             ReverseRequest::ModelInference(params) => params.prompt,
             _ => unreachable!("only model inference is exercised"),
         };
-        let completion = if prompt.contains("Tool word_count result") {
-            FINAL_ANSWER.to_owned()
+        // Drive real local tool calls over the loop's directive protocol: first a
+        // write, then a read of the same file, then the final answer.
+        let completion = if !prompt.contains("Tool write_file") {
+            format!("use-tool:write_file:{{\"path\":\"note.txt\",\"content\":\"{NOTE_CONTENT}\"}}")
+        } else if !prompt.contains("Tool read_file") {
+            "use-tool:read_file:{\"path\":\"note.txt\"}".to_owned()
         } else {
-            // Drive a real local tool call over the loop's directive protocol.
-            "use-tool:word_count:{\"text\":\"alpha beta gamma delta\"}".to_owned()
+            FINAL_ANSWER.to_owned()
         };
         Response::Ok(ReverseResult::ModelInference(ModelInferenceResult {
             completion,
@@ -127,8 +132,13 @@ async fn scenario() {
     .await
     .expect("attach accepted");
 
-    // Drive the agent loop; it dials its model steps back over the connection.
-    let agent = tokio::spawn(async move { run_agent(run, "count the words in the sample").await });
+    // Drive the agent loop; it dials its model steps back over the connection and
+    // runs its filesystem tools against a real workspace directory.
+    let workspace = tempfile::tempdir().expect("workspace");
+    let workspace_path = workspace.path().to_path_buf();
+    let agent = tokio::spawn(async move {
+        run_agent(run, "write a note then read it back", workspace_path).await
+    });
 
     // Drain the event stream until the terminal result arrives.
     let mut progress = Vec::new();
@@ -145,11 +155,16 @@ async fn scenario() {
     };
 
     assert_eq!(result, FINAL_ANSWER, "the run submitted its final answer");
-    // The loop actually ran the local tool: word_count("alpha beta gamma delta")
-    // is 4, surfaced on a progress event.
+    // The loop actually ran the local tools: the read surfaced the bytes the
+    // write laid down, on a progress event.
     assert!(
-        progress.iter().any(|line| line.contains("word_count -> 4")),
-        "the sandbox-resident tool ran locally: {progress:?}"
+        progress.iter().any(|line| line.contains(NOTE_CONTENT)),
+        "the sandbox read the file it wrote: {progress:?}"
+    );
+    // And the write landed on the real workspace filesystem.
+    assert_eq!(
+        std::fs::read_to_string(workspace.path().join("note.txt")).unwrap(),
+        NOTE_CONTENT
     );
 
     let answer = agent
@@ -158,12 +173,12 @@ async fn scenario() {
         .expect("agent run succeeds");
     assert_eq!(answer, FINAL_ANSWER);
 
-    // Exactly-once seam: two model steps, two distinct operations, each recorded
-    // once and executed once.
+    // Exactly-once seam: three model steps (write, read, final), three distinct
+    // operations, each recorded once and executed once.
     assert_eq!(
         executions.load(Ordering::SeqCst),
-        2,
+        3,
         "each model step executed exactly once"
     );
-    assert_eq!(store.len(), 2, "one operation-log record per model step");
+    assert_eq!(store.len(), 3, "one operation-log record per model step");
 }

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -94,8 +94,8 @@ windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
 winreg = "=0.55.0"
 
 [dev-dependencies]
-# The real in-container agent (loop, supervisor, word_count tool) so the
-# sandbox-resident driver tests can drive the actual sandbox side over a
+# The real in-container agent (loop, supervisor, sandbox-resident tool registry)
+# so the sandbox-resident driver tests can drive the actual sandbox side over a
 # loopback socket, with only Docker and the host model mocked.
 openwave-sandbox-agent = { path = "../openwave-sandbox-agent" }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }

--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -1,8 +1,8 @@
 //! Tests for the sandbox-resident container driver.
 //!
 //! The non-Docker tests drive the **real** in-container agent loop
-//! (`openwave_sandbox_agent::run_agent` plus its `word_count` tool and the
-//! sandbox transport server) over a real loopback TCP socket, with only Docker
+//! (`openwave_sandbox_agent::run_agent` plus its sandbox-resident tool registry
+//! and the sandbox transport server) over a real loopback TCP socket, with only Docker
 //! (the [`SandboxBackend`]) and the host model (the [`ProviderResolver`]) mocked.
 //! That exercises the whole stack — provision, attach, reverse-RPC model
 //! inference answered by the host proxy through the durable op-log, event drain,
@@ -50,8 +50,8 @@ use crate::resolver::ProviderResolver;
 
 /// A provider that scripts one directive step then a final answer, counting how
 /// many completions it is asked for. Drives the real in-container loop: the first
-/// completion tells the sandbox to run `word_count`, the second is the final
-/// result the sandbox submits.
+/// completion tells the sandbox to run a filesystem tool, the second is the
+/// final result the sandbox submits.
 struct ScriptedProvider {
     completions: Mutex<Vec<String>>,
     calls: AtomicUsize,
@@ -319,8 +319,13 @@ async fn spawn_sandbox_agent(task: &str) -> String {
     );
     let agent_run = run.clone();
     let task = task.to_owned();
+    // The in-container tool surface is rooted at a workspace directory; give the
+    // loop a private temp one that lives as long as the run.
+    let workspace = tempfile::tempdir().unwrap();
+    let workspace_path = workspace.path().to_path_buf();
     tokio::spawn(async move {
-        let _ = run_agent(agent_run, task).await;
+        let _workspace = workspace;
+        let _ = run_agent(agent_run, task, workspace_path).await;
     });
     tokio::spawn(async move {
         while let Ok((stream, _peer)) = listener.accept().await {
@@ -346,10 +351,10 @@ fn fast_config() -> SandboxContainerRunConfig {
 // --- Tests --------------------------------------------------------------------
 
 /// The whole stack over loopback: admit a container run, drive it with the real
-/// in-container agent loop answering `word_count` and dialing the host for model
-/// inference, and assert the host committed the result exactly once, proxied
-/// each model step through the resolver, delivered the run's ACTUAL task, and
-/// tore the container down.
+/// in-container agent loop running a sandbox filesystem tool and dialing the host
+/// for model inference, and assert the host committed the result exactly once,
+/// proxied each model step through the resolver, delivered the run's ACTUAL task,
+/// and tore the container down.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn drives_a_container_run_end_to_end_over_loopback() {
     tokio::time::timeout(Duration::from_secs(30), async {
@@ -360,9 +365,9 @@ async fn drives_a_container_run_end_to_end_over_loopback() {
         // The backend starts the sandbox on whatever task the driver delivered,
         // exactly as Docker starts the container from its environment.
         let backend = MockBackend::spawning();
-        // Step 1: run word_count on three words. Step 2: the final answer.
+        // Step 1: write a workspace file. Step 2: the final answer.
         let provider = Arc::new(ScriptedProvider::new(vec![
-            "use-tool:word_count:{\"text\":\"one two three\"}".to_owned(),
+            "use-tool:write_file:{\"path\":\"note.txt\",\"content\":\"delegated\"}".to_owned(),
             "the text has three words".to_owned(),
         ]));
         let resolver = Arc::new(FixedResolver(provider.clone()));
@@ -424,7 +429,7 @@ async fn terminalizes_and_tears_down_when_the_agent_loop_ends_without_a_result()
         // Every completion is another tool directive, so the loop never submits a
         // final answer and exhausts MAX_STEPS.
         let provider = Arc::new(ScriptedProvider::new(vec![
-            "use-tool:word_count:{\"text\":\"a\"}".to_owned();
+            "use-tool:write_file:{\"path\":\"note.txt\",\"content\":\"a\"}".to_owned();
             16
         ]));
         let resolver = Arc::new(FixedResolver(provider.clone()));
@@ -469,7 +474,7 @@ async fn heartbeats_the_lease_so_a_long_run_is_not_reaped() {
         // the drive stays open across several lease periods.
         let provider = Arc::new(ScriptedProvider::slow(
             vec![
-                "use-tool:word_count:{\"text\":\"a b\"}".to_owned(),
+                "use-tool:write_file:{\"path\":\"note.txt\",\"content\":\"a b\"}".to_owned(),
                 "done".to_owned(),
             ],
             Duration::from_millis(700),
@@ -721,8 +726,9 @@ async fn admission_routes_to_the_container_location_not_the_in_process_scheduler
 /// The full stack on a real Docker container: build the `openwave-sandbox-agent`
 /// image, admit a container run, and drive it end to end — provision a container
 /// from the image, attach over its published loopback port, answer its
-/// `word_count`-then-final model steps from a mock host model, and assert the
-/// result committed exactly once and the container was torn down.
+/// `exec`-then-final model steps from a mock host model (so the container really
+/// runs a shell command in its own boundary), and assert the result committed
+/// exactly once and the container was torn down.
 ///
 /// Skipped cleanly when no container runtime or daemon is present (there is none
 /// in the unit-test sandbox); CI runners have Docker. Building the image is heavy
@@ -785,7 +791,9 @@ async fn docker_end_to_end_drives_a_real_container() {
         ..DockerConfig::default()
     }));
     let provider = Arc::new(ScriptedProvider::new(vec![
-        "use-tool:word_count:{\"text\":\"count these four words\"}".to_owned(),
+        // Runs a real shell command inside the real container (in-container
+        // execution is the containment).
+        "use-tool:exec:{\"command\":\"echo count these four words\"}".to_owned(),
         "the count is four".to_owned(),
     ]));
     let resolver = Arc::new(FixedResolver(provider.clone()));


### PR DESCRIPTION
Give the sandbox-resident agent a real, bounded, **closed** tool surface that
runs **inside** the container. That in-container execution is the containment
(per `docs/sandbox-providers.md`): model output can only move the sandbox, and
the host consumes the run's bounded events and result as untrusted input, which
is what makes a wider surface than today's host-fixed budget admissible.

## What this adds

- **`exec`** — runs a model-authored shell command inside the container,
  bounded exactly the way the shipped foreground local exec adapter bounds its
  confined child: a cleared environment with a fixed `HOME`/`TMPDIR`/`PATH`,
  stdin from `/dev/null`, its **own process group**, a wall-time timeout that
  **kills the whole group** (SIGTERM, grace, SIGKILL), a captured-output cap,
  `setrlimit` ceilings (CPU, open files), and an argument bound. The container
  is the isolation boundary, so the command is **not** re-sandboxed inside it.
- **`read_file` / `write_file` / `list_dir`** — path-validated access within
  the agent's workspace directory. A `WorkspacePath` newtype mirrors
  `openwave-code-execution`'s `WorkspaceFilePath`: relative-only, rejects `..`,
  absolute, prefix, control characters, and backslashes, normalized to `a/b/c`.
  Resolution canonicalizes against the workspace root and refuses anything that
  escapes it (a symlinked intermediate cannot redirect a read or write), reads
  use `O_NOFOLLOW`, and reads/writes/listings are size-bounded.
- **A closed, test-pinned registry** — `SANDBOX_REGISTRY_TOOL_NAMES` names the
  exact set and `the_registry_is_the_pinned_closed_set` asserts the built
  registry matches it. Widening the surface is a deliberate edit to that named
  invariant, which review sees — the design's mechanical gate.

The sandbox-resident surface for this slice is
**{ model inference (reverse RPC, existing), `exec`, `read_file`, `write_file`,
`list_dir` }**. Model inference still dials back to the host over reverse RPC —
no model credential lives in the container. `run_agent` is now rooted at a
workspace directory it creates and canonicalizes, resolved from
`OPENWAVE_SANDBOX_WORKSPACE` (default `/workspace`) in the entrypoint. The image
gains a static busybox (`/bin/sh` + coreutils) and a `/workspace` root so `exec`
has a shell to run under in the real container.

## Tests

- **In-process determinism test (must-have):** `agent_run.rs` drives the real
  agent loop over a loopback socket against a scripted host model — the loop
  writes a workspace file with `write_file`, reads it back with `read_file`,
  and submits a result; the write is asserted on the real filesystem and the
  op-log seam confirms exactly-once. Every async test is timeout-wrapped.
- **The pinned closed-set test** (`tools.rs`).
- **Bounds** (`exec.rs`, `fs.rs`): a timeout kills a `sleep`, output past the
  cap is truncated, an empty command is refused; path traversal is rejected, an
  oversized write is refused and writes nothing, a symlink escaping the
  workspace is refused on read.
- **Server driver tests** (`sandbox_container_run/tests.rs`) updated to drive
  the new tools over the full stack.
- **Gated Docker end-to-end** (server, `#[ignore]`d): builds the image and now
  drives a real `exec` command inside a real container; skips cleanly without a
  daemon. (I dropped a duplicate image-build check I had added in the
  sandbox-agent crate — this one covers "run a command in a real container"
  better, and building the image twice is wasted CI time.)

## What still gates routing to production

`exec` can make network calls. Egress is meant to route through the sandbox
**supervisor** (credential separation + an egress proxy), which is still a
**stub**. In-container execution keeps model output from reaching host
authority, but **egress from the container is not yet externally enforced**.
This tool surface **must not** be routed to production credential-bearing work
until (a) externally-enforced egress — the run's egress policy applied to the
container's network from outside the workload — and (b) the transport-auth gate
(#920) land. No routing to production is wired here; this is doc-commented in
the crate and the tool modules.

Closes #950
