### PR TITLE
fix(exec): report per-file pull failures and distinguish containment refusals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3856,6 +3856,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
+ "tracing",
  "ts-rs",
  "uuid",
 ]

--- a/crates/openwave-code-execution/Cargo.toml
+++ b/crates/openwave-code-execution/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "process", "rt", "sync", "time"] }
+tracing = "=0.1.44"
 uuid = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/openwave-code-execution/src/host_paths.rs
+++ b/crates/openwave-code-execution/src/host_paths.rs
@@ -13,6 +13,51 @@ use std::path::{Path, PathBuf};
 
 use tokio::io::AsyncWriteExt;
 
+/// Why a host directory under the private scratch tree was refused.
+///
+/// The distinction is the point: a planted symlink and a permissions failure
+/// are the same `None` to a caller, but only one of them is the boundary being
+/// probed, and collapsing them makes an attack read as noise.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScratchRefusal {
+    /// A component tried to leave the root, or the resolved directory landed
+    /// outside it. Nothing legitimate aims there.
+    Escape,
+    /// An intermediate component is a symlink. Following it is exactly the
+    /// escape this resolver exists to refuse.
+    SymlinkedComponent,
+    /// An intermediate component exists and is neither a directory nor a
+    /// symlink — a regular file where a directory was expected.
+    NotADirectory,
+    /// The directory is missing and could not be created, or could not be
+    /// canonicalized: a permissions failure, or a lost race with another
+    /// writer. Says nothing about the caller's intent.
+    Unavailable,
+}
+
+impl ScratchRefusal {
+    /// Whether the refusal is the containment boundary doing its job rather
+    /// than the host failing at an ordinary filesystem operation.
+    pub fn is_containment(self) -> bool {
+        matches!(self, Self::Escape | Self::SymlinkedComponent)
+    }
+}
+
+/// Resolve `relative` as a directory under `root` without walking through a
+/// symlink at any component, discarding why a refusal happened.
+///
+/// Callers that report or log the refusal should use
+/// [`try_resolve_scratch_directory`] instead.
+pub async fn resolve_scratch_directory(
+    root: &Path,
+    relative: &str,
+    create: bool,
+) -> Option<PathBuf> {
+    try_resolve_scratch_directory(root, relative, create)
+        .await
+        .ok()
+}
+
 /// Resolve `relative` as a directory under `root` without walking through a
 /// symlink at any component.
 ///
@@ -20,34 +65,42 @@ use tokio::io::AsyncWriteExt;
 /// a regular file refuses. With `create`, a missing component is created one
 /// level at a time, so a component planted between two host runs is seen
 /// rather than followed. The canonical result must still sit inside the
