### PR TITLE
feat(host-broker): give exec its own capability

### DIFF
--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -321,7 +321,7 @@ struct PreparedRegistration {
     conversation_id: Uuid,
     root_id: RootId,
     root: RegisteredRoot,
-    grants: [Grant; 3],
+    grants: [Grant; 4],
     attachment: RootAttachment,
 }
 
@@ -871,6 +871,17 @@ impl Controller {
             request.subject,
             Capability::WriteFiles,
             Scope::Root { root_id },
+            consent.clone(),
+        )?;
+        // Choosing a folder is how the user says the agent may work in it, so
+        // exec reach is part of that consent rather than a second prompt. The
+        // capability exists so it can be named, audited, and revoked on its own
+        // afterwards, not to add a step here.
+        let exec_grant = Grant::from_consent(
+            GrantId::new(),
+            request.subject,
+            Capability::ExecuteCommands,
+            Scope::Root { root_id },
             consent,
         )?;
         Ok(PreparedRegistration {
@@ -881,7 +892,7 @@ impl Controller {
                 display_name,
                 root: Arc::new(validated),
             },
-            grants: [list_grant, read_grant, write_grant],
+            grants: [list_grant, read_grant, write_grant, exec_grant],
             attachment: RootAttachment::new(request.conversation_id, root_id)?,
         })
     }
@@ -1943,12 +1954,15 @@ fn apply_root_attachment(
                 .roots
                 .get(&request.root_id)
                 .ok_or(BrokerError::UnknownRoot)?;
-            let consent = ConsentRecord::new(
-                request
-                    .consent_method
-                    .ok_or(BrokerError::InvalidConsentMethod)?,
-                Utc::now(),
-            );
+            let method = request
+                .consent_method
+                .ok_or(BrokerError::InvalidConsentMethod)?;
+            // `CarriedForward` describes a migration, not an interaction, so a
+            // control caller must not be able to stamp it on a live grant.
+            if matches!(method, ConsentMethod::CarriedForward) {
+                return Err(BrokerError::InvalidConsentMethod);
+            }
+            let consent = ConsentRecord::new(method, Utc::now());
             ensure_subject_grants(state, request.subject, request.root_id, consent)?;
             if has_root_attachment(state, request.conversation_id, request.root_id) {
                 false
@@ -2089,6 +2103,19 @@ fn ensure_subject_grants(
             subject,
             Capability::WriteFiles,
             Scope::Root { root_id },
+            consent.clone(),
+        )?);
+    }
+    if !state.grants.iter().any(|grant| {
+        grant.subject() == subject
+            && grant.capability() == Capability::ExecuteCommands
+            && matches!(grant.scope(), Scope::Root { root_id: granted } if *granted == root_id)
+    }) {
+        state.grants.push(Grant::from_consent(
+            GrantId::new(),
+            subject,
+            Capability::ExecuteCommands,
+            Scope::Root { root_id },
             consent,
         )?);
     }
