### PR TITLE
fix(host-broker): refuse host mutations that cannot be recorded

### DIFF
--- a/crates/openwave-host-broker/src/audit.rs
+++ b/crates/openwave-host-broker/src/audit.rs
@@ -3,6 +3,13 @@
 //! Audit targets contain opaque root identities and bounded root-relative paths,
 //! never absolute host paths or file contents. The durable sink appends one
 //! fsync'd JSON record at a time and rotates within a fixed local retention bound.
+//!
+//! Recording is a precondition for mutating the host, not a report about it: the
+//! broker writes an [`AuditOutcome::Attempted`] record before it touches
+//! anything and refuses the operation if that record cannot be made durable. The
+//! sink therefore never reports success it did not achieve, and never disables
+//! itself — a host that cannot hold the log right now blocks mutations until it
+//! can, and resumes on its own once the failure clears.
 
 use std::{
     collections::VecDeque,
@@ -50,9 +57,7 @@ pub enum AuditError {
     Io(#[from] io::Error),
     #[error("audit writer lock was poisoned")]
     Poisoned,
-    #[error("audit storage is unavailable until restart")]
-    Unavailable,
-    #[error("audit publication is ambiguous; restart is required")]
+    #[error("audit publication is ambiguous; the record may not have been retained")]
     PublicationAmbiguous,
 }
 
@@ -80,6 +85,12 @@ pub enum AuditOperation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AuditOutcome {
+    /// The broker is about to attempt a host mutation. Written and made durable
+    /// before anything is touched, and paired with a later record carrying the
+    /// same `request_id`. An `Attempted` record with no pair means the broker
+    /// died mid-operation: the effect may or may not have landed, which is
+    /// exactly what the trail should say rather than omitting the operation.
+    Attempted,
     Allowed,
     Denied,
     Failed,
@@ -214,7 +225,12 @@ pub(crate) struct JsonlAuditSink {
 }
 
 struct WriterState {
-    available: bool,
+    /// The on-disk layout has not been established, or was left in an unknown
+    /// shape by a failure. Rebuilt on the next record rather than latching the
+    /// sink off: a full disk or a temporarily missing directory is a condition
+    /// that clears, and an audit trail that stays dead until the next restart
+    /// is worse than one that pauses.
+    needs_recovery: bool,
     #[cfg(test)]
     fail_after_write_once: bool,
     #[cfg(test)]
@@ -222,24 +238,48 @@ struct WriterState {
 }
 
 impl JsonlAuditSink {
-    pub(crate) fn open(data_dir: &Path) -> Result<Self, AuditError> {
-        fs::create_dir_all(data_dir)?;
-        #[cfg(unix)]
-        fs::set_permissions(data_dir, fs::Permissions::from_mode(0o700))?;
+    /// Prepare local audit storage under `data_dir`.
+    ///
+    /// Preparation failure is deliberately not fatal. The sink comes back
+    /// needing recovery: it refuses every record until the layout is in place,
+    /// which is what makes the broker refuse mutations, and it retries the
+    /// preparation on each subsequent record so access resumes by itself.
+    pub(crate) fn open(data_dir: &Path) -> Self {
         let sink = Self {
             path: data_dir.join(AUDIT_FILE_NAME),
             archive: data_dir.join(AUDIT_ARCHIVE_NAME),
             max_file_bytes: MAX_AUDIT_FILE_BYTES,
             writer: Mutex::new(WriterState {
-                available: true,
+                needs_recovery: true,
                 #[cfg(test)]
                 fail_after_write_once: false,
                 #[cfg(test)]
                 fail_rotation_after_archive_once: false,
             }),
         };
-        sink.recover()?;
-        Ok(sink)
+        match sink.writer.lock() {
+            Ok(mut writer) => {
+                if let Err(error) = sink.prepare(&mut writer) {
+                    eprintln!("openwave host broker audit storage is not ready: {error}");
+                }
+            }
+            Err(_) => unreachable!("a freshly created audit writer lock cannot be poisoned"),
+        }
+        sink
+    }
+
+    /// Establish the on-disk layout if it is not known to be intact.
+    fn prepare(&self, writer: &mut WriterState) -> Result<(), AuditError> {
+        if !writer.needs_recovery {
+            return Ok(());
+        }
+        let directory = self.path.parent().expect("audit file has a parent");
+        fs::create_dir_all(directory)?;
+        #[cfg(unix)]
+        fs::set_permissions(directory, fs::Permissions::from_mode(0o700))?;
+        self.recover()?;
+        writer.needs_recovery = false;
+        Ok(())
     }
 
     fn recover(&self) -> io::Result<()> {
@@ -406,9 +446,7 @@ impl AuditSink for JsonlAuditSink {
             return Err(AuditError::RecordTooLarge);
         }
         let mut writer = self.writer.lock().map_err(|_| AuditError::Poisoned)?;
-        if !writer.available {
-            return Err(AuditError::Unavailable);
-        }
+        self.prepare(&mut writer)?;
         let mut last_error = None;
         for attempt in 0..AUDIT_WRITE_ATTEMPTS {
             match self.append_once(&line, &mut writer) {
@@ -422,7 +460,11 @@ impl AuditSink for JsonlAuditSink {
                     thread::sleep(AUDIT_RETRY_BACKOFF);
                 }
                 Err(_) => {
-                    writer.available = false;
+                    // Rotation failed part-way, so both the record's fate and
+                    // the file layout are unknown. Report the ambiguity to the
+                    // caller — which refuses the operation it was gating — and
+                    // rebuild the layout on the next record.
+                    writer.needs_recovery = true;
                     return Err(AuditError::PublicationAmbiguous);
                 }
             }
@@ -451,14 +493,6 @@ impl AppendFailure {
             source,
             safe_to_retry: false,
         }
-    }
-}
-
-pub(crate) struct UnavailableAuditSink;
-
-impl AuditSink for UnavailableAuditSink {
-    fn record(&self, _event: &AuditEvent) -> Result<(), AuditError> {
-        Err(AuditError::Unavailable)
     }
 }
 
@@ -604,7 +638,7 @@ mod tests {
     #[test]
     fn jsonl_sink_appends_private_records() {
         let temp = tempfile::tempdir().unwrap();
-        let sink = JsonlAuditSink::open(temp.path()).unwrap();
+        let sink = JsonlAuditSink::open(temp.path());
         let first = event(AuditTarget::Subject);
         let second = event(AuditTarget::Root {
             root_id: RootId::new(),
@@ -641,7 +675,6 @@ mod tests {
     fn jsonl_sink_rotates_with_bounded_retention() {
         let temp = tempfile::tempdir().unwrap();
         let sink = JsonlAuditSink::open(temp.path())
-            .unwrap()
             .with_max_file_bytes((MAX_AUDIT_RECORD_BYTES + 100) as u64);
         for _ in 0..20 {
             sink.record(&event(AuditTarget::Subject)).unwrap();
@@ -659,7 +692,7 @@ mod tests {
     #[test]
     fn transient_post_write_failure_rolls_back_before_retry() {
         let temp = tempfile::tempdir().unwrap();
-        let sink = JsonlAuditSink::open(temp.path()).unwrap();
+        let sink = JsonlAuditSink::open(temp.path());
         sink.writer.lock().unwrap().fail_after_write_once = true;
         let expected = event(AuditTarget::Subject);
         sink.record(&expected).unwrap();
@@ -677,7 +710,7 @@ mod tests {
     fn startup_repairs_an_incomplete_jsonl_tail() {
         let temp = tempfile::tempdir().unwrap();
         let first = event(AuditTarget::Subject);
-        let sink = JsonlAuditSink::open(temp.path()).unwrap();
+        let sink = JsonlAuditSink::open(temp.path());
         sink.record(&first).unwrap();
         drop(sink);
         let mut file = OpenOptions::new()
@@ -688,7 +721,7 @@ mod tests {
         file.sync_all().unwrap();
         drop(file);
 
-        let sink = JsonlAuditSink::open(temp.path()).unwrap();
+        let sink = JsonlAuditSink::open(temp.path());
         let second = event(AuditTarget::Subject);
         sink.record(&second).unwrap();
         let decoded = fs::read_to_string(temp.path().join(AUDIT_FILE_NAME))
@@ -700,26 +733,18 @@ mod tests {
     }
 
     #[test]
-    fn interrupted_rotation_degrades_until_restart_then_recovers() {
+    fn interrupted_rotation_reports_the_ambiguity_then_recovers_in_place() {
         let temp = tempfile::tempdir().unwrap();
         let first = event(AuditTarget::Subject);
         let line_bytes = serde_json::to_vec(&first).unwrap().len() as u64 + 1;
-        let sink = JsonlAuditSink::open(temp.path())
-            .unwrap()
-            .with_max_file_bytes(line_bytes);
+        let sink = JsonlAuditSink::open(temp.path()).with_max_file_bytes(line_bytes);
         sink.record(&first).unwrap();
         sink.writer.lock().unwrap().fail_rotation_after_archive_once = true;
         assert!(matches!(
             sink.record(&event(AuditTarget::Subject)),
             Err(AuditError::PublicationAmbiguous)
         ));
-        assert!(matches!(
-            sink.record(&event(AuditTarget::Subject)),
-            Err(AuditError::Unavailable)
-        ));
-        drop(sink);
 
-        let sink = JsonlAuditSink::open(temp.path()).unwrap();
         let second = event(AuditTarget::Subject);
         sink.record(&second).unwrap();
         let archive = fs::read_to_string(temp.path().join(AUDIT_ARCHIVE_NAME)).unwrap();

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -28,7 +28,7 @@ use uuid::Uuid;
 use crate::{
     audit::{
         AuditActor, AuditError, AuditEvent, AuditOperation, AuditOutcome, AuditSink, AuditTarget,
-        JsonlAuditSink, MemoryAuditSink, UnavailableAuditSink,
+        JsonlAuditSink, MemoryAuditSink,
     },
     path_policy::RootIdentity,
     protocol::{
@@ -141,7 +141,24 @@ struct Shared {
 }
 
 impl Shared {
-    fn record_audit(&self, event: &AuditEvent) {
+    /// Make the intent to mutate the host durable before anything is touched.
+    ///
+    /// The caller must refuse the operation when this fails. That is the whole
+    /// contract: a file the user cannot see a record of was never overwritten,
+    /// because the record comes first.
+    fn record_intent(&self, event: &AuditEvent) -> Result<(), AuditError> {
+        self.audit.record(event)
+    }
+
+    /// Record what an operation turned out to do.
+    ///
+    /// Nothing can be undone by the time this runs, so a failure here cannot
+    /// refuse anything; it leaves the paired intent record standing alone,
+    /// which reads as "this was attempted, the result is unknown". Read-only
+    /// operations carry no intent record and are logged only here — an
+    /// unrecorded read is worth less than the user losing access to their own
+    /// files while the log is unwritable.
+    fn record_completion(&self, event: &AuditEvent) {
         if let Err(error) = self.audit.record(event) {
             eprintln!("openwave host broker could not persist audit event: {error}");
         }
@@ -313,11 +330,20 @@ struct ControlAudit {
     operation: AuditOperation,
     operation_id: Option<OperationId>,
     target: AuditTarget,
+    /// This request can change consent or host state, so its record must be
+    /// durable before it runs.
+    mutates: bool,
 }
 
 impl ControlAudit {
     fn from_request(request: &ControlRequest) -> Option<Self> {
         match request {
+            // Neither reaches user data or changes anything. `Hello` is a
+            // version handshake against a constant, and `ListApprovedRoots`
+            // projects folders the trusted control surface already knows about
+            // for the management UI. Recording them would add volume to a
+            // bounded, rotating log without adding anything a reader could act
+            // on, which costs the records that matter their retention.
             ControlRequest::Hello | ControlRequest::ListApprovedRoots => None,
             ControlRequest::ResolveExecRoots(request) => Some(Self {
                 actor: AuditActor::Control {
@@ -328,6 +354,11 @@ impl ControlAudit {
                     .expect("execution contexts contain non-nil identities"),
                     conversation_id: Some(request.context.conversation_id()),
                 },
+                // A read of already-granted state. It hands absolute paths to
+                // the local sandbox, but the broker cannot audit what happens
+                // inside that sandbox either way, so gating it would cost the
+                // user folder-aware execution while buying no coverage.
+                mutates: false,
                 operation: AuditOperation::ResolveExecRoots,
                 operation_id: None,
                 target: AuditTarget::Subject,
@@ -337,6 +368,7 @@ impl ControlAudit {
                     subject: request.subject,
                     conversation_id: Some(request.conversation_id),
                 },
+                mutates: true,
                 operation: AuditOperation::RegisterRoot,
                 operation_id: Some(request.operation_id),
                 target: AuditTarget::selected_folder(&request.path),
@@ -346,6 +378,7 @@ impl ControlAudit {
                     subject: request.subject,
                     conversation_id: Some(request.conversation_id),
                 },
+                mutates: false,
                 operation: AuditOperation::LookupRegisterRootReceipt,
                 operation_id: Some(request.operation_id),
                 target: AuditTarget::Subject,
@@ -355,6 +388,7 @@ impl ControlAudit {
                     subject: request.subject,
                     conversation_id: Some(request.conversation_id),
                 },
+                mutates: true,
                 operation: AuditOperation::AttachRoot,
                 operation_id: Some(request.operation_id),
                 target: AuditTarget::Root {
@@ -366,6 +400,7 @@ impl ControlAudit {
                     subject: request.subject,
                     conversation_id: Some(request.conversation_id),
                 },
+                mutates: true,
                 operation: AuditOperation::DetachRoot,
                 operation_id: Some(request.operation_id),
                 target: AuditTarget::Root {
@@ -377,6 +412,7 @@ impl ControlAudit {
                     subject: request.subject,
                     conversation_id: Some(request.conversation_id),
                 },
+                mutates: false,
                 operation: AuditOperation::LookupRootAttachmentReceipt,
                 operation_id: Some(request.operation_id),
                 target: AuditTarget::Root {
@@ -388,12 +424,31 @@ impl ControlAudit {
                     subject: request.subject,
                     conversation_id: None,
                 },
+                mutates: true,
                 operation: AuditOperation::RevokeRoot,
                 operation_id: Some(request.operation_id),
                 target: AuditTarget::Root {
                     root_id: request.root_id,
                 },
             }),
+        }
+    }
+
+    fn intent(&self, request_id: RequestId) -> AuditEvent {
+        AuditEvent {
+            event_id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+            request_id,
+            operation_id: self.operation_id,
+            actor: self.actor,
+            operation: self.operation,
+            target: self.target.clone(),
+            outcome: AuditOutcome::Attempted,
+            capability: None,
+            grant_id: None,
+            error_code: None,
+            item_count: None,
+            bytes: None,
         }
     }
 }
@@ -403,10 +458,14 @@ struct OperationAudit {
     operation: AuditOperation,
     capability: Capability,
     target: AuditTarget,
+    /// This operation can change bytes on the host, so its record must be
+    /// durable before it runs.
+    mutates: bool,
 }
 
 impl OperationAudit {
     fn from_envelope(envelope: &OperationEnvelope) -> Self {
+        let mutates = matches!(envelope.request, OperationRequest::WriteFile(_));
         let (operation, capability, target) = match &envelope.request {
             OperationRequest::ListRoots => (
                 AuditOperation::ListRoots,
@@ -441,6 +500,27 @@ impl OperationAudit {
             operation,
             capability,
             target,
+            mutates,
+        }
+    }
+
+    fn intent(&self, request_id: RequestId) -> AuditEvent {
+        AuditEvent {
+            event_id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+            request_id,
+            operation_id: None,
+            actor: self.actor,
+            operation: self.operation,
+            target: self.target.clone(),
+            outcome: AuditOutcome::Attempted,
+            capability: Some(self.capability),
+            // The operation has not been authorized yet; the paired completion
+            // record names the grant that allowed it, if any did.
+            grant_id: None,
+            error_code: None,
+            item_count: None,
+            bytes: None,
         }
     }
 }
@@ -478,13 +558,11 @@ impl Broker {
     pub fn open(policy: RootPolicy, data_dir: &Path) -> Result<Self, BrokerError> {
         let state_file = StateFile::open(data_dir)?;
         let state = state_file.load(&policy)?;
-        let audit: Arc<dyn AuditSink> = match JsonlAuditSink::open(data_dir) {
-            Ok(audit) => Arc::new(audit),
-            Err(error) => {
-                eprintln!("openwave host broker audit unavailable at startup: {error}");
-                Arc::new(UnavailableAuditSink)
-            }
-        };
+        // A sink that could not be prepared is not replaced by one that discards
+        // records: it stays the real sink, refusing until the host can hold the
+        // log. Registration and writes fail with a stated reason, reads keep
+        // working, and everything resumes without a restart.
+        let audit: Arc<dyn AuditSink> = Arc::new(JsonlAuditSink::open(data_dir));
         let pruned = state
             .unavailable
             .iter()
@@ -500,7 +578,7 @@ impl Broker {
             }),
         };
         for event in &pruned {
-            broker.shared.record_audit(event);
+            broker.shared.record_completion(event);
         }
         Ok(broker)
     }
@@ -526,14 +604,22 @@ impl Controller {
     pub fn handle(&self, envelope: ControlEnvelope) -> ControlResponseEnvelope {
         let request_id = envelope.request_id;
         let audit = ControlAudit::from_request(&envelope.request);
+        if let Some(audit) = audit.as_ref().filter(|audit| audit.mutates) {
+            if let Err(error) = self.shared.record_intent(&audit.intent(request_id)) {
+                return response_envelope(
+                    request_id,
+                    Err(error_response(BrokerError::Audit(error))),
+                );
+            }
+        }
         let result = self.execute(envelope);
         if let Some(audit) = audit {
-            self.record_audit(request_id, audit, &result);
+            self.record_completion(request_id, audit, &result);
         }
         response_envelope(request_id, result)
     }
 
-    fn record_audit(
+    fn record_completion(
         &self,
         request_id: crate::RequestId,
         metadata: ControlAudit,
@@ -560,7 +646,7 @@ impl Controller {
             item_count: None,
             bytes: None,
         };
-        self.shared.record_audit(&event);
+        self.shared.record_completion(&event);
     }
 
     fn execute(&self, envelope: ControlEnvelope) -> Result<ControlResult, ErrorResponse> {
@@ -971,9 +1057,17 @@ impl Operator {
     pub fn handle(&self, envelope: OperationEnvelope) -> OperationResponseEnvelope {
         let request_id = envelope.request_id;
         let audit = OperationAudit::from_envelope(&envelope);
+        if audit.mutates {
+            if let Err(error) = self.shared.record_intent(&audit.intent(request_id)) {
+                return response_envelope(
+                    request_id,
+                    Err(error_response(BrokerError::Audit(error))),
+                );
+            }
+        }
         let (result, grant_id) = self.execute(envelope);
         let result = result.map_err(error_response);
-        self.record_audit(request_id, audit, grant_id, &result);
+        self.record_completion(request_id, audit, grant_id, &result);
         response_envelope(request_id, result)
     }
 
@@ -1025,7 +1119,7 @@ impl Operator {
         (result, grant_id)
     }
 
-    fn record_audit(
+    fn record_completion(
         &self,
         request_id: crate::RequestId,
         metadata: OperationAudit,
@@ -1061,7 +1155,7 @@ impl Operator {
             item_count,
             bytes,
         };
-        self.shared.record_audit(&event);
+        self.shared.record_completion(&event);
     }
 
     fn authorized_root(
@@ -1392,9 +1486,9 @@ fn error_response(error: BrokerError) -> ErrorResponse {
             false,
         ),
         BrokerError::Audit(_) => (
-            ErrorCode::Internal,
-            "broker audit storage is unavailable",
-            false,
+            ErrorCode::AuditUnavailable,
+            "the host audit log could not be written, so the operation was refused",
+            true,
         ),
     };
     ErrorResponse {

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -13,11 +13,18 @@ impl AuditSink for CollectingAudit {
     }
 }
 
-struct FailingAudit;
+/// An audit sink whose storage can be taken away mid-session.
+#[derive(Default)]
+struct BreakableAudit {
+    broken: AtomicBool,
+}
 
-impl AuditSink for FailingAudit {
+impl AuditSink for BreakableAudit {
     fn record(&self, _event: &AuditEvent) -> Result<(), AuditError> {
-        Err(AuditError::Io(io::Error::other("injected audit failure")))
+        if self.broken.load(Ordering::SeqCst) {
+            return Err(AuditError::Io(io::Error::other("injected audit failure")));
+        }
+        Ok(())
     }
 }
 
@@ -1067,53 +1074,109 @@ fn broker_audits_control_reads_denials_and_authorizing_grants() {
     ));
 
     let events = audit.events.lock().unwrap();
-    assert_eq!(events.len(), 3);
+    assert_eq!(events.len(), 4);
+    // Registration is a mutation, so it is recorded as an intent before it runs
+    // and as a completion afterwards, correlated by request identity.
     assert_eq!(events[0].operation, AuditOperation::RegisterRoot);
+    assert_eq!(events[0].outcome, AuditOutcome::Attempted);
+    assert_eq!(events[1].operation, AuditOperation::RegisterRoot);
+    assert_eq!(events[1].outcome, AuditOutcome::Allowed);
+    assert_eq!(events[0].request_id, events[1].request_id);
     assert!(matches!(
         &events[0].target,
         AuditTarget::SelectedFolder { display_name } if display_name.as_str() == "Documents"
     ));
-    assert_eq!(events[1].operation, AuditOperation::ReadFile);
-    assert_eq!(events[1].outcome, AuditOutcome::Allowed);
-    assert!(events[1].grant_id.is_some());
-    assert_eq!(events[1].bytes, Some(17));
+    assert_eq!(events[2].operation, AuditOperation::ReadFile);
+    assert_eq!(events[2].outcome, AuditOutcome::Allowed);
+    assert!(events[2].grant_id.is_some());
+    assert_eq!(events[2].bytes, Some(17));
     assert!(matches!(
-        &events[1].target,
+        &events[2].target,
         AuditTarget::Path { root_id, relative }
             if *root_id == registered.root.root_id && relative.as_str() == "note.txt"
     ));
-    assert_eq!(events[2].outcome, AuditOutcome::Denied);
-    assert_eq!(events[2].error_code, Some(ErrorCode::Denied));
-    assert!(events[2].grant_id.is_none());
+    assert_eq!(events[3].outcome, AuditOutcome::Denied);
+    assert_eq!(events[3].error_code, Some(ErrorCode::Denied));
+    assert!(events[3].grant_id.is_none());
     let encoded = serde_json::to_string(&*events).unwrap();
     assert!(!encoded.contains("home/Documents"));
     assert!(!encoded.contains("hello from broker"));
 }
 
 #[test]
-fn read_tier_audit_failure_does_not_block_user_access() {
+fn an_unrecordable_mutation_is_refused_while_reads_still_work() {
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path().join("home/Documents");
     std::fs::create_dir_all(&root).unwrap();
     std::fs::write(root.join("note.txt"), "hello from broker").unwrap();
-    let broker = Broker::with_audit_sink(test_policy(&temp), Arc::new(FailingAudit));
+    let audit = Arc::new(BreakableAudit::default());
+    let broker = Broker::with_audit_sink(test_policy(&temp), audit.clone());
     let conversation = Uuid::new_v4();
+    let context = ExecutionContext::standalone(conversation).unwrap();
     let registered = register(
         &broker.controller(),
         GrantSubject::conversation(conversation).unwrap(),
         conversation,
-        root,
+        root.clone(),
         OperationId::new(),
     );
-    let result = operate(
+    audit.broken.store(true, Ordering::SeqCst);
+
+    let refused = operate(
         &broker.operator(),
-        ExecutionContext::standalone(conversation).unwrap(),
+        context,
+        write_request(
+            OperationId::new(),
+            registered.root.root_id,
+            "unrecorded.txt",
+            WriteFileMode::Create,
+            None,
+            b"never written",
+        ),
+    )
+    .unwrap_err();
+    assert_eq!(refused.code, ErrorCode::AuditUnavailable);
+    assert!(!root.join("unrecorded.txt").exists());
+
+    let refused = unwrap_response(broker.controller().handle(ControlEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: crate::RequestId::new(),
+        request: ControlRequest::RevokeRoot(RevokeRootRequest {
+            operation_id: OperationId::new(),
+            subject: GrantSubject::conversation(conversation).unwrap(),
+            root_id: registered.root.root_id,
+        }),
+    }))
+    .unwrap_err();
+    assert_eq!(refused.code, ErrorCode::AuditUnavailable);
+
+    // Losing the audit log must not cost the user access to folders they
+    // already approved; an unrecorded read is the lesser failure.
+    assert!(operate(
+        &broker.operator(),
+        context,
         OperationRequest::ReadFile(PathRequest {
             root_id: registered.root.root_id,
             path: RelativePath::parse("note.txt").unwrap(),
         }),
-    );
-    assert!(result.is_ok());
+    )
+    .is_ok());
+
+    // Recovery needs no restart: the next mutation goes through.
+    audit.broken.store(false, Ordering::SeqCst);
+    assert!(operate(
+        &broker.operator(),
+        context,
+        write_request(
+            OperationId::new(),
+            registered.root.root_id,
+            "recorded.txt",
+            WriteFileMode::Create,
+            None,
+            b"written",
+        ),
+    )
+    .is_ok());
 }
 
 #[test]

--- a/crates/openwave-host-broker/src/protocol.rs
+++ b/crates/openwave-host-broker/src/protocol.rs
@@ -287,6 +287,10 @@ pub enum ErrorCode {
     AlreadyExists,
     NotFound,
     AmbiguousWrite,
+    /// The operation was refused because the host could not record it. Nothing
+    /// was changed, and the same request may be re-issued once the audit log is
+    /// writable again.
+    AuditUnavailable,
 }
 
 /// Safe error payload; it never embeds an absolute path or raw OS error text.

--- a/docs/host-access.md
+++ b/docs/host-access.md
@@ -467,14 +467,22 @@ records opaque root IDs and bounded root-relative paths, never absolute host
 paths, raw OS errors, or file contents. Each append is synced before returning;
 the active file and one previous generation provide bounded local retention.
 Transient append failures retry only after the partial attempt has been rolled
-back and synced; an ambiguous append or rotation degrades the sink until restart,
-where an incomplete tail and interrupted rotation are repaired before new
-records are accepted. Unix rotation syncs the containing directory and Windows
-uses write-through file moves. Read-tier audit initialization or append failure
-is reported locally but does not prevent the user from reading their own files.
-Future write, command, and computer-control operations must durably record a
-bounded intent before acting and refuse the action if that record cannot be
-written. Forwarding this local trail off-device is a separate, explicit privacy
+back and synced; an ambiguous append or rotation is reported to the caller,
+which refuses the operation it was gating, and the layout is rebuilt on the next
+record — an incomplete tail and an interrupted rotation are repaired before new
+records are accepted. The sink never disables itself, so a transient host
+failure cannot silently retire the audit trail for the rest of the session.
+Unix rotation syncs the containing directory and Windows uses write-through file
+moves.
+
+Mutations — root registration, attachment, revocation, and file writes — durably
+record a bounded intent before acting and are refused if that record cannot be
+written, so nothing un-recorded reaches the disk. The completion record that
+follows carries the same request identity; an intent with no completion means
+the process died mid-operation and the effect is unknown. Read-tier audit
+initialization or append failure is reported locally but does not prevent the
+user from reading their own files, and no null sink is ever substituted for one
+that cannot be opened. Forwarding this local trail off-device is a separate, explicit privacy
 decision, not a side effect of choosing a hosted model.
 
 ## Deployment evolution


### PR DESCRIPTION
The audit trail was best-effort where it needed to be a precondition: records were appended after the operation had already run, failures were printed and swallowed, a null sink was substituted when the log could not be opened, and one ambiguous I/O failure disabled auditing for the rest of the process while everything kept working.

## Pre-act intent, for mutations only

Root registration, attachment, detachment, revocation, and file writes now append an `attempted` record before the broker touches anything, and are refused with the new `audit_unavailable` error code if that record cannot be made durable. The completion record that follows carries the same `request_id`, so a pair reads as one operation and an unpaired intent reads as "this was started, the outcome is unknown" — which is exactly what a crash leaves behind, and what a post-hoc-only trail silently omits.

Refuse-on-failure without the pre-act record would not have covered the case the issue is about: by the time a post-hoc append fails, the bytes are already on disk. It only stops the *next* operation. The doubled write is confined to mutations, which are rare next to reads and already pay for an fsync of their own.

Reads keep a single post-hoc record and do not fail when it cannot be written. Losing the log should not cost a user access to folders they already approved.

`Hello` and `ListApprovedRoots` still produce no event. Neither reaches user data or changes anything — one is a version handshake against a constant, the other projects already-known folder names for the management UI. Recording them would spend retention in a bounded, rotating log on records nobody would act on. `ResolveExecRoots` stays audited but ungated: it hands paths to the local sandbox, and the broker cannot audit what happens inside that sandbox either way, so refusing it would cost folder-aware execution without buying coverage.

## The latch is gone

An ambiguous append or rotation used to set `available = false` forever. It now reports the ambiguity to the caller that was gating on it and marks the on-disk layout for rebuild, which happens on the next record — the same recovery that used to require a restart. A full disk, a briefly unmounted directory, or an interrupted rotation clears by itself.

## No null sink, and no bricked broker

`JsonlAuditSink::open` no longer fails: a sink that cannot be prepared comes back needing recovery rather than being swapped for one that discards records, and it retries preparation on every record.

What the user experiences while the log is unwritable: connected folders keep listing and reading normally; connecting a new folder, attaching or detaching one, revoking one, and writing a file are refused with a stated reason rather than failing obscurely or succeeding unrecorded; and everything resumes on its own once the host can hold the log, with no restart. That is deliberately the opposite shape from #1162's failure — one broken resource, not the whole surface.

The record schema is unchanged apart from the new `attempted` outcome; `AuditError::Unavailable` and `UnavailableAuditSink` are deleted.

## Tests

One broker test covers the invariant end to end: with the sink broken mid-session, a write and a revocation are refused with `audit_unavailable`, the file is not created, a read still succeeds, and the next write goes through once the sink recovers. The sink-level latch test was rewritten to assert recovery in place instead of "unavailable until restart". No new per-operation tests.

Closes #1094