### PR TITLE
fix(exec): pin directory descriptors when resolving scratch destinations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3844,6 +3844,8 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.23.0",
+ "cap-fs-ext",
+ "cap-std",
  "futures",
  "image",
  "libc",

--- a/crates/openwave-code-execution/Cargo.toml
+++ b/crates/openwave-code-execution/Cargo.toml
@@ -13,6 +13,8 @@ workspace = true
 [dependencies]
 async-trait = { workspace = true }
 base64 = { workspace = true }
+cap-fs-ext = { workspace = true }
+cap-std = { workspace = true }
 futures = { workspace = true }
 image = { version = "=0.25.10", default-features = false, features = ["png", "jpeg", "webp"] }
 openwave-core = { path = "../openwave-core", default-features = false }

--- a/crates/openwave-code-execution/src/host_paths.rs
+++ b/crates/openwave-code-execution/src/host_paths.rs
@@ -5,13 +5,32 @@
 //! the host itself does to that same directory — creating the conventional
 //! subdirectories, installing the bundled document helpers, mirroring a
 //! workspace back — runs unsandboxed, and `create_dir_all` and a plain `write`
-//! both follow a symlinked *parent*. So the host resolves one component at a
-//! time, refuses anything that is not already a real directory, and writes
-//! through a no-follow create rather than by path.
+//! both follow a symlinked *parent*.
+//!
+//! Resolving a path and then using that path is not enough, because the two
+//! steps are separated by real time. A resolver that checks the components and
+//! hands back a `PathBuf` invites every later `open` and `rename` to walk the
+//! tree again from `/`, and a process with write access to scratch can rename
+//! the verified directory aside and drop a symlink in its place in between.
+//! `O_NOFOLLOW` does not help: it guards the final component, and the escape
+//! happens at an intermediate one.
+//!
+//! So resolution here hands back an open descriptor, not a path. Each
+//! component is opened relative to its parent with symlink following disabled,
+//! and every subsequent read, write, and rename is issued relative to that
+//! descriptor. The directory a caller acts on is then the exact directory that
+//! was checked — renaming that name afterwards renames a directory the
+//! descriptor no longer refers to. [`ScratchDir`] deliberately exposes no way
+//! to recover the path it points at, so containment cannot be re-lost by a
+//! caller reaching for `join`.
 
-use std::path::{Path, PathBuf};
+use std::io;
+use std::path::Path;
+use std::sync::Arc;
 
-use tokio::io::AsyncWriteExt;
+use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt};
+use cap_std::ambient_authority;
+use cap_std::fs::{Dir, OpenOptions};
 
 /// Why a host directory under the private scratch tree was refused.
 ///
@@ -20,8 +39,7 @@ use tokio::io::AsyncWriteExt;
 /// probed, and collapsing them makes an attack read as noise.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ScratchRefusal {
-    /// A component tried to leave the root, or the resolved directory landed
-    /// outside it. Nothing legitimate aims there.
+    /// A component tried to leave the root. Nothing legitimate aims there.
     Escape,
     /// An intermediate component is a symlink. Following it is exactly the
     /// escape this resolver exists to refuse.
@@ -30,8 +48,8 @@ pub enum ScratchRefusal {
     /// symlink — a regular file where a directory was expected.
     NotADirectory,
     /// The directory is missing and could not be created, or could not be
-    /// canonicalized: a permissions failure, or a lost race with another
-    /// writer. Says nothing about the caller's intent.
+    /// opened: a permissions failure, or a lost race with another writer. Says
+    /// nothing about the caller's intent.
     Unavailable,
 }
 
@@ -40,6 +58,23 @@ impl ScratchRefusal {
     /// than the host failing at an ordinary filesystem operation.
     pub fn is_containment(self) -> bool {
         matches!(self, Self::Escape | Self::SymlinkedComponent)
+    }
+}
+
+/// A directory inside a chat's private scratch tree, held open as a descriptor.
+///
+/// Obtained from [`try_resolve_scratch_directory`], which proves containment
+/// while it walks. Every operation is relative to the pinned descriptor, so no
+/// operation re-resolves the path and none can be steered elsewhere after the
+/// walk.
+#[derive(Clone)]
+pub struct ScratchDir {
+    directory: Arc<Dir>,
+}
+
+impl std::fmt::Debug for ScratchDir {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.debug_struct("ScratchDir").finish_non_exhaustive()
     }
 }
 
@@ -52,86 +87,181 @@ pub async fn resolve_scratch_directory(
     root: &Path,
     relative: &str,
     create: bool,
-) -> Option<PathBuf> {
+) -> Option<ScratchDir> {
     try_resolve_scratch_directory(root, relative, create)
         .await
         .ok()
 }
 
 /// Resolve `relative` as a directory under `root` without walking through a
