### PR TITLE
ci: keep parser contracts lightweight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,9 +370,10 @@ jobs:
             liteparse_image_parser::tests
           cargo test -p openwave-retrieval --features "$parser_features" --locked \
             spreadsheet_parser::tests
-          cargo test -p openwave-server --features document-parsers --locked --lib \
-            tests::documents::raw_ingest_parses_and_indexes_a_pdf_end_to_end \
-            -- --exact
+          cargo test -p openwave-retrieval --features "$parser_features" --locked \
+            production_registry_routes_rich_formats_to_the_intended_parser
+          cargo test -p openwave-retrieval --features "$parser_features" --locked \
+            --test liteparse_pdf
       - name: desktop tests
         run: cargo test -p openwave-desktop --locked
 

--- a/crates/openwave-retrieval/src/lib.rs
+++ b/crates/openwave-retrieval/src/lib.rs
@@ -116,8 +116,8 @@ pub use liteparse_parser::LiteParsePdfParser;
 pub use openai_embed::OpenAiEmbedder;
 pub use openwave_core::{DocumentGeneration, ProjectId};
 pub use parse::{
-    DocumentParser, FallbackParser, ParsedDocument, ParserRegistry, PlainTextParser,
-    StructuredTextParser,
+    document_parser_registry, DocumentParser, FallbackParser, ParsedDocument, ParserRegistry,
+    PlainTextParser, StructuredTextParser,
 };
 pub use rerank::Reranker;
 pub use retriever::{GenerationIndexOutcome, IngestOutcome, Retriever};

--- a/crates/openwave-retrieval/src/parse.rs
+++ b/crates/openwave-retrieval/src/parse.rs
@@ -51,6 +51,43 @@ impl ParserRegistry {
     }
 }
 
