### PR TITLE
fix(desktop): icon-only copy button and non-sticky timestamp

### DIFF
--- a/crates/openwave-desktop/ui/src/ClipboardCopyButton.tsx
+++ b/crates/openwave-desktop/ui/src/ClipboardCopyButton.tsx
@@ -65,7 +65,6 @@ export function ClipboardCopyButton({
           <span aria-hidden="true" className="clipboard-copy-icon">
             {copyState === "copied" ? <Check size={13} /> : <Copy size={13} />}
           </span>
-          <span>{visibleLabel}</span>
         </button>
       </WithTooltip>
       <span className="sr-only" role="status" aria-live="polite">

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -577,9 +577,9 @@ body {
 }
 
 .message-assistant:hover .message-footer time,
-.message-assistant:focus-within .message-footer time,
+.message-assistant:has(:focus-visible) .message-footer time,
 .message-user-frame:hover .message-footer time,
-.message-user-frame:focus-within .message-footer time {
+.message-user-frame:has(:focus-visible) .message-footer time {
   opacity: 1;
 }
 
@@ -590,10 +590,9 @@ body {
 .message-copy {
   display: inline-flex;
   align-items: center;
-  gap: 0.28rem;
   border: 0;
   border-radius: 5px;
-  padding: 0.18rem 0.32rem;
+  padding: 0.22rem;
   color: var(--muted-foreground);
   background: transparent;
   font-size: 0.72rem;


### PR DESCRIPTION
## Summary
- Remove the visible text label from the message copy button — it now shows only the icon, with the label available via tooltip on hover.
- Replace `:focus-within` with `:has(:focus-visible)` on the timestamp CSS so clicking a message no longer pins the timestamp visible; it still appears on hover and keyboard focus.
- Trim copy button padding/gap for the icon-only layout.