### PR TITLE
fix(server): back off exponentially and honor Retry-After

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3982,6 +3982,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.23.0",
+ "chrono",
  "futures",
  "openwave-core",
  "reqwest 0.12.28",

--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -504,6 +504,11 @@ pub enum AgentTurnOutcome {
     Failed {
         /// Stable terminal error payload for the durable failure event.
         error: crate::AgentErrorInfo,
+        /// The wait the provider asked for, when the failure carried a
+        /// `Retry-After`. The worker's retry schedule prefers it over its own
+        /// backoff; it is deliberately not part of the durable error payload,
+        /// which is a client-facing projection.
+        retry_after: Option<std::time::Duration>,
         /// Aggregate provider usage consumed before the failure.
         usage: Usage,
         /// Model-call steps consumed before the failure.
@@ -1056,6 +1061,7 @@ impl Agent {
                 } else if progress.model_steps > 0 {
                     return Ok(AgentTurnOutcome::Failed {
                         error: (&err).into(),
+                        retry_after: err.retry_after(),
                         usage: progress.usage,
                         model_steps: progress.model_steps,
                     });
@@ -1715,6 +1721,7 @@ impl Agent {
                 kind: "max_steps_exceeded".into(),
                 message: "max steps per turn exceeded".into(),
             },
+            retry_after: None,
             usage: total_usage,
             model_steps: self.config.max_steps,
         })
@@ -5673,6 +5680,7 @@ mod tests {
                     ..
                 },
                 model_steps: 1,
+                ..
             } if error.kind == "message" && error.message == "max steps per turn exceeded"
         ));
         let calls = store.list_tool_calls(chat.id).await.unwrap();

--- a/crates/openwave-core/src/error.rs
+++ b/crates/openwave-core/src/error.rs
@@ -5,6 +5,9 @@
 //! `#[non_exhaustive]` so growing it is never a breaking change for downstream
 //! matches.
 
+use std::fmt;
+use std::time::Duration;
+
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -12,6 +15,47 @@ use crate::ProjectId;
 
 /// Shorthand for results across the core crate.
 pub type Result<T, E = AgentError> = std::result::Result<T, E>;
+
+/// A client-safe provider failure plus the wait the provider asked for.
+///
+/// `retry_after` carries the response's `Retry-After` value when one was
+/// present. It is a hint from the provider about when the condition clears —
+/// the retry scheduler prefers it over its own blind backoff, because guessing
+/// shorter turns a rate limit into a wasted attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderFailure {
+    message: String,
+    retry_after: Option<Duration>,
+}
+
+impl ProviderFailure {
+    /// Build a failure carrying the provider's own retry hint.
+    #[must_use]
+    pub fn new(message: impl Into<String>, retry_after: Option<Duration>) -> Self {
+        Self {
+            message: message.into(),
+            retry_after,
+        }
+    }
+
+    /// The wait the provider asked for, when the response carried one.
+    #[must_use]
+    pub const fn retry_after(&self) -> Option<Duration> {
+        self.retry_after
+    }
+}
+
+impl fmt::Display for ProviderFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl<T: Into<String>> From<T> for ProviderFailure {
+    fn from(message: T) -> Self {
+        Self::new(message, None)
+    }
+}
 
 /// Anything that can go wrong inside the core.
 #[derive(Debug, Error)]
@@ -43,11 +87,11 @@ pub enum AgentError {
 
     /// The provider is rate limiting requests.
     #[error("provider rate limited the request: {0}")]
-    RateLimited(String),
+    RateLimited(ProviderFailure),
 
     /// The provider is temporarily overloaded or unavailable.
     #[error("provider overloaded: {0}")]
-    Overloaded(String),
+    Overloaded(ProviderFailure),
 
     /// The provider rejected a request that is invalid for the selected model.
     #[error("invalid provider request: {0}")]
@@ -101,6 +145,18 @@ impl AgentError {
             Self::PromptTooLong(_) => "prompt_too_long",
             Self::Message(_) => "message",
             Self::Serde(_) => "serde",
+        }
+    }
+
+    /// The wait the provider asked for, when this failure carried one.
+    ///
+    /// Only the throttling variants can carry a hint; every other failure
+    /// leaves the schedule to the caller's own backoff.
+    #[must_use]
+    pub const fn retry_after(&self) -> Option<Duration> {
+        match self {
+            Self::RateLimited(failure) | Self::Overloaded(failure) => failure.retry_after(),
+            _ => None,
         }
     }
 

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -121,7 +121,7 @@ pub use deliverable_acceptance::{
     accept_workspace_artifact, merge_agent_run_result, AgentResultOutputMerge,
     WorkspaceArtifactProposal,
 };
