### PR TITLE
fix(desktop): keep the window draggable on full-window boot and gate surfaces

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.tsx
@@ -25,6 +25,7 @@ import { ManagedGate } from "./ManagedGate";
 import { resolvedRoleKey } from "./ModelSelection";
 import { useTheme } from "./theme";
 import { Titlebar } from "./Titlebar";
+import { WindowDragStrip } from "./WindowDragStrip";
 import { useActiveChatId } from "./useActiveChatId";
 import { useChatPromptWatcher } from "./useChatPromptWatcher";
 import { useShellShortcuts } from "./ShellShortcuts";
@@ -269,6 +270,7 @@ export function AppShell() {
   if (bootError) {
     return (
       <div className="boot">
+        <WindowDragStrip />
         <div className="boot-brand">
           <Logomark />
           <h1>OpenWave</h1>
@@ -281,6 +283,7 @@ export function AppShell() {
   if (!client) {
     return (
       <div className="boot">
+        <WindowDragStrip />
         <div className="boot-brand">
           <Logomark />
           <h1>OpenWave</h1>

--- a/crates/openwave-desktop/ui/src/ManagedGate.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Logomark } from "./Logomark";
 import { ManagedPolicyContext } from "./managedPolicy";
 import { openSignInPage } from "./openSignInPage";
+import { WindowDragStrip } from "./WindowDragStrip";
 
 /** While the browser flow is pending the exchange lands out of band, so the
  * poll is what turns the gate off. Matches the settings panel's cadence. */
@@ -255,6 +256,7 @@ export function ManagedGate({
   if (policyState.kind === "blocked" || policyMisconfigured) {
     return (
       <div className="boot" aria-label="Managed policy unavailable">
+        <WindowDragStrip />
         <div className="boot-brand">
           <Logomark />
           <h1>OpenWave</h1>
@@ -306,6 +308,7 @@ export function ManagedGate({
 
   return (
     <div className="boot" aria-label="Sign in required">
+      <WindowDragStrip />
       <div className="boot-brand">
         <Logomark />
         <h1>OpenWave</h1>
@@ -379,6 +382,7 @@ function Published({
 function BootScreen({ children }: { children: ReactNode }) {
   return (
     <div className="boot">
+      <WindowDragStrip />
       <div className="boot-brand">
         <Logomark />
         <h1>OpenWave</h1>

--- a/crates/openwave-desktop/ui/src/WindowDragStrip.tsx
+++ b/crates/openwave-desktop/ui/src/WindowDragStrip.tsx
@@ -1,0 +1,16 @@
+import { hasMacOverlayTitlebar } from "./host";
+
+/**
+ * The draggable strip a full-window surface owes the macOS overlay titlebar.
+ *
+ * With the system chrome hidden, the window drags only where an element
+ * carries `data-tauri-drag-region`. The shell's `Titlebar` provides that for
+ * the normal chrome, but a surface that replaces the whole shell — a boot or
+ * error screen, the managed sign-in gate — otherwise leaves the window
+ * pinned. Rendered inside such a surface, this spans the strip the traffic
+ * lights sit in; on other platforms it renders nothing.
+ */
+export function WindowDragStrip() {
+  if (!hasMacOverlayTitlebar()) return null;
+  return <div className="window-drag-strip" data-tauri-drag-region />;
+}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -2172,6 +2172,18 @@ body {
   padding-top: 0;
 }
 
+/* Full-window surfaces that replace the shell (boot and error screens, the
+   managed sign-in gate) render this so the window stays draggable where the
+   traffic lights sit. Same height as the titlebar it stands in for. */
+.window-drag-strip {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 52px;
+  z-index: 50;
+}
+
 .app-body {
   display: flex;
   flex: 1;


### PR DESCRIPTION
Closes #1025

On macOS the app hides the system chrome (`titleBarStyle: Overlay`) and the shell's `Titlebar` supplies the drag region. Any surface that replaces the whole shell — the boot screen, boot-error screen, the managed-policy blocked screen, and the sign-in gate — rendered no drag region at all, so while one of them was up the window could not be moved by dragging where the traffic lights sit.

This adds a `WindowDragStrip`: a fixed, invisible strip matching the titlebar's 52px height that carries `data-tauri-drag-region`, rendered by every full-window surface. It renders nothing off macOS (Windows/Linux keep standard decorations; the browser has its own chrome).

No new tests: the strip is macOS-native drag behavior that a jsdom test cannot exercise — asserting the div exists would only re-assert the code's existence. Verified by typecheck and the existing desktop UI suite (664 passing).

Not verified here: actual drag behavior in the running app — worth a quick check during smoke testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)