### PR TITLE
fix(mcp): bound the server's stdio frames, negotiate the protocol version, and cap call results

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -219,6 +219,14 @@ impl ToolRegistry {
         }
     }
 
+    /// Whether any tool is registered under `name`, whatever its execution
+    /// surface. Callers registering names they do not control use this to avoid
+    /// replacing an existing registration.
+    #[must_use]
+    pub fn contains(&self, name: &str) -> bool {
+        self.tools.contains_key(name)
+    }
+
     /// Resolve the trusted execution surface for a registered tool name.
     #[must_use]
     pub fn execution(&self, name: &str) -> Option<ToolCallExecution> {

--- a/crates/openwave-mcp/src/client.rs
+++ b/crates/openwave-mcp/src/client.rs
@@ -35,6 +35,13 @@ const MAX_TOOL_LIST_PAGES: usize = 64;
 const MAX_CURSOR_BYTES: usize = 4 * 1024;
 const MAX_UI_RESOURCE_URI_BYTES: usize = 2 * 1024;
 const MAX_RESOURCE_CONTENT_BYTES: usize = 1024 * 1024;
+/// A `tools/call` result is held to the same ceiling as a resource document: the
+/// two are the same kind of server-controlled payload, and both are bounded well
+/// under the durable clamp applied further down the pipeline.
+const MAX_CALL_RESULT_BYTES: usize = MAX_RESOURCE_CONTENT_BYTES;
+const CALL_RESULT_TRUNCATION_MARKER: &str = "\n… [truncated: MCP result exceeded 1 MiB]";
+const CALL_RESULT_DATA_DROPPED_MARKER: &str =
+    "\n… [dropped: MCP structured content exceeded 1 MiB]";
 pub(crate) const MAX_JSON_RPC_FRAME_BYTES: usize = 2 * 1024 * 1024;
 
 /// Default maximum time to wait for one external MCP request.
@@ -342,10 +349,19 @@ impl McpClient {
 
     /// Register namespaced proxies for all discovered tools.
     ///
-    /// Registry registration follows [`ToolRegistry::register`] semantics, so a
-    /// tool with the same fully-qualified name replaces an older registration.
-    pub fn mount(&self, registry: &mut ToolRegistry) {
+    /// An already-registered name is never replaced: built-in tools and tools
+    /// mounted from another server keep the name, and the refused names are
+    /// returned so the caller can report them. Silently taking over a name a
+    /// caller already relies on would let a remote server decide what `exec` or
+    /// `read_file` means; silently dropping the remote tool instead would hide
+    /// the collision, so the refusal is reported rather than swallowed.
+    pub fn mount(&self, registry: &mut ToolRegistry) -> Vec<String> {
+        let mut refused = Vec::new();
         for tool in &self.tools {
+            if registry.contains(&tool.spec.name) {
+                refused.push(tool.spec.name.clone());
+                continue;
+            }
             registry.register(Box::new(McpTool {
                 spec: tool.spec.clone(),
                 remote_name: tool.remote_name.clone(),
@@ -354,6 +370,7 @@ impl McpClient {
                 session: Arc::clone(&self.session),
             }));
         }
+        refused
     }
 }
 
@@ -949,15 +966,18 @@ impl Tool for McpTool {
                 ))
             })?;
         let result: CallToolResponse = decode_result("tools/call", result)?;
