### PR TITLE
feat(chat): read-only Plan permission mode

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -85,10 +85,12 @@ enum RegisteredTool {
     Client {
         spec: ToolSpec,
         validate_arguments: Option<fn(&Value) -> bool>,
+        class: ApprovalClass,
     },
     ForegroundClient {
         spec: ToolSpec,
         validate_arguments: fn(&Value) -> bool,
+        class: ApprovalClass,
     },
     ForegroundOrchestration {
         spec: ToolSpec,
@@ -116,12 +118,17 @@ impl ToolRegistry {
     }
 
     /// Register a client-owned tool contract with no server-side executor.
-    pub fn register_client(&mut self, spec: ToolSpec) {
+    ///
+    /// The declared class is the host's reading of what the tool touches, kept
+    /// on the registration because a client tool has no [`Tool`] impl to ask.
+    /// Plan mode advertises and checkpoints only `ReadOnly` registrations.
+    pub fn register_client(&mut self, spec: ToolSpec, class: ApprovalClass) {
         self.tools.insert(
             spec.name.clone(),
             RegisteredTool::Client {
                 spec,
                 validate_arguments: None,
+                class,
             },
         );
     }
@@ -130,6 +137,7 @@ impl ToolRegistry {
     pub fn register_validated_client(
         &mut self,
         spec: ToolSpec,
+        class: ApprovalClass,
         validate_arguments: fn(&Value) -> bool,
     ) {
         self.tools.insert(
@@ -137,6 +145,7 @@ impl ToolRegistry {
             RegisteredTool::Client {
                 spec,
                 validate_arguments: Some(validate_arguments),
+                class,
             },
         );
     }
@@ -146,6 +155,7 @@ impl ToolRegistry {
     pub fn register_validated_foreground_client(
         &mut self,
         spec: ToolSpec,
+        class: ApprovalClass,
         validate_arguments: fn(&Value) -> bool,
     ) {
         self.tools.insert(
@@ -153,6 +163,7 @@ impl ToolRegistry {
             RegisteredTool::ForegroundClient {
                 spec,
                 validate_arguments,
+                class,
             },
         );
     }
@@ -223,23 +234,66 @@ impl ToolRegistry {
     /// other contexts receive the ordinary server/client tool set only.
     #[must_use]
     pub fn specs_for_foreground(&self, allow_agent_orchestration: bool) -> Vec<ToolSpec> {
+        self.specs_for_surface(allow_agent_orchestration, false)
+    }
+
+    /// The model-visible definitions for one execution surface, optionally
+    /// narrowed to the read-only planning subset.
+    ///
+    /// A plan-mode turn advertises only `ReadOnly` registrations — server
+    /// tools by their declared [`Tool::approval_class`], client tools by the
+    /// class declared at registration — and never the orchestration pair:
+    /// spawned agents execute, and executing is exactly what a plan turn
+    /// must not do.
+    #[must_use]
+    pub fn specs_for_surface(
+        &self,
+        allow_agent_orchestration: bool,
+        read_only: bool,
+    ) -> Vec<ToolSpec> {
         self.tools
             .values()
             .filter_map(|tool| match tool {
+                RegisteredTool::Server(tool)
+                    if read_only && tool.approval_class() != ApprovalClass::ReadOnly =>
+                {
+                    None
+                }
                 RegisteredTool::Server(tool) => Some(tool.spec()),
+                RegisteredTool::Client { class, .. }
+                | RegisteredTool::ForegroundClient { class, .. }
+                    if read_only && *class != ApprovalClass::ReadOnly =>
+                {
+                    None
+                }
                 RegisteredTool::Client { spec, .. } => Some(spec.clone()),
                 RegisteredTool::ForegroundClient { spec, .. } if allow_agent_orchestration => {
                     Some(spec.clone())
                 }
                 RegisteredTool::ForegroundClient { .. } => None,
                 RegisteredTool::ForegroundOrchestration { spec, .. }
-                    if allow_agent_orchestration =>
+                    if allow_agent_orchestration && !read_only =>
                 {
                     Some(spec.clone())
                 }
                 RegisteredTool::ForegroundOrchestration { .. } => None,
             })
             .collect()
+    }
+
+    /// The declared approval class of a registered tool, if it has one.
+    ///
+    /// Orchestration registrations return `None`: they have no class because
+    /// no mode admits them outside the foreground coordinator's opt-in, and
+    /// plan mode treats classless as mutating.
+    #[must_use]
+    pub fn registered_class(&self, name: &str) -> Option<ApprovalClass> {
+        match self.tools.get(name)? {
+            RegisteredTool::Server(tool) => Some(tool.approval_class()),
+            RegisteredTool::Client { class, .. }
+            | RegisteredTool::ForegroundClient { class, .. } => Some(*class),
+            RegisteredTool::ForegroundOrchestration { .. } => None,
+        }
     }
 
     /// Validate canonical arguments against a registered client-owned contract.
@@ -1169,9 +1223,10 @@ impl Agent {
                     reasoning_model: self.config.reasoning_model,
                     system: self.config.system_prompt.clone(),
                     messages: fitted,
-                    tools: self
-                        .tools
-                        .specs_for_foreground(self.agent_orchestration_active()),
+                    tools: self.tools.specs_for_surface(
+                        self.agent_orchestration_active(),
+                        matches!(chat.permission_mode, Some(PermissionMode::Plan)),
+                    ),
                     max_tokens: self.config.max_tokens,
                     temperature: self.config.temperature,
                     reasoning_effort: self.config.reasoning_effort,
@@ -1628,53 +1683,75 @@ impl Agent {
             // the resuming attempt to guess about.
             if let Some(index) = isolated {
                 let call = &calls[index];
-                match isolations[index].expect("an isolated call has a class") {
-                    CallIsolation::Client => {
-                        match self.client_checkpoint(chat, turn_id, call, generation_steer_revision)
-                        {
-                            Ok((request, steer_revision)) => {
-                                return Ok(AgentTurnOutcome::ClientToolCall {
-                                    request,
-                                    usage: total_usage,
-                                    steer_revision,
-                                    model_steps: step + 1,
-                                })
-                            }
-                            Err(reason) => {
-                                outputs[index] =
-                                    Some(self.decline_call(call, events, reason.into()));
+                // Delegated agents execute with their own tool surface, so a
+                // plan turn refuses to spawn or wait on them at all: the
+                // read-only promise has to hold transitively, not just for
+                // this agent's own calls.
+                let plan_mode_blocks_orchestration =
+                    matches!(chat.permission_mode, Some(PermissionMode::Plan))
+                        && matches!(
+                            isolations[index],
+                            Some(CallIsolation::SandboxSpawn | CallIsolation::AgentWait)
+                        );
+                if plan_mode_blocks_orchestration {
+                    outputs[index] = Some(self.decline_call(
+                        call,
+                        events,
+                        "not run: agent delegation is not available in plan mode; the chat is read-only until the reader leaves plan mode. Continue with read-only tools.".into(),
+                    ));
+                } else {
+                    match isolations[index].expect("an isolated call has a class") {
+                        CallIsolation::Client => {
+                            match self.client_checkpoint(
+                                chat,
+                                turn_id,
+                                call,
+                                generation_steer_revision,
+                            ) {
+                                Ok((request, steer_revision)) => {
+                                    return Ok(AgentTurnOutcome::ClientToolCall {
+                                        request,
+                                        usage: total_usage,
+                                        steer_revision,
+                                        model_steps: step + 1,
+                                    })
+                                }
+                                Err(reason) => {
+                                    outputs[index] =
+                                        Some(self.decline_call(call, events, reason.into()));
+                                }
                             }
                         }
-                    }
-                    CallIsolation::SandboxSpawn => {
-                        match self.sandbox_checkpoint(call, generation_steer_revision) {
-                            Ok((request, steer_revision)) => {
-                                return Ok(AgentTurnOutcome::SandboxAgentSpawn {
-                                    request,
-                                    usage: total_usage,
-                                    steer_revision,
-                                    model_steps: step + 1,
-                                })
-                            }
-                            Err(reason) => {
-                                outputs[index] =
-                                    Some(self.decline_call(call, events, reason.into()));
+                        CallIsolation::SandboxSpawn => {
+                            match self.sandbox_checkpoint(call, generation_steer_revision) {
+                                Ok((request, steer_revision)) => {
+                                    return Ok(AgentTurnOutcome::SandboxAgentSpawn {
+                                        request,
+                                        usage: total_usage,
+                                        steer_revision,
+                                        model_steps: step + 1,
+                                    })
+                                }
+                                Err(reason) => {
+                                    outputs[index] =
+                                        Some(self.decline_call(call, events, reason.into()));
+                                }
                             }
                         }
-                    }
-                    CallIsolation::AgentWait => {
-                        match self.agent_wait_checkpoint(call, generation_steer_revision) {
-                            Ok((request, steer_revision)) => {
-                                return Ok(AgentTurnOutcome::WaitForAgents {
-                                    request,
-                                    usage: total_usage,
-                                    steer_revision,
-                                    model_steps: step + 1,
-                                })
-                            }
-                            Err(reason) => {
-                                outputs[index] =
-                                    Some(self.decline_call(call, events, reason.into()));
+                        CallIsolation::AgentWait => {
+                            match self.agent_wait_checkpoint(call, generation_steer_revision) {
+                                Ok((request, steer_revision)) => {
+                                    return Ok(AgentTurnOutcome::WaitForAgents {
+                                        request,
+                                        usage: total_usage,
+                                        steer_revision,
+                                        model_steps: step + 1,
+                                    })
+                                }
+                                Err(reason) => {
+                                    outputs[index] =
+                                        Some(self.decline_call(call, events, reason.into()));
+                                }
                             }
                         }
                     }
@@ -1975,6 +2052,17 @@ impl Agent {
     ) -> std::result::Result<(crate::model::ClientToolCallRequest, i64), &'static str> {
         if self.tools.is_foreground_client(&call.name) && !self.agent_orchestration_active() {
             return Err("not run: that user continuation is available only from a durably claimed foreground turn. Continue without it.");
+        }
+        // Plan turns advertise only read-only client tools, and a call that
+        // slipped past advertisement is refused here for the same reason
+        // server-side mutations are: client execution is ungated by design,
+        // so the only write gate a plan turn has is never issuing the request.
+        if matches!(chat.permission_mode, Some(PermissionMode::Plan))
+            && self.tools.registered_class(&call.name) != Some(ApprovalClass::ReadOnly)
+        {
+            return Err(
+                "not run: this tool is not available in plan mode; the chat is read-only until the reader leaves plan mode. Continue with read-only tools.",
+            );
         }
         let Some(arguments) = parse_tool_args(&call.args) else {
             return Err("not run: the client tool arguments were not valid JSON. Ask again with one complete JSON value.");
@@ -2464,6 +2552,24 @@ impl Agent {
         let approval_class = durable_approval
             .map(|approval| approval.class)
             .unwrap_or_else(|| tool.approval_class());
+        // Plan mode is read-only by construction: a mutating call is refused
+        // outright, never parked, so nothing the reader could approve — and
+        // no standing grant made in another mode — lets a plan turn write.
+        // A recovered call keeps its durable-approval path so a card that
+        // was already pending resolves instead of dangling.
+        if durable_approval.is_none()
+            && matches!(chat.permission_mode, Some(PermissionMode::Plan))
+            && approval_class != ApprovalClass::ReadOnly
+        {
+            return ToolOutput::failed(
+                ToolErrorCategory::NotFound,
+                format!(
+                    "{} is not available in plan mode; this chat is read-only until \
+                     the reader leaves plan mode. Continue with read-only tools.",
+                    call.name
+                ),
+            );
+        }
         let kind_for_call = ToolApprovalKind::for_call(&call.name, approval_class);
         // The action a standing grant is matched against, and the one the card
         // shows if this call ends up parking. Built once so a grant can never
@@ -4180,7 +4286,7 @@ mod tests {
             input_schema: serde_json::json!({"type": "object"}),
         };
         let mut registry = ToolRegistry::new();
-        registry.register_client(client_spec.clone());
+        registry.register_client(client_spec.clone(), ApprovalClass::ReadOnly);
         assert_eq!(
             registry.execution("connect_folder"),
             Some(ToolCallExecution::Client)
@@ -4236,6 +4342,7 @@ mod tests {
         let mut validated_registry = ToolRegistry::new();
         validated_registry.register_validated_client(
             crate::request_folder_access_tool_spec(),
+            ApprovalClass::ReadOnly,
             crate::validate_request_folder_access_arguments,
         );
         let invalid_agent = Agent::new(
@@ -4275,6 +4382,7 @@ mod tests {
         let mut registry = ToolRegistry::new();
         registry.register_validated_foreground_client(
             crate::ask_user_questions_tool_spec(),
+            ApprovalClass::ReadOnly,
             crate::validate_ask_user_questions_arguments,
         );
 
@@ -4648,11 +4756,14 @@ mod tests {
             .await
             .unwrap();
         let mut registry = ToolRegistry::new();
-        registry.register_client(ToolSpec {
-            name: "connect_folder".into(),
-            description: "Ask the desktop to connect a folder".into(),
-            input_schema: serde_json::json!({"type": "object"}),
-        });
+        registry.register_client(
+            ToolSpec {
+                name: "connect_folder".into(),
+                description: "Ask the desktop to connect a folder".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+            },
+            ApprovalClass::ReadOnly,
+        );
         registry.register(Box::new(ReadFile));
         let agent = Agent::new(
             Arc::new(ClientToolProvider {
@@ -4756,11 +4867,14 @@ mod tests {
             .await
             .unwrap();
         let mut registry = ToolRegistry::new();
-        registry.register_client(ToolSpec {
-            name: "connect_folder".into(),
-            description: "Ask the desktop to connect a folder".into(),
-            input_schema: serde_json::json!({"type": "object"}),
-        });
+        registry.register_client(
+            ToolSpec {
+                name: "connect_folder".into(),
+                description: "Ask the desktop to connect a folder".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+            },
+            ApprovalClass::ReadOnly,
+        );
         let agent = Agent::new(
             Arc::new(ClientToolProvider {
                 assistant_text: false,
@@ -4948,11 +5062,14 @@ mod tests {
             .await
             .unwrap();
         let mut registry = ToolRegistry::new();
-        registry.register_client(ToolSpec {
-            name: "connect_folder".into(),
-            description: "Ask the desktop to connect a folder".into(),
-            input_schema: serde_json::json!({"type": "object"}),
-        });
+        registry.register_client(
+            ToolSpec {
+                name: "connect_folder".into(),
+                description: "Ask the desktop to connect a folder".into(),
+                input_schema: serde_json::json!({"type": "object"}),
+            },
+            ApprovalClass::ReadOnly,
+        );
         let agent = Agent::new(
             Arc::new(ClientToolProvider {
                 assistant_text: true,
@@ -6758,6 +6875,114 @@ mod tests {
             "Allow must not park a sensitive call"
         );
         assert_eq!(ran.load(Ordering::SeqCst), 1);
+    }
+
+    /// Plan mode refuses a mutating call outright: no approval card the
+    /// reader could accept, no tool run. Losing either half turns "plan mode
+    /// is read-only" into a prompt-level suggestion.
+    #[tokio::test]
+    async fn plan_mode_refuses_workspace_writes_without_parking() {
+        let store = search_grant_store().await;
+        let chat = permission_mode_chat(&store, Some(crate::model::PermissionMode::Plan)).await;
+
+        let ran = Arc::new(AtomicUsize::new(0));
+        let agent = workspace_write_agent(store, ran.clone());
+
+        let (tx, rx) = unbounded();
+        agent.run_turn(&chat, "go", &tx).await.unwrap();
+        drop(tx);
+        let events: Vec<AgentEvent> = rx.collect().await;
+
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::ApprovalRequired { .. })),
+            "plan mode must refuse, not park: there is nothing to approve"
+        );
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                AgentEvent::ToolCallCompleted { output, .. }
+                    if output.is_error && output.content.contains("plan mode")
+            )),
+            "the model must be told the call was refused because of plan mode"
+        );
+        assert_eq!(ran.load(Ordering::SeqCst), 0);
+    }
+
+    /// A standing grant made in another mode must not let a plan turn run a
+    /// mutating call: the refusal comes before grant matching on purpose.
+    #[tokio::test]
+    async fn plan_mode_standing_grant_does_not_bypass_the_refusal() {
+        use crate::approval::{GrantLevel, StandingGrant, StandingGrants};
+
+        let store = search_grant_store().await;
+        let chat = permission_mode_chat(&store, Some(crate::model::PermissionMode::Plan)).await;
+        let grants = Arc::new(StandingGrants::from_grants(vec![StandingGrant::new(
+            GrantLevel::Chat { chat_id: chat.id },
+            "search",
+            ToolApprovalKind::for_tool_name("search"),
+            Utc::now(),
+        )
+        .expect("search is grantable")]));
+
+        let ran = Arc::new(AtomicUsize::new(0));
+        let agent = search_agent(store, ran.clone(), grants);
+
+        let (tx, rx) = unbounded();
+        agent.run_turn(&chat, "go", &tx).await.unwrap();
+        drop(tx);
+        let events: Vec<AgentEvent> = rx.collect().await;
+
+        assert_eq!(
+            ran.load(Ordering::SeqCst),
+            0,
+            "a covered sensitive call must still be refused in plan mode"
+        );
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, AgentEvent::ApprovalRequired { .. })));
+    }
+
+    /// The plan surface advertises only read-only registrations, so the model
+    /// is never offered a tool the turn would refuse.
+    #[test]
+    fn plan_surface_advertises_only_read_only_tools() {
+        let mut tools = ToolRegistry::new()
+            .with(Box::new(ReadFile))
+            .with(Box::new(WorkspaceWriteTool {
+                ran: Arc::new(AtomicUsize::new(0)),
+            }))
+            .with(Box::new(SearchTool {
+                ran: Arc::new(AtomicUsize::new(0)),
+            }));
+        tools.register_validated_client(
+            crate::read_connected_file_tool_spec(),
+            ApprovalClass::ReadOnly,
+            crate::validate_read_connected_file_arguments,
+        );
+        tools.register_validated_client(
+            crate::write_output_to_connected_folder_tool_spec(),
+            ApprovalClass::Workspace,
+            crate::validate_write_output_to_connected_folder_arguments,
+        );
+        tools.register_validated_foreground_client(
+            crate::ask_user_questions_tool_spec(),
+            ApprovalClass::ReadOnly,
+            crate::validate_ask_user_questions_arguments,
+        );
+        tools.register_foreground_agent_orchestration();
+
+        let mut names = tools
+            .specs_for_surface(true, true)
+            .into_iter()
+            .map(|spec| spec.name)
+            .collect::<Vec<_>>();
+        names.sort();
+        assert_eq!(
+            names,
+            vec!["ask_user_questions", "read_connected_file", "read_file"]
+        );
     }
 
     /// A Sensitive tool that escapes the chat workspace (`exec`) and records

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -842,6 +842,11 @@ impl ReasoningEffort {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum PermissionMode {
+    /// The agent explores read-only and designs a plan instead of acting.
+    /// Mutating calls are refused outright — not parked on the approval
+    /// card — so a plan turn cannot change anything no matter what the
+    /// reader approves.
+    Plan,
     /// Every uncovered mutating call parks on the approval card. The default,
     /// and the only mode where `Workspace`-class tools ask.
     Ask,
@@ -856,12 +861,13 @@ pub enum PermissionMode {
 
 impl PermissionMode {
     /// Every mode, in ascending order of autonomy.
-    pub const ALL: &'static [Self] = &[Self::Ask, Self::Auto, Self::Allow];
+    pub const ALL: &'static [Self] = &[Self::Plan, Self::Ask, Self::Auto, Self::Allow];
 
     /// The wire/storage token for this mode.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
+            Self::Plan => "plan",
             Self::Ask => "ask",
             Self::Auto => "auto",
             Self::Allow => "allow",

--- a/crates/openwave-desktop/ui/src/NewChatSettings.ts
+++ b/crates/openwave-desktop/ui/src/NewChatSettings.ts
@@ -19,7 +19,12 @@ const REASONING_EFFORTS: readonly ReasoningEffort[] = [
   "max",
 ];
 
-const PERMISSION_MODES: readonly PermissionMode[] = ["ask", "auto", "allow"];
+const PERMISSION_MODES: readonly PermissionMode[] = [
+  "plan",
+  "ask",
+  "auto",
+  "allow",
+];
 
 
 function read(key: string): string | null {

--- a/crates/openwave-desktop/ui/src/PermissionModeMenu.tsx
+++ b/crates/openwave-desktop/ui/src/PermissionModeMenu.tsx
@@ -1,4 +1,11 @@
-import { Check, ChevronDown, ShieldCheck, Sparkles, Zap } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  NotebookPen,
+  ShieldCheck,
+  Sparkles,
+  Zap,
+} from "lucide-react";
 import type { PermissionMode } from "./api";
 import { Button } from "@/components/ui/button";
 import {
@@ -16,6 +23,15 @@ import { cn } from "@/lib/utils";
  * saved allowlists run without asking in every mode, and the mode governs
  * only the calls no grant covers.
  */
+const ASK_PERMISSION_MODE_OPTION = {
+  value: "ask",
+  label: "Ask",
+  description:
+    "Ask before edits and actions that leave the workspace. Allowlists you've saved still run without asking.",
+  icon: ShieldCheck,
+  elevated: false,
+} as const;
+
 const PERMISSION_MODE_SCALE: {
   value: PermissionMode;
   label: string;
@@ -25,13 +41,14 @@ const PERMISSION_MODE_SCALE: {
   elevated: boolean;
 }[] = [
   {
-    value: "ask",
-    label: "Ask",
+    value: "plan",
+    label: "Plan",
     description:
-      "Ask before edits and actions that leave the workspace. Allowlists you've saved still run without asking.",
-    icon: ShieldCheck,
+      "Read-only: the agent explores and proposes a plan. Nothing is edited or run until you switch modes.",
+    icon: NotebookPen,
     elevated: false,
   },
+  ASK_PERMISSION_MODE_OPTION,
   {
     value: "auto",
     label: "Auto",
@@ -56,7 +73,7 @@ export function permissionModeOption(mode: PermissionMode | null) {
   const value = mode ?? DEFAULT_PERMISSION_MODE;
   return (
     PERMISSION_MODE_SCALE.find((option) => option.value === value) ??
-    PERMISSION_MODE_SCALE[0]
+    ASK_PERMISSION_MODE_OPTION
   );
 }
 

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -775,7 +775,7 @@ export type PendingUserQuestions = { call_id: CallId, turn_id: TurnId, questions
  * start, like the model selection: changing it mid-turn applies from the
  * next turn, and a reopened chat runs the way it ran before.
  */
-export type PermissionMode = "ask" | "auto" | "allow";
+export type PermissionMode = "plan" | "ask" | "auto" | "allow";
 
 /**
  * An optional grouping of chats that share project context and a document

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -32,6 +32,7 @@ You are OpenWave, an assistant working with the user inside one conversation.
 - Never expose credentials, private broker state, hidden identifiers, or internal paths. A host folder path explicitly listed under Code execution is user-approved operating context and may be used for that purpose; otherwise refer only to user-visible names and opaque identifiers returned by available tools.
 - Respect tool approval and capability boundaries. A request or proposal is not proof that access was granted.";
 
+const PLAN_MODE_HEADING: &str = "## Plan mode";
 const USER_QUESTIONS_HEADING: &str = "## User clarification";
 const PRIVATE_SCRATCH_HEADING: &str = "## Private scratch";
 const SOURCES_HEADING: &str = "## Conversation sources and citations";
@@ -52,15 +53,21 @@ const MCP_HEADING: &str = "## External MCP tools";
 #[must_use]
 #[cfg(test)]
 pub(crate) fn compose(specs: &[ToolSpec]) -> String {
-    compose_with_exec_folders(specs, &[])
+    compose_for_surface(specs, &[], false)
 }
 
-/// Compose the prompt with a bounded snapshot of host-resolved local-exec
-/// folders. The sandbox profile resolves them again for each invocation.
+/// Compose the prompt for one exact tool surface, with a bounded snapshot of
+/// host-resolved local-exec folders, in the chat's current permission
+/// posture. The sandbox profile resolves the folders again per invocation.
+///
+/// A plan-mode surface is already narrowed to read-only tools before it
+/// reaches composition, so the section logic below stays truthful without
+/// consulting the flag; the flag only adds the planning contract itself.
 #[must_use]
-pub(crate) fn compose_with_exec_folders(
+pub(crate) fn compose_for_surface(
     specs: &[ToolSpec],
     exec_folders: &[ResolvedExecFolderGrant],
+    plan_mode: bool,
 ) -> String {
     let names = specs
         .iter()
@@ -68,6 +75,18 @@ pub(crate) fn compose_with_exec_folders(
         .collect::<BTreeSet<_>>();
     let has = |name: &str| names.contains(name);
     let mut prompt = BASELINE.to_owned();
+
+    if plan_mode {
+        push_section(
+            &mut prompt,
+            PLAN_MODE_HEADING,
+            &[
+                "- This chat is in plan mode: design the approach, do not carry it out. Every tool available this turn is read-only, and requests to modify anything will be refused until the user leaves plan mode.",
+                "- Explore with the available read-only tools until you understand the task, then present a concrete plan in your reply: the intended steps, what each one touches, and any open decisions the user should settle.",
+                "- Do not present work as done, staged, or in progress. The plan is a proposal; execution happens only after the user switches the chat out of plan mode.",
+            ],
+        );
+    }
 
     if has(openwave_core::ASK_USER_QUESTIONS_TOOL) {
         push_section(
@@ -366,6 +385,7 @@ mod tests {
         assert_eq!(prompt, BASELINE);
         assert!(prompt.contains("reasonable, reversible assumptions"));
         for unavailable in [
+            PLAN_MODE_HEADING,
             USER_QUESTIONS_HEADING,
             PRIVATE_SCRATCH_HEADING,
             SOURCES_HEADING,
@@ -454,6 +474,24 @@ mod tests {
     }
 
     #[test]
+    fn plan_mode_adds_the_planning_contract_and_nothing_else() {
+        let specs = [spec("read_file"), spec("list_sources")];
+        let plan = compose_for_surface(&specs, &[], true);
+        let normal = compose_for_surface(&specs, &[], false);
+
+        assert!(plan.contains(PLAN_MODE_HEADING));
+        assert!(plan.contains("do not carry it out"));
+        assert!(!normal.contains(PLAN_MODE_HEADING));
+        // The flag adds exactly one section; every tool-derived section stays
+        // keyed to the surface alone.
+        let start = plan.find("\n\n## Plan mode").expect("plan section present");
+        let end = plan[start + 2..]
+            .find("\n\n")
+            .map_or(plan.len(), |offset| start + 2 + offset);
+        assert_eq!(format!("{}{}", &plan[..start], &plan[end..]), normal);
+    }
+
+    #[test]
     fn composition_is_stable_across_registration_order_and_duplicates() {
         let forward = vec![
             spec("read_source"),
@@ -479,7 +517,7 @@ mod tests {
                 writable: index == 0,
             })
             .collect::<Vec<_>>();
-        let prompt = compose_with_exec_folders(&[spec("exec")], &folders);
+        let prompt = compose_for_surface(&[spec("exec")], &folders, false);
 
         assert!(prompt.contains("read-write folder: \"/Users/example/grant-0\""));
         assert!(prompt.contains("read-only folder: \"/Users/example/grant-1\""));

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -76,7 +76,7 @@ use openwave_core::{
     validate_import_connected_file_arguments, validate_list_connected_folders_arguments,
     validate_list_folder_arguments, validate_read_connected_file_arguments,
     validate_request_folder_access_arguments, validate_write_output_to_connected_folder_arguments,
-    write_output_to_connected_folder_tool_spec, AgentConfig, AgentError, BlobStore,
+    write_output_to_connected_folder_tool_spec, AgentConfig, AgentError, ApprovalClass, BlobStore,
     CachingSecretProvider, Config, CreateDeliverable, FsBlobStore, KeychainSecretProvider, ListDir,
     Profile, ReadFile, Result, SecretProvider, Store, Tool, ToolRegistry, WriteFile,
 };
@@ -888,27 +888,40 @@ fn agent_deps(
         .with(web_extract);
     tools.register_validated_client(
         request_folder_access_tool_spec(),
+        ApprovalClass::ReadOnly,
         validate_request_folder_access_arguments,
     );
     tools.register_validated_client(
         list_connected_folders_tool_spec(),
+        ApprovalClass::ReadOnly,
         validate_list_connected_folders_arguments,
     );
-    tools.register_validated_client(list_folder_tool_spec(), validate_list_folder_arguments);
     tools.register_validated_client(
-        read_connected_file_tool_spec(),
-        validate_read_connected_file_arguments,
+        list_folder_tool_spec(),
+        ApprovalClass::ReadOnly,
+        validate_list_folder_arguments,
     );
     tools.register_validated_client(
+        read_connected_file_tool_spec(),
+        ApprovalClass::ReadOnly,
+        validate_read_connected_file_arguments,
+    );
+    // Importing copies a connected file into the chat's sources: durable chat
+    // state, so it counts as a workspace mutation even though the connected
+    // folder itself is only read.
+    tools.register_validated_client(
         import_connected_file_tool_spec(),
+        ApprovalClass::Workspace,
         validate_import_connected_file_arguments,
     );
     tools.register_validated_client(
         write_output_to_connected_folder_tool_spec(),
+        ApprovalClass::Workspace,
         validate_write_output_to_connected_folder_arguments,
     );
     tools.register_validated_foreground_client(
         ask_user_questions_tool_spec(),
+        ApprovalClass::ReadOnly,
         validate_ask_user_questions_arguments,
     );
     // Foreground spawn checkpoints child acceptance and immediately resumes;

--- a/crates/openwave-server/src/tests/documents.rs
+++ b/crates/openwave-server/src/tests/documents.rs
@@ -1470,16 +1470,19 @@ async fn agent_deps_registers_server_tools_and_closed_foreground_capabilities() 
         config.system_prompt.is_none(),
         "prompt must not be frozen before boot-time tools are mounted"
     );
-    tools.register_client(ToolSpec {
-        name: "mcp__test__lookup".into(),
-        description: "untrusted remote metadata must not enter the operating prompt".into(),
-        input_schema: serde_json::json!({
-            "type": "object",
-            "properties": {
-                "private_runtime_value": {"default": "must-not-be-copied"}
-            }
-        }),
-    });
+    tools.register_client(
+        ToolSpec {
+            name: "mcp__test__lookup".into(),
+            description: "untrusted remote metadata must not enter the operating prompt".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "private_runtime_value": {"default": "must-not-be-copied"}
+                }
+            }),
+        },
+        openwave_core::ApprovalClass::Sensitive,
+    );
     let surface = crate::turn_worker::freeze_foreground_turn_surface(Arc::new(tools), &config);
     let system_prompt = surface
         .agent_config

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -2074,11 +2074,14 @@ async fn worker_checkpoints_a_client_tool_and_resumes_after_its_result() {
     let store: Arc<dyn Store> = injected;
     let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
     let mut tools = ToolRegistry::new();
-    tools.register_client(ToolSpec {
-        name: "connect_folder".into(),
-        description: "Ask the desktop to connect a folder".into(),
-        input_schema: serde_json::json!({"type": "object"}),
-    });
+    tools.register_client(
+        ToolSpec {
+            name: "connect_folder".into(),
+            description: "Ask the desktop to connect a folder".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+        },
+        openwave_core::ApprovalClass::ReadOnly,
+    );
     let state = AppState::new(
         Config::desktop(dir.path()),
         store.clone(),
@@ -2176,11 +2179,14 @@ async fn worker_checkpoints_a_client_tool_and_resumes_after_its_result() {
         .unwrap(),
     );
     let mut exhausted_tools = ToolRegistry::new();
-    exhausted_tools.register_client(ToolSpec {
-        name: "connect_folder".into(),
-        description: "Ask the desktop to connect a folder".into(),
-        input_schema: serde_json::json!({"type": "object"}),
-    });
+    exhausted_tools.register_client(
+        ToolSpec {
+            name: "connect_folder".into(),
+            description: "Ask the desktop to connect a folder".into(),
+            input_schema: serde_json::json!({"type": "object"}),
+        },
+        openwave_core::ApprovalClass::ReadOnly,
+    );
     let exhausted_state = AppState::new(
         Config::desktop(exhausted_dir.path()),
         exhausted_store.clone(),

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -123,18 +123,20 @@ pub(crate) fn freeze_foreground_turn_surface(
     tools: Arc<ToolRegistry>,
     base_agent_config: &AgentConfig,
 ) -> ForegroundTurnSurface {
-    freeze_foreground_turn_surface_with_folders(tools, base_agent_config, &[])
+    freeze_foreground_turn_surface_with_folders(tools, base_agent_config, &[], false)
 }
 
 fn freeze_foreground_turn_surface_with_folders(
     tools: Arc<ToolRegistry>,
     base_agent_config: &AgentConfig,
     exec_folders: &[crate::code_execution::ResolvedExecFolderGrant],
+    plan_mode: bool,
 ) -> ForegroundTurnSurface {
     let mut agent_config = base_agent_config.clone();
-    agent_config.system_prompt = Some(crate::foreground_prompt::compose_with_exec_folders(
-        &tools.specs_for_foreground(true),
+    agent_config.system_prompt = Some(crate::foreground_prompt::compose_for_surface(
+        &tools.specs_for_surface(true, plan_mode),
         exec_folders,
+        plan_mode,
     ));
     ForegroundTurnSurface {
         tools,
@@ -516,8 +518,15 @@ impl TurnWorker {
             },
             None => Vec::new(),
         };
-        let surface =
-            freeze_foreground_turn_surface_with_folders(tools, &self.agent_config, &exec_folders);
+        let surface = freeze_foreground_turn_surface_with_folders(
+            tools,
+            &self.agent_config,
+            &exec_folders,
+            matches!(
+                chat.permission_mode,
+                Some(openwave_core::PermissionMode::Plan)
+            ),
+        );
         if let Some(prompt) = surface.agent_config.system_prompt.as_deref() {
             eprintln!(
                 "openwave: turn {} operating_prompt={}",
@@ -2340,6 +2349,7 @@ mod committed_event_drain_tests {
         let mut original_registry = ToolRegistry::new();
         original_registry.register_validated_foreground_client(
             openwave_core::ask_user_questions_tool_spec(),
+            openwave_core::ApprovalClass::ReadOnly,
             openwave_core::validate_ask_user_questions_arguments,
         );
         let original_tools = Arc::new(original_registry);
@@ -2347,16 +2357,19 @@ mod committed_event_drain_tests {
             freeze_foreground_turn_surface(original_tools.clone(), &AgentConfig::default());
 
         let mut refreshed_registry = (*original_tools).clone();
-        refreshed_registry.register_client(openwave_core::ToolSpec {
-            name: "mcp__documents__lookup".into(),
-            description: "untrusted remote description marker".into(),
-            input_schema: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "credential_marker": {"default": "untrusted remote schema marker"}
-                }
-            }),
-        });
+        refreshed_registry.register_client(
+            openwave_core::ToolSpec {
+                name: "mcp__documents__lookup".into(),
+                description: "untrusted remote description marker".into(),
+                input_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "credential_marker": {"default": "untrusted remote schema marker"}
+                    }
+                }),
+            },
+            openwave_core::ApprovalClass::Sensitive,
+        );
         let refreshed =
             freeze_foreground_turn_surface(Arc::new(refreshed_registry), &AgentConfig::default());
 
@@ -2566,6 +2579,7 @@ mod committed_event_drain_tests {
         let mut tools = ToolRegistry::new();
         tools.register_validated_client(
             openwave_core::request_folder_access_tool_spec(),
+            openwave_core::ApprovalClass::ReadOnly,
             openwave_core::validate_request_folder_access_arguments,
         );
         let chat_id = openwave_core::ChatId::new();


### PR DESCRIPTION
Adds **Plan** as a fourth per-chat permission mode alongside Ask/Auto/Allow: the agent explores read-only and proposes a plan instead of acting.

## What changed

- `PermissionMode::Plan` (`"plan"` wire/DB token). Persistence needs no migration: the mode column is free text and unknown tokens already drop to Ask on read, so a downgrade degrades safely.
- **Client tools now declare an `ApprovalClass` at registration.** Client execution bypasses the server gate by design, so the only write gate a plan turn has is never issuing the request; the declared class is what advertisement and checkpointing filter on. Folder listing/reading are ReadOnly; `import_connected_file` and `write_output_to_connected_folder` are Workspace.
- **Advertisement**: `specs_for_surface(_, read_only)` narrows a plan turn's surface to ReadOnly registrations and drops the orchestration pair (spawned agents execute; the read-only promise must hold transitively).
- **Refusal, not parking**: `run_tool` refuses non-ReadOnly calls in plan mode before standing-grant matching — there is nothing to approve, and no grant made in another mode can make a plan turn write. Client checkpoints and sandbox spawn/wait decline the same way. Recovered durable approvals keep their path so a pending card resolves instead of dangling.
- **Prompt**: the frozen turn surface composes from the narrowed spec set plus a `## Plan mode` section stating the planning contract. Non-plan prompts are byte-identical to before.
- **UI**: Plan entry in the permission-mode menu (chat + home composer), wire types regenerated.

Plan-mode turns currently deliver the plan in the reply text; a dedicated `exit_plan_mode` continuation with an approval card and a mode hand-off on accept is the next slice.

## Tests

- Plan mode refuses a workspace write without emitting an approval card, and tells the model why.
- A chat-scoped standing grant does not bypass the refusal.
- The plan surface advertises only read-only registrations.
- The prompt gains exactly the planning section and nothing else; baseline test now also asserts the section is absent by default.