### PR TITLE
feat(server): sync gateway models at boot and on an interval

### DIFF
--- a/crates/openwave-server/src/error.rs
+++ b/crates/openwave-server/src/error.rs
@@ -73,6 +73,11 @@ impl ServerError {
         &self.info.kind
     }
 
+    /// The human-readable message, for surfaces that log rather than respond.
+    pub(crate) fn message(&self) -> &str {
+        &self.info.message
+    }
+
     /// A `409 Conflict` for a request that clashes with current state (e.g. a
     /// turn is already running for the chat).
     pub fn conflict(message: impl Into<String>) -> Self {

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -26,6 +26,18 @@ use crate::providers::{self, CustomModelConfig};
 /// How long a browser sign-in may stay pending before it fails.
 const SIGN_IN_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// How often the background loop refreshes the entitled-model snapshot while
+/// a session is connected. Entitlement changes are admin-driven and rare, and
+/// the gateway stays the live authority at inference time, so the snapshot
+/// only has to keep the picker and model policy from drifting for long; the
+/// settings page keeps the immediate manual refresh.
+const MODEL_SYNC_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
+/// Retry cadence after a failed background sync — short enough that a boot
+/// racing the network coming up doesn't stay stale for a whole interval,
+/// long enough not to hammer an unreachable gateway.
+const MODEL_SYNC_RETRY: Duration = Duration::from_secs(5 * 60);
+
 pub(crate) struct GatewayRuntime {
     store: Arc<dyn Store>,
     secrets: Arc<dyn SecretProvider>,
@@ -517,6 +529,60 @@ impl GatewayRuntime {
         .await?;
         Ok(count)
     }
+
+    /// Keep the entitled-model snapshot fresh without a manual refresh: sync
+    /// once immediately (the boot case) and then on a long interval, for as
+    /// long as the process runs. Every state where a sync cannot run —
+    /// unmanaged profile, misconfigured policy, no session for the policy's
+    /// deployment — is "nothing to do", not an error: the loop waits for the
+    /// state to change rather than exiting, because sign-in, pairing, and MDM
+    /// pushes can all happen at any time.
+    pub(crate) async fn sync_models_periodically(self: Arc<Self>) {
+        // One warning per outage, not one per retry: the failure state can
+        // legitimately persist for hours on an offline laptop.
+        let mut warned = false;
+        loop {
+            let delay = match self.sync_models_if_connected().await {
+                Ok(synced) => {
+                    if let Some(count) = synced {
+                        tracing::debug!("background gateway model sync: {count} models entitled");
+                    }
+                    warned = false;
+                    MODEL_SYNC_INTERVAL
+                }
+                Err(error) => {
+                    let message = error.message();
+                    if warned {
+                        tracing::debug!("background gateway model sync still failing: {message}");
+                    } else {
+                        tracing::warn!(
+                            "background gateway model sync failed (will retry): {message}"
+                        );
+                        warned = true;
+                    }
+                    MODEL_SYNC_RETRY
+                }
+            };
+            tokio::time::sleep(delay).await;
+        }
+    }
+
+    /// One background sync attempt: `Ok(None)` when there is nothing to sync,
+    /// `Ok(Some(count))` after a successful sync. The connected check mirrors
+    /// [`status`](Self::status): a stored session counts only when it belongs
+    /// to the policy's deployment.
+    async fn sync_models_if_connected(
+        &self,
+    ) -> std::result::Result<Option<usize>, crate::error::ServerError> {
+        let policy = self.policy().await?;
+        let Some(connection) = self.connection_for(&policy).await? else {
+            return Ok(None);
+        };
+        if connection.stored_credentials().await?.is_none() {
+            return Ok(None);
+        }
+        Ok(Some(self.sync_models().await?))
+    }
 }
 
 #[async_trait]
@@ -888,6 +954,31 @@ mod tests {
             crate::providers::ProviderKind::ModelGateway
         );
         assert_eq!(policy.display_name, "Sample Claude");
+    }
+
+    /// The background loop's first attempt is immediate — the boot case it
+    /// exists for: a signed-in profile gets a fresh snapshot without anyone
+    /// pressing Refresh.
+    #[tokio::test]
+    async fn the_background_sync_populates_the_snapshot_without_a_manual_refresh() {
+        let address = serve(Arc::new(FakeGateway::default())).await;
+        let base = format!("http://{address}");
+        let (runtime, store, _directory) = signed_in_runtime(&base).await;
+
+        let task = tokio::spawn(runtime.clone().sync_models_periodically());
+        let synced = async {
+            loop {
+                if let Some(snapshot) = providers::read_gateway_snapshot(&*store).await.unwrap() {
+                    break snapshot;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        };
+        let snapshot = tokio::time::timeout(Duration::from_secs(5), synced)
+            .await
+            .expect("the boot-time sync lands without a manual refresh");
+        task.abort();
+        assert_eq!(snapshot.models.len(), 2);
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -27,16 +27,15 @@ use crate::providers::{self, CustomModelConfig};
 const SIGN_IN_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// How often the background loop refreshes the entitled-model snapshot while
-/// a session is connected. Entitlement changes are admin-driven and rare, and
-/// the gateway stays the live authority at inference time, so the snapshot
-/// only has to keep the picker and model policy from drifting for long; the
-/// settings page keeps the immediate manual refresh.
-const MODEL_SYNC_INTERVAL: Duration = Duration::from_secs(60 * 60);
+/// a session is connected. A sync is one small GET against the org's own
+/// gateway, so a tight cadence is cheap — this is what bounds how quickly an
+/// admin's entitlement change reaches the picker without a manual refresh.
+const MODEL_SYNC_INTERVAL: Duration = Duration::from_secs(5 * 60);
 
 /// Retry cadence after a failed background sync — short enough that a boot
 /// racing the network coming up doesn't stay stale for a whole interval,
 /// long enough not to hammer an unreachable gateway.
-const MODEL_SYNC_RETRY: Duration = Duration::from_secs(5 * 60);
+const MODEL_SYNC_RETRY: Duration = Duration::from_secs(60);
 
 pub(crate) struct GatewayRuntime {
     store: Arc<dyn Store>,

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -473,6 +473,7 @@ pub struct Server {
     _blob_orphan_auditor: AbortTask,
     _approval_judge_worker: AbortTask,
     _mcp_supervisor: AbortTask,
+    _gateway_model_sync: AbortTask,
     _instance_lock: InstanceLock,
 }
 
@@ -835,6 +836,7 @@ async fn bind_inner(
     let blob_orphan_auditor = tokio::spawn(blob_orphan_auditor.run());
     let approval_judge_worker = tokio::spawn(approval_judge_worker.run());
     let mcp_supervisor = tokio::spawn(mcp_runtime.clone().supervise());
+    let gateway_model_sync = tokio::spawn(gateway_runtime.clone().sync_models_periodically());
 
     Ok(Server {
         local_addr,
@@ -852,6 +854,7 @@ async fn bind_inner(
         _blob_orphan_auditor: AbortTask(blob_orphan_auditor),
         _approval_judge_worker: AbortTask(approval_judge_worker),
         _mcp_supervisor: AbortTask(mcp_supervisor),
+        _gateway_model_sync: AbortTask(gateway_model_sync),
         _instance_lock: instance_lock,
     })
 }


### PR DESCRIPTION
Closes #1130

## What

On a managed profile, the entitled-model snapshot was refreshed in exactly two places: once after a successful sign-in, and manually via `POST /gateway/models/sync` — the **Refresh models** button in the Model Gateway settings panel. Nothing synced at boot and nothing polled, so a newly entitled model stayed invisible until each user opened Settings and clicked Refresh.

`GatewayRuntime` now owns `sync_models_periodically`, spawned from the product boot path alongside the other workers (and aborted with them on server drop):

- **one immediate sync at boot**, then **every 5 minutes** — a sync is one small GET against the org's own gateway, so a tight cadence is cheap and bounds how quickly an admin's entitlement change reaches the picker; the gateway stays the live authority at inference time (a revoked model is refused regardless of the snapshot), and the manual button remains for immediacy;
- **1-minute retry after a failure**, so a launch that races the network coming up doesn't stay stale for a whole interval;
- every not-connected state (unmanaged profile, signed out, misconfigured policy, session for a different deployment) is "nothing to do", not an error — the loop waits for the state to change rather than exiting, since sign-in, pairing, and MDM pushes can all happen at any time. The connected check mirrors `status()`: a stored session counts only when it belongs to the policy's deployment.
- Failures warn once per outage and then drop to debug: an offline laptop is a legitimate hours-long state, not a warning storm.

`ServerError` grows a `pub(crate) message()` accessor so the loop can log the human-readable message instead of a `Debug` dump (the same dump #624 flags on the settings surface).

## Tests

One behavior test: a signed-in runtime's spawned loop populates the snapshot with no manual refresh (the immediate first tick is the boot case the loop exists for). The existing sync/status/sign-out tests already cover the sync path itself; the not-connected guard is the same policy/credential logic `status()` pins.

## Out of scope (noted in #1130)

The renderer fetches the catalog at app boot and on explicit settings changes, so a snapshot refreshed mid-session isn't visible in the picker until the next catalog fetch. Server-side freshness (model policy, next boot, next settings visit) still improves; pushing a catalog-changed signal to the renderer is a separate slice.

## Verification

- `cargo test -p openwave-server --locked gateway_runtime` — 17 passed
- `cargo clippy -p openwave-server --all-targets --locked` — clean
- `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
