### PR TITLE
feat(protocol): deliver the task in a run-init frame after the handle commits

### DIFF
--- a/crates/openwave-sandbox-agent/src/main.rs
+++ b/crates/openwave-sandbox-agent/src/main.rs
@@ -16,9 +16,6 @@
 //!   it installs the connection. If it is absent the sandbox fails closed: it
 //!   still binds and answers, but refuses every attach rather than serving one
 //!   unauthenticated.
-//! - `OPENWAVE_SANDBOX_TASK` — the delegated task. In the full design the host
-//!   delivers the task in the run-init payload after the handle commits; until
-//!   that init frame is wired, the entrypoint reads it from the environment.
 //! - `OPENWAVE_SANDBOX_WORKSPACE` — the agent's in-container workspace directory,
 //!   the root the `exec` and filesystem tools are scoped to (default
 //!   `/workspace`, provisioned in the container image).
@@ -71,8 +68,6 @@ async fn main() {
 
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let listen = env::var("OPENWAVE_SANDBOX_LISTEN").unwrap_or_else(|_| DEFAULT_LISTEN.to_owned());
-    let task = env::var("OPENWAVE_SANDBOX_TASK")
-        .unwrap_or_else(|_| "Summarize what this sandbox agent can do.".to_owned());
     let workspace =
         env::var("OPENWAVE_SANDBOX_WORKSPACE").unwrap_or_else(|_| DEFAULT_WORKSPACE.to_owned());
 
@@ -100,9 +95,12 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // The agent loop is a separate future from the supervisor's listener: it
-    // waits for the host to attach, then runs to a submitted result.
+    // waits for the host to attach and deliver the run init — the task never
+    // rides the environment, so a sandbox reclaimed before its handle committed
+    // never executed anything — then runs to a submitted result.
     tokio::spawn(async move {
-        match run_agent(run, task, workspace).await {
+        let init = run.init().await;
+        match run_agent(run, init.task, workspace).await {
             Ok(answer) => eprintln!("openwave-sandbox-agent: submitted result: {answer}"),
             Err(error) => eprintln!("openwave-sandbox-agent: run failed: {error}"),
         }

--- a/crates/openwave-sandbox-protocol/src/conformance.rs
+++ b/crates/openwave-sandbox-protocol/src/conformance.rs
@@ -126,7 +126,6 @@ fn provision_request() -> ProvisionRequest {
         run_id: RunId::new(),
         tag: crate::ids::SandboxTag::new(),
         lifetime_cap_secs: None,
-        task: Some("the delegated task".to_owned()),
     }
 }
 

--- a/crates/openwave-sandbox-protocol/src/protocol.rs
+++ b/crates/openwave-sandbox-protocol/src/protocol.rs
@@ -21,7 +21,7 @@ use crate::provisioning::TransportSecret;
 ///
 /// Version 2 added the authenticated attach: [`AttachRequest`] carries a per-run
 /// [`TransportSecret`] the sandbox verifies before it installs the connection.
-pub const PROTOCOL_VERSION: u32 = 2;
+pub const PROTOCOL_VERSION: u32 = 3;
 
 /// Largest single reverse-RPC or event frame a conforming transport accepts,
 /// so a peer cannot force unbounded buffering with one enormous frame.

--- a/crates/openwave-sandbox-protocol/src/provisioning.rs
+++ b/crates/openwave-sandbox-protocol/src/provisioning.rs
@@ -49,19 +49,6 @@ pub struct ProvisionRequest {
     /// outside the sandbox. `None` means the backend cannot cap lifetime, which
     /// (per the design) makes the run attached-only.
     pub lifetime_cap_secs: Option<u64>,
-    /// The delegated task, as bounded UTF-8.
-    ///
-    /// **Interim.** The design delivers the task in the [run
-    /// init](crate::init::RunInit) *after* the handle commits, so a sandbox
-    /// reclaimed before that point never executed anything. No init frame exists
-    /// on the transport yet, so the task rides the provisioning request and the
-    /// backend delivers it through whatever its control plane is (for a local
-    /// container, the container's environment — the same path that already
-    /// carries the per-run transport secret). This field goes away when the init
-    /// frame lands; a backend that cannot carry a task ignores it, and `None`
-    /// leaves the sandbox on its own default.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub task: Option<String>,
 }
 
 /// An opaque, backend-specific handle to a provisioned sandbox.

--- a/crates/openwave-sandbox-protocol/src/wire/host.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/host.rs
@@ -210,6 +210,15 @@ impl HostConnection {
         self.events.recv().await
     }
 
+    /// Deliver the run init — task, policy snapshot, and (for a detached run)
+    /// the scoped token — to the sandbox. Sent after the handle has committed
+    /// on the host, and on every attach: the sandbox keeps the first delivery
+    /// and ignores the rest. Best-effort: a closed connection drops it, and the
+    /// reattach redelivers.
+    pub async fn send_init(&self, init: crate::init::RunInit) {
+        let _ = self.outbound.data.send(WireFrame::Init(init)).await;
+    }
+
     /// Acknowledge the event stream through `cursor`, letting the sandbox advance
     /// its un-acknowledged buffer. Best-effort: a closed connection drops it.
     pub async fn acknowledge(&self, cursor: EventCursor) {
@@ -310,7 +319,8 @@ async fn read_loop<R>(
             WireFrame::Request(RequestFrame::Response(_))
             | WireFrame::Attach(_)
             | WireFrame::Handshake(_)
-            | WireFrame::EventAck { .. } => {}
+            | WireFrame::EventAck { .. }
+            | WireFrame::Init(_) => {}
         }
     }
 }

--- a/crates/openwave-sandbox-protocol/src/wire/mod.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/mod.rs
@@ -109,6 +109,11 @@ pub enum WireFrame {
         /// The host's committed cursor.
         cursor: EventCursor,
     },
+    /// Host -> sandbox: the run init — task, policy snapshot, and (for a
+    /// detached run) the scoped token — delivered after the attach handshake,
+    /// once the handle has committed on the host. Redelivered on every attach;
+    /// the sandbox keeps the first and ignores the rest.
+    Init(crate::init::RunInit),
 }
 
 /// Why a framed read or write stopped.

--- a/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
@@ -94,6 +94,9 @@ struct RunInner {
     request_lane_capacity: usize,
     events: Mutex<EventBuffer>,
     conn: watch::Sender<Option<ConnHandle>>,
+    /// The run init the host delivers after attach. First delivery wins; a
+    /// redelivery on reattach is ignored.
+    init: watch::Sender<Option<crate::init::RunInit>>,
 }
 
 /// One run-scoped, cloneable sandbox. Every clone shares one event buffer and one
@@ -136,6 +139,7 @@ impl SandboxRun {
         expected_secret: Option<TransportSecret>,
     ) -> Self {
         let (conn, _) = watch::channel(None);
+        let (init, _) = watch::channel(None);
         Self {
             inner: Arc::new(RunInner {
                 protocol_version,
@@ -150,8 +154,39 @@ impl SandboxRun {
                     overflowed: false,
                 }),
                 conn,
+                init,
             }),
         }
+    }
+
+    /// Wait for the host to deliver the run init — the task, policy snapshot,
+    /// and (for a detached run) the scoped token. Delivered after the attach
+    /// handshake, once the handle has committed on the host; the agent loop
+    /// must not start before it arrives.
+    pub async fn init(&self) -> crate::init::RunInit {
+        let mut watcher = self.inner.init.subscribe();
+        loop {
+            if let Some(init) = watcher.borrow_and_update().clone() {
+                return init;
+            }
+            if watcher.changed().await.is_err() {
+                // The sender lives inside this run, so this is unreachable
+                // while the run exists; park rather than fabricate an init.
+                std::future::pending::<()>().await;
+            }
+        }
+    }
+
+    /// Record the host-delivered init. First delivery wins: a redelivery on
+    /// reattach — or from a superseded connection still draining — is ignored.
+    fn deliver_init(&self, init: crate::init::RunInit) {
+        self.inner.init.send_if_modified(|slot| {
+            if slot.is_some() {
+                return false;
+            }
+            *slot = Some(init);
+            true
+        });
     }
 
     /// Emit a bounded progress line, returning its assigned sequence.
