### PR TITLE
ci: retain PR compiler caches

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,27 @@
+name: PR compiler cache cleanup
+
+on:
+  # This trusted default-branch workflow never checks out or runs PR code. The
+  # target event keeps Actions deletion permission for caches created by forks.
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: pr-cache-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: delete closed PR caches
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Delete the PR merge-ref cache scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh cache delete --all --ref "refs/pull/${PR_NUMBER}/merge"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,7 +280,9 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
       SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'pull_request' && 'READ_ONLY' || 'READ_WRITE' }}
+      # GitHub scopes pull-request caches to the PR merge ref. Let reruns reuse
+      # changed compiler outputs; cache-cleanup.yml removes that scope on close.
+      SCCACHE_GHA_RW_MODE: READ_WRITE
       RUSTC_WRAPPER: sccache
       RUSTFLAGS: -C link-arg=-fuse-ld=mold
     steps:
@@ -329,7 +331,7 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
       SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'pull_request' && 'READ_ONLY' || 'READ_WRITE' }}
+      SCCACHE_GHA_RW_MODE: READ_WRITE
       RUSTC_WRAPPER: sccache
       RUSTFLAGS: -C link-arg=-fuse-ld=mold
     steps:
@@ -371,7 +373,7 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
       SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'pull_request' && 'READ_ONLY' || 'READ_WRITE' }}
+      SCCACHE_GHA_RW_MODE: READ_WRITE
       RUSTC_WRAPPER: sccache
       RUSTFLAGS: -C link-arg=-fuse-ld=mold
     steps:
@@ -420,7 +422,7 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: 0
       CARGO_PROFILE_TEST_DEBUG: 0
       SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'pull_request' && 'READ_ONLY' || 'READ_WRITE' }}
+      SCCACHE_GHA_RW_MODE: READ_WRITE
       RUSTC_WRAPPER: sccache
       RUSTFLAGS: -C link-arg=-fuse-ld=mold
     steps:
@@ -494,7 +496,7 @@ jobs:
       OPENWAVE_POSTGRES_TEST_URL: postgres://postgres:postgres@localhost:5432/openwave_test
       OPENWAVE_REQUIRE_POSTGRES_TEST: "true"
       SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_RW_MODE: ${{ github.event_name == 'pull_request' && 'READ_ONLY' || 'READ_WRITE' }}
+      SCCACHE_GHA_RW_MODE: READ_WRITE
       RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -157,6 +157,30 @@ test("UI tests and production build run as parallel matrix jobs", () => {
   assert.match(aggregate, /true\) test "\$UI_RESULT" = success ;;/);
 });
 
+test("PR compiler caches are writable, isolated, and deleted on close", () => {
+  const ci = workflows["ci.yml"];
+  for (const name of ["lint", "desktop", "test", "vectors", "postgres"]) {
+    assert.match(workflowJob(ci, name), /SCCACHE_GHA_RW_MODE: READ_WRITE/);
+  }
+  assert.doesNotMatch(
+    ci,
+    /github\.event_name == 'pull_request' && 'READ_ONLY' \|\| 'READ_WRITE'/,
+  );
+
+  const cleanup = workflows["cache-cleanup.yml"];
+  assert.ok(cleanup);
+  assert.match(
+    cleanup,
+    /^on:\n(?:  #.*\n)+  pull_request_target:\n    types: \[closed\]/m,
+  );
+  assert.match(cleanup, /^permissions:\n  actions: write\n  contents: read$/m);
+  assert.match(
+    cleanup,
+    /gh cache delete --all --ref "refs\/pull\/\$\{PR_NUMBER\}\/merge"/,
+  );
+  assert.doesNotMatch(cleanup, /actions\/checkout|secrets\./);
+});
+
 test("heavy capability lanes run only for relevant merges and scheduled backstops", () => {
   const ci = workflows["ci.yml"];
   const changes = workflowJob(ci, "changes");


### PR DESCRIPTION
Closes #988

## Summary
- let pull-request Rust jobs publish changed compiler outputs to their merge-ref cache scope
- retain read/write behavior for main while leaving release and sandbox caches read-only
- delete all caches tied to a PR merge ref when that PR closes
- run cleanup from trusted default-branch workflow code with only `actions: write` and `contents: read`
- pin the cache lifecycle in workflow security tests

## Why
PR jobs previously restored sccache but discarded every compiler output they produced. A retry or follow-up push therefore paid the same compilation cost again. GitHub isolates PR caches from main; cleanup prevents closed PR scopes from consuming quota indefinitely.

## Verification
- `node --test scripts/workflow-security.test.mjs`
- `actionlint .github/workflows/ci.yml .github/workflows/cache-cleanup.yml`