### PR TITLE
fix(router): bound provider connections with connect, dead-air, and stream timeouts

### DIFF
--- a/crates/openwave-router/Cargo.toml
+++ b/crates/openwave-router/Cargo.toml
@@ -13,11 +13,14 @@ workspace = true
 [features]
 default = ["anthropic", "openai-compat", "gemini"]
 # The Anthropic (Messages API) provider adapter.
-anthropic = ["dep:reqwest", "dep:async-stream"]
+anthropic = ["_http"]
 # OpenAI-compatible Chat Completions adapter (OpenAI, OpenRouter, vLLM, …).
-openai-compat = ["dep:reqwest", "dep:async-stream"]
+openai-compat = ["_http"]
 # Google Gemini Developer API adapter (native GenerateContent protocol).
-gemini = ["dep:reqwest", "dep:async-stream", "dep:ring", "dep:uuid"]
+gemini = ["_http", "dep:ring", "dep:uuid"]
+# Internal: the shared HTTP transport every adapter is built on. Not meant to
+# be enabled directly.
+_http = ["dep:reqwest", "dep:async-stream", "dep:tokio"]
 
 [dependencies]
 openwave-core = { path = "../openwave-core", default-features = false }
@@ -29,8 +32,9 @@ serde_json = { workspace = true }
 reqwest = { workspace = true, optional = true }
 ring = { workspace = true, optional = true }
 async-stream = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["time"], optional = true }
 uuid = { workspace = true, optional = true }
 
 [dev-dependencies]
 axum = { workspace = true }