@@ -470,6 +505,10 @@ where
                     run.acknowledge(cursor);
                 }
             }
+            // The run init: task, policy, and token, delivered only over an
+            // authenticated connection (an unauthenticated dial never reaches
+            // this loop). First delivery wins.
+            WireFrame::Init(init) => run.deliver_init(init),
             // The sandbox originates cancels and requests; it never receives
             // them. Pong is liveness only. Ignore rather than trust peer input.
             WireFrame::Control(ControlFrame::Pong { .. } | ControlFrame::Cancel { .. })

--- a/crates/openwave-sandbox-protocol/tests/wire_format.rs
+++ b/crates/openwave-sandbox-protocol/tests/wire_format.rs
@@ -324,28 +324,9 @@ fn provisioning_wire_shapes() {
         run_id: RunId::new(),
         tag: SandboxTag::new(),
         lifetime_cap_secs: Some(3600),
-        task: Some("summarize the corpus".to_owned()),
     };
     roundtrip(&request);
-    golden(
-        &request,
-        &[
-            ("/lifetime_cap_secs", json!(3600)),
-            ("/task", json!("summarize the corpus")),
-        ],
-    );
-
-    // An absent task is omitted entirely, so a backend that carries no task and
-    // an older encoding both decode.
-    let taskless = ProvisionRequest {
-        task: None,
-        ..request
-    };
-    roundtrip(&taskless);
-    assert!(serde_json::to_value(&taskless)
-        .unwrap()
-        .get("task")
-        .is_none());
+    golden(&request, &[("/lifetime_cap_secs", json!(3600))]);
 
     let handle = SandboxHandle {
         reference: "container-abc".to_owned(),

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -48,6 +48,7 @@ use openwave_core::{
 use openwave_sandbox_protocol::{
     events::EventPayload,
     ids::{EventCursor, RunId},
+    init::{AdmissionMode, PolicySnapshot, RunInit},
     protocol::{ErrorCode, ErrorResponse, Response, PROTOCOL_VERSION},
     reverse::{
         Capability, CapabilityResponder, GrantSet, ModelInferenceResult, ReverseRequest,
@@ -389,9 +390,6 @@ impl SandboxContainerRunner {
                         // A local container has no external lifetime cap, which
                         // is why the run is attached-only.
                         lifetime_cap_secs: None,
-                        // The delegated task. Interim delivery: see
-                        // `ProvisionRequest::task`.
-                        task: Some(task),
                     })
                     .await;
                 match provisioned {
@@ -462,7 +460,7 @@ impl SandboxContainerRunner {
         // From here on a container exists, so every terminal path must drive its
         // teardown obligation.
         let outcome = self
-            .attach_and_drive(&run, lease_token, protocol_run_id, config, &handle)
+            .attach_and_drive(&run, lease_token, protocol_run_id, config, task, &handle)
             .await;
         self.teardown(run_uuid, &handle).await;
         outcome
@@ -509,6 +507,7 @@ impl SandboxContainerRunner {
         lease_token: Uuid,
         protocol_run_id: RunId,
         config: AgentConfig,
+        task: String,
         handle: &SandboxHandle,
     ) -> Result<SandboxContainerRunOutcome> {
         let run_id = run.id;
@@ -534,13 +533,38 @@ impl SandboxContainerRunner {
             )),
         );
 
+        // The run init the host delivers after each attach: the task and the
+        // policy snapshot, only ever over the authenticated connection — the
+        // task no longer rides the container's environment, so a sandbox
+        // reclaimed before its handle committed never executed anything. An
+        // attached-only run carries no scoped token; the host is the model
+        // proxy.
+        let init = RunInit {
+            run_id: protocol_run_id,
+            provenance: RunProvenance {
+                run_id: protocol_run_id,
+                provider: CONTAINER_PROVENANCE_PROVIDER.to_owned(),
+            },
+            task,
+            deadline_unix_secs: run
+                .deadline_at
+                .map(|deadline| deadline.timestamp().max(0).unsigned_abs())
+                .unwrap_or_default(),
+            admission: AdmissionMode::AttachedOnly,
+            policy: PolicySnapshot {
+                egress_allowlist: Vec::new(),
+                granted_capabilities: vec![Capability::ModelInference],
+            },
+            scoped_token: None,
+        };
+
         // Drive the container while holding the lease live. A container run
         // routinely outlives one lease period, and the in-process reaper
         // terminalizes a background run whose lease expires — so without this
         // heartbeat the run is failed out from under a container that is still
         // working and still spending. The whole drive is additionally bounded by
         // the run's absolute deadline, so no path can wait forever.
-        let drive = self.drive_events(protocol_run_id, handle, &host);
+        let drive = self.drive_events(protocol_run_id, handle, &host, &init);
         tokio::pin!(drive);
         let mut heartbeat = tokio::time::interval(self.config.heartbeat);
         heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -644,12 +668,13 @@ impl SandboxContainerRunner {
         protocol_run_id: RunId,
         handle: &SandboxHandle,
         host: &CapabilityHost,
+        init: &RunInit,
     ) -> DriveEnd {
         let mut cursor = EventCursor::START;
         let mut attempt = 0u32;
         loop {
             match self
-                .drain_connection(protocol_run_id, handle, host, &mut cursor)
+                .drain_connection(protocol_run_id, handle, host, init, &mut cursor)
                 .await
             {
                 DrainOutcome::Result(text) => return DriveEnd::Result(text),
@@ -677,6 +702,7 @@ impl SandboxContainerRunner {
         protocol_run_id: RunId,
         handle: &SandboxHandle,
         host: &CapabilityHost,
+        init: &RunInit,
         cursor: &mut EventCursor,
     ) -> DrainOutcome {
         let address = match self.backend.address(handle).await {
@@ -720,6 +746,9 @@ impl SandboxContainerRunner {
                 };
             }
         };
+        // Deliver the run init on every attach; the sandbox keeps the first
+        // and ignores redeliveries, so a reattach is idempotent.
+        conn.send_init(init.clone()).await;
         // Drain events, committing the cursor by acknowledging each, until a
         // terminal event arrives or the connection closes. Both terminal events
         // end the drive: the supervisor keeps serving after its agent loop

--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -144,11 +144,11 @@ impl ProviderResolver for FixedResolver {
 /// A [`SandboxBackend`] that stands in for Docker.
 ///
 /// `provision` starts the real in-container agent on a loopback listener with
-/// **the task the driver asked to be delivered** — the same relationship Docker
-/// has to the container's `OPENWAVE_SANDBOX_TASK` environment. That is what makes
-/// task delivery genuinely testable here: if the driver failed to pass the run's
-/// task, the sandbox would run the image's default task and the committed result
-/// would answer the wrong question.
+/// no task — exactly as the image starts. The task only ever arrives in the
+/// run-init frame the driver sends after attach, so task delivery is genuinely
+/// testable: a driver that failed to send init leaves the agent parked and the
+/// test times out, and the prompt the agent asks the host to complete proves
+/// which task it actually received.
 struct MockBackend {
     /// When set, `address` resolves here instead of the provisioned sandbox —
     /// used to point the driver at an unreachable port, or at a sandbox the
@@ -163,7 +163,6 @@ struct MockBackend {
     /// Every live-tag set `reclaim_orphans` was asked to preserve.
     reclaim_live_sets:
         Mutex<Vec<std::collections::HashSet<openwave_sandbox_protocol::ids::SandboxTag>>>,
-    delivered_task: Mutex<Option<String>>,
 }
 
 impl MockBackend {
@@ -177,7 +176,6 @@ impl MockBackend {
             destroys: AtomicUsize::new(0),
             failing_destroys: std::sync::atomic::AtomicBool::new(false),
             reclaim_live_sets: Mutex::new(Vec::new()),
-            delivered_task: Mutex::new(None),
         })
     }
 
@@ -190,12 +188,7 @@ impl MockBackend {
             destroys: AtomicUsize::new(0),
             failing_destroys: std::sync::atomic::AtomicBool::new(false),
             reclaim_live_sets: Mutex::new(Vec::new()),
-            delivered_task: Mutex::new(None),
         })
-    }
-
-    fn task_delivered(&self) -> Option<String> {
-        self.delivered_task.lock().unwrap().clone()
     }
 }
 
@@ -206,16 +199,12 @@ impl SandboxBackend for MockBackend {
         request: ProvisionRequest,
     ) -> std::result::Result<SandboxHandle, BackendError> {
         self.provisions.fetch_add(1, Ordering::SeqCst);
-        *self.delivered_task.lock().unwrap() = request.task.clone();
         if self.address_override.is_none() {
-            // Start the sandbox on the delivered task, exactly as the image does
-            // from its environment. A driver that delivered nothing gets the
-            // image's default task, which is the failure this models.
-            let task = request
-                .task
-                .clone()
-                .unwrap_or_else(|| "Summarize what this sandbox agent can do.".to_owned());
-            *self.address.lock().unwrap() = Some(spawn_sandbox_agent(&task).await);
+            // Start the sandbox exactly as the image does: with no task at all.
+            // The agent waits for the run-init frame, so a driver that never
+            // delivers one leaves the loop parked and the test times out — the
+            // failure this models.
+            *self.address.lock().unwrap() = Some(spawn_sandbox_agent().await);
         }
         Ok(SandboxHandle {
             reference: format!("mock-{}", request.run_id),
@@ -331,7 +320,7 @@ async fn admit_container_run(store: &Arc<dyn Store>, chat_id: ChatId, task: &str
 /// transport server against a fresh [`SandboxRun`], plus the agent loop that
 /// dials model completions back over the reverse channel. Returns the bound
 /// `http://` base URL.
-async fn spawn_sandbox_agent(task: &str) -> String {
+async fn spawn_sandbox_agent() -> String {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let base_url = format!("http://{}", listener.local_addr().unwrap());
     // The supervisor expects the same per-run secret the MockBackend hands the
@@ -341,14 +330,16 @@ async fn spawn_sandbox_agent(task: &str) -> String {
         Some(TransportSecret::new("test-secret")),
     );
     let agent_run = run.clone();
-    let task = task.to_owned();
     // The in-container tool surface is rooted at a workspace directory; give the
     // loop a private temp one that lives as long as the run.
     let workspace = tempfile::tempdir().unwrap();
     let workspace_path = workspace.path().to_path_buf();
     tokio::spawn(async move {
         let _workspace = workspace;
-        let _ = run_agent(agent_run, task, workspace_path).await;
+        // As in the image's entrypoint: the loop starts only once the host
+        // delivers the run init.
+        let init = agent_run.init().await;
+        let _ = run_agent(agent_run, init.task, workspace_path).await;
     });
     tokio::spawn(async move {
         while let Ok((stream, _peer)) = listener.accept().await {
@@ -420,9 +411,9 @@ async fn drives_a_container_run_end_to_end_over_loopback() {
             "each model step should proxy through the host exactly once"
         );
 
-        // The run's ACTUAL delegated task reached the container — not the image's
-        // default — and is what the container asked the host to reason about.
-        assert_eq!(backend.task_delivered().as_deref(), Some(task));
+        // The run's ACTUAL delegated task reached the container over the
+        // run-init frame and is what the container asked the host to reason
+        // about.
         assert!(
             provider.first_prompt().contains(task),
             "the container must work on the delegated task, got prompt: {}",
@@ -944,7 +935,7 @@ async fn a_committed_handle_is_reconciled_not_reprovisioned() {
         // The sandbox already exists — a prior attempt provisioned it and
         // committed its handle before losing its own commit — so the backend
         // can only address it, never create it.
-        let base_url = spawn_sandbox_agent(task).await;
+        let base_url = spawn_sandbox_agent().await;
         let backend = MockBackend::unreachable(base_url);
         let tag = SandboxTag::new();
         store
@@ -1001,7 +992,7 @@ async fn a_dead_drivers_container_run_is_recovered_to_completion() {
             .await
             .unwrap()
             .expect("the dead driver's claim succeeds");
-        let base_url = spawn_sandbox_agent(task).await;
+        let base_url = spawn_sandbox_agent().await;
         let backend = MockBackend::unreachable(base_url);
         let tag = SandboxTag::new();
         store
@@ -1485,7 +1476,6 @@ async fn docker_container_conforms_at_the_transport_boundary() {
             run_id,
             tag: SandboxTag::new(),
             lifetime_cap_secs: None,
-            task: Some("answer briefly".to_owned()),
         })
         .await
         .expect("provisioning a conformance container succeeds");
@@ -1578,6 +1568,23 @@ async fn docker_container_conforms_at_the_transport_boundary() {
         )
         .await
         .expect("an authenticated attach is accepted");
+        // The packaged agent starts nothing until the run init arrives.
+        conn.send_init(openwave_sandbox_protocol::init::RunInit {
+            run_id,
+            provenance: RunProvenance {
+                run_id,
+                provider: "local-container".to_owned(),
+            },
+            task: "answer briefly".to_owned(),
+            deadline_unix_secs: 4_102_444_800,
+            admission: openwave_sandbox_protocol::init::AdmissionMode::AttachedOnly,
+            policy: openwave_sandbox_protocol::init::PolicySnapshot {
+                egress_allowlist: Vec::new(),
+                granted_capabilities: vec![Capability::ModelInference],
+            },
+            scoped_token: None,
+        })
+        .await;
         let first = conn.next_event().await.expect("the agent's first event");
         let mut committed = EventCursor::committed(first.sequence);
         conn.acknowledge(committed).await;

--- a/crates/openwave-server/src/sandbox_docker.rs
+++ b/crates/openwave-server/src/sandbox_docker.rs
@@ -95,10 +95,6 @@ pub const RUN_TAG_LABEL: &str = "openwave.run-tag";
 pub const RUN_ID_LABEL: &str = "openwave.run-id";
 /// Environment variable carrying the per-run transport secret into the container.
 const TRANSPORT_SECRET_ENV: &str = "OPENWAVE_TRANSPORT_SECRET";
-/// Environment variable carrying the delegated task into the container. The
-/// agent image reads its task from here; see [`ProvisionRequest::task`] for why
-/// this rides provisioning rather than a run-init frame today.
-const TASK_ENV: &str = "OPENWAVE_SANDBOX_TASK";
 /// Environment variable carrying the absolute lifetime cap, in seconds, into the
 /// container. The sandbox agent's entrypoint reads it and exits when it elapses.
 /// Kept in sync with the agent's own constant of the same name.
@@ -372,17 +368,14 @@ impl SandboxBackend for DockerSandboxBackend {
             &self.config,
             request.tag,
             request.run_id,
-            request.task.is_some(),
             effective_lifetime_cap(&self.config, &request),
         ));
         // Set the secret on the runtime CLI's own environment and pass it through with
-        // a valueless `--env`, so it never appears in this process's argv.
+        // a valueless `--env`, so it never appears in this process's argv. The
+        // delegated task never travels here at all: it arrives in the run-init
+        // frame after the handle commits, so a sandbox reclaimed before that
+        // point never executed anything.
         command.env(TRANSPORT_SECRET_ENV, &secret);
-        // The delegated task travels the same way: by name only, so task text
-        // never lands in this process's argv or in `ps` output.
-        if let Some(task) = &request.task {
-            command.env(TASK_ENV, task);
-        }
         let output = command
             .output()
             .await
@@ -494,7 +487,6 @@ fn run_args(
     config: &DockerConfig,
     tag: SandboxTag,
     run_id: RunId,
-    with_task: bool,
     lifetime_cap_secs: Option<u64>,
 ) -> Vec<String> {
     let mut args = vec![
@@ -508,11 +500,7 @@ fn run_args(
         TRANSPORT_SECRET_ENV.to_owned(),
     ];
     args.extend(hardening_args(&config.hardening));
-    if with_task {
-        args.push("--env".to_owned());
-        args.push(TASK_ENV.to_owned());
-    }
-    // Unlike the secret and the task, the cap is not sensitive, so it travels as
+    // Unlike the secret, the cap is not sensitive, so it travels as
     // an ordinary `--env NAME=value` rather than by name through this process's
     // own environment.
     if let Some(secs) = lifetime_cap_secs {
@@ -710,7 +698,6 @@ mod tests {
             run_id: RunId::new(),
             tag: SandboxTag::new(),
             lifetime_cap_secs: None,
-            task: None,
         };
         assert!(matches!(
             backend.provision(request).await,
@@ -746,7 +733,7 @@ mod tests {
             command: vec!["sleep".to_owned(), "infinity".to_owned()],
             ..DockerConfig::default()
         };
-        let args = run_args(&config, tag, run_id, true, Some(900));
+        let args = run_args(&config, tag, run_id, Some(900));
 
         assert_eq!(args[0], "run");
         assert!(args.contains(&"-d".to_owned()));
@@ -758,12 +745,6 @@ mod tests {
         assert!(args
             .iter()
             .all(|arg| !arg.contains(TRANSPORT_SECRET_ENV) || arg == TRANSPORT_SECRET_ENV));
-        // The delegated task is passed by name only too, so task text never
-        // reaches this process's argv.
-        assert!(args.contains(&TASK_ENV.to_owned()));
-        assert!(args
-            .iter()
-            .all(|arg| !arg.contains(TASK_ENV) || arg == TASK_ENV));
         assert!(args.contains(&"127.0.0.1::9000".to_owned()));
         // The image precedes the container command.
         let image_at = args
@@ -778,13 +759,10 @@ mod tests {
         // enforces it.
         assert!(args.contains(&format!("{LIFETIME_CAP_ENV}=900")));
 
-        // With no task to deliver the passthrough is omitted entirely, leaving
-        // the image on its own default.
-        let taskless = run_args(&config, tag, run_id, false, None);
-        assert!(!taskless.contains(&TASK_ENV.to_owned()));
         // An uncapped provisioning names no cap at all rather than passing a zero
         // the container would read as "expire now".
-        assert!(taskless.iter().all(|arg| !arg.contains(LIFETIME_CAP_ENV)));
+        let uncapped = run_args(&config, tag, run_id, None);
+        assert!(uncapped.iter().all(|arg| !arg.contains(LIFETIME_CAP_ENV)));
     }
 
     /// Every confinement control reaches the argv. A container missing them
@@ -793,7 +771,7 @@ mod tests {
     #[test]
     fn run_args_carry_the_container_confinement() {
         let config = DockerConfig::default();
-        let args = run_args(&config, SandboxTag::new(), RunId::new(), false, None);
+        let args = run_args(&config, SandboxTag::new(), RunId::new(), None);
         let pair = |flag: &str| {
             args.iter()
                 .position(|arg| arg == flag)
@@ -839,7 +817,6 @@ mod tests {
             run_id: RunId::new(),
             tag: SandboxTag::new(),
             lifetime_cap_secs,
-            task: None,
         };
         let config = DockerConfig::default();
         assert_eq!(config.lifetime_cap_secs, Some(DEFAULT_LIFETIME_CAP_SECS));
@@ -1022,7 +999,6 @@ mod tests {
                 run_id: RunId::new(),
                 tag: live_tag,
                 lifetime_cap_secs: None,
-                task: None,
             })
             .await
             .expect("provision live container");
@@ -1034,7 +1010,6 @@ mod tests {
                 run_id: RunId::new(),
                 tag: orphan_tag,
                 lifetime_cap_secs: None,
-                task: None,
             })
             .await
             .expect("provision orphan container");


### PR DESCRIPTION
The run-init bullet of #920, closing the interim marked on `ProvisionRequest::task` since #919: the delegated task rode the provisioning request and reached the container through its environment, which meant a sandbox could hold its task — and start working on it — before the host ever committed the handle.

## What changes

- **`WireFrame::Init(RunInit)`** — the `init::RunInit` type (task, provenance, deadline, admission mode, policy snapshot, optional scoped token) now actually rides the wire. The driver sends it on **every** attach, after the handshake, only over the authenticated connection; the sandbox keeps the first delivery and ignores redeliveries, so reattach is idempotent. `SandboxRun::init()` lets the agent await it.
- **The agent entrypoint starts with no task.** `OPENWAVE_SANDBOX_TASK` is gone; the loop parks until init arrives — so a sandbox reclaimed before its handle committed never executed anything, which is the design's whole point.
- **`ProvisionRequest.task` is removed**, along with the Docker backend's task-env passthrough. Attached-only runs carry no scoped token; the host remains the only model path.
- **`PROTOCOL_VERSION` 2 → 3.** New frame plus a removed provisioning field; the exact-equality handshake makes the bump the honest signal. The protocol is declared UNSTABLE.

## Tests

The existing loopback suite now proves init delivery end-to-end for free: the mock backend starts the real agent with no task at all (exactly as the image starts), so a driver that failed to send init would leave every drive parked and time out, and the prompt the agent asks the host to complete proves which task it received. The gated Docker conformance test sends init explicitly. Resolved against the container-hardening changes that landed in parallel.

Verified: sandbox server tests 76 passed, protocol suite passed, agent tests passed, clippy `-D warnings` on all three crates, fmt. The packaged image's behavior is covered by the post-merge `sandbox-resident container e2e` lane.

Part of #920.