### PR TITLE
fix(desktop): share live theme state across all consumers

### DIFF
--- a/crates/openwave-desktop/ui/src/AppContext.tsx
+++ b/crates/openwave-desktop/ui/src/AppContext.tsx
@@ -1,7 +1,6 @@
 import { createContext, useContext } from "react";
 
 import type { ApiClient, Chat, CitationFormat, ModelInfo, ProviderInfo } from "./api";
-import type { ThemeMode } from "./theme";
 import type { DesktopUpdateState } from "./updates";
 
 /**
@@ -42,9 +41,6 @@ export type AppContextValue = {
   startRename: (chat: Chat) => void;
   commitRename: (chat: Chat) => void;
   cancelRename: () => void;
-  themeMode: ThemeMode;
-  setThemeMode: (mode: ThemeMode) => void;
-  cycleTheme: () => void;
   updateState: DesktopUpdateState;
   checkForUpdate: () => Promise<DesktopUpdateState>;
   restartForUpdate: () => Promise<void>;

--- a/crates/openwave-desktop/ui/src/AppShell.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.tsx
@@ -23,7 +23,6 @@ import { useInterfaceZoom } from "./InterfaceZoom";
 import { Logomark } from "./Logomark";
 import { ManagedGate } from "./ManagedGate";
 import { resolvedRoleKey } from "./ModelSelection";
-import { useTheme } from "./theme";
 import { Titlebar } from "./Titlebar";
 import { useActiveChatId } from "./useActiveChatId";
 import { useChatPromptWatcher } from "./useChatPromptWatcher";
@@ -75,7 +74,6 @@ export function AppShell() {
   const creationInFlightRef = useRef(false);
   const deletionInFlightRef = useRef(false);
   const { confirm, dialog: confirmDialog } = useConfirm();
-  const { mode: themeMode, cycle: cycleTheme, setMode: setThemeMode } = useTheme();
   const desktopUpdates = useDesktopUpdates();
   const zoom = useInterfaceZoom();
 
@@ -307,9 +305,6 @@ export function AppShell() {
           startRename: startChatRename,
           commitRename: (target) => void commitChatRename(target),
           cancelRename: cancelChatRename,
-          themeMode,
-          setThemeMode,
-          cycleTheme,
           updateState: desktopUpdates.state,
           checkForUpdate: desktopUpdates.check,
           restartForUpdate: onRestartForUpdate,

--- a/crates/openwave-desktop/ui/src/McpAppCard.tsx
+++ b/crates/openwave-desktop/ui/src/McpAppCard.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { AppWindow, ShieldCheck } from "lucide-react";
 import { useApp } from "./AppContext";
 import { createMcpAppBridge, type McpAppBridge } from "./McpAppBridge";
+import { useTheme } from "./theme";
 
 /**
  * The sandboxed surface for an MCP Apps view.
@@ -37,23 +38,15 @@ export function McpAppCard({
   chatId?: string;
   callId?: string;
 }) {
-  const { client, themeMode } = useApp();
+  const { client } = useApp();
+  const { resolved: resolvedTheme } = useTheme();
   const [state, setState] = useState<ViewState>({ kind: "loading" });
   const [frameHeight, setFrameHeight] = useState(DEFAULT_FRAME_HEIGHT);
   const frameRef = useRef<HTMLIFrameElement | null>(null);
   const bridgeRef = useRef<McpAppBridge | null>(null);
 
-  const resolveTheme = useCallback(
-    (): "light" | "dark" =>
-      themeMode === "system"
-        ? window.matchMedia?.("(prefers-color-scheme: dark)").matches
-          ? "dark"
-          : "light"
-        : themeMode,
-    [themeMode],
-  );
-  const themeRef = useRef(resolveTheme);
-  themeRef.current = resolveTheme;
+  const themeRef = useRef(resolvedTheme);
+  themeRef.current = resolvedTheme;
 
   // The bridge listener must exist before the frame's document runs, or the
   // view's ui/initialize request is lost and it hangs until its timeout.
@@ -63,7 +56,7 @@ export function McpAppCard({
   useEffect(() => {
     const bridge = createMcpAppBridge({
       frame: () => frameRef.current?.contentWindow ?? null,
-      theme: () => themeRef.current(),
+      theme: () => themeRef.current,
       onHeight: setFrameHeight,
     });
     bridgeRef.current = bridge;

--- a/crates/openwave-desktop/ui/src/document/UniverSpreadsheetViewer.tsx
+++ b/crates/openwave-desktop/ui/src/document/UniverSpreadsheetViewer.tsx
@@ -14,9 +14,8 @@ import type { HTMLAttributes, ReactNode } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { ApiClient } from "@/api";
-import { useApp } from "@/AppContext";
 import { cn } from "@/lib/utils";
-import { resolveTheme } from "@/theme";
+import { useTheme } from "@/theme";
 import UniverFormulaWorker from "@/workers/univer-formula.worker?worker&inline";
 import { SpreadsheetShortcutsInfoBar } from "./SpreadsheetShortcutsInfo";
 import { parseCellAddress } from "./spreadsheet";
@@ -72,8 +71,7 @@ export default function UniverSpreadsheetViewer({
   highlightRangeRef.current = highlightRange;
   const [errorType, setErrorType] = useState<"parse" | "load" | null>(null);
   const univerWorker = useUniverWorker();
-  const { themeMode } = useApp();
-  const resolvedTheme = resolveTheme(themeMode);
+  const { resolved: resolvedTheme } = useTheme();
   const resolvedThemeRef = useRef(resolvedTheme);
   resolvedThemeRef.current = resolvedTheme;
 

--- a/crates/openwave-desktop/ui/src/settings/sections.tsx
+++ b/crates/openwave-desktop/ui/src/settings/sections.tsx
@@ -15,6 +15,7 @@ import {
 
 import { useApp } from "@/AppContext";
 import { useManagedPolicy } from "@/managedPolicy";
+import { useTheme } from "@/theme";
 import { AppearancePanel } from "./AppearancePanel";
 import { CitationsPanel } from "./CitationsPanel";
 import { CodeExecutionPanel } from "./CodeExecutionPanel";
@@ -102,8 +103,8 @@ function CitationsSection() {
 }
 
 function AppearanceSection() {
-  const { themeMode, setThemeMode } = useApp();
-  return <AppearancePanel mode={themeMode} onChange={setThemeMode} />;
+  const { mode, setMode } = useTheme();
+  return <AppearancePanel mode={mode} onChange={setMode} />;
 }
 
 function UpdatesSection() {

--- a/crates/openwave-desktop/ui/src/sidebar/SidebarFrame.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/SidebarFrame.tsx
@@ -21,6 +21,7 @@ import {
   SidebarHeader,
   useSidebarWidth,
 } from "./primitives";
+import { useTheme } from "@/theme";
 import { useUiStore } from "@/UiStore";
 
 /**
@@ -34,7 +35,8 @@ import { useUiStore } from "@/UiStore";
  */
 export function SidebarFrame({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
-  const { themeMode, cycleTheme, updateState, restartForUpdate } = useApp();
+  const { updateState, restartForUpdate } = useApp();
+  const { mode: themeMode, cycle: cycleTheme } = useTheme();
   const toggleSidebar = useUiStore((state) => state.toggleSidebar);
   const isCompact = useSidebarWidth() === "compact";
   const pathname = useRouterState({ select: (state) => state.location.pathname });

--- a/crates/openwave-desktop/ui/src/theme.test.ts
+++ b/crates/openwave-desktop/ui/src/theme.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
-import { isThemeMode, resolveTheme } from "./theme";
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { isThemeMode, resolveTheme, setThemeMode, useTheme } from "./theme";
 
 describe("theme", () => {
   it("accepts only the three known modes", () => {
@@ -15,5 +17,65 @@ describe("theme", () => {
   it("resolves explicit modes without consulting the system", () => {
     expect(resolveTheme("light")).toBe("light");
     expect(resolveTheme("dark")).toBe("dark");
+  });
+});
+
+/** A `prefers-color-scheme` query whose answer the test can flip. */
+function stubMediaQuery() {
+  const handlers = new Set<() => void>();
+  let dark = false;
+  window.matchMedia = ((query: string) => ({
+    media: query,
+    get matches() {
+      return dark;
+    },
+    addEventListener: (_: string, handler: () => void) => void handlers.add(handler),
+    removeEventListener: (_: string, handler: () => void) =>
+      void handlers.delete(handler),
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+    onchange: null,
+  })) as unknown as typeof window.matchMedia;
+  return {
+    flip(next: boolean) {
+      dark = next;
+      act(() => {
+        for (const handler of [...handlers]) handler();
+      });
+    },
+  };
+}
+
+describe("useTheme", () => {
+  beforeEach(() => setThemeMode("system"));
+  afterEach(cleanup);
+
+  it("hands every consumer the new resolved theme when the OS flips", () => {
+    // The OS listener used to write the `dark` class straight to the document
+    // without touching React state, so anything driven by the resolved value —
+    // the toaster, the grid's colour scheme — kept rendering the old one until
+    // it happened to remount.
+    const media = stubMediaQuery();
+    const first = renderHook(() => useTheme());
+    const second = renderHook(() => useTheme());
+    expect(first.result.current.resolved).toBe("light");
+
+    media.flip(true);
+
+    expect(first.result.current.resolved).toBe("dark");
+    expect(second.result.current.resolved).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("shows a mode change to consumers that did not make it", () => {
+    stubMediaQuery();
+    const reader = renderHook(() => useTheme());
+    const writer = renderHook(() => useTheme());
+
+    act(() => writer.result.current.setMode("dark"));
+
+    expect(reader.result.current.mode).toBe("dark");
+    expect(reader.result.current.resolved).toBe("dark");
   });
 });

--- a/crates/openwave-desktop/ui/src/theme.ts
+++ b/crates/openwave-desktop/ui/src/theme.ts
@@ -1,8 +1,10 @@
-import { useCallback, useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 
 export type ThemeMode = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
 
 const STORAGE_KEY = "openwave-theme";
+const DARK_QUERY = "(prefers-color-scheme: dark)";
 
 export function isThemeMode(value: unknown): value is ThemeMode {
   return value === "light" || value === "dark" || value === "system";
@@ -26,60 +28,114 @@ function storeTheme(mode: ThemeMode): void {
   }
 }
 
-export function systemPrefersDark(): boolean {
-  return (
-    typeof window !== "undefined" &&
-    typeof window.matchMedia === "function" &&
-    window.matchMedia("(prefers-color-scheme: dark)").matches
-  );
+function darkMediaQuery(): MediaQueryList | null {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return null;
+  }
+  return window.matchMedia(DARK_QUERY);
 }
 
-export function resolveTheme(mode: ThemeMode): "light" | "dark" {
+export function systemPrefersDark(): boolean {
+  return darkMediaQuery()?.matches === true;
+}
+
+export function resolveTheme(mode: ThemeMode): ResolvedTheme {
   if (mode === "system") return systemPrefersDark() ? "dark" : "light";
   return mode;
 }
 
-export function applyTheme(mode: ThemeMode): void {
+/**
+ * The `dark` class is what every token in the stylesheet keys off. The pre-paint
+ * snippet in `index.html` writes the same class from the same storage key before
+ * this module loads; keep the two in step.
+ */
+function paint(resolved: ResolvedTheme): void {
   if (typeof document === "undefined") return;
-  document.documentElement.classList.toggle("dark", resolveTheme(mode) === "dark");
+  document.documentElement.classList.toggle("dark", resolved === "dark");
+}
+
+type ThemeState = { mode: ThemeMode; resolved: ResolvedTheme };
+
+/**
+ * One copy of the theme for the whole app.
+ *
+ * The toaster, the grid and the shell all need the *resolved* theme, and they
+ * mount and unmount independently, so it cannot live in any one component's
+ * state — when it did, each call site kept its own boot-time snapshot and only
+ * the shell's ever moved. It is a module store rather than context so a
+ * consumer outside the shell's tree still sees the same value.
+ */
+let state: ThemeState = stateFor(readStoredTheme());
+const listeners = new Set<() => void>();
+let watchedQuery: MediaQueryList | null = null;
+
+function stateFor(mode: ThemeMode): ThemeState {
+  return { mode, resolved: resolveTheme(mode) };
+}
+
+/** Moves the store to `mode` and repaints, if anything actually changed. */
+function commit(mode: ThemeMode): void {
+  const next = stateFor(mode);
+  if (next.mode === state.mode && next.resolved === state.resolved) return;
+  state = next;
+  paint(next.resolved);
+  for (const listener of [...listeners]) listener();
+}
+
+/**
+ * The OS flipping is a change of `resolved`, not of `mode`, so it has to run
+ * through the store like any other: mutating the class alone leaves every
+ * consumer holding the old resolved value.
+ */
+function onSystemChange(): void {
+  commit(state.mode);
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  if (listeners.size === 1) {
+    watchedQuery = darkMediaQuery();
+    watchedQuery?.addEventListener("change", onSystemChange);
+    // The OS may have flipped while nothing was mounted to hear it.
+    onSystemChange();
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      watchedQuery?.removeEventListener("change", onSystemChange);
+      watchedQuery = null;
+    }
+  };
+}
+
+function getSnapshot(): ThemeState {
+  return state;
+}
+
+export function setThemeMode(mode: ThemeMode): void {
+  storeTheme(mode);
+  commit(mode);
+}
+
+export function cycleThemeMode(): void {
+  setThemeMode(
+    state.mode === "light" ? "dark" : state.mode === "dark" ? "system" : "light",
+  );
 }
 
 /** Applies the stored theme synchronously to avoid a flash before React mounts. */
 export function initTheme(): void {
-  applyTheme(readStoredTheme());
+  // Runs before anything subscribes, so there is nobody to notify yet.
+  state = stateFor(readStoredTheme());
+  paint(state.resolved);
 }
 
 export function useTheme(): {
   mode: ThemeMode;
-  resolved: "light" | "dark";
+  resolved: ResolvedTheme;
   setMode: (mode: ThemeMode) => void;
   cycle: () => void;
 } {
-  const [mode, setModeState] = useState<ThemeMode>(() => readStoredTheme());
-
-  useEffect(() => {
-    applyTheme(mode);
-    storeTheme(mode);
-  }, [mode]);
-
-  // Follow the OS preference live while in system mode.
-  useEffect(() => {
-    if (mode !== "system") return;
-    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-      return;
-    }
-    const query = window.matchMedia("(prefers-color-scheme: dark)");
-    const handler = () => applyTheme("system");
-    query.addEventListener("change", handler);
-    return () => query.removeEventListener("change", handler);
-  }, [mode]);
-
-  const setMode = useCallback((next: ThemeMode) => setModeState(next), []);
-  const cycle = useCallback(() => {
-    setModeState((current) =>
-      current === "light" ? "dark" : current === "dark" ? "system" : "light",
-    );
-  }, []);
-
-  return { mode, resolved: resolveTheme(mode), setMode, cycle };
+  const { mode, resolved } = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return { mode, resolved, setMode: setThemeMode, cycle: cycleThemeMode };
 }


### PR DESCRIPTION
`useTheme` kept its state in a `useState` per call site, so the shell, the Sonner toaster and the AG Grid theme hook each ended up with their own copy and only the shell's ever moved. Changing the theme in Settings left the toaster rendering against its boot-time value and the grid holding the old `browserColorScheme` — the scrollbars and form controls it picks from that — until something happened to remount them.

The system-mode OS listener had the same problem from the other end. It called `applyTheme("system")`, which toggles the `dark` class on the document but touches no React state, so flipping the OS appearance while in system mode repainted the tokens and left every consumer of the resolved value stale.

The theme now lives in one module-level store read through `useSyncExternalStore`. The `prefers-color-scheme` listener is attached while anything is subscribed, and an OS change is committed through the store like any other change, so mode and resolved theme always come out of the same snapshot and the class on the document cannot drift from what components render. Storage and the pre-paint snippet in `index.html` are untouched — same key, same class semantics.

With a shared store the shell has nothing left to publish, so `themeMode`, `setThemeMode` and `cycleTheme` come off `AppContext` and their readers (the sidebar rail, the appearance settings section) call `useTheme` directly. Two consumers were resolving the mode themselves off the context value, which is stale for exactly the OS-flip case: `McpAppCard` had grown its own copy of the system-resolution logic, and the spreadsheet viewer resolved at render. Both now read the resolved value from the store, so the viewer's dark-mode sync follows an OS flip as well.

One test added, for the OS-listener staleness: two mounted consumers in system mode, flip the media query, assert both see the new resolved theme. It fails against the old listener.

Verified with `pnpm test` (92 files, 666 tests), `tsc --noEmit`, and `pnpm build`. Not driven in the running app.
