### PR TITLE
feat(desktop): plan approval card with approve/request-changes flow

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -228,6 +228,9 @@ export function ChatRoute({ chatId }: { chatId: string }) {
       case "refresh_user_questions":
         signalRefresh("userQuestions");
         return;
+      case "refresh_plan_approvals":
+        signalRefresh("planApprovals");
+        return;
       case "turn_began":
         signalTurnLifecycle(effect.startsDifferentTurn ? "began" : "began_same_turn");
         return;

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -407,6 +407,7 @@ describe("terminal events", () => {
     expect(effects).toEqual([
       { type: "turn_resolved" },
       { type: "refresh_user_questions" },
+      { type: "refresh_plan_approvals" },
       { type: "hydrate_terminal_transcript" },
     ]);
   });
@@ -434,6 +435,7 @@ describe("terminal events", () => {
     expect(effects).toEqual([
       { type: "turn_resolved" },
       { type: "refresh_user_questions" },
+      { type: "refresh_plan_approvals" },
       { type: "hydrate_terminal_transcript" },
     ]);
   });
@@ -497,6 +499,7 @@ describe("terminal events", () => {
       { type: "invalidate_terminal_hydration" },
       { type: "turn_resolved" },
       { type: "refresh_user_questions" },
+      { type: "refresh_plan_approvals" },
     ]);
   });
 

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -44,6 +44,7 @@ export type ChatSessionEffect =
   | { type: "refresh_folder_access" }
   | { type: "refresh_output_writebacks" }
   | { type: "refresh_user_questions" }
+  | { type: "refresh_plan_approvals" }
   /** A turn began; the host resets cancel state (and steer state when asked). */
   | { type: "turn_began"; turnId: string; startsDifferentTurn: boolean }
   /** A turn reached a terminal event; the host clears cancel/steer state. */
@@ -236,6 +237,11 @@ export function reduceChatSessionEvent(
       return { state, effects };
     }
 