+/// Assemble the production document parsers, narrowest first. With the
+/// `parse-liteparse` feature, the PDF parser claims `application/pdf`; with
+/// `parse-spreadsheet`, the spreadsheet parser claims Excel and OpenDocument
+/// workbooks, reading their sheets and cells directly; with `parse-office`, the
+/// Office parser claims the remaining Word/PowerPoint/OpenDocument types
+/// (converting via LibreOffice when present, storing without searchable text
+/// when not); with `parse-image`, the image parser claims common raster types
+/// (PNG/JPEG/WebP/GIF/TIFF/BMP), stored without searchable text until OCR lands;
+/// the [`StructuredTextParser`] claims the tree-shaped text types (JSON, XML,
+/// HTML), whose text it passes through unchanged while recording which node
+/// each part came from; [`PlainTextParser`] claims the rest of `text/*`; the
+/// [`FallbackParser`] claims everything else so **any** upload is accepted —
+/// text-like unknown types stay searchable and binary ones are stored without
+/// polluting the index.
+///
+/// Order carries meaning between the two workbook paths: the Office parser
+/// still claims spreadsheets, and only registering the native one ahead of it
+/// keeps a workbook off the LibreOffice detour. That leaves the fallback
+/// intact — build without `parse-spreadsheet` and workbooks convert exactly as
+/// they did.
+#[must_use]
+pub fn document_parser_registry() -> ParserRegistry {
+    let registry = ParserRegistry::new();
+    #[cfg(feature = "parse-liteparse")]
+    let registry = registry.with_parser(crate::LiteParsePdfParser::new());
+    #[cfg(feature = "parse-spreadsheet")]
+    let registry = registry.with_parser(crate::SpreadsheetParser::new());
+    #[cfg(feature = "parse-office")]
+    let registry = registry.with_parser(crate::LiteParseOfficeParser::new());
+    #[cfg(feature = "parse-image")]
+    let registry = registry.with_parser(crate::LiteParseImageParser::new());
+    registry
+        .with_parser(StructuredTextParser::new())
+        .with_parser(PlainTextParser::new())
+        .with_parser(FallbackParser::new())
+}
+
 #[async_trait::async_trait]
 impl DocumentParser for ParserRegistry {
     fn fingerprint_for(&self, media_type: &str) -> Option<String> {
@@ -279,6 +316,58 @@ impl DocumentParser for FallbackParser {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(all(
+        feature = "parse-liteparse",
+        feature = "parse-office",
+        feature = "parse-image",
+        feature = "parse-spreadsheet"
+    ))]
+    #[test]
+    fn production_registry_routes_rich_formats_to_the_intended_parser() {
+        let registry = document_parser_registry();
+        let cases: [(&str, &dyn DocumentParser, &str); 7] = [
+            (
+                "application/pdf",
+                &crate::LiteParsePdfParser::new(),
+                "PDF parser",
+            ),
+            (
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                &crate::SpreadsheetParser::new(),
+                "native spreadsheet parser",
+            ),
+            (
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                &crate::LiteParseOfficeParser::new(),
+                "Office parser",
+            ),
+            (
+                "image/png",
+                &crate::LiteParseImageParser::new(),
+                "image parser",
+            ),
+            (
+                "application/json",
+                &StructuredTextParser::new(),
+                "structured-text parser",
+            ),
+            ("text/plain", &PlainTextParser::new(), "plain-text parser"),
+            (
+                "application/octet-stream",
+                &FallbackParser::new(),
+                "fallback parser",
+            ),
+        ];
+
+        for (media_type, expected_parser, parser_name) in cases {
+            assert_eq!(
+                registry.fingerprint_for(media_type),
+                expected_parser.fingerprint_for(media_type),
+                "{parser_name} should handle {media_type}"
+            );
+        }
+    }
 
     struct PrefixParser {
         media_type: &'static str,

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -85,9 +85,10 @@ use openwave_core::{
 };
 #[cfg(feature = "vec-lance")]
 use openwave_retrieval::LanceVectorStore;
+#[cfg(test)]
+use openwave_retrieval::PlainTextParser;
 use openwave_retrieval::{
-    Embedder, FallbackParser, HashEmbedder, OpenAiEmbedder, ParserRegistry, PlainTextParser,
-    Retriever, SearchTool, TextChunker, VectorStore,
+    Embedder, HashEmbedder, OpenAiEmbedder, Retriever, SearchTool, TextChunker, VectorStore,
 };
 
 use resolver::KeyedResolver;
@@ -1008,48 +1009,13 @@ fn build_retrieval(
     store: Arc<dyn VectorStore>,
 ) -> (Arc<Retriever>, Box<SearchTool>) {
     let retrieval = Arc::new(Retriever::new(
-        Box::new(document_parser_registry()),
+        Box::new(openwave_retrieval::document_parser_registry()),
         Box::new(TextChunker::default()),
         embedder.clone(),
         store.clone(),
     ));
     let search = Box::new(SearchTool::new(embedder, store));
     (retrieval, search)
-}
-
-/// Assemble the document parsers, narrowest first. With the `parse-liteparse`
-/// feature, the PDF parser claims `application/pdf`; with `parse-spreadsheet`,
-/// the spreadsheet parser claims Excel and OpenDocument workbooks, reading their
-/// sheets and cells directly; with `parse-office`, the Office parser claims the
-/// remaining Word/PowerPoint/OpenDocument types (converting via LibreOffice when
-/// present, storing without searchable text when not); with `parse-image`, the
-/// image parser claims common raster types (PNG/JPEG/WebP/GIF/TIFF/BMP), stored
-/// without searchable text until OCR lands; the `StructuredTextParser` claims
-/// the tree-shaped text types (JSON, XML, HTML), whose text it passes through
-/// unchanged while recording which node each part of it came from;
-/// `PlainTextParser` claims the rest of `text/*`; the `FallbackParser` claims
-/// everything else so **any** upload is accepted — text-like unknown types stay
-/// searchable and binary ones are stored without polluting the index.
-///
-/// Order carries meaning between the two workbook paths: the Office parser
-/// still claims spreadsheets, and only registering the native one ahead of it
-/// keeps a workbook off the LibreOffice detour. That leaves the fallback
-/// intact — build without `parse-spreadsheet` and workbooks convert exactly as
-/// they did.
-fn document_parser_registry() -> ParserRegistry {
-    let registry = ParserRegistry::new();
-    #[cfg(feature = "parse-liteparse")]
-    let registry = registry.with_parser(openwave_retrieval::LiteParsePdfParser::new());
-    #[cfg(feature = "parse-spreadsheet")]
-    let registry = registry.with_parser(openwave_retrieval::SpreadsheetParser::new());
-    #[cfg(feature = "parse-office")]
-    let registry = registry.with_parser(openwave_retrieval::LiteParseOfficeParser::new());
-    #[cfg(feature = "parse-image")]
-    let registry = registry.with_parser(openwave_retrieval::LiteParseImageParser::new());
-    registry
-        .with_parser(openwave_retrieval::StructuredTextParser::new())
-        .with_parser(PlainTextParser::new())
-        .with_parser(FallbackParser::new())
 }
 
 /// Open the persistent vector store for this launch: a LanceDB dataset under

--- a/crates/openwave-server/src/tests/documents.rs
+++ b/crates/openwave-server/src/tests/documents.rs
@@ -583,43 +583,6 @@ async fn streamed_raw_ingest_accepts_large_chunked_sources_and_deduplicates_by_c
     );
 }
 
-/// End-to-end proof that a PDF ingested through the raw route parses (via the
-/// liteparse parser registered in the real pipeline) and indexes to `Ready`,
-/// with the extracted text as canonical text. Only runs with the parser feature.
-#[cfg(feature = "parse-liteparse")]
-#[tokio::test]
-async fn raw_ingest_parses_and_indexes_a_pdf_end_to_end() {
-    let (router, token, store, _dir, worker) = test_app_with_worker().await;
-    let bearer = format!("Bearer {token}");
-    let pdf = include_bytes!("../fixtures/minimal.pdf").to_vec();
-
-    let response = post_raw(
-        &router,
-        &bearer,
-        "/documents/raw?uri=file%3A%2F%2F%2Freport.pdf",
-        Some("application/pdf"),
-        pdf,
-    )
-    .await;
-    assert_eq!(response.status(), StatusCode::ACCEPTED);
-    let accepted: serde_json::Value = json_body(response).await;
-    let document_id: openwave_core::DocumentId =
-        accepted["document_id"].as_str().unwrap().parse().unwrap();
-
-    run_parse_and_index(&worker).await;
-
-    let ready = store.get_document(document_id).await.unwrap().unwrap();
-    assert_eq!(
-        ready.processing_status,
-        openwave_core::DocumentProcessingStatus::Ready
-    );
-    assert!(
-        ready.canonical_text.contains("liteparse ingest report"),
-        "expected the PDF's extracted text as canonical text, got: {:?}",
-        ready.canonical_text
-    );
-}
-
 #[tokio::test]
 async fn raw_ingest_enforces_media_type_body_and_project_scope() {
     let (router, token, store, _dir) = test_app().await;

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -157,8 +157,10 @@ test("Rust CI requires the same PostgreSQL lane on pull requests and main", () =
   assert.match(desktop, /spreadsheet_parser::tests/);
   assert.match(
     desktop,
-    /tests::documents::raw_ingest_parses_and_indexes_a_pdf_end_to_end \\\n\s+-- --exact/,
+    /production_registry_routes_rich_formats_to_the_intended_parser/,
   );
+  assert.match(desktop, /--test liteparse_pdf/);
+  assert.doesNotMatch(desktop, /cargo test -p openwave-server/);
 });
 
 test("UI tests and production build run as parallel matrix jobs", () => {


### PR DESCRIPTION
Closes #1002

Moves the production parser registry into `openwave-retrieval`, where its feature wiring and precedence can be exercised without linking the full server unit-test harness. The desktop lane keeps the real PDF fixture tests and now runs the registry contract in the retrieval harness.

Test removed:
- Removed the server raw-route × real-PDF cross-product test. Generic server raw-ingest and worker tests already cover the route-to-index pipeline, while the retrieval registry contract plus the real-PDF integration suite cover production parser selection and extraction. Keeping the cross-product forced CI to compile hundreds of unrelated rich-feature server tests for one duplicate assertion.

Validation:
- `cargo fmt --all -- --check`
- `node --test scripts/workflow-security.test.mjs`
- `actionlint .github/workflows/ci.yml .github/workflows/cache-cleanup.yml`
- production registry contract with all parser features
- full `liteparse_pdf` integration target (4 passed)
- `cargo check -p openwave-server --features document-parsers --locked`