@@ -2220,14 +2247,7 @@ fn resolve_exec_roots(
     let mut seen = HashSet::new();
     let mut roots = Vec::new();
     for root_id in request.root_ids {
-        if !seen.insert(root_id)
-            || authorize(
-                state,
-                request.context,
-                Capability::ReadFiles,
-                Resource::Root(&root_id),
-            )
-            .is_err()
+        if !seen.insert(root_id) || authorize_exec_reach(state, request.context, &root_id).is_err()
         {
             continue;
         }
@@ -2251,6 +2271,31 @@ fn resolve_exec_roots(
     Ok(roots)
 }
 
+/// Whether commands may run against one root's contents in this conversation.
+///
+/// Exec reach sits on top of read rather than beside it. A command with the
+/// folder in front of it can read every byte the read capability covers, so
+/// holding exec without read is not a state the broker will act on: revoking
+/// read has to stop the shell too, or the narrower revocation would be a lie.
+fn authorize_exec_reach(
+    state: &State,
+    context: ExecutionContext,
+    root_id: &RootId,
+) -> Result<GrantId, BrokerError> {
+    authorize(
+        state,
+        context,
+        Capability::ReadFiles,
+        Resource::Root(root_id),
+    )?;
+    authorize(
+        state,
+        context,
+        Capability::ExecuteCommands,
+        Resource::Root(root_id),
+    )
+}
+
 /// Per-folder capabilities this conversation actually holds on one root.
 ///
 /// Each candidate is put through the same [`authorize`] call that gates the
@@ -2262,12 +2307,16 @@ fn root_capabilities(
     context: ExecutionContext,
     root_id: &RootId,
 ) -> Vec<Capability> {
-    [Capability::ReadFiles, Capability::WriteFiles]
+    let mut capabilities = [Capability::ReadFiles, Capability::WriteFiles]
         .into_iter()
         .filter(|capability| {
             authorize(state, context, *capability, Resource::Root(root_id)).is_ok()
         })
-        .collect()
+        .collect::<Vec<_>>();
+    if authorize_exec_reach(state, context, root_id).is_ok() {
+        capabilities.push(Capability::ExecuteCommands);
+    }
+    capabilities
 }
 
 fn root_display_name(path: &Path) -> String {

--- a/crates/openwave-host-broker/src/broker/state_file.rs
+++ b/crates/openwave-host-broker/src/broker/state_file.rs
@@ -1,7 +1,7 @@
 //! Durable broker registry and mutation receipts.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fs::{self, File, OpenOptions, TryLockError},
     io::{self, Read, Write},
     path::{Path, PathBuf},
@@ -18,11 +18,11 @@ use super::{
     RegisteredRoot, State, UnavailableRoot, UnavailableRootReason,
 };
 use crate::{
-    path_policy::RootIdentity, Grant, GrantSubject, OperationId, RootAttachment, RootId,
-    RootPolicy, Scope,
+    path_policy::RootIdentity, Capability, ConsentMethod, ConsentRecord, Grant, GrantId,
+    GrantSubject, OperationId, RootAttachment, RootId, RootPolicy, Scope,
 };
 
-const STATE_VERSION: u32 = 3;
+const STATE_VERSION: u32 = 4;
 const STATE_FILE_NAME: &str = "host-broker-state.json";
 pub(super) const MAX_STATE_FILE_BYTES: usize = 16 * 1024 * 1024;
 
@@ -112,7 +112,7 @@ impl StateFile {
             return Err(BrokerError::StateTooLarge);
         }
         let persisted: PersistedState = serde_json::from_slice(&bytes).map_err(invalid_data)?;
-        if !matches!(persisted.version, 2 | STATE_VERSION) {
+        if !matches!(persisted.version, 2 | 3 | STATE_VERSION) {
             return Err(invalid_data(format!(
                 "unsupported broker state version {}",
                 persisted.version
@@ -153,6 +153,9 @@ impl StateFile {
         }
 
         let mut grants = persisted.grants;
+        if persisted.version < 4 {
+            carry_forward_exec_grants(&mut grants)?;
+        }
         let mut attachments = persisted.attachments;
         for root in &mut unavailable {
             let root_id = root.id;
@@ -331,6 +334,59 @@ impl AtomicWriteError {
             published: true,
         }
     }
+}
+
+/// Name the exec reach a pre-version-4 root-scoped read grant already carried.
+///
+/// Before version 4 the broker resolved a folder for commands off its read
+/// grant, so every folder attached under those versions has been exec-reachable
+/// for as long as it has been attached. Splitting the capability out therefore
+/// has to choose between changing what those folders allow and recording a
+/// grant the user never saw a prompt for.
+///
+/// It records the grant, because the alternative is worse in both directions:
+/// dropping exec would silently break folders people are working in, and the
+/// re-consent affordance that would let them restore it does not exist yet. The
+/// reason this is not the forged-consent shape that mirroring read into write
+/// would have been is that no reach is created here — a command could already
+/// see everything in these folders, and still can see no more. The migration
+/// only makes an existing authority nameable, so it says so: the record is
+/// [`ConsentMethod::CarriedForward`], carrying the source grant's own timestamp
+/// rather than claiming the user approved anything today.
+///
+/// Read grants scoped to a subtree are left alone. Exec resolution has always
+/// asked about a whole root, so a subtree grant never reached a command, and
+/// widening one now would create authority instead of naming it.
+fn carry_forward_exec_grants(grants: &mut Vec<Grant>) -> Result<(), BrokerError> {
+    let mut covered = grants
+        .iter()
+        .filter_map(|grant| match (grant.capability(), grant.scope()) {
+            (Capability::ExecuteCommands, Scope::Root { root_id }) => {
+                Some((grant.subject(), *root_id))
+            }
+            _ => None,
+        })
+        .collect::<HashSet<_>>();
+    let carried = grants
+        .iter()
+        .filter_map(|grant| match (grant.capability(), grant.scope()) {
+            (Capability::ReadFiles, Scope::Root { root_id }) => {
+                Some((grant.subject(), *root_id, grant.consent().granted_at()))
+            }
+            _ => None,
+        })
+        .filter(|(subject, root_id, _)| covered.insert((*subject, *root_id)))
+        .collect::<Vec<_>>();
+    for (subject, root_id, granted_at) in carried {
+        grants.push(Grant::from_consent(
+            GrantId::new(),
+            subject,
+            Capability::ExecuteCommands,
+            Scope::Root { root_id },
+            ConsentRecord::new(ConsentMethod::CarriedForward, granted_at),
+        )?);
+    }
+    Ok(())
 }
 
 pub(super) fn validate_loaded_state(state: &State) -> Result<(), BrokerError> {

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -93,13 +93,17 @@ fn register(
     result
 }
 
-/// The listing shape a folder gets from a plain registration, which grants both
-/// reading and writing.
-fn read_write(root: RootSummary) -> RootAccess {
+/// The listing shape a folder gets from a plain registration, which grants
+/// reading, writing, and exec reach together.
+fn picker_access(root: RootSummary) -> RootAccess {
     RootAccess {
         root_id: root.root_id,
         display_name: root.display_name,
-        capabilities: vec![Capability::ReadFiles, Capability::WriteFiles],
+        capabilities: vec![
+            Capability::ReadFiles,
+            Capability::WriteFiles,
+            Capability::ExecuteCommands,
+        ],
     }
 }
 
@@ -455,7 +459,7 @@ fn approved_roots_can_be_explicitly_attached_to_another_standalone_conversation(
         )
         .unwrap(),
         OperationResult::ListRoots {
-            roots: vec![read_write(registered.root)]
+            roots: vec![picker_access(registered.root)]
         }
     );
     assert!(matches!(
@@ -524,7 +528,7 @@ fn reused_standalone_approval_and_chat_attachment_survive_restart() {
         )
         .unwrap(),
         OperationResult::ListRoots {
-            roots: vec![read_write(registered.root)]
+            roots: vec![picker_access(registered.root)]
         }
     );
 }
@@ -562,7 +566,7 @@ fn choosing_the_same_approved_folder_again_reuses_its_host_identity() {
         )
         .unwrap(),
         OperationResult::ListRoots {
-            roots: vec![read_write(first.root)]
+            roots: vec![picker_access(first.root)]
         }
     );
 }
@@ -738,7 +742,7 @@ fn basename_collisions_are_not_offered_as_approved_roots() {
         )
         .unwrap(),
         OperationResult::ListRoots {
-            roots: vec![read_write(first.root)],
+            roots: vec![picker_access(first.root)],
         }
     );
 }
@@ -761,7 +765,7 @@ fn register_list_read_and_revoke_are_one_live_authority_boundary() {
     assert_eq!(
         roots,
         OperationResult::ListRoots {
-            roots: vec![read_write(registered.root.clone())]
+            roots: vec![picker_access(registered.root.clone())]
         }
     );
     let listing = operate(
@@ -1025,7 +1029,7 @@ fn repeated_registration_reuses_the_same_root_and_attaches_new_project_chat() {
         assert_eq!(
             roots,
             OperationResult::ListRoots {
-                roots: vec![read_write(first.root.clone())]
+                roots: vec![picker_access(first.root.clone())]
             }
         );
     }
@@ -1434,7 +1438,7 @@ fn attach_and_detach_are_exact_conversation_mutations() {
     let second_context = ExecutionContext::project_chat(second_conversation, project_id).unwrap();
     assert!(matches!(
         operate(&broker.operator(), second_context, OperationRequest::ListRoots).unwrap(),
-        OperationResult::ListRoots { roots } if roots == vec![read_write(registered.root.clone())]
+        OperationResult::ListRoots { roots } if roots == vec![picker_access(registered.root.clone())]
     ));
 
     let detach_id = OperationId::new();
@@ -1455,7 +1459,7 @@ fn attach_and_detach_are_exact_conversation_mutations() {
     ));
     assert!(matches!(
         operate(&broker.operator(), second_context, OperationRequest::ListRoots).unwrap(),
-        OperationResult::ListRoots { roots } if roots == vec![read_write(registered.root)]
+        OperationResult::ListRoots { roots } if roots == vec![picker_access(registered.root)]
     ));
     assert!(
         !mutate_attachment(
@@ -2344,7 +2348,7 @@ fn an_unreachable_root_is_set_aside_rather_than_blocking_the_others() {
     assert_eq!(
         operate(&broker.operator(), context, OperationRequest::ListRoots).unwrap(),
         OperationResult::ListRoots {
-            roots: vec![read_write(reachable.root)]
+            roots: vec![picker_access(reachable.root)]
         }
     );
     assert!(
@@ -2602,6 +2606,67 @@ fn version_two_read_grants_migrate_without_gaining_write() {
         .any(|grant| grant.capability() == Capability::WriteFiles));
 }
 
+/// Folders attached before exec had its own capability keep working, and say
+/// how they got it.
+///
+/// Under version 3 a folder was resolved for commands off its read grant, so
+/// every attached folder was already exec-reachable. Dropping that on upgrade
+/// would break folders people are working in, and the record the migration
+/// writes must not pretend they approved a prompt they never saw.
+#[test]
+fn version_three_read_grants_carry_their_exec_reach_forward() {
+    let (temp, broker, path, state_dir) = durable_setup();
+    let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    let registered = register(
+        &broker.controller(),
+        subject,
+        conversation,
+        path,
+        OperationId::new(),
+    );
+    let root_id = registered.root.root_id;
+    drop(broker);
+
+    // Reshape the persisted file into what a version 3 install left behind:
+    // list, read, and write grants, before exec had a capability of its own.
+    let state_path = state_dir.join("host-broker-state.json");
+    let mut persisted: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&state_path).unwrap()).unwrap();
+    persisted["version"] = serde_json::json!(3);
+    let grants = persisted["grants"].as_array_mut().unwrap();
+    grants.retain(|grant| grant["capability"] != serde_json::json!("execute_commands"));
+    let read_granted_at = grants
+        .iter()
+        .find(|grant| grant["capability"] == serde_json::json!("read_files"))
+        .map(|grant| grant["consent"]["granted_at"].clone())
+        .unwrap();
+    std::fs::write(&state_path, serde_json::to_vec(&persisted).unwrap()).unwrap();
+
+    let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+    let context = ExecutionContext::standalone(conversation).unwrap();
+    assert_eq!(
+        resolve_exec(&broker.controller(), context, vec![root_id])
+            .unwrap()
+            .len(),
+        1,
+        "a folder that commands could already reach still reaches them"
+    );
+
+    let state = broker.shared.state.lock().unwrap();
+    let carried = state
+        .grants
+        .iter()
+        .find(|grant| grant.capability() == Capability::ExecuteCommands)
+        .expect("the migration named the reach the read grant already carried");
+    assert_eq!(carried.consent().method(), ConsentMethod::CarriedForward);
+    assert_eq!(
+        serde_json::to_value(carried.consent().granted_at()).unwrap(),
+        read_granted_at,
+        "the carried grant keeps the source consent's moment instead of claiming a new one"
+    );
+}
+
 #[test]
 fn binary_reads_return_bytes_that_text_reads_refuse() {
     let (_temp, broker, path, audit) = audited_setup();
@@ -2808,7 +2873,7 @@ fn a_listing_reports_the_capabilities_the_broker_would_authorize() {
     assert_eq!(
         operate(&broker.operator(), context, OperationRequest::ListRoots).unwrap(),
         OperationResult::ListRoots {
-            roots: vec![read_write(registered.root)]
+            roots: vec![picker_access(registered.root)]
         },
         "a folder connected through the picker allows reading and writing"
     );
@@ -2828,7 +2893,7 @@ fn a_listing_reports_the_capabilities_the_broker_would_authorize() {
     };
     assert_eq!(
         roots.first().map(|root| root.capabilities.as_slice()),
-        Some([Capability::ReadFiles].as_slice()),
+        Some([Capability::ReadFiles, Capability::ExecuteCommands].as_slice()),
         "write is not reported once the grant behind it is gone"
     );
     assert!(matches!(
@@ -2891,6 +2956,36 @@ fn exec_root_resolution_intersects_product_ids_with_live_grants() {
         .lock()
         .unwrap()
         .grants
+        .retain(|grant| grant.capability() != Capability::ExecuteCommands);
+    assert!(
+        resolve_exec(&broker.controller(), context, vec![root_id])
+            .unwrap()
+            .is_empty(),
+        "a readable folder is not reachable by commands on its own"
+    );
+
+    // Restore exec reach alone: revoking read has to take the shell with it,
+    // because a command in the folder can read everything the read grant
+    // covered.
+    broker
+        .shared
+        .state
+        .lock()
+        .unwrap()
+        .grants
+        .push(exec_grant(subject, root_id));
+    assert_eq!(
+        resolve_exec(&broker.controller(), context, vec![root_id])
+            .unwrap()
+            .len(),
+        1
+    );
+    broker
+        .shared
+        .state
+        .lock()
+        .unwrap()
+        .grants
         .retain(|grant| grant.capability() != Capability::ReadFiles);
     assert!(
         resolve_exec(&broker.controller(), context, vec![root_id])
@@ -2898,6 +2993,17 @@ fn exec_root_resolution_intersects_product_ids_with_live_grants() {
             .is_empty(),
         "a product root id is not authority after its live read grant is gone"
     );
+}
+
+fn exec_grant(subject: GrantSubject, root_id: RootId) -> Grant {
+    Grant::from_consent(
+        GrantId::new(),
+        subject,
+        Capability::ExecuteCommands,
+        Scope::Root { root_id },
+        ConsentRecord::new(ConsentMethod::PermissionDialog, Utc::now()),
+    )
+    .unwrap()
 }
 
 #[test]

--- a/crates/openwave-host-broker/src/capability.rs
+++ b/crates/openwave-host-broker/src/capability.rs
@@ -26,6 +26,15 @@ pub enum Capability {
     ReadFiles,
     /// Create or explicitly approved replacement of files in a connected root.
     WriteFiles,
+    /// Expose a connected root to model-authored commands.
+    ///
+    /// This is deliberately separate from [`Capability::ReadFiles`]: reading a
+    /// named file on the user's behalf and handing a whole folder to commands
+    /// the model wrote are different amounts of trust, even though the second
+    /// cannot see more than the first. It is only ever additional — exec reach
+    /// is authorized on top of read, never instead of it — so revoking it
+    /// leaves the folder readable, and revoking read takes exec with it.
+    ExecuteCommands,
 }
 
 /// Resource scope covered by one grant.
@@ -55,6 +64,13 @@ pub enum ConsentMethod {
     PermissionDialog,
     /// A local operator deliberately provisioned a headless installation.
     OperatorConfig,
+    /// A state migration named reach an existing grant already conveyed.
+    ///
+    /// No user interaction produced this record. It exists so a grant that was
+    /// split out of a broader one keeps an honest provenance instead of
+    /// borrowing the trusted interaction behind its source, and carries that
+    /// source's timestamp rather than claiming a fresh approval.
+    CarriedForward,
 }
 
 /// Auditable evidence attached to a grant.
@@ -225,7 +241,15 @@ pub enum GrantError {
 fn validate_capability_scope(capability: Capability, scope: &Scope) -> Result<(), GrantError> {
     match (capability, scope) {
         (Capability::ListRoots, Scope::Subject)
-        | (Capability::ReadFiles | Capability::WriteFiles, Scope::Root { .. }) => Ok(()),
+        | (
+            Capability::ReadFiles | Capability::WriteFiles | Capability::ExecuteCommands,
+            Scope::Root { .. },
+        ) => Ok(()),
+        // A command is handed a folder, not a subtree of one. Accepting a
+        // subtree scope here would record a confinement nothing enforces.
+        (Capability::ExecuteCommands, Scope::PathSubtree { .. }) => {
+            Err(GrantError::InvalidCapabilityScope)
+        }
         (Capability::ReadFiles | Capability::WriteFiles, Scope::PathSubtree { relative, .. })
             if !relative.is_root() =>
         {

--- a/crates/openwave-host-broker/src/protocol.rs
+++ b/crates/openwave-host-broker/src/protocol.rs
@@ -70,7 +70,9 @@ pub enum ControlRequest {
     ///
     /// This trusted-host operation returns absolute paths and must never be
     /// exposed as an agent-operation surface. The broker still intersects the
-    /// requested IDs with live attachment and capability state.
+    /// requested IDs with live attachment and capability state: a root is only
+    /// resolved when the conversation holds both [`crate::Capability::ReadFiles`]
+    /// and [`crate::Capability::ExecuteCommands`] over it.
     ResolveExecRoots(ResolveExecRootsRequest),
     /// Register the exact folder returned by a native picker and attach it to
     /// the conversation that initiated the trusted interaction.


### PR DESCRIPTION
`resolve_exec_roots` authorized shell reach with `Capability::ReadFiles`, so
"let this chat read my folder" and "let model-authored commands run against my
folder" were the same consent, indistinguishable in the grant list and in the
audit trail. This adds `Capability::ExecuteCommands` and resolves exec roots
against it.

Exec reach is additional, not alternative: a root resolves for exec only when
the conversation holds both `ReadFiles` and `ExecuteCommands` over it. A command
sitting in a folder can read every byte the read capability covers, so exec
cannot be the narrower of the two — revoking read has to stop the shell as well,
or the narrower revocation would be a lie. Revoking exec alone leaves the folder
readable through the file tools, which is the distinction the capability exists
to express. The listing's per-folder capability set reports exec through the
same conjunction, so what it shows and what the broker will do cannot drift.

Attaching a folder still grants it. The intent is that choosing a folder lets
the agent work in it, so the picker mints exec alongside list, read, and write
rather than raising a second prompt, and so does the attach path. In
`PermissionMode::Allow` nothing parks, so this changes nothing about what a turn
can do there. What it buys is that exec reach is now a named grant: it can be
revoked on its own without disconnecting the folder, and audit records say
whether the shell or a file read was the authority behind a touch.

Existing folders keep working. Under version 3 exec resolved off the read grant,
so every attached folder has been exec-reachable for as long as it has been
attached; the state migration writes the matching `ExecuteCommands` grant for
each root-scoped read grant. That is not the shape #1071 removed. Mirroring read
into write created reach that did not exist — files became writable by a
migration. Here no reach is created: a command could already see everything in
these folders and still sees no more, and the migration only makes an authority
that was already being exercised nameable and revocable. The record says exactly
that. A new `ConsentMethod::CarriedForward` marks these grants as produced by a
migration rather than an interaction, and each carries its source grant's
timestamp instead of claiming an approval happened today. Control callers cannot
stamp `CarriedForward` on a live grant; the attach path rejects it. Read grants
scoped to a subtree are left alone, since exec resolution has always asked about
a whole root and a subtree grant never reached a command.

Dropping exec on upgrade was the alternative, and it is the wrong trade while
1114 is open: it would silently break folders people are working in, with no
re-consent affordance to restore them.

`ExecuteCommands` is only valid at root scope. A command is handed a folder, not
a subtree of one, so accepting a subtree scope would record a confinement
nothing enforces.

Two tests carry the behavior. The migration test asserts that a version-3 state
still resolves for exec and that the carried grant names its provenance and
keeps the original timestamp. The exec-resolution test now covers both
directions of the conjunction: read alone no longer reaches a command, and
revoking read takes exec with it.

Closes #1093
