### PR TITLE
feat(server): add container run worker service

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -719,6 +719,10 @@ impl Store for DbStore {
         .await
     }
 
+    async fn list_container_agent_run_candidates(&self, limit: u64) -> Result<Vec<AgentRunId>> {
+        ops::agent_run::list_container_agent_run_candidates(self, limit).await
+    }
+
     async fn list_reclaimable_container_agent_runs(
         &self,
         now: chrono::DateTime<Utc>,

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -1248,6 +1248,42 @@ pub(in crate::db) async fn claim_container_agent_run(
     Ok(Some(claimed))
 }
 
+/// List bounded oldest-first candidates for a fresh container-run claim.
+///
+/// This deliberately does not reserve work. The worker passes each id through
+/// [`claim_container_agent_run`], whose scheduler lock and predicates remain
+/// the authority for admission and the global container concurrency cap.
+pub(in crate::db) async fn list_container_agent_run_candidates(
+    store: &DbStore,
+    limit: u64,
+) -> Result<Vec<AgentRunId>> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+    let now = database_now(&store.conn).await?;
+    Ok(entities::agent_run::Entity::find()
+        .filter(entities::agent_run::Column::Tier.eq(AgentRunTier::Background.as_str()))
+        .filter(
+            entities::agent_run::Column::ExecutionLocation
+                .eq(AgentRunExecutionLocation::Container.as_str()),
+        )
+        .filter(entities::agent_run::Column::Id.in_subquery(admitted_child_id_subquery()))
+        .filter(entities::agent_run::Column::Status.eq(AgentRunStatus::Queued.as_str()))
+        .filter(entities::agent_run::Column::AvailableAt.lte(now))
+        .filter(entities::agent_run::Column::DeadlineAt.gt(now))
+        .filter(entities::agent_run::Column::UpdatedAt.lte(now))
+        .order_by_asc(entities::agent_run::Column::AvailableAt)
+        .order_by_asc(entities::agent_run::Column::CreatedAt)
+        .order_by_asc(entities::agent_run::Column::Id)
+        .limit(limit)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(|run| AgentRunId(run.id))
+        .collect())
+}
+
 /// List container-located runs whose driver died: `running` under an expired
 /// lease with the deadline still open. The in-process lease reaper deliberately
 /// exempts container runs (lease expiry there means "the driving host died",

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1608,6 +1608,16 @@ pub trait Store: Send + Sync {
         agent_run_storage_unavailable()
     }
 
+    /// List bounded oldest-first candidates for the container-run worker.
+    ///
+    /// This scan is only latency and recovery plumbing: every returned id must
+    /// still pass [`Store::claim_container_agent_run`]'s transactional status,
+    /// deadline, admission, and concurrency checks before any container is
+    /// provisioned.
+    async fn list_container_agent_run_candidates(&self, _limit: u64) -> Result<Vec<AgentRunId>> {
+        agent_run_storage_unavailable()
+    }
+
     /// List container-located runs whose driver died: `running` under an
     /// expired lease with the deadline still open. The in-process lease reaper
     /// deliberately exempts container runs, so this scan feeds the recovery

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -41,6 +41,7 @@ mod retry;
 mod routes;
 mod sandbox_agent_run_worker;
 pub mod sandbox_container_run;
+mod sandbox_container_run_worker;
 /// A [`SandboxBackend`](openwave_sandbox_protocol::SandboxBackend) over the Docker
 /// CLI: container provision, loopback addressing, idempotent teardown, and a
 /// correlation-tag orphan sweep.
