### PR TITLE
fix(router): treat mid-stream error frames as stream failures

### DIFF
--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -20,7 +20,9 @@ use openwave_core::provider::{
 use openwave_core::tool::{strict_json_schema, OptionalProperties};
 use openwave_core::{ImageAttachments, Role};
 
-use crate::sse::{classify_provider_error, drain_frames, frame_data, read_bounded_error_body};
+use crate::sse::{
+    classify_provider_error, drain_frames, frame_data, read_bounded_error_body, safe_in_band_error,
+};
 
 const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
@@ -420,6 +422,9 @@ struct StreamState {
     output_block: Option<u32>,
     /// Whether any *other* tool call was announced this stream.
     saw_other_tool_call: bool,
+    /// Set once the stream has terminalized on an in-band error, so no later
+    /// frame can append events after the failure.
+    terminal: bool,
 }
 
 fn u32_at(value: &Value, key: &str) -> u32 {
@@ -428,7 +433,20 @@ fn u32_at(value: &Value, key: &str) -> u32 {
 
 /// Map one parsed Anthropic stream event into zero or more `ProviderEvent`s.
 fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
+    if state.terminal {
+        return Vec::new();
+    }
     match data.get("type").and_then(Value::as_str) {
+        // Anthropic answers 200, starts streaming, and can then send an error
+        // frame instead of finishing — overloaded_error and api_error both
+        // arrive this way. The stream closes right after, so without this arm
+        // the truncated step would read as a clean end and commit.
+        Some("error") => {
+            state.terminal = true;
+            vec![ProviderEvent::Failed {
+                message: safe_in_band_error("anthropic", data.get("error").unwrap_or(data)),
+            }]
+        }
         Some("message_start") => {
             if let Some(usage) = data.get("message").and_then(|m| m.get("usage")) {
                 state.input_tokens = u32_at(usage, "input_tokens");
@@ -754,6 +772,27 @@ mod tests {
             .iter()
             .flat_map(|e| normalize(e, &mut state))
             .collect()
+    }
+
+    #[test]
+    fn in_band_error_fails_the_stream_instead_of_ending_it_cleanly() {
+        let out = run(&[
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "partial"}}),
+            json!({"type": "error", "error": {"type": "overloaded_error", "message": "Overloaded"}}),
+            // Anything after the error must not resurrect a clean stop.
+            json!({"type": "message_delta", "delta": {"stop_reason": "end_turn"}}),
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                ProviderEvent::TextDelta {
+                    text: "partial".into()
+                },
+                ProviderEvent::Failed {
+                    message: "anthropic returned 500 (overloaded_error)".into()
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -26,7 +26,10 @@ use openwave_core::tool::{strict_json_schema, OptionalProperties};
 use openwave_core::{ImageAttachments, ReasoningEffort, Role};
 
 use crate::google_auth::{valid_resource_segment, valid_vertex_location};
-use crate::sse::{classify_provider_error, drain_frames, frame_data_raw, read_bounded_error_body};
+use crate::sse::{
+    classify_provider_error, drain_frames, frame_data_raw, read_bounded_error_body,
+    safe_in_band_error,
+};
 use crate::BearerTokenSource;
 
 const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com";
@@ -640,7 +643,7 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
     if let Some(error) = data.get("error") {
         state.terminal = true;
         return vec![ProviderEvent::Failed {
-            message: safe_in_band_error(error),
+            message: safe_in_band_error("gemini", error),
         }];
     }
     if let Some(block_reason) = data
@@ -829,16 +832,6 @@ fn refusal_details(reason: &str) -> RefusalDetails {
         })
         .collect::<String>();
     RefusalDetails::from_category(Some(&category))
-}
-
-fn safe_in_band_error(error: &Value) -> String {
-    let status = error
-        .get("code")
-        .and_then(Value::as_u64)
-        .and_then(|code| u16::try_from(code).ok())
-        .filter(|code| (100..=599).contains(code))
-        .unwrap_or(500);
-    format!("gemini returned {status}")
 }
 
 fn classify_gemini_error(status: u16, body: &str) -> AgentError {

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -22,7 +22,9 @@ use openwave_core::provider::{
 use openwave_core::tool::{strict_json_schema, OptionalProperties};
 use openwave_core::{ImageAttachments, Role};
 
-use crate::sse::{classify_provider_error, drain_frames, frame_data, read_bounded_error_body};
+use crate::sse::{
+    classify_provider_error, drain_frames, frame_data, read_bounded_error_body, safe_in_band_error,
+};
 
 const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
 const DEFAULT_MAX_TOKENS: u32 = 4096;
@@ -152,7 +154,7 @@ impl ModelProvider for OpenAiCompatProvider {
             }
             // Emit a Stop if the stream ended without a finish_reason (some
             // local servers omit it on clean close).
-            if !state.stopped {
+            if !state.stopped && !state.terminal {
                 yield ProviderEvent::Stop {
                     reason: if state.saw_tool_call {
                         StopReason::ToolUse
@@ -412,6 +414,9 @@ struct StreamState {
     usage: Usage,
     stopped: bool,
     saw_tool_call: bool,
+    /// Set once the stream has terminalized on an in-band error. It suppresses
+    /// both later frames and the synthetic end-of-stream `Stop` below.
+    terminal: bool,
 }
 
 #[derive(Default)]
@@ -427,6 +432,20 @@ struct ToolCallBuf {
 
 /// Map one parsed Chat Completions stream chunk into zero or more events.
 fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
+    if state.terminal {
+        return Vec::new();
+    }
+    // Gateways accept the request, stream a few chunks, and then push an error
+    // object in place of the next chunk. Nothing follows it, so ignoring it
+    // would leave the synthetic end-of-stream `Stop` below to report the
+    // truncated step as a clean finish.
+    if let Some(error) = data.get("error") {
+        state.terminal = true;
+        return vec![ProviderEvent::Failed {
+            message: safe_in_band_error("openai-compat", error),
+        }];
+    }
+
     let mut events = Vec::new();
 
     if let Some(usage) = data.get("usage") {
@@ -743,6 +762,40 @@ mod tests {
             .iter()
             .flat_map(|c| normalize(c, &mut state))
             .collect()
+    }
+
+    #[test]
+    fn in_band_error_fails_the_stream_and_suppresses_the_synthetic_stop() {
+        let mut state = StreamState::default();
+        let out: Vec<ProviderEvent> = [
+            json!({"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"read_file","arguments":"{\"pa"}}]}}]}),
+            json!({"error":{"message":"upstream is overloaded","type":"server_error","code":"server_overloaded"}}),
+        ]
+        .iter()
+        .flat_map(|chunk| normalize(chunk, &mut state))
+        .collect();
+
+        assert_eq!(
+            out,
+            vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "call_1".into(),
+                    name: "read_file".into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: "{\"pa".into(),
+                },
+                ProviderEvent::Failed {
+                    message: "openai-compat returned 500 (server_error)".into(),
+                },
+            ]
+        );
+        // The stream's end-of-stream fallback keys off this flag; without it a
+        // truncated tool call would be handed on under a clean `Stop`.
+        assert!(state.terminal);
+        assert!(!state.stopped);
     }
 
     #[test]

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -119,6 +119,32 @@ pub fn safe_http_error(provider: &str, status: u16, body: &str) -> String {
     }
 }
 
+/// Build a client-safe message for an error delivered *inside* a 200 stream.
+///
+/// Providers can accept a request, start streaming, and then emit an error
+/// frame instead of finishing. There is no HTTP status to report in that case:
+/// some providers carry a numeric `code` (Gemini), others only a stable
+/// enum-style `type` / `code` token (Anthropic, OpenAI-compatible). As with
+/// [`safe_http_error`], nothing else from the untrusted payload is forwarded —
+/// these strings reach the client through `TurnFailed`.
+pub fn safe_in_band_error(provider: &str, error: &serde_json::Value) -> String {
+    let status = error
+        .get("code")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|code| u16::try_from(code).ok())
+        .filter(|code| (100..=599).contains(code))
+        .unwrap_or(500);
+    let detail = error
+        .get("type")
+        .or_else(|| error.get("code"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|code| safe_error_code(code));
+    match detail {
+        Some(code) => format!("{provider} returned {status} ({code})"),
+        None => format!("{provider} returned {status}"),
+    }
+}
+
 /// Accept only a compact enum-style token. Error fields come from an
 /// untrusted gateway and may otherwise contain echoed credentials, prompts, or
 /// control characters that would reach the renderer through `TurnFailed`.


### PR DESCRIPTION
Anthropic can answer HTTP 200, stream part of a response, and then deliver
`{"type":"error","error":{...}}` instead of finishing — `overloaded_error`
and `api_error` both arrive that way. `normalize` had no arm for it, so the
frame fell through to the catch-all and the closed stream read as a clean
`StreamEnd::Done`. Partial text committed as a completed turn, and a tool
call cut off mid-JSON was handed on as if the model had finished emitting
it.

The OpenAI-compatible adapter had the same gap from the other direction: an
error chunk carries no `choices`, so it was dropped, and the end-of-stream
fallback then synthesized a clean `Stop` for a stream that never finished.

Both adapters now recognize the error frame, mark the stream terminal, and
emit `ProviderEvent::Failed`. The agent loop already handles that correctly:
it discards the partial candidate, emits `StreamInterrupted`, and returns
`AgentError::Provider`, which the turn worker classifies alongside
`overloaded` and `rate_limited` as retryable. So a mid-stream overload gets
the same retry treatment it would have had on a 529 response, even though
`ProviderEvent::Failed` carries only a message and cannot distinguish the
error taxonomy on its own.

Gemini already did this. Its `safe_in_band_error` helper moves to `sse.rs`
and takes the provider name, and now also reads the enum-style `type` /
`code` token through the existing `safe_error_code` filter — Gemini carries
a numeric `code` in band, Anthropic and OpenAI carry a string one. Gemini's
resulting message is unchanged.

Tests: one wire-shape fixture per adapter. The Anthropic one drives partial
text, the error frame, and a trailing `message_delta` to confirm nothing
resurrects a clean stop. The OpenAI one drives a truncated tool call and
checks the terminal flag that suppresses the synthetic `Stop`.

Closes #1083