-/// symlink at any component.
+/// symlink at any component, and keep it open.
 ///
 /// Each intermediate component must already be a real directory; a symlink or
 /// a regular file refuses. With `create`, a missing component is created one
 /// level at a time, so a component planted between two host runs is seen
-/// rather than followed. The canonical result must still sit inside the
-/// canonical `root`.
+/// rather than followed.
+///
+/// `root` itself is opened with ambient authority and its symlinks are
+/// followed — macOS puts chat scratch under a symlinked `/var`, and the root is
+/// host-owned rather than sandbox-writable. Everything below it is descriptor
+/// relative, which is what makes containment structural: no later step consults
+/// a path, so there is nothing left to compare against the root.
 pub async fn try_resolve_scratch_directory(
     root: &Path,
     relative: &str,
     create: bool,
-) -> Result<PathBuf, ScratchRefusal> {
-    // macOS puts chat scratch under a symlinked `/var`, so containment is
-    // judged against the canonical root rather than the path as handed in.
-    let root = tokio::fs::canonicalize(root)
+) -> Result<ScratchDir, ScratchRefusal> {
+    let root = root.to_path_buf();
+    let relative = relative.to_owned();
+    let directory = tokio::task::spawn_blocking(move || resolve_blocking(&root, &relative, create))
         .await
+        .map_err(|_| ScratchRefusal::Unavailable)??;
+    Ok(ScratchDir {
+        directory: Arc::new(directory),
+    })
+}
+
+fn resolve_blocking(root: &Path, relative: &str, create: bool) -> Result<Dir, ScratchRefusal> {
+    let mut directory = Dir::open_ambient_dir(root, ambient_authority())
         .map_err(|_| ScratchRefusal::Unavailable)?;
-    let mut dir = root.clone();
     for component in relative.split('/').filter(|part| !part.is_empty()) {
         if component == "." || component == ".." {
             return Err(ScratchRefusal::Escape);
         }
-        dir.push(component);
-        match tokio::fs::symlink_metadata(&dir).await {
-            Ok(metadata) if metadata.is_dir() => {}
-            Ok(metadata) if metadata.is_symlink() => {
-                return Err(ScratchRefusal::SymlinkedComponent)
-            }
-            Ok(_) => return Err(ScratchRefusal::NotADirectory),
-            Err(_) if create => tokio::fs::create_dir(&dir)
-                .await
-                .map_err(|_| ScratchRefusal::Unavailable)?,
-            Err(_) => return Err(ScratchRefusal::Unavailable),
-        }
+        directory = match directory.open_dir_nofollow(component) {
+            Ok(child) => child,
+            // The open is what refuses; the stat below only decides which
+            // refusal to report, and it too is relative to the pinned parent.
+            Err(_) => match directory.symlink_metadata(component) {
+                Ok(metadata) if metadata.is_symlink() => {
+                    return Err(ScratchRefusal::SymlinkedComponent)
+                }
+                Ok(metadata) if !metadata.is_dir() => return Err(ScratchRefusal::NotADirectory),
+                Ok(_) => return Err(ScratchRefusal::Unavailable),
+                Err(_) if create => {
+                    // A racing writer that lands the name first makes this fail
+                    // with `EEXIST`: closed, never adopted and never followed.
+                    directory
+                        .create_dir(component)
+                        .map_err(|_| ScratchRefusal::Unavailable)?;
+                    directory
+                        .open_dir_nofollow(component)
+                        .map_err(|_| ScratchRefusal::Unavailable)?
+                }
+                Err(_) => return Err(ScratchRefusal::Unavailable),
+            },
+        };
     }
-    let resolved = tokio::fs::canonicalize(&dir)
-        .await
-        .map_err(|_| ScratchRefusal::Unavailable)?;
-    if !resolved.starts_with(&root) {
-        return Err(ScratchRefusal::Escape);
-    }
-    Ok(resolved)
+    Ok(directory)
 }
 
