### PR TITLE
fix(desktop): carry the copy action and timestamp only on a turn's closing assistant bubble

### DIFF
--- a/crates/openwave-desktop/ui/src/MessageFooter.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageFooter.test.tsx
@@ -30,6 +30,19 @@ describe("MessageFooter", () => {
     expect(markup).toBe("");
   });
 
+  it("leaves a mid-turn assistant fragment bare", () => {
+    const markup = renderToStaticMarkup(
+      <MessageFooter
+        role="assistant"
+        text="Interim answer"
+        createdAt="2026-07-20T10:00:00Z"
+        sequenceEnd={false}
+      />,
+    );
+
+    expect(markup).toBe("");
+  });
+
   it("does not render a timestamp-only footer for an empty settled assistant", () => {
     const markup = renderToStaticMarkup(
       <MessageFooter

--- a/crates/openwave-desktop/ui/src/MessageFooter.tsx
+++ b/crates/openwave-desktop/ui/src/MessageFooter.tsx
@@ -6,6 +6,10 @@ type MessageFooterProps = {
   text: string;
   createdAt?: string;
   settled?: boolean;
+  /** A turn's assistant prose is split into one bubble per activity phase;
+   *  the copy action and timestamp belong to the turn, so only the bubble
+   *  that closes it carries them. */
+  sequenceEnd?: boolean;
 };
 
 export function MessageFooter({
@@ -13,7 +17,9 @@ export function MessageFooter({
   text,
   createdAt,
   settled = true,
+  sequenceEnd = true,
 }: MessageFooterProps) {
+  if (role === "assistant" && !sequenceEnd) return null;
   const hasContent = text.trim().length > 0;
   const timestamp = createdAt && (role === "user" || (settled && hasContent))
     ? formatMessageTimestamp(createdAt, new Date())

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -305,6 +305,12 @@ describe("MessageBubble", () => {
         createdAt: "2026-07-20T10:00:01Z",
       },
       {
+        id: "user-2",
+        role: "user",
+        text: "Follow-up question",
+        createdAt: "2026-07-20T10:00:30Z",
+      },
+      {
         id: "assistant-streaming",
         role: "assistant",
         text: "Partial answer",
@@ -332,9 +338,63 @@ describe("MessageBubble", () => {
     );
 
     expect(markup.match(/aria-label="Copy"/g)).toHaveLength(1);
-    expect(markup.match(/class="message-footer"/g)).toHaveLength(2);
+    expect(markup.match(/class="message-footer"/g)).toHaveLength(3);
     expect(markup).toContain('class="message-user-frame"');
     expect(markup).not.toContain('dateTime="2026-07-20T10:01:00Z"');
+  });
+
+  it("carries the copy action and timestamp only on the turn's closing assistant bubble", () => {
+    const messages: ChatMessage[] = [
+      {
+        id: "user-1",
+        role: "user",
+        text: "Question",
+        createdAt: "2026-07-20T10:00:00Z",
+      },
+      {
+        id: "assistant-interim",
+        role: "assistant",
+        text: "Let me check.",
+        sources: [],
+        createdAt: "2026-07-20T10:00:05Z",
+      },
+      {
+        id: "tool-1",
+        role: "tool",
+        callId: "call-1",
+        name: "read_file",
+        status: "completed",
+      },
+      {
+        id: "assistant-closing",
+        role: "assistant",
+        text: "Here is the answer.",
+        sources: [],
+        createdAt: "2026-07-20T10:00:20Z",
+      },
+    ];
+    const markup = renderToStaticMarkup(
+      <MessageList
+        messages={messages}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    expect(markup.match(/aria-label="Copy"/g)).toHaveLength(1);
+    expect(markup).not.toContain('dateTime="2026-07-20T10:00:05Z"');
+    expect(markup).toContain('dateTime="2026-07-20T10:00:20Z"');
   });
 
   it("does not add message actions to tool, system, or error rows", () => {

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -469,6 +469,23 @@ function isActivityMessage(message: ChatMessage | undefined): boolean {
   return message.role === "tool" || message.role === "approval";
 }
 
+/**
+ * Whether the assistant bubble at `index` closes its turn. A turn's prose is
+ * split into one bubble per activity phase it passed through, and the copy
+ * action and timestamp belong to the turn, not to each fragment — so only
+ * the closing bubble carries them. Activity after a bubble is the turn
+ * continuing, whatever it goes on to say; another assistant bubble right
+ * behind it (a superseded stream's replacement) is the same turn resuming.
+ */
+export function isTurnClosingAssistant(
+  messages: readonly ChatMessage[],
+  index: number,
+): boolean {
+  const follower = messages[index + 1];
+  if (isActivityMessage(follower)) return false;
+  return follower === undefined || follower.role !== "assistant";
+}
+
 export function groupMessageItems(
   messages: ChatMessage[],
   busy: boolean,
@@ -537,6 +554,10 @@ export function groupMessageItems(
           key={message.id}
           message={message}
           busy={message.id === streamingAssistantId}
+          sequenceEnd={
+            message.role !== "assistant" ||
+            isTurnClosingAssistant(messages, index)
+          }
           imageClient={imageClient}
           chatId={chatId}
           onRetry={
@@ -832,12 +853,15 @@ const EMPTY_SOURCES: readonly AssistantSource[] = [];
 function MessageBubbleImpl({
   message,
   busy,
+  sequenceEnd = true,
   imageClient,
   chatId,
   onRetry,
 }: {
   message: ChatMessage;
   busy: boolean;
+  /** Only the turn-closing assistant bubble carries the footer. */
+  sequenceEnd?: boolean;
   imageClient?: Pick<ApiClient, "getChatImageAttachment">;
   chatId?: string;
   /** Present only on the transcript's newest retryable failure. */
@@ -894,6 +918,7 @@ function MessageBubbleImpl({
             text={stripCitationDirectives(message.text)}
             createdAt={message.createdAt}
             settled={!busy}
+            sequenceEnd={sequenceEnd}
           />
         </article>
       </MessageCitationsProvider>


### PR DESCRIPTION
A turn's assistant prose is split into one bubble per activity phase it passed through, and every settled bubble drew its own copy button and timestamp. The actions belong to the turn, not to each fragment.

Alpha (`platform/browser-extension/src/components/chat.tsx`) renders message actions only when a message has content, is not streaming, and made no tool calls — i.e. only on the turn's terminal message. Our transcript is flat, with tool calls as separate activity messages between prose bubbles, so the equivalent rule lives in the message list: an assistant bubble followed by activity (the turn is continuing) or by another assistant bubble (a superseded stream's replacement) is mid-turn and renders no footer.

- `isTurnClosingAssistant` in `MessageList` decides; the result flows through `MessageBubble` to a new `sequenceEnd` prop on `MessageFooter` (defaults to `true`, so direct bubble renders are unaffected).
- The streaming tail is unchanged: it is the last bubble and the existing `settled` gate still hides its footer until the stream finishes.
- A turn ending on a refusal/failure notice still shows the footer on its final assistant bubble.

Tests: a new `MessageList` test walks assistant → tool → assistant and asserts a single copy button carrying only the closing bubble's timestamp; a new `MessageFooter` test covers `sequenceEnd={false}`. The existing "settled actions while streaming" test now puts a user message between its two assistant bubbles — two adjacent assistant bubbles correctly read as one turn now, so the user message is what keeps that test modeling two exchanges.

UI-only change; verified with `vitest` on the touched suites and `tsc --noEmit`.