### PR TITLE
feat(core): sync the exec output directory into the durable output record

### DIFF
--- a/crates/openwave-core/src/db/tests/output.rs
+++ b/crates/openwave-core/src/db/tests/output.rs
@@ -597,3 +597,232 @@ async fn acceptance_enforces_the_binary_cap_and_rejects_empty_artifacts() {
     .await
     .is_ok());
 }
+
+#[cfg(feature = "tools")]
+mod output_scan {
+    use super::*;
+    use crate::deliverable::{output_revision_relative_path, RevisionProducer};
+    use crate::id::CallId;
+    use crate::output_scan::{sync_output_directory, OutputSyncStatus, EXEC_OUTPUT_DIRECTORY};
+
+    async fn sync(
+        store: &DbStore,
+        scratch: &cap_std::fs::Dir,
+        chat_id: ChatId,
+        call_id: CallId,
+        second: i64,
+    ) -> crate::output_scan::OutputDirectorySync {
+        sync_output_directory(
+            store,
+            scratch,
+            chat_id,
+            call_id,
+            RevisionProducer::Turn(TurnId::new()),
+            at(second),
+        )
+        .await
+        .unwrap()
+    }
+
+    fn write_output_file(scratch: &std::path::Path, name: &str, content: &[u8]) {
+        let directory = scratch.join(EXEC_OUTPUT_DIRECTORY);
+        std::fs::create_dir_all(&directory).unwrap();
+        std::fs::write(directory.join(name), content).unwrap();
+    }
+
+    #[tokio::test]
+    async fn the_scan_creates_updates_and_matches_by_filename() {
+        let (_dir, store, chat) = store_with_chat().await;
+        let scratch = tempfile::tempdir().unwrap();
+        let dir = open_scratch(scratch.path());
+
+        // First call: a text report and an oversized-for-text binary chart.
+        write_output_file(scratch.path(), "report.md", b"# Draft");
+        let mut pixels = b"\x89PNG\r\n\x1a\n".to_vec();
+        pixels.resize(700 * 1024, 7);
+        write_output_file(scratch.path(), "chart.png", &pixels);
+
+        let first = sync(&store, &dir, chat.id, CallId::new(), 0).await;
+        assert!(first.notes.is_empty(), "{:?}", first.notes);
+        assert_eq!(first.entries.len(), 2);
+        assert!(first
+            .entries
+            .iter()
+            .all(|entry| entry.status == OutputSyncStatus::Created && entry.ordinal == 1));
+        let report = first
+            .entries
+            .iter()
+            .find(|entry| entry.filename == "report.md")
+            .unwrap();
+        let chart = first
+            .entries
+            .iter()
+            .find(|entry| entry.filename == "chart.png")
+            .unwrap();
+        let chart_record = store.get_output(chart.output_id).await.unwrap().unwrap();
+        assert_eq!(chart_record.media_type, "image/png");
+        // The bytes landed at the write-once revision path the desktop reads.
+        let published = scratch.path().join(output_revision_relative_path(
+            chart_record.id,
+            chart_record.current_revision,
+        ));
+        assert_eq!(std::fs::read(&published).unwrap(), pixels);
+        // The revision is attributed to the producing turn.
+        let revision = store
+            .get_output_revision(chart_record.current_revision)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(revision.turn_id.is_some());
+
+        // Second call, nothing rewritten: both files match their current
+        // revisions and nothing is minted.
+        let second = sync(&store, &dir, chat.id, CallId::new(), 30).await;
+        assert!(second
+            .entries
+            .iter()
+            .all(|entry| entry.status == OutputSyncStatus::Unchanged));
+        assert_eq!(
+            store
+                .get_output(report.output_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .revision_count,
+            1
+        );
+
+        // Third call: same filename, new bytes — a revision on the same output,
+        // never a second record.
+        write_output_file(scratch.path(), "report.md", b"# Final");
+        let third = sync(&store, &dir, chat.id, CallId::new(), 60).await;
+        let updated = third
+            .entries
+            .iter()
+            .find(|entry| entry.filename == "report.md")
+            .unwrap();
+        assert_eq!(updated.status, OutputSyncStatus::Updated);
+        assert_eq!(updated.output_id, report.output_id);
+        assert_eq!(updated.ordinal, 2);
+
+        // Deleting a file from output/ never deletes the durable record, and a
+        // renamed file is a new output rather than a revision.
+        std::fs::remove_file(scratch.path().join(EXEC_OUTPUT_DIRECTORY).join("report.md")).unwrap();
+        write_output_file(scratch.path(), "summary.md", b"# Summary");
+        let fourth = sync(&store, &dir, chat.id, CallId::new(), 90).await;
+        let summary = fourth
+            .entries
+            .iter()
+            .find(|entry| entry.filename == "summary.md")
+            .unwrap();
+        assert_eq!(summary.status, OutputSyncStatus::Created);
+        assert_ne!(summary.output_id, report.output_id);
+        let report_record = store.get_output(report.output_id).await.unwrap().unwrap();
+        assert!(report_record.deleted_at.is_none());
+        assert_eq!(report_record.revision_count, 2);
+        assert_eq!(store.list_outputs(chat.id, 10).await.unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn an_exact_scan_retry_is_idempotent() {
+        let (_dir, store, chat) = store_with_chat().await;
+        let scratch = tempfile::tempdir().unwrap();
+        let dir = open_scratch(scratch.path());
+        write_output_file(scratch.path(), "report.md", b"# Draft");
+
+        let call_id = CallId::new();
+        let first = sync(&store, &dir, chat.id, call_id, 0).await;
+        let retried = sync(&store, &dir, chat.id, call_id, 0).await;
+
+        assert_eq!(first.entries[0].output_id, retried.entries[0].output_id);
+        assert_eq!(retried.entries[0].status, OutputSyncStatus::Unchanged);
+        assert_eq!(store.list_outputs(chat.id, 10).await.unwrap().len(), 1);
+        assert_eq!(
+            store
+                .list_output_revisions(first.entries[0].output_id)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn unacceptable_files_become_notes_without_failing_the_scan() {
+        let (_dir, store, chat) = store_with_chat().await;
+        let scratch = tempfile::tempdir().unwrap();
+        let dir = open_scratch(scratch.path());
+
+        write_output_file(scratch.path(), "good.md", b"# Fine");
+        write_output_file(scratch.path(), "empty.md", b"");
+        write_output_file(
+            scratch.path(),
+            "huge.csv",
+            &vec![b'x'; MAX_DELIVERABLE_BYTES + 1],
+        );
+        write_output_file(scratch.path(), "binary.md", b"text\xff\xfe");
+        write_output_file(scratch.path(), ".hidden.md", b"# Plumbing");
+
+        let scan = sync(&store, &dir, chat.id, CallId::new(), 0).await;
+
+        assert_eq!(scan.entries.len(), 1);
+        assert_eq!(scan.entries[0].filename, "good.md");
+        assert!(scan.notes.iter().any(|note| note.contains("empty.md")));
+        assert!(scan
+            .notes
+            .iter()
+            .any(|note| note.contains("huge.csv") && note.contains("binary format")));
+        assert!(scan
+            .notes
+            .iter()
+            .any(|note| note.contains("binary.md") && note.contains("UTF-8")));
+        assert!(!scan.notes.iter().any(|note| note.contains(".hidden.md")));
+    }
+
+    #[tokio::test]
+    async fn the_revision_cap_is_a_note_and_other_files_still_land() {
+        let (_dir, store, chat) = store_with_chat().await;
+        let scratch = tempfile::tempdir().unwrap();
+        let dir = open_scratch(scratch.path());
+
+        let capped = store
+            .create_output(&create_request(chat.id, "capped.md", 1))
+            .await
+            .unwrap();
+        for ordinal in 2..=MAX_OUTPUT_REVISIONS {
+            store
+                .append_output_revision(capped.id, &revision(2, i64::from(ordinal)))
+                .await
+                .unwrap();
+        }
+
+        write_output_file(scratch.path(), "capped.md", b"# One too many");
+        write_output_file(scratch.path(), "fresh.md", b"# Lands anyway");
+        let scan = sync(&store, &dir, chat.id, CallId::new(), 500).await;
+
+        assert!(scan.notes.iter().any(|note| note.contains("capped.md")));
+        assert_eq!(scan.entries.len(), 1);
+        assert_eq!(scan.entries[0].filename, "fresh.md");
+        assert_eq!(scan.entries[0].status, OutputSyncStatus::Created);
+    }
+
+    /// A symlinked `output/` planted by local exec must not hand arbitrary host
+    /// files to the catalog.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_symlinked_output_directory_is_refused_rather_than_followed() {
+        let (_dir, store, chat) = store_with_chat().await;
+        let elsewhere = tempfile::tempdir().unwrap();
+        std::fs::write(elsewhere.path().join("private.md"), b"# Private").unwrap();
+        let scratch = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(elsewhere.path(), scratch.path().join(EXEC_OUTPUT_DIRECTORY))
+            .unwrap();
+        let dir = open_scratch(scratch.path());
+
+        let scan = sync(&store, &dir, chat.id, CallId::new(), 0).await;
+
+        assert!(scan.entries.is_empty());
+        assert!(scan.notes[0].contains("not a private workspace directory"));
+        assert!(store.list_outputs(chat.id, 10).await.unwrap().is_empty());
+    }
+}

--- a/crates/openwave-core/src/deliverable.rs
+++ b/crates/openwave-core/src/deliverable.rs
@@ -335,6 +335,34 @@ pub fn deliverable_media_type(name: &str) -> Option<&'static str> {
     }
 }
 
+/// The declared media type for a binary artifact filename.
+///
+/// Curated text extensions never reach this mapping — they classify as
+/// [`DeliverableKind::Text`] first — so every result here is valid for
+/// [`validate_binary_deliverable`]. Unknown extensions fall back to the generic
+/// byte-stream type rather than being refused: the filename is display metadata,
+/// and export works regardless.
+#[must_use]
+pub fn binary_media_type_for_extension(name: &str) -> &'static str {
+    let Some((_, extension)) = name.rsplit_once('.') else {
+        return "application/octet-stream";
+    };
+    match extension.to_ascii_lowercase().as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "webp" => "image/webp",
+        "gif" => "image/gif",
+        "svg" => "image/svg+xml",
+        "pdf" => "application/pdf",
+        "xlsx" | "xlsm" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "zip" => "application/zip",
+        "parquet" => "application/vnd.apache.parquet",
+        _ => "application/octet-stream",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -399,6 +399,28 @@ impl OutputId {
     pub fn for_run(run_id: AgentRunId) -> Self {
         Self(Uuid::new_v5(&Self::NAMESPACE, run_id.as_uuid().as_bytes()))
     }
+
+    /// Derive the retry-stable output identity for one artifact filename
+    /// published by one canonical tool call.
+    ///
+    /// An execution call can publish several files at once, so unlike
+    /// [`OutputId::for_call`] the identity covers the (call, filename) pair: a
+    /// retried call lands each file on the same output instead of forking new
+    /// records, and two files from one call never collide.
+    #[must_use]
+    pub fn for_call_artifact(call_id: CallId, filename: &str) -> Self {
+        Self(Uuid::new_v5(
+            &Self::NAMESPACE,
+            &call_artifact_name(call_id, filename),
+        ))
+    }
+}
+
+/// The stable UUIDv5 name for a (call, filename) artifact identity.
+fn call_artifact_name(call_id: CallId, filename: &str) -> Vec<u8> {
+    let mut name = call_id.as_uuid().as_bytes().to_vec();
+    name.extend_from_slice(filename.as_bytes());
+    name
 }
 
 id_type!(
@@ -420,6 +442,17 @@ impl OutputRevisionId {
     #[must_use]
     pub fn for_run(run_id: AgentRunId) -> Self {
         Self(Uuid::new_v5(&Self::NAMESPACE, run_id.as_uuid().as_bytes()))
+    }
+
+    /// Derive the retry-stable revision identity for one artifact filename
+    /// published by one canonical tool call. See
+    /// [`OutputId::for_call_artifact`].
+    #[must_use]
+    pub fn for_call_artifact(call_id: CallId, filename: &str) -> Self {
+        Self(Uuid::new_v5(
+            &Self::NAMESPACE,
+            &call_artifact_name(call_id, filename),
+        ))
     }
 }
 

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -48,6 +48,8 @@ pub mod image;
 #[cfg(feature = "keychain")]
 pub mod keychain;
 pub mod model;
+#[cfg(feature = "tools")]
+pub mod output_scan;
 pub mod preview;
 pub mod provider;
 mod renderer_tool;
@@ -109,12 +111,13 @@ pub use config::{Config, Profile};
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub use db::DbStore;
 pub use deliverable::{
-    deliverable_media_type, media_type_is_text, output_revision_relative_path,
-    revision_byte_ceiling, validate_binary_deliverable, validate_deliverable_media_type,
-    validate_deliverable_name, validate_portable_filename, CreateOutput, DeliverableKind,
-    NewOutputRevision, OutputRecord, OutputRevision, RevisionProducer, DELIVERABLES_DIRECTORY,
-    MAX_BINARY_DELIVERABLE_BYTES, MAX_DELIVERABLE_BYTES, MAX_DELIVERABLE_MEDIA_TYPE_CHARS,
-    MAX_DELIVERABLE_NAME_CHARS, MAX_OUTPUT_REVISIONS, OUTPUTS_DIRECTORY,
+    binary_media_type_for_extension, deliverable_media_type, media_type_is_text,
+    output_revision_relative_path, revision_byte_ceiling, validate_binary_deliverable,
+    validate_deliverable_media_type, validate_deliverable_name, validate_portable_filename,
+    CreateOutput, DeliverableKind, NewOutputRevision, OutputRecord, OutputRevision,
+    RevisionProducer, DELIVERABLES_DIRECTORY, MAX_BINARY_DELIVERABLE_BYTES, MAX_DELIVERABLE_BYTES,
+    MAX_DELIVERABLE_MEDIA_TYPE_CHARS, MAX_DELIVERABLE_NAME_CHARS, MAX_OUTPUT_REVISIONS,
+    OUTPUTS_DIRECTORY,
 };
 #[cfg(feature = "tools")]
 pub use deliverable_acceptance::{
@@ -151,6 +154,11 @@ pub use model::{
     TurnCheckpointProgress, TurnClientWait, TurnClientWaitStatus, TurnFailureReceipt,
     TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer, TurnSteerStatus, MAX_ATTACHMENT_REVISION,
     MAX_EXEC_WORKSPACE_FILE_BYTES, MAX_MESSAGE_ATTACHMENTS, MAX_ROOT_ATTACHMENTS,
+};
+#[cfg(feature = "tools")]
+pub use output_scan::{
+    sync_output_directory, OutputDirectorySync, OutputSyncEntry, OutputSyncStatus,
+    EXEC_OUTPUT_DIRECTORY, MAX_OUTPUT_SCAN_FILES,
 };
 pub use preview::{
     format_bytes, ResultEntry, ResultEntryKind, ResultFailure, ToolActionPreview,

--- a/crates/openwave-core/src/output_scan.rs
+++ b/crates/openwave-core/src/output_scan.rs
@@ -1,0 +1,359 @@
+//! Host-side sync of the execution `output/` directory into the durable
+//! conversation output record.
+//!
+//! Files an agent saves under `output/` during code execution are the
+//! files-first creation path for user-visible outputs: after each command the
+//! host scans the directory and publishes what it finds, keyed by filename
+//! within the conversation. A new filename creates an output at revision 1; an
+//! existing live output with the same filename gains a revision when the bytes
+//! changed and is left untouched when they did not. The model never names
+//! output identities — it just writes files — and deleting a file from
+//! `output/` never deletes the durable record.
+//!
+//! The scan is deliberately non-fatal: a file the host cannot accept (too
+//! large, unreadable, over the revision cap) becomes a note for the model
+//! rather than a failed command.
+
+use std::path::Path;
+
+use cap_std::fs::Dir;
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+
+use crate::deliverable::{
+    binary_media_type_for_extension, deliverable_media_type, output_revision_relative_path,
+    validate_portable_filename, CreateOutput, DeliverableKind, NewOutputRevision, RevisionProducer,
+    MAX_BINARY_DELIVERABLE_BYTES, MAX_DELIVERABLE_BYTES,
+};
+use crate::error::{AgentError, Result};
+use crate::id::{CallId, ChatId, OutputId, OutputRevisionId};
+use crate::storage::Store;
+use crate::OutputRecord;
+
+/// Conventional directory, relative to a conversation's private scratch, whose
+/// files the host publishes as durable outputs.
+pub const EXEC_OUTPUT_DIRECTORY: &str = "output";
+
+/// Most files considered by one scan. Files beyond the cap are named in a note
+/// rather than silently ignored.
+pub const MAX_OUTPUT_SCAN_FILES: usize = 64;
+
+/// Upper bound on the filename lookup when matching scan files to existing
+/// outputs. Far above the catalog's own display cap.
+const OUTPUT_LOOKUP_LIMIT: u64 = 1_000;
+
+/// What one scanned file did to the output record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputSyncStatus {
+    /// A new output was created at revision 1.
+    Created,
+    /// An existing output gained a new revision.
+    Updated,
+    /// The file's bytes match the output's current revision; nothing was
+    /// written.
+    Unchanged,
+}
+
+/// One file the scan accepted (or matched) against the output record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputSyncEntry {
+    /// Display filename, equal to the file's name under `output/`.
+    pub filename: String,
+    /// The durable output the file landed on.
+    pub output_id: OutputId,
+    /// The output's current revision ordinal after the sync.
+    pub ordinal: u32,
+    /// Whether the file created, updated, or matched the output.
+    pub status: OutputSyncStatus,
+}
+
+/// The outcome of scanning one conversation's `output/` directory.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OutputDirectorySync {
+    /// Accepted or matched files, in the deterministic scan order.
+    pub entries: Vec<OutputSyncEntry>,
+    /// Files the scan could not accept, with actionable reasons.
+    pub notes: Vec<String>,
+}
+
+/// A candidate file read out of `output/`, classified but not yet recorded.
+struct ScanCandidate {
+    filename: String,
+    kind: DeliverableKind,
+    content: Vec<u8>,
+}
+
+/// Scan `output/` under one conversation's private scratch and publish its
+/// files as durable outputs.
+///
+/// `scratch` is the exact owning conversation's private scratch directory.
+/// Identities derive from the (call, filename) pair, so an exact retry of the
+/// same call republishes idempotently instead of forking records.
+pub async fn sync_output_directory(
+    store: &dyn Store,
+    scratch: &Dir,
+    chat_id: ChatId,
+    call_id: CallId,
+    producer: RevisionProducer,
+    now: DateTime<Utc>,
+) -> Result<OutputDirectorySync> {
+    let mut sync = OutputDirectorySync::default();
+
+    // Reading is blocking capability I/O; keep it off the async runtime.
+    let read_scratch = scratch
+        .try_clone()
+        .map_err(|error| AgentError::Store(format!("could not open private scratch: {error}")))?;
+    let (candidates, mut read_notes) =
+        tokio::task::spawn_blocking(move || read_output_candidates(&read_scratch))
+            .await
+            .map_err(|error| AgentError::Store(format!("output scan task failed: {error}")))?;
+    sync.notes.append(&mut read_notes);
+    if candidates.is_empty() {
+        return Ok(sync);
+    }
+
+    // One lookup serves every candidate: the newest live output per filename.
+    let existing = store.list_outputs(chat_id, OUTPUT_LOOKUP_LIMIT).await?;
+
+    for candidate in candidates {
+        match record_candidate(
+            store, scratch, chat_id, call_id, producer, now, &existing, &candidate,
+        )
+        .await
+        {
+            Ok(entry) => sync.entries.push(entry),
+            Err(error) => sync.notes.push(format!(
+                "output/{} could not be published: {error}",
+                candidate.filename
+            )),
+        }
+    }
+    Ok(sync)
+}
+
+/// Record one classified candidate against the output record.
+#[allow(clippy::too_many_arguments)]
+async fn record_candidate(
+    store: &dyn Store,
+    scratch: &Dir,
+    chat_id: ChatId,
+    call_id: CallId,
+    producer: RevisionProducer,
+    now: DateTime<Utc>,
+    existing: &[OutputRecord],
+    candidate: &ScanCandidate,
+) -> Result<OutputSyncEntry> {
+    let sha256: [u8; 32] = Sha256::digest(&candidate.content).into();
+    let byte_len = candidate.content.len() as u64;
+
+    // `list_outputs` orders newest-updated first and excludes deleted outputs,
+    // so the first filename match is the live record this file addresses.
+    let matched = existing
+        .iter()
+        .find(|output| output.filename == candidate.filename);
+
+    if let Some(output) = matched {
+        let current = store
+            .get_output_revision(output.current_revision)
+            .await?
+            .ok_or_else(|| AgentError::Store("current revision is missing".into()))?;
+        if current.sha256 == sha256 && current.byte_len == byte_len {
+            return Ok(OutputSyncEntry {
+                filename: candidate.filename.clone(),
+                output_id: output.id,
+                ordinal: current.ordinal,
+                status: OutputSyncStatus::Unchanged,
+            });
+        }
+        let revision_id = OutputRevisionId::for_call_artifact(call_id, &candidate.filename);
+        publish_revision_bytes(scratch, output.id, revision_id, &candidate.content).await?;
+        let updated = store
+            .append_output_revision(
+                output.id,
+                &NewOutputRevision {
+                    id: revision_id,
+                    byte_len,
+                    sha256,
+                    turn_id: None,
+                    producing_run_id: None,
+                    created_at: now,
+                }
+                .with_producer(producer),
+            )
+            .await?;
+        return Ok(OutputSyncEntry {
+            filename: candidate.filename.clone(),
+            output_id: updated.id,
+            ordinal: updated.revision_count,
+            status: OutputSyncStatus::Updated,
+        });
+    }
+
+    let output_id = OutputId::for_call_artifact(call_id, &candidate.filename);
+    let revision_id = OutputRevisionId::for_call_artifact(call_id, &candidate.filename);
+    publish_revision_bytes(scratch, output_id, revision_id, &candidate.content).await?;
+    let created = store
+        .create_output(&CreateOutput {
+            id: output_id,
+            chat_id,
+            filename: candidate.filename.clone(),
+            kind: candidate.kind.clone(),
+            revision: NewOutputRevision {
+                id: revision_id,
+                byte_len,
+                sha256,
+                turn_id: None,
+                producing_run_id: None,
+                created_at: now,
+            }
+            .with_producer(producer),
+        })
+        .await?;
+    Ok(OutputSyncEntry {
+        filename: candidate.filename.clone(),
+        output_id: created.id,
+        ordinal: created.revision_count,
+        status: OutputSyncStatus::Created,
+    })
+}
+
+/// Publish revision bytes at the write-once derived path.
+async fn publish_revision_bytes(
+    scratch: &Dir,
+    output_id: OutputId,
+    revision_id: OutputRevisionId,
+    content: &[u8],
+) -> Result<()> {
+    let relative_path = output_revision_relative_path(output_id, revision_id);
+    let scratch = scratch
+        .try_clone()
+        .map_err(|error| AgentError::Store(format!("could not open private scratch: {error}")))?;
+    let content = content.to_vec();
+    tokio::task::spawn_blocking(move || {
+        crate::tools::private_scratch::publish_immutable_file(&scratch, &relative_path, &content)
+    })
+    .await
+    .map_err(|error| AgentError::Store(format!("publication task failed: {error}")))?
+    .map_err(|error| AgentError::Store(format!("could not publish output revision: {error}")))
+}
+
+/// Read and classify the acceptable files directly under `output/`.
+///
+/// Deterministic (alphabetical) order, bounded at [`MAX_OUTPUT_SCAN_FILES`].
+/// Anything skipped is explained in a note.
+fn read_output_candidates(scratch: &Dir) -> (Vec<ScanCandidate>, Vec<String>) {
+    let mut notes = Vec::new();
+
+    // A symlinked `output/` planted by local exec would hand host files from an
+    // arbitrary directory to the catalog; refuse it rather than follow it.
+    match scratch.symlink_metadata(EXEC_OUTPUT_DIRECTORY) {
+        Ok(metadata) if metadata.is_dir() => {}
+        Ok(_) => {
+            notes.push(
+                "outputs unavailable: output/ is not a private workspace directory. Remove it and rerun."
+                    .into(),
+            );
+            return (Vec::new(), notes);
+        }
+        Err(_) => return (Vec::new(), notes),
+    }
+    let Ok(directory) = scratch.open_dir(EXEC_OUTPUT_DIRECTORY) else {
+        notes.push("outputs unavailable: output/ could not be read".into());
+        return (Vec::new(), notes);
+    };
+    let Ok(entries) = directory.entries() else {
+        notes.push("outputs unavailable: output/ could not be read".into());
+        return (Vec::new(), notes);
+    };
+
+    let mut names = Vec::new();
+    for entry in entries.flatten() {
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            notes.push("a file with a non-UTF-8 name was ignored".into());
+            continue;
+        };
+        let is_regular_file = entry
+            .metadata()
+            .map(|metadata| metadata.is_file())
+            .unwrap_or(false);
+        if !is_regular_file {
+            // Subdirectories and symlinks are outside the outputs contract;
+            // dotfiles are workspace plumbing. Neither warrants a note.
+            continue;
+        }
+        if name.starts_with('.') {
+            continue;
+        }
+        names.push(name);
+    }
+    names.sort();
+    if names.len() > MAX_OUTPUT_SCAN_FILES {
+        notes.push(format!(
+            "output/ file cap is {MAX_OUTPUT_SCAN_FILES}; ignored {}",
+            names[MAX_OUTPUT_SCAN_FILES..].join(", ")
+        ));
+        names.truncate(MAX_OUTPUT_SCAN_FILES);
+    }
+
+    let mut candidates = Vec::new();
+    for name in names {
+        match classify_candidate(&directory, &name) {
+            Ok(candidate) => candidates.push(candidate),
+            Err(reason) => notes.push(format!("output/{name} was not published: {reason}")),
+        }
+    }
+    (candidates, notes)
+}
+
+/// Read one file and classify it as a text deliverable or binary artifact.
+fn classify_candidate(directory: &Dir, name: &str) -> std::result::Result<ScanCandidate, String> {
+    validate_portable_filename(name).map_err(str::to_owned)?;
+
+    let text_media_type = deliverable_media_type(name);
+    let ceiling = if text_media_type.is_some() {
+        MAX_DELIVERABLE_BYTES
+    } else {
+        MAX_BINARY_DELIVERABLE_BYTES
+    };
+
+    let metadata = directory
+        .metadata(Path::new(name))
+        .map_err(|_| "the file could not be read".to_owned())?;
+    if metadata.len() == 0 {
+        return Err("the file is empty".into());
+    }
+    if metadata.len() > ceiling as u64 {
+        return Err(if text_media_type.is_some() {
+            format!(
+                "text outputs are limited to {MAX_DELIVERABLE_BYTES} bytes; split it or produce a binary format"
+            )
+        } else {
+            format!("files are limited to {MAX_BINARY_DELIVERABLE_BYTES} bytes")
+        });
+    }
+    let content = directory
+        .read(Path::new(name))
+        .map_err(|_| "the file could not be read".to_owned())?;
+    if content.len() as u64 != metadata.len() || content.len() > ceiling {
+        return Err("the file changed while being read".into());
+    }
+
+    let kind = match text_media_type {
+        Some(_) => {
+            let text = std::str::from_utf8(&content)
+                .map_err(|_| "text outputs must be valid UTF-8".to_owned())?;
+            if text.contains('\0') {
+                return Err("text outputs must not contain NUL characters".into());
+            }
+            DeliverableKind::Text
+        }
+        None => DeliverableKind::Binary {
+            media_type: binary_media_type_for_extension(name).to_owned(),
+        },
+    };
+    Ok(ScanCandidate {
+        filename: name.to_owned(),
+        kind,
+        content,
+    })
+}


### PR DESCRIPTION
First slice of files-first output creation: a host-side primitive that scans a conversation's `output/` scratch directory and publishes what it finds as durable, versioned outputs. Nothing calls it yet — the exec wiring is the next slice — so this is additive and inert.

Semantics (matching how agents already iterate on files):
- Identity is the filename within the chat. A new filename creates an output at revision 1; an existing live output with the same name gains a revision when the bytes changed, and is left untouched (no write, no new revision) when they did not.
- Curated text extensions publish as text deliverables (UTF-8, 512 KiB ceiling); every other extension publishes as a binary artifact with a media type derived from the extension (`binary_media_type_for_extension`, generic byte-stream fallback), under the 16 MiB ceiling.
- Output/revision identities derive from the (call, filename) pair (`OutputId::for_call_artifact`), so retrying a call republishes idempotently instead of forking records.
- The scan never fails the surrounding command: per-file problems (empty, oversized, non-UTF-8 text, the 100-revision cap) become actionable notes. Deleting a file from `output/` never deletes the durable record. A symlinked `output/` is refused rather than followed, same as the preview scan.

Bytes land via the existing write-once `publish_immutable_file` path at the derived revision location, so downstream surfaces (catalog, preview, export) treat these outputs identically to existing ones.

Tests are store-backed contracts: create/update/unchanged across syncs, retry idempotency, per-file notes, revision-cap behavior, and symlink refusal.