### PR TITLE
fix(desktop): three transcript and sidebar bugs

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -93,6 +93,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   const { layout, openPanel } = usePanelNav();
   const sourceNav = useStableSourceNav(openPanel);
   const chats = useChatListStore((state) => state.chats);
+  const chatsLoaded = useChatListStore((state) => state.chatsLoaded);
   const deletingChatId = useChatListStore((state) => state.deletingChatId);
   const busy = useChatSessionStore((session) => session.busy);
   const [hydrated, setHydrated] = useState(false);
@@ -110,10 +111,13 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   const folders = useChatFolderAttachments(chat, nativeHost);
 
   // A chat id that is not in the list — deleted in another window, or a stale
-  // deep link — should land somewhere real rather than on an empty frame.
+  // deep link — should land somewhere real rather than on an empty frame. The
+  // gate is whether the list has been fetched, not whether it has rows: an
+  // account with no chats left is exactly the case that would otherwise sit on
+  // the loading frame forever.
   useEffect(() => {
-    if (chats.length > 0 && !chat) void navigate({ to: "/", replace: true });
-  }, [chats.length, chat, navigate]);
+    if (chatsLoaded && !chat) void navigate({ to: "/", replace: true });
+  }, [chatsLoaded, chat, navigate]);
 
   // A conversation opened from the home composer arrives with its first message
   // already written. `take` clears it, so a re-render cannot send it twice.

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -79,6 +79,26 @@ describe("terminal transcript presentation", () => {
     ]);
   });
 
+  it("carries an unreadable projection through to the renderer", () => {
+    const presented = presentChatTranscript({
+      messages: [],
+      tool_activity: [
+        {
+          tool: "web_search",
+          result_unreadable: true,
+          status: "completed",
+          started_at: "2026-07-27T12:00:00Z",
+          finished_at: "2026-07-27T12:00:01Z",
+        },
+      ],
+      last_event_seq: 4,
+    });
+
+    expect(presented.messages).toEqual([
+      expect.objectContaining({ role: "tool", resultUnreadable: true }),
+    ]);
+  });
+
   it("replaces optimistic text with authoritative content and sources", async () => {
     const listChatMessages = vi.fn(async () => transcript);
     const presented = await loadCurrentTerminalTranscript(

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
@@ -42,6 +42,7 @@ export function presentChatTranscript(
             status: entry.status,
             preview: entry.preview,
             result: entry.result,
+            resultUnreadable: entry.resultUnreadable,
           } satisfies ChatMessage,
         ];
       }

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -31,6 +31,8 @@ export type HydratedTranscriptEntry =
       backgroundAgentRunId?: string;
       preview: ToolActionPreview | null;
       result: ToolResultPreview | null;
+      /** Set when a retained projection no longer parses against this build. */
+      resultUnreadable?: boolean;
       status: ToolCallStatus;
       createdAt: string;
     };

--- a/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
@@ -10,12 +10,17 @@ import {
 import type { Chat } from "@/api";
 import { useChatAttention } from "@/ChatAttention";
 import { Badge } from "@/components/ui/badge";
-import { listDeliverables } from "@/deliverables";
+import { listDeliverables, type DeliverablesCatalog } from "@/deliverables";
 import type { PanelType } from "@/panel/panelTypes";
 import { usePanelNav } from "@/panel/usePanelNav";
 import { useRefreshSignals } from "@/RefreshSignals";
 import { SidebarButton } from "./primitives";
 import { SidebarFrame } from "./SidebarFrame";
+
+// Module scope, not an inline arrow: the count effect keys on the extractor's
+// identity, and this rail re-renders on every composer keystroke.
+const countDeliverables = (catalog: DeliverablesCatalog) =>
+  catalog.deliverables.length;
 
 /**
  * The rail inside one conversation, holding only what acts on that
@@ -45,7 +50,7 @@ export function ChatSidebar({ chat }: { chat: Chat }) {
     (id) => id !== chat.id,
   );
 
-  const outputCount = useSidebarCount(chat.id, listDeliverables, (c) => c.deliverables.length);
+  const outputCount = useSidebarCount(chat.id, listDeliverables, countDeliverables);
 
   return (
     <SidebarFrame>


### PR DESCRIPTION
Three independent UI bugs found in a parity audit, each verified in source.

**Deliverables refetched on every keystroke.** `ChatSidebar` passed an inline extractor arrow to `useSidebarCount`, and the count effect keys on that identity. Because `ChatRoute` re-renders on each composer keystroke, every character typed fired another `listDeliverables` request. The extractor now lives at module scope, so the effect only reruns when the chat or a refresh signal changes.

**`resultUnreadable` never reached the renderer.** `hydrateTranscriptHistory` produces the flag, but the hydrated tool entry's type never declared it and `presentChatTranscript` dropped it, so a retained projection this build cannot parse rendered as a call that produced nothing — and the "result can no longer be displayed" row was unreachable. The field is now declared on the hydrated entry and threaded into the presented tool message.

**A stale deep link with an empty chat list rendered blank forever.** The redirect out of a missing chat was gated on `chats.length > 0`, so an account with no chats — or a boot where the list never populated — sat on the bare loading frame with no way out. It now gates on the store's `chatsLoaded` flag, which is what distinguishes "no chats yet" from "not asked yet", the same way the home route does.

Added one test covering the presentation fix, since the flag being dropped was silent and nothing else asserts it survives hydration.

Closes #1105