-/// Write `content` at `host_path` without following a symlink at the final
-/// component either: the bytes go to an unpredictable temp name opened with an
-/// exclusive no-follow create, then a rename puts them in place. This is the
-/// same shape the workspace-put path in `local.rs` uses.
-pub async fn write_without_following(host_path: &Path, content: &[u8]) -> std::io::Result<()> {
-    let parent = host_path
-        .parent()
-        .ok_or_else(|| std::io::Error::other("host path has no parent"))?;
-    let temporary = parent.join(format!(".openwave-write.{}", uuid::Uuid::new_v4()));
-    let mut options = tokio::fs::OpenOptions::new();
-    options.write(true).create_new(true);
+impl ScratchDir {
+    /// Write `content` at `name` inside this directory without following a
+    /// symlink at the final component either: the bytes go to an unpredictable
+    /// temp name opened with an exclusive no-follow create, then a rename puts
+    /// them in place. Both operations are relative to the pinned descriptor.
+    pub async fn write_file(&self, name: &str, content: &[u8]) -> io::Result<()> {
+        let name = single_component(name)?;
+        let content = content.to_vec();
+        self.blocking(move |directory| write_blocking(directory, &name, &content))
+            .await
+    }
+
+    /// Read `name` inside this directory, refusing a symlink at the final
+    /// component rather than following it.
+    pub async fn read_file(&self, name: &str) -> io::Result<Vec<u8>> {
+        let file = self.open_file(name).await?;
+        tokio::task::spawn_blocking(move || {
+            use std::io::Read as _;
+            let mut file = file;
+            let mut content = Vec::new();
+            file.read_to_end(&mut content)?;
+            Ok(content)
+        })
+        .await
+        .map_err(|_| io::Error::other("scratch read did not complete"))?
+    }
+
+    /// Open `name` inside this directory for reading, refusing a symlink at the
+    /// final component. The returned handle is already pinned, so judging it by
+    /// `metadata()` reads the file that was opened rather than re-statting a
+    /// path that may since have changed.
+    pub async fn open_file(&self, name: &str) -> io::Result<std::fs::File> {
+        let name = single_component(name)?;
+        self.blocking(move |directory| {
+            let mut options = OpenOptions::new();
+            options.read(true).follow(FollowSymlinks::No);
+            Ok(directory.open_with(&name, &options)?.into_std())
+        })
+        .await
+    }
+
+    /// Whether `name` inside this directory is a symlink. Used only to explain
+    /// a refusal — the no-follow open and write are what enforce it.
+    pub async fn is_symlink(&self, name: &str) -> bool {
+        let Ok(name) = single_component(name) else {
+            return false;
+        };
+        self.blocking(move |directory| {
+            Ok(directory
+                .symlink_metadata(&name)
+                .is_ok_and(|metadata| metadata.is_symlink()))
+        })
+        .await
+        .unwrap_or(false)
+    }
+
+    async fn blocking<T, F>(&self, work: F) -> io::Result<T>
+    where
+        F: FnOnce(&Dir) -> io::Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let directory = Arc::clone(&self.directory);
+        tokio::task::spawn_blocking(move || work(&directory))
+            .await
+            .map_err(|_| io::Error::other("scratch operation did not complete"))?
+    }
+}
+
+fn write_blocking(directory: &Dir, name: &str, content: &[u8]) -> io::Result<()> {
+    use std::io::Write as _;
+
+    // A process with write access to chat scratch could plant a symlink at a
+    // guessable temp path, so the name is unpredictable and the create is
+    // exclusive and no-follow: it fails rather than following anything that is
+    // already there.
+    let temporary = format!(".openwave-write.{}", uuid::Uuid::new_v4());
+    let mut options = OpenOptions::new();
+    options
+        .write(true)
+        .create_new(true)
+        .follow(FollowSymlinks::No);
     #[cfg(unix)]
     {
+        use cap_std::fs::OpenOptionsExt as _;
         options.mode(0o600);
-        options.custom_flags(libc::O_NOFOLLOW);
     }
-    let mut file = options.open(&temporary).await?;
-    let write = async {
-        file.write_all(content).await?;
-        file.sync_all().await?;
-        tokio::fs::rename(&temporary, host_path).await
-    };
-    match write.await {
-        Ok(()) => Ok(()),
-        Err(error) => {
-            let _ = tokio::fs::remove_file(&temporary).await;
-            Err(error)
-        }
+    let mut file = directory.open_with(&temporary, &options)?;
+    let write = file
+        .write_all(content)
+        .and_then(|()| file.sync_all())
+        .and_then(|()| directory.rename(&temporary, directory, name));
+    if write.is_err() {
+        let _ = directory.remove_file(&temporary);
     }
+    write
+}
+
+/// Names addressed inside a pinned directory must be a single ordinary
+/// component. A nested path would be walked by the filesystem rather than by
+/// [`try_resolve_scratch_directory`], which is exactly the resolution this
+/// module exists to take over.
+fn single_component(name: &str) -> io::Result<String> {
+    let separated = name.contains('/') || (cfg!(windows) && name.contains(['\\', ':']));
+    if name.is_empty() || name == "." || name == ".." || separated {
+        return Err(io::Error::other("scratch entry name is not one component"));
+    }
+    Ok(name.to_owned())
 }
 
 #[cfg(all(test, unix))]
@@ -143,21 +273,88 @@ mod tests {
         let outside = tempfile::tempdir().unwrap();
         let root = tempfile::tempdir().unwrap();
         std::os::unix::fs::symlink(outside.path(), root.path().join("planted")).unwrap();
+        std::fs::write(root.path().join("file"), b"not a directory").unwrap();
+        let root_path = root.path();
 
-        assert!(resolve_scratch_directory(root.path(), "planted", true)
-            .await
-            .is_none());
-        assert!(
-            resolve_scratch_directory(root.path(), "planted/deeper", true)
+        let refusal = |relative: &'static str| async move {
+            try_resolve_scratch_directory(root_path, relative, true)
                 .await
-                .is_none()
+                .err()
+        };
+        assert_eq!(
+            refusal("planted/deeper").await,
+            Some(ScratchRefusal::SymlinkedComponent)
         );
+        assert_eq!(
+            refusal("file/deeper").await,
+            Some(ScratchRefusal::NotADirectory)
+        );
+        assert_eq!(refusal("../escape").await, Some(ScratchRefusal::Escape));
         assert!(!outside.path().join("deeper").exists());
 
         let made = resolve_scratch_directory(root.path(), "real/nested", true)
             .await
             .unwrap();
-        assert!(made.is_dir());
-        assert!(made.starts_with(root.path().canonicalize().unwrap()));
+        made.write_file("f.txt", b"inside").await.unwrap();
+        assert_eq!(
+            std::fs::read(root.path().join("real/nested/f.txt")).unwrap(),
+            b"inside"
+        );
+    }
+
+    /// The property the pinning buys, without racing anything: swap the
+    /// directory out from under a handle that has already been resolved, then
+    /// write through the handle. A resolver that returned a path would rewalk
+    /// the tree and land in the attacker's target; a pinned descriptor still
+    /// refers to the directory that was checked.
+    #[tokio::test]
+    async fn a_resolved_directory_swapped_for_a_symlink_is_still_the_directory_checked() {
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("authorized_keys"), b"host secret").unwrap();
+        let root = tempfile::tempdir().unwrap();
+
+        let pinned = resolve_scratch_directory(root.path(), "out", true)
+            .await
+            .unwrap();
+
+        // Exactly the move the resolve-then-use-by-path shape loses to: the
+        // verified directory is renamed aside and a symlink takes its name.
+        std::fs::rename(root.path().join("out"), root.path().join("moved")).unwrap();
+        std::os::unix::fs::symlink(outside.path(), root.path().join("out")).unwrap();
+
+        pinned
+            .write_file("authorized_keys", b"attacker key")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read(outside.path().join("authorized_keys")).unwrap(),
+            b"host secret"
+        );
+        assert_eq!(
+            std::fs::read(root.path().join("moved/authorized_keys")).unwrap(),
+            b"attacker key"
+        );
+    }
+
+    #[tokio::test]
+    async fn reads_and_writes_refuse_a_symlink_at_the_final_component() {
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret"), b"host secret").unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let pinned = resolve_scratch_directory(root.path(), "", false)
+            .await
+            .unwrap();
+        std::os::unix::fs::symlink(outside.path().join("secret"), root.path().join("link"))
+            .unwrap();
+
+        assert!(pinned.is_symlink("link").await);
+        assert!(pinned.read_file("link").await.is_err());
+        // The write replaces the link itself rather than writing through it.
+        pinned.write_file("link", b"replacement").await.unwrap();
+        assert_eq!(
+            std::fs::read(outside.path().join("secret")).unwrap(),
+            b"host secret"
+        );
     }
 }

