### PR TITLE
fix(desktop): isolate error boundaries per tool result

### DIFF
--- a/crates/openwave-desktop/ui/src/ErrorBoundary.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ErrorBoundary.dom.test.tsx
@@ -73,4 +73,30 @@ describe("ErrorBoundary with an inline fallback", () => {
     expect(screen.getByText("the conversation around it")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Reload" })).toBeNull();
   });
+
+  it("retries the children when their data changes, and not before", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    // Throws only while the result is half-written, the way a streaming row
+    // meets a shape its parser cannot read yet.
+    const Row = ({ result }: { result: string }) => {
+      if (result === "partial") throw new Error("half-written result");
+      return <p>{result}</p>;
+    };
+    const boundary = (result: string) => (
+      <ErrorBoundary resetKey={result} fallback={<p>unavailable</p>}>
+        <Row result={result} />
+      </ErrorBoundary>
+    );
+
+    const { rerender } = render(boundary("partial"));
+    expect(screen.getByText("unavailable")).toBeTruthy();
+
+    // A re-render carrying the same data leaves it alone: retrying every frame
+    // would throw on every frame.
+    rerender(boundary("partial"));
+    expect(screen.getByText("unavailable")).toBeTruthy();
+
+    rerender(boundary("settled"));
+    expect(screen.getByText("settled")).toBeTruthy();
+  });
 });

--- a/crates/openwave-desktop/ui/src/ErrorBoundary.tsx
+++ b/crates/openwave-desktop/ui/src/ErrorBoundary.tsx
@@ -15,6 +15,18 @@ type ErrorBoundaryProps = {
    * prompt.
    */
   fallback?: ReactNode;
+  /**
+   * Data signature of the children. A change clears a caught error and lets
+   * them render again.
+   *
+   * A boundary latches: whatever threw stays replaced by the fallback for the
+   * life of the mount, even though a streaming transcript re-renders around it
+   * many times a second. Callers pass a signal derived from the data being
+   * rendered, so a row that threw on a half-written result recovers once the
+   * result changes, while a row that is simply malformed stays quiet instead of
+   * throwing on every frame.
+   */
+  resetKey?: string | number;
 };
 
 type ErrorBoundaryState = {
@@ -38,6 +50,12 @@ export class ErrorBoundary extends Component<
 
   componentDidCatch(error: Error, info: { componentStack?: string | null }) {
     console.error("unhandled render error", error, info.componentStack);
+  }
+
+  componentDidUpdate(previous: ErrorBoundaryProps) {
+    if (this.state.error === null) return;
+    if (previous.resetKey === this.props.resetKey) return;
+    this.setState({ error: null });
   }
 
   render() {

--- a/crates/openwave-desktop/ui/src/MessageList.isolation.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.isolation.dom.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MessageList, type ChatMessage } from "./MessageList";
+
+// A tool result view that cannot render. Standing in for the real failure —
+// a defensive parser meeting a shape it did not expect — because the shapes
+// this build rejects are exactly the ones it renders safely today.
+vi.mock("./McpAppCard", () => ({
+  McpAppCard: () => {
+    throw new Error("malformed mcp app result");
+  },
+}));
+
+const noop = () => undefined;
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function list(messages: ChatMessage[]) {
+  return render(
+    <MessageList
+      messages={messages}
+      folderAccessRequests={[]}
+      nativeHost={false}
+      nativeBusy={false}
+      resolvingFolderCalls={new Set()}
+      folderAccessErrors={{}}
+      decidingApprovalCalls={new Set()}
+      approvalErrors={{}}
+      busy={false}
+      scrollRef={{ current: null }}
+      onScroll={noop}
+      onApproval={noop}
+      onFolderAccessDecision={noop}
+      onFolderAccessCancel={noop}
+    />,
+  );
+}
+
+describe("a tool result that cannot render", () => {
+  it("costs its own card and leaves the approval prompt standing", () => {
+    // React logs caught errors loudly; keep the test output readable.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    list([
+      {
+        id: "t1",
+        role: "tool",
+        callId: "c1",
+        name: "other",
+        status: "completed",
+        result: {
+          tool: "mcp_app",
+          server: "gateway",
+          resourceUri: "ui://gateway/app.html",
+        },
+      },
+      {
+        id: "t2",
+        role: "tool",
+        callId: "c2",
+        name: "exec",
+        status: "waiting_approval",
+        preview: { tool: "exec", command: "cargo", args: ["build"], cwd: "." },
+      },
+      {
+        id: "a1",
+        role: "approval",
+        callId: "c2",
+        summary: "Allow OpenWave to run a command?",
+        preview: { tool: "exec", command: "cargo", args: ["build"], cwd: "." },
+        canApprove: true,
+        canRemember: true,
+      },
+    ]);
+
+    // The broken card says so rather than leaving a gap...
+    expect(screen.getByText("This step could not be displayed.")).toBeTruthy();
+    // ...and the decision the turn is parked on is still there to make. A
+    // phase-wide boundary took this card down with its sibling, which leaves
+    // the reader unable to answer and unable to see why.
+    expect(
+      screen.getByRole("option", { name: /Yes, run it once/ }),
+    ).toBeTruthy();
+  });
+});

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -28,7 +28,10 @@ import { MessageCitationsProvider } from "./InlineCitation";
 import { McpAppCard } from "./McpAppCard";
 import { ToolCommandCard, type ToolCallStatus } from "./ToolCallCard";
 import { ErrorBoundary } from "./ErrorBoundary";
