### PR TITLE
fix(server): refuse to complete a turn on an empty model response

### DIFF
--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -196,7 +196,7 @@ impl TurnFailureCategory {
         match kind {
             "rate_limited" | "overloaded" => Self::RateLimited,
             "authentication" => Self::Auth,
-            "provider" | "store" | "secret" => Self::Transient,
+            "provider" | "store" | "secret" | "empty_model_response" => Self::Transient,
             _ => Self::Unknown,
         }
     }

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -367,10 +367,16 @@ impl ModelProvider for GatedProvider {
         let gate = self.gate.clone();
         Ok(stream::once(async move {
             gate.notified().await;
-            ProviderEvent::Stop {
-                reason: StopReason::EndTurn,
-            }
+            stream::iter(vec![
+                ProviderEvent::TextDelta {
+                    text: "gated answer".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ])
         })
+        .flatten()
         .boxed())
     }
 }

--- a/crates/openwave-server/src/tests/workers.rs
+++ b/crates/openwave-server/src/tests/workers.rs
@@ -705,13 +705,21 @@ async fn scanner_won_cancellation_does_not_wedge_the_only_worker_lane() {
                 output_tokens: 3,
                 ..Usage::default()
             })])
-            .chain(stream::once(async move {
-                entered.notify_one();
-                gate.notified().await;
-                ProviderEvent::Stop {
-                    reason: StopReason::EndTurn,
-                }
-            }))
+            .chain(
+                stream::once(async move {
+                    entered.notify_one();
+                    gate.notified().await;
+                    stream::iter(vec![
+                        ProviderEvent::TextDelta {
+                            text: "gated answer".into(),
+                        },
+                        ProviderEvent::Stop {
+                            reason: StopReason::EndTurn,
+                        },
+                    ])
+                })
+                .flatten(),
+            )
             .boxed())
         }
     }
@@ -976,6 +984,67 @@ async fn invalid_nul_agent_output_fails_without_wedging_the_worker() {
         Some(AgentEvent::TurnFailed { error }) if error.kind == "invalid_agent_output"
     ));
     assert_eq!(store.list_messages(chat.id).await.unwrap().len(), 1);
+}
+
+/// A response with no text and no tool calls is not an answer, so it must not
+/// end the turn as a success. The remedy is to ask again on the same
+/// transcript, which is what the user would do by hand.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_empty_model_response_does_not_complete_the_turn() {
+    struct EmptyOnceProvider {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for EmptyOnceProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("empty-once")
+        }
+
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Ok(stream::iter(vec![ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                }])
+                .boxed());
+            }
+            Ok(stream::iter(vec![
+                ProviderEvent::TextDelta {
+                    text: "here is the answer".into(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                },
+            ])
+            .boxed())
+        }
+    }
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let (router, token, store, _dir) = test_app_with(Arc::new(EmptyOnceProvider {
+        calls: calls.clone(),
+    }))
+    .await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    assert_eq!(
+        send_message(&router, &bearer, chat.id, "say something").await,
+        StatusCode::ACCEPTED
+    );
+
+    let events = wait_for_turn(&store, chat.id).await;
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert!(matches!(
+        events.last().map(|event| &event.event),
+        Some(AgentEvent::TurnCompleted { .. })
+    ));
+    let turn = store.list_turn_runs(chat.id).await.unwrap().pop().unwrap();
+    assert_eq!(turn.attempt_count, 2);
+    let messages = store.list_messages(chat.id).await.unwrap();
+    assert_eq!(
+        messages.last().map(|message| message.content.as_str()),
+        Some("here is the answer")
+    );
 }
 
 #[tokio::test]

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -985,6 +985,50 @@ impl TurnWorker {
                             )
                             .await;
                     }
+                    // A model step that ends the turn with neither prose nor a
+                    // tool call is not an answer, and completing on it hands the
+                    // user a blank turn that looks successful and gives them
+                    // nothing to act on. Two exemptions are deliberate: a
+                    // refusal is its own outcome and stays meaningful with no
+                    // prose behind it, and a step that only calls tools never
+                    // reaches here — the loop runs the calls and takes another
+                    // step. Assistant text persisted by earlier steps is already
+                    // durable and is not touched by failing here.
+                    if refusal.is_none() && output.content.trim().is_empty() {
+                        if remaining_steps == 0 {
+                            // The step budget is spent, so this was the turn's
+                            // closing call. A retry would reclaim the turn only
+                            // to fail immediately on the exhausted budget, so
+                            // report the budget as the reason it ended with
+                            // nothing to say.
+                            return self
+                                .record_failure(
+                                    &turn,
+                                    lease_token,
+                                    total_model_steps,
+                                    total_usage,
+                                    "max_steps_exceeded",
+                                    "the turn's closing model call returned no output after its step budget was spent",
+                                )
+                                .await;
+                        }
+                        // Budget is left, so asking again is the remedy: the
+                        // retry rebuilds the same transcript, tool results
+                        // included, and only re-runs the model call that came
+                        // back empty. Once the attempt budget is spent the user
+                        // gets a transient failure rather than a blank success.
+                        return self
+                            .record_classified_failure(
+                                &turn,
+                                lease_token,
+                                total_model_steps,
+                                total_usage,
+                                "empty_model_response",
+                                "the model returned neither text nor a tool call",
+                                None,
+                            )
+                            .await;
+                    }
                     let expected_steer_revision = steer_revision.ok_or_else(|| {
                         AgentError::msg(format!(
                             "turn {} completed without a durable generation fence",


### PR DESCRIPTION
A model step that returns neither text nor a tool call was committed as a successful completion — the worker's only output check rejected NUL bytes. The result was a blank turn that reported success, with nothing for the user to act on and no error to explain it.

An empty final response now ends the turn as a failure, with the disposition depending on whether asking again could help:

- **Step budget left.** The provider simply returned nothing, so the remedy is to ask again. The failure is classified transient and the turn is rescheduled; the retry rebuilds the same transcript, tool results included, so only the model call that came back empty runs again. When the attempt budget is spent the user gets a transient failure instead of a blank success.
- **Step budget spent.** The empty response was the turn's closing call, made after the step ceiling with tools withheld. A retry would reclaim the turn only to fail immediately on the exhausted budget, so it fails right away as `max_steps_exceeded` — the ceiling is the honest reason the turn ended with nothing to say.

Deliberately not treated as empty:

- **Refusals.** The refusal is the outcome and stays meaningful with no prose behind it, so the check skips them and `TurnRefused` still commits its partial output.
- **Tool-only steps.** They never reach this path; the loop runs the calls and takes another step.
- **Cancellation.** It resolves through a different outcome and commits no assistant message.

Prose persisted by earlier steps is durable and untouched either way: failing here does not remove text the reader can already see.

The gated test providers used across the worker and lifecycle tests were completing with no text, which the rule now rejects. They answer before stopping.

One test covers the invariant end to end: a provider that returns an empty response once and an answer on the second call. The turn does not complete on the empty response, is retried, and finishes with the answer.

Closes #1100
