### PR TITLE
feat(server): policy is the only gateway source — retire additive configuration

### DIFF
--- a/crates/openwave-desktop/ui/src/ManagedGate.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.dom.test.tsx
@@ -6,9 +6,9 @@ import type { ApiClient, GatewayStatus, ManagedPolicy } from "./api";
 import { ManagedGate } from "./ManagedGate";
 import { useManagedPolicy } from "./managedPolicy";
 
-// The policy stores its URL normalized with a trailing slash; the provider
-// config carries what the user (or a convergence) saved, typically without.
-// The fixtures differ deliberately so every match exercises normalization.
+// The policy stores its URL normalized with a trailing slash; the status
+// echo may not. The fixtures differ deliberately so every match exercises
+// normalization.
 const managed: ManagedPolicy = {
   managed: true,
   gateway_url: "https://gateway.example/",
@@ -17,8 +17,6 @@ const managed: ManagedPolicy = {
 };
 
 const signedOut: GatewayStatus = {
-  configured: true,
-  enabled: true,
   base_url: "https://gateway.example",
   signed_in: false,
   model_count: 0,
@@ -90,8 +88,8 @@ describe("ManagedGate", () => {
 
     await user.click(screen.getByRole("button", { name: /Connect/ }));
     await waitFor(() => expect(client.gatewaySignIn).toHaveBeenCalled());
-    // The config already points at the policy gateway (modulo the trailing
-    // slash), so there is nothing to converge.
+    // Connecting is the sign-in flow alone: the deployment comes from the
+    // policy server-side, and the retired provider row is never written.
     expect(client.putProvider).not.toHaveBeenCalled();
     expect(open).toHaveBeenCalledWith(
       "http://gw/oauth/authorize?x=1",
@@ -204,36 +202,6 @@ describe("ManagedGate", () => {
     // What is shown is the device's managed gateway, not the stray config.
     expect(screen.getByText("https://gateway.example/")).toBeInTheDocument();
     expect(screen.queryByText(/other\.example/)).not.toBeInTheDocument();
-  });
-
-  it("connect on an unconfigured profile converges the provider to the policy gateway first", async () => {
-    const client = api({
-      getGatewayStatus: vi
-        .fn()
-        .mockResolvedValueOnce({
-          ...signedOut,
-          configured: false,
-          base_url: undefined,
-        })
-        .mockResolvedValue(signedOut),
-    });
-    vi.stubGlobal("open", vi.fn());
-    const user = userEvent.setup();
-    mount(client);
-
-    await screen.findByText("Sign in to continue");
-    await user.click(screen.getByRole("button", { name: /Connect/ }));
-
-    await waitFor(() => expect(client.gatewaySignIn).toHaveBeenCalled());
-    expect(client.putProvider).toHaveBeenCalledWith("model_gateway", {
-      enabled: true,
-      base_url: "https://gateway.example/",
-    });
-    // Converge first, then sign in — the other order still refuses.
-    const putOrder = vi.mocked(client.putProvider).mock.invocationCallOrder[0];
-    const signInOrder = vi.mocked(client.gatewaySignIn).mock
-      .invocationCallOrder[0];
-    expect(putOrder).toBeLessThan(signInOrder);
   });
 
   it("unmanaged profiles see the app untouched and no gateway traffic", async () => {

--- a/crates/openwave-desktop/ui/src/ManagedGate.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.tsx
@@ -227,23 +227,9 @@ export function ManagedGate({
     setWorking(true);
     setActionError(null);
     try {
-      // Converge the provider config to the policy's locked gateway before
-      // starting the flow: begin_sign_in refuses without a configured
-      // provider, and the gate blocks the settings route that could fix it.
-      // Convergence only ever writes the policy's own URL — toward the
-      // policy, never away from it.
-      const target = policy.gateway_url;
-      if (
-        target &&
-        (!status?.configured ||
-          !status.enabled ||
-          !sameGateway(status.base_url, target))
-      ) {
-        await client.putProvider("model_gateway", {
-          enabled: true,
-          base_url: target,
-        });
-      }
+      // Sign-in needs no provider convergence: the server derives the
+      // deployment from the policy itself, and the retired provider row is
+      // not writable at all.
       const started = await client.gatewaySignIn();
       await openSignInPage(started.authorization_url);
       await reload();
@@ -300,9 +286,9 @@ export function ManagedGate({
     return <BootScreen>starting…</BootScreen>;
   }
 
-  // The gate lifts only for a session on the policy's own gateway: signed_in
-  // reflects whatever provider URL is configured, which nothing pins to the
-  // policy yet. A session on any other deployment stays gated.
+  // The gate lifts only for a session on the policy's own gateway. The
+  // server already pins signed_in to the policy URL; the comparison stays as
+  // defense in depth for a renderer running against an older server.
   const lockedUrl = policy?.gateway_url ?? null;
   const sessionSatisfiesPolicy =
     status?.signed_in === true && sameGateway(status.base_url, lockedUrl);

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -473,9 +473,12 @@ supported: boolean, apps: Array<GatewayAppInfo>, };
 
 /**
  * Renderer-safe projection of the gateway connection state. Never carries
- * token material — only what the settings surface displays.
+ * token material — only what the settings surface displays. `base_url` is
+ * the policy's gateway origin: present exactly when the profile is managed
+ * with a usable URL (the retired `configured`/`enabled` bits collapsed into
+ * its presence).
  */
-export type GatewayStatus = { configured: boolean, enabled: boolean, base_url?: string, signed_in: boolean, account_hint?: string, installation_id?: string, model_count: number, sign_in: SignInProgress, };
+export type GatewayStatus = { base_url?: string, signed_in: boolean, account_hint?: string, installation_id?: string, model_count: number, sign_in: SignInProgress, };
 
 /**
  * How far a standing grant reaches.

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
@@ -236,6 +236,31 @@ describe("GatewayPanel", () => {
     expect(openMcpSettings).toHaveBeenCalled();
   });
 
+  it("a policy that names no gateway cannot be connected to", async () => {
+    // Misconfigured managed policy: there is no deployment to sign in
+    // against, so the affordance stays off rather than failing on click.
+    // The server derives status from the same policy, so it names no
+    // origin either.
+    const client = api({
+      getGatewayStatus: vi
+        .fn()
+        .mockResolvedValue({ ...signedOut, base_url: undefined }),
+    });
+    render(
+      <GatewayPanel
+        client={client}
+        managed
+        gatewayUrl={null}
+        onChanged={() => undefined}
+        onOpenMcpSettings={() => undefined}
+      />,
+    );
+
+    expect(await screen.findByText("Not signed in")).toBeInTheDocument();
+    expect(screen.getByText(/names no gateway/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Connect/ })).toBeDisabled();
+  });
+
   it("surfaces a failed sign-in with its bounded message", async () => {
     const client = api({
       getGatewayStatus: vi.fn().mockResolvedValue({

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
@@ -5,10 +5,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient, GatewayStatus } from "../api";
 import { GatewayPanel } from "./GatewayPanel";
 
+const GATEWAY_URL = "http://127.0.0.1:28081/";
+
 const signedOut: GatewayStatus = {
-  configured: true,
-  enabled: true,
-  base_url: "http://127.0.0.1:28081",
+  base_url: GATEWAY_URL,
   signed_in: false,
   model_count: 0,
   sign_in: { state: "idle" },
@@ -36,6 +36,27 @@ function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
   } as unknown as ApiClient;
 }
 
+function managedPanel(
+  client: ApiClient,
+  {
+    onChanged = () => undefined,
+    onOpenMcpSettings = () => undefined,
+  }: {
+    onChanged?: () => void;
+    onOpenMcpSettings?: () => void;
+  } = {},
+) {
+  return (
+    <GatewayPanel
+      client={client}
+      managed
+      gatewayUrl={GATEWAY_URL}
+      onChanged={onChanged}
+      onOpenMcpSettings={onOpenMcpSettings}
+    />
+  );
+}
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
@@ -43,24 +64,52 @@ afterEach(() => {
 });
 
 describe("GatewayPanel", () => {
-  it("connects through the browser and never asks for a credential", async () => {
+  it("unmanaged: renders the pairing signpost with no gateway configuration surface", async () => {
     const client = api();
-    const open = vi.fn();
-    vi.stubGlobal("open", open);
-    const user = userEvent.setup();
     render(
       <GatewayPanel
         client={client}
+        managed={false}
+        gatewayUrl={null}
         onChanged={() => undefined}
         onOpenMcpSettings={() => undefined}
       />,
     );
 
+    expect(
+      screen.getByText(/not connected to a model gateway/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/gateway's own page/i)).toBeInTheDocument();
+    // No URL field, no enable toggle, no connect flow — and no gateway
+    // traffic at all: policy is the only way a profile becomes connected.
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Connect/ }),
+    ).not.toBeInTheDocument();
+    expect(client.getGatewayStatus).not.toHaveBeenCalled();
+  });
+
+  it("managed: shows the read-only policy origin and connects through the browser", async () => {
+    const client = api();
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    const user = userEvent.setup();
+    render(managedPanel(client));
+
     expect(await screen.findByText("Not signed in")).toBeInTheDocument();
+    // The origin comes from policy and is display-only: no input to edit
+    // it, no toggle to turn the gateway off, and no credential prompt.
+    expect(screen.getByText(GATEWAY_URL)).toBeInTheDocument();
+    expect(screen.getByText(/not editable here/i)).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
     expect(screen.queryByPlaceholderText(/API key/i)).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /Connect/ }));
     await waitFor(() => expect(client.gatewaySignIn).toHaveBeenCalled());
+    // Connecting is the sign-in flow alone — never a provider write.
+    expect(client.putProvider).not.toHaveBeenCalled();
     expect(open).toHaveBeenCalledWith(
       "http://gw/oauth/authorize?x=1",
       "_blank",
@@ -75,13 +124,7 @@ describe("GatewayPanel", () => {
     });
     const onChanged = vi.fn();
     const user = userEvent.setup();
-    render(
-      <GatewayPanel
-        client={client}
-        onChanged={onChanged}
-        onOpenMcpSettings={() => undefined}
-      />,
-    );
+    render(managedPanel(client, { onChanged }));
 
     expect(await screen.findByText("Signed in")).toBeInTheDocument();
     expect(screen.getByText(/abaas@example\.test/)).toBeInTheDocument();
@@ -96,38 +139,6 @@ describe("GatewayPanel", () => {
     await waitFor(() => expect(client.gatewaySignOut).toHaveBeenCalled());
   });
 
-  it("saves the gateway URL as provider configuration", async () => {
-    const client = api({
-      getGatewayStatus: vi
-        .fn()
-        .mockResolvedValue({ ...signedOut, configured: false, base_url: undefined }),
-    });
-    const user = userEvent.setup();
-    render(
-      <GatewayPanel
-        client={client}
-        onChanged={() => undefined}
-        onOpenMcpSettings={() => undefined}
-      />,
-    );
-
-    await screen.findByText("Not signed in");
-    // Unconfigured, the connect affordance stays off.
-    expect(screen.getByRole("button", { name: /Connect/ })).toBeDisabled();
-
-    await user.type(
-      screen.getByPlaceholderText("https://gateway.example"),
-      "http://127.0.0.1:28081",
-    );
-    await user.click(screen.getByRole("button", { name: "Save gateway URL" }));
-    await waitFor(() =>
-      expect(client.putProvider).toHaveBeenCalledWith("model_gateway", {
-        enabled: true,
-        base_url: "http://127.0.0.1:28081",
-      }),
-    );
-  });
-
   it("watches a pending browser sign-in and refreshes the catalog on completion", async () => {
     const getGatewayStatus = vi
       .fn()
@@ -139,13 +150,7 @@ describe("GatewayPanel", () => {
     const client = api({ getGatewayStatus });
     const onChanged = vi.fn();
     vi.useFakeTimers();
-    render(
-      <GatewayPanel
-        client={client}
-        onChanged={onChanged}
-        onOpenMcpSettings={() => undefined}
-      />,
-    );
+    render(managedPanel(client, { onChanged }));
     // Flush the initial status load.
     await act(async () => {});
 
@@ -178,13 +183,7 @@ describe("GatewayPanel", () => {
         ],
       }),
     });
-    render(
-      <GatewayPanel
-        client={client}
-        onChanged={() => undefined}
-        onOpenMcpSettings={() => undefined}
-      />,
-    );
+    render(managedPanel(client));
 
     expect(await screen.findByText("Incident API")).toBeInTheDocument();
     expect(screen.getByText(/via example-security-tools/)).toBeInTheDocument();
@@ -197,13 +196,7 @@ describe("GatewayPanel", () => {
         .fn()
         .mockResolvedValue({ supported: false, apps: [] }),
     });
-    render(
-      <GatewayPanel
-        client={older}
-        onChanged={() => undefined}
-        onOpenMcpSettings={() => undefined}
-      />,
-    );
+    render(managedPanel(older));
     expect(await screen.findByText("Signed in")).toBeInTheDocument();
     expect(screen.queryByText("Connected apps")).not.toBeInTheDocument();
     // The route to mounting still shows: older gateways mount by slug too.
@@ -230,13 +223,7 @@ describe("GatewayPanel", () => {
     });
     const openMcpSettings = vi.fn();
     const user = userEvent.setup();
-    render(
-      <GatewayPanel
-        client={client}
-        onChanged={() => undefined}
-        onOpenMcpSettings={openMcpSettings}
-      />,
-    );
+    render(managedPanel(client, { onOpenMcpSettings: openMcpSettings }));
 
     expect(await screen.findByText("Incident API")).toBeInTheDocument();
     expect(
@@ -256,13 +243,7 @@ describe("GatewayPanel", () => {
         sign_in: { state: "failed", message: "browser authorization timed out" },
       }),
     });
-    render(
-      <GatewayPanel
-        client={client}
-        onChanged={() => undefined}
-        onOpenMcpSettings={() => undefined}
-      />,
-    );
+    render(managedPanel(client));
 
     expect(
       await screen.findByText(/browser authorization timed out/),

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
@@ -249,7 +249,11 @@ function ManagedGatewayPanel({
             <SettingsStatus
               tone="not-configured"
               label="Not signed in"
-              description="Connect to sign in with your browser."
+              description={
+                origin === null
+                  ? "This device's managed policy names no gateway. Contact your administrator."
+                  : "Connect to sign in with your browser."
+              }
             />
             {status.sign_in.state === "failed" && (
               <SettingsError>{status.sign_in.message}</SettingsError>
@@ -275,7 +279,9 @@ function ManagedGatewayPanel({
             ) : (
               <Button
                 type="button"
-                disabled={working}
+                // No origin means a misconfigured policy: there is no
+                // deployment to sign in against, and the server would refuse.
+                disabled={working || origin === null}
                 onClick={() =>
                   void run(async () => {
                     const started = await client.gatewaySignIn();

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
@@ -4,11 +4,8 @@ import { ExternalLink, LogOut, PlugZap, RefreshCw } from "lucide-react";
 import type { ApiClient, GatewayApps, GatewayStatus } from "../api";
 import { openSignInPage } from "../openSignInPage";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Switch } from "@/components/ui/switch";
 import {
   SettingsError,
-  SettingsField,
   SettingsPanel,
   SettingsSection,
   SettingsStatus,
@@ -17,37 +14,85 @@ import {
 const SIGN_IN_POLL_MS = 2_000;
 
 /**
- * The Model Gateway connection: one toggle, one URL, one sign-in.
+ * The Model Gateway section.
  *
- * Authentication is the gateway's own OAuth flow in the system browser —
- * OpenWave never sees a password or IdP credential, only the gateway's
- * rotating tokens, which live in the keychain. Signed in, the entitled
- * models sync into the picker; signed out, the app is exactly the local
- * bring-your-own-key product it was before.
+ * Policy is the only gateway source: a profile connects through the
+ * gateway's own page (deep-link pairing) or the organization's device
+ * management, never from settings — there is no URL field and no enable
+ * toggle in any state. Unmanaged profiles render a signpost at that flow;
+ * managed profiles get the slim identity panel: who is signed in, the
+ * read-only gateway origin from policy, sign in/out, and a models refresh.
  */
 export function GatewayPanel({
   client,
+  managed,
+  gatewayUrl,
   onChanged,
   onOpenMcpSettings,
 }: {
   client: ApiClient;
+  /** Whether the resolved policy manages this profile. */
+  managed: boolean;
+  /** The policy's locked gateway origin, shown read-only. */
+  gatewayUrl: string | null;
   onChanged: () => void;
   /** Navigates to the MCP servers section, where entitled endpoints are
    * mounted. Mounting lives beside the health of what is mounted, so this
    * panel points at it rather than carrying its own toggles. */
   onOpenMcpSettings: () => void;
 }) {
+  if (!managed) {
+    // Deep links and stale history entries still resolve here even though
+    // the rail hides the section; say plainly how connecting works now.
+    return (
+      <SettingsPanel
+        title="Model Gateway"
+        description="This profile is not connected to a model gateway."
+      >
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          Connecting happens from your gateway&apos;s own page — open it in
+          your browser and choose Connect — or through your
+          organization&apos;s device management. There is nothing to
+          configure here; until then, OpenWave stays fully local with your
+          own provider keys.
+        </p>
+      </SettingsPanel>
+    );
+  }
+  return (
+    <ManagedGatewayPanel
+      client={client}
+      gatewayUrl={gatewayUrl}
+      onChanged={onChanged}
+      onOpenMcpSettings={onOpenMcpSettings}
+    />
+  );
+}
+
+/**
+ * Authentication is the gateway's own OAuth flow in the system browser —
+ * OpenWave never sees a password or IdP credential, only the gateway's
+ * rotating tokens, which live in the keychain.
+ */
+function ManagedGatewayPanel({
+  client,
+  gatewayUrl,
+  onChanged,
+  onOpenMcpSettings,
+}: {
+  client: ApiClient;
+  gatewayUrl: string | null;
+  onChanged: () => void;
+  onOpenMcpSettings: () => void;
+}) {
   const [status, setStatus] = useState<GatewayStatus | null>(null);
   const [apps, setApps] = useState<GatewayApps | null>(null);
-  const [baseUrl, setBaseUrl] = useState("");
-  const [dirty, setDirty] = useState(false);
   const [working, setWorking] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Refs, not state reads, inside `reload`: transition detection must not
+  // A ref, not a state read, inside `reload`: transition detection must not
   // live in a state updater (updaters are pure and StrictMode double-invokes
-  // them), and the poll must not refill a field the user is editing.
+  // them).
   const signedInRef = useRef(false);
-  const dirtyRef = useRef(false);
 
   const reload = useCallback(async () => {
     const next = await client.getGatewayStatus();
@@ -55,9 +100,6 @@ export function GatewayPanel({
     if (!signedInRef.current && next.signed_in) onChanged();
     signedInRef.current = next.signed_in;
     setStatus(next);
-    setBaseUrl((current) =>
-      current === "" && !dirtyRef.current ? (next.base_url ?? "") : current,
-    );
     return next;
   }, [client, onChanged]);
 
@@ -110,19 +152,6 @@ export function GatewayPanel({
     }
   }
 
-  async function save(enabled: boolean) {
-    await run(async () => {
-      await client.putProvider("model_gateway", {
-        enabled,
-        base_url: baseUrl.trim() === "" ? null : baseUrl.trim(),
-      });
-      setDirty(false);
-      dirtyRef.current = false;
-      onChanged();
-      toast.success("Saved gateway settings");
-    });
-  }
-
   if (!status) {
     return (
       <SettingsPanel title="Model Gateway" description="Loading…" busy>
@@ -133,6 +162,9 @@ export function GatewayPanel({
 
   const pendingUrl =
     status.sign_in.state === "pending" ? status.sign_in.authorization_url : null;
+  // The policy names the deployment; the status echoes it. Prefer the policy
+  // (it is what the profile is locked to) and fall back to the echo.
+  const origin = gatewayUrl ?? status.base_url ?? null;
   // The one route to mounting, shown whenever signed in: a gateway without
   // the apps surface still mounts endpoints by slug on the MCP servers page.
   const mountSignpost = (
@@ -150,52 +182,16 @@ export function GatewayPanel({
   return (
     <SettingsPanel
       title="Model Gateway"
-      description="Sign in to a model-gateway deployment to use the models and governed tools you are entitled to. Off, OpenWave stays fully local."
+      description="This profile is managed by your organization's model gateway: models and governed tools come from the deployment below."
       busy={working}
     >
-      <SettingsSection>
-        <div className="flex items-center justify-between gap-4">
-          <div className="flex-1">
-            <p className="text-sm font-bold">Use Model Gateway</p>
-            <p className="text-xs text-muted-foreground">
-              Route models and governed tools through a signed-in gateway. Off,
-              OpenWave stays fully local.
-            </p>
-          </div>
-          <Switch
-            aria-label="Use Model Gateway"
-            checked={status.enabled}
-            disabled={working}
-            onCheckedChange={(checked) => void save(checked)}
-          />
-        </div>
-
-        <SettingsField
-          label="Gateway URL"
-          hint="The deployment's base URL, e.g. http://127.0.0.1:28081 for a local dev gateway."
-        >
-          <Input
-            value={baseUrl}
-            disabled={working}
-            autoComplete="off"
-            spellCheck={false}
-            placeholder="https://gateway.example"
-            onChange={(event) => {
-              setBaseUrl(event.target.value);
-              setDirty(true);
-              dirtyRef.current = true;
-            }}
-          />
-        </SettingsField>
-        {dirty && (
-          <Button
-            type="button"
-            disabled={working}
-            onClick={() => void save(status.enabled)}
-          >
-            Save gateway URL
-          </Button>
-        )}
+      <SettingsSection title="Gateway">
+        <p className="text-sm">
+          <code className="font-medium">{origin ?? "—"}</code>
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Set by your organization&apos;s policy and not editable here.
+        </p>
       </SettingsSection>
 
       <SettingsSection title="Connection">
@@ -253,11 +249,7 @@ export function GatewayPanel({
             <SettingsStatus
               tone="not-configured"
               label="Not signed in"
-              description={
-                status.configured
-                  ? "Connect to sign in with your browser."
-                  : "Save the gateway URL, then connect."
-              }
+              description="Connect to sign in with your browser."
             />
             {status.sign_in.state === "failed" && (
               <SettingsError>{status.sign_in.message}</SettingsError>
@@ -283,7 +275,7 @@ export function GatewayPanel({
             ) : (
               <Button
                 type="button"
-                disabled={working || !status.configured || dirty}
+                disabled={working}
                 onClick={() =>
                   void run(async () => {
                     const started = await client.gatewaySignIn();

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
@@ -39,8 +39,6 @@ const healthy: McpServersInfo = {
 };
 
 const signedOut: GatewayStatus = {
-  configured: true,
-  enabled: true,
   base_url: "http://127.0.0.1:28081",
   signed_in: false,
   model_count: 0,

--- a/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ModelsPanel.tsx
@@ -383,6 +383,12 @@ function ModelRoleRow({
   const selectedValue =
     selected?.provider === provider ? (canonical ?? "") : "";
   const unresolvedSelection = info.selection !== null && selected === null;
+  // A pin left behind by the retired additive gateway mode. The catalog has
+  // no gateway models on an unmanaged profile, so it resolves to nothing —
+  // and the openai_compatible advice below cannot apply to it.
+  const retiredGatewayPin =
+    unresolvedSelection &&
+    (info.selection?.startsWith("model_gateway::") ?? false);
 
   return (
     <SettingsSection title={title}>
@@ -446,11 +452,19 @@ function ModelRoleRow({
           </SelectContent>
         </Select>
       </SettingsField>
-      {unresolvedSelection && (
+      {retiredGatewayPin ? (
         <SettingsError>
-          The saved model “{info.selection}” is not uniquely registered. Add it
-          under the OpenAI-compatible provider, then choose it here.
+          The saved model “{info.selection}” came from a model gateway, and
+          this profile is not connected to one. Pick a model here, or connect
+          from your gateway&apos;s page.
         </SettingsError>
+      ) : (
+        unresolvedSelection && (
+          <SettingsError>
+            The saved model “{info.selection}” is not uniquely registered. Add
+            it under the OpenAI-compatible provider, then choose it here.
+          </SettingsError>
+        )
       )}
     </SettingsSection>
   );

--- a/crates/openwave-desktop/ui/src/settings/sections.test.ts
+++ b/crates/openwave-desktop/ui/src/settings/sections.test.ts
@@ -12,9 +12,17 @@ describe("settings sections", () => {
     const managed = settingsSectionsFor(true);
     expect(managed.map((section) => section.path)).not.toContain("providers");
     expect(defaultSettingsPathFor(true)).toBe("/settings/gateway");
+  });
 
-    // An unmanaged profile is untouched: every section, providers first.
-    expect(settingsSectionsFor(false)).toEqual(SETTINGS_SECTIONS);
+  it("drops the gateway entry from an unmanaged profile's rail", () => {
+    // Policy is the only gateway source: an unmanaged profile has nothing to
+    // configure under Model Gateway, so the section leaves its rail — while
+    // every route in the registry still resolves for deep links.
+    const unmanaged = settingsSectionsFor(false);
+    expect(unmanaged.map((section) => section.path)).not.toContain("gateway");
     expect(defaultSettingsPathFor(false)).toBe("/settings/providers");
+    expect(SETTINGS_SECTIONS.map((section) => section.path)).toContain(
+      "gateway",
+    );
   });
 });

--- a/crates/openwave-desktop/ui/src/settings/sections.tsx
+++ b/crates/openwave-desktop/ui/src/settings/sections.tsx
@@ -46,6 +46,7 @@ function ProvidersSection() {
 
 function GatewaySection() {
   const { client, refreshCatalog } = useApp();
+  const policy = useManagedPolicy();
   const navigate = useNavigate();
   // Settings sections are registered from a runtime table, so TanStack's
   // generated route union contains `/settings` but not each literal child.
@@ -53,6 +54,8 @@ function GatewaySection() {
   return (
     <GatewayPanel
       client={client}
+      managed={policy.managed}
+      gatewayUrl={policy.gateway_url ?? null}
       onChanged={() => void refreshCatalog()}
       onOpenMcpSettings={() => void navigate({ to: mcpPath })}
     />
@@ -124,6 +127,9 @@ export type SettingsSectionDef = {
    * deep link or a stale history entry must land on something legible — and
    * the panel itself renders its locked state. */
   managedHidden?: boolean;
+  /** Kept out of the rail on an unmanaged profile, same deep-link contract:
+   * the route resolves and the panel renders its not-connected state. */
+  unmanagedHidden?: boolean;
 };
 
 /**
@@ -138,7 +144,13 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     Component: ProvidersSection,
     managedHidden: true,
   },
-  { path: "gateway", label: "Model Gateway", icon: Waypoints, Component: GatewaySection },
+  {
+    path: "gateway",
+    label: "Model Gateway",
+    icon: Waypoints,
+    Component: GatewaySection,
+    unmanagedHidden: true,
+  },
   { path: "models", label: "Models", icon: Cpu, Component: ModelsSection },
   { path: "web-search", label: "Web search", icon: Globe, Component: WebSearchSection },
   {
@@ -165,12 +177,14 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
  * A managed profile has no bring-your-own credentials to manage, so the
  * Providers section is dropped and the Model Gateway — the one place its
  * models and session come from — becomes the first section, and therefore
- * where settings opens.
+ * where settings opens. An unmanaged profile has no gateway at all — policy
+ * is the only gateway source, and connecting happens from the gateway's own
+ * page — so the Model Gateway section is dropped from its rail instead.
  */
 export function settingsSectionsFor(managed: boolean): SettingsSectionDef[] {
-  return managed
-    ? SETTINGS_SECTIONS.filter((section) => !section.managedHidden)
-    : SETTINGS_SECTIONS;
+  return SETTINGS_SECTIONS.filter((section) =>
+    managed ? !section.managedHidden : !section.unmanagedHidden,
+  );
 }
 
 export function defaultSettingsPathFor(managed: boolean): string {

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -1,11 +1,13 @@
 //! The server's handle on a signed-in model-gateway session.
 //!
-//! Owns the [`GatewayConnection`] built from the persisted provider
-//! configuration, hands the router a per-request token source for the
-//! gateway's short-lived `llm` tokens, and syncs the entitled model list into
-//! the provider's stored custom-model set so the picker and model policy work
-//! from durable local state while the gateway stays the live authority at
-//! inference time.
+//! Owns the [`GatewayConnection`] built from the resolved managed policy —
+//! the only gateway source in either direction — hands the router a
+//! per-request token source for the gateway's short-lived `llm` tokens, and
+//! syncs the entitled model list into the stored snapshot so the picker and
+//! model policy work from durable local state while the gateway stays the
+//! live authority at inference time. On an unmanaged profile every surface
+//! here is inert: no connection, no routes, and the sign-in endpoints refuse
+//! with a pointer at the pairing flow.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -19,7 +21,7 @@ use openwave_router::BearerTokenSource;
 use serde::Serialize;
 use tokio::sync::Mutex;
 
-use crate::providers::{self, CustomModelConfig, ProviderKind};
+use crate::providers::{self, CustomModelConfig};
 
 /// How long a browser sign-in may stay pending before it fails.
 const SIGN_IN_TIMEOUT: Duration = Duration::from_secs(300);
@@ -111,37 +113,26 @@ impl GatewayRuntime {
         })
     }
 
-    /// The renderer-facing connection status.
+    /// The renderer-facing connection status, derived from policy alone: a
+    /// profile is gateway-connected exactly when managed policy asserts it,
+    /// so an unmanaged profile reads unconfigured whatever legacy rows
+    /// persist, and a managed policy whose URL is missing (misconfigured)
+    /// reads unconfigured, honestly.
     ///
-    /// Where the deployment comes from follows [`connection`](Self::connection):
-    /// on a managed profile the resolved policy is the authority, so a
-    /// pure-MDM profile — which may have no stored provider row at all —
-    /// reads configured and enabled against its policy URL instead of
-    /// rendering "not configured" while everything works. A managed policy
-    /// whose URL is missing (misconfigured) reads unconfigured, honestly.
+    /// `configured` and `enabled` are now the same bit — kept apart only for
+    /// wire-shape stability until the renderer slice retires them.
     pub(crate) async fn status(&self) -> Result<GatewayStatus> {
         // One policy read for the whole projection: the renderer polls this
         // every couple of seconds while a sign-in is pending.
         let policy = crate::managed_policy::resolve(&*self.store, &*self.os_policy).await?;
-        let config = providers::read_config(&*self.store, ProviderKind::ModelGateway).await?;
-        let base_url = if policy.managed {
-            policy.gateway_url.clone()
-        } else {
-            config.base_url.clone()
-        };
+        let base_url = policy.gateway_url.clone();
         let credentials = match self.connection_for(&policy).await? {
             Some(connection) => connection.stored_credentials().await?,
             None => None,
         };
         Ok(GatewayStatus {
             configured: base_url.is_some(),
-            // A managed profile's gateway cannot be switched off from the
-            // stored row: policy decides whether it is on.
-            enabled: if policy.managed {
-                base_url.is_some()
-            } else {
-                config.enabled
-            },
+            enabled: base_url.is_some(),
             base_url,
             signed_in: credentials.is_some(),
             account_hint: credentials
@@ -150,19 +141,18 @@ impl GatewayRuntime {
             installation_id: credentials
                 .as_ref()
                 .map(|credentials| credentials.installation_id.clone()),
-            model_count: config.models.len(),
+            model_count: providers::gateway_models(&*self.store, &policy)
+                .await?
+                .len(),
             sign_in: self.sign_in.lock().await.clone(),
         })
     }
 
     /// The entitled connected apps, fetched live from the gateway with the
-    /// stored session. Requires a configured gateway and a signed-in session;
-    /// a gateway without the JSON apps surface reports `supported: false`.
+    /// stored session. Managed-only, like the whole sign-in surface; a
+    /// gateway without the JSON apps surface reports `supported: false`.
     pub(crate) async fn apps(&self) -> Result<GatewayApps> {
-        let connection = self
-            .connection()
-            .await?
-            .ok_or_else(|| AgentError::config("no model gateway is configured"))?;
+        let connection = self.managed_connection().await?;
         Ok(match connection.apps().await? {
             Some(apps) => GatewayApps {
                 supported: true,
@@ -190,10 +180,7 @@ impl GatewayRuntime {
     /// stored and the entitled models synced; on failure the status surface
     /// carries the bounded error until the next attempt.
     pub(crate) async fn begin_sign_in(self: &Arc<Self>) -> Result<String> {
-        let connection = self
-            .connection()
-            .await?
-            .ok_or_else(|| AgentError::config("no model gateway is configured"))?;
+        let connection = self.managed_connection().await?;
         let pending = connection.auth().start_sign_in().await?;
         let authorization_url = pending.authorization_url().to_string();
         let generation = {
@@ -246,8 +233,10 @@ impl GatewayRuntime {
     }
 
     /// Revoke the session (best-effort at the gateway), clear local state, and
-    /// drop the synced model snapshot.
+    /// drop the synced model snapshot. Managed-only, like sign-in.
     pub(crate) async fn sign_out(&self) -> Result<()> {
+        let policy = crate::managed_policy::resolve(&*self.store, &*self.os_policy).await?;
+        let base_url = require_managed(&policy)?;
         // Take the state lock for the whole operation and invalidate any
         // pending browser flow before revoking anything: an exchange that
         // completes during the revoke round-trip serializes behind this lock
@@ -256,35 +245,41 @@ impl GatewayRuntime {
         let mut sign_in = self.sign_in.lock().await;
         self.sign_in_generation
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        if let Some(connection) = self.connection().await? {
-            connection.sign_out().await?;
-        }
+        self.connection_at(base_url.clone())
+            .await?
+            .sign_out()
+            .await?;
         {
-            // Serialize the snapshot clear with the other row writers so it
-            // cannot land inside one of their read-modify-writes. Lock order
-            // matches the sign-in task's sync path: the sign-in state lock is
-            // already held, the row lock nests inside it.
-            let _row = providers::GATEWAY_ROW_WRITES.lock().await;
-            let mut config =
-                providers::read_config(&*self.store, ProviderKind::ModelGateway).await?;
-            if !config.models.is_empty() {
-                config.models = Vec::new();
-                providers::write_config(&*self.store, ProviderKind::ModelGateway, &config).await?;
+            // Serialize the snapshot clear with the other snapshot writers so
+            // it cannot land inside one of their recheck-and-write windows.
+            // Lock order matches the sign-in task's sync path: the sign-in
+            // state lock is already held, the snapshot lock nests inside it.
+            let _lock = providers::GATEWAY_STATE_WRITES.lock().await;
+            if !providers::gateway_models(&*self.store, &policy)
+                .await?
+                .is_empty()
+            {
+                providers::write_gateway_snapshot(
+                    &*self.store,
+                    &providers::GatewayModelSnapshot {
+                        gateway_url: base_url,
+                        models: Vec::new(),
+                    },
+                )
+                .await?;
             }
         }
         *sign_in = SignInProgress::Idle;
         Ok(())
     }
 
-    /// The connection for the effective gateway, or `None` when none is
-    /// configured.
+    /// The connection for the policy's gateway, or `None` when the profile is
+    /// unmanaged (or the managed policy is misconfigured).
     ///
-    /// A managed profile's deployment comes from the resolved policy, never
-    /// from the stored provider row: the row is renderer-writable while
-    /// unmanaged, so honoring it here would let a pre-provisioning write
-    /// redirect sign-in and every minted bearer — and a merely diverged (or
-    /// absent) row would drop the connection a managed profile is entitled
-    /// to. Under managed policy the row is display/session-cache only.
+    /// The deployment comes from the resolved policy and nowhere else. The
+    /// retired provider row was renderer-writable while unmanaged, so
+    /// honoring it here would let a pre-provisioning write redirect sign-in
+    /// and every minted bearer; it is never read.
     pub(crate) async fn connection(&self) -> Result<Option<Arc<GatewayConnection>>> {
         let policy = crate::managed_policy::resolve(&*self.store, &*self.os_policy).await?;
         self.connection_for(&policy).await
@@ -296,25 +291,19 @@ impl GatewayRuntime {
         &self,
         policy: &crate::managed_policy::ManagedPolicy,
     ) -> Result<Option<Arc<GatewayConnection>>> {
-        let Some(base_url) = self.effective_base_url(policy).await? else {
+        let Some(base_url) = policy.gateway_url.clone().filter(|_| policy.managed) else {
             return Ok(None);
         };
         Ok(Some(self.connection_at(base_url).await?))
     }
 
-    /// The effective deployment URL: the resolved policy's on a managed
-    /// profile, the stored row's otherwise. `None` when neither names one.
-    async fn effective_base_url(
-        &self,
-        policy: &crate::managed_policy::ManagedPolicy,
-    ) -> Result<Option<String>> {
-        Ok(if policy.managed {
-            policy.gateway_url.clone()
-        } else {
-            providers::read_config(&*self.store, ProviderKind::ModelGateway)
-                .await?
-                .base_url
-        })
+    /// The connection for the managed gateway, refusing legibly when the
+    /// profile is unmanaged: the sign-in surface (sign-in, sign-out, apps,
+    /// model sync) exists only under managed policy.
+    async fn managed_connection(&self) -> Result<Arc<GatewayConnection>> {
+        let policy = crate::managed_policy::resolve(&*self.store, &*self.os_policy).await?;
+        let base_url = require_managed(&policy)?;
+        self.connection_at(base_url).await
     }
 
     /// The cached connection for `base_url`, rebuilt when the URL changes.
@@ -334,17 +323,18 @@ impl GatewayRuntime {
         Ok(connection)
     }
 
-    /// A router token source, when the provider is configured and a session
-    /// for that deployment is stored. `None` keeps the gateway route out of
-    /// the router entirely — including when the stored session belongs to a
-    /// different gateway than the configured base URL.
+    /// A router token source, when policy names a gateway and a session for
+    /// that deployment is stored. `None` keeps the gateway route out of the
+    /// router entirely — including on unmanaged profiles and when the stored
+    /// session belongs to a different gateway than the policy URL.
     pub(crate) async fn route_token_source(&self) -> Option<Arc<dyn BearerTokenSource>> {
         let connection = self.connection().await.ok().flatten()?;
         connection.stored_credentials().await.ok().flatten()?;
         Some(Arc::new(GatewayTokenSource(connection)))
     }
 
-    /// Fetch the entitled models and persist them as the provider's model set.
+    /// Fetch the entitled models and persist them as the stored snapshot,
+    /// stamped with the deployment they came from. Managed-only.
     ///
     /// Returns how many models are entitled. The persisted snapshot drives the
     /// picker and model policy; entitlement itself stays live at the gateway,
@@ -354,10 +344,7 @@ impl GatewayRuntime {
         &self,
     ) -> std::result::Result<usize, crate::error::ServerError> {
         let policy = crate::managed_policy::resolve(&*self.store, &*self.os_policy).await?;
-        let base_url = self
-            .effective_base_url(&policy)
-            .await?
-            .ok_or_else(|| AgentError::config("no model gateway is configured"))?;
+        let base_url = require_managed(&policy)?;
         let connection = self.connection_at(base_url.clone()).await?;
         // The gateway routes these models over its Anthropic-compatible
         // surface, so sync exactly the set that protocol can serve. Fetched
@@ -380,13 +367,13 @@ impl GatewayRuntime {
             AgentError::config(format!("gateway model sync rejected: {error:?}"))
         })?;
         let count = models.len();
-        let _row = providers::GATEWAY_ROW_WRITES.lock().await;
-        // The fetch ran outside the lock, so a pairing (or an unmanaged
-        // re-point of the row) may have changed the deployment while it was
-        // in flight. Re-resolve under the lock and refuse to stamp another
-        // gateway's row with this one's model list.
+        let _lock = providers::GATEWAY_STATE_WRITES.lock().await;
+        // The fetch ran outside the lock, so the policy authority (an MDM
+        // push) may have re-pointed the deployment while it was in flight.
+        // Re-resolve under the lock and refuse to stamp a snapshot the new
+        // policy never entitled.
         let policy = crate::managed_policy::resolve(&*self.store, &*self.os_policy).await?;
-        if self.effective_base_url(&policy).await?.as_deref() != Some(base_url.as_str()) {
+        if policy.gateway_url.as_deref() != Some(base_url.as_str()) {
             // A benign, retryable race — the deployment was re-pointed while
             // the fetch was in flight — not an internal fault. The stable
             // kind lets clients branch on it, as with `managed_profile`.
@@ -395,9 +382,14 @@ impl GatewayRuntime {
                 "the model gateway configuration changed during model sync",
             ));
         }
-        let mut config = providers::read_config(&*self.store, ProviderKind::ModelGateway).await?;
-        config.models = models;
-        providers::write_config(&*self.store, ProviderKind::ModelGateway, &config).await?;
+        providers::write_gateway_snapshot(
+            &*self.store,
+            &providers::GatewayModelSnapshot {
+                gateway_url: base_url,
+                models,
+            },
+        )
+        .await?;
         Ok(count)
     }
 }
@@ -417,6 +409,23 @@ impl crate::mcp_config::GatewayEndpoints for GatewayRuntime {
             bearer_token: connection.mcp_access_token(slug).await?,
         })
     }
+}
+
+/// The one refusal for every managed-only gateway surface: unmanaged
+/// profiles have no gateway (policy is the only source), and a managed
+/// policy without a usable URL is misconfigured rather than open.
+fn require_managed(policy: &crate::managed_policy::ManagedPolicy) -> Result<String> {
+    if !policy.managed {
+        return Err(AgentError::config(
+            "this profile is not connected to a model gateway; \
+             pair via your gateway's page to connect",
+        ));
+    }
+    policy.gateway_url.clone().ok_or_else(|| {
+        AgentError::config(
+            "the managed gateway policy has no usable gateway URL; repair the policy authority",
+        )
+    })
 }
 
 fn clamp_u32(value: Option<i64>, default: u32) -> u32 {
@@ -574,8 +583,12 @@ mod tests {
         address
     }
 
-    async fn signed_in_runtime(
-        base_url: &str,
+    /// A runtime with a stored session for `session_base`, on a profile
+    /// provisioned (managed) to `provisioned` — policy being the only way a
+    /// profile is gateway-connected at all.
+    async fn signed_in_runtime_at(
+        session_base: &str,
+        provisioned: &str,
     ) -> (Arc<GatewayRuntime>, Arc<dyn Store>, tempfile::TempDir) {
         let directory = tempfile::tempdir().unwrap();
         let store: Arc<dyn Store> = Arc::new(
@@ -591,7 +604,7 @@ mod tests {
         // seed the vault through its serialized form, exactly as a completed
         // sign-in would have persisted it.
         let credentials: openwave_connectors::GatewayCredentials = serde_json::from_value(json!({
-            "base_url": base_url,
+            "base_url": session_base,
             "installation_id": "install-1",
             "user_id": "user-1",
             "account_hint": "abaas@example.test",
@@ -603,18 +616,9 @@ mod tests {
             .save(&credentials)
             .await
             .unwrap();
-        providers::write_config(
-            &*store,
-            ProviderKind::ModelGateway,
-            &providers::ProviderConfig {
-                enabled: true,
-                base_url: Some(base_url.to_string()),
-                vertex_location: None,
-                models: Vec::new(),
-            },
-        )
-        .await
-        .unwrap();
+        crate::managed_policy::provision(&*store, provisioned)
+            .await
+            .unwrap();
         (
             GatewayRuntime::new(
                 store.clone(),
@@ -626,27 +630,31 @@ mod tests {
         )
     }
 
+    async fn signed_in_runtime(
+        base_url: &str,
+    ) -> (Arc<GatewayRuntime>, Arc<dyn Store>, tempfile::TempDir) {
+        signed_in_runtime_at(base_url, base_url).await
+    }
+
     #[tokio::test]
-    async fn syncs_entitled_models_into_the_provider_config() {
+    async fn syncs_entitled_models_into_the_snapshot() {
         let address = serve(Arc::new(FakeGateway::default())).await;
         let base = format!("http://{address}");
         let (runtime, store, _directory) = signed_in_runtime(&base).await;
 
         assert_eq!(runtime.sync_models().await.unwrap(), 2);
 
-        let config = providers::read_config(&*store, ProviderKind::ModelGateway)
+        let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
             .await
             .unwrap();
-        assert_eq!(config.models.len(), 2);
-        assert_eq!(config.models[0].id, "sample-claude");
-        assert_eq!(
-            config.models[0].display_name.as_deref(),
-            Some("Sample Claude")
-        );
-        assert_eq!(config.models[0].context_window, 200_000);
+        let models = providers::gateway_models(&*store, &policy).await.unwrap();
+        assert_eq!(models.len(), 2);
+        assert_eq!(models[0].id, "sample-claude");
+        assert_eq!(models[0].display_name.as_deref(), Some("Sample Claude"));
+        assert_eq!(models[0].context_window, 200_000);
         // Absent limits fall back to the conservative custom-model defaults.
-        assert_eq!(config.models[1].context_window, 32_768);
-        assert_eq!(config.models[1].max_output_tokens, 4_096);
+        assert_eq!(models[1].context_window, 32_768);
+        assert_eq!(models[1].max_output_tokens, 4_096);
 
         // The synced snapshot resolves as a model policy under the gateway key.
         let policy =
@@ -654,7 +662,10 @@ mod tests {
                 .await
                 .unwrap()
                 .expect("synced model resolves");
-        assert_eq!(policy.provider, ProviderKind::ModelGateway);
+        assert_eq!(
+            policy.provider,
+            crate::providers::ProviderKind::ModelGateway
+        );
         assert_eq!(policy.display_name, "Sample Claude");
     }
 
@@ -676,7 +687,21 @@ mod tests {
         assert_eq!(gateway.refreshes.load(Ordering::SeqCst), 1);
 
         // The route set includes the gateway with its synced models claimed.
+        // A legacy provider row — even one pointing at a different deployment
+        // — is never read, so it changes nothing about the composite route.
         runtime.sync_models().await.unwrap();
+        providers::write_config(
+            &*store,
+            crate::providers::ProviderKind::ModelGateway,
+            &providers::ProviderConfig {
+                enabled: true,
+                base_url: Some("http://127.0.0.1:9".to_string()),
+                vertex_location: None,
+                models: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
         let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
             .await
             .unwrap();
@@ -699,19 +724,24 @@ mod tests {
         assert!(gateway_route
             .curated_models
             .contains(&"sample-claude".to_string()));
+        assert!(providers::provider_is_usable(
+            &*store,
+            &*runtime.secrets,
+            crate::providers::ProviderKind::ModelGateway,
+            &policy
+        )
+        .await
+        .unwrap());
     }
 
-    /// The race #896 names, forced deterministically: a model sync whose
-    /// entitlement fetch is still in flight when a pairing re-points the
-    /// profile at a different gateway. The sync must not stamp the old
-    /// gateway's model list (or base URL) over the row the pairing just
-    /// wrote. The pairing here runs to completion before the parked fetch
-    /// is released, so the two read-modify-writes never overlap: what this
-    /// pins is the under-lock recheck refusing the stale write. The lock
-    /// itself is pinned by
-    /// `pairing::tests::a_provider_update_parked_mid_write_cannot_overwrite_a_pairing`.
+    /// The race #896 named, in its surviving form: with policy the only
+    /// gateway source, the one authority that can re-point a deployment
+    /// mid-sync is an OS (MDM) push. A sync whose entitlement fetch is still
+    /// in flight when that happens must not stamp the old gateway's model
+    /// list into the snapshot — what this pins is the under-lock policy
+    /// recheck refusing the stale write.
     #[tokio::test]
-    async fn a_sync_racing_a_pairing_cannot_resurrect_the_old_gateways_state() {
+    async fn a_sync_racing_a_policy_repoint_cannot_stamp_the_old_gateways_models() {
         // Gateway A: answers token refreshes normally but parks the model
         // list until released — the window the pairing lands in.
         let (arrived_tx, mut arrived_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
@@ -747,26 +777,41 @@ mod tests {
             axum::serve(listener, app).await.unwrap();
         });
 
-        // Gateway B: answers only the pairing probe.
-        let meta = AxumRouter::new().route(
-            "/api/v1/meta",
-            get(|| async {
-                Json(json!({
-                    "api_version": "v1",
-                    "installation_id": "install-2",
-                    "gateway_version": "1.0.0",
-                    "public_url": "http://gateway-b.test",
-                    "auth_mode": "oidc",
-                }))
-            }),
-        );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let base_b = format!("http://{}", listener.local_addr().unwrap());
-        tokio::spawn(async move {
-            axum::serve(listener, meta).await.unwrap();
-        });
+        // An OS authority whose asserted deployment can change mid-test, as
+        // an MDM push would.
+        struct SwappableOs(std::sync::Mutex<String>);
 
-        let (runtime, store, _directory) = signed_in_runtime(&base_a).await;
+        impl crate::managed_policy::OsPolicySource for SwappableOs {
+            fn gateway_url(&self) -> Result<Option<String>> {
+                Ok(Some(self.0.lock().unwrap().clone()))
+            }
+        }
+
+        let directory = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("gateway.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let secrets: Arc<dyn SecretProvider> = Arc::new(MockSecrets::default());
+        let credentials: openwave_connectors::GatewayCredentials = serde_json::from_value(json!({
+            "base_url": base_a,
+            "installation_id": "install-1",
+            "user_id": "user-1",
+            "refresh_token": "mg_rt_seed",
+            "access_tokens": {}
+        }))
+        .unwrap();
+        CredentialVault::new(secrets.clone())
+            .save(&credentials)
+            .await
+            .unwrap();
+        let os = Arc::new(SwappableOs(std::sync::Mutex::new(base_a.clone())));
+        let runtime = GatewayRuntime::new(store.clone(), secrets, os.clone());
+
         let sync = tokio::spawn({
             let runtime = runtime.clone();
             async move { runtime.sync_models().await }
@@ -776,17 +821,9 @@ mod tests {
             .await
             .expect("the fetch reaches gateway A");
 
-        // While A's model list is in flight, pair the profile to gateway B.
-        let mcp = Arc::new(crate::mcp_config::McpRuntime::new(
-            Arc::new(openwave_core::ToolRegistry::new()),
-            store.clone(),
-            runtime.clone(),
-            Arc::new(crate::managed_policy::NoOsPolicy),
-        ));
-        let handle = crate::pairing::PairingHandle::new(store.clone(), mcp);
-        let outcome = crate::pairing::pair_with_gateway(&handle, &base_b)
-            .await
-            .unwrap();
+        // While A's model list is in flight, the MDM authority re-points the
+        // profile at gateway B.
+        *os.0.lock().unwrap() = "https://gateway-b.test".to_string();
 
         release.notify_one();
         let error = sync
@@ -799,17 +836,12 @@ mod tests {
             "the refusal is the stable retryable conflict, not a fault: {error:?}"
         );
 
-        let config = providers::read_config(&*store, ProviderKind::ModelGateway)
-            .await
-            .unwrap();
-        assert_eq!(
-            config.base_url.as_deref(),
-            Some(outcome.base_url.as_str()),
-            "the pairing's base URL must survive the racing sync"
-        );
         assert!(
-            config.models.is_empty(),
-            "gateway A's models must not land on gateway B's row"
+            providers::read_gateway_snapshot(&*store)
+                .await
+                .unwrap()
+                .is_none(),
+            "gateway A's models must not be stamped into the snapshot"
         );
     }
 
@@ -831,24 +863,20 @@ mod tests {
         assert!(!json.contains("mg_at_"));
         assert!(!json.contains("mg_rt_"));
 
-        // Managed policy is a separate layer with a separate lifecycle:
-        // disconnecting the session must never deprovision the profile.
-        crate::managed_policy::provision(&*store, &base)
-            .await
-            .unwrap();
-
         runtime.sign_out().await.unwrap();
         let status = runtime.status().await.unwrap();
         assert!(!status.signed_in);
         assert_eq!(status.model_count, 0);
         assert!(status.account_hint.is_none());
-        let config = providers::read_config(&*store, ProviderKind::ModelGateway)
-            .await
-            .unwrap();
-        assert!(config.models.is_empty());
         let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
             .await
             .unwrap();
+        assert!(providers::gateway_models(&*store, &policy)
+            .await
+            .unwrap()
+            .is_empty());
+        // Managed policy is a separate layer with a separate lifecycle:
+        // disconnecting the session must never deprovision the profile.
         assert!(policy.managed, "sign-out must not deprovision the profile");
     }
 
@@ -917,17 +945,9 @@ mod tests {
     async fn a_session_for_a_different_gateway_reads_signed_out() {
         let address = serve(Arc::new(FakeGateway::default())).await;
         let base = format!("http://{address}");
-        let (runtime, store, _directory) = signed_in_runtime(&base).await;
-
-        // Repoint the provider at a different deployment; the stored session
-        // (minted against `base`) stays in the vault untouched.
-        let mut config = providers::read_config(&*store, ProviderKind::ModelGateway)
-            .await
-            .unwrap();
-        config.base_url = Some("http://127.0.0.1:9".to_string());
-        providers::write_config(&*store, ProviderKind::ModelGateway, &config)
-            .await
-            .unwrap();
+        // The profile is managed to one deployment while the stored session
+        // (minted against `base`) belongs to another.
+        let (runtime, _store, _directory) = signed_in_runtime_at(&base, "http://127.0.0.1:9").await;
 
         let status = runtime.status().await.unwrap();
         assert!(status.configured);
@@ -938,70 +958,6 @@ mod tests {
         assert!(status.account_hint.is_none());
         assert!(status.installation_id.is_none());
         assert!(runtime.route_token_source().await.is_none());
-    }
-
-    /// The managed counterpart of the divergence test above, through the
-    /// REAL token path: once provisioned, the policy — not the
-    /// renderer-writable row — names the deployment, so a diverged (or
-    /// stale) row can neither redirect sign-in and bearers nor drop the
-    /// session and route a managed profile is entitled to.
-    #[tokio::test]
-    async fn a_managed_profile_reaches_its_gateway_despite_a_diverged_stored_row() {
-        let address = serve(Arc::new(FakeGateway::default())).await;
-        let base = format!("http://{address}");
-        let (runtime, store, _directory) = signed_in_runtime(&base).await;
-        runtime.sync_models().await.unwrap();
-
-        // Provision to the real deployment, then re-point the stored row —
-        // the write `update_provider` would refuse, applied directly to
-        // model a row that pre-dates provisioning or was tampered with.
-        crate::managed_policy::provision(&*store, &base)
-            .await
-            .unwrap();
-        let mut config = providers::read_config(&*store, ProviderKind::ModelGateway)
-            .await
-            .unwrap();
-        config.base_url = Some("http://127.0.0.1:9".to_string());
-        providers::write_config(&*store, ProviderKind::ModelGateway, &config)
-            .await
-            .unwrap();
-
-        // Tokens still mint against the provisioned deployment.
-        let source = runtime
-            .route_token_source()
-            .await
-            .expect("a managed session follows policy, not the row");
-        let token = source.bearer_token().await.unwrap();
-        assert!(token.starts_with("mg_at_llm_"), "{token}");
-
-        // And the composite route aims at the policy URL, with the synced
-        // models still claimed and the gateway usable for the picker.
-        let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
-            .await
-            .unwrap();
-        let routes = providers::collect_routes(
-            &*store,
-            &*runtime.secrets,
-            runtime.route_token_source().await,
-            &policy,
-        )
-        .await;
-        assert_eq!(routes.len(), 1);
-        assert_eq!(
-            routes[0].base_url.as_deref(),
-            Some(format!("{base}/compat/anthropic").as_str())
-        );
-        assert!(routes[0]
-            .curated_models
-            .contains(&"sample-claude".to_string()));
-        assert!(providers::provider_is_usable(
-            &*store,
-            &*runtime.secrets,
-            ProviderKind::ModelGateway,
-            &policy
-        )
-        .await
-        .unwrap());
     }
 
     /// An OS (MDM) authority asserting one gateway, as a device-managed
@@ -1050,12 +1006,11 @@ mod tests {
             GatewayRuntime::new(store.clone(), secrets, Arc::new(OsManaged(base.clone())));
 
         assert!(
-            providers::read_config(&*store, ProviderKind::ModelGateway)
+            providers::read_gateway_snapshot(&*store)
                 .await
                 .unwrap()
-                .base_url
                 .is_none(),
-            "the fixture must have no stored row for the assertion to mean anything"
+            "the fixture must have no stored gateway state for the assertion to mean anything"
         );
         let status = runtime.status().await.unwrap();
         assert!(status.configured && status.enabled && status.signed_in);
@@ -1078,18 +1033,9 @@ mod tests {
             .unwrap(),
         );
         let secrets: Arc<dyn SecretProvider> = Arc::new(MockSecrets::default());
-        providers::write_config(
-            &*store,
-            ProviderKind::ModelGateway,
-            &providers::ProviderConfig {
-                enabled: true,
-                base_url: Some("http://127.0.0.1:1".to_string()),
-                vertex_location: None,
-                models: Vec::new(),
-            },
-        )
-        .await
-        .unwrap();
+        crate::managed_policy::provision(&*store, "http://127.0.0.1:1")
+            .await
+            .unwrap();
         let runtime = GatewayRuntime::new(
             store.clone(),
             secrets,
@@ -1104,5 +1050,193 @@ mod tests {
         assert!(routes
             .iter()
             .all(|route| route.kind != openwave_router::RouteKind::ModelGateway));
+    }
+
+    /// The legacy hard cut: an unmanaged profile with a stored additive
+    /// gateway row — and even a leftover signed-in session — has zero
+    /// gateway surface. The row is ignored, never auto-converted to
+    /// managed: lockdown must not be imposed without the pairing consent
+    /// flow, so the remedy is pairing, and the sign-in surface says so.
+    #[tokio::test]
+    async fn an_unmanaged_profile_with_a_legacy_row_has_no_gateway_surface() {
+        struct StaticTokens;
+
+        #[async_trait]
+        impl BearerTokenSource for StaticTokens {
+            async fn bearer_token(&self) -> Result<String> {
+                Ok("mg_at_test".into())
+            }
+        }
+
+        let address = serve(Arc::new(FakeGateway::default())).await;
+        let base = format!("http://{address}");
+        let directory = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("gateway.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let secrets: Arc<dyn SecretProvider> = Arc::new(MockSecrets::default());
+        let credentials: openwave_connectors::GatewayCredentials = serde_json::from_value(json!({
+            "base_url": base,
+            "installation_id": "install-1",
+            "user_id": "user-1",
+            "refresh_token": "mg_rt_seed",
+            "access_tokens": {}
+        }))
+        .unwrap();
+        CredentialVault::new(secrets.clone())
+            .save(&credentials)
+            .await
+            .unwrap();
+        providers::write_config(
+            &*store,
+            crate::providers::ProviderKind::ModelGateway,
+            &providers::ProviderConfig {
+                enabled: true,
+                base_url: Some(format!("{base}/")),
+                vertex_location: None,
+                models: vec![CustomModelConfig {
+                    id: "legacy-model".to_string(),
+                    display_name: None,
+                    context_window: 32_768,
+                    max_output_tokens: 4_096,
+                }],
+            },
+        )
+        .await
+        .unwrap();
+        let runtime = GatewayRuntime::new(
+            store.clone(),
+            secrets.clone(),
+            Arc::new(crate::managed_policy::NoOsPolicy),
+        );
+
+        // The boot cutover warns and ignores the row: no snapshot appears
+        // and the profile stays unmanaged.
+        let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
+            .await
+            .unwrap();
+        providers::retire_legacy_gateway_row(&*store, &policy)
+            .await
+            .unwrap();
+        assert!(providers::read_gateway_snapshot(&*store)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(
+            !policy.managed,
+            "a legacy row must never auto-convert the profile to managed"
+        );
+
+        // The status surface reads unconfigured and signed out.
+        let status = runtime.status().await.unwrap();
+        assert!(!status.configured && !status.enabled && !status.signed_in);
+        assert!(status.base_url.is_none());
+        assert_eq!(status.model_count, 0);
+
+        // Routing, the picker, and enumeration offer nothing — even with a
+        // token source in hand, the gateway route is not built.
+        assert!(runtime.route_token_source().await.is_none());
+        let tokens: Arc<dyn BearerTokenSource> = Arc::new(StaticTokens);
+        let routes = providers::collect_routes(&*store, &*secrets, Some(tokens), &policy).await;
+        assert!(routes
+            .iter()
+            .all(|route| route.kind != openwave_router::RouteKind::ModelGateway));
+        assert!(providers::catalog_models(&*store, &*secrets, &policy)
+            .await
+            .unwrap()
+            .iter()
+            .all(|model| model.policy.provider != crate::providers::ProviderKind::ModelGateway));
+        assert!(providers::list_providers(&*store, &*secrets, &policy)
+            .await
+            .unwrap()
+            .iter()
+            .all(|provider| provider.kind != crate::providers::ProviderKind::ModelGateway));
+        assert!(!providers::provider_is_usable(
+            &*store,
+            &*secrets,
+            crate::providers::ProviderKind::ModelGateway,
+            &policy
+        )
+        .await
+        .unwrap());
+
+        // The sign-in surface is managed-only, and the refusal names the
+        // remedy.
+        let error = runtime.begin_sign_in().await.err().unwrap();
+        assert!(
+            error.to_string().contains("pair via your gateway"),
+            "{error}"
+        );
+        assert!(runtime.sync_models().await.is_err());
+        assert!(runtime.apps().await.is_err());
+        assert!(runtime.sign_out().await.is_err());
+    }
+
+    /// The boot cutover's carry-forward: a managed profile whose legacy row
+    /// was stamped by the policy's own deployment keeps its synced models
+    /// across the upgrade — once, and only from that deployment.
+    #[tokio::test]
+    async fn boot_carries_a_managed_rows_snapshot_forward_once() {
+        let directory = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("gateway.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        crate::managed_policy::provision(&*store, "https://corp.gateway")
+            .await
+            .unwrap();
+        let legacy_row = |id: &str| providers::ProviderConfig {
+            enabled: true,
+            base_url: Some("https://corp.gateway/".to_string()),
+            vertex_location: None,
+            models: vec![CustomModelConfig {
+                id: id.to_string(),
+                display_name: None,
+                context_window: 32_768,
+                max_output_tokens: 4_096,
+            }],
+        };
+        providers::write_config(
+            &*store,
+            crate::providers::ProviderKind::ModelGateway,
+            &legacy_row("carried-model"),
+        )
+        .await
+        .unwrap();
+
+        let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
+            .await
+            .unwrap();
+        providers::retire_legacy_gateway_row(&*store, &policy)
+            .await
+            .unwrap();
+        let models = providers::gateway_models(&*store, &policy).await.unwrap();
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "carried-model");
+
+        // One-shot: once a snapshot exists, later boots never overwrite it
+        // from the retired row.
+        providers::write_config(
+            &*store,
+            crate::providers::ProviderKind::ModelGateway,
+            &legacy_row("other-model"),
+        )
+        .await
+        .unwrap();
+        providers::retire_legacy_gateway_row(&*store, &policy)
+            .await
+            .unwrap();
+        let models = providers::gateway_models(&*store, &policy).await.unwrap();
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "carried-model");
     }
 }

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -56,11 +56,12 @@ pub(crate) enum SignInProgress {
 }
 
 /// Renderer-safe projection of the gateway connection state. Never carries
-/// token material — only what the settings surface displays.
+/// token material — only what the settings surface displays. `base_url` is
+/// the policy's gateway origin: present exactly when the profile is managed
+/// with a usable URL (the retired `configured`/`enabled` bits collapsed into
+/// its presence).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub(crate) struct GatewayStatus {
-    pub(crate) configured: bool,
-    pub(crate) enabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub(crate) base_url: Option<String>,
@@ -115,12 +116,9 @@ impl GatewayRuntime {
 
     /// The renderer-facing connection status, derived from policy alone: a
     /// profile is gateway-connected exactly when managed policy asserts it,
-    /// so an unmanaged profile reads unconfigured whatever legacy rows
+    /// so an unmanaged profile reads no gateway whatever legacy rows
     /// persist, and a managed policy whose URL is missing (misconfigured)
-    /// reads unconfigured, honestly.
-    ///
-    /// `configured` and `enabled` are now the same bit — kept apart only for
-    /// wire-shape stability until the renderer slice retires them.
+    /// reads none, honestly.
     pub(crate) async fn status(&self) -> Result<GatewayStatus> {
         // One policy read for the whole projection: the renderer polls this
         // every couple of seconds while a sign-in is pending.
@@ -131,8 +129,6 @@ impl GatewayRuntime {
             None => None,
         };
         Ok(GatewayStatus {
-            configured: base_url.is_some(),
-            enabled: base_url.is_some(),
             base_url,
             signed_in: credentials.is_some(),
             account_hint: credentials
@@ -853,7 +849,7 @@ mod tests {
         runtime.sync_models().await.unwrap();
 
         let status = runtime.status().await.unwrap();
-        assert!(status.configured && status.enabled && status.signed_in);
+        assert!(status.base_url.is_some() && status.signed_in);
         assert_eq!(status.account_hint.as_deref(), Some("abaas@example.test"));
         assert_eq!(status.installation_id.as_deref(), Some("install-1"));
         assert_eq!(status.model_count, 2);
@@ -950,7 +946,7 @@ mod tests {
         let (runtime, _store, _directory) = signed_in_runtime_at(&base, "http://127.0.0.1:9").await;
 
         let status = runtime.status().await.unwrap();
-        assert!(status.configured);
+        assert!(status.base_url.is_some());
         assert!(
             !status.signed_in,
             "a foreign session must not read signed-in"
@@ -1013,7 +1009,7 @@ mod tests {
             "the fixture must have no stored gateway state for the assertion to mean anything"
         );
         let status = runtime.status().await.unwrap();
-        assert!(status.configured && status.enabled && status.signed_in);
+        assert!(status.signed_in);
         assert_eq!(
             status.base_url.as_deref(),
             Some(format!("{base}/").as_str())
@@ -1132,9 +1128,9 @@ mod tests {
             "a legacy row must never auto-convert the profile to managed"
         );
 
-        // The status surface reads unconfigured and signed out.
+        // The status surface reads no gateway and signed out.
         let status = runtime.status().await.unwrap();
-        assert!(!status.configured && !status.enabled && !status.signed_in);
+        assert!(!status.signed_in);
         assert!(status.base_url.is_none());
         assert_eq!(status.model_count, 0);
 

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -407,6 +407,57 @@ impl crate::mcp_config::GatewayEndpoints for GatewayRuntime {
     }
 }
 
+/// Complete the legacy hard cut for the session, not just the configuration.
+///
+/// An unmanaged profile can carry a gateway session signed in under the
+/// retired additive mode. Nothing reaches it any more — the whole sign-in
+/// surface is managed-only, and the renderer has no gateway page — so
+/// without this the refresh token would sit in the keychain forever with no
+/// path to revoke it. Boot owns that cleanup instead.
+///
+/// Revocation is best-effort and bounded: an unreachable gateway can no more
+/// hold this hostage than it can a normal sign-out (the server-side session
+/// still dies at refresh-token expiry), and boot must not stall on it. The
+/// local clear afterwards is unconditional, so the session is gone locally
+/// whether or not the gateway ever answered — and because it is gone, this
+/// whole step runs at most once per profile.
+///
+/// An unreadable stored blob is left alone: it carries no usable refresh
+/// token, so it is not the live zombie this exists to kill.
+pub(crate) async fn retire_unmanaged_gateway_session(
+    secrets: Arc<dyn SecretProvider>,
+    policy: &crate::managed_policy::ManagedPolicy,
+) -> Result<()> {
+    /// Long enough for a healthy gateway to answer a revoke, short enough
+    /// that a dead one is a hiccup at boot rather than a hang.
+    const REVOKE_TIMEOUT: Duration = Duration::from_secs(5);
+
+    if policy.managed {
+        return Ok(());
+    }
+    let vault = CredentialVault::new(secrets.clone());
+    let Ok(Some(credentials)) = vault.load().await else {
+        return Ok(());
+    };
+    tracing::warn!(
+        "clearing a model-gateway session left by the retired additive \
+         configuration ({}); pair via your gateway's page to sign in again",
+        credentials.base_url
+    );
+    // The connection owns revoke-then-clear (the refresh token never leaves
+    // the connectors crate), so the session is retired through the same path
+    // an explicit sign-out takes.
+    if let Ok(config) = GatewayAuthConfig::new(&credentials.base_url) {
+        if let Ok(auth) = GatewayAuth::new(config) {
+            let connection = GatewayConnection::new(auth, CredentialVault::new(secrets.clone()));
+            let _ = tokio::time::timeout(REVOKE_TIMEOUT, connection.sign_out()).await;
+        }
+    }
+    // Unconditional: a gateway that never answered, or a stored base URL that
+    // no longer parses, must not leave the credential behind.
+    CredentialVault::new(secrets).clear().await
+}
+
 /// The one refusal for every managed-only gateway surface: unmanaged
 /// profiles have no gateway (policy is the only source), and a managed
 /// policy without a usable URL is misconfigured rather than open.
@@ -1173,9 +1224,19 @@ mod tests {
         assert!(runtime.sign_out().await.is_err());
     }
 
-    /// The boot cutover's carry-forward: a managed profile whose legacy row
-    /// was stamped by the policy's own deployment keeps its synced models
-    /// across the upgrade — once, and only from that deployment.
+    /// The boot cutover's carry-forward: a managed profile — the shape a
+    /// gateway-page pairing produces — keeps the models its row had synced,
+    /// once, and only from the deployment policy actually names.
+    ///
+    /// Nothing re-syncs the entitled set for a reader who is already signed
+    /// in, so dropping this leaves their picker empty until they find the
+    /// refresh button.
+    ///
+    /// The row URL is the VERBATIM form here: the old provider write path
+    /// did not normalize (#935), so a profile that became managed by MDM
+    /// over such a row holds "https://corp.gateway" beside a policy's
+    /// "https://corp.gateway/". Compare deployments as strings instead of
+    /// URLs and that profile silently reaches the picker empty.
     #[tokio::test]
     async fn boot_carries_a_managed_rows_snapshot_forward_once() {
         let directory = tempfile::tempdir().unwrap();
@@ -1192,7 +1253,7 @@ mod tests {
             .unwrap();
         let legacy_row = |id: &str| providers::ProviderConfig {
             enabled: true,
-            base_url: Some("https://corp.gateway/".to_string()),
+            base_url: Some("https://corp.gateway".to_string()),
             vertex_location: None,
             models: vec![CustomModelConfig {
                 id: id.to_string(),
@@ -1219,8 +1280,18 @@ mod tests {
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "carried-model");
 
-        // One-shot: once a snapshot exists, later boots never overwrite it
-        // from the retired row.
+        // The row is gone once it has been dealt with, so "retired entirely"
+        // is true of the store and not only of the read paths.
+        assert!(
+            providers::read_config(&*store, crate::providers::ProviderKind::ModelGateway)
+                .await
+                .unwrap()
+                .base_url
+                .is_none()
+        );
+
+        // One-shot: once a snapshot exists, a row that reappears never
+        // overwrites it.
         providers::write_config(
             &*store,
             crate::providers::ProviderKind::ModelGateway,
@@ -1234,5 +1305,192 @@ mod tests {
         let models = providers::gateway_models(&*store, &policy).await.unwrap();
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "carried-model");
+    }
+
+    /// A row from a deployment the profile is no longer managed by is not
+    /// carried forward: its models describe another gateway's entitlements.
+    /// The row still goes.
+    #[tokio::test]
+    async fn boot_discards_a_snapshot_from_a_foreign_deployment() {
+        let directory = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("gateway.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        crate::managed_policy::provision(&*store, "https://corp.gateway")
+            .await
+            .unwrap();
+        providers::write_config(
+            &*store,
+            crate::providers::ProviderKind::ModelGateway,
+            &providers::ProviderConfig {
+                enabled: true,
+                base_url: Some("https://other.gateway".to_string()),
+                vertex_location: None,
+                models: vec![CustomModelConfig {
+                    id: "foreign-model".to_string(),
+                    display_name: None,
+                    context_window: 32_768,
+                    max_output_tokens: 4_096,
+                }],
+            },
+        )
+        .await
+        .unwrap();
+
+        let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
+            .await
+            .unwrap();
+        providers::retire_legacy_gateway_row(&*store, &policy)
+            .await
+            .unwrap();
+        assert!(providers::read_gateway_snapshot(&*store)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(
+            providers::read_config(&*store, crate::providers::ProviderKind::ModelGateway)
+                .await
+                .unwrap()
+                .base_url
+                .is_none()
+        );
+    }
+
+    /// The unmanaged half of the cutover: the row is ignored (never
+    /// converted to managed) and dropped, so the warning naming the remedy
+    /// is a one-time upgrade notice rather than a line on every boot.
+    #[tokio::test]
+    async fn boot_drops_an_unmanaged_legacy_row_without_making_it_managed() {
+        let directory = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("gateway.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        providers::write_config(
+            &*store,
+            crate::providers::ProviderKind::ModelGateway,
+            &providers::ProviderConfig {
+                enabled: true,
+                base_url: Some("https://corp.gateway".to_string()),
+                vertex_location: None,
+                models: vec![CustomModelConfig {
+                    id: "legacy-model".to_string(),
+                    display_name: None,
+                    context_window: 32_768,
+                    max_output_tokens: 4_096,
+                }],
+            },
+        )
+        .await
+        .unwrap();
+
+        let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
+            .await
+            .unwrap();
+        providers::retire_legacy_gateway_row(&*store, &policy)
+            .await
+            .unwrap();
+
+        assert!(
+            !crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
+                .await
+                .unwrap()
+                .managed,
+            "a legacy row must never auto-convert the profile to managed"
+        );
+        assert!(providers::read_gateway_snapshot(&*store)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(
+            providers::read_config(&*store, crate::providers::ProviderKind::ModelGateway)
+                .await
+                .unwrap()
+                .base_url
+                .is_none()
+        );
+    }
+
+    /// The session half of the legacy hard cut: an unmanaged profile with a
+    /// session left over from the retired additive mode has no surface that
+    /// could ever revoke it, so boot clears it. Without this the refresh
+    /// token lives in the keychain forever.
+    #[tokio::test]
+    async fn boot_clears_a_gateway_session_left_on_an_unmanaged_profile() {
+        let directory = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("gateway.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let secrets: Arc<dyn SecretProvider> = Arc::new(MockSecrets::default());
+        let seed = |secrets: Arc<dyn SecretProvider>, base_url: &'static str| async move {
+            let credentials: openwave_connectors::GatewayCredentials =
+                serde_json::from_value(json!({
+                    "base_url": base_url,
+                    "installation_id": "install-1",
+                    "user_id": "user-1",
+                    "refresh_token": "mg_rt_zombie",
+                    "access_tokens": {}
+                }))
+                .unwrap();
+            CredentialVault::new(secrets)
+                .save(&credentials)
+                .await
+                .unwrap();
+        };
+        // Nothing listens here: the revoke fails fast and the clear happens
+        // anyway, which is the contract.
+        seed(secrets.clone(), "http://127.0.0.1:1").await;
+
+        let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
+            .await
+            .unwrap();
+        assert!(!policy.managed);
+        retire_unmanaged_gateway_session(secrets.clone(), &policy)
+            .await
+            .unwrap();
+        assert!(
+            !openwave_connectors::has_stored_credentials(&*secrets).await,
+            "the retired session must not survive boot on an unmanaged profile"
+        );
+
+        // A stored base URL that no longer passes the gateway contract has
+        // no connection to revoke through, so only the unconditional clear
+        // can retire it. Drop that clear and the credential survives here.
+        seed(secrets.clone(), "http://user:pw@stale.example").await;
+        retire_unmanaged_gateway_session(secrets.clone(), &policy)
+            .await
+            .unwrap();
+        assert!(
+            !openwave_connectors::has_stored_credentials(&*secrets).await,
+            "a session whose stored URL cannot be parsed must still be cleared"
+        );
+
+        // A managed profile's session is untouched: it is the credential the
+        // profile actually runs on.
+        seed(secrets.clone(), "https://corp.gateway/").await;
+        crate::managed_policy::provision(&*store, "https://corp.gateway")
+            .await
+            .unwrap();
+        let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
+            .await
+            .unwrap();
+        retire_unmanaged_gateway_session(secrets.clone(), &policy)
+            .await
+            .unwrap();
+        assert!(openwave_connectors::has_stored_credentials(&*secrets).await);
     }
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -670,16 +670,21 @@ async fn bind_inner(
     // deliberately swallowed as "not allowed": an unreadable policy fails
     // closed to no BYOK arming while boot still proceeds, so the profile can
     // surface the error and be repaired instead of bricking.
-    let byok_boot_allowed = matches!(
-        managed_policy::resolve(&*store, &*os_policy).await,
-        Ok(policy) if !policy.managed
-    );
+    let boot_policy = managed_policy::resolve(&*store, &*os_policy).await;
+    let byok_boot_allowed = matches!(&boot_policy, Ok(policy) if !policy.managed);
     // Pre-providers installs may only have an env/legacy key — enable Anthropic
     // so `KeyedResolver`'s enabled check doesn't fail-closed on upgrade. Never
     // on a managed profile: auto-enabling a BYOK provider would fight the
     // lockdown.
     if byok_boot_allowed {
         providers::migrate_legacy_anthropic(&*store, &*secrets).await?;
+    }
+    // The additive gateway configuration is retired: carry a managed row's
+    // model snapshot forward once, and name the remedy for a legacy
+    // unmanaged one. Skipped when policy is unreadable — fail closed, and
+    // the legacy row stays untouched for when the policy is repaired.
+    if let Ok(policy) = &boot_policy {
+        providers::retire_legacy_gateway_row(&*store, policy).await?;
     }
     let gateway =
         gateway_runtime::GatewayRuntime::new(store.clone(), secrets.clone(), os_policy.clone());

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -680,11 +680,13 @@ async fn bind_inner(
         providers::migrate_legacy_anthropic(&*store, &*secrets).await?;
     }
     // The additive gateway configuration is retired: carry a managed row's
-    // model snapshot forward once, and name the remedy for a legacy
-    // unmanaged one. Skipped when policy is unreadable — fail closed, and
-    // the legacy row stays untouched for when the policy is repaired.
+    // model snapshot forward once, name the remedy for a legacy unmanaged
+    // one, and revoke the session an unmanaged profile can no longer reach.
+    // Skipped when policy is unreadable — fail closed, and the legacy state
+    // stays untouched for when the policy is repaired.
     if let Ok(policy) = &boot_policy {
         providers::retire_legacy_gateway_row(&*store, policy).await?;
+        gateway_runtime::retire_unmanaged_gateway_session(secrets.clone(), policy).await?;
     }
     let gateway =
         gateway_runtime::GatewayRuntime::new(store.clone(), secrets.clone(), os_policy.clone());

--- a/crates/openwave-server/src/model_roles.rs
+++ b/crates/openwave-server/src/model_roles.rs
@@ -169,7 +169,7 @@ pub async fn resolve(
     // state, not a registry row — so the managed substitution applies only to
     // roles that walk one at all.
     let defaults: Vec<String> = if managed.managed && !role.defaults().is_empty() {
-        gateway_defaults(store).await?
+        gateway_defaults(store, &managed).await?
     } else {
         role.defaults()
             .iter()
@@ -192,10 +192,11 @@ pub async fn resolve(
 /// not bill it to a flagship. The gateway describes entitlement, not price,
 /// so context window is the proxy available — it tracks model tier closely
 /// enough to keep that intent, and ties keep the gateway's own order.
-async fn gateway_defaults(store: &dyn Store) -> Result<Vec<String>> {
-    let mut models = providers::read_config(store, providers::ProviderKind::ModelGateway)
-        .await?
-        .models;
+async fn gateway_defaults(
+    store: &dyn Store,
+    policy: &crate::managed_policy::ManagedPolicy,
+) -> Result<Vec<String>> {
+    let mut models = providers::gateway_models(store, policy).await?;
     models.sort_by_key(|model| model.context_window);
     Ok(models
         .iter()
@@ -386,13 +387,10 @@ mod tests {
             .save(&credentials)
             .await
             .unwrap();
-        providers::write_config(
+        providers::write_gateway_snapshot(
             &*store,
-            ProviderKind::ModelGateway,
-            &ProviderConfig {
-                enabled: true,
-                base_url: Some("https://corp.gateway/".to_string()),
-                vertex_location: None,
+            &providers::GatewayModelSnapshot {
+                gateway_url: "https://corp.gateway/".to_string(),
                 // Listed flagship-first, as a gateway well might: the walk
                 // must not bill background work to the biggest model it is
                 // entitled to.

--- a/crates/openwave-server/src/model_roles.rs
+++ b/crates/openwave-server/src/model_roles.rs
@@ -205,11 +205,12 @@ async fn gateway_defaults(
 /// composer picker renders them, and therefore the chat role's fallback
 /// order. Contrast [`gateway_defaults`], which re-sorts the same list
 /// cheapest-first for background work.
-async fn gateway_listed(store: &dyn Store) -> Result<Vec<String>> {
+async fn gateway_listed(
+    store: &dyn Store,
+    policy: &crate::managed_policy::ManagedPolicy,
+) -> Result<Vec<String>> {
     Ok(selection_keys(
-        &providers::read_config(store, providers::ProviderKind::ModelGateway)
-            .await?
-            .models,
+        &providers::gateway_models(store, policy).await?,
     ))
 }
 
@@ -247,7 +248,7 @@ pub async fn effective_chat_policy(
             return Ok(Some(policy));
         }
     }
-    for key in gateway_listed(store).await? {
+    for key in gateway_listed(store, managed).await? {
         if let Some(policy) = usable_policy(store, secrets, managed, &key).await? {
             return Ok(Some(policy));
         }

--- a/crates/openwave-server/src/pairing.rs
+++ b/crates/openwave-server/src/pairing.rs
@@ -16,7 +16,6 @@ use tokio::sync::Mutex;
 
 use crate::managed_policy;
 use crate::mcp_config::McpRuntime;
-use crate::providers;
 
 /// Serializes pairing end to end. [`managed_policy::provision`] is a
 /// check-then-write over the settings store, and the [`Store`] API offers no
@@ -150,26 +149,24 @@ pub async fn pair_with_gateway(
     let base_url = config.base_url().to_string();
     GatewayAuth::new(config)?.meta().await?;
     let _guard = PAIRING.lock().await;
-    // Model sync rechecks the resolved policy and writes its snapshot under
-    // the shared gateway-state lock, and neither runs under PAIRING; hold
-    // that lock across the conflict check and the policy write so a sync in
-    // flight either sees the pre-pairing policy and refuses, or the
-    // post-pairing one — never a torn middle. Lock order is PAIRING first,
-    // state lock second — this is the only path that takes both.
-    let already_provisioned = {
-        let _lock = providers::GATEWAY_STATE_WRITES.lock().await;
-        // Refuse a conflicting pairing before the write.
-        let already_provisioned = match managed_policy::provisioned_url(store).await? {
-            Some(existing) if existing != base_url => {
-                return Err(PairingError::Conflict {
-                    provisioned_url: existing,
-                });
-            }
-            other => other.is_some(),
-        };
-        managed_policy::provision(store, &base_url).await?;
-        already_provisioned
+    // No gateway-state lock here, deliberately. Pairing writes only the
+    // policy now, and the model snapshot is stamped with the deployment it
+    // was fetched from — so a sync racing this pairing cannot corrupt
+    // anything: whichever order the two land in, a snapshot stamped by the
+    // old gateway is simply never honored once policy names the new one
+    // (`gateway_models` filters on the stamp). The stamp is the guard, and
+    // taking a lock that guards nothing would only claim protection this
+    // path does not actually depend on. PAIRING alone still makes the
+    // conflict check and the policy write atomic against another pairing.
+    let already_provisioned = match managed_policy::provisioned_url(store).await? {
+        Some(existing) if existing != base_url => {
+            return Err(PairingError::Conflict {
+                provisioned_url: existing,
+            });
+        }
+        other => other.is_some(),
     };
+    managed_policy::provision(store, &base_url).await?;
     handle.mcp.enforce_manual_lockdown().await;
     Ok(PairingOutcome {
         base_url,
@@ -194,6 +191,7 @@ mod tests {
         GatewayEndpointAccess, GatewayEndpoints, McpHealth, McpServerDefinition, McpServersConfig,
         MANAGED_DISABLED_DIAGNOSTIC,
     };
+    use crate::providers;
 
     /// The signed-out stand-in: pairing never resolves an endpoint.
     struct NoGateway;

--- a/crates/openwave-server/src/pairing.rs
+++ b/crates/openwave-server/src/pairing.rs
@@ -3,10 +3,10 @@
 //! The desktop shell's `openwave://provision` handler lands here. The gateway
 //! is probed (`GET /api/v1/meta`) before anything is written, so a mistyped
 //! or unreachable URL never becomes durable policy; only then does the
-//! managed-policy write path run and the ModelGateway provider config get
-//! pointed at the gateway. This function is exported for native embedders
-//! only — pairing changes policy, and policy must never be reachable from a
-//! renderer-writable route.
+//! managed-policy write path run. Policy is the only gateway source — there
+//! is no provider row to point — so provisioning is the whole write. This
+//! function is exported for native embedders only — pairing changes policy,
+//! and policy must never be reachable from a renderer-writable route.
 
 use std::sync::Arc;
 
@@ -16,7 +16,7 @@ use tokio::sync::Mutex;
 
 use crate::managed_policy;
 use crate::mcp_config::McpRuntime;
-use crate::providers::{self, ProviderKind};
+use crate::providers;
 
 /// Serializes pairing end to end. [`managed_policy::provision`] is a
 /// check-then-write over the settings store, and the [`Store`] API offers no
@@ -130,12 +130,12 @@ impl From<AgentError> for PairingError {
 /// plus whether this call is the one that provisioned the profile. Nothing
 /// is written unless the URL passes the gateway contract and the deployment
 /// answers `GET /api/v1/meta`; a conflicting re-provision is refused as the
-/// typed [`PairingError::Conflict`] before either write, leaving both the
-/// policy and the provider configuration untouched — the desktop shell
-/// surfaces that refusal instead of treating it as a generic fault. Success
-/// also points the ModelGateway provider at
-/// the gateway and enables it, dropping any model snapshot synced from a
-/// previously configured base URL — sign-in resyncs the entitled set.
+/// typed [`PairingError::Conflict`] before the write, leaving the policy
+/// untouched — the desktop shell surfaces that refusal instead of treating
+/// it as a generic fault. Provisioning is the only durable write: the model
+/// snapshot is stamped with the deployment it was synced from, so one left
+/// behind by any earlier configuration is simply never honored for this
+/// gateway — sign-in resyncs the entitled set.
 ///
 /// The new policy is applied to this process before returning: manual MCP
 /// servers running under the previously open profile are taken down here
@@ -150,20 +150,15 @@ pub async fn pair_with_gateway(
     let base_url = config.base_url().to_string();
     GatewayAuth::new(config)?.meta().await?;
     let _guard = PAIRING.lock().await;
-    // The provider row is also written by model sync, sign-out, and
-    // `PUT /providers/model_gateway`, none of which run under PAIRING; hold
-    // the shared row lock across the conflict check, the row write, and the
-    // policy write so no interleaved read-modify-write can resurrect
-    // pre-pairing state. Lock order is PAIRING first, row lock second — this
-    // is the only path that takes both.
+    // Model sync rechecks the resolved policy and writes its snapshot under
+    // the shared gateway-state lock, and neither runs under PAIRING; hold
+    // that lock across the conflict check and the policy write so a sync in
+    // flight either sees the pre-pairing policy and refuses, or the
+    // post-pairing one — never a torn middle. Lock order is PAIRING first,
+    // state lock second — this is the only path that takes both.
     let already_provisioned = {
-        let _row = providers::GATEWAY_ROW_WRITES.lock().await;
-        // Refuse a conflicting pairing before either write, then write the
-        // provider configuration before the sticky policy. Neither write is
-        // transactional with the other, so the order decides the failure mode:
-        // provider-first fails into a still-unmanaged profile recoverable from
-        // settings, while policy-first could strand a permanently managed
-        // profile with no configured provider.
+        let _lock = providers::GATEWAY_STATE_WRITES.lock().await;
+        // Refuse a conflicting pairing before the write.
         let already_provisioned = match managed_policy::provisioned_url(store).await? {
             Some(existing) if existing != base_url => {
                 return Err(PairingError::Conflict {
@@ -172,15 +167,6 @@ pub async fn pair_with_gateway(
             }
             other => other.is_some(),
         };
-        let mut provider = providers::read_config(store, ProviderKind::ModelGateway).await?;
-        if provider.base_url.as_deref() != Some(base_url.as_str()) {
-            // A model snapshot synced from a previously configured gateway does
-            // not describe this one.
-            provider.models = Vec::new();
-            provider.base_url = Some(base_url.clone());
-        }
-        provider.enabled = true;
-        providers::write_config(store, ProviderKind::ModelGateway, &provider).await?;
         managed_policy::provision(store, &base_url).await?;
         already_provisioned
     };
@@ -316,19 +302,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pairing_provisions_policy_and_points_the_provider() {
+    async fn pairing_provisions_policy_and_a_stale_snapshot_is_never_honored() {
         let (store, _directory) = test_store().await;
         let base = serve_meta().await;
 
-        // A stale snapshot from a manually configured endpoint must not
+        // A model snapshot synced from some earlier deployment must not
         // survive as this gateway's model set.
-        providers::write_config(
+        providers::write_gateway_snapshot(
             &*store,
-            ProviderKind::ModelGateway,
-            &providers::ProviderConfig {
-                enabled: false,
-                base_url: Some("http://old.gateway.test".into()),
-                vertex_location: None,
+            &providers::GatewayModelSnapshot {
+                gateway_url: "http://old.gateway.test/".to_string(),
                 models: vec![providers::CustomModelConfig {
                     id: "stale-model".into(),
                     display_name: None,
@@ -354,12 +337,12 @@ mod tests {
         assert!(policy.managed);
         assert_eq!(policy.gateway_url.as_deref(), Some(normalized.as_str()));
 
-        let provider = providers::read_config(&*store, ProviderKind::ModelGateway)
+        // The stale snapshot carries the old deployment's stamp, so the new
+        // policy reads no models until sign-in resyncs the entitled set.
+        assert!(providers::gateway_models(&*store, &policy)
             .await
-            .unwrap();
-        assert!(provider.enabled);
-        assert_eq!(provider.base_url.as_deref(), Some(normalized.as_str()));
-        assert!(provider.models.is_empty());
+            .unwrap()
+            .is_empty());
 
         // Re-pairing the same gateway is idempotent, and reports that no
         // transition happened — the desktop shell keys its restart prompt
@@ -416,128 +399,6 @@ mod tests {
         );
     }
 
-    /// The row lock itself, pinned deterministically: an unmanaged provider
-    /// update parked between its row read and row write (inside its keychain
-    /// credential write, a seam on that window) must be holding the shared
-    /// row lock, so a pairing arriving mid-window serializes behind the
-    /// whole update instead of committing inside it and being overwritten by
-    /// the update's stale read. Removing the writers' row-lock acquisitions
-    /// lets the parked update resurrect the old gateway on top of the
-    /// committed pairing, and fails this.
-    #[tokio::test]
-    async fn a_provider_update_parked_mid_write_cannot_overwrite_a_pairing() {
-        /// In-memory secrets that signal and park (once) inside the gateway
-        /// credential write — after `update_provider` has read the row,
-        /// before it writes the row back.
-        struct ParkingSecrets {
-            inner: std::sync::Mutex<std::collections::HashMap<String, String>>,
-            arrived: tokio::sync::mpsc::UnboundedSender<()>,
-            release: Arc<tokio::sync::Notify>,
-            armed: std::sync::atomic::AtomicBool,
-        }
-
-        #[async_trait::async_trait]
-        impl openwave_core::SecretProvider for ParkingSecrets {
-            async fn get_secret(&self, key: &str) -> Result<Option<String>> {
-                Ok(self.inner.lock().unwrap().get(key).cloned())
-            }
-            async fn set_secret(&self, key: &str, value: &str) -> Result<()> {
-                if key == ProviderKind::ModelGateway.credential_key()
-                    && self.armed.swap(false, std::sync::atomic::Ordering::SeqCst)
-                {
-                    self.arrived.send(()).expect("the test is listening");
-                    self.release.notified().await;
-                }
-                self.inner.lock().unwrap().insert(key.into(), value.into());
-                Ok(())
-            }
-            async fn delete_secret(&self, key: &str) -> Result<()> {
-                self.inner.lock().unwrap().remove(key);
-                Ok(())
-            }
-        }
-
-        let (store, _directory) = test_store().await;
-        providers::write_config(
-            &*store,
-            ProviderKind::ModelGateway,
-            &providers::ProviderConfig {
-                enabled: true,
-                base_url: Some("http://old.gateway.test/".into()),
-                vertex_location: None,
-                models: Vec::new(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let (arrived_tx, mut arrived_rx) = tokio::sync::mpsc::unbounded_channel();
-        let release = Arc::new(tokio::sync::Notify::new());
-        let secrets = Arc::new(ParkingSecrets {
-            inner: std::sync::Mutex::new(std::collections::HashMap::new()),
-            arrived: arrived_tx,
-            release: release.clone(),
-            armed: std::sync::atomic::AtomicBool::new(true),
-        });
-
-        let update = tokio::spawn({
-            let store = store.clone();
-            let secrets = secrets.clone();
-            async move {
-                providers::update_provider(
-                    &*store,
-                    &*secrets,
-                    ProviderKind::ModelGateway,
-                    providers::ProviderUpdate {
-                        enabled: Some(true),
-                        base_url: None,
-                        vertex_location: None,
-                        credential: Some(providers::ProviderCredential::Oauth {}),
-                        models: None,
-                    },
-                    &NoOsPolicy,
-                )
-                .await
-            }
-        });
-        arrived_rx
-            .recv()
-            .await
-            .expect("the update reaches its credential write");
-
-        // A pairing arrives inside the update's read-to-write window.
-        let base = serve_meta().await;
-        let mut pairing = tokio::spawn({
-            let handle = test_handle(&store);
-            async move { pair_with_gateway(&handle, &base).await }
-        });
-        // Serialized, the pairing cannot finish while the update is parked
-        // holding the row lock, so only the timeout branch can release the
-        // window; unserialized, the pairing commits first and the release
-        // then lets the update's stale write race in after it.
-        let outcome =
-            match tokio::time::timeout(std::time::Duration::from_millis(500), &mut pairing).await {
-                Ok(joined) => {
-                    release.notify_one();
-                    joined.unwrap().unwrap()
-                }
-                Err(_) => {
-                    release.notify_one();
-                    pairing.await.unwrap().unwrap()
-                }
-            };
-        update.await.unwrap().unwrap();
-
-        let provider = providers::read_config(&*store, ProviderKind::ModelGateway)
-            .await
-            .unwrap();
-        assert_eq!(
-            provider.base_url.as_deref(),
-            Some(outcome.base_url.as_str()),
-            "the pairing's base URL must survive the parked update's write"
-        );
-    }
-
     #[tokio::test]
     async fn a_failed_pairing_changes_nothing() {
         let (store, _directory) = test_store().await;
@@ -551,14 +412,9 @@ mod tests {
             .unwrap();
         assert!(matches!(error, PairingError::Other(_)));
         assert!(!resolve(&*store, &NoOsPolicy).await.unwrap().managed);
-        let provider = providers::read_config(&*store, ProviderKind::ModelGateway)
-            .await
-            .unwrap();
-        assert!(!provider.enabled);
-        assert!(provider.base_url.is_none());
 
         // A reachable but conflicting gateway: refused after the probe, and
-        // the original pairing survives in both policy and provider config.
+        // the original pairing survives in policy.
         let first = serve_meta().await;
         let second = serve_meta().await;
         let normalized = pair_with_gateway(&test_handle(&store), &first)
@@ -580,9 +436,5 @@ mod tests {
         assert!(error.to_string().contains("already provisioned"));
         let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
         assert_eq!(policy.gateway_url.as_deref(), Some(normalized.as_str()));
-        let provider = providers::read_config(&*store, ProviderKind::ModelGateway)
-            .await
-            .unwrap();
-        assert_eq!(provider.base_url.as_deref(), Some(normalized.as_str()));
     }
 }

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -27,17 +27,21 @@ const CREDENTIAL_SUFFIX: &str = ".credential";
 /// Legacy Anthropic API-key secret (pre-providers). Still read as a fallback.
 pub const LEGACY_ANTHROPIC_API_KEY: &str = "provider.anthropic.api_key";
 
-/// Serializes every writer of the durable gateway state: the provisioning
-/// write (pairing) and the entitled-model snapshot (model sync, sign-out).
+/// Serializes the writers of the entitled-model snapshot: model sync and
+/// sign-out.
 ///
-/// The [`Store`] API has no cross-call transaction, so a sync whose policy
-/// recheck and snapshot write interleaved with a provisioning write could
-/// stamp a snapshot the new policy never entitled. Process-local for the
-/// same reason as pairing's own mutex: the server's instance lock guarantees
-/// one process owns the store, and a static cannot be accidentally wired
-/// into two instances that no longer exclude each other. Lock order:
-/// acquired after the pairing mutex and after the gateway runtime's sign-in
-/// state lock, never before either, and never held across a network call.
+/// Both read the resolved policy, decide what the snapshot should say, and
+/// write it, and the [`Store`] API has no cross-call transaction — so
+/// unserialized, a sign-out's clear could land inside a sync's
+/// recheck-and-write and be overwritten by the models it was clearing.
+/// Pairing deliberately does not take this lock: it writes only policy, and
+/// the snapshot's deployment stamp already makes a racing sync's write
+/// inert. Process-local for the same reason as pairing's own mutex: the
+/// server's instance lock guarantees one process owns the store, and a
+/// static cannot be accidentally wired into two instances that no longer
+/// exclude each other. Lock order: acquired after the gateway runtime's
+/// sign-in state lock, never before it, and never held across a network
+/// call.
 pub(crate) static GATEWAY_STATE_WRITES: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 /// Setting key for the entitled-model snapshot synced from the managed
@@ -101,13 +105,23 @@ pub(crate) async fn gateway_models(
 /// One-shot boot cutover for the retired additive gateway configuration.
 ///
 /// The `provider.model_gateway` row is no longer read anywhere: policy is
-/// the only gateway source. On a managed profile whose row was stamped by
-/// the policy's own deployment, the row's synced model list is carried into
-/// [`GATEWAY_MODELS_KEY`] once, so the picker does not go blank on upgrade.
-/// On an unmanaged profile a stored row is the retired legacy state: it is
-/// ignored outright — never auto-converted to managed, because lockdown must
-/// not be imposed without the pairing consent flow — and one boot warning
-/// names the remedy.
+/// the only gateway source. Two things still have to happen once, on the
+/// boot after the upgrade.
+///
+/// A managed profile keeps its models. Profiles paired from a gateway's own
+/// page carry the entitled set the pairing synced, and nothing re-syncs it
+/// for a reader who is already signed in — so without this their picker goes
+/// empty until they find the refresh button. The row's list is carried into
+/// [`GATEWAY_MODELS_KEY`] when it names the policy's own deployment.
+///
+/// An unmanaged profile's gateway vanishes, by decision: that mode is
+/// retired, and the row is never read as identity, so nothing here can
+/// convert a profile to managed — lockdown must not be imposed without the
+/// pairing consent flow. One warning names the remedy.
+///
+/// Either way the row is dropped once it has been dealt with, which is what
+/// makes "the provider row is retired" true of the store and not only of the
+/// read paths — and keeps the warning a one-time upgrade notice.
 pub(crate) async fn retire_legacy_gateway_row(
     store: &dyn Store,
     policy: &crate::managed_policy::ManagedPolicy,
@@ -119,6 +133,10 @@ pub(crate) async fn retire_legacy_gateway_row(
     else {
         return Ok(());
     };
+    if row.base_url.is_none() && row.models.is_empty() {
+        // Already retired (or never configured).
+        return Ok(());
+    }
     if !policy.managed {
         if row.base_url.is_some() {
             tracing::warn!(
@@ -127,16 +145,39 @@ pub(crate) async fn retire_legacy_gateway_row(
                  pair via your gateway's page to reconnect"
             );
         }
-        return Ok(());
+        return clear_legacy_gateway_row(store).await;
     }
     let Some(gateway_url) = policy.gateway_url.clone() else {
+        // A misconfigured managed policy names no deployment to attribute the
+        // row to. Leave it untouched: the authority is repairable, and the
+        // next boot can still carry the snapshot forward.
         return Ok(());
     };
-    if row.models.is_empty()
-        || row.base_url.as_deref() != Some(gateway_url.as_str())
-        || read_gateway_snapshot(store).await?.is_some()
-    {
-        return Ok(());
+    if row.models.is_empty() || read_gateway_snapshot(store).await?.is_some() {
+        return clear_legacy_gateway_row(store).await;
+    }
+    // Compare deployments as URLs, not as strings. Pairing wrote the
+    // normalized form, but a row written through the old provider route
+    // before that path normalized (#935) holds whatever was typed — so a
+    // profile that became managed by MDM over such a row has
+    // `https://corp.gateway` beside a policy's `https://corp.gateway/`. An
+    // unparseable legacy value can be attributed to no deployment and is
+    // treated as a mismatch.
+    let row_url = row
+        .base_url
+        .as_deref()
+        .and_then(|url| crate::managed_policy::validated_gateway_url(url).ok());
+    if row_url.as_deref() != Some(gateway_url.as_str()) {
+        // A row from a gateway this profile is no longer managed by: its
+        // models describe another deployment's entitlements. Rare, which is
+        // exactly when the reason for an empty picker is worth a log line.
+        tracing::warn!(
+            "the legacy model-gateway row names a different deployment than the \
+             managed policy ({:?} vs {gateway_url}); its synced models are \
+             discarded — refresh the model list to resync the entitled set",
+            row.base_url
+        );
+        return clear_legacy_gateway_row(store).await;
     }
     write_gateway_snapshot(
         store,
@@ -144,6 +185,19 @@ pub(crate) async fn retire_legacy_gateway_row(
             gateway_url,
             models: row.models,
         },
+    )
+    .await?;
+    clear_legacy_gateway_row(store).await
+}
+
+/// Drop the retired row. Written as the disabled default rather than deleted
+/// outright: [`Store`] exposes no setting delete, and the default is exactly
+/// what an absent row already reads as everywhere.
+async fn clear_legacy_gateway_row(store: &dyn Store) -> Result<()> {
+    write_config(
+        store,
+        ProviderKind::ModelGateway,
+        &ProviderConfig::disabled(),
     )
     .await
 }

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -27,21 +27,126 @@ const CREDENTIAL_SUFFIX: &str = ".credential";
 /// Legacy Anthropic API-key secret (pre-providers). Still read as a fallback.
 pub const LEGACY_ANTHROPIC_API_KEY: &str = "provider.anthropic.api_key";
 
-/// Serializes every writer of the ModelGateway provider row.
+/// Serializes every writer of the durable gateway state: the provisioning
+/// write (pairing) and the entitled-model snapshot (model sync, sign-out).
 ///
-/// Pairing, model sync, sign-out, and `PUT /providers/model_gateway` each
-/// read `provider.model_gateway`, mutate part of it, and write the whole row
-/// back, and the [`Store`] API has no cross-call transaction. Unserialized,
-/// two read-modify-writes can interleave and resurrect fields the other just
-/// replaced — a model sync racing a pairing could stamp the old gateway's
-/// base URL or stale model list over the row the pairing wrote while policy
-/// already points at the new gateway. Process-local for the same reason as
-/// pairing's own mutex: the server's instance lock guarantees one process
-/// owns the store, and a static cannot be accidentally wired into two
-/// instances that no longer exclude each other. Lock order: acquired after
-/// the pairing mutex and after the gateway runtime's sign-in state lock,
-/// never before either, and never held across a network call.
-pub(crate) static GATEWAY_ROW_WRITES: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+/// The [`Store`] API has no cross-call transaction, so a sync whose policy
+/// recheck and snapshot write interleaved with a provisioning write could
+/// stamp a snapshot the new policy never entitled. Process-local for the
+/// same reason as pairing's own mutex: the server's instance lock guarantees
+/// one process owns the store, and a static cannot be accidentally wired
+/// into two instances that no longer exclude each other. Lock order:
+/// acquired after the pairing mutex and after the gateway runtime's sign-in
+/// state lock, never before either, and never held across a network call.
+pub(crate) static GATEWAY_STATE_WRITES: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Setting key for the entitled-model snapshot synced from the managed
+/// gateway. This replaces the retired `provider.model_gateway` row's model
+/// list: policy names the gateway, this key caches what it entitles, and no
+/// other stored state describes the gateway.
+const GATEWAY_MODELS_KEY: &str = "gateway.models_v1";
+
+/// The persisted snapshot of the managed gateway's entitled models, stamped
+/// with the deployment it was synced from. The stamp is what keeps the cache
+/// honest without coordinated clears: a snapshot synced from one gateway is
+/// simply never honored while policy names another.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct GatewayModelSnapshot {
+    /// The normalized gateway base URL the models were fetched from.
+    pub(crate) gateway_url: String,
+    pub(crate) models: Vec<CustomModelConfig>,
+}
+
+/// Read the stored snapshot regardless of provenance. Callers that offer
+/// models to anything must use [`gateway_models`] instead; this raw read
+/// exists for selection-key resolution, where usability is enforced
+/// separately by [`provider_is_usable`] and route collection.
+pub(crate) async fn read_gateway_snapshot(
+    store: &dyn Store,
+) -> Result<Option<GatewayModelSnapshot>> {
+    Ok(store
+        .get_setting(GATEWAY_MODELS_KEY)
+        .await?
+        .and_then(|value| serde_json::from_value(value).ok()))
+}
+
+/// Persist the entitled-model snapshot. Callers hold
+/// [`GATEWAY_STATE_WRITES`] across their policy recheck and this write.
+pub(crate) async fn write_gateway_snapshot(
+    store: &dyn Store,
+    snapshot: &GatewayModelSnapshot,
+) -> Result<()> {
+    store
+        .set_setting(GATEWAY_MODELS_KEY, &serde_json::to_value(snapshot)?)
+        .await
+}
+
+/// The entitled models of the gateway the resolved policy names: empty for
+/// an unmanaged profile, for a misconfigured policy, and for a snapshot
+/// stamped by a different deployment.
+pub(crate) async fn gateway_models(
+    store: &dyn Store,
+    policy: &crate::managed_policy::ManagedPolicy,
+) -> Result<Vec<CustomModelConfig>> {
+    let Some(gateway_url) = policy.gateway_url.as_deref().filter(|_| policy.managed) else {
+        return Ok(Vec::new());
+    };
+    Ok(read_gateway_snapshot(store)
+        .await?
+        .filter(|snapshot| snapshot.gateway_url == gateway_url)
+        .map(|snapshot| snapshot.models)
+        .unwrap_or_default())
+}
+
+/// One-shot boot cutover for the retired additive gateway configuration.
+///
+/// The `provider.model_gateway` row is no longer read anywhere: policy is
+/// the only gateway source. On a managed profile whose row was stamped by
+/// the policy's own deployment, the row's synced model list is carried into
+/// [`GATEWAY_MODELS_KEY`] once, so the picker does not go blank on upgrade.
+/// On an unmanaged profile a stored row is the retired legacy state: it is
+/// ignored outright — never auto-converted to managed, because lockdown must
+/// not be imposed without the pairing consent flow — and one boot warning
+/// names the remedy.
+pub(crate) async fn retire_legacy_gateway_row(
+    store: &dyn Store,
+    policy: &crate::managed_policy::ManagedPolicy,
+) -> Result<()> {
+    let Some(row) = store
+        .get_setting(&ProviderKind::ModelGateway.setting_key())
+        .await?
+        .and_then(|value| serde_json::from_value::<ProviderConfig>(value).ok())
+    else {
+        return Ok(());
+    };
+    if !policy.managed {
+        if row.base_url.is_some() {
+            tracing::warn!(
+                "this profile carries a legacy additive model-gateway configuration; \
+                 that mode is retired and the stored configuration is ignored — \
+                 pair via your gateway's page to reconnect"
+            );
+        }
+        return Ok(());
+    }
+    let Some(gateway_url) = policy.gateway_url.clone() else {
+        return Ok(());
+    };
+    if row.models.is_empty()
+        || row.base_url.as_deref() != Some(gateway_url.as_str())
+        || read_gateway_snapshot(store).await?.is_some()
+    {
+        return Ok(());
+    }
+    write_gateway_snapshot(
+        store,
+        &GatewayModelSnapshot {
+            gateway_url,
+            models: row.models,
+        },
+    )
+    .await
+}
 
 /// The known provider kinds. `#[non_exhaustive]` so new kinds can land without
 /// breaking wire clients that match on the string form.
@@ -548,12 +653,31 @@ pub async fn has_credential(secrets: &dyn SecretProvider, kind: ProviderKind) ->
 }
 
 /// Build the public [`ProviderInfo`] for every known kind.
+///
+/// The gateway is not an additive provider: an unmanaged profile has no
+/// gateway entry at all, and a managed profile's entry is a projection of
+/// the resolved policy plus the synced snapshot — never a stored row.
 pub async fn list_providers(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
+    policy: &crate::managed_policy::ManagedPolicy,
 ) -> Result<Vec<ProviderInfo>> {
     let mut out = Vec::with_capacity(ProviderKind::ALL.len());
     for &kind in ProviderKind::ALL {
+        if kind == ProviderKind::ModelGateway {
+            if !policy.managed {
+                continue;
+            }
+            out.push(ProviderInfo {
+                kind,
+                enabled: policy.gateway_url.is_some(),
+                base_url: policy.gateway_url.clone(),
+                vertex_location: None,
+                has_credential: has_credential(secrets, kind).await,
+                models: gateway_models(store, policy).await?,
+            });
+            continue;
+        }
         let config = read_config(store, kind).await?;
         out.push(ProviderInfo {
             kind,
@@ -575,64 +699,34 @@ pub(crate) fn managed_profile_refusal(message: impl Into<String>) -> ServerError
 
 /// Apply a [`ProviderUpdate`] and return the resulting [`ProviderInfo`].
 ///
-/// On a managed profile, BYOK providers are locked: credential and base-URL
-/// writes for any non-gateway kind are refused, and the gateway's own base
-/// URL only accepts a value that normalizes to the policy's locked gateway
-/// URL (which keeps the stored row in sync — routing itself reads the policy
-/// URL directly, see [`collect_routes`]).
+/// The ModelGateway kind refuses every write: policy is the only gateway
+/// source, so the profile connects through MDM policy or deep-link pairing
+/// and there is no user-writable gateway configuration in any state. On a
+/// managed profile, BYOK providers are locked: credential and base-URL
+/// writes for any other kind are refused.
 pub async fn update_provider(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
     kind: ProviderKind,
-    mut update: ProviderUpdate,
+    update: ProviderUpdate,
     os_policy: &dyn crate::managed_policy::OsPolicySource,
 ) -> std::result::Result<ProviderInfo, ServerError> {
-    // The gateway row is also written by pairing, model sync, and sign-out;
-    // serialize this read-modify-write with them. The policy is resolved
-    // under the same lock so a pairing that lands first is seen as managed
-    // here rather than bypassed with a stale resolution. Other kinds have no
-    // concurrent writers and take no lock.
-    let row_lock = match kind {
-        ProviderKind::ModelGateway => Some(GATEWAY_ROW_WRITES.lock().await),
-        _ => None,
-    };
+    if kind == ProviderKind::ModelGateway {
+        // Refused wholesale, managed or not — before any read, so no lock is
+        // needed here and nothing this route does can race the snapshot
+        // writers. The stable kind lets clients branch on it, exactly as
+        // `managed_profile` does for the BYOK lockdown.
+        return Err(ServerError::conflict_kind(
+            "gateway_policy",
+            "the model gateway is configured by policy, not provider settings; \
+             pair via your gateway's page to connect",
+        ));
+    }
     let policy = crate::managed_policy::resolve(store, os_policy).await?;
-    if policy.managed {
-        if kind != ProviderKind::ModelGateway
-            && (update.credential.is_some() || update.base_url.is_some())
-        {
-            return Err(managed_profile_refusal(format!(
-                "this profile is managed by a model gateway; {kind} credentials and endpoints are locked"
-            )));
-        }
-        if kind == ProviderKind::ModelGateway {
-            if let Some(base_url) = update.base_url.take() {
-                // Structurally fail closed: a managed policy without a URL
-                // (which resolution today never produces) locks the field
-                // outright rather than comparing against an empty string.
-                let Some(locked) = policy.gateway_url.as_deref() else {
-                    return Err(managed_profile_refusal(
-                        "this profile is managed; the model gateway base URL is locked",
-                    ));
-                };
-                let matches_locked = base_url.as_deref().is_some_and(|url| {
-                    crate::managed_policy::validated_gateway_url(url)
-                        .ok()
-                        .as_deref()
-                        == Some(locked)
-                });
-                if !matches_locked {
-                    return Err(managed_profile_refusal(format!(
-                        "this profile is managed; the model gateway base URL is locked to {locked}"
-                    )));
-                }
-                // Store the normalized contract form, not the raw input: the
-                // guard compared normalized, and downstream scheme checks
-                // must see the same shape (`HTTPS://…` would otherwise pass
-                // here and fail them).
-                update.base_url = Some(Some(locked.to_owned()));
-            }
-        }
+    if policy.managed && (update.credential.is_some() || update.base_url.is_some()) {
+        return Err(managed_profile_refusal(format!(
+            "this profile is managed by a model gateway; {kind} credentials and endpoints are locked"
+        )));
     }
 
     let mut config = read_config(store, kind).await?;
@@ -647,18 +741,7 @@ pub async fn update_provider(
             if url.is_empty() {
                 return Err(ServerError::bad_request("base_url must not be empty"));
             }
-            config.base_url = Some(if kind == ProviderKind::ModelGateway {
-                // Store the normalized contract form on every profile, not
-                // only managed ones: pairing and policy store the normalized
-                // shape, and both the sync recheck and the connection cache
-                // compare exact strings — a verbatim `https://gw` beside a
-                // normalized `https://gw/` would refuse a same-deployment
-                // sync and split the connection cache for one gateway.
-                crate::managed_policy::validated_gateway_url(&url)
-                    .map_err(|error| ServerError::bad_request(error.to_string()))?
-            } else {
-                url
-            });
+            config.base_url = Some(url);
         }
     }
     match update.vertex_location {
@@ -696,16 +779,6 @@ pub async fn update_provider(
     }
 
     if let Some(credential) = update.credential {
-        // The gateway's only credential is its OAuth session, managed by the
-        // sign-in flow; accepting a pasted key here would light up
-        // has_credential with nothing the router can use.
-        if kind == ProviderKind::ModelGateway
-            && matches!(credential, ProviderCredential::ApiKey { .. })
-        {
-            return Err(ServerError::bad_request(
-                "model_gateway signs in with OAuth; api keys are not accepted",
-            ));
-        }
         if let Some(json) = credential.as_service_account() {
             if !kind.accepts_credential(&credential) {
                 return Err(ServerError::bad_request(format!(
@@ -720,9 +793,6 @@ pub async fn update_provider(
     }
 
     write_config(store, kind, &config).await?;
-    // The response's has_credential is keychain I/O; the row lock exists to
-    // serialize the row write, so drop it before building the response.
-    drop(row_lock);
 
     Ok(ProviderInfo {
         kind,
@@ -868,7 +938,9 @@ pub fn route_kind(kind: ProviderKind) -> openwave_router::RouteKind {
 /// On a managed profile only the gateway route is offered: BYOK kinds are
 /// skipped before any credential is read, so stored keys and the env-var
 /// fallbacks are inert without being deleted, and the gateway's bearer target
-/// comes from the policy's locked URL — stored config can never redirect it.
+/// is the policy URL. On an unmanaged profile there is no gateway route at
+/// all: policy is the only gateway source, and a legacy stored row is never
+/// read.
 pub async fn collect_routes(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
@@ -877,43 +949,40 @@ pub async fn collect_routes(
 ) -> Vec<openwave_router::Route> {
     let mut routes = Vec::new();
     for &kind in ProviderKind::ALL {
-        if policy.managed && kind != ProviderKind::ModelGateway {
+        if kind == ProviderKind::ModelGateway {
+            if !policy.managed {
+                continue;
+            }
+            // The gateway route rides its live token source; without a signed-in
+            // session there is nothing to route to.
+            let Some(source) = gateway_tokens.clone() else {
+                continue;
+            };
+            let Some(base) = policy.gateway_url.as_deref() else {
+                continue;
+            };
+            if !(base.starts_with("https://") || base.starts_with("http://")) {
+                continue;
+            }
+            let models = gateway_models(store, policy).await.unwrap_or_default();
+            routes.push(openwave_router::Route {
+                kind: route_kind(kind),
+                api_key: String::new(),
+                base_url: Some(format!("{}/compat/anthropic", base.trim_end_matches('/'))),
+                curated_models: models.into_iter().map(|model| model.id).collect(),
+                token_source: Some(source),
+                vertex: None,
+            });
+            continue;
+        }
+        if policy.managed {
             continue;
         }
         let config = match read_config(store, kind).await {
             Ok(c) => c,
             Err(_) => continue,
         };
-        // A managed profile's gateway presence comes from policy, not the
-        // stored row: a pure-MDM profile may have no row at all (disabled
-        // default), and the row must not be able to turn the gateway off.
-        if !config.enabled && !policy.managed {
-            continue;
-        }
-        if kind == ProviderKind::ModelGateway {
-            // The gateway route rides its live token source; without a signed-in
-            // session there is nothing to route to.
-            let Some(source) = gateway_tokens.clone() else {
-                continue;
-            };
-            let Some(base) = (if policy.managed {
-                policy.gateway_url.as_deref()
-            } else {
-                config.base_url.as_deref()
-            }) else {
-                continue;
-            };
-            if !(base.starts_with("https://") || base.starts_with("http://")) {
-                continue;
-            }
-            routes.push(openwave_router::Route {
-                kind: route_kind(kind),
-                api_key: String::new(),
-                base_url: Some(format!("{}/compat/anthropic", base.trim_end_matches('/'))),
-                curated_models: config.models.into_iter().map(|model| model.id).collect(),
-                token_source: Some(source),
-                vertex: None,
-            });
+        if !config.enabled {
             continue;
         }
 
@@ -1037,15 +1106,18 @@ pub async fn resolve_model_policy(
         if let Some(spec) = model_registry::find_for(provider, id) {
             return Ok(Some(ResolvedModelPolicy::curated(spec)));
         }
-        if !matches!(
-            provider,
-            ProviderKind::OpenaiCompatible | ProviderKind::ModelGateway
-        ) {
-            return Ok(None);
-        }
-        let config = read_config(store, provider).await?;
-        return Ok(config
-            .models
+        let models = match provider {
+            ProviderKind::OpenaiCompatible => read_config(store, provider).await?.models,
+            // Resolution is not an offer: usability and routing gate the
+            // gateway on policy separately, so the raw snapshot read here
+            // only keeps stored selections legible.
+            ProviderKind::ModelGateway => read_gateway_snapshot(store)
+                .await?
+                .map(|snapshot| snapshot.models)
+                .unwrap_or_default(),
+            _ => return Ok(None),
+        };
+        return Ok(models
             .iter()
             .find(|model| model.id == id)
             .map(|model| ResolvedModelPolicy::custom_for(provider, model)));
@@ -1072,9 +1144,10 @@ pub async fn resolve_model_policy(
 
 /// Whether the provider can accept a new turn right now.
 ///
-/// On a managed profile the gateway's presence is derived from policy — the
-/// stored row is display/session-cache only and may not exist at all — so it
-/// is usable exactly when a session is stored; BYOK kinds are never usable.
+/// The gateway is derived from policy in both directions: on a managed
+/// profile it is usable exactly when a session is stored (and BYOK kinds
+/// never are), and on an unmanaged profile it is never usable — whatever
+/// legacy rows persist in the store.
 pub async fn provider_is_usable(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
@@ -1086,6 +1159,9 @@ pub async fn provider_is_usable(
             return Ok(false);
         }
         return Ok(has_credential(secrets, kind).await);
+    }
+    if kind == ProviderKind::ModelGateway {
+        return Ok(false);
     }
     let config = read_config(store, kind).await?;
     if !config.enabled || !has_credential(secrets, kind).await {
@@ -1099,10 +1175,7 @@ pub async fn provider_is_usable(
     {
         return Ok(false);
     }
-    if matches!(
-        kind,
-        ProviderKind::OpenaiCompatible | ProviderKind::ModelGateway
-    ) {
+    if kind == ProviderKind::OpenaiCompatible {
         let Some(base) = config.base_url.as_deref() else {
             return Ok(false);
         };
@@ -1122,21 +1195,23 @@ pub async fn catalog_models(
 ) -> Result<Vec<CatalogModel>> {
     let mut models = Vec::new();
     for &kind in ProviderKind::ALL {
-        let config = read_config(store, kind).await?;
         let available = provider_is_usable(store, secrets, kind, policy).await?;
         models.extend(model_registry::models_for(kind).map(|spec| CatalogModel {
             policy: ResolvedModelPolicy::curated(spec),
             available,
         }));
-        if matches!(
-            kind,
-            ProviderKind::OpenaiCompatible | ProviderKind::ModelGateway
-        ) {
-            models.extend(config.models.iter().map(|model| CatalogModel {
-                policy: ResolvedModelPolicy::custom_for(kind, model),
-                available,
-            }));
-        }
+        // Configured model sets: the compatible endpoint's custom entries,
+        // and the managed gateway's entitled snapshot — which is empty on an
+        // unmanaged profile, so no gateway row ever reaches the catalog there.
+        let configured = match kind {
+            ProviderKind::OpenaiCompatible => read_config(store, kind).await?.models,
+            ProviderKind::ModelGateway => gateway_models(store, policy).await?,
+            _ => Vec::new(),
+        };
+        models.extend(configured.iter().map(|model| CatalogModel {
+            policy: ResolvedModelPolicy::custom_for(kind, model),
+            available,
+        }));
     }
     Ok(models)
 }

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -737,12 +737,14 @@ pub struct ProvidersList {
     pub providers: Vec<ProviderInfo>,
 }
 
-/// `GET /providers` — every known provider kind and its current config.
+/// `GET /providers` — every known provider kind and its current config. The
+/// model gateway appears only on a managed profile, projected from policy.
 pub async fn list_providers(
     State(state): State<AppState>,
 ) -> Result<Json<ProvidersList>, ServerError> {
+    let policy = crate::managed_policy::resolve(&*state.store, &*state.os_policy).await?;
     Ok(Json(ProvidersList {
-        providers: providers::list_providers(&*state.store, &*state.secrets).await?,
+        providers: providers::list_providers(&*state.store, &*state.secrets, &policy).await?,
     }))
 }
 

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1973,7 +1973,9 @@ async fn a_managed_profile_offers_only_the_gateway_route() {
     }
 
     // Unmanaged control: the same store offers the BYOK routes, and the env
-    // fallback is honored — so the managed delta below is load-bearing.
+    // fallback is honored — so the managed delta below is load-bearing. The
+    // enabled legacy gateway row builds nothing even with a token source in
+    // hand: policy is the only gateway source in both directions.
     let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
         .await
         .unwrap();
@@ -1985,6 +1987,7 @@ async fn a_managed_profile_offers_only_the_gateway_route() {
             .collect();
     assert!(kinds.contains(&openwave_router::RouteKind::Anthropic));
     assert!(kinds.contains(&openwave_router::RouteKind::Gemini));
+    assert!(!kinds.contains(&openwave_router::RouteKind::ModelGateway));
 
     // Provisioned: only the gateway remains, aimed at the policy URL. The
     // stale stored row and every BYOK credential — stored or env — are inert.
@@ -2116,13 +2119,29 @@ async fn delete(router: &Router, bearer: &str, uri: &str) -> axum::response::Res
 }
 
 /// Every locked write path over the real routes: BYOK credential/endpoint
-/// writes, the legacy api-key shim, credential deletion, and a gateway
-/// re-point all refuse with the stable `managed_profile` kind — while an
-/// enable toggle and a same-gateway base URL write stay open.
+/// writes, the legacy api-key shim, and credential deletion refuse with the
+/// stable `managed_profile` kind — while an enable toggle stays open — and
+/// the model gateway kind refuses every write in every state with its own
+/// stable `gateway_policy` kind: policy is the only gateway source.
 #[tokio::test]
 async fn a_managed_profile_refuses_byok_and_gateway_repoint_writes() {
     let (router, token, store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");
+
+    // Unmanaged first: the retired additive configuration is not writable
+    // even on an open profile — there is no URL field to type into any more.
+    let response = put_json(
+        &router,
+        &bearer,
+        "/providers/model_gateway",
+        serde_json::json!({"enabled": true, "base_url": "https://byo.gateway"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let info: AgentErrorInfo = json_body(response).await;
+    assert_eq!(info.kind, "gateway_policy");
+    assert!(info.message.contains("pair via your gateway"));
+
     crate::managed_policy::provision(&*store, "https://corp.gateway")
         .await
         .unwrap();
@@ -2158,25 +2177,19 @@ async fn a_managed_profile_refuses_byok_and_gateway_repoint_writes() {
     .await;
     assert_eq!(response.status(), StatusCode::OK);
 
-    // The gateway base URL is locked to the policy URL: a re-point is refused,
-    // re-asserting the same gateway (modulo normalization) keeps the stored
-    // row in sync.
-    let response = put_json(
-        &router,
-        &bearer,
-        "/providers/model_gateway",
+    // Managed: still refused wholesale — a re-point, and even a write that
+    // matches the policy URL, because the row it would write no longer
+    // exists as a gateway source.
+    for body in [
         serde_json::json!({"base_url": "https://evil.example"}),
-    )
-    .await;
-    assert_eq!(response.status(), StatusCode::CONFLICT);
-    let response = put_json(
-        &router,
-        &bearer,
-        "/providers/model_gateway",
         serde_json::json!({"base_url": "https://corp.gateway"}),
-    )
-    .await;
-    assert_eq!(response.status(), StatusCode::OK);
+        serde_json::json!({"enabled": false}),
+    ] {
+        let response = put_json(&router, &bearer, "/providers/model_gateway", body).await;
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let info: AgentErrorInfo = json_body(response).await;
+        assert_eq!(info.kind, "gateway_policy");
+    }
 
     // The legacy api-key shim and credential deletion refuse the same way.
     let response = put_json(

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -1640,13 +1640,10 @@ async fn model_roles_resolve_at_read_time_and_honor_an_explicit_pin() {
         .save(&credentials)
         .await
         .unwrap();
-    providers::write_config(
+    providers::write_gateway_snapshot(
         &*store,
-        providers::ProviderKind::ModelGateway,
-        &providers::ProviderConfig {
-            enabled: true,
-            base_url: Some("https://corp.gateway/".to_string()),
-            vertex_location: None,
+        &providers::GatewayModelSnapshot {
+            gateway_url: "https://corp.gateway/".to_string(),
             // Flagship-first, as a gateway well might list them: chat takes
             // the gateway's first pick, utility must not.
             models: vec![

--- a/docs/managed-policy.md
+++ b/docs/managed-policy.md
@@ -49,3 +49,33 @@ the permissions are deployment guidance, not an enforced guarantee.
 
 An absent file means no OS policy; an unreadable or malformed file resolves
 managed-but-misconfigured, as above.
+
+## Developer flow — the sqlite policy toggle
+
+There is no unmanaged gateway settings surface: the hand-typed gateway URL
+field and the additive "use model gateway" toggle are retired, and policy is
+the only way a profile becomes gateway-connected. To exercise the real
+managed path against a local gateway without an MDM profile, write the same
+sticky provisioned state that deep-link pairing writes — the
+`managed_policy_v1` row in the profile database:
+
+```sh
+sqlite3 "<data dir>/openwave.db" \
+  "INSERT INTO setting(key, value_json) VALUES
+     ('managed_policy_v1', '{\"gateway_url\":\"http://127.0.0.1:8081\"}')
+   ON CONFLICT(key) DO UPDATE SET value_json = excluded.value_json;"
+```
+
+Policy is re-resolved on every read, so the profile turns managed
+(`source: provisioned`) on the next `/policy` read — sign-in, model sync,
+and routing all run the genuine managed path against the URL you provided.
+Delete the row to return to the open profile:
+
+```sh
+sqlite3 "<data dir>/openwave.db" \
+  "DELETE FROM setting WHERE key = 'managed_policy_v1';"
+```
+
+Note that an OS-managed (MDM) assertion always outranks this row, and a
+profile provisioned to one gateway refuses re-provisioning to another —
+delete the row first to switch deployments.


### PR DESCRIPTION
Implements #948 in phases on this branch: the server-side retirement, then the renderer half after #956/#957 merged (origin/main merged in between), then the review follow-ups.

## Server: policy is the only gateway source

- **Both directions derive from policy.** `GatewayRuntime::connection()`/`status()` read the resolved policy alone; the stored `provider.model_gateway` row is never read as identity. `collect_routes`, `provider_is_usable`, `catalog_models`, and `GET /providers` offer the `model_gateway` kind only under managed policy. `ProviderKind::ModelGateway` stays in the enum for wire compat.
- **All `PUT /providers/model_gateway` writes are refused** — managed or not — with a stable `gateway_policy` conflict kind (409, same pattern as `managed_profile`) pointing at the pairing flow.
- **The sign-in surface is managed-only.** Sign-in, sign-out, apps, and model sync refuse on an unmanaged profile with a clear "pair via your gateway's page to connect" error.
- **Legacy hard cut**, with no auto-convert to managed under any circumstances — lockdown is never imposed without the pairing consent flow.
- **Snapshot storage: the provider row is retired entirely.** The entitled-model snapshot moves to `gateway.models_v1`, **stamped with the deployment it was synced from** — the stamp keeps the cache honest without coordinated clears (a snapshot from one gateway is never honored while policy names another), which let pairing stop touching provider state.
- **Docs.** `docs/managed-policy.md` documents the dev flow replacing the URL field: the sqlite `managed_policy_v1` toggle, which exercises the real managed path.

## Upgrade behavior (what an existing profile sees)

The boot cutover `providers::retire_legacy_gateway_row` runs once and then drops the row, so this is a one-time transition, not per-boot behavior.

- **Managed (the shape a gateway-page pairing produces): nothing is lost.** The row's synced model list is carried into the stamped snapshot when it names the policy's own deployment, because nothing re-syncs entitlements for a reader who is already signed in — without it their picker would be empty until they found the refresh button. Both URLs are normalized before comparing: the old provider write path did not normalize (#935), so a profile managed by MDM over such a row holds `https://corp.gateway` beside a policy's `https://corp.gateway/`, and an exact-string compare discarded exactly the rows this exists to preserve. A row naming a genuinely different deployment is discarded and logged.
- **Unmanaged: the gateway vanishes, by decision.** One warning names the remedy ("pair via your gateway's page to reconnect"), the row is dropped, and a leftover gateway session is retired at boot — bounded best-effort revoke, then an unconditional local clear. Without that the refresh token would sit in the keychain forever: the sign-in surface is managed-only and the renderer has no gateway page, so nothing could ever reach it. A leftover role pin naming a gateway model now says so in the models page rather than offering openai_compatible advice that cannot apply to it.

## Renderer: no additive gateway UI

- **Unmanaged: no Model Gateway section.** The entry leaves the settings rail; deep links still resolve to a signpost at the pairing/MDM flow. The URL field, the "Use Model Gateway" toggle, and the settings Connect flow are deleted.
- **Managed: the slim identity panel.** Signed-in account, read-only gateway origin from policy, sign in/out, refresh models, plus the Connected apps list and MCP-page mount signpost from #957. Connect stays disabled when a misconfigured policy names no origin, where the server would refuse.
- **ManagedGate stops converging the provider row before sign-in** — the server derives the deployment from policy and refuses that write.
- `GatewayStatus` drops its vestigial `configured`/`enabled` bits (both had collapsed into `base_url` presence); wire types regenerated. #956's `gateway_listed` reads the snapshot instead of the retired row.

## Locking

`GATEWAY_ROW_WRITES` becomes `GATEWAY_STATE_WRITES` and now serializes only the snapshot writers (model sync, sign-out), which is what it actually protects: a sign-out's clear landing inside a sync's recheck-and-write. **Pairing deliberately does not take it** — it writes only policy, and the snapshot's deployment stamp already makes a racing sync's write inert, so a lock there would claim a protection nothing depends on. An earlier revision of this description claimed the sync-race test pinned that acquisition; it did not (deleting the acquisition left the suite green), and the acquisition is gone rather than the claim being softened.

## Tests

Extended the existing managed/unmanaged suites rather than duplicating.

- `an_unmanaged_profile_with_a_legacy_row_has_no_gateway_surface` — zero surface (status, routes even with a token source, catalog, listing, usability, all four sign-in endpoints refusing with the remedy) and never-auto-convert.
- `boot_carries_a_managed_rows_snapshot_forward_once` — the carry-forward against a **verbatim** legacy row (the normalization is the point), that the row is dropped, and that a reappearing row never overwrites the snapshot.
- `boot_discards_a_snapshot_from_a_foreign_deployment`, `boot_drops_an_unmanaged_legacy_row_without_making_it_managed`.
- `boot_clears_a_gateway_session_left_on_an_unmanaged_profile` — the vault is cleared when the gateway is unreachable and when the stored URL no longer parses (the branch with no connection to revoke through), and a managed profile's session is untouched.
- `a_managed_profile_refuses_byok_and_gateway_repoint_writes` — the unmanaged and managed `gateway_policy` refusals, including a write matching the policy URL.
- DOM: unmanaged `GatewayPanel` signpost (no textbox/switch/Connect, no gateway traffic), managed read-only origin + Connect issuing no provider write, Connect disabled when policy names no gateway, and the rail dropping the gateway entry when unmanaged.

Every guard above was mutation-tested: unnormalized stamp compare, removed one-shot cutover guard, removed foreign-deployment discard, removed row clear, removed snapshot stamp filter, removed vault clear, and session retirement not gated on unmanaged — each fails a test that names it.

Deleted tests, per line:

- `gateway_runtime::a_managed_profile_reaches_its_gateway_despite_a_diverged_stored_row` — the renderer-writable row it defended against is never read; its surviving assertions are folded into `the_route_token_source_mints_llm_tokens_per_rotation`.
- `pairing::a_provider_update_parked_mid_write_cannot_overwrite_a_pairing` — `PUT /providers/model_gateway` refuses before any read, so the read-to-write window it pinned no longer exists.
- DOM `GatewayPanel > saves the gateway URL as provider configuration` — the URL field and provider write it exercised are the retired flow itself.
- DOM `ManagedGate > connect on an unconfigured profile converges the provider…` — that write is now refused; the surviving invariant (Connect never writes provider config) is asserted in the first ManagedGate test.

Reworked: `a_sync_racing_a_pairing_cannot_resurrect_the_old_gateways_state` → `a_sync_racing_a_policy_repoint_cannot_stamp_the_old_gateways_models` (an MDM push is the surviving mid-sync repoint authority); `a_session_for_a_different_gateway_reads_signed_out` (policy-vs-session); `a_signed_out_runtime_offers_no_route`, the gateway fixture, and `pairing_provisions_policy_and_points_the_provider` → `…_and_a_stale_snapshot_is_never_honored`; #956's role test seeds entitlements via the snapshot.

Verified locally: `cargo fmt --all --check`, `cargo clippy -p openwave-server --all-targets --locked -- -D warnings`, `cargo test -p openwave-server --locked` (473 passing), `cargo check --workspace --locked` (no lock diff), and under `crates/openwave-desktop/ui`: `tsc`, `vitest run` (665 passing), production `vite build`.

Closes #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)