### PR TITLE
fix(desktop): read granted folders through the turn's exec staging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3917,6 +3917,7 @@ dependencies = [
  "chrono",
  "futures",
  "infer 0.22.0",
+ "openwave-code-execution",
  "openwave-core",
  "openwave-host-broker",
  "openwave-server",

--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -36,6 +36,7 @@ cap-fs-ext.workspace = true
 cap-std.workspace = true
 futures.workspace = true
 infer = { version = "=0.22.0", default-features = false }
+openwave-code-execution = { path = "../openwave-code-execution" }
 openwave-core = { path = "../openwave-core", default-features = false }
 openwave-host-broker = { path = "../openwave-host-broker" }
 openwave-server = { path = "../openwave-server" }

--- a/crates/openwave-desktop/src/client_execution/folder_operations.rs
+++ b/crates/openwave-desktop/src/client_execution/folder_operations.rs
@@ -7,6 +7,7 @@
 
 use std::collections::HashSet;
 
+use openwave_code_execution::host_paths::{resolve_scratch_directory, ScratchEntryKind};
 use openwave_core::{
     validate_import_connected_file_arguments, validate_list_connected_folders_arguments,
     validate_list_folder_arguments, validate_read_connected_file_arguments, CallId, ListFolderArgs,
@@ -15,8 +16,8 @@ use openwave_core::{
     READ_CONNECTED_FILE_TOOL,
 };
 use openwave_host_broker::{
-    OperationEnvelope, OperationRequest, OperationResult, PathRequest, RelativePath, RootId,
-    PROTOCOL_VERSION,
+    DirectoryEntry, EntryKind, OperationEnvelope, OperationRequest, OperationResult, PathRequest,
+    ReadFileResult, RelativePath, RootId, PROTOCOL_VERSION,
 };
 use tauri::Manager;
 
@@ -31,6 +32,10 @@ const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
 const MAX_DIRECTORY_ENTRIES: usize = 128;
 const MAX_RESULT_CONTENT_BYTES: usize = 60 * 1024;
 const MAX_FILE_CONTENT_BYTES: usize = 56 * 1024;
+/// Ceiling on a file read out of a staged folder, before the result is trimmed
+/// to [`MAX_FILE_CONTENT_BYTES`]. It exists so a large file the agent staged is
+/// refused rather than buffered whole to be thrown away.
+const MAX_STAGED_READ_BYTES: u64 = 4 * 1024 * 1024;
 
 /// Recover persisted outcomes, then discover new matching client calls. The
 /// loop is deliberately native-owned: no renderer event or user action is an
@@ -270,6 +275,16 @@ async fn execute_operation(
         Ok(request) => request,
         Err(()) => return unavailable("invalid_request", "The folder request was not available."),
     };
+    match staged_outcome(state, context, &request).await {
+        StagedOutcome::Unstaged => {}
+        StagedOutcome::Result(result) => return serialize_result(call, result),
+        StagedOutcome::Missing => {
+            return unavailable(
+                "path_not_found",
+                "That path is not in the connected folder.",
+            )
+        }
+    }
     let result = state
         .broker
         .operation(OperationEnvelope {
@@ -287,6 +302,151 @@ async fn execute_operation(
             "folder_unavailable",
             "That connected folder is no longer available to this conversation. You can ask the user to connect a folder again.",
         ),
+    }
+}
+
+/// What the staged copy of a granted folder has to say about one read.
+enum StagedOutcome {
+    /// The folder is not staged for this turn, so the user's folder is still
+    /// the only view and the broker answers as it always has.
+    Unstaged,
+    /// The staged copy's answer, in the shape the broker would have returned.
+    Result(OperationResult),
+    /// The folder is staged and the path is not in the staged tree — because
+    /// the agent deleted it this turn, or because it never existed. Answering
+    /// from the user's folder here would show the model a file the shell it is
+    /// driving cannot see.
+    Missing,
+}
+
+/// Answer a folder read from this turn's staged copy when the folder has one.
+///
+/// Exec writes into a per-turn copy of every writable granted folder rather
+/// than the folder itself, so inside a turn the user's folder is the stale
+/// view: a file the agent has just written is not in it, and one the agent has
+/// deleted is still there. A `list_folder` that disagreed with the shell in the
+/// same turn is worse than either view alone, because nothing tells the model
+/// which one is lying — so the folder tools read the staged copy too.
+///
+/// Only reads are redirected. A folder the turn does not stage — no exec grant,
+/// a read-only grant, a folder the overlay could not copy, or a managed
+/// execution provider that mounts nothing — takes the broker path unchanged.
+///
+/// Authority stays with the broker. The staged copy is served only after the
+/// broker confirms this conversation may read that root *now*, which is what
+/// keeps a grant revoked mid-turn from being answered out of staging. The
+/// probe is a root listing rather than the request itself because the request
+/// may name a path that exists only in the staged tree.
+async fn staged_outcome(
+    state: &HostAccess,
+    context: AuthoritativeContext,
+    request: &OperationRequest,
+) -> StagedOutcome {
+    let (root_id, path, read_file) = match request {
+        OperationRequest::ListDirectory(PathRequest { root_id, path }) => (root_id, path, false),
+        OperationRequest::ReadFile(PathRequest { root_id, path }) => (root_id, path, true),
+        _ => return StagedOutcome::Unstaged,
+    };
+    let Some(staged) = state.staged_folders() else {
+        return StagedOutcome::Unstaged;
+    };
+    let Ok(root) = openwave_core::HostRootId::from_uuid(root_id.as_uuid()) else {
+        return StagedOutcome::Unstaged;
+    };
+    let Some(overlay) = staged.staged_root(openwave_core::ChatId::from(context.chat_id), root)
+    else {
+        return StagedOutcome::Unstaged;
+    };
+    if !may_read_root(state, context, *root_id).await {
+        return StagedOutcome::Unstaged;
+    }
+    let staged = if read_file {
+        staged_file(&overlay, path).await
+    } else {
+        staged_directory(&overlay, path).await
+    };
+    staged.map_or(StagedOutcome::Missing, StagedOutcome::Result)
+}
+
+/// Whether the broker would allow this conversation to read `root_id` right now.
+///
+/// `list_roots` filters its answer through the same `ReadFiles` authorization
+/// call that gates a read of the folder, so a root appearing in it is the
+/// broker's live judgement rather than a cached one. It is asked instead of the
+/// caller's own request because it does not depend on the requested path
+/// existing in the user's folder.
+async fn may_read_root(state: &HostAccess, context: AuthoritativeContext, root_id: RootId) -> bool {
+    let result = state
+        .broker
+        .operation(OperationEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: openwave_host_broker::RequestId::new(),
+            context: context.execution,
+            request: OperationRequest::ListRoots,
+        })
+        .await;
+    matches!(
+        result,
+        Ok(OperationResult::ListRoots { roots })
+            if roots.iter().any(|root| root.root_id == root_id)
+    )
+}
+
+/// List one directory inside a staged folder, in the broker's own result shape.
+async fn staged_directory(
+    overlay: &std::path::Path,
+    path: &RelativePath,
+) -> Option<OperationResult> {
+    let directory = resolve_scratch_directory(overlay, staged_relative(path), false).await?;
+    let entries = directory
+        .entries()
+        .await
+        .ok()?
+        .into_iter()
+        // A name the protocol cannot address is one no follow-up call could
+        // name, and the broker drops it from a listing for the same reason.
+        .filter(|entry| RelativePath::parse(&entry.name).is_ok())
+        .map(|entry| DirectoryEntry {
+            name: entry.name,
+            kind: match entry.kind {
+                ScratchEntryKind::File => EntryKind::File,
+                ScratchEntryKind::Directory => EntryKind::Directory,
+                ScratchEntryKind::Other => EntryKind::Other,
+            },
+        })
+        .take(MAX_DIRECTORY_ENTRIES)
+        .collect();
+    Some(OperationResult::ListDirectory { entries })
+}
+
+/// Read one file inside a staged folder, in the broker's own result shape.
+async fn staged_file(overlay: &std::path::Path, path: &RelativePath) -> Option<OperationResult> {
+    let (prefix, name) = staged_relative(path).rsplit_once('/').map_or_else(
+        || ("", staged_relative(path)),
+        |(prefix, name)| (prefix, name),
+    );
+    if name.is_empty() {
+        return None;
+    }
+    let directory = resolve_scratch_directory(overlay, prefix, false).await?;
+    if directory.file_stamp(name).await?.len > MAX_STAGED_READ_BYTES {
+        return None;
+    }
+    let bytes = directory.read_file(name).await.ok()?;
+    let bytes_read = bytes.len();
+    Some(OperationResult::ReadFile(ReadFileResult {
+        content: String::from_utf8(bytes).ok()?,
+        bytes: bytes_read,
+    }))
+}
+
+/// The overlay-relative form of a protocol path. The protocol spells the root
+/// itself `.`, which the pinned scratch walk refuses rather than resolves.
+fn staged_relative(path: &RelativePath) -> &str {
+    if path.is_root() {
+        ""
+    } else {
+        path.as_str()
     }
 }
 
