### PR TITLE
fix(desktop): stop the sign-in link opening the browser twice

### DIFF
--- a/crates/openwave-desktop/ui/src/ManagedGate.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.tsx
@@ -392,11 +392,12 @@ export function ManagedGate({
           <a
             className="underline"
             href={pendingUrl}
-            target="_blank"
             rel="noreferrer noopener"
             onClick={(event) => {
-              // The webview swallows target="_blank"; route through the
-              // native opener and keep the href for hover/copy.
+              // No target="_blank": the shell plugin's injected click handler
+              // opens such links itself without honoring preventDefault,
+              // which doubled this one. Route through the native opener and
+              // keep the href for hover/copy.
               event.preventDefault();
               void openSignInPage(pendingUrl);
             }}

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
@@ -264,11 +264,12 @@ function ManagedGatewayPanel({
                 <a
                   className="underline"
                   href={pendingUrl}
-                  target="_blank"
                   rel="noreferrer noopener"
                   onClick={(event) => {
-                    // The webview swallows target="_blank"; route through the
-                    // native opener and keep the href for hover/copy.
+                    // No target="_blank": the shell plugin's injected click
+                    // handler opens such links itself without honoring
+                    // preventDefault, which doubled this one. Route through
+                    // the native opener and keep the href for hover/copy.
                     event.preventDefault();
                     void openSignInPage(pendingUrl);
                   }}


### PR DESCRIPTION
Clicking **Open the sign-in page again** on the sign-in gate (and the same link in the gateway settings panel) opened the authorize page in two browser tabs.

## Cause

`tauri-plugin-shell` injects an init script that adds a body-level click listener: any `<a target="_blank">` with an http(s) href is opened via `plugin:shell|open`, and the listener does not check `defaultPrevented`. Our anchor also opens the URL from its own `onClick` (via `openSignInPage`), so both paths fired — the React handler's `preventDefault` only suppressed the webview's native navigation, not the plugin's listener. The old comment claiming the webview swallows `target="_blank"` predates the plugin behavior.

## Fix

Drop `target="_blank"` from the two anchors. The injected handler only matches `_blank` links, so the explicit opener becomes the only path; `preventDefault` still stops in-webview navigation, the href stays for hover/copy, and the plain-browser fallback in `openSignInPage` (`window.open`) is unaffected. `MessageMarkdown` links keep `target="_blank"` deliberately — they have no onClick and rely on the plugin's single open.

Existing DOM tests pin the link's role and href; both suites pass, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)