### PR TITLE
feat: auto-merge background-agent outputs into conversation outputs with revert

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1874,6 +1874,23 @@ impl Store for DbStore {
         ops::output::delete_output(self, id, deleted_at).await
     }
 
+    async fn restore_output(
+        &self,
+        id: OutputId,
+        restored_at: chrono::DateTime<Utc>,
+    ) -> Result<bool> {
+        ops::output::restore_output(self, id, restored_at).await
+    }
+
+    async fn set_current_output_revision(
+        &self,
+        output_id: OutputId,
+        revision_id: OutputRevisionId,
+        updated_at: chrono::DateTime<Utc>,
+    ) -> Result<OutputRecord> {
+        ops::output::set_current_output_revision(self, output_id, revision_id, updated_at).await
+    }
+
     async fn save_context_checkpoint(
         &self,
         checkpoint: &ContextCheckpoint,

--- a/crates/openwave-core/src/db/ops/output.rs
+++ b/crates/openwave-core/src/db/ops/output.rs
@@ -295,6 +295,92 @@ pub(in crate::db) async fn delete_output(
     Ok(true)
 }
 
+pub(in crate::db) async fn restore_output(
+    store: &DbStore,
+    id: OutputId,
+    restored_at: chrono::DateTime<chrono::Utc>,
+) -> Result<bool> {
+    let restored_at = canonical_db_timestamp(restored_at)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    let Some(existing) = find_output_on(&transaction, id).await? else {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(false);
+    };
+    if existing.deleted_at.is_none() {
+        // Restoring a live output is the same durable outcome, not a conflict.
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(true);
+    }
+    // Clearing the soft-delete is the exact inverse of `delete_output`; the
+    // revision history is untouched. Surfacing the restored output as freshly
+    // updated keeps a reversed retraction visible at the top of the catalog.
+    entities::output::ActiveModel {
+        id: Set(id.0),
+        deleted_at: Set(None),
+        updated_at: Set(restored_at),
+        ..Default::default()
+    }
+    .update(&transaction)
+    .await
+    .map_err(store_err)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(true)
+}
+
+pub(in crate::db) async fn set_current_output_revision(
+    store: &DbStore,
+    output_id: OutputId,
+    revision_id: OutputRevisionId,
+    updated_at: chrono::DateTime<chrono::Utc>,
+) -> Result<OutputRecord> {
+    let updated_at = canonical_db_timestamp(updated_at)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    let Some(existing) = find_output_on(&transaction, output_id).await? else {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!("output {output_id} not found")));
+    };
+    // Serialize against a concurrent append so a revert and a new revision
+    // cannot both publish a current revision from the same starting point.
+    if !acquire_chat_write_lock(&transaction, existing.chat_id).await? {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "chat {} does not exist",
+            existing.chat_id
+        )));
+    }
+    if existing.deleted_at.is_some() {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!("output {output_id} is deleted")));
+    }
+    // The target must be a revision already recorded for this exact output.
+    // Reverting never mints a revision, so an unknown or foreign id is a caller
+    // bug rather than a new version.
+    let Some(revision) = find_revision_on(&transaction, revision_id).await? else {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "output revision {revision_id} not found"
+        )));
+    };
+    if revision.output_id != output_id {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "output revision {revision_id} does not belong to output {output_id}"
+        )));
+    }
+    entities::output::ActiveModel {
+        id: Set(output_id.0),
+        current_revision_id: Set(revision_id.0),
+        updated_at: Set(updated_at),
+        ..Default::default()
+    }
+    .update(&transaction)
+    .await
+    .map_err(store_err)?;
+    let record = require_output_on(&transaction, output_id).await?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(record)
+}
+
 fn validate_new_output(request: &CreateOutput) -> Result<String> {
     let media_type = match &request.kind {
         DeliverableKind::Text => {

--- a/crates/openwave-core/src/db/tests/output.rs
+++ b/crates/openwave-core/src/db/tests/output.rs
@@ -285,6 +285,89 @@ async fn deleting_an_output_hides_it_but_retains_its_revisions() {
 }
 
 #[tokio::test]
+async fn reverting_republishes_a_prior_revision_without_losing_history() {
+    let (_dir, store, chat) = store_with_chat().await;
+    let first = store
+        .create_output(&create_request(chat.id, "brief.md", 1))
+        .await
+        .unwrap();
+    let second = revision(2, 30);
+    let updated = store
+        .append_output_revision(first.id, &second)
+        .await
+        .unwrap();
+    assert_eq!(updated.current_revision, second.id);
+    assert_eq!(updated.revision_count, 2);
+
+    // Revert steps the current pointer back to the first revision. Nothing is
+    // appended or destroyed: the revision count is unchanged and the superseded
+    // revision stays addressable.
+    let reverted = store
+        .set_current_output_revision(first.id, first.current_revision, at(60))
+        .await
+        .unwrap();
+    assert_eq!(reverted.current_revision, first.current_revision);
+    assert_eq!(reverted.revision_count, 2, "revert never mints a revision");
+    assert_eq!(reverted.updated_at, at(60));
+    assert_eq!(
+        store.list_output_revisions(first.id).await.unwrap().len(),
+        2
+    );
+
+    // Revert is reversible: the newer revision can be republished again.
+    let forward = store
+        .set_current_output_revision(first.id, second.id, at(90))
+        .await
+        .unwrap();
+    assert_eq!(forward.current_revision, second.id);
+    assert_eq!(forward.revision_count, 2);
+
+    // A revision that belongs to another output can never become current.
+    let other = store
+        .create_output(&create_request(chat.id, "other.md", 3))
+        .await
+        .unwrap();
+    assert!(store
+        .set_current_output_revision(first.id, other.current_revision, at(120))
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn restoring_a_retracted_output_is_the_exact_inverse_of_deleting_it() {
+    let (_dir, store, chat) = store_with_chat().await;
+    let created = store
+        .create_output(&create_request(chat.id, "brief.md", 1))
+        .await
+        .unwrap();
+    store.delete_output(created.id, at(60)).await.unwrap();
+    assert!(store.list_outputs(chat.id, 10).await.unwrap().is_empty());
+
+    assert!(store.restore_output(created.id, at(90)).await.unwrap());
+    let restored = store.get_output(created.id).await.unwrap().unwrap();
+    assert!(restored.deleted_at.is_none(), "the retraction is cleared");
+    assert_eq!(
+        store.list_outputs(chat.id, 10).await.unwrap().len(),
+        1,
+        "the output returns to the catalog"
+    );
+    // Reverting again after restore still works: the history was untouched.
+    assert!(store
+        .append_output_revision(created.id, &revision(2, 120))
+        .await
+        .is_ok());
+
+    assert!(
+        store.restore_output(created.id, at(150)).await.unwrap(),
+        "restoring a live output is the same durable outcome"
+    );
+    assert!(
+        !store.restore_output(OutputId::new(), at(60)).await.unwrap(),
+        "an unknown output reports no restore"
+    );
+}
+
+#[tokio::test]
 async fn a_deleted_output_refuses_further_revisions() {
     let (_dir, store, chat) = store_with_chat().await;
     let created = store
@@ -621,6 +704,65 @@ async fn a_binary_workspace_artifact_is_accepted_published_and_attributed_to_its
         revision.sha256,
         <[u8; 32]>::from(sha2::Sha256::digest(&content))
     );
+}
+
+#[cfg(feature = "tools")]
+#[tokio::test]
+async fn a_background_run_result_auto_merges_into_a_revertible_text_output() {
+    use crate::deliverable::output_revision_relative_path;
+    use crate::deliverable_acceptance::{merge_agent_run_result, AgentResultOutputMerge};
+    use crate::id::AgentRunId;
+
+    let (_dir, store, chat) = store_with_chat().await;
+    let scratch = tempfile::tempdir().unwrap();
+    let dir = open_scratch(scratch.path());
+
+    let run_id = AgentRunId::new();
+    let merge = AgentResultOutputMerge {
+        run_id,
+        chat_id: chat.id,
+        filename: "Agent result.md".into(),
+        text: "# Findings\n\nThe background agent finished.".into(),
+        created_at: at(0),
+    };
+
+    let record = merge_agent_run_result(&store, &dir, &merge).await.unwrap();
+    assert_eq!(record.chat_id, chat.id);
+    assert_eq!(record.media_type, "text/markdown");
+    assert_eq!(record.revision_count, 1);
+    // Identity is derived from the run, so it is stable and idempotent.
+    assert_eq!(record.id, OutputId::for_run(run_id));
+    assert_eq!(record.current_revision, OutputRevisionId::for_run(run_id));
+
+    // The bytes landed at the write-once revision path the desktop reads.
+    let published = scratch.path().join(output_revision_relative_path(
+        record.id,
+        record.current_revision,
+    ));
+    assert_eq!(std::fs::read(&published).unwrap(), merge.text.as_bytes());
+
+    // The revision is attributed to the producing run, never a turn — this is
+    // what the agent-run surface correlates against.
+    let revision = store
+        .get_output_revision(record.current_revision)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(revision.producing_run_id, Some(run_id));
+    assert_eq!(revision.turn_id, None);
+
+    // An ambiguous submit retry re-runs the merge without forking a second
+    // output or revision.
+    let retried = merge_agent_run_result(&store, &dir, &merge).await.unwrap();
+    assert_eq!(retried, record);
+    assert_eq!(store.list_outputs(chat.id, 10).await.unwrap().len(), 1);
+
+    // The auto-merge is safe because it is revertible: retracting it hides the
+    // output while keeping its revision, and restoring brings it back.
+    assert!(store.delete_output(record.id, at(30)).await.unwrap());
+    assert!(store.list_outputs(chat.id, 10).await.unwrap().is_empty());
+    assert!(store.restore_output(record.id, at(60)).await.unwrap());
+    assert_eq!(store.list_outputs(chat.id, 10).await.unwrap().len(), 1);
 }
 
 #[cfg(feature = "tools")]

--- a/crates/openwave-core/src/deliverable_acceptance.rs
+++ b/crates/openwave-core/src/deliverable_acceptance.rs
@@ -17,10 +17,10 @@ use sha2::{Digest, Sha256};
 
 use crate::deliverable::{
     output_revision_relative_path, CreateOutput, DeliverableKind, NewOutputRevision,
-    RevisionProducer, MAX_BINARY_DELIVERABLE_BYTES,
+    RevisionProducer, MAX_BINARY_DELIVERABLE_BYTES, MAX_DELIVERABLE_BYTES,
 };
 use crate::error::{AgentError, Result};
-use crate::id::{ChatId, OutputId, OutputRevisionId};
+use crate::id::{AgentRunId, ChatId, OutputId, OutputRevisionId};
 use crate::storage::Store;
 use crate::OutputRecord;
 
@@ -119,4 +119,98 @@ pub async fn accept_workspace_artifact(
             })
             .await
     }
+}
+
+/// A completed background agent run's text result, ready to auto-merge into the
+/// conversation's output record.
+///
+/// The merge is performed by the host at result-commit time; the model that
+/// produced the text can neither author nor decline it. Its identities are
+/// derived from the producing run ([`OutputId::for_run`],
+/// [`OutputRevisionId::for_run`]) so an ambiguous submit retry lands on the same
+/// output rather than forking a second one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentResultOutputMerge {
+    /// Completed background run whose result is being merged. Fixes the derived
+    /// output and revision identities and is recorded as the revision's producer.
+    pub run_id: AgentRunId,
+    /// Conversation that owns both the run and the merged output.
+    pub chat_id: ChatId,
+    /// Host-derived display filename. Portable ASCII ending in a text extension;
+    /// the model never names it.
+    pub filename: String,
+    /// The run's bounded final text.
+    pub text: String,
+    /// Host-stamped merge time.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Auto-merge a completed background run's text result into a conversation
+/// output.
+///
+/// The bytes are published once at the derived revision path under the exact
+/// conversation's private scratch, then recorded as a text output whose producer
+/// is the background run. Re-running the same run id is idempotent: the derived
+/// identities and matching content return the original record.
+///
+/// This is host-side by construction — nothing the sandbox model returns can
+/// steer the filename, the media type, or whether the merge happens. Safety
+/// comes from the merge being a durable, revertible output revision, not from a
+/// human accept gate.
+pub async fn merge_agent_run_result(
+    store: &dyn Store,
+    scratch: &Dir,
+    merge: &AgentResultOutputMerge,
+) -> Result<OutputRecord> {
+    if merge.text.is_empty() {
+        return Err(AgentError::Store("agent result is empty".into()));
+    }
+    let content = merge.text.as_bytes();
+    if content.len() > MAX_DELIVERABLE_BYTES {
+        return Err(AgentError::Store(format!(
+            "agent result is too large (maximum {MAX_DELIVERABLE_BYTES} bytes)"
+        )));
+    }
+
+    let output_id = OutputId::for_run(merge.run_id);
+    let revision_id = OutputRevisionId::for_run(merge.run_id);
+    let byte_len = content.len() as u64;
+    let sha256: [u8; 32] = Sha256::digest(content).into();
+    let relative_path = output_revision_relative_path(output_id, revision_id);
+
+    // Publishing is blocking capability I/O; keep it off the async runtime. The
+    // path is write-once, so an interrupted retry re-publishes identical bytes.
+    let scratch = scratch
+        .try_clone()
+        .map_err(|error| AgentError::Store(format!("could not open private scratch: {error}")))?;
+    let content = content.to_vec();
+    tokio::task::spawn_blocking(move || {
+        crate::tools::private_scratch::publish_immutable_file(&scratch, &relative_path, &content)
+    })
+    .await
+    .map_err(|error| AgentError::Store(format!("result publication task failed: {error}")))?
+    .map_err(|error| AgentError::Store(format!("could not publish agent result: {error}")))?;
+
+    let revision = NewOutputRevision {
+        id: revision_id,
+        byte_len,
+        sha256,
+        // Provenance is the background run, never a foreground turn, so the
+        // revision carries no turn-scoped retrieval citations.
+        turn_id: None,
+        producing_run_id: None,
+        citations: Vec::new(),
+        created_at: merge.created_at,
+    }
+    .with_producer(RevisionProducer::Run(merge.run_id));
+
+    store
+        .create_output(&CreateOutput {
+            id: output_id,
+            chat_id: merge.chat_id,
+            filename: merge.filename.clone(),
+            kind: DeliverableKind::Text,
+            revision,
+        })
+        .await
 }

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -393,6 +393,17 @@ impl OutputId {
     pub fn for_call(call_id: CallId) -> Self {
         Self(Uuid::new_v5(&Self::NAMESPACE, call_id.as_uuid().as_bytes()))
     }
+
+    /// Derive the retry-stable output identity for one background agent run.
+    ///
+    /// A completed background run auto-merges its result into exactly one
+    /// conversation output. Deriving the identity from the run makes the merge
+    /// idempotent: an ambiguous submit retry lands on the same output rather than
+    /// forking a second record.
+    #[must_use]
+    pub fn for_run(run_id: AgentRunId) -> Self {
+        Self(Uuid::new_v5(&Self::NAMESPACE, run_id.as_uuid().as_bytes()))
+    }
 }
 
 id_type!(
@@ -407,6 +418,13 @@ impl OutputRevisionId {
     #[must_use]
     pub fn for_call(call_id: CallId) -> Self {
         Self(Uuid::new_v5(&Self::NAMESPACE, call_id.as_uuid().as_bytes()))
+    }
+
+    /// Derive the retry-stable first-revision identity for one background agent
+    /// run's auto-merged output.
+    #[must_use]
+    pub fn for_run(run_id: AgentRunId) -> Self {
+        Self(Uuid::new_v5(&Self::NAMESPACE, run_id.as_uuid().as_bytes()))
     }
 }
 

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -120,7 +120,10 @@ pub use deliverable::{
     MAX_OUTPUT_REVISIONS, OUTPUTS_DIRECTORY,
 };
 #[cfg(feature = "tools")]
-pub use deliverable_acceptance::{accept_workspace_artifact, WorkspaceArtifactProposal};
+pub use deliverable_acceptance::{
+    accept_workspace_artifact, merge_agent_run_result, AgentResultOutputMerge,
+    WorkspaceArtifactProposal,
+};
 pub use error::{AgentError, AgentErrorInfo, Result};
 pub use event::{AgentEvent, SequencedEvent};
 pub use id::{

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1628,6 +1628,35 @@ pub trait Store: Send + Sync {
         output_storage_unavailable()
     }
 
+    /// Restore a soft-deleted output, returning it to the catalog. This is the
+    /// exact inverse of [`Store::delete_output`], so retracting an auto-merged
+    /// output is reversible. Returns `false` only when the output does not
+    /// exist; restoring a live output is the same durable outcome, not a
+    /// conflict. Nothing about the revision history changes.
+    async fn restore_output(
+        &self,
+        _id: OutputId,
+        _restored_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool> {
+        output_storage_unavailable()
+    }
+
+    /// Republish an existing revision of an output as its current one.
+    ///
+    /// This is the revert primitive: it moves the current-revision pointer to
+    /// any revision already recorded for the output without appending or
+    /// destroying anything, so it is fully reversible. The revision must belong
+    /// to the output, and the output must be live. The revision count is
+    /// unchanged; only the current pointer and update time move.
+    async fn set_current_output_revision(
+        &self,
+        _output_id: OutputId,
+        _revision_id: OutputRevisionId,
+        _updated_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<OutputRecord> {
+        output_storage_unavailable()
+    }
+
     /// Persist the next versioned context checkpoint for one conversation.
     ///
     /// Implementations verify that the inclusive source-message boundary

--- a/crates/openwave-desktop/src/deliverables.rs
+++ b/crates/openwave-desktop/src/deliverables.rs
@@ -12,6 +12,7 @@ use std::path::{Path, PathBuf};
 use cap_fs_ext::{DirExt as _, FollowSymlinks, OpenOptionsFollowExt};
 use cap_std::ambient_authority;
 use cap_std::fs::{Dir, OpenOptions};
+use chrono::Utc;
 use openwave_core::{
     deliverable_media_type, media_type_is_text, revision_byte_ceiling, ChatId, OutputId,
     OutputRecord, OutputRevision, OutputRevisionId, Store, MAX_BINARY_DELIVERABLE_BYTES,
@@ -64,6 +65,29 @@ pub(crate) struct DeliverableSummary {
     size_bytes: u64,
     revision_count: u32,
     updated_at: String,
+    /// Background run that produced the current revision, when the output was
+    /// auto-merged from a background agent rather than a foreground turn. The
+    /// renderer uses it to badge the output and correlate it with the agent-run
+    /// surface; it is a display key, not authority.
+    producing_run_id: Option<Uuid>,
+}
+
+/// Outcome of reverting a merged output.
+///
+/// Reverting an output with earlier revisions republishes the previous one;
+/// reverting one that has only its initial merge retracts it. Both are durable
+/// and reversible — a retract is undone by `restore_output`, and a revert can be
+/// followed forward again.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "status", rename_all = "camelCase")]
+pub(crate) enum OutputRevertResult {
+    Reverted {
+        output_id: OutputId,
+        revision_id: OutputRevisionId,
+    },
+    Retracted {
+        output_id: OutputId,
+    },
 }
 
 #[derive(Debug, Serialize)]
@@ -284,6 +308,76 @@ pub(crate) async fn export_deliverable(
     terminalize_output_export(&host_access.receipts, &mut receipt, terminal)
 }
 
+#[tauri::command]
+pub(crate) async fn revert_output(
+    host_access: State<'_, HostAccess>,
+    request: DeliverableRequest,
+) -> Result<OutputRevertResult, String> {
+    let chat_id = resolve_conversation_scope(&host_access, request.chat_id).await?;
+    let store = host_access
+        .store()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    let (output, current) =
+        require_live_output(host_access.store(), chat_id, request.output_id).await?;
+    // Reverting is a host action, never the model's. An output that has only its
+    // initial merge cannot step back to an earlier version, so reverting it
+    // retracts the merge entirely — a soft delete that `restore_output` undoes.
+    if current.ordinal <= 1 {
+        store
+            .delete_output(output.id, Utc::now())
+            .await
+            .map_err(|_| "Could not revert that output".to_owned())?;
+        return Ok(OutputRevertResult::Retracted {
+            output_id: output.id,
+        });
+    }
+    // Otherwise step the current pointer back to the immediately previous
+    // revision. The superseded revision is retained and addressable, so a revert
+    // destroys nothing and can be followed forward again.
+    let previous = store
+        .list_output_revisions(output.id)
+        .await
+        .map_err(|_| "Could not revert that output".to_owned())?
+        .into_iter()
+        .find(|revision| revision.ordinal == current.ordinal - 1)
+        .ok_or_else(|| "That output has no earlier revision to revert to".to_owned())?;
+    let record = store
+        .set_current_output_revision(output.id, previous.id, Utc::now())
+        .await
+        .map_err(|_| "Could not revert that output".to_owned())?;
+    Ok(OutputRevertResult::Reverted {
+        output_id: record.id,
+        revision_id: previous.id,
+    })
+}
+
+#[tauri::command]
+pub(crate) async fn restore_output(
+    host_access: State<'_, HostAccess>,
+    request: DeliverableRequest,
+) -> Result<DeliverableSummary, String> {
+    let chat_id = resolve_conversation_scope(&host_access, request.chat_id).await?;
+    let store = host_access
+        .store()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    // A restore targets a soft-deleted output, so it cannot go through the
+    // live-only `require_live_output`. Bind it to the exact conversation before
+    // clearing the retraction.
+    let output = store
+        .get_output(request.output_id)
+        .await
+        .map_err(|_| "Could not restore that output".to_owned())?
+        .filter(|output| output.chat_id == chat_id)
+        .ok_or_else(|| "Output not found in this conversation".to_owned())?;
+    store
+        .restore_output(output.id, Utc::now())
+        .await
+        .map_err(|_| "Could not restore that output".to_owned())?;
+    let (output, revision) =
+        require_live_output(host_access.store(), chat_id, request.output_id).await?;
+    summary_from_record(&output, &revision)
+}
+
 pub(crate) async fn require_live_output(
     store: Option<&std::sync::Arc<dyn Store>>,
     chat_id: ChatId,
@@ -364,6 +458,7 @@ fn summary_from_record(
         size_bytes: revision.byte_len,
         revision_count: output.revision_count,
         updated_at: output.updated_at.to_rfc3339(),
+        producing_run_id: revision.producing_run_id.map(|run_id| *run_id.as_uuid()),
     })
 }
 

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -202,6 +202,8 @@ pub fn run() {
             deliverables::list_deliverables,
             deliverables::read_deliverable,
             deliverables::export_deliverable,
+            deliverables::revert_output,
+            deliverables::restore_output,
             client_execution::resolve_folder_access_request,
             client_execution::output_writeback::resolve_output_writeback_request,
             host_access::connect_folder,

--- a/crates/openwave-desktop/ui/src/deliverables.test.ts
+++ b/crates/openwave-desktop/ui/src/deliverables.test.ts
@@ -8,6 +8,7 @@ import {
   parseDeliverablePreview,
   parseDeliverablesCatalog,
   parseOutputExportResult,
+  parseOutputRevertResult,
 } from "./deliverables";
 
 const outputId = "550062d4-2528-5cc6-90f8-a788e119bf36";
@@ -27,6 +28,7 @@ describe("deliverable renderer projections", () => {
             sizeBytes: 42,
             revisionCount: 2,
             updatedAt: "2026-07-24T00:00:00Z",
+            producingRunId: null,
           },
         ],
         truncated: false,
@@ -40,10 +42,66 @@ describe("deliverable renderer projections", () => {
           sizeBytes: 42,
           revisionCount: 2,
           updatedAt: "2026-07-24T00:00:00Z",
+          producingRunId: null,
         },
       ],
       truncated: false,
     });
+  });
+
+  it("carries an auto-merged output's producing run and rejects a malformed one", () => {
+    const runId = "ce116263-15b5-5df2-b472-269378e9da58";
+    const [summary] = parseDeliverablesCatalog({
+      deliverables: [
+        {
+          outputId,
+          filename: "Agent result ce116263.md",
+          mediaType: "text/markdown",
+          sizeBytes: 42,
+          revisionCount: 1,
+          updatedAt: "2026-07-24T00:00:00Z",
+          producingRunId: runId,
+        },
+      ],
+      truncated: false,
+    }).deliverables;
+    expect(summary.producingRunId).toBe(runId);
+    expect(() =>
+      parseDeliverablesCatalog({
+        deliverables: [
+          {
+            outputId,
+            filename: "brief.md",
+            mediaType: "text/markdown",
+            sizeBytes: 42,
+            revisionCount: 1,
+            updatedAt: "2026-07-24T00:00:00Z",
+            producingRunId: "not-a-uuid",
+          },
+        ],
+        truncated: false,
+      }),
+    ).toThrow("Invalid output response");
+  });
+
+  it("accepts both revert outcomes and rejects a mismatched output", () => {
+    expect(
+      parseOutputRevertResult(
+        { status: "reverted", outputId, revisionId },
+        outputId,
+      ),
+    ).toEqual({ status: "reverted", outputId, revisionId });
+    expect(
+      parseOutputRevertResult({ status: "retracted", outputId }, outputId),
+    ).toEqual({ status: "retracted", outputId });
+    // A reverted outcome must carry the revision it republished.
+    expect(() =>
+      parseOutputRevertResult({ status: "reverted", outputId }, outputId),
+    ).toThrow("Invalid output revert response");
+    // The response must be for the output the caller reverted.
+    expect(() =>
+      parseOutputRevertResult({ status: "retracted", outputId }, revisionId),
+    ).toThrow("Invalid output revert response");
   });
 
   it.each([
@@ -63,6 +121,7 @@ describe("deliverable renderer projections", () => {
             sizeBytes: 1,
             revisionCount: 1,
             updatedAt: "2026-07-24T00:00:00Z",
+            producingRunId: null,
           },
         ],
         truncated: false,

--- a/crates/openwave-desktop/ui/src/deliverables.ts
+++ b/crates/openwave-desktop/ui/src/deliverables.ts
@@ -7,7 +7,15 @@ export type DeliverableSummary = {
   sizeBytes: number;
   revisionCount: number;
   updatedAt: string;
+  // The background run that produced the current revision, when this output was
+  // auto-merged from a background agent rather than written by a foreground
+  // turn. `null` for a foreground deliverable.
+  producingRunId: string | null;
 };
+
+export type OutputRevertResult =
+  | { status: "reverted"; outputId: string; revisionId: string }
+  | { status: "retracted"; outputId: string };
 
 export type DeliverablesCatalog = {
   deliverables: DeliverableSummary[];
@@ -67,6 +75,25 @@ export async function readDeliverable(
 ): Promise<DeliverablePreview> {
   return parseDeliverablePreview(
     await invoke("read_deliverable", { request: { chatId, outputId } }),
+  );
+}
+
+export async function revertOutput(
+  chatId: string,
+  outputId: string,
+): Promise<OutputRevertResult> {
+  return parseOutputRevertResult(
+    await invoke("revert_output", { request: { chatId, outputId } }),
+    outputId,
+  );
+}
+
+export async function restoreOutput(
+  chatId: string,
+  outputId: string,
+): Promise<DeliverableSummary> {
+  return parseDeliverableSummary(
+    await invoke("restore_output", { request: { chatId, outputId } }),
   );
 }
 
@@ -189,7 +216,7 @@ export function parseOutputExportResult(
   throw new Error("Invalid output export response");
 }
 
-function parseDeliverableSummary(value: unknown): DeliverableSummary {
+export function parseDeliverableSummary(value: unknown): DeliverableSummary {
   if (
     !isExactRecord(value, [
       "outputId",
@@ -198,6 +225,7 @@ function parseDeliverableSummary(value: unknown): DeliverableSummary {
       "sizeBytes",
       "revisionCount",
       "updatedAt",
+      "producingRunId",
     ]) ||
     !isOpaqueId(value.outputId) ||
     !isDeliverableFilename(value.filename) ||
@@ -211,7 +239,8 @@ function parseDeliverableSummary(value: unknown): DeliverableSummary {
     value.revisionCount < 1 ||
     value.revisionCount > MAX_OUTPUT_REVISIONS ||
     typeof value.updatedAt !== "string" ||
-    !Number.isFinite(Date.parse(value.updatedAt))
+    !Number.isFinite(Date.parse(value.updatedAt)) ||
+    (value.producingRunId !== null && !isOpaqueId(value.producingRunId))
   ) {
     throw new Error("Invalid output response");
   }
@@ -222,7 +251,39 @@ function parseDeliverableSummary(value: unknown): DeliverableSummary {
     sizeBytes: value.sizeBytes,
     revisionCount: value.revisionCount,
     updatedAt: value.updatedAt,
+    producingRunId: value.producingRunId,
   };
+}
+
+export function parseOutputRevertResult(
+  value: unknown,
+  expectedOutputId?: string,
+): OutputRevertResult {
+  if (
+    !isRecord(value) ||
+    !isOpaqueId(value.outputId) ||
+    (expectedOutputId !== undefined && value.outputId !== expectedOutputId)
+  ) {
+    throw new Error("Invalid output revert response");
+  }
+  if (
+    value.status === "reverted" &&
+    isExactRecord(value, ["status", "outputId", "revisionId"]) &&
+    isOpaqueId(value.revisionId)
+  ) {
+    return {
+      status: "reverted",
+      outputId: value.outputId,
+      revisionId: value.revisionId,
+    };
+  }
+  if (
+    value.status === "retracted" &&
+    isExactRecord(value, ["status", "outputId"])
+  ) {
+    return { status: "retracted", outputId: value.outputId };
+  }
+  throw new Error("Invalid output revert response");
 }
 
 function isDeliverableFilename(value: unknown): value is string {

--- a/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
@@ -35,6 +35,10 @@ function detailApis(overrides: Partial<OutputDetailApis> = {}): OutputDetailApis
       revisionId,
       status: "completed" as const,
     }),
+    revert: vi.fn().mockResolvedValue({
+      status: "retracted" as const,
+      outputId,
+    }),
     ...overrides,
   };
 }

--- a/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.tsx
@@ -1,4 +1,4 @@
-import { DownloadIcon } from "lucide-react";
+import { DownloadIcon, Undo2Icon } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { PanelBreadcrumb } from "@/components/PanelHeader";
@@ -7,8 +7,10 @@ import { WithTooltip } from "@/components/ui/tooltip";
 import {
   exportDeliverable,
   readDeliverable,
+  revertOutput,
   type DeliverablePreview,
   type OutputExportResult,
+  type OutputRevertResult,
 } from "@/deliverables";
 import { MessageMarkdown } from "@/MessageMarkdown";
 import {
@@ -25,11 +27,13 @@ import { exportFailureMessage, friendlyOutputError } from "./OutputsView";
 export type OutputDetailApis = {
   read: (chatId: string, outputId: string) => Promise<DeliverablePreview>;
   export: (chatId: string, outputId: string) => Promise<OutputExportResult>;
+  revert: (chatId: string, outputId: string) => Promise<OutputRevertResult>;
 };
 
 const defaultApis: OutputDetailApis = {
   read: readDeliverable,
   export: exportDeliverable,
+  revert: revertOutput,
 };
 
 /**
@@ -55,6 +59,7 @@ export function OutputDetailRoot({
   const [preview, setPreview] = useState<DeliverablePreview | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [reverting, setReverting] = useState(false);
   const [saveStatus, setSaveStatus] = useState<{
     message: string;
     error: boolean;
@@ -107,6 +112,34 @@ export function OutputDetailRoot({
     }
   }
 
+  async function onRevert() {
+    if (reverting) return;
+    setReverting(true);
+    setSaveStatus(null);
+    try {
+      const result = await apis.revert(chatId, outputId);
+      if (result.status === "retracted") {
+        // The output no longer exists in the conversation; there is nothing left
+        // to preview here, so return to the catalog where Undo is offered.
+        openPanel({ type: "outputs" });
+        return;
+      }
+      const next = await apis.read(chatId, outputId);
+      setPreview(next);
+      setSaveStatus({
+        message: "Reverted to the previous version.",
+        error: false,
+      });
+    } catch (caught) {
+      setSaveStatus({
+        message: friendlyOutputError(caught, "Could not revert that output."),
+        error: true,
+      });
+    } finally {
+      setReverting(false);
+    }
+  }
+
   return (
     <PanelFrame
       position={position}
@@ -126,17 +159,30 @@ export function OutputDetailRoot({
         />
       }
       headerRightSlot={
-        <WithTooltip label="Save as…">
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            disabled={!preview || saving}
-            onClick={() => void onSave()}
-          >
-            <DownloadIcon className="size-4" />
-            <span className="sr-only">Save as…</span>
-          </Button>
-        </WithTooltip>
+        <div className="flex items-center gap-1">
+          <WithTooltip label="Revert">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              disabled={!preview || reverting}
+              onClick={() => void onRevert()}
+            >
+              <Undo2Icon className="size-4" />
+              <span className="sr-only">Revert</span>
+            </Button>
+          </WithTooltip>
+          <WithTooltip label="Save as…">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              disabled={!preview || saving}
+              onClick={() => void onSave()}
+            >
+              <DownloadIcon className="size-4" />
+              <span className="sr-only">Save as…</span>
+            </Button>
+          </WithTooltip>
+        </div>
       }
     >
       {loadError ? (

--- a/crates/openwave-desktop/ui/src/outputs/OutputsTable.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputsTable.tsx
@@ -32,6 +32,7 @@ type Props = {
   busyOutputId: string | null;
   onOpen: (outputId: string) => void;
   onSave: (output: DeliverableSummary) => void;
+  onRevert: (output: DeliverableSummary) => void;
   /** Publishes "12" or "showing 3 of 12" for the panel header to draw. */
   onCountChange: (suffix: string) => void;
 };
@@ -42,6 +43,7 @@ export function OutputsTable({
   busyOutputId,
   onOpen,
   onSave,
+  onRevert,
   onCountChange,
 }: Props) {
   const [searchQuery, setSearchQuery] = useState("");
@@ -69,8 +71,8 @@ export function OutputsTable({
   const hasActiveFilters = searchQuery.length > 0 || types.selected.size > 0;
 
   const gridContext = useMemo<OutputGridContext>(
-    () => ({ onOpen, onSave, busyOutputId }),
-    [onOpen, onSave, busyOutputId],
+    () => ({ onOpen, onSave, onRevert, busyOutputId }),
+    [onOpen, onSave, onRevert, busyOutputId],
   );
 
   // Cell renderers read their actions off `context`, which the grid snapshots

--- a/crates/openwave-desktop/ui/src/outputs/OutputsView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputsView.dom.test.tsx
@@ -23,6 +23,7 @@ function output(overrides: Partial<DeliverableSummary> = {}): DeliverableSummary
     sizeBytes: 42,
     revisionCount: 1,
     updatedAt: "2026-07-24T00:00:00Z",
+    producingRunId: null,
     ...overrides,
   };
 }
@@ -36,6 +37,11 @@ function outputApis(deliverables: DeliverableSummary[]): OutputsApis {
       revisionId,
       status: "completed" as const,
     }),
+    revert: vi.fn().mockResolvedValue({
+      status: "retracted" as const,
+      outputId: ids.brief,
+    }),
+    restore: vi.fn().mockResolvedValue(output()),
   };
 }
 
@@ -85,6 +91,30 @@ describe("OutputsView", () => {
 
     await waitFor(() => expect(apis.export).toHaveBeenCalledWith("chat-1", ids.brief));
     expect(await screen.findByText("Research brief.md was saved.")).toBeVisible();
+  });
+
+  it("retracts a merged output and offers an undo that restores it", async () => {
+    const apis = outputApis([output({ producingRunId: ids.sheet })]);
+    const user = userEvent.setup();
+
+    render(<OutputsView chatId="chat-1" apis={apis} />);
+    // The auto-merged output is badged as coming from a background agent.
+    expect(await screen.findByText("Agent")).toBeVisible();
+
+    await user.click(
+      await screen.findByRole("button", { name: "More options for Research brief.md" }),
+    );
+    await user.click(await screen.findByRole("menuitem", { name: "Revert" }));
+
+    await waitFor(() => expect(apis.revert).toHaveBeenCalledWith("chat-1", ids.brief));
+    expect(
+      await screen.findByText("Research brief.md was retracted from this conversation."),
+    ).toBeVisible();
+
+    // The retract is reversible: Undo restores the exact output.
+    await user.click(screen.getByRole("button", { name: "Undo" }));
+    await waitFor(() => expect(apis.restore).toHaveBeenCalledWith("chat-1", ids.brief));
+    expect(await screen.findByText("Research brief.md was restored.")).toBeVisible();
   });
 
   it("names the reason a save failed rather than reporting it as saved", async () => {

--- a/crates/openwave-desktop/ui/src/outputs/OutputsView.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputsView.tsx
@@ -14,9 +14,12 @@ import { WithTooltip } from "@/components/ui/tooltip";
 import {
   exportDeliverable,
   listDeliverables,
+  restoreOutput,
+  revertOutput,
   type DeliverableSummary,
   type DeliverablesCatalog,
   type OutputExportResult,
+  type OutputRevertResult,
 } from "@/deliverables";
 import {
   PICKER_BUSY_MESSAGE,
@@ -28,11 +31,15 @@ import { OutputsTable } from "./OutputsTable";
 export type OutputsApis = {
   list: (chatId: string) => Promise<DeliverablesCatalog>;
   export: (chatId: string, outputId: string) => Promise<OutputExportResult>;
+  revert: (chatId: string, outputId: string) => Promise<OutputRevertResult>;
+  restore: (chatId: string, outputId: string) => Promise<DeliverableSummary>;
 };
 
 const defaultApis: OutputsApis = {
   list: listDeliverables,
   export: exportDeliverable,
+  revert: revertOutput,
+  restore: restoreOutput,
 };
 
 /**
@@ -64,6 +71,8 @@ export function OutputsView({
   const [saveStatus, setSaveStatus] = useState<{
     message: string;
     error: boolean;
+    /** A retract offers an inline undo that restores the output. */
+    undo?: () => void;
   } | null>(null);
   const [countSuffix, setCountSuffix] = useState("");
   const generationRef = useRef(0);
@@ -124,6 +133,54 @@ export function OutputsView({
     [apis, chatId, busyOutputId],
   );
 
+  const onRestore = useCallback(
+    async (output: DeliverableSummary) => {
+      try {
+        await apis.restore(chatId, output.outputId);
+        setSaveStatus({ message: `${output.filename} was restored.`, error: false });
+        void refresh();
+      } catch (caught) {
+        setSaveStatus({
+          message: friendlyOutputError(caught, "Could not restore that output."),
+          error: true,
+        });
+      }
+    },
+    [apis, chatId],
+  );
+
+  const onRevert = useCallback(
+    async (output: DeliverableSummary) => {
+      if (busyOutputId) return;
+      setBusyOutputId(output.outputId);
+      setSaveStatus(null);
+      try {
+        const result = await apis.revert(chatId, output.outputId);
+        if (result.status === "retracted") {
+          setSaveStatus({
+            message: `${output.filename} was retracted from this conversation.`,
+            error: false,
+            undo: () => void onRestore(output),
+          });
+        } else {
+          setSaveStatus({
+            message: `${output.filename} was reverted to its previous version.`,
+            error: false,
+          });
+        }
+        void refresh();
+      } catch (caught) {
+        setSaveStatus({
+          message: friendlyOutputError(caught, "Could not revert that output."),
+          error: true,
+        });
+      } finally {
+        setBusyOutputId(null);
+      }
+    },
+    [apis, chatId, busyOutputId, onRestore],
+  );
+
   const hasOutputs = catalog.deliverables.length > 0;
 
   return (
@@ -156,12 +213,22 @@ export function OutputsView({
           <div
             className={
               saveStatus.error
-                ? "mx-4 shrink-0 rounded-md bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted"
-                : "mx-4 shrink-0 rounded-md bg-info-background px-3 py-2 text-sm text-info-foreground-muted"
+                ? "mx-4 flex shrink-0 items-center justify-between gap-3 rounded-md bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted"
+                : "mx-4 flex shrink-0 items-center justify-between gap-3 rounded-md bg-info-background px-3 py-2 text-sm text-info-foreground-muted"
             }
             role={saveStatus.error ? "alert" : "status"}
           >
-            {saveStatus.message}
+            <span>{saveStatus.message}</span>
+            {saveStatus.undo && (
+              <Button
+                variant="outline"
+                size="xs"
+                className="shrink-0"
+                onClick={saveStatus.undo}
+              >
+                Undo
+              </Button>
+            )}
           </div>
         )}
         {error && (
@@ -209,6 +276,7 @@ export function OutputsView({
             busyOutputId={busyOutputId}
             onOpen={onOpen}
             onSave={(output) => void onSave(output)}
+            onRevert={(output) => void onRevert(output)}
             onCountChange={setCountSuffix}
           />
         )}

--- a/crates/openwave-desktop/ui/src/outputs/outputCellRenderers.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/outputCellRenderers.tsx
@@ -1,6 +1,6 @@
 import type { CustomCellRendererProps } from "ag-grid-react";
 import { format } from "date-fns";
-import { DownloadIcon, MoreHorizontalIcon } from "lucide-react";
+import { BotIcon, DownloadIcon, MoreHorizontalIcon, Undo2Icon } from "lucide-react";
 import { useState } from "react";
 
 import { DocumentIcon } from "@/components/document-table/DocumentIcon";
@@ -9,6 +9,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { WithTooltip } from "@/components/ui/tooltip";
@@ -25,7 +26,9 @@ import { outputTypeLabel, revisionLabel } from "./outputFormat";
 export type OutputGridContext = {
   onOpen: (outputId: string) => void;
   onSave: (output: DeliverableSummary) => void;
-  /** The output with a save in flight, whose actions are disabled. */
+  /** Revert a merged output: step back a revision, or retract the merge. */
+  onRevert: (output: DeliverableSummary) => void;
+  /** The output with a save or revert in flight, whose actions are disabled. */
   busyOutputId: string | null;
 };
 
@@ -54,6 +57,14 @@ export function NameCellRenderer(props: CellProps) {
         </WithTooltip>
         <span className="truncate">{output.filename}</span>
       </button>
+      {output.producingRunId !== null && (
+        <WithTooltip label="Auto-merged from a background agent">
+          <span className="ml-2 flex shrink-0 items-center gap-1 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+            <BotIcon className="size-3" />
+            Agent
+          </span>
+        </WithTooltip>
+      )}
     </div>
   );
 }
@@ -129,6 +140,11 @@ export function ActionsCellRenderer(props: CellProps) {
           <DropdownMenuItem onClick={() => context.onSave(output)}>
             <DownloadIcon />
             <span>Save as…</span>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem variant="destructive" onClick={() => context.onRevert(output)}>
+            <Undo2Icon />
+            <span>{output.revisionCount > 1 ? "Revert version" : "Revert"}</span>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -566,9 +566,7 @@ impl SandboxAgentRunWorker {
                 .await;
         };
         match completion_result {
-            Ok(SandboxCompletion::Final(text)) => {
-                self.submit_result(run.id, lease_token, text).await
-            }
+            Ok(SandboxCompletion::Final(text)) => self.submit_result(&run, lease_token, text).await,
             Ok(SandboxCompletion::WebSearch {
                 provider_id,
                 arguments,
@@ -657,23 +655,79 @@ impl SandboxAgentRunWorker {
 
     async fn submit_result(
         &self,
-        id: openwave_core::AgentRunId,
+        run: &AgentRun,
         lease_token: uuid::Uuid,
         text: String,
     ) -> Result<SandboxAgentRunWorkerOutcome> {
+        let id = run.id;
         match self
             .store
             .submit_agent_run_result(id, lease_token, &text)
             .await?
         {
-            Some(SubmitAgentRunResultOutcome::Completed(_))
-            | Some(SubmitAgentRunResultOutcome::Existing(_)) => {
+            Some(SubmitAgentRunResultOutcome::Completed(result))
+            | Some(SubmitAgentRunResultOutcome::Existing(result)) => {
+                // The result is durably committed and delivered to the parent
+                // inbox. Now the host — never the model — merges it into the
+                // conversation's output record as a revertible version. The
+                // merge runs on the committed text, so the model that produced
+                // it cannot author, decline, or steer the merge.
+                self.auto_merge_result_output(run, &result).await;
                 Ok(SandboxAgentRunWorkerOutcome::Completed(id))
             }
             None => {
                 self.acknowledge_cancellation_or_lease_loss(id, lease_token)
                     .await
             }
+        }
+    }
+
+    /// Auto-merge a completed background run's text result into its
+    /// conversation's outputs.
+    ///
+    /// This is best-effort after the result has already committed: the merge is
+    /// idempotent on the run's derived output identity, so an ambiguous submit
+    /// retry re-runs it harmlessly, and a failure here never fails a run whose
+    /// result is already delivered. Only a `FinalText` result becomes an output;
+    /// a folder-access proposal or cancellation is not conversation content.
+    async fn auto_merge_result_output(
+        &self,
+        run: &AgentRun,
+        result: &openwave_core::AgentRunResult,
+    ) {
+        let openwave_core::AgentRunResultPayload::FinalText { text } = &result.payload else {
+            return;
+        };
+        if text.is_empty() {
+            return;
+        }
+        let Some(root) = &self.private_scratch_root else {
+            return;
+        };
+        let scratch = match open_chat_scratch(root, run.chat_id) {
+            Ok(scratch) => scratch,
+            Err(error) => {
+                tracing::warn!(
+                    "could not open scratch to auto-merge agent run {} output: {error}",
+                    run.id
+                );
+                return;
+            }
+        };
+        let merge = openwave_core::AgentResultOutputMerge {
+            run_id: run.id,
+            chat_id: run.chat_id,
+            filename: agent_result_filename(run.id),
+            text: text.clone(),
+            created_at: result.submitted_at,
+        };
+        if let Err(error) =
+            openwave_core::merge_agent_run_result(&*self.store, &scratch, &merge).await
+        {
+            tracing::warn!(
+                "could not auto-merge agent run {} result into outputs: {error}",
+                run.id
+            );
         }
     }
 
@@ -889,6 +943,53 @@ impl SandboxAgentRunWorker {
         }
         Ok(())
     }
+}
+
+/// Open one conversation's private-scratch directory as a capability root.
+///
+/// This is the same `<scratch root>/<chat id>` directory the desktop reads an
+/// output revision from; the merge writes the revision bytes below it under
+/// `outputs/`. The directory is created and locked to the owner on first use.
+fn open_chat_scratch(
+    root: &std::path::Path,
+    chat_id: openwave_core::ChatId,
+) -> Result<cap_std::fs::Dir> {
+    let path = root.join(chat_id.to_string());
+    std::fs::create_dir_all(&path).map_err(|error| {
+        AgentError::Store(format!(
+            "failed to create chat scratch {}: {error}",
+            path.display()
+        ))
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).map_err(
+            |error| {
+                AgentError::Store(format!(
+                    "failed to secure chat scratch {}: {error}",
+                    path.display()
+                ))
+            },
+        )?;
+    }
+    cap_std::fs::Dir::open_ambient_dir(&path, cap_std::ambient_authority()).map_err(|error| {
+        AgentError::Store(format!(
+            "failed to open chat scratch {}: {error}",
+            path.display()
+        ))
+    })
+}
+
+/// Host-derived, portable display filename for an auto-merged agent result.
+///
+/// The model never names the output. A short, run-derived suffix keeps several
+/// background results in one conversation distinguishable while the record's
+/// opaque identity remains the authority.
+fn agent_result_filename(run_id: openwave_core::AgentRunId) -> String {
+    let id = run_id.to_string();
+    let short = id.get(..8).unwrap_or(id.as_str());
+    format!("Agent result {short}.md")
 }
 
 fn delegated_file_admission_matches(

--- a/docs/deliverables.md
+++ b/docs/deliverables.md
@@ -112,6 +112,49 @@ it, and acceptance is a host-side operation the model cannot perform for itself.
 Acceptance changes nothing about export: a person still chooses the destination
 through **Save As…**, and the bytes never leave private app data until then.
 
+## Auto-merging a background agent's result
+
+A background agent finishes by submitting one immutable text result to its
+foreground parent. That result also becomes conversation output: when the run
+completes, the **host** merges the text into the output record as a durable
+revision. The merge is host-side by construction — it runs on the already
+committed result text, so the sandbox model can neither author, decline, nor
+steer it, and there is no pre-accept prompt. Safety comes from the merge being a
+versioned, revertible output rather than from a human gate.
+
+- The merge happens at result-commit time, right after the fenced result
+  transition. Its output and revision identities are derived from the producing
+  run, so an ambiguous submit retry re-runs the merge onto the same record
+  instead of forking a second output. The revision records the background run as
+  its producer, exactly like an accepted binary artifact, so the agent-run
+  surface can correlate a completed run with the output it produced.
+- The merged output is bounded and media-typed like every other deliverable: a
+  text result becomes a `text/markdown` output under the 512 KiB text ceiling,
+  written once at the same revision path a foreground deliverable uses. A folder
+  proposal or a cancellation is not conversation content and is never merged.
+- The merge is best-effort after the result has committed and delivered: a
+  failure to publish never fails a run whose result the parent can already
+  consume.
+
+## Versioning and revert
+
+Auto-merge is safe because every merged output is a durable, reversible version,
+so the host can always undo it:
+
+- **Revert to a prior revision.** An output's current-revision pointer is
+  independent of its newest revision, so republishing an earlier revision is a
+  pointer move that appends and destroys nothing. Every superseded revision
+  stays addressable, so a revert can be followed forward again.
+- **Retract the merge.** An auto-merged output that has only its initial
+  revision has no earlier version to fall back to, so reverting it retracts the
+  merge — a soft delete that hides the output while retaining its revision. The
+  desktop offers an inline undo, and restoring is the exact inverse of the
+  retraction, so nothing about the history changes.
+
+Both operations are host actions the model cannot perform, and neither is
+destructive: the revision history is insert-only, so a revert or a retract only
+moves pointers a person can move back.
+
 ## Deliberate limits
 
 An export is a synchronous user action, so it is not automatically retried and


### PR DESCRIPTION
A finished background agent returns a single bounded text result today. This makes that result durable conversation output: when a background run completes, the **host** merges its text into the conversation's output record as a revision, automatically and with no pre-accept prompt. The model can never author the merge — it only produces text; the host performs the merge at result-commit time on the already-committed result. Safety comes from versioning + revert, mirroring alpha's auto-merge-with-revert posture (per the merge decision on #952), not a human gate.

## Auto-merge (host-side, at result completion)

- The sandbox worker, after the fenced result transition commits, merges a `FinalText` result into the chat's outputs as a `text/markdown` deliverable under the existing 512 KiB text ceiling. Folder proposals and cancellations are not conversation content and are never merged.
- The output and revision identities are derived from the producing run (`OutputId::for_run` / `OutputRevisionId::for_run`), so an ambiguous submit retry re-runs the merge onto the same record instead of forking a second output.
- The revision records the background run as its producer, reusing the `producing_run_id` attribution from the binary-artifact work. This is the correlation key the parallel agent-run surface (#965) links against.
- The merge is best-effort after the result has committed and delivered: a publish failure never fails a run whose result the parent can already consume.

## Versioning + revert (what makes auto-merge safe)

Two host-only store primitives, both building on the existing output record — **no migration**:

- `set_current_output_revision` moves an output's current-revision pointer to any revision it already has. Reverting appends and destroys nothing; every superseded revision stays addressable and a revert can be followed forward again.
- `restore_output` is the exact inverse of the existing soft delete, so a retract is reversible.

The desktop `revert_output` command reverts a merged output to its previous revision, or — when only the initial merge exists — retracts it (soft delete). `restore_output` undoes a retract; the Outputs view shows an inline **Undo**. Nothing is destructive: the revision history is insert-only and revert/retract only move pointers a person can move back.

## UI

Reuses the existing outputs surface (`OutputsView` / `OutputDetailRoot`) — no new viewer. Auto-merged outputs are badged **Agent** and carry a **Revert** control in the table row menu and the reader header; retracting offers Undo.

## Verification

- `cargo test -p openwave-core --features tools` (incl. new revert/restore/auto-merge store tests), `-p openwave-server` (sandbox worker + wire-types current), `-p openwave-desktop` (deliverables).
- Postgres lane: `cargo check -p openwave-core --no-default-features --features postgres --locked` green.
- clippy `--all-targets -D warnings` and rustfmt clean on the three touched crates.
- UI: `tsc`, `vitest run` (657 pass, incl. new retract+undo and revert-parser tests), `vite build`.

Not verified: driving the running desktop app end to end.

Closes #952