### PR TITLE
fix(desktop): surface the pairing gate immediately after a provision link

### DIFF
--- a/crates/openwave-desktop/src/deep_link.rs
+++ b/crates/openwave-desktop/src/deep_link.rs
@@ -29,9 +29,12 @@
 //! policy write path. The webview cannot reach it either: the main window's
 //! capability denies `core:event:emit`, so a compromised renderer cannot
 //! forge the plugin's open-URL event; its influence stops at completing or
-//! dismissing the sign-in it can already perform.
+//! dismissing the sign-in it can already perform. Events flow the other
+//! direction only: after a registration parks a pairing, the shell emits a
+//! best-effort [`PAIRING_CHANGED_EVENT`] nudge so the gate refetches policy
+//! immediately instead of waiting out its poll tick.
 
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use tokio::sync::{oneshot, watch};
@@ -183,6 +186,18 @@ fn provision_link(url: &tauri::Url) -> Result<ProvisionLink, String> {
     })
 }
 
+/// Renderer nudge emitted after a pending pairing is parked or replaced: the
+/// sign-in gate refetches `/policy` on it instead of waiting out a poll tick,
+/// which is what makes the gate appear promptly after a provision link or a
+/// confirmed re-pair. Best-effort — a webview that has not subscribed yet
+/// (cold start by link) is covered by the gate's polling fallback. The
+/// listener is `onPairingChanged` in `ui/src/host.ts`.
+const PAIRING_CHANGED_EVENT: &str = "gateway:pairing-changed";
+
+fn notify_pairing_changed(app: &tauri::AppHandle) {
+    let _ = app.emit(PAIRING_CHANGED_EVENT, ());
+}
+
 fn spawn_pairing(app: tauri::AppHandle, link: ProvisionLink) {
     tauri::async_runtime::spawn(async move {
         let origin = link.origin.clone();
@@ -203,6 +218,7 @@ fn spawn_pairing(app: tauri::AppHandle, link: ProvisionLink) {
         match openwave_server::register_pending_pairing(&handle, &link.gateway_url).await {
             Ok(PendingRegistration::Registered) => {
                 log_pairing(&app, &format!("pairing with {origin} awaits sign-in"));
+                notify_pairing_changed(&app);
             }
             Ok(PendingRegistration::AlreadyManaged) => {
                 log_pairing(&app, &format!("{origin} already manages this device"));
@@ -262,6 +278,7 @@ async fn confirm_and_replace(
                 app,
                 &format!("re-pairing with {} awaits sign-in", link.origin),
             );
+            notify_pairing_changed(app);
         }
         Ok(PendingRegistration::AlreadyManaged) => {
             log_pairing(app, &format!("{} already manages this device", link.origin));

--- a/crates/openwave-desktop/ui/src/ManagedGate.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.dom.test.tsx
@@ -42,6 +42,23 @@ function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
   } as unknown as ApiClient;
 }
 
+/** Captures the gate's subscription to the shell's pairing nudge so a test
+ * can fire it. Only `onPairingChanged` is replaced — everything else in the
+ * host module keeps its real plain-browser behavior. */
+const pairingNudge: { fire: (() => void) | null } = { fire: null };
+vi.mock("./host", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./host")>();
+  return {
+    ...actual,
+    onPairingChanged: (handler: () => void) => {
+      pairingNudge.fire = handler;
+      return () => {
+        pairingNudge.fire = null;
+      };
+    },
+  };
+});
+
 function mount(client: ApiClient) {
   return render(
     <ManagedGate client={client}>
@@ -451,5 +468,35 @@ describe("ManagedGate", () => {
       await screen.findByText(/browser authorization timed out/),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Connect/ })).toBeEnabled();
+  });
+
+  it("the shell's pairing nudge surfaces the gate without waiting out a poll tick", async () => {
+    const unmanaged: ManagedPolicy = {
+      managed: false,
+      source: "unmanaged",
+      misconfigured: false,
+    };
+    const client = api({
+      getPolicy: vi
+        .fn()
+        .mockResolvedValueOnce(unmanaged)
+        .mockResolvedValue({
+          ...unmanaged,
+          pending_gateway_url: "https://next-gateway.example/",
+        }),
+    });
+    mount(client);
+    expect(await screen.findByText("the open product")).toBeInTheDocument();
+
+    // No timer advance: the nudge alone must refetch and lower the gate.
+    await act(async () => {
+      pairingNudge.fire?.();
+    });
+    expect(
+      await screen.findByText("Connect to your model gateway"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("https://next-gateway.example/"),
+    ).toBeInTheDocument();
   });
 });

--- a/crates/openwave-desktop/ui/src/ManagedGate.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.tsx
@@ -5,6 +5,7 @@ import type { ApiClient, GatewayStatus, ManagedPolicy } from "./api";
 import { Button } from "@/components/ui/button";
 import { Logomark } from "./Logomark";
 import { ManagedPolicyContext } from "./managedPolicy";
+import { onPairingChanged } from "./host";
 import { openSignInPage } from "./openSignInPage";
 import { WindowDragStrip } from "./WindowDragStrip";
 
@@ -176,29 +177,41 @@ export function ManagedGate({
   // that had already started refusing them. `/policy` is a local read, so the
   // session cadence is affordable.
   const watching = policyState.kind === "resolved";
+  const refreshPolicy = useCallback(() => {
+    void client
+      .getPolicy()
+      .then((next) => {
+        setPolicyState((current) =>
+          current.kind === "resolved" && samePolicy(current.policy, next)
+            ? current
+            : { kind: "resolved", policy: next },
+        );
+      })
+      .catch((err) => {
+        // An error *response* means the server says the policy is
+        // unreadable, which fails closed exactly as it does on first read.
+        // A transport failure says nothing, so the last answer stands.
+        if (httpStatusOf(err) !== null && httpStatusOf(err) !== 404) {
+          setPolicyState({ kind: "blocked" });
+        }
+      });
+  }, [client]);
   useEffect(() => {
     if (!watching) return;
-    const timer = window.setInterval(() => {
-      void client
-        .getPolicy()
-        .then((next) => {
-          setPolicyState((current) =>
-            current.kind === "resolved" && samePolicy(current.policy, next)
-              ? current
-              : { kind: "resolved", policy: next },
-          );
-        })
-        .catch((err) => {
-          // An error *response* means the server says the policy is
-          // unreadable, which fails closed exactly as it does on first read.
-          // A transport failure says nothing, so the last answer stands.
-          if (httpStatusOf(err) !== null && httpStatusOf(err) !== 404) {
-            setPolicyState({ kind: "blocked" });
-          }
-        });
-    }, SESSION_WATCH_MS);
+    const timer = window.setInterval(refreshPolicy, SESSION_WATCH_MS);
     return () => window.clearInterval(timer);
-  }, [client, watching]);
+  }, [watching, refreshPolicy]);
+
+  // The shell nudges when a provision link parks a pending pairing or a
+  // confirmed re-pair replaces one; refetching now instead of on the next
+  // tick is what makes the gate appear promptly after the user clicks a
+  // link or confirms the native dialog. The poll above stays the fallback —
+  // it still covers MDM flips and a nudge that fired before this
+  // subscription existed (cold start by link).
+  useEffect(() => {
+    if (!watching) return;
+    return onPairingChanged(refreshPolicy);
+  }, [watching, refreshPolicy]);
 
   const reload = useCallback(async () => {
     const next = await client.getGatewayStatus();

--- a/crates/openwave-desktop/ui/src/host.ts
+++ b/crates/openwave-desktop/ui/src/host.ts
@@ -1,4 +1,5 @@
 import { invoke, isTauri } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import type { Chat } from "./api";
 
 export type ConnectedFolder = {
@@ -105,4 +106,20 @@ export async function openExternal(url: string): Promise<boolean> {
   if (!isTauri()) return false;
   await invoke("plugin:shell|open", { path: url });
   return true;
+}
+
+/**
+ * Subscribe to the shell's nudge that a pending gateway pairing was parked or
+ * replaced (a provision link, or a re-pair the user confirmed in the native
+ * dialog). The sign-in gate refetches policy on it instead of waiting out a
+ * poll tick. Returns an unsubscribe; no-op outside the native host, where no
+ * deep link can land. The emitter is `PAIRING_CHANGED_EVENT` in
+ * `crates/openwave-desktop/src/deep_link.rs`.
+ */
+export function onPairingChanged(handler: () => void): () => void {
+  if (!isTauri()) return () => {};
+  const subscription = listen("gateway:pairing-changed", () => handler());
+  return () => {
+    void subscription.then((unlisten) => unlisten());
+  };
 }


### PR DESCRIPTION
Smoke-testing the pairing flows showed a noticeable lag: after clicking **Connect** on a gateway page, the app lingered on its previous screen before the pairing gate appeared, and confirming the native **Re-pair** dialog took a couple of seconds to land on the sign-in screen.

## Cause

Deep links and the re-pair confirmation are handled entirely in the shell (`deep_link.rs`); parking the pending pairing writes nothing the renderer can observe except through the sign-in gate's `/policy` poll, which runs on a 5-second timer (`SESSION_WATCH_MS`). Both delays are just waiting out that tick — there is no renderer-side signal that a flow started, so tightening the poll during "connection flows" can't catch it.

## Fix

Push instead of poll for exactly this transition:

- `deep_link.rs` emits a best-effort `gateway:pairing-changed` event after either registration parks a pairing (plain provision and confirmed re-pair).
- `host.ts` gains `onPairingChanged` — subscribe via the Tauri event API, no-op outside the native host.
- `ManagedGate` refetches policy on the nudge. The interval body is factored into `refreshPolicy` and the 5s poll stays as the fallback: it still covers MDM flips and a nudge that fired before the webview subscribed (cold start by link).

The main window capability still denies `core:event:emit`/`emit-to`, so a compromised renderer cannot forge pairing events — this adds only the shell→renderer direction, and the module docs say so.

## Tests

- New DOM test: the nudge alone (no timer advance) refetches policy and surfaces the pairing gate. This pins the renderer half of the cross-boundary contract.
- No Rust test for the emit itself: it is one glue line whose only observable effect is the renderer behavior the DOM test covers.
- `ManagedGate.dom.test.tsx` 15/15, `tsc` clean, `cargo check -p openwave-desktop --locked` clean.

Remaining known lag, out of scope here: the browser→app hop after OAuth completes is still the 2s pending poll, and that exchange lands in `openwave-server`, which has no Tauri handle to emit from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)