### PR TITLE
feat(server): publish files saved in output/ as durable conversation outputs

### DIFF
--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -34,10 +34,10 @@ pub use tool::{ExecTool, EXEC_TOOL_NAME};
 pub use types::{
     CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest,
     CodeExecutionResponse, ExecFolderAccess, ExecFolderGrant, ExecutionId, ExecutionWorkspaceId,
-    WorkspaceFileEntry, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, MAX_ARGUMENTS,
-    MAX_ARGUMENT_BYTES, MAX_CAPTURE_BYTES, MAX_COMMAND_BYTES, MAX_CWD_BYTES,
-    MAX_EXEC_FOLDER_GRANTS, MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES,
-    MAX_WORKSPACE_PATH_BYTES,
+    OutputArtifactEntry, OutputArtifactScan, OutputArtifactStatus, WorkspaceFileEntry,
+    WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, MAX_ARGUMENTS, MAX_ARGUMENT_BYTES,
+    MAX_CAPTURE_BYTES, MAX_COMMAND_BYTES, MAX_CWD_BYTES, MAX_EXEC_FOLDER_GRANTS,
+    MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES, MAX_WORKSPACE_PATH_BYTES,
 };
 
 /// Stable workspace-relative location populated by hosts that ship the

--- a/crates/openwave-code-execution/src/tool.rs
+++ b/crates/openwave-code-execution/src/tool.rs
@@ -52,9 +52,14 @@ impl Tool for ExecTool {
                           have the chat's private scratch mirrored in before the command runs and \
                           mirrored back after, so files from write_file are visible here and \
                           files this command writes are visible to read_file. Every provider \
-                          returns bounded stdout/stderr. For visual review, save up to three \
+                          returns bounded stdout/stderr. Files you save in output/ are published \
+                          to the user automatically as durable outputs. To update an output you \
+                          already published, save to the same filename in output/ — it becomes a \
+                          new version of the same output in place; you never track output ids. \
+                          For visual review, save up to three \
                           PNG, JPEG, or WebP images in preview/; overview, grid, thumbnail, page, \
-                          and slide filenames are prioritized. Use output/ for durable artifacts. \
+                          and slide filenames are prioritized; preview images are for your own \
+                          review and never become outputs. \
                           When bundled document helpers are present, invoke them directly from \
                           .openwave/exec-scripts. Examples: command python3 with args \
                           [\".openwave/exec-scripts/render_pdf.py\", \"documents/report.pdf\", \
@@ -121,7 +126,7 @@ impl Tool for ExecTool {
             Err(error) => return Ok(ToolOutput::error(error.to_string())),
         };
         let request = match CodeExecutionRequest::new(
-            execution_id,
+            execution_id.clone(),
             workspace_id.clone(),
             arguments.command,
             arguments.args,
@@ -133,6 +138,19 @@ impl Tool for ExecTool {
         let response = match self.provider.execute(request).await {
             Ok(response) => response,
             Err(error) => return Ok(ToolOutput::error(error.to_string())),
+        };
+        // Regardless of the exit code: a failing later step must not hide
+        // files the command already durably wrote to output/.
+        let artifacts = match self
+            .provider
+            .collect_output_artifacts(&workspace_id, &execution_id)
+            .await
+        {
+            Ok(artifacts) => artifacts,
+            Err(error) => crate::OutputArtifactScan {
+                entries: Vec::new(),
+                notes: vec![format!("outputs unavailable: {error}")],
+            },
         };
         let successful = !response.timed_out && response.exit_code == Some(0);
         let previews = if successful {
@@ -174,6 +192,29 @@ impl Tool for ExecTool {
                 content.push_str(note);
             }
         }
+        let published: Vec<String> = artifacts
+            .entries
+            .iter()
+            .filter_map(|entry| match entry.status {
+                crate::OutputArtifactStatus::Created => Some(format!(
+                    "created {} (version {})",
+                    entry.filename, entry.ordinal
+                )),
+                crate::OutputArtifactStatus::Updated => Some(format!(
+                    "updated {} (version {})",
+                    entry.filename, entry.ordinal
+                )),
+                // A file that still matches its published version is not news.
+                crate::OutputArtifactStatus::Unchanged => None,
+            })
+            .collect();
+        if !published.is_empty() || !artifacts.notes.is_empty() {
+            content.push_str("\n\noutputs:");
+            for line in published.iter().chain(&artifacts.notes) {
+                content.push('\n');
+                content.push_str(line);
+            }
+        }
         if !response.stdout.is_empty() {
             content.push_str("\n\nstdout:\n");
             content.push_str(&response.stdout);
@@ -196,6 +237,21 @@ impl Tool for ExecTool {
                 "stdout": response.stdout,
                 "stderr": response.stderr,
                 "sync_notes": response.sync_notes,
+                "outputs": artifacts
+                    .entries
+                    .iter()
+                    .map(|entry| {
+                        json!({
+                            "filename": entry.filename,
+                            "version": entry.ordinal,
+                            "status": match entry.status {
+                                crate::OutputArtifactStatus::Created => "created",
+                                crate::OutputArtifactStatus::Updated => "updated",
+                                crate::OutputArtifactStatus::Unchanged => "unchanged",
+                            },
+                        })
+                    })
+                    .collect::<Vec<_>>(),
             }))
             .with_images(previews.images);
         output.is_error = failed;
@@ -319,6 +375,85 @@ mod tests {
                 notes: Vec::new(),
             })
         }
