### PR TITLE
test(core): amortize repeated SQLite migrations

### DIFF
--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -33,10 +33,51 @@ fn document_content_placement(
     }
 }
 
+struct MigratedSqliteTemplate {
+    _directory: tempfile::TempDir,
+    database: std::path::PathBuf,
+}
+
+static MIGRATED_SQLITE_TEMPLATE: tokio::sync::OnceCell<MigratedSqliteTemplate> =
+    tokio::sync::OnceCell::const_new();
+
+/// Build the current empty schema once, then clone it for ordinary store tests.
+///
+/// Every caller still owns a distinct writable file. Tests that exercise the
+/// migration chain itself create their historical/raw schemas directly and do
+/// not use this helper.
+async fn migrated_sqlite_template() -> &'static MigratedSqliteTemplate {
+    MIGRATED_SQLITE_TEMPLATE
+        .get_or_init(|| async {
+            let directory = tempfile::tempdir().unwrap();
+            let database = directory.path().join("template.db");
+            let url = format!("sqlite://{}?mode=rwc", database.display());
+            let store = DbStore::connect(&url).await.unwrap();
+            store
+                .conn
+                .execute_unprepared("PRAGMA wal_checkpoint(TRUNCATE);")
+                .await
+                .unwrap();
+            drop(store);
+            MigratedSqliteTemplate {
+                _directory: directory,
+                database,
+            }
+        })
+        .await
+}
+
 async fn temp_store() -> (tempfile::TempDir, DbStore) {
+    let template = migrated_sqlite_template().await;
     let dir = tempfile::tempdir().unwrap();
-    let url = format!("sqlite://{}?mode=rwc", dir.path().join("test.db").display());
-    let store = DbStore::connect(&url).await.unwrap();
+    let database = dir.path().join("test.db");
+    std::fs::copy(&template.database, &database).unwrap();
+    let url = format!("sqlite://{}?mode=rw", database.display());
+    let conn = Database::connect(&url).await.unwrap();
+    conn.execute_unprepared("PRAGMA journal_mode=WAL;")
+        .await
+        .unwrap();
+    let store = DbStore { conn };
     (dir, store)
 }
 


### PR DESCRIPTION
## Summary

- build the current empty SQLite schema once per core test process
- checkpoint and close that template before copying it into each ordinary test's own writable file
- reconnect copied databases with the production WAL setting while skipping redundant migration DDL
- leave historical migration, raw-schema, restart, and locking tests on their explicit setup paths

## Why

`temp_store` created a new file and ran the complete migration chain for almost every core database test. That repeated filesystem/schema work dominated the harness and became more contentious as test concurrency increased. The template removes only redundant setup; no database state is shared between tests.

## Measurements

Same machine, debug test profile, four libtest workers:

| Suite | Before | After |
| --- | ---: | ---: |
| 294 `db::` tests | 45.03s | 4.83s |
| full core library harness | 42.64s | 13.90s |

The subset and full harness have different parallel schedules, so their absolute baselines are not additive; both show the setup cost disappearing.

## Verification

- `cargo test -p openwave-core --lib --locked -- --test-threads=4` (555 passed)
- `cargo fmt --all --check`
- `git diff --check`

Closes #978
