### PR TITLE
feat(exec): bundled scripts render documents into preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ node_modules/
 dist/
 .vite/
 
+# Python helper bytecode
+__pycache__/
+*.py[cod]
+
 # Tauri codegen (regenerated on build)
 crates/openwave-desktop/gen/
 crates/openwave-desktop/binaries/openwave-host-broker-*

--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -36,3 +36,16 @@ pub use types::{
     MAX_CAPTURE_BYTES, MAX_COMMAND_BYTES, MAX_CWD_BYTES, MAX_WORKSPACE_FILE_BYTES,
     MAX_WORKSPACE_LIST_ENTRIES, MAX_WORKSPACE_PATH_BYTES,
 };
+
+/// Stable workspace-relative location populated by hosts that ship the
+/// document helper library.
+pub const DOCUMENT_SCRIPTS_DIR: &str = ".openwave/exec-scripts";
+
+/// Files copied as one indivisible helper library into an exec workspace.
+pub const DOCUMENT_SCRIPT_FILES: [&str; 5] = [
+    "_openwave_preview.py",
+    "render_pdf.py",
+    "extract_pdf_figures.py",
+    "render_office.py",
+    "analyze_xlsx.py",
+];

--- a/crates/openwave-code-execution/src/local.rs
+++ b/crates/openwave-code-execution/src/local.rs
@@ -46,6 +46,7 @@ const MAX_OPEN_FILES: u64 = 64;
 pub struct LocalExecutionProvider {
     scratch_root: PathBuf,
     timeout: Duration,
+    document_scripts_dir: Option<PathBuf>,
 }
 
 impl LocalExecutionProvider {
@@ -61,7 +62,15 @@ impl LocalExecutionProvider {
         Ok(Self {
             scratch_root: scratch_root.into(),
             timeout,
+            document_scripts_dir: None,
         })
+    }
+
+    /// Expose the trusted bundled document helpers as a read-only subtree.
+    #[must_use]
+    pub fn with_document_scripts(mut self, directory: Option<PathBuf>) -> Self {
+        self.document_scripts_dir = directory;
+        self
     }
 
     /// Whether the mandatory native confinement primitive exists on this host.
@@ -230,7 +239,25 @@ impl CodeExecutionProvider for LocalExecutionProvider {
             BeginExecution::Started => {}
         }
 
-        let result = run_native(&request, &workspace, &cwd, self.timeout).await;
+        let document_scripts_dir = self
+            .document_scripts_dir
+            .as_ref()
+            .map(|path| {
+                fs::canonicalize(path).map_err(|_| {
+                    CodeExecutionError::Sandbox(
+                        "bundled document helper directory is unavailable".into(),
+                    )
+                })
+            })
+            .transpose()?;
+        let result = run_native(
+            &request,
+            &workspace,
+            &cwd,
+            self.timeout,
+            document_scripts_dir.as_deref(),
+        )
+        .await;
         match result {
             Ok(response) => {
                 finish_execution(
@@ -640,9 +667,10 @@ async fn run_native(
     workspace: &Path,
     cwd: &Path,
     timeout: Duration,
+    document_scripts_dir: Option<&Path>,
 ) -> Result<CodeExecutionResponse, CodeExecutionError> {
     let developer_dir = macos_developer_dir();
-    let profile = macos_profile(workspace, developer_dir.as_deref())?;
+    let profile = macos_profile(workspace, developer_dir.as_deref(), document_scripts_dir)?;
     let mut command = Command::new(SANDBOX_EXEC);
     command
         .args(["-p", &profile, "--", &request.command])
@@ -665,6 +693,9 @@ async fn run_native(
         );
     } else {
         command.env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin");
+    }
+    if let Some(directory) = document_scripts_dir {
+        command.env("OPENWAVE_EXEC_SCRIPTS", directory);
     }
     configure_unix_limits(&mut command, timeout);
 
@@ -731,6 +762,7 @@ async fn run_native(
     _workspace: &Path,
     _cwd: &Path,
     _timeout: Duration,
+    _document_scripts_dir: Option<&Path>,
 ) -> Result<CodeExecutionResponse, CodeExecutionError> {
     Err(CodeExecutionError::Unavailable(
         "native local sandboxing is not supported on this host".into(),
@@ -808,6 +840,7 @@ async fn finish_reader(mut reader: tokio::task::JoinHandle<()>) {
 fn macos_profile(
     workspace: &Path,
     developer_dir: Option<&Path>,
+    document_scripts_dir: Option<&Path>,
 ) -> Result<String, CodeExecutionError> {
     const DENIED_READS: &[&str] = &[
         "/Applications",
@@ -894,6 +927,10 @@ fn macos_profile(
         .map(sandbox_subpath)
         .transpose()?
         .unwrap_or_default();
+    let document_scripts = document_scripts_dir
+        .map(sandbox_subpath)
+        .transpose()?
+        .unwrap_or_default();
     let workspace = sandbox_subpath(workspace)?;
     Ok(format!(
         "(version 1)\n\
@@ -904,7 +941,7 @@ fn macos_profile(
          (allow file-read*)\n\
          (deny file-read*\n  {denied})\n\
          (allow file-read-metadata\n  {runtime_metadata})\n\
-         (allow file-read*\n  {literals}\n  {runtimes}\n  {selected_runtime}\n  {workspace})\n\
+         (allow file-read*\n  {literals}\n  {runtimes}\n  {selected_runtime}\n  {document_scripts}\n  {workspace})\n\
          (allow file-write*\n  {workspace}\n  (literal \"/dev/null\"))\n"
     ))
 }
@@ -1255,7 +1292,14 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn profile_denies_network_and_escapes_workspace_paths() {
-        let profile = macos_profile(Path::new("/Users/test/we\"ird\\workspace"), None).unwrap();
+        let profile = macos_profile(
+            Path::new("/Users/test/we\"ird\\workspace"),
+            None,
+            Some(Path::new(
+                "/Applications/OpenWave.app/Contents/Resources/exec-scripts",
+            )),
+        )
+        .unwrap();
         assert!(profile.contains("(deny default)"));
         assert!(!profile.contains("allow network"));
         assert!(!profile.contains("mach-lookup"));
@@ -1263,6 +1307,12 @@ mod tests {
         assert!(profile.contains("(allow process-exec)"));
         assert!(profile.contains("(allow process-fork)"));
         assert!(profile.contains("we\\\"ird\\\\workspace"));
-        assert!(macos_profile(Path::new("/Users/test/control\nworkspace"), None).is_err());
+        assert!(profile.contains("Resources/exec-scripts"));
+        let write_rule = profile
+            .split("(allow file-write*")
+            .nth(1)
+            .expect("profile has a write rule");
+        assert!(!write_rule.contains("Resources/exec-scripts"));
+        assert!(macos_profile(Path::new("/Users/test/control\nworkspace"), None, None).is_err());
     }
 }

--- a/crates/openwave-code-execution/src/sync.rs
+++ b/crates/openwave-code-execution/src/sync.rs
@@ -444,4 +444,27 @@ mod tests {
             .iter()
             .any(|note| { note.contains("preview/too-large.png") && note.contains("file limit") }));
     }
+
+    #[tokio::test]
+    async fn bundled_document_helpers_are_not_on_the_sync_skip_list() {
+        let host = tempfile::tempdir().unwrap();
+        let helper = host
+            .path()
+            .join(crate::DOCUMENT_SCRIPTS_DIR)
+            .join("render_pdf.py");
+        std::fs::create_dir_all(helper.parent().unwrap()).unwrap();
+        std::fs::write(&helper, b"print('render')").unwrap();
+        let fake = FakeWorkspace::default();
+
+        let pushed = push_host_dir(&fake, &workspace_id(), host.path())
+            .await
+            .unwrap();
+
+        assert_eq!(pushed.transferred, 1);
+        assert!(pushed.notes.is_empty());
+        assert_eq!(
+            fake.get(".openwave/exec-scripts/render_pdf.py").unwrap(),
+            b"print('render')"
+        );
+    }
 }

--- a/crates/openwave-code-execution/src/tool.rs
+++ b/crates/openwave-code-execution/src/tool.rs
@@ -52,7 +52,17 @@ impl Tool for ExecTool {
                           files this command writes are visible to read_file. Every provider \
                           returns bounded stdout/stderr. For visual review, save up to three \
                           PNG, JPEG, or WebP images in preview/; overview, grid, thumbnail, page, \
-                          and slide filenames are prioritized. Use output/ for durable artifacts."
+                          and slide filenames are prioritized. Use output/ for durable artifacts. \
+                          When bundled document helpers are present, invoke them directly from \
+                          .openwave/exec-scripts. Examples: command python3 with args \
+                          [\".openwave/exec-scripts/render_pdf.py\", \"documents/report.pdf\", \
+                          \"--pages\", \"1-2\"]; command python3 with args \
+                          [\".openwave/exec-scripts/extract_pdf_figures.py\", \
+                          \"documents/report.pdf\"]; or command python3 with args \
+                          [\".openwave/exec-scripts/analyze_xlsx.py\", \
+                          \"documents/model.xlsx\"]. Each helper writes visual review files to \
+                          preview/ and prints a concise summary; a missing Python or document \
+                          dependency is reported as a command error."
                 .into(),
             input_schema: json!({
                 "type": "object",
@@ -258,6 +268,9 @@ mod tests {
         assert_eq!(spec.name, EXEC_TOOL_NAME);
         assert_eq!(spec.input_schema["additionalProperties"], false);
         assert!(spec.description.contains("preview/"));
+        assert!(spec.description.contains(".openwave/exec-scripts"));
+        assert!(spec.description.contains("render_pdf.py"));
+        assert!(spec.description.contains("analyze_xlsx.py"));
     }
 
     struct PreviewProvider {

--- a/crates/openwave-code-execution/tests/document_scripts.rs
+++ b/crates/openwave-code-execution/tests/document_scripts.rs
@@ -1,0 +1,127 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SCRIPTS: [&str; 4] = [
+    "render_pdf.py",
+    "extract_pdf_figures.py",
+    "render_office.py",
+    "analyze_xlsx.py",
+];
+
+fn python() -> Option<PathBuf> {
+    ["python3", "python"].into_iter().find_map(|candidate| {
+        Command::new(candidate)
+            .args(["-c", "import sys; print(sys.executable)"])
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .and_then(|output| {
+                let executable = String::from_utf8(output.stdout).ok()?;
+                let executable = PathBuf::from(executable.trim());
+                executable.is_absolute().then_some(executable)
+            })
+    })
+}
+
+fn scripts_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../scripts/exec-documents")
+        .canonicalize()
+        .expect("document scripts directory exists")
+}
+
+fn run_missing_tool_case(python: &Path, script: &Path, input: &Path, needle: &str) -> Output {
+    let output = Command::new(python)
+        .arg("-S")
+        .arg(script)
+        .arg(input)
+        .env("PATH", "")
+        .output()
+        .expect("Python starts");
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.starts_with("error: ") && stderr.contains(needle),
+        "expected an actionable missing-tool error containing {needle:?}, got {stderr:?}"
+    );
+    output
+}
+
+#[test]
+fn document_scripts_compile_and_expose_argparse_help() {
+    let Some(python) = python() else {
+        eprintln!("skipping document script contracts: Python is unavailable");
+        return;
+    };
+    let directory = scripts_dir();
+    let cache = tempfile::tempdir().unwrap();
+    for script in SCRIPTS {
+        let path = directory.join(script);
+        let compiled = Command::new(&python)
+            .args(["-m", "py_compile"])
+            .arg(&path)
+            .env("PYTHONPYCACHEPREFIX", cache.path())
+            .output()
+            .expect("Python starts");
+        assert!(
+            compiled.status.success(),
+            "{script} must compile: {}",
+            String::from_utf8_lossy(&compiled.stderr)
+        );
+
+        let help = Command::new(&python)
+            .arg(&path)
+            .arg("--help")
+            .output()
+            .expect("Python starts");
+        assert!(
+            help.status.success(),
+            "{script} --help must succeed: {}",
+            String::from_utf8_lossy(&help.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&help.stdout);
+        assert!(stdout.starts_with("usage:"), "{script} uses argparse");
+        assert!(stdout.contains("--preview-dir"));
+    }
+}
+
+#[test]
+fn missing_document_tooling_fails_concisely() {
+    let Some(python) = python() else {
+        eprintln!("skipping document script diagnostics: Python is unavailable");
+        return;
+    };
+    let directory = scripts_dir();
+    let inputs = tempfile::tempdir().unwrap();
+    let pdf = inputs.path().join("sample.pdf");
+    let docx = inputs.path().join("sample.docx");
+    let xlsx = inputs.path().join("sample.xlsx");
+    std::fs::write(&pdf, b"not needed: dependency discovery fails first").unwrap();
+    std::fs::write(&docx, b"not needed: dependency discovery fails first").unwrap();
+    std::fs::write(&xlsx, b"not needed: dependency discovery fails first").unwrap();
+
+    run_missing_tool_case(
+        &python,
+        &directory.join("render_pdf.py"),
+        &pdf,
+        "pypdfium2 or pdf2image",
+    );
+    run_missing_tool_case(
+        &python,
+        &directory.join("extract_pdf_figures.py"),
+        &pdf,
+        "pdfimages",
+    );
+    run_missing_tool_case(
+        &python,
+        &directory.join("render_office.py"),
+        &docx,
+        "LibreOffice",
+    );
+    run_missing_tool_case(
+        &python,
+        &directory.join("analyze_xlsx.py"),
+        &xlsx,
+        "openpyxl",
+    );
+}

--- a/crates/openwave-core/src/config.rs
+++ b/crates/openwave-core/src/config.rs
@@ -53,6 +53,11 @@ pub struct Config {
     /// the Windows and Linux readers are machine-scoped and ignore it.
     #[serde(default)]
     pub bundle_id: Option<String>,
+    /// Trusted source directory for helper scripts copied into isolated exec
+    /// workspaces. Desktop resolves this from its signed application resources;
+    /// other embeddings leave it absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exec_scripts_dir: Option<PathBuf>,
 }
 
 impl Config {
@@ -63,6 +68,7 @@ impl Config {
             data_dir: data_dir.into(),
             keychain_service: None,
             bundle_id: None,
+            exec_scripts_dir: None,
         }
     }
 
@@ -101,6 +107,7 @@ impl Config {
             data_dir,
             keychain_service: None,
             bundle_id: None,
+            exec_scripts_dir: None,
         })
     }
 
@@ -180,5 +187,6 @@ mod tests {
     fn legacy_config_without_keychain_service_defaults_to_none() {
         let config = serde_json::from_str::<Config>(r#"{"data_dir":"/data"}"#).unwrap();
         assert_eq!(config.keychain_service, None);
+        assert_eq!(config.exec_scripts_dir, None);
     }
 }

--- a/crates/openwave-desktop/build.rs
+++ b/crates/openwave-desktop/build.rs
@@ -7,6 +7,7 @@ fn main() {
     };
     let sidecar = format!("binaries/openwave-host-broker-{target}{extension}");
     println!("cargo:rerun-if-changed={sidecar}");
+    println!("cargo:rerun-if-changed=../../scripts/exec-documents");
 
     // Plain `cargo check` and `cargo test` do not run Tauri's before-build
     // hook. Keep those workflows usable from a clean checkout; Tauri dev/build

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -113,6 +113,27 @@ fn home_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
         .map_err(|e| format!("resolve home dir: {e}"))
 }
 
+fn exec_scripts_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    const REQUIRED_HELPERS: [&str; 5] = [
+        "_openwave_preview.py",
+        "render_pdf.py",
+        "extract_pdf_figures.py",
+        "render_office.py",
+        "analyze_xlsx.py",
+    ];
+    let directory = app
+        .path()
+        .resource_dir()
+        .map_err(|error| format!("app resource dir: {error}"))?
+        .join("exec-scripts");
+    for name in REQUIRED_HELPERS {
+        if !directory.join(name).is_file() {
+            return Err(format!("bundled exec document helper is missing: {name}"));
+        }
+    }
+    Ok(directory)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     #[cfg_attr(not(debug_assertions), allow(unused_mut))]
@@ -230,6 +251,7 @@ async fn boot_server(
 ) -> Result<(), String> {
     let client_executor_id = app.state::<host_access::HostAccess>().client_executor_id();
     let mut config = Config::desktop(data_dir);
+    config.exec_scripts_dir = Some(exec_scripts_dir(&app)?);
     // The effective identifier — including the debug-build override — keys
     // the macOS managed-preferences (MDM) domain the server reads policy from.
     config.bundle_id = Some(app.config().identifier.clone());

--- a/crates/openwave-desktop/tauri.conf.json
+++ b/crates/openwave-desktop/tauri.conf.json
@@ -53,6 +53,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "resources": {
+      "../../scripts/exec-documents/": "exec-scripts/"
+    },
     "externalBin": [
       "binaries/openwave-host-broker"
     ],

--- a/crates/openwave-sandbox-agent/Dockerfile
+++ b/crates/openwave-sandbox-agent/Dockerfile
@@ -14,11 +14,8 @@
 # issue #873); pinning-by-digest and host verification live on the host side in
 # #874, not in the image itself.
 #
-# Image build/verification for this slice is intentionally MANUAL, not a CI lane:
-# building it compiles the crate's slice of the workspace inside Docker, which is
-# far heavier than the cheap gates this foundational PR runs, and the container
-# runtime is a detected capability rather than a hard dependency. The command
-# above is the manual check.
+# The scoped post-merge sandbox-resident lane builds and drives this image on a
+# real container boundary.
 
 # ---- build stage -----------------------------------------------------------
 # Pinned to the workspace toolchain channel (stable) via the bookworm image; the
@@ -37,46 +34,38 @@ COPY . .
 # tools live in this crate and are the point of the image.)
 RUN cargo build --release --locked -p openwave-sandbox-agent
 
-# The sandbox-resident `exec` tool runs model-authored commands through /bin/sh
-# inside the container — in-container execution IS the containment. distroless/cc
-# ships no shell, so stage a static busybox (a shell plus the common coreutils
-# applets) and the workspace root the tools are scoped to, then copy just those
-# into the runtime. busybox is a deliberate, bounded surface for running the
-# model's commands, not a general package manager.
-#
-# The applet symlinks must resolve in the RUNTIME image, where this staging tree
-# lands at `/`. `busybox --install -s` would bake in the *build-time* absolute
-# path (`/rootfs/bin/busybox`), which does not exist after the copy — every
-# symlink would dangle and `/bin/sh -c` would fail for every exec. So create each
-# applet as a RELATIVE symlink to `busybox`: at runtime `/bin/sh -> busybox`
-# resolves to `/bin/busybox`, which is there. Correct by construction regardless
-# of where the staging tree was assembled.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends busybox-static \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /rootfs/bin /rootfs/workspace \
-    && cp /bin/busybox /rootfs/bin/busybox \
-    && for applet in $(/rootfs/bin/busybox --list); do \
-         [ "$applet" = busybox ] || ln -s busybox /rootfs/bin/"$applet"; \
-       done \
-    && test "$(readlink /rootfs/bin/sh)" = busybox
-
 # ---- runtime stage ---------------------------------------------------------
-# distroless/cc provides glibc and libgcc for the dynamically-linked binary; the
-# binary uses rustls (no OpenSSL) and opens no keychain, so cc is sufficient. It
-# ships no package manager — the only added surface is the staged busybox the
-# exec tool shells out to, in a container that runs untrusted model output.
-FROM gcr.io/distroless/cc-debian12 AS runtime
+# The document helpers need Python plus native renderers. The container remains
+# the isolation boundary; packages are installed at image-build time and no
+# helper performs a network request at runtime.
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ca-certificates \
+       libreoffice-impress \
+       libreoffice-writer \
+       poppler-utils \
+       python3 \
+       python3-openpyxl \
+       python3-pil \
+       python3-pip \
+    && python3 -m pip install --break-system-packages --no-cache-dir pypdfium2==4.30.0 \
+    && rm -rf /var/lib/apt/lists/* /root/.cache \
+    && mkdir -p /workspace /opt/openwave/exec-scripts
 
 COPY --from=build /src/target/release/openwave-sandbox-agent /usr/local/bin/openwave-sandbox-agent
-# busybox (/bin/sh + coreutils applets) and the /workspace tool root.
-COPY --from=build /rootfs /
+COPY scripts/exec-documents/ /opt/openwave/exec-scripts/
+
+RUN python3 /opt/openwave/exec-scripts/render_pdf.py --help >/dev/null \
+    && python3 /opt/openwave/exec-scripts/analyze_xlsx.py --help >/dev/null
 
 # The listener address the supervisor binds; the host dials this port.
 ENV OPENWAVE_SANDBOX_LISTEN=0.0.0.0:8080
 # The in-container workspace root the exec and filesystem tools are scoped to.
 ENV OPENWAVE_SANDBOX_WORKSPACE=/workspace
+# The helper library path shown to the model-facing exec tool.
+ENV OPENWAVE_EXEC_SCRIPTS=/opt/openwave/exec-scripts
 EXPOSE 8080
 
-# distroless has no shell for a RUN, so use the exec form for the entrypoint.
 ENTRYPOINT ["/usr/local/bin/openwave-sandbox-agent"]

--- a/crates/openwave-sandbox-agent/src/exec.rs
+++ b/crates/openwave-sandbox-agent/src/exec.rs
@@ -55,6 +55,9 @@ const SHELL: &str = "/bin/sh";
 /// on an inherited environment (which is cleared).
 const FIXED_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 
+/// Stable location of the document helper scripts baked into the sandbox image.
+const DOCUMENT_SCRIPTS_DIR: &str = "/opt/openwave/exec-scripts";
+
 /// Arguments for [`ExecTool`].
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -93,7 +96,10 @@ impl Tool for ExecTool {
             "Run a shell command inside the sandbox workspace and return its \
              output. The command runs with the workspace as its working \
              directory; it is bounded by a wall-time limit and a captured-output \
-             cap.",
+             cap. Document helpers live at $OPENWAVE_EXEC_SCRIPTS and write visual \
+             results to preview/; overview/grid/thumbnail names are reviewed first. \
+             Examples: python3 $OPENWAVE_EXEC_SCRIPTS/render_pdf.py report.pdf \
+             --pages 1-2; python3 $OPENWAVE_EXEC_SCRIPTS/analyze_xlsx.py budget.xlsx.",
         )
     }
 
@@ -122,6 +128,13 @@ impl Tool for ExecTool {
             ));
         }
 
+        for directory in ["output", "preview", "documents"] {
+            if let Err(error) = tokio::fs::create_dir_all(self.workspace.join(directory)).await {
+                return Ok(ToolOutput::error(format!(
+                    "workspace directory '{directory}/' is unavailable: {error}"
+                )));
+            }
+        }
         let outcome = run_bounded(&args.command, &self.workspace, self.timeout).await;
         Ok(ToolOutput::text(outcome.render()))
     }
@@ -228,6 +241,7 @@ async fn run_bounded(command: &str, workspace: &Path, timeout: Duration) -> Exec
         .env("HOME", workspace)
         .env("TMPDIR", workspace)
         .env("PATH", FIXED_PATH)
+        .env("OPENWAVE_EXEC_SCRIPTS", DOCUMENT_SCRIPTS_DIR)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -394,6 +408,30 @@ mod tests {
             "ran in the workspace: {}",
             out.content
         );
+    }
+
+    #[tokio::test]
+    async fn exposes_document_helpers_and_workspace_conventions() {
+        let dir = workspace();
+        let tool = ExecTool::new(dir.path(), DEFAULT_EXEC_TIMEOUT);
+        let spec = tool.spec();
+        assert!(spec.description.contains("OPENWAVE_EXEC_SCRIPTS"));
+        assert!(spec.description.contains("render_pdf.py"));
+        assert!(spec.description.contains("analyze_xlsx.py"));
+
+        let out = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({
+                    "command": "printf '%s' \"$OPENWAVE_EXEC_SCRIPTS\""
+                }),
+            )
+            .await
+            .unwrap();
+        assert!(out.content.contains(DOCUMENT_SCRIPTS_DIR));
+        for directory in ["output", "preview", "documents"] {
+            assert!(dir.path().join(directory).is_dir());
+        }
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -16,7 +16,7 @@ use openwave_code_execution::{
     CodeExecutionRequest, CodeExecutionResponse, DaytonaCredential, DaytonaExecutionProvider,
     E2BCredential, E2BExecutionProvider, ExecutionWorkspaceId, LocalExecutionProvider, PreviewScan,
     RemoteSessionPool, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing,
-    DAYTONA_CREDENTIAL_KEY, E2B_CREDENTIAL_KEY,
+    DAYTONA_CREDENTIAL_KEY, DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES, E2B_CREDENTIAL_KEY,
 };
 use openwave_core::{Result, SecretProvider, Store};
 use openwave_egress::{
@@ -547,6 +547,7 @@ pub struct ConfiguredCodeExecutionProvider {
     store: Arc<dyn Store>,
     secrets: Arc<dyn SecretProvider>,
     scratch_root: PathBuf,
+    document_scripts_source: Option<PathBuf>,
     remote_sessions: RemoteSessionPool,
 }
 
@@ -561,8 +562,16 @@ impl ConfiguredCodeExecutionProvider {
             store,
             secrets,
             scratch_root: scratch_root.into(),
+            document_scripts_source: None,
             remote_sessions: RemoteSessionPool::default(),
         }
+    }
+
+    /// Install a trusted bundled helper directory into every exec workspace.
+    #[must_use]
+    pub fn with_document_scripts(mut self, source: Option<PathBuf>) -> Self {
+        self.document_scripts_source = source;
+        self
     }
 
     /// Resolve the currently selected adapter at the last boundary before use.
@@ -579,10 +588,13 @@ impl ConfiguredCodeExecutionProvider {
             return Err(CodeExecutionError::NotConfigured);
         };
         let resolved: Box<dyn CodeExecutionProvider> = match provider {
-            CodeExecutionProviderKind::Local => Box::new(LocalExecutionProvider::new(
-                &self.scratch_root,
-                Duration::from_millis(config.timeout_ms),
-            )?),
+            CodeExecutionProviderKind::Local => Box::new(
+                LocalExecutionProvider::new(
+                    &self.scratch_root,
+                    Duration::from_millis(config.timeout_ms),
+                )?
+                .with_document_scripts(self.document_scripts_source.clone()),
+            ),
             CodeExecutionProviderKind::E2b => {
                 let credential = E2BCredential::load(&*self.secrets)
                     .await?
@@ -643,7 +655,12 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
     ) -> std::result::Result<CodeExecutionResponse, CodeExecutionError> {
         let (kind, provider) = self.resolve().await?;
         let host_dir = self.scratch_root.join(request.workspace_id.as_str());
-        prepare_execution_directories(&host_dir, kind != CodeExecutionProviderKind::Local).await?;
+        prepare_execution_directories(
+            &host_dir,
+            kind != CodeExecutionProviderKind::Local,
+            self.document_scripts_source.as_deref(),
+        )
+        .await?;
         // A remote sandbox has its own filesystem, but the model is shown one
         // path vocabulary across the file tools and exec. Mirror the chat's
         // private scratch into the workspace before the command and back out
@@ -696,6 +713,7 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
 async fn prepare_execution_directories(
     host_dir: &std::path::Path,
     mirrored: bool,
+    document_scripts_source: Option<&std::path::Path>,
 ) -> std::result::Result<(), CodeExecutionError> {
     for name in ["output", "preview", "documents"] {
         let directory = host_dir.join(name);
@@ -716,6 +734,52 @@ async fn prepare_execution_directories(
                     ))
                 })?;
         }
+    }
+    if let Some(source) = document_scripts_source {
+        install_document_scripts(source, host_dir).await?;
+    }
+    Ok(())
+}
+
+async fn install_document_scripts(
+    source: &std::path::Path,
+    host_dir: &std::path::Path,
+) -> std::result::Result<(), CodeExecutionError> {
+    let destination = host_dir.join(DOCUMENT_SCRIPTS_DIR);
+    tokio::fs::create_dir_all(&destination).await.map_err(|_| {
+        CodeExecutionError::Sandbox("document helper directory is unavailable".into())
+    })?;
+    for name in DOCUMENT_SCRIPT_FILES {
+        let source_file = source.join(name);
+        let metadata = tokio::fs::symlink_metadata(&source_file)
+            .await
+            .map_err(|_| {
+                CodeExecutionError::Sandbox(format!(
+                    "bundled document helper '{name}' is unavailable"
+                ))
+            })?;
+        if !metadata.is_file() || metadata.file_type().is_symlink() {
+            return Err(CodeExecutionError::Sandbox(format!(
+                "bundled document helper '{name}' is not a regular file"
+            )));
+        }
+        let content = tokio::fs::read(&source_file).await.map_err(|_| {
+            CodeExecutionError::Sandbox(format!(
+                "bundled document helper '{name}' could not be read"
+            ))
+        })?;
+        if content.len() > openwave_code_execution::MAX_WORKSPACE_FILE_BYTES {
+            return Err(CodeExecutionError::Sandbox(format!(
+                "bundled document helper '{name}' exceeds the workspace file limit"
+            )));
+        }
+        tokio::fs::write(destination.join(name), content)
+            .await
+            .map_err(|_| {
+                CodeExecutionError::Sandbox(format!(
+                    "bundled document helper '{name}' could not be installed"
+                ))
+            })?;
     }
     Ok(())
 }
@@ -824,13 +888,34 @@ mod tests {
     #[tokio::test]
     async fn exec_workspace_conventions_exist_before_a_command_runs() {
         let dir = tempfile::tempdir().unwrap();
-        prepare_execution_directories(dir.path(), true)
+        prepare_execution_directories(dir.path(), true, None)
             .await
             .unwrap();
 
         for name in ["output", "preview", "documents"] {
             assert!(dir.path().join(name).is_dir());
             assert!(dir.path().join(name).join(".openwave-directory").is_file());
+        }
+    }
+
+    #[tokio::test]
+    async fn bundled_document_helpers_are_installed_as_one_library() {
+        let source = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        for name in DOCUMENT_SCRIPT_FILES {
+            std::fs::write(source.path().join(name), format!("helper:{name}")).unwrap();
+        }
+
+        prepare_execution_directories(workspace.path(), false, Some(source.path()))
+            .await
+            .unwrap();
+
+        for name in DOCUMENT_SCRIPT_FILES {
+            let installed = workspace.path().join(DOCUMENT_SCRIPTS_DIR).join(name);
+            assert_eq!(
+                std::fs::read_to_string(installed).unwrap(),
+                format!("helper:{name}")
+            );
         }
     }
 

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -679,11 +679,14 @@ async fn bind_inner(
         gateway.clone(),
         os_policy.clone(),
     ));
-    let code_execution = Arc::new(code_execution::ConfiguredCodeExecutionProvider::new(
-        store.clone(),
-        secrets.clone(),
-        config.data_dir.join("scratch"),
-    ));
+    let code_execution = Arc::new(
+        code_execution::ConfiguredCodeExecutionProvider::new(
+            store.clone(),
+            secrets.clone(),
+            config.data_dir.join("scratch"),
+        )
+        .with_document_scripts(config.exec_scripts_dir.clone()),
+    );
     let foreground_web_search =
         Box::new(web_search::foreground_tool(store.clone(), secrets.clone()));
     let web_extract = Box::new(web_search::foreground_extract_tool(

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -157,6 +157,29 @@ code, stdout, stderr, timeout and truncation flags, and duration. Provider-nativ
 responses, credentials, absolute host paths, and unbounded logs do not cross
 the contract.
 
+## Document helpers
+
+Desktop builds ship a network-free Python helper library into every exec
+workspace at `.openwave/exec-scripts`. The sandbox container includes the same
+library at `/opt/openwave/exec-scripts`, exposed through
+`OPENWAVE_EXEC_SCRIPTS`. The helpers print short summaries and write visual
+review images into `preview/`, using priority names such as
+`overview-grid.png` before per-page or per-sheet images.
+
+Examples:
+
+```text
+python3 .openwave/exec-scripts/render_pdf.py documents/report.pdf --pages 1-2
+python3 .openwave/exec-scripts/extract_pdf_figures.py documents/report.pdf
+python3 .openwave/exec-scripts/analyze_xlsx.py documents/model.xlsx
+```
+
+PDF rendering uses pypdfium2 or pdf2image with Poppler, figure extraction uses
+Poppler, DOCX/PPTX rendering uses LibreOffice, and XLSX analysis uses openpyxl
+and Pillow. The sandbox image includes these tools. Local execution reports a
+concise command error when the host lacks Python or an underlying renderer; it
+does not download tooling or use an unconfined fallback.
+
 ## Workspace lifecycle
 
 Beside `execute`, a provider may offer an optional durable-workspace

--- a/scripts/exec-documents/README.md
+++ b/scripts/exec-documents/README.md
@@ -1,0 +1,16 @@
+# Exec document helpers
+
+These network-free Python command-line scripts turn documents already present
+in an exec workspace into concise stdout summaries and bounded images under
+`preview/`.
+
+| Script | Purpose | Required tooling |
+| --- | --- | --- |
+| `render_pdf.py` | Render selected PDF pages and an overview grid | Python, Pillow, and either pypdfium2 or pdf2image + Poppler |
+| `extract_pdf_figures.py` | Extract embedded PDF raster figures and an overview | Python, Pillow, and Poppler `pdfimages` |
+| `render_office.py` | Convert DOCX/PPTX to PDF, then render selected pages | The PDF renderer above plus LibreOffice |
+| `analyze_xlsx.py` | Print sheet inventory, used ranges, and sample rows; thumbnail sheets | Python, openpyxl, and Pillow |
+
+The desktop copies this directory into each exec workspace at
+`.openwave/exec-scripts`. The sandbox image exposes it at
+`/opt/openwave/exec-scripts` and sets `OPENWAVE_EXEC_SCRIPTS` to that path.

--- a/scripts/exec-documents/_openwave_preview.py
+++ b/scripts/exec-documents/_openwave_preview.py
@@ -1,0 +1,138 @@
+"""Shared, dependency-light helpers for OpenWave's document scripts."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+class HelperError(RuntimeError):
+    """A concise, model-actionable command failure."""
+
+
+def existing_file(value: str, suffixes: Sequence[str]) -> Path:
+    path = Path(value).expanduser()
+    if not path.is_file():
+        raise HelperError(f"input file does not exist: {path}")
+    if path.suffix.lower() not in suffixes:
+        expected = ", ".join(suffixes)
+        raise HelperError(f"expected one of {expected}, got: {path.name}")
+    return path
+
+
+def ensure_preview_dir(value: str) -> Path:
+    path = Path(value)
+    path.mkdir(parents=True, exist_ok=True)
+    if not path.is_dir():
+        raise HelperError(f"preview path is not a directory: {path}")
+    return path
+
+
+def remove_matching(directory: Path, patterns: Iterable[str]) -> None:
+    for pattern in patterns:
+        for path in directory.glob(pattern):
+            if path.is_file():
+                path.unlink()
+
+
+def parse_pages(spec: str, page_count: int, limit: int = 12) -> tuple[list[int], int]:
+    """Return one-based pages plus the count truncated by the safety limit."""
+
+    if page_count < 1:
+        raise HelperError("document has no pages")
+    if spec.strip().lower() == "all":
+        pages = list(range(1, page_count + 1))
+    else:
+        pages: list[int] = []
+        for token in spec.split(","):
+            token = token.strip()
+            if not token:
+                raise HelperError("page selection contains an empty item")
+            match = re.fullmatch(r"(\d+)(?:-(\d+))?", token)
+            if match is None:
+                raise HelperError(
+                    "pages must be 'all' or comma-separated numbers/ranges such as 1,3-5"
+                )
+            start = int(match.group(1))
+            end = int(match.group(2) or start)
+            if start < 1 or end < start or end > page_count:
+                raise HelperError(
+                    f"page range {token} is outside this {page_count}-page document"
+                )
+            pages.extend(range(start, end + 1))
+        pages = list(dict.fromkeys(pages))
+    omitted = max(0, len(pages) - limit)
+    return pages[:limit], omitted
+
+
+def require_pillow():
+    try:
+        from PIL import Image, ImageDraw, ImageOps
+    except ImportError as error:
+        raise HelperError(
+            "Pillow is required to create preview images; install the Python 'Pillow' package"
+        ) from error
+    return Image, ImageDraw, ImageOps
+
+
+def overview_grid(
+    images: Sequence[tuple[Path, str]],
+    destination: Path,
+    *,
+    cell_width: int = 420,
+    cell_height: int = 320,
+) -> None:
+    """Build a bounded overview whose priority name wins the three-image scan."""
+
+    if not images:
+        raise HelperError("cannot build an overview without images")
+    Image, ImageDraw, ImageOps = require_pillow()
+    count = min(len(images), 6)
+    columns = 2 if count > 1 else 1
+    rows = (count + columns - 1) // columns
+    label_height = 28
+    canvas = Image.new(
+        "RGB",
+        (columns * cell_width, rows * (cell_height + label_height)),
+        "white",
+    )
+    draw = ImageDraw.Draw(canvas)
+    for index, (path, label) in enumerate(images[:count]):
+        with Image.open(path) as source:
+            thumbnail = ImageOps.contain(
+                source.convert("RGB"),
+                (cell_width - 16, cell_height - 16),
+            )
+        x = (index % columns) * cell_width
+        y = (index // columns) * (cell_height + label_height)
+        canvas.paste(
+            thumbnail,
+            (x + (cell_width - thumbnail.width) // 2, y + 8),
+        )
+        draw.rectangle(
+            (x, y, x + cell_width - 1, y + cell_height + label_height - 1),
+            outline="#b8bec8",
+        )
+        draw.text((x + 8, y + cell_height + 6), label[:64], fill="black")
+    canvas.save(destination, format="PNG", optimize=True)
+
+
+def slug(value: str, fallback: str = "sheet") -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", value.strip()).strip("-._")
+    return (cleaned or fallback)[:48]
+
+
+def run_cli(function) -> int:
+    try:
+        return int(function() or 0)
+    except HelperError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    except Exception as error:  # Third-party parsers should fail without a traceback dump.
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        print("error: interrupted", file=sys.stderr)
+        return 130

--- a/scripts/exec-documents/analyze_xlsx.py
+++ b/scripts/exec-documents/analyze_xlsx.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Inventory an XLSX workbook, sample rows, and thumbnail its first sheets."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from _openwave_preview import (
+    HelperError,
+    ensure_preview_dir,
+    existing_file,
+    overview_grid,
+    remove_matching,
+    require_pillow,
+    run_cli,
+    slug,
+)
+
+
+def parser() -> argparse.ArgumentParser:
+    cli = argparse.ArgumentParser(
+        description="Print XLSX sheet ranges/sample rows and write thumbnails into preview/.",
+    )
+    cli.add_argument("workbook", help="XLSX file inside the exec workspace")
+    cli.add_argument(
+        "--sample-rows",
+        type=int,
+        default=5,
+        help="non-empty rows printed per sheet, from 1 through 20 (default: 5)",
+    )
+    cli.add_argument(
+        "--max-sheets",
+        type=int,
+        default=2,
+        help="sheet thumbnails to emit, from 1 through 8 (default: 2)",
+    )
+    cli.add_argument(
+        "--preview-dir",
+        default="preview",
+        help="preview output directory (default: preview)",
+    )
+    return cli
+
+
+def _openpyxl():
+    try:
+        import openpyxl
+    except ImportError as error:
+        raise HelperError(
+            "XLSX analysis requires the Python 'openpyxl' package"
+        ) from error
+    return openpyxl
+
+
+def _display(value) -> str:
+    if value is None:
+        return ""
+    rendered = str(value).replace("\r", " ").replace("\n", " ")
+    return rendered[:80] + ("…" if len(rendered) > 80 else "")
+
+
+def _sample_rows(sheet, count: int, columns: int) -> list[list[str]]:
+    samples: list[list[str]] = []
+    for row in sheet.iter_rows(
+        min_row=1,
+        max_row=min(sheet.max_row, 500),
+        min_col=1,
+        max_col=min(max(columns, 1), 12),
+        values_only=True,
+    ):
+        values = [_display(value) for value in row]
+        if any(values):
+            samples.append(values)
+            if len(samples) == count:
+                break
+    return samples
+
+
+def _sheet_thumbnail(name: str, samples: list[list[str]], destination: Path) -> None:
+    Image, ImageDraw, _ImageOps = require_pillow()
+    columns = max(1, min(max((len(row) for row in samples), default=1), 8))
+    rows = max(1, min(len(samples), 10))
+    cell_width = 150
+    cell_height = 34
+    title_height = 42
+    image = Image.new(
+        "RGB",
+        (columns * cell_width, title_height + rows * cell_height),
+        "white",
+    )
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((0, 0, image.width - 1, title_height - 1), fill="#e9eef6")
+    draw.text((10, 13), name[:80], fill="#172033")
+    for row_index in range(rows):
+        values = samples[row_index] if row_index < len(samples) else []
+        for column_index in range(columns):
+            x = column_index * cell_width
+            y = title_height + row_index * cell_height
+            fill = "#f7f9fc" if row_index % 2 else "white"
+            draw.rectangle(
+                (x, y, x + cell_width - 1, y + cell_height - 1),
+                fill=fill,
+                outline="#c8ced8",
+            )
+            value = values[column_index] if column_index < len(values) else ""
+            draw.text((x + 6, y + 10), value[:22], fill="#172033")
+    image.save(destination, format="PNG", optimize=True)
+
+
+def main() -> int:
+    args = parser().parse_args()
+    if not 1 <= args.sample_rows <= 20:
+        raise HelperError("sample-rows must be between 1 and 20")
+    if not 1 <= args.max_sheets <= 8:
+        raise HelperError("max-sheets must be between 1 and 8")
+    source = existing_file(args.workbook, [".xlsx", ".xlsm"])
+    preview = ensure_preview_dir(args.preview_dir)
+    openpyxl = _openpyxl()
+    require_pillow()
+
+    workbook = openpyxl.load_workbook(
+        source,
+        read_only=True,
+        data_only=True,
+    )
+    remove_matching(preview, ["overview-grid.png", "sheet-*.png"])
+    print(f"Workbook: {source.name}")
+    print(f"Sheets: {len(workbook.sheetnames)}")
+    thumbnails: list[tuple[Path, str]] = []
+    for index, name in enumerate(workbook.sheetnames, start=1):
+        sheet = workbook[name]
+        used_range = sheet.calculate_dimension(force=True)
+        rows = max(sheet.max_row or 0, 0)
+        columns = max(sheet.max_column or 0, 0)
+        samples = _sample_rows(sheet, args.sample_rows, columns)
+        print(f"- {name}: used={used_range}, rows={rows}, columns={columns}")
+        if samples:
+            for sample_index, values in enumerate(samples, start=1):
+                print(f"  sample {sample_index}: " + " | ".join(values))
+        else:
+            print("  sample: <empty>")
+        if index <= args.max_sheets:
+            output = preview / f"sheet-{index:03d}-{slug(name)}.png"
+            _sheet_thumbnail(name, samples, output)
+            thumbnails.append((output, name))
+
+    if thumbnails:
+        overview = preview / "overview-grid.png"
+        overview_grid(thumbnails, overview)
+        names = ", ".join(
+            path.name for path, _label in [(overview, "Overview"), *thumbnails]
+        )
+        print(f"Preview images: {names}")
+    if len(workbook.sheetnames) > len(thumbnails):
+        print(
+            f"Thumbnail limit skipped {len(workbook.sheetnames) - len(thumbnails)} "
+            "sheet(s); rerun with --max-sheets after narrowing the workbook."
+        )
+    workbook.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_cli(main))

--- a/scripts/exec-documents/extract_pdf_figures.py
+++ b/scripts/exec-documents/extract_pdf_figures.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Extract embedded raster figures from a PDF into preview/."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from _openwave_preview import (
+    HelperError,
+    ensure_preview_dir,
+    existing_file,
+    overview_grid,
+    remove_matching,
+    run_cli,
+)
+
+
+def parser() -> argparse.ArgumentParser:
+    cli = argparse.ArgumentParser(
+        description="Extract embedded PDF figures and an overview into preview/.",
+    )
+    cli.add_argument("pdf", help="PDF file inside the exec workspace")
+    cli.add_argument(
+        "--max-figures",
+        type=int,
+        default=8,
+        help="maximum figures to retain before preview scan capping (default: 8)",
+    )
+    cli.add_argument(
+        "--preview-dir",
+        default="preview",
+        help="preview output directory (default: preview)",
+    )
+    return cli
+
+
+def main() -> int:
+    args = parser().parse_args()
+    if not 1 <= args.max_figures <= 24:
+        raise HelperError("max-figures must be between 1 and 24")
+    source = existing_file(args.pdf, [".pdf"])
+    preview = ensure_preview_dir(args.preview_dir)
+    pdfimages = shutil.which("pdfimages")
+    if pdfimages is None:
+        raise HelperError(
+            "embedded figure extraction requires Poppler's 'pdfimages' executable"
+        )
+
+    remove_matching(preview, ["overview-grid.png", "figure-*.png"])
+    with tempfile.TemporaryDirectory(prefix="openwave-pdf-figures-") as temporary:
+        prefix = Path(temporary) / "figure"
+        completed = subprocess.run(
+            [pdfimages, "-png", str(source), str(prefix)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout).strip()
+            raise HelperError(f"pdfimages failed: {detail or 'unknown error'}")
+        extracted = sorted(Path(temporary).glob("figure-*.png"))
+        retained = extracted[: args.max_figures]
+        outputs: list[Path] = []
+        for index, path in enumerate(retained, start=1):
+            output = preview / f"figure-{index:03d}.png"
+            shutil.copyfile(path, output)
+            outputs.append(output)
+
+    if not outputs:
+        print("No embedded raster figures were found.")
+        return 0
+    overview = preview / "overview-grid.png"
+    overview_grid(
+        [(path, f"Figure {index}") for index, path in enumerate(outputs, start=1)],
+        overview,
+    )
+    names = ", ".join(path.name for path in [overview, *outputs])
+    print(f"Extracted {len(outputs)} embedded figure(s).")
+    print(f"Preview images: {names}")
+    if len(extracted) > len(outputs):
+        print(
+            f"Skipped {len(extracted) - len(outputs)} figure(s) past the "
+            f"{args.max_figures}-figure script limit."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_cli(main))

--- a/scripts/exec-documents/render_office.py
+++ b/scripts/exec-documents/render_office.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Convert DOCX/PPTX with LibreOffice and render the resulting PDF."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from _openwave_preview import (
+    HelperError,
+    ensure_preview_dir,
+    existing_file,
+    run_cli,
+)
+from render_pdf import render_document
+
+
+def parser() -> argparse.ArgumentParser:
+    cli = argparse.ArgumentParser(
+        description="Render DOCX or PPTX pages into preview/ through LibreOffice.",
+    )
+    cli.add_argument("document", help="DOCX or PPTX file inside the exec workspace")
+    cli.add_argument(
+        "--pages",
+        default="1",
+        help="one-based pages, ranges such as 1,3-5, or all (default: 1)",
+    )
+    cli.add_argument(
+        "--dpi",
+        type=int,
+        default=144,
+        help="render resolution from 72 through 300 DPI (default: 144)",
+    )
+    cli.add_argument(
+        "--preview-dir",
+        default="preview",
+        help="preview output directory (default: preview)",
+    )
+    return cli
+
+
+def main() -> int:
+    args = parser().parse_args()
+    if not 72 <= args.dpi <= 300:
+        raise HelperError("dpi must be between 72 and 300")
+    source = existing_file(args.document, [".docx", ".pptx"])
+    preview = ensure_preview_dir(args.preview_dir)
+    libreoffice = shutil.which("libreoffice") or shutil.which("soffice")
+    if libreoffice is None:
+        raise HelperError(
+            "Office rendering requires the LibreOffice 'libreoffice' or 'soffice' executable"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="openwave-office-") as temporary:
+        temporary_path = Path(temporary)
+        profile = temporary_path / "profile"
+        profile.mkdir()
+        environment = os.environ.copy()
+        environment["HOME"] = temporary
+        completed = subprocess.run(
+            [
+                libreoffice,
+                "--headless",
+                f"-env:UserInstallation={profile.resolve().as_uri()}",
+                "--convert-to",
+                "pdf",
+                "--outdir",
+                temporary,
+                str(source.resolve()),
+            ],
+            capture_output=True,
+            text=True,
+            env=environment,
+            check=False,
+        )
+        converted = temporary_path / f"{source.stem}.pdf"
+        if completed.returncode != 0 or not converted.is_file():
+            detail = (completed.stderr or completed.stdout).strip()
+            raise HelperError(f"LibreOffice conversion failed: {detail or 'no PDF produced'}")
+        renderer, outputs, count, omitted = render_document(
+            converted,
+            preview,
+            args.pages,
+            args.dpi,
+        )
+
+    names = ", ".join(path.name for path in outputs)
+    print(
+        f"Converted {source.name} with LibreOffice and rendered "
+        f"{len(outputs) - 1} of {count} page(s) with {renderer}."
+    )
+    print(f"Preview images: {names}")
+    if omitted:
+        print(f"Skipped {omitted} selected page(s) past the 12-page script limit.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_cli(main))

--- a/scripts/exec-documents/render_pdf.py
+++ b/scripts/exec-documents/render_pdf.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Render selected PDF pages plus an overview thumbnail into preview/."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from _openwave_preview import (
+    HelperError,
+    ensure_preview_dir,
+    existing_file,
+    overview_grid,
+    parse_pages,
+    remove_matching,
+    run_cli,
+)
+
+
+def _pdfium_renderer(source: Path, pages: list[int], dpi: int):
+    try:
+        import pypdfium2 as pdfium
+    except ImportError:
+        return None
+
+    document = pdfium.PdfDocument(str(source))
+    if not pages:
+        return len(document), []
+    rendered = []
+    scale = dpi / 72
+    for page_number in pages:
+        bitmap = document[page_number - 1].render(scale=scale)
+        rendered.append((page_number, bitmap.to_pil()))
+    return len(document), rendered
+
+
+def _pdf2image_page_count(source: Path) -> int | None:
+    try:
+        from pdf2image import pdfinfo_from_path
+    except ImportError:
+        return None
+    info = pdfinfo_from_path(str(source))
+    return int(info["Pages"])
+
+
+def _pdf2image_renderer(source: Path, pages: list[int], dpi: int):
+    try:
+        from pdf2image import convert_from_path
+    except ImportError:
+        return None
+
+    rendered = []
+    for page_number in pages:
+        images = convert_from_path(
+            str(source),
+            dpi=dpi,
+            first_page=page_number,
+            last_page=page_number,
+            fmt="png",
+            single_file=True,
+        )
+        if len(images) != 1:
+            raise HelperError(f"PDF renderer returned no image for page {page_number}")
+        rendered.append((page_number, images[0]))
+    return rendered
+
+
+def page_count(source: Path) -> tuple[str, int]:
+    pdfium = _pdfium_renderer(source, [], 72)
+    if pdfium is not None:
+        return "pypdfium2", pdfium[0]
+    count = _pdf2image_page_count(source)
+    if count is not None:
+        return "pdf2image", count
+    raise HelperError(
+        "PDF rendering requires pypdfium2 or pdf2image with Poppler; "
+        "install one of those Python toolchains"
+    )
+
+
+def render_document(
+    source: Path,
+    preview_dir: Path,
+    pages_spec: str,
+    dpi: int,
+) -> tuple[str, list[Path], int, int]:
+    renderer, count = page_count(source)
+    pages, omitted = parse_pages(pages_spec, count)
+    if renderer == "pypdfium2":
+        pdfium = _pdfium_renderer(source, pages, dpi)
+        if pdfium is None:
+            raise HelperError("pypdfium2 became unavailable during rendering")
+        rendered = pdfium[1]
+    else:
+        rendered = _pdf2image_renderer(source, pages, dpi)
+        if rendered is None:
+            raise HelperError("pdf2image became unavailable during rendering")
+
+    remove_matching(preview_dir, ["overview-grid.png", "page-*.png"])
+    outputs: list[Path] = []
+    for page_number, image in rendered:
+        output = preview_dir / f"page-{page_number:04d}.png"
+        image.convert("RGB").save(output, format="PNG", optimize=True)
+        outputs.append(output)
+    overview = preview_dir / "overview-grid.png"
+    overview_grid(
+        [(path, f"Page {page}") for path, page in zip(outputs, pages)],
+        overview,
+    )
+    return renderer, [overview, *outputs], count, omitted
+
+
+def parser() -> argparse.ArgumentParser:
+    cli = argparse.ArgumentParser(
+        description="Render PDF pages and a thumbnail overview into preview/.",
+    )
+    cli.add_argument("pdf", help="PDF file inside the exec workspace")
+    cli.add_argument(
+        "--pages",
+        default="1",
+        help="one-based pages, ranges such as 1,3-5, or all (default: 1)",
+    )
+    cli.add_argument(
+        "--dpi",
+        type=int,
+        default=144,
+        help="render resolution from 72 through 300 DPI (default: 144)",
+    )
+    cli.add_argument(
+        "--preview-dir",
+        default="preview",
+        help="preview output directory (default: preview)",
+    )
+    return cli
+
+
+def main() -> int:
+    args = parser().parse_args()
+    if not 72 <= args.dpi <= 300:
+        raise HelperError("dpi must be between 72 and 300")
+    source = existing_file(args.pdf, [".pdf"])
+    preview = ensure_preview_dir(args.preview_dir)
+    renderer, outputs, count, omitted = render_document(
+        source,
+        preview,
+        args.pages,
+        args.dpi,
+    )
+    names = ", ".join(path.name for path in outputs)
+    print(f"Rendered {len(outputs) - 1} of {count} PDF page(s) with {renderer}.")
+    print(f"Preview images: {names}")
+    if omitted:
+        print(f"Skipped {omitted} selected page(s) past the 12-page script limit.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_cli(main))


### PR DESCRIPTION
## What and why

Rich documents now travel through exec, so OpenWave ships a small network-free helper library that turns PDFs, Office files, and workbooks into concise text plus preview images the model can inspect. The desktop bundles the library as a signed resource, restores it into each local or managed exec workspace at `.openwave/exec-scripts`, exposes the signed source read-only to the macOS sandbox, and the sandbox image carries the same helpers at `/opt/openwave/exec-scripts`.

The helpers are argparse CLIs and prioritize `overview-grid.png` before individual page, figure, or sheet images so the existing three-image preview cap produces a useful visual summary. The exec descriptions include direct PDF, figure-extraction, and XLSX examples; remote workspace sync explicitly covers the helper directory without widening its existing file-count or per-file byte caps.

## Script inventory

- `render_pdf.py`: renders selected PDF pages through pypdfium2 or pdf2image and builds an overview grid.
- `extract_pdf_figures.py`: extracts embedded raster figures with Poppler `pdfimages` and builds an overview grid.
- `render_office.py`: converts DOCX/PPTX through headless LibreOffice, then uses the PDF renderer.
- `analyze_xlsx.py`: prints sheet inventory, used ranges, and sample rows, then renders sheet thumbnails and an overview.
- `_openwave_preview.py`: shared path, selection, naming, Pillow, grid, and concise-error helpers.

## Tool matrix

| Environment | Behavior |
| --- | --- |
| Sandbox container | Includes Python, Pillow, pypdfium2, openpyxl, Poppler, and LibreOffice; all four workflows work without a runtime download. |
| Desktop/local with Python and matching renderer libraries | The relevant helper works from the bundled path; the signed resource path is read-only and output remains confined to the chat workspace. |
| Desktop/local without Python | The exec command honestly reports that Python cannot start; OpenWave does not download or run an unconfined fallback. |
| Python without an underlying renderer | Each helper exits nonzero with a short actionable dependency message; Office conversion specifically requires LibreOffice plus the PDF stack. |
| Managed E2B/Daytona | The desktop-bundled scripts mirror into the managed workspace under the existing sync limits; installed document tooling still depends on that provider image. |

The sandbox-resident container e2e lane is intentionally the image-inclusion boundary and runs after merge; local Rust tests do not duplicate a Docker image build.

## Tests

- Added Python contract coverage that compiles every entry point, verifies argparse help, and exercises deterministic missing-tool diagnostics. It skips cleanly only when neither `python3` nor `python` is available.
- Added workspace sync coverage proving `.openwave/exec-scripts` is not skipped and remains subject to normal file limits.
- Added server coverage proving the exact trusted helper set is installed into a workspace.
- Added sandbox-agent coverage for the helper environment, tool guidance, and conventional workspace directories.
- Updated local Seatbelt coverage to prove the signed resource path is readable but absent from the write rule.
- Deleted tests: none; no prior behavior or test subject was removed.

## Verification

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p openwave-code-execution -p openwave-core -p openwave-server -p openwave-sandbox-agent -p openwave-desktop`
- `cargo check --workspace --locked`
- `cargo test -p openwave-code-execution --test document_scripts` (targeted rerun after the final script default adjustment)

All commands passed. UI sources and generated wire types are unchanged.

Closes #1051