### PR TITLE
feat(server): cap a container run's model-inference spend host-side

### DIFF
--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -34,6 +34,7 @@
 //! multi-thread runtime. The host runs on one; every test here uses the
 //! multi-thread flavor.
 
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -85,6 +86,16 @@ pub struct SandboxContainerRunConfig {
     pub reattach_attempts: u32,
     /// Backoff between re-dials.
     pub reattach_backoff: Duration,
+    /// How many model-inference operations the host will answer for one run.
+    ///
+    /// The sandbox's own step limit runs inside the untrusted container, so it
+    /// bounds nothing; this cap is what actually stops a compromised or buggy
+    /// sandbox from spending the user's model credentials indefinitely. Every
+    /// call that reaches the host's provider spends one unit — including a call
+    /// that then fails retryably — while a re-issue answered from the recorded
+    /// operation log spends nothing. Exhaustion is refused non-retryably, which
+    /// fails the sandbox's model step and terminalizes the run.
+    pub max_inference_operations: u32,
 }
 
 impl Default for SandboxContainerRunConfig {
@@ -95,6 +106,11 @@ impl Default for SandboxContainerRunConfig {
             dial_timeout: Duration::from_secs(10),
             reattach_attempts: 5,
             reattach_backoff: Duration::from_millis(250),
+            // Three times the in-container loop's own step limit: a well-behaved
+            // run never approaches it even with retried provider failures, and a
+            // hostile one is cut off within one order of magnitude of legitimate
+            // spend.
+            max_inference_operations: 24,
         }
     }
 }
@@ -131,6 +147,13 @@ struct HostModelProxy {
     /// run would. Resolved once at attach and failed closed there, never
     /// re-derived per request from an untrusted prompt.
     config: AgentConfig,
+    /// Model-inference operations answered so far, against
+    /// [`SandboxContainerRunConfig::max_inference_operations`]. One proxy lives
+    /// for the whole drive, so the count survives reattaches; replays from the
+    /// operation log never reach this responder and spend nothing.
+    spent: AtomicU32,
+    /// The per-run cap the count is checked against.
+    budget: u32,
 }
 
 #[async_trait]
@@ -146,6 +169,16 @@ impl CapabilityResponder for HostModelProxy {
                 false,
             ));
         };
+        // Spend before resolving: a call that fails retryably still consumed a
+        // provider attempt, and counting refused calls keeps a sandbox that
+        // ignores the refusal from probing forever at zero cost accounting.
+        if self.spent.fetch_add(1, Ordering::SeqCst) >= self.budget {
+            return Response::Error(ErrorResponse::new(
+                ErrorCode::Denied,
+                "the run's model-inference budget is exhausted",
+                false,
+            ));
+        }
         let provider = self.resolver.resolve().await;
         // The sandbox names no model, provider, or endpoint: it supplies only a
         // prompt, and the host's policy-resolved config decides where it goes.