+    }
+
+    struct ArtifactProvider {
+        exit_code: i32,
+        scans: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl CodeExecutionProvider for ArtifactProvider {
+        async fn execute(
+            &self,
+            _request: CodeExecutionRequest,
+        ) -> std::result::Result<CodeExecutionResponse, CodeExecutionError> {
+            Ok(CodeExecutionResponse {
+                provider: CodeExecutionProviderKind::Local,
+                exit_code: Some(self.exit_code),
+                stdout: String::new(),
+                stderr: String::new(),
+                timed_out: false,
+                output_truncated: false,
+                duration_ms: 1,
+                sync_notes: Vec::new(),
+            })
+        }
+
+        async fn collect_output_artifacts(
+            &self,
+            _workspace: &ExecutionWorkspaceId,
+            _execution: &ExecutionId,
+        ) -> std::result::Result<crate::OutputArtifactScan, CodeExecutionError> {
+            self.scans.fetch_add(1, Ordering::SeqCst);
+            Ok(crate::OutputArtifactScan {
+                entries: vec![
+                    crate::OutputArtifactEntry {
+                        filename: "report.md".into(),
+                        ordinal: 2,
+                        status: crate::OutputArtifactStatus::Updated,
+                    },
+                    crate::OutputArtifactEntry {
+                        filename: "data.csv".into(),
+                        ordinal: 1,
+                        status: crate::OutputArtifactStatus::Unchanged,
+                    },
+                ],
+                notes: vec!["output/huge.bin was not published: too large".into()],
+            })
+        }
+    }
+
+    /// The scan reports through the model-facing content and the structured
+    /// data, and runs even when the command failed — a failing later step must
+    /// not hide files that were already durably written.
+    #[tokio::test]
+    async fn published_outputs_are_reported_even_when_the_command_fails() {
+        let provider = Arc::new(ArtifactProvider {
+            exit_code: 2,
+            scans: AtomicUsize::new(0),
+        });
+        let tool = ExecTool::new(provider.clone());
+        let output = tool
+            .execute(
+                &ToolCtx::new_legacy_workspace(ChatId::new(), None, PathBuf::from("/tmp/unused"))
+                    .with_call_id(CallId::new()),
+                json!({"command": "/bin/false"}),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(provider.scans.load(Ordering::SeqCst), 1);
+        assert!(output.is_error);
+        assert!(output.content.contains("outputs:"));
+        assert!(output.content.contains("updated report.md (version 2)"));
+        // A file that still matches its published version is not news.
+        assert!(!output.content.contains("data.csv"));
+        assert!(output.content.contains("output/huge.bin was not published"));
+        let outputs = output.data.as_ref().unwrap()["outputs"].as_array().unwrap();
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(outputs[0]["status"], "updated");
+        assert_eq!(outputs[1]["status"], "unchanged");
     }
 
     #[tokio::test]

--- a/crates/openwave-code-execution/src/types.rs
+++ b/crates/openwave-code-execution/src/types.rs
@@ -404,6 +404,37 @@ pub struct CodeExecutionResponse {
     pub sync_notes: Vec<String>,
 }
 
+/// What one file under `output/` did to the durable output record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputArtifactStatus {
+    /// A new output was created at version 1.
+    Created,
+    /// An existing same-filename output gained a new version.
+    Updated,
+    /// The file matches the output's current version; nothing was written.
+    Unchanged,
+}
+
+/// One file under `output/` published or matched after an execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputArtifactEntry {
+    /// Display filename, equal to the file's name under `output/`.
+    pub filename: String,
+    /// The output's current version ordinal after the scan.
+    pub ordinal: u32,
+    /// Whether the file created, updated, or matched the output.
+    pub status: OutputArtifactStatus,
+}
+
+/// The outcome of publishing `output/` files as durable conversation outputs.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OutputArtifactScan {
+    /// Published or matched files, in deterministic scan order.
+    pub entries: Vec<OutputArtifactEntry>,
+    /// Files that could not be published, with actionable reasons.
+    pub notes: Vec<String>,
+}
+
 /// A configured execution provider. Implementations must treat
 /// `request.execution_id` as an idempotency key and reject an identity reused
 /// with different canonical arguments.
@@ -424,6 +455,22 @@ pub trait CodeExecutionProvider: Send + Sync {
         _workspace: &ExecutionWorkspaceId,
     ) -> Result<crate::PreviewScan, CodeExecutionError> {
         Ok(crate::PreviewScan::default())
+    }
+
+    /// Publish files saved under the workspace's `output/` directory as durable
+    /// conversation outputs after an execution.
+    ///
+    /// Runs regardless of the command's exit code: a failing later step must
+    /// not hide files that were already durably written. Providers without a
+    /// host-visible durable record return an empty scan; the configured server
+    /// wrapper overrides this after mirroring a managed workspace back into
+    /// private scratch.
+    async fn collect_output_artifacts(
+        &self,
+        _workspace: &ExecutionWorkspaceId,
+        _execution: &ExecutionId,
+    ) -> Result<OutputArtifactScan, CodeExecutionError> {
+        Ok(OutputArtifactScan::default())
     }
 
     /// The provider's optional durable-workspace capability. `None` means the

--- a/crates/openwave-core/src/db/tests/output.rs
+++ b/crates/openwave-core/src/db/tests/output.rs
@@ -597,3 +597,232 @@ async fn acceptance_enforces_the_binary_cap_and_rejects_empty_artifacts() {
     .await
     .is_ok());
 }
