### PR TITLE
feat: re-pair a provisioned gateway behind explicit confirmation

### DIFF
--- a/crates/openwave-desktop/src/deep_link.rs
+++ b/crates/openwave-desktop/src/deep_link.rs
@@ -16,18 +16,25 @@
 //! ([`openwave_server::register_pending_pairing`]), and the in-app sign-in
 //! gate presents it. The consent is the sign-in: only a browser sign-in the
 //! user completes against that gateway commits the provision, so a drive-by
-//! link can at most raise a sign-in screen the user ignores. Registration
-//! and the commit both live server-side, called directly on the embedded
-//! server's handles, so no HTTP route — authenticated or otherwise — can
-//! reach the policy write path. The webview cannot reach it either: the main
-//! window's capability denies `core:event:emit`, so a compromised renderer
-//! cannot forge the plugin's open-URL event; its influence stops at
-//! completing or dismissing the sign-in it can already perform.
+//! link can at most raise a sign-in screen the user ignores. A link that
+//! conflicts with the gateway already provisioned escalates instead of
+//! refusing outright: a native confirmation names both origins, and only an
+//! explicit confirmation parks the *replacing* pairing
+//! ([`openwave_server::register_replacing_pairing`]) — the sign-in against
+//! the new gateway is still the commit, so a drive-by link on a managed
+//! device gets at most one dialog that defaults to changing nothing. An
+//! OS (MDM) assertion is never replaceable this way. Registration and the
+//! commit both live server-side, called directly on the embedded server's
+//! handles, so no HTTP route — authenticated or otherwise — can reach the
+//! policy write path. The webview cannot reach it either: the main window's
+//! capability denies `core:event:emit`, so a compromised renderer cannot
+//! forge the plugin's open-URL event; its influence stops at completing or
+//! dismissing the sign-in it can already perform.
 
 use tauri::Manager;
 use tauri_plugin_deep_link::DeepLinkExt;
-use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
-use tokio::sync::watch;
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+use tokio::sync::{oneshot, watch};
 
 use openwave_server::{PairingError, PairingHandle, PendingRegistration};
 
@@ -188,10 +195,11 @@ fn spawn_pairing(app: tauri::AppHandle, link: ProvisionLink) {
         };
         // Registration writes nothing durable and probes nothing; the
         // sign-in gate presents the pairing on its next policy poll, and a
-        // sign-in the user completes there is what commits it. Only the
-        // refusals need a native surface — with no dialog in the happy
-        // path, a refusal that reached only the log would read as the app
-        // silently ignoring the link.
+        // sign-in the user completes there is what commits it. Only a
+        // conflict with the provisioned gateway gets a native question, and
+        // only the refusals get a native error — with no dialog in the
+        // happy path, a refusal that reached only the log would read as the
+        // app silently ignoring the link.
         match openwave_server::register_pending_pairing(&handle, &link.gateway_url).await {
             Ok(PendingRegistration::Registered) => {
                 log_pairing(&app, &format!("pairing with {origin} awaits sign-in"));
@@ -199,12 +207,97 @@ fn spawn_pairing(app: tauri::AppHandle, link: ProvisionLink) {
             Ok(PendingRegistration::AlreadyManaged) => {
                 log_pairing(&app, &format!("{origin} already manages this device"));
             }
+            Err(PairingError::Conflict {
+                provisioned_url,
+                replaceable: true,
+            }) => {
+                log_pairing(
+                    &app,
+                    &format!(
+                        "pairing with {origin} conflicts with {}; asking whether to re-pair",
+                        origin_of(&provisioned_url)
+                    ),
+                );
+                confirm_and_replace(&app, &handle, &link, &provisioned_url).await;
+            }
             Err(failure) => {
                 log_pairing(&app, &format!("pairing refused for {origin}: {failure}"));
                 show_pairing_failure(&app, &origin, &failure);
             }
         }
     });
+}
+
+/// Escalate a replaceable conflict to the user's explicit choice: a native
+/// dialog naming both origins, defaulting to changing nothing. Confirmation
+/// parks the replacing pairing — still nothing durable; the sign-in the gate
+/// then presents is the commit. A registration the confirmation raced (the
+/// provisioned row moved in between) surfaces as one failure dialog, never a
+/// retry loop: the link can simply be opened again against the new state.
+async fn confirm_and_replace(
+    app: &tauri::AppHandle,
+    handle: &PairingHandle,
+    link: &ProvisionLink,
+    provisioned_url: &str,
+) {
+    if PAIRING_DIALOG_SHOWING.swap(true, std::sync::atomic::Ordering::SeqCst) {
+        log_pairing(app, "a pairing dialog is already up; logged only");
+        return;
+    }
+    let approved = ask_to_repair(
+        app,
+        &repair_prompt(&link.origin, &origin_of(provisioned_url)),
+    )
+    .await;
+    PAIRING_DIALOG_SHOWING.store(false, std::sync::atomic::Ordering::SeqCst);
+    if !approved {
+        log_pairing(app, &format!("re-pairing with {} declined", link.origin));
+        return;
+    }
+    match openwave_server::register_replacing_pairing(handle, &link.gateway_url, provisioned_url)
+        .await
+    {
+        Ok(PendingRegistration::Registered) => {
+            log_pairing(
+                app,
+                &format!("re-pairing with {} awaits sign-in", link.origin),
+            );
+        }
+        Ok(PendingRegistration::AlreadyManaged) => {
+            log_pairing(app, &format!("{} already manages this device", link.origin));
+        }
+        Err(failure) => {
+            log_pairing(
+                app,
+                &format!("re-pairing refused for {}: {failure}", link.origin),
+            );
+            show_pairing_failure(app, &link.origin, &failure);
+        }
+    }
+}
+
+/// The confirmation itself, non-blocking like the folder-attachment prompt:
+/// the dialog's answer arrives on a callback, and a channel that drops
+/// unanswered reads as a decline — the failure direction of every path here
+/// is "change nothing".
+async fn ask_to_repair(app: &tauri::AppHandle, message: &str) -> bool {
+    let (tx, rx) = oneshot::channel();
+    let mut dialog = app
+        .dialog()
+        .message(message)
+        .title("Re-pair this device?")
+        .kind(MessageDialogKind::Warning)
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Re-pair".to_owned(),
+            "Cancel".to_owned(),
+        ));
+    if let Some(window) = app.get_webview_window("main") {
+        dialog = dialog.parent(&window);
+    }
+    dialog.show(move |approved| {
+        let _ = tx.send(approved);
+    });
+    rx.await.unwrap_or(false)
 }
 
 /// Reduce a stored gateway base URL to its origin — the only form
