### PR TITLE
refactor(desktop): adopt existing primitives where hand-rolled

### DIFF
--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
@@ -12,6 +12,7 @@ import {
 } from "./AgentRunDisplay";
 import type { ToolCallStatus } from "./ToolCallCard";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
 export type BackgroundAgentSpawn = {
@@ -149,8 +150,8 @@ export function BackgroundAgentList({
           })}
           {unresolvedSpawns.map((spawn) => (
             <div key={spawn.callId} className="flex min-w-0 items-center gap-2 border-t border-border px-3 py-2.5">
-              <span className="size-2 shrink-0 animate-pulse rounded-full bg-muted-foreground" aria-hidden="true" />
-              <span className="h-4 w-28 animate-pulse rounded bg-muted" aria-hidden="true" />
+              <Skeleton className="size-2 shrink-0 rounded-full bg-muted-foreground" aria-hidden="true" />
+              <Skeleton className="h-4 w-28" aria-hidden="true" />
               <span className="text-sm text-muted-foreground">
                 {loading ? "Starting background agent" : "Waiting for background agent"}
               </span>

--- a/crates/openwave-desktop/ui/src/ChatHeaderTitle.tsx
+++ b/crates/openwave-desktop/ui/src/ChatHeaderTitle.tsx
@@ -14,6 +14,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
+import { WithTooltip } from "@/components/ui/tooltip";
 
 /**
  * BW-style breadcrumb header: "Chats / chat title".
@@ -77,14 +78,15 @@ export function ChatHeaderTitle({ chat }: { chat: Chat }) {
           />
         </div>
       ) : (
-        <button
-          type="button"
-          className="min-w-0 truncate font-medium hover:underline cursor-pointer"
-          title="Rename chat"
-          onClick={() => startRename(chat)}
-        >
-          {displayTitle}
-        </button>
+        <WithTooltip label="Rename chat">
+          <button
+            type="button"
+            className="min-w-0 truncate font-medium hover:underline cursor-pointer"
+            onClick={() => startRename(chat)}
+          >
+            {displayTitle}
+          </button>
+        </WithTooltip>
       )}
 
       <DropdownMenu>

--- a/crates/openwave-desktop/ui/src/ClipboardCopyButton.test.tsx
+++ b/crates/openwave-desktop/ui/src/ClipboardCopyButton.test.tsx
@@ -19,7 +19,6 @@ describe("ClipboardCopyButton", () => {
     );
 
     expect(markup).toContain('aria-label="Copy table contents"');
-    expect(markup).toContain('title="Copy table contents"');
     expect(markup).toContain('role="status"');
     expect(markup).toContain('aria-live="polite"');
   });

--- a/crates/openwave-desktop/ui/src/ClipboardCopyButton.tsx
+++ b/crates/openwave-desktop/ui/src/ClipboardCopyButton.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Check, Copy } from "lucide-react";
+import { WithTooltip } from "@/components/ui/tooltip";
 
 export type ClipboardWriter = {
   writeText(text: string): Promise<void>;
@@ -54,18 +55,19 @@ export function ClipboardCopyButton({
 
   return (
     <>
-      <button
-        type="button"
-        className={className}
-        aria-label={visibleLabel}
-        title={visibleLabel}
-        onClick={() => void onCopy()}
-      >
-        <span aria-hidden="true" className="clipboard-copy-icon">
-          {copyState === "copied" ? <Check size={13} /> : <Copy size={13} />}
-        </span>
-        <span>{visibleLabel}</span>
-      </button>
+      <WithTooltip label={visibleLabel}>
+        <button
+          type="button"
+          className={className}
+          aria-label={visibleLabel}
+          onClick={() => void onCopy()}
+        >
+          <span aria-hidden="true" className="clipboard-copy-icon">
+            {copyState === "copied" ? <Check size={13} /> : <Copy size={13} />}
+          </span>
+          <span>{visibleLabel}</span>
+        </button>
+      </WithTooltip>
       <span className="sr-only" role="status" aria-live="polite">
         {copyState === "copied"
           ? copiedAnnouncement

--- a/crates/openwave-desktop/ui/src/MessageFooter.tsx
+++ b/crates/openwave-desktop/ui/src/MessageFooter.tsx
@@ -1,3 +1,4 @@
+import { WithTooltip } from "@/components/ui/tooltip";
 import { ClipboardCopyButton } from "./ClipboardCopyButton";
 
 type MessageFooterProps = {
@@ -34,9 +35,11 @@ export function MessageFooter({
       )}
       <span className="message-footer-spacer" />
       {timestamp && (
-        <time dateTime={createdAt} title={timestamp.full}>
-          {timestamp.short}
-        </time>
+        <WithTooltip label={timestamp.full}>
+          <time dateTime={createdAt}>
+            {timestamp.short}
+          </time>
+        </WithTooltip>
       )}
     </footer>
   );

--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -363,7 +363,6 @@ export function ReasoningEffortMenu({
           className="h-8 gap-1.5"
           disabled={disabled}
           aria-label={`Reasoning effort: ${label}`}
-          title={`Reasoning effort: ${label}`}
         >
           <Gauge className="size-4 text-muted-foreground" />
           <span className="truncate">{label}</span>

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Check, Clock, Terminal, X } from "lucide-react";
 import {
   isRendererToolName,
@@ -8,6 +7,7 @@ import {
 } from "./api";
 import { Badge } from "@/components/ui/badge";
 import { Spinner } from "@/components/ui/spinner";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import type { ToolTone } from "./ToolStatusIcon";
 import { ScrollableContainer } from "./ScrollableContainer";
@@ -237,7 +237,6 @@ export function ToolCommandCard({
   const presentation = toolCallPresentation(name, status);
   const command = toolPreviewPresentation(preview, result);
   const running = presentation.tone === "running";
-  const [tab, setTab] = useState<"command" | "output">("output");
   const output = commandOutput(result);
   // A command that finished silently has nothing to tab between, and a
   // "Command / Output → no output" pair reads as confusing noise.
@@ -252,47 +251,43 @@ export function ToolCommandCard({
       badge={<ToolStatusBadge presentation={presentation} result={result} />}
       defaultExpanded={running}
     >
-      {tabbed && (
-        <div
-          role="tablist"
-          aria-label="Command detail"
-          className="flex w-full items-center justify-start gap-1 border-b px-1"
-        >
-          {(["command", "output"] as const).map((value) => (
-            <button
-              key={value}
-              type="button"
-              role="tab"
-              aria-selected={tab === value}
-              onClick={() => setTab(value)}
-              className={cn(
-                "cursor-pointer rounded-md px-2.5 py-1 text-xs font-medium capitalize transition-colors",
-                tab === value
-                  ? "text-foreground"
-                  : "text-muted-foreground hover:text-foreground",
+      {tabbed ? (
+        <Tabs defaultValue="output">
+          <TabsList className="flex w-full items-center justify-start gap-1 border-b px-1">
+            <TabsTrigger value="command" className="py-1 text-xs capitalize">
+              command
+            </TabsTrigger>
+            <TabsTrigger value="output" className="py-1 text-xs capitalize">
+              output
+            </TabsTrigger>
+          </TabsList>
+          <div className="p-1">
+            <TabsContent value="command" className="mt-0">
+              <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
+                {command.detail}
+              </ScrollableContainer>
+            </TabsContent>
+            <TabsContent value="output" className="mt-0">
+              {output === null ? (
+                <p className="text-muted-foreground flex items-center gap-1.5 p-2 text-xs">
+                  <Spinner className="size-3.5" aria-hidden="true" />
+                  Waiting for output…
+                </p>
+              ) : (
+                <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
+                  {output}
+                </ScrollableContainer>
               )}
-            >
-              {value}
-            </button>
-          ))}
-        </div>
-      )}
-      <div className="p-1">
-        {!tabbed || tab === "command" ? (
+            </TabsContent>
+          </div>
+        </Tabs>
+      ) : (
+        <div className="p-1">
           <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
             {command.detail}
           </ScrollableContainer>
-        ) : output === null ? (
-          <p className="text-muted-foreground flex items-center gap-1.5 p-2 text-xs">
-            <Spinner className="size-3.5" aria-hidden="true" />
-            Waiting for output…
-          </p>
-        ) : (
-          <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
-            {output}
-          </ScrollableContainer>
-        )}
-      </div>
+        </div>
+      )}
     </ToolCardShell>
   );
 }

--- a/crates/openwave-desktop/ui/src/ToolStatusIcon.tsx
+++ b/crates/openwave-desktop/ui/src/ToolStatusIcon.tsx
@@ -1,6 +1,7 @@
 import { Ban, CircleAlert, Clock } from "lucide-react";
 
 import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
 
 export type ToolTone =
   | "running"
@@ -29,15 +30,15 @@ export function ToolStatusIcon({
     case "running":
       // Running takes the row's own colour; the other tones are deliberately
       // muted beside it.
-      return <Spinner className={`${className} text-current`} />;
+      return <Spinner className={cn(className, "text-current")} />;
     case "waiting_approval":
-      return <Clock className={`text-muted-foreground ${className}`} />;
+      return <Clock className={cn("text-muted-foreground", className)} />;
     case "completed":
       return null;
     case "cancelled":
-      return <Ban className={`text-muted-foreground ${className}`} />;
+      return <Ban className={cn("text-muted-foreground", className)} />;
     case "failed":
     case "unknown":
-      return <CircleAlert className={`text-muted-foreground ${className}`} />;
+      return <CircleAlert className={cn("text-muted-foreground", className)} />;
   }
 }

--- a/crates/openwave-desktop/ui/src/components/ui/tooltip.tsx
+++ b/crates/openwave-desktop/ui/src/components/ui/tooltip.tsx
@@ -16,13 +16,13 @@ const TooltipContent = React.forwardRef<
       hideWhenDetached
       sideOffset={sideOffset}
       className={cn(
-        "z-50 max-w-xs rounded-lg bg-neutral-900 px-3 py-2.5 text-sm font-medium text-neutral-50 shadow-lg select-none dark:bg-neutral-100 dark:text-neutral-900 data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-[state=closed]:zoom-out-95",
+        "z-50 max-w-xs rounded-lg bg-primary px-3 py-2.5 text-sm font-medium text-primary-foreground shadow-lg select-none data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-[state=closed]:zoom-out-95",
         className,
       )}
       {...props}
     >
       {children}
-      <TooltipPrimitive.Arrow className="fill-neutral-900 dark:fill-neutral-100" />
+      <TooltipPrimitive.Arrow className="fill-primary" />
     </TooltipPrimitive.Content>
   </TooltipPrimitive.Portal>
 ));

--- a/crates/openwave-desktop/ui/src/outputs/outputCellRenderers.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/outputCellRenderers.tsx
@@ -3,6 +3,7 @@ import { format } from "date-fns";
 import { BotIcon, DownloadIcon, MoreHorizontalIcon, Undo2Icon } from "lucide-react";
 import { useState } from "react";
 
+import { Badge } from "@/components/ui/badge";
 import { DocumentIcon } from "@/components/document-table/DocumentIcon";
 import { Button } from "@/components/ui/button";
 import {
@@ -59,10 +60,10 @@ export function NameCellRenderer(props: CellProps) {
       </button>
       {output.producingRunId !== null && (
         <WithTooltip label="Auto-merged from a background agent">
-          <span className="ml-2 flex shrink-0 items-center gap-1 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+          <Badge variant="outline" size="sm" className="ml-2 shrink-0 px-1.5 text-[10px] font-medium">
             <BotIcon className="size-3" />
             Agent
-          </span>
+          </Badge>
         </WithTooltip>
       )}
     </div>

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.dom.test.tsx
@@ -7,6 +7,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient, ProviderInfo } from "../api";
 import { ProvidersPanel } from "./ProvidersPanel";
@@ -144,9 +145,13 @@ describe("ProvidersPanel", () => {
       />,
     );
 
-    fireEvent.change(screen.getByLabelText("Gemini credential type"), {
-      target: { value: "service_account" },
-    });
+    const user = userEvent.setup();
+    await user.click(screen.getByLabelText("Gemini credential type"));
+    await user.click(
+      await screen.findByRole("option", {
+        name: "Google Cloud service account",
+      }),
+    );
     fireEvent.change(screen.getByLabelText("Vertex AI location"), {
       target: { value: "us-central1" },
     });

--- a/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ProvidersPanel.tsx
@@ -8,6 +8,13 @@ import type {
 } from "../api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { useConfirm } from "../components/ConfirmDialog";
@@ -309,20 +316,23 @@ function ProviderRow({
       {info.kind === "gemini" && (
         <label className="grid gap-1 text-xs text-muted-foreground">
           Credential type
-          <select
-            aria-label="Gemini credential type"
-            className="h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground"
+          <Select
             value={credentialType}
             disabled={saving}
-            onChange={(event) =>
-              setCredentialType(
-                event.target.value as "api_key" | "service_account",
-              )
+            onValueChange={(value) =>
+              setCredentialType(value as "api_key" | "service_account")
             }
           >
-            <option value="api_key">Gemini API key</option>
-            <option value="service_account">Google Cloud service account</option>
-          </select>
+            <SelectTrigger aria-label="Gemini credential type" className="h-9">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="api_key">Gemini API key</SelectItem>
+              <SelectItem value="service_account">
+                Google Cloud service account
+              </SelectItem>
+            </SelectContent>
+          </Select>
         </label>
       )}
       {credentialType === "api_key" && (

--- a/crates/openwave-desktop/ui/src/sidebar/RecentChatRow.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/RecentChatRow.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
 
 /** One conversation in a rail list, with its rename field and row actions. */
 export function RecentChatRow({
@@ -77,9 +78,10 @@ export function RecentChatRow({
 
   return (
     <div
-      className={`group flex items-center rounded-md transition-colors hover:bg-muted ${
-        active ? "bg-muted" : ""
-      }`}
+      className={cn(
+        "group flex items-center rounded-md transition-colors hover:bg-muted",
+        active && "bg-muted",
+      )}
     >
       <button
         type="button"


### PR DESCRIPTION
## Summary

Sweep through the desktop UI replacing hand-rolled patterns with existing shadcn
primitives. Follows the same direction as #1017 (textarea/spinner/input
adoption); this covers the remaining sites that duplicated what the component
library already provides.

## Sites migrated

| File | What was | What it became |
|---|---|---|
| tooltip.tsx:19,25 | Hardcoded bg-neutral-900 text-neutral-50 dark:bg-neutral-100 dark:text-neutral-900 and fill-neutral-900 dark:fill-neutral-100 | Semantic bg-primary text-primary-foreground and fill-primary |
| ToolCallCard.tsx:256-278 | Hand-rolled role=tablist + role=tab + aria-selected + useState tab bar | Tabs / TabsList / TabsTrigger / TabsContent from the tabs primitive; manual tab state removed |
| ProvidersPanel.tsx:311-325 | Native select + option for Gemini credential type | Select / SelectTrigger / SelectContent / SelectItem matching the pattern used elsewhere in settings |
| BackgroundAgentList.tsx:152-153 | Two hand-rolled animate-pulse rounded bg-muted spans | Skeleton primitive |
| outputCellRenderers.tsx:62 | Hand-rolled rounded-full bg-muted px-1.5 py-0.5 pill span | Badge variant=outline size=sm |
| ChatHeaderTitle.tsx:83 | title=Rename chat | WithTooltip label=Rename chat |
| ClipboardCopyButton.tsx:61 | title=visibleLabel | WithTooltip label=visibleLabel |
| MessageFooter.tsx:37 | title=timestamp.full on time | WithTooltip label=timestamp.full |
| ModelMenu.tsx:366 | title= on Button inside DropdownMenuTrigger | Removed (incompatible with WithTooltip; aria-label and visible text already present) |
| ToolStatusIcon.tsx:28-41 | Template literal className concatenation | cn() with twMerge so callers can override text colors |
| RecentChatRow.tsx:79 | Template literal className with ternary | cn() |

## Skipped sites

- ToolCallCard.tsx:249 -- title=command.headline is a component prop on ToolCardShell, not an HTML title attribute.
- Composer.tsx -- rewritten in #1020; no stale title= to migrate.
- ModelMenu.tsx:195 -- not in scope (only :366 was listed).

## Test changes

- ClipboardCopyButton.test.tsx: removed assertion on title= attribute (now handled by WithTooltip; aria-label assertion still covers accessibility).

## Verification

pnpm install --frozen-lockfile && pnpm test && pnpm build -- all 358 tests pass, production build succeeds.