### PR TITLE
fix(server): bound the streamed document upload route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7130,6 +7130,8 @@ dependencies = [
  "bitflags 2.13.0",
  "bytes",
  "http",
+ "http-body",
+ "http-body-util",
  "percent-encoding",
  "pin-project-lite",
  "tower-layer",

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -24,7 +24,7 @@ axum = { workspace = true }
 # `rt-multi-thread` backs the durable operation log's synchronous `OperationStore`
 # bridge (`tokio::task::block_in_place`); the host runs on a multi-thread runtime.
 tokio = { workspace = true, features = ["net", "process", "rt", "rt-multi-thread", "sync", "macros", "time"] }
-tower-http = { version = "=0.7.0", features = ["cors"] }
+tower-http = { version = "=0.7.0", features = ["cors", "limit"] }
 futures = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -64,6 +64,7 @@ use axum::routing::{delete, get, post};
 use axum::Router;
 use tokio::net::TcpListener;
 use tower_http::cors::{AllowOrigin, CorsLayer};
+use tower_http::limit::RequestBodyLimitLayer;
 use uuid::Uuid;
 
 use openwave_code_execution::ExecTool;
@@ -90,7 +91,7 @@ pub use pairing::{
 };
 pub use state::AppState;
 
-const MAX_RAW_DOCUMENT_BYTES: usize = 16 * 1024 * 1024;
+pub(crate) const MAX_RAW_DOCUMENT_BYTES: usize = 16 * 1024 * 1024;
 const MAX_WEB_SEARCH_CREDENTIAL_BODY_BYTES: usize = 16 * 1024;
 const MAX_CODE_EXECUTION_CONFIG_BODY_BYTES: usize = 1_024;
 const MAX_CODE_EXECUTION_CREDENTIAL_BODY_BYTES: usize = 16 * 1024;
@@ -111,7 +112,14 @@ pub fn app(state: AppState) -> Router {
         )
         .route(
             "/chats/{chat_id}/documents/raw-stream",
-            post(routes::ingest_streamed_raw_chat_document),
+            // `DefaultBodyLimit` only binds extractors that buffer the body,
+            // and this handler takes the raw `Body` so it can write straight
+            // to the blob store — hence the transport-level limit instead.
+            // The cap is the same 16 MiB the buffered routes use: the handler
+            // reads the finished blob back to decode it, so streaming saves
+            // the upload from being buffered twice, not from being large.
+            post(routes::ingest_streamed_raw_chat_document)
+                .layer(RequestBodyLimitLayer::new(MAX_RAW_DOCUMENT_BYTES)),
         )
         .route(
             "/chats/{chat_id}/documents/{document_id}",

--- a/crates/openwave-server/src/routes/document.rs
+++ b/crates/openwave-server/src/routes/document.rs
@@ -18,6 +18,7 @@ use crate::document_decode::decode_document;
 use crate::error::ServerError;
 use crate::extract::{Json, Path, Query, RawBytes};
 use crate::state::AppState;
+use crate::MAX_RAW_DOCUMENT_BYTES;
 
 /// Body of `POST /documents`.
 #[derive(Debug, Deserialize)]
@@ -524,6 +525,14 @@ fn streamed_source_blob(
 ) -> Result<DocumentSourceBlob, ServerError> {
     if query.byte_len == 0 {
         return Err(ServerError::bad_request("content must not be empty"));
+    }
+    // The blob writer stops a stream at its declared length, so refusing an
+    // over-large declaration up front turns a doomed upload into an immediate
+    // answer instead of 16 MiB written to disk and then discarded.
+    if query.byte_len > MAX_RAW_DOCUMENT_BYTES as u64 {
+        return Err(ServerError::payload_too_large(
+            "document must be 16 MiB or smaller",
+        ));
     }
     let sha256 = decode_sha256(&query.sha256).ok_or_else(|| {
         ServerError::bad_request("sha256 must be a 64-character hexadecimal digest")

--- a/crates/openwave-server/src/tests/documents.rs
+++ b/crates/openwave-server/src/tests/documents.rs
@@ -676,13 +676,14 @@ async fn raw_ingest_retains_exact_bytes_and_decodes_before_responding() {
 }
 
 #[tokio::test]
-async fn streamed_raw_ingest_accepts_large_chunked_sources_and_deduplicates_by_content() {
+async fn streamed_raw_ingest_accepts_full_size_chunked_sources_and_deduplicates_by_content() {
     let (router, token, store, dir) = test_app().await;
     let bearer = format!("Bearer {token}");
     let chat = make_chat(&router, &bearer).await;
-    // One byte over the legacy raw route's limit proves this endpoint is not
-    // collected by Axum's buffered-body extractor before blob publication.
-    let raw = vec![b'x'; MAX_RAW_DOCUMENT_BYTES + 1];
+    // A body at the full raw-document limit, delivered in chunks, proves this
+    // endpoint publishes the blob from the stream rather than collecting it
+    // through Axum's buffered-body extractor first.
+    let raw = vec![b'x'; MAX_RAW_DOCUMENT_BYTES];
     let source_blob = openwave_core::DocumentSourceBlob::from_bytes(&raw);
     let sha256: String = source_blob
         .sha256
@@ -733,6 +734,30 @@ async fn streamed_raw_ingest_accepts_large_chunked_sources_and_deduplicates_by_c
             .unwrap(),
         vec![document_id]
     );
+}
+
+#[tokio::test]
+async fn streamed_raw_ingest_refuses_a_source_declared_over_the_document_limit() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let uri = format!(
+        "/chats/{}/documents/raw-stream?title=huge.md&sha256={}&byte_len={}",
+        chat.id,
+        "a".repeat(64),
+        MAX_RAW_DOCUMENT_BYTES + 1
+    );
+
+    // The declaration alone is enough to refuse: nothing of the body is read,
+    // so the answer arrives without a partial blob ever reaching disk.
+    let response =
+        post_streamed_raw(&router, &bearer, &uri, "text/markdown", vec![b"x".to_vec()]).await;
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    assert!(store
+        .list_document_ids(openwave_core::DocumentScope::Chat(chat.id))
+        .await
+        .unwrap()
+        .is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
`POST /chats/{id}/documents/raw-stream` was the only document route with no
size limit. Its `/raw` siblings all cap at 16 MiB, and the asymmetry was an
omission rather than a decision.

The route takes the request body directly (`Body`) so it can write straight
into the blob store. That is also why the gap was easy to miss: `Body`'s
`FromRequest` hands the body over untouched, so `DefaultBodyLimit` — which only
binds extractors that buffer — would have been a silent no-op here. The limit
has to come from a transport-level layer, so this uses
`RequestBodyLimitLayer`.

## The limit

16 MiB, the same `MAX_RAW_DOCUMENT_BYTES` the buffered routes use. The
streaming/buffered distinction here is about not holding the upload in memory
twice, not about accepting bigger documents:

- After publishing the blob the handler reads it straight back
  (`state.blobs.get`) to decode the canonical text, so peak memory for a
  successful ingest is the whole document either way.
- The route's only client is the desktop importer, which refuses anything over
  16 MiB before it opens the stream ("Files must be 16 MB or smaller"). Nothing
  posts here expecting a larger document to be accepted.

So the same cap holds for the same reason, and the server now agrees with the
maximum document size the app already states rather than contradicting it.

An over-large *declared* `byte_len` is now refused before any of the body is
read. The blob writer already stops a stream at its declared length, so without
this the answer to a 1 GB declaration was 16 MiB written to a temporary file
and then discarded; with it, the request is answered immediately with `413`.

## Other routes

`raw-stream` is the only handler in the server that takes an unbuffered body.
Every other route reads through `RawBytes` or `Json`, both of which honour
`DefaultBodyLimit` — the routes with an explicit layer get their own cap and
the rest fall back to Axum's 2 MiB default. The other crates that build routers
(`openwave-mcp`, `openwave-connectors`, `openwave-code-execution`,
`openwave-router`) have no raw-body handlers either.

## Tests

The existing streamed-ingest test posted one byte *over* the raw limit to show
the endpoint is not collected by the buffered extractor. That probe now
conflicts with the cap, so it posts a full-limit body in chunks instead — same
property, still multi-chunk, and it now also pins the cap as reachable rather
than off by one.

One test added, for the declared-length refusal. That check is logic of ours
rather than framework configuration, and it is what keeps a lying declaration
from touching the disk at all. The layer itself is not separately tested: with
the declaration check in front of it, no request that reaches the layer can
exceed it, so a test would only be able to assert the framework's own behaviour.

Closes #1169
