### PR TITLE
feat(router): cache Anthropic prompt prefixes

### DIFF
--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -176,7 +176,7 @@ impl ModelProvider for AnthropicProvider {
 /// becomes a top-level field, and only `user`/`assistant` roles are valid on
 /// messages.
 fn build_request_json(req: &ChatRequest) -> Result<Value> {
-    let messages = req
+    let mut messages = req
         .messages
         .iter()
         .map(|message| {
@@ -186,6 +186,7 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
             }))
         })
         .collect::<Result<Vec<_>>>()?;
+    mark_cacheable_transcript_tail(&mut messages);
 
     let mut body = json!({
         "model": req.model,
@@ -199,7 +200,13 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
     // policy and make durable model attribution ambiguous.
 
     if let Some(system) = &req.system {
-        body["system"] = json!(system);
+        // Block form, not a bare string, so the prefix through the system
+        // prompt carries a cache breakpoint.
+        body["system"] = json!([{
+            "type": "text",
+            "text": system,
+            "cache_control": ephemeral_cache_control(),
+        }]);
     }
     if !req.tools.is_empty() {
         body["tools"] = Value::Array(
@@ -256,6 +263,9 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
             )))
         }
     }
+    // After the whole tool array is settled, including a structured-output tool
+    // appended above.
+    mark_last_tool_cacheable(&mut body);
     if let Some(temperature) = req.temperature {
         body["temperature"] = json!(temperature);
     }
@@ -277,6 +287,65 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         }
     }
     Ok(body)
+}
+
+/// The breakpoint marker. Five-minute TTL: an agentic turn's model calls land
+/// seconds apart, so the longer TTL would only double the write price for reads
+/// that already happen well inside the default window.
+fn ephemeral_cache_control() -> Value {
+    json!({ "type": "ephemeral" })
+}
+
+/// Put a breakpoint on the last tool definition.
+///
+/// Tools render before `system`, so the system breakpoint already covers them.
+/// This second one buys the segment on its own: it is the only breakpoint when
+/// a request carries no system prompt, and it survives a system prompt that
+/// differs between two chats sharing one tool set. Both breakpoints sit inside
+/// the same prefix, so the tokens are written once either way.
+///
+/// Requires deterministic tool order to hit at all — see the note on
+/// `mark_cacheable_transcript_tail`.
+fn mark_last_tool_cacheable(body: &mut Value) {
+    if let Some(last) = body
+        .get_mut("tools")
+        .and_then(Value::as_array_mut)
+        .and_then(|tools| tools.last_mut())
+        .and_then(Value::as_object_mut)
+    {
+        last.insert("cache_control".into(), ephemeral_cache_control());
+    }
+}
+
+/// Put a breakpoint on the last content block of the transcript.
+///
+/// The breakpoint moves to the tail on every call rather than being anchored to
+/// a fixed early message. An agentic turn appends an assistant message and its
+/// tool results per step and re-sends the whole transcript, so the tail is
+/// exactly the boundary between what the previous call already wrote and what
+/// this call adds: each step writes only its own delta and reads everything
+/// before it. Anchoring instead — at the head of the conversation, say — would
+/// cache a fixed prefix and pay full price for the growth, and the head is the
+/// worst place to anchor here besides: context fitting rewrites it when it
+/// truncates, checkpoints it, or evicts an old image, while leaving the tail
+/// untouched.
+///
+/// A write costs more than uncached input and a read costs far less, so a
+/// breakpoint only pays if the prefix under it is byte-identical next call.
+/// Two things above this one must therefore stay stable: the tool
+/// advertisement order (see #1088) and the system prompt, which is fixed for a
+/// chat's configuration. A prefix that is under the model's minimum cacheable
+/// length is not a loss — the breakpoint is ignored rather than charged.
+fn mark_cacheable_transcript_tail(messages: &mut [Value]) {
+    if let Some(last) = messages
+        .last_mut()
+        .and_then(|message| message.get_mut("content"))
+        .and_then(Value::as_array_mut)
+        .and_then(|tools| tools.last_mut())
+        .and_then(Value::as_object_mut)
+    {
+        last.insert("cache_control".into(), ephemeral_cache_control());
+    }
 }
 
 /// Whether the request obliges the model to call a specific tool or any tool.
