### PR TITLE
fix(sandbox-agent): type the setrlimit resource selector per-platform

### DIFF
--- a/crates/openwave-sandbox-agent/src/exec.rs
+++ b/crates/openwave-sandbox-agent/src/exec.rs
@@ -333,8 +333,17 @@ async fn run_bounded(_command: &str, _workspace: &Path, _timeout: Duration) -> E
     }
 }
 
+/// The integer type `libc::setrlimit` takes for the resource selector. glibc
+/// types the `RLIMIT_*` constants as `__rlimit_resource_t` (a `u32`); every
+/// other unix we build for (musl, macOS, the BSDs) uses a plain `c_int`, so a
+/// single `c_int` signature fails to compile on the glibc Linux CI host.
+#[cfg(all(unix, target_os = "linux", target_env = "gnu"))]
+type RlimitResource = libc::__rlimit_resource_t;
+#[cfg(all(unix, not(all(target_os = "linux", target_env = "gnu"))))]
+type RlimitResource = libc::c_int;
+
 #[cfg(unix)]
-fn set_limit(resource: libc::c_int, value: u64) -> std::io::Result<()> {
+fn set_limit(resource: RlimitResource, value: u64) -> std::io::Result<()> {
     let limit = libc::rlimit {
         rlim_cur: value as libc::rlim_t,
         rlim_max: value as libc::rlim_t,


### PR DESCRIPTION
`openwave-sandbox-agent/src/exec.rs`'s `set_limit` took the resource selector as `libc::c_int`. On macOS/BSD that's correct, so it compiled on the dev host — but glibc types the `RLIMIT_*` constants and `setrlimit`'s resource argument as `__rlimit_resource_t` (a `u32`). When CI's toolchain rolled to stable **1.97.1** and built on the glibc Linux runner, this surfaced as three `E0308` mismatches in `exec.rs` (239/240/344), taking **main red on clippy and test**.

Fix: a per-platform `RlimitResource` alias — `__rlimit_resource_t` on `target_env = "gnu"`, `c_int` everywhere else (musl, macOS, BSD) — so the signature lines up with what `libc` exposes on each target.

Verified with `cargo check --target x86_64-unknown-linux-gnu -p openwave-sandbox-agent` (the exact failing config — clean now) and macOS host clippy. The macOS dev host structurally cannot catch this class of `cfg(linux)`-gated libc mismatch.