--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -27,8 +27,7 @@ mod types;
 pub use daytona::{DaytonaCredential, DaytonaExecutionProvider, DAYTONA_CREDENTIAL_KEY};
 pub use e2b::{E2BCredential, E2BExecutionProvider, E2B_CREDENTIAL_KEY};
 pub use host_paths::{
-    resolve_scratch_directory, try_resolve_scratch_directory, write_without_following,
-    ScratchRefusal,
+    resolve_scratch_directory, try_resolve_scratch_directory, ScratchDir, ScratchRefusal,
 };
 pub use local::LocalExecutionProvider;
 pub use preview::{scan_preview_directory, PreviewScan};

--- a/crates/openwave-code-execution/src/local.rs
+++ b/crates/openwave-code-execution/src/local.rs
@@ -19,7 +19,7 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 #[cfg(target_os = "macos")]
 use tokio::process::Command;
 
-use crate::host_paths::resolve_scratch_directory;
+use crate::host_paths::{resolve_scratch_directory, ScratchDir};
 #[cfg(target_os = "macos")]
 use crate::output::{Capture, StreamKind};
 use crate::receipt::{request_fingerprint, BeginExecution, ExecutionReceipt};
@@ -194,27 +194,27 @@ impl LocalExecutionProvider {
             .ok_or_else(|| CodeExecutionError::Sandbox("private workspace is unavailable".into()))
     }
 