-/// canonical `root`. `None` means the path did not resolve inside the scratch
-/// directory, or the directories could not be made.
-pub async fn resolve_scratch_directory(
+/// canonical `root`.
+pub async fn try_resolve_scratch_directory(
     root: &Path,
     relative: &str,
     create: bool,
-) -> Option<PathBuf> {
+) -> Result<PathBuf, ScratchRefusal> {
     // macOS puts chat scratch under a symlinked `/var`, so containment is
     // judged against the canonical root rather than the path as handed in.
-    let root = tokio::fs::canonicalize(root).await.ok()?;
+    let root = tokio::fs::canonicalize(root)
+        .await
+        .map_err(|_| ScratchRefusal::Unavailable)?;
     let mut dir = root.clone();
     for component in relative.split('/').filter(|part| !part.is_empty()) {
         if component == "." || component == ".." {
-            return None;
+            return Err(ScratchRefusal::Escape);
         }
         dir.push(component);
         match tokio::fs::symlink_metadata(&dir).await {
             Ok(metadata) if metadata.is_dir() => {}
-            Ok(_) => return None,
-            Err(_) if create => tokio::fs::create_dir(&dir).await.ok()?,
-            Err(_) => return None,
+            Ok(metadata) if metadata.is_symlink() => {
+                return Err(ScratchRefusal::SymlinkedComponent)
+            }
+            Ok(_) => return Err(ScratchRefusal::NotADirectory),
+            Err(_) if create => tokio::fs::create_dir(&dir)
+                .await
+                .map_err(|_| ScratchRefusal::Unavailable)?,
+            Err(_) => return Err(ScratchRefusal::Unavailable),
         }
     }
-    let resolved = tokio::fs::canonicalize(&dir).await.ok()?;
+    let resolved = tokio::fs::canonicalize(&dir)
+        .await
+        .map_err(|_| ScratchRefusal::Unavailable)?;
     if !resolved.starts_with(&root) {
-        return None;
+        return Err(ScratchRefusal::Escape);
     }
-    Some(resolved)
+    Ok(resolved)
 }
 
 /// Write `content` at `host_path` without following a symlink at the final

--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -26,7 +26,10 @@ mod types;
 
 pub use daytona::{DaytonaCredential, DaytonaExecutionProvider, DAYTONA_CREDENTIAL_KEY};
 pub use e2b::{E2BCredential, E2BExecutionProvider, E2B_CREDENTIAL_KEY};
-pub use host_paths::{resolve_scratch_directory, write_without_following};
+pub use host_paths::{
+    resolve_scratch_directory, try_resolve_scratch_directory, write_without_following,
+    ScratchRefusal,
+};
 pub use local::LocalExecutionProvider;
 pub use preview::{scan_preview_directory, PreviewScan};
 pub use remote::RemoteSessionPool;

--- a/crates/openwave-code-execution/src/sync.rs
+++ b/crates/openwave-code-execution/src/sync.rs
@@ -13,7 +13,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::host_paths::{resolve_scratch_directory, write_without_following};
+use crate::host_paths::{try_resolve_scratch_directory, write_without_following, ScratchRefusal};
 use crate::{
     CodeExecutionError, ExecutionWorkspaceId, WorkspaceFilePath, WorkspaceLifecycle,
     MAX_WORKSPACE_FILE_BYTES,
@@ -206,28 +206,49 @@ pub async fn pull_into_host_dir(
         .await
         .map_err(|_| unwritable_dir())?;
     for path in files {
-        let content = lifecycle.get_workspace_file(workspace, &path).await?;
-        let Some(host_path) = host_file_path(&host_root, &path).await else {
-            report.skip(format!(
-                "not pulled: {} does not resolve inside the private scratch directory",
-                path.as_str()
-            ));
-            continue;
-        };
-        if let Ok(existing) = tokio::fs::read(&host_path).await {
-            if existing == content {
+        let content = match lifecycle.get_workspace_file(workspace, &path).await {
+            Ok(content) => content,
+            Err(error) if aborts_the_pull(&error) => return Err(error),
+            Err(error) => {
+                tracing::warn!(
+                    "workspace file '{}' could not be pulled: {error}",
+                    path.as_str()
+                );
+                report.skip(format!(
+                    "not pulled: {} could not be read from the workspace ({error})",
+                    path.as_str()
+                ));
                 continue;
             }
-        }
+        };
+        let host_path = match host_file_path(&host_root, &path).await {
+            Ok(host_path) => host_path,
+            Err(refusal) => {
+                refuse(&mut report, &path, refusal);
+                continue;
+            }
+        };
+        // Read for the equality shortcut only after the symlink check: reading
+        // by path follows a symlink at the final component, which would turn a
+        // planted link into a content-equality oracle on a host file.
         if tokio::fs::symlink_metadata(&host_path)
             .await
             .is_ok_and(|metadata| metadata.is_symlink())
         {
+            tracing::warn!(
+                "workspace pull refused: '{}' is a symlink on the host",
+                path.as_str()
+            );
             report.skip(format!(
                 "not pulled: {} is a symlink on the host",
                 path.as_str()
             ));
             continue;
+        }
+        if let Ok(existing) = tokio::fs::read(&host_path).await {
+            if existing == content {
+                continue;
+            }
         }
         write_without_following(&host_path, &content)
             .await
@@ -243,15 +264,61 @@ pub async fn pull_into_host_dir(
 /// Local exec is confined to this same scratch tree, so it can plant
 /// `<scratch>/out -> ~/.ssh` and wait for a pull: `create_dir_all` and a plain
 /// `write` both follow a symlinked *parent*, and the pull's host write is not
-/// sandboxed. `None` means the path resolved outside the scratch directory, or
-/// the directories could not be made.
-async fn host_file_path(host_root: &Path, path: &WorkspaceFilePath) -> Option<PathBuf> {
+/// sandboxed.
+async fn host_file_path(
+    host_root: &Path,
+    path: &WorkspaceFilePath,
+) -> Result<PathBuf, ScratchRefusal> {
     let parent = path
         .as_str()
         .rsplit_once('/')
         .map_or("", |(parent, _)| parent);
-    let dir = resolve_scratch_directory(host_root, parent, true).await?;
-    Some(dir.join(path.file_name()))
+    let dir = try_resolve_scratch_directory(host_root, parent, true).await?;
+    Ok(dir.join(path.file_name()))
+}
+
+/// Record a refused file in the report and, for the containment cases, on the
+/// host.
+///
+/// The note goes to the model; without the log line a sandbox probing the
+/// boundary would generate output only it can see.
+fn refuse(report: &mut SyncReport, path: &WorkspaceFilePath, refusal: ScratchRefusal) {
+    let reason = match refusal {
+        ScratchRefusal::Escape => "resolves outside the private scratch directory",
+        ScratchRefusal::SymlinkedComponent => "has a symlinked parent directory on the host",
+        ScratchRefusal::NotADirectory => "has a host parent that is not a directory",
+        ScratchRefusal::Unavailable => "has a host parent directory that could not be created",
+    };
+    if refusal.is_containment() {
+        tracing::warn!("workspace pull refused: '{}' {reason}", path.as_str());
+    } else {
+        tracing::debug!(
+            "workspace file '{}' was not pulled: {reason}",
+            path.as_str()
+        );
+    }
+    report.skip(format!("not pulled: {} {reason}", path.as_str()));
+}
+
+/// Whether one file's failure should end the whole pull.
+///
+/// A file that is missing, oversized, or unreadable is this file's problem:
+/// the pull reports it and keeps going, which is what the module promises. A
+/// provider that is unreachable or misconfigured is every remaining file's
+/// problem too, and degrading it into a few hundred identical notes would hide
+/// a real failure from the caller.
+fn aborts_the_pull(error: &CodeExecutionError) -> bool {
+    match error {
+        CodeExecutionError::WorkspaceFileNotFound
+        | CodeExecutionError::WorkspaceFileTooLarge
+        | CodeExecutionError::InvalidRequest(_)
+        | CodeExecutionError::Sandbox(_) => false,
+        CodeExecutionError::NotConfigured
+        | CodeExecutionError::Unavailable(_)
+        | CodeExecutionError::Spawn
+        | CodeExecutionError::IdentityConflict
+        | CodeExecutionError::AmbiguousExecution => true,
+    }
 }
 
 fn unreadable(path: &str) -> CodeExecutionError {
@@ -477,10 +544,37 @@ mod tests {
             std::fs::read(outside.path().join("authorized_keys")).unwrap(),
             b"host secret"
         );
+        assert!(pulled.notes.iter().any(|note| {
+            note.contains("out/authorized_keys") && note.contains("symlinked parent directory")
+        }));
+    }
+
+    #[tokio::test]
+    async fn pull_reports_an_unreadable_file_and_keeps_going() {
+        let host = tempfile::tempdir().unwrap();
+        let fake = FakeWorkspace::default();
+        fake.insert("kept.txt", b"sandbox output");
+        // A backend that omits the size passes the oversize filter and can
+        // still refuse the download; older E2B envd and Daytona both do.
+        fake.planted.lock().unwrap().push(WorkspaceFileEntry {
+            path: "huge.bin".into(),
+            directory: false,
+            size_bytes: None,
+        });
+
+        let pulled = pull_into_host_dir(&fake, &workspace_id(), host.path())
+            .await
+            .unwrap();
+
+        assert_eq!(pulled.transferred, 1, "{:?}", pulled.notes);
+        assert_eq!(
+            std::fs::read(host.path().join("kept.txt")).unwrap(),
+            b"sandbox output"
+        );
         assert!(pulled
             .notes
             .iter()
-            .any(|note| note.contains("out/authorized_keys")));
+            .any(|note| note.contains("huge.bin") && note.contains("could not be read")));
     }
 
     #[tokio::test]


### PR DESCRIPTION
The workspace-to-host pull had two reporting problems that sit on the same
error paths, so they are fixed together.

**One file's failure aborted the whole pull.** `get_workspace_file` propagated
through `?`, which contradicts the module's own contract that a sync reports
what it leaves behind rather than skipping it. It is reachable without a
hostile backend: a listing entry with no `size_bytes` passes the oversize
filter — older E2B envd and Daytona both omit the size — and then trips the
download bound, losing every file that sorted after it. A per-file failure is
now a note and the pull continues. Provider-wide failures still abort:
`Unavailable`, `NotConfigured`, `Spawn`, `IdentityConflict`, and
`AmbiguousExecution` mean every remaining file would fail the same way, and
degrading an unreachable sandbox into a few hundred identical notes would hide
a real failure from the caller. `WorkspaceFileNotFound`,
`WorkspaceFileTooLarge`, `InvalidRequest`, and `Sandbox` are one file's problem
and are reported per file.

**Containment refusals were visible only to the sandbox.** A refusal became a
`report.skip` note that flows into `sync_notes` and on to the model, with no
host-side record at all — a sandbox probing the boundary produced output only
it could see. The containment cases now also log a warning on the host; the
benign ones log at debug, since the note is the actionable half.

**One message covered three unrelated causes.** `host_file_path` returned
`None` whether the path escaped the root, hit a planted symlink, hit a regular
file where a directory belonged, or simply could not create the directory. A
permissions failure read as an attack and an attack read as noise.
`try_resolve_scratch_directory` now returns a `ScratchRefusal` — `Escape`,
`SymlinkedComponent`, `NotADirectory`, `Unavailable` — each with its own note,
and only the first two are treated as the boundary doing its job. The
`Option`-returning `resolve_scratch_directory` stays for callers that do not
report the reason.

**The equality shortcut read through a symlink.** The destination was read by
path, following symlinks, before the symlink check. With a symlink at the final
component, matching content continued silently while a mismatch emitted a note
— a content-equality oracle on a host file of the sandbox's choosing. The read
now happens after the symlink check.

Descriptor pinning for the remaining lstat-then-open window is #1127 and is not
touched here.

Two provider inconsistencies noted in #1103 are left alone deliberately.
Daytona's `process/execute` returns a single `result` field, so separating
stderr from stdout means moving to a different execution API rather than making
a small change. Its unrooted `cwd` matches the rest of that adapter, whose file
and listing endpoints are all sandbox-relative; E2B roots `cwd` because its file
API is absolute. Both are worth revisiting when the Daytona adapter next
changes.

Tests: the symlinked-parent test asserted only that a note mentioned the path,
which any skip reason would satisfy; it now asserts the containment reason. One
test covers a single unreadable file being reported without ending the pull.

Closes #1103
Closes #1128
