### PR TITLE
feat(approvals): a command-prefix rung, and a floor under every grant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6712,6 +6712,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "keyring",
+ "openwave-shell-policy",
  "schemars 1.2.2",
  "sea-orm",
  "sea-orm-migration",

--- a/crates/openwave-core/Cargo.toml
+++ b/crates/openwave-core/Cargo.toml
@@ -35,6 +35,7 @@ tools = ["dep:cap-fs-ext", "dep:cap-std", "dep:tokio"]
 blob-fs = ["dep:async-stream", "dep:tokio", "dep:windows-sys"]
 
 [dependencies]
+openwave-shell-policy = { path = "../openwave-shell-policy" }
 async-trait = { workspace = true }
 async-stream = { workspace = true, optional = true }
 cap-std = { workspace = true, optional = true }

--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -429,6 +429,15 @@ pub enum GrantScope {
     ExactAction(ToolActionPreview),
     /// This executable, with any arguments.
     AnyArgsFor { command: String },
+    /// A leading run of argv tokens: the executable plus its subcommand
+    /// chain, with any arguments after it.
+    ///
+    /// The rung people actually reach for — "any `cargo test`", not "any
+    /// `cargo`". It is matched token-wise rather than as a string prefix, and
+    /// only after the command has cleared the analyzer's floor, so a grant
+    /// for `cargo test` cannot be stretched to something that merely starts
+    /// with those letters or that smuggles a shell in behind them.
+    CommandPrefix { tokens: Vec<String> },
     /// Every call to the tool.
     WholeTool,
 }
@@ -448,23 +457,75 @@ impl GrantScope {
     /// asking.
     #[must_use]
     pub fn covers_call(&self, tool_name: &str, arguments: &serde_json::Value) -> bool {
-        if matches!(self, Self::WholeTool) {
-            return true;
-        }
         if !ToolActionPreview::describes_exactly(tool_name, arguments) {
-            return false;
+            // Nothing describable to match, so only the widest scope can
+            // apply — and it applies to a call the renderer could not show,
+            // which is exactly what granting the whole tool agreed to.
+            return matches!(self, Self::WholeTool);
         }
         let Some(action) = ToolActionPreview::build(tool_name, arguments) else {
-            return false;
+            return matches!(self, Self::WholeTool);
         };
+        // A command is matched against its argv rather than its rendering,
+        // and only once the analyzer says the call is safe to auto-run under
+        // this very rule. That check is what makes a widened rung honest: a
+        // grant for `cargo` stops covering `cargo` the moment the arguments
+        // reach somewhere they should not, instead of covering it forever
+        // because the executable still matches.
+        if let ToolActionPreview::Exec { command, args, .. } = &action {
+            return self.covers_argv(&action, command, args);
+        }
         match self {
             Self::WholeTool => true,
             Self::ExactAction(granted) => *granted == action,
-            Self::AnyArgsFor { command } => matches!(
-                &action,
-                ToolActionPreview::Exec { command: called, .. } if called == command
-            ),
+            // Only a command has an executable or a token run to name.
+            Self::AnyArgsFor { .. } | Self::CommandPrefix { .. } => false,
         }
+    }
+
+    /// Whether this scope authorizes one command invocation.
+    ///
+    /// Two independent questions, in order. Does the scope *name* this call —
+    /// for the exact rung that still means the whole projection, working
+    /// directory included, because "exactly this" was said about an action in
+    /// a place. And would the analyzer auto-run it under that rule — the
+    /// floor, which no rung escapes, so an interpreter or a path that climbs
+    /// out keeps asking however broadly it was granted.
+    fn covers_argv(&self, action: &ToolActionPreview, command: &str, args: &[String]) -> bool {
+        if let Self::ExactAction(granted) = self {
+            if granted != action {
+                return false;
+            }
+        }
+        let rule = match self {
+            Self::WholeTool => openwave_shell_policy::CommandRule::new(
+                openwave_shell_policy::CommandRuleKind::All,
+                Vec::new(),
+            ),
+            Self::AnyArgsFor { command } => openwave_shell_policy::CommandRule::new(
+                openwave_shell_policy::CommandRuleKind::Prefix,
+                vec![command.clone()],
+            ),
+            Self::CommandPrefix { tokens } => openwave_shell_policy::CommandRule::new(
+                openwave_shell_policy::CommandRuleKind::Prefix,
+                tokens.clone(),
+            ),
+            // The projection already matched above, so the analyzer is asked
+            // only whether this invocation clears the floor.
+            Self::ExactAction(_) => openwave_shell_policy::CommandRule::new(
+                openwave_shell_policy::CommandRuleKind::Exact,
+                exec_argv(command, args),
+            ),
+        };
+        let Ok(rule) = rule else {
+            return false;
+        };
+        let ruleset = openwave_shell_policy::ShellRuleSet {
+            allow: vec![rule],
+            deny: Vec::new(),
+        };
+        openwave_shell_policy::analyze_argv(&exec_argv(command, args), &ruleset).verdict
+            == openwave_shell_policy::ShellVerdict::Allow
     }
 
     /// The scopes offered for a call, narrowest first.
@@ -483,20 +544,52 @@ impl GrantScope {
         let Some(action) = ToolActionPreview::build(tool_name, arguments) else {
             return vec![Self::WholeTool];
         };
-        let mut ladder = vec![Self::ExactAction(action.clone())];
-        // A command is the one action with a rung between "this exact call" and
-        // "every call": the executable it runs. With no arguments even that
-        // would read as two names for one grant.
-        if let ToolActionPreview::Exec { command, args, .. } = &action {
-            if !args.is_empty() {
-                ladder.push(Self::AnyArgsFor {
-                    command: command.clone(),
-                });
-            }
-        }
-        ladder.push(Self::WholeTool);
-        ladder
+        Self::ladder_for_action(&action)
     }
+
+    /// The ladder for an action already projected from a parked call.
+    ///
+    /// The same rungs [`Self::ladder_for`] offers, reachable from the durable
+    /// action so a decision arriving later is rebuilt against exactly what
+    /// the card showed rather than against anything the client sent.
+    #[must_use]
+    pub fn ladder_for_action(action: &ToolActionPreview) -> Vec<Self> {
+        let action = action.clone();
+        // A command's ladder is built by the analyzer rather than assembled
+        // here, and every rung on it is verified: a rung appears only when
+        // granting exactly that rule would in fact stop the asking. That is
+        // what stops the card offering "always allow any `timeout`", which
+        // the gate would then refuse to honor.
+        if let ToolActionPreview::Exec { command, args, .. } = &action {
+            let argv = exec_argv(command, args);
+            let mut ladder: Vec<Self> = openwave_shell_policy::suggested_rungs_for_argv(&argv)
+                .into_iter()
+                .map(|rule| match rule.kind {
+                    openwave_shell_policy::CommandRuleKind::Exact => {
+                        Self::ExactAction(action.clone())
+                    }
+                    openwave_shell_policy::CommandRuleKind::Prefix => Self::CommandPrefix {
+                        tokens: rule.tokens,
+                    },
+                    openwave_shell_policy::CommandRuleKind::All => Self::WholeTool,
+                })
+                .collect();
+            // A command the analyzer will not auto-run under any rule has no
+            // ladder at all, and offering one anyway would promise something
+            // the gate refuses. Approving once stays available.
+            ladder.dedup();
+            return ladder;
+        }
+        vec![Self::ExactAction(action), Self::WholeTool]
+    }
+}
+
+/// One command invocation as the analyzer reads it.
+fn exec_argv(command: &str, args: &[String]) -> Vec<String> {
+    let mut argv = Vec::with_capacity(args.len() + 1);
+    argv.push(command.to_owned());
+    argv.extend(args.iter().cloned());
+    argv
 }
 
 impl StandingGrant {
@@ -976,28 +1069,26 @@ mod standing_grant_tests {
                 GrantLevel::Chat { chat_id: chat },
                 "exec",
                 kind,
-                exact_command("bash", &["-c", &long]),
+                exact_command("echo", &[&long]),
                 Utc::now(),
             )
             .unwrap(),
         );
 
