### PR TITLE
feat(desktop): attach folders to a chat

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -60,6 +60,7 @@ import { ChatSidebar } from "./sidebar/ChatSidebar";
 import { useRefreshSignals } from "./RefreshSignals";
 import { TranscriptVisibilityProvider } from "./TranscriptVisibility";
 import { useTurnLifecycle } from "./TurnLifecycleSignals";
+import { useChatFolderAttachments } from "./useChatFolderAttachments";
 
 let msgSeq = 0;
 
@@ -105,6 +106,8 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   const draftRef = useRef("");
 
   const chat = chats.find((candidate) => candidate.id === chatId) ?? null;
+  const nativeHost = hasNativeHost();
+  const folders = useChatFolderAttachments(chat, nativeHost);
 
   // A chat id that is not in the list — deleted in another window, or a stale
   // deep link — should land somewhere real rather than on an empty frame.
@@ -412,7 +415,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             client={client}
             chat={chat!}
             hydrated={hydrated}
-            nativeHost={hasNativeHost()}
+            nativeHost={nativeHost}
             deletingChat={deletingChatId !== null}
             draft={draft}
             draftRef={draftRef}
@@ -425,6 +428,13 @@ export function ChatRoute({ chatId }: { chatId: string }) {
                 setFiles((current) =>
                   current.filter((file) => file.documentId !== documentId),
                 ),
+            }}
+            folders={{
+              items: folders.items,
+              working: folders.working,
+              error: folders.error,
+              onAttach: nativeHost ? folders.attach : undefined,
+              onRemove: folders.remove,
             }}
             nativeDropTarget={
               <DocumentDropTarget

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -13,6 +13,7 @@ import { useChatSessionStore } from "./ChatSessionStore";
 import {
   Composer,
   type ComposerFiles,
+  type ComposerFolders,
   type ComposerImages,
 } from "./Composer";
 import { MessageList } from "./MessageList";
@@ -38,6 +39,7 @@ export type ChatViewProps = {
   composerModelMenu: ReactNode;
   composerImages: ComposerImages;
   files: ComposerFiles;
+  folders?: ComposerFolders;
   nativeDropTarget?: ReactNode;
   attachError: string | null;
   onDraftChange: (value: string) => void;
@@ -65,6 +67,7 @@ export function ChatView({
   composerModelMenu,
   composerImages,
   files,
+  folders,
   nativeDropTarget,
   attachError,
   onDraftChange,
@@ -326,6 +329,7 @@ export function ChatView({
           modelMenu={composerModelMenu}
           images={composerImages}
           files={files}
+          folders={folders}
           nativeDropTarget={nativeDropTarget}
           attachError={attachError}
           // Typing retires the verdict on the last piece of guidance. Accepted

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -10,6 +10,8 @@ import {
 } from "react";
 import {
   ArrowUpRight,
+  FolderOpen,
+  FolderPlus,
   Image as ImageIcon,
   LoaderCircle,
   Paperclip,
@@ -26,10 +28,13 @@ import {
   type ImageAttachment,
 } from "./ImageAttachments";
 import { Button } from "@/components/ui/button";
+import { useConfirm } from "@/components/ConfirmDialog";
 import { WithTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { documentIcon } from "@/documentIcon";
 import type { ImportedDocument } from "@/documents";
+import { folderAccessLabel } from "./FolderAccess";
+import type { ConnectedFolderAccess } from "./host";
 
 const MIN_COMPOSER_LINES = 1;
 export const MAX_COMPOSER_LINES = 6;
@@ -120,6 +125,14 @@ export type ComposerFiles = {
   onRemove: (documentId: string) => void;
 };
 
+export type ComposerFolders = {
+  items: ConnectedFolderAccess[];
+  working: boolean;
+  error: string | null;
+  onAttach?: () => void;
+  onRemove: (rootId: string) => void;
+};
+
 /** Whether attached images stop this turn from being sent, and why. */
 export function imageSendBlocker(images: ComposerImages | undefined): string | null {
   if (!images || images.items.length === 0) return null;
@@ -143,6 +156,7 @@ export type ComposerProps = {
   modelMenu?: ReactNode;
   images?: ComposerImages;
   files?: ComposerFiles;
+  folders?: ComposerFolders;
   nativeDropTarget?: ReactNode;
   attachError?: string | null;
   onDraftChange: (draft: string) => void;
@@ -165,6 +179,7 @@ export function Composer({
   modelMenu,
   images,
   files,
+  folders,
   nativeDropTarget,
   attachError = null,
   onDraftChange,
@@ -183,6 +198,7 @@ export function Composer({
   // boolean flickers the drop hint on and off while the file is held still.
   const dragDepthRef = useRef(0);
   const [dragging, setDragging] = useState(false);
+  const { confirm, dialog: confirmDialog } = useConfirm();
   const inputDisabled = disabled;
   const active = busy && activeTurnId !== null;
   const hasDraft = Boolean(draft.trim());
@@ -262,6 +278,16 @@ export function Composer({
     if (acceptTransfer(event.clipboardData)) event.preventDefault();
   }
 
+  async function removeFolder(folder: ConnectedFolderAccess) {
+    const accepted = await confirm({
+      title: `Disconnect ${folder.displayName}?`,
+      description: "The agent loses access to this folder.",
+      confirmLabel: "Disconnect",
+      destructive: true,
+    });
+    if (accepted) folders?.onRemove(folder.rootId);
+  }
+
   return (
     <form
       className={cn(
@@ -326,6 +352,21 @@ export function Composer({
           ))}
         </ul>
       )}
+      {folders && folders.items.length > 0 && (
+        <ul
+          className="m-0 flex list-none flex-wrap gap-2 p-0"
+          aria-label="Attached folders"
+        >
+          {folders.items.map((folder) => (
+            <FolderAttachmentChip
+              key={folder.rootId}
+              folder={folder}
+              disabled={folders.working}
+              onRemove={() => void removeFolder(folder)}
+            />
+          ))}
+        </ul>
+      )}
       <textarea
         ref={textareaRef}
         className="w-full resize-none border-none bg-transparent px-1 text-base placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-0"
@@ -362,6 +403,28 @@ export function Composer({
                   <LoaderCircle className="animate-spin" size={15} />
                 ) : (
                   <Paperclip size={15} />
+                )}
+              </Button>
+            </WithTooltip>
+          )}
+          {folders?.onAttach && (
+            <WithTooltip
+              label={folders.working ? "Updating folders…" : "Attach folder"}
+            >
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-8"
+                aria-label={
+                  folders.working ? "Updating attached folders" : "Attach folder"
+                }
+                disabled={inputDisabled || folders.working}
+                onClick={folders.onAttach}
+              >
+                {folders.working ? (
+                  <LoaderCircle className="animate-spin" size={15} />
+                ) : (
+                  <FolderPlus size={15} />
                 )}
               </Button>
             </WithTooltip>
@@ -446,6 +509,11 @@ export function Composer({
           {"Couldn’t attach: "}{attachError}
         </span>
       )}
+      {folders?.error && (
+        <span className="text-xs text-destructive" role="alert">
+          {"Couldn’t update folders: "}{folders.error}
+        </span>
+      )}
       {images?.error && (
         <span className="text-xs text-destructive" role="alert">
           {"Couldn’t attach image: "}{images.error}
@@ -457,7 +525,46 @@ export function Composer({
           {" can’t read images. Choose a model that accepts image input, or remove the attached image."}
         </span>
       )}
+      {confirmDialog}
     </form>
+  );
+}
+
+function FolderAttachmentChip({
+  folder,
+  disabled,
+  onRemove,
+}: {
+  folder: ConnectedFolderAccess;
+  disabled: boolean;
+  onRemove: () => void;
+}) {
+  return (
+    <li className="relative flex min-w-0 max-w-full items-center gap-2 rounded-lg border border-border bg-muted/50 py-1.5 pl-2 pr-7 text-muted-foreground">
+      <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-md bg-background">
+        <FolderOpen size={16} aria-hidden="true" />
+      </span>
+      <span className="grid min-w-0 gap-px">
+        <strong
+          className="max-w-[12rem] truncate text-xs font-semibold text-foreground"
+          title={folder.displayName}
+        >
+          {folder.displayName}
+        </strong>
+        <small className="text-[0.68rem]">
+          {folderAccessLabel(folder.capabilities)}
+        </small>
+      </span>
+      <button
+        type="button"
+        className="absolute right-0.5 top-0.5 inline-flex items-center justify-center rounded-full border-0 bg-transparent p-0.5 text-inherit hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-50"
+        aria-label={`Disconnect ${folder.displayName}`}
+        disabled={disabled}
+        onClick={onRemove}
+      >
+        <X size={14} aria-hidden="true" />
+      </button>
+    </li>
   );
 }
 

--- a/crates/openwave-desktop/ui/src/ComposerFolders.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerFolders.dom.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { Composer } from "./Composer";
+
+afterEach(cleanup);
+
+it("attaches and confirms revoking a folder from the ordinary chat composer", async () => {
+  const onAttach = vi.fn();
+  const onRemove = vi.fn();
+  const user = userEvent.setup();
+  render(
+    <Composer
+      activeTurnId={null}
+      busy={false}
+      cancelError={null}
+      cancelPending={false}
+      disabled={false}
+      draft=""
+      folders={{
+        items: [
+          {
+            rootId: "root-1",
+            displayName: "Research",
+            capabilities: ["read", "write"],
+          },
+        ],
+        working: false,
+        error: null,
+        onAttach,
+        onRemove,
+      }}
+      onDraftChange={vi.fn()}
+      onSend={vi.fn(async () => {})}
+      onSteer={vi.fn(async () => {})}
+      onStop={vi.fn(async () => {})}
+      resetKey="chat-1"
+      steerError={null}
+      steerPending={false}
+      steerStatus={null}
+    />,
+  );
+
+  await user.click(screen.getByRole("button", { name: "Attach folder" }));
+  expect(onAttach).toHaveBeenCalledOnce();
+  expect(screen.getByText("Read and write")).toBeInTheDocument();
+
+  await user.click(
+    screen.getByRole("button", { name: "Disconnect Research" }),
+  );
+  expect(onRemove).not.toHaveBeenCalled();
+  await user.click(screen.getByRole("button", { name: "Disconnect" }));
+  expect(onRemove).toHaveBeenCalledWith("root-1");
+});

--- a/crates/openwave-desktop/ui/src/FolderAccess.ts
+++ b/crates/openwave-desktop/ui/src/FolderAccess.ts
@@ -1,0 +1,15 @@
+import type { FolderCapability } from "./host";
+
+export function folderAccessLabel(
+  capabilities: readonly FolderCapability[],
+): string {
+  const read = capabilities.includes("read");
+  const write = capabilities.includes("write");
+  return read
+    ? write
+      ? "Read and write"
+      : "Read only"
+    : write
+      ? "Write only"
+      : "No access";
+}

--- a/crates/openwave-desktop/ui/src/FoldersView.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersView.tsx
@@ -30,6 +30,8 @@ import {
   PICKER_HOLDERS,
   useNativePickerLatch,
 } from "./NativePickerLatch";
+import { folderAccessLabel } from "./FolderAccess";
+import { useRefreshSignals } from "./RefreshSignals";
 
 /**
  * A chat's connected folders: the directories the native host may reach on this
@@ -48,6 +50,7 @@ export function FoldersView({ chat }: { chat: Chat }) {
   const [working, setWorking] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const refreshGeneration = useRef(0);
+  const folderAccess = useRefreshSignals((state) => state.folderAccess);
   const { confirm, dialog: confirmDialog } = useConfirm();
   const connectedIds = new Set(folders.map((folder) => folder.rootId));
   const availableFolders = approvedFolders.filter(
@@ -80,7 +83,7 @@ export function FoldersView({ chat }: { chat: Chat }) {
     return () => {
       refreshGeneration.current += 1;
     };
-  }, [chat.id, chat.project_id]);
+  }, [chat.id, chat.project_id, folderAccess]);
 
   /**
    * Run one native picker interaction under the app-wide latch.
@@ -98,7 +101,7 @@ export function FoldersView({ chat }: { chat: Chat }) {
     setError(null);
     try {
       const connected = await open();
-      if (connected) await refresh();
+      if (connected) useRefreshSignals.getState().signal("folderAccess");
     } catch (err) {
       setError(String(err));
     } finally {
@@ -129,7 +132,7 @@ export function FoldersView({ chat }: { chat: Chat }) {
     setError(null);
     try {
       await disconnectFolder(chat, folder.rootId);
-      await refresh();
+      useRefreshSignals.getState().signal("folderAccess");
     } catch (err) {
       setError(String(err));
     } finally {
@@ -253,17 +256,10 @@ export function FoldersView({ chat }: { chat: Chat }) {
  * access the agent no longer has, which is the failure worth designing out.
  */
 function AccessBadge({ capabilities }: { capabilities: FolderCapability[] }) {
-  const read = capabilities.includes("read");
-  const write = capabilities.includes("write");
-  const label = read
-    ? write
-      ? "Read and write"
-      : "Read only"
-    : write
-      ? "Write only"
-      : "No access";
+  const label = folderAccessLabel(capabilities);
+  const hasAccess = label !== "No access";
   return (
-    <Badge variant={read || write ? "secondary" : "outline"} size="sm">
+    <Badge variant={hasAccess ? "secondary" : "outline"} size="sm">
       {label}
     </Badge>
   );

--- a/crates/openwave-desktop/ui/src/useChatFolderAttachments.test.tsx
+++ b/crates/openwave-desktop/ui/src/useChatFolderAttachments.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import type { Chat } from "./api";
+import * as host from "./host";
+import { useNativePickerLatch } from "./NativePickerLatch";
+import { useRefreshSignals } from "./RefreshSignals";
+import { useChatFolderAttachments } from "./useChatFolderAttachments";
+
+vi.mock("./host", () => ({
+  connectFolder: vi.fn(),
+  disconnectFolder: vi.fn(),
+  listConnectedFolders: vi.fn(),
+}));
+
+const chat = {
+  id: "chat-1",
+  project_id: null,
+} as unknown as Chat;
+
+function Harness() {
+  const folders = useChatFolderAttachments(chat, true);
+  return (
+    <>
+      <button type="button" onClick={folders.attach}>
+        Attach
+      </button>
+      {folders.items.map((folder) => (
+        <button
+          type="button"
+          key={folder.rootId}
+          onClick={() => folders.remove(folder.rootId)}
+        >
+          Remove {folder.displayName}
+        </button>
+      ))}
+    </>
+  );
+}
+
+beforeEach(() => {
+  useNativePickerLatch.setState({ holder: null });
+  useRefreshSignals.setState({
+    folderAccess: 0,
+    outputWritebacks: 0,
+    userQuestions: 0,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+it("connects and revokes a chat folder through the existing host flow", async () => {
+  vi.mocked(host.listConnectedFolders)
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([
+      {
+        rootId: "root-1",
+        displayName: "Research",
+        capabilities: ["read", "write"],
+      },
+    ])
+    .mockResolvedValueOnce([]);
+  vi.mocked(host.connectFolder).mockResolvedValue({
+    rootId: "root-1",
+    displayName: "Research",
+  });
+  vi.mocked(host.disconnectFolder).mockResolvedValue(true);
+  const user = userEvent.setup();
+
+  render(<Harness />);
+  await waitFor(() => expect(host.listConnectedFolders).toHaveBeenCalledOnce());
+
+  await user.click(screen.getByRole("button", { name: "Attach" }));
+
+  expect(host.connectFolder).toHaveBeenCalledWith(chat);
+  expect(
+    await screen.findByRole("button", { name: "Remove Research" }),
+  ).toBeInTheDocument();
+
+  await user.click(screen.getByRole("button", { name: "Remove Research" }));
+
+  expect(host.disconnectFolder).toHaveBeenCalledWith(chat, "root-1");
+  await waitFor(() =>
+    expect(
+      screen.queryByRole("button", { name: "Remove Research" }),
+    ).not.toBeInTheDocument(),
+  );
+});

--- a/crates/openwave-desktop/ui/src/useChatFolderAttachments.ts
+++ b/crates/openwave-desktop/ui/src/useChatFolderAttachments.ts
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useState } from "react";
+
+import type { Chat } from "./api";
+import {
+  connectFolder,
+  disconnectFolder,
+  listConnectedFolders,
+  type ConnectedFolderAccess,
+} from "./host";
+import {
+  PICKER_BUSY_MESSAGE,
+  PICKER_HOLDERS,
+  useNativePickerLatch,
+} from "./NativePickerLatch";
+import { useRefreshSignals } from "./RefreshSignals";
+
+export type ChatFolderAttachments = {
+  items: ConnectedFolderAccess[];
+  working: boolean;
+  error: string | null;
+  attach: () => void;
+  remove: (rootId: string) => void;
+};
+
+/**
+ * The compact folder controls beside the composer and the full Folders panel
+ * share the same host reconciliation path. The refresh signal keeps both
+ * surfaces honest when either one changes the chat's grants.
+ */
+export function useChatFolderAttachments(
+  chat: Chat | null,
+  nativeHost: boolean,
+): ChatFolderAttachments {
+  const [items, setItems] = useState<ConnectedFolderAccess[]>([]);
+  const [working, setWorking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const refreshGeneration = useRef(0);
+  const folderAccess = useRefreshSignals((state) => state.folderAccess);
+
+  useEffect(() => {
+    const generation = ++refreshGeneration.current;
+    if (!chat || !nativeHost) {
+      setItems([]);
+      setError(null);
+      return;
+    }
+    setError(null);
+    void listConnectedFolders(chat).then(
+      (folders) => {
+        if (generation === refreshGeneration.current) setItems(folders);
+      },
+      (reason) => {
+        if (generation === refreshGeneration.current) setError(String(reason));
+      },
+    );
+    return () => {
+      refreshGeneration.current += 1;
+    };
+  }, [chat?.id, chat?.project_id, nativeHost, folderAccess]);
+
+  async function attach() {
+    if (!chat || !nativeHost || working) return;
+    if (!useNativePickerLatch.getState().claim(PICKER_HOLDERS.connectFolder)) {
+      setError(PICKER_BUSY_MESSAGE);
+      return;
+    }
+    setWorking(true);
+    setError(null);
+    try {
+      const connected = await connectFolder(chat);
+      if (connected) {
+        useRefreshSignals.getState().signal("folderAccess");
+      }
+    } catch (reason) {
+      setError(String(reason));
+    } finally {
+      useNativePickerLatch.getState().release(PICKER_HOLDERS.connectFolder);
+      setWorking(false);
+    }
+  }
+
+  async function remove(rootId: string) {
+    if (!chat || !nativeHost || working) return;
+    setWorking(true);
+    setError(null);
+    try {
+      await disconnectFolder(chat, rootId);
+      useRefreshSignals.getState().signal("folderAccess");
+    } catch (reason) {
+      setError(String(reason));
+    } finally {
+      setWorking(false);
+    }
+  }
+
+  return {
+    items,
+    working,
+    error,
+    attach: () => void attach(),
+    remove: (rootId) => void remove(rootId),
+  };
+}


### PR DESCRIPTION
## What changed

- Added an Attach folder action beside the ordinary chat composer attachment controls.
- Rendered connected folders as persistent composer chips with the broker-reported read or read-write access and a confirmed disconnect action.
- Kept the compact composer controls and the existing full Folders panel synchronized after attach, detach, or agent-driven folder access changes.
- Reused the existing desktop commands, host-broker consent, and root-attachment begin/finish reconciliation without adding server authority or wire types.

## Existing flow

The broker and product reconciliation flow already worked end to end through the full Folders panel and agent folder-access prompts. This change is UI exposure: an ordinary chat now puts the same authority-preserving flow where files and images are attached, while retaining the detailed panel.

## Tests

- Added a composer interaction test covering attach, access labeling, confirmation, and revoke dispatch.
- Added a chat-folder hook test proving connect and disconnect use the existing host bridge and refresh the visible grant list.
- No tests were deleted.

## Verification

- PASS: cargo check --workspace --locked
- PASS: pnpm exec tsc --noEmit
- PASS: pnpm test (89 files, 623 tests)
- PASS: pnpm build

No Rust source changed, so Rust formatting, clippy, and crate test suites were not rerun. No generated wire types changed.

## Screenshots

Screenshots are not required for this wiring-only change. The packaged desktop app was not manually driven; automated DOM coverage exercises the new controls.

Closes #1053