### PR TITLE
feat(desktop): background-agent observation UX — cancel, activity timeline, result presence

### DIFF
--- a/crates/openwave-desktop/ui/src/AgentRunDisplay.ts
+++ b/crates/openwave-desktop/ui/src/AgentRunDisplay.ts
@@ -1,6 +1,8 @@
-import type { AgentRun } from "./api";
+import type { AgentActivityHistoryEntry, AgentRun } from "./api";
 
 type AgentRunStatus = AgentRun["status"];
+type AgentActivityKind = AgentActivityHistoryEntry["kind"];
+type AgentActivityOutcome = AgentActivityHistoryEntry["outcome"];
 
 export type AgentRunStatusGroup = {
   id: string;
@@ -90,5 +92,79 @@ export function agentRunStatusDetail(run: AgentRun): string {
       return "Could not finish";
     case "cancelled":
       return "Stopped";
+  }
+}
+
+/**
+ * One line for a settled or live step in a run's activity history, phrased by
+ * outcome. Every phrase is a closed, renderer-safe label — it names what kind
+ * of step this was, never what it read, searched for, or found.
+ */
+const ACTIVITY_HISTORY_LABELS: Record<
+  AgentActivityKind,
+  Record<AgentActivityOutcome, string>
+> = {
+  web_search: {
+    waiting: "Waiting to search the web",
+    running: "Searching the web",
+    completed: "Searched the web",
+    failed: "Web search failed",
+    cancelled: "Web search stopped",
+  },
+  read_delegated_file: {
+    waiting: "Waiting to read a delegated file",
+    running: "Reading a delegated file",
+    completed: "Read a delegated file",
+    failed: "Could not read a delegated file",
+    cancelled: "File read stopped",
+  },
+  list_connected_folders: {
+    waiting: "Waiting to check connected folders",
+    running: "Checking connected folders",
+    completed: "Checked connected folders",
+    failed: "Could not check connected folders",
+    cancelled: "Folder check stopped",
+  },
+  list_folder: {
+    waiting: "Waiting to list a folder",
+    running: "Listing a folder",
+    completed: "Listed a folder",
+    failed: "Could not list a folder",
+    cancelled: "Folder listing stopped",
+  },
+  read_connected_file: {
+    waiting: "Waiting to read a file",
+    running: "Reading a file",
+    completed: "Read a file",
+    failed: "Could not read a file",
+    cancelled: "File read stopped",
+  },
+  import_connected_file: {
+    waiting: "Waiting to add a source",
+    running: "Adding a source",
+    completed: "Added a source",
+    failed: "Could not add a source",
+    cancelled: "Adding a source stopped",
+  },
+};
+
+export function agentActivityHistoryLabel(
+  entry: AgentActivityHistoryEntry,
+): string {
+  return ACTIVITY_HISTORY_LABELS[entry.kind][entry.outcome];
+}
+
+export function getAgentActivityOutcomeDotClass(
+  outcome: AgentActivityOutcome,
+): string {
+  switch (outcome) {
+    case "waiting":
+    case "running":
+      return "animate-pulse bg-muted-foreground";
+    case "completed":
+      return "bg-success";
+    case "failed":
+    case "cancelled":
+      return "bg-destructive";
   }
 }

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
@@ -20,10 +20,14 @@ function run(
     finished_at: null,
     last_error_code: null,
     activity: null,
+    produced_output: status === "completed",
     created_at: "2026-07-27T12:00:00Z",
     updated_at: "2026-07-27T12:00:00Z",
   };
 }
