### PR TITLE
feat(server): bound container-run concurrency at the claim

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -707,8 +707,16 @@ impl Store for DbStore {
         id: AgentRunId,
         lease_token: uuid::Uuid,
         lease_duration: chrono::Duration,
+        max_running_containers: u32,
     ) -> Result<Option<AgentRun>> {
-        ops::agent_run::claim_container_agent_run(self, id, lease_token, lease_duration).await
+        ops::agent_run::claim_container_agent_run(
+            self,
+            id,
+            lease_token,
+            lease_duration,
+            max_running_containers,
+        )
+        .await
     }
 
     async fn list_reclaimable_container_agent_runs(

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use sea_orm::{
     sea_query::ExprTrait, ActiveModelTrait, ColumnTrait, Condition, DatabaseBackend, EntityTrait,
-    NotSet, QueryFilter, QueryOrder, QuerySelect, Set, Statement, TransactionTrait,
+    NotSet, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Set, Statement, TransactionTrait,
 };
 
 use crate::agent_tools::SandboxAgentFileResource;
@@ -1070,11 +1070,20 @@ pub(in crate::db) async fn claim_agent_run(
 /// work. A container run has exactly one execution attempt, so this only
 /// transitions a fresh `queued` run to `running`; it never reclaims an expired
 /// lease into a second attempt.
+///
+/// `max_running_containers` bounds concurrency: container runs bypass the
+/// in-process scheduler's global and per-chat limits, so this claim refuses —
+/// leaving the run `queued` for a later pass — while that many container runs
+/// are already `running`. The count is taken inside the claim transaction under
+/// the scheduler lock, so racing drivers cannot admit past the cap. Recovery
+/// (`reclaim_container_agent_run`) is exempt: a reclaimed run is already
+/// `running` and adds nothing to the count.
 pub(in crate::db) async fn claim_container_agent_run(
     store: &DbStore,
     id: AgentRunId,
     lease_token: uuid::Uuid,
     lease_duration: chrono::Duration,
+    max_running_containers: u32,
 ) -> Result<Option<AgentRun>> {
     if lease_token.is_nil() || lease_duration <= chrono::Duration::zero() {
         return Err(AgentError::Store(
@@ -1134,6 +1143,24 @@ pub(in crate::db) async fn claim_container_agent_run(
         && candidate.deadline_at.is_some_and(|deadline| deadline > now)
         && candidate.updated_at <= now;
     if !claimable {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(None);
+    }
+    // Every `running` container run counts against the cap, live lease or not:
+    // an expired-lease run may still have a working container, and counting it
+    // keeps the bound on real containers conservative until recovery or the
+    // deadline scan settles it.
+    let running_containers = entities::agent_run::Entity::find()
+        .filter(entities::agent_run::Column::Tier.eq(AgentRunTier::Background.as_str()))
+        .filter(
+            entities::agent_run::Column::ExecutionLocation
+                .eq(AgentRunExecutionLocation::Container.as_str()),
+        )
+        .filter(entities::agent_run::Column::Status.eq(AgentRunStatus::Running.as_str()))
+        .count(&transaction)
+        .await
+        .map_err(store_err)?;
+    if running_containers >= u64::from(max_running_containers) {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
     }

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1558,12 +1558,16 @@ pub trait Store: Send + Sync {
     /// only transitions a fresh `queued` `container` run to `running`. Reusing
     /// `lease_token` recovers its original still-live claim and never claims
     /// different work. The returned lease fences the run's result commit exactly
-    /// as an in-process claim does.
+    /// as an in-process claim does. Refuses — leaving the run queued — while
+    /// `max_running_containers` container runs are already running; container
+    /// runs bypass the in-process scheduler's limits, so this claim is where
+    /// their own bound is enforced.
     async fn claim_container_agent_run(
         &self,
         _id: AgentRunId,
         _lease_token: uuid::Uuid,
         _lease_duration: chrono::Duration,
+        _max_running_containers: u32,
     ) -> Result<Option<AgentRun>> {
         agent_run_storage_unavailable()
     }

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -95,6 +95,12 @@ pub struct SandboxContainerRunConfig {
     /// tag sweep, and a handle commit that arrives after the lapse finds the
     /// record already disowned and destroys its own container.
     pub provision_window: Duration,
+    /// How many container runs may be `running` at once.
+    ///
+    /// Container runs bypass the in-process scheduler's global and per-chat
+    /// caps, so the claim enforces this bound instead; a run refused by it
+    /// stays queued for a later pass.
+    pub max_concurrent_containers: u32,
     /// How many model-inference operations the host will answer for one run.
     ///
     /// The sandbox's own step limit runs inside the untrusted container, so it
@@ -118,6 +124,10 @@ impl Default for SandboxContainerRunConfig {
             // Ample for `docker run` against a present image; an image pull on
             // a cold machine is paid at build/install time, not here.
             provision_window: Duration::from_secs(120),
+            // Containers are heavier than in-process runs (a full agent image
+            // each); a small bound keeps a burst of spawns from exhausting the
+            // local machine.
+            max_concurrent_containers: 4,
             // Three times the in-container loop's own step limit: a well-behaved
             // run never approaches it even with retried provider failures, and a
             // hostile one is cut off within one order of magnitude of legitimate
@@ -281,7 +291,12 @@ impl SandboxContainerRunner {
         let lease_token = Uuid::new_v4();
         let Some(run) = self
             .store
-            .claim_container_agent_run(run_id, lease_token, chrono_duration(self.config.lease)?)
+            .claim_container_agent_run(
+                run_id,
+                lease_token,
+                chrono_duration(self.config.lease)?,
+                self.config.max_concurrent_containers,
+            )
             .await?
         else {
             return Ok(None);

--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -369,6 +369,7 @@ fn fast_config() -> SandboxContainerRunConfig {
         reattach_attempts: 2,
         reattach_backoff: Duration::from_millis(10),
         provision_window: Duration::from_secs(120),
+        max_concurrent_containers: 4,
         max_inference_operations: 24,
     }
 }
@@ -634,7 +635,7 @@ async fn the_in_process_reaper_leaves_an_expired_container_lease_alone() {
         // the moment it is claimed).
         let lease = Uuid::new_v4();
         store
-            .claim_container_agent_run(run_id, lease, chrono::Duration::milliseconds(1))
+            .claim_container_agent_run(run_id, lease, chrono::Duration::milliseconds(1), 4)
             .await
             .unwrap()
             .expect("the container claim should pick up the queued run");
@@ -788,7 +789,7 @@ async fn admission_routes_to_the_container_location_not_the_in_process_scheduler
         // The container claim transitions it to running under a lease.
         let lease = Uuid::new_v4();
         let claimed = store
-            .claim_container_agent_run(run_id, lease, chrono::Duration::minutes(5))
+            .claim_container_agent_run(run_id, lease, chrono::Duration::minutes(5), 4)
             .await
             .unwrap()
             .expect("the container claim should pick up the queued run");
@@ -799,7 +800,7 @@ async fn admission_routes_to_the_container_location_not_the_in_process_scheduler
         // Re-claiming with the same token recovers the same live claim, never a
         // second attempt.
         let reclaimed = store
-            .claim_container_agent_run(run_id, lease, chrono::Duration::minutes(5))
+            .claim_container_agent_run(run_id, lease, chrono::Duration::minutes(5), 4)
             .await
             .unwrap()
             .expect("reusing the token recovers the live claim");
@@ -996,7 +997,7 @@ async fn a_dead_drivers_container_run_is_recovered_to_completion() {
         // its handle — then vanished, leaving the lease to expire.
         let dead_token = Uuid::new_v4();
         store
-            .claim_container_agent_run(run_id, dead_token, chrono::Duration::milliseconds(50))
+            .claim_container_agent_run(run_id, dead_token, chrono::Duration::milliseconds(50), 4)
             .await
             .unwrap()
             .expect("the dead driver's claim succeeds");
@@ -1054,7 +1055,7 @@ async fn a_terminal_container_failure_enqueues_its_teardown() {
     let run_uuid = *run_id.as_uuid();
     let token = Uuid::new_v4();
     store
-        .claim_container_agent_run(run_id, token, chrono::Duration::seconds(30))
+        .claim_container_agent_run(run_id, token, chrono::Duration::seconds(30), 4)
         .await
         .unwrap()
         .expect("the claim succeeds");
@@ -1088,6 +1089,56 @@ async fn a_terminal_container_failure_enqueues_its_teardown() {
     assert_eq!(teardowns.len(), 1);
     assert_eq!(teardowns[0].run_id, run_uuid);
     assert_eq!(teardowns[0].handle.as_deref(), Some("doomed-container"));
+}
+
+/// Container runs bypass the in-process scheduler's caps, so their own bound is
+/// enforced at the claim: a second claim past the cap is refused and the run
+/// stays queued, becoming claimable once a slot frees.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_container_claim_refuses_past_the_concurrency_cap() {
+    let (_dir, store, chat) = store().await;
+    // The cap is global across chats, so give each run its own chat (a chat
+    // runs one turn at a time, and the admit helper claims the chat's turn).
+    let other = Chat {
+        id: ChatId::new(),
+        title: Some("second container chat".into()),
+        ..chat.clone()
+    };
+    store.create_chat(&other).await.unwrap();
+    let first = admit_container_run(&store, chat.id, "occupies the only slot").await;
+    let second = admit_container_run(&store, other.id, "waits for the slot").await;
+
+    let first_token = Uuid::new_v4();
+    store
+        .claim_container_agent_run(first, first_token, chrono::Duration::seconds(30), 1)
+        .await
+        .unwrap()
+        .expect("the first claim takes the only slot");
+    assert!(
+        store
+            .claim_container_agent_run(second, Uuid::new_v4(), chrono::Duration::seconds(30), 1)
+            .await
+            .unwrap()
+            .is_none(),
+        "a claim past the cap must be refused, not queued into a second container"
+    );
+    // The refused run is still queued, not damaged: it claims once a slot frees.
+    store
+        .fail_agent_run(
+            first,
+            first_token,
+            "sandbox_agent_failed",
+            "released its slot",
+            chrono::Duration::seconds(1),
+        )
+        .await
+        .unwrap()
+        .expect("the first run fails terminally");
+    store
+        .claim_container_agent_run(second, Uuid::new_v4(), chrono::Duration::seconds(30), 1)
+        .await
+        .unwrap()
+        .expect("the freed slot admits the queued run");
 }
 
 // --- Docker end-to-end (gated on a container runtime + the agent image) -------


### PR DESCRIPTION
The concurrency bullet of #920: container runs bypass the in-process scheduler's global and per-chat caps entirely — nothing bounded how many containers a burst of spawns could stand up.

The bound now lives inside `claim_container_agent_run`, taken under the scheduler lock in the claim transaction so racing drivers cannot admit past it. Every `running` container run counts, live lease or not: an expired-lease run may still have a working container, so the count stays conservative until recovery or the deadline scan settles it. A refused claim leaves the run queued — it claims normally once a slot frees. Recovery (`reclaim_container_agent_run`) is exempt: a reclaimed run is already `running` and adds nothing to the count.

The driver's config gains `max_concurrent_containers` (default 4 — containers are heavier than in-process runs, and a small bound keeps a spawn burst from exhausting the local machine).

Tested: a second claim past a cap of 1 is refused across chats; the queued run claims as soon as the first run goes terminal.

Verified: container-run module 16 passed, core db suite 258 passed, clippy `-D warnings`, fmt, no lockfile drift.

Part of #920.