### PR TITLE
feat(pairing): restart automatically after a commit only when the BYOK embedder is live

### DIFF
--- a/crates/openwave-desktop/src/deep_link.rs
+++ b/crates/openwave-desktop/src/deep_link.rs
@@ -253,7 +253,7 @@ async fn wait_pairing_handle(app: &tauri::AppHandle) -> Result<PairingHandle, St
 /// launches, `pairing.log` under app-data for GUI launches. Only the gateway
 /// origin is ever named — never the full link or URL — and gateway errors
 /// already strip URLs and token material.
-fn log_pairing(app: &tauri::AppHandle, message: &str) {
+pub(crate) fn log_pairing(app: &tauri::AppHandle, message: &str) {
     use std::io::Write;
     eprintln!("openwave-desktop: gateway pairing: {message}");
     let Ok(dir) = crate::data_dir(app) else {

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -290,6 +290,22 @@ async fn boot_server(
         .initialize_store(server.store())?;
     // Unblock any pairing task parked on a deep link that arrived pre-boot.
     let _ = store_tx.send(Some(server.pairing_handle()));
+    // A pairing commit that finds this launch's BYOK embedder still live
+    // requests the restart that applies the embedder lockdown; fresh
+    // installs boot with the offline embedder and never trip this.
+    let mut restart_rx = server.enforcement_restart_watch();
+    let restart_app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        while restart_rx.changed().await.is_ok() {
+            if *restart_rx.borrow_and_update() {
+                deep_link::log_pairing(
+                    &restart_app,
+                    "restarting to apply managed embedder enforcement",
+                );
+                restart_app.restart();
+            }
+        }
+    });
     let base_url = format!("http://{}", server.local_addr());
     let token = server.token().to_string();
     let executor_token = server.client_executor_token().to_string();

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -50,6 +50,15 @@ pub(crate) struct GatewayRuntime {
     /// shell through [`crate::register_pending_pairing`] — the renderer can
     /// read and dismiss it, never set it or choose its URL.
     pending_pairing: Mutex<Option<PendingPairing>>,
+    /// True when this launch resolved the BYOK (OpenAI) embedder — the one
+    /// piece of enforcement only a fresh boot can apply once a pairing
+    /// commits (see `resolve_embedder`). Stamped once during bind.
+    boot_embedder_byok: std::sync::atomic::AtomicBool,
+    /// Flipped to `true` when a pairing commit finds the BYOK embedder
+    /// live: the desktop shell watches this and restarts the app to close
+    /// the enforcement gap immediately. Never reset — the restart is the
+    /// reset.
+    enforcement_restart: tokio::sync::watch::Sender<bool>,
 }
 
 /// The shell-registered pairing a sign-in may commit.
@@ -132,7 +141,23 @@ impl GatewayRuntime {
             sign_in: Mutex::new(SignInProgress::Idle),
             sign_in_generation: std::sync::atomic::AtomicU64::new(0),
             pending_pairing: Mutex::new(None),
+            boot_embedder_byok: std::sync::atomic::AtomicBool::new(false),
+            enforcement_restart: tokio::sync::watch::channel(false).0,
         })
+    }
+
+    /// Record that this launch resolved the BYOK embedder. Called once
+    /// during bind; a pairing commit in this process then wants a restart.
+    pub(crate) fn note_boot_embedder_byok(&self) {
+        self.boot_embedder_byok
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Watch for the enforcement restart a pairing commit may request. The
+    /// desktop shell restarts the app when this reads `true`; headless
+    /// embedders may ignore it (the gap still closes at their next start).
+    pub(crate) fn enforcement_restart_watch(&self) -> tokio::sync::watch::Receiver<bool> {
+        self.enforcement_restart.subscribe()
     }
 
     /// The one policy read every surface here shares.
@@ -338,6 +363,17 @@ impl GatewayRuntime {
         )
         .await?;
         *self.pending_pairing.lock().await = None;
+        // The one enforcement a running process cannot apply: a BYOK
+        // embedder resolved at boot keeps serving until the next start, so
+        // ask the shell for that start now rather than leaving the gap open
+        // until the user happens to relaunch. Fresh installs boot with the
+        // offline embedder and never restart.
+        if self
+            .boot_embedder_byok
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            let _ = self.enforcement_restart.send(true);
+        }
         Ok(())
     }
 