-        // Truncation: a longer script sharing the granted prefix projects to
+        // Deliberately not an interpreter: the floor refuses those outright,
+        // which would pass this test for a reason that has nothing to do with
+        // the clamping it is here to check.
+        //
+        // Truncation: a longer argument sharing the granted prefix projects to
         // the same preview. Keying on the projection would run it unprompted.
         let appended = format!("{long}; rm -rf ~");
-        assert!(!grants.covers(
-            chat,
-            None,
-            "exec",
-            kind,
-            &exec_args("bash", &["-c", &appended])
-        ));
+        assert!(!grants.covers(chat, None, "exec", kind, &exec_args("echo", &[&appended])));
         // A value exactly at the bound is not truncated, so it stays faithful
         // and the grant still covers the command it was actually given for.
-        assert!(grants.covers(chat, None, "exec", kind, &exec_args("bash", &["-c", &long])));
+        assert!(grants.covers(chat, None, "exec", kind, &exec_args("echo", &[&long])));
         // Nothing at or past the bound can be turned into a narrow grant.
         assert_eq!(
-            GrantScope::ladder_for("exec", &exec_args("bash", &["-c", &appended])),
+            GrantScope::ladder_for("exec", &exec_args("echo", &[&appended])),
             vec![GrantScope::WholeTool]
         );
     }
@@ -1096,14 +1187,32 @@ mod standing_grant_tests {
         assert!(!grants.covers(chat, None, "exec", kind, &exec_args("rm", &["-rf"])));
     }
 
+    /// No rung outruns the floor, including the widest one.
+    ///
+    /// "Don't ask again about commands" used to mean every command, so a
+    /// grant taken for `cargo` also carried `rm -rf` and `bash -c`. It now
+    /// means every command the analyzer would run on its own — a grant is a
+    /// standing yes to the routine, never a blanket one.
     #[test]