-        let content = result
-            .content
-            .iter()
-            .map(content_for_model)
-            .collect::<Vec<_>>()
-            .join("\n");
+        let (content, data) = clamp_call_result(
+            result
+                .content
+                .iter()
+                .map(content_for_model)
+                .collect::<Vec<_>>()
+                .join("\n"),
+            result.structured_content,
+        );
         Ok(ToolOutput {
             content,
-            data: result.structured_content,
+            data,
             is_error: result.is_error,
             // The external server reports that it failed, not why in terms this
             // side can classify, so it is the tool's own failure.
@@ -983,6 +1003,32 @@ struct CallToolResponse {
     structured_content: Option<Value>,
     #[serde(default, rename = "isError")]
     is_error: bool,
+}
+
+/// Bound a `tools/call` result at [`MAX_CALL_RESULT_BYTES`].
+///
+/// Both halves of the result are server-controlled, so both are clamped: the text
+/// is cut at a character boundary and the structured payload is dropped whole,
+/// because a partial JSON document is not a document. Either clamp leaves a
+/// marker in the text the model reads, so a shortened result never passes for a
+/// complete one.
+fn clamp_call_result(mut content: String, data: Option<Value>) -> (String, Option<Value>) {
+    if content.len() > MAX_CALL_RESULT_BYTES {
+        let mut cut = MAX_CALL_RESULT_BYTES - CALL_RESULT_TRUNCATION_MARKER.len();
+        while cut > 0 && !content.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        content.truncate(cut);
+        content.push_str(CALL_RESULT_TRUNCATION_MARKER);
+    }
+    let oversized_data = data.as_ref().is_some_and(|data| {
+        serde_json::to_vec(data).is_ok_and(|bytes| bytes.len() > MAX_CALL_RESULT_BYTES)
+    });
+    if oversized_data {
+        content.push_str(CALL_RESULT_DATA_DROPPED_MARKER);
+        return (content, None);
+    }
+    (content, data)
 }
 
 fn content_for_model(content: &Value) -> String {

--- a/crates/openwave-mcp/src/server.rs
+++ b/crates/openwave-mcp/src/server.rs
@@ -225,8 +225,25 @@ impl McpServer {
     }
 
     fn initialize(&self, params: Value) -> Result<Value, RpcError> {
-        let _params: InitializeParams = serde_json::from_value(params)
+        let params: InitializeParams = serde_json::from_value(params)
             .map_err(|e| RpcError::invalid_params(format!("invalid initialize params: {e}")))?;
+
+        // The protocol says the two sides agree on a version or the handshake
+        // fails. This face implements exactly one version, so a request for any
+        // other is refused with the supported set rather than answered with a
+        // version the client never asked for — the same strictness this crate's
+        // client applies to servers.
+        if params.protocol_version != PROTOCOL_VERSION {
+            let mut error = RpcError::invalid_params(format!(
+                "unsupported protocol version {}",
+                params.protocol_version
+            ));
+            error.data = Some(serde_json::json!({
+                "supported": [PROTOCOL_VERSION],
+                "requested": params.protocol_version,
+            }));
+            return Err(error);
+        }
 
         self.session_state
             .compare_exchange(
@@ -620,7 +637,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn server_negotiates_unsupported_protocol_version() {
+    async fn server_refuses_an_unsupported_protocol_version() {
         let server = server();
         let mut params = initialize_params();
         params["protocolVersion"] = json!("2099-01-01");
@@ -628,8 +645,18 @@ mod tests {
             .handle(request(1, "initialize", params))
             .await
             .unwrap();
+        let error = response.error.unwrap();
+        assert_eq!(error.code, error_code::INVALID_PARAMS);
+        assert_eq!(error.data.unwrap()["supported"], json!([PROTOCOL_VERSION]));
+
+        // A refused handshake leaves the session uninitialized, so the client can
+        // retry with a version this face speaks.
+        let retried = server
+            .handle(request(2, "initialize", initialize_params()))
+            .await
+            .unwrap();
         assert_eq!(
-            response.result.unwrap()["protocolVersion"],
+            retried.result.unwrap()["protocolVersion"],
             PROTOCOL_VERSION
         );
     }

--- a/crates/openwave-mcp/src/server.rs
+++ b/crates/openwave-mcp/src/server.rs
@@ -655,10 +655,7 @@ mod tests {
             .handle(request(2, "initialize", initialize_params()))
             .await
             .unwrap();
-        assert_eq!(
-            retried.result.unwrap()["protocolVersion"],
-            PROTOCOL_VERSION
-        );
+        assert_eq!(retried.result.unwrap()["protocolVersion"], PROTOCOL_VERSION);
     }
 
     #[tokio::test]

--- a/crates/openwave-mcp/src/stdio.rs
+++ b/crates/openwave-mcp/src/stdio.rs
@@ -7,6 +7,7 @@
 
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 
+use crate::client::MAX_JSON_RPC_FRAME_BYTES;
 use crate::protocol::{error_code, Request, Response, RpcError};
 use crate::server::McpServer;
 use serde_json::Value;
@@ -26,25 +27,97 @@ pub async fn serve_stdio(server: McpServer) -> std::io::Result<()> {
 /// Each non-blank input line is parsed as a JSON-RPC request and dispatched;
 /// responses (and parse errors) are written as one JSON line each. Notifications
 /// and blank lines produce no output. Returns when the reader reaches EOF.
-pub async fn serve<R, W>(reader: R, mut writer: W, server: McpServer) -> std::io::Result<()>
+///
+/// A frame longer than [`MAX_JSON_RPC_FRAME_BYTES`] — the same bound this crate's
+/// client applies to the identical framing — is refused rather than buffered, so
+/// a hostile or broken client cannot drive unbounded memory growth. The oversized
+/// frame is discarded up to its newline so the stream stays in sync, and the
+/// client gets a protocol error instead of a silently truncated request.
+pub async fn serve<R, W>(mut reader: R, mut writer: W, server: McpServer) -> std::io::Result<()>
 where
     R: AsyncBufRead + Unpin,
     W: AsyncWrite + Unpin,
 {
-    let mut lines = reader.lines();
-    while let Some(line) = lines.next_line().await? {
-        if line.trim().is_empty() {
-            continue;
-        }
-        let response = match parse_request(&line) {
-            Ok(request) => server.handle(request).await,
-            Err(error) => Some(Response::error(Value::Null, error)),
+    loop {
+        let Some(frame) = read_bounded_frame(&mut reader).await? else {
+            return Ok(());
+        };
+        let response = match frame {
+            Frame::Line(line) => {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                match parse_request(&line) {
+                    Ok(request) => server.handle(request).await,
+                    Err(error) => Some(Response::error(Value::Null, error)),
+                }
+            }
+            Frame::TooLarge => Some(Response::error(
+                Value::Null,
+                RpcError::new(
+                    error_code::INVALID_REQUEST,
+                    format!("request exceeds the {MAX_JSON_RPC_FRAME_BYTES}-byte frame limit"),
+                ),
+            )),
         };
         if let Some(response) = response {
             write_line(&mut writer, &response).await?;
         }
     }
-    Ok(())
+}
+
+/// One input frame: a complete line, or the marker that an oversized one was
+/// discarded.
+enum Frame {
+    Line(String),
+    TooLarge,
+}
+
+/// Read one newline-delimited frame, holding at most [`MAX_JSON_RPC_FRAME_BYTES`]
+/// in memory. Returns `None` at EOF with nothing buffered.
+async fn read_bounded_frame<R>(reader: &mut R) -> std::io::Result<Option<Frame>>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut line = Vec::new();
+    let mut over_limit = false;
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            if over_limit {
+                return Ok(Some(Frame::TooLarge));
+            }
+            return Ok((!line.is_empty()).then(|| Frame::Line(lossy_line(line))));
+        }
+        let newline = available.iter().position(|byte| *byte == b'\n');
+        let consumed = newline.map_or(available.len(), |index| index + 1);
+        if over_limit || line.len().saturating_add(consumed) > MAX_JSON_RPC_FRAME_BYTES {
+            // Keep draining to the newline so the next frame starts on a request
+            // boundary, but stop growing the buffer.
+            over_limit = true;
+            line = Vec::new();
+        } else {
+            line.extend_from_slice(&available[..consumed]);
+        }
+        reader.consume(consumed);
+        if newline.is_some() {
+            return Ok(Some(if over_limit {
+                Frame::TooLarge
+            } else {
+                Frame::Line(lossy_line(line))
+            }));
+        }
+    }
+}
+
+/// Decode a frame's bytes, trimming the delimiter. Invalid UTF-8 falls through to
+/// the parser, which reports it as a JSON parse error.
+fn lossy_line(bytes: Vec<u8>) -> String {
+    let mut line = String::from_utf8_lossy(&bytes).into_owned();
+    while line.ends_with('\n') || line.ends_with('\r') {
+        line.pop();
+    }
+    line
 }
 
 /// Parse one line into a [`Request`], distinguishing a syntax error (`-32700
@@ -133,5 +206,31 @@ mod tests {
         let response: serde_json::Value =
             serde_json::from_str(String::from_utf8(output).unwrap().trim()).unwrap();
         assert_eq!(response["error"]["code"], error_code::INVALID_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn an_oversized_frame_is_refused_without_desynchronizing_the_stream() {
+        let mut input = vec![b'x'; MAX_JSON_RPC_FRAME_BYTES + 1];
+        input.push(b'\n');
+        input.extend_from_slice(
+            br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}"#,
+        );
+        input.push(b'\n');
+
+        let mut output = Vec::new();
+        serve(&input[..], &mut output, empty_server())
+            .await
+            .unwrap();
+
+        let out = String::from_utf8(output).unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 2);
+        let refused: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(refused["error"]["code"], error_code::INVALID_REQUEST);
+        // The request after the oversized frame is still read as a request, so
+        // the discarded bytes did not shift the framing.
+        let accepted: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(accepted["id"], 1);
+        assert!(accepted["result"]["protocolVersion"].is_string());
     }
 }

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -831,9 +831,16 @@ impl McpRuntime {
 
     fn registry_for(&self, servers: &HashMap<String, ManagedServer>) -> ToolRegistry {
         let mut registry = self.base_tools.clone();
-        for server in servers.values() {
+        for (name, server) in servers {
             if let Some(client) = &server.client {
-                client.mount(&mut registry);
+                let refused = client.mount(&mut registry);
+                if !refused.is_empty() {
+                    tracing::warn!(
+                        server = %name,
+                        tools = %refused.join(", "),
+                        "MCP tools were not mounted because the names are already registered"
+                    );
+                }
             }
         }
         registry


### PR DESCRIPTION
The MCP server face was looser than this crate's own client on three protocol
points, and the mount path could take over a tool name it did not own.

**Frame bound.** The stdio transport read a line with no ceiling, so a hostile or
broken client could drive unbounded memory growth by never sending a newline. It
now reads frames through the same 2 MiB bound the client applies to the identical
framing. An oversized frame is refused with a JSON-RPC error rather than
truncated, and its bytes are drained up to the newline so the next request still
starts on a frame boundary — a refusal does not desynchronize the stream.

**Version negotiation.** `initialize` parsed the client's `protocolVersion` and
threw it away, always answering `2025-06-18` even when the client asked for
something else. It now answers only a version it speaks and otherwise fails the
handshake with `-32602` carrying the supported set, which is what the client half
of this crate already demands of external servers. A refused handshake leaves the
session uninitialized so a client can retry with a version this face speaks.

**Call-result cap.** Discovery metadata was bounded per tool and in aggregate, but
`tools/call` results were unbounded until the 512 KiB durable clamp far
downstream. Results are now held to the same 1 MiB ceiling as resource content —
the other server-controlled payload this client reads. Text is cut at a character
boundary; structured content is dropped whole, since a partial JSON document is
not a document. Either clamp leaves a marker in the text the model reads, so a
shortened result never passes for a complete one.

**Name shadowing.** Mounting registered through `ToolRegistry::register`, which
replaces by name. Mounted names are namespaced as `mcp__{server}__{tool}`, so a
remote server cannot reach `exec` today, but the registry was the only thing
standing between a mounted tool and a name the caller already relies on, and it
was not standing. `mount` now refuses any name that is already registered and
returns the refused names; the server logs them, so a dropped tool is visible
rather than silent. `ToolRegistry::contains` is the one addition on the core side.

Tests: the frame bound and the version handshake are protocol contracts and get
one test each. The existing version test asserted the discarded-and-overridden
behavior — that a request for `2099-01-01` still returned `2025-06-18` — and is
rewritten to assert the refusal and the retry.

Closes #1095
