### PR TITLE
fix(server): announce an answered question's completion to live renderers

### DIFF
--- a/crates/openwave-core/src/db/ops/user_question.rs
+++ b/crates/openwave-core/src/db/ops/user_question.rs
@@ -341,6 +341,39 @@ pub(in crate::db) async fn answer(
     active_call.error_detail = Set(None);
     active_call.resolved_at = Set(Some(answered_at));
     let resolved = active_call.update(&transaction).await.map_err(store_err)?;
+    // The question call resolves outside the agent loop, so nothing else ever
+    // announces that it finished: the resumed worker reads the committed
+    // result straight into the model transcript and never revisits the call.
+    // Without this event the renderer showed the card waiting from
+    // `ToolCallStarted` until the turn's terminal hydration finally settled
+    // it — the answer looked lost exactly when it had committed.
+    //
+    // Journaled here, in the transaction that makes the row terminal, so the
+    // event cannot disagree with the row it describes. An exact retry returns
+    // above as `Existing` without reaching this, so the call announces itself
+    // once. Chat-scoped like its `UserQuestionsAsked`: the turn is parked
+    // with no lease, so no attempt owns this event.
+    let completion_event = AgentEvent::ToolCallCompleted {
+        call_id: request.call_id,
+        output: crate::ToolOutput::text(resolved.result.clone().ok_or_else(|| {
+            AgentError::Store(format!(
+                "answered question {} committed no result",
+                request.call_id
+            ))
+        })?),
+        action: crate::ToolActionPreview::build(&resolved.name, &resolved.arguments),
+        result: None,
+    };
+    let seq = super::conversation::append_event_on(
+        &transaction,
+        ChatId(resolved.chat_id),
+        None,
+        None,
+        None,
+        None,
+        &completion_event,
+    )
+    .await?;
     let transition =
         super::turn::advance_turn_after_client_resolution_on(&transaction, &resolved, answered_at)
             .await?
@@ -351,7 +384,13 @@ pub(in crate::db) async fn answer(
                 ))
             })?;
     transaction.commit().await.map_err(store_err)?;
-    Ok(AnswerUserQuestionsOutcome::Answered(transition.turn))
+    Ok(AnswerUserQuestionsOutcome::Answered {
+        turn: transition.turn,
+        completion_event: Box::new(SequencedEvent {
+            seq,
+            event: completion_event,
+        }),
+    })
 }
 
 /// Close presentation state when cancellation terminalizes the unclaimed

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -4540,14 +4540,41 @@ async fn user_questions_survive_reconnect_and_answer_exactly_once() {
         answers: sample_user_answers(),
     };
     let answered_at = parked_at + chrono::Duration::seconds(1);
-    assert!(matches!(
-        restarted
-            .answer_user_questions(&answer_request, answered_at)
-            .await
-            .unwrap(),
-        crate::AnswerUserQuestionsOutcome::Answered(turn)
-            if turn.id == turn_id && turn.status == TurnRunStatus::Resuming
-    ));
+    let answered = restarted
+        .answer_user_questions(&answer_request, answered_at)
+        .await
+        .unwrap();
+    let crate::AnswerUserQuestionsOutcome::Answered {
+        turn,
+        completion_event,
+    } = answered
+    else {
+        panic!("unexpected answer outcome: {answered:?}");
+    };
+    assert_eq!(turn.id, turn_id);
+    assert_eq!(turn.status, TurnRunStatus::Resuming);
+    // The answer announces the call's completion itself: the renderer settles
+    // the card from this event rather than waiting for the turn to end.
+    let crate::AgentEvent::ToolCallCompleted {
+        call_id, output, ..
+    } = &completion_event.event
+    else {
+        panic!("unexpected completion event: {completion_event:?}");
+    };
+    assert_eq!(*call_id, request.id);
+    assert!(!output.is_error);
+    assert_eq!(
+        serde_json::from_str::<crate::AnswerUserQuestions>(&output.content).unwrap(),
+        sample_user_answers()
+    );
+    let journaled_completions = restarted
+        .list_events(chat.id, 0)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|event| matches!(event.event, crate::AgentEvent::ToolCallCompleted { .. }))
+        .collect::<Vec<_>>();
+    assert_eq!(journaled_completions, vec![*completion_event]);
     assert!(restarted
         .list_pending_user_questions(chat.id)
         .await
@@ -4589,6 +4616,18 @@ async fn user_questions_survive_reconnect_and_answer_exactly_once() {
         crate::AnswerUserQuestionsOutcome::Existing(turn)
             if turn.id == turn_id
     ));