@@ -490,6 +491,7 @@ pub struct Server {
     router: Router,
     _turn_worker: AbortTask,
     _sandbox_agent_run_worker: AbortTask,
+    _sandbox_container_run_worker: Option<AbortTask>,
     _sandbox_web_search_worker: AbortTask,
     _blob_retirement_worker: AbortTask,
     _blob_orphan_auditor: AbortTask,
@@ -848,6 +850,23 @@ async fn bind_inner(
             state.sandbox_attempts.clone(),
             sandbox_web_search_worker::SandboxWebSearchWorkerConfig::default(),
         );
+    let sandbox_container_run_worker = {
+        // Issue #1230 replaces this constructor gate with the profile flag.
+        // Keep it false in this slice so admission routing and configuration
+        // remain independently reviewable.
+        let container_execution_enabled = false;
+        let backend = Arc::new(sandbox_docker::DockerSandboxBackend::with_defaults());
+        let enabled = container_execution_enabled && backend.is_available();
+        sandbox_container_run_worker::SandboxContainerRunWorker::new(
+            state.store.clone(),
+            backend,
+            state.resolver.clone(),
+            state.agent_run_wake.clone(),
+            enabled,
+            sandbox_container_run::SandboxContainerRunConfig::default(),
+            sandbox_container_run_worker::SandboxContainerRunWorkerConfig::default(),
+        )
+    };
     let server_store = state.store.clone();
     let mcp_runtime = state.mcp.clone();
     let gateway_runtime = state.gateway.clone();
@@ -862,6 +881,8 @@ async fn bind_inner(
 
     let turn_worker = tokio::spawn(turn_worker.run());
     let sandbox_agent_run_worker = tokio::spawn(sandbox_agent_run_worker.run());
+    let sandbox_container_run_worker =
+        sandbox_container_run_worker.map(|worker| tokio::spawn(worker.run()));
     let sandbox_web_search_worker = tokio::spawn(sandbox_web_search_worker.run());
     let blob_retirement_worker = tokio::spawn(blob_retirement_worker.run());
     let blob_orphan_auditor = tokio::spawn(blob_orphan_auditor.run());
@@ -881,6 +902,7 @@ async fn bind_inner(
         router,
         _turn_worker: AbortTask(turn_worker),
         _sandbox_agent_run_worker: AbortTask(sandbox_agent_run_worker),
+        _sandbox_container_run_worker: sandbox_container_run_worker.map(AbortTask),
         _sandbox_web_search_worker: AbortTask(sandbox_web_search_worker),
         _blob_retirement_worker: AbortTask(blob_retirement_worker),
         _blob_orphan_auditor: AbortTask(blob_orphan_auditor),

--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -38,6 +38,7 @@ use openwave_sandbox_protocol::{
     SandboxBackend, SandboxHandle, SandboxRun, TransportSecret,
 };
 use tokio::net::TcpListener;
+use tokio::sync::Notify;
 use uuid::Uuid;
 
 use super::{
@@ -45,6 +46,9 @@ use super::{
 };
 use crate::durable_oplog::DurableOperationStore;
 use crate::resolver::ProviderResolver;
+use crate::sandbox_container_run_worker::{
+    SandboxContainerRunWorker, SandboxContainerRunWorkerConfig,
+};
 
 // --- Mock host model (the resolver the driver proxies inference through) ------
 
@@ -365,7 +369,123 @@ fn fast_config() -> SandboxContainerRunConfig {
     }
 }
 
+fn fast_worker_config() -> SandboxContainerRunWorkerConfig {
+    SandboxContainerRunWorkerConfig {
+        idle_min: Duration::from_millis(10),
+        idle_cap: Duration::from_millis(20),
+        failure_delay: Duration::from_millis(10),
+        maintenance_interval: Duration::from_millis(25),
+        candidate_limit: 8,
+        max_concurrency: 2,
+    }
+}
+
 // --- Tests --------------------------------------------------------------------
+
+/// The production service seam finds a durable queued container run without
+/// being handed its id, claims it under the runner's cap, and drives the real
+/// sandbox agent over loopback to its committed result.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn container_worker_service_drives_queued_work_over_loopback() {
+    tokio::time::timeout(Duration::from_secs(30), async {
+        let (_dir, store, chat) = store().await;
+        let run_id = admit_container_run(&store, chat.id, "driven by the service").await;
+        let backend = MockBackend::spawning();
+        let provider = Arc::new(ScriptedProvider::new(vec!["service result".to_owned()]));
+        let worker = SandboxContainerRunWorker::new(
+            store.clone(),
+            backend.clone(),
+            Arc::new(FixedResolver(provider)),
+            Arc::new(Notify::new()),
+            true,
+            fast_config(),
+            fast_worker_config(),
+        )
+        .expect("the explicitly enabled service is constructed");
+        let task = tokio::spawn(worker.run());
+
+        loop {
+            let run = store.get_agent_run(run_id).await.unwrap().unwrap();
+            if run.status == AgentRunStatus::Completed
+                && backend.destroys.load(Ordering::SeqCst) == 1
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+        assert_eq!(backend.provisions.load(Ordering::SeqCst), 1);
+        assert_eq!(backend.destroys.load(Ordering::SeqCst), 1);
+    })
+    .await
+    .expect("service drive completed within its time bound");
+}
+
+/// A teardown created after the service's startup pass is completed by a later
+/// maintenance cadence, proving teardown recovery is periodic rather than a
+/// one-shot boot action.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn container_worker_service_cadence_completes_pending_teardown() {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        let (_dir, store, _chat) = store().await;
+        let backend = MockBackend::spawning();
+        let provider = Arc::new(ScriptedProvider::new(Vec::new()));
+        let worker = SandboxContainerRunWorker::new(
+            store.clone(),
+            backend.clone(),
+            Arc::new(FixedResolver(provider)),
+            Arc::new(Notify::new()),
+            true,
+            fast_config(),
+            fast_worker_config(),
+        )
+        .expect("the explicitly enabled service is constructed");
+        let task = tokio::spawn(worker.run());
+
+        // Let the immediate startup maintenance pass finish before creating the
+        // obligation, so only a subsequent cadence can observe it.
+        loop {
+            if !backend.reclaim_live_sets.lock().unwrap().is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        let run_id = Uuid::new_v4();
+        store
+            .begin_sandbox_provision(
+                run_id,
+                &SandboxTag::new().to_string(),
+                chrono::Utc::now() + chrono::Duration::seconds(60),
+            )
+            .await
+            .unwrap();
+        assert!(store
+            .commit_sandbox_provision_handle(run_id, "pending-service-teardown")
+            .await
+            .unwrap());
+        store
+            .enqueue_sandbox_teardown(run_id)
+            .await
+            .unwrap()
+            .expect("the committed handle becomes a teardown obligation");
+
+        loop {
+            if store.list_sandbox_teardowns().await.unwrap().is_empty() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+        assert_eq!(backend.destroys.load(Ordering::SeqCst), 1);
+    })
+    .await
+    .expect("maintenance cadence completed within its time bound");
+}
 
 /// The whole stack over loopback: admit a container run, drive it with the real
 /// in-container agent loop running a sandbox filesystem tool and dialing the host

--- a/crates/openwave-server/src/sandbox_container_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_container_run_worker.rs
@@ -1,0 +1,164 @@
+//! Production scheduling for sandbox-resident container runs.
+//!
+//! The runner owns one exact claimed run. This worker supplies the surrounding
+//! service seam: bounded polling for fresh queued work, concurrent drive lanes,
+//! and an ordered recovery-then-sweep maintenance cadence.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use openwave_core::{Result, Store};
+use openwave_sandbox_protocol::SandboxBackend;
+use tokio::sync::Notify;
+
+use crate::resolver::ProviderResolver;
+use crate::sandbox_container_run::{SandboxContainerRunConfig, SandboxContainerRunner};
+
+/// Service-level polling and maintenance tunables.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SandboxContainerRunWorkerConfig {
+    pub(crate) idle_min: Duration,
+    pub(crate) idle_cap: Duration,
+    pub(crate) failure_delay: Duration,
+    pub(crate) maintenance_interval: Duration,
+    pub(crate) candidate_limit: u64,
+    pub(crate) max_concurrency: usize,
+}
+
+impl Default for SandboxContainerRunWorkerConfig {
+    fn default() -> Self {
+        Self {
+            idle_min: Duration::from_millis(250),
+            idle_cap: Duration::from_secs(5),
+            failure_delay: Duration::from_secs(1),
+            maintenance_interval: Duration::from_secs(30),
+            candidate_limit: 16,
+            max_concurrency: 4,
+        }
+    }
+}
+
+/// Polls for and drives container-located background runs.
+#[derive(Clone)]
+pub(crate) struct SandboxContainerRunWorker {
+    store: Arc<dyn Store>,
+    runner: Arc<SandboxContainerRunner>,
+    wake: Arc<Notify>,
+    config: SandboxContainerRunWorkerConfig,
+}
+
+impl SandboxContainerRunWorker {
+    /// Build the service only when container execution is enabled.
+    ///
+    /// Production assembly passes `false` until the profile flag lands. The
+    /// caller separately checks backend availability before spawning the
+    /// returned worker, so absence of a container runtime stays an inert
+    /// capability miss rather than a boot failure.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        store: Arc<dyn Store>,
+        backend: Arc<dyn SandboxBackend>,
+        resolver: Arc<dyn ProviderResolver>,
+        wake: Arc<Notify>,
+        enabled: bool,
+        runner_config: SandboxContainerRunConfig,
+        config: SandboxContainerRunWorkerConfig,
+    ) -> Option<Self> {
+        if !enabled {
+            return None;
+        }
+        assert!(!config.idle_min.is_zero());
+        assert!(config.idle_min <= config.idle_cap);
+        assert!(!config.failure_delay.is_zero());
+        assert!(!config.maintenance_interval.is_zero());
+        assert!(config.candidate_limit > 0);
+        assert!(config.max_concurrency > 0);
+        let runner = Arc::new(SandboxContainerRunner::new(
+            store.clone(),
+            backend,
+            resolver,
+            runner_config,
+        ));
+        Some(Self {
+            store,
+            runner,
+            wake,
+            config,
+        })
+    }
+
+    /// Run the owned drive lanes and maintenance lane until the server drops
+    /// the worker task. Dropping this future drops the [`tokio::task::JoinSet`],
+    /// which aborts every child lane rather than detaching background work.
+    pub(crate) async fn run(self) {
+        let mut lanes = tokio::task::JoinSet::new();
+        for _ in 0..self.config.max_concurrency {
+            lanes.spawn(self.clone().run_drive_lane());
+        }
+        lanes.spawn(self.run_maintenance_lane());
+        while let Some(result) = lanes.join_next().await {
+            match result {
+                Ok(()) => eprintln!("openwave: container worker lane stopped unexpectedly"),
+                Err(error) => eprintln!("openwave: container worker lane stopped: {error}"),
+            }
+        }
+    }
+
+    async fn run_drive_lane(self) {
+        let mut idle_delay = self.config.idle_min;
+        loop {
+            match self.drive_one().await {
+                Ok(true) => idle_delay = self.config.idle_min,
+                Ok(false) => {
+                    tokio::select! {
+                        _ = tokio::time::sleep(idle_delay) => {}
+                        _ = self.wake.notified() => {}
+                    }
+                    idle_delay = idle_delay.saturating_mul(2).min(self.config.idle_cap);
+                }
+                Err(error) => {
+                    eprintln!("openwave: container worker iteration failed: {error}");
+                    tokio::select! {
+                        _ = tokio::time::sleep(self.config.failure_delay) => {}
+                        _ = self.wake.notified() => {}
+                    }
+                }
+            }
+        }
+    }
+
+    async fn drive_one(&self) -> Result<bool> {
+        let candidates = self
+            .store
+            .list_container_agent_run_candidates(self.config.candidate_limit)
+            .await?;
+        for run_id in candidates {
+            if self.runner.drive(run_id).await?.is_some() {
+                // A completed drive frees a claim slot. Wake one sleeping lane
+                // so queued work can consume it without waiting for backoff.
+                self.wake.notify_one();
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    async fn run_maintenance_lane(self) {
+        loop {
+            match self.runner.recover().await {
+                Ok(_) => {
+                    if let Err(error) = self.runner.sweep().await {
+                        eprintln!("openwave: container worker sweep failed: {error}");
+                    }
+                }
+                Err(error) => {
+                    // Do not sweep after an incomplete recovery pass: a
+                    // reclaimable run must be re-driven before its container
+                    // can be considered an orphan.
+                    eprintln!("openwave: container worker recovery failed: {error}");
+                }
+            }
+            tokio::time::sleep(self.config.maintenance_interval).await;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a bounded oldest-first candidate scan and concurrent service lanes for queued container runs
- recover dead drivers before each periodic teardown and orphan sweep
- wire Docker capability detection behind a constructor gate that stays off until the sibling configuration slice lands
- cover queued loopback execution and a later maintenance cadence completing pending teardown

## Testing

- cargo test -p openwave-server --locked sandbox
- cargo clippy -p openwave-server --all-targets --locked -- -D warnings
- cargo fmt -p openwave-server -- --check

Closes #1229