### PR TITLE
docs: describe citations and sources as they now work

### DIFF
--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -598,32 +598,29 @@ but never became referenced because a later catalog transaction failed.
 
 ## How grounded sources reach a chat answer
 
-Source-tool results and assistant citations are related, but they are not the
-same record. When a source tool returns private evidence, each passage receives
-a random opaque reference that the model may place in its answer. That reference
-is an internal protocol token, not a URL and not Markdown.
+A citation is written by the model itself: an inline directive wrapping the
+cited phrase and naming a document id plus a human-scale locator — a page or
+page range, a line range, or a workbook sheet optionally narrowed to a cell
+range. The model cites the position it saw when it read the source; there is
+no server-side span resolution, no evidence store, and no opaque token
+protocol. The loop validates only shape and bounds before committing the
+message and its ordered citation records together, and exact retries reuse the
+same message and citation identities, so an ambiguous database response cannot
+create a second historical answer.
 
-Before publishing assistant text, the agent loop removes those internal tokens,
-resolves only references produced by a tool from the same chat and turn, and
-commits the clean message and its ordered citations together. The same rule
-applies to an assistant message that precedes another tool call, to a message
-accepted at a steering boundary, and to the final answer. Exact retries reuse
-the same message and citation identities, so an ambiguous database response
-cannot create a second historical answer.
+The transcript API exposes each citation as a small record: ordinal, document
+id, and locator. Clicking a citation opens the document viewer at that
+locator. The precision is deliberately coarse — the reader lands on the page
+or lines, not a highlighted span — and a locator the model gets slightly wrong
+still opens the right document. Deleting or replacing a document leaves older
+citations pointing at a source that may no longer exist; the viewer says so
+rather than rewriting history.
 
-The transcript API exposes a deliberately smaller source card: a bounded
-excerpt, optional heading, and page numbers. It does not expose paths, source
-URIs, document revisions, chunk IDs, search arguments, tool results, or the
-opaque model token. Replacing or deleting the current document does not rewrite
-an older answer's source card because the card comes from the immutable evidence
-snapshot captured when the answer was produced.
-
-During generation, an incremental filter recognizes references even when a
-provider splits them across many streaming events. Valid internal references
-never enter the live or durable renderer event stream; malformed or incomplete
-marker-like prose remains ordinary text. After a terminal event, the desktop
-rehydrates the authoritative transcript and attaches the structured source cards
-to the completed assistant message.
+During generation, an incremental filter recognizes directives even when a
+provider splits them across many streaming events, so partially streamed
+directive syntax never flashes through the live renderer stream; malformed or
+incomplete marker-like prose remains ordinary text. Messages written before
+this grammar render their historical directives as plain cited text.
 
 ## The different ways to run OpenWave
 
@@ -635,10 +632,12 @@ The browser-facing API is not exposed on a public network interface.
 
 The current UI is a workspace-style conversation shell, not the complete
 product. It reopens durable chats and supports conversation create/list/switch/
-rename/delete, transcript hydration, Markdown messages, live and historical
-tool-call rendering, reconnectable streaming, provider and web-search setup,
-model selection, a foreground-turn stop control, approval prompts, and native
-connected-folder pick/list/revoke. The foreground stop control sends
+rename/delete, transcript hydration, Markdown messages, file and photo
+attachments on messages with a document viewer, inline citation chips that
+open the viewer at the cited position, live and historical tool-call rendering
+including exec preview images, reconnectable streaming, provider and
+web-search setup, model selection, a foreground-turn stop control, approval
+prompts, and native connected-folder attach/list/revoke from the chat. The foreground stop control sends
 cancellation for the exact active turn, prevents duplicate requests, and stays
 in a pending state until an authoritative terminal event arrives; it never
 treats a request as a locally completed cancellation.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -16,12 +16,11 @@ The current foreground agent surface contains nineteen tools:
 | `write_file` | Atomically write private-scratch text | Server, workspace |
 | `create_deliverable` | Create or update a bounded user-visible text output | Server, workspace |
 | `exec` | Run a bounded command through the configured execution provider | Server, sensitive native sandbox |
-| `search` | Search sources indexed for this exact conversation | Server, read-only |
 | `list_sources` | List bounded metadata for sources in this exact conversation | Server, read-only |
-| `read_source` | Read a bounded canonical-text range from one source and create citable evidence | Server, read-only |
+| `read_source` | Read a bounded canonical-text range from one source | Server, read-only |
 | `read_tool_result` | Read past the point a large tool result was cut short for the turn | Server, read-only |
 | `web_search` | Search the public web through the configured provider (Exa, Tavily, Brave, or a self-hosted SearXNG) | Server, sensitive approval |
