### PR TITLE
ci: keep headless tests off rich parsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,6 +357,20 @@ jobs:
           cache-bin: false
           cache-targets: false
           save-if: false
+      - name: rich document parser contracts
+        run: |
+          parser_features="parse-liteparse,parse-office,parse-image,parse-spreadsheet"
+          cargo test -p openwave-retrieval --features "$parser_features" --locked \
+            liteparse_parser::tests
+          cargo test -p openwave-retrieval --features "$parser_features" --locked \
+            liteparse_office_parser::tests
+          cargo test -p openwave-retrieval --features "$parser_features" --locked \
+            liteparse_image_parser::tests
+          cargo test -p openwave-retrieval --features "$parser_features" --locked \
+            spreadsheet_parser::tests
+          cargo test -p openwave-server --features document-parsers --locked --lib \
+            tests::documents::raw_ingest_parses_and_indexes_a_pdf_end_to_end \
+            -- --exact
       - name: desktop tests
         run: cargo test -p openwave-desktop --locked
 
@@ -401,7 +415,12 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         run: cargo fetch --locked
       - name: headless tests
-        run: cargo test --workspace --exclude openwave-desktop --locked
+        run: >-
+          cargo test --workspace --exclude openwave-desktop
+          --no-default-features
+          --features
+          openwave-core/default,openwave-retrieval/default,openwave-router/default
+          --locked
 
   vectors:
     name: durable vector store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,17 +115,20 @@ is the whole rule, and it is coarse on purpose:
 - Any changed file outside `*.md`, `docs/`, `assets/`, `LICENSE`, `NOTICE`, and
   `crates/openwave-desktop/ui/` marks the change **Rust** — including
   `Cargo.toml` and `Cargo.lock`. That runs rustfmt, clippy (`--all-targets
-  -D warnings`), and the desktop tests. Every cargo invocation passes
-  `--locked`, so a lockfile drift fails there too.
+  -D warnings`), the rich document-parser contracts, and the desktop tests.
+  Every cargo invocation passes `--locked`, so a lockfile drift fails there too.
 - A Rust change also marks the **workspace** scope, which adds the headless
-  workspace tests and the PostgreSQL turn-state lane, unless every changed file
-  is one of `openwave-desktop`'s own sources. Nothing in the workspace depends on
-  that crate and the headless lane already excludes it, so those lanes cannot see
-  such a change. Its `Cargo.toml` is not covered by the carve-out — it forwards
-  features into `openwave-server` — and neither is
+  workspace tests with the server's rich parser adapters disabled, plus the
+  PostgreSQL turn-state lane, unless every changed file is one of
+  `openwave-desktop`'s own sources. Parser-specific tests run in the already-rich
+  desktop lane instead of linking PDF/Office/image/spreadsheet support into every
+  headless test binary. Nothing in the workspace depends on the desktop crate and
+  the headless lane already excludes it, so those lanes cannot see such a change.
+  Its `Cargo.toml` is not covered by the carve-out — it forwards features into
+  `openwave-server` — and neither is
   `ui/src/generated/`, whose staleness check lives in `openwave-server`.
 - Any file under `crates/openwave-desktop/ui/` marks it **UI**, which runs
-  `pnpm test` and `pnpm build`.
+  `pnpm test` and `pnpm build` as parallel matrix jobs.
 - The aggregate `fmt · clippy · build · test` check asserts each lane either
   succeeded or was legitimately skipped, and branch protection requires it. A
   lane is skipped only when the change could not have affected it.

--- a/crates/openwave-cli/Cargo.toml
+++ b/crates/openwave-cli/Cargo.toml
@@ -11,6 +11,11 @@ authors.workspace = true
 workspace = true
 
 [features]
+# Keep ordinary `openwave serve` builds feature-complete while allowing the
+# headless workspace lane to exercise the server without its heavyweight parser
+# adapters. Parser-specific coverage runs separately with this feature enabled.
+default = ["document-parsers"]
+document-parsers = ["openwave-server/document-parsers"]
 # Forwards the server's durable, on-disk vector store. Off by default so an
 # ordinary build and the workspace tests skip the LanceDB dependency tree; a
 # release build has to enable it (`openwave-server`'s build script says so).
@@ -27,7 +32,7 @@ path = "src/main.rs"
 # through `openwave-server`. This avoids directly enabling unrelated defaults.
 openwave-core = { path = "../openwave-core", default-features = false, features = ["tools"] }
 openwave-mcp = { path = "../openwave-mcp" }
-openwave-server = { path = "../openwave-server" }
+openwave-server = { path = "../openwave-server", default-features = false }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -15,7 +15,13 @@ workspace = true
 # default so the desktop and `openwave serve` accept `application/pdf` uploads.
 # The liteparse build downloads a prebuilt PDFium binary; build with
 # `--no-default-features` for a lean, text-only pipeline with no such fetch.
-default = ["parse-liteparse", "parse-office", "parse-image", "parse-spreadsheet"]
+default = ["document-parsers"]
+document-parsers = [
+    "parse-liteparse",
+    "parse-office",
+    "parse-image",
+    "parse-spreadsheet",
+]
 parse-liteparse = ["openwave-retrieval/parse-liteparse"]
 # Rich Office ingestion (Word/Excel/PowerPoint/OpenDocument) via liteparse's
 # LibreOffice conversion path. On by default, adding no build cost beyond

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -142,6 +142,23 @@ test("Rust CI requires the same PostgreSQL lane on pull requests and main", () =
   }
   assert.match(testJob, /save-if: \$\{\{ github\.ref == 'refs\/heads\/main' \}\}/);
   assert.match(testJob, /cache-on-failure: true/);
+  assert.match(
+    testJob,
+    /cargo test --workspace --exclude openwave-desktop\n\s+--no-default-features\n\s+--features\n\s+openwave-core\/default,openwave-retrieval\/default,openwave-router\/default\n\s+--locked/,
+  );
+  const desktop = workflowJob(ci, "desktop");
+  assert.match(
+    desktop,
+    /parser_features="parse-liteparse,parse-office,parse-image,parse-spreadsheet"/,
+  );
+  assert.match(desktop, /liteparse_parser::tests/);
+  assert.match(desktop, /liteparse_office_parser::tests/);
+  assert.match(desktop, /liteparse_image_parser::tests/);
+  assert.match(desktop, /spreadsheet_parser::tests/);
+  assert.match(
+    desktop,
+    /tests::documents::raw_ingest_parses_and_indexes_a_pdf_end_to_end \\\n\s+-- --exact/,
+  );
 });
 
 test("UI tests and production build run as parallel matrix jobs", () => {


### PR DESCRIPTION
Closes #991

## Summary
- add an aggregate `document-parsers` server feature and forward it from the CLI default
- preserve feature-complete ordinary `openwave serve` and desktop builds
- run the general headless workspace with core/retrieval/router defaults but without server parser adapters
- move only the parser-specific retrieval modules and end-to-end server PDF contract onto the already-rich desktop Rust lane
- document and pin the feature topology

## Expected impact
The headless workspace dependency graph falls from 627 packages to 465 (26% fewer) while retaining all general tests and the valuable parser contracts. This removes liteparse/PDFium, workbook, image-conversion, and related link work from the current longest CI lane.

## Verification
- workflow policy tests and `actionlint`
- `cargo metadata --locked` with no lockfile change
- all four parser-specific retrieval test modules (20 passed, 2 ignored environment E2Es)
- exact server PDF ingest contract (1 passed)
- `cargo check -p openwave-cli --no-default-features --locked`
- lean Cargo graph contains no server parser features