### PR TITLE
ci: run UI checks in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,11 +571,15 @@ jobs:
           -- --ignored --exact --nocapture
 
   ui:
-    name: desktop UI test · build
+    name: desktop UI · ${{ matrix.task }}
     needs: changes
     if: ${{ needs.changes.outputs.ui == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        task: [test, build]
     defaults:
       run:
         working-directory: crates/openwave-desktop/ui
@@ -591,10 +595,8 @@ jobs:
           cache-dependency-path: crates/openwave-desktop/ui/pnpm-lock.yaml
       - name: Install UI dependencies
         run: pnpm install --frozen-lockfile
-      - name: Test UI
-        run: pnpm test
-      - name: Build UI
-        run: pnpm build
+      - name: Run UI ${{ matrix.task }}
+        run: pnpm ${{ matrix.task }}
 
   rust:
     # Keep this historical name stable because branch protection requires it.

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -144,6 +144,19 @@ test("Rust CI requires the same PostgreSQL lane on pull requests and main", () =
   assert.match(testJob, /cache-on-failure: true/);
 });
 
+test("UI tests and production build run as parallel matrix jobs", () => {
+  const ci = workflows["ci.yml"];
+  const ui = workflowJob(ci, "ui");
+  const aggregate = workflowJob(ci, "rust");
+
+  assert.match(ui, /name: desktop UI · \$\{\{ matrix\.task \}\}/);
+  assert.match(ui, /strategy:\n\s+fail-fast: false\n\s+matrix:\n\s+task: \[test, build\]/);
+  assert.match(ui, /run: pnpm install --frozen-lockfile/);
+  assert.match(ui, /run: pnpm \$\{\{ matrix\.task \}\}/);
+  assert.match(aggregate, /UI_RESULT: \$\{\{ needs\.ui\.result \}\}/);
+  assert.match(aggregate, /true\) test "\$UI_RESULT" = success ;;/);
+});
+
 test("heavy capability lanes run only for relevant merges and scheduled backstops", () => {
   const ci = workflows["ci.yml"];
   const changes = workflowJob(ci, "changes");


### PR DESCRIPTION
Closes #986

## Summary
- fan the desktop UI lane into `test` and `build` matrix jobs
- keep installs frozen and allow both jobs to finish independently
- preserve the single aggregate required check
- pin the parallel topology in workflow policy tests

## Expected impact
Recent UI lanes spend roughly 117 seconds testing and 53 seconds building after a ~3 second install. Running those independent phases concurrently should remove about 53 seconds from UI-scoped CI wall time, at the cost of one additional short install.

## Verification
- `node --test scripts/workflow-security.test.mjs`
- `actionlint .github/workflows/ci.yml`