-| `web_extract` | Fetch one exact public page URL, return its readable content through the configured provider or the built-in engine, and keep it as a citable source of the conversation | Server, sensitive approval |
+| `web_extract` | Fetch one exact public page URL, return its readable content through the configured provider or the built-in engine, and keep it as a source of the conversation | Server, sensitive approval |
 | `request_folder_access` | Ask the trusted desktop host to connect another folder | Client continuation |
 | `list_connected_folders` | List roots already attached to this chat | Native client continuation |
 | `list_folder` | List one directory below an attached root | Native client continuation |
@@ -89,16 +88,17 @@ Sandbox agents never receive the definition. See
 [Durable user questions](user-questions.md).
 
 `list_sources` discovers the conversation's exact corpus without loading
-content. `read_source` reads one bounded Unicode-character range as soon as
-parser output exists and returns an opaque reference that produces a durable
-citation card.
+content. `read_source` reads one bounded Unicode-character range; the text is
+available the moment a source is stored, because ingestion decodes
+synchronously. The model cites what it reads inline, naming the document id
+and a coarse locator — a page or page range, a line range, or a workbook
+sheet — and no reference resolution happens server-side.
 
 `web_extract` joins that tier from the other direction: a page it fetches is
-stored as a source of the conversation, so it too returns opaque references and
-produces the same citation cards, and `read_source` can reach the page
-afterwards. Those two are the only server calls permitted to retain
-retrieval evidence at all, which is what keeps a citation traceable to a call
-that was allowed to make one. See [Web search](web-search.md#fetched-pages-as-sources).
+stored as an ordinary source of the conversation, so the model can cite the
+stored document the same way or put the page URL directly in prose, and
+`read_source` can reach the page afterwards. See
+[Web search](web-search.md#fetched-pages-as-sources).
 
 ## Core module layout
 
@@ -194,7 +194,7 @@ advertise every installed integration to every model call.
 
 The foreground coordinator needs tools for:
 
-- conversation-scoped source search plus source list/read;
+- conversation-scoped source list/read;
 - conversation-private deliverable creation for explicit native export;
 - web search and page retrieval;
 - connected-root list/read/import and explicit export;
@@ -290,7 +290,7 @@ WebSearchService
 WebSearchTool
 ├── model-facing schema
 ├── credential-free request
-├── bounded output and citations
+├── bounded normalized output
 └── optional durable web-document ingestion
 ```
 
@@ -310,7 +310,7 @@ only then resolves current host policy and credentials. `web_extract` sits
 beside it on the same terms: Sensitive, with the exact page URL on the
 approval card, and routed deterministically to the configured provider when it
 implements the extract contract or to the built-in native extraction engine
-otherwise. Each page it returns is also kept as a citable conversation source. Exa and Tavily both implement it, so a configured host extracts
+otherwise. Each page it returns is also kept as a conversation source the model can cite. Exa and Tavily both implement it, so a configured host extracts
 through the vendor and falls back to native — except on a rejected key, which
 surfaces for repair rather than degrading silently. Brave and SearXNG are
 search-only, so a host on either extracts natively. See
@@ -343,9 +343,9 @@ Sensitive server-tool approvals are durable. OpenWave commits the approval
 request and its journal event atomically, freezes a renderer-safe approval kind,
 and uses exact idempotent decisions. A reclaimed turn resumes persisted pending
 calls before requesting another model step, so restart recovery cannot silently
-skip an approval or execute a call under a newly relaxed tool policy. Search
-consent tells the user that the query and potentially matching source excerpts
-may leave OpenWave for the configured AI service.
+skip an approval or execute a call under a newly relaxed tool policy. Web
+search consent tells the user that the query may leave OpenWave for the
+configured search provider.
 
 ## Reliability rules
 


### PR DESCRIPTION
Docs-only follow-through for #1010. The workers kept the docs adjacent to their slices current; this pass fixes the two narratives nobody's slice owned:

- **tools.md** still listed the deleted `search` tool and described `read_source`/`web_extract` as producing opaque evidence references and citation cards. Rewritten against the model-authored locator grammar and synchronous ingestion; the approval-consent wording now describes the one remaining (web-search) kind.
- **how-openwave-works.md**'s "How grounded sources reach a chat answer" described the retired token-resolution/evidence-snapshot pipeline end to end. Rewritten: citations are inline model-authored directives (document + page/lines/sheet), loosely validated, committed with the message; the viewer opens at the locator; pre-grammar directives degrade to plain text. The current-UI capability list gains message file/photo attachments, citation chips, and exec preview images.

Verified the rest of the tree is already current (`crates.md`, `code-execution.md`, `host-access.md`, `web-search.md`, `README`s): no remaining references to vectors, embedders, LanceDB, liteparse/PDFium, calamine, index jobs, processing status, revision clocks, evidence stores, or the sources panel.