@@ -600,7 +669,7 @@ mod tests {
         assert_eq!(body["model"], "claude-opus-4-8");
         assert_eq!(body["max_tokens"], DEFAULT_MAX_TOKENS);
         assert_eq!(body["stream"], true);
-        assert_eq!(body["system"], "be brief");
+        assert_eq!(body["system"][0]["text"], "be brief");
         assert_eq!(body["messages"][0]["role"], "user");
         assert_eq!(body["messages"][0]["content"][0]["type"], "text");
         assert_eq!(body["tools"][0]["name"], "read_file");
@@ -609,6 +678,55 @@ mod tests {
             body.get("fallbacks").is_none(),
             "fallback models require an explicit registry contract"
         );
+    }
+
+    #[test]
+    fn cache_breakpoints_sit_on_the_last_tool_system_block_and_transcript_tail() {
+        let req = ChatRequest {
+            provider: Some(ProviderId::new("anthropic")),
+            model: "claude-opus-4-8".into(),
+            system: Some("be brief".into()),
+            messages: vec![
+                ChatMessage::text(Role::User, "hi"),
+                ChatMessage::text(Role::Assistant, "hello"),
+            ],
+            tools: vec![
+                ToolSpec {
+                    name: "read_file".into(),
+                    description: "read a file".into(),
+                    input_schema: json!({"type": "object"}),
+                },
+                ToolSpec {
+                    name: "write_file".into(),
+                    description: "write a file".into(),
+                    input_schema: json!({"type": "object"}),
+                },
+            ],
+            images: ImageAttachments::new(),
+            ..Default::default()
+        };
+        let body = build_request_json(&req).unwrap();
+
+        let ephemeral = json!({ "type": "ephemeral" });
+        // Tools render before the system prompt, which renders before the
+        // messages, so these three breakpoints are the ends of the three
+        // segments — in ascending prefix order.
+        assert!(body["tools"][0].get("cache_control").is_none());
+        assert_eq!(body["tools"][1]["cache_control"], ephemeral);
+        assert_eq!(body["system"][0]["cache_control"], ephemeral);
+        assert!(body["messages"][0]["content"][0]
+            .get("cache_control")
+            .is_none());
+        assert_eq!(
+            body["messages"][1]["content"][0]["cache_control"],
+            ephemeral
+        );
+        // Four is the hard cap; going over rejects the request outright.
+        let breakpoints = serde_json::to_string(&body)
+            .unwrap()
+            .matches("cache_control")
+            .count();
+        assert_eq!(breakpoints, 3, "{body}");
     }
 
     fn reasoning_request(model: &str, effort: Option<ReasoningEffort>) -> ChatRequest {


### PR DESCRIPTION
An agentic turn makes up to 16 model calls, and every one of them re-sent the
system prompt, the whole tool advertisement, and the entire growing transcript
at full input price. Nothing in the workspace set `cache_control`, so the
`cache_read_input_tokens` / `cache_creation_input_tokens` fields on `Usage` have
always read zero.

The Anthropic adapter now places three ephemeral breakpoints, which is the whole
change:

- **Last tool definition.** Tools render first, so this caches the tool segment
  on its own. It is the only breakpoint that applies when a request carries no
  system prompt, and it still hits when two chats share a tool set but differ in
  their system prompt.
- **The system prompt.** Sent as a one-element block array rather than a bare
  string so it can carry the marker. Tools render before `system`, so this
  breakpoint covers tools *and* system; both breakpoints live inside the same
  prefix, so the tokens are written once either way.
- **The last content block of the transcript**, moved to the tail on every call.

Three, against a hard cap of four.

## Why the transcript breakpoint moves rather than anchors

A write costs about 1.25x uncached input and a read about 0.1x, so a breakpoint
placed where the prefix changes every call is strictly worse than no caching.
The tail is the one place in an agentic loop where that is not true: each step
appends an assistant message and its tool results and re-sends everything, so
the tail is exactly the boundary between what the previous call already wrote
and what this call adds. Each step writes only its own delta and reads
everything before it. The write premium is paid once per token and recovered on
the second read; in a 16-call turn most deltas are read many times over.

An anchored breakpoint, as in the reference implementation, would cache a fixed
early prefix and pay full price for all the growth above it. It is also the
worst place to anchor in this codebase specifically: context fitting mutates the
*head* of the transcript — it truncates there, replaces it with a checkpoint
summary, evicts old images to text stand-ins — while leaving the tail untouched.
An anchor would sit precisely where the invalidation happens.

## What has to hold for any of this to hit

Caching is a prefix match, so the stability of everything above a breakpoint is
what decides whether it earns its price:

- **Tool order.** `ToolRegistry::specs_for_foreground` iterates a `HashMap`, so
  the advertised order is currently random per process. That invalidates the
  tool and system breakpoints on every call and would make this change a net
  loss on its own. #1088 makes the order deterministic; **these two pair, and
  the caching only starts paying once that lands.**
- **The system prompt** is `AgentConfig::system_prompt`, fixed for a chat's
  configuration and unchanged across a turn's calls.
- **Minimum cacheable prefix.** Anthropic enforces a per-model floor — 512
  tokens on Opus 5, 1024 on Opus 4.8 and the Sonnet 5/4.6 line, higher on some
  older models. A short prompt with few tools may not clear it, but an
  under-length breakpoint is *ignored*, not charged, so there is nothing to gate
  on and no downside to placing it.

TTL is the 5-minute default. A turn's calls land seconds apart, so the 1-hour
TTL would double the write price to buy a window that is never needed.

One test covers this: the request JSON is a wire contract, and a regression here
is invisible except as a bill.

Closes #1087