-    /// Resolve `path`'s parent inside `workspace` and rejoin the final
-    /// component, so a symlinked intermediate directory cannot escape the
-    /// workspace. The final component's own type is checked separately.
+    /// Open `path`'s parent directory inside `workspace` as a pinned
+    /// descriptor, so a symlinked intermediate directory cannot escape the
+    /// workspace and cannot be swapped for one after the check. The final
+    /// component's own type is checked separately, against that descriptor.
     ///
     /// Resolution walks one component at a time and establishes containment
     /// before creating anything, so a write through a planted symlinked parent
     /// refuses without having made directories outside the workspace first.
     /// `None` means the parent did not resolve inside the workspace — a missing
     /// directory, a planted symlink, or a component that is not a directory.
-    async fn resolve_file(
+    async fn resolve_parent(
         workspace: &Path,
         path: &WorkspaceFilePath,
         create_parents: bool,
-    ) -> Option<PathBuf> {
+    ) -> Option<ScratchDir> {
         let relative = path.as_str();
         let parent = relative
             .rsplit_once('/')
             .map(|(parent, _)| parent)
             .unwrap_or("");
-        let parent = resolve_scratch_directory(workspace, parent, create_parents).await?;
-        Some(parent.join(path.file_name()))
+        resolve_scratch_directory(workspace, parent, create_parents).await
     }
 }
 
@@ -339,41 +339,21 @@ impl WorkspaceLifecycle for LocalExecutionProvider {
             return Err(CodeExecutionError::WorkspaceFileTooLarge);
         }
         let workspace = self.ensured_workspace(workspace)?;
-        let target = Self::resolve_file(&workspace, path, true)
+        let parent = Self::resolve_parent(&workspace, path, true)
             .await
             .ok_or_else(|| {
                 CodeExecutionError::Sandbox("workspace directories are unavailable".into())
             })?;
