### PR TITLE
refactor(desktop): add textarea and spinner primitives, adopt input where hand-rolled

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatHeaderTitle.tsx
+++ b/crates/openwave-desktop/ui/src/ChatHeaderTitle.tsx
@@ -4,6 +4,7 @@ import type { Chat } from "./api";
 import { useApp } from "./AppContext";
 import { useChatListStore } from "./ChatListStore";
 import { useTypewriterOnce } from "./useTypewriterOnce";
+import { Input } from "@/components/ui/input";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -39,8 +40,8 @@ export function ChatHeaderTitle({ chat }: { chat: Chat }) {
 
   if (renaming) {
     return (
-      <input
-        className="min-w-0 max-w-sm flex-1 rounded-md border border-input bg-background px-2 py-1 text-center text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      <Input
+        className="h-auto min-w-0 max-w-sm flex-1 px-2 py-1 text-center text-sm"
         autoFocus
         aria-label="Chat title"
         value={renameDraft}

--- a/crates/openwave-desktop/ui/src/ImportQueue.tsx
+++ b/crates/openwave-desktop/ui/src/ImportQueue.tsx
@@ -1,7 +1,6 @@
 import {
   CheckCircle2Icon,
   FileWarningIcon,
-  Loader2Icon,
   UploadIcon,
   XIcon,
 } from "lucide-react";
@@ -9,6 +8,7 @@ import {
 import { DocumentIcon } from "@/components/document-table/DocumentIcon";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import type { LibraryImportState } from "./documents";
 import {
   importIsActive,
@@ -69,7 +69,7 @@ export function ImportQueue() {
           )}
           {running ? (
             <Badge variant="info">
-              <Loader2Icon className="size-3 animate-spin" />
+              <Spinner className="size-3 text-current" />
               {percentage}%
             </Badge>
           ) : (
@@ -133,7 +133,9 @@ function StateGlyph({ status }: { status: LibraryImportState }) {
         />
       );
     case "streaming":
-      return <Loader2Icon aria-label="Adding" className="size-3 shrink-0 animate-spin" />;
+      return (
+        <Spinner aria-label="Adding" className="size-3 shrink-0 text-current" />
+      );
     case "imported":
     case "already_present":
       return (

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Check, Clock, Loader2, Terminal, X } from "lucide-react";
+import { Check, Clock, Terminal, X } from "lucide-react";
 import {
   isRendererToolName,
   type ExecResultPreview,
@@ -7,6 +7,7 @@ import {
   type ToolActionPreview,
 } from "./api";
 import { Badge } from "@/components/ui/badge";
+import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 import type { ToolTone } from "./ToolStatusIcon";
 import { ScrollableContainer } from "./ScrollableContainer";
@@ -283,7 +284,7 @@ export function ToolCommandCard({
           </ScrollableContainer>
         ) : output === null ? (
           <p className="text-muted-foreground flex items-center gap-1.5 p-2 text-xs">
-            <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+            <Spinner className="size-3.5" aria-hidden="true" />
             Waiting for output…
           </p>
         ) : (
@@ -327,7 +328,7 @@ function ToolStatusBadge({
   if (presentation.tone === "running") {
     return (
       <Badge variant="outline" className="shrink-0 gap-1">
-        <Loader2 className="size-3 animate-spin" aria-hidden="true" />
+        <Spinner className="size-3" aria-hidden="true" />
         Running…
       </Badge>
     );

--- a/crates/openwave-desktop/ui/src/ToolStatusIcon.tsx
+++ b/crates/openwave-desktop/ui/src/ToolStatusIcon.tsx
@@ -1,4 +1,6 @@
-import { Ban, CircleAlert, Clock, Loader2 } from "lucide-react";
+import { Ban, CircleAlert, Clock } from "lucide-react";
+
+import { Spinner } from "@/components/ui/spinner";
 
 export type ToolTone =
   | "running"
@@ -25,7 +27,9 @@ export function ToolStatusIcon({
 }) {
   switch (tone) {
     case "running":
-      return <Loader2 className={`${className} animate-spin`} />;
+      // Running takes the row's own colour; the other tones are deliberately
+      // muted beside it.
+      return <Spinner className={`${className} text-current`} />;
     case "waiting_approval":
       return <Clock className={`text-muted-foreground ${className}`} />;
     case "completed":

--- a/crates/openwave-desktop/ui/src/UserQuestionsCard.tsx
+++ b/crates/openwave-desktop/ui/src/UserQuestionsCard.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState } from "react";
 import { CornerDownLeft, X } from "lucide-react";
 import type { PendingUserQuestions, UserQuestionAnswer } from "./api";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 
 type DraftAnswer =
@@ -144,7 +146,7 @@ export function UserQuestionsCard({
                 onChange={() => updateFreeForm(currentQuestion.id, "")}
                 className="accent-foreground size-[18px] shrink-0"
               />
-              <input
+              <Input
                 type="text"
                 maxLength={2000}
                 value={
@@ -161,7 +163,7 @@ export function UserQuestionsCard({
                 disabled={working}
                 aria-label="Other answer"
                 placeholder="Other"
-                className="border-border bg-background placeholder:text-muted-foreground focus-visible:border-foreground min-w-0 flex-1 rounded-lg border px-2.5 py-2 text-sm outline-hidden"
+                className="h-auto min-w-0 flex-1 rounded-lg px-2.5 py-2 text-sm focus-visible:border-foreground focus-visible:ring-0 focus-visible:ring-offset-0"
               />
             </label>
           )}
@@ -170,7 +172,7 @@ export function UserQuestionsCard({
 
       {currentQuestion.allowFreeForm &&
         currentQuestion.options.length === 0 && (
-          <textarea
+          <Textarea
             maxLength={2000}
             rows={3}
             value={
@@ -182,7 +184,7 @@ export function UserQuestionsCard({
             disabled={working}
             aria-label={currentQuestion.header}
             placeholder="Your answer"
-            className="border-border bg-background placeholder:text-muted-foreground focus-visible:border-foreground min-h-16 w-full resize-y rounded-[10px] border px-3 py-2.5 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
+            className="min-h-16 resize-y rounded-[10px] py-2.5 text-sm focus-visible:border-foreground focus-visible:ring-0 focus-visible:ring-offset-0"
           />
         )}
 

--- a/crates/openwave-desktop/ui/src/components/ui/spinner.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/spinner.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The indeterminate-progress glyph, in one place.
+ *
+ * Size and colour are ordinary class overrides: `size-3` for a badge, an
+ * explicit `text-*` where the spinner should take its surroundings' colour
+ * instead of the muted default. Callers own the accessible name — pass
+ * `aria-hidden` when adjacent text already says what is happening, or an
+ * `aria-label` when the glyph is the only signal.
+ */
+const Spinner = React.forwardRef<
+  SVGSVGElement,
+  React.ComponentProps<typeof Loader2>
+>(({ className, ...props }, ref) => {
+  return (
+    <Loader2
+      className={cn("size-4 animate-spin text-muted-foreground", className)}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Spinner.displayName = "Spinner";
+
+export { Spinner };

--- a/crates/openwave-desktop/ui/src/components/ui/textarea.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/textarea.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Multi-line counterpart to `Input`, sharing its border, focus ring, and
+ * disabled treatment. Height is left to the caller — `rows` or a `min-h-*`
+ * override — because the fields that use one are sized to the content they
+ * expect rather than to a single shared line height.
+ */
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "flex w-full rounded-md border border-border bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
@@ -10,6 +10,7 @@ import type {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
 import {
   ActiveProviderField,
   ProviderCredentialField,
@@ -262,7 +263,7 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
                   label="Allowed domains"
                   hint="One per line. An exact host (api.example.com) or a leading wildcard (*.pypi.org)."
                 >
-                  <textarea
+                  <Textarea
                     className={ENTRY_TEXTAREA_CLASS}
                     rows={4}
                     spellCheck={false}
@@ -277,7 +278,7 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
                   label="Allowed address blocks"
                   hint="One per line, in CIDR notation (140.82.112.0/20) or a bare address."
                 >
-                  <textarea
+                  <Textarea
                     className={ENTRY_TEXTAREA_CLASS}
                     rows={3}
                     spellCheck={false}
@@ -324,9 +325,8 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
   );
 }
 
-/** Textarea styled to match the shared `Input`, sized for a list of entries. */
-const ENTRY_TEXTAREA_CLASS =
-  "flex w-full rounded-md border border-border bg-background px-3 py-2 font-mono text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50";
+/** One grant per line reads as a list, so the entries are set in monospace. */
+const ENTRY_TEXTAREA_CLASS = "font-mono text-sm";
 
 /**
  * Split a textarea of grants into trimmed, non-empty entries. Newlines and

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -9,6 +9,7 @@ import type {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
 import { useConfirm } from "../components/ConfirmDialog";
 import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
 import { providerLabel } from "../ModelSelection";
@@ -347,9 +348,9 @@ function ProviderRow({
             Gemini 3 models always use Google&apos;s global endpoint. This
             location applies to models that support regional Vertex endpoints.
           </p>
-          <textarea
+          <Textarea
             aria-label="Google service account JSON"
-            className="min-h-28 w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm text-foreground"
+            className="min-h-28 font-mono text-sm text-foreground"
             placeholder="Paste the Google service-account JSON key file"
             value={serviceAccountJson}
             onChange={(event) => setServiceAccountJson(event.target.value)}

--- a/crates/openwave-desktop/ui/src/sidebar/RecentChatRow.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/RecentChatRow.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
 
 /** One conversation in a rail list, with its rename field and row actions. */
 export function RecentChatRow({
@@ -52,8 +53,8 @@ export function RecentChatRow({
 
   if (renaming) {
     return (
-      <input
-        className="w-full rounded-md border border-input bg-background px-2 py-1.5 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      <Input
+        className="h-auto px-2 py-1.5 text-sm"
         autoFocus
         aria-label="Chat title"
         value={renameDraft}


### PR DESCRIPTION
The primitive registry had no Textarea and no Spinner, so feature code kept respelling both. Two settings panels carried a full copy of the `Input` recipe on a raw `<textarea>` — one of them in a comment that said as much — and five icon sites repeated `Loader2` plus `animate-spin` at whatever size and colour the surrounding row wanted. Three text inputs hand-spelled `rounded-md border border-input bg-background … focus-visible:ring-2` rather than using the `Input` we already have.

**Added**

- `components/ui/textarea.tsx` — shares `Input`'s border, focus ring, placeholder, and disabled treatment. Height is left to the caller, because the fields that use a textarea are sized by `rows` or a `min-h-*` to the content they expect rather than to one shared line height.
- `components/ui/spinner.tsx` — `Loader2` with the animation and a `text-muted-foreground` default. Size and colour are ordinary class overrides, so a badge passes `size-3` and a row that wants the spinner in its own colour passes `text-current`. The accessible name stays with the caller: `aria-hidden` where adjacent text already says what is happening, `aria-label` where the glyph is the only signal.

**Migrated**

Four textareas (`UserQuestionsCard`, `ProvidersPanel`, two in `CodeExecutionPanel`), five spinners (`ToolCallCard` ×2, `ToolStatusIcon`, `ImportQueue` ×2), and three text inputs (`ChatHeaderTitle`, `sidebar/RecentChatRow`, `UserQuestionsCard`). `CodeExecutionPanel`'s local `ENTRY_TEXTAREA_CLASS` shrinks from the whole recipe to the one thing it was really saying: the entries are monospace.

Rendering is unchanged. Each site keeps its own geometry and focus affordance through `className` — the rename fields override the primitive's `h-10` to keep their tighter padding, and the question card keeps its border-colour focus treatment instead of picking up the ring. The one deliberate difference: the three inputs now use the primitive's border token in place of the `border-input` they had copied from upstream shadcn, so their borders match every other input in the app. That is a slight tint change on those three borders in dark mode.

No tests were added — these are styling shells, and asserting a class string exists would not tell us anything we would act on. The existing suites over the migrated components pass untouched.