### PR TITLE
ci: focus durable vector coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,7 +465,9 @@ jobs:
       - name: LanceDB-backed tests
         run: |
           cargo test -p openwave-retrieval --features vec-lance --locked
-          cargo test -p openwave-server --features vec-lance --locked
+          cargo test -p openwave-server --features vec-lance --locked --lib \
+            tests::documents::connect_vector_store_opens_a_durable_lance_index_under_data_dir \
+            -- --exact
 
   postgres:
     name: postgres state machine

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -189,6 +189,10 @@ test("heavy capability lanes run only for relevant merges and scheduled backstop
     /if:.*needs\.changes\.outputs\.vectors == 'true'.*github\.event_name != 'pull_request'/,
   );
   assert.match(
+    vectors,
+    /cargo test -p openwave-server --features vec-lance --locked --lib \\\n\s+tests::documents::connect_vector_store_opens_a_durable_lance_index_under_data_dir \\\n\s+-- --exact/,
+  );
+  assert.match(
     sandboxContainer,
     /if:.*needs\.changes\.outputs\.sandbox_container == 'true'.*github\.event_name != 'pull_request'/,
   );


### PR DESCRIPTION
Closes #984

## Summary
- keep the full `openwave-retrieval` LanceDB feature suite
- restrict the server feature run to its sole `vec-lance`-gated contract
- compile only the server library test target and select the test by its exact name
- pin that command in workflow policy tests

## Expected impact
The previous server command reran the entire test harness (roughly 470 tests) after the expensive feature build. The focused command executes the one durable wiring and reopen contract in 0.09 seconds locally; recent CI spent roughly 72 seconds executing the unrelated server suite. Compilation remains cached and unchanged.

## Verification
- `node --test scripts/workflow-security.test.mjs`
- `actionlint .github/workflows/ci.yml`
- `cargo test -p openwave-server --features vec-lance --locked --lib tests::documents::connect_vector_store_opens_a_durable_lance_index_under_data_dir -- --exact`