+    // The exact retry recovered the committed answers without announcing the
+    // completion a second time.
+    assert_eq!(
+        restarted
+            .list_events(chat.id, 0)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|event| matches!(event.event, crate::AgentEvent::ToolCallCompleted { .. }))
+            .count(),
+        1
+    );
     let contradictory = crate::AnswerUserQuestionsRequest {
         answers: crate::AnswerUserQuestions {
             answers: vec![
@@ -4765,7 +4804,7 @@ async fn user_question_answer_and_cancel_race_has_one_serial_outcome() {
     let cancel = cancel.await.unwrap();
     assert!(matches!(
         answer,
-        crate::AnswerUserQuestionsOutcome::Answered(_)
+        crate::AnswerUserQuestionsOutcome::Answered { .. }
             | crate::AnswerUserQuestionsOutcome::Unavailable
     ));
     assert!(matches!(
@@ -4827,7 +4866,7 @@ async fn pending_question_projection_serializes_with_answer() {
     );
     assert!(matches!(
         answer.await.unwrap().unwrap(),
-        crate::AnswerUserQuestionsOutcome::Answered(_)
+        crate::AnswerUserQuestionsOutcome::Answered { .. }
     ));
     assert!(store
         .list_pending_user_questions(chat.id)
@@ -4876,7 +4915,7 @@ async fn user_question_answer_and_worker_claim_race_is_recoverable() {
     });
     assert!(matches!(
         answer.await.unwrap(),
-        crate::AnswerUserQuestionsOutcome::Answered(turn)
+        crate::AnswerUserQuestionsOutcome::Answered { turn, .. }
             if turn.id == turn_id && turn.status == TurnRunStatus::Resuming
     ));
     let first_claim = claim.await.unwrap();

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -741,7 +741,13 @@ pub enum DecidePlanOutcome {
 #[derive(Debug, Clone, PartialEq)]
 pub enum AnswerUserQuestionsOutcome {
     /// The exact answers completed the tool call and made the turn resumable.
-    Answered(TurnRun),
+    Answered {
+        /// The resumable turn.
+        turn: TurnRun,
+        /// The call's journaled completion, committed with the answer so a
+        /// live renderer settles the card now rather than at the turn's end.
+        completion_event: Box<SequencedEvent>,
+    },
     /// An ambiguous retry recovered the same committed answers.
     Existing(TurnRun),
     /// The request already committed different answers.

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -3629,7 +3629,7 @@ async fn postgres_user_questions_resume_exactly_and_serialize_with_cancellation(
     });
     assert!(matches!(
         answer_task.await.unwrap(),
-        AnswerUserQuestionsOutcome::Answered(turn)
+        AnswerUserQuestionsOutcome::Answered { turn, .. }
             if turn.id == turn_id && turn.status == TurnRunStatus::Resuming
     ));
     let first_claim = claim_task.await.unwrap();
@@ -3715,7 +3715,7 @@ async fn postgres_user_questions_resume_exactly_and_serialize_with_cancellation(
     });
     assert!(matches!(
         answer_task.await.unwrap(),
-        AnswerUserQuestionsOutcome::Answered(_) | AnswerUserQuestionsOutcome::Unavailable
+        AnswerUserQuestionsOutcome::Answered { .. } | AnswerUserQuestionsOutcome::Unavailable
     ));
     assert!(matches!(
         cancel_task.await.unwrap(),

--- a/crates/openwave-server/src/routes/user_questions.rs
+++ b/crates/openwave-server/src/routes/user_questions.rs
@@ -66,7 +66,15 @@ pub async fn answer_user_questions(
         )
         .await?;
     let (disposition, turn) = match outcome {
-        AnswerUserQuestionsOutcome::Answered(turn) => (AnswerDisposition::Answered, turn),
+        AnswerUserQuestionsOutcome::Answered {
+            turn,
+            completion_event,
+        } => {
+            // Live delivery of the journaled completion; replay covers anyone
+            // not connected, so a missed send is not a correctness gap.
+            let _ = state.events.sender(chat_id).send(*completion_event);
+            (AnswerDisposition::Answered, turn)
+        }
         AnswerUserQuestionsOutcome::Existing(turn) => (AnswerDisposition::Existing, turn),
         AnswerUserQuestionsOutcome::AnswerConflict => {
             return Err(ServerError::conflict(format!(

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -1303,6 +1303,73 @@ async fn user_question_api_is_renderer_safe_exact_and_not_native_claimable() {
 }
 
 #[tokio::test]
+async fn user_question_answer_announces_the_completion_live_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    let router = app(state.clone());
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    let (_turn_id, call) = park_user_questions_for_route_test(&*store, chat.id).await;
+
+    // The answer resolves the call outside the agent loop, so this live frame
+    // is the only thing settling the renderer's card before the turn ends.
+    let mut live = state.events.subscribe(chat.id);
+    let answer_uri = format!("/chats/{}/questions/{}/answer", chat.id, call.id);
+    let answer = serde_json::json!({
+        "answers": [{"question_id": "target", "option_id": "staging"}]
+    });
+    let answered = post_json(&router, &bearer, &answer_uri, answer.clone()).await;
+    assert_eq!(answered.status(), StatusCode::OK);
+    let announced = tokio::time::timeout(Duration::from_secs(1), live.recv())
+        .await
+        .expect("the answer must publish its completion live")
+        .unwrap();
+    let AgentEvent::ToolCallCompleted {
+        call_id, output, ..
+    } = &announced.event
+    else {
+        panic!("unexpected live event: {announced:?}");
+    };
+    assert_eq!(*call_id, call.id);
+    assert!(!output.is_error);
+    assert_eq!(
+        store.list_events(chat.id, 0).await.unwrap().last(),
+        Some(&announced)
+    );
+
+    // An exact retry recovers the committed answers without announcing twice.
+    let retry = post_json(&router, &bearer, &answer_uri, answer).await;
+    assert_eq!(retry.status(), StatusCode::OK);
+    assert_eq!(
+        json_body::<serde_json::Value>(retry).await["disposition"],
+        "existing"
+    );
+    assert!(matches!(
+        live.try_recv(),
+        Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+    ));
+}
+
+#[tokio::test]
 async fn client_execution_api_polls_claims_heartbeats_and_resolves_idempotently() {
     let (router, token, store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");

--- a/docs/user-questions.md
+++ b/docs/user-questions.md
@@ -24,9 +24,12 @@ foreground coordinator, which decides whether to ask the user.
 4. The user answers every question once through
    `POST /chats/{chat_id}/questions/{call_id}/answer`.
 5. One transaction stores the exact answers, completes the tool call with the
-   model-facing JSON result, closes the wait, and moves the original turn to
-   `resuming`. A worker then reclaims that turn and reconstructs the matching
-   `ToolUse` and `ToolResult` in the provider transcript.
+   model-facing JSON result, journals the call's `ToolCallCompleted`, closes
+   the wait, and moves the original turn to `resuming`. The route publishes the
+   completion live so the renderer settles the card immediately instead of at
+   the turn's terminal hydration. A worker then reclaims that turn and
+   reconstructs the matching `ToolUse` and `ToolResult` in the provider
+   transcript.
 
 Cancelling the turn closes an unanswered card and the wait in the same
 serialized state transition. Answer and cancellation take the same chat, turn,
@@ -73,6 +76,8 @@ correctness.
 Changes to this path should preserve:
 
 - atomic question, wait, event, and tool-call checkpointing;
+- a single renderer completion announcement committed with the answer, never
+  repeated by an exact retry;
 - exact idempotent answer recovery with contradictory retries rejected;
 - serialization of pending projection reads with answer and cancellation;
 - deletion ordering for question rows before their chat, turn, tool, and event


### PR DESCRIPTION
## Why

Submitting answers to an `ask_user_questions` card committed the answer, completed the tool call, and made the turn resumable — but journaled no renderer event for the resolution. The transcript card stayed at **"Waiting for your answer"** from `ToolCallStarted` until the turn's terminal hydration finally settled it. Whenever the resumed turn was slow, retrying, or failed quietly, a committed answer looked exactly like a lost one: stuck at waiting, then the pending card disappears on refresh.

Cross-referenced the equivalent Alpha flow (`complete_user_questions_and_resume_conversation`): it updates the tool call with the result and immediately pushes `user_questions_answered` plus the completed message over the websocket, so the reader gets confirmation the moment the answer commits. OpenWave had no equivalent announcement.

## What

The answer transaction now journals the call's `ToolCallCompleted` (chat-scoped, like its `UserQuestionsAsked` — the parked turn holds no lease) and the answer route publishes it on the live bus, the same pattern the native client-execution resolve path already uses. The card settles to "Answer received" the moment the answer commits; reconnect replay settles it too, since the event is journaled.

Exact retries (`disposition: existing`) recover the committed answers without announcing the completion twice.

## Tests

- `user_questions_survive_reconnect_and_answer_exactly_once` now asserts the answer journals exactly one completion event carrying the committed answers, and that an exact retry adds none.
- New `user_question_answer_announces_the_completion_live_once`: the route publishes the journaled completion live, its seq is the journal's tail, and an exact retry publishes nothing further.
- Existing answer/cancel, projection-race, worker-claim-race, and validation suites unchanged and passing; clippy `--all-targets -D warnings` clean.

Not verified: driving the running desktop app against this build.