### PR TITLE
fix(sandbox-agent): survive transient accept errors and bound the attach read

### DIFF
--- a/crates/openwave-sandbox-agent/src/supervisor.rs
+++ b/crates/openwave-sandbox-agent/src/supervisor.rs
@@ -19,10 +19,20 @@
 //! different UID; this slice has no subprocess tools, so that obligation is
 //! recorded here rather than exercised.
 
-use std::io;
+use std::{io, time::Duration};
 
 use openwave_sandbox_protocol::{serve_connection, SandboxRun};
-use tokio::net::TcpListener;
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    net::{TcpListener, TcpStream},
+};
+
+/// The first pause after an accept failure that is not a per-connection error.
+const ACCEPT_BACKOFF_MIN: Duration = Duration::from_millis(5);
+
+/// The ceiling the accept backoff grows to, so a listener that is failing for a
+/// reason that never clears retries at a steady, cheap rate instead of spinning.
+const ACCEPT_BACKOFF_MAX: Duration = Duration::from_secs(1);
 
 /// The credential and egress boundary the supervisor owns — a documented stub.
 ///
@@ -89,12 +99,159 @@ impl Supervisor {
     /// Each connection is served on its own task, so a reconnect after a
     /// disconnect reattaches to the same [`SandboxRun`] — its event buffer and
     /// operation identities outlive any single connection.
+    ///
+    /// The loop never ends on an accept failure. The listener is the run's only
+    /// reachability: a supervisor that stopped accepting would leave a container
+    /// that is alive and looks healthy but can never be attached to again, which
+    /// is strictly worse than a process that exits and is observed to have died.
+    /// So every `accept` error is retried — see [`serve_accepted`] for how the
+    /// two classes of error are paced.
     pub async fn serve(self) {
-        while let Ok((stream, _peer)) = self.listener.accept().await {
-            let run = self.run.clone();
-            tokio::spawn(async move {
-                let _ = serve_connection(stream, run).await;
-            });
+        serve_accepted(self.listener, self.run).await;
+    }
+}
+
+/// The accept loop, over anything that can accept connections, so the retry
+/// behavior can be driven against a listener that fails on demand.
+///
+/// Errors split into two classes:
+///
+/// - A per-connection error (the peer went away between the SYN and the accept,
+///   or the syscall was interrupted) says nothing about the listener. The failed
+///   connection is dropped and the next one accepted immediately; pausing here
+///   would let one aborted dial delay a real host's attach.
+/// - Anything else — descriptor exhaustion above all — is a condition of the
+///   process or the host, not of one connection, and retrying it in a tight loop
+///   would spin a core. Those back off exponentially to
+///   [`ACCEPT_BACKOFF_MAX`], and the delay resets once a connection is accepted.
+async fn serve_accepted<L>(listener: L, run: SandboxRun)
+where
+    L: Accept,
+{
+    let mut backoff = ACCEPT_BACKOFF_MIN;
+    loop {
+        match listener.accept().await {
+            Ok(stream) => {
+                backoff = ACCEPT_BACKOFF_MIN;
+                let run = run.clone();
+                tokio::spawn(async move {
+                    let _ = serve_connection(stream, run).await;
+                });
+            }
+            Err(error) if is_per_connection(&error) => {}
+            Err(_) => {
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(ACCEPT_BACKOFF_MAX);
+            }
         }
+    }
+}
+
+/// Whether an accept failure concerns only the connection being accepted, and so
+/// carries no signal about the listener's health.
+fn is_per_connection(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::ConnectionAborted
+            | io::ErrorKind::ConnectionRefused
+            | io::ErrorKind::ConnectionReset
+            | io::ErrorKind::Interrupted
+    )
+}
+
+/// A source of inbound connections. Implemented for [`TcpListener`] in
+/// production; the tests implement it over a scripted sequence of failures.
+trait Accept {
+    /// The stream one accepted connection is served over.
+    type Stream: AsyncRead + AsyncWrite + Send + 'static;
+
+    /// Accept the next connection, or report why none could be taken.
+    async fn accept(&self) -> io::Result<Self::Stream>;
+}
+
+impl Accept for TcpListener {
+    type Stream = TcpStream;
+
+    async fn accept(&self) -> io::Result<TcpStream> {
+        TcpListener::accept(self)
+            .await
+            .map(|(stream, _peer)| stream)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::VecDeque, sync::Mutex};
+
+    use openwave_sandbox_protocol::{
+        protocol::{AttachRequest, HandshakeResponse, PROTOCOL_VERSION},
+        read_frame, write_frame, EventCursor, RunId, TransportSecret, WireFrame,
+    };
+    use tokio::io::{split, BufReader, DuplexStream};
+
+    use super::{io, serve_accepted, Accept, Duration, SandboxRun};
+
+    /// A listener that hands out a scripted sequence of accept outcomes and then
+    /// stops producing connections, as an idle listener does.
+    struct ScriptedListener {
+        steps: Mutex<VecDeque<io::Result<DuplexStream>>>,
+    }
+
+    impl Accept for ScriptedListener {
+        type Stream = DuplexStream;
+
+        async fn accept(&self) -> io::Result<DuplexStream> {
+            let step = self.steps.lock().expect("script lock").pop_front();
+            match step {
+                Some(step) => step,
+                // The script is spent: park, like a listener with nothing pending.
+                None => std::future::pending().await,
+            }
+        }
+    }
+
+    /// A transient accept failure must not end the accept loop — a sandbox that
+    /// stopped accepting is alive but unreachable forever. Both error classes are
+    /// exercised, the per-connection one retried immediately and the
+    /// listener-wide one backed off, and the connection behind them is still
+    /// accepted and served.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn accept_failures_do_not_end_the_accept_loop() {
+        let (host_side, sandbox_side) = tokio::io::duplex(64 * 1024);
+        let listener = ScriptedListener {
+            steps: Mutex::new(VecDeque::from([
+                Err(io::Error::from(io::ErrorKind::ConnectionAborted)),
+                // Descriptor exhaustion: the class that backs off.
+                Err(io::Error::other("too many open files")),
+                Ok(sandbox_side),
+            ])),
+        };
+        let secret = TransportSecret::new("accept-loop-test");
+        let run = SandboxRun::new([], Some(secret.clone()));
+        tokio::spawn(serve_accepted(listener, run));
+
+        let (read_half, mut write_half) = split(host_side);
+        let mut reader = BufReader::new(read_half);
+        let attach = WireFrame::Attach(AttachRequest {
+            protocol_version: PROTOCOL_VERSION,
+            run_id: RunId::new(),
+            resume_from: EventCursor::START,
+            transport_secret: secret,
+        });
+        write_frame(&mut write_half, &attach)
+            .await
+            .expect("send attach");
+
+        let answered = tokio::time::timeout(Duration::from_secs(5), read_frame(&mut reader))
+            .await
+            .expect("the connection behind the failures is accepted and served")
+            .expect("handshake frame");
+        assert!(
+            matches!(
+                answered,
+                WireFrame::Handshake(HandshakeResponse::Accepted(_))
+            ),
+            "expected the attach to be accepted, got {answered:?}"
+        );
     }
 }

