### PR TITLE
feat(desktop): align chat sidebar and header with BW project layout

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatHeaderTitle.tsx
+++ b/crates/openwave-desktop/ui/src/ChatHeaderTitle.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "@tanstack/react-router";
 import { Ellipsis, Pencil, Trash2 } from "lucide-react";
 
 import type { Chat } from "./api";
@@ -12,18 +13,17 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
 
 /**
- * The open conversation's title, made actable from where it is shown.
+ * BW-style breadcrumb header: "Chats / chat title".
  *
- * Rename and delete used to live only on the sidebar's chat row, out of reach
- * whenever the rail was collapsed. Clicking the title here swaps it for an edit
- * field, and the menu beside it offers the same two actions — both wired to the
- * shell's existing orchestration, so a deletion of the open chat lands home the
- * same way it does from the rail. The rename draft is the shared one, so the
- * two entry points cannot disagree about what is being typed.
+ * Clicking "Chats" navigates home; clicking the title swaps it for an inline
+ * edit field. The ellipsis menu offers Rename and Delete, wired to the shell's
+ * existing orchestration.
  */
 export function ChatHeaderTitle({ chat }: { chat: Chat }) {
+  const navigate = useNavigate();
   const { startRename, commitRename, cancelRename, deleteChat } = useApp();
   const renaming = useChatListStore((state) => state.renamingChatId === chat.id);
   const renameDraft = useChatListStore((state) => state.renameChatDraft);
@@ -34,58 +34,72 @@ export function ChatHeaderTitle({ chat }: { chat: Chat }) {
     (state) => state.derivedTitleChatId === chat.id,
   );
   const title = chat.title?.trim() || "New chat";
-  // Typed out only when the name arrived just now, in step with the sidebar row
-  // showing the same conversation.
   const displayTitle = useTypewriterOnce(title, justNamed);
 
-  if (renaming) {
-    return (
-      <Input
-        className="h-auto min-w-0 max-w-sm flex-1 px-2 py-1 text-center text-sm"
-        autoFocus
-        aria-label="Chat title"
-        value={renameDraft}
-        disabled={savingTitle}
-        onChange={(event) => setRenameDraft(event.target.value)}
-        onBlur={() => commitRename(chat)}
-        onKeyDown={(event) => {
-          // Enter commits through the same blur the field would fire on losing
-          // focus; Escape flags the pending blur to skip so it does not patch.
-          if (event.key === "Enter") {
-            event.preventDefault();
-            event.currentTarget.blur();
-          }
-          if (event.key === "Escape") {
-            event.preventDefault();
-            cancelRename();
-          }
-        }}
-      />
-    );
-  }
-
   return (
-    <div className="flex min-w-0 max-w-sm flex-1 items-center justify-center gap-1">
+    <div className="flex min-w-0 items-center gap-2 text-sm">
       <button
         type="button"
-        className="min-w-0 cursor-pointer truncate rounded-md px-2 py-1 text-center text-sm font-medium transition-colors hover:bg-muted"
-        title="Rename chat"
-        onClick={() => startRename(chat)}
+        className="shrink-0 font-medium text-muted-foreground hover:underline cursor-pointer"
+        onClick={() => void navigate({ to: "/" })}
       >
-        {displayTitle}
+        Chats
       </button>
+      <span className="text-muted-foreground shrink-0">/</span>
+
+      {renaming ? (
+        <div className="inline-grid min-w-0">
+          {/* Hidden span to auto-size the grid cell */}
+          <span
+            className="invisible col-start-1 row-start-1 max-w-sm px-2 py-1 text-sm font-medium whitespace-nowrap"
+            aria-hidden="true"
+          >
+            {renameDraft || " "}
+          </span>
+          <Input
+            className="col-start-1 row-start-1 h-auto max-w-sm min-w-0 px-2 py-1 text-sm"
+            autoFocus
+            aria-label="Chat title"
+            value={renameDraft}
+            disabled={savingTitle}
+            onChange={(event) => setRenameDraft(event.target.value)}
+            onBlur={() => commitRename(chat)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                event.currentTarget.blur();
+              }
+              if (event.key === "Escape") {
+                event.preventDefault();
+                cancelRename();
+              }
+            }}
+          />
+        </div>
+      ) : (
+        <button
+          type="button"
+          className="min-w-0 truncate font-medium hover:underline cursor-pointer"
+          title="Rename chat"
+          onClick={() => startRename(chat)}
+        >
+          {displayTitle}
+        </button>
+      )}
+
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            className="shrink-0 cursor-pointer rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
-            aria-label={`Actions for ${title}`}
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="shrink-0"
             disabled={deletingChatId !== null}
           >
