### PR TITLE
refactor(desktop): retire legacy button and widget CSS onto primitives

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -20,6 +20,7 @@ import { useTurnControls } from "./useTurnControls";
 import { useUserQuestions } from "./useUserQuestions";
 import { useAgentRuns } from "./useAgentRuns";
 import { ArrowDown } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 export type ChatViewProps = {
   client: ApiClient;
@@ -294,7 +295,10 @@ export function ChatView({
         />
         <button
           type="button"
-          className={`scroll-to-latest${scrolledAway ? " is-visible" : ""}`}
+          className={cn(
+            "absolute z-[1] left-1/2 bottom-3 -translate-x-1/2 inline-flex items-center justify-center rounded-full border border-border p-2 text-foreground bg-background shadow transition-[opacity,background-color] duration-150 ease-in-out opacity-0 pointer-events-none hover:bg-accent motion-reduce:transition-none",
+            scrolledAway && "opacity-100 pointer-events-auto",
+          )}
           aria-label="Scroll to latest"
           aria-hidden={!scrolledAway}
           tabIndex={scrolledAway ? 0 : -1}

--- a/crates/openwave-desktop/ui/src/ErrorBoundary.tsx
+++ b/crates/openwave-desktop/ui/src/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
 import { Logomark } from "./Logomark";
 
 type ErrorBoundaryProps = {
@@ -50,9 +51,9 @@ export class ErrorBoundary extends Component<
         </div>
         <p>OpenWave hit an unexpected error.</p>
         <p className="boot-error-detail">{String(this.state.error.message)}</p>
-        <button
-          type="button"
-          className="btn btn-primary"
+        <Button
+          size="sm"
+          className="mt-3"
           onClick={() =>
             this.props.onReload
               ? this.props.onReload()
@@ -60,7 +61,7 @@ export class ErrorBoundary extends Component<
           }
         >
           Reload
-        </button>
+        </Button>
       </div>
     );
   }

--- a/crates/openwave-desktop/ui/src/Titlebar.tsx
+++ b/crates/openwave-desktop/ui/src/Titlebar.tsx
@@ -20,7 +20,7 @@ export function Titlebar() {
         <WithTooltip label="Back" side="bottom">
           <button
             type="button"
-            className="titlebar-nav-btn"
+            className="inline-flex items-center justify-center size-6 rounded-md text-muted-foreground hover:not-disabled:text-foreground hover:not-disabled:bg-[color-mix(in_srgb,var(--ink)_8%,transparent)] disabled:opacity-40 disabled:cursor-default"
             aria-label="Back"
             disabled={!navigation.canGoBack}
             onClick={navigation.goBack}
@@ -31,7 +31,7 @@ export function Titlebar() {
         <WithTooltip label="Forward" side="bottom">
           <button
             type="button"
-            className="titlebar-nav-btn"
+            className="inline-flex items-center justify-center size-6 rounded-md text-muted-foreground hover:not-disabled:text-foreground hover:not-disabled:bg-[color-mix(in_srgb,var(--ink)_8%,transparent)] disabled:opacity-40 disabled:cursor-default"
             aria-label="Forward"
             disabled={!navigation.canGoForward}
             onClick={navigation.goForward}

--- a/crates/openwave-desktop/ui/src/WelcomeState.tsx
+++ b/crates/openwave-desktop/ui/src/WelcomeState.tsx
@@ -52,7 +52,7 @@ export function WelcomeState({
             <button
               key={label}
               type="button"
-              className="welcome-prompt"
+              className="flex items-center gap-2.5 rounded-[10px] border border-border bg-background px-3.5 py-2.5 text-[0.85rem] font-medium text-left text-foreground transition-[background-color,border-color] duration-[120ms] ease-in-out hover:border-[color-mix(in_srgb,var(--ink)_22%,var(--line))] hover:bg-accent [&_svg]:flex-none [&_svg]:text-muted-foreground [&:hover_svg]:text-foreground"
               onClick={() => onSelectPrompt(prompt)}
             >
               <Icon size={16} />

--- a/crates/openwave-desktop/ui/src/settings/AppearancePanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/AppearancePanel.tsx
@@ -1,5 +1,6 @@
 import { Monitor, Moon, Sun } from "lucide-react";
 import type { ComponentType } from "react";
+import { cn } from "@/lib/utils";
 import type { ThemeMode } from "../theme";
 import { SettingsField, SettingsPanel, SettingsSection } from "./primitives";
 
@@ -37,7 +38,10 @@ export function AppearancePanel({
                   type="button"
                   role="radio"
                   aria-checked={active}
-                  className={`theme-option${active ? " is-active" : ""}`}
+                  className={cn(
+                    "inline-flex items-center gap-2 rounded-lg border border-border px-3.5 py-2 bg-background text-foreground text-[0.85rem] font-medium transition-[border-color,background-color] duration-[120ms] ease-in-out hover:bg-accent [&_svg]:text-muted-foreground",
+                    active && "border-primary bg-accent [&_svg]:text-foreground",
+                  )}
                   onClick={() => onChange(option.mode)}
                 >
                   <Icon size={16} />

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -337,42 +337,6 @@ body {
   background: var(--page-background);
 }
 
-/* ---------- Buttons ---------- */
-
-.btn {
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  padding: 0.35rem 0.7rem;
-  background: var(--bg-elevated);
-  font-size: 0.84rem;
-  font-weight: 500;
-}
-
-.btn:hover {
-  background: var(--accent);
-}
-
-.btn-primary {
-  border-color: var(--ink);
-  background: var(--ink);
-  color: var(--bg-elevated);
-}
-
-.btn-primary:hover {
-  opacity: 0.9;
-}
-
-.btn-danger {
-  border-color: color-mix(in srgb, var(--danger) 45%, var(--line));
-  color: var(--danger);
-}
-
-.btn-danger:hover:not(:disabled) {
-  border-color: var(--danger);
-  background: var(--critical-background);
-}
-
-.btn:disabled,
 .new-chat:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -617,11 +581,6 @@ body {
   box-shadow: var(--shadow-sm);
 }
 
-.mobile-settings-actions .btn.is-active {
-  border-color: var(--ink);
-  background: var(--accent);
-}
-
 .eyebrow {
   margin-bottom: 0.05rem !important;
   color: var(--muted-foreground);
@@ -718,75 +677,9 @@ body {
   margin-top: 0.25rem;
 }
 
-.welcome-prompt {
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-  padding: 0.7rem 0.85rem;
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  background: var(--bg-elevated);
-  color: var(--ink);
-  font-size: 0.85rem;
-  font-weight: 500;
-  text-align: left;
-  transition: background-color 120ms ease, border-color 120ms ease;
-}
-
-.welcome-prompt svg {
-  flex: 0 0 auto;
-  color: var(--muted-foreground);
-}
-
-.welcome-prompt:hover {
-  border-color: color-mix(in srgb, var(--ink) 22%, var(--line));
-  background: var(--accent);
-}
-
-.welcome-prompt:hover svg {
-  color: var(--ink);
-}
-
 @media (max-width: 720px) {
   .welcome-prompts {
     grid-template-columns: minmax(0, 1fr);
-  }
-}
-
-/* An icon-only affordance centered just above the composer. It stays mounted
-   and fades on opacity so scrolling away and back doesn't pop it in and out. */
-.scroll-to-latest {
-  position: absolute;
-  z-index: 1;
-  left: 50%;
-  bottom: 0.75rem;
-  transform: translateX(-50%);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  padding: 0.5rem;
-  color: var(--ink);
-  background: var(--bg-elevated);
-  box-shadow: var(--shadow);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 150ms ease, background-color 120ms ease;
-}
-
-.scroll-to-latest.is-visible {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-.scroll-to-latest:hover {
-  background: var(--muted);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .scroll-to-latest {
-    transition: none;
   }
 }
 
@@ -1541,37 +1434,6 @@ body {
   gap: 0.5rem;
 }
 
-.theme-option {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 0.5rem 0.85rem;
-  background: var(--bg-elevated);
-  color: var(--ink);
-  font-size: 0.85rem;
-  font-weight: 500;
-  transition: border-color 120ms ease, background-color 120ms ease;
-}
-
-.theme-option:hover {
-  background: var(--accent);
-}
-
-.theme-option svg {
-  color: var(--muted-foreground);
-}
-
-.theme-option.is-active {
-  border-color: var(--primary);
-  background: var(--accent);
-}
-
-.theme-option.is-active svg {
-  color: var(--ink);
-}
-
 .settings-status {
   display: grid;
   gap: 0.18rem;
@@ -1642,10 +1504,6 @@ body {
   font-family: var(--mono);
   font-size: 0.8rem;
   overflow-wrap: anywhere;
-}
-
-.boot .btn {
-  margin-top: 0.75rem;
 }
 
 /* A transcript phase whose row threw while rendering. Deliberately quiet: the
@@ -1795,26 +1653,6 @@ body {
   display: flex;
   align-items: center;
   gap: 0.1rem;
-}
-
-.titlebar-nav-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.5rem;
-  height: 1.5rem;
-  border-radius: 6px;
-  color: var(--muted-foreground);
-}
-
-.titlebar-nav-btn:hover:not(:disabled) {
-  color: var(--ink);
-  background: color-mix(in srgb, var(--ink) 8%, transparent);
-}
-
-.titlebar-nav-btn:disabled {
-  opacity: 0.4;
-  cursor: default;
 }
 
 .titlebar-title {


### PR DESCRIPTION
## Summary

Converts every remaining consumer of the hand-rolled `.btn`, `.welcome-prompt`,
`.scroll-to-latest`, `.titlebar-nav-btn`, and `.theme-option` CSS classes to
Tailwind utilities and the shadcn `<Button>` primitive, then deletes the dead
rules from `styles.css`.

### Retired CSS rules and their replacements

| Selector | Replacement |
|---|---|
| `.btn` / `.btn:hover` / `.btn:disabled` | shadcn `<Button>` in ErrorBoundary; no other consumers remained |
| `.btn-primary` / `.btn-primary:hover` | `<Button size="sm">` (default variant maps to the same filled style) |
| `.btn-danger` / `.btn-danger:hover` | Already dead (zero TSX references) |
| `.boot .btn` | Replaced by `className="mt-3"` on the `<Button>` |
| `.mobile-settings-actions .btn.is-active` | Dead CSS-only rule with no TSX consumer |
| `.welcome-prompt` / `:hover` / `svg` | Inline Tailwind on the starter-prompt buttons in WelcomeState |
| `.scroll-to-latest` / `.is-visible` / `:hover` / `prefers-reduced-motion` | Inline Tailwind with `cn()` toggling opacity in ChatView |
| `.titlebar-nav-btn` / `:hover` / `:disabled` | Inline Tailwind ghost buttons in Titlebar |
| `.theme-option` / `:hover` / `svg` / `.is-active` | Inline Tailwind with `cn()` for active state in AppearancePanel |

Net: -171 lines of CSS, +18 lines of Tailwind in components.

## Test plan

- [x] `pnpm test` -- 666 tests pass
- [x] `pnpm build` -- production build succeeds
- [ ] Visual: error boundary reload button renders as a filled primary button
- [ ] Visual: welcome starter prompts show border + hover treatment
- [ ] Visual: scroll-to-latest pill appears/hides on scroll
- [ ] Visual: titlebar back/forward buttons show ghost hover
- [ ] Visual: theme picker active state shows primary border