@@ -399,6 +432,8 @@ impl SandboxContainerRunner {
             Arc::new(HostModelProxy {
                 resolver: Arc::clone(&self.resolver),
                 config,
+                spent: AtomicU32::new(0),
+                budget: self.config.max_inference_operations,
             }),
             Arc::new(DurableOperationStore::new(
                 Arc::clone(&self.store),

--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -14,7 +14,7 @@
 //! than hanging CI, and every test uses the multi-thread runtime the durable
 //! operation store's `block_in_place` bridge requires.
 
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -344,6 +344,7 @@ fn fast_config() -> SandboxContainerRunConfig {
         dial_timeout: Duration::from_secs(2),
         reattach_attempts: 2,
         reattach_backoff: Duration::from_millis(10),
+        max_inference_operations: 24,
     }
 }
 
@@ -450,6 +451,68 @@ async fn terminalizes_and_tears_down_when_the_agent_loop_ends_without_a_result()
             "a loop that ended without a result is an agent failure, not a transport one"
         );
         // The container did not leak: teardown ran even though no result arrived.
+        assert_eq!(backend.destroys.load(Ordering::SeqCst), 1);
+    })
+    .await
+    .expect("test completed within its time bound");
+}
+
+/// The host stops answering model inference at the run's spend budget, no matter
+/// how many reverse calls the sandbox issues.
+///
+/// The in-container step limit is enforced by untrusted code, so it bounds
+/// nothing; this is the host-side cap #920 requires before anything routes to
+/// the container location. The refusal is non-retryable, so the sandbox's failed
+/// model step terminalizes the run and the container is torn down — and the
+/// provider must have been asked for exactly the budgeted number of completions,
+/// not one more.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn stops_proxying_inference_at_the_runs_spend_budget() {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        let (_dir, store, chat) = store().await;
+        let run_id = admit_container_run(&store, chat.id, "spends forever").await;
+
+        let backend = MockBackend::spawning();
+        // Every completion is another tool directive: left alone, the loop would
+        // take all of its 8 in-container steps. The host's budget of 2 must cut
+        // it off first.
+        let provider = Arc::new(ScriptedProvider::new(vec![
+            "use-tool:write_file:{\"path\":\"note.txt\",\"content\":\"a\"}".to_owned();
+            16
+        ]));
+        let resolver = Arc::new(FixedResolver(provider.clone()));
+
+        let runner = SandboxContainerRunner::new(
+            store.clone(),
+            backend.clone(),
+            resolver,
+            SandboxContainerRunConfig {
+                max_inference_operations: 2,
+                ..fast_config()
+            },
+        );
+        let outcome = runner
+            .drive(run_id)
+            .await
+            .expect("driving succeeds")
+            .expect("the container run is claimable");
+        assert_eq!(outcome, SandboxContainerRunOutcome::Failed(run_id));
+
+        let failed = store.get_agent_run(run_id).await.unwrap().unwrap();
+        assert_eq!(failed.status, AgentRunStatus::Failed);
+        assert_eq!(
+            failed.last_error_code.as_deref(),
+            Some("sandbox_agent_failed")
+        );
+
+        // The user's credentials were spent exactly the budgeted number of
+        // times; the third request was refused before reaching the provider.
+        assert_eq!(
+            provider.calls.load(Ordering::SeqCst),
+            2,
+            "the host must not answer inference past the run's budget"
+        );
+        // The refusal closed the run rather than leaking the container.
         assert_eq!(backend.destroys.load(Ordering::SeqCst), 1);
     })
     .await
@@ -593,6 +656,8 @@ async fn host_model_proxy_answers_a_reissued_inference_from_the_op_log() {
                     model: "host-model".to_owned(),
                     ..AgentConfig::default()
                 },
+                spent: AtomicU32::new(0),
+                budget: 24,
             }),
             Arc::new(DurableOperationStore::new(store.clone(), run_id)),
         );


### PR DESCRIPTION
Routing blocker 2 from #920: nothing on the host capped how many model-inference operations a sandbox-resident run could request. The agent's own step limit runs inside the untrusted container, so a compromised or buggy sandbox could issue reverse calls indefinitely and the host would keep answering them from the user's credentials.

## What this does

- `SandboxContainerRunConfig` gains `max_inference_operations` (default 24 — three times the in-container loop's step limit, so a well-behaved run never approaches it even with retried provider failures).
- `HostModelProxy` counts every call that reaches it and refuses past the cap with a non-retryable `Denied`. The proxy is built once per drive and shared across reattaches, so the count survives reconnects; a re-issue answered from the durable operation log never reaches the responder and spends nothing.
- Spend is counted before the provider is resolved: a call that then fails retryably still consumed a provider attempt, and a sandbox that ignores the refusal is refused again at zero provider cost.
- No new failure plumbing: the non-retryable refusal fails the sandbox's model step, the agent emits its terminal `Failed` event, and the driver terminalizes and tears down through the paths #919 landed.

## Test

One loopback test against the real in-container agent: a provider scripted to keep the loop tool-calling forever, a budget of 2 — the run fails terminally as `sandbox_agent_failed`, the container is torn down, and the provider was asked for exactly 2 completions, not a third.

## Verified

`cargo test -p openwave-server --locked sandbox_container_run` (8 passed), `cargo clippy -p openwave-server --all-targets --locked -- -D warnings`, `cargo fmt --check`. No lockfile change.

Part of #920.