--- a/crates/openwave-sandbox-protocol/Cargo.toml
+++ b/crates/openwave-sandbox-protocol/Cargo.toml
@@ -20,7 +20,9 @@ async-trait = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync", "macros", "time", "io-util"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "macros", "time", "io-util", "net"] }
+# `test-util` pauses the clock so the handshake deadline can be exercised without
+# the suite waiting on it.
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "macros", "time", "io-util", "net", "test-util"] }
 
 [lints]
 workspace = true

--- a/crates/openwave-sandbox-protocol/src/wire/host.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/host.rs
@@ -28,7 +28,7 @@ use crate::{
     ids::EventCursor,
     protocol::{AttachAccepted, AttachRefused, AttachRequest, ErrorCode, HandshakeResponse},
     reverse::{ControlFrame, RequestFrame, ReverseResponseEnvelope},
-    wire::{read_frame, write_frame, write_prioritized, FrameError, WireFrame},
+    wire::{read_frame, write_frame, write_prioritized, FrameError, WireFrame, ATTACH_TIMEOUT},
 };
 
 /// Why dialing and attaching to a sandbox over the wire failed.
@@ -134,7 +134,18 @@ impl WireClient {
                 .await
                 .map_err(ConnectError::Transport)?;
 
-            let accepted = match read_frame(&mut reader).await {
+            // Bounded the same way the sandbox bounds its read of the attach: a
+            // peer that accepts the connection and then says nothing would
+            // otherwise park this dial forever.
+            let answer = match tokio::time::timeout(ATTACH_TIMEOUT, read_frame(&mut reader)).await {
+                Ok(answer) => answer,
+                Err(_elapsed) => {
+                    return Err(ConnectError::Handshake(
+                        "the sandbox did not answer the handshake in time".to_owned(),
+                    ));
+                }
+            };
+            let accepted = match answer {
                 Ok(WireFrame::Handshake(HandshakeResponse::Accepted(accepted))) => accepted,
                 Ok(WireFrame::Handshake(HandshakeResponse::Refused(refused))) => {
                     return Err(match refused.code {

--- a/crates/openwave-sandbox-protocol/src/wire/mod.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/mod.rs
@@ -57,6 +57,18 @@ use crate::{
 pub use host::{HostConnection, WireClient};
 pub use sandbox::{serve_connection, ReverseOutcome, SandboxRun};
 
+/// How long either side waits for the handshake frame it is owed before it drops
+/// the connection.
+///
+/// [`read_frame`] bounds how *much* a peer may make this side buffer, not how
+/// long it may take: without a deadline a peer that connects and then says
+/// nothing — or dribbles a frame a byte at a time — holds a serving task and a
+/// descriptor indefinitely. The bound covers the whole frame rather than each
+/// read, so a slow drip is dropped just as an idle peer is. It is generous
+/// against the work being waited on (one write on a freshly established
+/// connection) and so is not a latency budget for anything else.
+pub const ATTACH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Largest single frame a conforming transport reads or writes, re-exported from
 /// the protocol's [`MAX_FRAME_BYTES`](crate::protocol::MAX_FRAME_BYTES) so the
 /// byte transport and the semantic bound stay one number.

--- a/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
@@ -39,7 +39,7 @@ use crate::{
     reverse::{
         Capability, ControlFrame, RequestFrame, ReverseEnvelope, ReverseRequest, ReverseResult,
     },
-    wire::{read_frame, write_frame, write_prioritized, FrameError, WireFrame},
+    wire::{read_frame, write_frame, write_prioritized, FrameError, WireFrame, ATTACH_TIMEOUT},
 };
 
 /// The outcome of one sandbox-originated reverse call over the current
@@ -319,6 +319,17 @@ impl SandboxRun {
             .collect()
     }
 
+    /// Whether `closed` belongs to the connection currently installed as the
+    /// run's live peer.
+    ///
+    /// A serve loop keeps reading until its own socket drops, which can be after
+    /// a reconnect has already installed a newer connection. Frames that mutate
+    /// run-scoped state are gated on this so a superseded peer cannot speak for
+    /// the run.
+    fn is_live(&self, closed: &Arc<AtomicBool>) -> bool {
+        matches!(&*self.inner.conn.borrow(), Some(current) if Arc::ptr_eq(&current.closed, closed))
+    }
+
     /// Advance the un-acknowledged buffer to the host's committed cursor.
     fn acknowledge(&self, cursor: EventCursor) {
         let mut buffer = self.inner.events.lock().expect("event buffer lock");
@@ -341,6 +352,13 @@ impl SandboxRun {
 /// responses back. Returns when the connection drops; the `run` survives for the
 /// host to reattach to.
 ///
+/// The attach frame is read under [`ATTACH_TIMEOUT`]. A peer that connects and
+/// then sends nothing, or dribbles bytes without ever completing the frame,
+/// holds a serving task and a descriptor for as long as it likes otherwise —
+/// [`read_frame`] bounds how *much* it will buffer, not how long it will wait.
+/// The bound applies to the whole frame, not to each read, so a slow drip is
+/// dropped just as an idle peer is.
+///
 /// # Errors
 /// [`FrameError`] if the transport fails before or during the handshake.
 pub async fn serve_connection<S>(stream: S, run: SandboxRun) -> Result<(), FrameError>
@@ -351,11 +369,17 @@ where
     let mut reader = BufReader::new(read_half);
     let mut write_half = write_half;
 
-    // The first frame must be the attach handshake.
-    let attach = match read_frame(&mut reader).await? {
-        WireFrame::Attach(attach) => attach,
-        // A peer that opens with anything else is not speaking the protocol.
-        _ => return Ok(()),
+    // The first frame must be the attach handshake, and must arrive promptly.
+    let opening = tokio::time::timeout(ATTACH_TIMEOUT, read_frame(&mut reader)).await;
+    let attach = match opening {
+        Ok(frame) => match frame? {
+            WireFrame::Attach(attach) => attach,
+            // A peer that opens with anything else is not speaking the protocol.
+            _ => return Ok(()),
+        },
+        // A peer that never finished its attach is dropped; nothing was
+        // installed, so the run is untouched and stands for a real host.
+        Err(_elapsed) => return Ok(()),
     };
 
     let response = handshake(
@@ -402,6 +426,11 @@ where
     // for want of one and leave the slot empty — `send_replace` updates the value
     // unconditionally, and a `call` that subscribes afterward still sees it.
     run.inner.conn.send_replace(Some(conn.clone()));
+    // The resume cursor is this host's own committed position, so take it as an
+    // acknowledgement. It is what makes ignoring a superseded peer's acks below
+    // lossless: the incoming host restates its commitment on attach rather than
+    // the run depending on an ack that may still be in flight on the old socket.
+    run.acknowledge(attach.resume_from);
     for event in run.events_since(attach.resume_from) {
         if conn.data.send(WireFrame::Event(event)).await.is_err() {
             break;
@@ -431,7 +460,16 @@ where
                     .send(WireFrame::Control(ControlFrame::Pong { nonce }))
                     .await;
             }
-            WireFrame::EventAck { cursor } => run.acknowledge(cursor),
+            // An acknowledgement is run-scoped state, so only the connection that
+            // is currently installed may advance it. A superseded peer still
+            // draining its socket after a reconnect speaks for a delivery the
+            // live host has not made — and the live host's own commitment is
+            // already taken from its resume cursor at attach.
+            WireFrame::EventAck { cursor } => {
+                if run.is_live(&closed) {
+                    run.acknowledge(cursor);
+                }
+            }
             // The sandbox originates cancels and requests; it never receives
             // them. Pong is liveness only. Ignore rather than trust peer input.
             WireFrame::Control(ControlFrame::Pong { .. } | ControlFrame::Cancel { .. })
@@ -456,4 +494,138 @@ where
     });
     writer.abort();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::io::{split, DuplexStream, WriteHalf};
+
+    use super::{
+        read_frame, write_frame, ControlFrame, EventCursor, SandboxRun, Sequence, TransportSecret,
+        WireFrame, ATTACH_TIMEOUT, PROTOCOL_VERSION,
+    };
+    use crate::{
+        ids::RunId,
+        protocol::{AttachRequest, HandshakeResponse},
+    };
+
+    fn run_with(secret: &TransportSecret) -> SandboxRun {
+        SandboxRun::new([], Some(secret.clone()))
+    }
+
+    /// Attach over `host_side`, returning the halves so the caller can keep
+    /// speaking on the connection afterwards.
+    async fn attach(
+        host_side: DuplexStream,
+        secret: &TransportSecret,
+        resume_from: EventCursor,
+    ) -> (
+        tokio::io::BufReader<tokio::io::ReadHalf<DuplexStream>>,
+        WriteHalf<DuplexStream>,
+    ) {
+        let (read_half, mut write_half) = split(host_side);
+        let mut reader = tokio::io::BufReader::new(read_half);
+        let attach = WireFrame::Attach(AttachRequest {
+            protocol_version: PROTOCOL_VERSION,
+            run_id: RunId::new(),
+            resume_from,
+            transport_secret: secret.clone(),
+        });
+        write_frame(&mut write_half, &attach)
+            .await
+            .expect("send attach");
+        let answered = read_frame(&mut reader).await.expect("handshake answered");
+        assert!(matches!(
+            answered,
+            WireFrame::Handshake(HandshakeResponse::Accepted(_))
+        ));
+        (reader, write_half)
+    }
+
+    /// A peer that connects and then never completes its attach is dropped rather
+    /// than holding a serving task forever, and nothing is installed on the run.
+    ///
+    /// Time is paused, so the deadline is exercised without the test waiting on
+    /// it: the runtime advances the clock once every task is idle, which a serve
+    /// loop that reads without a deadline never becomes.
+    #[tokio::test(start_paused = true)]
+    async fn a_peer_that_never_completes_its_attach_is_dropped() {
+        let secret = TransportSecret::new("slowloris-test");
+        let run = run_with(&secret);
+        let (host_side, sandbox_side) = tokio::io::duplex(1024);
+        let served = tokio::spawn(super::serve_connection(sandbox_side, run.clone()));
+
+        // The peer holds the connection open and sends nothing at all.
+        let outcome = tokio::time::timeout(ATTACH_TIMEOUT * 3, served)
+            .await
+            .expect("the silent peer is dropped at the attach deadline");
+        assert!(outcome.expect("serve task").is_ok());
+        assert!(
+            run.current_conn().is_none(),
+            "a peer that never attached must not be installed"
+        );
+        drop(host_side);
+    }
+
+    /// A superseded peer — still draining its socket after the host reconnected —
+    /// cannot advance the run's acknowledged cursor. Its ack speaks for a
+    /// delivery the live host has not made, and taking it would let the sandbox
+    /// discard backpressure the live host is entitled to.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_superseded_peer_cannot_advance_the_acknowledged_cursor() {
+        let secret = TransportSecret::new("stale-ack-test");
+        let run = run_with(&secret);
+
+        let (first_host, first_sandbox) = tokio::io::duplex(4096);
+        tokio::spawn(super::serve_connection(first_sandbox, run.clone()));
+        let (mut first_reader, mut first_writer) =
+            attach(first_host, &secret, EventCursor::START).await;
+
+        // The host reconnects; the second connection becomes the live one while
+        // the first is still readable.
+        let (second_host, second_sandbox) = tokio::io::duplex(4096);
+        tokio::spawn(super::serve_connection(second_sandbox, run.clone()));
+        let (_second_reader, _second_writer) =
+            attach(second_host, &secret, EventCursor::START).await;
+
+        // The stale peer acknowledges. A ping behind it, answered on the same
+        // connection, proves the ack was processed before we assert.
+        write_frame(
+            &mut first_writer,
+            &WireFrame::EventAck {
+                cursor: EventCursor::committed(Sequence::new(5)),
+            },
+        )
+        .await
+        .expect("send stale ack");
+        write_frame(
+            &mut first_writer,
+            &WireFrame::Control(ControlFrame::Ping { nonce: 1 }),
+        )
+        .await
+        .expect("send ping");
+        let pong = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            read_frame(&mut first_reader),
+        )
+        .await
+        .expect("the stale connection is still served")
+        .expect("pong");
+        assert!(matches!(
+            pong,
+            WireFrame::Control(ControlFrame::Pong { nonce: 1 })
+        ));
+
+        let acked = run
+            .inner
+            .events
+            .lock()
+            .expect("event buffer lock")
+            .acked_through;
+        assert_eq!(
+            acked,
+            EventCursor::START.get(),
+            "a superseded peer advanced the acknowledged cursor"
+        );
+    }
 }


### PR DESCRIPTION
Three robustness defects in the sandbox transport, all in the connection setup path.

**The accept loop no longer ends on an error.** `while let Ok(..) = listener.accept()` exited permanently on the first failure, including recoverable ones like `ECONNABORTED` or descriptor exhaustion. That leaves a container that is alive and looks healthy but can never be attached to again — worse than a process that dies and is observed to have died. The loop now retries every error. A per-connection error (aborted/reset/refused, or an interrupted syscall) says nothing about the listener, so the next connection is accepted immediately; anything else backs off exponentially from 5ms to a 1s ceiling and resets on the next accepted connection, so a listener failing for a reason that never clears retries cheaply instead of spinning a core.

**The handshake read is bounded in time.** `read_frame` bounds how much a peer can make us buffer, not how long it may take, so a peer that connected and then said nothing — or dribbled a frame a byte at a time — held a serving task and a descriptor indefinitely. The sandbox now reads the attach frame under a 10s deadline covering the whole frame, and drops the connection without installing anything if it expires. The host's read of the handshake answer had the same gap and gets the same bound, reported as `ConnectError::Handshake`.

**A superseded peer can no longer advance the acknowledged cursor.** A serve loop keeps reading until its own socket drops, which can be well after a reconnect installed a newer connection; its `EventAck` frames were applied to run-scoped state regardless. The ack is now gated on the connection still being the installed one. On its own that would tighten backpressure — a final ack lost on the old socket would leave the sandbox counting acknowledged events as un-acknowledged — so the attach now also takes the incoming host's resume cursor as an acknowledgement. That cursor is by definition what the host has committed, and it is already what the replay is filtered on, so no resume semantics change: the same events replay, and the un-acknowledged watermark now follows the live host rather than whatever was last heard from a dead one.

Tests: one per behavior that would otherwise regress silently. The accept loop is driven through both error classes against a scripted listener and must still serve the connection behind them; the attach deadline runs with the clock paused so it costs no wall time; the stale-ack guard attaches two connections and checks the superseded one cannot move the cursor. `test-util` is added to the crate's dev-dependencies for the paused clock.

Closes #1101