+    case "plan_proposed": {
+      effects.push({ type: "refresh_plan_approvals" });
+      return { state, effects };
+    }
+
     case "approval_required": {
       const approval = toolApprovalPresentation(event.approval);
       const provisionalToolCallIds = new Set(state.provisionalToolCallIds);
@@ -344,6 +350,7 @@ export function reduceChatSessionEvent(
       effects.push(
         { type: "turn_resolved" },
         { type: "refresh_user_questions" },
+        { type: "refresh_plan_approvals" },
         { type: "hydrate_terminal_transcript" },
       );
       return {
@@ -363,6 +370,7 @@ export function reduceChatSessionEvent(
       effects.push(
         { type: "turn_resolved" },
         { type: "refresh_user_questions" },
+        { type: "refresh_plan_approvals" },
         { type: "hydrate_terminal_transcript" },
       );
       return {
@@ -395,6 +403,7 @@ export function reduceChatSessionEvent(
         { type: "invalidate_terminal_hydration" },
         { type: "turn_resolved" },
         { type: "refresh_user_questions" },
+        { type: "refresh_plan_approvals" },
       );
       return {
         state: {
@@ -422,6 +431,7 @@ export function reduceChatSessionEvent(
         { type: "invalidate_terminal_hydration" },
         { type: "turn_resolved" },
         { type: "refresh_user_questions" },
+        { type: "refresh_plan_approvals" },
       );
       return {
         state: {

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -22,6 +22,7 @@ import { useFolderAccessRequests } from "./useFolderAccessRequests";
 import { useOutputWritebackRequests } from "./useOutputWritebackRequests";
 import { useToolApprovals } from "./useToolApprovals";
 import { useTurnControls } from "./useTurnControls";
+import { usePlanApprovals } from "./usePlanApprovals";
 import { useUserQuestions } from "./useUserQuestions";
 import { useAgentRuns } from "./useAgentRuns";
 import { ArrowDown } from "lucide-react";
@@ -82,6 +83,7 @@ export function ChatView({
   const folderAccess = useFolderAccessRequests(client, chat.id);
   const outputWritebacks = useOutputWritebackRequests(client, chat.id);
   const userQuestions = useUserQuestions(client, chat.id);
+  const planApprovals = usePlanApprovals(client, chat.id);
   const approvals = useToolApprovals(client, chat.id);
   const turnControls = useTurnControls(client, chat.id, draftRef, () =>
     onDraftChange(""),
@@ -265,6 +267,7 @@ export function ChatView({
           folderAccessRequests={folderAccess.requests}
           outputWritebackRequests={outputWritebacks.requests}
           userQuestionRequests={userQuestions.requests}
+          planApprovalRequests={planApprovals.requests}
           nativeHost={nativeHost}
           nativeBusy={folderAccess.resolving.size > 0}
           resolvingFolderCalls={folderAccess.resolving}
@@ -273,6 +276,10 @@ export function ChatView({
           outputWritebackErrors={outputWritebacks.errors}
           answeringQuestionCalls={userQuestions.answering}
           userQuestionErrors={userQuestions.errors}
+          decidingPlanCalls={planApprovals.deciding}
+          planApprovalErrors={planApprovals.errors}
+          onPlanDecision={planApprovals.decide}
+          onPlanCancel={planApprovals.cancel}
           decidingApprovalCalls={approvals.deciding}
           approvalErrors={approvals.errors}
           grantScope={chat.project_id ? "project" : "chat"}

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -7,7 +7,9 @@ import type {
   AgentActivityHistoryEntry,
   PendingFolderAccessRequest,
   PendingOutputWritebackRequest,
+  PendingPlanApproval,
   PendingUserQuestions,
+  PlanDecision,
   ToolActionPreview,
   ToolResultPreview,
   UserQuestionAnswer,
@@ -33,6 +35,7 @@ import {
   ToolActivityUnavailable,
 } from "./ToolActivityGroup";
 import { WelcomeState } from "./WelcomeState";
+import { PlanApprovalCard } from "./PlanApprovalCard";
 import { UserQuestionsCard } from "./UserQuestionsCard";
 import type { TranscriptImageAttachment } from "./ImageAttachments";
 import { TranscriptImageAttachments } from "./TranscriptImageAttachments";
@@ -154,6 +157,7 @@ type MessageListProps = {
   folderAccessRequests: PendingFolderAccessRequest[];
   outputWritebackRequests?: PendingOutputWritebackRequest[];
   userQuestionRequests?: PendingUserQuestions[];
+  planApprovalRequests?: PendingPlanApproval[];
   nativeHost: boolean;
   nativeBusy: boolean;
   resolvingFolderCalls: Set<string>;
@@ -206,6 +210,10 @@ type MessageListProps = {
     answers: UserQuestionAnswer[],
   ) => void;
   onUserQuestionsCancel?: (turnId: string) => void;
+  decidingPlanCalls?: Set<string>;
+  planApprovalErrors?: Record<string, string>;
+  onPlanDecision?: (callId: string, decision: PlanDecision) => void;
+  onPlanCancel?: (turnId: string) => void;
   onSelectPrompt?: (prompt: string) => void;
   /** Resend the failed turn. Offered only on the transcript's newest failure. */
   onRetryTurn?: (turn: RetryableTurn) => void;
@@ -250,6 +258,11 @@ export function MessageList({
   onOutputWritebackDecision = () => undefined,
   onOutputWritebackCancel = () => undefined,
   onAnswerUserQuestions = () => undefined,
+  planApprovalRequests = [],
+  decidingPlanCalls = new Set<string>(),
+  planApprovalErrors = {},
+  onPlanDecision = () => undefined,
+  onPlanCancel = () => undefined,
   onUserQuestionsCancel = () => undefined,
   onSelectPrompt,
   onRetryTurn,
@@ -376,12 +389,26 @@ export function MessageList({
           />,
         ),
       )}
+      {planApprovalRequests.map((request) =>
+        isolatedCard(
+          `plan-approval-${request.callId}`,
+          `${decidingPlanCalls.has(request.callId)} ${planApprovalErrors[request.callId] ?? ""}`,
+          <PlanApprovalCard
+            request={request}
+            working={decidingPlanCalls.has(request.callId)}
+            error={planApprovalErrors[request.callId]}
+            onDecide={(decision) => onPlanDecision(request.callId, decision)}
+            onCancel={() => onPlanCancel(request.turnId)}
+          />,
+        ),
+      )}
       {shouldShowAssistantWorking(
         messages,
         busy,
         folderAccessRequests.length +
           outputWritebackRequests.length +
-          userQuestionRequests.length,
+          userQuestionRequests.length +
+          planApprovalRequests.length,
       ) && <AssistantWorkingIndicator thinking={reasoningActive} />}
     </>
   );

--- a/crates/openwave-desktop/ui/src/PendingPrompts.ts
+++ b/crates/openwave-desktop/ui/src/PendingPrompts.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 import type {
   PendingFolderAccessRequest,
   PendingOutputWritebackRequest,
+  PendingPlanApproval,
   PendingUserQuestions,
 } from "./api";
 
@@ -19,6 +20,7 @@ export type PendingPromptsStore = {
   /** The conversation these requests belong to; null before the first read. */
   chatId: string | null;
   userQuestions: PendingUserQuestions[];
+  planApprovals: PendingPlanApproval[];
   folderAccess: PendingFolderAccessRequest[];
   outputWritebacks: PendingOutputWritebackRequest[];
   /**
@@ -27,6 +29,7 @@ export type PendingPromptsStore = {
    */
   refresh: () => void;
   setUserQuestions: (chatId: string, requests: PendingUserQuestions[]) => void;
+  setPlanApprovals: (chatId: string, requests: PendingPlanApproval[]) => void;
   setFolderAccess: (chatId: string, requests: PendingFolderAccessRequest[]) => void;
   setOutputWritebacks: (
     chatId: string,
@@ -41,6 +44,7 @@ export function createPendingPromptsStore() {
   return create<PendingPromptsStore>()((set, get) => ({
     chatId: null,
     userQuestions: [],
+    planApprovals: [],
     folderAccess: [],
     outputWritebacks: [],
     refresh: () => {},
@@ -50,6 +54,10 @@ export function createPendingPromptsStore() {
     setUserQuestions: (chatId, userQuestions) => {
       if (get().chatId !== chatId) return;
       set({ userQuestions });
+    },
+    setPlanApprovals: (chatId, planApprovals) => {
+      if (get().chatId !== chatId) return;
+      set({ planApprovals });
     },
     setFolderAccess: (chatId, folderAccess) => {
       if (get().chatId !== chatId) return;
@@ -61,7 +69,13 @@ export function createPendingPromptsStore() {
     },
     setRefresh: (refresh) => set({ refresh }),
     reset: (chatId) =>
-      set({ chatId, userQuestions: [], folderAccess: [], outputWritebacks: [] }),
+      set({
+        chatId,
+        userQuestions: [],
+        planApprovals: [],
+        folderAccess: [],
+        outputWritebacks: [],
+      }),
   }));
 }
 

--- a/crates/openwave-desktop/ui/src/PlanApprovalCard.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/PlanApprovalCard.dom.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PlanApprovalCard } from "./PlanApprovalCard";
+
+afterEach(cleanup);
+
+const request = {
+  callId: "call-1",
+  turnId: "turn-1",
+  title: "Add health checks",
+  plan: "## Steps\n1. Add a `/healthz` route.\n2. Cover it with one lifecycle test.",
+  proposedAt: "2026-07-30T12:00:00Z",
+};
+
+describe("PlanApprovalCard", () => {
+  it("approves with one click and no feedback payload", async () => {
+    const user = userEvent.setup();
+    const onDecide = vi.fn();
+    render(
+      <PlanApprovalCard
+        request={request}
+        working={false}
+        error={undefined}
+        onDecide={onDecide}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Add health checks")).toBeInTheDocument();
+    expect(screen.getByText(/lifecycle test/)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Approve and run/ }));
+    expect(onDecide).toHaveBeenCalledWith({ decision: "accept" });
+  });
+
+  it("sends the plan back with the exact typed feedback", async () => {
+    const user = userEvent.setup();
+    const onDecide = vi.fn();
+    render(
+      <PlanApprovalCard
+        request={request}
+        working={false}
+        error={undefined}
+        onDecide={onDecide}
+        onCancel={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Request changes" }));
+    await user.type(
+      screen.getByLabelText("What should change"),
+      "Split step 2 into its own slice.",
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Send back for changes" }),
+    );
+    expect(onDecide).toHaveBeenCalledWith({
+      decision: "reject",
+      feedback: "Split step 2 into its own slice.",
+    });
+  });
+});

--- a/crates/openwave-desktop/ui/src/PlanApprovalCard.tsx
+++ b/crates/openwave-desktop/ui/src/PlanApprovalCard.tsx
@@ -1,0 +1,141 @@
+import { useState } from "react";
+import { CornerDownLeft, NotebookPen, X } from "lucide-react";
+import type { PendingPlanApproval, PlanDecision } from "./api";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { MessageMarkdown } from "./MessageMarkdown";
+
+/**
+ * The decision card for a plan the agent proposed from plan mode.
+ *
+ * Approving is the mode hand-off: the server moves the chat out of plan mode
+ * and the resumed turn executes with its full tool surface, so the primary
+ * action says exactly that. "Request changes" keeps the chat in plan mode and
+ * sends the feedback back to be revised.
+ */
+export function PlanApprovalCard({
+  request,
+  working,
+  error,
+  onDecide,
+  onCancel,
+}: {
+  request: PendingPlanApproval;
+  working: boolean;
+  error: string | undefined;
+  onDecide: (decision: PlanDecision) => void;
+  onCancel: () => void;
+}) {
+  const [revising, setRevising] = useState(false);
+  const [feedback, setFeedback] = useState("");
+
+  return (
+    <section
+      className="bg-background flex w-full max-w-prose flex-col gap-3 rounded-[20px] border p-3.5 shadow-sm"
+      aria-labelledby={`plan-${request.callId}`}
+      aria-busy={working}
+    >
+      <div className="flex items-start gap-2.5">
+        <div className="min-w-0 flex-1">
+          <p className="text-muted-foreground flex items-center gap-1.5 text-xs font-semibold tracking-wide uppercase">
+            <NotebookPen aria-hidden="true" className="size-3.5" />
+            Proposed plan
+          </p>
+          <h3
+            id={`plan-${request.callId}`}
+            className="mt-1 text-[15px] leading-5 font-semibold break-words"
+          >
+            {request.title}
+          </h3>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          disabled={working}
+          onClick={onCancel}
+          aria-label="Cancel turn"
+          title="Cancel turn"
+          className="text-muted-foreground shrink-0"
+        >
+          <X aria-hidden="true" />
+        </Button>
+      </div>
+
+      <div className="max-h-80 overflow-y-auto rounded-[10px] border px-3 py-2 text-sm">
+        <MessageMarkdown>{request.plan}</MessageMarkdown>
+      </div>
+
+      {revising && (
+        <Textarea
+          maxLength={4000}
+          rows={3}
+          value={feedback}
+          onChange={(event) => setFeedback(event.target.value)}
+          disabled={working}
+          aria-label="What should change"
+          placeholder="What should change?"
+          autoFocus
+          className="min-h-16 resize-y rounded-[10px] py-2.5 text-sm focus-visible:border-foreground focus-visible:ring-0 focus-visible:ring-offset-0"
+        />
+      )}
+
+      {error && (
+        <p className="text-destructive text-xs break-words" role="alert">
+          {error}
+        </p>
+      )}
+
+      <div className="flex items-center justify-end gap-2 pt-0.5">
+        {revising ? (
+          <>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={working}
+              onClick={() => setRevising(false)}
+            >
+              Back
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              disabled={working}
+              onClick={() =>
+                onDecide(
+                  feedback.trim()
+                    ? { decision: "reject", feedback: feedback.trim() }
+                    : { decision: "reject" },
+                )
+              }
+            >
+              {working ? "Sending…" : "Send back for changes"}
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={working}
+              onClick={() => setRevising(true)}
+            >
+              Request changes
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              disabled={working}
+              onClick={() => onDecide({ decision: "accept" })}
+            >
+              {working ? "Sending…" : "Approve and run"}
+              {!working && <CornerDownLeft aria-hidden="true" />}
+            </Button>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/crates/openwave-desktop/ui/src/RefreshSignals.ts
+++ b/crates/openwave-desktop/ui/src/RefreshSignals.ts
@@ -6,7 +6,8 @@ import { create } from "zustand";
 export type RefreshTarget =
   | "folderAccess"
   | "outputWritebacks"
-  | "userQuestions";
+  | "userQuestions"
+  | "planApprovals";
 
 /**
  * A revision counter per pollable target.
@@ -22,6 +23,7 @@ export type RefreshSignalStore = {
   folderAccess: number;
   outputWritebacks: number;
   userQuestions: number;
+  planApprovals: number;
   signal: (target: RefreshTarget) => void;
 };
 
@@ -30,6 +32,7 @@ export function createRefreshSignalStore() {
     folderAccess: 0,
     outputWritebacks: 0,
     userQuestions: 0,
+    planApprovals: 0,
     signal: (target) =>
       set((state) => ({ [target]: state[target] + 1 }) as Partial<RefreshSignalStore>),
   }));

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -46,6 +46,7 @@ import {
   type WebSearchProviderKind as WireWebSearchProviderKind,
   type PendingFolderAccessRequest as WirePendingFolderAccessRequest,
   type PendingOutputWritebackRequest as WirePendingOutputWritebackRequest,
+  type PendingPlanApproval as WirePendingPlanApproval,
   type PendingUserQuestions as WirePendingUserQuestions,
   type UserQuestion as WireUserQuestion,
   type UserQuestionOption as WireUserQuestionOption,
@@ -492,6 +493,19 @@ export type UserQuestionAnswer = {
   optionId?: string;
   freeForm?: string;
 };
+
+/** Closed renderer projection of one durable plan continuation. */
+export type PendingPlanApproval = {
+  callId: string;
+  turnId: string;
+  title: string;
+  plan: string;
+  proposedAt: string;
+};
+
+export type PlanDecision =
+  | { decision: "accept" }
+  | { decision: "reject"; feedback?: string };
 
 /**
  * The only consent prose a folder-access prompt will render.
@@ -1319,6 +1333,42 @@ export class ApiClient {
     });
   }
 
+  async listPendingPlanApprovals(
+    chatId: string,
+  ): Promise<PendingPlanApproval[]> {
+    const body = await this.json<unknown>(`/chats/${chatId}/plans/pending`, {
+      headers: this.headers(),
+    });
+    if (!Array.isArray(body)) {
+      throw new Error("pending plan response is not an array");
+    }
+    const requests = new Map<string, PendingPlanApproval>();
+    for (const item of body) {
+      const request = parsePendingPlanApproval(item);
+      if (!request || requests.has(request.callId)) {
+        throw new Error("pending plan response contains invalid data");
+      }
+      requests.set(request.callId, request);
+    }
+    return [...requests.values()];
+  }
+
+  async decidePlan(
+    chatId: string,
+    callId: string,
+    decision: PlanDecision,
+  ): Promise<void> {
+    await this.json(`/chats/${chatId}/plans/${callId}/decision`, {
+      method: "POST",
+      headers: this.headers(true),
+      body: JSON.stringify(
+        decision.decision === "reject" && decision.feedback !== undefined
+          ? { decision: "reject", feedback: decision.feedback }
+          : { decision: decision.decision },
+      ),
+    });
+  }
+
   /** Open the chat event stream; auth via Sec-WebSocket-Protocol. */
   openEvents(chatId: string, after: number, onFrame: (frame: ChatFrame) => void): WebSocket {
     const url = `${this.baseUrl.replace(/^http/, "ws")}/chats/${chatId}/events?after=${after}`;
@@ -1470,6 +1520,37 @@ function parseOpaqueCallIds(value: unknown): string[] | null {
     callIds.add(callId);
   }
   return [...callIds];
+}
+
+export function parsePendingPlanApproval(
+  value: unknown,
+): PendingPlanApproval | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<WirePendingPlanApproval>(value, [
+      "call_id",
+      "turn_id",
+      "title",
+      "plan",
+      "proposed_at",
+    ]) ||
+    !nonEmptyBounded(value.call_id, 128) ||
+    !nonEmptyBounded(value.turn_id, 128) ||
+    !nonEmptyBounded(value.title, 120) ||
+    typeof value.plan !== "string" ||
+    !value.plan.trim() ||
+    Array.from(value.plan).length > 40_000 ||
+    !nonEmptyBounded(value.proposed_at, 64)
+  ) {
+    return null;
+  }
+  return {
+    callId: value.call_id,
+    turnId: value.turn_id,
+    title: value.title,
+    plan: value.plan,
+    proposedAt: value.proposed_at,
+  };
 }
 
 export function parsePendingUserQuestions(

--- a/crates/openwave-desktop/ui/src/useChatPromptWatcher.ts
+++ b/crates/openwave-desktop/ui/src/useChatPromptWatcher.ts
@@ -27,6 +27,7 @@ export function useChatPromptWatcher(client: ApiClient | null, chatId: string | 
   const refreshRef = useRef<(() => void) | null>(null);
   const detailsRefreshRef = useRef<(() => void) | null>(null);
   const questionsSignal = useRefreshSignals((state) => state.userQuestions);
+  const plansSignal = useRefreshSignals((state) => state.planApprovals);
   const folderSignal = useRefreshSignals((state) => state.folderAccess);
   const writebackSignal = useRefreshSignals((state) => state.outputWritebacks);
 
@@ -108,6 +109,7 @@ export function useChatPromptWatcher(client: ApiClient | null, chatId: string | 
 
     let cancelled = false;
     let questionsSeq = 0;
+    let plansSeq = 0;
     let folderSeq = 0;
     let writebackSeq = 0;
 
@@ -121,6 +123,20 @@ export function useChatPromptWatcher(client: ApiClient | null, chatId: string | 
       } catch (err) {
         if (!cancelled && seq === questionsSeq) {
           console.error("failed to refresh pending user questions", err);
+        }
+      }
+    };
+
+    const readPlans = async () => {
+      const seq = ++plansSeq;
+      try {
+        const pending = await client.listPendingPlanApprovals(chatId);
+        if (!cancelled && seq === plansSeq) {
+          promptActions.setPlanApprovals(chatId, pending);
+        }
+      } catch (err) {
+        if (!cancelled && seq === plansSeq) {
+          console.error("failed to refresh pending plan approvals", err);
         }
       }
     };
@@ -155,6 +171,7 @@ export function useChatPromptWatcher(client: ApiClient | null, chatId: string | 
 
     const readDetails = () => {
       void readQuestions();
+      void readPlans();
       void readFolderAccess();
       void readOutputWritebacks();
     };
@@ -166,6 +183,7 @@ export function useChatPromptWatcher(client: ApiClient | null, chatId: string | 
     return () => {
       cancelled = true;
       questionsSeq += 1;
+      plansSeq += 1;
       folderSeq += 1;
       writebackSeq += 1;
       detailsRefreshRef.current = null;
@@ -177,6 +195,7 @@ export function useChatPromptWatcher(client: ApiClient | null, chatId: string | 
   // app-wide and may already be well past zero on arrival.
   const lastSignalsRef = useRef({
     questions: questionsSignal,
+    plans: plansSignal,
     folder: folderSignal,
     writeback: writebackSignal,
   });
@@ -184,14 +203,16 @@ export function useChatPromptWatcher(client: ApiClient | null, chatId: string | 
     const last = lastSignalsRef.current;
     if (
       last.questions === questionsSignal &&
+      last.plans === plansSignal &&
       last.folder === folderSignal &&
       last.writeback === writebackSignal
     ) return;
     lastSignalsRef.current = {
       questions: questionsSignal,
+      plans: plansSignal,
       folder: folderSignal,
       writeback: writebackSignal,
     };
     refreshRef.current?.();
-  }, [questionsSignal, folderSignal, writebackSignal]);
+  }, [questionsSignal, plansSignal, folderSignal, writebackSignal]);
 }

--- a/crates/openwave-desktop/ui/src/usePlanApprovals.ts
+++ b/crates/openwave-desktop/ui/src/usePlanApprovals.ts
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from "react";
+import type { ApiClient, PendingPlanApproval, PlanDecision } from "./api";
+import { useOpenConversation } from "./OpenConversation";
+import { usePendingPrompts } from "./PendingPrompts";
+
+export type PlanApprovals = {
+  requests: PendingPlanApproval[];
+  deciding: Set<string>;
+  errors: Record<string, string>;
+  decide: (callId: string, decision: PlanDecision) => void;
+  cancel: (turnId: string) => void;
+};
+
+/**
+ * Deciding the plan the agent is waiting on.
+ *
+ * The pending plans themselves are watched by the shell, exactly like user
+ * questions: the agent parks a turn until the plan is decided, so being told
+ * about it must survive the reader looking at another screen. This hook owns
+ * only what is genuinely the view's — which decisions are in flight, and which
+ * failed.
+ */
+export function usePlanApprovals(
+  client: ApiClient | null,
+  chatId: string | null,
+): PlanApprovals {
+  const requests = usePendingPrompts((state) => state.planApprovals);
+  const refresh = usePendingPrompts((state) => state.refresh);
+  const [deciding, setDeciding] = useState<Set<string>>(new Set());
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const decidingRef = useRef<Set<string>>(new Set());
+  const stillOpen = useOpenConversation(chatId);
+
+  useEffect(
+    () => () => {
+      setDeciding(new Set());
+      setErrors({});
+      decidingRef.current = new Set();
+    },
+    [chatId],
+  );
+
+  async function send(
+    callId: string,
+    startedChatId: string,
+    request: () => Promise<unknown>,
+    failure: (err: unknown) => string,
+  ) {
+    decidingRef.current.add(callId);
+    setDeciding((calls) => new Set(calls).add(callId));
+    setErrors((current) => {
+      const next = { ...current };
+      delete next[callId];
+      return next;
+    });
+    try {
+      await request();
+    } catch (err) {
+      if (stillOpen(startedChatId)) {
+        setErrors((current) => ({ ...current, [callId]: failure(err) }));
+      }
+    } finally {
+      decidingRef.current.delete(callId);
+      setDeciding((calls) => {
+        const next = new Set(calls);
+        next.delete(callId);
+        return next;
+      });
+      if (stillOpen(startedChatId)) refresh();
+    }
+  }
+
+  function decide(callId: string, decision: PlanDecision) {
+    if (!client || !chatId || decidingRef.current.has(callId)) return;
+    const startedChatId = chatId;
+    void send(
+      callId,
+      startedChatId,
+      () => client.decidePlan(startedChatId, callId, decision),
+      (err) => `Could not send your decision: ${String(err)}`,
+    );
+  }
+
+  function cancel(turnId: string) {
+    if (!client || !chatId) return;
+    const request = requests.find((candidate) => candidate.turnId === turnId);
+    if (!request || decidingRef.current.has(request.callId)) return;
+    const startedChatId = chatId;
+    void send(
+      request.callId,
+      startedChatId,
+      () => client.cancel(startedChatId, turnId),
+      (err) => `Could not cancel the turn: ${String(err)}`,
+    );
+  }
+
+  return { requests, deciding, errors, decide, cancel };
+}


### PR DESCRIPTION
Final plan-mode slice, on top of #1155 and #1172: the desktop surfaces a proposed plan as a decision card.

## What changed

- **`PlanApprovalCard`** — title, scrollable Markdown plan body, and the two decisions: **Approve and run** (accept; the server flips the chat out of plan mode and the turn resumes executing) and **Request changes** (opens a feedback field; reject keeps the chat in plan mode and the agent revises). The X cancels the turn, same as the questions card.
- Pending plans ride the same shell machinery as user questions: `listPendingPlanApprovals` / `decidePlan` client methods with a strict parser, `planApprovals` in the pending-prompts store, a detail read in the chat prompt watcher, and a `planApprovals` refresh signal raised by the `plan_proposed` event and on terminal turn transitions — so a parked plan survives reload and chat switches, and announces attention like any other parked prompt.
- `usePlanApprovals` mirrors `useUserQuestions` (in-flight/error tracking scoped to the conversation the request started under); the card renders in the trailing prompt-card block via the memoized `isolatedCard` wrapper.

## Tests

- Card dom tests: approve dispatches `{decision: accept}` with one click; request-changes sends the exact typed feedback as a reject.
- Reducer expectations extended for the `refresh_plan_approvals` effect on `plan_proposed` and terminal events.