@@ -501,6 +661,60 @@ fn read_file_name(path: &str) -> String {
 mod tests {
     use super::*;
     use openwave_core::ChatId;
+
+    /// The confusion this exists to prevent: the agent writes a file with
+    /// `exec`, calls `list_folder` to confirm it, and is shown a folder that
+    /// does not have it. Exec works in the turn's staged copy, so the folder
+    /// tools read that copy too — including a file that only exists there, and
+    /// excluding one the agent deleted — while the user's folder is left
+    /// untouched until the turn ends.
+    #[tokio::test]
+    async fn a_folder_listing_shows_what_exec_wrote_in_the_same_turn() {
+        let granted = tempfile::tempdir().unwrap();
+        std::fs::write(granted.path().join("notes.md"), "original").unwrap();
+
+        let scratch = tempfile::tempdir().unwrap();
+        let overlay = openwave_code_execution::WriteOverlay::prepare(
+            scratch.path(),
+            "chat",
+            &[granted.path().to_path_buf()],
+        )
+        .await
+        .expect("a readable granted folder stages");
+        let staged = overlay.slots()[0].overlay().to_path_buf();
+
+        // What exec does mid-turn.
+        std::fs::write(staged.join("report.md"), "draft").unwrap();
+        std::fs::remove_file(staged.join("notes.md")).unwrap();
+
+        let Some(OperationResult::ListDirectory { entries }) =
+            staged_directory(&staged, &RelativePath::root()).await
+        else {
+            panic!("a staged folder lists from its staged copy");
+        };
+        let names: Vec<_> = entries.iter().map(|entry| entry.name.as_str()).collect();
+        assert_eq!(names, ["report.md"]);
+
+        let Some(OperationResult::ReadFile(file)) =
+            staged_file(&staged, &RelativePath::parse("report.md").unwrap()).await
+        else {
+            panic!("a staged folder reads from its staged copy");
+        };
+        assert_eq!(file.content, "draft");
+
+        // A file the agent deleted this turn is gone from the tool's view too,
+        // rather than being served from the folder the shell cannot see.
+        assert!(
+            staged_file(&staged, &RelativePath::parse("notes.md").unwrap())
+                .await
+                .is_none()
+        );
+
+        // None of it has reached the user's folder: the tools report the turn's
+        // view, they do not apply it.
+        assert!(granted.path().join("notes.md").exists());
+        assert!(!granted.path().join("report.md").exists());
+    }
 
     #[test]
     fn results_are_bounded_and_do_not_include_host_error_detail() {

--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -26,6 +26,7 @@ pub(crate) struct HostAccess {
     store: OnceCell<std::sync::Arc<dyn Store>>,
     pub(super) control_plane: OnceCell<ControlPlaneClient>,
     pub(super) receipts: ReceiptStore,
+    staged_folders: OnceCell<std::sync::Arc<dyn openwave_server::code_execution::StagedFolders>>,
 }
 
 impl HostAccess {
@@ -45,7 +46,29 @@ impl HostAccess {
             store: OnceCell::new(),
             control_plane: OnceCell::new(),
             receipts,
+            staged_folders: OnceCell::new(),
         })
+    }
+
+    /// Install the server's per-turn exec staging registry.
+    ///
+    /// The folder tools run here, in the desktop process, while the overlay
+    /// they have to agree with is owned by the server's execution provider.
+    /// Handing the lookup across is what lets a folder listing answer from the
+    /// tree exec is writing into without the broker learning about turns.
+    pub(crate) fn initialize_staged_folders(
+        &self,
+        staged: std::sync::Arc<dyn openwave_server::code_execution::StagedFolders>,
+    ) -> Result<(), String> {
+        self.staged_folders
+            .set(staged)
+            .map_err(|_| "exec staging lookup was initialized more than once".to_owned())
+    }
+
+    pub(super) fn staged_folders(
+        &self,
+    ) -> Option<&std::sync::Arc<dyn openwave_server::code_execution::StagedFolders>> {
+        self.staged_folders.get()
     }
 
     pub(crate) fn initialize_store(&self, store: std::sync::Arc<dyn Store>) -> Result<(), String> {

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -287,6 +287,8 @@ async fn boot_server(
     .map_err(|e| e.to_string())?;
     app.state::<host_access::HostAccess>()
         .initialize_store(server.store())?;
+    app.state::<host_access::HostAccess>()
+        .initialize_staged_folders(server.staged_folders())?;
     // Unblock any pairing task parked on a deep link that arrived pre-boot.
     let _ = store_tx.send(Some(server.pairing_handle()));
     let base_url = format!("http://{}", server.local_addr());

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -597,7 +597,50 @@ pub struct ConfiguredCodeExecutionProvider {
     /// A turn opens one entry when it resolves its folder grants and closes it
     /// when the turn ends; every `exec` in between finds it here and points the
     /// sandbox at the staged copy instead of the user's folder.
-    write_overlays: Mutex<HashMap<ChatId, WriteOverlay>>,
+    write_overlays: Mutex<HashMap<ChatId, StagedTurn>>,
+}
+
+/// One turn's staging for one chat.
+///
+/// The overlay itself is addressed by folder path, which is what exec needs.
+/// The host folder tools arrive with a product root id instead, so the same
+/// staging is also indexed that way rather than making every caller re-resolve
+/// a path through the broker to find it.
+struct StagedTurn {
+    overlay: WriteOverlay,
+    staged_roots: HashMap<HostRootId, PathBuf>,
+}
+
+/// Where a chat's current turn stages writes for one granted folder.
+///
+/// For the length of a turn, exec addresses a private copy of each writable
+/// granted folder rather than the folder itself, so the user's folder is the
+/// stale view: a file the agent has just written is not in it yet, and one the
+/// agent has deleted is still there. A host tool that reads the same folder in
+/// the same turn consults this first, so the model is never shown two versions
+/// of one folder.
+///
+/// The broker is deliberately not involved. Staging is a property of the turn,
+/// and the broker knows nothing about turns; it stays the authority on whether
+/// a folder may be read at all.
+pub trait StagedFolders: Send + Sync {
+    /// The staged copy of `root_id` for this chat's current turn, if the turn
+    /// stages that folder. `None` covers every case where the user's folder is
+    /// still the only view — no turn in flight, a read-only grant, or a folder
+    /// the overlay could not stage.
+    fn staged_root(&self, chat: ChatId, root_id: HostRootId) -> Option<PathBuf>;
+}
+
+impl StagedFolders for ConfiguredCodeExecutionProvider {
+    fn staged_root(&self, chat: ChatId, root_id: HostRootId) -> Option<PathBuf> {
+        self.write_overlays
+            .lock()
+            .expect("write overlay registry is not poisoned")
+            .get(&chat)?
+            .staged_roots
+            .get(&root_id)
+            .cloned()
+    }
 }
 
 impl ConfiguredCodeExecutionProvider {
@@ -681,18 +724,26 @@ impl ConfiguredCodeExecutionProvider {
         else {
             return;
         };
+        let mut staged_roots = HashMap::new();
         for slot in overlay.slots() {
             for grant in grants
                 .iter_mut()
                 .filter(|grant| grant.path == slot.source())
             {
                 grant.overlay = Some(slot.overlay().to_path_buf());
+                staged_roots.insert(grant.root_id, slot.overlay().to_path_buf());
             }
         }
         self.write_overlays
             .lock()
             .expect("write overlay registry is not poisoned")
-            .insert(chat, overlay);
+            .insert(
+                chat,
+                StagedTurn {
+                    overlay,
+                    staged_roots,
+                },
+            );
     }
 
     /// Apply this turn's staged writes to the user's folders and end staging.
@@ -707,10 +758,10 @@ impl ConfiguredCodeExecutionProvider {
             .lock()
             .expect("write overlay registry is not poisoned")
             .remove(&chat);
-        let Some(overlay) = overlay else {
+        let Some(staged) = overlay else {
             return;
         };
-        let outcome = overlay.materialize().await;
+        let outcome = staged.overlay.materialize().await;
         if outcome.written > 0 || outcome.deleted > 0 || outcome.refused > 0 {
             tracing::info!(
                 chat = %chat,
@@ -733,8 +784,9 @@ impl ConfiguredCodeExecutionProvider {
             .lock()
             .expect("write overlay registry is not poisoned")
             .get(&chat)
-            .map(|overlay| {
-                overlay
+            .map(|staged| {
+                staged
+                    .overlay
                     .slots()
                     .iter()
                     .map(|slot| (slot.source().to_path_buf(), slot.overlay().to_path_buf()))

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -477,6 +477,9 @@ pub struct Server {
     token: Arc<str>,
     client_executor_token: Arc<str>,
     store: Arc<dyn Store>,
+    /// The live exec staging registry, handed to native embedders so the host
+    /// folder tools answer from the same per-turn copy exec writes into.
+    code_execution: Arc<code_execution::ConfiguredCodeExecutionProvider>,
     /// The live MCP runtime, handed to pairing so a profile that becomes
     /// managed mid-session takes its manual servers down immediately.
     mcp: Arc<mcp_config::McpRuntime>,
@@ -558,6 +561,15 @@ impl Server {
     /// to server-owned records before granting host capabilities.
     pub fn store(&self) -> Arc<dyn Store> {
         self.store.clone()
+    }
+
+    /// Where this server stages a turn's exec writes for granted folders.
+    ///
+    /// Native embedders execute the host folder tools themselves, and those
+    /// tools must not show the model the pre-turn folder while exec is working
+    /// in a staged copy of it. See [`code_execution::StagedFolders`].
+    pub fn staged_folders(&self) -> Arc<dyn code_execution::StagedFolders> {
+        self.code_execution.clone()
     }
 
     /// The handles the native deep-link pairing flow needs.
@@ -814,7 +826,7 @@ async fn bind_inner(
     )
     .with_blobs(state.blobs.clone())
     .with_mcp_runtime(state.mcp.clone())
-    .with_exec_folder_context(code_execution);
+    .with_exec_folder_context(code_execution.clone());
     let sandbox_worker_config = sandbox_agent_run_worker::SandboxAgentRunWorkerConfig::default()
         .with_delegated_file_executor(client_executor_id.is_some());
     let sandbox_agent_run_worker = sandbox_agent_run_worker::SandboxAgentRunWorker::with_attempts(
@@ -862,6 +874,7 @@ async fn bind_inner(
         token,
         client_executor_token,
         store: server_store,
+        code_execution,
         mcp: mcp_runtime,
         gateway: gateway_runtime,
         listener,


### PR DESCRIPTION
Exec writes into a per-turn copy of every writable granted folder, but
`list_folder` and `read_connected_file` still read the user's folder. Inside a
turn the folder is the stale view: a file the agent has just written is not in
it, and one the agent has deleted is still there. The failure that produces is
worse than either view on its own — the agent writes a file with `exec`, calls
`list_folder` to confirm it, does not see it, and concludes the write failed.
Nothing in the two answers says which one is current.

The folder tools now resolve through the same staging registry `exec` uses. The
broker is untouched: staging is a property of the turn and the broker
deliberately knows nothing about turns, so the redirect lives in the tool
executor, which already runs in the desktop process alongside the server that
owns the registry. `ConfiguredCodeExecutionProvider` indexes the turn's overlay
by product root id as well as by folder path, and exposes that lookup as
`code_execution::StagedFolders`; the native folder executor consults it before
dispatching a read.

Authority stays with the broker. A staged answer is served only after the broker
confirms this conversation may read that root right now, so a grant revoked
mid-turn is refused rather than answered out of staging. The check is a
`list_roots` — which filters its answer through the same `ReadFiles`
authorization call that gates a read of the folder — rather than the caller's
own request, because the requested path may exist only in the staged tree, which
is precisely the case that has to work.

Only reads through a staged folder change. A folder the turn does not stage
takes the broker path exactly as before, and that covers every case where the
user's folder is still the only view: a read-only grant, which since #1211 can
exist without exec reach at all; a folder the overlay could not copy; a managed
execution provider, which mounts no host folders; and any non-macOS host. A path
that is missing from a staged tree is reported as missing instead of falling
back to the folder, since falling back is the inconsistency being removed.

One test: a file written into the staged copy is listed and read back by the
folder tools in the same turn, a file deleted there is gone from them, and the
user's folder is untouched throughout. That last pair of assertions is the
answer this change replaces — on `main` the tools return the folder's contents,
so they would report the deleted file and not the written one.

Adjacent and deliberately not folded in: `import_connected_file` still reads the
pre-turn bytes through `ReadFileBinary`. It produces a durable source with a
content digest rather than a transient answer to the model, so pointing it at
staging is a separate decision about what an import of an unapplied file means.
Filed as a follow-up.

Closes #1218
