### PR TITLE
fix(desktop): carry the canonical call id through transcript history so MCP App views rehydrate

### DIFF
--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -952,6 +952,7 @@ fn tool_activity_from_call(
         ),
     };
     ChatToolActivitySnapshot {
+        call_id: call.id,
         tool: crate::RendererToolName::from(call.name.as_str()),
         action: crate::preview::ToolActionPreview::build(&call.name, &call.arguments),
         result,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -198,6 +198,16 @@ pub enum ChatToolActivityStatus {
 /// result it can carry is one a tool explicitly projects through a closed type.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub struct ChatToolActivitySnapshot {
+    /// Canonical call id, the same [`crate::id::CallId`] the live event stream
+    /// carried for this call.
+    ///
+    /// History withholds arbitrary call detail, but not this identity: the MCP
+    /// App payload route already keys renderer-readable data on exactly this id
+    /// for the same authenticated client, and a rehydrated app view must present
+    /// it to resolve its payload. Without it, history cards invented a local id
+    /// and every replayed app view fetched a payload the server could only
+    /// reject.
+    pub call_id: crate::id::CallId,
     /// Allowlisted renderer tool name, never a provider-supplied one.
     ///
     /// A name rather than display copy: the renderer already derives a live

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -34,6 +34,7 @@ describe("terminal transcript presentation", () => {
       messages: [],
       tool_activity: [
         {
+          call_id: "call-1",
           tool: "spawn_sandbox_agent",
           result_unreadable: false,
           status: "completed",
@@ -51,6 +52,9 @@ describe("terminal transcript presentation", () => {
         role: "tool",
         name: "spawn_sandbox_agent",
         backgroundAgentRunId: "child-run",
+        // The canonical id, not an invented one: an MCP App card resolves
+        // its payload by this id after rehydration.
+        callId: "call-1",
       }),
     ]);
   });
@@ -60,6 +64,7 @@ describe("terminal transcript presentation", () => {
       messages: [],
       tool_activity: [
         {
+          call_id: "call-2",
           tool: "web_search",
           result: { tool: "web_search_provider_required" },
           result_unreadable: false,
@@ -87,6 +92,7 @@ describe("terminal transcript presentation", () => {
       messages: [],
       tool_activity: [
         {
+          call_id: "call-3",
           tool: "web_search",
           result_unreadable: true,
           status: "completed",

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
@@ -47,7 +47,7 @@ export function presentChatTranscript(
           {
             id: entry.id,
             role: "tool",
-            callId: entry.id,
+            callId: entry.callId,
             name: entry.name,
             backgroundAgentRunId: entry.backgroundAgentRunId,
             status: entry.status,

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.test.ts
@@ -22,6 +22,7 @@ describe("hydrateTranscriptHistory", () => {
       ],
       [
         {
+          call_id: "call-1",
           tool: "web_search",
           result_unreadable: false,
           status: "completed",
@@ -34,7 +35,8 @@ describe("hydrateTranscriptHistory", () => {
     expect(entries).toEqual([
       expect.objectContaining({ id: "user-1", kind: "message" }),
       expect.objectContaining({
-        id: "tool-history:2026-07-16T10:00:01Z:0",
+        id: "call-1",
+        callId: "call-1",
         kind: "tool",
         name: "web_search",
         status: "completed",
@@ -46,6 +48,7 @@ describe("hydrateTranscriptHistory", () => {
   it("hydrates background delegation and wait activity with fixed tool kinds", () => {
     const entries = hydrateTranscriptHistory([], [
       {
+        call_id: "call-2",
         tool: "spawn_sandbox_agent",
         result_unreadable: false,
         status: "completed",
@@ -53,6 +56,7 @@ describe("hydrateTranscriptHistory", () => {
         finished_at: "2026-07-16T10:00:00Z",
       },
       {
+        call_id: "call-3",
         tool: "wait_for_agents",
         result_unreadable: false,
         status: "completed",
@@ -71,6 +75,7 @@ describe("hydrateTranscriptHistory", () => {
   it("hydrates answered questions with a fixed presentation kind", () => {
     const entries = hydrateTranscriptHistory([], [
       {
+        call_id: "call-4",
         tool: "ask_user_questions",
         result_unreadable: false,
         status: "completed",
@@ -87,6 +92,7 @@ describe("hydrateTranscriptHistory", () => {
   it("hydrates delegated file reads as their fixed presentation kind", () => {
     const entries = hydrateTranscriptHistory([], [
       {
+        call_id: "call-5",
         tool: "read_delegated_file",
         result_unreadable: false,
         status: "completed",
@@ -104,6 +110,7 @@ describe("hydrateTranscriptHistory", () => {
   it("hydrates source discovery, direct reads, and semantic search distinctly", () => {
     const entries = hydrateTranscriptHistory([], [
       {
+        call_id: "call-6",
         tool: "list_sources",
         result_unreadable: false,
         status: "completed",
@@ -111,6 +118,7 @@ describe("hydrateTranscriptHistory", () => {
         finished_at: "2026-07-16T10:00:00Z",
       },
       {
+        call_id: "call-7",
         tool: "read_source",
         result_unreadable: false,
         status: "completed",
@@ -118,6 +126,7 @@ describe("hydrateTranscriptHistory", () => {
         finished_at: "2026-07-16T10:00:01Z",
       },
       {
+        call_id: "call-8",
         tool: "search",
         result_unreadable: false,
         status: "completed",
@@ -201,6 +210,7 @@ describe("hydrateTranscriptHistory", () => {
   it("folds an unrecognized historical tool to the generic card", () => {
     const [entry] = hydrateTranscriptHistory([], [
       {
+        call_id: "call-10",
         tool: "other",
         result_unreadable: false,
         status: "failed",

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -29,6 +29,8 @@ export type HydratedTranscriptEntry =
   | {
       id: string;
       kind: "tool";
+      /** Canonical call id — the payload key for a rehydrated MCP App view. */
+      callId: string;
       name: string;
       /** Opaque child correlation for a historical sandbox spawn. */
       backgroundAgentRunId?: string;
@@ -97,11 +99,12 @@ export function hydrateTranscriptHistory(
       refusal: message.refusal,
       reasoning: message.role === "assistant" ? message.reasoning : undefined,
     })),
-    ...toolActivity.map((activity, index) => ({
-      // The server deliberately withholds a canonical call id. This identity
-      // is therefore local to one snapshot and only supports React rendering;
-      // it is never used to resolve or replay a tool operation.
-      id: `tool-history:${activity.started_at}:${index}`,
+    ...toolActivity.map((activity) => ({
+      // The canonical call id, not a snapshot-local one: an MCP App card
+      // resolves its payload by this id, so inventing an identity here left
+      // every rehydrated app view fetching a payload the server rejected.
+      id: activity.call_id,
+      callId: activity.call_id,
       kind: "tool" as const,
       // Already an allowlisted renderer tool name, folded server-side, so the
       // same presentation the live stream uses applies directly.

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -251,6 +251,18 @@ origin: RootAttachmentOrigin, };
  */
 export type ChatToolActivitySnapshot = { 
 /**
+ * Canonical call id, the same [`crate::id::CallId`] the live event stream
+ * carried for this call.
+ *
+ * History withholds arbitrary call detail, but not this identity: the MCP
+ * App payload route already keys renderer-readable data on exactly this id
+ * for the same authenticated client, and a rehydrated app view must present
+ * it to resolve its payload. Without it, history cards invented a local id
+ * and every replayed app view fetched a payload the server could only
+ * reject.
+ */
+call_id: CallId, 
+/**
  * Allowlisted renderer tool name, never a provider-supplied one.
  *
  * A name rather than display copy: the renderer already derives a live

--- a/crates/openwave-server/src/tests/conversations.rs
+++ b/crates/openwave-server/src/tests/conversations.rs
@@ -1041,7 +1041,6 @@ async fn transcript_tool_activity_is_allowlisted_and_redacts_canonical_tool_data
             .to_vec(),
     )
     .unwrap();
-    let call_id_text = call_id.to_string();
     for hidden in [
         secret_path,
         secret_result,
@@ -1053,7 +1052,6 @@ async fn transcript_tool_activity_is_allowlisted_and_redacts_canonical_tool_data
         "configuration_required",
         "private_error_code",
         "private diagnostic detail",
-        call_id_text.as_str(),
         "mcp__private_server__read_sensitive_path",
         "arguments",
         "provider_id",
@@ -1071,9 +1069,14 @@ async fn transcript_tool_activity_is_allowlisted_and_redacts_canonical_tool_data
     let transcript: serde_json::Value = serde_json::from_str(&body).unwrap();
     let activity = transcript["tool_activity"].as_array().unwrap();
     assert_eq!(activity.len(), 4);
+    // The canonical call id is the one deliberate exception to redaction: the
+    // MCP App payload route keys renderer-readable data on exactly this id, so
+    // a rehydrated app view must be able to present it. Everything else about
+    // the call — name, arguments, results, provider identity — stays hidden.
     assert!(activity.iter().any(|card| {
         card["tool"] == "other"
             && card["status"] == "failed"
+            && card["call_id"] == serde_json::json!(call_id)
             && card["started_at"].is_string()
             && card["finished_at"].is_string()
     }));


### PR DESCRIPTION
Found during the connected-apps / MCP Apps end-to-end smoke test against a local model-gateway (deferred-items context: #624; the swallowed payload-fetch catch listed there is what made this silent).

## What breaks

During a live turn the MCP App card fetches `GET /chats/{chat}/calls/{call}/mcp-app-payload` with the real call id (200, view renders). On turn completion the transcript rehydrates from the durable snapshot, and history entries invented a snapshot-local id — `tool-history:${started_at}:${index}` — because `ChatToolActivitySnapshot` deliberately withheld the canonical call id. The remounted card's payload fetch then 400s (`call_id` must be a UUID), the failure is swallowed, and the sandboxed view sits at its own loading state ("Waiting for a governed API call…") while looking healthy. Every historical / reloaded MCP App view is affected; the working view exists only between tool completion and rehydration.

## Fix

- Expose the canonical `CallId` on `ChatToolActivitySnapshot`. The withholding stance predates MCP Apps: the payload route already keys renderer-readable data on exactly this id for the same authenticated client, so this widens no boundary — history cards just stop inventing an identity the server can only reject.
- Regenerate `wire.ts` (`UPDATE_WIRE_TYPES=1 cargo test -p openwave-server`).
- Use it as the tool entry's `id` and `callId` in `hydrateTranscriptHistory` / `presentChatTranscript` — which also makes history keys stable across snapshots instead of index-derived.

## Tests

- `TranscriptHistory.test.ts` asserts the hydrated tool entry carries the canonical id/callId (was pinned to the synthetic `tool-history:` shape).
- `ChatTranscriptPresentation.test.ts` asserts the presented tool message's `callId` is the wire `call_id` — the exact contract the MCP App card depends on.
- Full UI suite green (640 tests); `cargo test -p openwave-core --lib` green (514).

Verified end to end against a local gateway: with this fix a reloaded chat's MCP App card fetches its payload with the real id and the governed tool audit receipt view renders with data (screenshot in #1223 thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)