### PR TITLE
fix(host-broker): set unreachable roots aside instead of failing startup

### DIFF
--- a/crates/openwave-host-broker/src/audit.rs
+++ b/crates/openwave-host-broker/src/audit.rs
@@ -66,6 +66,7 @@ pub enum AuditOperation {
     DetachRoot,
     LookupRootAttachmentReceipt,
     RevokeRoot,
+    PruneUnavailableRoot,
     ResolveExecRoots,
     ListRoots,
     ListDirectory,

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -30,6 +30,7 @@ use crate::{
         AuditActor, AuditError, AuditEvent, AuditOperation, AuditOutcome, AuditSink, AuditTarget,
         JsonlAuditSink, MemoryAuditSink, UnavailableAuditSink,
     },
+    path_policy::RootIdentity,
     protocol::{
         ControlEnvelope, ControlRequest, ControlResponseEnvelope, ControlResult, DirectoryEntry,
         EntryKind, ErrorCode, ErrorResponse, HelloResult, LookupRegisterRootReceiptRequest,
@@ -43,8 +44,8 @@ use crate::{
         WriteFileRequest, WriteFileResult, MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
     },
     Capability, ConsentMethod, ConsentRecord, ExecutionContext, Grant, GrantError, GrantId,
-    GrantSubject, OperationId, RelativePath, RootAttachment, RootId, RootPolicy, RootPolicyError,
-    Scope, SubjectKind, ValidatedRoot,
+    GrantSubject, OperationId, RelativePath, RequestId, RootAttachment, RootId, RootPolicy,
+    RootPolicyError, Scope, SubjectKind, ValidatedRoot,
 };
 
 mod state_file;
@@ -154,6 +155,73 @@ struct State {
     attachments: Vec<RootAttachment>,
     mutations: HashMap<OperationId, MutationRecord>,
     active_mutations: HashSet<OperationId>,
+    /// Persisted roots whose directory could not be reopened at load. They are
+    /// held out of the live tables so the rest of the registry still works, and
+    /// written back verbatim so the approval survives the outage.
+    unavailable: Vec<UnavailableRoot>,
+}
+
+/// A registration that is dormant for the lifetime of this process.
+///
+/// The user approved this folder and nothing has withdrawn that approval; the
+/// host simply cannot produce a pinned handle for it right now. Its grants and
+/// attachments travel with it rather than being dropped, because the common
+/// cause — an external volume that is not mounted — resolves on its own, and
+/// re-consenting for a folder that was never disconnected is a poor trade for
+/// the small amount of state this holds.
+#[derive(Clone)]
+struct UnavailableRoot {
+    id: RootId,
+    owner: GrantSubject,
+    path: PathBuf,
+    identity: RootIdentity,
+    reason: UnavailableRootReason,
+    grants: Vec<Grant>,
+    attachments: Vec<RootAttachment>,
+}
+
+/// Why a persisted root could not be reopened.
+///
+/// The causes are recorded rather than acted on: an unmounted volume reports
+/// itself as missing on some hosts and as an I/O failure on others, so no cause
+/// here is reliable enough to justify destroying an approval on its own.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum UnavailableRootReason {
+    /// Nothing exists at the approved path.
+    Missing,
+    /// The path exists but the broker may no longer open it.
+    PermissionDenied,
+    /// Host I/O failed for some other reason, including a device that is
+    /// present but not ready.
+    HostIo,
+    /// The path resolves to a directory the current policy would not approve.
+    Rejected,
+    /// A different directory now occupies the approved path. Consent named the
+    /// original directory, and rebinding it to whatever replaced it would hand
+    /// out authority the user never gave.
+    Replaced,
+}
+
+impl UnavailableRootReason {
+    fn from_policy_error(error: &RootPolicyError) -> Self {
+        match error {
+            RootPolicyError::Io(error) => match error.kind() {
+                io::ErrorKind::NotFound => Self::Missing,
+                io::ErrorKind::PermissionDenied => Self::PermissionDenied,
+                _ => Self::HostIo,
+            },
+            _ => Self::Rejected,
+        }
+    }
+
+    const fn error_code(self) -> ErrorCode {
+        match self {
+            Self::Missing => ErrorCode::NotFound,
+            Self::PermissionDenied => ErrorCode::Denied,
+            Self::HostIo => ErrorCode::HostIo,
+            Self::Rejected | Self::Replaced => ErrorCode::InvalidRoot,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -417,7 +485,12 @@ impl Broker {
                 Arc::new(UnavailableAuditSink)
             }
         };
-        Ok(Self {
+        let pruned = state
+            .unavailable
+            .iter()
+            .map(unavailable_root_event)
+            .collect::<Vec<_>>();
+        let broker = Self {
             shared: Arc::new(Shared {
                 policy,
                 state: Mutex::new(state),
@@ -425,7 +498,11 @@ impl Broker {
                 audit,
                 failed_closed: AtomicBool::new(false),
             }),
-        })
+        };
+        for event in &pruned {
+            broker.shared.record_audit(event);
+        }
+        Ok(broker)
     }
 
     /// Obtain the trusted host-only interface.
@@ -832,9 +909,16 @@ impl Controller {
         // deleting every alias would invalidate durable receipts and product
         // projections that still name those IDs. Preserve that legacy state
         // and report that no global revocation occurred.
-        let revoked = owned && !has_physical_root_alias(&next, request.root_id);
+        // Revocation is the one deliberate instruction to forget a root, so it
+        // reaches the set-aside registrations too. Nothing else deletes them.
+        let set_aside = next
+            .unavailable
+            .iter()
+            .any(|root| root.id == request.root_id && root.owner == request.subject);
+        let revoked = set_aside || (owned && !has_physical_root_alias(&next, request.root_id));
         if revoked {
             next.roots.remove(&request.root_id);
+            next.unavailable.retain(|root| root.id != request.root_id);
             next.grants
                 .retain(|grant| !scope_targets_root(grant.scope(), request.root_id));
             next.attachments
@@ -1796,7 +1880,20 @@ fn apply_root_attachment(
                 attachment.conversation_id() != request.conversation_id
                     || attachment.root_id() != request.root_id
             });
-            state.attachments.len() != before
+            let mut detached = state.attachments.len() != before;
+            // A conversation can detach a folder whose directory is currently
+            // out of reach. Without this the attachment would come back the
+            // moment the folder did.
+            for root in &mut state.unavailable {
+                if root.id != request.root_id {
+                    continue;
+                }
+                let before = root.attachments.len();
+                root.attachments
+                    .retain(|attachment| attachment.conversation_id() != request.conversation_id);
+                detached |= root.attachments.len() != before;
+            }
+            detached
         }
     };
     Ok(RootAttachmentMutationResult {
@@ -1913,6 +2010,28 @@ fn preferred_root_alias(state: &State, candidate: &RegisteredRoot) -> Option<(Ro
         // then use the opaque UUID as the host-wide deterministic tie-breaker.
         .min_by_key(|(root_id, root)| (root.owner != candidate.owner, root_id.as_uuid()))
         .map(|(root_id, root)| (*root_id, root.display_name.clone()))
+}
+
+/// Record that an approved folder went dark, without naming its host path.
+fn unavailable_root_event(root: &UnavailableRoot) -> AuditEvent {
+    AuditEvent {
+        event_id: Uuid::new_v4(),
+        timestamp: Utc::now(),
+        request_id: RequestId::new(),
+        operation_id: None,
+        actor: AuditActor::Control {
+            subject: root.owner,
+            conversation_id: None,
+        },
+        operation: AuditOperation::PruneUnavailableRoot,
+        target: AuditTarget::Root { root_id: root.id },
+        outcome: AuditOutcome::Failed,
+        capability: None,
+        grant_id: None,
+        error_code: Some(root.reason.error_code()),
+        item_count: None,
+        bytes: None,
+    }
 }
 
 fn has_physical_root_alias(state: &State, root_id: RootId) -> bool {

--- a/crates/openwave-host-broker/src/broker/state_file.rs
+++ b/crates/openwave-host-broker/src/broker/state_file.rs
@@ -14,7 +14,8 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    has_physical_root_alias, root_display_name, BrokerError, MutationRecord, RegisteredRoot, State,
+    has_physical_root_alias, root_display_name, scope_targets_root, BrokerError, MutationRecord,
+    RegisteredRoot, State, UnavailableRoot, UnavailableRootReason,
 };
 use crate::{
     path_policy::RootIdentity, Grant, GrantSubject, OperationId, RootAttachment, RootId,
@@ -119,26 +120,48 @@ impl StateFile {
             .into());
         }
 
+        // One folder that cannot be reopened must not take the others down with
+        // it. Every root the host can still pin is admitted; the rest are set
+        // aside, keeping their grants and attachments, so a broker whose
+        // external drive is unplugged still starts and still serves the folders
+        // that are there.
         let mut roots = HashMap::new();
+        let mut unavailable = Vec::new();
+        let mut seen = std::collections::HashSet::new();
         for item in persisted.roots {
-            let validated = policy.open_root(&item.path)?;
-            if validated.identity() != item.identity {
-                return Err(invalid_data("persisted root identity changed").into());
-            }
-            let display_name = root_display_name(validated.canonical_path());
-            if roots
-                .insert(
-                    item.id,
-                    RegisteredRoot {
-                        owner: item.owner,
-                        display_name,
-                        root: Arc::new(validated),
-                    },
-                )
-                .is_some()
-            {
+            if !seen.insert(item.id) {
                 return Err(invalid_data("duplicate persisted root identity").into());
             }
+            match policy.open_root(&item.path) {
+                Ok(validated) if validated.identity() == item.identity => {
+                    let display_name = root_display_name(validated.canonical_path());
+                    roots.insert(
+                        item.id,
+                        RegisteredRoot {
+                            owner: item.owner,
+                            display_name,
+                            root: Arc::new(validated),
+                        },
+                    );
+                }
+                Ok(_) => unavailable.push(set_aside(item, UnavailableRootReason::Replaced)),
+                Err(error) => unavailable.push(set_aside(
+                    item,
+                    UnavailableRootReason::from_policy_error(&error),
+                )),
+            }
+        }
+
+        let mut grants = persisted.grants;
+        let mut attachments = persisted.attachments;
+        for root in &mut unavailable {
+            let root_id = root.id;
+            root.grants = take_matching(&mut grants, |grant| {
+                scope_targets_root(grant.scope(), root_id)
+            });
+            root.attachments = take_matching(&mut attachments, |attachment| {
+                attachment.root_id() == root_id
+            });
         }
 
         let mut mutations = HashMap::new();
@@ -154,10 +177,11 @@ impl StateFile {
         // existing root has to come from a fresh consent instead.
         let state = State {
             roots,
-            grants: persisted.grants,
-            attachments: persisted.attachments,
+            grants,
+            attachments,
             mutations,
             active_mutations: Default::default(),
+            unavailable,
         };
         validate_loaded_state(&state)?;
         Ok(state)
@@ -187,6 +211,15 @@ impl StateFile {
                 identity: root.root.identity(),
             })
             .collect::<Vec<_>>();
+        // Roots that were unavailable at load are written back untouched. This
+        // is what makes the pruning a property of the session rather than a
+        // deletion: the approval is still on disk when the folder returns.
+        roots.extend(state.unavailable.iter().map(|root| PersistedRoot {
+            id: root.id,
+            owner: root.owner,
+            path: root.path.clone(),
+            identity: root.identity,
+        }));
         roots.sort_by_key(|root| root.id.to_string());
         let mut mutations = state
             .mutations
@@ -197,11 +230,25 @@ impl StateFile {
             })
             .collect::<Vec<_>>();
         mutations.sort_by_key(|item| item.operation_id.to_string());
+        let mut grants = state.grants.clone();
+        grants.extend(
+            state
+                .unavailable
+                .iter()
+                .flat_map(|root| root.grants.iter().cloned()),
+        );
+        let mut attachments = state.attachments.clone();
+        attachments.extend(
+            state
+                .unavailable
+                .iter()
+                .flat_map(|root| root.attachments.iter().copied()),
+        );
         let persisted = PersistedState {
             version: STATE_VERSION,
             roots,
-            grants: state.grants.clone(),
-            attachments: state.attachments.clone(),
+            grants,
+            attachments,
             mutations,
         };
         let bytes = serde_json::to_vec_pretty(&persisted).map_err(invalid_data)?;
@@ -358,6 +405,13 @@ pub(super) fn validate_loaded_state(state: &State) -> Result<(), BrokerError> {
                         )
                         .into());
                     }
+                } else if state
+                    .unavailable
+                    .iter()
+                    .any(|root| root.id == result.root.root_id)
+                {
+                    // The registration is intact on disk; only its directory is
+                    // out of reach, so the receipt still describes real state.
                 } else {
                     let was_revoked = state.mutations.values().any(|record| {
                         matches!(
@@ -437,6 +491,32 @@ pub(super) fn validate_loaded_state(state: &State) -> Result<(), BrokerError> {
         }
     }
     Ok(())
+}
+
+fn set_aside(item: PersistedRoot, reason: UnavailableRootReason) -> UnavailableRoot {
+    UnavailableRoot {
+        id: item.id,
+        owner: item.owner,
+        path: item.path,
+        identity: item.identity,
+        reason,
+        grants: Vec::new(),
+        attachments: Vec::new(),
+    }
+}
+
+fn take_matching<T>(items: &mut Vec<T>, mut matches: impl FnMut(&T) -> bool) -> Vec<T> {
+    let mut taken = Vec::new();
+    let mut kept = Vec::with_capacity(items.len());
+    for item in items.drain(..) {
+        if matches(&item) {
+            taken.push(item);
+        } else {
+            kept.push(item);
+        }
+    }
+    *items = kept;
+    taken
 }
 
 fn invalid_data(error: impl std::fmt::Display) -> io::Error {

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -2250,33 +2250,80 @@ fn durable_state_uses_private_directory_and_file_permissions() {
 }
 
 #[test]
-fn restart_revalidates_every_persisted_root_before_advertising_state() {
-    let (temp, broker, path, state_dir) = durable_setup();
+fn an_unreachable_root_is_set_aside_rather_than_blocking_the_others() {
+    let (temp, broker, offline_path, state_dir) = durable_setup();
     let conversation = Uuid::new_v4();
-    register(
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    let reachable_path = temp.path().join("home/Reports");
+    std::fs::create_dir_all(&reachable_path).unwrap();
+    let offline = register(
         &broker.controller(),
-        GrantSubject::conversation(conversation).unwrap(),
+        subject,
         conversation,
-        path.clone(),
+        offline_path.clone(),
+        OperationId::new(),
+    );
+    let reachable = register(
+        &broker.controller(),
+        subject,
+        conversation,
+        reachable_path,
         OperationId::new(),
     );
     drop(broker);
-    std::fs::remove_file(path.join("note.txt")).unwrap();
-    std::fs::remove_dir(path).unwrap();
+    // Renaming stands in for the volume going away: the directory keeps its
+    // host identity, so it is the same folder when it comes back.
+    let stashed = offline_path.with_file_name("Documents-offline");
+    std::fs::rename(&offline_path, &stashed).unwrap();
 
-    assert!(matches!(
-        Broker::open(test_policy(&temp), &state_dir),
-        Err(BrokerError::RootPolicy(_))
-    ));
+    let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+    let context = ExecutionContext::standalone(conversation).unwrap();
+    assert_eq!(
+        operate(&broker.operator(), context, OperationRequest::ListRoots).unwrap(),
+        OperationResult::ListRoots {
+            roots: vec![read_write(reachable.root)]
+        }
+    );
+    assert!(
+        std::fs::read_to_string(state_dir.join("host-broker-audit.jsonl"))
+            .unwrap()
+            .contains("prune_unavailable_root")
+    );
+
+    // A later mutation rewrites the state file. The offline approval has to
+    // survive that, or an unplugged drive would silently cost the user their
+    // consent.
+    let another = temp.path().join("home/Archive");
+    std::fs::create_dir_all(&another).unwrap();
+    register(
+        &broker.controller(),
+        subject,
+        conversation,
+        another,
+        OperationId::new(),
+    );
+    drop(broker);
+    std::fs::rename(&stashed, &offline_path).unwrap();
+
+    let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+    let OperationResult::ListRoots { roots } =
+        operate(&broker.operator(), context, OperationRequest::ListRoots).unwrap()
+    else {
+        panic!("unexpected operation result")
+    };
+    assert!(roots
+        .iter()
+        .any(|root| root.root_id == offline.root.root_id));
 }
 
 #[test]
 fn restart_refuses_to_rebind_a_grant_to_a_replaced_folder() {
     let (temp, broker, path, state_dir) = durable_setup();
     let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
     register(
         &broker.controller(),
-        GrantSubject::conversation(conversation).unwrap(),
+        subject,
         conversation,
         path.clone(),
         OperationId::new(),
@@ -2286,10 +2333,12 @@ fn restart_refuses_to_rebind_a_grant_to_a_replaced_folder() {
     std::fs::rename(&path, original).unwrap();
     std::fs::create_dir(&path).unwrap();
 
-    assert!(matches!(
-        Broker::open(test_policy(&temp), &state_dir),
-        Err(BrokerError::Io(error)) if error.kind() == io::ErrorKind::InvalidData
-    ));
+    let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+    let context = ExecutionContext::standalone(conversation).unwrap();
+    assert_eq!(
+        operate(&broker.operator(), context, OperationRequest::ListRoots).unwrap(),
+        OperationResult::ListRoots { roots: Vec::new() }
+    );
 }
 
 #[test]


### PR DESCRIPTION
Loading persisted state propagated the first root that could not be
reopened out of `Broker::open`, and the sidecar treats that as fatal. One
deleted folder or one unplugged external drive therefore made every other
attached folder inaccessible, with no in-product way back.

Roots the host cannot pin are now held out of the live registry instead.
They keep their grants and attachments, and `save` writes them back
verbatim, so the pruning lasts for the session rather than destroying an
approval the user never withdrew — which matters most for the case that
prompted this, a volume that is simply not mounted right now. When the
folder returns with its original host identity, so does the registration.

A directory that has been replaced by a different one at the same path is
set aside the same way. Consent named the original directory, so rebinding
is still refused, but refusing no longer costs the user the rest of their
folders.

Each set-aside root emits an audit event carrying its cause — missing,
permission denied, host I/O, or replaced. The causes are recorded rather
than acted on: an unmounted volume reports itself as missing on some hosts
and as an I/O failure on others, so none of them is a reliable enough
signal to delete an approval on its own.

Revoking a root now also reaches the set-aside registrations, since it is
the one deliberate instruction to forget a folder, and detaching one drops
its held attachment so it does not reappear when the folder does.

Closes #1097