-        // The final `target` is written by an atomic rename, so its own type is
-        // not load-bearing for containment — the temp file below is what we
-        // actually write into, and it must not be a pre-planted symlink. A
-        // process with write access to chat scratch (an exec-tool command runs
-        // Seatbelt-confined to this same root) could otherwise plant a symlink
-        // at a guessable temp path and redirect the unsandboxed host write onto
-        // an arbitrary host file. Two defenses close that: an unpredictable
-        // temp name, and an exclusive, no-follow create that fails rather than
-        // following anything that already exists at the path.
-        let parent = target
-            .parent()
-            .ok_or_else(|| CodeExecutionError::Sandbox("workspace path has no parent".into()))?;
-        let temporary = parent.join(format!(".workspace-put.{}", uuid::Uuid::new_v4()));
-        let mut options = OpenOptions::new();
-        options.write(true).create_new(true);
-        #[cfg(unix)]
-        {
-            options.mode(0o600);
-            options.custom_flags(libc::O_NOFOLLOW);
-        }
-        let mut file = options.open(&temporary).map_err(|_| {
-            CodeExecutionError::Sandbox("could not write the workspace file".into())
-        })?;
-        file.write_all(content)
-            .and_then(|()| file.sync_all())
-            .and_then(|()| fs::rename(&temporary, &target))
-            .map_err(|_| {
-                let _ = fs::remove_file(&temporary);
-                CodeExecutionError::Sandbox("could not write the workspace file".into())
-            })
+        // The write goes to an unpredictable temp name created exclusively and
+        // without following, then renamed into place — both relative to the
+        // pinned parent. A process with write access to chat scratch (an
+        // exec-tool command runs Seatbelt-confined to this same root) can
+        // neither pre-plant a symlink at the temp path nor swap the parent
+        // directory itself for one after it was resolved.
+        parent
+            .write_file(path.file_name(), content)
+            .await
+            .map_err(|_| CodeExecutionError::Sandbox("could not write the workspace file".into()))
     }
 
     async fn get_workspace_file(
@@ -387,57 +367,30 @@ impl WorkspaceLifecycle for LocalExecutionProvider {
         let Some(workspace) = Self::workspace_in(&root, workspace, false)? else {
             return Err(CodeExecutionError::WorkspaceFileNotFound);
         };
-        let Some(target) = Self::resolve_file(&workspace, path, false).await else {
+        let Some(parent) = Self::resolve_parent(&workspace, path, false).await else {
             return Err(CodeExecutionError::WorkspaceFileNotFound);
         };
-        // Open without following the final component, then judge the opened
-        // descriptor — never a path stat'd separately from the open. A
-        // lstat-then-open read races a writer that keeps the path a regular
-        // file at the check and swaps in a symlink to a host secret before the
-        // open, so on unix containment comes from the descriptor we actually
-        // read (O_NOFOLLOW + fstat below).
-        //
-        // Without O_NOFOLLOW we cannot refuse a final symlink at open time, so
-        // restore the prior cross-platform guard: reject a symlinked final
-        // component with a pre-open lstat. This is the same lstat-then-open
-        // shape the unix path deliberately abandons, kept here only to preserve
-        // the earlier refusal rather than to defend against a local race the
-        // platform cannot express away.
-        #[cfg(not(unix))]
-        match fs::symlink_metadata(&target) {
-            Ok(metadata) if metadata.file_type().is_symlink() => {
-                return Err(CodeExecutionError::InvalidRequest(
-                    "workspace path is not a regular file".into(),
-                ));
-            }
-            Ok(_) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                return Err(CodeExecutionError::WorkspaceFileNotFound);
-            }
-            Err(_) => {
-                return Err(CodeExecutionError::Sandbox(
-                    "could not read the workspace file".into(),
-                ));
-            }
-        }
-        let mut open = OpenOptions::new();
-        open.read(true);
-        #[cfg(unix)]
-        open.custom_flags(libc::O_NOFOLLOW);
-        let file = match open.open(&target) {
+        // Open relative to the pinned parent without following the final
+        // component, then judge the opened descriptor — never a path stat'd
+        // separately from the open. A resolve-then-open-by-path read races a
+        // writer that keeps the path a regular file at the check and swaps in a
+        // symlink to a host secret before the open; containment here comes from
+        // the descriptors actually used.
+        let file = match parent.open_file(path.file_name()).await {
             Ok(file) => file,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                return Err(CodeExecutionError::WorkspaceFileNotFound);
-            }
-            // A final symlink fails the no-follow open with ELOOP; report it as
-            // an invalid path rather than a missing file so a planted symlink
-            // is not silently indistinguishable from absence.
-            Err(error) if is_symlink_loop(&error) => {
-                return Err(CodeExecutionError::InvalidRequest(
-                    "workspace path is not a regular file".into(),
-                ));
-            }
-            Err(_) => {
+            Err(error) => {
+                // A planted symlink fails the no-follow open. Label it as an
+                // invalid path rather than a missing file so it is not silently
+                // indistinguishable from absence; the stat explains the refusal
+                // and is not what enforced it.
+                if parent.is_symlink(path.file_name()).await {
+                    return Err(CodeExecutionError::InvalidRequest(
+                        "workspace path is not a regular file".into(),
+                    ));
+                }
+                if error.kind() == std::io::ErrorKind::NotFound {
+                    return Err(CodeExecutionError::WorkspaceFileNotFound);
+                }
                 return Err(CodeExecutionError::Sandbox(
                     "could not read the workspace file".into(),
                 ));
@@ -640,17 +593,6 @@ fn finish_execution(path: &Path, receipt: &ExecutionReceipt) -> Result<(), CodeE
 
 fn sync_dir(path: &Path) -> std::io::Result<()> {
     fs::File::open(path)?.sync_all()
-}
-
-/// Whether an open error is the no-follow refusal of a final symlink.
-#[cfg(unix)]
-fn is_symlink_loop(error: &std::io::Error) -> bool {
-    error.raw_os_error() == Some(libc::ELOOP)
-}
-
-#[cfg(not(unix))]
-fn is_symlink_loop(_error: &std::io::Error) -> bool {
-    false
 }
 
 fn secure_dir(path: &Path) -> Result<(), CodeExecutionError> {

--- a/crates/openwave-code-execution/src/sync.rs
+++ b/crates/openwave-code-execution/src/sync.rs
@@ -13,7 +13,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::host_paths::{try_resolve_scratch_directory, write_without_following, ScratchRefusal};
+use crate::host_paths::{try_resolve_scratch_directory, ScratchDir, ScratchRefusal};
 use crate::{
     CodeExecutionError, ExecutionWorkspaceId, WorkspaceFilePath, WorkspaceLifecycle,
     MAX_WORKSPACE_FILE_BYTES,
@@ -196,13 +196,7 @@ pub async fn pull_into_host_dir(
     if files.is_empty() {
         return Ok(report);
     }
-    // Every write below is bounded by the canonical host directory. macOS puts
-    // chat scratch under a symlinked `/var`, so comparing against the path as
-    // handed in would reject legitimate files.
     tokio::fs::create_dir_all(host_dir)
-        .await
-        .map_err(|_| unwritable_dir())?;
-    let host_root = tokio::fs::canonicalize(host_dir)
         .await
         .map_err(|_| unwritable_dir())?;
     for path in files {
@@ -221,20 +215,21 @@ pub async fn pull_into_host_dir(
                 continue;
             }
         };
-        let host_path = match host_file_path(&host_root, &path).await {
-            Ok(host_path) => host_path,
+        let parent = match host_parent_dir(host_dir, &path).await {
+            Ok(parent) => parent,
             Err(refusal) => {
                 refuse(&mut report, &path, refusal);
                 continue;
             }
         };
-        // Read for the equality shortcut only after the symlink check: reading
-        // by path follows a symlink at the final component, which would turn a
-        // planted link into a content-equality oracle on a host file.
-        if tokio::fs::symlink_metadata(&host_path)
-            .await
-            .is_ok_and(|metadata| metadata.is_symlink())
-        {
+        // Everything below addresses `name` inside the pinned parent, so the
+        // entry judged here is the entry written; nothing in between re-walks
+        // the scratch tree from `/`.
+        let name = path.file_name();
+        // Read for the equality shortcut only after the symlink check: a
+        // planted link should be reported as one rather than becoming a
+        // content-equality oracle on whatever it points at.
+        if parent.is_symlink(name).await {
             tracing::warn!(
                 "workspace pull refused: '{}' is a symlink on the host",
                 path.as_str()
@@ -245,12 +240,13 @@ pub async fn pull_into_host_dir(
             ));
             continue;
         }
-        if let Ok(existing) = tokio::fs::read(&host_path).await {
+        if let Ok(existing) = parent.read_file(name).await {
             if existing == content {
                 continue;
             }
         }
-        write_without_following(&host_path, &content)
+        parent
+            .write_file(name, &content)
             .await
             .map_err(|_| unwritable(path.as_str()))?;
         report.transferred += 1;
@@ -258,23 +254,25 @@ pub async fn pull_into_host_dir(
     Ok(report)
 }
 
-/// Where `path` lands under `host_root`, creating missing parent directories
-/// only through components already proven to be real directories.
+/// The pinned directory `path`'s file lands in under `host_dir`, creating
+/// missing parents only through components already proven to be real
+/// directories.
 ///
 /// Local exec is confined to this same scratch tree, so it can plant
 /// `<scratch>/out -> ~/.ssh` and wait for a pull: `create_dir_all` and a plain
 /// `write` both follow a symlinked *parent*, and the pull's host write is not
-/// sandboxed.
-async fn host_file_path(
-    host_root: &Path,
+/// sandboxed. Handing back a descriptor rather than a path also closes the
+/// window between the walk and the write, which a process still running in
+/// scratch could otherwise use to swap the verified directory for a symlink.
+async fn host_parent_dir(
+    host_dir: &Path,
     path: &WorkspaceFilePath,
-) -> Result<PathBuf, ScratchRefusal> {
+) -> Result<ScratchDir, ScratchRefusal> {
     let parent = path
         .as_str()
         .rsplit_once('/')
         .map_or("", |(parent, _)| parent);
-    let dir = try_resolve_scratch_directory(host_root, parent, true).await?;
-    Ok(dir.join(path.file_name()))
+    try_resolve_scratch_directory(host_dir, parent, true).await
 }
 
 /// Record a refused file in the report and, for the containment cases, on the

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -14,10 +14,10 @@ use std::time::Duration;
 use async_trait::async_trait;
 use chrono::Utc;
 use openwave_code_execution::{
-    resolve_scratch_directory, sync, write_without_following, CodeExecutionError,
-    CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest, CodeExecutionResponse,
-    DaytonaCredential, DaytonaExecutionProvider, E2BCredential, E2BExecutionProvider,
-    ExecFolderAccess, ExecFolderGrant, ExecutionId, ExecutionWorkspaceId, LocalExecutionProvider,
+    resolve_scratch_directory, sync, CodeExecutionError, CodeExecutionProvider,
+    CodeExecutionProviderKind, CodeExecutionRequest, CodeExecutionResponse, DaytonaCredential,
+    DaytonaExecutionProvider, E2BCredential, E2BExecutionProvider, ExecFolderAccess,
+    ExecFolderGrant, ExecutionId, ExecutionWorkspaceId, LocalExecutionProvider,
     OutputArtifactEntry, OutputArtifactScan, OutputArtifactStatus, PreviewScan, RemoteSessionPool,
     WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, DAYTONA_CREDENTIAL_KEY,
     DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES, E2B_CREDENTIAL_KEY,
@@ -1062,8 +1062,9 @@ async fn prepare_execution_directories(
     // everything inside it is writable by local exec, which can plant
     // `<scratch>/output -> /any/dir` between two runs. `create_dir_all` and a
     // plain `write` both follow a symlinked parent, so each conventional
-    // directory is resolved a component at a time and the marker is written
-    // without following a link at the final component either.
+    // directory is resolved a component at a time into an open descriptor and
+    // the marker is written relative to that descriptor, without following a
+    // link at the final component either.
     tokio::fs::create_dir_all(host_dir).await.map_err(|_| {
         CodeExecutionError::Sandbox("the private workspace directory is unavailable".into())
     })?;
@@ -1080,7 +1081,8 @@ async fn prepare_execution_directories(
             // The sync protocol mirrors files rather than empty directories.
             // A hidden zero-byte marker makes the conventional directories
             // exist in managed workspaces without becoming a user artifact.
-            write_without_following(&directory.join(".openwave-directory"), &[])
+            directory
+                .write_file(".openwave-directory", &[])
                 .await
                 .map_err(|_| unavailable())?;
         }
@@ -1097,7 +1099,9 @@ async fn install_document_scripts(
 ) -> std::result::Result<(), CodeExecutionError> {
     // `.openwave/` sits inside the scratch directory local exec writes to, so
     // a planted `.openwave -> /elsewhere` would relocate the helper install
-    // and truncate known filenames there. Resolve it a component at a time.
+    // and truncate known filenames there. Resolve it a component at a time and
+    // keep the descriptor, so the helpers land in the directory the walk proved
+    // rather than whatever the name points at by the time we write.
     let destination = resolve_scratch_directory(host_dir, DOCUMENT_SCRIPTS_DIR, true)
         .await
         .ok_or_else(|| {
@@ -1127,13 +1131,11 @@ async fn install_document_scripts(
                 "bundled document helper '{name}' exceeds the workspace file limit"
             )));
         }
-        write_without_following(&destination.join(name), &content)
-            .await
-            .map_err(|_| {
-                CodeExecutionError::Sandbox(format!(
-                    "bundled document helper '{name}' could not be installed"
-                ))
-            })?;
+        destination.write_file(name, &content).await.map_err(|_| {
+            CodeExecutionError::Sandbox(format!(
+                "bundled document helper '{name}' could not be installed"
+            ))
+        })?;
     }
     Ok(())
 }


### PR DESCRIPTION
Host-side scratch resolution walked the path one component at a time and handed back a `PathBuf`. Every later use — the pull's symlink check, its read, the temp-file create, the rename into place — re-resolved that path from `/`, so the containment the walk established only held at the instant it was measured.

A process with write access to the chat's scratch tree can rename the verified directory aside and drop a symlink in its place between the two steps. `O_NOFOLLOW` guards only the final component, so the planted intermediate is followed and the write lands outside the root; on a cross-device rename failure the cleanup then unlinks through the same symlink. The window is a few `spawn_blocking` round trips wide and the pull retries it once per file, up to `MAX_SYNC_FILES`, with unlimited pulls available.

It needs a process writing into scratch concurrently with a pull. Local exec is the only thing with that access, and its cleanup is `signal_group(pgid, SIGKILL)` while `process-fork`/`process-exec` are permitted, so a child that calls `setsid()` outlives it: local exec daemonizes a flip loop, the chat switches to a remote provider, and the next pull loses the race.

## What changed

Resolution returns an open descriptor instead of a path. `ScratchDir` opens each component relative to its parent with symlink following disabled and issues every subsequent read, open, write, and rename relative to that descriptor, so the directory a caller acts on is the directory that was checked — renaming that name afterwards renames a directory the descriptor no longer refers to. It exposes no accessor for the path it points at, which is what keeps the guarantee from being re-lost by a caller reaching for `join`.

Containment stops being a `starts_with` comparison against a canonicalized root and becomes structural: there is no path left for a later step to consult. The refusals the walk already made are unchanged — a symlinked component, a component that is not a directory, `.`/`..` — and a racing `create_dir` still fails closed with `EEXIST` rather than adopting whatever appeared. `ScratchRefusal` and the host-side warning on containment refusals survive intact; the stat that picks which refusal to report now runs against the pinned parent and only labels it, because the no-follow open is what refused.

The walk uses `cap-std`, already in the workspace and already used for exactly this in `openwave-host-broker`'s root policy. It covers Windows, which a hand-rolled `openat` would not, and it lets the local provider's read drop its separate non-unix lstat guard now that the no-follow open is cross-platform. Both new dependency edges resolve to versions already in the lockfile.

All four callers move over: the workspace mirror's pull, the local provider's workspace put and get, and the server's conventional-directory and document-helper installs.

## Tests

One added, in `host_paths`. A genuine race test would be flaky and would not tell us anything we would act on, so it asserts the structural property deterministically instead: resolve a directory, then rename it aside and plant a symlink at its name, then write through the handle. A resolver that returned a path lands the bytes in the symlink's target; the pinned descriptor still writes into the directory that was checked, and the test asserts both halves. A second test covers the no-follow read and the replace-the-link-rather-than-write-through-it behaviour of the final component, and the existing resolver test now pins each `ScratchRefusal` variant rather than only that a refusal happened.

The existing pull and local-provider symlink tests are unmodified and still pass, which is the point — the refusal semantics did not move, only where they are enforced.

Closes #1127
