### PR TITLE
fix(server): give each durable worker its own retry schedule

### DIFF
--- a/crates/openwave-server/src/blob_retirement_worker.rs
+++ b/crates/openwave-server/src/blob_retirement_worker.rs
@@ -9,14 +9,14 @@ use openwave_core::{AgentError, BlobRetirement, BlobRetirementStatus, BlobStore,
 use tokio::sync::Notify;
 use uuid::Uuid;
 
+use crate::retry::{RetryAttempt, RetrySchedule};
 use crate::state::BlobWriteGuard;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct BlobRetirementWorkerConfig {
     lease: Duration,
     heartbeat: Duration,
-    retry_base: Duration,
-    retry_cap: Duration,
+    retry: RetrySchedule,
     idle_min: Duration,
     idle_cap: Duration,
     failure_delay: Duration,
@@ -27,8 +27,18 @@ impl Default for BlobRetirementWorkerConfig {
         Self {
             lease: Duration::from_secs(60),
             heartbeat: Duration::from_secs(15),
-            retry_base: Duration::from_secs(5),
-            retry_cap: Duration::from_secs(5 * 60),
+            // Retiring a blob is background housekeeping with nobody waiting
+            // on it, and its failures are slow ones: a file still held open, a
+            // volume that is busy or briefly unmounted. Retrying in seconds
+            // buys nothing, so the first wait is a minute, later waits reach
+            // half an hour, and the sweep may keep trying for a day before the
+            // cost of giving up — one blob left on disk until the orphan
+            // auditor sees it — is worth paying.
+            retry: RetrySchedule::new(
+                Duration::from_secs(60),
+                Duration::from_secs(30 * 60),
+                Duration::from_secs(24 * 60 * 60),
+            ),
             idle_min: Duration::from_millis(250),
             idle_cap: Duration::from_secs(5),
             failure_delay: Duration::from_secs(1),
@@ -264,11 +274,16 @@ impl BlobRetirementWorker {
         detail: &str,
     ) -> Result<BlobRetirementWorkerOutcome> {
         let failed_at = Utc::now();
-        let retry_at = if retirement.attempt_count < retirement.max_attempts {
-            Some(failed_at + chrono_duration(self.retry_delay(retirement))?)
-        } else {
-            None
-        };
+        let retry_at = self.config.retry.next_attempt_at(
+            RetryAttempt {
+                id: retirement.blob_id,
+                attempt_count: retirement.attempt_count,
+                max_attempts: retirement.max_attempts,
+                first_attempt_at: retirement.started_at.unwrap_or(retirement.created_at),
+            },
+            None,
+            failed_at,
+        );
         let detail = truncate_detail(detail);
         let status = self
             .store
@@ -290,14 +305,6 @@ impl BlobRetirementWorker {
             }
             Some(_) | None => BlobRetirementWorkerOutcome::LeaseLost(retirement.blob_id),
         })
-    }
-
-    fn retry_delay(&self, retirement: &BlobRetirement) -> Duration {
-        let exponent = retirement.attempt_count.saturating_sub(1).clamp(0, 20) as u32;
-        self.config
-            .retry_base
-            .saturating_mul(2_u32.saturating_pow(exponent))
-            .min(self.config.retry_cap)
     }
 }
 
@@ -329,8 +336,11 @@ mod tests {
         BlobRetirementWorkerConfig {
             lease: Duration::from_millis(500),
             heartbeat: Duration::from_millis(25),
-            retry_base: Duration::from_millis(5),
-            retry_cap: Duration::from_millis(20),
+            retry: RetrySchedule::new(
+                Duration::from_millis(5),
+                Duration::from_millis(20),
+                Duration::from_secs(60),
+            ),
             idle_min: Duration::from_millis(1),
             idle_cap: Duration::from_millis(5),
             failure_delay: Duration::from_millis(1),

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -37,6 +37,7 @@ mod pairing;
 mod provider;
 mod providers;
 mod resolver;
+mod retry;
 mod routes;
 mod sandbox_agent_run_worker;
 pub mod sandbox_container_run;

--- a/crates/openwave-server/src/retry.rs
+++ b/crates/openwave-server/src/retry.rs
@@ -1,0 +1,204 @@
+//! Shared retry scheduling for the durable workers.
+//!
+//! Every durable worker parks a retryable failure for a while and eventually
+//! gives up. The policy is the same everywhere — exponential waits, jitter so
+//! items that failed together do not retry together, a ceiling on any single
+//! wait, and a wall-clock envelope past which waiting longer cannot help. Only
+//! the numbers differ, because a chat turn, a sandboxed background run, and a
+//! blob deletion sweep have very different ideas of how long anyone is willing
+//! to wait.
+
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+
+/// The durable retry state of one work item, as the schedule sees it.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RetryAttempt {
+    /// Row identity. Seeds the jitter so a given item's schedule is
+    /// reproducible in a debugger and in tests.
+    pub(crate) id: uuid::Uuid,
+    /// Attempts already started, including the one that just failed.
+    pub(crate) attempt_count: i32,
+    /// Attempt budget after which the failure becomes terminal.
+    pub(crate) max_attempts: i32,
+    /// When this item's current episode began. The envelope is measured from
+    /// here, not from the current failure.
+    pub(crate) first_attempt_at: DateTime<Utc>,
+}
+
+/// When a retryably failed work item becomes claimable again.
+///
+/// The schedule is bounded by wall clock, not by attempt count: each attempt
+/// waits twice as long as the last, and no attempt is scheduled past
+/// `envelope` measured from the item's first claim. Work that cannot be
+/// retried inside the envelope fails now with its own error rather than being
+/// parked for longer than anyone is waiting.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RetrySchedule {
+    /// Wait before the first retry, doubled for each attempt after it.
+    initial: Duration,
+    /// Ceiling on any single computed wait.
+    max_delay: Duration,
+    /// Wall-clock budget from the item's first claim to its last retry.
+    envelope: Duration,
+}
+
+impl RetrySchedule {
+    pub(crate) const fn new(initial: Duration, max_delay: Duration, envelope: Duration) -> Self {
+        Self {
+            initial,
+            max_delay,
+            envelope,
+        }
+    }
+
+    /// The ceiling on any single wait, for the callers that must supply some
+    /// delay even when the schedule has decided no further attempt is useful.
+    pub(crate) const fn max_delay(self) -> Duration {
+        self.max_delay
+    }
+
+    /// Decide when a retryable failure may be attempted again, or `None` when
+    /// waiting can no longer help and the failure should be made permanent.
+    pub(crate) fn next_attempt_at(
+        self,
+        attempt: RetryAttempt,
+        hint: Option<Duration>,
+        now: DateTime<Utc>,
+    ) -> Option<DateTime<Utc>> {
+        let delay = self.delay(attempt, hint, now)?;
+        now.checked_add_signed(chrono::Duration::from_std(delay).ok()?)
+    }
+
+    /// The same decision expressed as a wait, for the durable transitions that
+    /// take a delay and derive the timestamp from the database clock.
+    ///
+    /// `hint` is the provider's `Retry-After`. It wins over the computed
+    /// backoff whenever it is longer, because retrying before a rate limit
+    /// clears spends an attempt on a request that is already refused — the
+    /// exact way a fixed one-second delay burns a whole budget in a few
+    /// seconds. It is floored at `initial` so a `Retry-After: 0` cannot
+    /// produce a hot loop.
+    ///
+    /// A hint longer than the remaining envelope is refused outright instead
+    /// of being honored: parking the work for it would consume an attempt that
+    /// the deadline will never let run.
+    pub(crate) fn delay(
+        self,
+        attempt: RetryAttempt,
+        hint: Option<Duration>,
+        now: DateTime<Utc>,
+    ) -> Option<Duration> {
+        if attempt.attempt_count >= attempt.max_attempts {
+            return None;
+        }
+        let deadline = attempt.first_attempt_at + chrono::Duration::from_std(self.envelope).ok()?;
+        if now >= deadline {
+            return None;
+        }
+        let delay = match hint {
+            Some(hint) => hint.max(self.initial),
+            None => jitter(
+                self.backoff(attempt.attempt_count),
+                attempt.id,
+                attempt.attempt_count,
+            ),
+        };
+        let at = now.checked_add_signed(chrono::Duration::from_std(delay).ok()?)?;
+        (at <= deadline).then_some(delay)
+    }
+
+    /// Exponential wait for the attempt that just failed, capped at
+    /// `max_delay`. Attempt one waits `initial`.
+    fn backoff(self, attempt_count: i32) -> Duration {
+        let doublings = u32::try_from(attempt_count.saturating_sub(1)).unwrap_or(0);
+        self.initial
+            .checked_mul(1_u32.checked_shl(doublings.min(31)).unwrap_or(u32::MAX))
+            .unwrap_or(self.max_delay)
+            .min(self.max_delay)
+    }
+}
+
+/// Spread a computed wait over `[delay / 2, delay]`.
+///
+/// Items that failed together — the common case, since they failed against the
+/// same provider or the same busy file — must not retry together. The offset
+/// is derived from the item's own identity rather than a random source so a
+/// given item's schedule is reproducible in a debugger and in tests.
+fn jitter(delay: Duration, id: uuid::Uuid, attempt_count: i32) -> Duration {
+    let seed = u64::from_le_bytes(id.as_bytes()[..8].try_into().unwrap_or([0; 8]))
+        .wrapping_add(u64::from(attempt_count.unsigned_abs()));
+    // splitmix64 finalizer: the raw UUID bytes are not uniformly spread across
+    // the low bits we sample.
+    let mut mixed = seed.wrapping_mul(0x9e37_79b9_7f4a_7c15);
+    mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    mixed ^= mixed >> 31;
+    let half = delay / 2;
+    half + half.mul_f64(((mixed >> 11) as f64) / ((1_u64 << 53) as f64))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn failed(attempt_count: i32, first_attempt_at: DateTime<Utc>) -> RetryAttempt {
+        RetryAttempt {
+            id: uuid::Uuid::new_v4(),
+            attempt_count,
+            max_attempts: 4,
+            first_attempt_at,
+        }
+    }
+
+    /// The scheduling contract a rate-limited turn depends on: waits grow, the
+    /// provider's own `Retry-After` beats a guess that is far too short, and
+    /// neither the attempt budget nor a long hint can schedule work the
+    /// wall-clock envelope will never let run.
+    #[test]
+    fn retry_waits_grow_and_defer_to_the_provider_inside_the_envelope() {
+        let schedule = RetrySchedule::new(
+            Duration::from_millis(250),
+            Duration::from_secs(100),
+            Duration::from_secs(600),
+        );
+        let start = Utc::now();
+
+        // Exponential, jittered into the top half of each computed wait.
+        for (attempt, base) in [(1, 250), (2, 500), (3, 1_000)] {
+            let at = schedule
+                .next_attempt_at(failed(attempt, start), None, start)
+                .expect("a fresh item retries");
+            let waited = (at - start).num_milliseconds();
+            assert!(
+                (base / 2..=base).contains(&waited),
+                "attempt {attempt} waited {waited}ms, expected {}..={base}ms",
+                base / 2
+            );
+        }
+
+        // A 60-second rate-limit hint replaces the sub-second guess that used
+        // to spend the whole budget before the limit cleared.
+        let hinted = schedule
+            .next_attempt_at(failed(1, start), Some(Duration::from_secs(60)), start)
+            .expect("a hint inside the envelope is honored");
+        assert_eq!((hinted - start).num_seconds(), 60);
+
+        // A hint reaching past the envelope is refused outright rather than
+        // spending an attempt on work the deadline will cancel.
+        assert!(schedule
+            .next_attempt_at(failed(1, start), Some(Duration::from_secs(900)), start)
+            .is_none());
+
+        // So is any retry once the envelope has elapsed, or once the durable
+        // attempt budget is spent.
+        let late = start + chrono::Duration::seconds(601);
+        assert!(schedule
+            .next_attempt_at(failed(1, start), None, late)
+            .is_none());
+        assert!(schedule
+            .next_attempt_at(failed(4, start), None, start)
+            .is_none());
+    }
+}

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -29,6 +29,7 @@ use tokio::sync::Notify;
 
 use crate::bus::EventBus;
 use crate::resolver::ProviderResolver;
+use crate::retry::{RetryAttempt, RetrySchedule};
 use crate::state::SandboxAttemptGuard;
 
 /// Fixed instruction set for the initial isolated executor.
@@ -47,6 +48,7 @@ pub(crate) struct SandboxAgentRunWorkerConfig {
     idle_min: Duration,
     idle_cap: Duration,
     failure_delay: Duration,
+    retry: RetrySchedule,
     max_concurrency: usize,
     max_running_global: u32,
     max_running_per_chat: u32,
@@ -63,6 +65,18 @@ impl Default for SandboxAgentRunWorkerConfig {
             idle_min: Duration::from_millis(250),
             idle_cap: Duration::from_secs(5),
             failure_delay: Duration::from_secs(1),
+            // A parent turn may be waiting on this run, but nothing it retries
+            // recovers in milliseconds: a sandbox that is still provisioning,
+            // a provider that just refused, a delegated resource that has not
+            // appeared yet. Retrying inside a second only spends one of three
+            // attempts on the same unfinished state, so the first wait is five
+            // seconds. The envelope matches the run's own wall-clock deadline,
+            // which the database already enforces.
+            retry: RetrySchedule::new(
+                Duration::from_secs(5),
+                Duration::from_secs(60),
+                Duration::from_secs(60 * 60),
+            ),
             max_concurrency: 4,
             max_running_global: 4,
             max_running_per_chat: 2,
@@ -585,7 +599,7 @@ impl SandboxAgentRunWorker {
                 self.park_delegated_file_read(run, lease_token, provider_id, arguments)
                     .await
             }
-            Err(error) => self.record_failure(run.id, lease_token, error).await,
+            Err(error) => self.record_failure(&run, lease_token, error).await,
         }
     }
 
@@ -619,10 +633,29 @@ impl SandboxAgentRunWorker {
 
     async fn record_failure(
         &self,
-        id: openwave_core::AgentRunId,
+        run: &AgentRun,
         lease_token: uuid::Uuid,
         error: AgentError,
     ) -> Result<SandboxAgentRunWorkerOutcome> {
+        let id = run.id;
+        // `fail_agent_run` owns the terminal decision — it compares the run's
+        // own attempt budget under the claim lock — so the schedule's refusals
+        // arrive here only as a wait that no longer matters. The deadline sweep
+        // settles a run whose retry lands past its deadline.
+        let delay = self
+            .config
+            .retry
+            .delay(
+                RetryAttempt {
+                    id: *id.as_uuid(),
+                    attempt_count: run.attempt_count,
+                    max_attempts: run.max_attempts,
+                    first_attempt_at: run.started_at.unwrap_or(run.created_at),
+                },
+                error.retry_after(),
+                chrono::Utc::now(),
+            )
+            .unwrap_or_else(|| self.config.retry.max_delay());
         let detail = error.to_string();
         let detail = detail
             .chars()
@@ -635,7 +668,7 @@ impl SandboxAgentRunWorker {
                 lease_token,
                 "sandbox_execution_failed",
                 &detail,
-                chrono_duration(self.config.failure_delay)?,
+                chrono_duration(delay)?,
             )
             .await?
         {
@@ -807,7 +840,7 @@ impl SandboxAgentRunWorker {
             }
             ParkSandboxToolCallOutcome::IdentityConflict => {
                 self.record_failure(
-                    run.id,
+                    &run,
                     lease_token,
                     AgentError::msg("sandbox web-search checkpoint identity conflict"),
                 )
@@ -815,7 +848,7 @@ impl SandboxAgentRunWorker {
             }
             ParkSandboxToolCallOutcome::DelegatedResourceUnavailable => {
                 self.record_failure(
-                    run.id,
+                    &run,
                     lease_token,
                     AgentError::msg("sandbox delegated resource is unavailable"),
                 )
@@ -876,7 +909,7 @@ impl SandboxAgentRunWorker {
             }
             ParkSandboxToolCallOutcome::IdentityConflict => {
                 self.record_failure(
-                    run.id,
+                    &run,
                     lease_token,
                     AgentError::msg("sandbox delegated-file checkpoint identity conflict"),
                 )
@@ -884,7 +917,7 @@ impl SandboxAgentRunWorker {
             }
             ParkSandboxToolCallOutcome::DelegatedResourceUnavailable => {
                 self.record_failure(
-                    run.id,
+                    &run,
                     lease_token,
                     AgentError::msg("sandbox delegated resource is unavailable"),
                 )
@@ -2489,6 +2522,13 @@ mod tests {
             None,
             SandboxAgentRunWorkerConfig {
                 failure_delay: Duration::from_secs(1),
+                // Shrink the production backoff so the test observes each
+                // retry becoming claimable without waiting seconds for it.
+                retry: RetrySchedule::new(
+                    Duration::from_millis(100),
+                    Duration::from_millis(200),
+                    Duration::from_secs(60),
+                ),
                 max_concurrency: 1,
                 max_running_global: 1,
                 max_running_per_chat: 1,
@@ -2516,12 +2556,12 @@ mod tests {
             .finish_agent_run_cancellation(second, claimed.lease_token.unwrap())
             .await
             .unwrap();
-        tokio::time::sleep(Duration::from_millis(1_100)).await;
+        tokio::time::sleep(Duration::from_millis(300)).await;
         assert_eq!(
             worker.run_once().await.unwrap(),
             SandboxAgentRunWorkerOutcome::RetryScheduled(first)
         );
-        tokio::time::sleep(Duration::from_millis(1_100)).await;
+        tokio::time::sleep(Duration::from_millis(300)).await;
         assert_eq!(
             worker.run_once().await.unwrap(),
             SandboxAgentRunWorkerOutcome::Failed(first)

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -1527,12 +1527,12 @@ async fn test_app_with_scanner_resolution_race(
 
 /// Shrink the retry backoff so failure-injection tests observe the next
 /// attempt without waiting out the production schedule.
-fn fast_retry_schedule() -> turn_worker::RetrySchedule {
-    turn_worker::RetrySchedule {
-        initial: Duration::from_millis(10),
-        max_delay: Duration::from_millis(50),
-        ..turn_worker::RetrySchedule::default()
-    }
+fn fast_retry_schedule() -> crate::retry::RetrySchedule {
+    crate::retry::RetrySchedule::new(
+        Duration::from_millis(10),
+        Duration::from_millis(50),
+        Duration::from_secs(600),
+    )
 }
 
 fn spawn_turn_worker(state: &AppState) {

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -11,7 +11,7 @@ use cap_std::ambient_authority;
 use cap_std::fs::{Dir, DirBuilder};
 #[cfg(unix)]
 use cap_std::fs::{DirBuilderExt as CapDirBuilderExt, PermissionsExt as CapPermissionsExt};
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver};
 use futures::StreamExt;
 use openwave_core::{
@@ -30,6 +30,7 @@ use crate::bus::EventBus;
 use crate::chat_titling::ChatTitler;
 use crate::mcp_config::McpRuntime;
 use crate::resolver::ProviderResolver;
+use crate::retry::{RetryAttempt, RetrySchedule};
 use crate::state::TurnGuard;
 
 #[derive(Debug, Clone, Copy)]
@@ -53,108 +54,17 @@ impl Default for TurnWorkerConfig {
             idle_min: Duration::from_millis(250),
             idle_cap: Duration::from_secs(5),
             failure_delay: Duration::from_secs(1),
-            retry: RetrySchedule::default(),
+            // A user is watching this turn: start retrying in well under a
+            // second, and give up after ten minutes rather than hold a chat
+            // open longer than anyone waits.
+            retry: RetrySchedule::new(
+                Duration::from_millis(250),
+                Duration::from_secs(100),
+                Duration::from_secs(600),
+            ),
             max_concurrency: 4,
         }
     }
-}
-
-/// When a retryably failed turn becomes claimable again.
-///
-/// The schedule is bounded by wall clock, not by attempt count: each attempt
-/// waits twice as long as the last, and no attempt is scheduled past
-/// `envelope` measured from the turn's first claim. A turn that cannot be
-/// retried inside the envelope fails now with the provider's own error rather
-/// than being parked for longer than anyone is waiting.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct RetrySchedule {
-    /// Wait before the first retry, doubled for each attempt after it.
-    pub(crate) initial: Duration,
-    /// Ceiling on any single computed wait.
-    pub(crate) max_delay: Duration,
-    /// Wall-clock budget from the turn's first claim to its last retry.
-    pub(crate) envelope: Duration,
-}
-
-impl Default for RetrySchedule {
-    fn default() -> Self {
-        Self {
-            initial: Duration::from_millis(250),
-            max_delay: Duration::from_secs(100),
-            envelope: Duration::from_secs(600),
-        }
-    }
-}
-
-impl RetrySchedule {
-    /// Decide when a retryable failure may be attempted again, or `None` when
-    /// waiting can no longer help and the failure should be made permanent.
-    ///
-    /// `hint` is the provider's `Retry-After`. It wins over the computed
-    /// backoff whenever it is longer, because retrying before a rate limit
-    /// clears spends an attempt on a request that is already refused — the
-    /// exact way the fixed one-second delay used to burn a turn's whole
-    /// budget in a few seconds. It is floored at `initial` so a `Retry-After:
-    /// 0` cannot produce a hot loop.
-    ///
-    /// A hint longer than the remaining envelope is refused outright instead
-    /// of being honored: parking the turn for it would consume an attempt that
-    /// the deadline will never let run.
-    fn next_attempt_at(
-        self,
-        turn: &TurnRun,
-        hint: Option<Duration>,
-        now: DateTime<Utc>,
-    ) -> Option<DateTime<Utc>> {
-        if turn.attempt_count >= turn.max_attempts {
-            return None;
-        }
-        let deadline = turn.started_at.unwrap_or(turn.created_at)
-            + chrono::Duration::from_std(self.envelope).ok()?;
-        if now >= deadline {
-            return None;
-        }
-        let backoff = self.backoff(turn.attempt_count);
-        let delay = match hint {
-            Some(hint) => hint.max(self.initial),
-            None => jitter(backoff, turn.id, turn.attempt_count),
-        };
-        let at = now + chrono::Duration::from_std(delay).ok()?;
-        (at <= deadline).then_some(at)
-    }
-
-    /// Exponential wait for the attempt that just failed, capped at
-    /// `max_delay`. Attempt one waits `initial`.
-    fn backoff(self, attempt_count: i32) -> Duration {
-        let doublings = u32::try_from(attempt_count.saturating_sub(1)).unwrap_or(0);
-        self.initial
-            .checked_mul(1_u32.checked_shl(doublings.min(31)).unwrap_or(u32::MAX))
-            .unwrap_or(self.max_delay)
-            .min(self.max_delay)
-    }
-}
-
-/// Spread a computed wait over `[delay / 2, delay]`.
-///
-/// Turns that failed together — the common case, since they failed against the
-/// same provider — must not retry together. The offset is derived from the
-/// turn's own identity rather than a random source so a given turn's schedule
-/// is reproducible in a debugger and in tests.
-fn jitter(delay: Duration, turn_id: TurnId, attempt_count: i32) -> Duration {
-    let seed = u64::from_le_bytes(
-        turn_id.as_uuid().as_bytes()[..8]
-            .try_into()
-            .unwrap_or([0; 8]),
-    )
-    .wrapping_add(u64::from(attempt_count.unsigned_abs()));
-    // splitmix64 finalizer: the raw UUID bytes are not uniformly spread across
-    // the low bits we sample.
-    let mut mixed = seed.wrapping_mul(0x9e37_79b9_7f4a_7c15);
-    mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
-    mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
-    mixed ^= mixed >> 31;
-    let half = delay / 2;
-    half + half.mul_f64(((mixed >> 11) as f64) / ((1_u64 << 53) as f64))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2294,7 +2204,7 @@ impl TurnWorker {
             .then(|| {
                 self.config
                     .retry
-                    .next_attempt_at(turn, retry_after, Utc::now())
+                    .next_attempt_at(retry_attempt(turn), retry_after, Utc::now())
             })
             .flatten()
             .map_or(TurnFailureRetry::Permanent, TurnFailureRetry::RetryAt);
@@ -2492,6 +2402,16 @@ fn checked_model_step_sum(total: i32, delta: usize) -> Result<i32> {
         .ok_or_else(|| AgentError::msg("model-step total exceeds the durable range"))
 }
 
+/// The turn's retry state, with its envelope measured from the first claim.
+fn retry_attempt(turn: &TurnRun) -> RetryAttempt {
+    RetryAttempt {
+        id: *turn.id.as_uuid(),
+        attempt_count: turn.attempt_count,
+        max_attempts: turn.max_attempts,
+        first_attempt_at: turn.started_at.unwrap_or(turn.created_at),
+    }
+}
+
 fn chrono_duration(duration: Duration) -> Result<chrono::Duration> {
     chrono::Duration::from_std(duration)
         .map_err(|error| AgentError::msg(format!("invalid turn-worker duration: {error}")))
@@ -2502,85 +2422,6 @@ fn log_turn_result(result: std::result::Result<Result<TurnWorkerOutcome>, tokio:
         Ok(Ok(_)) => {}
         Ok(Err(error)) => eprintln!("openwave: turn worker execution failed: {error}"),
         Err(error) => eprintln!("openwave: turn worker task stopped: {error}"),
-    }
-}
-
-#[cfg(test)]
-mod retry_schedule_tests {
-    use super::*;
-
-    fn failed_turn(attempt_count: i32, started_at: DateTime<Utc>) -> TurnRun {
-        TurnRun {
-            id: TurnId::new(),
-            chat_id: openwave_core::ChatId::new(),
-            agent_run_id: openwave_core::AgentRunId::new(),
-            input_message_id: MessageId::new(),
-            output_message_id: None,
-            model: "test-model".into(),
-            status: TurnRunStatus::Running,
-            attempt_count,
-            max_attempts: 4,
-            claim_count: attempt_count,
-            model_steps: 0,
-            usage: openwave_core::Usage::default(),
-            available_at: started_at,
-            lease_token: None,
-            lease_expires_at: None,
-            started_at: Some(started_at),
-            finished_at: None,
-            last_error_code: None,
-            last_error_detail: None,
-            steer_revision: 0,
-            last_steer_applied_at: None,
-            created_at: started_at,
-            updated_at: started_at,
-        }
-    }
-
-    /// The scheduling contract a rate-limited turn depends on: waits grow, the
-    /// provider's own `Retry-After` beats a guess that is far too short, and
-    /// neither the attempt budget nor a long hint can schedule work the
-    /// wall-clock envelope will never let run.
-    #[test]
-    fn retry_waits_grow_and_defer_to_the_provider_inside_the_envelope() {
-        let schedule = RetrySchedule::default();
-        let start = Utc::now();
-
-        // Exponential, jittered into the top half of each computed wait.
-        for (attempt, base) in [(1, 250), (2, 500), (3, 1_000)] {
-            let turn = failed_turn(attempt, start);
-            let at = schedule
-                .next_attempt_at(&turn, None, start)
-                .expect("a fresh turn retries");
-            let waited = (at - start).num_milliseconds();
-            assert!(
-                (base / 2..=base).contains(&waited),
-                "attempt {attempt} waited {waited}ms, expected {}..={base}ms",
-                base / 2
-            );
-        }
-
-        // A 60-second rate-limit hint replaces the sub-second guess that used
-        // to spend the whole budget before the limit cleared.
-        let turn = failed_turn(1, start);
-        let hinted = schedule
-            .next_attempt_at(&turn, Some(Duration::from_secs(60)), start)
-            .expect("a hint inside the envelope is honored");
-        assert_eq!((hinted - start).num_seconds(), 60);
-
-        // A hint reaching past the envelope is refused outright rather than
-        // spending an attempt on work the deadline will cancel.
-        assert!(schedule
-            .next_attempt_at(&turn, Some(Duration::from_secs(900)), start)
-            .is_none());
-
-        // So is any retry once the envelope has elapsed, or once the durable
-        // attempt budget is spent.
-        let late = start + chrono::Duration::seconds(601);
-        assert!(schedule.next_attempt_at(&turn, None, late).is_none());
-        assert!(schedule
-            .next_attempt_at(&failed_turn(4, start), None, start)
-            .is_none());
     }
 }
 


### PR DESCRIPTION
The turn worker got a real retry policy in #1137; the other durable workers were
still parking every retryable failure for a flat one second. This moves
`RetrySchedule` out of `turn_worker.rs` into its own `retry` module and gives
each worker its own numbers, because their tolerances are not the same.

`RetrySchedule` is unchanged in behavior. It now takes a small `RetryAttempt`
(row id, attempt count, budget, first-claim time) instead of a `TurnRun`, and
exposes the same decision as either an absolute timestamp (`next_attempt_at`,
for the transitions that persist a `retry_at`) or a wait (`delay`, for the ones
that hand the database a delay and let it derive the timestamp). The turn
worker's schedule keeps its existing values: 250ms initial, 100s ceiling, 600s
envelope — a user is watching, so retries start well under a second and stop
before the chat has been held open for longer than anyone waits.

Blob retirement: 60s initial, 30m ceiling, 24h envelope. Nobody is waiting on a
retirement sweep, and its failures are slow ones — a file still held open, a
volume that is busy or briefly unmounted. Retrying in five seconds (the old
base) buys nothing against any of them, and giving up costs only a blob left on
disk until the orphan auditor sees it, so the envelope is generous. This worker
already had exponential backoff; what it gained is jitter, so blobs that failed
together against the same busy volume no longer retry together, and an envelope.

Sandbox agent runs: 5s initial, 60s ceiling, 1h envelope. A parent turn may be
waiting, but nothing this worker retries recovers in milliseconds — a sandbox
still provisioning, a provider that just refused, a delegated resource that has
not appeared. An aggressive early retry only spends one of three attempts on the
same unfinished state, so the first wait is deliberately seconds. The run's
`Retry-After`, where the provider supplied one, is now honored here as it is on
turns. The envelope is set to `AgentRun::DEFAULT_MAX_DURATION` to match the run's
own deadline rather than to introduce a second, weaker one: `fail_agent_run`
owns the terminal decision under the claim lock, so a schedule that refuses to
retry cannot terminalize from the worker side. Runs are already bounded in the
database by `deadline_at`, and the expired-deadline sweep settles anything whose
retry lands past it.

The sandbox web-search worker is left alone, and it is worth saying why. Its
one-second delay is the lane's poll delay after an unexpected iteration error —
the same one the turn worker still has — not a retry schedule. A web search that
fails does not retry at all: `resolve_sandbox_tool_call` writes a terminal
failure receipt and resumes the sandbox, which sees the error in its tool result
and decides what to do. Sandbox tool calls carry no retry-wait state and no
`retry_at`, so adopting the schedule there would mean adding a retry state
machine, not tuning one. That is a separate change; #1224 tracks it. It is also
the worker where a long envelope would be most wrong — it sits inside a turn a
user is waiting on — which is an argument for keeping any future retry there to
a handful of seconds.

Attempt budgets, for the record, since #1147 raised the same mismatch on turns:
sandbox runs have a budget of 3 and blob retirements 5. Neither envelope binds
before the budget does under normal failure — a retirement burns all five
attempts inside about fifteen minutes of a 24h envelope. That is the intended
direction (the envelope is a backstop, not the usual limit), and the budgets look
defensible on their own, so this change leaves them alone.

No new tests. The schedule's mechanics are already covered by the test that moved
with it, and three near-identical per-worker scheduling tests would be duplicate
coverage of one shared function. One existing sandbox-run test asserted through
the old flat delay by sleeping past it; it now sets an explicitly shrunken
schedule, which also cuts about two seconds of sleeping from the suite.

Closes #1148
