### PR TITLE
test(server): call the zero-arg build_retrieval in the misconfigured-policy e2e

### DIFF
--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -2246,10 +2246,7 @@ async fn a_misconfigured_policy_gates_the_renderer_and_refuses_a_turn() {
     )
     .await
     .unwrap();
-    let (retrieval, _search) = build_retrieval(
-        Arc::new(HashEmbedder::default()),
-        Arc::new(InMemoryVectorStore::new(HashEmbedder::DEFAULT_DIMS)),
-    );
+    let retrieval = build_retrieval();
     let state = AppState::new(
         Config::desktop(dir.path()),
         store.clone(),


### PR DESCRIPTION
Main's server test target is currently red: #1034 deleted `HashEmbedder` and made `build_retrieval` zero-arg, and #1029 — textually conflict-free, so its pre-merge CI never saw the deletion — added `a_misconfigured_policy_gates_the_renderer_and_refuses_a_turn` against the old API. Both merge-to-main runs since (#1029's and #1031's) fail on it.

One-line fix: construct retrieval through the current zero-arg `build_retrieval()`. The test's actual subject (misconfigured policy gates the renderer and refuses a turn) is untouched and passes.

Verified: `cargo check -p openwave-server --locked --all-targets` clean; the e2e test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)