+
+#[cfg(feature = "tools")]
+mod output_scan {
+    use super::*;
+    use crate::deliverable::{output_revision_relative_path, RevisionProducer};
+    use crate::id::CallId;
+    use crate::output_scan::{sync_output_directory, OutputSyncStatus, EXEC_OUTPUT_DIRECTORY};
+
+    async fn sync(
+        store: &DbStore,
+        scratch: &cap_std::fs::Dir,
+        chat_id: ChatId,
+        call_id: CallId,
+        second: i64,
+    ) -> crate::output_scan::OutputDirectorySync {
+        sync_output_directory(
+            store,
+            scratch,
+            chat_id,
+            call_id,
+            RevisionProducer::Turn(TurnId::new()),
+            at(second),
+        )
+        .await
+        .unwrap()
+    }
+
+    fn write_output_file(scratch: &std::path::Path, name: &str, content: &[u8]) {
+        let directory = scratch.join(EXEC_OUTPUT_DIRECTORY);
+        std::fs::create_dir_all(&directory).unwrap();
+        std::fs::write(directory.join(name), content).unwrap();
+    }
+
+    #[tokio::test]
+    async fn the_scan_creates_updates_and_matches_by_filename() {
+        let (_dir, store, chat) = store_with_chat().await;
+        let scratch = tempfile::tempdir().unwrap();
+        let dir = open_scratch(scratch.path());
+
+        // First call: a text report and an oversized-for-text binary chart.
+        write_output_file(scratch.path(), "report.md", b"# Draft");
+        let mut pixels = b"\x89PNG\r\n\x1a\n".to_vec();
+        pixels.resize(700 * 1024, 7);
+        write_output_file(scratch.path(), "chart.png", &pixels);
+
+        let first = sync(&store, &dir, chat.id, CallId::new(), 0).await;
+        assert!(first.notes.is_empty(), "{:?}", first.notes);
+        assert_eq!(first.entries.len(), 2);
+        assert!(first
+            .entries
+            .iter()
+            .all(|entry| entry.status == OutputSyncStatus::Created && entry.ordinal == 1));
+        let report = first
+            .entries
+            .iter()
+            .find(|entry| entry.filename == "report.md")
+            .unwrap();
+        let chart = first
+            .entries
+            .iter()
+            .find(|entry| entry.filename == "chart.png")
+            .unwrap();
+        let chart_record = store.get_output(chart.output_id).await.unwrap().unwrap();
+        assert_eq!(chart_record.media_type, "image/png");
+        // The bytes landed at the write-once revision path the desktop reads.
+        let published = scratch.path().join(output_revision_relative_path(
+            chart_record.id,
+            chart_record.current_revision,
+        ));
+        assert_eq!(std::fs::read(&published).unwrap(), pixels);
+        // The revision is attributed to the producing turn.
+        let revision = store
+            .get_output_revision(chart_record.current_revision)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(revision.turn_id.is_some());
+
+        // Second call, nothing rewritten: both files match their current
+        // revisions and nothing is minted.
+        let second = sync(&store, &dir, chat.id, CallId::new(), 30).await;
+        assert!(second
+            .entries
+            .iter()
+            .all(|entry| entry.status == OutputSyncStatus::Unchanged));
+        assert_eq!(
+            store
+                .get_output(report.output_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .revision_count,
+            1
+        );
+
+        // Third call: same filename, new bytes — a revision on the same output,
+        // never a second record.
+        write_output_file(scratch.path(), "report.md", b"# Final");
+        let third = sync(&store, &dir, chat.id, CallId::new(), 60).await;
+        let updated = third
+            .entries
+            .iter()
+            .find(|entry| entry.filename == "report.md")
+            .unwrap();
+        assert_eq!(updated.status, OutputSyncStatus::Updated);
+        assert_eq!(updated.output_id, report.output_id);
+        assert_eq!(updated.ordinal, 2);
+
+        // Deleting a file from output/ never deletes the durable record, and a
+        // renamed file is a new output rather than a revision.
+        std::fs::remove_file(scratch.path().join(EXEC_OUTPUT_DIRECTORY).join("report.md")).unwrap();
+        write_output_file(scratch.path(), "summary.md", b"# Summary");
+        let fourth = sync(&store, &dir, chat.id, CallId::new(), 90).await;
+        let summary = fourth
+            .entries
+            .iter()
+            .find(|entry| entry.filename == "summary.md")
+            .unwrap();
+        assert_eq!(summary.status, OutputSyncStatus::Created);
+        assert_ne!(summary.output_id, report.output_id);
+        let report_record = store.get_output(report.output_id).await.unwrap().unwrap();
+        assert!(report_record.deleted_at.is_none());
+        assert_eq!(report_record.revision_count, 2);
+        assert_eq!(store.list_outputs(chat.id, 10).await.unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn an_exact_scan_retry_is_idempotent() {
+        let (_dir, store, chat) = store_with_chat().await;
+        let scratch = tempfile::tempdir().unwrap();
+        let dir = open_scratch(scratch.path());
+        write_output_file(scratch.path(), "report.md", b"# Draft");
+
+        let call_id = CallId::new();
+        let first = sync(&store, &dir, chat.id, call_id, 0).await;
+        let retried = sync(&store, &dir, chat.id, call_id, 0).await;
+
+        assert_eq!(first.entries[0].output_id, retried.entries[0].output_id);
+        assert_eq!(retried.entries[0].status, OutputSyncStatus::Unchanged);
+        assert_eq!(store.list_outputs(chat.id, 10).await.unwrap().len(), 1);
+        assert_eq!(
+            store
+                .list_output_revisions(first.entries[0].output_id)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn unacceptable_files_become_notes_without_failing_the_scan() {
+        let (_dir, store, chat) = store_with_chat().await;
+        let scratch = tempfile::tempdir().unwrap();
+        let dir = open_scratch(scratch.path());
+
+        write_output_file(scratch.path(), "good.md", b"# Fine");
+        write_output_file(scratch.path(), "empty.md", b"");
+        write_output_file(
+            scratch.path(),
+            "huge.csv",
+            &vec![b'x'; MAX_DELIVERABLE_BYTES + 1],
+        );
+        write_output_file(scratch.path(), "binary.md", b"text\xff\xfe");
+        write_output_file(scratch.path(), ".hidden.md", b"# Plumbing");
+
+        let scan = sync(&store, &dir, chat.id, CallId::new(), 0).await;
+
+        assert_eq!(scan.entries.len(), 1);
+        assert_eq!(scan.entries[0].filename, "good.md");
+        assert!(scan.notes.iter().any(|note| note.contains("empty.md")));
+        assert!(scan
+            .notes
+            .iter()
+            .any(|note| note.contains("huge.csv") && note.contains("binary format")));
+        assert!(scan
+            .notes
+            .iter()
+            .any(|note| note.contains("binary.md") && note.contains("UTF-8")));
+        assert!(!scan.notes.iter().any(|note| note.contains(".hidden.md")));
+    }
+
+    #[tokio::test]
+    async fn the_revision_cap_is_a_note_and_other_files_still_land() {
+        let (_dir, store, chat) = store_with_chat().await;
+        let scratch = tempfile::tempdir().unwrap();
+        let dir = open_scratch(scratch.path());
+
+        let capped = store
+            .create_output(&create_request(chat.id, "capped.md", 1))
+            .await
+            .unwrap();
+        for ordinal in 2..=MAX_OUTPUT_REVISIONS {
+            store
+                .append_output_revision(capped.id, &revision(2, i64::from(ordinal)))
+                .await
+                .unwrap();
+        }
+
+        write_output_file(scratch.path(), "capped.md", b"# One too many");
+        write_output_file(scratch.path(), "fresh.md", b"# Lands anyway");
+        let scan = sync(&store, &dir, chat.id, CallId::new(), 500).await;
+
+        assert!(scan.notes.iter().any(|note| note.contains("capped.md")));
+        assert_eq!(scan.entries.len(), 1);
+        assert_eq!(scan.entries[0].filename, "fresh.md");
+        assert_eq!(scan.entries[0].status, OutputSyncStatus::Created);
+    }
+
+    /// A symlinked `output/` planted by local exec must not hand arbitrary host
+    /// files to the catalog.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_symlinked_output_directory_is_refused_rather_than_followed() {
+        let (_dir, store, chat) = store_with_chat().await;
+        let elsewhere = tempfile::tempdir().unwrap();
+        std::fs::write(elsewhere.path().join("private.md"), b"# Private").unwrap();
+        let scratch = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(elsewhere.path(), scratch.path().join(EXEC_OUTPUT_DIRECTORY))
+            .unwrap();
+        let dir = open_scratch(scratch.path());
+
+        let scan = sync(&store, &dir, chat.id, CallId::new(), 0).await;
+
+        assert!(scan.entries.is_empty());
+        assert!(scan.notes[0].contains("not a private workspace directory"));
+        assert!(store.list_outputs(chat.id, 10).await.unwrap().is_empty());
+    }
+}

--- a/crates/openwave-core/src/deliverable.rs
+++ b/crates/openwave-core/src/deliverable.rs
@@ -335,6 +335,34 @@ pub fn deliverable_media_type(name: &str) -> Option<&'static str> {
     }
 }
 
+/// The declared media type for a binary artifact filename.
+///
+/// Curated text extensions never reach this mapping — they classify as
+/// [`DeliverableKind::Text`] first — so every result here is valid for
+/// [`validate_binary_deliverable`]. Unknown extensions fall back to the generic
+/// byte-stream type rather than being refused: the filename is display metadata,
+/// and export works regardless.
+#[must_use]
+pub fn binary_media_type_for_extension(name: &str) -> &'static str {
+    let Some((_, extension)) = name.rsplit_once('.') else {
+        return "application/octet-stream";
+    };
+    match extension.to_ascii_lowercase().as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "webp" => "image/webp",
+        "gif" => "image/gif",
+        "svg" => "image/svg+xml",
+        "pdf" => "application/pdf",
+        "xlsx" | "xlsm" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "zip" => "application/zip",
+        "parquet" => "application/vnd.apache.parquet",
+        _ => "application/octet-stream",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -399,6 +399,28 @@ impl OutputId {
     pub fn for_run(run_id: AgentRunId) -> Self {
         Self(Uuid::new_v5(&Self::NAMESPACE, run_id.as_uuid().as_bytes()))
     }
+
+    /// Derive the retry-stable output identity for one artifact filename
+    /// published by one canonical tool call.
+    ///
+    /// An execution call can publish several files at once, so unlike
+    /// [`OutputId::for_call`] the identity covers the (call, filename) pair: a
+    /// retried call lands each file on the same output instead of forking new
+    /// records, and two files from one call never collide.
+    #[must_use]
+    pub fn for_call_artifact(call_id: CallId, filename: &str) -> Self {
+        Self(Uuid::new_v5(
+            &Self::NAMESPACE,
+            &call_artifact_name(call_id, filename),
+        ))
+    }
+}
+
+/// The stable UUIDv5 name for a (call, filename) artifact identity.
+fn call_artifact_name(call_id: CallId, filename: &str) -> Vec<u8> {
+    let mut name = call_id.as_uuid().as_bytes().to_vec();
+    name.extend_from_slice(filename.as_bytes());
+    name
 }
 
 id_type!(
@@ -420,6 +442,17 @@ impl OutputRevisionId {
     #[must_use]
     pub fn for_run(run_id: AgentRunId) -> Self {
         Self(Uuid::new_v5(&Self::NAMESPACE, run_id.as_uuid().as_bytes()))
+    }
+
+    /// Derive the retry-stable revision identity for one artifact filename
+    /// published by one canonical tool call. See
+    /// [`OutputId::for_call_artifact`].
+    #[must_use]
+    pub fn for_call_artifact(call_id: CallId, filename: &str) -> Self {
+        Self(Uuid::new_v5(
+            &Self::NAMESPACE,
+            &call_artifact_name(call_id, filename),
+        ))
     }
 }
 

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -48,6 +48,8 @@ pub mod image;
 #[cfg(feature = "keychain")]
 pub mod keychain;
 pub mod model;
+#[cfg(feature = "tools")]
+pub mod output_scan;
 pub mod preview;
 pub mod provider;
 mod renderer_tool;
@@ -109,12 +111,13 @@ pub use config::{Config, Profile};
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub use db::DbStore;
 pub use deliverable::{
-    deliverable_media_type, media_type_is_text, output_revision_relative_path,
-    revision_byte_ceiling, validate_binary_deliverable, validate_deliverable_media_type,
-    validate_deliverable_name, validate_portable_filename, CreateOutput, DeliverableKind,
-    NewOutputRevision, OutputRecord, OutputRevision, RevisionProducer, DELIVERABLES_DIRECTORY,
-    MAX_BINARY_DELIVERABLE_BYTES, MAX_DELIVERABLE_BYTES, MAX_DELIVERABLE_MEDIA_TYPE_CHARS,
-    MAX_DELIVERABLE_NAME_CHARS, MAX_OUTPUT_REVISIONS, OUTPUTS_DIRECTORY,
+    binary_media_type_for_extension, deliverable_media_type, media_type_is_text,
+    output_revision_relative_path, revision_byte_ceiling, validate_binary_deliverable,
+    validate_deliverable_media_type, validate_deliverable_name, validate_portable_filename,
+    CreateOutput, DeliverableKind, NewOutputRevision, OutputRecord, OutputRevision,
+    RevisionProducer, DELIVERABLES_DIRECTORY, MAX_BINARY_DELIVERABLE_BYTES, MAX_DELIVERABLE_BYTES,
+    MAX_DELIVERABLE_MEDIA_TYPE_CHARS, MAX_DELIVERABLE_NAME_CHARS, MAX_OUTPUT_REVISIONS,
+    OUTPUTS_DIRECTORY,
 };
 #[cfg(feature = "tools")]
 pub use deliverable_acceptance::{
@@ -151,6 +154,11 @@ pub use model::{
     TurnCheckpointProgress, TurnClientWait, TurnClientWaitStatus, TurnFailureReceipt,
     TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer, TurnSteerStatus, MAX_ATTACHMENT_REVISION,
     MAX_EXEC_WORKSPACE_FILE_BYTES, MAX_MESSAGE_ATTACHMENTS, MAX_ROOT_ATTACHMENTS,
+};
+#[cfg(feature = "tools")]
+pub use output_scan::{
+    sync_output_directory, OutputDirectorySync, OutputSyncEntry, OutputSyncStatus,
+    EXEC_OUTPUT_DIRECTORY, MAX_OUTPUT_SCAN_FILES,
 };
 pub use preview::{
     format_bytes, ResultEntry, ResultEntryKind, ResultFailure, ToolActionPreview,

--- a/crates/openwave-core/src/output_scan.rs
+++ b/crates/openwave-core/src/output_scan.rs
@@ -1,0 +1,359 @@
+//! Host-side sync of the execution `output/` directory into the durable
+//! conversation output record.
+//!
+//! Files an agent saves under `output/` during code execution are the
+//! files-first creation path for user-visible outputs: after each command the
+//! host scans the directory and publishes what it finds, keyed by filename
+//! within the conversation. A new filename creates an output at revision 1; an
+//! existing live output with the same filename gains a revision when the bytes
+//! changed and is left untouched when they did not. The model never names
+//! output identities — it just writes files — and deleting a file from
+//! `output/` never deletes the durable record.
+//!
+//! The scan is deliberately non-fatal: a file the host cannot accept (too
+//! large, unreadable, over the revision cap) becomes a note for the model
+//! rather than a failed command.
+
+use std::path::Path;
+
+use cap_std::fs::Dir;
+use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
+
+use crate::deliverable::{
+    binary_media_type_for_extension, deliverable_media_type, output_revision_relative_path,
+    validate_portable_filename, CreateOutput, DeliverableKind, NewOutputRevision, RevisionProducer,
+    MAX_BINARY_DELIVERABLE_BYTES, MAX_DELIVERABLE_BYTES,
+};
+use crate::error::{AgentError, Result};
+use crate::id::{CallId, ChatId, OutputId, OutputRevisionId};
+use crate::storage::Store;
+use crate::OutputRecord;
+
+/// Conventional directory, relative to a conversation's private scratch, whose
+/// files the host publishes as durable outputs.
+pub const EXEC_OUTPUT_DIRECTORY: &str = "output";
+
+/// Most files considered by one scan. Files beyond the cap are named in a note
+/// rather than silently ignored.
+pub const MAX_OUTPUT_SCAN_FILES: usize = 64;
+
+/// Upper bound on the filename lookup when matching scan files to existing
+/// outputs. Far above the catalog's own display cap.
+const OUTPUT_LOOKUP_LIMIT: u64 = 1_000;
+
+/// What one scanned file did to the output record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputSyncStatus {
+    /// A new output was created at revision 1.
+    Created,
+    /// An existing output gained a new revision.
+    Updated,
+    /// The file's bytes match the output's current revision; nothing was
+    /// written.
+    Unchanged,
+}
+
+/// One file the scan accepted (or matched) against the output record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputSyncEntry {
+    /// Display filename, equal to the file's name under `output/`.
+    pub filename: String,
+    /// The durable output the file landed on.
+    pub output_id: OutputId,
+    /// The output's current revision ordinal after the sync.
+    pub ordinal: u32,
+    /// Whether the file created, updated, or matched the output.
+    pub status: OutputSyncStatus,
+}
+
+/// The outcome of scanning one conversation's `output/` directory.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OutputDirectorySync {
+    /// Accepted or matched files, in the deterministic scan order.
+    pub entries: Vec<OutputSyncEntry>,
+    /// Files the scan could not accept, with actionable reasons.
+    pub notes: Vec<String>,
+}
+
+/// A candidate file read out of `output/`, classified but not yet recorded.
+struct ScanCandidate {
+    filename: String,
+    kind: DeliverableKind,
+    content: Vec<u8>,
+}
+
+/// Scan `output/` under one conversation's private scratch and publish its
+/// files as durable outputs.
+///
+/// `scratch` is the exact owning conversation's private scratch directory.
+/// Identities derive from the (call, filename) pair, so an exact retry of the
+/// same call republishes idempotently instead of forking records.
+pub async fn sync_output_directory(
+    store: &dyn Store,
+    scratch: &Dir,
+    chat_id: ChatId,
+    call_id: CallId,
+    producer: RevisionProducer,
+    now: DateTime<Utc>,
+) -> Result<OutputDirectorySync> {
+    let mut sync = OutputDirectorySync::default();
+
+    // Reading is blocking capability I/O; keep it off the async runtime.
+    let read_scratch = scratch
+        .try_clone()
+        .map_err(|error| AgentError::Store(format!("could not open private scratch: {error}")))?;
+    let (candidates, mut read_notes) =
+        tokio::task::spawn_blocking(move || read_output_candidates(&read_scratch))
+            .await
+            .map_err(|error| AgentError::Store(format!("output scan task failed: {error}")))?;
+    sync.notes.append(&mut read_notes);
+    if candidates.is_empty() {
+        return Ok(sync);
+    }
+
+    // One lookup serves every candidate: the newest live output per filename.
+    let existing = store.list_outputs(chat_id, OUTPUT_LOOKUP_LIMIT).await?;
+
+    for candidate in candidates {
+        match record_candidate(
+            store, scratch, chat_id, call_id, producer, now, &existing, &candidate,
+        )
+        .await
+        {
+            Ok(entry) => sync.entries.push(entry),
+            Err(error) => sync.notes.push(format!(
+                "output/{} could not be published: {error}",
+                candidate.filename
+            )),
+        }
+    }
+    Ok(sync)
+}
+
+/// Record one classified candidate against the output record.
+#[allow(clippy::too_many_arguments)]
+async fn record_candidate(
+    store: &dyn Store,
+    scratch: &Dir,
+    chat_id: ChatId,
+    call_id: CallId,
+    producer: RevisionProducer,
+    now: DateTime<Utc>,
+    existing: &[OutputRecord],
+    candidate: &ScanCandidate,
+) -> Result<OutputSyncEntry> {
+    let sha256: [u8; 32] = Sha256::digest(&candidate.content).into();
+    let byte_len = candidate.content.len() as u64;
+
+    // `list_outputs` orders newest-updated first and excludes deleted outputs,
+    // so the first filename match is the live record this file addresses.
+    let matched = existing
+        .iter()
+        .find(|output| output.filename == candidate.filename);
+
+    if let Some(output) = matched {
+        let current = store
+            .get_output_revision(output.current_revision)
+            .await?
+            .ok_or_else(|| AgentError::Store("current revision is missing".into()))?;
+        if current.sha256 == sha256 && current.byte_len == byte_len {
+            return Ok(OutputSyncEntry {
+                filename: candidate.filename.clone(),
+                output_id: output.id,
+                ordinal: current.ordinal,
+                status: OutputSyncStatus::Unchanged,
+            });
+        }
+        let revision_id = OutputRevisionId::for_call_artifact(call_id, &candidate.filename);
+        publish_revision_bytes(scratch, output.id, revision_id, &candidate.content).await?;
+        let updated = store
+            .append_output_revision(
+                output.id,
+                &NewOutputRevision {
+                    id: revision_id,
+                    byte_len,
+                    sha256,
+                    turn_id: None,
+                    producing_run_id: None,
+                    created_at: now,
+                }
+                .with_producer(producer),
+            )
+            .await?;
+        return Ok(OutputSyncEntry {
+            filename: candidate.filename.clone(),
+            output_id: updated.id,
+            ordinal: updated.revision_count,
+            status: OutputSyncStatus::Updated,
+        });
+    }
+
+    let output_id = OutputId::for_call_artifact(call_id, &candidate.filename);
+    let revision_id = OutputRevisionId::for_call_artifact(call_id, &candidate.filename);
+    publish_revision_bytes(scratch, output_id, revision_id, &candidate.content).await?;
+    let created = store
+        .create_output(&CreateOutput {
+            id: output_id,
+            chat_id,
+            filename: candidate.filename.clone(),
+            kind: candidate.kind.clone(),
+            revision: NewOutputRevision {
+                id: revision_id,
+                byte_len,
+                sha256,
+                turn_id: None,
+                producing_run_id: None,
+                created_at: now,
+            }
+            .with_producer(producer),
+        })
+        .await?;
+    Ok(OutputSyncEntry {
+        filename: candidate.filename.clone(),
+        output_id: created.id,
+        ordinal: created.revision_count,
+        status: OutputSyncStatus::Created,
+    })
+}
+
+/// Publish revision bytes at the write-once derived path.
+async fn publish_revision_bytes(
+    scratch: &Dir,
+    output_id: OutputId,
+    revision_id: OutputRevisionId,
+    content: &[u8],
+) -> Result<()> {
+    let relative_path = output_revision_relative_path(output_id, revision_id);
+    let scratch = scratch
+        .try_clone()
+        .map_err(|error| AgentError::Store(format!("could not open private scratch: {error}")))?;
+    let content = content.to_vec();
+    tokio::task::spawn_blocking(move || {
+        crate::tools::private_scratch::publish_immutable_file(&scratch, &relative_path, &content)
+    })
+    .await
+    .map_err(|error| AgentError::Store(format!("publication task failed: {error}")))?
+    .map_err(|error| AgentError::Store(format!("could not publish output revision: {error}")))
+}
+
+/// Read and classify the acceptable files directly under `output/`.
+///
+/// Deterministic (alphabetical) order, bounded at [`MAX_OUTPUT_SCAN_FILES`].
+/// Anything skipped is explained in a note.
+fn read_output_candidates(scratch: &Dir) -> (Vec<ScanCandidate>, Vec<String>) {
+    let mut notes = Vec::new();
+
+    // A symlinked `output/` planted by local exec would hand host files from an
+    // arbitrary directory to the catalog; refuse it rather than follow it.
+    match scratch.symlink_metadata(EXEC_OUTPUT_DIRECTORY) {
+        Ok(metadata) if metadata.is_dir() => {}
+        Ok(_) => {
+            notes.push(
+                "outputs unavailable: output/ is not a private workspace directory. Remove it and rerun."
+                    .into(),
+            );
+            return (Vec::new(), notes);
+        }
+        Err(_) => return (Vec::new(), notes),
+    }
+    let Ok(directory) = scratch.open_dir(EXEC_OUTPUT_DIRECTORY) else {
+        notes.push("outputs unavailable: output/ could not be read".into());
+        return (Vec::new(), notes);
+    };
+    let Ok(entries) = directory.entries() else {
+        notes.push("outputs unavailable: output/ could not be read".into());
+        return (Vec::new(), notes);
+    };
+
+    let mut names = Vec::new();
+    for entry in entries.flatten() {
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            notes.push("a file with a non-UTF-8 name was ignored".into());
+            continue;
+        };
+        let is_regular_file = entry
+            .metadata()
+            .map(|metadata| metadata.is_file())
+            .unwrap_or(false);
+        if !is_regular_file {
+            // Subdirectories and symlinks are outside the outputs contract;
+            // dotfiles are workspace plumbing. Neither warrants a note.
+            continue;
+        }
+        if name.starts_with('.') {
+            continue;
+        }
+        names.push(name);
+    }
+    names.sort();
+    if names.len() > MAX_OUTPUT_SCAN_FILES {
+        notes.push(format!(
+            "output/ file cap is {MAX_OUTPUT_SCAN_FILES}; ignored {}",
+            names[MAX_OUTPUT_SCAN_FILES..].join(", ")
+        ));
+        names.truncate(MAX_OUTPUT_SCAN_FILES);
+    }
+
+    let mut candidates = Vec::new();
+    for name in names {
+        match classify_candidate(&directory, &name) {
+            Ok(candidate) => candidates.push(candidate),
+            Err(reason) => notes.push(format!("output/{name} was not published: {reason}")),
+        }
+    }
+    (candidates, notes)
+}
+
+/// Read one file and classify it as a text deliverable or binary artifact.
+fn classify_candidate(directory: &Dir, name: &str) -> std::result::Result<ScanCandidate, String> {
+    validate_portable_filename(name).map_err(str::to_owned)?;
+
+    let text_media_type = deliverable_media_type(name);
+    let ceiling = if text_media_type.is_some() {
+        MAX_DELIVERABLE_BYTES
+    } else {
+        MAX_BINARY_DELIVERABLE_BYTES
+    };
+
+    let metadata = directory
+        .metadata(Path::new(name))
+        .map_err(|_| "the file could not be read".to_owned())?;
+    if metadata.len() == 0 {
+        return Err("the file is empty".into());
+    }
+    if metadata.len() > ceiling as u64 {
+        return Err(if text_media_type.is_some() {
+            format!(
+                "text outputs are limited to {MAX_DELIVERABLE_BYTES} bytes; split it or produce a binary format"
+            )
+        } else {
+            format!("files are limited to {MAX_BINARY_DELIVERABLE_BYTES} bytes")
+        });
+    }
+    let content = directory
+        .read(Path::new(name))
+        .map_err(|_| "the file could not be read".to_owned())?;
+    if content.len() as u64 != metadata.len() || content.len() > ceiling {
+        return Err("the file changed while being read".into());
+    }
+
+    let kind = match text_media_type {
+        Some(_) => {
+            let text = std::str::from_utf8(&content)
+                .map_err(|_| "text outputs must be valid UTF-8".to_owned())?;
+            if text.contains('\0') {
+                return Err("text outputs must not contain NUL characters".into());
+            }
+            DeliverableKind::Text
+        }
+        None => DeliverableKind::Binary {
+            media_type: binary_media_type_for_extension(name).to_owned(),
+        },
+    };
+    Ok(ScanCandidate {
+        filename: name.to_owned(),
+        kind,
+        content,
+    })
+}

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -12,17 +12,20 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use chrono::Utc;
 use openwave_code_execution::{
     resolve_scratch_directory, sync, write_without_following, CodeExecutionError,
     CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest, CodeExecutionResponse,
     DaytonaCredential, DaytonaExecutionProvider, E2BCredential, E2BExecutionProvider,
-    ExecFolderAccess, ExecFolderGrant, ExecutionWorkspaceId, LocalExecutionProvider, PreviewScan,
-    RemoteSessionPool, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing,
-    DAYTONA_CREDENTIAL_KEY, DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES, E2B_CREDENTIAL_KEY,
+    ExecFolderAccess, ExecFolderGrant, ExecutionId, ExecutionWorkspaceId, LocalExecutionProvider,
+    OutputArtifactEntry, OutputArtifactScan, OutputArtifactStatus, PreviewScan, RemoteSessionPool,
+    WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, DAYTONA_CREDENTIAL_KEY,
+    DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES, E2B_CREDENTIAL_KEY,
 };
 use openwave_core::{
-    exec_attachment_file_name, BlobStore, Chat, ChatId, HostRootId, MessageDocumentAttachment,
-    ProjectId, Result, SecretProvider, Store, MAX_EXEC_WORKSPACE_FILE_BYTES,
+    exec_attachment_file_name, BlobStore, CallId, Chat, ChatId, HostRootId,
+    MessageDocumentAttachment, ProjectId, Result, RevisionProducer, SecretProvider, Store,
+    MAX_EXEC_WORKSPACE_FILE_BYTES,
 };
 use openwave_egress::{
     CidrBlock, DomainPattern, EgressAllowlist, EgressEnforcement, EgressError, EgressPolicy,
@@ -887,6 +890,76 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
         .map_err(|_| CodeExecutionError::Sandbox("preview scan task failed".into()))
     }
 
+    async fn collect_output_artifacts(
+        &self,
+        workspace: &ExecutionWorkspaceId,
+        execution: &ExecutionId,
+    ) -> std::result::Result<OutputArtifactScan, CodeExecutionError> {
+        let chat_id = workspace.as_str().parse::<ChatId>().map_err(|_| {
+            CodeExecutionError::InvalidRequest(
+                "execution workspace does not identify a conversation".into(),
+            )
+        })?;
+        let call_id = execution.as_str().parse::<CallId>().map_err(|_| {
+            CodeExecutionError::InvalidRequest(
+                "execution does not carry a canonical tool-call identity".into(),
+            )
+        })?;
+        // The revision's producer is the turn that owns this exec call, read
+        // from the durable call record rather than anything the model asserts.
+        let calls = self.store.list_tool_calls(chat_id).await.map_err(|_| {
+            CodeExecutionError::Unavailable("tool-call storage is unavailable".into())
+        })?;
+        let turn_id = calls
+            .into_iter()
+            .find(|call| call.id == call_id)
+            .map(|call| call.turn_id)
+            .ok_or_else(|| {
+                CodeExecutionError::InvalidRequest(
+                    "execution identity is not owned by this conversation".into(),
+                )
+            })?;
+
+        let scratch_path = self.scratch_root.join(workspace.as_str());
+        let scratch = tokio::task::spawn_blocking(move || {
+            cap_std::fs::Dir::open_ambient_dir(&scratch_path, cap_std::ambient_authority())
+        })
+        .await
+        .map_err(|_| CodeExecutionError::Sandbox("output scan task failed".into()))?
+        .map_err(|_| CodeExecutionError::Sandbox("the private workspace is unavailable".into()))?;
+
+        let sync = openwave_core::sync_output_directory(
+            &*self.store,
+            &scratch,
+            chat_id,
+            call_id,
+            RevisionProducer::Turn(turn_id),
+            Utc::now(),
+        )
+        .await
+        .map_err(|error| {
+            CodeExecutionError::Unavailable(format!("outputs could not be recorded: {error}"))
+        })?;
+        Ok(OutputArtifactScan {
+            entries: sync
+                .entries
+                .into_iter()
+                .map(|entry| OutputArtifactEntry {
+                    filename: entry.filename,
+                    ordinal: entry.ordinal,
+                    status: match entry.status {
+                        openwave_core::OutputSyncStatus::Created => OutputArtifactStatus::Created,
+                        openwave_core::OutputSyncStatus::Updated => OutputArtifactStatus::Updated,
+                        openwave_core::OutputSyncStatus::Unchanged => {
+                            OutputArtifactStatus::Unchanged
+                        }
+                    },
+                })
+                .collect(),
+            notes: sync.notes,
+        })
+    }
+
     // `workspace_lifecycle` stays `None` here on purpose: the capability of
     // this late-binding wrapper depends on the configuration read at call
     // time, which the synchronous trait flag cannot express. Host callers use
@@ -1244,6 +1317,119 @@ mod tests {
         .with_folder_grant_resolver(Some(bad_resolver));
         assert!(bad_provider
             .resolve_chat_folder_grants(&chat)
+            .await
+            .is_err());
+    }
+
+    /// The files-first creation path end to end at the provider seam: a file
+    /// written to `output/` becomes a turn-attributed output, an identical
+    /// rerun mints nothing, and changed bytes append a revision.
+    #[tokio::test]
+    async fn output_files_publish_as_turn_attributed_outputs() {
+        use openwave_core::model::{ToolCallExecution, ToolCallRecord, ToolCallStatus};
+        use openwave_core::{CallId, TurnId};
+
+        let (store, _database) = test_store().await;
+        let store = Arc::new(store);
+        let scratch_root = tempfile::tempdir().unwrap();
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            reasoning_effort: None,
+            permission_mode: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let turn_id = TurnId::new();
+        let accept_exec_call = |store: Arc<DbStore>| async move {
+            let call_id = CallId::new();
+            store
+                .accept_tool_call(&ToolCallRecord {
+                    id: call_id,
+                    chat_id: chat.id,
+                    turn_id,
+                    provider_id: format!("provider-{call_id}"),
+                    name: "exec".into(),
+                    arguments: serde_json::json!({}),
+                    execution: ToolCallExecution::Server,
+                    status: ToolCallStatus::Pending,
+                    result: None,
+                    result_preview: None,
+                    error_code: None,
+                    error_detail: None,
+                    client_executor_id: None,
+                    client_lease_expires_at: None,
+                    created_at: Utc::now(),
+                    resolved_at: None,
+                })
+                .await
+                .unwrap();
+            call_id
+        };
+        let call_id = accept_exec_call(store.clone()).await;
+
+        let output_dir = scratch_root.path().join(chat.id.to_string()).join("output");
+        std::fs::create_dir_all(&output_dir).unwrap();
+        std::fs::write(output_dir.join("report.md"), b"# Draft").unwrap();
+
+        let provider = ConfiguredCodeExecutionProvider::new(
+            store.clone(),
+            Arc::new(NoSecrets),
+            scratch_root.path(),
+        );
+        let workspace = ExecutionWorkspaceId::parse(chat.id.to_string()).unwrap();
+        let execution = ExecutionId::parse(call_id.to_string()).unwrap();
+
+        let scan = provider
+            .collect_output_artifacts(&workspace, &execution)
+            .await
+            .unwrap();
+        assert_eq!(scan.entries.len(), 1);
+        assert_eq!(scan.entries[0].status, OutputArtifactStatus::Created);
+        let outputs = store.list_outputs(chat.id, 10).await.unwrap();
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].filename, "report.md");
+        let revision = store
+            .get_output_revision(outputs[0].current_revision)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(revision.turn_id, Some(turn_id));
+
+        // Identical rerun: nothing minted.
+        let rerun = provider
+            .collect_output_artifacts(&workspace, &execution)
+            .await
+            .unwrap();
+        assert_eq!(rerun.entries[0].status, OutputArtifactStatus::Unchanged);
+        assert_eq!(
+            store.list_outputs(chat.id, 10).await.unwrap()[0].revision_count,
+            1
+        );
+
+        // Changed bytes from a later call: a revision on the same output. (The
+        // same call identity republishing different bytes is refused by the
+        // write-once path, so each update rides its own call.)
+        std::fs::write(output_dir.join("report.md"), b"# Final").unwrap();
+        let later_call = accept_exec_call(store.clone()).await;
+        let later_execution = ExecutionId::parse(later_call.to_string()).unwrap();
+        let changed = provider
+            .collect_output_artifacts(&workspace, &later_execution)
+            .await
+            .unwrap();
+        assert_eq!(changed.entries[0].status, OutputArtifactStatus::Updated);
+        let updated = store.list_outputs(chat.id, 10).await.unwrap();
+        assert_eq!(updated[0].id, outputs[0].id);
+        assert_eq!(updated[0].revision_count, 2);
+
+        // A call identity the conversation does not own publishes nothing.
+        let foreign = ExecutionId::parse(CallId::new().to_string()).unwrap();
+        assert!(provider
+            .collect_output_artifacts(&workspace, &foreign)
             .await
             .is_err());
     }


