### PR TITLE
ci: parallelize lean desktop and parser tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
     name: change scope
     runs-on: ubuntu-latest
     outputs:
+      parsers: ${{ steps.scope.outputs.parsers }}
       rust: ${{ steps.scope.outputs.rust }}
       sandbox_container: ${{ steps.scope.outputs.sandbox_container }}
       ui: ${{ steps.scope.outputs.ui }}
@@ -116,6 +117,7 @@ jobs:
           full_validation() {
             {
               echo "rust=true"
+              echo "parsers=true"
               echo "sandbox_container=true"
               echo "ui=true"
               echo "vectors=true"
@@ -157,6 +159,7 @@ jobs:
           # change cannot reach them. `workspace` implies `rust`; the gate below
           # asserts that.
           rust=false
+          parsers=false
           sandbox_container=false
           ui=false
           vectors=false
@@ -168,6 +171,7 @@ jobs:
               *.md|docs/*|assets/*|LICENSE|NOTICE) ;;
               .github/workflows/ci.yml)
                 rust=true
+                parsers=true
                 sandbox_container=true
                 ui=true
                 vectors=true
@@ -177,6 +181,7 @@ jobs:
               # behavior for either heavyweight capability.
               .cargo/*|Cargo.lock|Cargo.toml|rust-toolchain.toml)
                 rust=true
+                parsers=true
                 sandbox_container=true
                 vectors=true
                 workspace=true
@@ -193,12 +198,14 @@ jobs:
               # change how the rest of the workspace builds. Its sources cannot.
               crates/openwave-desktop/Cargo.toml)
                 rust=true
+                parsers=true
                 vectors=true
                 workspace=true
                 ;;
               # The CLI forwards the release-only durable-store feature.
               crates/openwave-cli/Cargo.toml)
                 rust=true
+                parsers=true
                 vectors=true
                 workspace=true
                 ;;
@@ -206,17 +213,20 @@ jobs:
               # only surfaces the durable-store lane adds over headless tests.
               crates/openwave-retrieval/*)
                 rust=true
+                parsers=true
                 vectors=true
                 workspace=true
                 ;;
               crates/openwave-server/Cargo.toml)
                 rust=true
+                parsers=true
                 sandbox_container=true
                 vectors=true
                 workspace=true
                 ;;
               crates/openwave-server/build.rs|crates/openwave-server/src/lib.rs|crates/openwave-server/src/tests/documents.rs)
                 rust=true
+                parsers=true
                 vectors=true
                 workspace=true
                 ;;
@@ -234,8 +244,30 @@ jobs:
               *) rust=true; workspace=true ;;
             esac
           done < "$RUNNER_TEMP/changed-files"
+
+          # Keep narrower scopes honest here, before conditional jobs consume
+          # them. Required skipped jobs report success, so an impossible scope
+          # combination must fail the always-running detector itself.
+          if [[ "$workspace" == true && "$rust" != true ]]; then
+            echo "workspace scope without Rust scope; the detector is wrong." >&2
+            exit 1
+          fi
+          if [[ "$parsers" == true && "$workspace" != true ]]; then
+            echo "parser scope without workspace scope; the detector is wrong." >&2
+            exit 1
+          fi
+          if [[ "$vectors" == true && "$workspace" != true ]]; then
+            echo "vector scope without workspace scope; the detector is wrong." >&2
+            exit 1
+          fi
+          if [[ "$sandbox_container" == true && "$workspace" != true ]]; then
+            echo "sandbox-container scope without workspace scope; the detector is wrong." >&2
+            exit 1
+          fi
+
           {
             echo "rust=$rust"
+            echo "parsers=$parsers"
             echo "sandbox_container=$sandbox_container"
             echo "ui=$ui"
             echo "vectors=$vectors"
@@ -320,6 +352,56 @@ jobs:
       - name: clippy
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
 
+  parsers:
+    name: rich document parser contracts
+    needs: changes
+    if: ${{ needs.changes.outputs.parsers == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_PROFILE_DEV_DEBUG: 0
+      CARGO_PROFILE_TEST_DEBUG: 0
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: READ_WRITE
+      RUSTC_WRAPPER: sccache
+      RUSTFLAGS: -C link-arg=-fuse-ld=mold
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install toolchain (honors rust-toolchain.toml)
+        run: rustup show
+      - name: Set up compiler cache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        with:
+          version: v0.16.0
+      - name: Install headless system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends mold
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: cargo-registry-v3-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          cache-targets: false
+          save-if: false
+      - name: Exercise rich parser contracts
+        run: |
+          parser_features="parse-liteparse,parse-office,parse-image,parse-spreadsheet"
+          cargo test -p openwave-retrieval --features "$parser_features" --locked \
+            liteparse_parser::tests
+          cargo test -p openwave-retrieval --features "$parser_features" --locked \
+            liteparse_office_parser::tests
+          cargo test -p openwave-retrieval --features "$parser_features" --locked \
+            liteparse_image_parser::tests
+          cargo test -p openwave-retrieval --features "$parser_features" --locked \
+            spreadsheet_parser::tests
+          cargo test -p openwave-retrieval --features "$parser_features" --locked \
+            production_registry_routes_rich_formats_to_the_intended_parser
+          cargo test -p openwave-retrieval --features "$parser_features" --locked \
+            --test liteparse_pdf
+
   desktop:
     name: desktop test
     needs: changes
@@ -359,23 +441,8 @@ jobs:
           cache-bin: false
           cache-targets: false
           save-if: false
-      - name: rich document parser contracts
-        run: |
-          parser_features="parse-liteparse,parse-office,parse-image,parse-spreadsheet"
-          cargo test -p openwave-retrieval --features "$parser_features" --locked \
-            liteparse_parser::tests
-          cargo test -p openwave-retrieval --features "$parser_features" --locked \
-            liteparse_office_parser::tests
-          cargo test -p openwave-retrieval --features "$parser_features" --locked \
-            liteparse_image_parser::tests
-          cargo test -p openwave-retrieval --features "$parser_features" --locked \
-            spreadsheet_parser::tests
-          cargo test -p openwave-retrieval --features "$parser_features" --locked \
-            production_registry_routes_rich_formats_to_the_intended_parser
-          cargo test -p openwave-retrieval --features "$parser_features" --locked \
-            --test liteparse_pdf
       - name: desktop tests
-        run: cargo test -p openwave-desktop --locked
+        run: cargo test -p openwave-desktop --no-default-features --locked
 
   test:
     name: test
@@ -594,16 +661,12 @@ jobs:
           sandbox_container_run::tests::docker_end_to_end_drives_a_real_container
           -- --ignored --exact --nocapture
 
-  ui:
-    name: desktop UI · ${{ matrix.task }}
+  ui-test:
+    name: desktop UI · test
     needs: changes
     if: ${{ needs.changes.outputs.ui == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        task: [test, build]
     defaults:
       run:
         working-directory: crates/openwave-desktop/ui
@@ -619,144 +682,29 @@ jobs:
           cache-dependency-path: crates/openwave-desktop/ui/pnpm-lock.yaml
       - name: Install UI dependencies
         run: pnpm install --frozen-lockfile
-      - name: Run UI ${{ matrix.task }}
-        run: pnpm ${{ matrix.task }}
+      - name: Run UI tests
+        run: pnpm test
 
-  rust:
-    # Keep this historical name stable because branch protection requires it.
-    # PostgreSQL is part of this gate even though the old display name omits it.
-    name: fmt · clippy · build · test
-    if: ${{ always() }}
-    needs:
-      [
-        pr-title,
-        release-policy,
-        changes,
-        fmt,
-        lint,
-        desktop,
-        test,
-        vectors,
-        postgres,
-        sandbox-container,
-        ui,
-      ]
+  ui-build:
+    name: desktop UI · build
+    needs: changes
+    if: ${{ needs.changes.outputs.ui == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: crates/openwave-desktop/ui
     steps:
-      - name: Require every Rust lane
-        env:
-          FMT_RESULT: ${{ needs.fmt.result }}
-          LINT_RESULT: ${{ needs.lint.result }}
-          DESKTOP_RESULT: ${{ needs.desktop.result }}
-          TEST_RESULT: ${{ needs.test.result }}
-          VECTORS_RESULT: ${{ needs.vectors.result }}
-          POSTGRES_RESULT: ${{ needs.postgres.result }}
-          SANDBOX_CONTAINER_RESULT: ${{ needs.sandbox-container.result }}
-          UI_RESULT: ${{ needs.ui.result }}
-          PR_TITLE_RESULT: ${{ needs.pr-title.result }}
-          RELEASE_POLICY_RESULT: ${{ needs.release-policy.result }}
-          CHANGES_RESULT: ${{ needs.changes.result }}
-          RUST_CHANGED: ${{ needs.changes.outputs.rust }}
-          UI_CHANGED: ${{ needs.changes.outputs.ui }}
-          VECTORS_CHANGED: ${{ needs.changes.outputs.vectors }}
-          WORKSPACE_CHANGED: ${{ needs.changes.outputs.workspace }}
-          SANDBOX_CONTAINER_CHANGED: ${{ needs.changes.outputs.sandbox_container }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          test "$CHANGES_RESULT" = success
-          test "$RELEASE_POLICY_RESULT" = success
-          case "$EVENT_NAME" in
-            pull_request) test "$PR_TITLE_RESULT" = success ;;
-            *) test "$PR_TITLE_RESULT" = skipped ;;
-          esac
-
-          case "$UI_CHANGED" in
-            true) test "$UI_RESULT" = success ;;
-            false) test "$UI_RESULT" = skipped ;;
-            *)
-              echo "invalid UI change detector output: $UI_CHANGED" >&2
-              exit 1
-              ;;
-          esac
-
-          case "$RUST_CHANGED" in
-            true)
-              test "$FMT_RESULT" = success
-              test "$LINT_RESULT" = success
-              test "$DESKTOP_RESULT" = success
-              ;;
-            false)
-              test "$FMT_RESULT" = skipped
-              test "$LINT_RESULT" = skipped
-              test "$DESKTOP_RESULT" = skipped
-              ;;
-            *)
-              echo "invalid Rust change detector output: $RUST_CHANGED" >&2
-              exit 1
-              ;;
-          esac
-
-          # A workspace-scoped change is always Rust-scoped. If the detector ever
-          # reports otherwise it has a hole, and the lanes below would be checked
-          # against a scope the ones above never ran for.
-          if test "$WORKSPACE_CHANGED" = true && test "$RUST_CHANGED" != true; then
-            echo "workspace scope without Rust scope; the detector is wrong." >&2
-            exit 1
-          fi
-          if test "$VECTORS_CHANGED" = true && test "$WORKSPACE_CHANGED" != true; then
-            echo "vector scope without workspace scope; the detector is wrong." >&2
-            exit 1
-          fi
-          if test "$SANDBOX_CONTAINER_CHANGED" = true && test "$WORKSPACE_CHANGED" != true; then
-            echo "sandbox-container scope without workspace scope; the detector is wrong." >&2
-            exit 1
-          fi
-
-          # The lanes that cover the workspace minus openwave-desktop. A change
-          # confined to that crate's own sources cannot affect them.
-          case "$WORKSPACE_CHANGED" in
-            true)
-              test "$TEST_RESULT" = success
-              test "$POSTGRES_RESULT" = success
-              ;;
-            false)
-              test "$TEST_RESULT" = skipped
-              test "$POSTGRES_RESULT" = skipped
-              ;;
-            *)
-              echo "invalid workspace change detector output: $WORKSPACE_CHANGED" >&2
-              exit 1
-              ;;
-          esac
-
-          # The durable vector store is deliberately not a pull-request gate
-          # (see the job's own comment and #760). Assert the exemption and the
-          # post-merge scope rather than dropping the lane from the aggregate.
-          if test "$EVENT_NAME" = pull_request; then
-            test "$VECTORS_RESULT" = skipped
-          else
-            case "$VECTORS_CHANGED" in
-              true) test "$VECTORS_RESULT" = success ;;
-              false) test "$VECTORS_RESULT" = skipped ;;
-              *)
-                echo "invalid vector change detector output: $VECTORS_CHANGED" >&2
-                exit 1
-                ;;
-            esac
-          fi
-
-          # The sandbox-resident container e2e is post-merge only for the same
-          # reason (see the job's own comment): it builds the agent image. Assert
-          # the exemption and the post-merge scope here too.
-          if test "$EVENT_NAME" = pull_request; then
-            test "$SANDBOX_CONTAINER_RESULT" = skipped
-          else
-            case "$SANDBOX_CONTAINER_CHANGED" in
-              true) test "$SANDBOX_CONTAINER_RESULT" = success ;;
-              false) test "$SANDBOX_CONTAINER_RESULT" = skipped ;;
-              *)
-                echo "invalid sandbox-container change detector output: $SANDBOX_CONTAINER_CHANGED" >&2
-                exit 1
-                ;;
-            esac
-          fi
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          version: 10
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: crates/openwave-desktop/ui/pnpm-lock.yaml
+      - name: Install UI dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build production UI
+        run: pnpm build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,23 +115,29 @@ is the whole rule, and it is coarse on purpose:
 - Any changed file outside `*.md`, `docs/`, `assets/`, `LICENSE`, `NOTICE`, and
   `crates/openwave-desktop/ui/` marks the change **Rust** — including
   `Cargo.toml` and `Cargo.lock`. That runs rustfmt, clippy (`--all-targets
-  -D warnings`), the rich document-parser contracts, and the desktop tests.
-  Every cargo invocation passes `--locked`, so a lockfile drift fails there too.
+  -D warnings`), and the desktop tests. Every cargo invocation passes `--locked`,
+  so a lockfile drift fails there too.
 - A Rust change also marks the **workspace** scope, which adds the headless
   workspace tests with the server's rich parser adapters disabled, plus the
   PostgreSQL turn-state lane, unless every changed file is one of
-  `openwave-desktop`'s own sources. Parser-specific tests run in the already-rich
-  desktop lane instead of linking PDF/Office/image/spreadsheet support into every
-  headless test binary. Nothing in the workspace depends on the desktop crate and
-  the headless lane already excludes it, so those lanes cannot see such a change.
+  `openwave-desktop`'s own sources. Nothing in the workspace depends on the
+  desktop crate and the headless lane already excludes it, so those lanes cannot
+  see such a change.
   Its `Cargo.toml` is not covered by the carve-out — it forwards features into
   `openwave-server` — and neither is
   `ui/src/generated/`, whose staleness check lives in `openwave-server`.
+- Parser, feature-wiring, dependency, and CI changes also mark the **parser**
+  scope. Its focused PDF/Office/image/spreadsheet contracts run in a headless
+  job parallel to the desktop behavior suite. Normal desktop builds keep those
+  parsers enabled by default; the desktop test harness disables them because the
+  focused lane already covers their behavior and clippy compile-checks the rich
+  production topology.
 - Any file under `crates/openwave-desktop/ui/` marks it **UI**, which runs
-  `pnpm test` and `pnpm build` as parallel matrix jobs.
-- The aggregate `fmt · clippy · build · test` check asserts each lane either
-  succeeded or was legitimately skipped, and branch protection requires it. A
-  lane is skipped only when the change could not have affected it.
+  `pnpm test` and `pnpm build` as two fixed parallel jobs.
+- Branch protection requires the pull-request gate jobs directly. Conditional
+  jobs report a successful skip when their scope is false; the always-running
+  change detector rejects impossible narrower-scope combinations before those
+  jobs consume them. There is no serial aggregate wrapper after the slowest job.
 - The two heavyweight capability lanes are scoped separately on merges to
   `main`. `durable vector store` runs when retrieval, its server/CLI/desktop
   feature wiring, or dependency/toolchain inputs change. `sandbox-resident
@@ -153,9 +159,9 @@ wasted time. Run a cheap subset for fast feedback on what you actually touched �
 
 **The real trap is a PR that got no CI at all.** A conflicting PR runs nothing
 but the trivial policy checks, so "no checks failed" reads green while nothing
-was verified. Judge by whether the required aggregate check ran and passed, not
-by the absence of red. `gh pr checks <n>` shows the truth; rebase a conflicting
-PR before believing anything about it.
+was verified. Judge by whether every applicable required job is present and
+passed, not by the absence of red. `gh pr checks <n>` shows the truth; rebase a
+conflicting PR before believing anything about it.
 
 Enable auto-merge (`gh pr merge <n> --squash --auto --delete-branch`) so a PR
 lands the moment its lanes go green instead of waiting for you to come back.

--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -11,6 +11,11 @@ authors.workspace = true
 workspace = true
 
 [features]
+# Keep ordinary desktop builds feature-complete while allowing the behavior
+# suite to exercise the shell without compiling parser adapters that have their
+# own focused contracts.
+default = ["document-parsers"]
+document-parsers = ["openwave-server/document-parsers"]
 # Forwards the server's durable, on-disk vector store. Off by default so a dev
 # build and the workspace tests skip the LanceDB dependency tree; every shipped
 # bundle enables it (`cargo tauri build --features vec-lance`), and
@@ -44,7 +49,7 @@ futures.workspace = true
 infer = { version = "=0.22.0", default-features = false }
 openwave-core = { path = "../openwave-core", default-features = false }
 openwave-host-broker = { path = "../openwave-host-broker" }
-openwave-server = { path = "../openwave-server" }
+openwave-server = { path = "../openwave-server", default-features = false }
 reqwest = { workspace = true }
 sha2 = { workspace = true }
 tauri = { version = "=2.11.5", features = [] }

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -98,9 +98,10 @@ test("workflow container images are pinned by digest", () => {
 
 test("Rust CI requires the same PostgreSQL lane on pull requests and main", () => {
   const ci = workflows["ci.yml"];
+  const changes = workflowJob(ci, "changes");
   const postgres = workflowJob(ci, "postgres");
+  const parsers = workflowJob(ci, "parsers");
   const testJob = workflowJob(ci, "test");
-  const aggregate = workflowJob(ci, "rust");
 
   assert.match(
     ci,
@@ -112,23 +113,18 @@ test("Rust CI requires the same PostgreSQL lane on pull requests and main", () =
   assert.match(postgres, /if:.*needs\.changes\.outputs\.workspace == 'true'/);
   assert.doesNotMatch(postgres, /github\.event_name != 'pull_request'/);
   assert.match(postgres, /OPENWAVE_REQUIRE_POSTGRES_TEST: "true"/);
-  assert.match(aggregate, /^\s+postgres,$/m);
-  assert.match(aggregate, /test "\$POSTGRES_RESULT" = success/);
   // The narrower `workspace` scope must imply the `rust` one. Without this the
-  // crate-coverage lanes could be gated on a scope that never ran for them, and
-  // the aggregate would check their results against the wrong bit.
+  // crate-coverage lanes could be gated on a scope that never ran for them.
   assert.match(
-    aggregate,
-    /if test "\$WORKSPACE_CHANGED" = true && test "\$RUST_CHANGED" != true; then/,
+    changes,
+    /if \[\[ "\$workspace" == true && "\$rust" != true \]\]; then/,
   );
-  assert.match(
-    aggregate,
-    /pull_request\) test "\$PR_TITLE_RESULT" = success ;;/,
-  );
-  assert.match(aggregate, /\*\) test "\$PR_TITLE_RESULT" = skipped ;;/);
+  assert.doesNotMatch(ci, /^  rust:$/m);
+  assert.doesNotMatch(ci, /name: fmt · clippy · build · test/);
 
   for (const job of [
     workflowJob(ci, "lint"),
+    parsers,
     workflowJob(ci, "desktop"),
     testJob,
     postgres,
@@ -146,39 +142,74 @@ test("Rust CI requires the same PostgreSQL lane on pull requests and main", () =
     testJob,
     /cargo test --workspace --exclude openwave-desktop\n\s+--no-default-features\n\s+--features\n\s+openwave-core\/default,openwave-retrieval\/default,openwave-router\/default\n\s+--locked/,
   );
+  assert.match(
+    parsers,
+    /if:.*needs\.changes\.outputs\.parsers == 'true'/,
+  );
+  assert.match(ci, /parsers: \$\{\{ steps\.scope\.outputs\.parsers \}\}/);
+  assert.match(ci, /echo "parsers=\$parsers"/);
+  assert.match(
+    parsers,
+    /parser_features="parse-liteparse,parse-office,parse-image,parse-spreadsheet"/,
+  );
+  assert.match(parsers, /liteparse_parser::tests/);
+  assert.match(parsers, /liteparse_office_parser::tests/);
+  assert.match(parsers, /liteparse_image_parser::tests/);
+  assert.match(parsers, /spreadsheet_parser::tests/);
+  assert.match(
+    parsers,
+    /production_registry_routes_rich_formats_to_the_intended_parser/,
+  );
+  assert.match(parsers, /--test liteparse_pdf/);
+  assert.doesNotMatch(parsers, /cargo test -p openwave-server/);
+  assert.doesNotMatch(parsers, /Install system deps \(Tauri\)/);
+
   const desktop = workflowJob(ci, "desktop");
   assert.match(
     desktop,
-    /parser_features="parse-liteparse,parse-office,parse-image,parse-spreadsheet"/,
+    /cargo test -p openwave-desktop --no-default-features --locked/,
   );
-  assert.match(desktop, /liteparse_parser::tests/);
-  assert.match(desktop, /liteparse_office_parser::tests/);
-  assert.match(desktop, /liteparse_image_parser::tests/);
-  assert.match(desktop, /spreadsheet_parser::tests/);
+  assert.match(desktopCargo, /default = \["document-parsers"\]/);
   assert.match(
-    desktop,
-    /production_registry_routes_rich_formats_to_the_intended_parser/,
+    desktopCargo,
+    /document-parsers = \["openwave-server\/document-parsers"\]/,
   );
-  assert.match(desktop, /--test liteparse_pdf/);
-  assert.doesNotMatch(desktop, /cargo test -p openwave-server/);
+  assert.match(
+    desktopCargo,
+    /openwave-server = \{ path = "\.\.\/openwave-server", default-features = false \}/,
+  );
+  assert.match(
+    changes,
+    /if \[\[ "\$parsers" == true && "\$workspace" != true \]\]; then/,
+  );
 });
 
-test("UI tests and production build run as parallel matrix jobs", () => {
+test("UI tests and production build run as fixed parallel jobs", () => {
   const ci = workflows["ci.yml"];
-  const ui = workflowJob(ci, "ui");
-  const aggregate = workflowJob(ci, "rust");
+  const uiTest = workflowJob(ci, "ui-test");
+  const uiBuild = workflowJob(ci, "ui-build");
 
-  assert.match(ui, /name: desktop UI · \$\{\{ matrix\.task \}\}/);
-  assert.match(ui, /strategy:\n\s+fail-fast: false\n\s+matrix:\n\s+task: \[test, build\]/);
-  assert.match(ui, /run: pnpm install --frozen-lockfile/);
-  assert.match(ui, /run: pnpm \$\{\{ matrix\.task \}\}/);
-  assert.match(aggregate, /UI_RESULT: \$\{\{ needs\.ui\.result \}\}/);
-  assert.match(aggregate, /true\) test "\$UI_RESULT" = success ;;/);
+  for (const job of [uiTest, uiBuild]) {
+    assert.match(job, /if:.*needs\.changes\.outputs\.ui == 'true'/);
+    assert.match(job, /run: pnpm install --frozen-lockfile/);
+  }
+  assert.match(uiTest, /name: desktop UI · test/);
+  assert.match(uiTest, /run: pnpm test/);
+  assert.match(uiBuild, /name: desktop UI · build/);
+  assert.match(uiBuild, /run: pnpm build/);
+  assert.doesNotMatch(ci, /matrix\.task/);
 });
 
 test("PR compiler caches are writable, isolated, and deleted on close", () => {
   const ci = workflows["ci.yml"];
-  for (const name of ["lint", "desktop", "test", "vectors", "postgres"]) {
+  for (const name of [
+    "lint",
+    "parsers",
+    "desktop",
+    "test",
+    "vectors",
+    "postgres",
+  ]) {
     assert.match(workflowJob(ci, name), /SCCACHE_GHA_RW_MODE: READ_WRITE/);
   }
   assert.doesNotMatch(
@@ -205,7 +236,6 @@ test("heavy capability lanes run only for relevant merges and scheduled backstop
   const changes = workflowJob(ci, "changes");
   const vectors = workflowJob(ci, "vectors");
   const sandboxContainer = workflowJob(ci, "sandbox-container");
-  const aggregate = workflowJob(ci, "rust");
 
   assert.match(ci, /^  schedule:\n    - cron: "17 6 \* \* 1"$/m);
   assert.match(changes, /schedule\|workflow_dispatch\)/);
@@ -239,15 +269,13 @@ test("heavy capability lanes run only for relevant merges and scheduled backstop
     sandboxContainer,
     /if:.*needs\.changes\.outputs\.sandbox_container == 'true'.*github\.event_name != 'pull_request'/,
   );
-  assert.match(aggregate, /case "\$VECTORS_CHANGED" in/);
-  assert.match(aggregate, /case "\$SANDBOX_CONTAINER_CHANGED" in/);
   assert.match(
-    aggregate,
-    /vector scope without workspace scope; the detector is wrong/,
+    changes,
+    /if \[\[ "\$vectors" == true && "\$workspace" != true \]\]; then/,
   );
   assert.match(
-    aggregate,
-    /sandbox-container scope without workspace scope; the detector is wrong/,
+    changes,
+    /if \[\[ "\$sandbox_container" == true && "\$workspace" != true \]\]; then/,
   );
 });
 


### PR DESCRIPTION
Closes #1006

Runs rich parser contracts in a dedicated headless job parallel to lean desktop behavior tests. The desktop crate explicitly forwards parser support as a default feature, preserving normal dev/release behavior, while CI disables that feature for the shell behavior suite. Default-feature clippy still compile-checks production wiring and the focused parser lane exercises registry precedence plus real PDF behavior.

Also removes the serial `fmt · clippy · build · test` wrapper. UI test/build are fixed parallel jobs rather than dynamic matrix contexts, and branch protection will require every PR gate directly. Scope implications now fail inside the always-running change detector, before conditional jobs consume them.

Measured shape:
- PR #1003 baseline: parser contracts 1m58 + desktop command 2m21, sequential
- lean desktop normal/build dependency graph: 587 → 468 unique package lines (20% smaller)
- empty aggregate wrapper: removed (~3s after the critical path)
- all desktop behavior tests retained and passing

Validation:
- `node --test scripts/workflow-security.test.mjs` (18 passed)
- `actionlint .github/workflows/ci.yml .github/workflows/cache-cleanup.yml`
- `cargo fmt --all -- --check`
- `cargo test -p openwave-desktop --no-default-features --locked` (88 passed before #1008 pruning)
- `cargo check -p openwave-desktop --locked` (rich production defaults)
- `cargo metadata --locked --no-deps --format-version 1`

Migration: after every new static job passes on this PR, temporarily remove the old aggregate required context, merge, then require the individual job contexts directly.