### PR TITLE
fix(server): serve document bytes under a media-type allowlist

### DIFF
--- a/crates/openwave-server/src/routes/document.rs
+++ b/crates/openwave-server/src/routes/document.rs
@@ -2,7 +2,7 @@
 
 use axum::body::Body;
 use axum::extract::State;
-use axum::http::{header, HeaderMap, HeaderValue, Method, StatusCode};
+use axum::http::{header, HeaderMap, Method, StatusCode};
 use axum::response::{IntoResponse, Response};
 use chrono::Utc;
 use futures::StreamExt;
@@ -755,6 +755,121 @@ pub async fn get_chat_document_file_content(
     serve_document_file_content(&state, document_id, Some(chat_id), None, method, &headers).await
 }
 
+/// The policy every original-bytes response carries.
+///
+/// The route serves reader-supplied bytes from the API's own origin, so a
+/// response that a browser ever renders must be unable to reach back into that
+/// origin. `sandbox` drops the response into an opaque origin with scripting
+/// off, and `default-src 'none'` denies it every subresource and every
+/// outbound request.
+const DOCUMENT_CONTENT_POLICY: &str =
+    "default-src 'none'; sandbox; frame-ancestors 'none'; base-uri 'none'; form-action 'none'";
+
+/// How one response names and offers a document's original bytes.
+struct ServedMediaType {
+    content_type: &'static str,
+    disposition: &'static str,
+}
+
+/// Media types the route will name back to the client.
+///
+/// Ingest records whatever type its caller declared — the desktop sniffs the
+/// bytes, but the HTTP API takes the header at its word — so the stored type is
+/// reader-controlled and must not decide, unchecked, how a browser treats the
+/// response. Serving is where that is settled: a type on this list is named
+/// verbatim, everything else is named `application/octet-stream`.
+///
+/// The second column is whether a browser may draw the bytes in place. Only
+/// formats that are inert when rendered are `inline`; markup and container
+/// formats are still named honestly, because callers key off the type, but are
+/// offered as a download so that naming them can never mean executing them.
+///
+/// Nothing is refused. A format missing from this table still serves its bytes,
+/// which matters because the set of types the desktop's content sniffer can
+/// produce is open-ended — anything `infer` recognizes — and a reader's file
+/// should not stop opening because its type is unfamiliar here.
+const SERVED_MEDIA_TYPES: &[(&str, &str)] = &[
+    // Inert renderable formats.
+    ("application/pdf", "inline"),
+    ("image/avif", "inline"),
+    ("image/bmp", "inline"),
+    ("image/gif", "inline"),
+    ("image/heic", "inline"),
+    ("image/heif", "inline"),
+    ("image/jpeg", "inline"),
+    ("image/png", "inline"),
+    ("image/tiff", "inline"),
+    ("image/webp", "inline"),
+    ("text/csv", "inline"),
+    ("text/markdown", "inline"),
+    ("text/plain", "inline"),
+    ("text/tab-separated-values", "inline"),
+    // Named, never rendered in place: markup a browser would treat as active,
+    // and the office/container formats the viewers parse for themselves.
+    ("application/epub+zip", "attachment"),
+    ("application/json", "attachment"),
+    ("application/msword", "attachment"),
+    ("application/rtf", "attachment"),
+    ("application/vnd.ms-excel", "attachment"),
+    ("application/vnd.ms-powerpoint", "attachment"),
+    (
+        "application/vnd.oasis.opendocument.presentation",
+        "attachment",
+    ),
+    (
+        "application/vnd.oasis.opendocument.spreadsheet",
+        "attachment",
+    ),
+    ("application/vnd.oasis.opendocument.text", "attachment"),
+    (
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "attachment",
+    ),
+    (
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "attachment",
+    ),
+    (
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "attachment",
+    ),
+    ("application/xml", "attachment"),
+    ("application/yaml", "attachment"),
+    ("application/zip", "attachment"),
+    ("image/svg+xml", "attachment"),
+    ("text/html", "attachment"),
+    ("text/xml", "attachment"),
+];
+
+impl ServedMediaType {
+    /// Resolve a stored media type against [`SERVED_MEDIA_TYPES`].
+    ///
+    /// Parameters are dropped rather than echoed: a stored `charset` is a guess
+    /// made at ingest about bytes nobody re-decoded, and passing arbitrary
+    /// parameters through would hand the reader a second lever on the header.
+    fn for_stored(stored: &str) -> Self {
+        let base = stored
+            .split(';')
+            .next()
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase();
+        match SERVED_MEDIA_TYPES
+            .iter()
+            .find(|(media_type, _)| *media_type == base)
+        {
+            Some((content_type, disposition)) => Self {
+                content_type,
+                disposition,
+            },
+            None => Self {
+                content_type: "application/octet-stream",
+                disposition: "attachment",
+            },
+        }
+    }
+}
+
 async fn serve_document_file_content(
     state: &AppState,
     document_id: DocumentId,
@@ -789,11 +904,7 @@ async fn serve_document_file_content(
             "original byte length for document {document_id} does not match its descriptor"
         )));
     }