-    fn a_whole_tool_grant_covers_an_action_it_cannot_read() {
+    fn the_widest_grant_still_stops_at_the_floor() {
         let chat = ChatId::new();
         let kind = ToolApprovalKind::for_tool_name("exec");
         let grants = StandingGrants::new();
         grants.record(grant(chat, "exec"));
 
-        assert!(grants.covers(chat, None, "exec", kind, &exec_args("rm", &["-rf"])));
+        assert!(grants.covers(chat, None, "exec", kind, &exec_args("cargo", &["test"])));
+        // Destructive, and an interpreter, and a path out of the workspace.
+        assert!(!grants.covers(chat, None, "exec", kind, &exec_args("rm", &["-rf", "/"])));
+        assert!(!grants.covers(chat, None, "exec", kind, &exec_args("bash", &["-c", "id"])));
+        assert!(!grants.covers(
+            chat,
+            None,
+            "exec",
+            kind,
+            &exec_args("cat", &["../../outside.txt"])
+        ));
+        // An action with nothing to read is still covered: that is what
+        // granting the whole tool agreed to.
         assert!(grants.covers(chat, None, "exec", kind, &no_args()));
     }
 
@@ -1113,17 +1222,29 @@ mod standing_grant_tests {
             GrantScope::ladder_for("exec", &exec_args("cargo", &["test"])),
             vec![
                 exact_command("cargo", &["test"]),
-                GrantScope::AnyArgsFor {
-                    command: "cargo".into(),
+                // The rung this ladder previously could not offer: the
+                // subcommand, not the whole executable.
+                GrantScope::CommandPrefix {
+                    tokens: vec!["cargo".into(), "test".into()],
+                },
+                GrantScope::CommandPrefix {
+                    tokens: vec!["cargo".into()],
                 },
                 GrantScope::WholeTool,
             ]
         );
-        // With no arguments, "exactly this" and "any arguments to this" would
-        // be two names for the same grant.
+        // With no arguments the two narrow rungs are still different grants:
+        // "exactly `true`" runs only that, while the prefix also covers
+        // `true --whatever`.
         assert_eq!(
             GrantScope::ladder_for("exec", &exec_args("true", &[])),
-            vec![exact_command("true", &[]), GrantScope::WholeTool,]
+            vec![
+                exact_command("true", &[]),
+                GrantScope::CommandPrefix {
+                    tokens: vec!["true".into()],
+                },
+                GrantScope::WholeTool,
+            ]
         );
         // Nothing to describe means nothing narrower to offer.
         assert_eq!(

--- a/crates/openwave-desktop/ui/src/ApprovalCard.tsx
+++ b/crates/openwave-desktop/ui/src/ApprovalCard.tsx
@@ -28,6 +28,8 @@ type ApprovalCardProps = {
   canRemember: boolean;
   /** How far a remembered answer will reach, for the option labels. */
   grantScope?: GrantScopeName;
+  /** Token counts of the prefix rungs the server will honor for this call. */
+  prefixRungs?: readonly number[];
   /** The Auto-mode judge is deciding. Advisory only: the card stays live. */
   autoJudging?: boolean;
   deciding: boolean;
@@ -58,13 +60,21 @@ export function ApprovalCard({
   canApprove,
   canRemember,
   grantScope = "chat",
+  prefixRungs = [],
   autoJudging,
   deciding,
   error,
   onDecide,
 }: ApprovalCardProps) {
   const [expanded, setExpanded] = useState(false);
-  const options = approvalOptions(preview, canApprove, canRemember, expanded, grantScope);
+  const options = approvalOptions(
+    preview,
+    canApprove,
+    canRemember,
+    expanded,
+    grantScope,
+    prefixRungs,
+  );
   const [highlight, setHighlight] = useState(0);
   const rowRefs = useRef<Array<HTMLDivElement | null>>([]);
   const hasAutoFocused = useRef(false);
@@ -261,6 +271,7 @@ export function approvalOptions(
   canRemember: boolean,
   expanded = false,
   scope: GrantScopeName = "chat",
+  prefixRungs: readonly number[] = [],
 ): ApprovalOption[] {
   if (!canApprove) return [declineOption()];
 
@@ -277,7 +288,7 @@ export function approvalOptions(
     },
   ];
 
-  const grants = canRemember ? grantLadder(preview, scope) : [];
+  const grants = canRemember ? grantLadder(preview, scope, prefixRungs) : [];
   const visible = expanded ? grants : grants.slice(0, INLINE_GRANTS);
   options.push(...visible);
   if (grants.length > visible.length) {
@@ -308,6 +319,7 @@ function declineOption(): ApprovalOption {
 export function grantLadder(
   preview: ToolActionPreview | null,
   scope: GrantScopeName = "chat",
+  prefixRungs: readonly number[] = [],
 ): ApprovalOption[] {
   // The label names the level the server will actually write. A chat filed
   // under a project grants across it, and saying "this chat" while writing
@@ -332,23 +344,23 @@ export function grantLadder(
     decision: "approve",
     grant: "exact_action",
   };
-  // A command is the one action with a rung between itself and its whole tool:
-  // the executable it runs. With no arguments even that would be the same
-  // grant as the exact one.
-  if (preview.tool !== "exec" || preview.args.length === 0) {
+  if (preview.tool !== "exec") {
     return [exact, wholeTool];
   }
-  return [
-    exact,
-    {
+  // Which token runs may be granted is the server's answer, not a guess made
+  // here: a command the analyzer would never auto-run under a prefix rule has
+  // none, and offering one anyway would promise something the gate refuses.
+  const argv = [preview.command, ...preview.args];
+  const prefixes: ApprovalOption[] = prefixRungs
+    .filter((tokens) => tokens > 0 && tokens <= argv.length)
+    .map((tokens) => ({
       kind: "decide",
-      key: "any-args",
-      label: `Yes, and always allow any \u201c${preview.command}\u201d command`,
+      key: `prefix-${tokens}`,
+      label: `Yes, and always allow any \u201c${argv.slice(0, tokens).join(" ")}\u201d command`,
       decision: "approve",
-      grant: "any_args_for_command",
-    },
-    wholeTool,
-  ];
+      grant: { command_prefix: { tokens } },
+    }));
+  return [exact, ...prefixes, wholeTool];
 }
 
 /** How much of an action fits in one row of the option list. */

--- a/crates/openwave-desktop/ui/src/ApprovalHistory.test.ts
+++ b/crates/openwave-desktop/ui/src/ApprovalHistory.test.ts
@@ -13,6 +13,7 @@ const pending = {
   preview: null,
   canApprove: true,
   canRemember: true,
+  prefixRungs: [],
   autoJudgeStatus: null,
 };
 
@@ -37,6 +38,7 @@ describe("reconcilePendingApprovalCards", () => {
         canApprove: true,
         canRemember: true,
         autoJudging: false,
+        prefixRungs: [],
       },
     ]);
   });

--- a/crates/openwave-desktop/ui/src/ApprovalHistory.ts
+++ b/crates/openwave-desktop/ui/src/ApprovalHistory.ts
@@ -24,6 +24,7 @@ export function reconcilePendingApprovalCards(
     next = upsertPendingApprovalCard(next, {
       ...approval,
       autoJudging: approval.autoJudgeStatus === "judging",
+      prefixRungs: approval.prefixRungs,
     });
   }
   return next;
@@ -35,7 +36,10 @@ export function upsertPendingApprovalCard(
     PendingToolApproval,
     "callId" | "action" | "approval" | "canApprove" | "canRemember"
   > &
-    Partial<Pick<PendingToolApproval, "preview">> & { autoJudging?: boolean },
+    Partial<Pick<PendingToolApproval, "preview">> & {
+      autoJudging?: boolean;
+      prefixRungs?: readonly number[];
+    },
 ): ChatMessage[] {
     let next = messages;
     const presentation = toolApprovalPresentation(approval.approval);
@@ -82,6 +86,7 @@ export function upsertPendingApprovalCard(
       canApprove: approval.canApprove && presentation.canApprove,
       canRemember: approval.canRemember && presentation.canRemember,
       autoJudging: approval.autoJudging ?? false,
+      prefixRungs: approval.prefixRungs ?? [],
     };
     if (cardIndex >= 0) {
       next = next.map((message, index) => (index === cardIndex ? card : message));

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -202,6 +202,7 @@ describe("tool call lifecycle", () => {
       {
         type: "approval_required",
       auto_judging: false,
+      prefix_rungs: [],
         call_id: "call-1",
         action: "search",
         approval: "search_may_share_query_and_excerpts",
@@ -229,6 +230,7 @@ describe("tool call lifecycle", () => {
       {
         type: "approval_required",
       auto_judging: false,
+      prefix_rungs: [],
         call_id: "call-1",
         action: "search",
         approval: "search_may_share_query_and_excerpts",
@@ -247,6 +249,7 @@ describe("approvals", () => {
   const APPROVAL: AgentEvent = {
     type: "approval_required",
       auto_judging: false,
+      prefix_rungs: [],
     call_id: "call-1",
     action: "search",
     approval: "search_may_share_query_and_excerpts",
@@ -436,6 +439,7 @@ describe("terminal events", () => {
       {
         type: "approval_required",
       auto_judging: false,
+      prefix_rungs: [],
         call_id: "call-1",
         action: "search",
         approval: "search_may_share_query_and_excerpts",

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -246,6 +246,7 @@ export function reduceChatSessionEvent(
             canApprove: approval.canApprove,
             canRemember: approval.canRemember,
             autoJudging: event.auto_judging,
+            prefixRungs: event.prefix_rungs,
           }),
         },
         effects,

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -162,6 +162,8 @@ describe("approval card interactions", () => {
           args: ["test"],
           cwd: ".",
         },
+        // Both prefix rungs the server offers for `cargo test`.
+        prefixRungs: [2, 1],
       }),
     );
 
@@ -182,9 +184,11 @@ describe("approval card interactions", () => {
     ).toEqual([
       "1.Yes, run it once",
       "2.Yes, and always allow exactly \u201ccargo test\u201d",
-      "3.Yes, and always allow any \u201ccargo\u201d command",
-      "4.Yes, and don't ask again about commands in this chat",
-      "5.No, don't allow this",
+      // The rung this ladder previously could not offer.
+      "3.Yes, and always allow any \u201ccargo test\u201d command",
+      "4.Yes, and always allow any \u201ccargo\u201d command",
+      "5.Yes, and don't ask again about commands in this chat",
+      "6.No, don't allow this",
     ]);
     expect(onDecide).not.toHaveBeenCalled();
   });

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -88,6 +88,8 @@ export type ChatMessage =
       canRemember: boolean;
       /** The Auto-mode judge is deciding; the card stays fully actionable. */
       autoJudging?: boolean;
+      /** Prefix rungs the server will honor for this call. */
+      prefixRungs?: readonly number[];
       resolved?: boolean;
     }
   | { id: string; role: "error"; text: string };
@@ -526,6 +528,7 @@ function surfacedCards(
           canRemember={entry.canRemember}
           grantScope={approvalState?.grantScope ?? "chat"}
           autoJudging={entry.autoJudging ?? false}
+          prefixRungs={entry.prefixRungs ?? []}
           deciding={
             approvalState?.decidingApprovalCalls.has(entry.callId) ?? false
           }

--- a/crates/openwave-desktop/ui/src/WireFixtures.test.ts
+++ b/crates/openwave-desktop/ui/src/WireFixtures.test.ts
@@ -40,6 +40,8 @@ describe("validators against real server output", () => {
       preview: { tool: "exec", command: "git", args: ["status"], cwd: "." },
       canApprove: true,
       canRemember: true,
+      // The fixture is real server output: `git` is a one-token prefix rung.
+      prefixRungs: [1],
       autoJudgeStatus: null,
     });
   });

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -274,6 +274,7 @@ describe("pending approval recovery", () => {
       preview: null,
       canApprove: true,
       canRemember: true,
+      prefixRungs: [],
       autoJudgeStatus: null,
     });
     expect(parsePendingToolApproval({ ...safe, arguments: { query: "private" } })).toBeNull();

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -404,7 +404,7 @@ export function isApprovableKind(kind: RendererApprovalKind): boolean {
  */
 export type ApprovalGrantRung =
   | "exact_action"
-  | "any_args_for_command"
+  | { command_prefix: { tokens: number } }
   | "whole_tool";
 
 /** Approval kinds whose authority is stable enough to remember by tool name. */
@@ -423,6 +423,8 @@ export type PendingToolApproval = {
   preview: ToolActionPreview | null;
   canApprove: boolean;
   canRemember: boolean;
+  /** Token counts of the prefix rungs the server will honor for this call. */
+  prefixRungs: number[];
   /** Where the Auto-mode judge stands, or null when no judge was engaged. */
   autoJudgeStatus: "judging" | "approved" | "declined" | null;
 };
@@ -1577,6 +1579,7 @@ const PENDING_APPROVAL_KEYS = [
   "preview",
   "can_approve",
   "can_remember",
+  "prefix_rungs",
   "auto_judge_status",
 ] as const satisfies readonly (keyof PendingApprovalSnapshot)[];
 
@@ -1602,6 +1605,14 @@ export function parsePendingToolApproval(
     value.can_approve !== isApprovableKind(value.approval) ||
     typeof value.can_remember !== "boolean" ||
     value.can_remember !== isRememberableKind(value.approval) ||
+    // Absent reads as "no prefix rungs", which is the safe answer: the card
+    // offers nothing it was not told about.
+    (value.prefix_rungs !== undefined &&
+      (!Array.isArray(value.prefix_rungs) ||
+        value.prefix_rungs.some(
+          (tokens) =>
+            typeof tokens !== "number" || !Number.isInteger(tokens) || tokens < 1,
+        ))) ||
     !(
       value.auto_judge_status === undefined ||
       value.auto_judge_status === "judging" ||
@@ -1620,6 +1631,7 @@ export function parsePendingToolApproval(
     preview: parseToolActionPreview(value.preview),
     canApprove: value.can_approve,
     canRemember: value.can_remember,
+    prefixRungs: (value.prefix_rungs as number[] | undefined) ?? [],
     autoJudgeStatus: value.auto_judge_status ?? null,
   };
 }

--- a/crates/openwave-desktop/ui/src/generated/fixtures.ts
+++ b/crates/openwave-desktop/ui/src/generated/fixtures.ts
@@ -15,6 +15,9 @@ export const PENDING_APPROVAL = {
   "can_approve": true,
   "can_remember": true,
   "class": "sensitive",
+  "prefix_rungs": [
+    1
+  ],
   "preview": {
     "args": [
       "status"
@@ -33,6 +36,7 @@ export const PENDING_APPROVAL_WITHOUT_PREVIEW = {
   "can_approve": false,
   "can_remember": false,
   "class": "read_only",
+  "prefix_rungs": [],
   "turn_id": "00000000-0000-0000-0000-000000000002"
 } as const;
 

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -498,7 +498,7 @@ export type GrantLevel = { "level": "chat", chat_id: ChatId, } | { "level": "pro
  * narrower variants exist because "don't ask me about commands again" is a
  * much larger thing to agree to than "don't ask me about `cargo` again".
  */
-export type GrantScope = { "scope": "exact_action" } & ToolActionPreview | { "scope": "any_args_for", command: string, } | { "scope": "whole_tool" };
+export type GrantScope = { "scope": "exact_action" } & ToolActionPreview | { "scope": "any_args_for", command: string, } | { "scope": "command_prefix", tokens: Array<string>, } | { "scope": "whole_tool" };
 
 /**
  * Opaque identifier for a folder registered with a host broker.
@@ -746,6 +746,16 @@ export type PendingApprovalSnapshot = { call_id: CallId, turn_id: TurnId, action
  */
 preview?: ToolActionPreview, can_approve: boolean, can_remember: boolean, 
 /**
+ * Token counts of the command-prefix rungs this call may be granted at,
+ * narrowest first.
+ *
+ * Derived server-side, because whether a prefix rung exists at all is a
+ * question only the analyzer can answer — a wrapper has none. The
+ * renderer slices the action's own tokens to these lengths for the
+ * labels rather than deciding for itself what to offer.
+ */
+prefix_rungs: Array<number>, 
+/**
  * Where the Auto-mode judge stands, when one was engaged. Absent means
  * no judge ever owned this card.
  */
@@ -881,6 +891,11 @@ export type RendererAgentEvent = { "type": "turn_started", turn_id: TurnId, } | 
  * automatically" hint.
  */
 auto_judging: boolean, 
+/**
+ * Token counts of the command-prefix rungs on offer, narrowest
+ * first. Empty when the action has none.
+ */
+prefix_rungs: Array<number>, 
 /**
  * The one deliberate opening in this boundary. A human cannot consent
  * to a command they are not shown, so a tool may project a closed,

--- a/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
@@ -28,8 +28,8 @@ export function toolGrantLabel(action: RendererToolName): string {
 
 /**
  * The scope line, worded as the width of what was agreed to. Mirrors the
- * approval card's rungs: the exact action, an executable with any arguments,
- * or the whole tool.
+ * approval card's rungs: the exact action, a run of command tokens, an
+ * executable with any arguments, or the whole tool.
  */
 export function grantScopeLabel(
   scope: GrantScope,
@@ -49,6 +49,8 @@ export function grantScopeLabel(
     }
     case "any_args_for":
       return `${scope.command} …`;
+    case "command_prefix":
+      return `${scope.tokens.join(" ")} …`;
     case "whole_tool":
       switch (action) {
         case "exec":

--- a/crates/openwave-server/src/approvals.rs
+++ b/crates/openwave-server/src/approvals.rs
@@ -205,15 +205,31 @@ fn grant_scope(
     match (rung, action?) {
         (ApprovalGrantRung::WholeTool, _) => Some(GrantScope::WholeTool),
         (ApprovalGrantRung::ExactAction, action) => Some(GrantScope::ExactAction(action.clone())),
-        (ApprovalGrantRung::AnyArgsForCommand, ToolActionPreview::Exec { command, .. }) => {
-            Some(GrantScope::AnyArgsFor {
-                command: command.clone(),
-            })
+        (ApprovalGrantRung::CommandPrefix { tokens }, action @ ToolActionPreview::Exec { .. }) => {
+            command_prefix_scope(action, tokens)
         }
-        // Only a command has an executable to name, so no other action can
+        // Only a command has a token run to name, so no other action can
         // reach the rung between exact and whole-tool.
-        (ApprovalGrantRung::AnyArgsForCommand, _) => None,
+        (ApprovalGrantRung::CommandPrefix { .. }, _) => None,
     }
+}
+
+/// Rebuild a prefix rung from the parked call rather than from the request.
+///
+/// The renderer sends only a length. The concrete tokens come from the
+/// action the call is actually parked on, and the length is honored only if
+/// the analyzer offered a prefix of exactly that many tokens for this
+/// command — so a client cannot name a wider prefix than the card showed, and
+/// cannot name one at all for a command whose ladder has none.
+fn command_prefix_scope(
+    action: &openwave_core::ToolActionPreview,
+    tokens: usize,
+) -> Option<GrantScope> {
+    openwave_core::GrantScope::ladder_for_action(action)
+        .into_iter()
+        .find(|scope| {
+            matches!(scope, GrantScope::CommandPrefix { tokens: offered } if offered.len() == tokens)
+        })
 }
 
 impl ApprovalGate for ApprovalBroker {
@@ -697,6 +713,75 @@ mod tests {
         drop(registration.decision);
     }
 
+    /// The rung the ladder exists for, end to end: a grant taken for
+    /// `cargo test` covers the next `cargo test` without asking, and does not
+    /// quietly become a grant for every `cargo`.
+    #[tokio::test]
+    async fn a_prefix_grant_covers_its_subcommand_and_no_more() {
+        let (store, request) = setup_with_arguments(
+            "exec",
+            json!({ "command": "cargo", "args": ["test", "--all"], "cwd": "." }),
+        )
+        .await;
+        let broker = ApprovalBroker::new(store.clone());
+        let pending = broker.register(request.clone(), None).await;
+        drop(pending.decision);
+        assert_eq!(
+            broker
+                .resolve_with_grant(
+                    request.chat_id,
+                    request.call_id,
+                    ApprovalDecision::Approve,
+                    // Two tokens: `cargo test`.
+                    Some(crate::routes::ApprovalGrantRung::CommandPrefix { tokens: 2 }),
+                )
+                .await
+                .unwrap(),
+            ResolveApprovalOutcome::Resolved
+        );
+
+        let exec = |args: &[&str]| json!({ "command": "cargo", "args": args, "cwd": "." });
+        // Another `cargo test` runs without asking...
+        let covered = request_for(&store, request.chat_id, "exec", exec(&["test", "--lib"])).await;
+        assert!(matches!(
+            broker.register(covered, None).await.publication,
+            openwave_core::ApprovalRequiredPublication::StandingGrant
+        ));
+        // ...but a different `cargo` subcommand still asks.
+        let uncovered = request_for(&store, request.chat_id, "exec", exec(&["publish"])).await;
+        let registration = broker.register(uncovered, None).await;
+        assert!(!matches!(
+            registration.publication,
+            openwave_core::ApprovalRequiredPublication::StandingGrant
+        ));
+        drop(registration.decision);
+    }
+
+    /// A prefix the card never offered cannot be claimed by asking for it.
+    #[tokio::test]
+    async fn a_prefix_longer_than_the_ladder_offered_is_refused() {
+        let (store, request) = setup_with_arguments(
+            "exec",
+            json!({ "command": "cargo", "args": ["test"], "cwd": "." }),
+        )
+        .await;
+        let broker = ApprovalBroker::new(store);
+        let _pending = broker.register(request.clone(), None).await;
+        assert_eq!(
+            broker
+                .resolve_with_grant(
+                    request.chat_id,
+                    request.call_id,
+                    ApprovalDecision::Approve,
+                    // The ladder offers 1 and 2 tokens; 9 is not on it.
+                    Some(crate::routes::ApprovalGrantRung::CommandPrefix { tokens: 9 }),
+                )
+                .await
+                .unwrap(),
+            ResolveApprovalOutcome::GrantNotAvailable
+        );
+    }
+
     #[tokio::test]
     async fn a_revoked_grant_leaves_the_list_and_stops_covering() {
         let exec_args = json!({ "command": "cargo", "args": ["test"], "cwd": "." });
@@ -1089,7 +1174,7 @@ mod tests {
                     request.chat_id,
                     request.call_id,
                     ApprovalDecision::Approve,
-                    Some(crate::routes::ApprovalGrantRung::AnyArgsForCommand),
+                    Some(crate::routes::ApprovalGrantRung::CommandPrefix { tokens: 1 }),
                 )
                 .await
                 .unwrap(),

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -103,6 +103,10 @@ pub(crate) enum RendererAgentEvent {
         /// automatically" hint.
         #[serde(default)]
         auto_judging: bool,
+        /// Token counts of the command-prefix rungs on offer, narrowest
+        /// first. Empty when the action has none.
+        #[serde(default)]
+        prefix_rungs: Vec<usize>,
         /// The one deliberate opening in this boundary. A human cannot consent
         /// to a command they are not shown, so a tool may project a closed,
         /// field-by-field view of the action under review. Tools without one
@@ -191,6 +195,10 @@ impl From<&SequencedEvent> for RendererSequencedEvent {
                 approval: *kind,
                 class: *class,
                 auto_judging: *auto_judging,
+                prefix_rungs: preview
+                    .as_ref()
+                    .map(crate::routes::prefix_rung_lengths)
+                    .unwrap_or_default(),
                 preview: preview.clone(),
             },
             AgentEvent::ApprovalDecided { call_id, approved } => {

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -2271,8 +2271,14 @@ pub struct ApprovalBody {
 pub enum ApprovalGrantRung {
     /// Exactly the action the card showed.
     ExactAction,
-    /// This executable, with any arguments.
-    AnyArgsForCommand,
+    /// A leading run of the command's argv tokens, with any arguments after
+    /// it — "any `cargo test`", not just "any `cargo`".
+    ///
+    /// The renderer names how many tokens it was offered rather than the
+    /// tokens themselves. The server derives the ladder from the parked
+    /// call's own arguments and honors the length only if it appears there,
+    /// so a client cannot invent a prefix the card never showed.
+    CommandPrefix { tokens: usize },
     /// Every call to this tool.
     WholeTool,
 }
@@ -2312,6 +2318,14 @@ pub(crate) struct PendingApprovalSnapshot {
     pub preview: Option<openwave_core::ToolActionPreview>,
     pub can_approve: bool,
     pub can_remember: bool,
+    /// Token counts of the command-prefix rungs this call may be granted at,
+    /// narrowest first.
+    ///
+    /// Derived server-side, because whether a prefix rung exists at all is a
+    /// question only the analyzer can answer — a wrapper has none. The
+    /// renderer slices the action's own tokens to these lengths for the
+    /// labels rather than deciding for itself what to offer.
+    pub prefix_rungs: Vec<usize>,
     /// Where the Auto-mode judge stands, when one was engaged. Absent means
     /// no judge ever owned this card.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2328,12 +2342,31 @@ impl PendingApprovalSnapshot {
             action: openwave_core::RendererToolName::from(approval.tool_name.as_str()),
             approval: kind,
             class: approval.class,
+            prefix_rungs: approval
+                .preview
+                .as_ref()
+                .map(prefix_rung_lengths)
+                .unwrap_or_default(),
             preview: approval.preview,
             can_approve: kind.is_approvable(),
             can_remember: kind.is_standing_grantable(),
             auto_judge_status: approval.auto_judge_status,
         }
     }
+}
+
+/// The command-prefix rungs on offer for an action, as token counts.
+///
+/// Empty for anything that is not a command, and for a command the analyzer
+/// would not auto-run under a prefix rule however it were granted.
+pub(crate) fn prefix_rung_lengths(action: &openwave_core::ToolActionPreview) -> Vec<usize> {
+    openwave_core::GrantScope::ladder_for_action(action)
+        .into_iter()
+        .filter_map(|scope| match scope {
+            openwave_core::GrantScope::CommandPrefix { tokens } => Some(tokens.len()),
+            _ => None,
+        })
+        .collect()
 }
 
 /// `GET /chats/{id}/approvals` — recover a bounded page of pending cards.

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -550,6 +550,7 @@ mod tests {
             }),
             can_approve: true,
             can_remember: true,
+            prefix_rungs: vec![1],
         };
         // The same shape with the omittable field absent, because "the key is
         // missing" is a distinct case the validator has to survive and the one
@@ -564,6 +565,7 @@ mod tests {
             preview: None,
             can_approve: false,
             can_remember: false,
+            prefix_rungs: Vec::new(),
         };
 
         let folder_access = crate::routes::client_execution::PendingFolderAccessRequest {

--- a/crates/openwave-shell-policy/src/lib.rs
+++ b/crates/openwave-shell-policy/src/lib.rs
@@ -183,6 +183,40 @@ pub fn analyze_shell_command(command: &str, ruleset: &ShellRuleSet) -> ShellAnal
         return ShellAnalysis::new(ShellVerdict::Ask, "no executable command found");
     }
 
+    evaluate(&acc, ruleset)
+}
+
+/// Classify one already-parsed `argv` against `ruleset`.
+///
+/// For callers whose tool takes an executable and an argument vector rather
+/// than a command line — there is no shell, so there is nothing to parse, but
+/// every reason the analyzer would refuse a leaf still applies. An interpreter
+/// is still an interpreter when it arrives as `["bash", "-c", …]` rather than
+/// as text, and a wrapper is still one that a prefix grant must not reach
+/// through.
+///
+/// Returns `Ask` for an empty `argv`: nothing to run is not something to
+/// allow.
+#[must_use]
+pub fn analyze_argv(argv: &[String], ruleset: &ShellRuleSet) -> ShellAnalysis {
+    let Some(program) = argv.first() else {
+        return ShellAnalysis::new(ShellVerdict::Ask, "empty command");
+    };
+    let acc = Collected {
+        simples: vec![SimpleCmd {
+            program: program.clone(),
+            argv: argv.to_vec(),
+            // An argv carries no redirections; there is no shell to write them.
+            write_targets: Vec::new(),
+            read_targets: Vec::new(),
+        }],
+        ..Collected::default()
+    };
+    evaluate(&acc, ruleset)
+}
+
+/// The three tiers, applied to whatever leaves were collected.
+fn evaluate(acc: &Collected, ruleset: &ShellRuleSet) -> ShellAnalysis {
     // (1) Deny floor — wins over every allow rule, including `All`.
     for sc in &acc.simples {
         if INTERPRETERS.contains(&basename(&sc.program)) {
@@ -1887,6 +1921,45 @@ fn subcommand_prefix(argv: &[String]) -> Vec<String> {
         prefix.push(token.clone());
     }
     prefix
+}
+
+/// The grant rungs worth offering for one `argv`, narrowest first.
+///
+/// The argv analogue of [`suggested_rungs`], and verified the same way: a
+/// rung is offered only when granting exactly that rule would in fact stop
+/// the asking, so a wrapper yields no prefix rung and an interpreter yields
+/// none at all.
+#[must_use]
+pub fn suggested_rungs_for_argv(argv: &[String]) -> Vec<CommandRule> {
+    if argv.is_empty() {
+        return Vec::new();
+    }
+    let mut candidates: Vec<CommandRule> = Vec::new();
+    candidates.extend(CommandRule::new(CommandRuleKind::Exact, argv.to_vec()));
+    candidates.extend(CommandRule::new(
+        CommandRuleKind::Prefix,
+        subcommand_prefix(argv),
+    ));
+    candidates.extend(CommandRule::new(
+        CommandRuleKind::Prefix,
+        vec![argv[0].clone()],
+    ));
+    candidates.extend(CommandRule::new(CommandRuleKind::All, Vec::new()));
+
+    let mut rungs: Vec<CommandRule> = Vec::new();
+    for rule in candidates {
+        if rungs.contains(&rule) {
+            continue;
+        }
+        let ruleset = ShellRuleSet {
+            allow: vec![rule.clone()],
+            deny: Vec::new(),
+        };
+        if analyze_argv(argv, &ruleset).verdict == ShellVerdict::Allow {
+            rungs.push(rule);
+        }
+    }
+    rungs
 }
 
 /// The grant rungs worth offering for `command`, narrowest first.

--- a/crates/openwave-shell-policy/src/tests.rs
+++ b/crates/openwave-shell-policy/src/tests.rs
@@ -725,3 +725,63 @@ fn a_compound_command_is_offered_nothing_narrow() {
     );
     assert!(simple_command_argvs("echo ${x:-$(rm -rf ~)}").is_none());
 }
+
+/// The argv path must reach the same floor as the parsed path. A tool that
+/// takes an executable and an argument vector has no shell, but an
+/// interpreter arriving as `["bash", "-c", …]` is the same hazard as one
+/// arriving as text — and the corpus above only exercises the text path.
+#[test]
+fn an_argv_reaches_the_same_floor_as_a_parsed_command() {
+    let argv = |tokens: &[&str]| tokens.iter().map(|t| (*t).to_owned()).collect::<Vec<_>>();
+
+    // Interpreters are denied even under the broadest grant.
+    assert_eq!(
+        analyze_argv(&argv(&["bash", "-c", "id"]), &allow_all()).verdict,
+        ShellVerdict::Deny
+    );
+    // Destructive and escaping arguments still force a human, granted or not.
+    assert_eq!(
+        analyze_argv(&argv(&["rm", "-rf", "/"]), &allow_all()).verdict,
+        ShellVerdict::Ask
+    );
+    assert_eq!(
+        analyze_argv(&argv(&["cat", "../../outside.txt"]), &allow_all()).verdict,
+        ShellVerdict::Ask
+    );
+    assert_eq!(
+        analyze_argv(&argv(&["cat", "/home/someone/.ssh/id_rsa"]), &allow_all()).verdict,
+        ShellVerdict::Ask
+    );
+    // A wrapper cannot be reached through a prefix grant.
+    assert_eq!(
+        analyze_argv(
+            &argv(&["timeout", "5", "sh", "-c", "id"]),
+            &allow(vec![prefix(&["timeout"])])
+        )
+        .verdict,
+        ShellVerdict::Ask
+    );
+    // And an ordinary covered command runs.
+    assert_eq!(
+        analyze_argv(&argv(&["cargo", "test"]), &allow(vec![prefix(&["cargo"])])).verdict,
+        ShellVerdict::Allow
+    );
+}
+
+/// The rung the whole change exists for: something between one invocation and
+/// every command.
+#[test]
+fn an_argv_is_offered_a_subcommand_rung() {
+    let argv = ["cargo", "test", "--all"].map(str::to_owned).to_vec();
+    assert_eq!(
+        suggested_rungs_for_argv(&argv),
+        vec![
+            exact(&["cargo", "test", "--all"]),
+            prefix(&["cargo", "test"]),
+            prefix(&["cargo"]),
+            all_rule(),
+        ]
+    );
+    // An interpreter is offered nothing: no grant would make it run.
+    assert!(suggested_rungs_for_argv(&["bash".to_owned(), "-c".to_owned()]).is_empty());
+}


### PR DESCRIPTION
Closes #938. Consumes the analyzer from #961.

## The rung

The ladder went from "exactly this invocation" straight to "every `cargo`", so remembering `cargo test` also handed over `cargo publish`. `GrantScope::CommandPrefix { tokens }` fills the gap, matched **token-wise** — `["git","diff"]` covers `git diff --stat` but not `git difftool`.

The rungs are not assembled by hand. The analyzer proposes them and **verifies each one** by asking whether granting exactly that rule would in fact stop the asking. A wrapper is therefore offered no prefix rung at all, rather than one the gate would refuse to honor.

The renderer is **told** which lengths are on offer rather than deriving them: whether a prefix rung exists is a question only the analyzer can answer, and a row that fails on click is worse than a row that never appears. A decision names a length; the server rebuilds the tokens from the call the approval is parked on, so a client cannot claim a wider prefix than the card showed. A length that is not on the server's own ladder is refused.

## The larger change: no grant outruns the floor

Every `exec` match now runs through the analyzer. **"Don't ask again about commands" stops covering `rm -rf /`, `bash -c id`, and anything reaching out of the workspace.** A grant is a standing yes to the routine, not a blanket one.

Approving once remains available for all of those — the grant simply stops being the thing that authorizes them. This is a deliberate narrowing of an existing promise, so it is asserted directly (`the_widest_grant_still_stops_at_the_floor`) rather than left implicit.

## Two bugs I introduced, both caught by existing tests

Worth calling out because they are the kind that would have been quiet:

- The exact rung was briefly matched against **the incoming call** rather than the granted action — so it matched itself, and any exact grant covered every command.
- It also dropped `cwd`, so a grant given in one directory covered another.

Both existed only within this branch; `an_exact_grant_covers_only_the_vector_it_named` and `an_exact_grant_is_scoped_to_the_directory_it_was_given_in` failed immediately.

## Test changes worth reviewing

- `a_clamped_call_never_matches_or_creates_a_narrow_grant` moved off `bash` to `echo`. It is about truncation, and an interpreter now fails it for a reason unrelated to what it checks — it would have passed for the wrong reason.
- The bare-command ladder now offers a prefix rung. With no arguments "exactly `true`" and "any `true`" are still different grants; the second also covers `true --whatever`.
- New: a prefix grant covers its subcommand and no more, end to end through the broker; and a prefix longer than the ladder offered is refused.

Verified: fmt, clippy (workspace, all targets), 571 core + 467 server + 47 MCP + 15 shell-policy tests, `tsc`, 655 UI tests, build.

Next per the plan: #941 (read-only mode), then #939 (one vocabulary). With a deterministic floor now in place, the `exec` exclusion in the Auto-mode judge is also worth revisiting — it was excluded precisely because there was nothing beneath it.