### PR TITLE
fix(host-broker): stop mirroring read grants into write grants on migration

### DIFF
--- a/crates/openwave-host-broker/src/broker/state_file.rs
+++ b/crates/openwave-host-broker/src/broker/state_file.rs
@@ -147,27 +147,14 @@ impl StateFile {
                 return Err(invalid_data("duplicate persisted operation identity").into());
             }
         }
-        let mut grants = persisted.grants;
-        if persisted.version == 2 {
-            let write_grants = grants
-                .iter()
-                .filter(|grant| grant.capability() == crate::Capability::ReadFiles)
-                .map(|grant| {
-                    Grant::from_consent(
-                        crate::GrantId::new(),
-                        grant.subject(),
-                        crate::Capability::WriteFiles,
-                        grant.scope().clone(),
-                        grant.consent().clone(),
-                    )
-                    .map_err(BrokerError::from)
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            grants.extend(write_grants);
-        }
+        // Version 2 predates write grants. Its read grants migrate as they
+        // stand: widening them would hand out authority the user never
+        // approved, and the only consent record available to attach to such a
+        // grant is the one they gave for reading. Write authority on an
+        // existing root has to come from a fresh consent instead.
         let state = State {
             roots,
-            grants,
+            grants: persisted.grants,
             attachments: persisted.attachments,
             mutations,
             active_mutations: Default::default(),

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -2453,6 +2453,44 @@ fn restart_rejects_an_oversized_state_file_before_parsing_it() {
 }
 
 #[test]
+fn version_two_read_grants_migrate_without_gaining_write() {
+    let (temp, broker, path, state_dir) = durable_setup();
+    let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    register(
+        &broker.controller(),
+        subject,
+        conversation,
+        path,
+        OperationId::new(),
+    );
+    drop(broker);
+
+    // Reshape the persisted file into what a version 2 install left behind:
+    // read grants only, before write grants existed.
+    let state_path = state_dir.join("host-broker-state.json");
+    let mut persisted: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&state_path).unwrap()).unwrap();
+    persisted["version"] = serde_json::json!(2);
+    persisted["grants"]
+        .as_array_mut()
+        .unwrap()
+        .retain(|grant| grant["capability"] != serde_json::json!("write_files"));
+    std::fs::write(&state_path, serde_json::to_vec(&persisted).unwrap()).unwrap();
+
+    let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+    let state = broker.shared.state.lock().unwrap();
+    assert!(state
+        .grants
+        .iter()
+        .any(|grant| grant.capability() == Capability::ReadFiles));
+    assert!(!state
+        .grants
+        .iter()
+        .any(|grant| grant.capability() == Capability::WriteFiles));
+}
+
+#[test]
 fn binary_reads_return_bytes_that_text_reads_refuse() {
     let (_temp, broker, path, audit) = audited_setup();
     // A minimal PDF header followed by a byte sequence that is not valid UTF-8.


### PR DESCRIPTION
The version 2 to version 3 state migration copied every `ReadFiles` grant into a
`WriteFiles` grant and reused the original consent record for it. Someone who
attached a folder while the broker only understood reads came back after an
upgrade with the agent able to write into it, and with a consent record on file
asserting they had approved exactly that.

Version 2 grants now load as they were persisted. The consent record is the part
that mattered: the only consent available to attach to a widened grant is the one
the user gave for reading, so there is no honest way to mint the write grant here.
Write authority on an existing root has to come from a fresh consent.

Newly attached folders are unaffected — `prepare_registration` still mints read
and write grants together when a folder is picked, which is the intended product
behavior.

One test: a version 2 fixture carrying a read grant loads with the read grant
intact and no write grant.

Note for follow-up: roots registered before version 3 now load read-only, so a
user who had been writing to one since upgrading will find writes refused until
they re-attach the folder. That is the correct authority state, but the
re-consent path is worth designing rather than leaving as a surprise.

Closes #1071