### PR DESCRIPTION
Wires the output-directory sync primitive (#1165) into code execution, making `output/` the files-first creation path for user-visible outputs.

- New provider hook `collect_output_artifacts(workspace, execution)` on `CodeExecutionProvider` (default empty, mirroring `collect_preview_images`). The configured server provider implements it: it parses the chat and call identities, resolves the producing turn from the durable call record — never from anything the model asserts — opens the chat's scratch, and delegates to `sync_output_directory`.
- `ExecTool` runs the scan after every command **regardless of exit code** — a failing later step must not hide files already durably written. Created/updated files and scan notes are reported in an `outputs:` section of the result text (unchanged files are matched silently), and the full entry list rides in the structured data.
- The exec tool description now tells the model the contract directly: files saved in `output/` are published automatically; saving to the same filename updates the output in place as a new version, no ids to track; `preview/` images never become outputs.
- Because the scan hook runs on the host after `pull_into_host_dir`, the same path covers local, E2B, and Daytona uniformly.

Tests: an ExecTool unit test pinning the reporting contract (outputs section present on failed commands, unchanged files not renarrated, notes surfaced), and a provider-seam test driving create → unchanged → update against the real store, including turn attribution and rejection of a call identity the conversation does not own.

Stacked on #1165; retargets to main when it lands.