### PR TITLE
feat(desktop): persist composer drafts per chat

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.tsx
@@ -16,6 +16,7 @@ import {
   prependReplacementChat,
 } from "./ChatDeletion";
 import { useChatListStore } from "./ChatListStore";
+import { useComposerDrafts } from "./ComposerDrafts";
 import { useConfirm } from "./components/ConfirmDialog";
 import { hasMacOverlayTitlebar } from "./host";
 import { useInterfaceZoom } from "./InterfaceZoom";
@@ -212,6 +213,8 @@ export function AppShell() {
     try {
       await detachChatFolders(current);
       await client.deleteChat(target.id);
+      // Nothing left to send it to.
+      useComposerDrafts.getState().clearDraft(target.id);
       let refreshed = await client.listChats();
       if (!deletingOpenChat) {
         chatListActions.setChats(refreshed);

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -14,6 +14,7 @@ import { ChatHeaderTitle } from "./ChatHeaderTitle";
 import { reconcilePendingApprovalCards } from "./ApprovalHistory";
 import { loadChatApprovalHydration } from "./ChatApprovalHydration";
 import { useChatListStore } from "./ChatListStore";
+import { useComposerDraft, useComposerDrafts } from "./ComposerDrafts";
 import { ChatSessionController } from "./ChatSessionController";
 import {
   applyTerminalHydration,
@@ -75,6 +76,7 @@ const sessionDeps = {
 };
 
 const chatListActions = useChatListStore.getState();
+const composerDraftActions = useComposerDrafts.getState();
 const firstMessageActions = useFirstMessage.getState();
 const { signal: signalRefresh } = useRefreshSignals.getState();
 const { signal: signalTurnLifecycle } = useTurnLifecycle.getState();
@@ -97,14 +99,16 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   const deletingChatId = useChatListStore((state) => state.deletingChatId);
   const busy = useChatSessionStore((session) => session.busy);
   const [hydrated, setHydrated] = useState(false);
-  const [draft, setDraft] = useState("");
+  const draft = useComposerDraft(chatId);
   const [attaching, setAttaching] = useState(false);
   const [files, setFiles] = useState<ImportedDocument[]>([]);
   const [attachError, setAttachError] = useState<string | null>(null);
   const images = useImageAttachments(client, chatId);
   const handleEventRef = useRef<(event: SequencedEvent) => void>(() => {});
   const terminalHydrationGenerationRef = useRef(0);
-  const draftRef = useRef("");
+  // Steering reads the draft synchronously, from outside a render.
+  const draftRef = useRef(draft);
+  draftRef.current = draft;
 
   const chat = chats.find((candidate) => candidate.id === chatId) ?? null;
   const nativeHost = hasNativeHost();
@@ -252,7 +256,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
 
   function setComposerDraft(next: string) {
     draftRef.current = next;
-    setDraft(next);
+    composerDraftActions.setDraft(chatId, next);
   }
 
   async function onSend() {
@@ -275,6 +279,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     const documentIds = fileItems.map((file) => file.documentId);
     const turnId = crypto.randomUUID();
     terminalHydrationGenerationRef.current += 1;
+    const optimisticId = nextId();
     setComposerDraft("");
     updateSession((session) => ({
       ...session,
@@ -283,7 +288,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
       messages: [
         ...session.messages,
         {
-          id: nextId(),
+          id: optimisticId,
           role: "user",
           text: content,
           images: transcriptImages,
@@ -311,12 +316,20 @@ export function ChatRoute({ chatId }: { chatId: string }) {
       images.clear();
       setFiles([]);
     } catch (err) {
+      // Nothing was accepted, so the message has to go back to where it can be
+      // fixed and sent again: the text returns to the composer and the
+      // optimistic bubble — which no turn will ever answer — comes out of the
+      // transcript. Attachments are already left in place for the same reason.
       updateSession((session) => ({
         ...session,
         busy: false,
         activeTurnId: null,
-        messages: [...session.messages, { id: nextId(), role: "error", text: String(err) }],
+        messages: [
+          ...session.messages.filter((message) => message.id !== optimisticId),
+          { id: nextId(), role: "error", text: String(err) },
+        ],
       }));
+      if (!draftRef.current) setComposerDraft(content);
       signalTurnLifecycle("resolved");
     }
   }

--- a/crates/openwave-desktop/ui/src/ComposerDrafts.ts
+++ b/crates/openwave-desktop/ui/src/ComposerDrafts.ts
@@ -1,0 +1,80 @@
+import { create } from "zustand";
+
+const KEY_PREFIX = "composer_";
+
+/** The home composer's draft, written before a chat exists to hold it. */
+export const HOME_DRAFT_KEY = "home";
+
+function storageKeyFor(key: string): string {
+  return `${KEY_PREFIX}${key}`;
+}
+
+function readStoredDrafts(): Record<string, string> {
+  const drafts: Record<string, string> = {};
+  try {
+    const storage = window.sessionStorage;
+    for (let index = 0; index < storage.length; index += 1) {
+      const name = storage.key(index);
+      if (!name?.startsWith(KEY_PREFIX)) continue;
+      const text = storage.getItem(name);
+      if (text) drafts[name.slice(KEY_PREFIX.length)] = text;
+    }
+  } catch {
+    // A composer with no memory still works; an unreadable store is not fatal.
+  }
+  return drafts;
+}
+
+function writeStoredDraft(key: string, text: string): void {
+  try {
+    if (text) window.sessionStorage.setItem(storageKeyFor(key), text);
+    else window.sessionStorage.removeItem(storageKeyFor(key));
+  } catch {
+    // Persisting a draft is best-effort; the session still holds it.
+  }
+}
+
+/**
+ * What is typed but not yet sent, kept per composer.
+ *
+ * The chat route is remounted per conversation, so a draft held in the route
+ * dies the moment you look at another chat — which is exactly when people
+ * switch away to check something they were about to reference. The draft
+ * belongs to the conversation, not to the mounted route, so it lives here.
+ *
+ * Session storage rather than local: an unsent message should survive
+ * navigation and a reload, but a draft still sitting there weeks later is
+ * clutter, not a courtesy. Keys are the chat id, or [HOME_DRAFT_KEY] for the
+ * composer that has no chat yet.
+ */
+export type ComposerDraftStore = {
+  drafts: Record<string, string>;
+  setDraft: (key: string, text: string) => void;
+  clearDraft: (key: string) => void;
+};
+
+export function createComposerDraftStore() {
+  return create<ComposerDraftStore>()((set) => ({
+    drafts: readStoredDrafts(),
+    setDraft: (key, text) => {
+      writeStoredDraft(key, text);
+      set((state) => ({ drafts: { ...state.drafts, [key]: text } }));
+    },
+    clearDraft: (key) => {
+      writeStoredDraft(key, "");
+      set((state) => {
+        if (!(key in state.drafts)) return state;
+        const drafts = { ...state.drafts };
+        delete drafts[key];
+        return { drafts };
+      });
+    },
+  }));
+}
+
+export const useComposerDrafts = createComposerDraftStore();
+
+/** This composer's unsent text, restored from a previous visit if there is one. */
+export function useComposerDraft(key: string): string {
+  return useComposerDrafts((state) => state.drafts[key] ?? "");
+}

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -7,6 +7,11 @@ import { ChatExplorer } from "./ChatExplorer";
 import { useChatListStore } from "./ChatListStore";
 import { Composer, type ComposerImages } from "./Composer";
 import {
+  HOME_DRAFT_KEY,
+  useComposerDraft,
+  useComposerDrafts,
+} from "./ComposerDrafts";
+import {
   type ImportedDocument,
   type LibraryImportSuccess,
 } from "./documents";
@@ -28,6 +33,7 @@ import type { AttachedFiles } from "./attachments";
 import { MAX_IMAGE_ATTACHMENTS } from "./ImageAttachments";
 
 const chatListActions = useChatListStore.getState();
+const composerDraftActions = useComposerDrafts.getState();
 const firstMessageActions = useFirstMessage.getState();
 
 function isImportedDocument(
@@ -41,7 +47,9 @@ export function HomeRoute() {
   const { client, models, defaultModelKey } = useApp();
   const chatsLoaded = useChatListStore((state) => state.chatsLoaded);
   const creatingChat = useChatListStore((state) => state.creatingChat);
-  const [draft, setDraft] = useState("");
+  const draft = useComposerDraft(HOME_DRAFT_KEY);
+  const setDraft = (text: string) =>
+    composerDraftActions.setDraft(HOME_DRAFT_KEY, text);
   const [error, setError] = useState<string | null>(null);
   const newChat = useNewChatSettings();
   const efforts = modelForSelection(models, newChat.model)?.reasoning_efforts ?? [];


### PR DESCRIPTION
The composer draft was `useState` in the route. The chat route remounts per
conversation, so glancing at another chat discarded whatever had been typed —
which is exactly when people switch away, to go look at the thing they were
about to reference.

Drafts now live in a small zustand store keyed by chat id and backed by session
storage, alongside the other persisted composer state. Session storage rather
than local: an unsent message should survive navigation and a reload, but a
draft still sitting there weeks later is clutter. The home composer keeps its
own draft under the same key space.

The send path also lost text on failure. It cleared the draft before posting,
and the catch never put it back, so a refused send left the message only in an
optimistic bubble that nothing could resend. Now a failure restores the text to
the composer and removes that bubble from the transcript — no turn will ever
answer it — while attachments stay put, as they already did. Text typed while
the send was in flight wins over the restore. Deleting a chat drops its draft.

No tests: the behavior lives in `ChatRoute`, which has no test harness today,
and standing one up would be more scaffolding than assertion.

Closes #1106
