### PR TITLE
feat(server): recover dead-driver container runs and sweep expired ones

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -711,6 +711,22 @@ impl Store for DbStore {
         ops::agent_run::claim_container_agent_run(self, id, lease_token, lease_duration).await
     }
 
+    async fn list_reclaimable_container_agent_runs(
+        &self,
+        now: chrono::DateTime<Utc>,
+    ) -> Result<Vec<AgentRun>> {
+        ops::agent_run::list_reclaimable_container_agent_runs(self, now).await
+    }
+
+    async fn reclaim_container_agent_run(
+        &self,
+        id: AgentRunId,
+        lease_token: uuid::Uuid,
+        lease_duration: chrono::Duration,
+    ) -> Result<Option<AgentRun>> {
+        ops::agent_run::reclaim_container_agent_run(self, id, lease_token, lease_duration).await
+    }
+
     async fn begin_sandbox_provision(
         &self,
         run_id: uuid::Uuid,

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -1221,6 +1221,165 @@ pub(in crate::db) async fn claim_container_agent_run(
     Ok(Some(claimed))
 }
 
+/// List container-located runs whose driver died: `running` under an expired
+/// lease with the deadline still open. The in-process lease reaper deliberately
+/// exempts container runs (lease expiry there means "the driving host died",
+/// not "the work died"), so this scan feeds the recovery pass that replaces it.
+pub(in crate::db) async fn list_reclaimable_container_agent_runs(
+    store: &DbStore,
+    now: chrono::DateTime<Utc>,
+) -> Result<Vec<AgentRun>> {
+    entities::agent_run::Entity::find()
+        .filter(entities::agent_run::Column::Tier.eq(AgentRunTier::Background.as_str()))
+        .filter(
+            entities::agent_run::Column::ExecutionLocation
+                .eq(AgentRunExecutionLocation::Container.as_str()),
+        )
+        .filter(entities::agent_run::Column::Status.eq(AgentRunStatus::Running.as_str()))
+        .filter(entities::agent_run::Column::LeaseExpiresAt.lte(now))
+        .filter(entities::agent_run::Column::DeadlineAt.gt(now))
+        .order_by_asc(entities::agent_run::Column::CreatedAt)
+        .order_by_asc(entities::agent_run::Column::Id)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(agent_run_from_model)
+        .collect()
+}
+
+/// Reclaim one expired-lease container run under a fresh bounded lease,
+/// **without** a second execution attempt.
+///
+/// A container run has exactly one attempt — exactly one container was ever
+/// asked to run it — so recovery re-drives that same attempt: the claim count
+/// advances, the attempt count does not, and the drive that follows reconciles
+/// the container through the durable provisioning record and the operation
+/// log rather than executing anything twice. Refuses a live lease (another
+/// driver still owns the run) and a crossed deadline (the claim scan fails
+/// those, enqueueing the container's teardown).
+pub(in crate::db) async fn reclaim_container_agent_run(
+    store: &DbStore,
+    id: AgentRunId,
+    lease_token: uuid::Uuid,
+    lease_duration: chrono::Duration,
+) -> Result<Option<AgentRun>> {
+    if lease_token.is_nil() || lease_duration <= chrono::Duration::zero() {
+        return Err(AgentError::Store(
+            "container agent-run reclaim requires a non-nil token and positive duration".into(),
+        ));
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    acquire_agent_run_claim_lock(&transaction).await?;
+    let now = database_now(&transaction).await?;
+    let lease_expires_at = now.checked_add_signed(lease_duration).ok_or_else(|| {
+        AgentError::Store("agent-run lease duration overflows the database timestamp range".into())
+    })?;
+
+    // Idempotent re-claim: recover only the exact still-live claim this token
+    // owns, exactly as the fresh-claim path does.
+    if let Some(receipt) = entities::agent_run_claim::Entity::find_by_id(lease_token)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    {
+        let Some(agent_run_id) = receipt.agent_run_id else {
+            transaction.commit().await.map_err(store_err)?;
+            return Ok(None);
+        };
+        let existing = find_by_id_on(&transaction, AgentRunId(agent_run_id))
+            .await?
+            .filter(|run| {
+                run.tier == AgentRunTier::Background.as_str()
+                    && run.execution_location == AgentRunExecutionLocation::Container.as_str()
+                    && matches!(run.status.as_str(), "running" | "cancelling")
+                    && Some(run.attempt_count) == receipt.attempt_count
+                    && Some(run.claim_count) == receipt.claim_count
+                    && run.lease_token == Some(lease_token)
+                    && run.lease_expires_at.is_some_and(|expiry| expiry > now)
+                    && run.deadline_at.is_some_and(|deadline| deadline > now)
+            })
+            .map(agent_run_from_model)
+            .transpose()?;
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(existing);
+    }
+
+    let Some(candidate) = find_by_id_on(&transaction, id).await? else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    };
+    let reclaimable = candidate.tier == AgentRunTier::Background.as_str()
+        && candidate.execution_location == AgentRunExecutionLocation::Container.as_str()
+        && candidate.status == AgentRunStatus::Running.as_str()
+        && candidate
+            .lease_expires_at
+            .is_some_and(|expiry| expiry <= now)
+        && candidate.deadline_at.is_some_and(|deadline| deadline > now)
+        && candidate.updated_at <= now;
+    if !reclaimable {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let claim_count = candidate.claim_count.checked_add(1).ok_or_else(|| {
+        AgentError::Store(format!("agent run {} claim count overflow", candidate.id))
+    })?;
+    let deadline_at = candidate
+        .deadline_at
+        .ok_or_else(|| AgentError::Store("container agent run is missing its deadline".into()))?;
+    let effective_lease_expires_at = Ord::min(deadline_at, lease_expires_at);
+    entities::agent_run_claim::ActiveModel {
+        token: Set(lease_token),
+        agent_run_id: Set(Some(candidate.id)),
+        attempt_count: Set(Some(candidate.attempt_count)),
+        claim_count: Set(Some(claim_count)),
+        claimed_at: Set(now),
+        lease_expires_at: Set(Some(effective_lease_expires_at)),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+
+    let reclaimed = entities::agent_run::Entity::update_many()
+        .col_expr(
+            entities::agent_run::Column::ClaimCount,
+            sea_orm::sea_query::Expr::value(claim_count),
+        )
+        .col_expr(
+            entities::agent_run::Column::LeaseToken,
+            sea_orm::sea_query::Expr::value(Some(lease_token)),
+        )
+        .col_expr(
+            entities::agent_run::Column::LeaseExpiresAt,
+            sea_orm::sea_query::Expr::value(Some(effective_lease_expires_at)),
+        )
+        .col_expr(
+            entities::agent_run::Column::UpdatedAt,
+            sea_orm::sea_query::Expr::value(now),
+        )
+        .filter(entities::agent_run::Column::Id.eq(candidate.id))
+        .filter(entities::agent_run::Column::Status.eq(AgentRunStatus::Running.as_str()))
+        .filter(entities::agent_run::Column::AttemptCount.eq(candidate.attempt_count))
+        .filter(entities::agent_run::Column::ClaimCount.eq(candidate.claim_count))
+        .filter(entities::agent_run::Column::UpdatedAt.eq(candidate.updated_at))
+        .filter(entities::agent_run::Column::LeaseToken.eq(candidate.lease_token))
+        .filter(entities::agent_run::Column::LeaseExpiresAt.lte(now))
+        .filter(entities::agent_run::Column::DeadlineAt.gt(now))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    if reclaimed.rows_affected != 1 {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    let reclaimed = find_by_id_on(&transaction, id)
+        .await?
+        .ok_or_else(|| AgentError::Store("reclaimed container agent run disappeared".into()))?;
+    let reclaimed = agent_run_from_model(reclaimed)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(Some(reclaimed))
+}
+
 async fn record_empty_claim_scan_on<C>(
     conn: &C,
     lease_token: uuid::Uuid,
@@ -1453,6 +1612,12 @@ pub(in crate::db) async fn fail_agent_run(
         .await
         .map_err(store_err)?
         .expect("inserted result exists");
+    // A container run that just failed terminally owes its container a
+    // teardown in the same transaction, so the sweep can never observe a
+    // failed run whose provisioning record still calls the container live.
+    if run.execution_location == AgentRunExecutionLocation::Container.as_str() {
+        super::sandbox_provision::enqueue_teardown_on(&transaction, id.0).await?;
+    }
     transaction.commit().await.map_err(store_err)?;
     Ok(Some(FailAgentRunOutcome::Failed(
         agent_run_result_from_model(result)?,
@@ -2448,6 +2613,12 @@ where
     if updated.rows_affected == 1 {
         deliver_terminal_candidate_failure_on(conn, candidate, now, error_code, error_detail)
             .await?;
+        // A container run that went terminal owes its container a teardown in
+        // the same transition — deadline expiry against a live unattached
+        // container is exactly the leak this closes.
+        if candidate.execution_location == AgentRunExecutionLocation::Container.as_str() {
+            super::sandbox_provision::enqueue_teardown_on(conn, candidate.id).await?;
+        }
     }
     Ok(updated.rows_affected == 1)
 }

--- a/crates/openwave-core/src/db/ops/sandbox_provision.rs
+++ b/crates/openwave-core/src/db/ops/sandbox_provision.rs
@@ -153,6 +153,32 @@ pub(in crate::db) async fn enqueue_teardown(
     Ok(row)
 }
 
+/// Transaction-scoped teardown enqueue for a container run that just went
+/// terminal: whatever provisioning record exists — an open intent or a
+/// committed handle — now owes a teardown, in the same transaction as the
+/// run's terminal transition, so the sweep can never observe a failed run
+/// whose container the records still call live.
+pub(in crate::db) async fn enqueue_teardown_on<C>(conn: &C, run_id: uuid::Uuid) -> Result<()>
+where
+    C: sea_orm::ConnectionTrait,
+{
+    entities::sandbox_provision::Entity::update_many()
+        .col_expr(
+            sandbox_provision::Column::State,
+            Expr::value(STATE_TEARDOWN),
+        )
+        .col_expr(
+            sandbox_provision::Column::UpdatedAt,
+            Expr::value(Utc::now()),
+        )
+        .filter(sandbox_provision::Column::RunId.eq(run_id))
+        .filter(sandbox_provision::Column::State.is_in([STATE_INTENDED, STATE_COMMITTED]))
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(())
+}
+
 pub(in crate::db) async fn complete_teardown(store: &DbStore, run_id: uuid::Uuid) -> Result<()> {
     entities::sandbox_provision::Entity::update_many()
         .col_expr(sandbox_provision::Column::State, Expr::value(STATE_DONE))

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1568,6 +1568,32 @@ pub trait Store: Send + Sync {
         agent_run_storage_unavailable()
     }
 
+    /// List container-located runs whose driver died: `running` under an
+    /// expired lease with the deadline still open. The in-process lease reaper
+    /// deliberately exempts container runs, so this scan feeds the recovery
+    /// pass that replaces it.
+    async fn list_reclaimable_container_agent_runs(
+        &self,
+        _now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<AgentRun>> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Reclaim one expired-lease container run under a fresh bounded lease,
+    /// **without** a second execution attempt: exactly one container was ever
+    /// asked to run it, so recovery re-drives that same attempt through the
+    /// durable provisioning record and the operation log. Refuses a live lease
+    /// and a crossed deadline. Reusing `lease_token` recovers only its original
+    /// still-live claim.
+    async fn reclaim_container_agent_run(
+        &self,
+        _id: AgentRunId,
+        _lease_token: uuid::Uuid,
+        _lease_duration: chrono::Duration,
+    ) -> Result<Option<AgentRun>> {
+        agent_run_storage_unavailable()
+    }
+
     /// Commit a durable provisioning intent for one container run, before the
     /// backend is asked to create anything. Returns the existing record instead
     /// when one is already present, so a restarted host reconciles rather than

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -799,6 +799,49 @@ impl SandboxContainerRunner {
         );
     }
 
+    /// Recover container runs whose driver died: reclaim each expired-lease
+    /// run under a fresh lease — the **same** execution attempt, since exactly
+    /// one container was ever asked to run it — and drive it to a terminal
+    /// state.
+    ///
+    /// The drive that follows reconciles through the durable records: a
+    /// committed handle reattaches to the existing container and first drains
+    /// whatever it buffered while unattached (a finished run's result commits
+    /// instead of being reaped), the operation log replays recorded reverse
+    /// answers rather than spending twice, and every terminal path drives the
+    /// teardown obligation. A run whose deadline already crossed is not
+    /// reclaimed here — the claim scan fails it, enqueueing its teardown in
+    /// the same transition.
+    ///
+    /// # Errors
+    /// Propagates a durable-store failure; per-run drive outcomes are returned,
+    /// not raised.
+    pub async fn recover(&self) -> Result<Vec<SandboxContainerRunOutcome>> {
+        let mut outcomes = Vec::new();
+        for run in self
+            .store
+            .list_reclaimable_container_agent_runs(chrono::Utc::now())
+            .await?
+        {
+            let lease_token = Uuid::new_v4();
+            let Some(claimed) = self
+                .store
+                .reclaim_container_agent_run(
+                    run.id,
+                    lease_token,
+                    chrono_duration(self.config.lease)?,
+                )
+                .await?
+            else {
+                // Lost to a racing driver or a crossed deadline; both leave
+                // the run in owned hands.
+                continue;
+            };
+            outcomes.push(self.drive_claimed(claimed, lease_token).await?);
+        }
+        Ok(outcomes)
+    }
+
     /// One recovery pass over the durable provisioning records: lapse every
     /// `Intended` record whose window expired, drive every pending teardown
     /// obligation, and reclaim any backend sandbox whose tag names no live

--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -980,6 +980,116 @@ async fn a_committed_handle_is_reconciled_not_reprovisioned() {
     .expect("test completed within its time bound");
 }
 
+/// The recovery pass that replaces the lease reaper for container runs: a run
+/// abandoned `running` under an expired lease is reclaimed under a fresh lease
+/// on the SAME attempt, its committed container reattached and driven to the
+/// result the reaper would have thrown away.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_dead_drivers_container_run_is_recovered_to_completion() {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        let (_dir, store, chat) = store().await;
+        let task = "finish what the dead driver started";
+        let run_id = admit_container_run(&store, chat.id, task).await;
+        let run_uuid = *run_id.as_uuid();
+
+        // The dead driver: claimed the run, provisioned a container, committed
+        // its handle — then vanished, leaving the lease to expire.
+        let dead_token = Uuid::new_v4();
+        store
+            .claim_container_agent_run(run_id, dead_token, chrono::Duration::milliseconds(50))
+            .await
+            .unwrap()
+            .expect("the dead driver's claim succeeds");
+        let base_url = spawn_sandbox_agent(task).await;
+        let backend = MockBackend::unreachable(base_url);
+        let tag = SandboxTag::new();
+        store
+            .begin_sandbox_provision(
+                run_uuid,
+                &tag.to_string(),
+                chrono::Utc::now() + chrono::Duration::seconds(600),
+            )
+            .await
+            .unwrap();
+        assert!(store
+            .commit_sandbox_provision_handle(run_uuid, "abandoned-container")
+            .await
+            .unwrap());
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let provider = Arc::new(ScriptedProvider::new(vec![]));
+        let runner = SandboxContainerRunner::new(
+            store.clone(),
+            backend.clone(),
+            Arc::new(FixedResolver(provider)),
+            fast_config(),
+        );
+        let outcomes = runner.recover().await.expect("recovery succeeds");
+        assert_eq!(
+            outcomes,
+            vec![SandboxContainerRunOutcome::Completed(run_id)]
+        );
+
+        let recovered = store.get_agent_run(run_id).await.unwrap().unwrap();
+        assert_eq!(recovered.status, AgentRunStatus::Completed);
+        assert_eq!(
+            recovered.attempt_count, 1,
+            "recovery re-drives the single attempt, never a second one"
+        );
+        // Reconciled the abandoned container: no new provision, torn down once.
+        assert_eq!(backend.provisions.load(Ordering::SeqCst), 0);
+        assert_eq!(backend.destroys.load(Ordering::SeqCst), 1);
+    })
+    .await
+    .expect("test completed within its time bound");
+}
+
+/// A container run failed terminally through the fenced store path leaves its
+/// provisioning record owing a teardown in the same transaction — the link the
+/// deadline scan uses so an expired run's live container is swept, not leaked.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_terminal_container_failure_enqueues_its_teardown() {
+    let (_dir, store, chat) = store().await;
+    let run_id = admit_container_run(&store, chat.id, "fails terminally").await;
+    let run_uuid = *run_id.as_uuid();
+    let token = Uuid::new_v4();
+    store
+        .claim_container_agent_run(run_id, token, chrono::Duration::seconds(30))
+        .await
+        .unwrap()
+        .expect("the claim succeeds");
+    let tag = SandboxTag::new();
+    store
+        .begin_sandbox_provision(
+            run_uuid,
+            &tag.to_string(),
+            chrono::Utc::now() + chrono::Duration::seconds(600),
+        )
+        .await
+        .unwrap();
+    assert!(store
+        .commit_sandbox_provision_handle(run_uuid, "doomed-container")
+        .await
+        .unwrap());
+
+    store
+        .fail_agent_run(
+            run_id,
+            token,
+            "sandbox_agent_failed",
+            "the loop ended without a result",
+            chrono::Duration::seconds(1),
+        )
+        .await
+        .unwrap()
+        .expect("the terminal failure commits");
+
+    let teardowns = store.list_sandbox_teardowns().await.unwrap();
+    assert_eq!(teardowns.len(), 1);
+    assert_eq!(teardowns[0].run_id, run_uuid);
+    assert_eq!(teardowns[0].handle.as_deref(), Some("doomed-container"));
+}
+
 // --- Docker end-to-end (gated on a container runtime + the agent image) -------
 
 /// Build the sandbox-agent image for the Docker-gated tests, returning its tag,


### PR DESCRIPTION
The reaper bullet of #920. The in-process lease reaper deliberately exempts container runs (#919) — lease expiry there means "the driving host died", not "the work died" — but nothing replaced it: a run abandoned `running` under an expired lease was unclaimable forever, and the deadline scan that eventually failed it left the provisioning record calling the container live, so the sweep preserved the leak.

## Recovery instead of reaping

- **`Store::reclaim_container_agent_run`** — reclaims one expired-lease container run under a fresh bounded lease **without a second execution attempt**: exactly one container was ever asked to run it, so recovery re-drives that same attempt (claim count advances, attempt count does not), with the same claim-receipt discipline as the fresh claim. Refuses a live lease and a crossed deadline.
- **`Store::list_reclaimable_container_agent_runs`** feeds it, and **`SandboxContainerRunner::recover()`** drives it: each reclaimed run goes through the normal drive, which reconciles the committed handle from the durable provisioning record (#1138), reattaches, drains whatever the container buffered while unattached — a finished run's result **commits** instead of being reaped — replays recorded reverse answers from the op-log, and drives teardown on every terminal path.

## Deadline expiry enqueues teardown in the same transition

A container run failed terminally through either store path — the claim scan's deadline terminalization (`fail_candidate_on`) or the lease-fenced `fail_agent_run` — now moves its provisioning record to `teardown` in the same transaction. The sweep can never observe a failed run whose records still call its container live.

## Tests

Two new loopback tests: a dead driver's run (claimed, provisioned, handle committed, lease left to expire) recovered to completion on the same attempt with zero re-provisions; and a terminal container failure leaving its provisioning record owing a teardown with the committed handle on it.

Not wired to a scheduler yet, same as `drive()` and `sweep()` — production wiring comes with routing. Remaining #920 bullets after this: late-result-as-evidence, cancellation cascade, the run-init frame, concurrency caps.

## Verified

Container-run module 14 passed; core db suite 258 passed; clippy `-D warnings` + fmt on both crates; `cargo check --no-default-features --features postgres --locked`. No lockfile drift.

Part of #920.