-import { ToolActivityGroup } from "./ToolActivityGroup";
+import {
+  ToolActivityGroup,
+  ToolActivityUnavailable,
+} from "./ToolActivityGroup";
 import { WelcomeState } from "./WelcomeState";
 import { UserQuestionsCard } from "./UserQuestionsCard";
 import type { TranscriptImageAttachment } from "./ImageAttachments";
@@ -490,31 +493,29 @@ export function groupMessageItems(
     const children: ReactNode[] = [...cards];
     if (spawns.length > 0) {
       children.push(
-        <BackgroundAgentList
-          key="background-agents"
-          spawns={spawns}
-          runs={backgroundAgents.runs}
-          loading={backgroundAgents.loading}
-          error={backgroundAgents.error}
-          onRetry={backgroundAgents.retry}
-          onCancel={backgroundAgents.cancel}
-          onLoadActivity={backgroundAgents.loadActivity}
-          onViewOutput={backgroundAgents.viewOutput}
-        />,
+        isolatedCard(
+          "background-agents",
+          spawns.map((spawn) => spawn.status).join(" "),
+          <BackgroundAgentList
+            spawns={spawns}
+            runs={backgroundAgents.runs}
+            loading={backgroundAgents.loading}
+            error={backgroundAgents.error}
+            onRetry={backgroundAgents.retry}
+            onCancel={backgroundAgents.cancel}
+            onLoadActivity={backgroundAgents.loadActivity}
+            onViewOutput={backgroundAgents.viewOutput}
+          />,
+        ),
       );
     }
 
-    // A tool row renders model-influenced data through several defensive
-    // parsers. If one of them is ever wrong, the throw should cost this phase
-    // and not the conversation around it.
+    // The rail and every card inside carry their own boundary, so this one is
+    // only a backstop for the phase's own frame.
     items.push(
       <ErrorBoundary
         key={`tool-activity-group-${groupIndex}`}
-        fallback={
-          <p className="tool-activity-unavailable" role="status">
-            This step could not be displayed.
-          </p>
-        }
+        fallback={<ToolActivityUnavailable />}
       >
         <ToolActivityGroup activities={activities} groupIndex={groupIndex}>
           {children.length > 0 ? children : undefined}
@@ -525,6 +526,34 @@ export function groupMessageItems(
   }
 
   return { items, lastTurnStart };
+}
+
+/**
+ * One card, contained.
+ *
+ * Cards render model-influenced data through several defensive parsers, and one
+ * of them being wrong must not cost the card next to it. The sibling that makes
+ * this matter is the approval prompt: a phase parked on a decision that renders
+ * as nothing leaves the reader with no way to answer and no explanation.
+ *
+ * `signature` is the data the card draws on, reduced to what decides whether it
+ * can render, so a card that threw mid-stream is retried when its call moves on
+ * rather than staying broken for the life of the transcript.
+ */
+function isolatedCard(
+  key: string,
+  signature: string,
+  card: ReactNode,
+): ReactNode {
+  return (
+    <ErrorBoundary
+      key={key}
+      resetKey={signature}
+      fallback={<ToolActivityUnavailable />}
+    >
+      {card}
+    </ErrorBoundary>
+  );
 }
 
 /**
@@ -557,22 +586,25 @@ function surfacedCards(
     if (entry.role === "approval") {
       if (entry.resolved) continue;
       cards.push(
-        <ApprovalCard
-          key={entry.id}
-          callId={entry.callId}
-          summary={entry.summary}
-          preview={entry.preview ?? null}
-          canApprove={entry.canApprove}
-          canRemember={entry.canRemember}
-          grantScope={approvalState?.grantScope ?? "chat"}
-          autoJudging={entry.autoJudging ?? false}
-          prefixRungs={entry.prefixRungs ?? []}
-          deciding={
-            approvalState?.decidingApprovalCalls.has(entry.callId) ?? false
-          }
-          error={approvalState?.approvalErrors[entry.callId]}
-          onDecide={onApproval}
-        />,
+        isolatedCard(
+          entry.id,
+          `${entry.canApprove} ${approvalState?.approvalErrors[entry.callId] ?? ""}`,
+          <ApprovalCard
+            callId={entry.callId}
+            summary={entry.summary}
+            preview={entry.preview ?? null}
+            canApprove={entry.canApprove}
+            canRemember={entry.canRemember}
+            grantScope={approvalState?.grantScope ?? "chat"}
+            autoJudging={entry.autoJudging ?? false}
+            prefixRungs={entry.prefixRungs ?? []}
+            deciding={
+              approvalState?.decidingApprovalCalls.has(entry.callId) ?? false
+            }
+            error={approvalState?.approvalErrors[entry.callId]}
+            onDecide={onApproval}
+          />,
+        ),
       );
       continue;
     }
@@ -581,7 +613,7 @@ function surfacedCards(
       entry.result?.tool === "web_search_provider_required" &&
       !parked.has(entry.callId)
     ) {
-      cards.push(<WebSearchProviderRequiredCard key={entry.id} />);
+      cards.push(isolatedCard(entry.id, "", <WebSearchProviderRequiredCard />));
       continue;
     }
     // An MCP App view is keyed on the *result*: the tool has no action
@@ -589,13 +621,16 @@ function surfacedCards(
     // renders — inside the sandbox — not to restate arguments or output.
     if (entry.result?.tool === "mcp_app" && !parked.has(entry.callId)) {
       cards.push(
-        <McpAppCard
-          key={entry.id}
-          server={entry.result.server}
-          resourceUri={entry.result.resourceUri}
-          chatId={chatId}
-          callId={entry.callId}
-        />,
+        isolatedCard(
+          entry.id,
+          `${entry.result.server} ${entry.result.resourceUri}`,
+          <McpAppCard
+            server={entry.result.server}
+            resourceUri={entry.result.resourceUri}
+            chatId={chatId}
+            callId={entry.callId}
+          />,
+        ),
       );
       continue;
     }
@@ -610,15 +645,18 @@ function surfacedCards(
     // exec-shaped card with tabs and an exit code.
     if (entry.preview.tool !== "exec") continue;
     cards.push(
-      <ToolCommandCard
-        key={entry.id}
-        name={entry.name}
-        status={entry.status}
-        preview={entry.preview}
-        result={entry.result?.tool === "exec" ? entry.result : null}
-        imageClient={imageClient}
-        chatId={chatId}
-      />,
+      isolatedCard(
+        entry.id,
+        `${entry.status} ${entry.result?.tool ?? ""}`,
+        <ToolCommandCard
+          name={entry.name}
+          status={entry.status}
+          preview={entry.preview}
+          result={entry.result?.tool === "exec" ? entry.result : null}
+          imageClient={imageClient}
+          chatId={chatId}
+        />,
+      ),
     );
   }
   return cards;

--- a/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
+++ b/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
@@ -1,6 +1,7 @@
 import { useState, type ReactNode } from "react";
 import { ChevronDown } from "lucide-react";
 import type { ToolActionPreview, ToolResultPreview } from "./api";
+import { ErrorBoundary } from "./ErrorBoundary";
 import { toolCallPresentation, type ToolCallStatus } from "./ToolCallCard";
 import { ToolEntriesList } from "./ToolEntriesList";
 import { ToolIcon } from "./ToolIcon";
@@ -54,35 +55,71 @@ export function ToolActivityGroup({
   groupIndex,
   children,
 }: ToolActivityGroupProps) {
+  const safeActivities = normalizeActivities(activities);
+
+  // The rail reads model-shaped data through several defensive parsers; the
+  // cards below it are the part a reader may have to act on. Containing the
+  // rail on its own means a phase line that cannot render costs the line and
+  // not the approval prompt sitting under it.
+  const rail =
+    safeActivities.length === 0 ? null : (
+      <ErrorBoundary
+        resetKey={railSignature(safeActivities)}
+        fallback={<ToolActivityUnavailable />}
+      >
+        <ToolActivityRail
+          activities={safeActivities}
+          groupIndex={groupIndex}
+        />
+      </ErrorBoundary>
+    );
+
+  // A phase can be all cards and no rail — every call in it parked on an
+  // approval, say. The cards are the part that must never go missing, so they
+  // render on their own rather than taking the trigger down with them.
+  if (rail === null && children === undefined) {
+    return (
+      <p className="text-muted-foreground self-start text-sm" role="status">
+        Tool activity unavailable
+      </p>
+    );
+  }
+
+  return (
+    <div className="w-full self-start">
+      {rail}
+      <div
+        className={cn(
+          "flex flex-col gap-2 empty:hidden",
+          rail !== null && "mt-2",
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The collapsed phase line and, once opened, the rail of rows beneath it.
+ */
+function ToolActivityRail({
+  activities: safeActivities,
+  groupIndex,
+}: {
+  activities: ToolActivity[];
+  groupIndex: number;
+}) {
   const [expanded, setExpanded] = useState(false);
   const contentId = `tool-activity-group-${groupIndex}`;
-  const safeActivities = normalizeActivities(activities);
   const summary = toolActivityGroupPresentation(safeActivities);
   // The phase line types itself out once when the phase first goes live, then
   // updates instantly as calls settle and nudge the wording — re-typing on
   // every change reads as a stutter, and a settled phase should never animate.
   const displayedSummary = useTypewriterOnce(summary.label, summary.inProgress);
 
-  // A phase can be all cards and no rail — every call in it parked on an
-  // approval, say. The cards are the part that must never go missing, so they
-  // render on their own rather than taking the trigger down with them.
-  if (safeActivities.length === 0) {
-    if (children === undefined) {
-      return (
-        <p className="text-muted-foreground self-start text-sm" role="status">
-          Tool activity unavailable
-        </p>
-      );
-    }
-    return (
-      <div className="flex w-full flex-col gap-2 self-start empty:hidden">
-        {children}
-      </div>
-    );
-  }
-
   return (
-    <div className="w-full self-start">
+    <>
       <Button
         type="button"
         variant="link"
@@ -116,17 +153,60 @@ export function ToolActivityGroup({
           className="relative ml-1.5 flex flex-col gap-4 border-l-2 py-1 pl-4 text-sm"
           role="list"
         >
+          {/* One boundary per row, not one per phase: a result this build
+              cannot render should cost its own line and leave the rest of the
+              rail — and the cards under it — standing. */}
           {safeActivities.map((activity, index) => (
-            <ToolActivityRow
+            <ErrorBoundary
               key={activity.id ?? `position:${index}`}
-              activity={activity}
-            />
+              resetKey={rowSignature(activity)}
+              fallback={<ToolActivityUnavailable role="listitem" />}
+            >
+              <ToolActivityRow activity={activity} />
+            </ErrorBoundary>
           ))}
         </div>
       )}
-      <div className="mt-2 flex flex-col gap-2 empty:hidden">{children}</div>
-    </div>
+    </>
   );
+}
+
+/**
+ * What stands in for a row, a rail, or a card that threw while rendering.
+ *
+ * Deliberately quiet and deliberately not blank: a gap reads as a step that
+ * never happened, which is a different and untrue claim.
+ */
+export function ToolActivityUnavailable({
+  role = "status",
+}: {
+  role?: string;
+}) {
+  return (
+    <p className="tool-activity-unavailable" role={role}>
+      This step could not be displayed.
+    </p>
+  );
+}
+
+/**
+ * The data a row draws on, reduced to what decides whether it can render.
+ *
+ * A row that threw is retried when its call moves on or its result arrives,
+ * and left alone while the transcript re-renders around it.
+ */
+function rowSignature(activity: ToolActivity): string {
+  return [
+    activity.name,
+    activity.status,
+    activity.resultUnreadable === true ? "unreadable" : "",
+    activity.preview?.tool ?? "",
+    activity.result?.tool ?? "",
+  ].join(" ");
+}
+
+function railSignature(activities: readonly ToolActivity[]): string {
+  return activities.map(rowSignature).join("|");
 }
 
 function ToolActivityRow({ activity }: { activity: ToolActivity }) {


### PR DESCRIPTION
A transcript phase wrapped its rail and every card under it in one error boundary, so a single tool result view that threw erased all of its siblings. The case that makes this worth fixing is the approval prompt: approvals render as cards in that same group, so a malformed result next to one leaves the reader with a turn parked on a decision, no card to act on, and no explanation of what happened.

Each card and each rail row now carries its own boundary, and the rail is contained separately from the cards below it, so a phase line that cannot render does not take an approval prompt with it. The fallback is the quiet line the phase boundary already used ("This step could not be displayed."), rather than a gap — a gap reads as a step that never happened.

Boundaries latch once they catch, and a streaming transcript re-renders many times a second, so each boundary now takes a signature of the data it is rendering. A row that threw on a half-written result gets another chance when the result changes; a row that is simply malformed stays quiet instead of throwing on every frame.

Two tests: one drives a transcript with a throwing result view next to a live approval and checks the approval is still there to answer (it fails on the previous structure), and one covers the reset rule directly — same data leaves the fallback alone, changed data retries.

Closes #1110
