### PR TITLE
fix(exec): stop workspace preparation following symlinks planted in scratch

### DIFF
--- a/crates/openwave-code-execution/src/host_paths.rs
+++ b/crates/openwave-code-execution/src/host_paths.rs
@@ -1,0 +1,110 @@
+//! Host-side path resolution that never traverses a planted symlink.
+//!
+//! Local exec runs inside a chat's private scratch directory and can create
+//! entries there, including a symlink aimed anywhere on the host. Everything
+//! the host itself does to that same directory — creating the conventional
+//! subdirectories, installing the bundled document helpers, mirroring a
+//! workspace back — runs unsandboxed, and `create_dir_all` and a plain `write`
+//! both follow a symlinked *parent*. So the host resolves one component at a
+//! time, refuses anything that is not already a real directory, and writes
+//! through a no-follow create rather than by path.
+
+use std::path::{Path, PathBuf};
+
+use tokio::io::AsyncWriteExt;
+
+/// Resolve `relative` as a directory under `root` without walking through a
+/// symlink at any component.
+///
+/// Each intermediate component must already be a real directory; a symlink or
+/// a regular file refuses. With `create`, a missing component is created one
+/// level at a time, so a component planted between two host runs is seen
+/// rather than followed. The canonical result must still sit inside the
+/// canonical `root`. `None` means the path did not resolve inside the scratch
+/// directory, or the directories could not be made.
+pub async fn resolve_scratch_directory(
+    root: &Path,
+    relative: &str,
+    create: bool,
+) -> Option<PathBuf> {
+    // macOS puts chat scratch under a symlinked `/var`, so containment is
+    // judged against the canonical root rather than the path as handed in.
+    let root = tokio::fs::canonicalize(root).await.ok()?;
+    let mut dir = root.clone();
+    for component in relative.split('/').filter(|part| !part.is_empty()) {
+        if component == "." || component == ".." {
+            return None;
+        }
+        dir.push(component);
+        match tokio::fs::symlink_metadata(&dir).await {
+            Ok(metadata) if metadata.is_dir() => {}
+            Ok(_) => return None,
+            Err(_) if create => tokio::fs::create_dir(&dir).await.ok()?,
+            Err(_) => return None,
+        }
+    }
+    let resolved = tokio::fs::canonicalize(&dir).await.ok()?;
+    if !resolved.starts_with(&root) {
+        return None;
+    }
+    Some(resolved)
+}
+
+/// Write `content` at `host_path` without following a symlink at the final
+/// component either: the bytes go to an unpredictable temp name opened with an
+/// exclusive no-follow create, then a rename puts them in place. This is the
+/// same shape the workspace-put path in `local.rs` uses.
+pub async fn write_without_following(host_path: &Path, content: &[u8]) -> std::io::Result<()> {
+    let parent = host_path
+        .parent()
+        .ok_or_else(|| std::io::Error::other("host path has no parent"))?;
+    let temporary = parent.join(format!(".openwave-write.{}", uuid::Uuid::new_v4()));
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        options.mode(0o600);
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut file = options.open(&temporary).await?;
+    let write = async {
+        file.write_all(content).await?;
+        file.sync_all().await?;
+        tokio::fs::rename(&temporary, host_path).await
+    };
+    match write.await {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let _ = tokio::fs::remove_file(&temporary).await;
+            Err(error)
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn a_symlinked_component_refuses_instead_of_being_followed() {
+        let outside = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(outside.path(), root.path().join("planted")).unwrap();
+
+        assert!(resolve_scratch_directory(root.path(), "planted", true)
+            .await
+            .is_none());
+        assert!(
+            resolve_scratch_directory(root.path(), "planted/deeper", true)
+                .await
+                .is_none()
+        );
+        assert!(!outside.path().join("deeper").exists());
+
+        let made = resolve_scratch_directory(root.path(), "real/nested", true)
+            .await
+            .unwrap();
+        assert!(made.is_dir());
+        assert!(made.starts_with(root.path().canonicalize().unwrap()));
+    }
+}

--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -13,6 +13,7 @@
 mod credential;
 mod daytona;
 mod e2b;
+pub mod host_paths;
 mod http;
 mod local;
 mod output;
@@ -25,6 +26,7 @@ mod types;
 
 pub use daytona::{DaytonaCredential, DaytonaExecutionProvider, DAYTONA_CREDENTIAL_KEY};
 pub use e2b::{E2BCredential, E2BExecutionProvider, E2B_CREDENTIAL_KEY};
+pub use host_paths::{resolve_scratch_directory, write_without_following};
 pub use local::LocalExecutionProvider;
 pub use preview::{scan_preview_directory, PreviewScan};
 pub use remote::RemoteSessionPool;

--- a/crates/openwave-code-execution/src/preview.rs
+++ b/crates/openwave-code-execution/src/preview.rs
@@ -33,6 +33,25 @@ struct Candidate {
 /// are named in a compact note so the model can repair the preview and rerun.
 pub fn scan_preview_directory(preview_dir: &Path) -> PreviewScan {
     let mut scan = PreviewScan::default();
+    // Skipping symlinked *entries* below is not enough on its own: the
+    // directory itself is opened by path, and local exec is confined to the
+    // scratch tree but can plant `<scratch>/preview -> ~/Pictures` there. The
+    // traversal has already happened by the time entries are filtered, so
+    // images from an arbitrary host directory would be attached to the chat.
+    match fs::symlink_metadata(preview_dir) {
+        Ok(metadata) if metadata.is_dir() => {}
+        Ok(_) => {
+            scan.notes
+                .push("preview images unavailable: preview/ is not a private workspace directory. Remove it and rerun.".into());
+            return scan;
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return scan,
+        Err(_) => {
+            scan.notes
+                .push("preview images unavailable: preview/ could not be read".into());
+            return scan;
+        }
+    }
     let entries = match fs::read_dir(preview_dir) {
         Ok(entries) => entries,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return scan,
@@ -197,6 +216,25 @@ mod tests {
         assert_eq!(scan.images[0].0.height, 1_000);
         assert!(scan.notes[0].contains("page-2.png"));
         assert!(scan.notes[0].contains("z.png"));
+    }
+
+    /// A preview directory replaced by a symlink would otherwise hand host
+    /// images from an arbitrary directory to the model: skipping symlinked
+    /// entries does not help once the traversal itself has happened.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_preview_directory_is_refused_rather_than_followed() {
+        let elsewhere = tempfile::tempdir().unwrap();
+        write_png(elsewhere.path(), "private.png", 16, 16);
+        let scratch = tempfile::tempdir().unwrap();
+        let preview = scratch.path().join("preview");
+        std::os::unix::fs::symlink(elsewhere.path(), &preview).unwrap();
+
+        let scan = scan_preview_directory(&preview);
+
+        assert!(scan.images.is_empty());
+        assert_eq!(scan.notes.len(), 1);
+        assert!(scan.notes[0].contains("not a private workspace directory"));
     }
 
     #[test]

--- a/crates/openwave-code-execution/src/sync.rs
+++ b/crates/openwave-code-execution/src/sync.rs
@@ -13,8 +13,7 @@
 
 use std::path::{Path, PathBuf};
 
-use tokio::io::AsyncWriteExt;
-
+use crate::host_paths::{resolve_scratch_directory, write_without_following};
 use crate::{
     CodeExecutionError, ExecutionWorkspaceId, WorkspaceFilePath, WorkspaceLifecycle,
     MAX_WORKSPACE_FILE_BYTES,
@@ -244,60 +243,15 @@ pub async fn pull_into_host_dir(
 /// Local exec is confined to this same scratch tree, so it can plant
 /// `<scratch>/out -> ~/.ssh` and wait for a pull: `create_dir_all` and a plain
 /// `write` both follow a symlinked *parent*, and the pull's host write is not
-/// sandboxed. So each intermediate component is checked before it is walked or
-/// created, and the canonical parent must still sit inside `host_root`.
-/// `None` means the path resolved outside the scratch directory, or the
-/// directories could not be made.
+/// sandboxed. `None` means the path resolved outside the scratch directory, or
+/// the directories could not be made.
 async fn host_file_path(host_root: &Path, path: &WorkspaceFilePath) -> Option<PathBuf> {
-    let mut dir = host_root.to_path_buf();
-    let mut components = path.as_str().split('/').peekable();
-    while let Some(component) = components.next() {
-        if components.peek().is_none() {
-            break;
-        }
-        dir.push(component);
-        match tokio::fs::symlink_metadata(&dir).await {
-            Ok(metadata) if metadata.is_dir() => {}
-            Ok(_) => return None,
-            Err(_) => tokio::fs::create_dir(&dir).await.ok()?,
-        }
-    }
-    let parent = tokio::fs::canonicalize(&dir).await.ok()?;
-    if !parent.starts_with(host_root) {
-        return None;
-    }
-    Some(parent.join(path.file_name()))
-}
-
-/// Write `content` at `host_path` without following a symlink at the final
-/// component either: the bytes go to an unpredictable temp name opened with an
-/// exclusive no-follow create, then a rename puts them in place. This is the
-/// same shape the workspace-put path in `local.rs` uses.
-async fn write_without_following(host_path: &Path, content: &[u8]) -> std::io::Result<()> {
-    let parent = host_path
-        .parent()
-        .ok_or_else(|| std::io::Error::other("host path has no parent"))?;
-    let temporary = parent.join(format!(".workspace-pull.{}", uuid::Uuid::new_v4()));
-    let mut options = tokio::fs::OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        options.mode(0o600);
-        options.custom_flags(libc::O_NOFOLLOW);
-    }
-    let mut file = options.open(&temporary).await?;
-    let write = async {
-        file.write_all(content).await?;
-        file.sync_all().await?;
-        tokio::fs::rename(&temporary, host_path).await
-    };
-    match write.await {
-        Ok(()) => Ok(()),
-        Err(error) => {
-            let _ = tokio::fs::remove_file(&temporary).await;
-            Err(error)
-        }
-    }
+    let parent = path
+        .as_str()
+        .rsplit_once('/')
+        .map_or("", |(parent, _)| parent);
+    let dir = resolve_scratch_directory(host_root, parent, true).await?;
+    Some(dir.join(path.file_name()))
 }
 
 fn unreadable(path: &str) -> CodeExecutionError {

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -13,12 +13,12 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use openwave_code_execution::{
-    sync, CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind,
-    CodeExecutionRequest, CodeExecutionResponse, DaytonaCredential, DaytonaExecutionProvider,
-    E2BCredential, E2BExecutionProvider, ExecFolderAccess, ExecFolderGrant, ExecutionWorkspaceId,
-    LocalExecutionProvider, PreviewScan, RemoteSessionPool, WorkspaceFilePath, WorkspaceLifecycle,
-    WorkspaceListing, DAYTONA_CREDENTIAL_KEY, DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES,
-    E2B_CREDENTIAL_KEY,
+    resolve_scratch_directory, sync, write_without_following, CodeExecutionError,
+    CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest, CodeExecutionResponse,
+    DaytonaCredential, DaytonaExecutionProvider, E2BCredential, E2BExecutionProvider,
+    ExecFolderAccess, ExecFolderGrant, ExecutionWorkspaceId, LocalExecutionProvider, PreviewScan,
+    RemoteSessionPool, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing,
+    DAYTONA_CREDENTIAL_KEY, DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES, E2B_CREDENTIAL_KEY,
 };
 use openwave_core::{
     exec_attachment_file_name, BlobStore, Chat, ChatId, HostRootId, MessageDocumentAttachment,
@@ -985,24 +985,31 @@ async fn prepare_execution_directories(
     mirrored: bool,
     document_scripts_source: Option<&std::path::Path>,
 ) -> std::result::Result<(), CodeExecutionError> {
+    // The scratch directory itself is host-owned and named after the chat, but
+    // everything inside it is writable by local exec, which can plant
+    // `<scratch>/output -> /any/dir` between two runs. `create_dir_all` and a
+    // plain `write` both follow a symlinked parent, so each conventional
+    // directory is resolved a component at a time and the marker is written
+    // without following a link at the final component either.
+    tokio::fs::create_dir_all(host_dir).await.map_err(|_| {
+        CodeExecutionError::Sandbox("the private workspace directory is unavailable".into())
+    })?;
     for name in ["output", "preview", "documents"] {
-        let directory = host_dir.join(name);
-        tokio::fs::create_dir_all(&directory).await.map_err(|_| {
+        let unavailable = || {
             CodeExecutionError::Sandbox(format!(
                 "private workspace directory '{name}/' is unavailable"
             ))
-        })?;
+        };
+        let directory = resolve_scratch_directory(host_dir, name, true)
+            .await
+            .ok_or_else(unavailable)?;
         if mirrored {
             // The sync protocol mirrors files rather than empty directories.
             // A hidden zero-byte marker makes the conventional directories
             // exist in managed workspaces without becoming a user artifact.
-            tokio::fs::write(directory.join(".openwave-directory"), [])
+            write_without_following(&directory.join(".openwave-directory"), &[])
                 .await
-                .map_err(|_| {
-                    CodeExecutionError::Sandbox(format!(
-                        "private workspace directory '{name}/' is unavailable"
-                    ))
-                })?;
+                .map_err(|_| unavailable())?;
         }
     }
     if let Some(source) = document_scripts_source {
@@ -1015,10 +1022,14 @@ async fn install_document_scripts(
     source: &std::path::Path,
     host_dir: &std::path::Path,
 ) -> std::result::Result<(), CodeExecutionError> {
-    let destination = host_dir.join(DOCUMENT_SCRIPTS_DIR);
-    tokio::fs::create_dir_all(&destination).await.map_err(|_| {
-        CodeExecutionError::Sandbox("document helper directory is unavailable".into())
-    })?;
+    // `.openwave/` sits inside the scratch directory local exec writes to, so
+    // a planted `.openwave -> /elsewhere` would relocate the helper install
+    // and truncate known filenames there. Resolve it a component at a time.
+    let destination = resolve_scratch_directory(host_dir, DOCUMENT_SCRIPTS_DIR, true)
+        .await
+        .ok_or_else(|| {
+            CodeExecutionError::Sandbox("document helper directory is unavailable".into())
+        })?;
     for name in DOCUMENT_SCRIPT_FILES {
         let source_file = source.join(name);
         let metadata = tokio::fs::symlink_metadata(&source_file)
@@ -1043,7 +1054,7 @@ async fn install_document_scripts(
                 "bundled document helper '{name}' exceeds the workspace file limit"
             )));
         }
-        tokio::fs::write(destination.join(name), content)
+        write_without_following(&destination.join(name), &content)
             .await
             .map_err(|_| {
                 CodeExecutionError::Sandbox(format!(
@@ -1384,6 +1395,37 @@ mod tests {
                 format!("helper:{name}")
             );
         }
+    }
+
+    /// Local exec is confined to the scratch directory but can create entries
+    /// in it, including a symlink aimed at the host. Both preparation writes
+    /// run on that directory before the next command, unsandboxed.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn preparation_does_not_write_through_a_planted_symlink() {
+        let outside = tempfile::tempdir().unwrap();
+        let source = tempfile::tempdir().unwrap();
+        for name in DOCUMENT_SCRIPT_FILES {
+            std::fs::write(source.path().join(name), format!("helper:{name}")).unwrap();
+        }
+        let workspace = tempfile::tempdir().unwrap();
+
+        std::os::unix::fs::symlink(outside.path(), workspace.path().join("output")).unwrap();
+        assert!(
+            prepare_execution_directories(workspace.path(), true, Some(source.path()))
+                .await
+                .is_err()
+        );
+        assert!(!outside.path().join(".openwave-directory").exists());
+
+        std::fs::remove_file(workspace.path().join("output")).unwrap();
+        std::os::unix::fs::symlink(outside.path(), workspace.path().join(".openwave")).unwrap();
+        assert!(
+            prepare_execution_directories(workspace.path(), true, Some(source.path()))
+                .await
+                .is_err()
+        );
+        assert!(!outside.path().join("exec-scripts").exists());
     }
 
     #[test]


### PR DESCRIPTION
Local exec is confined to a chat's private scratch directory, but it can create
entries there, including symlinks. The host then touches that same directory
before the next command runs, unsandboxed, and `create_dir_all` and a plain
`write` both follow a symlinked parent. That is the defect #1116 fixed on the
pull path; three sibling paths still had it, and unlike #1116 they run for every
provider kind, so local exec alone reaches them.

The worst one is a read. `scan_preview_directory` skips symlinked *entries* —
`DirEntry::metadata` does not traverse — but the directory itself is opened by
path. A planted `<scratch>/preview -> ~/Pictures` meant up to three images from
an arbitrary host directory were read, resized, and attached to the chat as
model input. The scan now refuses a `preview/` that is not a real directory and
returns a note rather than an error, so a broken preview still does not turn a
successful command into a failed one.

The other two are writes. `prepare_execution_directories` created
`output/`, `preview/`, and `documents/` and dropped a zero-byte
`.openwave-directory` marker in each; `install_document_scripts` created
`.openwave/exec-scripts` and wrote the five bundled helpers into it. A symlink
at either first component relocated the whole operation, creating directories
and truncating known filenames outside the scratch tree.

The component-by-component resolution and no-follow write that #1116 introduced
in `sync.rs` move into a `host_paths` module and all three callers share them:
each component must already be a real directory, a missing one is created a
level at a time so a planted entry is seen rather than followed, and the
canonical result must still sit inside the canonical scratch root. Writes go to
an unpredictable temp name opened with `O_NOFOLLOW | O_EXCL` and are renamed
into place, which also refuses a symlink at the final component.

Two tests, both reproductions: the preview scan against a symlinked `preview/`,
and workspace preparation against a planted `output` and then a planted
`.openwave`. Each was confirmed to fail against the unfixed code.

Descriptor pinning to close the remaining lstat-then-open window is #1127 and is
deliberately not attempted here. `resolve_file` in `local.rs` has the same
create-before-check ordering — it creates directories outside the root before the
containment check refuses the write — and is untouched; it is noted on the issue.

Closes #1126
