### PR TITLE
fix(desktop): stop shell work behind the managed gate and tighten deep-link pairing

### DIFF
--- a/crates/openwave-desktop/src/deep_link.rs
+++ b/crates/openwave-desktop/src/deep_link.rs
@@ -59,16 +59,26 @@ struct ProvisionLink {
     origin: String,
 }
 
+/// The scheme dev builds register and answer alongside `openwave`. A dev run
+/// used to `register_all()`, which persistently re-pointed the real scheme's
+/// per-user registration at whatever debug binary ran last — links on that
+/// machine then bypassed the installed app until it was reinstalled. The dev
+/// scheme keeps dev deep-link work exercisable without ever touching the
+/// installed registration. It must stay in the deep-link config's scheme
+/// list: the plugin only recognizes configured schemes when it picks deep
+/// links out of launch arguments.
+const DEV_SCHEME: &str = "openwave-dev";
+
 /// Register the open-URL listener and pick up a launch link.
 pub(crate) fn install(app: &tauri::AppHandle) {
     // Dev builds have no installer run to write the scheme registration, so
-    // register at runtime. Debug-only: in a release build this would write
-    // a per-user registration for whatever path the binary runs from,
-    // shadowing the installer's registration. Not available on macOS, where
-    // the bundle's Info.plist (generated from the deep-link config) is the
-    // only registration path.
+    // register at runtime — only the dev scheme, never the real one, which
+    // in a dev run would shadow the installed app's registration. Debug-only:
+    // a release binary's registration is the installer's job. Not available
+    // on macOS, where the bundle's Info.plist (generated from the deep-link
+    // config) is the only registration path.
     #[cfg(all(debug_assertions, any(windows, target_os = "linux")))]
-    if let Err(error) = app.deep_link().register_all() {
+    if let Err(error) = app.deep_link().register(DEV_SCHEME) {
         eprintln!("openwave-desktop: deep-link scheme registration failed: {error}");
     }
     let handle = app.clone();
@@ -111,16 +121,17 @@ pub(crate) fn focus_main_window(app: &tauri::AppHandle) {
 
 /// Parse and validate a provision link.
 ///
-/// The contract is strict — scheme `openwave`, action `provision` with no
-/// userinfo, port, or extra path, exactly one query parameter named
-/// `gateway`, and a gateway value that is an http(s) URL with no query or
-/// fragment — so a malformed or hostile link is refused whole rather than
-/// partially honored. Near-miss gateway values matter: the conflict check on
-/// the write path compares normalized URL strings, so accepting a decorated
-/// variant would mint a distinct, permanently conflicting policy value. The
-/// gateway URL is additionally held to the connectors contract server-side.
+/// The contract is strict — scheme `openwave` (dev builds also answer
+/// `openwave-dev`), action `provision` with no userinfo, port, or extra
+/// path, exactly one query parameter named `gateway`, and a gateway value
+/// that is an http(s) URL with no userinfo, query, or fragment — so a
+/// malformed or hostile link is refused whole rather than partially honored.
+/// Near-miss gateway values matter: the conflict check on the write path
+/// compares normalized URL strings, so accepting a decorated variant would
+/// mint a distinct, permanently conflicting policy value. The gateway URL is
+/// additionally held to the connectors contract server-side.
 fn provision_link(url: &tauri::Url) -> Result<ProvisionLink, String> {
-    if url.scheme() != "openwave" {
+    if url.scheme() != "openwave" && !(cfg!(debug_assertions) && url.scheme() == DEV_SCHEME) {
         return Err("not an openwave:// link".into());
     }
     if !url.username().is_empty() || url.password().is_some() {
@@ -158,6 +169,9 @@ fn provision_link(url: &tauri::Url) -> Result<ProvisionLink, String> {
         tauri::Url::parse(&value).map_err(|_| "the gateway URL is invalid".to_string())?;
     if !matches!(gateway.scheme(), "http" | "https") {
         return Err("the gateway URL must use http or https".into());
+    }
+    if !gateway.username().is_empty() || gateway.password().is_some() {
+        return Err("the gateway URL must not carry credentials".into());
     }
     if gateway.query().is_some() || gateway.fragment().is_some() {
         return Err("the gateway URL must not carry a query or fragment".into());
@@ -381,6 +395,12 @@ async fn wait_pairing_handle(app: &tauri::AppHandle) -> Result<PairingHandle, St
     }
 }
 
+/// Growth cap for `pairing.log`. Every ignored deep link writes a line, and
+/// a deep link is an unauthenticated remote trigger, so without a cap a
+/// hostile page could grow the file without bound. Attempts past the cap
+/// still reach stderr.
+const PAIRING_LOG_MAX_BYTES: u64 = 256 * 1024;
+
 /// One bounded, secret-free line per pairing attempt: stderr for terminal
 /// launches, `pairing.log` under app-data for GUI launches. Only the gateway
 /// origin is ever named — never the full link or URL — and gateway errors
@@ -391,11 +411,15 @@ fn log_pairing(app: &tauri::AppHandle, message: &str) {
     let Ok(dir) = crate::data_dir(app) else {
         return;
     };
+    let path = dir.join("pairing.log");
+    if std::fs::metadata(&path).is_ok_and(|meta| meta.len() >= PAIRING_LOG_MAX_BYTES) {
+        return;
+    }
     let line = format!("{} {message}\n", chrono::Local::now().to_rfc3339());
     let _ = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
-        .open(dir.join("pairing.log"))
+        .open(path)
         .and_then(|mut file| file.write_all(line.as_bytes()));
 }
 
@@ -451,12 +475,18 @@ mod tests {
             ),
             ("openwave://provision:9999?gateway=https://gw.example", None),
             ("openwave://pro%76ision?gateway=https://gw.example", None),
-            // Near-miss gateway values: not a URL, wrong scheme, or carrying
-            // a query or fragment (which would also leak into any log that
-            // echoed them, and would mint a permanently conflicting policy
-            // value under the string-equality conflict check).
+            // Near-miss gateway values: not a URL, wrong scheme, carrying
+            // credentials, or carrying a query or fragment (which would also
+            // leak into any log that echoed them, and would mint a
+            // permanently conflicting policy value under the string-equality
+            // conflict check).
             ("openwave://provision?gateway=notaurl", None),
             ("openwave://provision?gateway=ftp://gw.example", None),
+            (
+                "openwave://provision?gateway=https://user:pw@gw.example",
+                None,
+            ),
+            ("openwave://provision?gateway=https://user@gw.example", None),
             (
                 "openwave://provision?gateway=https://gw.example/?token=x",
                 None,
@@ -476,6 +506,15 @@ mod tests {
                 "{link}"
             );
         }
+    }
+
+    /// Dev builds answer the dev scheme so a dev run never has to claim the
+    /// real one; release builds refuse it. The expectation flips with the
+    /// build profile, which is exactly the contract.
+    #[test]
+    fn the_dev_scheme_is_a_debug_only_alias() {
+        let url = tauri::Url::parse("openwave-dev://provision?gateway=https://gw.example").unwrap();
+        assert_eq!(provision_link(&url).is_ok(), cfg!(debug_assertions));
     }
 
     #[tokio::test]

--- a/crates/openwave-desktop/tauri.conf.json
+++ b/crates/openwave-desktop/tauri.conf.json
@@ -40,7 +40,7 @@
   "plugins": {
     "deep-link": {
       "desktop": {
-        "schemes": ["openwave"]
+        "schemes": ["openwave", "openwave-dev"]
       }
     },
     "updater": {

--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -44,6 +44,21 @@ const listPendingChatPrompts = vi.fn(async () => [] as unknown[]);
 const listPendingOutputWritebackRequests = vi.fn(async () => [] as unknown[]);
 const requestUserAttention = vi.fn(async () => {});
 const postMessage = vi.fn(async () => {});
+// Unmanaged is the shape most of these shell tests model; the managed gate
+// has its own DOM tests, and the one shell test that flips this to managed
+// pins that a gated shell does no work at all.
+const unmanaged: import("./api").ManagedPolicy = {
+  managed: false,
+  source: "unmanaged",
+  misconfigured: false,
+};
+const getPolicy = vi.fn(async () => unmanaged);
+const getGatewayStatus = vi.fn(async () => ({
+  base_url: "https://gateway.example",
+  signed_in: false,
+  model_count: 0,
+  sign_in: { state: "idle" },
+}));
 
 vi.mock("./boot", () => ({
   resolveServerInfo: vi.fn(async () => ({ baseUrl: "http://127.0.0.1:1", token: "t" })),
@@ -51,9 +66,9 @@ vi.mock("./boot", () => ({
 
 vi.mock("./api", () => ({
   ApiClient: class {
-    // Unmanaged is the shape these shell tests model; the managed gate has
-    // its own DOM tests.
-    getPolicy = vi.fn(async () => ({ managed: false, source: "unmanaged" }));
+    getPolicy = getPolicy;
+    getGatewayStatus = getGatewayStatus;
+    gatewaySignIn = vi.fn(async () => ({ authorization_url: "http://gw/authorize" }));
     listModels = vi.fn(async () => ({ models: [], roles: [] }));
     listProviders = vi.fn(async () => ({ providers: [] }));
     getSettings = vi.fn(async () => ({
@@ -155,6 +170,9 @@ beforeEach(() => {
   listPendingOutputWritebackRequests.mockResolvedValue([]);
   requestUserAttention.mockClear();
   postMessage.mockClear();
+  getPolicy.mockClear();
+  getPolicy.mockResolvedValue(unmanaged);
+  getGatewayStatus.mockClear();
   usePendingPrompts.setState({ chatId: null, userQuestions: [], folderAccess: [] });
   // The stores outlive a test file's renders, so a chat list left behind would
   // decide the next test's routing before its own boot ever ran.
@@ -372,6 +390,27 @@ describe("app shell", () => {
     );
     // And the dock still gets told, which is the whole point.
     await waitFor(() => expect(requestUserAttention).toHaveBeenCalled());
+  });
+
+  it("does no shell work behind the managed sign-in gate", async () => {
+    // Managed and signed out: the gate is a hard stop, not a curtain in
+    // front of a running app. The prompt watcher must not poll and the
+    // shortcuts must not act — Cmd+N creating chats behind the sign-in
+    // screen is the regression this pins.
+    getPolicy.mockResolvedValue({
+      managed: true,
+      gateway_url: "https://gateway.example/",
+      source: "os",
+      misconfigured: false,
+    });
+    const user = userEvent.setup();
+    await mountApp();
+
+    expect(await screen.findByText("Sign in to continue")).toBeInTheDocument();
+    await user.keyboard("{Meta>}n{/Meta}");
+
+    expect(createChat).not.toHaveBeenCalled();
+    expect(listPendingChatPrompts).not.toHaveBeenCalled();
   });
 
   it("returns from settings to the conversation that was open", async () => {

--- a/crates/openwave-desktop/ui/src/AppShell.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.tsx
@@ -27,7 +27,7 @@ import { useTheme } from "./theme";
 import { Titlebar } from "./Titlebar";
 import { useActiveChatId } from "./useActiveChatId";
 import { useChatPromptWatcher } from "./useChatPromptWatcher";
-import { useShellShortcuts } from "./ShellShortcuts";
+import { useShellShortcuts, type ShellShortcutHandlers } from "./ShellShortcuts";
 import { ShortcutsDialog } from "./ShortcutsDialog";
 import { useUiStore } from "./UiStore";
 import { useDesktopUpdates } from "./updates";
@@ -42,6 +42,29 @@ function focusComposer(): void {
 // Store actions are stable for the store's lifetime; these handles are for
 // calling actions only — never read state fields from them.
 const chatListActions = useChatListStore.getState();
+
+/**
+ * The shell hooks that do work on their own — the parked-prompt poll and the
+ * shortcuts that create chats. Mounted as a child of the managed gate rather
+ * than in the shell itself, so that while the sign-in gate is up the app does
+ * none of it: the gate is a hard stop, not a curtain in front of a running
+ * app.
+ */
+function GatedShellHooks({
+  client,
+  chatId,
+  shortcuts,
+}: {
+  client: ApiClient;
+  chatId: string | null;
+  shortcuts: ShellShortcutHandlers;
+}) {
+  // Watched here rather than in the conversation, so that the agent parking a
+  // turn on a question is noticed whatever screen the reader is on.
+  useChatPromptWatcher(client, chatId);
+  useShellShortcuts(shortcuts);
+  return null;
+}
 
 /**
  * The frame every route hangs in: the titlebar, the window, and the connection
@@ -79,14 +102,11 @@ export function AppShell() {
   const desktopUpdates = useDesktopUpdates();
   const zoom = useInterfaceZoom();
 
-  // Watched here rather than in the conversation, so that the agent parking a
-  // turn on a question is noticed whatever screen the reader is on.
-  useChatPromptWatcher(client, openChatId);
-
-  // Shell shortcuts live here because these actions outlive any one route:
-  // toggling the frame, starting a chat, reaching the composer, and scaling the
-  // window all work wherever the reader is.
-  useShellShortcuts({
+  // Shell shortcuts are defined here because these actions outlive any one
+  // route: toggling the frame, starting a chat, reaching the composer, and
+  // scaling the window all work wherever the reader is. They are installed
+  // below the gate, by GatedShellHooks.
+  const shellShortcuts: ShellShortcutHandlers = {
     "toggle-sidebar": () => useUiStore.getState().toggleSidebar(),
     "new-chat": () => void onNewChat(),
     "focus-composer": focusComposer,
@@ -94,7 +114,7 @@ export function AppShell() {
     "zoom-out": zoom.zoomOut,
     "zoom-reset": zoom.resetZoom,
     "show-shortcuts": () => setShortcutsOpen(true),
-  });
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -292,6 +312,11 @@ export function AppShell() {
 
   return (
     <ManagedGate client={client}>
+      <GatedShellHooks
+        client={client}
+        chatId={openChatId}
+        shortcuts={shellShortcuts}
+      />
       <AppContextProvider
         value={{
           client,

--- a/crates/openwave-desktop/ui/src/ManagedGate.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.dom.test.tsx
@@ -298,6 +298,34 @@ describe("ManagedGate", () => {
     expect(screen.queryByText("the open product")).not.toBeInTheDocument();
   });
 
+  it("a stalled pending sign-in can be started over without waiting it out", async () => {
+    // The server holds a pending flow for the full sign-in timeout; the gate
+    // must not make the reader wait it out with reopening the same page as
+    // the only affordance.
+    const client = api({
+      getGatewayStatus: vi.fn().mockResolvedValue({
+        ...signedOut,
+        sign_in: { state: "pending", authorization_url: "http://gw/stalled" },
+      }),
+    });
+    const open = vi.fn();
+    vi.stubGlobal("open", open);
+    const user = userEvent.setup();
+    mount(client);
+
+    expect(await screen.findByText(/Waiting for the browser/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Start over/ }));
+
+    // A fresh flow begins — a new attempt server-side, and the new page
+    // opens — rather than reopening the stalled attempt's page.
+    await waitFor(() => expect(client.gatewaySignIn).toHaveBeenCalled());
+    expect(open).toHaveBeenCalledWith(
+      "http://gw/oauth/authorize?x=1",
+      "_blank",
+      "noreferrer,noopener",
+    );
+  });
+
   it("surfaces a failed browser sign-in and offers to try again", async () => {
     const client = api({
       getGatewayStatus: vi.fn().mockResolvedValue({

--- a/crates/openwave-desktop/ui/src/ManagedGate.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.tsx
@@ -343,7 +343,20 @@ export function ManagedGate({
             }}
           >
             Open the sign-in page again
-          </a>
+          </a>{" "}
+          ·{" "}
+          {/* A stalled flow otherwise blocks the gate for the full sign-in
+              timeout. Starting over begins a fresh attempt; the server
+              invalidates the abandoned one, so a late completion of it
+              cannot sign the device in. */}
+          <button
+            type="button"
+            className="underline disabled:opacity-50"
+            disabled={working}
+            onClick={() => void connect()}
+          >
+            Start over
+          </button>
         </p>
       ) : (
         <Button type="button" disabled={working} onClick={() => void connect()}>

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -2215,6 +2215,111 @@ async fn an_unreadable_policy_fails_the_resolver_closed() {
     assert_eq!(resolver.resolve().await.id().0, "unconfigured");
 }
 
+/// `misconfigured` is a fail-closed security state end to end: `/policy`
+/// reporting it is the exact wire signal the renderer blocks the whole app
+/// on, and the accept path refuses the turn a blocked gate can no longer
+/// send. Driven over the real routes with the production resolver, against a
+/// profile whose BYOK setup demonstrably serves a turn until the policy
+/// breaks — so the refusal below is the policy's doing and nothing else's.
+#[tokio::test]
+async fn a_misconfigured_policy_gates_the_renderer_and_refuses_a_turn() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("misconfigured.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+    providers::write_credential(
+        &*secrets,
+        providers::ProviderKind::Anthropic,
+        &providers::ProviderCredential::api_key("sk-ready"),
+    )
+    .await
+    .unwrap();
+    providers::write_config(
+        &*store,
+        providers::ProviderKind::Anthropic,
+        &providers::ProviderConfig {
+            enabled: true,
+            base_url: None,
+            vertex_location: None,
+            models: Vec::new(),
+        },
+    )
+    .await
+    .unwrap();
+    let (retrieval, _search) = build_retrieval(
+        Arc::new(HashEmbedder::default()),
+        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
+    );
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(resolver::ConfiguredResolver::new(
+            store.clone(),
+            secrets.clone(),
+            crate::gateway_runtime::GatewayRuntime::new(
+                store.clone(),
+                secrets.clone(),
+                Arc::new(crate::managed_policy::NoOsPolicy),
+            ),
+            Arc::new(crate::managed_policy::NoOsPolicy),
+        )),
+        secrets.clone(),
+        Arc::new(ToolRegistry::new()),
+        retrieval,
+        AgentConfig {
+            model: "claude-opus-5".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let bearer = format!("Bearer {}", state.token);
+    let router = app(state);
+
+    // Control: with the policy healthy, this profile accepts a turn.
+    let healthy_chat = make_chat(&router, &bearer).await;
+    assert_eq!(
+        send_message(&router, &bearer, healthy_chat.id, "hello").await,
+        StatusCode::ACCEPTED
+    );
+
+    // The profile now claims to be managed but the claim cannot be read.
+    store
+        .set_setting("managed_policy_v1", &serde_json::json!({"gateway_url": 42}))
+        .await
+        .unwrap();
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/policy")
+                .header(header::AUTHORIZATION, &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let policy: serde_json::Value = json_body(response).await;
+    assert_eq!(policy["managed"], serde_json::json!(true));
+    assert_eq!(policy["misconfigured"], serde_json::json!(true));
+
+    // A turn cannot run: the send is refused at accept, and nothing was
+    // queued for the worker to pick up behind the blocked gate.
+    let gated_chat = make_chat(&router, &bearer).await;
+    let turn_id = TurnId::new();
+    assert_eq!(
+        send_message_with_id(&router, &bearer, gated_chat.id, turn_id, "hello").await,
+        StatusCode::CONFLICT
+    );
+    assert!(store.get_turn_run(turn_id).await.unwrap().is_none());
+}
+
 async fn put_json(
     router: &Router,
     bearer: &str,


### PR DESCRIPTION
Closes #763 — the four "worth doing" items plus both optionals, one slice.

## What changed

**Shell hooks no longer run behind the managed sign-in gate.** `useChatPromptWatcher` and `useShellShortcuts` moved from `AppShell` into a `GatedShellHooks` child of `ManagedGate`, so while the gate is up the app does none of their work: no Cmd+N → `createChat`, no 10-second prompt polling. A new AppShell DOM test pins it (managed + signed out → Cmd+N creates nothing, the summary poll never fires).

**End-to-end misconfigured-policy test.** `misconfigured` is a fail-closed security state that had only unit + DOM coverage. The new server behavior test drives the real routes with the production resolver against a profile whose BYOK setup demonstrably accepts a turn, then corrupts the persisted policy record: `/policy` reports `managed: true, misconfigured: true` (the exact wire signal the renderer's gate blocks on) and the accept path refuses the send with nothing queued for the worker.

**Userinfo refused in the gateway value.** The parser rejected `user:pw@` in the provision link but not in the `gateway=` value, while the doc comment claimed otherwise. It now refuses both (`user:pw@` and bare `user@` covered in the contract table) and the comment matches the code.

**Dev builds use a distinct `openwave-dev` scheme.** A dev run used to `register_all()`, persistently re-pointing the real `openwave://` per-user registration at whatever debug binary ran last. Debug builds now register only `openwave-dev` and the parser answers it only under `debug_assertions` — pinned by a test whose expectation flips with the build profile. The scheme is added to the deep-link config list because the plugin only picks configured schemes out of launch arguments. Release builds therefore also *claim* `openwave-dev` in their installer/Info.plist registration, but refuse such links at the parser, so they are inert there. Residual (macOS only): runtime registration doesn't exist on macOS, so a stale debug *bundle* indexed by Launch Services can still shadow the installed app — out of reach of runtime code.

**`pairing.log` capped at 256 KiB.** Every ignored deep link writes a line and a deep link is an unauthenticated remote trigger. Past the cap, attempts still reach stderr.

**Stalled pending sign-in can be started over.** The gate's pending state offered only "open the sign-in page again" while the server holds the flow for the full 5-minute timeout. A "Start over" affordance begins a fresh attempt; the server's sign-in generation counter already invalidates the abandoned flow, so its late completion cannot sign the device in.

## Verification

- `pnpm test` (666 tests, includes 3 new), `tsc --noEmit`, `pnpm build` — green
- `cargo test -p openwave-desktop --no-default-features --locked deep_link` — 5 pass (2 new)
- `cargo test -p openwave-server --locked a_misconfigured_policy_gates` — passes
- `cargo clippy -p openwave-desktop --no-default-features --all-targets --locked`, `cargo fmt` — clean

Not verified by hand: OS-level scheme registration behavior on Windows/Linux dev runs (needs a real dev machine of each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)