+
+const noop = async () => undefined;
+const noActivity = async () => [];
 
 describe("BackgroundAgentList", () => {
   it("groups only the durable children of its own spawn step", () => {
@@ -41,6 +45,8 @@ describe("BackgroundAgentList", () => {
         loading={false}
         error={null}
         onRetry={() => undefined}
+        onCancel={noop}
+        onLoadActivity={noActivity}
       />,
     );
 
@@ -59,6 +65,8 @@ describe("BackgroundAgentList", () => {
         loading
         error={null}
         onRetry={() => undefined}
+        onCancel={noop}
+        onLoadActivity={noActivity}
       />,
     );
 
@@ -73,9 +81,51 @@ describe("BackgroundAgentList", () => {
         loading={false}
         error={null}
         onRetry={() => undefined}
+        onCancel={noop}
+        onLoadActivity={noActivity}
       />,
     );
 
     expect(markup).toEqual("");
+  });
+
+  it("offers Stop on a cancellable run and View output only once it produced a result", () => {
+    const markup = renderToStaticMarkup(
+      <BackgroundAgentList
+        spawns={[
+          { callId: "call-running", status: "running" },
+          { callId: "call-done", status: "completed" },
+        ]}
+        runs={[
+          run("run-running", "call-running", "running"),
+          run("run-done", "call-done", "completed"),
+        ]}
+        loading={false}
+        error={null}
+        onRetry={() => undefined}
+        onCancel={noop}
+        onLoadActivity={noActivity}
+        onViewOutput={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Stop");
+    expect(markup).toContain("View output");
+  });
+
+  it("does not offer Stop on a settled run", () => {
+    const markup = renderToStaticMarkup(
+      <BackgroundAgentList
+        spawns={[{ callId: "call-done", status: "completed" }]}
+        runs={[run("run-done", "call-done", "completed")]}
+        loading={false}
+        error={null}
+        onRetry={() => undefined}
+        onCancel={noop}
+        onLoadActivity={noActivity}
+      />,
+    );
+
+    expect(markup).not.toContain(">Stop<");
   });
 });

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
@@ -1,13 +1,17 @@
-import { useState } from "react";
-import { Bot, ChevronRight } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Bot, ChevronDown, ChevronRight, FileOutput, Square } from "lucide-react";
 
-import type { AgentRun } from "./api";
+import type { AgentActivityHistoryEntry, AgentRun } from "./api";
 import {
   AGENT_RUN_STATUS_GROUPS,
+  agentActivityHistoryLabel,
   agentRunStatusDetail,
+  getAgentActivityOutcomeDotClass,
   getAgentRunDotClass,
+  RUNNING_AGENT_STATUSES,
 } from "./AgentRunDisplay";
 import type { ToolCallStatus } from "./ToolCallCard";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 export type BackgroundAgentSpawn = {
@@ -22,12 +26,18 @@ type BackgroundAgentListProps = {
   loading: boolean;
   error: string | null;
   onRetry: () => void;
+  /** Durably request cancellation of one background run. */
+  onCancel: (runId: string) => Promise<void>;
+  /** Fetch a run's ordered, renderer-safe activity history. */
+  onLoadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
+  /** Open the outputs surface, when a completed run produced a result. */
+  onViewOutput?: () => void;
 };
 
 /**
  * One transcript-local view of the agents requested by a single spawn step.
- * It observes chat-scoped snapshots only; no scheduler or worker state can be
- * changed from this card.
+ * It observes chat-scoped snapshots only; the one command it can issue is a
+ * durable cancellation request, resolved by the same read model it polls.
  */
 export function BackgroundAgentList({
   spawns,
@@ -35,6 +45,9 @@ export function BackgroundAgentList({
   loading,
   error,
   onRetry,
+  onCancel,
+  onLoadActivity,
+  onViewOutput,
 }: BackgroundAgentListProps) {
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const sandboxRuns = runs.filter((run) => run.tier === "background");
@@ -120,18 +133,14 @@ export function BackgroundAgentList({
                 {!collapsed && (
                   <div className="divide-y divide-border/60">
                     {groupRuns.map((run, index) => (
-                      <div key={run.id} className="flex min-w-0 items-center gap-2 px-3 py-2.5">
-                        <span
-                          className={cn("size-2 shrink-0 rounded-full", getAgentRunDotClass(run.status))}
-                          aria-hidden="true"
-                        />
-                        <span className="min-w-0 flex-1 truncate font-medium text-foreground">
-                          Background agent {index + 1}
-                        </span>
-                        <span className="shrink-0 text-xs text-muted-foreground">
-                          {agentRunStatusDetail(run)}
-                        </span>
-                      </div>
+                      <BackgroundAgentRow
+                        key={run.id}
+                        run={run}
+                        label={`Background agent ${index + 1}`}
+                        onCancel={onCancel}
+                        onLoadActivity={onLoadActivity}
+                        onViewOutput={onViewOutput}
+                      />
                     ))}
                   </div>
                 )}
@@ -151,4 +160,196 @@ export function BackgroundAgentList({
       )}
     </section>
   );
+}
+
+type ActivityState = {
+  loading: boolean;
+  error: boolean;
+  loaded: boolean;
+  items: AgentActivityHistoryEntry[];
+};
+
+/**
+ * One background run: its live status on a line, expandable into the ordered
+ * timeline of what it has done, with a Stop control while it is cancellable and
+ * a link to its output once it finishes with one.
+ */
+function BackgroundAgentRow({
+  run,
+  label,
+  onCancel,
+  onLoadActivity,
+  onViewOutput,
+}: {
+  run: AgentRun;
+  label: string;
+  onCancel: (runId: string) => Promise<void>;
+  onLoadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
+  onViewOutput?: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [stopping, setStopping] = useState(false);
+  const [activity, setActivity] = useState<ActivityState>({
+    loading: false,
+    error: false,
+    loaded: false,
+    items: [],
+  });
+
+  // The Stop control is offered only while a fresh cancel would still change
+  // anything. A run that is already `cancelling` shows a settled "Stopping".
+  const stoppable =
+    RUNNING_AGENT_STATUSES.has(run.status) && run.status !== "cancelling";
+  const showStopping = stopping || run.status === "cancelling";
+  const canViewOutput = run.produced_output && onViewOutput !== undefined;
+
+  // Drop the optimistic bridge once the durable transition has caught up: any
+  // status that is no longer a cancellable running state is confirmation
+  // enough (`cancelling`, `cancelled`, or a terminal outcome).
+  useEffect(() => {
+    if (!stoppable) setStopping(false);
+  }, [stoppable]);
+
+  // Re-read the timeline whenever the row is open and the run advances, so a
+  // live run's steps settle in place without a manual refresh.
+  useEffect(() => {
+    if (!expanded) return;
+    let cancelled = false;
+    setActivity((state) => ({ ...state, loading: !state.loaded, error: false }));
+    onLoadActivity(run.id)
+      .then((items) => {
+        if (!cancelled) {
+          setActivity({ loading: false, error: false, loaded: true, items });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setActivity((state) => ({ ...state, loading: false, error: true }));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [expanded, run.id, run.updated_at, onLoadActivity]);
+
+  const handleStop = async () => {
+    setStopping(true);
+    try {
+      await onCancel(run.id);
+    } catch {
+      // The durable request did not commit; return the control so the reader
+      // can try again rather than leave a run stuck reading "Stopping".
+      setStopping(false);
+    }
+  };
+
+  const contentId = `background-agent-activity-${run.id}`;
+
+  return (
+    <div className="px-3 py-2.5">
+      <div className="flex min-w-0 items-center gap-2">
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+          onClick={() => setExpanded((open) => !open)}
+          aria-expanded={expanded}
+          aria-controls={contentId}
+        >
+          <ChevronDown
+            className={cn(
+              "size-3.5 shrink-0 text-muted-foreground transition-transform",
+              !expanded && "-rotate-90",
+            )}
+            aria-hidden="true"
+          />
+          <span
+            className={cn("size-2 shrink-0 rounded-full", getAgentRunDotClass(run.status))}
+            aria-hidden="true"
+          />
+          <span className="min-w-0 flex-1 truncate font-medium text-foreground">
+            {label}
+          </span>
+        </button>
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {showStopping ? "Stopping" : agentRunStatusDetail(run)}
+        </span>
+        {canViewOutput && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 shrink-0 gap-1 px-2 text-xs"
+            onClick={onViewOutput}
+          >
+            <FileOutput className="size-3.5" aria-hidden="true" />
+            View output
+          </Button>
+        )}
+        {stoppable && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 shrink-0 gap-1 px-2 text-xs"
+            onClick={handleStop}
+            disabled={stopping}
+          >
+            <Square className="size-3 fill-current" aria-hidden="true" />
+            Stop
+          </Button>
+        )}
+      </div>
+      {expanded && (
+        <div id={contentId} className="mt-2 pl-5">
+          <AgentActivityTimeline state={activity} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AgentActivityTimeline({ state }: { state: ActivityState }) {
+  if (state.error) {
+    return (
+      <p className="text-xs text-muted-foreground" role="status">
+        Activity history is unavailable.
+      </p>
+    );
+  }
+  if (state.items.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground" role="status">
+        {state.loading && !state.loaded
+          ? "Loading activity…"
+          : "No recorded activity yet."}
+      </p>
+    );
+  }
+  return (
+    <ol className="flex flex-col gap-2 border-l-2 border-border py-0.5 pl-3" role="list">
+      {state.items.map((entry, index) => (
+        <li key={`${entry.at}:${index}`} className="flex items-center gap-2 text-xs">
+          <span
+            className={cn(
+              "size-1.5 shrink-0 rounded-full",
+              getAgentActivityOutcomeDotClass(entry.outcome),
+            )}
+            aria-hidden="true"
+          />
+          <span className="min-w-0 flex-1 truncate text-foreground">
+            {agentActivityHistoryLabel(entry)}
+          </span>
+          <time className="shrink-0 text-muted-foreground" dateTime={entry.at}>
+            {formatActivityTime(entry.at)}
+          </time>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function formatActivityTime(at: string): string {
+  const parsed = new Date(at);
+  if (Number.isNaN(parsed.getTime())) return "";
+  return parsed.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -437,6 +437,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             onDismissAttachedSource={() => setRecentSource(null)}
             onSelectPrompt={setComposerDraft}
             onSend={onSend}
+            onViewOutput={() => openPanel({ type: "outputs" })}
           />
         </TranscriptVisibilityProvider>
       );

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -38,6 +38,8 @@ export type ChatViewProps = {
   onDismissAttachedSource: () => void;
   onSelectPrompt: (prompt: string) => void;
   onSend: () => Promise<void>;
+  /** Open the outputs surface, offered on a completed background run's row. */
+  onViewOutput?: () => void;
 };
 
 /**
@@ -63,6 +65,7 @@ export function ChatView({
   onDismissAttachedSource,
   onSelectPrompt,
   onSend,
+  onViewOutput,
 }: ChatViewProps) {
   const transcriptVisible = useTranscriptVisible();
   const folderAccess = useFolderAccessRequests(client, chat.id);
@@ -266,6 +269,9 @@ export function ChatView({
           backgroundAgentRunsLoading={agentRuns.loading}
           backgroundAgentRunsError={agentRuns.error}
           onRetryBackgroundAgentRuns={agentRuns.refresh}
+          onCancelBackgroundAgentRun={agentRuns.cancel}
+          onLoadBackgroundAgentActivity={agentRuns.loadActivity}
+          onViewBackgroundAgentOutput={onViewOutput}
           busy={busy}
           reasoningActive={reasoningActive}
           scrollRef={attachScrollRef}

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -21,6 +21,7 @@ function backgroundRun(
     finished_at: null,
     last_error_code: null,
     activity: null,
+    produced_output: status === "completed",
     created_at: "2026-07-27T12:00:00Z",
     updated_at: "2026-07-27T12:00:00Z",
   };

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -4,6 +4,7 @@ import type {
   ApprovalGrantRung,
   ApiClient,
   AgentRun,
+  AgentActivityHistoryEntry,
   PendingFolderAccessRequest,
   PendingOutputWritebackRequest,
   PendingUserQuestions,
@@ -115,6 +116,11 @@ type MessageListProps = {
   backgroundAgentRunsLoading?: boolean;
   backgroundAgentRunsError?: string | null;
   onRetryBackgroundAgentRuns?: () => void;
+  onCancelBackgroundAgentRun?: (runId: string) => Promise<void>;
+  onLoadBackgroundAgentActivity?: (
+    runId: string,
+  ) => Promise<AgentActivityHistoryEntry[]>;
+  onViewBackgroundAgentOutput?: () => void;
   busy: boolean;
   reasoningActive?: boolean;
   scrollRef: Ref<HTMLDivElement>;
@@ -172,6 +178,9 @@ export function MessageList({
   backgroundAgentRunsLoading = false,
   backgroundAgentRunsError = null,
   onRetryBackgroundAgentRuns = () => undefined,
+  onCancelBackgroundAgentRun = async () => undefined,
+  onLoadBackgroundAgentActivity = async () => [],
+  onViewBackgroundAgentOutput,
   busy,
   reasoningActive = false,
   scrollRef,
@@ -208,6 +217,9 @@ export function MessageList({
       loading: backgroundAgentRunsLoading,
       error: backgroundAgentRunsError,
       retry: onRetryBackgroundAgentRuns,
+      cancel: onCancelBackgroundAgentRun,
+      loadActivity: onLoadBackgroundAgentActivity,
+      viewOutput: onViewBackgroundAgentOutput,
     },
   );
   // Only greet a genuinely empty, fully-hydrated conversation. While an
@@ -375,7 +387,17 @@ export function groupMessageItems(
     loading: boolean;
     error: string | null;
     retry: () => void;
-  } = { runs: [], loading: false, error: null, retry: () => undefined },
+    cancel: (runId: string) => Promise<void>;
+    loadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
+    viewOutput?: () => void;
+  } = {
+    runs: [],
+    loading: false,
+    error: null,
+    retry: () => undefined,
+    cancel: async () => undefined,
+    loadActivity: async () => [],
+  },
 ) {
   const items: ReactNode[] = [];
   // The item index at which the trailing turn opens (its user message). Lets the
@@ -461,6 +483,9 @@ export function groupMessageItems(
           loading={backgroundAgents.loading}
           error={backgroundAgents.error}
           onRetry={backgroundAgents.retry}
+          onCancel={backgroundAgents.cancel}
+          onLoadActivity={backgroundAgents.loadActivity}
+          onViewOutput={backgroundAgents.viewOutput}
         />,
       );
     }

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -5,6 +5,9 @@ import {
   type ChatMessageSnapshot,
   type PendingApprovalSnapshot,
   type AgentActivitySnapshot,
+  type AgentActivityHistoryItem,
+  type AgentActivityKind,
+  type AgentActivityOutcome,
   type AgentRunCancellationSnapshot,
   type AgentRunSnapshot,
   type Chat as WireChat,
@@ -291,6 +294,15 @@ export type SandboxAgentCancellation = AgentRunCancellationSnapshot;
  * provider identities, or diagnostics.
  */
 export type AgentActivity = AgentActivitySnapshot;
+
+/**
+ * One settled or live step in a background run's ordered activity history.
+ *
+ * Same closed vocabulary and posture as {@link AgentActivity}: the server
+ * sends only a fixed kind, a coarse outcome, and a timestamp — never tool
+ * inputs, queries, results, identities, paths, leases, or diagnostics.
+ */
+export type AgentActivityHistoryEntry = AgentActivityHistoryItem;
 
 
 
@@ -1101,6 +1113,24 @@ export class ApiClient {
     });
   }
 
+  /**
+   * The ordered, renderer-safe activity history for one background run.
+   *
+   * Malformed or unknown entries are dropped rather than trusted, keeping the
+   * closed vocabulary the server promises. A wrong-chat, foreground, or missing
+   * run answers `404`, which surfaces as a thrown error.
+   */
+  async listAgentRunActivity(
+    chatId: string,
+    runId: string,
+  ): Promise<AgentActivityHistoryEntry[]> {
+    const body = await this.json<unknown>(
+      `/chats/${encodeURIComponent(chatId)}/agent-runs/${encodeURIComponent(runId)}/activity`,
+      { headers: this.headers() },
+    );
+    return parseAgentActivityHistory(body);
+  }
+
   async cancelAgentRun(
     chatId: string,
     runId: string,
@@ -1548,6 +1578,55 @@ function nonEmptyBounded(value: unknown, maxChars: number): value is string {
       return code < 32 || (code >= 127 && code <= 159);
     })
   );
+}
+
+const AGENT_ACTIVITY_KINDS = new Set<AgentActivityKind>([
+  "web_search",
+  "read_delegated_file",
+  "list_connected_folders",
+  "list_folder",
+  "read_connected_file",
+  "import_connected_file",
+]);
+
+const AGENT_ACTIVITY_OUTCOMES = new Set<AgentActivityOutcome>([
+  "waiting",
+  "running",
+  "completed",
+  "failed",
+  "cancelled",
+]);
+
+/**
+ * Keep only well-formed history entries in their server order. An entry whose
+ * kind or outcome falls outside the closed vocabulary, or whose timestamp is
+ * missing, is dropped rather than rendered — the same defensive discipline the
+ * transcript applies to every model-influenced projection.
+ */
+export function parseAgentActivityHistory(
+  value: unknown,
+): AgentActivityHistoryEntry[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (
+      !isRecord(entry) ||
+      typeof entry.kind !== "string" ||
+      !AGENT_ACTIVITY_KINDS.has(entry.kind as AgentActivityKind) ||
+      typeof entry.outcome !== "string" ||
+      !AGENT_ACTIVITY_OUTCOMES.has(entry.outcome as AgentActivityOutcome) ||
+      typeof entry.at !== "string" ||
+      entry.at.length === 0
+    ) {
+      return [];
+    }
+    return [
+      {
+        kind: entry.kind as AgentActivityKind,
+        outcome: entry.outcome as AgentActivityOutcome,
+        at: entry.at,
+      },
+    ];
+  });
 }
 
 export function parseSandboxAgentCancellation(

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -9,12 +9,33 @@
 // which a type can express. See docs/wire-types.md.
 
 /**
+ * One renderer-safe entry in a background run's ordered activity history.
+ *
+ * Built from durable sandbox tool calls, but it carries only the fixed
+ * [`AgentActivityKind`] vocabulary, a coarse lifecycle, and a timestamp. Tool
+ * arguments, queries, results, folder and file identities, host paths,
+ * provider identities, executor leases, and raw diagnostics all remain
+ * server-side, exactly as they do for the live `activity` projection.
+ */
+export type AgentActivityHistoryItem = { kind: AgentActivityKind, outcome: AgentActivityOutcome, at: string, };
+
+/**
  * Fixed, renderer-safe names for supported live work.
  *
  * Adding a durable tool does not automatically expose it to a renderer: it
  * must be deliberately admitted here with a safe label.
  */
 export type AgentActivityKind = "web_search" | "read_delegated_file" | "list_connected_folders" | "list_folder" | "read_connected_file" | "import_connected_file";
+
+/**
+ * Coarse, renderer-safe lifecycle for one historical activity entry.
+ *
+ * Unlike [`AgentActivityStatus`], which only names live work, this also
+ * admits the three terminal outcomes so a settled step can be shown in an
+ * ordered timeline. It carries no failure detail: a failed step is only
+ * "failed", never why.
+ */
+export type AgentActivityOutcome = "waiting" | "running" | "completed" | "failed" | "cancelled";
 
 /**
  * Renderer-safe projection of one live supported checkpoint.
@@ -68,7 +89,16 @@ last_error_code: string | null,
  * arguments, results, provider call identities, executor leases, or raw
  * executor diagnostics.
  */
-activity: AgentActivitySnapshot | null, created_at: string, updated_at: string, spawn_call_id: CallId | null, };
+activity: AgentActivitySnapshot | null, 
+/**
+ * Whether a completed background run committed an immutable terminal
+ * receipt, which happens atomically with its terminal state.
+ *
+ * This is presence only: the payload, its display text, and any merged
+ * deliverable never cross this boundary. A renderer uses it to offer a
+ * "view output" affordance and link to the outputs surface.
+ */
+produced_output: boolean, created_at: string, updated_at: string, spawn_call_id: CallId | null, };
 
 /**
  * Durable lifecycle of an [`AgentRun`].

--- a/crates/openwave-desktop/ui/src/useAgentRuns.test.ts
+++ b/crates/openwave-desktop/ui/src/useAgentRuns.test.ts
@@ -17,6 +17,7 @@ function run(status: AgentRun["status"] = "running"): AgentRun {
     finished_at: null,
     last_error_code: null,
     activity: null,
+    produced_output: status === "completed",
     created_at: "2026-07-27T12:00:00Z",
     updated_at: "2026-07-27T12:00:00Z",
   };

--- a/crates/openwave-desktop/ui/src/useAgentRuns.ts
+++ b/crates/openwave-desktop/ui/src/useAgentRuns.ts
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-import type { AgentRun, ApiClient } from "./api";
+import type { AgentActivityHistoryEntry, AgentRun, ApiClient } from "./api";
 import { RUNNING_AGENT_STATUSES } from "./AgentRunDisplay";
 
 const LIVE_POLL_INTERVAL_MS = 5_000;
@@ -10,6 +10,14 @@ export type AgentRuns = {
   loading: boolean;
   error: string | null;
   refresh: () => void;
+  /**
+   * Durably request cancellation of one background run, then refresh so the
+   * poll picks up the `cancelling`/`cancelled` transition. The caller holds its
+   * own optimistic "Stopping" state until that durable status arrives.
+   */
+  cancel: (runId: string) => Promise<void>;
+  /** Fetch the ordered, renderer-safe activity history for one background run. */
+  loadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
 };
 
 /**
@@ -92,10 +100,30 @@ export function useAgentRuns(
     return () => window.clearInterval(interval);
   }, [hasLiveSandbox, hasUnresolvedSpawn]);
 
+  // Stable identities so a row can list them as effect dependencies without
+  // re-fetching its timeline on every parent render.
+  const cancel = useCallback(
+    async (runId: string) => {
+      if (!client || !chatId) return;
+      await client.cancelAgentRun(chatId, runId);
+      refreshRef.current?.();
+    },
+    [client, chatId],
+  );
+  const loadActivity = useCallback(
+    async (runId: string) => {
+      if (!client || !chatId) return [];
+      return client.listAgentRunActivity(chatId, runId);
+    },
+    [client, chatId],
+  );
+
   return {
     runs,
     loading,
     error,
     refresh: () => refreshRef.current?.(),
+    cancel,
+    loadActivity,
   };
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -377,6 +377,10 @@ pub fn app(state: AppState) -> Router {
         .route("/chats/{id}/messages", get(routes::list_chat_messages))
         .route("/chats/{id}/agent-runs", get(routes::list_agent_runs))
         .route(
+            "/chats/{chat_id}/agent-runs/{run_id}/activity",
+            get(routes::list_agent_run_activity),
+        )
+        .route(
             "/chats/{chat_id}/agent-runs/{run_id}/cancel",
             post(routes::post_agent_run_cancel),
         )

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1508,6 +1508,13 @@ pub struct AgentRunSnapshot {
     /// arguments, results, provider call identities, executor leases, or raw
     /// executor diagnostics.
     pub activity: Option<AgentActivitySnapshot>,
+    /// Whether a completed background run committed an immutable terminal
+    /// receipt, which happens atomically with its terminal state.
+    ///
+    /// This is presence only: the payload, its display text, and any merged
+    /// deliverable never cross this boundary. A renderer uses it to offer a
+    /// "view output" affordance and link to the outputs surface.
+    pub produced_output: bool,
     pub created_at: chrono::DateTime<Utc>,
     pub updated_at: chrono::DateTime<Utc>,
     // This is an OpenWave call id, not a provider call identity. It lets a
@@ -1518,6 +1525,11 @@ pub struct AgentRunSnapshot {
 
 impl AgentRunSnapshot {
     fn from_run(run: AgentRun, activity: Option<AgentActivitySnapshot>) -> Self {
+        // A background child commits its final result receipt in the same
+        // transaction as its terminal `Completed` state, so the terminal state
+        // is an exact, renderer-safe proxy for output presence.
+        let produced_output =
+            run.tier == AgentRunTier::Background && run.status == AgentRunStatus::Completed;
         Self {
             id: run.id,
             parent_id: run.parent_id,
@@ -1529,6 +1541,7 @@ impl AgentRunSnapshot {
             finished_at: run.finished_at,
             last_error_code: run.last_error_code,
             activity,
+            produced_output,
             created_at: run.created_at,
             updated_at: run.updated_at,
         }
@@ -1588,6 +1601,81 @@ fn sandbox_activity(calls: &[SandboxToolCall]) -> Option<AgentActivitySnapshot> 
         _ => return None,
     };
     Some(AgentActivitySnapshot { kind, status })
+}
+
+/// Coarse, renderer-safe lifecycle for one historical activity entry.
+///
+/// Unlike [`AgentActivityStatus`], which only names live work, this also
+/// admits the three terminal outcomes so a settled step can be shown in an
+/// ordered timeline. It carries no failure detail: a failed step is only
+/// "failed", never why.
+#[derive(Debug, Clone, Copy, Serialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentActivityOutcome {
+    Waiting,
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+/// One renderer-safe entry in a background run's ordered activity history.
+///
+/// Built from durable sandbox tool calls, but it carries only the fixed
+/// [`AgentActivityKind`] vocabulary, a coarse lifecycle, and a timestamp. Tool
+/// arguments, queries, results, folder and file identities, host paths,
+/// provider identities, executor leases, and raw diagnostics all remain
+/// server-side, exactly as they do for the live `activity` projection.
+#[derive(Debug, Clone, Copy, Serialize, ts_rs::TS)]
+pub struct AgentActivityHistoryItem {
+    pub kind: AgentActivityKind,
+    pub outcome: AgentActivityOutcome,
+    pub at: chrono::DateTime<Utc>,
+}
+
+/// Project a background run's durable sandbox tool calls into an ordered,
+/// renderer-safe activity history.
+///
+/// The store returns calls in durable creation order, so the projection keeps
+/// that order. Tool names outside the admitted vocabulary are executor data,
+/// not a renderer contract, and are skipped rather than leaked as raw labels.
+fn sandbox_activity_history(calls: &[SandboxToolCall]) -> Vec<AgentActivityHistoryItem> {
+    calls
+        .iter()
+        .filter_map(sandbox_activity_history_item)
+        .collect()
+}
+
+fn sandbox_activity_history_item(call: &SandboxToolCall) -> Option<AgentActivityHistoryItem> {
+    let kind = match call.name.as_str() {
+        "web_search" => AgentActivityKind::WebSearch,
+        openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL => AgentActivityKind::ReadDelegatedFile,
+        // Unknown tool names are executor data, not a renderer API contract.
+        _ => return None,
+    };
+    // A terminal step is dated by when it resolved; a live step by when it was
+    // admitted. `resolved_at` is always present once terminal, but fall back to
+    // the creation time rather than dropping a settled step from the timeline.
+    let (outcome, at) = match call.status {
+        SandboxToolCallStatus::Accepted => (AgentActivityOutcome::Waiting, call.created_at),
+        SandboxToolCallStatus::Claimed => (AgentActivityOutcome::Running, call.created_at),
+        SandboxToolCallStatus::Completed => (
+            AgentActivityOutcome::Completed,
+            call.resolved_at.unwrap_or(call.created_at),
+        ),
+        SandboxToolCallStatus::Failed => (
+            AgentActivityOutcome::Failed,
+            call.resolved_at.unwrap_or(call.created_at),
+        ),
+        SandboxToolCallStatus::Cancelled => (
+            AgentActivityOutcome::Cancelled,
+            call.resolved_at.unwrap_or(call.created_at),
+        ),
+        // `SandboxToolCallStatus` is non-exhaustive; an unrecognized future
+        // state is executor data, not a renderer contract.
+        _ => return None,
+    };
+    Some(AgentActivityHistoryItem { kind, outcome, at })
 }
 
 fn foreground_activity(
@@ -1651,6 +1739,40 @@ pub async fn list_agent_runs(
         snapshots.push(AgentRunSnapshot::from_run(run, activity));
     }
     Ok(Json(snapshots))
+}
+
+/// `GET /chats/{id}/agent-runs/{run_id}/activity` — ordered, renderer-safe
+/// activity history for one background run.
+///
+/// This is the durable companion to the live `activity` field on a run
+/// snapshot: where that field names only the single current checkpoint, this
+/// returns every admitted step in order, each with a coarse terminal outcome
+/// and timestamp. It keeps the same posture — no tool arguments, queries,
+/// results, identities, leases, or diagnostics cross the boundary. A missing,
+/// wrong-chat, or foreground run returns `404` rather than revealing whether an
+/// unrelated run identifier exists.
+pub async fn list_agent_run_activity(
+    State(state): State<AppState>,
+    Path((chat_id, run_id)): Path<(ChatId, openwave_core::AgentRunId)>,
+) -> Result<Json<Vec<AgentActivityHistoryItem>>, ServerError> {
+    if state.store.get_chat(chat_id).await?.is_none() {
+        return Err(ServerError::not_found(format!("chat {chat_id} not found")));
+    }
+    let run = state
+        .store
+        .get_agent_run(run_id)
+        .await?
+        .filter(|run| run.chat_id == chat_id && run.tier == AgentRunTier::Background);
+    let Some(run) = run else {
+        return Err(ServerError::not_found(format!(
+            "agent run {run_id} not found"
+        )));
+    };
+    let calls = state
+        .store
+        .list_sandbox_tool_calls_for_agent_run(run.id)
+        .await?;
+    Ok(Json(sandbox_activity_history(&calls)))
 }
 
 /// Closed renderer-safe acknowledgement for sandbox cancellation.

--- a/crates/openwave-server/src/tests/sandbox.rs
+++ b/crates/openwave-server/src/tests/sandbox.rs
@@ -215,6 +215,162 @@ async fn agent_run_snapshots_expose_only_safe_live_sandbox_activity() {
 }
 
 #[tokio::test]
+async fn agent_run_activity_history_is_ordered_renderer_safe_and_flags_a_produced_result() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let other_chat = make_chat(&router, &bearer).await;
+
+    let run = admit_sandbox_for_test(&store, chat.id, "research").await;
+    let worker_lease = uuid::Uuid::new_v4();
+    assert_eq!(
+        store
+            .claim_agent_run(worker_lease, chrono::Duration::minutes(5), 4, 4)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        run.id
+    );
+
+    let checkpoint = SandboxToolCallRequest {
+        id: CallId::new(),
+        agent_run_id: run.id,
+        chat_id: chat.id,
+        provider_id: "provider-call-identity".into(),
+        name: "web_search".into(),
+        arguments: serde_json::json!({
+            "query": "private query that must not reach the renderer",
+            "api_key": "secret-value"
+        }),
+    };
+    assert!(matches!(
+        store
+            .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &checkpoint)
+            .await
+            .unwrap(),
+        ParkSandboxToolCallOutcome::Parked { .. }
+    ));
+    let executor_lease = uuid::Uuid::new_v4();
+    assert!(matches!(
+        store
+            .claim_sandbox_tool_call(checkpoint.id, executor_lease, chrono::Duration::minutes(5))
+            .await
+            .unwrap(),
+        openwave_core::ClaimSandboxToolCallOutcome::Claimed(_)
+    ));
+    assert!(matches!(
+        store
+            .resolve_sandbox_tool_call(
+                checkpoint.id,
+                executor_lease,
+                &ToolCallResolution::Completed {
+                    result: "private result that must not reach the renderer".into(),
+                },
+            )
+            .await
+            .unwrap(),
+        openwave_core::ResolveSandboxToolCallOutcome::Resolved
+    ));
+
+    // Resolving the checkpoint hands the run back for continuation; take it and
+    // commit its terminal result so the snapshot reports a produced result.
+    let continuation_lease = uuid::Uuid::new_v4();
+    assert_eq!(
+        store
+            .claim_agent_run(continuation_lease, chrono::Duration::minutes(5), 4, 4)
+            .await
+            .unwrap()
+            .unwrap()
+            .id,
+        run.id
+    );
+    store
+        .submit_agent_run_result(run.id, continuation_lease, "final answer")
+        .await
+        .unwrap()
+        .expect("completion commits");
+
+    // The run snapshot flags result presence without carrying any payload.
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/chats/{}/agent-runs", chat.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let snapshots: Vec<serde_json::Value> = json_body(response).await;
+    let snapshot = snapshots
+        .iter()
+        .find(|snapshot| snapshot.get("id") == Some(&serde_json::json!(run.id)))
+        .expect("sandbox snapshot is returned");
+    assert_eq!(
+        snapshot.get("produced_output"),
+        Some(&serde_json::json!(true))
+    );
+    assert_eq!(snapshot.get("activity"), Some(&serde_json::json!(null)));
+
+    // The activity history is the ordered, terminal-outcome projection.
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/chats/{}/agent-runs/{}/activity", chat.id, run.id))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let history: Vec<serde_json::Value> = json_body(response).await;
+    assert_eq!(history.len(), 1);
+    assert_eq!(
+        history[0].get("kind"),
+        Some(&serde_json::json!("web_search"))
+    );
+    assert_eq!(
+        history[0].get("outcome"),
+        Some(&serde_json::json!("completed"))
+    );
+    assert!(history[0].get("at").is_some_and(|at| at.is_string()));
+
+    let encoded = serde_json::to_string(&history).unwrap();
+    for forbidden in [
+        "private query that must not reach the renderer",
+        "private result that must not reach the renderer",
+        "secret-value",
+        "provider-call-identity",
+        "arguments",
+        "lease_token",
+        "result",
+    ] {
+        assert!(!encoded.contains(forbidden), "history leaked {forbidden}");
+    }
+
+    // Binding to the wrong chat must not reveal that the run exists.
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/chats/{}/agent-runs/{}/activity",
+                    other_chat.id, run.id
+                ))
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn delegated_file_routes_are_native_only_and_expose_only_exact_broker_authority() {
     let (router, token, _state, store, _dir) = test_app_with_state().await;
     let bearer = format!("Bearer {token}");

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -354,6 +354,9 @@ mod tests {
         generate::collect_from::<openwave_core::Chat>(&cfg, &mut out);
         generate::collect_from::<crate::routes::AgentRunSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::AgentRunCancellationSnapshot>(&cfg, &mut out);
+        // A separate endpoint root: the ordered activity history is returned by
+        // its own route, so the snapshot walk never reaches it.
+        generate::collect_from::<crate::routes::AgentActivityHistoryItem>(&cfg, &mut out);
         out
     }
 


### PR DESCRIPTION
Enriches the native background-agent tracking UI so a reader can watch an agent work and see what it produced — three cohesive pieces over the same files.

## Cancel
Each cancellable row (status in a running state) gets a Stop control wired to the existing `POST /chats/{id}/agent-runs/{run_id}/cancel` route via `useAgentRuns`. On click the row holds an optimistic "Stopping" until polling observes the durable `cancelling`/`cancelled` transition; the optimistic bridge clears the moment the run leaves its cancellable running states, and a failed request returns the control rather than leaving the row stuck.

## Live activity timeline
The run snapshot only ever exposed the single live checkpoint (`sandbox_activity` returns the latest non-terminal call). This adds a renderer-safe ordered history behind a new `GET /chats/{id}/agent-runs/{run_id}/activity`, projected from `list_sandbox_tool_calls_for_agent_run` into `{ kind, outcome, at }` items over the existing fixed `AgentActivityKind` vocabulary, each carrying a terminal outcome (completed/failed/cancelled) or a live status (waiting/running) plus a timestamp. Each row expands into that timeline, reusing the collapsible pattern; the collapsed one-line summary is unchanged.

Renderer-safe posture is preserved exactly as for the live projection: no tool arguments, queries, results, folder/file identities, host paths, provider identities, executor leases, or diagnostics cross the boundary, and tool names outside the admitted vocabulary are skipped rather than leaked. A wrong-chat, foreground, or missing run answers `404` so the endpoint never reveals whether an unrelated run exists. The client validator drops malformed or unknown entries. Loading the history on demand keeps the run-list read cheap (it deliberately avoids the full transcript).

## Result presence
The snapshot gains `produced_output`, true when a background run reached terminal `Completed` — which commits its immutable result receipt atomically with the terminal state, so the state is an exact proxy for output presence. A completed row offers a "view output" affordance that links to the outputs surface (`openPanel({ type: "outputs" })`). This surfaces presence only; the output-to-deliverable merge and rendering the output content are out of scope (owned by #952). The field is presence only — no payload, text, or deliverable crosses.

## Notes
- New ts-rs types (`AgentActivityHistoryItem`, `AgentActivityOutcome`, `produced_output`) are registered and wire types regenerated; the currency test passes.
- Stays in the agent-run read model and its consumers; does not touch the outputs BE, `deliverable.rs`, or `OutputsView`.
- No agent-type machinery or steering — UX for the existing single-type native background agents.

## Verification
- `cargo test -p openwave-server --locked` (sandbox + wire lanes), clippy `--all-targets -D warnings`, fmt
- `tsc --noEmit`, `vitest run` (656 pass), `vite build`

Closes #965