### PR TITLE
feat(ui): enable file upload from the home page

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -27,6 +27,7 @@ import {
   presentChatTranscript,
 } from "./ChatTranscriptPresentation";
 import { useFirstMessage } from "./FirstMessage";
+import { usePendingAttach } from "./PendingAttach";
 import { ChatView } from "./ChatView";
 import { OutputDetailRoot } from "./outputs/OutputDetailRoot";
 import { OutputsView } from "./outputs/OutputsView";
@@ -80,6 +81,7 @@ const sessionDeps = {
 
 const chatListActions = useChatListStore.getState();
 const firstMessageActions = useFirstMessage.getState();
+const pendingAttachActions = usePendingAttach.getState();
 const { signal: signalRefresh } = useRefreshSignals.getState();
 const { signal: signalTurnLifecycle } = useTurnLifecycle.getState();
 
@@ -128,6 +130,14 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     if (!chat) return;
     const pending = firstMessageActions.take(chatId);
     if (pending) void sendMessage(pending);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chat, chatId]);
+
+  // "Upload files" on the home page creates the chat and navigates here; the
+  // signal tells us to open the native picker immediately.
+  useEffect(() => {
+    if (!chat) return;
+    if (pendingAttachActions.take(chatId)) void onAttach();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chat, chatId]);
 

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -6,9 +6,11 @@ import { ChatExplorer } from "./ChatExplorer";
 import { useChatListStore } from "./ChatListStore";
 import { Composer } from "./Composer";
 import { useFirstMessage } from "./FirstMessage";
+import { hasNativeHost } from "./host";
 import { ModelMenu, ReasoningEffortMenu } from "./ModelMenu";
 import { modelForSelection } from "./ModelSelection";
 import { useNewChatSettings } from "./NewChatSettings";
+import { usePendingAttach } from "./PendingAttach";
 import { PermissionModeMenu } from "./PermissionModeMenu";
 import { RouteFrame } from "./RouteFrame";
 import { HomeSidebar } from "./sidebar/HomeSidebar";
@@ -16,6 +18,7 @@ import { ToolsMenu } from "./ToolsMenu";
 
 const chatListActions = useChatListStore.getState();
 const firstMessageActions = useFirstMessage.getState();
+const pendingAttachActions = usePendingAttach.getState();
 
 /**
  * Where the app opens, and where the logo goes back to.
@@ -55,6 +58,27 @@ export function HomeRoute() {
       chatListActions.setChatsError(null);
       firstMessageActions.hold(created.id, content);
       setDraft("");
+      await navigate({ to: "/c/$chatId", params: { chatId: created.id } });
+    } catch (err) {
+      setError(`Could not start a chat: ${String(err)}`);
+    } finally {
+      chatListActions.setCreatingChat(false);
+    }
+  }
+
+  async function attachToNewChat() {
+    if (creatingChat) return;
+    chatListActions.setCreatingChat(true);
+    setError(null);
+    try {
+      const created = await client.createChat(newChat.model ?? undefined, null, {
+        reasoningEffort: newChat.reasoningEffort,
+        permissionMode: newChat.permissionMode,
+        citationFormat: newChat.citationFormat,
+      });
+      chatListActions.prependChat(created);
+      chatListActions.setChatsError(null);
+      pendingAttachActions.hold(created.id);
       await navigate({ to: "/c/$chatId", params: { chatId: created.id } });
     } catch (err) {
       setError(`Could not start a chat: ${String(err)}`);
@@ -103,6 +127,7 @@ export function HomeRoute() {
               <>
                 <ToolsMenu
                   disabled={creatingChat}
+                  onAttach={hasNativeHost() ? attachToNewChat : undefined}
                   citationFormat={newChat.citationFormat}
                   defaultCitationFormat={defaultCitationFormat}
                   onCitationFormatChange={newChat.setCitationFormat}

--- a/crates/openwave-desktop/ui/src/PendingAttach.ts
+++ b/crates/openwave-desktop/ui/src/PendingAttach.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+
+/**
+ * Signals that the file picker should open as soon as a conversation mounts.
+ *
+ * When "Upload files" is clicked on the home page there is no chat yet, so the
+ * home route creates one, navigates to it, and drops a marker here. The chat
+ * route picks it up on mount and opens the native picker — the same code path
+ * as clicking "Upload files" inside a conversation.
+ *
+ * `take` reads and clears atomically so a re-render cannot open it twice.
+ */
+type PendingAttachStore = {
+  chatId: string | null;
+  hold: (chatId: string) => void;
+  take: (chatId: string) => boolean;
+};
+
+export const usePendingAttach = create<PendingAttachStore>()((set, get) => ({
+  chatId: null,
+  hold: (chatId) => set({ chatId }),
+  take: (chatId) => {
+    if (get().chatId !== chatId) return false;
+    set({ chatId: null });
+    return true;
+  },
+}));


### PR DESCRIPTION
## Summary

- Clicking "Upload files" in the home page's "+" menu now creates a chat with the current settings, navigates to it, and opens the native file picker automatically.
- Introduces a `PendingAttach` store (same pattern as `FirstMessage`) to carry the "open picker" signal across the navigation boundary: the home route holds the new chat's id, and the chat route's mount effect picks it up and calls `onAttach()`.

In alpha, files upload to a project-agnostic endpoint and sit as composer attachments until the message is sent. OW's `attachChatFiles` Tauri command bundles the picker, upload, and chat association in one step, so a chat must exist first. This is the minimal path to make "Upload files" functional on the home page within that constraint.

## Test plan

- [ ] On the home page, click "+" → "Upload files" — a new chat should be created, navigated to, and the native file picker should open immediately
- [ ] Cancel the file picker — the chat remains (empty but navigated)
- [ ] Pick a file — it should attach to the newly created chat
- [ ] Verify the home page's new-chat settings (model, reasoning, permissions, citation format) are applied to the created chat
- [ ] `pnpm build` passes
- [ ] `pnpm test` — all 653 tests pass