-pub use error::{AgentError, AgentErrorInfo, Result};
+pub use error::{AgentError, AgentErrorInfo, ProviderFailure, Result};
 pub use event::{AgentEvent, SequencedEvent};
 pub use id::{
     AgentRunId, AssistantCitationId, CallId, ChatId, ChunkId, DocumentId, HostRootId,

--- a/crates/openwave-router/Cargo.toml
+++ b/crates/openwave-router/Cargo.toml
@@ -23,6 +23,8 @@ gemini = ["dep:reqwest", "dep:async-stream", "dep:ring", "dep:uuid"]
 openwave-core = { path = "../openwave-core", default-features = false }
 async-trait = { workspace = true }
 base64 = { workspace = true }
+# `Retry-After` in its HTTP-date form is resolved against the current clock.
+chrono = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -121,8 +121,14 @@ impl ModelProvider for AnthropicProvider {
         // stable error type/code when present) is enough for classification.
         let status = response.status();
         if !status.is_success() {
+            let retry_after = crate::sse::retry_after_hint(response.headers());
             let body = read_bounded_error_body(response.bytes_stream()).await;
-            return Err(classify_provider_error("anthropic", status.as_u16(), &body));
+            return Err(classify_provider_error(
+                "anthropic",
+                status.as_u16(),
+                &body,
+                retry_after,
+            ));
         }
 
         let stream = async_stream::stream! {

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -195,8 +195,9 @@ impl ModelProvider for GeminiProvider {
 
         let status = response.status();
         if !status.is_success() {
+            let retry_after = crate::sse::retry_after_hint(response.headers());
             let body = read_bounded_error_body(response.bytes_stream()).await;
-            return Err(classify_gemini_error(status.as_u16(), &body));
+            return Err(classify_gemini_error(status.as_u16(), &body, retry_after));
         }
 
         let stream = async_stream::stream! {
@@ -834,7 +835,11 @@ fn refusal_details(reason: &str) -> RefusalDetails {
     RefusalDetails::from_category(Some(&category))
 }
 
-fn classify_gemini_error(status: u16, body: &str) -> AgentError {
+fn classify_gemini_error(
+    status: u16,
+    body: &str,
+    retry_after: Option<std::time::Duration>,
+) -> AgentError {
     let prompt_too_long = serde_json::from_str::<Value>(body)
         .ok()
         .and_then(|value| value.get("error").cloned().or(Some(value)))
@@ -853,7 +858,7 @@ fn classify_gemini_error(status: u16, body: &str) -> AgentError {
     if prompt_too_long {
         return AgentError::PromptTooLong(crate::sse::safe_http_error("gemini", status, body));
     }
-    classify_provider_error("gemini", status, body)
+    classify_provider_error("gemini", status, body, retry_after)
 }
 
 #[cfg(test)]

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -110,11 +110,13 @@ impl ModelProvider for OpenAiCompatProvider {
         if !status.is_success() {
             // Never forward the raw body — gateways sometimes echo key material
             // or request fragments, and `AgentError` strings reach the client.
+            let retry_after = crate::sse::retry_after_hint(response.headers());
             let body = read_bounded_error_body(response.bytes_stream()).await;
             return Err(classify_provider_error(
                 "openai-compat",
                 status.as_u16(),
                 &body,
+                retry_after,
             ));
         }
 

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -5,6 +5,8 @@
 //! extract the `data:` JSON payload — the same shape Anthropic and OpenAI-compat
 //! both speak.
 
+use std::time::Duration;
+
 use futures::{Stream, StreamExt};
 
 /// Maximum provider error bytes inspected for classification.
@@ -158,14 +160,53 @@ fn safe_error_code(code: &str) -> bool {
             .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || *byte == b'_')
 }
 
+/// Longest provider-requested wait taken at face value.
+///
+/// The header is untrusted; a gateway that asks for a day-long wait would park
+/// a turn indefinitely. The retry scheduler applies its own wall-clock envelope
+/// on top of this — the clamp only keeps the value in a sane range.
+const MAX_RETRY_AFTER: Duration = Duration::from_secs(3600);
+
+/// Read the `Retry-After` hint from a provider's error response.
+///
+/// Returns `None` when the header is absent, unparseable, or not a form we
+/// understand; a missing hint just leaves the caller on its own backoff.
+#[cfg(any(feature = "anthropic", feature = "openai-compat", feature = "gemini"))]
+pub fn retry_after_hint(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    parse_retry_after(headers.get(reqwest::header::RETRY_AFTER)?.to_str().ok()?)
+}
+
+/// Parse a `Retry-After` header value into a wait.
+///
+/// RFC 9110 permits two forms. Delay-seconds is what model providers send and
+/// is parsed exactly. The HTTP-date form is accepted and resolved against the
+/// current clock; a date already in the past yields a zero wait rather than an
+/// error, since the condition it described has passed. Anything else is
+/// `None`.
+#[must_use]
+pub fn parse_retry_after(value: &str) -> Option<Duration> {
+    let value = value.trim();
+    if let Ok(seconds) = value.parse::<u64>() {
+        return Some(Duration::from_secs(seconds).min(MAX_RETRY_AFTER));
+    }
+    let deadline = chrono::DateTime::parse_from_rfc2822(value).ok()?;
+    let wait = deadline.signed_duration_since(chrono::Utc::now());
+    Some(wait.to_std().unwrap_or(Duration::ZERO).min(MAX_RETRY_AFTER))
+}
+
 /// Classify a provider HTTP error, detecting prompt-too-long patterns that the
 /// agent loop can retry with a tighter context budget.
+///
+/// `retry_after` is the response's parsed `Retry-After`, which rides along on
+/// the throttling variants so the turn's retry schedule can honor it instead of
+/// guessing.
 pub fn classify_provider_error(
     provider: &str,
     status: u16,
     body: &str,
+    retry_after: Option<Duration>,
 ) -> openwave_core::error::AgentError {
-    use openwave_core::error::AgentError;
+    use openwave_core::error::{AgentError, ProviderFailure};
 
     let parsed = serde_json::from_str::<serde_json::Value>(body).ok();
     let error = parsed
@@ -190,12 +231,12 @@ pub fn classify_provider_error(
         return AgentError::Authentication(safe());
     }
     if status == 429 || code == "rate_limit_error" {
-        return AgentError::RateLimited(safe());
+        return AgentError::RateLimited(ProviderFailure::new(safe(), retry_after));
     }
     if matches!(status, 502 | 503 | 504 | 529)
         || matches!(code, "overloaded_error" | "server_overloaded")
     {
-        return AgentError::Overloaded(safe());
+        return AgentError::Overloaded(ProviderFailure::new(safe(), retry_after));
     }
     if matches!(
         code,
@@ -265,7 +306,7 @@ mod tests {
     fn classify_detects_anthropic_prompt_too_long() {
         use openwave_core::error::AgentError;
         let body = r#"{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 250000 tokens > 200000 maximum"}}"#;
-        let err = classify_provider_error("anthropic", 400, body);
+        let err = classify_provider_error("anthropic", 400, body, None);
         assert!(
             matches!(err, AgentError::PromptTooLong(_)),
             "expected PromptTooLong, got {err:?}"
@@ -276,7 +317,7 @@ mod tests {
     fn classify_detects_openai_context_length_exceeded() {
         use openwave_core::error::AgentError;
         let body = r#"{"error":{"message":"maximum context length","type":"invalid_request_error","code":"context_length_exceeded"}}"#;
-        let err = classify_provider_error("openai-compat", 400, body);
+        let err = classify_provider_error("openai-compat", 400, body, None);
         assert!(
             matches!(err, AgentError::PromptTooLong(_)),
             "expected PromptTooLong, got {err:?}"
@@ -287,7 +328,7 @@ mod tests {
     fn classify_returns_invalid_request_for_other_400s() {
         use openwave_core::error::AgentError;
         let body = r#"{"error":{"type":"invalid_request_error","message":"invalid api key"}}"#;
-        let err = classify_provider_error("anthropic", 400, body);
+        let err = classify_provider_error("anthropic", 400, body, None);
         assert!(
             matches!(err, AgentError::InvalidRequest(_)),
             "expected InvalidRequest, got {err:?}"
@@ -298,19 +339,29 @@ mod tests {
     fn classify_distinguishes_auth_rate_limit_overload_and_refusal() {
         use openwave_core::error::AgentError;
         assert!(matches!(
-            classify_provider_error("provider", 401, "{}"),
+            classify_provider_error("provider", 401, "{}", None),
             AgentError::Authentication(_)
         ));
         assert!(matches!(
-            classify_provider_error("provider", 429, "{}"),
+            classify_provider_error("provider", 429, "{}", None),
             AgentError::RateLimited(_)
         ));
         assert!(matches!(
-            classify_provider_error("anthropic", 529, r#"{"error":{"type":"overloaded_error"}}"#),
+            classify_provider_error(
+                "anthropic",
+                529,
+                r#"{"error":{"type":"overloaded_error"}}"#,
+                None
+            ),
             AgentError::Overloaded(_)
         ));
         assert!(matches!(
-            classify_provider_error("provider", 400, r#"{"error":{"code":"content_filter"}}"#),
+            classify_provider_error(
+                "provider",
+                400,
+                r#"{"error":{"code":"content_filter"}}"#,
+                None
+            ),
             AgentError::Refusal(_)
         ));
     }

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -1519,6 +1519,16 @@ async fn test_app_with_scanner_resolution_race(
     (app(state), token, store, dir)
 }
 
+/// Shrink the retry backoff so failure-injection tests observe the next
+/// attempt without waiting out the production schedule.
+fn fast_retry_schedule() -> turn_worker::RetrySchedule {
+    turn_worker::RetrySchedule {
+        initial: Duration::from_millis(10),
+        max_delay: Duration::from_millis(50),
+        ..turn_worker::RetrySchedule::default()
+    }
+}
+
 fn spawn_turn_worker(state: &AppState) {
     spawn_turn_worker_with_config(state, turn_worker::TurnWorkerConfig::default());
 }

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -847,6 +847,7 @@ async fn committed_steer_event_recovers_when_cancellation_wins_ambiguous_respons
             idle_min: Duration::from_millis(5),
             idle_cap: Duration::from_millis(20),
             failure_delay: Duration::from_millis(5),
+            retry: fast_retry_schedule(),
             max_concurrency: 1,
         },
     );

--- a/crates/openwave-server/src/tests/workers.rs
+++ b/crates/openwave-server/src/tests/workers.rs
@@ -522,6 +522,7 @@ async fn worker_recovers_ambiguous_claim_and_completion_with_exact_receipts() {
             // lease even when a loaded test host delays the retry task.
             lease: Duration::from_secs(5 * 60),
             failure_delay: Duration::from_millis(10),
+            retry: fast_retry_schedule(),
             max_concurrency: 1,
             ..turn_worker::TurnWorkerConfig::default()
         },
@@ -814,6 +815,7 @@ async fn worker_renews_a_near_expiry_ambiguous_claim_before_execution() {
             idle_min: Duration::from_millis(10),
             idle_cap: Duration::from_millis(20),
             failure_delay: Duration::from_millis(10),
+            retry: fast_retry_schedule(),
             max_concurrency: 1,
         },
     );
@@ -906,6 +908,7 @@ async fn worker_heartbeats_while_event_journaling_is_blocked() {
             idle_min: Duration::from_millis(10),
             idle_cap: Duration::from_millis(20),
             failure_delay: Duration::from_millis(10),
+            retry: fast_retry_schedule(),
             max_concurrency: 1,
         },
     );

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -11,7 +11,7 @@ use cap_std::ambient_authority;
 use cap_std::fs::{Dir, DirBuilder};
 #[cfg(unix)]
 use cap_std::fs::{DirBuilderExt as CapDirBuilderExt, PermissionsExt as CapPermissionsExt};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use futures::channel::mpsc::{unbounded, UnboundedReceiver};
 use futures::StreamExt;
 use openwave_core::{
@@ -40,6 +40,7 @@ pub(crate) struct TurnWorkerConfig {
     pub(crate) idle_min: Duration,
     pub(crate) idle_cap: Duration,
     pub(crate) failure_delay: Duration,
+    pub(crate) retry: RetrySchedule,
     pub(crate) max_concurrency: usize,
 }
 
@@ -52,9 +53,108 @@ impl Default for TurnWorkerConfig {
             idle_min: Duration::from_millis(250),
             idle_cap: Duration::from_secs(5),
             failure_delay: Duration::from_secs(1),
+            retry: RetrySchedule::default(),
             max_concurrency: 4,
         }
     }
+}
+
+/// When a retryably failed turn becomes claimable again.
+///
+/// The schedule is bounded by wall clock, not by attempt count: each attempt
+/// waits twice as long as the last, and no attempt is scheduled past
+/// `envelope` measured from the turn's first claim. A turn that cannot be
+/// retried inside the envelope fails now with the provider's own error rather
+/// than being parked for longer than anyone is waiting.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RetrySchedule {
+    /// Wait before the first retry, doubled for each attempt after it.
+    pub(crate) initial: Duration,
+    /// Ceiling on any single computed wait.
+    pub(crate) max_delay: Duration,
+    /// Wall-clock budget from the turn's first claim to its last retry.
+    pub(crate) envelope: Duration,
+}
+
+impl Default for RetrySchedule {
+    fn default() -> Self {
+        Self {
+            initial: Duration::from_millis(250),
+            max_delay: Duration::from_secs(100),
+            envelope: Duration::from_secs(600),
+        }
+    }
+}
+
+impl RetrySchedule {
+    /// Decide when a retryable failure may be attempted again, or `None` when
+    /// waiting can no longer help and the failure should be made permanent.
+    ///
+    /// `hint` is the provider's `Retry-After`. It wins over the computed
+    /// backoff whenever it is longer, because retrying before a rate limit
+    /// clears spends an attempt on a request that is already refused — the
+    /// exact way the fixed one-second delay used to burn a turn's whole
+    /// budget in a few seconds. It is floored at `initial` so a `Retry-After:
+    /// 0` cannot produce a hot loop.
+    ///
+    /// A hint longer than the remaining envelope is refused outright instead
+    /// of being honored: parking the turn for it would consume an attempt that
+    /// the deadline will never let run.
+    fn next_attempt_at(
+        self,
+        turn: &TurnRun,
+        hint: Option<Duration>,
+        now: DateTime<Utc>,
+    ) -> Option<DateTime<Utc>> {
+        if turn.attempt_count >= turn.max_attempts {
+            return None;
+        }
+        let deadline = turn.started_at.unwrap_or(turn.created_at)
+            + chrono::Duration::from_std(self.envelope).ok()?;
+        if now >= deadline {
+            return None;
+        }
+        let backoff = self.backoff(turn.attempt_count);
+        let delay = match hint {
+            Some(hint) => hint.max(self.initial),
+            None => jitter(backoff, turn.id, turn.attempt_count),
+        };
+        let at = now + chrono::Duration::from_std(delay).ok()?;
+        (at <= deadline).then_some(at)
+    }
+
+    /// Exponential wait for the attempt that just failed, capped at
+    /// `max_delay`. Attempt one waits `initial`.
+    fn backoff(self, attempt_count: i32) -> Duration {
+        let doublings = u32::try_from(attempt_count.saturating_sub(1)).unwrap_or(0);
+        self.initial
+            .checked_mul(1_u32.checked_shl(doublings.min(31)).unwrap_or(u32::MAX))
+            .unwrap_or(self.max_delay)
+            .min(self.max_delay)
+    }
+}
+
+/// Spread a computed wait over `[delay / 2, delay]`.
+///
+/// Turns that failed together — the common case, since they failed against the
+/// same provider — must not retry together. The offset is derived from the
+/// turn's own identity rather than a random source so a given turn's schedule
+/// is reproducible in a debugger and in tests.
+fn jitter(delay: Duration, turn_id: TurnId, attempt_count: i32) -> Duration {
+    let seed = u64::from_le_bytes(
+        turn_id.as_uuid().as_bytes()[..8]
+            .try_into()
+            .unwrap_or([0; 8]),
+    )
+    .wrapping_add(u64::from(attempt_count.unsigned_abs()));
+    // splitmix64 finalizer: the raw UUID bytes are not uniformly spread across
+    // the low bits we sample.
+    let mut mixed = seed.wrapping_mul(0x9e37_79b9_7f4a_7c15);
+    mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    mixed ^= mixed >> 31;
+    let half = delay / 2;
+    half + half.mul_f64(((mixed >> 11) as f64) / ((1_u64 << 53) as f64))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1756,6 +1856,7 @@ impl TurnWorker {
                 }
                 Ok(AgentTurnOutcome::Failed {
                     error,
+                    retry_after,
                     usage,
                     model_steps,
                 }) => {
@@ -1790,6 +1891,7 @@ impl TurnWorker {
                             total_usage,
                             &error.kind,
                             &error.message,
+                            retry_after,
                         )
                         .await;
                 }
@@ -1808,6 +1910,7 @@ impl TurnWorker {
                             total_usage,
                             error.kind(),
                             &error.to_string(),
+                            error.retry_after(),
                         )
                         .await;
                 }
@@ -2107,6 +2210,7 @@ impl TurnWorker {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn record_classified_failure(
         &self,
         turn: &TurnRun,
@@ -2115,15 +2219,20 @@ impl TurnWorker {
         usage: openwave_core::Usage,
         code: &str,
         detail: &str,
+        retry_after: Option<Duration>,
     ) -> Result<TurnWorkerOutcome> {
-        let retry = if matches!(
+        let retryable = matches!(
             code,
             "provider" | "rate_limited" | "overloaded" | "store" | "secret"
-        ) {
-            TurnFailureRetry::RetryAt(Utc::now() + chrono_duration(self.config.failure_delay)?)
-        } else {
-            TurnFailureRetry::Permanent
-        };
+        );
+        let retry = retryable
+            .then(|| {
+                self.config
+                    .retry
+                    .next_attempt_at(turn, retry_after, Utc::now())
+            })
+            .flatten()
+            .map_or(TurnFailureRetry::Permanent, TurnFailureRetry::RetryAt);
         self.record_failure_with_retry(turn, lease_token, model_steps, usage, code, detail, retry)
             .await
     }
@@ -2328,6 +2437,85 @@ fn log_turn_result(result: std::result::Result<Result<TurnWorkerOutcome>, tokio:
         Ok(Ok(_)) => {}
         Ok(Err(error)) => eprintln!("openwave: turn worker execution failed: {error}"),
         Err(error) => eprintln!("openwave: turn worker task stopped: {error}"),
+    }
+}
+
+#[cfg(test)]
+mod retry_schedule_tests {
+    use super::*;
+
+    fn failed_turn(attempt_count: i32, started_at: DateTime<Utc>) -> TurnRun {
+        TurnRun {
+            id: TurnId::new(),
+            chat_id: openwave_core::ChatId::new(),
+            agent_run_id: openwave_core::AgentRunId::new(),
+            input_message_id: MessageId::new(),
+            output_message_id: None,
+            model: "test-model".into(),
+            status: TurnRunStatus::Running,
+            attempt_count,
+            max_attempts: 4,
+            claim_count: attempt_count,
+            model_steps: 0,
+            usage: openwave_core::Usage::default(),
+            available_at: started_at,
+            lease_token: None,
+            lease_expires_at: None,
+            started_at: Some(started_at),
+            finished_at: None,
+            last_error_code: None,
+            last_error_detail: None,
+            steer_revision: 0,
+            last_steer_applied_at: None,
+            created_at: started_at,
+            updated_at: started_at,
+        }
+    }
+
+    /// The scheduling contract a rate-limited turn depends on: waits grow, the
+    /// provider's own `Retry-After` beats a guess that is far too short, and
+    /// neither the attempt budget nor a long hint can schedule work the
+    /// wall-clock envelope will never let run.
+    #[test]
+    fn retry_waits_grow_and_defer_to_the_provider_inside_the_envelope() {
+        let schedule = RetrySchedule::default();
+        let start = Utc::now();
+
+        // Exponential, jittered into the top half of each computed wait.
+        for (attempt, base) in [(1, 250), (2, 500), (3, 1_000)] {
+            let turn = failed_turn(attempt, start);
+            let at = schedule
+                .next_attempt_at(&turn, None, start)
+                .expect("a fresh turn retries");
+            let waited = (at - start).num_milliseconds();
+            assert!(
+                (base / 2..=base).contains(&waited),
+                "attempt {attempt} waited {waited}ms, expected {}..={base}ms",
+                base / 2
+            );
+        }
+
+        // A 60-second rate-limit hint replaces the sub-second guess that used
+        // to spend the whole budget before the limit cleared.
+        let turn = failed_turn(1, start);
+        let hinted = schedule
+            .next_attempt_at(&turn, Some(Duration::from_secs(60)), start)
+            .expect("a hint inside the envelope is honored");
+        assert_eq!((hinted - start).num_seconds(), 60);
+
+        // A hint reaching past the envelope is refused outright rather than
+        // spending an attempt on work the deadline will cancel.
+        assert!(schedule
+            .next_attempt_at(&turn, Some(Duration::from_secs(900)), start)
+            .is_none());
+
+        // So is any retry once the envelope has elapsed, or once the durable
+        // attempt budget is spent.
+        let late = start + chrono::Duration::seconds(601);
+        assert!(schedule.next_attempt_at(&turn, None, late).is_none());
+        assert!(schedule
+            .next_attempt_at(&failed_turn(4, start), None, start)
+            .is_none());
     }
 }
 


### PR DESCRIPTION
A turn that failed retryably was rescheduled a flat second later, three
times, and then failed permanently. A 429 carrying `Retry-After: 60` was
therefore guaranteed to fail: all three attempts landed inside the first
five seconds of a minute-long rate limit, and no code path read the
header at all.

The durable machinery — lease fencing, `record_classified_failure`, crash
resume — is untouched, as is the retryable classification. What changes
is the scheduling policy layered on it.

## The schedule

`RetrySchedule` computes the next attempt time and returns `None` when
waiting can no longer help:

- Waits double from 250ms, capped at 100s for any single attempt.
- Each wait is jittered into the top half of its window, so turns that
  failed against the same provider do not come back at the same instant.
  The offset is derived from the turn's own id rather than a random
  source, which keeps a given turn's schedule reproducible in a debugger
  and lets the test assert real bounds.
- Nothing is scheduled past a 600s wall-clock envelope measured from the
  turn's first claim. Once the envelope is spent the failure is recorded
  as permanent rather than parking the turn for longer than anyone is
  waiting for it.

## Retry-After

`sse.rs` parses the header where provider errors are already classified.
Delay-seconds is handled exactly; the HTTP-date form is resolved against
the current clock, with a date in the past yielding a zero wait. Anything
else is `None`, which just leaves the caller on its own backoff. The
value is clamped at an hour before it reaches the scheduler, since the
header is untrusted.

The hint rides to the worker on `ProviderFailure`, a payload carried by
the throttling variants of `AgentError` and by `AgentTurnOutcome::Failed`
for turns that already consumed model steps. It stays out of
`AgentErrorInfo`, which is the client-facing error projection and has no
business growing a scheduling field.

The schedule prefers the hint whenever it is longer than the computed
backoff — the provider knows when its limit clears and we are guessing —
and floors it at the initial delay so `Retry-After: 0` cannot produce a
hot loop. A hint reaching past the envelope is refused rather than
honored: parking the turn for it would spend an attempt the deadline will
never let run, which is the original bug in a new shape.

## Tests

One, on `RetrySchedule::next_attempt_at`: waits grow and stay inside
their jitter window, a 60-second hint replaces the sub-second guess, a
hint past the envelope is refused, and neither an elapsed envelope nor a
spent attempt budget schedules anything. That is the whole contract a
rate-limited turn depends on, and it is the part that is easy to reverse
by accident.

Closes #1086
