### PR TITLE
feat(exec): stage writes to granted folders in a per-turn overlay

### DIFF
--- a/crates/openwave-code-execution/src/host_paths.rs
+++ b/crates/openwave-code-execution/src/host_paths.rs
@@ -78,6 +78,34 @@ impl std::fmt::Debug for ScratchDir {
     }
 }
 
+/// What one entry inside a pinned directory is, judged without following a
+/// symlink. Anything that is neither a regular file nor a directory —
+/// including every symlink — is `Other`, because nothing here should traverse
+/// or copy it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScratchEntryKind {
+    File,
+    Directory,
+    Other,
+}
+
+/// One entry inside a pinned directory.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScratchEntry {
+    pub name: String,
+    pub kind: ScratchEntryKind,
+}
+
+/// The cheap identity of a regular file: enough to notice a change without
+/// reading the bytes back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FileStamp {
+    pub len: u64,
+    pub modified: Option<std::time::SystemTime>,
+    #[cfg(unix)]
+    pub mode: u32,
+}
+
 /// Resolve `relative` as a directory under `root` without walking through a
 /// symlink at any component, discarding why a refusal happened.
 ///
@@ -161,9 +189,24 @@ impl ScratchDir {
     /// temp name opened with an exclusive no-follow create, then a rename puts
     /// them in place. Both operations are relative to the pinned descriptor.
     pub async fn write_file(&self, name: &str, content: &[u8]) -> io::Result<()> {
+        self.write_file_with_mode(name, content, None).await
+    }
+
+    /// Write `content` at `name` and give the result `mode`.
+    ///
+    /// The default is the private `0o600` every host-authored scratch file
+    /// wants. A caller replacing a file the user owns passes the mode that file
+    /// already had, so writing it back does not quietly strip its execute bit
+    /// or narrow who can read it.
+    pub async fn write_file_with_mode(
+        &self,
+        name: &str,
+        content: &[u8],
+        mode: Option<u32>,
+    ) -> io::Result<()> {
         let name = single_component(name)?;
         let content = content.to_vec();
-        self.blocking(move |directory| write_blocking(directory, &name, &content))
+        self.blocking(move |directory| write_blocking(directory, &name, &content, mode))
             .await
     }
 
@@ -211,6 +254,104 @@ impl ScratchDir {
         .unwrap_or(false)
     }
 
+    /// Open `name` as a child directory, refusing a symlink at that component.
+    ///
+    /// The child is pinned the same way its parent is, so a recursive walk
+    /// built from repeated calls never consults a path and never re-enters the
+    /// filesystem from `/`.
+    pub async fn open_dir(&self, name: &str) -> io::Result<Self> {
+        let name = single_component(name)?;
+        let directory = self
+            .blocking(move |directory| directory.open_dir_nofollow(&name))
+            .await?;
+        Ok(Self {
+            directory: Arc::new(directory),
+        })
+    }
+
+    /// Create `name` as a child directory if it is not already one, then open
+    /// it. An existing symlink at that name refuses rather than being adopted.
+    pub async fn create_dir(&self, name: &str) -> io::Result<Self> {
+        let name = single_component(name)?;
+        let directory = self
+            .blocking(move |directory| match directory.open_dir_nofollow(&name) {
+                Ok(child) => Ok(child),
+                Err(_) => {
+                    // A racing writer that lands the name first makes the
+                    // create fail; the open below then decides whether what is
+                    // there is a directory we may use or something we refuse.
+                    let _ = directory.create_dir(&name);
+                    directory.open_dir_nofollow(&name)
+                }
+            })
+            .await?;
+        Ok(Self {
+            directory: Arc::new(directory),
+        })
+    }
+
+    /// The entries directly inside this directory, classified without following
+    /// a symlink. Names that are not valid UTF-8 are dropped: every path this
+    /// crate carries is UTF-8, and a name that cannot be represented is a name
+    /// no later operation could address.
+    pub async fn entries(&self) -> io::Result<Vec<ScratchEntry>> {
+        self.blocking(|directory| {
+            let mut entries = Vec::new();
+            for entry in directory.entries()? {
+                let entry = entry?;
+                let Ok(name) = entry.file_name().into_string() else {
+                    continue;
+                };
+                let kind = match directory.symlink_metadata(&name) {
+                    Ok(metadata) if metadata.is_symlink() => ScratchEntryKind::Other,
+                    Ok(metadata) if metadata.is_dir() => ScratchEntryKind::Directory,
+                    Ok(metadata) if metadata.is_file() => ScratchEntryKind::File,
+                    Ok(_) => ScratchEntryKind::Other,
+                    Err(_) => continue,
+                };
+                entries.push(ScratchEntry { name, kind });
+            }
+            entries.sort_by(|left, right| left.name.cmp(&right.name));
+            Ok(entries)
+        })
+        .await
+    }
+
+    /// The length and modification time of `name`, judged without following a
+    /// symlink. `None` covers every reason the answer is unavailable, because
+    /// the callers use it only to decide whether a file looks untouched.
+    pub async fn file_stamp(&self, name: &str) -> Option<FileStamp> {
+        let name = single_component(name).ok()?;
+        self.blocking(move |directory| {
+            let metadata = directory.symlink_metadata(&name)?;
+            if !metadata.is_file() {
+                return Err(io::Error::other("not a regular file"));
+            }
+            Ok(FileStamp {
+                len: metadata.len(),
+                modified: metadata.modified().ok().map(|time| time.into_std()),
+                #[cfg(unix)]
+                mode: {
+                    use cap_std::fs::MetadataExt as _;
+                    metadata.mode()
+                },
+            })
+        })
+        .await
+        .ok()
+    }
+
+    /// Remove `name` from this directory. A symlink is unlinked rather than
+    /// followed, and a directory is removed only when it is already empty.
+    pub async fn remove(&self, name: &str, kind: ScratchEntryKind) -> io::Result<()> {
+        let name = single_component(name)?;
+        self.blocking(move |directory| match kind {
+            ScratchEntryKind::Directory => directory.remove_dir(&name),
+            _ => directory.remove_file(&name),
+        })
+        .await
+    }
+
     async fn blocking<T, F>(&self, work: F) -> io::Result<T>
     where
         F: FnOnce(&Dir) -> io::Result<T> + Send + 'static,
@@ -223,7 +364,12 @@ impl ScratchDir {
     }
 }
 
