### PR TITLE
feat(gateway): revoke and clear the session an MDM repoint superseded

### DIFF
--- a/crates/openwave-connectors/src/gateway.rs
+++ b/crates/openwave-connectors/src/gateway.rs
@@ -189,6 +189,30 @@ pub struct GatewayCredentials {
     access_tokens: BTreeMap<String, CachedAccessToken>,
 }
 
+impl GatewayCredentials {
+    /// Whether these credentials were minted against `base_url`. Trailing
+    /// slashes are normalized the same way [`GatewayAuth::endpoint`] does, so
+    /// a subpath deployment retyped with or without one never reads as a
+    /// different gateway. A base URL that does not parse matches nothing.
+    #[must_use]
+    pub fn matches_base_url(&self, base_url: &str) -> bool {
+        fn normalized(url: &reqwest::Url) -> String {
+            let mut base = url.to_string();
+            if !base.ends_with('/') {
+                base.push('/');
+            }
+            base
+        }
+        match (
+            reqwest::Url::parse(&self.base_url),
+            reqwest::Url::parse(base_url),
+        ) {
+            (Ok(stored), Ok(expected)) => normalized(&stored) == normalized(&expected),
+            _ => false,
+        }
+    }
+}
+
 impl std::fmt::Debug for GatewayCredentials {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
@@ -213,6 +237,20 @@ pub async fn has_stored_credentials(secrets: &dyn SecretProvider) -> bool {
     matches!(
         secrets.get_secret(SECRET_KEY).await,
         Ok(Some(raw)) if serde_json::from_str::<GatewayCredentials>(&raw).is_ok()
+    )
+}
+
+/// Whether a gateway session minted against `base_url` is stored.
+///
+/// The deployment-matched form of [`has_stored_credentials`], for readiness
+/// surfaces on a managed profile: a session left by a superseded deployment
+/// must not read as a credential for the policy's current one — every route
+/// and token path already refuses it.
+pub async fn has_stored_credentials_for(secrets: &dyn SecretProvider, base_url: &str) -> bool {
+    matches!(
+        secrets.get_secret(SECRET_KEY).await,
+        Ok(Some(raw)) if serde_json::from_str::<GatewayCredentials>(&raw)
+            .is_ok_and(|credentials| credentials.matches_base_url(base_url))
     )
 }
 
@@ -602,8 +640,18 @@ impl GatewayConnection {
     }
 
     /// Persist a completed sign-in as the connection's stored credentials.
+    ///
+    /// The vault holds one session, so whatever was stored is superseded the
+    /// moment this saves: its refresh token is revoked first (best-effort, at
+    /// its own gateway), or it would stay live server-side with no local
+    /// state left to ever revoke it.
     pub async fn store_session(&self, session: &AuthorizedSession) -> Result<()> {
         let _guard = self.token_motion.lock().await;
+        // An unreadable stored blob is skipped, as in sign-out: it carries no
+        // usable refresh token to revoke.
+        if let Ok(Some(superseded)) = self.vault.load().await {
+            self.revoke_stored(&superseded).await;
+        }
         let mut access_tokens = BTreeMap::new();
         access_tokens.insert(
             session.tokens.resource.clone(),
@@ -634,15 +682,29 @@ impl GatewayConnection {
     /// [`GatewayAuth::endpoint`] does, so a subpath deployment retyped with
     /// or without one never reads as a different gateway.
     fn matches_deployment(&self, credentials: &GatewayCredentials) -> bool {
-        fn normalized(url: &reqwest::Url) -> String {
-            let mut base = url.to_string();
-            if !base.ends_with('/') {
-                base.push('/');
-            }
-            base
-        }
-        reqwest::Url::parse(&credentials.base_url)
-            .is_ok_and(|url| normalized(&url) == normalized(&self.auth.config.base_url))
+        credentials.matches_base_url(self.auth.config.base_url.as_str())
+    }
+
+    /// Best-effort, bounded revocation of a stored session at its own
+    /// gateway.
+    ///
+    /// The stored credentials name the deployment they were minted against,
+    /// which need not be this connection's own (an MDM re-point, a re-pair):
+    /// the revoke goes where the token is valid. A gateway that is
+    /// unreachable, gone, or whose stored URL no longer parses cannot hold
+    /// the caller hostage — the server-side session still dies at
+    /// refresh-token expiry.
+    async fn revoke_stored(&self, credentials: &GatewayCredentials) {
+        const REVOKE_TIMEOUT: Duration = Duration::from_secs(5);
+        let auth = if self.matches_deployment(credentials) {
+            Some(self.auth.clone())
+        } else {
+            GatewayAuthConfig::new(&credentials.base_url)
+                .and_then(GatewayAuth::new)
+                .ok()
+        };
+        let Some(auth) = auth else { return };
+        let _ = tokio::time::timeout(REVOKE_TIMEOUT, auth.revoke(&credentials.refresh_token)).await;
     }
 
     /// The stored (offline) identity, if signed in to this connection's
@@ -731,13 +793,14 @@ impl GatewayConnection {
         self.access_token(&format!("mcp:{slug}")).await
     }
 
-    /// Revoke the session at the gateway (best-effort) and always clear the
-    /// local vault. A gateway that is unreachable cannot hold local sign-out
-    /// hostage; its server-side session still dies at refresh-token expiry.
+    /// Revoke the session at its own gateway (best-effort, bounded) and
+    /// always clear the local vault. A gateway that is unreachable cannot
+    /// hold local sign-out hostage; its server-side session still dies at
+    /// refresh-token expiry.
     pub async fn sign_out(&self) -> Result<()> {
         let _guard = self.token_motion.lock().await;
         if let Some(credentials) = self.vault.load().await? {
-            let _ = self.auth.revoke(&credentials.refresh_token).await;
+            self.revoke_stored(&credentials).await;
         }
         self.vault.clear().await
     }

--- a/crates/openwave-connectors/src/lib.rs
+++ b/crates/openwave-connectors/src/lib.rs
@@ -22,8 +22,8 @@
 mod gateway;
 
 pub use gateway::{
-    has_stored_credentials, is_sign_in_required, validate_mcp_endpoint_slug, AuthorizedSession,
-    CredentialVault, GatewayApp, GatewayAuth, GatewayAuthConfig, GatewayConnection,
-    GatewayCredentials, GatewayIdentity, GatewayMeta, GatewayModel, PendingSignIn, TokenSet,
-    RESOURCE_CONTROL, RESOURCE_LLM,
+    has_stored_credentials, has_stored_credentials_for, is_sign_in_required,
+    validate_mcp_endpoint_slug, AuthorizedSession, CredentialVault, GatewayApp, GatewayAuth,
+    GatewayAuthConfig, GatewayConnection, GatewayCredentials, GatewayIdentity, GatewayMeta,
+    GatewayModel, PendingSignIn, TokenSet, RESOURCE_CONTROL, RESOURCE_LLM,
 };

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -407,24 +407,31 @@ impl crate::mcp_config::GatewayEndpoints for GatewayRuntime {
     }
 }
 
-/// Complete the legacy hard cut for the session, not just the configuration.
+/// Retire a stored gateway session the resolved policy no longer stands
+/// behind.
 ///
-/// An unmanaged profile can carry a gateway session signed in under the
-/// retired additive mode. Nothing reaches it any more — the whole sign-in
-/// surface is managed-only, and the renderer has no gateway page — so
-/// without this the refresh token would sit in the keychain forever with no
-/// path to revoke it. Boot owns that cleanup instead.
+/// Two ways a session ends up superseded. An unmanaged profile can carry one
+/// signed in under the retired additive mode: nothing reaches it any more —
+/// the whole sign-in surface is managed-only, and the renderer has no
+/// gateway page. And a managed profile's policy authority can re-point the
+/// deployment (an MDM push): the old deployment's session is filtered out
+/// of every route and token path, but its refresh token stays live at the
+/// old gateway. Either way no surface will ever revoke it, so boot owns
+/// that cleanup.
 ///
 /// Revocation is best-effort and bounded: an unreachable gateway can no more
 /// hold this hostage than it can a normal sign-out (the server-side session
 /// still dies at refresh-token expiry), and boot must not stall on it. The
 /// local clear afterwards is unconditional, so the session is gone locally
 /// whether or not the gateway ever answered — and because it is gone, this
-/// whole step runs at most once per profile.
+/// whole step runs at most once per superseded session.
 ///
 /// An unreadable stored blob is left alone: it carries no usable refresh
-/// token, so it is not the live zombie this exists to kill.
-pub(crate) async fn retire_unmanaged_gateway_session(
+/// token, so it is not the live zombie this exists to kill. So is the
+/// session under a managed policy with no usable URL — that is a
+/// misconfigured policy to repair, not a supersession, and the session may
+/// well match it once repaired.
+pub(crate) async fn retire_superseded_gateway_session(
     secrets: Arc<dyn SecretProvider>,
     policy: &crate::managed_policy::ManagedPolicy,
 ) -> Result<()> {
@@ -432,18 +439,29 @@ pub(crate) async fn retire_unmanaged_gateway_session(
     /// that a dead one is a hiccup at boot rather than a hang.
     const REVOKE_TIMEOUT: Duration = Duration::from_secs(5);
 
-    if policy.managed {
-        return Ok(());
-    }
     let vault = CredentialVault::new(secrets.clone());
     let Ok(Some(credentials)) = vault.load().await else {
         return Ok(());
     };
-    tracing::warn!(
-        "clearing a model-gateway session left by the retired additive \
-         configuration ({}); pair via your gateway's page to sign in again",
-        credentials.base_url
-    );
+    if policy.managed {
+        let Some(gateway_url) = policy.gateway_url.as_deref() else {
+            return Ok(());
+        };
+        if credentials.matches_base_url(gateway_url) {
+            return Ok(());
+        }
+        tracing::warn!(
+            "retiring the model-gateway session for {}: the managed policy \
+             now resolves {gateway_url}; sign in there to connect",
+            credentials.base_url
+        );
+    } else {
+        tracing::warn!(
+            "clearing a model-gateway session left by the retired additive \
+             configuration ({}); pair via your gateway's page to sign in again",
+            credentials.base_url
+        );
+    }
     // The connection owns revoke-then-clear (the refresh token never leaves
     // the connectors crate), so the session is retired through the same path
     // an explicit sign-out takes.
@@ -529,6 +547,8 @@ mod tests {
     #[derive(Default)]
     struct FakeGateway {
         refreshes: AtomicUsize,
+        /// Every refresh token posted to `/oauth/revoke`, in order.
+        revoked: std::sync::Mutex<Vec<String>>,
     }
 
     async fn token(
@@ -616,9 +636,22 @@ mod tests {
         Json(json!({"jsonrpc": "2.0", "id": id, "result": result})).into_response()
     }
 
+    async fn revoke(
+        State(gateway): State<Arc<FakeGateway>>,
+        Form(form): Form<HashMap<String, String>>,
+    ) -> Json<Value> {
+        gateway
+            .revoked
+            .lock()
+            .unwrap()
+            .push(form.get("token").cloned().unwrap_or_default());
+        Json(json!({}))
+    }
+
     async fn serve(gateway: Arc<FakeGateway>) -> std::net::SocketAddr {
         let app = AxumRouter::new()
             .route("/oauth/token", post(token))
+            .route("/oauth/revoke", post(revoke))
             .route("/api/v1/cli/models", get(models))
             .route("/mcp/{slug}", post(mcp_endpoint))
             .with_state(gateway);
@@ -1459,7 +1492,7 @@ mod tests {
             .await
             .unwrap();
         assert!(!policy.managed);
-        retire_unmanaged_gateway_session(secrets.clone(), &policy)
+        retire_superseded_gateway_session(secrets.clone(), &policy)
             .await
             .unwrap();
         assert!(
@@ -1471,7 +1504,7 @@ mod tests {
         // no connection to revoke through, so only the unconditional clear
         // can retire it. Drop that clear and the credential survives here.
         seed(secrets.clone(), "http://user:pw@stale.example").await;
-        retire_unmanaged_gateway_session(secrets.clone(), &policy)
+        retire_superseded_gateway_session(secrets.clone(), &policy)
             .await
             .unwrap();
         assert!(
@@ -1488,9 +1521,135 @@ mod tests {
         let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
             .await
             .unwrap();
-        retire_unmanaged_gateway_session(secrets.clone(), &policy)
+        retire_superseded_gateway_session(secrets.clone(), &policy)
             .await
             .unwrap();
         assert!(openwave_connectors::has_stored_credentials(&*secrets).await);
+    }
+
+    /// The managed analogue of the legacy hard cut: an MDM re-point
+    /// supersedes the stored session, and boot is the only surface that will
+    /// ever revoke it at the old deployment.
+    #[tokio::test]
+    async fn boot_retires_the_session_an_mdm_repoint_superseded() {
+        let directory = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("gateway.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let secrets: Arc<dyn SecretProvider> = Arc::new(MockSecrets::default());
+        let old_gateway = Arc::new(FakeGateway::default());
+        let old_base = format!("http://{}", serve(old_gateway.clone()).await);
+        let credentials: openwave_connectors::GatewayCredentials = serde_json::from_value(json!({
+            "base_url": old_base,
+            "installation_id": "install-1",
+            "user_id": "user-1",
+            "refresh_token": "mg_rt_zombie",
+            "access_tokens": {}
+        }))
+        .unwrap();
+        CredentialVault::new(secrets.clone())
+            .save(&credentials)
+            .await
+            .unwrap();
+        crate::managed_policy::provision(&*store, "https://corp-new.gateway")
+            .await
+            .unwrap();
+        let mut policy =
+            crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
+                .await
+                .unwrap();
+        assert!(policy.managed);
+
+        // A managed policy with no usable URL is misconfiguration, not a
+        // re-point: the session is left for the repaired policy to judge.
+        policy.gateway_url = None;
+        retire_superseded_gateway_session(secrets.clone(), &policy)
+            .await
+            .unwrap();
+        assert!(openwave_connectors::has_stored_credentials(&*secrets).await);
+
+        policy.gateway_url = Some("https://corp-new.gateway".into());
+        retire_superseded_gateway_session(secrets.clone(), &policy)
+            .await
+            .unwrap();
+        assert!(
+            !openwave_connectors::has_stored_credentials(&*secrets).await,
+            "the superseded session must not survive the re-point"
+        );
+        // Revoked at the old deployment, with the superseded refresh token.
+        assert_eq!(
+            old_gateway.revoked.lock().unwrap().as_slice(),
+            ["mg_rt_zombie"]
+        );
+    }
+
+    /// A completed sign-in supersedes whatever session is stored — possibly
+    /// one minted at a different deployment, after a re-point. Its refresh
+    /// token is revoked at its own gateway before the overwrite orphans it.
+    #[tokio::test]
+    async fn signing_in_revokes_the_superseded_session_at_its_own_gateway() {
+        let old_gateway = Arc::new(FakeGateway::default());
+        let old_base = format!("http://{}", serve(old_gateway.clone()).await);
+        let new_gateway = Arc::new(FakeGateway::default());
+        let new_base = format!("http://{}", serve(new_gateway.clone()).await);
+        let secrets: Arc<dyn SecretProvider> = Arc::new(MockSecrets::default());
+        let superseded: openwave_connectors::GatewayCredentials = serde_json::from_value(json!({
+            "base_url": old_base,
+            "installation_id": "install-1",
+            "user_id": "user-1",
+            "refresh_token": "mg_rt_zombie",
+            "access_tokens": {}
+        }))
+        .unwrap();
+        CredentialVault::new(secrets.clone())
+            .save(&superseded)
+            .await
+            .unwrap();
+
+        let connection = GatewayConnection::new(
+            GatewayAuth::new(GatewayAuthConfig::new(&new_base).unwrap()).unwrap(),
+            CredentialVault::new(secrets.clone()),
+        );
+        connection
+            .store_session(&openwave_connectors::AuthorizedSession {
+                meta: openwave_connectors::GatewayMeta {
+                    api_version: "1".into(),
+                    installation_id: "install-2".into(),
+                    gateway_version: "1".into(),
+                    public_url: new_base.clone(),
+                    auth_mode: "oauth".into(),
+                },
+                identity: openwave_connectors::GatewayIdentity {
+                    user_id: "user-2".into(),
+                    email: Some("user@example.test".into()),
+                    display_name: None,
+                    session_id: "session-2".into(),
+                    installation_id: "install-2".into(),
+                },
+                tokens: openwave_connectors::TokenSet {
+                    access_token: "mg_at_fresh".into(),
+                    refresh_token: "mg_rt_fresh".into(),
+                    expires_at_unix: u64::MAX,
+                    scope: "models:read inference:invoke".into(),
+                    resource: "control".into(),
+                    installation_id: "install-2".into(),
+                },
+            })
+            .await
+            .unwrap();
+
+        // The revoke went to the superseded session's own deployment — not
+        // the connection's — and the new session is stored for the new one.
+        assert_eq!(
+            old_gateway.revoked.lock().unwrap().as_slice(),
+            ["mg_rt_zombie"]
+        );
+        assert!(new_gateway.revoked.lock().unwrap().is_empty());
+        assert!(openwave_connectors::has_stored_credentials_for(&*secrets, &new_base).await);
     }
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -686,12 +686,14 @@ async fn bind_inner(
     }
     // The additive gateway configuration is retired: carry a managed row's
     // model snapshot forward once, name the remedy for a legacy unmanaged
-    // one, and revoke the session an unmanaged profile can no longer reach.
-    // Skipped when policy is unreadable — fail closed, and the legacy state
-    // stays untouched for when the policy is repaired.
+    // one, and revoke any stored session the resolved policy no longer
+    // stands behind — one an unmanaged profile can no longer reach, or one
+    // an MDM re-point orphaned at a superseded deployment. Skipped when
+    // policy is unreadable — fail closed, and the legacy state stays
+    // untouched for when the policy is repaired.
     if let Ok(policy) = &boot_policy {
         providers::retire_legacy_gateway_row(&*store, policy).await?;
-        gateway_runtime::retire_unmanaged_gateway_session(secrets.clone(), policy).await?;
+        gateway_runtime::retire_superseded_gateway_session(secrets.clone(), policy).await?;
     }
     let gateway =
         gateway_runtime::GatewayRuntime::new(store.clone(), secrets.clone(), os_policy.clone());

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -727,7 +727,14 @@ pub async fn list_providers(
                 enabled: policy.gateway_url.is_some(),
                 base_url: policy.gateway_url.clone(),
                 vertex_location: None,
-                has_credential: has_credential(secrets, kind).await,
+                // Deployment-matched: a session a re-point superseded must
+                // not read as this deployment's credential.
+                has_credential: match policy.gateway_url.as_deref() {
+                    Some(gateway_url) => {
+                        openwave_connectors::has_stored_credentials_for(secrets, gateway_url).await
+                    }
+                    None => false,
+                },
                 models: gateway_models(store, policy).await?,
             });
             continue;
@@ -1199,9 +1206,12 @@ pub async fn resolve_model_policy(
 /// Whether the provider can accept a new turn right now.
 ///
 /// The gateway is derived from policy in both directions: on a managed
-/// profile it is usable exactly when a session is stored (and BYOK kinds
-/// never are), and on an unmanaged profile it is never usable — whatever
-/// legacy rows persist in the store.
+/// profile it is usable exactly when a session for the policy's own
+/// deployment is stored (and BYOK kinds never are), and on an unmanaged
+/// profile it is never usable — whatever legacy rows persist in the store.
+/// The deployment match matters after an MDM re-point: the superseded
+/// session is unroutable (`route_token_source` filters it), so counting it
+/// usable would advertise models no route can serve.
 pub async fn provider_is_usable(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
@@ -1212,7 +1222,10 @@ pub async fn provider_is_usable(
         if kind != ProviderKind::ModelGateway {
             return Ok(false);
         }
-        return Ok(has_credential(secrets, kind).await);
+        let Some(gateway_url) = policy.gateway_url.as_deref() else {
+            return Ok(false);
+        };
+        return Ok(openwave_connectors::has_stored_credentials_for(secrets, gateway_url).await);
     }
     if kind == ProviderKind::ModelGateway {
         return Ok(false);

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -2420,3 +2420,71 @@ async fn a_managed_profile_refuses_manual_mcp_servers_and_accepts_gateway_mounts
     let info: serde_json::Value = json_body(removed).await;
     assert_eq!(info["servers"].as_array().unwrap().len(), 1);
 }
+
+/// After an MDM re-point the stored session belongs to the superseded
+/// deployment. Every route and token path already refuses it, so the
+/// readiness surfaces must agree: reading it as usable would advertise
+/// models no route can serve.
+#[tokio::test]
+async fn a_superseded_gateway_session_never_reads_usable() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}/test.db?mode=rwc",
+            dir.path().display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let secrets: Arc<dyn SecretProvider> = Arc::new(MemSecrets::default());
+    let seed = |secrets: Arc<dyn SecretProvider>, base_url: &'static str| async move {
+        let credentials: openwave_connectors::GatewayCredentials =
+            serde_json::from_value(serde_json::json!({
+                "base_url": base_url,
+                "installation_id": "install-1",
+                "user_id": "user-1",
+                "refresh_token": "mg_rt_seed",
+                "access_tokens": {}
+            }))
+            .unwrap();
+        openwave_connectors::CredentialVault::new(secrets)
+            .save(&credentials)
+            .await
+            .unwrap();
+    };
+    seed(secrets.clone(), "https://old.gateway").await;
+    crate::managed_policy::provision(&*store, "https://corp.gateway")
+        .await
+        .unwrap();
+    let policy = crate::managed_policy::resolve(&*store, &crate::managed_policy::NoOsPolicy)
+        .await
+        .unwrap();
+
+    assert!(!providers::provider_is_usable(
+        &*store,
+        &*secrets,
+        providers::ProviderKind::ModelGateway,
+        &policy
+    )
+    .await
+    .unwrap());
+    let gateway = providers::list_providers(&*store, &*secrets, &policy)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|provider| provider.kind == providers::ProviderKind::ModelGateway)
+        .unwrap();
+    assert!(!gateway.has_credential);
+
+    // A session for the policy's own deployment — trailing slash included,
+    // per the shared normalization — reads usable again.
+    seed(secrets.clone(), "https://corp.gateway/").await;
+    assert!(providers::provider_is_usable(
+        &*store,
+        &*secrets,
+        providers::ProviderKind::ModelGateway,
+        &policy
+    )
+    .await
+    .unwrap());
+}


### PR DESCRIPTION
Closes #1014.

## Root cause

`GatewayConnection::store_session` overwrote the vault's single session slot without revoking the prior one, and nothing retired a stored session when a managed policy re-pointed the deployment. #970 solved the unmanaged case at boot; this is the managed analogue plus the readiness-surface fix.

## What changed

**Revoke-before-overwrite (`openwave-connectors`).** `store_session` now loads whatever session it is about to supersede and revokes its refresh token first — best-effort, bounded at 5s, and aimed at the *superseded session's own* `base_url`, which after a repoint is not the connection's. `sign_out` shares the same targeted-revoke helper, fixing a latent wrong-deployment revoke: it previously posted the stored token to the connection's configured gateway even when the session was minted elsewhere.

**Boot retire generalized (`openwave-server`).** `retire_unmanaged_gateway_session` becomes `retire_superseded_gateway_session`: it now also retires a managed profile's session when the resolved policy names a different deployment (revoke at the old gateway + unconditional local clear). A managed policy with no usable URL leaves the session alone — that is misconfiguration to repair, not a supersession.

**Deployment-matched readiness (`openwave-server`).** `provider_is_usable` and `list_providers` now check the stored session against the policy's deployment via the new `has_stored_credentials_for`, instead of merely checking that some session exists. This closes the window where the catalog advertised gateway models as available while `route_token_source` (deployment-filtered) offered no route — including for a mid-run MDM push, where the boot retire hasn't run yet. The URL normalization (trailing-slash-insensitive) moved to `GatewayCredentials::matches_base_url` so all three consumers share one seam.

## Tests

- `boot_retires_the_session_an_mdm_repoint_superseded` — repoint retire clears the vault and revokes the exact superseded token at the old deployment (fake gateway records `/oauth/revoke`); a managed policy without a URL leaves the session untouched.
- `signing_in_revokes_the_superseded_session_at_its_own_gateway` — `store_session` revokes at the old deployment, not the new connection's, and stores the new session.
- `a_superseded_gateway_session_never_reads_usable` — `provider_is_usable`/`list_providers` refuse a mismatched session and accept a matching one (trailing-slash variant).
- The existing unmanaged retire test keeps its coverage under the renamed function; its managed-keep block now also exercises the new match seam.

## Absorbs

Per the issue: #763 bullets 17 and 24, #624's #607 `store_session` no-revoke item, and the MDM-repoint residue from #724.

🤖 Generated with [Claude Code](https://claude.com/claude-code)