### PR TITLE
fix(server): surface a failure category to the renderer

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -504,7 +504,7 @@ describe("terminal events", () => {
     const { state } = play([
       TURN,
       { type: "tool_call_started", call_id: "call-1", name: "search" },
-      { type: "turn_failed" },
+      { type: "turn_failed", category: "unknown" },
     ]);
     expect(state.messages.find((m) => m.role === "tool")).toMatchObject({
       status: "failed",
@@ -520,7 +520,7 @@ describe("terminal events", () => {
       TURN,
       { type: "tool_call_started", call_id: "done", name: "search" },
       { type: "tool_call_completed", call_id: "done", status: "completed" },
-      { type: "turn_failed" },
+      { type: "turn_failed", category: "unknown" },
     ]);
     expect(state.messages.find((m) => m.role === "tool")).toMatchObject({
       status: "completed",
@@ -611,7 +611,7 @@ describe("reasoning presentation", () => {
       { type: "tool_call_started", call_id: "c", name: "search" },
       { type: "stream_interrupted" },
       { type: "turn_completed" },
-      { type: "turn_failed" },
+      { type: "turn_failed", category: "unknown" },
     ] as AgentEvent[]) {
       const thinking = play([TURN, { type: "reasoning_delta" }]);
       const next = reduceChatSessionEvent(

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1220,9 +1220,9 @@ export type TranscriptRole = "user" | "assistant";
  * worth a variant here unless a client would say or do something different
  * for it.
  *
- * It is also the worker's own retry taxonomy: [`Self::retries_may_succeed`]
- * decides whether a failed turn is rescheduled, so the category a client sees
- * and the category the scheduler acted on cannot drift apart.
+ * It is also the worker's own retry taxonomy — the same classification decides
+ * whether a failed turn is rescheduled — so the category a client sees and the
+ * category the scheduler acted on cannot drift apart.
  */
 export type TurnFailureCategory = "rate_limited" | "auth" | "transient" | "unknown";
 

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -908,7 +908,12 @@ action?: ToolActionPreview,
  * withholding it leaves the transcript asserting that something
  * happened without ever showing what.
  */
-result?: ToolResultPreview, } | { "type": "turn_completed" } | { "type": "turn_refused", refusal: RendererRefusal, } | { "type": "turn_failed" } | { "type": "turn_cancelled" } | { "type": "user_steered", message_id: MessageId, text: string, } | { "type": "context_truncated" } | { "type": "event_omitted" };
+result?: ToolResultPreview, } | { "type": "turn_completed" } | { "type": "turn_refused", refusal: RendererRefusal, } | { "type": "turn_failed", 
+/**
+ * Why the turn failed, at the only resolution a client can act on.
+ * The failure's `kind` and `message` stay internal.
+ */
+category: TurnFailureCategory, } | { "type": "turn_cancelled" } | { "type": "user_steered", message_id: MessageId, text: string, } | { "type": "context_truncated" } | { "type": "event_omitted" };
 
 /**
  * One frame on a chat's event socket.
@@ -1203,6 +1208,23 @@ width: number, height: number, };
  * something that silently appears in the transcript.
  */
 export type TranscriptRole = "user" | "assistant";
+
+/**
+ * Why a turn failed, closed and coarse enough to be stable.
+ *
+ * A failure's `kind` is an internal diagnostic vocabulary: it grows with the
+ * server, and its `message` can carry provider diagnostics and host paths, so
+ * neither crosses to the renderer. What a client actually needs is narrower —
+ * what to tell the person, and whether running the same turn again could
+ * plausibly do anything different. This enum is exactly that, and nothing is
+ * worth a variant here unless a client would say or do something different
+ * for it.
+ *
+ * It is also the worker's own retry taxonomy: [`Self::retries_may_succeed`]
+ * decides whether a failed turn is rescheduled, so the category a client sees
+ * and the category the scheduler acted on cannot drift apart.
+ */
+export type TurnFailureCategory = "rate_limited" | "auth" | "transient" | "unknown";
 
 /**
  * Identifies one turn: a single user input through to the final answer.

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -138,7 +138,11 @@ pub(crate) enum RendererAgentEvent {
     TurnRefused {
         refusal: RendererRefusal,
     },
-    TurnFailed,
+    TurnFailed {
+        /// Why the turn failed, at the only resolution a client can act on.
+        /// The failure's `kind` and `message` stay internal.
+        category: TurnFailureCategory,
+    },
     TurnCancelled,
     /// The message body is available through the transcript endpoint. Keeping
     /// only its durable id lets clients reconcile without duplicating content.
@@ -150,6 +154,57 @@ pub(crate) enum RendererAgentEvent {
     /// Fail-closed marker for a newer internal event until it gets an explicit
     /// renderer projection. The sequence still advances without dropping it.
     EventOmitted,
+}
+
+/// Why a turn failed, closed and coarse enough to be stable.
+///
+/// A failure's `kind` is an internal diagnostic vocabulary: it grows with the
+/// server, and its `message` can carry provider diagnostics and host paths, so
+/// neither crosses to the renderer. What a client actually needs is narrower —
+/// what to tell the person, and whether running the same turn again could
+/// plausibly do anything different. This enum is exactly that, and nothing is
+/// worth a variant here unless a client would say or do something different
+/// for it.
+///
+/// It is also the worker's own retry taxonomy — the same classification decides
+/// whether a failed turn is rescheduled — so the category a client sees and the
+/// category the scheduler acted on cannot drift apart.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TurnFailureCategory {
+    /// The provider throttled or shed the request. Automatic retries were
+    /// already spent, but waiting and asking again is the actual remedy.
+    RateLimited,
+    /// The provider rejected our credentials. Retrying replays the same
+    /// rejection; only fixing the key changes the outcome.
+    Auth,
+    /// A transient fault below the turn — an upstream error, a storage or
+    /// secret-store failure. Retrying is reasonable.
+    Transient,
+    /// Everything else: budgets the turn exceeded, malformed agent output,
+    /// internal invariants. Retrying is a guess, so a client should not promise
+    /// that it helps.
+    Unknown,
+}
+
+impl TurnFailureCategory {
+    /// Classify a failure `kind` from the internal vocabulary.
+    ///
+    /// Unrecognized kinds fall to [`Self::Unknown`], so a new internal failure
+    /// code is coarse rather than wrong.
+    pub(crate) fn from_kind(kind: &str) -> Self {
+        match kind {
+            "rate_limited" | "overloaded" => Self::RateLimited,
+            "authentication" => Self::Auth,
+            "provider" | "store" | "secret" => Self::Transient,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Whether running the same turn again could plausibly succeed.
+    pub(crate) const fn retries_may_succeed(self) -> bool {
+        matches!(self, Self::RateLimited | Self::Transient)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
@@ -226,7 +281,9 @@ impl From<&SequencedEvent> for RendererSequencedEvent {
             AgentEvent::TurnRefused { refusal, .. } => RendererAgentEvent::TurnRefused {
                 refusal: refusal.into(),
             },
-            AgentEvent::TurnFailed { .. } => RendererAgentEvent::TurnFailed,
+            AgentEvent::TurnFailed { error } => RendererAgentEvent::TurnFailed {
+                category: TurnFailureCategory::from_kind(&error.kind),
+            },
             AgentEvent::TurnCancelled { .. } => RendererAgentEvent::TurnCancelled,
             AgentEvent::UserSteered {
                 message_id,
@@ -360,6 +417,52 @@ mod tests {
         assert!(serialized.contains(r#""action":"other""#));
         assert!(serialized.contains(r#""status":"failed""#));
         assert!(serialized.contains(r#""text":"visible steer text""#));
+    }
+
+    /// The category is the one thing a failure is allowed to tell a client, and
+    /// a client branches on it — so both halves of that boundary are contract:
+    /// the classification each failure lands in, and the diagnostics that stay
+    /// behind.
+    #[test]
+    fn failure_projection_carries_a_category_and_nothing_else() {
+        let cases = [
+            (
+                AgentError::RateLimited("upstream said 429 for key sk-live".into()),
+                TurnFailureCategory::RateLimited,
+            ),
+            (
+                AgentError::Authentication("invalid x-api-key sk-live".into()),
+                TurnFailureCategory::Auth,
+            ),
+            (
+                AgentError::Provider("upstream 503 from api.example".into()),
+                TurnFailureCategory::Transient,
+            ),
+            (
+                AgentError::msg("max steps per turn were consumed"),
+                TurnFailureCategory::Unknown,
+            ),
+        ];
+
+        for (error, expected) in cases {
+            let projected = RendererSequencedEvent::from(&SequencedEvent {
+                seq: 1,
+                event: AgentEvent::TurnFailed {
+                    error: (&error).into(),
+                },
+            });
+            assert_eq!(
+                projected.event,
+                RendererAgentEvent::TurnFailed { category: expected },
+                "{error}"
+            );
+            let encoded = serde_json::to_value(&projected).unwrap();
+            assert_eq!(
+                encoded["event"].as_object().unwrap().len(),
+                2,
+                "the failure frame carries only its type and category: {encoded}"
+            );
+        }
     }
 
     #[test]

--- a/crates/openwave-server/src/tests/websocket.rs
+++ b/crates/openwave-server/src/tests/websocket.rs
@@ -113,7 +113,7 @@ async fn read_until_turns_end(
             let event: RendererSequencedEvent = serde_json::from_str(text.as_str()).unwrap();
             if matches!(
                 event.event,
-                RendererAgentEvent::TurnCompleted | RendererAgentEvent::TurnFailed
+                RendererAgentEvent::TurnCompleted | RendererAgentEvent::TurnFailed { .. }
             ) {
                 completed += 1;
             }

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -2230,11 +2230,8 @@ impl TurnWorker {
         detail: &str,
         retry_after: Option<Duration>,
     ) -> Result<TurnWorkerOutcome> {
-        let retryable = matches!(
-            code,
-            "provider" | "rate_limited" | "overloaded" | "store" | "secret"
-        );
-        let retry = retryable
+        let retry = crate::event_projection::TurnFailureCategory::from_kind(code)
+            .retries_may_succeed()
             .then(|| {
                 self.config
                     .retry


### PR DESCRIPTION
A failed turn was carefully classified and sanitized on the way into the journal, and then the renderer projection dropped both `kind` and `message`. A rate-limited turn, a dead API key and an internal invariant break all arrived at the client as the same unexplained failure.

Withholding the raw message is the right instinct — it can carry provider diagnostics and host paths — but the classification is not the message. `TurnFailed` now carries a closed `TurnFailureCategory`.

The cut is what a client would say or do differently, not every distinction the server can make:

- `rate_limited` — the provider throttled or shed us. Waiting and asking again is the actual remedy.
- `auth` — the provider rejected our credentials. Repeating the turn only replays the rejection; the key has to be fixed. This is the bit the retry affordance most needs: it is the one failure where offering a naive retry is wrong.
- `transient` — an upstream error, or a storage or secret-store failure. Retrying is reasonable.
- `unknown` — budgets the turn exceeded, malformed agent output, internal invariants. Retrying is a guess and a client should not promise it helps.

Alpha's timeout category has no producer here — no failure kind means "timed out" — so it is deliberately absent rather than declared and dead.

The worker's retry scheduler already carried this taxonomy inline, as the list of error codes worth rescheduling (`provider | rate_limited | overloaded | store | secret`). Rather than invent a second classification beside it, the scheduler now asks the enum: `rate_limited` and `transient` are exactly that set, so the category a client sees and the category the scheduler acted on are one decision instead of two that can drift.

Nothing is added to `AgentErrorInfo`. That is the journal and wire shape, and the category is a presentation decision derived at the projection boundary from the failure kind. Unrecognized kinds classify as `unknown`, so a new internal failure code is coarse rather than wrong — which also means #1125's mid-stream failures, which currently all surface as kind `provider`, land as `transient` today and simply re-classify when that issue gives them real kinds. No enum change is needed for it.

The generated wire types are regenerated, and the three reducer tests that construct a `turn_failed` frame carry the new field. No UI behavior changes here — the retry affordance is #1107 and depends on this landing first.

One test: the projection carrying a category is a wire contract, and both halves of it matter — which category each failure lands in, and that the frame still carries nothing else. That is one table-driven test over the four categories, not one test per category.

Closes #1099