### PR TITLE
fix(core): advertise tools in a stable order

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -16,7 +16,7 @@
 //! - context reduction is deterministic floor+restore (no LLM summarization);
 //!   retries with progressive reduction on provider prompt-too-long errors.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -74,9 +74,18 @@ const MAX_ANNOUNCED_FILES: usize = 8;
 const MAX_ANNOUNCED_IMAGES: usize = 8;
 
 /// A name-keyed registry of the tools available to the agent.
+///
+/// The map is ordered by name so that [advertisement](Self::specs) is a pure
+/// function of *which* tools are registered, never of how or when they got
+/// there. A `HashMap` reordered the advertised block between turns, which
+/// invalidates the provider-side prompt-prefix cache and makes a run harder to
+/// reproduce. Registration order would be stable within one process but is not
+/// set-determined: MCP servers mount and unmount mid-session, so unmounting a
+/// server and remounting it would advertise the same tools in a new order.
+/// Sorting by name has neither problem.
 #[derive(Clone, Default)]
 pub struct ToolRegistry {
-    tools: HashMap<String, RegisteredTool>,
+    tools: BTreeMap<String, RegisteredTool>,
 }
 
 #[derive(Clone)]
@@ -3922,7 +3931,7 @@ mod tests {
     use crate::id::{ChatId, ProjectId};
     use crate::model::Project;
     use crate::provider::ProviderId;
-    use crate::tools::{ReadFile, WriteFile};
+    use crate::tools::{ListDir, ReadFile, WriteFile};
 
     fn tool_scratch(path: &std::path::Path) -> ToolScratch {
         ToolScratch::from_dir(
@@ -3940,6 +3949,27 @@ mod tests {
                 ClaimedAgentEvent::Flush(_) => panic!("unhandled claimed-event flush"),
             })
             .collect()
+    }
+
+    /// Advertisement order has to depend only on which tools are registered.
+    /// A regression here is invisible in behavior — it shows up as prompt-cache
+    /// misses and irreproducible runs, so nothing else would catch it.
+    #[test]
+    fn advertised_tools_are_ordered_by_name_whatever_the_registration_order() {
+        let forwards = ToolRegistry::default()
+            .with(Box::new(ListDir))
+            .with(Box::new(ReadFile))
+            .with(Box::new(WriteFile));
+        let backwards = ToolRegistry::default()
+            .with(Box::new(WriteFile))
+            .with(Box::new(ReadFile))
+            .with(Box::new(ListDir));
+
+        let names = |registry: &ToolRegistry| -> Vec<String> {
+            registry.specs().into_iter().map(|spec| spec.name).collect()
+        };
+        assert_eq!(names(&forwards), ["list_dir", "read_file", "write_file"]);
+        assert_eq!(names(&forwards), names(&backwards));
     }
 
     #[test]

--- a/crates/openwave-core/src/agent_tools.rs
+++ b/crates/openwave-core/src/agent_tools.rs
@@ -687,7 +687,12 @@ mod tests {
             foreground.input_schema["properties"]["end_published_at"],
             serde_json::json!({"type": "string", "format": "date-time"})
         );
-        assert!(!foreground.input_schema.to_string().contains("\"default\""));
+        // Omitting `max_results` is a choice, so the model is told what it
+        // chooses by omitting it.
+        assert_eq!(
+            foreground.input_schema["properties"]["max_results"]["default"],
+            DEFAULT_WEB_SEARCH_RESULTS
+        );
         assert_eq!(foreground.input_schema["additionalProperties"], false);
         assert!(foreground.description.contains("exact result URLs"));
         assert!(sandbox.description.contains("at most once"));

--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -115,6 +115,14 @@ impl ToolSpec {
 }
 
 /// Generate the compact provider-facing JSON Schema for one argument type.
+///
+/// A meaningful `default` is kept. Most optional tool arguments are
+/// `#[serde(default)]` fields whose absent value is a real decision — `exec`
+/// runs in `"."`, `create_deliverable` writes Markdown — and the model cannot
+/// infer any of that from the type alone. A null default is dropped: it is what
+/// an `Option` field emits, and "omitting this omits it" is not information
+/// worth spending tokens on. The strict conversion drops the keyword entirely,
+/// since there every property is required and a default can never apply.
 #[must_use]
 pub fn input_schema_for<Args: JsonSchema>() -> Value {
     let schema = SchemaSettings::draft2020_12()
@@ -135,21 +143,23 @@ pub fn input_schema_for<Args: JsonSchema>() -> Value {
         root.entry("properties")
             .or_insert_with(|| Value::Object(serde_json::Map::new()));
     }
-    remove_schema_defaults(&mut schema);
+    remove_null_schema_defaults(&mut schema);
     schema
 }
 
-fn remove_schema_defaults(schema: &mut Value) {
+fn remove_null_schema_defaults(schema: &mut Value) {
     match schema {
         Value::Object(object) => {
-            object.remove("default");
+            if object.get("default") == Some(&Value::Null) {
+                object.remove("default");
+            }
             for value in object.values_mut() {
-                remove_schema_defaults(value);
+                remove_null_schema_defaults(value);
             }
         }
         Value::Array(values) => {
             for value in values {
-                remove_schema_defaults(value);
+                remove_null_schema_defaults(value);
             }
         }
         Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
@@ -235,7 +245,9 @@ pub fn strict_json_schema(schema: &Value, optional: OptionalProperties) -> Optio
             // Handled structurally below.
             "type" | "properties" | "required" | "items" | "additionalProperties" | "anyOf" => {}
             // Not a constraint on the value, so it neither survives nor blocks.
-            "title" => {}
+            // Strict mode requires every property, so an absent-value default
+            // can never apply and providers reject the keyword outright.
+            "title" | "default" => {}
             "format" => {
                 if value.as_str().is_some_and(|f| STRICT_FORMATS.contains(&f)) {
                     strict.insert(keyword.clone(), value.clone());
@@ -697,6 +709,13 @@ mod tests {
         #[serde(default)]
         #[schemars(with = "String", description = "Optional text.")]
         optional: Option<String>,
+        #[serde(default = "defaulted")]
+        #[schemars(description = "Text with a default.")]
+        defaulted: String,
+    }
+
+    fn defaulted() -> String {
+        ".".to_owned()
     }
 
     #[test]
@@ -709,6 +728,11 @@ mod tests {
                     "optional": {
                         "type": "string",
                         "description": "Optional text."
+                    },
+                    "defaulted": {
+                        "type": "string",
+                        "description": "Text with a default.",
+                        "default": "."
                     }
                 },
                 "additionalProperties": false
@@ -718,8 +742,10 @@ mod tests {
 
     #[test]
     fn strict_mode_requires_every_property_or_refuses_to_convert() {
-        // The case the post-processor exists for: schemars leaves an `Option`
+        // The case the post-processor exists for: schemars leaves a defaulted
         // field out of `required`, and strict mode has no optional properties.
+        // The advertised `default` goes with it — every property is required
+        // here, so no default could ever apply.
         let schema = input_schema_for::<DerivedArguments>();
         assert_eq!(
             strict_json_schema(&schema, OptionalProperties::AcceptNull).unwrap(),
@@ -729,9 +755,13 @@ mod tests {
                     "optional": {
                         "type": ["string", "null"],
                         "description": "Optional text."
+                    },
+                    "defaulted": {
+                        "type": ["string", "null"],
+                        "description": "Text with a default."
                     }
                 },
-                "required": ["optional"],
+                "required": ["defaulted", "optional"],
                 "additionalProperties": false
             })
         );

--- a/crates/openwave-core/src/user_questions.rs
+++ b/crates/openwave-core/src/user_questions.rs
@@ -289,7 +289,12 @@ mod tests {
             option["properties"]["description"]["maxLength"],
             MAX_QUESTION_OPTION_DESCRIPTION_CHARS
         );
-        assert!(!schema.to_string().contains("\"default\""));
+        // What omitting an optional field means is part of the contract.
+        assert_eq!(question["properties"]["allow_free_form"]["default"], false);
+        assert_eq!(
+            question["properties"]["options"]["default"],
+            serde_json::json!([])
+        );
     }
 
     #[test]


### PR DESCRIPTION
`ToolRegistry` kept its tools in a `HashMap`, so `specs()` handed the provider a differently ordered tool block on every process. Two costs: the provider's prompt-prefix cache keys on the serialized request prefix, and the tool block sits at the very top of it, so a reorder is a guaranteed miss; and a run that advertises tools in a different order than the last one is harder to reproduce from its journal.

The registry is now a `BTreeMap`, so it iterates by name and `specs()` needs no sort of its own. `openwave-mcp`'s `tools/list` already sorted its surface by name for the same reason.

## Why name order

The requirement is stronger than "deterministic": advertisement has to be a pure function of *which* tools are registered. Registration order satisfies determinism within a single process but not that — MCP servers mount and unmount mid-session, so unmounting a server and remounting it would advertise the same tool set in a new order, and the order would also differ between the desktop and headless registration paths. An explicit priority list would need maintaining as a third place tools are enumerated, and it degrades to name order for the MCP tools it cannot know about anyway. Name order is set-determined, needs nothing kept in sync, and is what the MCP surface already does.

A newly mounted tool still shifts the block and costs one cache miss, which is unavoidable — the tool set genuinely changed.

This pairs with #1087, which is adding Anthropic prompt-cache breakpoints. That only pays off if the prefix above the breakpoint is byte-stable between calls, which is what this gives it.

## Advertised defaults

`input_schema_for` stripped `default` from every generated schema. That came in with the typed-schema derivation in #581, whose goal was schemas byte-for-byte identical to the hand-written ones it replaced — the hand-written ones had no defaults, so the post-processor removed them. It was compatibility, not a decision that the model shouldn't see them.

Meanwhile the tools lean on `#[serde(default)]` throughout, and the value a field defaults to is frequently a real choice: `web_search` returns 5 results, `ask_user_questions` defaults `allow_free_form` to false. None of that was reachable from the advertised contract. Defaults are now carried through, with two exceptions:

- A `null` default is dropped. It is what an `Option` field emits, and "omitting this omits it" is not worth the tokens.
- The strict conversion drops the keyword entirely. Strict mode requires every property, so a default can never apply there, and providers reject the keyword outright — it is now handled alongside `title` as something that neither survives nor blocks the conversion.

## Tests

One added, in `agent.rs`: two registries built in opposite orders advertise the same list. Order is invisible in behavior — a regression shows up only as cache misses — so nothing else would catch it.

Three existing tests asserted that no advertised schema contained `"default"`. Each now asserts the specific default it should carry instead.

Closes #1088