@@ -1163,6 +1199,59 @@ mod tests {
         assert_eq!(runtime.pending_pairing_url().await, None);
         assert_eq!(runtime.status().await.unwrap().sign_in, SignInProgress::Idle);
         assert!(runtime.begin_sign_in().await.is_err());
+    }
+
+    /// The restart request is keyed to an actual enforcement gap: a commit
+    /// on a launch that resolved the BYOK embedder asks for the restart
+    /// that swaps it out; a fresh install's offline-embedder launch commits
+    /// without one.
+    #[tokio::test]
+    async fn a_commit_requests_a_restart_only_when_the_byok_embedder_is_live() {
+        async fn runtime_with_pending() -> (Arc<GatewayRuntime>, PendingPairing, tempfile::TempDir)
+        {
+            let directory = tempfile::tempdir().unwrap();
+            let store: Arc<dyn Store> = Arc::new(
+                DbStore::connect(&format!(
+                    "sqlite://{}?mode=rwc",
+                    directory.path().join("gateway.db").display()
+                ))
+                .await
+                .unwrap(),
+            );
+            let runtime = GatewayRuntime::new(
+                store.clone(),
+                Arc::new(MockSecrets::default()),
+                Arc::new(crate::managed_policy::NoOsPolicy),
+            );
+            let mcp = Arc::new(crate::mcp_config::McpRuntime::new(
+                Arc::new(openwave_core::ToolRegistry::new()),
+                store,
+                runtime.clone(),
+                Arc::new(crate::managed_policy::NoOsPolicy),
+            ));
+            let pending = PendingPairing {
+                base_url: "http://gw.invalid/".to_string(),
+                mcp,
+            };
+            (runtime, pending, directory)
+        }
+
+        let (runtime, pending, _directory) = runtime_with_pending().await;
+        let mut restart = runtime.enforcement_restart_watch();
+        runtime.note_boot_embedder_byok();
+        runtime.commit_pairing(&pending).await.unwrap();
+        assert!(
+            *restart.borrow_and_update(),
+            "a live BYOK embedder at commit must request the restart"
+        );
+
+        let (runtime, pending, _directory) = runtime_with_pending().await;
+        let mut restart = runtime.enforcement_restart_watch();
+        runtime.commit_pairing(&pending).await.unwrap();
+        assert!(
+            !*restart.borrow_and_update(),
+            "an offline-embedder launch has no gap and must not restart"
+        );
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -1021,7 +1021,10 @@ async fn resolve_embedder(
         None
     };
     match key {
-        Some(key) => (Arc::new(OpenAiEmbedder::new(key, EMBED_MODEL, EMBED_DIMS)), true),
+        Some(key) => (
+            Arc::new(OpenAiEmbedder::new(key, EMBED_MODEL, EMBED_DIMS)),
+            true,
+        ),
         None => (Arc::new(HashEmbedder::default()), false),
     }
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -576,6 +576,15 @@ impl Server {
         PairingHandle::new(self.store.clone(), self.mcp.clone(), self.gateway.clone())
     }
 
+    /// Watch for the restart a pairing commit may request: `true` means this
+    /// launch's BYOK embedder is still live on a profile that just became
+    /// managed, and only a fresh start applies the embedder lockdown. The
+    /// desktop shell restarts the app on it; an embedder that ignores it
+    /// still closes the gap at its next start.
+    pub fn enforcement_restart_watch(&self) -> tokio::sync::watch::Receiver<bool> {
+        self.gateway.enforcement_restart_watch()
+    }
+
     /// Run the accept loop until the process exits.
     pub async fn serve(self) -> Result<()> {
         axum::serve(self.listener, self.router)
@@ -708,7 +717,11 @@ async fn bind_inner(
         gateway.clone(),
         os_policy.clone(),
     ));
-    let embedder = resolve_embedder(&*store, &*secrets, byok_boot_allowed).await;
+    let (embedder, byok_embedder_live) =
+        resolve_embedder(&*store, &*secrets, byok_boot_allowed).await;
+    if byok_embedder_live {
+        gateway.note_boot_embedder_byok();
+    }
     let vector_store = connect_vector_store(&config, embedder.dimensions()).await?;
     let code_execution = Arc::new(code_execution::ConfiguredCodeExecutionProvider::new(
         store.clone(),
@@ -988,13 +1001,15 @@ const EMBED_DIMS: usize = 1536;
 /// Because the embedder is boot-scoped (the vector index is dimension-bound
 /// to it), a profile provisioned managed at runtime keeps a live BYOK
 /// embedder until the next app start; this gate closes at the next boot.
-/// Closing it eagerly — an automatic restart when a pairing commit finds a
-/// live BYOK embedder — is #1024.
+/// The second value reports whether this launch picked the BYOK embedder —
+/// when a pairing commits mid-session with it live, the gateway runtime
+/// signals the desktop shell to restart and close the gate immediately
+/// instead of leaving it open until the user happens to relaunch.
 async fn resolve_embedder(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
     byok_allowed: bool,
-) -> Arc<dyn Embedder> {
+) -> (Arc<dyn Embedder>, bool) {
     let enabled = byok_allowed
         && providers::read_config(store, providers::ProviderKind::Openai)
             .await
@@ -1006,8 +1021,8 @@ async fn resolve_embedder(
         None
     };
     match key {
-        Some(key) => Arc::new(OpenAiEmbedder::new(key, EMBED_MODEL, EMBED_DIMS)),
-        None => Arc::new(HashEmbedder::default()),
+        Some(key) => (Arc::new(OpenAiEmbedder::new(key, EMBED_MODEL, EMBED_DIMS)), true),
+        None => (Arc::new(HashEmbedder::default()), false),
     }
 }
 

--- a/crates/openwave-server/src/tests/documents.rs
+++ b/crates/openwave-server/src/tests/documents.rs
@@ -2577,7 +2577,10 @@ async fn resolve_embedder_uses_openai_only_when_enabled_and_keyed() {
     .unwrap();
     let (online, byok) = resolve_embedder(&*store, &secrets, true).await;
     assert_eq!(online.dimensions(), EMBED_DIMS);
-    assert!(byok, "the BYOK pick must be reported — it gates the restart");
+    assert!(
+        byok,
+        "the BYOK pick must be reported — it gates the restart"
+    );
     assert_ne!(EMBED_DIMS, HashEmbedder::default().dimensions());
 
     // Enabled + keyed but BYOK disallowed (managed profile, or an unreadable

--- a/crates/openwave-server/src/tests/documents.rs
+++ b/crates/openwave-server/src/tests/documents.rs
@@ -2575,14 +2575,16 @@ async fn resolve_embedder_uses_openai_only_when_enabled_and_keyed() {
     )
     .await
     .unwrap();
-    let online = resolve_embedder(&*store, &secrets, true).await;
+    let (online, byok) = resolve_embedder(&*store, &secrets, true).await;
     assert_eq!(online.dimensions(), EMBED_DIMS);
+    assert!(byok, "the BYOK pick must be reported — it gates the restart");
     assert_ne!(EMBED_DIMS, HashEmbedder::default().dimensions());
 
     // Enabled + keyed but BYOK disallowed (managed profile, or an unreadable
     // policy) → document text must never egress through the stored key.
-    let locked = resolve_embedder(&*store, &secrets, false).await;
+    let (locked, byok) = resolve_embedder(&*store, &secrets, false).await;
     assert_eq!(locked.dimensions(), HashEmbedder::default().dimensions());
+    assert!(!byok);
 
     // Disabled but keyed → the key is ignored (no silent egress), even though
     // it's present. Deterministic regardless of any ambient OPENAI_API_KEY,
@@ -2599,8 +2601,9 @@ async fn resolve_embedder_uses_openai_only_when_enabled_and_keyed() {
     )
     .await
     .unwrap();
-    let offline = resolve_embedder(&*store, &secrets, true).await;
+    let (offline, byok) = resolve_embedder(&*store, &secrets, true).await;
     assert_eq!(offline.dimensions(), HashEmbedder::default().dimensions());
+    assert!(!byok);
 }
 
 #[cfg(feature = "vec-lance")]


### PR DESCRIPTION
Closes #1024

Stacked on #1032; GitHub will retarget when it merges.

The removed "Pairing complete — restart now/later" dialog guarded exactly one enforcement gap: `resolve_embedder` is boot-scoped (the vector index is dimension-bound to the embedder), so a profile that booted unmanaged with a live BYOK OpenAI embedder keeps embedding documents through it after a pairing commits. Everything else about managed enforcement applies live.

This closes that gap without any prompt, and only when it exists:

- `resolve_embedder` now also reports whether it picked the BYOK embedder; `bind_inner` stamps that onto the gateway runtime.
- A pairing commit that finds the flag set flips a `watch::Sender` the `Server` exposes as `enforcement_restart_watch()`.
- The desktop shell watches it after boot and calls `app.restart()` with a `pairing.log` line. The restart lands immediately after the sign-in that committed the pairing — a natural transition moment with nothing in flight, and the relaunch comes back signed in and fully enforced.
- Fresh installs (the normal deep-link onboarding case) boot with the offline embedder and never see a restart.

Tests: the runtime commit requests a restart exactly when the flag is set (`a_commit_requests_a_restart_only_when_the_byok_embedder_is_live`), and the `resolve_embedder` contract test now pins the reported pick in all three arms.

Not verified here: the actual `app.restart()` relaunch, which needs the running app — the suggested smoke test from #1032 extends naturally: pair on a profile that had OpenAI enabled+keyed and watch it relaunch straight into the signed-in managed state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)