### PR TITLE
test(desktop): skip empty Cargo targets

### DIFF
--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -20,10 +20,16 @@ vec-lance = ["openwave-server/vec-lance"]
 [lib]
 name = "openwave_desktop_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
+# This crate has no executable documentation examples. Its behavior contracts
+# live in the library test suite.
+doctest = false
 
 [[bin]]
 name = "openwave-desktop"
 path = "src/main.rs"
+# The binary is only a four-line launcher into the tested library. The
+# all-targets clippy lane still compiles it on every Rust change.
+test = false
 
 [build-dependencies]
 tauri-build = { version = "=2.6.3", features = [] }


### PR DESCRIPTION
Closes #1004

Stops Cargo from building test harnesses for two targets that contain no tests: the four-line desktop launcher and the library doctest target (there are no executable documentation examples). The package-wide command remains unchanged, so future integration tests under `tests/` will still run. The all-targets clippy lane continues to compile the binary.

All 88 desktop behavior tests are retained.

Validation:
- `cargo test -p openwave-desktop --locked` (88 passed; only the library target launched)
- `cargo metadata --locked --no-deps --format-version 1`
- clean lockfile and diff checks