### PR TITLE
ci: identify PR cache cleanup repository

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -18,10 +18,16 @@ jobs:
   cleanup:
     name: delete closed PR caches
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # sccache stores compiler objects as many small Actions cache entries. The
+    # CLI deletes them individually, so a compile-heavy PR can take a few
+    # minutes to drain even though this runs only once, after the PR closes.
+    timeout-minutes: 10
     steps:
       - name: Delete the PR merge-ref cache scope
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh cache delete --all --ref "refs/pull/${PR_NUMBER}/merge"
+        run: >-
+          gh cache delete --repo "$GITHUB_REPOSITORY"
+          --all --succeed-on-no-caches
+          --ref "refs/pull/${PR_NUMBER}/merge"

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -193,7 +193,7 @@ test("PR compiler caches are writable, isolated, and deleted on close", () => {
   assert.match(cleanup, /^permissions:\n  actions: write\n  contents: read$/m);
   assert.match(
     cleanup,
-    /gh cache delete --all --ref "refs\/pull\/\$\{PR_NUMBER\}\/merge"/,
+    /gh cache delete --repo "\$GITHUB_REPOSITORY"\n\s+--all --succeed-on-no-caches\n\s+--ref "refs\/pull\/\$\{PR_NUMBER\}\/merge"/,
   );
   assert.doesNotMatch(cleanup, /actions\/checkout|secrets\./);
 });


### PR DESCRIPTION
Closes #1000

## Summary
- pass the repository explicitly to `gh cache delete` because the trusted cleanup job has no checkout
- treat an empty PR cache scope as a successful cleanup
- allow ten minutes for sccache’s many small entries to drain
- pin both command-line safeguards in workflow policy tests

## Live verification
Ran the corrected command against the four just-closed optimization PR refs. It removed 319 cache entries from #989 and the remaining refs completed successfully, including empty scopes. The largest cleanup took about four minutes, which informed the ten-minute bound.

## Verification
- `node --test scripts/workflow-security.test.mjs`
- `actionlint .github/workflows/cache-cleanup.yml`
- live cleanup of `refs/pull/{989,990,994,998}/merge`