### PR TITLE
fix(desktop): keep optimistic chat state in sync

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -88,6 +88,7 @@ vi.mock("./host", () => ({
   hasNativeHost: () => false,
   hasMacOverlayTitlebar: () => false,
   requestUserAttention,
+  onPairingChanged: () => () => undefined,
 }));
 
 vi.mock("./updates", () => ({
@@ -98,9 +99,23 @@ vi.mock("./updates", () => ({
   }),
 }));
 
-vi.mock("./ChatView", () => ({
-  ChatView: () => <div data-testid="transcript">transcript</div>,
-}));
+vi.mock("./ChatView", async () => {
+  const { useChatSessionStore } = await import("./ChatSessionStore");
+  return {
+    ChatView: () => {
+      const messages = useChatSessionStore((session) => session.messages);
+      return (
+        <div data-testid="transcript">
+          {messages.flatMap((message) =>
+            "text" in message
+              ? [<span key={message.id}>{message.text}</span>]
+              : [],
+          )}
+        </div>
+      );
+    },
+  };
+});
 
 vi.mock("./outputs/OutputsView", () => ({
   OutputsView: () => <div data-testid="outputs">outputs</div>,
@@ -118,7 +133,10 @@ vi.mock("./settings/ProvidersPanel", () => ({
 }));
 
 vi.mock("./ChatApprovalHydration", () => ({
-  loadChatApprovalHydration: vi.fn(async () => null),
+  loadChatApprovalHydration: vi.fn(async () => ({
+    transcript: { messages: [], tool_activity: [], last_event_seq: 0 },
+    pendingApprovals: [],
+  })),
 }));
 
 // The resize library lays out from real element measurements, which jsdom does
@@ -244,6 +262,9 @@ describe("app shell", () => {
         [],
       ),
     );
+    expect(
+      await screen.findByText("summarise the filing"),
+    ).toBeInTheDocument();
   });
 
   it("opens a conversation from the sidebar", async () => {

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -120,13 +120,16 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   }, [chatsLoaded, chat, navigate]);
 
   // A conversation opened from the home composer arrives with its first message
-  // already written. `take` clears it, so a re-render cannot send it twice.
+  // already written. Wait for the empty chat's authoritative snapshot before
+  // appending it: hydration replaces the session transcript, so sending during
+  // the first mount pass would let the reset below erase the optimistic bubble.
+  // `take` clears it, so a re-render cannot send it twice.
   useEffect(() => {
-    if (!chat) return;
+    if (!chat || !hydrated) return;
     const pending = firstMessageActions.take(chatId);
     if (pending) void sendMessage(pending.text, pending.images, pending.files);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chat, chatId]);
+  }, [chat, chatId, hydrated]);
 
   useEffect(() => {
     let cancelled = false;

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -95,6 +95,39 @@ describe("turn_started", () => {
       startsDifferentTurn: false,
     });
   });
+
+  it("drops unadmitted parallel calls when an approved turn resumes", () => {
+    const { state } = play([
+      TURN,
+      {
+        type: "tool_call_started",
+        call_id: "call-approved",
+        name: "web_search",
+      },
+      {
+        type: "tool_call_started",
+        call_id: "call-unadmitted",
+        name: "web_search",
+      },
+      {
+        type: "approval_required",
+        auto_judging: false,
+        prefix_rungs: [],
+        call_id: "call-approved",
+        action: "search",
+        approval: "search_may_share_query_and_excerpts",
+        class: "sensitive",
+      },
+      TURN,
+    ]);
+
+    expect(
+      state.messages.flatMap((message) =>
+        message.role === "tool" ? [message.callId] : [],
+      ),
+    ).toEqual(["call-approved"]);
+    expect(state.provisionalToolCallIds.size).toBe(0);
+  });
 });
 
 describe("text_delta", () => {

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -90,6 +90,14 @@ export function reduceChatSessionEvent(
 
   switch (event.type) {
     case "turn_started": {
+      // A resumed attempt starts a new renderer candidate for the same turn.
+      // Calls admitted before an approval boundary have already left this set;
+      // any IDs still here were only streamed optimistically and will never
+      // receive completion events from the resumed attempt.
+      const messages = discardToolCalls(
+        state.messages,
+        state.provisionalToolCallIds,
+      );
       effects.push(
         { type: "invalidate_terminal_hydration" },
         {
@@ -109,7 +117,7 @@ export function reduceChatSessionEvent(
           markerScrubber: new AssistantSourceMarkerStreamScrubber(),
           provisionalToolCallIds: new Set(),
           messages: [
-            ...state.messages,
+            ...messages,
             {
               id: deps.nextId(),
               role: "assistant",

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -510,15 +510,16 @@ body {
 }
 
 .message-user-frame {
-  width: fit-content;
+  width: 100%;
   max-width: 100%;
   align-self: flex-start;
 }
 
 .message-user {
-  width: 100%;
+  width: fit-content;
+  max-width: 100%;
   border-radius: 12px;
-  padding: 0.6rem 0.85rem;
+  padding: 0.625rem 0.75rem;
   background: color-mix(in oklch, var(--muted) 60%, transparent);
   color: var(--ink);
 }


### PR DESCRIPTION
## Summary

- wait for initial transcript hydration before inserting and posting the first message from the home composer
- discard streamed-but-unadmitted tool calls when an approved turn resumes
- size user bubbles independently from their footer and match the established compact padding
- cover both state-reconciliation regressions in the reducer and shell tests

## Why

The chat route sent its first message before the mount hydration reset, which erased the optimistic user bubble until the conversation was reopened. Separately, an approval boundary in a parallel tool batch could abandon a later provisional call while leaving its running row visible forever. User bubble width also inherited the hidden timestamp footer footprint, creating extra empty space for short messages.

## Verification

- pnpm exec vitest run src/ChatSessionReducer.test.ts src/AppShell.dom.test.tsx
- pnpm exec tsc --noEmit
- pnpm build