-tokio = { workspace = true, features = ["net", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["net", "rt-multi-thread", "test-util"] }

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -56,7 +56,7 @@ impl AnthropicProvider {
     /// Build a provider with the given API key, hitting api.anthropic.com.
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: crate::http::streaming_client(),
             api_key: api_key.into(),
             base_url: DEFAULT_BASE_URL.to_string(),
             token_source: None,
@@ -125,8 +125,10 @@ impl ModelProvider for AnthropicProvider {
             return Err(classify_provider_error("anthropic", status.as_u16(), &body));
         }
 
+        let ceiling = crate::http::timeouts().total_stream;
         let stream = async_stream::stream! {
-            let mut bytes = response.bytes_stream();
+            let bytes = crate::http::with_stream_deadline(response.bytes_stream(), ceiling);
+            futures::pin_mut!(bytes);
             // Accumulate raw BYTES, not a String: a chunk may split a multi-byte
             // UTF-8 character, so we only decode once a whole frame is buffered.
             let mut buffer: Vec<u8> = Vec::new();

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -69,7 +69,7 @@ impl GeminiProvider {
     /// Build a provider using a Gemini Developer API key.
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: crate::http::streaming_client(),
             auth: GeminiAuth::ApiKey(api_key.into()),
             endpoint_family: EndpointFamily::DeveloperApi,
             base_url: DEFAULT_BASE_URL.to_string(),
@@ -97,7 +97,7 @@ impl GeminiProvider {
             format!("https://{location}-aiplatform.googleapis.com")
         };
         Ok(Self {
-            client: reqwest::Client::new(),
+            client: crate::http::streaming_client(),
             auth: GeminiAuth::Bearer(token_source),
             endpoint_family: EndpointFamily::VertexAi {
                 project_id,
@@ -199,16 +199,29 @@ impl ModelProvider for GeminiProvider {
             return Err(classify_gemini_error(status.as_u16(), &body));
         }
 
+        let ceiling = crate::http::timeouts().total_stream;
         let stream = async_stream::stream! {
-            let mut bytes = response.bytes_stream();
+            let bytes = crate::http::with_stream_deadline(response.bytes_stream(), ceiling);
+            futures::pin_mut!(bytes);
             let mut buffer = Vec::new();
             let mut state = StreamState::default();
             while let Some(chunk) = bytes.next().await {
                 let chunk = match chunk {
                     Ok(chunk) => chunk,
-                    Err(_) => {
+                    // The transport error's own text stays suppressed — reqwest's
+                    // display includes the URL, and a Vertex URL carries the
+                    // project id from the secret key file. Our own deadline text
+                    // carries no such thing and is worth surfacing.
+                    Err(error) => {
                         yield ProviderEvent::Failed {
-                            message: "gemini stream ended early".to_string(),
+                            message: match error {
+                                crate::http::StreamFailure::Deadline(_) => {
+                                    format!("gemini stream ended early: {error}")
+                                }
+                                crate::http::StreamFailure::Transport(_) => {
+                                    "gemini stream ended early".to_string()
+                                }
+                            },
                         };
                         return;
                     }

--- a/crates/openwave-router/src/google_auth.rs
+++ b/crates/openwave-router/src/google_auth.rs
@@ -190,7 +190,7 @@ impl GoogleServiceAccountTokenSource {
     pub fn new(account: GoogleServiceAccount) -> Self {
         Self {
             account,
-            client: reqwest::Client::new(),
+            client: crate::http::request_client(),
             token_uri: GOOGLE_TOKEN_URI.to_string(),
             cached: Mutex::new(None),
             #[cfg(test)]

--- a/crates/openwave-router/src/http.rs
+++ b/crates/openwave-router/src/http.rs
@@ -1,0 +1,243 @@
+//! Shared HTTP client construction and stream deadlines for provider adapters.
+//!
+//! A provider connection that hangs is indistinguishable, from the agent loop's
+//! point of view, from a model that is thinking: the loop only wakes on cancel
+//! or steer, and the turn worker keeps heartbeating its lease. Without a
+//! timeout somewhere in the transport, a stalled socket stalls the turn until
+//! the user presses Stop.
+//!
+//! Two layers guard that, and they guard different failures:
+//!
+//! * A **dead-air read timeout** ([`ProviderTimeouts::dead_air`]) — reqwest's
+//!   `read_timeout` resets on every successful read, so it fires only when *no*
+//!   bytes at all arrive for the whole window. Token-by-token generation, however
+//!   slow, keeps resetting it; a silently dropped connection does not. This is
+//!   the distinction that matters, and it is why the client-level total
+//!   [`timeout`](reqwest::ClientBuilder::timeout) is deliberately not set on the
+//!   streaming client — that one is a wall-clock deadline on the whole response
+//!   and would cut healthy long generations off mid-turn.
+//! * A **total stream ceiling** ([`ProviderTimeouts::total_stream`]) — a stream
+//!   that trickles a byte often enough to keep resetting the read timeout would
+//!   otherwise run forever. [`with_stream_deadline`] caps the whole thing.
+//!
+//! Both are configurable, because a local model on consumer hardware and a
+//! hosted frontier model have very different latency profiles:
+//!
+//! | Variable | Default |
+//! |---|---|
+//! | `OPENWAVE_PROVIDER_CONNECT_TIMEOUT_SECS` | 10 |
+//! | `OPENWAVE_PROVIDER_READ_TIMEOUT_SECS` | 300 |
+//! | `OPENWAVE_PROVIDER_STREAM_TIMEOUT_SECS` | 3600 |
+//!
+//! Setting any of them to `0` disables that timeout. An unparseable value is
+//! ignored in favor of the default rather than failing provider construction.
+
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use futures::{Stream, StreamExt};
+
+/// Connect-phase budget. Loopback is instant and a reachable hosted provider
+/// completes TCP + TLS well inside this; anything slower is unreachable, not
+/// slow.
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Dead-air budget: the longest a healthy stream may deliver *zero* bytes.
+///
+/// Deliberately more generous than a server-side default would be. A local
+/// model ingesting a long prompt on CPU can spend minutes before the first
+/// token, with nothing on the wire in the meantime, and a spurious mid-turn
+/// failure is worse for that user than the hang this guards against. Hosted
+/// providers emit SSE keep-alives far inside the window.
+const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Wall-clock ceiling on a single provider stream. One model step running for
+/// an hour is pathological under any latency profile.
+const DEFAULT_STREAM_TIMEOUT: Duration = Duration::from_secs(3600);
+
+/// Total budget for a non-streaming provider call (token exchange, and other
+/// small request/response round trips). These have a known, small body, so a
+/// plain total deadline is the right shape.
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The transport deadlines applied to every provider adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProviderTimeouts {
+    /// Connect-phase budget (DNS + TCP + TLS).
+    pub connect: Option<Duration>,
+    /// Longest gap between reads before the connection is declared dead.
+    pub dead_air: Option<Duration>,
+    /// Ceiling on the total duration of one provider stream.
+    pub total_stream: Option<Duration>,
+}
+
+impl ProviderTimeouts {
+    /// Read the deadlines from the environment, falling back to the defaults.
+    #[must_use]
+    pub fn from_env() -> Self {
+        Self {
+            connect: env_duration(
+                "OPENWAVE_PROVIDER_CONNECT_TIMEOUT_SECS",
+                DEFAULT_CONNECT_TIMEOUT,
+            ),
+            dead_air: env_duration("OPENWAVE_PROVIDER_READ_TIMEOUT_SECS", DEFAULT_READ_TIMEOUT),
+            total_stream: env_duration(
+                "OPENWAVE_PROVIDER_STREAM_TIMEOUT_SECS",
+                DEFAULT_STREAM_TIMEOUT,
+            ),
+        }
+    }
+}
+
+/// `None` means "disabled": an explicit `0`, or a default of zero.
+fn env_duration(name: &str, default: Duration) -> Option<Duration> {
+    let seconds = std::env::var(name)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .map_or(default, Duration::from_secs);
+    (!seconds.is_zero()).then_some(seconds)
+}
+
+/// The process-wide deadlines. Read once; provider construction must not depend
+/// on when in the process lifetime it happens.
+pub fn timeouts() -> &'static ProviderTimeouts {
+    static TIMEOUTS: LazyLock<ProviderTimeouts> = LazyLock::new(ProviderTimeouts::from_env);
+    &TIMEOUTS
+}
+
+fn build(builder: reqwest::ClientBuilder) -> reqwest::Client {
+    let builder = match timeouts().connect {
+        Some(connect) => builder.connect_timeout(connect),
+        None => builder,
+    };
+    // Matches `reqwest::Client::new`, which panics on the same failure: the
+    // only way this fails is a TLS backend that could not initialize, and a
+    // provider adapter has nothing useful to do without one.
+    builder
+        .build()
+        .expect("provider HTTP client: TLS backend failed to initialize")
+}
+
+/// A client for streaming provider requests: connect and dead-air deadlines,
+/// and deliberately no total-response deadline (see the module docs).
+///
+/// Pair it with [`with_stream_deadline`] on the response body to get the total
+/// ceiling.
+#[must_use]
+pub fn streaming_client() -> reqwest::Client {
+    let builder = reqwest::Client::builder();
+    let builder = match timeouts().dead_air {
+        Some(dead_air) => builder.read_timeout(dead_air),
+        None => builder,
+    };
+    build(builder)
+}
+
+/// A client for small, non-streaming provider calls, under a total deadline.
+#[must_use]
+pub fn request_client() -> reqwest::Client {
+    build(reqwest::Client::builder().timeout(DEFAULT_REQUEST_TIMEOUT))
+}
+
+/// Why a provider byte stream stopped early.
+///
+/// Adapters already treat a mid-stream error as a hard failure (the step's
+/// tool-call arguments may be truncated mid-JSON), so the ceiling reuses that
+/// path rather than inventing a second one.
+#[derive(Debug)]
+pub enum StreamFailure<E> {
+    /// The underlying transport failed — including reqwest's own dead-air read
+    /// timeout, which surfaces here as an ordinary body error.
+    Transport(E),
+    /// The stream outlived [`ProviderTimeouts::total_stream`].
+    Deadline(Duration),
+}
+
+impl<E: std::fmt::Display> std::fmt::Display for StreamFailure<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Transport(error) => write!(f, "{error}"),
+            Self::Deadline(limit) => {
+                write!(f, "exceeded the {}s stream duration limit", limit.as_secs())
+            }
+        }
+    }
+}
+
+/// Cap the total duration of a provider byte stream.
+///
+/// The returned stream forwards items unchanged until `ceiling` elapses, then
+/// yields a single [`StreamFailure::Deadline`] and ends. A `None` ceiling
+/// forwards the stream untouched.
+pub fn with_stream_deadline<S, B, E>(
+    stream: S,
+    ceiling: Option<Duration>,
+) -> impl Stream<Item = Result<B, StreamFailure<E>>>
+where
+    S: Stream<Item = Result<B, E>>,
+{
+    async_stream::stream! {
+        futures::pin_mut!(stream);
+        let deadline = ceiling.map(|ceiling| tokio::time::Instant::now() + ceiling);
+        loop {
+            let next = match (deadline, ceiling) {
+                (Some(deadline), Some(ceiling)) => {
+                    match tokio::time::timeout_at(deadline, stream.next()).await {
+                        Ok(next) => next,
+                        Err(_) => {
+                            yield Err(StreamFailure::Deadline(ceiling));
+                            return;
+                        }
+                    }
+                }
+                _ => stream.next().await,
+            };
+            match next {
+                Some(Ok(item)) => yield Ok(item),
+                Some(Err(error)) => {
+                    yield Err(StreamFailure::Transport(error));
+                    return;
+                }
+                None => return,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The ceiling must cut a stream that is still *making progress* — that is
+    /// the case the dead-air read timeout can never catch, since every trickled
+    /// byte resets it.
+    #[tokio::test(start_paused = true)]
+    async fn ceiling_ends_a_stream_that_trickles_forever() {
+        let trickle = async_stream::stream! {
+            loop {
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                yield Ok::<_, String>(b"data: ping\n\n".to_vec());
+            }
+        };
+        let capped = with_stream_deadline(trickle, Some(Duration::from_secs(120)));
+        futures::pin_mut!(capped);
+
+        let mut delivered = 0;
+        let ending = loop {
+            match capped.next().await {
+                Some(Ok(_)) => delivered += 1,
+                other => break other,
+            }
+        };
+
+        assert_eq!(
+            delivered, 4,
+            "chunks arriving inside the ceiling pass through"
+        );
+        let message = match ending {
+            Some(Err(failure)) => failure.to_string(),
+            other => panic!("expected a deadline failure, got {other:?}"),
+        };
+        assert_eq!(message, "exceeded the 120s stream duration limit");
+    }
+}

--- a/crates/openwave-router/src/lib.rs
+++ b/crates/openwave-router/src/lib.rs
@@ -11,6 +11,9 @@
 pub mod router;
 mod sse;
 
+#[cfg(feature = "_http")]
+pub mod http;
+
 #[cfg(feature = "anthropic")]
 pub mod anthropic;
 

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -48,7 +48,7 @@ impl OpenAiCompatProvider {
     /// Build a provider hitting OpenAI's Chat Completions API.
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: crate::http::streaming_client(),
             api_key: api_key.into(),
             base_url: DEFAULT_BASE_URL.to_string(),
             provider_id: "openai".to_string(),
@@ -58,7 +58,7 @@ impl OpenAiCompatProvider {
     /// Build a provider for a custom OpenAI-compatible gateway.
     pub fn compatible(api_key: impl Into<String>, base_url: impl Into<String>) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: crate::http::streaming_client(),
             api_key: api_key.into(),
             base_url: base_url.into(),
             provider_id: "openai_compatible".to_string(),
@@ -118,8 +118,10 @@ impl ModelProvider for OpenAiCompatProvider {
             ));
         }
 
+        let ceiling = crate::http::timeouts().total_stream;
         let stream = async_stream::stream! {
-            let mut bytes = response.bytes_stream();
+            let bytes = crate::http::with_stream_deadline(response.bytes_stream(), ceiling);
+            futures::pin_mut!(bytes);
             let mut buffer: Vec<u8> = Vec::new();
             let mut state = StreamState::default();
             while let Some(chunk) = bytes.next().await {


### PR DESCRIPTION
Every provider adapter built a bare `reqwest::Client::new()`: no connect
timeout, no read timeout, no cap on how long a stream may run. A provider
connection that hangs is indistinguishable from a model that is thinking —
the agent loop only wakes on cancel or steer, and the turn worker keeps
heartbeating its lease — so a stalled socket stalls the turn until the user
presses Stop.

A new `http` module owns the transport for all four call sites (Anthropic,
OpenAI-compatible, Gemini, and the Google OAuth token exchange), with two
layers that catch different failures:

- A dead-air read timeout. reqwest's `read_timeout` resets on every
  successful read, so it fires only when *no* bytes at all arrive for the
  whole window. Token-by-token generation keeps resetting it however slowly
  it progresses; a dropped connection does not. The client-level total
  `timeout` is deliberately left unset on the streaming clients — that one is
  a wall-clock deadline on the whole response and would cut healthy long
  generations off mid-turn.
- A total stream ceiling, applied by `with_stream_deadline` around the
  response body, for a stream that trickles just enough to keep resetting the
  read timeout but never finishes.

Defaults are 10s connect, 300s dead air, and 3600s per stream, all
overridable via `OPENWAVE_PROVIDER_{CONNECT,READ,STREAM}_TIMEOUT_SECS` (`0`
disables). The dead-air window is more generous than a server-side default
would be: a local model ingesting a long prompt on CPU can spend minutes
with nothing on the wire before the first token, and a spurious mid-turn
failure is worse for that user than the hang this fixes. Hosted providers
emit SSE keep-alives well inside the window. Non-streaming calls have a
known, small body, so the token exchange gets a plain 30s total deadline
instead.

Both layers land on paths that already existed. A connect or dead-air
failure during setup surfaces from `send()` as `AgentError::Provider`; a
dead-air or ceiling failure mid-stream reaches the agent loop as
`ProviderEvent::Failed`, which it converts to `AgentError::Provider` under
`StreamInterrupted` semantics. That is kind `provider`, which the turn
worker already treats as retryable.

One test, on the ceiling: it is the case the read timeout can never catch,
since every trickled byte resets that one.

Closes #1085
