### PR TITLE
fix(server): harden the image attachment response headers

### DIFF
--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -56,6 +56,20 @@ pub use plans::*;
 pub use root_attachment::*;
 pub use user_questions::*;
 
+/// The policy every stored-bytes response carries.
+///
+/// Both byte-serving routes hand back content that originated outside OpenWave
+/// — a reader's file, or an image an agent produced — from the API's own
+/// origin, so a response a browser ever renders must be unable to reach back
+/// into that origin. `sandbox` drops the response into an opaque origin with
+/// scripting off, and `default-src 'none'` denies it every subresource and
+/// every outbound request.
+///
+/// It is shared rather than duplicated so the two routes cannot drift into
+/// serving comparable bytes under different rules.
+pub(crate) const SERVED_BYTES_CONTENT_POLICY: &str =
+    "default-src 'none'; sandbox; frame-ancestors 'none'; base-uri 'none'; form-action 'none'";
+
 /// `GET /mcp/servers` — renderer-safe definitions and current connection health.
 pub async fn get_mcp_servers(
     State(state): State<AppState>,

--- a/crates/openwave-server/src/routes/document.rs
+++ b/crates/openwave-server/src/routes/document.rs
@@ -17,6 +17,7 @@ use openwave_core::{
 use crate::document_decode::decode_document;
 use crate::error::ServerError;
 use crate::extract::{Json, Path, Query, RawBytes};
+use crate::routes::SERVED_BYTES_CONTENT_POLICY;
 use crate::state::AppState;
 use crate::MAX_RAW_DOCUMENT_BYTES;
 
@@ -764,16 +765,6 @@ pub async fn get_chat_document_file_content(
     serve_document_file_content(&state, document_id, Some(chat_id), None, method, &headers).await
 }
 
-/// The policy every original-bytes response carries.
-///
-/// The route serves reader-supplied bytes from the API's own origin, so a
-/// response that a browser ever renders must be unable to reach back into that
-/// origin. `sandbox` drops the response into an opaque origin with scripting
-/// off, and `default-src 'none'` denies it every subresource and every
-/// outbound request.
-const DOCUMENT_CONTENT_POLICY: &str =
-    "default-src 'none'; sandbox; frame-ancestors 'none'; base-uri 'none'; form-action 'none'";
-
 /// How one response names and offers a document's original bytes.
 struct ServedMediaType {
     content_type: &'static str,
@@ -954,7 +945,7 @@ async fn serve_document_file_content(
         .header(header::CONTENT_TYPE, served.content_type)
         .header(header::CONTENT_DISPOSITION, served.disposition)
         .header(header::X_CONTENT_TYPE_OPTIONS, "nosniff")
-        .header(header::CONTENT_SECURITY_POLICY, DOCUMENT_CONTENT_POLICY)
+        .header(header::CONTENT_SECURITY_POLICY, SERVED_BYTES_CONTENT_POLICY)
         .header(header::REFERRER_POLICY, "no-referrer")
         .header(header::ACCEPT_RANGES, "bytes")
         .header(header::CONTENT_LENGTH, body_len.to_string());

--- a/crates/openwave-server/src/routes/image_attachment.rs
+++ b/crates/openwave-server/src/routes/image_attachment.rs
@@ -34,6 +34,7 @@ use openwave_core::{
 
 use crate::error::ServerError;
 use crate::extract::{Path, RawBytes};
+use crate::routes::SERVED_BYTES_CONTENT_POLICY;
 use crate::state::AppState;
 
 /// Body limit for the publish endpoint, matching the durable per-image ceiling
@@ -158,12 +159,35 @@ pub async fn get_chat_image_attachment(
     }
     Response::builder()
         .status(StatusCode::OK)
+        // Named exactly as stored, with no resolution table in between. The
+        // document route needs one because its stored type is whatever the
+        // ingesting caller declared; here the type is an `ImageMediaType`, a
+        // closed enum of four inert raster formats that only a magic-byte
+        // sniff can produce. The allowlist is the type, and it is enforced at
+        // ingest rather than re-derived on every read. Naming it verbatim is
+        // also required by the renderer, which compares the fetched blob's
+        // type against the transcript's record and refuses to draw a
+        // disagreement.
         .header(header::CONTENT_TYPE, image.media_type.as_str())
         .header(header::CONTENT_LENGTH, actual_len.to_string())
         // The bearer is never put in a URL. Do not let the resulting pixels
         // persist in an HTTP cache either; the renderer owns the object URL's
         // short lifetime instead.
         .header(header::CACHE_CONTROL, "no-store")
+        // Defense in depth rather than a live hole: the bytes were sniffed at
+        // ingest, so they really are the format named above and a sniffing
+        // browser would reach the same answer. These say so anyway, because
+        // the guarantee lives in a validation step several layers away and a
+        // future format admitted there should not silently widen what a
+        // browser will do with the response.
+        .header(header::X_CONTENT_TYPE_OPTIONS, "nosniff")
+        .header(header::CONTENT_SECURITY_POLICY, SERVED_BYTES_CONTENT_POLICY)
+        .header(header::REFERRER_POLICY, "no-referrer")
+        // `inline` is the honest answer for every format this route can serve,
+        // and it is what keeps the renderer working: the fetch that feeds the
+        // `<img>` ignores the disposition, but a reader who opens the URL
+        // directly should see the image rather than a download.
+        .header(header::CONTENT_DISPOSITION, "inline")
         .body(Body::from(bytes))
         .map_err(|error| {
             ServerError::internal(format!(

--- a/crates/openwave-server/src/tests/image_attachment.rs
+++ b/crates/openwave-server/src/tests/image_attachment.rs
@@ -409,6 +409,15 @@ async fn transcript_projects_image_identity_and_fetches_pixels_with_the_chat_bea
     assert_eq!(pixels.status(), StatusCode::OK);
     assert_eq!(pixels.headers()[header::CONTENT_TYPE], "image/png");
     assert_eq!(pixels.headers()[header::CACHE_CONTROL], "no-store");
+    // Hardening a browser applies but nothing in the app surfaces. The exact
+    // content type matters beyond correctness: the renderer refuses to draw a
+    // blob whose type disagrees with the transcript's record.
+    assert_eq!(pixels.headers()[header::X_CONTENT_TYPE_OPTIONS], "nosniff");
+    assert_eq!(pixels.headers()[header::CONTENT_DISPOSITION], "inline");
+    assert_eq!(pixels.headers()[header::REFERRER_POLICY], "no-referrer");
+    assert!(pixels
+        .headers()
+        .contains_key(header::CONTENT_SECURITY_POLICY));
     assert_eq!(
         pixels.headers()[header::CONTENT_LENGTH],
         bytes.len().to_string()


### PR DESCRIPTION
The image attachment route served pixels with `Cache-Control: no-store` and nothing else, while the document route gained `nosniff`, a content policy, a referrer policy, and an explicit disposition when its byte serving was hardened. Comparable bytes were coming back under different rules, which is the sort of gap that later gets closed in whichever direction is noticed first.

The image route now carries the same four headers.

It deliberately does not route through the document route's `ServedMediaType` table. That table exists because a document's stored media type is whatever the ingesting caller declared — the HTTP API takes the `Content-Type` header at its word — so serving is the first place the type can be constrained. An image attachment's type is an `ImageMediaType`, a closed enum of four inert raster formats that only a magic-byte sniff can produce, and the declared type must agree with the sniff or the upload is refused. The allowlist is already the type, enforced once at ingest; re-deriving it per read would add a lookup that can only ever return the value it was given. No path admits SVG or any other markup format.

The exact stored type also has to survive to the client. The renderer fetches these bytes with a bearer header, wraps them in a `Blob`, and compares `blob.type` against the type recorded in the transcript before creating the object URL — a disagreement renders as unavailable rather than as an image. Naming anything other than the stored type would break display. `Content-Disposition: inline` is correct for every format the route can serve and is ignored by the fetch that feeds the `<img>`, so it changes nothing for the renderer while giving a reader who opens the URL directly the image rather than a download.

The content policy is inert against a raster image on its own; its value is that it holds if the admitted format set ever widens, which is the same reason `nosniff` is worth the line even though the bytes were sniffed at ingest. The guarantee lives several layers from the response, and the response should not depend on it silently.

The policy string moved from `document.rs` to `routes.rs` so both routes read one constant rather than two copies that can drift.

No new test. This is a header layer over an unchanged body, so the existing end-to-end test that already asserts the served content type and cache directive picked up the four new assertions instead. That test earns its place for the reason it did before: none of this is visible from the running app, and the exact content type is load-bearing for the renderer's blob check.

Closes #1170
