### PR TITLE
feat(server): retain a late container result as evidence, never commit it

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -311,6 +311,9 @@ pub mod sandbox_provision {
         pub state: String,
         /// The backend's sandbox reference, `NULL` until committed.
         pub handle: Option<String>,
+        /// A well-formed result that arrived after the run was already
+        /// terminal: retained as non-authoritative evidence, never committed.
+        pub late_result_evidence: Option<String>,
         /// When the provisioning window lapses for an `intended` record.
         pub window_expires_at: DateTimeUtc,
         pub created_at: DateTimeUtc,

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -93,7 +93,50 @@ impl MigratorTrait for Migrator {
             Box::new(RetireDocumentPipeline),
             Box::new(AddMessageDocumentAttachments),
             Box::new(AddSandboxProvision),
+            Box::new(AddLateResultEvidence),
         ]
+    }
+}
+
+/// Adds the late-result evidence column to the sandbox provisioning record
+/// (issue #920): a well-formed result that arrives after its container run is
+/// already terminal fails the fenced commit predicate — it must never commit —
+/// but it is still evidence of what the container produced, retained here for
+/// diagnosis. Purely additive nullable column with a symmetric `down`.
+struct AddLateResultEvidence;
+
+impl MigrationName for AddLateResultEvidence {
+    fn name(&self) -> &str {
+        "m20260730_000034_add_late_result_evidence"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddLateResultEvidence {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(SandboxProvision::Table)
+                    .add_column(
+                        ColumnDef::new(SandboxProvision::LateResultEvidence)
+                            .text()
+                            .null(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(SandboxProvision::Table)
+                    .drop_column(SandboxProvision::LateResultEvidence)
+                    .to_owned(),
+            )
+            .await
     }
 }
 
@@ -8801,6 +8844,7 @@ enum SandboxProvision {
     Tag,
     State,
     Handle,
+    LateResultEvidence,
     WindowExpiresAt,
     CreatedAt,
     UpdatedAt,

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -774,6 +774,21 @@ impl Store for DbStore {
         ops::sandbox_provision::list_teardowns(self).await
     }
 
+    async fn get_sandbox_provision(
+        &self,
+        run_id: uuid::Uuid,
+    ) -> Result<Option<crate::storage::SandboxProvision>> {
+        ops::sandbox_provision::get(self, run_id).await
+    }
+
+    async fn record_late_container_result_evidence(
+        &self,
+        run_id: uuid::Uuid,
+        text: &str,
+    ) -> Result<bool> {
+        ops::sandbox_provision::record_late_result_evidence(self, run_id, text).await
+    }
+
     async fn live_sandbox_tags(&self) -> Result<Vec<String>> {
         ops::sandbox_provision::live_tags(self).await
     }

--- a/crates/openwave-core/src/db/ops/sandbox_provision.rs
+++ b/crates/openwave-core/src/db/ops/sandbox_provision.rs
@@ -44,6 +44,7 @@ fn from_model(model: sandbox_provision::Model) -> SandboxProvision {
         tag: model.tag,
         state: state_from_str(&model.state),
         handle: model.handle,
+        late_result_evidence: model.late_result_evidence,
         window_expires_at: model.window_expires_at,
     }
 }
@@ -65,6 +66,7 @@ pub(in crate::db) async fn begin(
         tag: Set(tag.to_owned()),
         state: Set(STATE_INTENDED.to_owned()),
         handle: Set(None),
+        late_result_evidence: Set(None),
         window_expires_at: Set(window_expires_at),
         created_at: Set(now),
         updated_at: Set(now),
@@ -275,4 +277,39 @@ pub(in crate::db) async fn live_tags(store: &DbStore) -> Result<Vec<String>> {
         .into_iter()
         .map(|row| row.tag)
         .collect())
+}
+
+pub(in crate::db) async fn get(
+    store: &DbStore,
+    run_id: uuid::Uuid,
+) -> Result<Option<SandboxProvision>> {
+    Ok(entities::sandbox_provision::Entity::find_by_id(run_id)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .map(from_model))
+}
+
+pub(in crate::db) async fn record_late_result_evidence(
+    store: &DbStore,
+    run_id: uuid::Uuid,
+    text: &str,
+) -> Result<bool> {
+    // First writer wins: the NULL predicate makes a redelivered late result a
+    // no-op rather than an overwrite.
+    let updated = entities::sandbox_provision::Entity::update_many()
+        .col_expr(
+            sandbox_provision::Column::LateResultEvidence,
+            Expr::value(text),
+        )
+        .col_expr(
+            sandbox_provision::Column::UpdatedAt,
+            Expr::value(Utc::now()),
+        )
+        .filter(sandbox_provision::Column::RunId.eq(run_id))
+        .filter(sandbox_provision::Column::LateResultEvidence.is_null())
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(updated.rows_affected == 1)
 }

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1070,6 +1070,9 @@ pub struct SandboxProvision {
     pub state: SandboxProvisionState,
     /// The backend's own reference for the sandbox, present once committed.
     pub handle: Option<String>,
+    /// A well-formed result that arrived after the run was already terminal:
+    /// retained as non-authoritative evidence, never committed.
+    pub late_result_evidence: Option<String>,
     /// When the provisioning window lapses: an `Intended` record older than
     /// this failed its admission whether or not a create ever reached the
     /// provider.
@@ -1667,6 +1670,23 @@ pub trait Store: Send + Sync {
 
     /// Every record currently owing a teardown.
     async fn list_sandbox_teardowns(&self) -> Result<Vec<SandboxProvision>> {
+        agent_run_storage_unavailable()
+    }
+
+    /// One run's provisioning record, if any.
+    async fn get_sandbox_provision(&self, _run_id: uuid::Uuid) -> Result<Option<SandboxProvision>> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Retain a well-formed result that failed the fenced commit predicate —
+    /// the run was already terminal or the lease was gone — as
+    /// non-authoritative evidence on the provisioning record. First writer
+    /// wins; returns whether this call retained it. Never commits anything.
+    async fn record_late_container_result_evidence(
+        &self,
+        _run_id: uuid::Uuid,
+        _text: &str,
+    ) -> Result<bool> {
         agent_run_storage_unavailable()
     }
 

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -747,7 +747,26 @@ impl SandboxContainerRunner {
             Some(SubmitAgentRunResultOutcome::Existing(_)) => {
                 Ok(SandboxContainerRunOutcome::AlreadyCompleted(run_id))
             }
-            None => Ok(SandboxContainerRunOutcome::LeaseLost(run_id)),
+            None => {
+                // The fenced commit refused: the run is already terminal or the
+                // lease is gone. The container it truly ran in still produced a
+                // well-formed result — retain it as non-authoritative evidence
+                // on the provisioning record, never commit it.
+                match self
+                    .store
+                    .record_late_container_result_evidence(*run_id.as_uuid(), text)
+                    .await
+                {
+                    Ok(true) => eprintln!(
+                        "openwave: retained a late container result for run {run_id} as evidence"
+                    ),
+                    Ok(false) => {}
+                    Err(error) => eprintln!(
+                        "openwave: could not retain a late container result for run {run_id}: {error}"
+                    ),
+                }
+                Ok(SandboxContainerRunOutcome::LeaseLost(run_id))
+            }
         }
     }
 

--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -1141,6 +1141,71 @@ async fn the_container_claim_refuses_past_the_concurrency_cap() {
         .expect("the freed slot admits the queued run");
 }
 
+/// A well-formed result that arrives after the run is already terminal fails
+/// the fenced commit predicate and is retained as evidence instead — first
+/// writer wins, and nothing is ever committed from it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_late_result_is_retained_as_evidence_not_committed() {
+    let (_dir, store, chat) = store().await;
+    let run_id = admit_container_run(&store, chat.id, "finishes too late").await;
+    let run_uuid = *run_id.as_uuid();
+    let token = Uuid::new_v4();
+    store
+        .claim_container_agent_run(run_id, token, chrono::Duration::seconds(30), 4)
+        .await
+        .unwrap()
+        .expect("the claim succeeds");
+    store
+        .begin_sandbox_provision(
+            run_uuid,
+            &SandboxTag::new().to_string(),
+            chrono::Utc::now() + chrono::Duration::seconds(600),
+        )
+        .await
+        .unwrap();
+
+    // The run goes terminal (the deadline scan, a cancellation) while the
+    // container still works; its result then arrives and must not commit.
+    store
+        .fail_agent_run(
+            run_id,
+            token,
+            "deadline_exceeded",
+            "went terminal before the result arrived",
+            chrono::Duration::seconds(1),
+        )
+        .await
+        .unwrap()
+        .expect("the terminal failure commits");
+    assert!(store
+        .submit_agent_run_result(run_id, token, "the late answer")
+        .await
+        .unwrap()
+        .is_none());
+
+    assert!(store
+        .record_late_container_result_evidence(run_uuid, "the late answer")
+        .await
+        .unwrap());
+    // A redelivery is a no-op, not an overwrite.
+    assert!(!store
+        .record_late_container_result_evidence(run_uuid, "a different answer")
+        .await
+        .unwrap());
+    let record = store
+        .get_sandbox_provision(run_uuid)
+        .await
+        .unwrap()
+        .expect("the provisioning record exists");
+    assert_eq!(
+        record.late_result_evidence.as_deref(),
+        Some("the late answer")
+    );
+    // The run's authoritative outcome is still the failure.
+    let run = store.get_agent_run(run_id).await.unwrap().unwrap();
+    assert_eq!(run.status, AgentRunStatus::Failed);
+}
+
 // --- Docker end-to-end (gated on a container runtime + the agent image) -------
 
 /// Build the sandbox-agent image for the Docker-gated tests, returning its tag,


### PR DESCRIPTION
The late-result bullet of #920: a well-formed result that arrives after its container run is already terminal — the deadline scan fired, a cancellation landed — fails the fenced commit predicate and was silently dropped. The container it truly ran in still produced it, and it is worth keeping for diagnosis.

- New nullable `late_result_evidence` column on the `sandbox_provision` record (the run's durable container-scoped companion — deliberately not on `agent_run`, whose committed result stays the only authoritative outcome).
- `Store::record_late_container_result_evidence` retains it first-writer-wins: a redelivered late result is a no-op, never an overwrite. `Store::get_sandbox_provision` reads the record back.
- The driver's commit path calls it when the fenced commit refuses, then still reports `LeaseLost` — nothing about the run's outcome changes, and nothing is ever committed from the evidence.

Tested: a run failed terminally while its container still worked, the late submit refused, the evidence retained exactly once, a second delivery refused as a no-op, and the run's authoritative outcome still the failure.

Verified: container-run module tests, core db suite (migration up on both backends via the shared migrator), clippy `-D warnings`, fmt, postgres feature check. No lockfile drift.

Part of #920.