@@ -217,19 +310,39 @@ fn origin_of(url: &str) -> String {
         .unwrap_or_else(|_| "another gateway".to_string())
 }
 
+/// The re-pair question, pure for the same reason as [`refusal_message`]:
+/// what the confirmation claims — both origins, and what confirming does —
+/// is the load-bearing part, and it must be testable without a GUI.
+fn repair_prompt(new_origin: &str, old_origin: &str) -> String {
+    format!(
+        "This device is managed by {old_origin}. Replace it with {new_origin}?\n\n\
+         OpenWave will sign out of {old_origin}, and {new_origin} will control \
+         which models and settings are available. You'll complete a sign-in to \
+         {new_origin} to finish — until then, nothing changes."
+    )
+}
+
 /// The one user-facing line per refusal class, pure so the choice of what a
-/// refusal says is testable without a GUI. The conflict names the gateway
-/// that actually manages this device — refuse-forever is the recorded
-/// decision, so it points at the administrator instead of offering a retry.
-/// Any other refusal names only the link's origin — the raw reason stays in
-/// `pairing.log`.
+/// refusal says is testable without a GUI. An MDM-asserted conflict names
+/// the gateway that actually manages this device and points at the
+/// administrator — that tier is never replaceable locally. A replaceable
+/// conflict only reaches this dialog when the confirmed re-pair raced a
+/// change to the provisioned row, so it says the state moved and leaves the
+/// retry to the user's next link click. Any other refusal names only the
+/// link's origin — the raw reason stays in `pairing.log`.
 fn refusal_message(origin: &str, failure: &PairingError) -> String {
     match failure {
-        PairingError::Conflict { provisioned_url } => format!(
+        PairingError::Conflict {
+            provisioned_url,
+            replaceable: false,
+        } => format!(
             "This device is already managed by {}. Contact \
              your administrator to change gateways.",
             origin_of(provisioned_url)
         ),
+        PairingError::Conflict { .. } => "The gateway managing this device changed while \
+             re-pairing. Nothing was changed; open the pairing link again to retry."
+            .to_string(),
         _ => format!(
             "OpenWave could not accept the pairing link for {origin}. This \
              device was not paired; details are in pairing.log."
@@ -237,19 +350,20 @@ fn refusal_message(origin: &str, failure: &PairingError) -> String {
     }
 }
 
+/// At most one pairing dialog — question or refusal — is up at a time. A
+/// deep link is an unauthenticated remote trigger, and a page firing links
+/// in a loop must not stack dialogs; the extras get the log line only.
+static PAIRING_DIALOG_SHOWING: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 /// One bounded error dialog per refused link. The happy path shows no
 /// native dialog at all — the sign-in gate is the surface — so a refusal
 /// that reached only the log would read as the app silently ignoring the
 /// link the user just clicked. No retry affordance, no loop: the dialog
-/// closes and the attempt is over. At most one refusal dialog is up at a
-/// time — a deep link is an unauthenticated remote trigger, and a page
-/// firing links in a loop must not stack blocking dialogs; the extras get
-/// the log line only.
+/// closes and the attempt is over.
 fn show_pairing_failure(app: &tauri::AppHandle, origin: &str, failure: &PairingError) {
-    static REFUSAL_SHOWING: std::sync::atomic::AtomicBool =
-        std::sync::atomic::AtomicBool::new(false);
-    if REFUSAL_SHOWING.swap(true, std::sync::atomic::Ordering::SeqCst) {
-        log_pairing(app, "a refusal dialog is already up; logged only");
+    if PAIRING_DIALOG_SHOWING.swap(true, std::sync::atomic::Ordering::SeqCst) {
+        log_pairing(app, "a pairing dialog is already up; logged only");
         return;
     }
     app.dialog()
@@ -257,7 +371,7 @@ fn show_pairing_failure(app: &tauri::AppHandle, origin: &str, failure: &PairingE
         .title("Pairing refused")
         .kind(MessageDialogKind::Error)
         .blocking_show();
-    REFUSAL_SHOWING.store(false, std::sync::atomic::Ordering::SeqCst);
+    PAIRING_DIALOG_SHOWING.store(false, std::sync::atomic::Ordering::SeqCst);
 }
 
 async fn wait_pairing_handle(app: &tauri::AppHandle) -> Result<PairingHandle, String> {
@@ -302,7 +416,7 @@ fn log_pairing(app: &tauri::AppHandle, message: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::{origin_of, provision_link, refusal_message, PairingError};
+    use super::{origin_of, provision_link, refusal_message, repair_prompt, PairingError};
 
     #[test]
     fn provision_links_are_held_to_the_contract() {
@@ -389,23 +503,38 @@ mod tests {
         assert_eq!(provision_link(&url).is_ok(), cfg!(debug_assertions));
     }
 
-    /// The refusal dialog's one line per failure class: the conflict names
-    /// the gateway that actually manages this device (never the link's) —
-    /// reduced to its origin — and points at the administrator; a generic
-    /// failure names only the link's origin, keeping the raw reason out of
-    /// the dialog.
+    /// The refusal dialog's one line per failure class: an MDM-asserted
+    /// conflict names the gateway that actually manages this device (never
+    /// the link's) — reduced to its origin — and points at the
+    /// administrator; a raced replaceable conflict says the state moved and
+    /// offers no automatic retry; a generic failure names only the link's
+    /// origin, keeping the raw reason out of the dialog.
     #[test]
     fn the_refusal_dialog_names_the_right_gateway() {
         let conflict = refusal_message(
             "https://new.example",
             &PairingError::Conflict {
                 provisioned_url: "https://old.example/base/".to_string(),
+                replaceable: false,
             },
         );
         assert!(conflict.contains("already managed by https://old.example"));
         assert!(conflict.contains("administrator"));
         assert!(!conflict.contains("new.example"));
         assert!(!conflict.contains("/base"));
+
+        let raced = refusal_message(
+            "https://new.example",
+            &PairingError::Conflict {
+                provisioned_url: "https://third.example/".to_string(),
+                replaceable: true,
+            },
+        );
+        assert!(raced.contains("changed while"));
+        assert!(
+            !raced.contains("administrator"),
+            "a user-replaceable row must not be blamed on an administrator"
+        );
 
         let other = refusal_message(
             "https://new.example",
@@ -415,6 +544,18 @@ mod tests {
         );
         assert!(other.contains("https://new.example"));
         assert!(!other.contains("token=shh"));
+    }
+
+    /// The re-pair confirmation's load-bearing claims: both origins by name,
+    /// which one currently manages the device, and that nothing changes
+    /// before the finishing sign-in.
+    #[test]
+    fn the_repair_prompt_names_both_origins() {
+        let prompt = repair_prompt("https://new.example", "https://old.example");
+        assert!(prompt.contains("managed by https://old.example"));
+        assert!(prompt.contains("Replace it with https://new.example?"));
+        assert!(prompt.contains("sign out of https://old.example"));
+        assert!(prompt.contains("nothing changes"));
     }
 
     /// Pins the load-bearing reduction the conflict dialog's claim rests

--- a/crates/openwave-desktop/ui/src/ManagedGate.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.dom.test.tsx
@@ -260,6 +260,46 @@ describe("ManagedGate", () => {
     expect(client.gatewaySignIn).not.toHaveBeenCalled();
   });
 
+  it("a confirmed re-pair gates even a signed-in managed profile until dismissed", async () => {
+    // The shell's confirmed re-pair parked a pending pairing on a profile
+    // provisioned to — and signed in to — the old gateway. The satisfied
+    // session must not hide the re-pair prompt.
+    const repairing: ManagedPolicy = {
+      managed: true,
+      gateway_url: "https://gateway.example/",
+      source: "provisioned",
+      misconfigured: false,
+      pending_gateway_url: "https://new-gw.example/",
+    };
+    const client = api({
+      getPolicy: vi.fn().mockResolvedValue(repairing),
+      getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+      dismissGatewayPairing: vi.fn().mockResolvedValue({
+        ...repairing,
+        pending_gateway_url: undefined,
+      } satisfies ManagedPolicy),
+    });
+    const user = userEvent.setup();
+    mount(client);
+
+    // The prompt names the new gateway and what it replaces.
+    expect(
+      await screen.findByText("Connect to your model gateway"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("https://new-gw.example/")).toBeInTheDocument();
+    expect(
+      screen.getByText(/currently manages this device/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("https://gateway.example/")).toBeInTheDocument();
+    expect(screen.queryByText("the open product")).not.toBeInTheDocument();
+
+    // "Not now" abandons the re-pair and returns the signed-in app.
+    await user.click(screen.getByRole("button", { name: "Not now" }));
+    expect(await screen.findByText("the open product")).toBeInTheDocument();
+    expect(client.dismissGatewayPairing).toHaveBeenCalled();
+    expect(client.gatewaySignIn).not.toHaveBeenCalled();
+  });
+
   it("a session on the wrong gateway does not lift the gate", async () => {
     const client = api({
       getGatewayStatus: vi.fn().mockResolvedValue({

--- a/crates/openwave-desktop/ui/src/ManagedGate.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.tsx
@@ -125,8 +125,11 @@ export function ManagedGate({
   // presents it exactly like the managed sign-in — full-window, nothing of
   // the app behind it — because from the user's seat it is the same step:
   // sign in to the named gateway. The one durable difference (the sign-in
-  // commits the provision) is the server's business.
-  const pendingPairingUrl = !managed ? (policy?.pending_gateway_url ?? null) : null;
+  // commits the provision) is the server's business. On a managed profile a
+  // pending pairing is a *re*-pair the user confirmed in the shell's native
+  // dialog, and it must surface even over a signed-in session — dismissing
+  // it ("Not now") is what returns the app.
+  const pendingPairingUrl = policy?.pending_gateway_url ?? null;
   const gateActive = managed || pendingPairingUrl !== null;
 
   useEffect(() => {
@@ -314,15 +317,18 @@ export function ManagedGate({
   // server already pins signed_in to the policy URL; the comparison stays as
   // defense in depth for a renderer running against an older server. A
   // pending pairing never lifts here — its sign-in flips the policy to
-  // managed server-side, and the managed branch takes over on the next poll.
+  // managed server-side, and the managed branch takes over on the next poll
+  // — and it holds the gate down even over a satisfied session, or a
+  // confirmed re-pair would be invisible exactly when the old gateway is
+  // still signed in.
+  const pairing = pendingPairingUrl !== null;
   const lockedUrl = policy?.gateway_url ?? null;
   const sessionSatisfiesPolicy =
     managed &&
+    !pairing &&
     status?.signed_in === true &&
     sameGateway(status.base_url, lockedUrl);
   if (sessionSatisfiesPolicy) return <Published policy={policy}>{children}</Published>;
-
-  const pairing = pendingPairingUrl !== null;
   // The device's managed gateway is the policy's URL — or, for a pairing
   // awaiting consent, the URL the shell registered from the provision link.
   const shownUrl = pairing
@@ -354,6 +360,13 @@ export function ManagedGate({
               manage this device — it controls which models are available —
               and the connection cannot be undone from within OpenWave.
             </p>
+            {managed && lockedUrl && (
+              <p>
+                This replaces <code className="font-medium">{lockedUrl}</code>,
+                which currently manages this device; OpenWave will sign out of
+                it when the new sign-in completes.
+              </p>
+            )}
           </>
         ) : (
           <>

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -61,6 +61,10 @@ struct PendingPairing {
     /// the commit cannot run without also applying what it decides to the
     /// MCP servers this process is running.
     mcp: Arc<crate::mcp_config::McpRuntime>,
+    /// For a re-pairing the user confirmed: the provisioned URL the
+    /// confirmation named, which the commit's compare-and-swap holds the row
+    /// to. `None` for a plain first-time pairing.
+    replaces: Option<String>,
 }
 
 /// Renderer-safe progress of the current sign-in attempt.
@@ -149,12 +153,17 @@ impl GatewayRuntime {
         &self,
         base_url: String,
         mcp: Arc<crate::mcp_config::McpRuntime>,
+        replaces: Option<String>,
     ) {
         let mut sign_in = self.sign_in.lock().await;
         self.sign_in_generation
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         *sign_in = SignInProgress::Idle;
-        *self.pending_pairing.lock().await = Some(PendingPairing { base_url, mcp });
+        *self.pending_pairing.lock().await = Some(PendingPairing {
+            base_url,
+            mcp,
+            replaces,
+        });
     }
 
     /// The pending pairing's gateway URL, for the `/policy` projection.
@@ -241,12 +250,15 @@ impl GatewayRuntime {
 
     /// Start a browser sign-in and return the URL to open.
     ///
-    /// On a managed profile the sign-in targets the policy's gateway. On an
-    /// unmanaged profile with a pending pairing it targets the pairing's
-    /// gateway instead, and a successful exchange is what commits the
+    /// A pending pairing wins the target: the sign-in runs against the
+    /// pairing's gateway, and a successful exchange is what commits the
     /// provision — the sign-in the user chose to complete is the pairing's
-    /// consent, so nothing durable exists until it succeeds. Unmanaged with
-    /// no pending pairing keeps the legible refusal.
+    /// consent, so nothing durable exists until it succeeds. That holds on a
+    /// managed profile too: a pending pairing can only exist there through
+    /// the shell's confirmed re-pair flow, never a bare deep link, so
+    /// honoring it is honoring that confirmation. With nothing pending, a
+    /// managed profile's sign-in targets the policy's gateway, and an
+    /// unmanaged one keeps the legible refusal.
     ///
     /// The exchange completes in a background task: on success the session is
     /// stored (after any pairing commit) and the entitled models synced; on
@@ -254,11 +266,7 @@ impl GatewayRuntime {
     /// attempt.
     pub(crate) async fn begin_sign_in(self: &Arc<Self>) -> Result<String> {
         let policy = self.policy().await?;
-        let pairing = if policy.managed {
-            None
-        } else {
-            self.pending_pairing.lock().await.clone()
-        };
+        let pairing = self.pending_pairing.lock().await.clone();
         let connection = match &pairing {
             Some(pending) => self.connection_at(pending.base_url.clone()).await?,
             None => self.connection_at(require_managed(&policy)?).await?,
@@ -339,8 +347,10 @@ impl GatewayRuntime {
         crate::pairing::commit_signed_in_pairing(
             &*self.store,
             &*self.os_policy,
+            self.secrets.clone(),
             &pending.mcp,
             &pending.base_url,
+            pending.replaces.as_deref(),
         )
         .await?;
         *self.pending_pairing.lock().await = None;
@@ -1185,7 +1195,7 @@ mod tests {
         assert!(runtime.begin_sign_in().await.is_err());
 
         runtime
-            .register_pending_pairing(base.clone(), mcp.clone())
+            .register_pending_pairing(base.clone(), mcp.clone(), None)
             .await;
         let url = runtime.begin_sign_in().await.unwrap();
         assert!(

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -84,7 +84,10 @@ use resolver::KeyedResolver;
 
 pub use durable_oplog::DurableOperationStore;
 pub use error::ServerError;
-pub use pairing::{register_pending_pairing, PairingError, PairingHandle, PendingRegistration};
+pub use pairing::{
+    register_pending_pairing, register_replacing_pairing, PairingError, PairingHandle,
+    PendingRegistration,
+};
 pub use state::AppState;
 
 const MAX_RAW_DOCUMENT_BYTES: usize = 16 * 1024 * 1024;

--- a/crates/openwave-server/src/managed_policy.rs
+++ b/crates/openwave-server/src/managed_policy.rs
@@ -522,9 +522,10 @@ pub(crate) fn validated_gateway_url(gateway_url: &str) -> Result<String> {
 /// A pairing payload cannot smuggle an invalid or credentialed origin into
 /// durable policy (the URL contract), and it cannot silently re-point an
 /// already-provisioned profile at a different gateway: re-provisioning the
-/// same gateway is idempotent, a conflicting one is refused. If re-pairing
-/// ever becomes a product flow, it belongs behind an explicit user
-/// confirmation in the deep-link slice, not in this write path.
+/// same gateway is idempotent, a conflicting one is refused. Re-pairing is
+/// a real product flow, but it runs through [`reprovision`] — which demands
+/// the caller name the row it believes it is replacing — never through this
+/// write path.
 pub(crate) async fn provision(store: &dyn Store, gateway_url: &str) -> Result<()> {
     let gateway_url = validated_gateway_url(gateway_url)?;
     if let Some(existing) = provisioned_url(store).await? {
@@ -539,6 +540,34 @@ pub(crate) async fn provision(store: &dyn Store, gateway_url: &str) -> Result<()
         .set_setting(
             SETTING_KEY,
             &serde_json::to_value(ProvisionedPolicy { gateway_url })?,
+        )
+        .await
+}
+
+/// Replace the provisioned gateway, compare-and-swap style: the write lands
+/// only if the row still holds `expected_current` — the URL the user's
+/// re-pair confirmation actually named. A row that changed in between (a
+/// competing pairing; deletion) refuses rather than overwrites, because the
+/// consent on record was given against a different state. Callers serialize
+/// the read-check-write under the pairing lock; this check is the belt to
+/// that suspender, and the part a unit seam can hold still.
+pub(crate) async fn reprovision(
+    store: &dyn Store,
+    new_url: &str,
+    expected_current: &str,
+) -> Result<()> {
+    let new_url = validated_gateway_url(new_url)?;
+    if provisioned_url(store).await?.as_deref() != Some(expected_current) {
+        return Err(AgentError::config(
+            "the gateway managing this profile changed while re-pairing; nothing was changed",
+        ));
+    }
+    store
+        .set_setting(
+            SETTING_KEY,
+            &serde_json::to_value(ProvisionedPolicy {
+                gateway_url: new_url,
+            })?,
         )
         .await
 }

--- a/crates/openwave-server/src/pairing.rs
+++ b/crates/openwave-server/src/pairing.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use openwave_connectors::GatewayAuthConfig;
-use openwave_core::{AgentError, Result, Store};
+use openwave_core::{AgentError, Result, SecretProvider, Store};
 use tokio::sync::Mutex;
 
 use crate::managed_policy;
@@ -70,10 +70,12 @@ impl PairingHandle {
 /// Why a pairing did not provision this profile.
 ///
 /// The conflict is its own variant because it is a product refusal, not a
-/// fault: the recorded decision is refuse-forever (gateway migration is the
-/// MDM tier's job — OS-asserted policy already outranks provisioned state —
-/// or a profile reset), and the shell owes the user an explanation naming
-/// the gateway that actually manages this device rather than a log line.
+/// fault: the shell owes the user an explanation naming the gateway that
+/// actually manages this device rather than a log line. What the shell may
+/// offer next depends on the conflicting authority: the provisioned row is
+/// user-consented state, so the shell can escalate to an explicit re-pair
+/// confirmation ([`register_replacing_pairing`]); an OS (MDM) assertion is
+/// refuse-forever — gateway migration at that tier is the MDM's job.
 /// Every other failure — invalid URL, unreachable gateway, bad manifest,
 /// store errors — stays the [`AgentError`] it was.
 #[derive(Debug)]
@@ -86,6 +88,10 @@ pub enum PairingError {
     Conflict {
         /// The normalized base URL this profile is provisioned to.
         provisioned_url: String,
+        /// Whether the shell may offer re-pairing: true when the conflicting
+        /// authority is the user-consented provisioned row, false when the
+        /// OS (MDM) asserts the gateway and no local flow may replace it.
+        replaceable: bool,
     },
     /// Any other failure. No policy was written and nothing is pending.
     Other(AgentError),
@@ -150,10 +156,12 @@ pub async fn register_pending_pairing(
     let _guard = PAIRING.lock().await;
     let policy = handle.gateway.policy().await?;
     if policy.managed {
+        let replaceable = policy.source == crate::managed_policy::ManagedPolicySource::Provisioned;
         return match policy.gateway_url {
             Some(existing) if existing == base_url => Ok(PendingRegistration::AlreadyManaged),
             Some(existing) => Err(PairingError::Conflict {
                 provisioned_url: existing,
+                replaceable,
             }),
             None => Err(PairingError::Other(AgentError::config(
                 "this device's managed policy is misconfigured; contact your administrator",
@@ -162,7 +170,68 @@ pub async fn register_pending_pairing(
     }
     handle
         .gateway
-        .register_pending_pairing(base_url, handle.mcp.clone())
+        .register_pending_pairing(base_url, handle.mcp.clone(), None)
+        .await;
+    Ok(PendingRegistration::Registered)
+}
+
+/// Park a re-pairing the user explicitly confirmed: once a sign-in consents,
+/// replace the provisioned gateway `expected_current` with `gateway_url`.
+///
+/// The shell calls this only after a native confirmation naming both origins
+/// — it is the escalation a replaceable [`PairingError::Conflict`] invites,
+/// never a first move. Like plain registration, nothing durable is written
+/// here and the gateway is not probed: the parked pairing carries the URL
+/// the confirmation named, and the commit re-checks it under the pairing
+/// lock, so a row that changed in between refuses rather than overwrites. A
+/// state that moved since the confirmation — the provisioned URL is no
+/// longer `expected_current`, or an OS authority claimed the profile — is
+/// refused here the same way, so the shell reports a raced failure instead
+/// of parking a pairing whose consent no longer describes the device.
+pub async fn register_replacing_pairing(
+    handle: &PairingHandle,
+    gateway_url: &str,
+    expected_current: &str,
+) -> Result<PendingRegistration, PairingError> {
+    let config = GatewayAuthConfig::new(gateway_url)?;
+    let base_url = config.base_url().to_string();
+    let _guard = PAIRING.lock().await;
+    let policy = handle.gateway.policy().await?;
+    if policy.managed {
+        let replaceable = policy.source == crate::managed_policy::ManagedPolicySource::Provisioned;
+        match policy.gateway_url {
+            Some(existing) if existing == base_url => {
+                return Ok(PendingRegistration::AlreadyManaged)
+            }
+            Some(existing) if !replaceable || existing != expected_current => {
+                return Err(PairingError::Conflict {
+                    provisioned_url: existing,
+                    replaceable,
+                })
+            }
+            Some(_) => {}
+            None => {
+                return Err(PairingError::Other(AgentError::config(
+                    "this device's managed policy is misconfigured; contact your administrator",
+                )))
+            }
+        }
+        handle
+            .gateway
+            .register_pending_pairing(
+                base_url,
+                handle.mcp.clone(),
+                Some(expected_current.to_string()),
+            )
+            .await;
+        return Ok(PendingRegistration::Registered);
+    }
+    // The row vanished between the conflict and the confirmation (a profile
+    // reset). What the user confirmed — pair with this gateway — still
+    // describes the device; it just no longer replaces anything.
+    handle
+        .gateway
+        .register_pending_pairing(base_url, handle.mcp.clone(), None)
         .await;
     Ok(PendingRegistration::Registered)
 }
@@ -172,20 +241,29 @@ pub async fn register_pending_pairing(
 /// Called from the sign-in exchange task with a session already minted for
 /// `base_url`. Policy is re-resolved under the pairing lock: an authority
 /// that claimed the profile while the browser flow ran (an MDM push) wins,
-/// and the pairing is refused rather than written under it. Provisioning is
-/// the only durable write — the model snapshot is stamped with the
-/// deployment it was synced from, so one left behind by any earlier
-/// configuration is simply never honored for this gateway.
+/// and the pairing is refused rather than written under it. A *replacing*
+/// pairing carries the provisioned URL its confirmation named in `replaces`,
+/// and may write over exactly that row — the compare-and-swap in
+/// [`managed_policy::reprovision`] — so a row that moved to anything else
+/// mid-flow still wins and the pairing is refused. Provisioning is the only
+/// durable policy write — the model snapshot is stamped with the deployment
+/// it was synced from, so one left behind by any earlier configuration is
+/// simply never honored for this gateway.
 ///
 /// The new policy is applied to this process before returning: manual MCP
-/// servers running under the previously open profile are taken down here
-/// rather than at the supervisor's next sweep, so no locked child keeps
-/// serving tools across the window in between.
+/// servers running under the previous profile are taken down here rather
+/// than at the supervisor's next sweep, and a stored session the new policy
+/// no longer stands behind — the replaced gateway's — is retired
+/// (best-effort revoke, unconditional local clear) before the exchange task
+/// stores the new one, so its refresh token does not stay live at a gateway
+/// this profile no longer answers to.
 pub(crate) async fn commit_signed_in_pairing(
     store: &dyn Store,
     os_policy: &dyn crate::managed_policy::OsPolicySource,
+    secrets: Arc<dyn SecretProvider>,
     mcp: &McpRuntime,
     base_url: &str,
+    replaces: Option<&str>,
 ) -> openwave_core::Result<()> {
     // PAIRING makes the policy re-read and the write atomic against another
     // pairing path; no gateway-state lock, for the same reason the old
@@ -193,14 +271,23 @@ pub(crate) async fn commit_signed_in_pairing(
     let _guard = PAIRING.lock().await;
     let policy = managed_policy::resolve(store, os_policy).await?;
     if policy.managed && policy.gateway_url.as_deref() != Some(base_url) {
-        let authority = policy
-            .gateway_url
-            .unwrap_or_else(|| "another authority".to_string());
-        return Err(AgentError::config(format!(
-            "this device became managed by {authority} during sign-in; the pairing was not applied"
-        )));
+        let replacing = policy.source == crate::managed_policy::ManagedPolicySource::Provisioned
+            && replaces.is_some()
+            && policy.gateway_url.as_deref() == replaces;
+        if !replacing {
+            let authority = policy
+                .gateway_url
+                .unwrap_or_else(|| "another authority".to_string());
+            return Err(AgentError::config(format!(
+                "this device became managed by {authority} during sign-in; the pairing was not applied"
+            )));
+        }
+        managed_policy::reprovision(store, base_url, replaces.expect("checked above")).await?;
+    } else {
+        managed_policy::provision(store, base_url).await?;
     }
-    managed_policy::provision(store, base_url).await?;
+    let policy = managed_policy::resolve(store, os_policy).await?;
+    crate::gateway_runtime::retire_superseded_gateway_session(secrets, &policy).await?;
     mcp.enforce_manual_lockdown().await;
     Ok(())
 }
@@ -250,6 +337,10 @@ mod tests {
             self.0.lock().unwrap().remove(key);
             Ok(())
         }
+    }
+
+    fn test_secrets() -> Arc<dyn SecretProvider> {
+        Arc::new(TestSecrets::default())
     }
 
     /// The handle plus the runtimes behind it, for the assertions that are
@@ -379,8 +470,15 @@ mod tests {
             .err()
             .unwrap();
         match &error {
-            PairingError::Conflict { provisioned_url } => {
-                assert_eq!(provisioned_url, "http://managed.invalid/")
+            PairingError::Conflict {
+                provisioned_url,
+                replaceable,
+            } => {
+                assert_eq!(provisioned_url, "http://managed.invalid/");
+                assert!(
+                    replaceable,
+                    "a provisioned row is user-consented state, so the shell may offer re-pairing"
+                );
             }
             other => panic!("expected the typed conflict, got {other:?}"),
         }
@@ -398,6 +496,103 @@ mod tests {
             policy.gateway_url.as_deref(),
             Some("http://managed.invalid/")
         );
+    }
+
+    /// The confirmed re-pair's registration seam: parking demands the caller
+    /// name the row it replaces, a stale expectation is the typed conflict
+    /// (and clobbers nothing already parked), and an OS-asserted gateway is
+    /// never replaceable — from either registration path.
+    #[tokio::test]
+    async fn a_replacing_registration_holds_the_row_to_the_confirmed_expectation() {
+        let (store, _directory) = test_store().await;
+        managed_policy::provision(&*store, "http://managed.invalid/")
+            .await
+            .unwrap();
+        let (handle, _mcp, gateway) = test_handle_with_runtimes(&store);
+
+        let outcome =
+            register_replacing_pairing(&handle, "http://new.invalid", "http://managed.invalid/")
+                .await
+                .unwrap();
+        assert_eq!(outcome, PendingRegistration::Registered);
+        assert_eq!(
+            gateway.pending_pairing_url().await.as_deref(),
+            Some("http://new.invalid/")
+        );
+        // Parking is process-ephemeral: the durable row has not moved.
+        let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
+        assert_eq!(
+            policy.gateway_url.as_deref(),
+            Some("http://managed.invalid/")
+        );
+
+        // A confirmation that raced a row change: the expectation no longer
+        // matches, so the registration is the typed conflict naming what the
+        // row now holds — and the already-parked pairing is not clobbered.
+        let error =
+            register_replacing_pairing(&handle, "http://new.invalid", "http://elsewhere.invalid/")
+                .await
+                .err()
+                .unwrap();
+        match &error {
+            PairingError::Conflict {
+                provisioned_url,
+                replaceable: true,
+            } => assert_eq!(provisioned_url, "http://managed.invalid/"),
+            other => panic!("expected the replaceable conflict, got {other:?}"),
+        }
+        assert_eq!(
+            gateway.pending_pairing_url().await.as_deref(),
+            Some("http://new.invalid/")
+        );
+    }
+
+    /// An OS (MDM) assertion outranks pairing in both directions: plain
+    /// registration refuses with a conflict the shell must not escalate, and
+    /// even the confirmed replacing path refuses the same way.
+    #[tokio::test]
+    async fn an_os_asserted_gateway_is_never_replaceable() {
+        struct OsAsserted;
+
+        impl crate::managed_policy::OsPolicySource for OsAsserted {
+            fn gateway_url(&self) -> Result<Option<String>> {
+                Ok(Some("http://mdm.invalid/".to_string()))
+            }
+        }
+
+        let (store, _directory) = test_store().await;
+        let mcp = Arc::new(McpRuntime::new(
+            Arc::new(ToolRegistry::new()),
+            store.clone(),
+            Arc::new(NoGateway),
+            Arc::new(OsAsserted),
+        ));
+        let gateway = crate::gateway_runtime::GatewayRuntime::new(
+            store.clone(),
+            test_secrets(),
+            Arc::new(OsAsserted),
+        );
+        let handle = PairingHandle::new(store.clone(), mcp, gateway.clone());
+
+        for error in [
+            register_pending_pairing(&handle, "http://other.invalid")
+                .await
+                .err()
+                .unwrap(),
+            register_replacing_pairing(&handle, "http://other.invalid", "http://mdm.invalid/")
+                .await
+                .err()
+                .unwrap(),
+        ] {
+            match &error {
+                PairingError::Conflict {
+                    provisioned_url,
+                    replaceable: false,
+                } => assert_eq!(provisioned_url, "http://mdm.invalid/"),
+                other => panic!("expected the non-replaceable conflict, got {other:?}"),
+            }
+        }
+        assert_eq!(gateway.pending_pairing_url().await, None);
     }
 
     #[tokio::test]
@@ -422,9 +617,16 @@ mod tests {
         .await
         .unwrap();
 
-        commit_signed_in_pairing(&*store, &NoOsPolicy, &mcp, "http://gateway-a.invalid/")
-            .await
-            .unwrap();
+        commit_signed_in_pairing(
+            &*store,
+            &NoOsPolicy,
+            test_secrets(),
+            &mcp,
+            "http://gateway-a.invalid/",
+            None,
+        )
+        .await
+        .unwrap();
 
         let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
         assert!(policy.managed);
@@ -441,9 +643,16 @@ mod tests {
             .is_empty());
 
         // A later sign-in against the same gateway re-commits harmlessly.
-        commit_signed_in_pairing(&*store, &NoOsPolicy, &mcp, "http://gateway-a.invalid/")
-            .await
-            .unwrap();
+        commit_signed_in_pairing(
+            &*store,
+            &NoOsPolicy,
+            test_secrets(),
+            &mcp,
+            "http://gateway-a.invalid/",
+            None,
+        )
+        .await
+        .unwrap();
     }
 
     /// An authority that claimed the profile while the browser flow ran
@@ -457,15 +666,154 @@ mod tests {
             .await
             .unwrap();
 
-        let error = commit_signed_in_pairing(&*store, &NoOsPolicy, &mcp, "http://pending.invalid/")
-            .await
-            .err()
-            .unwrap();
+        let error = commit_signed_in_pairing(
+            &*store,
+            &NoOsPolicy,
+            test_secrets(),
+            &mcp,
+            "http://pending.invalid/",
+            None,
+        )
+        .await
+        .err()
+        .unwrap();
         assert!(error.to_string().contains("http://mdm.invalid/"));
         assert!(!error.to_string().contains("pending.invalid"));
 
         let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
         assert_eq!(policy.gateway_url.as_deref(), Some("http://mdm.invalid/"));
+    }
+
+    /// A minimal gateway that answers session revocation, standing in for
+    /// the *old* deployment during a re-pair: the commit must revoke the
+    /// superseded session there. Returns the base URL and the raw bodies
+    /// posted to `/oauth/revoke`.
+    async fn serve_revocable_gateway() -> (String, Arc<std::sync::Mutex<Vec<String>>>) {
+        let revoked = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorded = revoked.clone();
+        let app = axum::Router::new()
+            .route(
+                "/api/v1/meta",
+                axum::routing::get(|| async {
+                    axum::Json(json!({
+                        "api_version": "v1",
+                        "installation_id": "install-1",
+                        "gateway_version": "1.0.0",
+                        "public_url": "http://gateway.test",
+                        "auth_mode": "oidc",
+                    }))
+                }),
+            )
+            .route(
+                "/oauth/revoke",
+                axum::routing::post(move |body: String| {
+                    let recorded = recorded.clone();
+                    async move {
+                        recorded.lock().unwrap().push(body);
+                        axum::Json(json!({}))
+                    }
+                }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{address}"), revoked)
+    }
+
+    /// The whole point of the slice, at the commit seam: a replacing commit
+    /// swaps the provisioned row to the new gateway and retires the old
+    /// deployment's session — revoked at the old gateway and gone locally —
+    /// before the exchange task would store the new one.
+    #[tokio::test]
+    async fn a_replacing_commit_swaps_the_row_and_retires_the_old_session() {
+        let (old_base, revoked) = serve_revocable_gateway().await;
+        let old_url = format!("{old_base}/");
+        let (store, _directory) = test_store().await;
+        managed_policy::provision(&*store, &old_url).await.unwrap();
+        let (_handle, mcp, _gateway) = test_handle_with_runtimes(&store);
+        let secrets = test_secrets();
+        let credentials: openwave_connectors::GatewayCredentials = serde_json::from_value(json!({
+            "base_url": old_url,
+            "installation_id": "install-1",
+            "user_id": "user-1",
+            "refresh_token": "mg_rt_old",
+            "access_tokens": {}
+        }))
+        .unwrap();
+        openwave_connectors::CredentialVault::new(secrets.clone())
+            .save(&credentials)
+            .await
+            .unwrap();
+
+        commit_signed_in_pairing(
+            &*store,
+            &NoOsPolicy,
+            secrets.clone(),
+            &mcp,
+            "http://new-gw.invalid/",
+            Some(&old_url),
+        )
+        .await
+        .unwrap();
+
+        let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
+        assert!(policy.managed);
+        assert_eq!(
+            policy.gateway_url.as_deref(),
+            Some("http://new-gw.invalid/")
+        );
+        assert!(
+            revoked
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|body| body.contains("mg_rt_old")),
+            "the old session's refresh token must be revoked at the old gateway"
+        );
+        assert!(
+            !openwave_connectors::has_stored_credentials(&*secrets).await,
+            "the old session must be cleared before the new one is stored"
+        );
+    }
+
+    /// The compare-and-swap the confirmation rests on: a provisioned row
+    /// that moved to a third gateway while the browser flow ran wins, and
+    /// the replacing commit refuses rather than writing over consent the
+    /// user never gave.
+    #[tokio::test]
+    async fn a_replacing_commit_refuses_a_row_that_moved_mid_flow() {
+        let (store, _directory) = test_store().await;
+        managed_policy::provision(&*store, "http://old.invalid/")
+            .await
+            .unwrap();
+        let (_handle, mcp, _gateway) = test_handle_with_runtimes(&store);
+        // Another pairing path re-pointed the row after the user's
+        // confirmation named http://old.invalid/.
+        store
+            .set_setting(
+                "managed_policy_v1",
+                &json!({"gateway_url": "http://third.invalid/"}),
+            )
+            .await
+            .unwrap();
+
+        let error = commit_signed_in_pairing(
+            &*store,
+            &NoOsPolicy,
+            test_secrets(),
+            &mcp,
+            "http://new-gw.invalid/",
+            Some("http://old.invalid/"),
+        )
+        .await
+        .err()
+        .unwrap();
+        assert!(error.to_string().contains("http://third.invalid/"));
+
+        let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
+        assert_eq!(policy.gateway_url.as_deref(), Some("http://third.invalid/"));
     }
 
     /// The commit applies the policy it writes, not just persists it: a
@@ -499,9 +847,16 @@ mod tests {
         assert_eq!(mcp.info().await.servers[0].health, McpHealth::Healthy);
         assert!(mcp.snapshot().get("mcp__private_docs__lookup").is_some());
 
-        commit_signed_in_pairing(&*store, &NoOsPolicy, &mcp, "http://gateway.invalid/")
-            .await
-            .unwrap();
+        commit_signed_in_pairing(
+            &*store,
+            &NoOsPolicy,
+            test_secrets(),
+            &mcp,
+            "http://gateway.invalid/",
+            None,
+        )
+        .await
+        .unwrap();
 
         assert!(
             mcp.snapshot().get("mcp__private_docs__lookup").is_none(),

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -169,10 +169,11 @@ fn mcp_app_payload_from_events(
 
 /// `GET /policy` — the resolved managed-mode policy. Read-only by design:
 /// provisioning has no renderer-writable route, which is what keeps the
-/// state sticky. A shell-registered pending pairing rides along while the
-/// profile is unmanaged, so the gate can present the sign-in that would
-/// commit it — runtime state, merged here and never part of the durable
-/// resolution.
+/// state sticky. A shell-registered pending pairing rides along — on an
+/// unmanaged profile awaiting its first sign-in, or on a provisioned one
+/// where the shell's confirmed re-pair flow parked it — so the gate can
+/// present the sign-in that would commit it. Runtime state, merged here and
+/// never part of the durable resolution.
 pub async fn get_policy(
     State(state): State<AppState>,
 ) -> Result<Json<crate::managed_policy::ManagedPolicy>, ServerError> {
@@ -183,9 +184,7 @@ async fn policy_with_pending(
     state: &AppState,
 ) -> Result<crate::managed_policy::ManagedPolicy, ServerError> {
     let mut policy = crate::managed_policy::resolve(&*state.store, &*state.os_policy).await?;
-    if !policy.managed {
-        policy.pending_gateway_url = state.gateway.pending_pairing_url().await;
-    }
+    policy.pending_gateway_url = state.gateway.pending_pairing_url().await;
     Ok(policy)
 }
 

--- a/docs/managed-policy.md
+++ b/docs/managed-policy.md
@@ -76,6 +76,11 @@ sqlite3 "<data dir>/openwave.db" \
   "DELETE FROM setting WHERE key = 'managed_policy_v1';"
 ```
 
-Note that an OS-managed (MDM) assertion always outranks this row, and a
-profile provisioned to one gateway refuses re-provisioning to another —
-delete the row first to switch deployments.
+Note that an OS-managed (MDM) assertion always outranks this row. A profile
+provisioned to one gateway refuses a bare provision link for another;
+opening such a link instead asks, in a native dialog naming both gateways,
+whether to re-pair. Confirming parks the replacement, and completing a
+sign-in against the new gateway commits it — the old gateway's session is
+revoked and cleared in the same step. Deleting the row (above) remains the
+way to return to the open profile; an OS-asserted gateway can never be
+replaced by re-pairing.


### PR DESCRIPTION
Closes #1064. Part of #742.

A profile provisioned to one gateway refused a provision link for another, permanently — the dialog pointed at an administrator, and the only way to switch deployments was deleting the `managed_policy_v1` row by hand. The provisioned tier is user-consented state, so switching gateways should be a confirmed link-click.

## What changed

**Conflict escalation (desktop shell, `deep_link.rs`).** A provision link that conflicts with the *provisioned* gateway now raises a native confirmation naming both origins and what confirming does; it defaults to changing nothing, and the existing one-dialog-at-a-time guard covers it, so a page firing links in a loop still gets at most one dialog. Confirming parks a *replacing* pending pairing — still nothing durable. An OS (MDM) conflict keeps the refuse-forever dialog; that tier is never replaceable locally.

**Consent stays the sign-in (`pairing.rs`, `gateway_runtime.rs`).** The new `register_replacing_pairing` parks the replacement only while the row still holds the URL the confirmation named, and the sign-in gate presents it — now on a managed profile too, and even over a satisfied session (dismissing it returns the app). The finishing sign-in commits through a compare-and-swap (`managed_policy::reprovision`): a row that moved to anything else mid-flow wins and the pairing is refused. A successful commit retires the superseded session — best-effort revoke at the old gateway, unconditional local clear, via the existing `retire_superseded_gateway_session` path — before the new session is stored, and re-runs manual-MCP lockdown.

**Renderer surface (`routes.rs`, `ManagedGate.tsx`).** `/policy` merges the pending pairing on managed profiles as well; the gate holds while one is parked and names the gateway being replaced. No wire-type changes — `pending_gateway_url` already existed.

`PairingError::Conflict` gained a `replaceable` flag so the shell can tell the user-consented row from an MDM assertion.

## Tests

- `a_replacing_registration_holds_the_row_to_the_confirmed_expectation` — parking demands the confirmed row; a stale expectation is the typed conflict and clobbers nothing parked.
- `an_os_asserted_gateway_is_never_replaceable` — both registration paths refuse with `replaceable: false` under OS policy.
- `a_replacing_commit_swaps_the_row_and_retires_the_old_session` — end to end at the commit seam: row swapped, old refresh token revoked at the old gateway (real HTTP fixture), vault cleared.
- `a_replacing_commit_refuses_a_row_that_moved_mid_flow` — the compare-and-swap refusal.
- Message-function tests pin the confirmation naming both origins and the raced-conflict copy not blaming an administrator; a DOM test pins the gate surfacing a re-pair over a signed-in session and "Not now" restoring the app.

Verified locally: `openwave-server` pairing/gateway_runtime suites, desktop `deep_link` tests, clippy on both crates, full UI suite (623) + `tsc` + `pnpm build`. Not verified: the native dialogs in a running app — the confirm/cancel flow deserves a smoke test with a real link click.
