### PR TITLE
feat(server): cancellation for container runs — attached acknowledgment and unattached cascade

### DIFF
--- a/crates/openwave-core/src/db/ops/agent_run/cancellation.rs
+++ b/crates/openwave-core/src/db/ops/agent_run/cancellation.rs
@@ -654,6 +654,12 @@ where
     .insert(conn)
     .await
     .map_err(store_err)?;
+    // A cancelled container run owes its container a teardown in the same
+    // transaction — this is what lets a parent's cancellation cascade over an
+    // unattached container child without leaking the container.
+    if run.execution_location == crate::AgentRunExecutionLocation::Container.as_str() {
+        super::super::sandbox_provision::enqueue_teardown_on(conn, run.id).await?;
+    }
     Ok(true)
 }
 

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -148,6 +148,9 @@ pub enum SandboxContainerRunOutcome {
     /// The run failed terminally (no result within its bounds); a sandbox-
     /// resident run is never re-executed.
     Failed(AgentRunId),
+    /// The run was cancelled while the driver drove it; the driver committed
+    /// the terminal cancellation and tore the container down.
+    Cancelled(AgentRunId),
     /// The lease was lost or the run was already terminal when the driver tried
     /// to commit — nothing was committed by this attempt.
     LeaseLost(AgentRunId),
@@ -596,7 +599,26 @@ impl SandboxContainerRunner {
                 )
                 .await
             }
-            DriveEnd::LeaseLost => Ok(SandboxContainerRunOutcome::LeaseLost(run_id)),
+            DriveEnd::LeaseLost => {
+                // The heartbeat was refused. Cancellation moves a run to
+                // `cancelling`, which fails the running-only heartbeat filter —
+                // so before reading this as a lost lease, acknowledge a
+                // cancellation this driver still owns: commit the terminal
+                // cancellation, and let the teardown that follows be the
+                // signal that actually stops the container.
+                let run = self.store.get_agent_run(run_id).await?;
+                if run.as_ref().is_some_and(|run| {
+                    run.status == AgentRunStatus::Cancelling && run.lease_token == Some(lease_token)
+                }) && self
+                    .store
+                    .finish_agent_run_cancellation(run_id, lease_token)
+                    .await?
+                    .is_some()
+                {
+                    return Ok(SandboxContainerRunOutcome::Cancelled(run_id));
+                }
+                Ok(SandboxContainerRunOutcome::LeaseLost(run_id))
+            }
         }
     }
 

--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -1206,6 +1206,96 @@ async fn a_late_result_is_retained_as_evidence_not_committed() {
     assert_eq!(run.status, AgentRunStatus::Failed);
 }
 
+/// Cancelling a run mid-drive: the heartbeat refusal is read as cancellation,
+/// the driver commits the terminal cancellation it still owns, and the teardown
+/// that follows is what actually stops the container.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn an_attached_cancellation_is_acknowledged_and_torn_down() {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        let (_dir, store, chat) = store().await;
+        let run_id = admit_container_run(&store, chat.id, "cancelled mid-flight").await;
+
+        let backend = MockBackend::spawning();
+        // Slow completions hold the drive open across several heartbeats, so
+        // the cancellation lands while the container is genuinely working.
+        let provider = Arc::new(ScriptedProvider::slow(vec![], Duration::from_secs(5)));
+        let runner = Arc::new(SandboxContainerRunner::new(
+            store.clone(),
+            backend.clone(),
+            Arc::new(FixedResolver(provider)),
+            SandboxContainerRunConfig {
+                lease: Duration::from_secs(2),
+                heartbeat: Duration::from_millis(100),
+                ..fast_config()
+            },
+        ));
+        let drive = tokio::spawn({
+            let runner = runner.clone();
+            async move { runner.drive(run_id).await }
+        });
+        // Let the drive claim and attach, then cancel out from under it.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        store
+            .request_agent_run_cancellation(run_id)
+            .await
+            .unwrap()
+            .expect("the cancellation request lands");
+
+        let outcome = drive
+            .await
+            .unwrap()
+            .expect("driving succeeds")
+            .expect("the container run is claimable");
+        assert_eq!(outcome, SandboxContainerRunOutcome::Cancelled(run_id));
+        let cancelled = store.get_agent_run(run_id).await.unwrap().unwrap();
+        assert_eq!(cancelled.status, AgentRunStatus::Cancelled);
+        // The container did not outlive the cancellation.
+        assert_eq!(backend.destroys.load(Ordering::SeqCst), 1);
+    })
+    .await
+    .expect("test completed within its time bound");
+}
+
+/// Cancelling an unattached container child — its driver is gone, its lease
+/// expired — terminalizes immediately and leaves the container's teardown
+/// obligation enqueued in the same transaction, for the sweep to destroy.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancelling_an_unattached_container_child_enqueues_its_teardown() {
+    let (_dir, store, chat) = store().await;
+    let run_id = admit_container_run(&store, chat.id, "orphaned by its driver").await;
+    let run_uuid = *run_id.as_uuid();
+    store
+        .claim_container_agent_run(run_id, Uuid::new_v4(), chrono::Duration::milliseconds(1), 4)
+        .await
+        .unwrap()
+        .expect("the dead driver's claim succeeds");
+    store
+        .begin_sandbox_provision(
+            run_uuid,
+            &SandboxTag::new().to_string(),
+            chrono::Utc::now() + chrono::Duration::seconds(600),
+        )
+        .await
+        .unwrap();
+    assert!(store
+        .commit_sandbox_provision_handle(run_uuid, "unattended-container")
+        .await
+        .unwrap());
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    store
+        .request_agent_run_cancellation(run_id)
+        .await
+        .unwrap()
+        .expect("the cancellation request lands");
+
+    let cancelled = store.get_agent_run(run_id).await.unwrap().unwrap();
+    assert_eq!(cancelled.status, AgentRunStatus::Cancelled);
+    let teardowns = store.list_sandbox_teardowns().await.unwrap();
+    assert_eq!(teardowns.len(), 1);
+    assert_eq!(teardowns[0].handle.as_deref(), Some("unattended-container"));
+}
+
 // --- Docker end-to-end (gated on a container runtime + the agent image) -------
 
 /// Build the sandbox-agent image for the Docker-gated tests, returning its tag,


### PR DESCRIPTION
The cancellation bullet of #920, in both halves:

**Attached.** Cancellation moves a run to `cancelling`, which fails the driver's running-only heartbeat filter — previously read as a lost lease, leaving the cancellation receipt uncommitted. The driver now resolves that refusal: if the run is `cancelling` under its own still-held lease, it commits the terminal cancellation (`finish_agent_run_cancellation`, the same acknowledgment the in-process worker makes) and reports a new `Cancelled` outcome. The teardown that always follows the drive is what actually stops the container — no separate stop signal is needed for an attached-only local container, whose destroy is the stop.

**Unattached cascade.** `terminalize_cancellation_on` — the single terminal cancellation transition, shared by the immediate-cancel path and the parent cascade — now enqueues the container's teardown obligation in the same transaction when the run is container-located. Cancelling a child whose driver died (expired lease, live container) terminalizes immediately and leaves the obligation for the sweep, instead of leaking a container whose provisioning record still called it live.

Two loopback tests: a mid-drive cancellation acknowledged with the container torn down before the drive returns, and an unattached expired-lease child cancelled with its teardown row (committed handle attached) enqueued transactionally.

Verified: container-run module 18 passed, core db suite passed, clippy `-D warnings`, fmt. No lockfile drift.

Part of #920.