### PR TITLE
feat(desktop): explain a failed turn and offer the retry it has

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -28,6 +28,9 @@ import {
 } from "./ChatTranscriptPresentation";
 import { useFirstMessage } from "./FirstMessage";
 import { ChatView } from "./ChatView";
+import type { RetryableTurn } from "./MessageList";
+import type { TranscriptFileAttachment } from "./TranscriptFileAttachments";
+import type { TranscriptImageAttachment } from "./ImageAttachments";
 import { OutputDetailRoot } from "./outputs/OutputDetailRoot";
 import { OutputsView } from "./outputs/OutputsView";
 import { DocumentDetailRoot } from "./document-detail/DocumentDetailRoot";
@@ -276,14 +279,66 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     imageItems: readonly ImageAttachment[] = images.attachments,
     fileItems: readonly ImportedDocument[] = files,
   ) {
+    await postTurn({
+      content,
+      attachments: readyImageAttachmentIds(imageItems),
+      transcriptImages: readyTranscriptImageAttachments(imageItems),
+      documentIds: fileItems.map((file) => file.documentId),
+      transcriptFiles: fileItems.map((file) => ({
+        documentId: file.documentId,
+        name: file.displayName,
+        mediaType: file.mediaType,
+      })),
+      fromComposer: true,
+    });
+  }
+
+  /**
+   * Retry sends the failed turn again — same prompt, same attachments, a new
+   * turn id.
+   *
+   * There is no server-side resume: a failed turn is terminal in the journal
+   * and nothing re-runs one in place. A fresh turn is exactly what the reader
+   * would get by retyping the prompt, without the retyping, and it reuses the
+   * attachment and document ids the first attempt published, so the model sees
+   * the same message rather than a text-only shadow of it.
+   */
+  function retryTurn(turn: RetryableTurn) {
+    void postTurn({
+      content: turn.text,
+      attachments: turn.images.map((image) => image.attachmentId),
+      transcriptImages: [...turn.images],
+      documentIds: turn.files.map((file) => file.documentId),
+      transcriptFiles: [...turn.files],
+      fromComposer: false,
+    });
+  }
+
+  /**
+   * The one path a turn takes to the server, whether the reader typed it or the
+   * retry button resent it. `fromComposer` is what separates the two: only a
+   * send that drew on the composer may empty it.
+   */
+  async function postTurn({
+    content,
+    attachments,
+    transcriptImages,
+    documentIds,
+    transcriptFiles,
+    fromComposer,
+  }: {
+    content: string;
+    attachments: readonly string[];
+    transcriptImages: readonly TranscriptImageAttachment[];
+    documentIds: readonly string[];
+    transcriptFiles: readonly TranscriptFileAttachment[];
+    fromComposer: boolean;
+  }) {
     if (!chat || !content || busy || deletingChatId !== null) return;
-    const attachments = readyImageAttachmentIds(imageItems);
-    const transcriptImages = readyTranscriptImageAttachments(imageItems);
-    const documentIds = fileItems.map((file) => file.documentId);
     const turnId = crypto.randomUUID();
     terminalHydrationGenerationRef.current += 1;
     const optimisticId = nextId();
-    setComposerDraft("");
+    if (fromComposer) setComposerDraft("");
     updateSession((session) => ({
       ...session,
       busy: true,
@@ -294,12 +349,8 @@ export function ChatRoute({ chatId }: { chatId: string }) {
           id: optimisticId,
           role: "user",
           text: content,
-          images: transcriptImages,
-          files: fileItems.map((file) => ({
-            documentId: file.documentId,
-            name: file.displayName,
-            mediaType: file.mediaType,
-          })),
+          images: [...transcriptImages],
+          files: [...transcriptFiles],
           createdAt: new Date().toISOString(),
         },
       ],
@@ -313,11 +364,15 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         attachments,
         documentIds,
       );
-      // Only once the turn is durably accepted. A refused send — an image the
-      // selected model cannot read, say — must leave the attachments where the
-      // reader can fix the problem and try again.
-      images.clear();
-      setFiles([]);
+      // Only once the turn is durably accepted, and only for what the composer
+      // actually contributed. A refused send — an image the selected model
+      // cannot read, say — must leave the attachments where the reader can fix
+      // the problem and try again; a retry must not throw away attachments the
+      // reader has queued for their *next* message.
+      if (fromComposer) {
+        images.clear();
+        setFiles([]);
+      }
     } catch (err) {
       // Nothing was accepted, so the message has to go back to where it can be
       // fixed and sent again: the text returns to the composer and the
@@ -509,6 +564,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             onDraftChange={setComposerDraft}
             onSelectPrompt={setComposerDraft}
             onSend={onSend}
+            onRetryTurn={retryTurn}
             onViewOutput={() => openPanel({ type: "outputs" })}
           />
         </TranscriptVisibilityProvider>

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -500,18 +500,18 @@ describe("terminal events", () => {
     ]);
   });
 
