### PR TITLE
fix(desktop): match letter shortcuts on physical key

### DIFF
--- a/crates/openwave-desktop/ui/src/ShellShortcuts.test.ts
+++ b/crates/openwave-desktop/ui/src/ShellShortcuts.test.ts
@@ -14,12 +14,18 @@ import {
 function keyEvent(overrides: Partial<KeyboardEvent>): KeyboardEvent {
   return {
     key: "b",
+    code: "KeyB",
     metaKey: true,
     ctrlKey: false,
     shiftKey: false,
     altKey: false,
     ...overrides,
   } as KeyboardEvent;
+}
+
+/** The default context: a mac-style keyboard, nothing in the way. */
+function context(overrides: Partial<Parameters<typeof resolveShellShortcut>[1]> = {}) {
+  return { editable: true, modalOpen: false, command: true, ...overrides };
 }
 
 describe("shell shortcut resolution", () => {
@@ -40,19 +46,51 @@ describe("shell shortcut resolution", () => {
   it("fires chorded shortcuts even while the composer has focus", () => {
     // The whole point of mod-chorded combos: the reader can reach them without
     // leaving the field they are typing in.
-    const cases: Array<[string, ShellShortcutAction]> = [
-      ["b", "toggle-sidebar"],
-      ["n", "new-chat"],
-      ["k", "focus-composer"],
-      ["/", "show-shortcuts"],
+    const cases: Array<[Partial<KeyboardEvent>, ShellShortcutAction]> = [
+      [{ key: "b", code: "KeyB" }, "toggle-sidebar"],
+      [{ key: "n", code: "KeyN" }, "new-chat"],
+      [{ key: "k", code: "KeyK" }, "focus-composer"],
+      [{ key: "/", code: "Slash" }, "show-shortcuts"],
+      [{ key: "0", code: "Digit0" }, "zoom-reset"],
     ];
-    for (const [key, id] of cases) {
-      const resolved = resolveShellShortcut(keyEvent({ key }), {
-        editable: true,
-        modalOpen: false,
-      });
+    for (const [event, id] of cases) {
+      const resolved = resolveShellShortcut(keyEvent(event), context());
       expect(resolved?.id).toBe(id);
     }
+  });
+
+  it("keeps letter shortcuts under the same physical keys on any layout", () => {
+    // Dvorak puts "l" where QWERTY puts N. The shortcut belongs to the key
+    // position the reader's muscle memory knows, not to the character that
+    // position happens to produce.
+    const dvorakN = keyEvent({ key: "l", code: "KeyN" });
+    expect(resolveShellShortcut(dvorakN, context())?.id).toBe("new-chat");
+
+    // And the key that does produce "n" on Dvorak is not a new chat.
+    const dvorakElsewhere = keyEvent({ key: "n", code: "KeyL" });
+    expect(resolveShellShortcut(dvorakElsewhere, context())).toBeNull();
+  });
+
+  it("matches punctuation on the character, which has no fixed position", () => {
+    // "/" sits on Period on AZERTY, on Bracketleft-adjacent keys elsewhere. The
+    // glyph is what the shortcut is named after, so the glyph is what matches.
+    const azertySlash = keyEvent({ key: "/", code: "Period", shiftKey: true });
+    expect(resolveShellShortcut(azertySlash, context())?.id).toBe(
+      "show-shortcuts",
+    );
+  });
+
+  it("takes only the modifier the platform actually uses", () => {
+    // Ctrl+B on macOS is the caret moving back a character; the sidebar has no
+    // claim on it. The same chord is the real binding everywhere else.
+    const ctrlB = keyEvent({ metaKey: false, ctrlKey: true });
+    expect(resolveShellShortcut(ctrlB, context())).toBeNull();
+    expect(resolveShellShortcut(ctrlB, context({ command: false }))?.id).toBe(
+      "toggle-sidebar",
+    );
+    expect(
+      resolveShellShortcut(keyEvent({}), context({ command: false })),
+    ).toBeNull();
   });
 
   it("reaches zoom whether or not shift is held for the key", () => {
@@ -64,26 +102,27 @@ describe("shell shortcut resolution", () => {
       ["-", false],
       ["_", true],
     ] as Array<[string, boolean]>) {
-      const resolved = resolveShellShortcut(keyEvent({ key, shiftKey }), {
-        editable: true,
-        modalOpen: false,
-      });
+      const resolved = resolveShellShortcut(
+        keyEvent({ key, shiftKey, code: "Equal" }),
+        context(),
+      );
       expect(resolved?.id).toBe(key === "=" || key === "+" ? "zoom-in" : "zoom-out");
     }
   });
 
   it("stays out of the way of plain typing", () => {
     const resolved = resolveShellShortcut(
-      keyEvent({ key: "n", metaKey: false, ctrlKey: false }),
-      { editable: true, modalOpen: false },
+      keyEvent({ key: "n", code: "KeyN", metaKey: false, ctrlKey: false }),
+      context(),
     );
     expect(resolved).toBeNull();
   });
 
   it("suppresses every shortcut while a modal dialog is open", () => {
-    const resolved = resolveShellShortcut(keyEvent({ key: "n" }), {
+    const resolved = resolveShellShortcut(keyEvent({ key: "n", code: "KeyN" }), {
       editable: false,
       modalOpen: true,
+      command: true,
     });
     expect(resolved).toBeNull();
   });

--- a/crates/openwave-desktop/ui/src/ShellShortcuts.ts
+++ b/crates/openwave-desktop/ui/src/ShellShortcuts.ts
@@ -27,14 +27,35 @@ export const SHELL_SHORTCUT_GROUPS: readonly ShellShortcutGroup[] = [
   "Help",
 ];
 
-export type ShellShortcutDef = {
-  id: ShellShortcutAction;
+/**
+ * How a definition recognises its key, which differs by what kind of key it is.
+ *
+ * Letters and digits are matched on `event.code` — the physical key position,
+ * `KeyN` for the key labelled N on a US board. A layout decides which character
+ * a position produces, so matching the character would move the shortcut to
+ * wherever that letter happens to sit: Cmd+N is under the QWERTY N on AZERTY
+ * too, and matching `event.key` would put it under the physical `?` key
+ * instead.
+ *
+ * Punctuation goes the other way. The glyph is the whole point of `Cmd+/`, and
+ * its position is nowhere near fixed across layouts, so those match the
+ * character the keyboard actually produced.
+ */
+type ShellShortcutBinding =
+  /**
+   * `event.code` values that trigger it. More than one because separate
+   * physical keys can carry the same digit — the number row and the numpad.
+   */
+  | { codes: readonly string[]; keys?: never }
   /**
    * The characters that trigger it, matched case-insensitively against
    * `event.key`. More than one because a keyboard can reach the same intent
    * through more than one glyph — zooming in is `=` unshifted and `+` shifted.
    */
-  keys: readonly string[];
+  | { keys: readonly string[]; codes?: never };
+
+export type ShellShortcutDef = ShellShortcutBinding & {
+  id: ShellShortcutAction;
   /** Requires the platform command modifier — Cmd on macOS, Ctrl elsewhere. */
   mod: boolean;
   /**
@@ -57,7 +78,7 @@ export type ShellShortcutDef = {
 export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
   {
     id: "new-chat",
-    keys: ["n"],
+    codes: ["KeyN"],
     mod: true,
     description: "Start a new chat",
     group: "Chat",
@@ -65,7 +86,7 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
   },
   {
     id: "focus-composer",
-    keys: ["k"],
+    codes: ["KeyK"],
     mod: true,
     description: "Focus the message composer",
     group: "Chat",
@@ -73,7 +94,7 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
   },
   {
     id: "toggle-sidebar",
-    keys: ["b"],
+    codes: ["KeyB"],
     mod: true,
     description: "Show or hide the sidebar",
     group: "View",
@@ -99,7 +120,7 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
   },
   {
     id: "zoom-reset",
-    keys: ["0"],
+    codes: ["Digit0", "Numpad0"],
     mod: true,
     description: "Reset the interface size",
     group: "View",
@@ -121,10 +142,12 @@ export const SHELL_SHORTCUTS: readonly ShellShortcutDef[] = [
 /**
  * Whether the platform command modifier is Cmd rather than Ctrl.
  *
- * The table records `mod: true` rather than a glyph because the listener
- * accepts either modifier; only the help dialog has to commit to one, and it
- * commits to whichever one the reader's keyboard actually has. Takes the
- * user-agent string rather than reading `navigator` so it is testable.
+ * The table records `mod: true` rather than a glyph because the modifier is a
+ * property of the platform, not of the shortcut. Both the listener and the help
+ * dialog resolve it through here, so what the dialog draws is what fires: on
+ * macOS only Cmd+B toggles the sidebar, and Ctrl+B is left to the text field it
+ * means something else in. Takes the user-agent string rather than reading
+ * `navigator` so it is testable.
  */
 export function usesCommandModifier(userAgent: string): boolean {
   return /Mac|iPhone|iPad|iPod/.test(userAgent);
@@ -135,8 +158,12 @@ export function usesCommandModifier(userAgent: string): boolean {
  *
  * Derived from the same definition the listener matches on, so the help dialog
  * cannot come to disagree with the binding. Only the first of a definition's
- * keys is shown — the alternates exist so a shifted glyph still matches, not
- * because they are a second shortcut worth documenting.
+ * keys is shown — the alternates exist so a shifted glyph or a second physical
+ * key still matches, not because they are a second shortcut worth documenting.
+ *
+ * A code-matched binding is drawn as the character its physical key carries on
+ * a US board, which is the label on most keycaps and the only name the reader
+ * has for the position.
  */
 export function shortcutKeycaps(
   def: ShellShortcutDef,
@@ -145,9 +172,19 @@ export function shortcutKeycaps(
   const caps: string[] = [];
   if (def.mod) caps.push(command ? "⌘" : "Ctrl");
   if (def.shift === true) caps.push(command ? "⇧" : "Shift");
-  const key = def.keys[0] ?? "";
-  caps.push(key.length === 1 ? key.toUpperCase() : key);
+  caps.push(shortcutKeyLabel(def));
   return caps;
+}
+
+/** The single keycap a definition's key is drawn as. */
+function shortcutKeyLabel(def: ShellShortcutDef): string {
+  if (def.codes) {
+    const code = def.codes[0] ?? "";
+    const label = code.replace(/^(Key|Digit|Numpad)/, "");
+    return label.length === 1 ? label.toUpperCase() : code;
+  }
+  const key = def.keys[0] ?? "";
+  return key.length === 1 ? key.toUpperCase() : key;
 }
 
 /**
@@ -174,18 +211,29 @@ export function groupedShellShortcuts(): Array<{
 
 type ShortcutKeyEvent = Pick<
   KeyboardEvent,
-  "key" | "metaKey" | "ctrlKey" | "shiftKey" | "altKey"
+  "key" | "code" | "metaKey" | "ctrlKey" | "shiftKey" | "altKey"
 >;
 
-/** Whether a key event is the combo a shortcut is bound to. */
+/**
+ * Whether a key event is the combo a shortcut is bound to.
+ *
+ * `command` says which modifier this platform's shortcuts are chorded with, and
+ * the other one is a mismatch rather than an alternative: Ctrl+B on macOS is
+ * the reader moving the caret back a character, not asking for the sidebar.
+ */
 export function matchesShellShortcut(
   event: ShortcutKeyEvent,
   def: ShellShortcutDef,
+  command: boolean,
 ): boolean {
   if (event.altKey) return false;
-  if (!def.keys.includes(event.key.toLowerCase())) return false;
+  const hit = def.codes
+    ? def.codes.includes(event.code)
+    : def.keys.includes(event.key.toLowerCase());
+  if (!hit) return false;
   if (def.shift !== "any" && event.shiftKey !== (def.shift ?? false)) return false;
-  const hasMod = event.metaKey || event.ctrlKey;
+  if (command ? event.ctrlKey : event.metaKey) return false;
+  const hasMod = command ? event.metaKey : event.ctrlKey;
   return def.mod ? hasMod : !hasMod;
 }
 
@@ -210,11 +258,11 @@ export function isEditableTarget(target: EventTarget | null): boolean {
  */
 export function resolveShellShortcut(
   event: ShortcutKeyEvent,
-  context: { editable: boolean; modalOpen: boolean },
+  context: { editable: boolean; modalOpen: boolean; command: boolean },
 ): ShellShortcutDef | null {
   if (context.modalOpen) return null;
   for (const def of SHELL_SHORTCUTS) {
-    if (!matchesShellShortcut(event, def)) continue;
+    if (!matchesShellShortcut(event, def, context.command)) continue;
     if (context.editable && !def.allowInEditable) return null;
     return def;
   }
@@ -243,11 +291,13 @@ export function useShellShortcuts(handlers: ShellShortcutHandlers): void {
   handlersRef.current = handlers;
 
   useEffect(() => {
+    const command = usesCommandModifier(navigator.userAgent);
     function onKeyDown(event: KeyboardEvent) {
       if (event.defaultPrevented) return;
       const def = resolveShellShortcut(event, {
         editable: isEditableTarget(event.target),
         modalOpen: hasOpenModalDialog(document),
+        command,
       });
       if (!def) return;
       event.preventDefault();


### PR DESCRIPTION
Shell shortcuts matched `event.key`, so the letter bindings moved with the keyboard layout. On Dvorak, Cmd+N fired from whichever key produces "n" — the physical K position — rather than from the key labelled N. Letters and digits now match `event.code`, which names the physical position and is what the Brightwave shortcut layer matches on.

Punctuation deliberately stays on `event.key`. The glyph is what Cmd+/ is named after, and where it sits varies by layout, so `/` should trigger the shortcuts dialog wherever the reader finds it. That split lives in the definition table — a binding declares either `codes` or `keys`, and the matcher follows — rather than being reconstructed at the comparison site.

The modifier is platform-strict now as well. `mod` previously accepted either Cmd or Ctrl, so Ctrl+N and Ctrl+B fired on macOS, where Ctrl+B is the caret moving back a character. The listener resolves the platform's modifier once and treats the other one as a mismatch, through the same helper the help dialog uses to draw the keycap.

Non-letter bindings all still work: zoom in/out (`=`/`+`, `-`/`_`) and the shortcuts dialog (`/`/`?`) match on the character; Cmd+0 matches Digit0 and Numpad0, so the numpad reaches zoom reset the way it did before.

Tests cover the layout case directly, since it is behavior almost no one has the hardware to notice: a Dvorak Cmd+N (key "l", code KeyN) resolves to a new chat, the key that produces "n" on Dvorak does not, an AZERTY-position `/` still opens the dialog, and Ctrl+B resolves only off macOS.

Closes #1108
