### PR TITLE
fix(desktop): accept binary outputs in the catalog UI

### DIFF
--- a/crates/openwave-desktop/src/deliverables.rs
+++ b/crates/openwave-desktop/src/deliverables.rs
@@ -156,6 +156,17 @@ pub(crate) async fn read_deliverable(
     let chat_id = resolve_conversation_scope(&host_access, request.chat_id).await?;
     let (output, revision) =
         require_live_output(host_access.store(), chat_id, request.output_id).await?;
+    // Binary artifacts have no inline preview; the renderer keys its placeholder
+    // off the media type, so the response carries identity without content.
+    if !media_type_is_text(&output.media_type) {
+        return Ok(DeliverablePreview {
+            output_id: output.id,
+            filename: output.filename.clone(),
+            media_type: output.media_type.clone(),
+            content: String::new(),
+            truncated: false,
+        });
+    }
     let scratch_root = crate::data_dir(&app)?.join("scratch");
     let read_output = output.clone();
     let bytes = tauri::async_runtime::spawn_blocking(move || {

--- a/crates/openwave-desktop/ui/src/deliverables.test.ts
+++ b/crates/openwave-desktop/ui/src/deliverables.test.ts
@@ -104,11 +104,68 @@ describe("deliverable renderer projections", () => {
     ).toThrow("Invalid output revert response");
   });
 
+  it("accepts a binary artifact at its wider size ceiling and bounds it there", () => {
+    const summary = {
+      outputId,
+      filename: "chart.png",
+      mediaType: "image/png",
+      sizeBytes: 16 * 1024 * 1024,
+      revisionCount: 1,
+      updatedAt: "2026-07-24T00:00:00Z",
+      producingRunId: null,
+    };
+    expect(
+      parseDeliverablesCatalog({ deliverables: [summary], truncated: false })
+        .deliverables[0],
+    ).toEqual(summary);
+    expect(() =>
+      parseDeliverablesCatalog({
+        deliverables: [{ ...summary, sizeBytes: 16 * 1024 * 1024 + 1 }],
+        truncated: false,
+      }),
+    ).toThrow("Invalid output response");
+    // Curated text keeps its own, smaller ceiling.
+    expect(() =>
+      parseDeliverablesCatalog({
+        deliverables: [
+          {
+            ...summary,
+            filename: "table.csv",
+            mediaType: "text/csv",
+            sizeBytes: 512 * 1024 + 1,
+          },
+        ],
+        truncated: false,
+      }),
+    ).toThrow("Invalid output response");
+  });
+
+  it.each(["", "noslash", "two/sl/ashes", "text/há", `x/${"y".repeat(127)}`])(
+    "rejects malformed media type %s",
+    (mediaType) => {
+      expect(() =>
+        parseDeliverablesCatalog({
+          deliverables: [
+            {
+              outputId,
+              filename: "artifact.bin",
+              mediaType,
+              sizeBytes: 1,
+              revisionCount: 1,
+              updatedAt: "2026-07-24T00:00:00Z",
+              producingRunId: null,
+            },
+          ],
+          truncated: false,
+        }),
+      ).toThrow("Invalid output response");
+    },
+  );
+
   it.each([
     "../escape.md",
     "/tmp/private.md",
     ".hidden.md",
-    "report.pdf",
     "bad\u{202e}.md",
   ])("rejects unsafe filename %s", (filename) => {
     expect(() =>

--- a/crates/openwave-desktop/ui/src/deliverables.ts
+++ b/crates/openwave-desktop/ui/src/deliverables.ts
@@ -3,7 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 export type DeliverableSummary = {
   outputId: string;
   filename: string;
-  mediaType: DeliverableMediaType;
+  mediaType: string;
   sizeBytes: number;
   revisionCount: number;
   updatedAt: string;
@@ -25,7 +25,7 @@ export type DeliverablesCatalog = {
 export type DeliverablePreview = {
   outputId: string;
   filename: string;
-  mediaType: DeliverableMediaType;
+  mediaType: string;
   content: string;
   truncated: boolean;
 };
@@ -48,7 +48,8 @@ export type OutputExportResult =
         | "ambiguous_native_failure";
     };
 
-export type DeliverableMediaType =
+/** The curated model-authored text types, which are the only previewable ones. */
+export type TextDeliverableMediaType =
   | "text/markdown"
   | "text/plain"
   | "text/csv"
@@ -57,9 +58,23 @@ export type DeliverableMediaType =
 
 const MAX_DELIVERABLES = 100;
 const MAX_FILENAME_CHARACTERS = 120;
+const MAX_MEDIA_TYPE_CHARACTERS = 127;
 const MAX_PREVIEW_CHARACTERS = 100_000;
 const MAX_DELIVERABLE_BYTES = 512 * 1024;
+const MAX_BINARY_DELIVERABLE_BYTES = 16 * 1024 * 1024;
 const MAX_OUTPUT_REVISIONS = 100;
+
+export function isTextDeliverableMediaType(
+  value: string,
+): value is TextDeliverableMediaType {
+  return [
+    "text/markdown",
+    "text/plain",
+    "text/csv",
+    "application/json",
+    "text/html",
+  ].includes(value);
+}
 
 export async function listDeliverables(
   chatId: string,
@@ -233,7 +248,7 @@ export function parseDeliverableSummary(value: unknown): DeliverableSummary {
     typeof value.sizeBytes !== "number" ||
     !Number.isSafeInteger(value.sizeBytes) ||
     value.sizeBytes < 0 ||
-    value.sizeBytes > MAX_DELIVERABLE_BYTES ||
+    value.sizeBytes > deliverableByteCeiling(value.mediaType) ||
     typeof value.revisionCount !== "number" ||
     !Number.isSafeInteger(value.revisionCount) ||
     value.revisionCount < 1 ||
@@ -287,27 +302,38 @@ export function parseOutputRevertResult(
 }
 
 function isDeliverableFilename(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    [...value].length <= MAX_FILENAME_CHARACTERS &&
+    /^[A-Za-z0-9][A-Za-z0-9 _().-]*$/.test(value) &&
+    !value.endsWith(".") &&
+    value.trim() === value
+  );
+}
+
+// Mirrors the native `validate_deliverable_media_type`: a bounded, well-formed
+// `type/subtype` token with no parameters. Binary artifacts carry arbitrary
+// media types, so this is a shape check, not an allowlist.
+function isDeliverableMediaType(value: unknown): value is string {
   if (
     typeof value !== "string" ||
     value.length === 0 ||
-    [...value].length > MAX_FILENAME_CHARACTERS ||
-    !/^[A-Za-z0-9][A-Za-z0-9 _().-]*$/.test(value) ||
-    value.endsWith(".") ||
-    value.trim() !== value
+    value.length > MAX_MEDIA_TYPE_CHARACTERS
   ) {
     return false;
   }
-  return /\.(?:md|txt|csv|json|html)$/i.test(value);
+  const parts = value.split("/");
+  return (
+    parts.length === 2 &&
+    parts.every((token) => /^[A-Za-z0-9!#$&^_.+-]+$/.test(token))
+  );
 }
 
-function isDeliverableMediaType(value: unknown): value is DeliverableMediaType {
-  return [
-    "text/markdown",
-    "text/plain",
-    "text/csv",
-    "application/json",
-    "text/html",
-  ].includes(String(value));
+function deliverableByteCeiling(mediaType: unknown): number {
+  return typeof mediaType === "string" && isTextDeliverableMediaType(mediaType)
+    ? MAX_DELIVERABLE_BYTES
+    : MAX_BINARY_DELIVERABLE_BYTES;
 }
 
 function isOpaqueId(value: unknown): value is string {

--- a/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
@@ -105,4 +105,24 @@ describe("OutputDetailRoot", () => {
     expect(screen.queryByRole("heading", { name: "not a heading,2" })).toBeNull();
     expect(screen.getByText(/Saving writes the complete file/)).toBeVisible();
   });
+
+  // Binary artifacts arrive with empty content; the panel offers export rather
+  // than an inline rendering it cannot produce.
+  it("offers export instead of a preview for a binary artifact", async () => {
+    const apis = detailApis({
+      read: vi.fn().mockResolvedValue(
+        preview({
+          filename: "chart.png",
+          mediaType: "image/png",
+          content: "",
+        }),
+      ),
+    });
+    await openOutput(apis);
+
+    expect(
+      await screen.findByText(/No preview for this file type/),
+    ).toBeVisible();
+    expect(screen.getByRole("button", { name: "Save as…" })).toBeEnabled();
+  });
 });

--- a/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { WithTooltip } from "@/components/ui/tooltip";
 import {
   exportDeliverable,
+  isTextDeliverableMediaType,
   readDeliverable,
   revertOutput,
   type DeliverablePreview,
@@ -196,7 +197,11 @@ export function OutputDetailRoot({
           </div>
           <div className="min-h-0 flex-1 overflow-auto p-6">
             <div className="mx-auto max-w-4xl">
-              {preview.mediaType === "text/markdown" ? (
+              {!isTextDeliverableMediaType(preview.mediaType) ? (
+                <p className="text-sm text-muted-foreground" role="status">
+                  No preview for this file type. Save as… exports the file.
+                </p>
+              ) : preview.mediaType === "text/markdown" ? (
                 <MessageMarkdown>{preview.content}</MessageMarkdown>
               ) : (
                 <pre className="font-mono text-xs break-words whitespace-pre-wrap">

--- a/crates/openwave-desktop/ui/src/outputs/outputFormat.ts
+++ b/crates/openwave-desktop/ui/src/outputs/outputFormat.ts
@@ -1,7 +1,7 @@
-import type { DeliverableMediaType, DeliverableSummary } from "@/deliverables";
+import type { DeliverableSummary } from "@/deliverables";
 
 /** The reader-facing name for an output's format, and the Type facet's values. */
-export function outputTypeLabel(mediaType: DeliverableMediaType): string {
+export function outputTypeLabel(mediaType: string): string {
   switch (mediaType) {
     case "text/markdown":
       return "Markdown";
@@ -13,6 +13,26 @@ export function outputTypeLabel(mediaType: DeliverableMediaType): string {
       return "HTML";
     case "text/plain":
       return "Plain text";
+    case "image/png":
+      return "PNG image";
+    case "image/jpeg":
+      return "JPEG image";
+    case "image/webp":
+      return "WebP image";
+    case "image/gif":
+      return "GIF image";
+    case "application/pdf":
+      return "PDF";
+    case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+      return "Excel spreadsheet";
+    case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+      return "Word document";
+    case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+      return "PowerPoint presentation";
+    case "application/zip":
+      return "ZIP archive";
+    default:
+      return "File";
   }
 }
 


### PR DESCRIPTION
The renderer's deliverable parsers only admitted the five curated text media types, text extensions, and the 512 KiB text ceiling — so the first binary output in a chat would make `list_deliverables` throw and blank the whole Outputs catalog. The store and native commands already accept binary artifacts (16 MiB ceiling, explicit media type); this aligns the renderer contract with them.

- `deliverables.ts`: media types validated as bounded `type/subtype` tokens (mirroring `validate_deliverable_media_type`) instead of a five-entry allowlist; size bounded per kind (512 KiB curated text, 16 MiB otherwise); filenames keep the portability rules but drop the text-extension requirement.
- `read_deliverable` returns an identity-only preview (empty content) for binary media types instead of erroring; the detail panel shows "No preview for this file type — Save as… exports the file" and keeps export enabled.
- `outputTypeLabel` gains labels for common binary types and a generic fallback.

Test changes: dropped `report.pdf` from the unsafe-filename rejection case — a .pdf name is now a valid binary output, and the remaining cases still pin the path-traversal/charset rules. Added parser contracts for the per-kind size ceilings and malformed media types, and a dom test for the binary placeholder.

This lands ahead of the exec output-directory scan, which is what will start producing binary outputs.