-fn write_blocking(directory: &Dir, name: &str, content: &[u8]) -> io::Result<()> {
+fn write_blocking(
+    directory: &Dir,
+    name: &str,
+    content: &[u8],
+    mode: Option<u32>,
+) -> io::Result<()> {
     use std::io::Write as _;
 
     // A process with write access to chat scratch could plant a symlink at a
@@ -239,12 +385,24 @@ fn write_blocking(directory: &Dir, name: &str, content: &[u8]) -> io::Result<()>
     #[cfg(unix)]
     {
         use cap_std::fs::OpenOptionsExt as _;
+        // The temp name is created private regardless; a wider mode is applied
+        // only once the bytes are all there, so nothing observes a
+        // world-readable half-written file.
         options.mode(0o600);
     }
+    let _ = &mode;
     let mut file = directory.open_with(&temporary, &options)?;
     let write = file
         .write_all(content)
         .and_then(|()| file.sync_all())
+        .and_then(|()| {
+            #[cfg(unix)]
+            if let Some(mode) = mode {
+                use cap_std::fs::PermissionsExt as _;
+                file.set_permissions(cap_std::fs::Permissions::from_mode(mode))?;
+            }
+            Ok(())
+        })
         .and_then(|()| directory.rename(&temporary, directory, name));
     if write.is_err() {
         let _ = directory.remove_file(&temporary);

--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -17,6 +17,7 @@ pub mod host_paths;
 mod http;
 mod local;
 mod output;
+pub mod overlay;
 mod preview;
 mod receipt;
 mod remote;
@@ -27,9 +28,13 @@ mod types;
 pub use daytona::{DaytonaCredential, DaytonaExecutionProvider, DAYTONA_CREDENTIAL_KEY};
 pub use e2b::{E2BCredential, E2BExecutionProvider, E2B_CREDENTIAL_KEY};
 pub use host_paths::{
-    resolve_scratch_directory, try_resolve_scratch_directory, ScratchDir, ScratchRefusal,
+    resolve_scratch_directory, try_resolve_scratch_directory, FileStamp, ScratchDir, ScratchEntry,
+    ScratchEntryKind, ScratchRefusal,
 };
 pub use local::LocalExecutionProvider;
+pub use overlay::{
+    sweep_abandoned_overlays, OverlayOutcome, OverlaySlot, WriteOverlay, OVERLAY_DIR,
+};
 pub use preview::{scan_preview_directory, PreviewScan};
 pub use remote::RemoteSessionPool;
 pub use tool::{ExecTool, EXEC_TOOL_NAME};

--- a/crates/openwave-code-execution/src/local.rs
+++ b/crates/openwave-code-execution/src/local.rs
@@ -57,6 +57,7 @@ pub struct LocalExecutionProvider {
 struct CanonicalExecFolderGrant {
     path: PathBuf,
     access: ExecFolderAccess,
+    overlay: Option<PathBuf>,
 }
 
 impl LocalExecutionProvider {
@@ -895,20 +896,27 @@ fn macos_profile(
     // `folder_grants` is the canonical, host-resolved list prepared above.
     // Command, arguments, cwd, and every other model-authored field are
     // deliberately absent from these profile clauses.
+    //
+    // A staged grant keeps its read allowance at the folder's own path and
+    // moves its write allowance to the overlay. That pairing is the whole
+    // containment story for staging: the only writable location is the copy,
+    // so a command cannot reach the user's files even by naming them exactly.
     let granted_reads = folder_grants
         .iter()
-        .map(|grant| sandbox_subpath(&grant.path))
+        .flat_map(|grant| std::iter::once(&grant.path).chain(grant.overlay.as_ref()))
+        .map(|path| sandbox_subpath(path))
         .collect::<Result<Vec<_>, _>>()?
         .join("\n  ");
     let granted_writes = folder_grants
         .iter()
         .filter(|grant| grant.access == ExecFolderAccess::ReadWrite)
-        .map(|grant| sandbox_subpath(&grant.path))
+        .map(|grant| sandbox_subpath(grant.overlay.as_ref().unwrap_or(&grant.path)))
         .collect::<Result<Vec<_>, _>>()?
         .join("\n  ");
     let mut grant_ancestors = folder_grants
         .iter()
-        .flat_map(|grant| grant.path.ancestors().skip(1))
+        .flat_map(|grant| std::iter::once(&grant.path).chain(grant.overlay.as_ref()))
+        .flat_map(|path| path.ancestors().skip(1))
         .collect::<Vec<_>>();
     grant_ancestors.sort_unstable();
     grant_ancestors.dedup();
@@ -938,32 +946,52 @@ fn canonicalize_folder_grants(
 ) -> Result<Vec<CanonicalExecFolderGrant>, CodeExecutionError> {
     let mut canonical = Vec::<CanonicalExecFolderGrant>::new();
     for grant in grants {
-        let metadata = fs::symlink_metadata(&grant.path)
-            .map_err(|_| CodeExecutionError::Sandbox("granted folder is unavailable".into()))?;
-        if metadata.file_type().is_symlink() {
-            return Err(CodeExecutionError::Sandbox(
-                "granted folder must not be a symbolic link".into(),
-            ));
-        }
-        if !metadata.is_dir() {
-            return Err(CodeExecutionError::Sandbox(
-                "granted folder is not a directory".into(),
-            ));
-        }
-        let path = fs::canonicalize(&grant.path)
-            .map_err(|_| CodeExecutionError::Sandbox("granted folder is unavailable".into()))?;
+        let path = canonicalize_grant_directory(&grant.path)?;
+        let overlay = grant
+            .overlay
+            .as_deref()
+            .map(canonicalize_grant_directory)
+            .transpose()?;
         if let Some(existing) = canonical.iter_mut().find(|existing| existing.path == path) {
             if grant.access == ExecFolderAccess::ReadWrite {
-                existing.access = ExecFolderAccess::ReadWrite;
+                if existing.access == ExecFolderAccess::ReadWrite {
+                    // Two write grants for one folder: staging holds only if
+                    // both are staged, because one unstaged grant would make
+                    // the folder directly writable and the other's overlay
+                    // would be decorative.
+                    existing.overlay = existing.overlay.take().and(overlay);
+                } else {
+                    existing.access = ExecFolderAccess::ReadWrite;
+                    existing.overlay = overlay;
+                }
             }
             continue;
         }
         canonical.push(CanonicalExecFolderGrant {
             path,
             access: grant.access,
+            overlay,
         });
     }
     Ok(canonical)
+}
+
+#[cfg(target_os = "macos")]
+fn canonicalize_grant_directory(path: &Path) -> Result<PathBuf, CodeExecutionError> {
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|_| CodeExecutionError::Sandbox("granted folder is unavailable".into()))?;
+    if metadata.file_type().is_symlink() {
+        return Err(CodeExecutionError::Sandbox(
+            "granted folder must not be a symbolic link".into(),
+        ));
+    }
+    if !metadata.is_dir() {
+        return Err(CodeExecutionError::Sandbox(
+            "granted folder is not a directory".into(),
+        ));
+    }
+    fs::canonicalize(path)
+        .map_err(|_| CodeExecutionError::Sandbox("granted folder is unavailable".into()))
 }
 
 #[cfg(target_os = "macos")]
@@ -1467,5 +1495,60 @@ mod tests {
         let response = provider.execute(request).await.unwrap();
         assert_eq!(response.exit_code, Some(0), "stderr: {}", response.stderr);
         assert_eq!(response.stdout, "visibleungranted-blocked");
+    }
+
+    /// The invariant staging rests on: a staged grant is writable only at the
+    /// overlay. A command that names the user's folder directly — which is the
+    /// path the model has always been given — is refused rather than silently
+    /// staged, so nothing reaches the real files mid-turn.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn a_staged_grant_is_writable_only_at_its_overlay() {
+        let scratch = tempfile::tempdir().unwrap();
+        let workspace = "chat-staged";
+        fs::create_dir(scratch.path().join(workspace)).unwrap();
+        let host = tempfile::tempdir().unwrap();
+        let granted = host.path().join("granted");
+        let overlay = host.path().join("overlay");
+        fs::create_dir(&granted).unwrap();
+        fs::create_dir(&overlay).unwrap();
+        fs::write(granted.join("report.md"), "original").unwrap();
+        let granted_path = fs::canonicalize(&granted).unwrap();
+        let overlay_path = fs::canonicalize(&overlay).unwrap();
+
+        let provider = LocalExecutionProvider::new(scratch.path(), Duration::from_secs(3)).unwrap();
+        let script = format!(
+            "cat '{}'; \
+             if printf staged > '{}' 2>/dev/null; then printf ' overlay-written'; else printf ' overlay-blocked'; fi; \
+             if printf direct > '{}' 2>/dev/null; then printf ' root-written'; else printf ' root-blocked'; fi",
+            granted_path.join("report.md").display(),
+            overlay_path.join("report.md").display(),
+            granted_path.join("report.md").display(),
+        );
+        let request = request(workspace, "call-staged-grant", &script)
+            .with_folder_grants(vec![ExecFolderGrant::new(
+                &granted_path,
+                ExecFolderAccess::ReadWrite,
+            )
+            .unwrap()
+            .staged_at(&overlay_path)
+            .unwrap()])
+            .unwrap();
+
+        let response = provider.execute(request).await.unwrap();
+        assert_eq!(response.exit_code, Some(0), "stderr: {}", response.stderr);
+        assert_eq!(
+            response.stdout, "original overlay-written root-blocked",
+            "stderr: {}",
+            response.stderr
+        );
+        assert_eq!(
+            fs::read_to_string(granted_path.join("report.md")).unwrap(),
+            "original"
+        );
+        assert_eq!(
+            fs::read_to_string(overlay_path.join("report.md")).unwrap(),
+            "staged"
+        );
     }
 }

--- a/crates/openwave-code-execution/src/overlay.rs
+++ b/crates/openwave-code-execution/src/overlay.rs
@@ -1,0 +1,602 @@
+//! Per-turn write staging for granted host folders.
+//!
+//! Exec writes into a folder the user granted currently land on the user's real
+//! files the moment the command runs. This module puts a per-turn overlay in
+//! between: each writable granted root gets a private copy under the chat's
+//! scratch tree, the sandbox profile makes that copy the only writable
+//! location, and the turn's changes are applied to the real folder when the
+//! turn ends.
+//!
+//! ## Why the overlay is a whole copy
+//!
+//! The agent drives an ordinary shell. It creates a file, greps for it, appends
+//! to it, renames it, deletes it — and every one of those steps has to see what
+//! the previous one did. A sparse overlay would need reads to fall through to
+//! the real root, and on macOS there is no way to arrange that: Seatbelt is a
+//! policy engine over real paths, not a mount namespace, so nothing can make
+//! one path show two directories merged.
+//!
+//! Copying the root sidesteps the problem rather than solving it. Read-through
+//! is not emulated, it is structural: the overlay *is* the tree, so every
+//! filesystem operation works exactly as it would against the real folder, and
+//! there is no operation to enumerate as unsupported. On APFS the copy is a
+//! `clonefile`, which shares storage until a block is written, so this costs
+//! directory metadata rather than the folder's bytes.
+//!
+//! The price is that exec addresses the staged tree at the overlay path rather
+//! than the folder's own path. That is the one thing the user-visible surface
+//! has to say out loud, and the operating prompt does.
+//!
+//! ## Why applying changes is manifest-driven
+//!
+//! At the end of the turn the overlay is compared against the manifest recorded
+//! when it was made — not against whatever the real folder holds now. A file
+//! whose length and modification time still match the manifest was never
+//! touched and is left alone. A file that differs is written back. A file the
+//! manifest lists and the overlay no longer has was deleted, and is deleted
+//! from the folder too.
+//!
+//! Judging deletions against the manifest rather than against the real folder
+//! is deliberate: it is what keeps a partial copy, or a file the user added
+//! while the turn ran, from being read as "the agent deleted this". Nothing is
+//! removed unless this module watched it exist in the overlay first.
+//!
+//! Every step is issued against a descriptor pinned when the overlay was
+//! prepared. Exec can write inside the overlay for the length of the turn, so
+//! it can rename directories under the paths this module would otherwise walk;
+//! pinning means the directory acted on is the directory that was checked.
+
+use std::collections::BTreeMap;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::host_paths::{
+    resolve_scratch_directory, FileStamp, ScratchDir, ScratchEntry, ScratchEntryKind,
+};
+
+/// Scratch-root-relative home for every live overlay. It sits beside the chat
+/// workspaces rather than inside one, so it is never listed as a workspace
+/// file, never synced, and never writable by exec except through the one
+/// per-turn subdirectory the profile names.
+pub const OVERLAY_DIR: &str = ".exec-overlays";
+
+/// Ceiling on the entries one overlay may stage. A granted root larger than
+/// this is left unstaged and keeps today's direct-write behavior rather than
+/// making every turn pay an unbounded walk.
+const MAX_OVERLAY_ENTRIES: usize = 20_000;
+
+/// Ceiling on directory nesting inside one overlay, so a pathological tree
+/// cannot turn the walk into unbounded recursion.
+const MAX_OVERLAY_DEPTH: usize = 24;
+
+/// Ceiling on one staged file's size when it is written back.
+const MAX_STAGED_FILE_BYTES: u64 = 64 * 1_024 * 1_024;
+
+/// One granted root and the private copy exec writes to instead.
+pub struct OverlaySlot {
+    /// The real folder, as granted.
+    source: PathBuf,
+    /// Where the staged copy lives. Exec sees this path.
+    overlay: PathBuf,
+    /// The real folder, pinned when the overlay was prepared.
+    source_dir: ScratchDir,
+    /// The staged copy, pinned when it was made.
+    overlay_dir: ScratchDir,
+    /// Every regular file the copy started with, by overlay-relative path.
+    manifest: BTreeMap<String, FileStamp>,
+}
+
+impl std::fmt::Debug for OverlaySlot {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("OverlaySlot")
+            .field("source", &self.source)
+            .field("overlay", &self.overlay)
+            .field("staged", &self.manifest.len())
+            .finish()
+    }
+}
+
+impl OverlaySlot {
+    /// The granted folder this slot stages writes for.
+    #[must_use]
+    pub fn source(&self) -> &Path {
+        &self.source
+    }
+
+    /// The path exec writes to. This is what the operating prompt names and
+    /// what the Seatbelt profile makes writable.
+    #[must_use]
+    pub fn overlay(&self) -> &Path {
+        &self.overlay
+    }
+}
+
+/// Every writable granted root staged for one turn.
+#[derive(Debug)]
+pub struct WriteOverlay {
+    home: PathBuf,
+    slots: Vec<OverlaySlot>,
+}
+
+/// What applying one overlay did, for the caller to report.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct OverlayOutcome {
+    pub written: usize,
+    pub deleted: usize,
+    pub refused: usize,
+}
+
+impl WriteOverlay {
+    /// Stage `sources` under a fresh per-turn home inside `scratch_root`.
+    ///
+    /// A source that cannot be copied — unreadable, too large, or a name that
+    /// something already occupies — is simply not staged. It keeps direct write
+    /// access, which is what it had before this module existed, so a folder
+    /// this cannot handle degrades to the previous behavior instead of losing
+    /// the agent's writes.
+    pub async fn prepare(scratch_root: &Path, scope: &str, sources: &[PathBuf]) -> Option<Self> {
+        if sources.is_empty() || scope.is_empty() || scope.contains('/') {
+            return None;
+        }
+        // Anything already staged for this scope belongs to a turn that never
+        // finished. Its writes are deliberately dropped rather than applied to
+        // a folder that has moved on since.
+        sweep_abandoned_overlays(scratch_root, scope).await;
+        let relative = format!("{OVERLAY_DIR}/{scope}/{}", uuid::Uuid::new_v4());
+        let home_dir = resolve_scratch_directory(scratch_root, &relative, true).await?;
+        let home = scratch_root.join(&relative);
+
+        let mut slots = Vec::new();
+        let mut used = Vec::<String>::new();
+        for source in sources {
+            let name = slot_name(source, &used);
+            used.push(name.clone());
+            match stage_one(source, &home, &home_dir, &name).await {
+                Some(slot) => slots.push(slot),
+                None => {
+                    tracing::warn!(
+                        source = %source.display(),
+                        "exec write overlay could not stage a granted folder; writes stay direct"
+                    );
+                }
+            }
+        }
+        if slots.is_empty() {
+            let _ = tokio::fs::remove_dir_all(&home).await;
+            return None;
+        }
+        Some(Self { home, slots })
+    }
+
+    /// The staged roots, for the sandbox profile and the operating prompt.
+    #[must_use]
+    pub fn slots(&self) -> &[OverlaySlot] {
+        &self.slots
+    }
+
+    /// Apply every staged change to the real folders and drop the overlay.
+    ///
+    /// Errors are per file: one refused write does not abandon the rest, since
+    /// leaving the remainder unapplied would strand work the agent believes it
+    /// finished.
+    pub async fn materialize(self) -> OverlayOutcome {
+        let mut outcome = OverlayOutcome::default();
+        for slot in &self.slots {
+            let mut seen = Vec::new();
+            apply_directory(slot, "", &slot.overlay_dir, &mut seen, 0, &mut outcome).await;
+            apply_deletions(slot, &seen, &mut outcome).await;
+        }
+        self.discard().await;
+        outcome
+    }
+
+    /// Drop the overlay without applying anything.
+    pub async fn discard(self) {
+        let _ = tokio::fs::remove_dir_all(&self.home).await;
+    }
+}
+
+/// Remove overlay homes left behind by a turn that did not finish cleanly.
+///
+/// Scoped to one caller's own subtree, so sweeping never touches an overlay a
+/// concurrent chat is still writing into.
+pub async fn sweep_abandoned_overlays(scratch_root: &Path, scope: &str) {
+    if scope.is_empty() || scope.contains('/') {
+        return;
+    }
+    let _ = tokio::fs::remove_dir_all(scratch_root.join(OVERLAY_DIR).join(scope)).await;
+}
+
+async fn stage_one(
+    source: &Path,
+    home: &Path,
+    home_dir: &ScratchDir,
+    name: &str,
+) -> Option<OverlaySlot> {
+    let source_dir = resolve_scratch_directory(source, "", false).await?;
+    let destination = home.join(name);
+    clone_tree(source, &destination).await.ok()?;
+    // Reopening through the pinned home rather than by path is what ties the
+    // handle to the directory just created: whatever the name refers to later,
+    // this descriptor still refers to the copy.
+    let overlay_dir = home_dir.open_dir(name).await.ok()?;
+
+    let mut manifest = BTreeMap::new();
+    if !record_manifest(&overlay_dir, "", &mut manifest, 0).await {
+        let _ = tokio::fs::remove_dir_all(&destination).await;
+        return None;
+    }
+    Some(OverlaySlot {
+        source: source.to_path_buf(),
+        overlay: destination,
+        source_dir,
+        overlay_dir,
+        manifest,
+    })
+}
+
+/// Walk the fresh copy and record what it started with. `false` means the tree
+/// exceeded a bound, in which case the caller discards the slot.
+///
+/// An individual entry that cannot be inspected is left out rather than failing
+/// the walk. Omission is the safe direction: an unrecorded file is never
+/// deleted from the folder, and the worst it costs is writing identical bytes
+/// back over itself.
+async fn record_manifest(
+    directory: &ScratchDir,
+    prefix: &str,
+    manifest: &mut BTreeMap<String, FileStamp>,
+    depth: usize,
+) -> bool {
+    if depth > MAX_OVERLAY_DEPTH {
+        return false;
+    }
+    let Ok(entries) = directory.entries().await else {
+        return false;
+    };
+    for ScratchEntry { name, kind } in entries {
+        if manifest.len() >= MAX_OVERLAY_ENTRIES {
+            return false;
+        }
+        let relative = join_relative(prefix, &name);
+        match kind {
+            ScratchEntryKind::File => {
+                if let Some(stamp) = directory.file_stamp(&name).await {
+                    manifest.insert(relative, stamp);
+                }
+            }
+            ScratchEntryKind::Directory => {
+                let Ok(child) = directory.open_dir(&name).await else {
+                    continue;
+                };
+                if !Box::pin(record_manifest(&child, &relative, manifest, depth + 1)).await {
+                    return false;
+                }
+            }
+            // Symlinks and everything exotic are copied by the clone but never
+            // walked, written back, or deleted. They are inert.
+            ScratchEntryKind::Other => {}
+        }
+    }
+    true
+}
+
+async fn apply_directory(
+    slot: &OverlaySlot,
+    prefix: &str,
+    directory: &ScratchDir,
+    seen: &mut Vec<String>,
+    depth: usize,
+    outcome: &mut OverlayOutcome,
+) {
+    if depth > MAX_OVERLAY_DEPTH {
+        return;
+    }
+    let Ok(entries) = directory.entries().await else {
+        outcome.refused += 1;
+        return;
+    };
+    for ScratchEntry { name, kind } in entries {
+        let relative = join_relative(prefix, &name);
+        match kind {
+            ScratchEntryKind::File => {
+                seen.push(relative.clone());
+                let stamp = directory.file_stamp(&name).await;
+                if stamp.is_some() && stamp == slot.manifest.get(&relative).copied() {
+                    continue;
+                }
+                if stamp.is_some_and(|stamp| stamp.len > MAX_STAGED_FILE_BYTES) {
+                    outcome.refused += 1;
+                    continue;
+                }
+                match write_back(slot, prefix, &name, directory, stamp).await {
+                    Ok(()) => outcome.written += 1,
+                    Err(_) => outcome.refused += 1,
+                }
+            }
+            ScratchEntryKind::Directory => match directory.open_dir(&name).await {
+                Ok(child) => {
+                    Box::pin(apply_directory(
+                        slot,
+                        &relative,
+                        &child,
+                        seen,
+                        depth + 1,
+                        outcome,
+                    ))
+                    .await;
+                }
+                Err(_) => outcome.refused += 1,
+            },
+            ScratchEntryKind::Other => {}
+        }
+    }
+}
+
+async fn write_back(
+    slot: &OverlaySlot,
+    prefix: &str,
+    name: &str,
+    directory: &ScratchDir,
+    stamp: Option<FileStamp>,
+) -> io::Result<()> {
+    let content = directory.read_file(name).await?;
+    let target = descend(&slot.source_dir, prefix, true).await?;
+    // The staged file carries the mode the folder's copy had, so writing it
+    // back does not turn a script into a non-executable file or narrow who can
+    // read a document the user shares.
+    #[cfg(unix)]
+    let mode = stamp.map(|stamp| stamp.mode);
+    #[cfg(not(unix))]
+    let mode = {
+        let _ = stamp;
+        None
+    };
+    target.write_file_with_mode(name, &content, mode).await
+}
+
+/// Remove from the real folder every file the overlay started with and no
+/// longer has. This is the only place anything is deleted, and it consults the
+/// manifest rather than the folder, so a file that was never staged is never a
+/// candidate.
+async fn apply_deletions(slot: &OverlaySlot, seen: &[String], outcome: &mut OverlayOutcome) {
+    let seen = seen.iter().collect::<std::collections::HashSet<_>>();
+    for relative in slot.manifest.keys() {
+        if seen.contains(relative) {
+            continue;
+        }
+        let (prefix, name) = split_relative(relative);
+        let Ok(target) = descend(&slot.source_dir, prefix, false).await else {
+            outcome.refused += 1;
+            continue;
+        };
+        match target.remove(name, ScratchEntryKind::File).await {
+            Ok(()) => outcome.deleted += 1,
+            // Already gone is the outcome we wanted, not a refusal.
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(_) => outcome.refused += 1,
+        }
+    }
+}
+
+/// Open `relative` under `directory` one pinned component at a time.
+async fn descend(directory: &ScratchDir, relative: &str, create: bool) -> io::Result<ScratchDir> {
+    let mut current = directory.clone();
+    for component in relative.split('/').filter(|part| !part.is_empty()) {
+        current = if create {
+            current.create_dir(component).await?
+        } else {
+            current.open_dir(component).await?
+        };
+    }
+    Ok(current)
+}
+
+/// Copy `source` to `destination`, which must not exist.
+///
+/// On macOS this is `clonefile`, so an APFS volume shares the bytes until one
+/// side writes and the copy costs directory metadata rather than the folder's
+/// contents. Elsewhere — and if the clone is refused, which is what a
+/// cross-volume or non-APFS source does — it falls back to reading and writing
+/// the tree. Symlinks are copied as symlinks and never followed.
+async fn clone_tree(source: &Path, destination: &Path) -> io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        if clonefile(source, destination).await.is_ok() {
+            return Ok(());
+        }
+    }
+    copy_tree(source.to_path_buf(), destination.to_path_buf()).await
+}
+
+#[cfg(target_os = "macos")]
+async fn clonefile(source: &Path, destination: &Path) -> io::Result<()> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    /// `CLONE_NOFOLLOW` from `<sys/clonefile.h>`.
+    const CLONE_NOFOLLOW: u32 = 0x0001;
+
+    let source = CString::new(source.as_os_str().as_bytes())?;
+    let destination = CString::new(destination.as_os_str().as_bytes())?;
+    tokio::task::spawn_blocking(move || {
+        // SAFETY: both arguments are NUL-terminated C strings that outlive the
+        // call, and `clonefile` reads them without retaining either.
+        let result =
+            unsafe { libc::clonefile(source.as_ptr(), destination.as_ptr(), CLONE_NOFOLLOW) };
+        if result == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    })
+    .await
+    .map_err(|_| io::Error::other("clone did not complete"))?
+}
+
+async fn copy_tree(source: PathBuf, destination: PathBuf) -> io::Result<()> {
+    tokio::task::spawn_blocking(move || copy_tree_blocking(&source, &destination, 0))
+        .await
+        .map_err(|_| io::Error::other("copy did not complete"))?
+}
+
+fn copy_tree_blocking(source: &Path, destination: &Path, depth: usize) -> io::Result<()> {
+    if depth > MAX_OVERLAY_DEPTH {
+        return Err(io::Error::other("granted folder nests too deeply"));
+    }
+    std::fs::create_dir(destination)?;
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        let kind = entry.file_type()?;
+        let target = destination.join(entry.file_name());
+        if kind.is_dir() {
+            copy_tree_blocking(&entry.path(), &target, depth + 1)?;
+        } else if kind.is_file() {
+            std::fs::copy(entry.path(), &target)?;
+        }
+        // A symlink is left out rather than recreated. The fallback path only
+        // runs where cloning is unavailable, and a dangling or escaping link is
+        // not worth reproducing to serve it.
+    }
+    Ok(())
+}
+
+/// A readable, collision-free directory name for one granted root.
+fn slot_name(source: &Path, used: &[String]) -> String {
+    let base = source
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty() && !name.contains('/') && *name != "." && *name != "..")
+        .unwrap_or("folder");
+    if !used.iter().any(|existing| existing == base) {
+        return base.to_owned();
+    }
+    (2..)
+        .map(|suffix| format!("{base}-{suffix}"))
+        .find(|candidate| !used.iter().any(|existing| existing == candidate))
+        .expect("an unused suffix always exists")
+}
+
+fn join_relative(prefix: &str, name: &str) -> String {
+    if prefix.is_empty() {
+        name.to_owned()
+    } else {
+        format!("{prefix}/{name}")
+    }
+}
+
+fn split_relative(relative: &str) -> (&str, &str) {
+    relative
+        .rsplit_once('/')
+        .map_or(("", relative), |(prefix, name)| (prefix, name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn overlay_for(source: &Path) -> (tempfile::TempDir, WriteOverlay) {
+        let scratch = tempfile::tempdir().unwrap();
+        let overlay = WriteOverlay::prepare(scratch.path(), "chat", &[source.to_path_buf()])
+            .await
+            .expect("a readable granted folder stages");
+        (scratch, overlay)
+    }
+
+    /// The invariant every later slice is built on: exec writing a granted path
+    /// changes the overlay and leaves the user's folder alone until the turn
+    /// ends, and a read of that path in between returns what was just written
+    /// rather than the original.
+    #[tokio::test]
+    async fn a_write_lands_in_the_overlay_and_shadows_the_original_until_the_turn_ends() {
+        let granted = tempfile::tempdir().unwrap();
+        std::fs::write(granted.path().join("notes.md"), "original").unwrap();
+        std::fs::create_dir(granted.path().join("nested")).unwrap();
+        std::fs::write(granted.path().join("nested/data.csv"), "a,b").unwrap();
+
+        let (_scratch, overlay) = overlay_for(granted.path()).await;
+        let staged = overlay.slots()[0].overlay().to_path_buf();
+
+        // The copy is the whole tree, so the agent reads through it without
+        // anything falling back to the real folder.
+        assert_eq!(
+            std::fs::read_to_string(staged.join("notes.md")).unwrap(),
+            "original"
+        );
+        assert_eq!(
+            std::fs::read_to_string(staged.join("nested/data.csv")).unwrap(),
+            "a,b"
+        );
+
+        // What exec does during the turn: overwrite, create, delete.
+        std::fs::write(staged.join("notes.md"), "revised").unwrap();
+        std::fs::write(staged.join("nested/new.txt"), "fresh").unwrap();
+        std::fs::remove_file(staged.join("nested/data.csv")).unwrap();
+
+        // Read-back inside the turn sees the overlay, not the original.
+        assert_eq!(
+            std::fs::read_to_string(staged.join("notes.md")).unwrap(),
+            "revised"
+        );
+        // None of it has reached the user's folder yet.
+        assert_eq!(
+            std::fs::read_to_string(granted.path().join("notes.md")).unwrap(),
+            "original"
+        );
+        assert!(granted.path().join("nested/data.csv").exists());
+
+        let outcome = overlay.materialize().await;
+        assert_eq!(
+            outcome,
+            OverlayOutcome {
+                written: 2,
+                deleted: 1,
+                refused: 0
+            }
+        );
+        assert_eq!(
+            std::fs::read_to_string(granted.path().join("notes.md")).unwrap(),
+            "revised"
+        );
+        assert_eq!(
+            std::fs::read_to_string(granted.path().join("nested/new.txt")).unwrap(),
+            "fresh"
+        );
+        assert!(!granted.path().join("nested/data.csv").exists());
+
+        // A file written back keeps the mode it had rather than becoming a
+        // private host-owned file the user can no longer share.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            let mode = std::fs::metadata(granted.path().join("notes.md"))
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(mode & 0o777, 0o644);
+        }
+    }
+
+    /// Deletions are judged against what the overlay started with, so a file
+    /// the user adds mid-turn survives and an untouched file is not rewritten.
+    #[tokio::test]
+    async fn a_file_the_overlay_never_saw_is_left_alone() {
+        let granted = tempfile::tempdir().unwrap();
+        std::fs::write(granted.path().join("kept.txt"), "kept").unwrap();
+
+        let (_scratch, overlay) = overlay_for(granted.path()).await;
+        std::fs::write(granted.path().join("arrived-later.txt"), "user").unwrap();
+
+        let outcome = overlay.materialize().await;
+        assert_eq!(outcome, OverlayOutcome::default());
+        assert_eq!(
+            std::fs::read_to_string(granted.path().join("arrived-later.txt")).unwrap(),
+            "user"
+        );
+        assert_eq!(
+            std::fs::read_to_string(granted.path().join("kept.txt")).unwrap(),
+            "kept"
+        );
+    }
+}

--- a/crates/openwave-code-execution/src/types.rs
+++ b/crates/openwave-code-execution/src/types.rs
@@ -258,6 +258,14 @@ pub enum ExecFolderAccess {
 pub struct ExecFolderGrant {
     pub path: PathBuf,
     pub access: ExecFolderAccess,
+    /// Where this turn's writes are staged, when the folder is staged at all.
+    ///
+    /// Present only for a read-write grant. When it is set the sandbox makes
+    /// the overlay writable and leaves `path` read-only, so a command that
+    /// edits the folder edits the staged copy and the real folder is updated
+    /// once, at the end of the turn.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overlay: Option<PathBuf>,
 }
 
 impl ExecFolderGrant {
@@ -268,9 +276,26 @@ impl ExecFolderGrant {
         let grant = Self {
             path: path.into(),
             access,
+            overlay: None,
         };
         validate_folder_grant(&grant)?;
         Ok(grant)
+    }
+
+    /// Stage this grant's writes at `overlay`. Host-set, like the grant itself.
+    pub fn staged_at(mut self, overlay: impl Into<PathBuf>) -> Result<Self, CodeExecutionError> {
+        self.overlay = Some(overlay.into());
+        validate_folder_grant(&self)?;
+        Ok(self)
+    }
+
+    /// Where a command in this turn may write for this folder.
+    #[must_use]
+    pub fn writable_path(&self) -> Option<&Path> {
+        if self.access != ExecFolderAccess::ReadWrite {
+            return None;
+        }
+        Some(self.overlay.as_deref().unwrap_or(&self.path))
     }
 }
 
@@ -364,14 +389,29 @@ fn default_cwd() -> String {
 }
 
 fn validate_folder_grant(grant: &ExecFolderGrant) -> Result<(), CodeExecutionError> {
-    let Some(path) = grant.path.to_str() else {
+    validate_folder_path(&grant.path)?;
+    match &grant.overlay {
+        None => Ok(()),
+        // A read-only folder with a write overlay would be a contradiction the
+        // profile builder would have to resolve, so it is rejected here.
+        Some(_) if grant.access != ExecFolderAccess::ReadWrite => {
+            Err(CodeExecutionError::InvalidRequest(
+                "a read-only execution folder cannot stage writes".into(),
+            ))
+        }
+        Some(overlay) => validate_folder_path(overlay),
+    }
+}
+
+fn validate_folder_path(path: &Path) -> Result<(), CodeExecutionError> {
+    let Some(rendered) = path.to_str() else {
         return Err(CodeExecutionError::InvalidRequest(
             "execution folder path must be valid UTF-8".into(),
         ));
     };
-    if !grant.path.is_absolute()
-        || path.len() > MAX_EXEC_FOLDER_PATH_BYTES
-        || path.chars().any(char::is_control)
+    if !path.is_absolute()
+        || rendered.len() > MAX_EXEC_FOLDER_PATH_BYTES
+        || rendered.chars().any(char::is_control)
     {
         return Err(CodeExecutionError::InvalidRequest(
             "invalid execution folder path".into(),

--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -155,6 +155,10 @@ impl openwave_server::code_execution::ExecFolderGrantResolver for DesktopExecFol
                     root_id,
                     path: root.path,
                     writable: root.writable,
+                    // Staging is a property of the turn, decided by the server
+                    // once it knows which folders it will stage. The broker
+                    // answers about authority and nothing else.
+                    overlay: None,
                 })
             })
             .collect()

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -8,7 +8,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -19,7 +19,7 @@ use openwave_code_execution::{
     DaytonaExecutionProvider, E2BCredential, E2BExecutionProvider, ExecFolderAccess,
     ExecFolderGrant, ExecutionId, ExecutionWorkspaceId, LocalExecutionProvider,
     OutputArtifactEntry, OutputArtifactScan, OutputArtifactStatus, PreviewScan, RemoteSessionPool,
-    WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, DAYTONA_CREDENTIAL_KEY,
+    WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, WriteOverlay, DAYTONA_CREDENTIAL_KEY,
     DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES, E2B_CREDENTIAL_KEY,
 };
 use openwave_core::{
@@ -53,6 +53,11 @@ pub struct ResolvedExecFolderGrant {
     pub root_id: HostRootId,
     pub path: PathBuf,
     pub writable: bool,
+    /// Where this turn stages writes for the folder, when it stages them.
+    ///
+    /// Set by the server after the broker answers, never by the broker: it is
+    /// a property of the turn, not of the attachment.
+    pub overlay: Option<PathBuf>,
 }
 
 /// Native-only bridge from product root attachments to live broker authority.
@@ -587,6 +592,12 @@ pub struct ConfiguredCodeExecutionProvider {
     document_scripts_source: Option<PathBuf>,
     folder_grant_resolver: Option<Arc<dyn ExecFolderGrantResolver>>,
     remote_sessions: RemoteSessionPool,
+    /// The write overlay each chat's current turn is staging into.
+    ///
+    /// A turn opens one entry when it resolves its folder grants and closes it
+    /// when the turn ends; every `exec` in between finds it here and points the
+    /// sandbox at the staged copy instead of the user's folder.
+    write_overlays: Mutex<HashMap<ChatId, WriteOverlay>>,
 }
 
 impl ConfiguredCodeExecutionProvider {
@@ -604,6 +615,7 @@ impl ConfiguredCodeExecutionProvider {
             document_scripts_source: None,
             folder_grant_resolver: None,
             remote_sessions: RemoteSessionPool::default(),
+            write_overlays: Mutex::new(HashMap::new()),
         }
     }
 
@@ -647,7 +659,88 @@ impl ConfiguredCodeExecutionProvider {
         if config.provider != Some(CodeExecutionProviderKind::Local) || !cfg!(target_os = "macos") {
             return Ok(Vec::new());
         }
-        self.resolve_chat_folder_grants(chat).await
+        let mut grants = self.resolve_chat_folder_grants(chat).await?;
+        self.open_write_overlay(chat.id, &mut grants).await;
+        Ok(grants)
+    }
+
+    /// Stage this turn's writes for every writable granted folder.
+    ///
+    /// Called once, when the turn resolves the grants it will show the model.
+    /// A folder that cannot be staged keeps direct write access, which is the
+    /// behavior it had before staging existed.
+    async fn open_write_overlay(&self, chat: ChatId, grants: &mut [ResolvedExecFolderGrant]) {
+        self.close_write_overlay(chat).await;
+        let writable = grants
+            .iter()
+            .filter(|grant| grant.writable)
+            .map(|grant| grant.path.clone())
+            .collect::<Vec<_>>();
+        let scope = chat.to_string();
+        let Some(overlay) = WriteOverlay::prepare(&self.scratch_root, &scope, &writable).await
+        else {
+            return;
+        };
+        for slot in overlay.slots() {
+            for grant in grants
+                .iter_mut()
+                .filter(|grant| grant.path == slot.source())
+            {
+                grant.overlay = Some(slot.overlay().to_path_buf());
+            }
+        }
+        self.write_overlays
+            .lock()
+            .expect("write overlay registry is not poisoned")
+            .insert(chat, overlay);
+    }
+
+    /// Apply this turn's staged writes to the user's folders and end staging.
+    ///
+    /// A turn that never staged anything finds nothing to do. A turn that is
+    /// abandoned rather than finished never reaches here, and its staged writes
+    /// are discarded when the next turn sweeps them: applying them later would
+    /// write a folder that has since moved on.
+    pub(crate) async fn close_write_overlay(&self, chat: ChatId) {
+        let overlay = self
+            .write_overlays
+            .lock()
+            .expect("write overlay registry is not poisoned")
+            .remove(&chat);
+        let Some(overlay) = overlay else {
+            return;
+        };
+        let outcome = overlay.materialize().await;
+        if outcome.written > 0 || outcome.deleted > 0 || outcome.refused > 0 {
+            tracing::info!(
+                chat = %chat,
+                written = outcome.written,
+                deleted = outcome.deleted,
+                refused = outcome.refused,
+                "applied staged exec writes to granted folders"
+            );
+        }
+    }
+
+    /// The folder-to-overlay pairs this chat's current turn is staging.
+    ///
+    /// Only the paths leave the lock. The overlay itself is owned by the
+    /// registry for exactly the length of the turn, so nothing an in-flight
+    /// execution holds can keep it alive past the point where its writes are
+    /// applied.
+    fn staged_folders(&self, chat: ChatId) -> HashMap<PathBuf, PathBuf> {
+        self.write_overlays
+            .lock()
+            .expect("write overlay registry is not poisoned")
+            .get(&chat)
+            .map(|overlay| {
+                overlay
+                    .slots()
+                    .iter()
+                    .map(|slot| (slot.source().to_path_buf(), slot.overlay().to_path_buf()))
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     async fn resolve_chat_folder_grants(
@@ -811,19 +904,31 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
                         "execution conversation does not exist".into(),
                     )
                 })?;
+            // Authority is resolved again here rather than reused from the
+            // turn's prompt snapshot, so a revocation mid-turn fails closed.
+            // Staging is looked up rather than re-established: the overlay
+            // belongs to the turn, and every command in it writes to the same
+            // staged tree.
+            let staged = self.staged_folders(chat_id);
             let grants = self
                 .resolve_chat_folder_grants(&chat)
                 .await?
                 .into_iter()
                 .map(|grant| {
-                    ExecFolderGrant::new(
+                    let writable = grant.writable;
+                    let overlay = writable.then(|| staged.get(&grant.path)).flatten().cloned();
+                    let resolved = ExecFolderGrant::new(
                         grant.path,
-                        if grant.writable {
+                        if writable {
                             ExecFolderAccess::ReadWrite
                         } else {
                             ExecFolderAccess::ReadOnly
                         },
-                    )
+                    )?;
+                    match overlay {
+                        Some(overlay) => resolved.staged_at(overlay),
+                        None => Ok(resolved),
+                    }
                 })
                 .collect::<std::result::Result<Vec<_>, _>>()?;
             request = request.with_folder_grants(grants)?;
@@ -1278,6 +1383,7 @@ mod tests {
                 root_id: granted,
                 path: folder.path().to_path_buf(),
                 writable: false,
+                overlay: None,
             }],
         });
         let provider = ConfiguredCodeExecutionProvider::new(
@@ -1311,6 +1417,7 @@ mod tests {
                 root_id: injected,
                 path: folder.path().to_path_buf(),
                 writable: true,
+                overlay: None,
             }],
         });
         let (store, _database) = test_store().await;

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -56,6 +56,13 @@ pub(crate) fn compose(specs: &[ToolSpec]) -> String {
     compose_for_surface(specs, &[], false)
 }
 
+/// Render a host path as a quoted JSON string, so a path carrying a quote or a
+/// newline cannot forge a prompt line.
+fn quoted(path: &std::path::Path) -> String {
+    serde_json::to_string(&path.to_string_lossy())
+        .expect("serializing a folder path string cannot fail")
+}
+
 /// Compose the prompt for one exact tool surface, with a bounded snapshot of
 /// host-resolved local-exec folders, in the chat's current permission
 /// posture. The sandbox profile resolves the folders again per invocation.
@@ -269,15 +276,30 @@ pub(crate) fn compose_for_surface(
                 "- Local exec can use only the following host-resolved folder grants; managed execution providers cannot access these host paths."
                     .to_owned(),
             );
+            let mut any_staged = false;
             for folder in exec_folders.iter().take(MAX_LISTED_EXEC_FOLDER_GRANTS) {
-                let access = if folder.writable {
-                    "read-write"
-                } else {
-                    "read-only"
-                };
-                let path = serde_json::to_string(&folder.path.to_string_lossy())
-                    .expect("serializing a folder path string cannot fail");
-                lines.push(format!("- {access} folder: {path}"));
+                let path = quoted(&folder.path);
+                match (&folder.overlay, folder.writable) {
+                    (Some(overlay), true) => {
+                        any_staged = true;
+                        lines.push(format!(
+                            "- read-write folder: {path}, staged at {}",
+                            quoted(overlay)
+                        ));
+                    }
+                    (_, true) => lines.push(format!("- read-write folder: {path}")),
+                    (_, false) => lines.push(format!("- read-only folder: {path}")),
+                }
+            }
+            if any_staged {
+                lines.push(
+                    "- A staged folder is writable only at its staged path, which holds a complete copy of the folder made for this turn. Read and edit the copy exactly as you would the folder itself; the changes are applied to the real folder when the turn ends."
+                        .to_owned(),
+                );
+                lines.push(
+                    "- When you tell the user about a file in a staged folder, name it by the folder's own path, not the staged path."
+                        .to_owned(),
+                );
             }
             let omitted = exec_folders
                 .len()
@@ -511,13 +533,18 @@ mod tests {
             .map(|index| ResolvedExecFolderGrant {
                 root_id: openwave_core::HostRootId::from_uuid(Uuid::new_v4()).unwrap(),
                 path: format!("/Users/example/grant-{index}").into(),
-                writable: index == 0,
+                writable: index < 2,
+                overlay: (index == 0).then(|| "/scratch/.exec-overlays/chat/staged".into()),
             })
             .collect::<Vec<_>>();
         let prompt = compose_for_surface(&[spec("exec")], &folders, false);
 
-        assert!(prompt.contains("read-write folder: \"/Users/example/grant-0\""));
-        assert!(prompt.contains("read-only folder: \"/Users/example/grant-1\""));
+        assert!(prompt.contains(
+            "read-write folder: \"/Users/example/grant-0\", staged at \"/scratch/.exec-overlays/chat/staged\""
+        ));
+        // An unstaged writable grant must not be described as staged.
+        assert!(prompt.contains("read-write folder: \"/Users/example/grant-1\"\n"));
+        assert!(prompt.contains("read-only folder: \"/Users/example/grant-2\""));
         assert!(prompt.contains("2 additional granted folder(s) are omitted"));
         assert!(!prompt.contains("/Users/example/grant-12"));
         assert!(prompt.contains("Revocation applies to the next invocation"));

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -543,7 +543,22 @@ impl TurnWorker {
         Ok(ClaimAction::Claimed(Box::new(turn), lease_token))
     }
 
+    /// Run one claimed turn and close out whatever the turn staged.
+    ///
+    /// Exec writes into a granted folder land in a per-turn overlay, and the
+    /// end of the turn is the only place that can apply them. Every way the run
+    /// below returns has to pass through here, which is why the run itself is a
+    /// separate function rather than an early return in this one.
     async fn process(&self, turn: TurnRun, lease_token: uuid::Uuid) -> Result<TurnWorkerOutcome> {
+        let chat_id = turn.chat_id;
+        let outcome = self.run_turn(turn, lease_token).await;
+        if let Some(provider) = self.exec_folder_context.as_ref() {
+            provider.close_write_overlay(chat_id).await;
+        }
+        outcome
+    }
+
+    async fn run_turn(&self, turn: TurnRun, lease_token: uuid::Uuid) -> Result<TurnWorkerOutcome> {
         if turn.status != TurnRunStatus::Running || turn.lease_token != Some(lease_token) {
             return Err(AgentError::msg(format!(
                 "claimed turn {} has an invalid execution identity",


### PR DESCRIPTION
Attaching a folder gives exec recursive write over it, and every write
lands on the user's real file the instant the command runs. There is no
point at which the change can be reviewed, counted, or undone, because by
the time anything could look at it the original bytes are gone.

This puts a per-turn overlay in between. Each writable granted folder is
copied under the chat's scratch tree when the turn starts, the Seatbelt
profile makes that copy the only writable location, and the turn's
changes are applied to the real folder when the turn ends. Folders stay
readable at their own paths; scratch and workspace writes are untouched.

The end state is what it was: the same edits land on the same files by
the time the turn finishes. What changes is that they now land in one
place, once, from a tree that can be compared against what the folder
started with. Preconditions, snapshots, and undo build on that.

## Read-through

The agent drives an ordinary shell, so a file it creates has to be
greppable, appendable, and removable by the next command. That rules out
a sparse overlay: reads would have to fall through to the real folder,
and on macOS nothing can arrange it. Seatbelt is a policy engine over
real paths, not a mount namespace, so no path can be made to show two
directories merged.

So the overlay is the whole tree. Read-through is not emulated, it is
structural — every filesystem operation behaves exactly as it would
against the folder, and there is no operation to list as unsupported.
On APFS the copy is a `clonefile`, which shares storage until a block is
written, so it costs directory metadata rather than the folder's bytes;
elsewhere it falls back to a recursive copy.

The cost is that exec addresses the staged tree at the overlay path
rather than the folder's own path, which the operating prompt now states,
along with the instruction to name files back to the user by the folder's
path.

## Applying the changes

The overlay is compared against a manifest recorded when it was made, not
against whatever the folder holds at the end of the turn. A file whose
length and modification time still match was never touched. A file that
differs is written back, keeping the mode it had. A file the manifest
lists and the overlay no longer has was deleted, and is deleted from the
folder.

Judging deletions against the manifest is what keeps a file the user
added mid-turn, or one that could not be inspected during the copy, from
reading as "the agent deleted this". Nothing is removed unless the
overlay was watched holding it first.

A folder that cannot be staged — too large, or unreadable — keeps direct
write access rather than losing the agent's writes, which is the behavior
it had before. A turn that is abandoned rather than finished leaves its
overlay unapplied, and the next turn for that chat sweeps it.

## Containment

Every step is issued against a descriptor pinned when the overlay was
prepared, extending the `ScratchDir` handles rather than working around
them. Exec can write inside the overlay for the length of the turn, so it
can rename directories under paths the write-back would otherwise walk;
pinning means the directory acted on is the directory that was checked.
No step in the overlay resolves a path.

## Tests

Three, all on invariants the following slices assume:

- A write through the overlay shadows the original, is read back through
  the overlay, and reaches the folder only when the turn ends — covering
  create, overwrite, delete, and nested paths in one pass.
- A file the overlay never saw survives, so deletion cannot be inferred
  from the folder's current contents.
- A staged grant is writable only at its overlay, driven through the real
  sandbox: naming the folder's own path — the path the model has always
  been given — is refused rather than silently staged.

Closes #1074.
