### PR TITLE
fix(desktop): wire font and radius tokens into the Tailwind theme

### DIFF
--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -235,6 +235,14 @@
 
   --color-brightwave: var(--brightwave);
 
+  --font-sans: var(--sans);
+  --font-mono: var(--mono);
+
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+
   --shadow-2xs: var(--shadow-sm);
   --shadow-xs: var(--shadow-sm);
   --shadow-sm: var(--shadow-sm);
@@ -1421,7 +1429,7 @@ body {
   align-items: center;
   gap: 0.3rem;
   padding: 0.2rem 0.5rem;
-  border: 1px solid oklch(0.32 0.01 285);
+  border: 1px solid var(--code-block-border);
   border-radius: 6px;
   background: var(--code-block-bg);
   color: var(--code-block-ink);
@@ -1519,7 +1527,7 @@ body {
 }
 
 .composer:focus-within {
-  border-color: var(--color-zinc-300, var(--line));
+  border-color: var(--ring);
   box-shadow: var(--shadow-lg);
 }
 


### PR DESCRIPTION
The `@theme inline` block in `styles.css` mapped colors and shadows but skipped typography and radius, so the Tailwind utilities never saw our tokens. `font-sans` resolved to Tailwind's default stack, which means the handful of places applying it were switching *away* from Inter, and the eleven `font-mono` call sites got a different mono stack than the `var(--mono)` used elsewhere in the CSS layer. `--radius` was defined and then referenced exactly once, with every `rounded-*` utility falling back to Tailwind's defaults. Mapping `--font-sans`/`--font-mono` fixes the font mismatch; the radius scale is derived from `--radius` at its current 0.5rem, which resolves to the same 6px/8px Tailwind already produced, so it is visually a no-op and just makes the token real.

Two hardcoded colors in the same file also go through tokens now. The composer's `:focus-within` border reached into Tailwind's raw `--color-zinc-300`, which does not vary by theme and drew a light-gray edge on the dark surface; it uses `--ring` instead, since `--input` is actually lighter than the resting border in light mode and would invert the focus cue. The code block copy button had a literal `oklch()` border sitting next to siblings already using `--code-block-bg`/`--code-block-ink`, so it picks up the `--code-block-border` token that was defined for both themes but unused.