### PR TITLE
test(server): checkpoint SQLite template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6949,6 +6949,7 @@ dependencies = [
  "plist",
  "reqwest 0.12.28",
  "schemars 1.2.2",
+ "sea-orm",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -98,6 +98,7 @@ winreg = "=0.55.0"
 # so the sandbox-resident driver tests can drive the actual sandbox side over a
 # loopback socket, with only Docker and the host model mocked.
 openwave-sandbox-agent = { path = "../openwave-sandbox-agent" }
+sea-orm = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
 tower = { version = "=0.5.3", features = ["util"] }
 reqwest = { workspace = true }

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -31,6 +31,7 @@ use openwave_web_search::{
     WebSearchResolverError, WebSearchResponse, WebSearchResult, WebSearchTool,
 };
 use resolver::ProviderResolver;
+use sea_orm::ConnectionTrait;
 use serde::de::DeserializeOwned;
 use tokio::sync::Notify;
 use tower::ServiceExt;
@@ -69,6 +70,13 @@ async fn migrated_sqlite_template() -> &'static MigratedSqliteTemplate {
             let url = format!("sqlite://{}?mode=rwc", database.display());
             let store = DbStore::connect(&url).await.unwrap();
             drop(store);
+
+            let checkpoint = sea_orm::Database::connect(&url).await.unwrap();
+            checkpoint
+                .execute_unprepared("PRAGMA wal_checkpoint(TRUNCATE);")
+                .await
+                .unwrap();
+            checkpoint.close().await.unwrap();
 
             MigratedSqliteTemplate {
                 _directory: directory,


### PR DESCRIPTION
Closes #997

## Summary
- add SeaORM as an exact, already-resolved server dev dependency
- explicitly checkpoint and truncate the migrated SQLite template WAL
- close the checkpoint connection before the template file becomes copyable

## Why
Dropping the original pool did not synchronously guarantee that WAL contents had reached the main database file. Isolated-process scheduling reproduced a copied database opening with SQLite code 11 (`database disk image is malformed`).

## Verification
- the formerly failing server test passed in 20 fresh test processes
- full lean server libtest suite: 469 passed, 1 ignored in 25.31s at four workers
- `cargo check --offline -p openwave-server --tests`
- `cargo metadata --locked`; lockfile adds only the existing SeaORM package to openwave-server’s dependency list, with no version changes