-            <Ellipsis size={15} />
-          </button>
+            <Ellipsis className="size-4" />
+            <span className="sr-only">Chat menu</span>
+          </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="center">
+        <DropdownMenuContent align="end">
           <DropdownMenuItem onSelect={() => startRename(chat)}>
             <Pencil />
             Rename

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -93,7 +93,7 @@ const { signal: signalTurnLifecycle } = useTurnLifecycle.getState();
  */
 export function ChatRoute({ chatId }: { chatId: string }) {
   const navigate = useNavigate();
-  const { client, models, defaultModelKey, defaultCitationFormat, status, setStatus } =
+  const { client, models, defaultModelKey, defaultCitationFormat, setStatus } =
     useApp();
   const { layout, openPanel } = usePanelNav();
   const sourceNav = useStableSourceNav(openPanel);
@@ -117,10 +117,6 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   useEffect(() => {
     if (chats.length > 0 && !chat) void navigate({ to: "/", replace: true });
   }, [chats.length, chat, navigate]);
-
-  useEffect(() => {
-    setStatus(`chat ${chatId.slice(0, 8)}…`);
-  }, [chatId, setStatus]);
 
   // A conversation opened from the home composer arrives with its first message
   // already written. `take` clears it, so a re-render cannot send it twice.
@@ -482,14 +478,8 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   return (
     <RouteFrame sidebar={<ChatSidebar chat={chat} />}>
     <div className="mr-2 flex min-h-0 min-w-0 flex-1 flex-col">
-      <header className="mt-2 flex h-9 w-full shrink-0 items-center justify-between gap-2 px-1">
-        <div className="w-24" />
+      <header className="mt-2 flex h-9 w-full shrink-0 items-center justify-between gap-2 pl-4 pr-1">
         <ChatHeaderTitle chat={chat} />
-        <div className="flex w-24 items-center justify-end">
-          <span className="truncate text-xs text-muted-foreground" title={status}>
-            {status}
-          </span>
-        </div>
       </header>
       {/* Citations live in the transcript but open into the panel beside it,
           so the way there is provided above both slots. */}

--- a/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState, type ReactNode } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import {
   ChevronLeft,
@@ -8,13 +9,14 @@ import {
 } from "lucide-react";
 
 import type { Chat } from "@/api";
-import { useApp } from "@/AppContext";
 import { useChatAttention } from "@/ChatAttention";
-import { useChatListStore } from "@/ChatListStore";
+import { Badge } from "@/components/ui/badge";
+import { listDeliverables } from "@/deliverables";
+import { listLibraryDocuments } from "@/documents";
 import type { PanelType } from "@/panel/panelTypes";
 import { usePanelNav } from "@/panel/usePanelNav";
-import { NewChatButton } from "./NewChatButton";
-import { SidebarButton, SidebarSectionTitle } from "./primitives";
+import { useRefreshSignals } from "@/RefreshSignals";
+import { SidebarButton } from "./primitives";
 import { SidebarFrame } from "./SidebarFrame";
 
 /**
@@ -28,10 +30,7 @@ import { SidebarFrame } from "./SidebarFrame";
  */
 export function ChatSidebar({ chat }: { chat: Chat }) {
   const navigate = useNavigate();
-  const { newChat } = useApp();
   const { layout, openPanel } = usePanelNav();
-  const creatingChat = useChatListStore((state) => state.creatingChat);
-  const deletingChatId = useChatListStore((state) => state.deletingChatId);
   const chatIdsWithPendingPrompts = useChatAttention(
     (state) => state.chatIdsWithPendingPrompts,
   );
@@ -47,6 +46,9 @@ export function ChatSidebar({ chat }: { chat: Chat }) {
   const elsewhereNeedsAttention = [...chatIdsWithPendingPrompts].some(
     (id) => id !== chat.id,
   );
+
+  const sourceCount = useSidebarCount(chat.id, listLibraryDocuments, (c) => c.documents.length);
+  const outputCount = useSidebarCount(chat.id, listDeliverables, (c) => c.deliverables.length);
 
   return (
     <SidebarFrame>
@@ -64,27 +66,23 @@ export function ChatSidebar({ chat }: { chat: Chat }) {
         )}
       </SidebarButton>
 
-      <NewChatButton
-        onClick={newChat}
-        disabled={creatingChat || deletingChatId !== null}
-        creating={creatingChat}
-      />
-
-      <SidebarSectionTitle className="mt-4">
-        {chat.title?.trim() || "New chat"}
-      </SidebarSectionTitle>
-
       <ChatPanelButton
         label="Sources"
         icon={<Library />}
         active={openPanelTypes.has("sources")}
         onClick={() => openPanel({ type: "sources" })}
+        badge={sourceCount > 0 ? (
+          <Badge variant="outline" className="-my-0.5">{sourceCount}</Badge>
+        ) : undefined}
       />
       <ChatPanelButton
         label="Outputs"
         icon={<Shapes />}
         active={openPanelTypes.has("outputs")}
         onClick={() => openPanel({ type: "outputs" })}
+        badge={outputCount > 0 ? (
+          <Badge variant="outline" className="-my-0.5">{outputCount}</Badge>
+        ) : undefined}
       />
       <ChatPanelButton
         label="Folders"
@@ -100,11 +98,13 @@ function ChatPanelButton({
   label,
   icon,
   active,
+  badge,
   onClick,
 }: {
   label: string;
-  icon: React.ReactNode;
+  icon: ReactNode;
   active: boolean;
+  badge?: ReactNode;
   onClick: () => void;
 }) {
   return (
@@ -116,6 +116,34 @@ function ChatPanelButton({
     >
       {icon}
       <span>{label}</span>
+      {badge}
     </SidebarButton>
   );
+}
+
+/**
+ * Fetch a count on mount and whenever the refresh-signal store ticks any of the
+ * targets that could change the number (folder access for sources, output
+ * writebacks for deliverables). Errors are swallowed — the badge simply stays at
+ * its last known value or zero.
+ */
+function useSidebarCount<T>(
+  chatId: string,
+  fetcher: (chatId: string) => Promise<T>,
+  extract: (result: T) => number,
+): number {
+  const [count, setCount] = useState(0);
+  const folderAccess = useRefreshSignals((s) => s.folderAccess);
+  const outputWritebacks = useRefreshSignals((s) => s.outputWritebacks);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetcher(chatId).then(
+      (result) => { if (!cancelled) setCount(extract(result)); },
+      () => { /* swallow — stale count is acceptable */ },
+    );
+    return () => { cancelled = true; };
+  }, [chatId, folderAccess, outputWritebacks, fetcher, extract]);
+
+  return count;
 }


### PR DESCRIPTION
## Summary

- Stripped the "New chat" button and `SidebarSectionTitle` from the in-chat sidebar, matching BW's project rail which keeps only navigation items inside a conversation.
- Added count badges to the Sources and Outputs sidebar items. Counts are fetched once on mount and refresh whenever the event stream signals a change to folder access or output writebacks. The badge renders only when count > 0, matching BW's `Badge variant="outline"` pattern.
- Replaced the centered title-with-spacers header with a left-aligned breadcrumb: "Chats / chat title". Clicking "Chats" navigates home, clicking the title starts inline rename, and the ellipsis menu sits at the end of the breadcrumb row.
- Removed the "chat {id}..." status text that occupied the header's right side. The `setStatus` call that seeded it is gone; the connection-state append in `ChatSessionController` remains functional.

## Test plan

- [x] `pnpm build` passes (tsc + vite)
- [x] `pnpm test` passes (666/666)
- [ ] Visual: sidebar shows Sources/Outputs count pills when documents or deliverables exist
- [ ] Visual: header shows "Chats / title" breadcrumb left-aligned, no right-side status text
- [ ] Click "Chats" in breadcrumb navigates to home
- [ ] Click title in breadcrumb starts inline rename; Enter commits, Escape cancels
- [ ] Ellipsis menu offers Rename and Delete actions