-    let content_type = HeaderValue::from_str(&document.media_type).map_err(|_| {
-        ServerError::internal(format!(
-            "document {document_id} has an invalid stored media type"
-        ))
-    })?;
+    let served = ServedMediaType::for_stored(&document.media_type);
 
     let requested_range = match requested_byte_range(headers, actual_len) {
         Ok(range) => range,
@@ -831,7 +942,11 @@ async fn serve_document_file_content(
 
     let mut response = Response::builder()
         .status(status)
-        .header(header::CONTENT_TYPE, content_type)
+        .header(header::CONTENT_TYPE, served.content_type)
+        .header(header::CONTENT_DISPOSITION, served.disposition)
+        .header(header::X_CONTENT_TYPE_OPTIONS, "nosniff")
+        .header(header::CONTENT_SECURITY_POLICY, DOCUMENT_CONTENT_POLICY)
+        .header(header::REFERRER_POLICY, "no-referrer")
         .header(header::ACCEPT_RANGES, "bytes")
         .header(header::CONTENT_LENGTH, body_len.to_string());
     if let Some(content_range) = content_range {
@@ -910,6 +1025,8 @@ fn range_not_satisfiable_response(full_len: u64) -> Response {
 
 #[cfg(test)]
 mod byte_range_tests {
+    use axum::http::HeaderValue;
+
     use super::*;
 
     fn parse(value: &str, full_len: u64) -> Result<Option<ByteRange>, ()> {

--- a/crates/openwave-server/src/tests/documents.rs
+++ b/crates/openwave-server/src/tests/documents.rs
@@ -266,6 +266,95 @@ async fn document_file_content_supports_full_head_and_single_range_responses() {
     }
 }
 
+/// Original bytes are reader-supplied and served from the API's own origin, so
+/// the response must never let the stored media type decide that a browser may
+/// run them. The contract is invisible in the app — the renderer reads these
+/// responses as bytes and never navigates to one — so nothing else would notice
+/// the headers going missing.
+#[tokio::test]
+async fn document_file_content_serves_bytes_under_a_type_allowlist() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+
+    let ingest = |uri: &'static str, media_type: &'static str, body: &'static str| {
+        let router = router.clone();
+        let bearer = bearer.clone();
+        async move {
+            let accepted: serde_json::Value = json_body(
+                post_raw(
+                    &router,
+                    &bearer,
+                    uri,
+                    Some(media_type),
+                    body.as_bytes().to_vec(),
+                )
+                .await,
+            )
+            .await;
+            let document_id = accepted["document_id"].as_str().unwrap().to_owned();
+            let response = request_document_file_content(
+                &router,
+                axum::http::Method::GET,
+                &format!("/documents/{document_id}/file-content"),
+                Some(&bearer),
+                None,
+                None,
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::OK);
+            let header = |name: axum::http::HeaderName| {
+                response
+                    .headers()
+                    .get(name)
+                    .map(|value| value.to_str().unwrap().to_owned())
+            };
+            (
+                header(header::CONTENT_TYPE),
+                header(header::CONTENT_DISPOSITION),
+                header(header::X_CONTENT_TYPE_OPTIONS),
+                header(header::CONTENT_SECURITY_POLICY),
+            )
+        }
+    };
+
+    // A renderable format keeps its name and may be drawn in place, with
+    // sniffing off and a policy that denies the bytes any reach.
+    let (content_type, disposition, nosniff, policy) = ingest(
+        "/documents/raw?title=page.png&uri=file:///page.png",
+        "image/png",
+        "not really a png",
+    )
+    .await;
+    assert_eq!(content_type.as_deref(), Some("image/png"));
+    assert_eq!(disposition.as_deref(), Some("inline"));
+    assert_eq!(nosniff.as_deref(), Some("nosniff"));
+    assert_eq!(
+        policy.as_deref(),
+        Some("default-src 'none'; sandbox; frame-ancestors 'none'; base-uri 'none'; form-action 'none'")
+    );
+
+    // Markup is still named honestly but is only ever offered as a download.
+    let (content_type, disposition, ..) = ingest(
+        "/documents/raw?title=page.html&uri=file:///page.html",
+        "text/html",
+        "<script>alert(document.cookie)</script>",
+    )
+    .await;
+    assert_eq!(content_type.as_deref(), Some("text/html"));
+    assert_eq!(disposition.as_deref(), Some("attachment"));
+
+    // An unfamiliar type still serves its bytes, but unnamed. The stored
+    // parameters are dropped rather than echoed back.
+    let (content_type, disposition, ..) = ingest(
+        "/documents/raw?title=odd.xhtml&uri=file:///odd.xhtml",
+        "application/xhtml+xml; charset=utf-8",
+        "<html/>",
+    )
+    .await;
+    assert_eq!(content_type.as_deref(), Some("application/octet-stream"));
+    assert_eq!(disposition.as_deref(), Some("attachment"));
+}
+
 #[tokio::test]
 async fn document_file_content_streams_only_the_requested_range() {
     let (upload_router, token, mut state, _store, _dir) = test_app_with_state().await;


### PR DESCRIPTION
The file-content route echoed the stored media type straight back as the
response Content-Type. That type is reader-controlled — the HTTP API takes
the ingest Content-Type at its word — so a source ingested as text/html was
served as active content from the API's own origin, with no nosniff, no
disposition, and no policy of its own.

Serving now decides how bytes are named. A type on the allowlist is named
verbatim; anything else is named application/octet-stream. Only formats that
are inert when rendered are offered inline, so markup and container formats
keep an honest type but are always a download. Every response carries
nosniff and a policy that sandboxes the bytes into an opaque origin with no
subresources and no egress.

Nothing is refused: the desktop types imports by sniffing their bytes, which
can produce anything the sniffer recognizes, and an unfamiliar type should
not stop a reader's file from opening. The renderer is unaffected either way
— it fetches these responses as bytes with a bearer header and dispatches on
the catalog's media type, never on the response header, and never navigates
to one of these URLs.

Closes #1096