-  it("turn_failed settles active tools as failed and appends the error bubble", () => {
+  it("turn_failed settles active tools as failed and carries the category through", () => {
     const { state } = play([
       TURN,
       { type: "tool_call_started", call_id: "call-1", name: "search" },
-      { type: "turn_failed", category: "unknown" },
+      { type: "turn_failed", category: "rate_limited" },
     ]);
     expect(state.messages.find((m) => m.role === "tool")).toMatchObject({
       status: "failed",
     });
     expect(state.messages[state.messages.length - 1]).toMatchObject({
-      role: "error",
-      text: "The turn could not be completed.",
+      role: "turn_failure",
+      category: "rate_limited",
     });
   });
 

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -432,10 +432,12 @@ export function reduceChatSessionEvent(
           provisionalToolCallIds: new Set(),
           messages: [
             ...settleActiveToolCalls(state.messages, "failed"),
+            // The category rides into the transcript as data; the renderer
+            // owns both the copy and which recovery it offers.
             {
               id: deps.nextId(),
-              role: "error",
-              text: "The turn could not be completed.",
+              role: "turn_failure",
+              category: event.category,
             },
           ],
         },

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -16,7 +16,7 @@ import {
   type ComposerFolders,
   type ComposerImages,
 } from "./Composer";
-import { MessageList } from "./MessageList";
+import { MessageList, type RetryableTurn } from "./MessageList";
 import { useTranscriptVisible } from "./TranscriptVisibility";
 import { useFolderAccessRequests } from "./useFolderAccessRequests";
 import { useOutputWritebackRequests } from "./useOutputWritebackRequests";
@@ -45,6 +45,8 @@ export type ChatViewProps = {
   onDraftChange: (value: string) => void;
   onSelectPrompt: (prompt: string) => void;
   onSend: () => Promise<void>;
+  /** Put a failed turn back on the wire, unchanged, as a new turn. */
+  onRetryTurn?: (turn: RetryableTurn) => void;
   /** Open the outputs surface, offered on a completed background run's row. */
   onViewOutput?: () => void;
 };
@@ -73,6 +75,7 @@ export function ChatView({
   onDraftChange,
   onSelectPrompt,
   onSend,
+  onRetryTurn,
   onViewOutput,
 }: ChatViewProps) {
   const transcriptVisible = useTranscriptVisible();
@@ -297,6 +300,7 @@ export function ChatView({
           onAnswerUserQuestions={userQuestions.answer}
           onUserQuestionsCancel={userQuestions.cancel}
           onSelectPrompt={onSelectPrompt}
+          onRetryTurn={onRetryTurn}
           hydrated={hydrated}
           imageClient={client}
         />

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -1,7 +1,13 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import type { AgentRun } from "./api";
-import { MessageBubble, MessageList, type ChatMessage } from "./MessageList";
+import {
+  MessageBubble,
+  MessageList,
+  retryableTurn,
+  type ChatMessage,
+} from "./MessageList";
+import type { TurnFailureCategory } from "./generated/wire";
 
 const noop = () => undefined;
 
@@ -463,5 +469,56 @@ describe("superseded responses", () => {
     expect(markup).toContain("message-superseded");
     expect(markup).toContain("Superseded response");
     expect(markup).toContain("abandoned partial");
+  });
+});
+
+describe("retryableTurn", () => {
+  const failed = (category: TurnFailureCategory): ChatMessage[] => [
+    { id: "u1", role: "user", text: "summarize this" },
+    { id: "f1", role: "turn_failure", category },
+  ];
+
+  // `auth` is the case worth pinning: a retry would present the same credential
+  // the provider just rejected, so offering the button lies about recovery.
+  it("offers a retry for every terminal category except auth", () => {
+    expect(retryableTurn(failed("rate_limited"))).toMatchObject({
+      failureId: "f1",
+      text: "summarize this",
+    });
+    expect(retryableTurn(failed("transient"))).not.toBeNull();
+    expect(retryableTurn(failed("unknown"))).not.toBeNull();
+    expect(retryableTurn(failed("auth"))).toBeNull();
+  });
+
+  it("offers nothing once the failure is no longer the newest message", () => {
+    expect(
+      retryableTurn([
+        ...failed("transient"),
+        { id: "u2", role: "user", text: "never mind" },
+      ]),
+    ).toBeNull();
+  });
+
+  it("carries the failed turn's attachments so the resend is not text-only", () => {
+    const turn = retryableTurn([
+      {
+        id: "u1",
+        role: "user",
+        text: "what is in this",
+        images: [
+          { attachmentId: "img-1", mediaType: "image/png", width: 8, height: 8 },
+        ],
+        files: [
+          {
+            documentId: "doc-1",
+            name: "notes.pdf",
+            mediaType: "application/pdf",
+          },
+        ],
+      },
+      { id: "f1", role: "turn_failure", category: "rate_limited" },
+    ]);
+    expect(turn?.images.map((image) => image.attachmentId)).toEqual(["img-1"]);
+    expect(turn?.files.map((file) => file.documentId)).toEqual(["doc-1"]);
   });
 });

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -43,6 +43,11 @@ import {
 import { BackgroundAgentList } from "./BackgroundAgentList";
 import { WebSearchProviderRequiredCard } from "./WebSearchProviderRequiredCard";
 import { useSourceNav } from "./panel/SourceNav";
+import {
+  TurnFailureNotice,
+  turnFailureOffersRetry,
+} from "./TurnFailureNotice";
+import type { TurnFailureCategory } from "./generated/wire";
 import { useStreamingTypewriter } from "./useStreamingTypewriter";
 import { Skeleton } from "./components/ui/skeleton";
 
@@ -101,7 +106,46 @@ export type ChatMessage =
       prefixRungs?: readonly number[];
       resolved?: boolean;
     }
-  | { id: string; role: "error"; text: string };
+  | { id: string; role: "error"; text: string }
+  | { id: string; role: "turn_failure"; category: TurnFailureCategory };
+
+/** Everything a retry needs to put the failed turn back on the wire unchanged. */
+export type RetryableTurn = {
+  /** The failure notice that offers this retry. */
+  failureId: string;
+  text: string;
+  images: readonly TranscriptImageAttachment[];
+  files: readonly TranscriptFileAttachment[];
+};
+
+/**
+ * The retry the transcript currently offers, if any.
+ *
+ * Only a transcript that *ends* on a retryable failure has one. An older
+ * failure keeps its explanation but loses its button: resending a prompt from
+ * the middle of a conversation the reader has since moved past is a footgun,
+ * and the turns after it already answered whatever came next.
+ */
+export function retryableTurn(
+  messages: readonly ChatMessage[],
+): RetryableTurn | null {
+  const failure = messages[messages.length - 1];
+  if (failure?.role !== "turn_failure") return null;
+  if (!turnFailureOffersRetry(failure.category)) return null;
+  for (let index = messages.length - 2; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== "user") continue;
+    // Nothing to resend — the prompt the turn failed on is no longer in hand.
+    if (message.text.trim().length === 0) return null;
+    return {
+      failureId: failure.id,
+      text: message.text,
+      images: message.images ?? [],
+      files: message.files ?? [],
+    };
+  }
+  return null;
+}
 
 type MessageListProps = {
   messages: ChatMessage[];
@@ -163,6 +207,8 @@ type MessageListProps = {
   ) => void;
   onUserQuestionsCancel?: (turnId: string) => void;
   onSelectPrompt?: (prompt: string) => void;
+  /** Resend the failed turn. Offered only on the transcript's newest failure. */
+  onRetryTurn?: (turn: RetryableTurn) => void;
   hydrated?: boolean;
   imageClient?: Pick<ApiClient, "getChatImageAttachment">;
 };
@@ -206,6 +252,7 @@ export function MessageList({
   onAnswerUserQuestions = () => undefined,
   onUserQuestionsCancel = () => undefined,
   onSelectPrompt,
+  onRetryTurn,
   hydrated = true,
   imageClient,
 }: MessageListProps) {
@@ -215,6 +262,12 @@ export function MessageList({
     () => ({ decidingApprovalCalls, approvalErrors, grantScope }),
     [decidingApprovalCalls, approvalErrors, grantScope],
   );
+  const retry = useMemo(() => {
+    if (!onRetryTurn) return undefined;
+    const turn = retryableTurn(messages);
+    if (!turn) return undefined;
+    return { failureId: turn.failureId, onRetry: () => onRetryTurn(turn) };
+  }, [messages, onRetryTurn]);
   const { items: messageItems, lastTurnStart } = groupMessageItems(
     messages,
     busy,
@@ -231,6 +284,7 @@ export function MessageList({
       loadActivity: onLoadBackgroundAgentActivity,
       viewOutput: onViewBackgroundAgentOutput,
     },
+    retry,
   );
   // Only greet a genuinely empty, fully-hydrated conversation. While an
   // existing chat's transcript is still loading it is transiently empty; showing
@@ -408,6 +462,7 @@ export function groupMessageItems(
     cancel: async () => undefined,
     loadActivity: async () => [],
   },
+  retry?: { failureId: string; onRetry: () => void },
 ) {
   const items: ReactNode[] = [];
   // The item index at which the trailing turn opens (its user message). Lets the
@@ -446,6 +501,9 @@ export function groupMessageItems(
           busy={message.id === streamingAssistantId}
           imageClient={imageClient}
           chatId={chatId}
+          onRetry={
+            retry?.failureId === message.id ? retry.onRetry : undefined
+          }
         />,
       );
       index += 1;
@@ -698,11 +756,14 @@ function MessageBubbleImpl({
   busy,
   imageClient,
   chatId,
+  onRetry,
 }: {
   message: ChatMessage;
   busy: boolean;
   imageClient?: Pick<ApiClient, "getChatImageAttachment">;
   chatId?: string;
+  /** Present only on the transcript's newest retryable failure. */
+  onRetry?: () => void;
 }) {
   const sourceNav = useSourceNav();
   // One way into the source panel for both anchors a citation has: the phrase
@@ -797,6 +858,10 @@ function MessageBubbleImpl({
     );
   }
 
+  if (message.role === "turn_failure") {
+    return <TurnFailureNotice category={message.category} onRetry={onRetry} />;
+  }
+
   if (message.role === "refusal") {
     return (
       <div className="message-notice is-refusal" role="status">
@@ -865,6 +930,12 @@ export function shouldShowAssistantWorking(
   if (latest?.role === "assistant") {
     return latest.text.trim().length === 0 && latest.sources.length === 0;
   }
-  if (latest?.role === "system" || latest?.role === "error") return false;
+  if (
+    latest?.role === "system" ||
+    latest?.role === "error" ||
+    latest?.role === "turn_failure"
+  ) {
+    return false;
+  }
   return true;
 }

--- a/crates/openwave-desktop/ui/src/TurnFailureNotice.tsx
+++ b/crates/openwave-desktop/ui/src/TurnFailureNotice.tsx
@@ -1,0 +1,91 @@
+import { RefreshCw, Settings } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
+
+import { Button } from "@/components/ui/button";
+import type { TurnFailureCategory } from "./generated/wire";
+
+/**
+ * Whether a category's recovery is "send it again".
+ *
+ * Derived from the category alone — there is no separate retryable flag on the
+ * wire, deliberately, so nothing can contradict this.
+ *
+ * `auth` is the case that must stay false: the credential the provider rejected
+ * is the same one a retry would present, so the button would only replay the
+ * rejection. That case points at settings instead.
+ */
+export function turnFailureOffersRetry(category: TurnFailureCategory): boolean {
+  return category !== "auth";
+}
+
+/**
+ * Renderer-owned failure copy; the server's category stays data, not prose.
+ *
+ * The categories only ever describe a *terminal* failure. A turn still waiting
+ * on the server's own retry emits nothing at all, so `rate_limited` here means
+ * those retries were already spent — copy that asks the reader to be patient
+ * would be describing something that has already finished happening.
+ */
+export function turnFailureCopy(category: TurnFailureCategory): string {
+  switch (category) {
+    case "rate_limited":
+      return "The model provider rate-limited this turn, and the automatic retries behind it are already spent. Sending it again may work once demand eases.";
+    case "auth":
+      return "The model provider rejected the credentials for this model. Sending the turn again would be rejected the same way — check the provider's API key in Settings.";
+    case "transient":
+      return "The connection to the model provider broke before the turn finished. Sending it again should pick up where this left off.";
+    case "unknown":
+      return "The turn could not be completed, and the provider gave no reason we can act on. Sending it again may not help; if it keeps failing, check the provider's API key in Settings.";
+  }
+}
+
+/**
+ * A terminal turn failure, with whatever recovery its category actually offers.
+ *
+ * `onRetry` is supplied only for the newest failure in the transcript: a button
+ * on a failure buried in scrollback would resend a prompt the reader has long
+ * since moved past.
+ */
+export function TurnFailureNotice({
+  category,
+  onRetry,
+}: {
+  category: TurnFailureCategory;
+  onRetry?: () => void;
+}) {
+  const navigate = useNavigate();
+  // Settings sections are registered from a runtime table, so TanStack's
+  // generated route union contains `/settings` but not each literal child.
+  const providerSettingsPath: string = "/settings/providers";
+
+  return (
+    <div className="message-notice is-error message-turn-failure" role="alert">
+      <p className="message-turn-failure-text">{turnFailureCopy(category)}</p>
+      {turnFailureOffersRetry(category) ? (
+        onRetry && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            onClick={onRetry}
+          >
+            <RefreshCw aria-hidden="true" />
+            Retry
+          </Button>
+        )
+      ) : (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          onClick={() => void navigate({ to: providerSettingsPath })}
+        >
+          <Settings aria-hidden="true" />
+          Open provider settings
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -856,6 +856,22 @@ body {
   text-align: left;
 }
 
+/* A failure carries its recovery, so the notice becomes a row: explanation on
+   the left, the one action it offers pinned to the right. */
+.message-turn-failure {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.5rem 0.5rem 0.5rem 0.7rem;
+}
+
+.message-turn-failure-text {
+  min-width: 0;
+  flex: 1 1 16rem;
+}
+
 .message-notice.is-refusal {
   align-self: stretch;
   border: 1px solid color-mix(in srgb, var(--warning) 42%, var(--line));


### PR DESCRIPTION
A failed turn used to leave one sentence — "The turn could not be completed." — and no way forward but retyping the prompt. Now that `turn_failed` carries a category, the transcript can say what went wrong and offer the recovery that category actually has.

The failure enters the transcript as its own message role carrying the category; the copy and the affordance stay renderer-owned, the same split the refusal notice already uses.

Copy per category:

- **rate_limited** — "The model provider rate-limited this turn, and the automatic retries behind it are already spent. Sending it again may work once demand eases."
- **auth** — "The model provider rejected the credentials for this model. Sending the turn again would be rejected the same way — check the provider's API key in Settings."
- **transient** — "The connection to the model provider broke before the turn finished. Sending it again should pick up where this left off."
- **unknown** — "The turn could not be completed, and the provider gave no reason we can act on. Sending it again may not help; if it keeps failing, check the provider's API key in Settings."

Two things the copy has to get right. A turn still inside the server's own retry window emits no `turn_failed` at all, so every category here describes a failure that is already terminal — nothing says or implies that waiting will resolve it. And `auth` gets no Retry button: the credential a retry would present is the one the provider just rejected, so it points at provider settings instead. `unknown` keeps a button, since it genuinely might be transient, but its copy promises nothing — a missing API key currently lands there rather than in `auth` (#1171).

Retry resends the failed turn as a new turn: same prompt, same attachment and document ids, new turn id. There is no server-side resume — a failed turn is terminal in the journal and nothing re-runs one in place — so this is what the reader would get by retyping, minus the retyping and minus losing the attachments. Sending and retrying now share one path through `postTurn`, with a flag for the one thing that differs: only a send that drew on the composer may empty it, so a retry cannot discard attachments queued for the next message.

The button is offered only on the transcript's newest failure. A retry sitting on a failure halfway up the scrollback would resend a prompt the conversation has long since moved past.

Tests: three cases on `retryableTurn` in the existing `MessageList` suite — the category-to-retry mapping (`auth` is the one that costs us if it flips), the newest-failure rule, and that the resend carries the original attachments. The reducer test that asserted the old flat string now asserts the category reaches the transcript.

Verified with `pnpm exec tsc --noEmit`, `pnpm test`, and `pnpm build` in `crates/openwave-desktop/ui`. No Rust changed. I did not drive the running app.

One gap this leaves: a reopened conversation does not show its failures at all — the durable transcript presenter never produced a failure notice, so the explanation and its retry live only in the session that saw the turn fail.

Closes #1107
