### PR TITLE
feat(desktop): greet on home and move the full chat list to an All chats table

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -24,6 +24,7 @@ const chats = [
     model: null,
     reasoning_effort: null,
     project_id: null,
+    created_at: "2026-07-28T12:00:00Z",
   },
   {
     id: "chat-2",
@@ -31,6 +32,7 @@ const chats = [
     model: null,
     reasoning_effort: null,
     project_id: null,
+    created_at: "2026-07-27T12:00:00Z",
   },
 ];
 
@@ -165,9 +167,27 @@ async function mountApp({ at }: { at?: string } = {}) {
   return { ...result, router };
 }
 
+let rectSpy: ReturnType<typeof vi.spyOn>;
+
 beforeEach(() => {
   window.localStorage.clear();
   window.location.hash = "";
+  // jsdom reports zero for every measurement, and the All chats grid is
+  // virtualised: a zero-height viewport renders no rows at all. Give it a
+  // fixed box so the rows under test actually exist.
+  rectSpy = vi
+    .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+    .mockReturnValue({
+      width: 800,
+      height: 600,
+      top: 0,
+      left: 0,
+      right: 800,
+      bottom: 600,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
   listChats.mockClear();
   listChats.mockResolvedValue(chats);
   createChat.mockClear();
@@ -190,13 +210,19 @@ beforeEach(() => {
   useChatListStore.setState({ chats: [], chatsLoaded: false });
   useUiStore.setState({ sidebarCollapsed: false });
 });
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  rectSpy.mockRestore();
+});
 
 describe("app shell", () => {
-  it("opens on home rather than on a conversation", async () => {
+  // The first mount pays the one-time import of the route tree, which now
+  // includes the All chats grid — comfortably over the default timeout on a
+  // loaded machine.
+  it("opens on home rather than on a conversation", { timeout: 15000 }, async () => {
     const { router } = await mountApp();
 
-    expect(await screen.findByText("What are we working on?")).toBeInTheDocument();
+    expect(await screen.findByText("How can I help?")).toBeInTheDocument();
     expect(router.state.location.pathname).toBe("/");
     // Home used to create a chat on every cold start, leaving an empty one
     // behind whenever the reader did not use it.
@@ -232,7 +258,7 @@ describe("app shell", () => {
 
   it("says so when there is nothing to pick up", async () => {
     listChats.mockResolvedValue([]);
-    await mountApp();
+    await mountApp({ at: "/chats" });
 
     expect(await screen.findByText("No chats yet")).toBeInTheDocument();
   });
@@ -240,10 +266,8 @@ describe("app shell", () => {
   it("starts a conversation from the home composer and sends what was written", async () => {
     const user = userEvent.setup();
     const { router } = await mountApp();
-    await screen.findByText("What are we working on?");
+    await screen.findByText("How can I help?");
 
-    // Home also carries the chat explorer's search field, so the composer has
-    // to be picked out by name rather than by being the only input.
     await user.type(
       screen.getByRole("textbox", { name: "Message" }),
       "summarise the filing",
@@ -271,9 +295,9 @@ describe("app shell", () => {
   it("opens a conversation from the sidebar", async () => {
     const user = userEvent.setup();
     const { router } = await mountApp();
-    await screen.findByText("What are we working on?");
+    await screen.findByText("How can I help?");
 
-    const recentList = screen.getByLabelText("Chats");
+    const recentList = screen.getByLabelText("Recent chats");
     const [row] = screen
       .getAllByRole("button", { name: "Roadmap" })
       .filter((button) => recentList.contains(button));
@@ -317,7 +341,10 @@ describe("app shell", () => {
     expect(await screen.findByTestId("outputs")).toBeInTheDocument();
   });
 
-  it("leaves a conversation to find another one, and searches for it there", async () => {
+  it(
+    "leaves a conversation to find another one, and searches for it there",
+    { timeout: 15000 },
+    async () => {
     const user = userEvent.setup();
     const { router } = await mountApp({ at: "/c/chat-1" });
     await screen.findByTestId("transcript");
@@ -325,22 +352,25 @@ describe("app shell", () => {
     // Finding a chat is something done between conversations, so the way out
     // of one is what leads to it.
     await user.click(screen.getByRole("button", { name: "All chats" }));
-    await waitFor(() => expect(router.state.location.pathname).toBe("/"));
-    const search = await screen.findByRole("textbox", { name: "Search chats" });
+    await waitFor(() => expect(router.state.location.pathname).toBe("/chats"));
+    const search = await screen.findByRole("searchbox", { name: "Search chats" });
 
     await user.type(search, "roadmap");
-    expect(screen.getAllByRole("button", { name: "Roadmap" }).length).toBeGreaterThan(0);
+    const grid = await screen.findByRole("grid");
+    await within(grid).findByText("Roadmap");
+    expect(within(grid).queryByText("Release notes")).not.toBeInTheDocument();
 
     await user.clear(search);
     await user.type(search, "nothing matches this");
     expect(await screen.findByText("No matches")).toBeInTheDocument();
-  });
+    },
+  );
 
   it("gives each route only the controls that route can act on", async () => {
     const conversationOnly = ["Outputs", "Folders"];
 
     await mountApp();
-    await screen.findByText("What are we working on?");
+    await screen.findByText("How can I help?");
     // Not disabled — absent. Home has no conversation for these to describe,
     // and offering them here is what let the rail navigate into whichever
     // chat happened to have been open last.
@@ -355,13 +385,13 @@ describe("app shell", () => {
       expect(screen.getByRole("button", { name: label })).toBeEnabled();
     }
     // And the conversation's rail is not a place to browse the others from.
-    expect(screen.queryByLabelText("Chats")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Recent chats")).not.toBeInTheDocument();
   });
 
   it("remembers the collapsed rail across a restart", async () => {
     const user = userEvent.setup();
     await mountApp();
-    await screen.findByText("What are we working on?");
+    await screen.findByText("How can I help?");
 
     await user.click(screen.getByRole("button", { name: "Collapse sidebar" }));
 

--- a/crates/openwave-desktop/ui/src/ChatExplorer.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatExplorer.dom.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
-import { cleanup, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Chat } from "./api";
 import { useChatAttention } from "./ChatAttention";
@@ -9,11 +10,35 @@ import { ChatExplorer } from "./ChatExplorer";
 import { renderWithRouter } from "./test/router";
 
 const chats: Chat[] = [
-  { id: "chat-1", title: "Roadmap", project_id: null } as unknown as Chat,
-  { id: "chat-2", title: "Release notes", project_id: null } as unknown as Chat,
+  {
+    id: "chat-1",
+    title: "Roadmap",
+    project_id: null,
+    created_at: "2026-07-28T12:00:00Z",
+  } as unknown as Chat,
+  {
+    id: "chat-2",
+    title: "Release notes",
+    project_id: null,
+    created_at: "2026-07-27T12:00:00Z",
+  } as unknown as Chat,
 ];
 
+// jsdom reports zero for every measurement, and a virtualised grid with a
+// zero-height viewport renders no rows at all. Give it a fixed box to lay out
+// in so the rows under test actually exist.
 beforeEach(() => {
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+    width: 800,
+    height: 600,
+    top: 0,
+    left: 0,
+    right: 800,
+    bottom: 600,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  } as DOMRect);
   useChatListStore.setState({
     chats,
     creatingChat: false,
@@ -21,14 +46,37 @@ beforeEach(() => {
   });
   useChatAttention.getState().clear();
 });
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
 describe("ChatExplorer", () => {
-  it("marks waiting chats throughout the searchable list", async () => {
+  it("marks waiting chats throughout the searchable table", async () => {
     useChatAttention.getState().setChatIdsWithPendingPrompts(["chat-2"]);
     await renderWithRouter(<ChatExplorer />);
 
-    expect(screen.getByLabelText("Release notes needs attention")).toBeInTheDocument();
+    expect(
+      await screen.findByLabelText("Release notes needs attention"),
+    ).toBeInTheDocument();
     expect(screen.queryByLabelText("Roadmap needs attention")).not.toBeInTheDocument();
+  });
+
+  it("filters rows by title, and says so when nothing matches", async () => {
+    const user = userEvent.setup();
+    await renderWithRouter(<ChatExplorer />);
+
+    await user.type(screen.getByRole("searchbox", { name: "Search chats" }), "roadmap");
+    await waitFor(() =>
+      expect(screen.queryByText("Release notes")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText("Roadmap")).toBeInTheDocument();
+
+    await user.clear(screen.getByRole("searchbox", { name: "Search chats" }));
+    await user.type(
+      screen.getByRole("searchbox", { name: "Search chats" }),
+      "nothing matches this",
+    );
+    expect(await screen.findByText("No matches")).toBeInTheDocument();
   });
 });

--- a/crates/openwave-desktop/ui/src/ChatExplorer.tsx
+++ b/crates/openwave-desktop/ui/src/ChatExplorer.tsx
@@ -1,10 +1,18 @@
-import { useMemo, useState } from "react";
+import {
+  AllCommunityModule,
+  ModuleRegistry,
+  type ColDef,
+} from "ag-grid-community";
+import { AgGridReact, type CustomCellRendererProps } from "ag-grid-react";
+import { format } from "date-fns";
+import { CircleAlert, MessageCircleMore } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { CircleAlert, MessageCircleMore, Search } from "lucide-react";
 
 import type { Chat } from "./api";
 import { useChatAttention } from "./ChatAttention";
 import { useChatListStore } from "./ChatListStore";
+import { SearchInput } from "./components/SearchInput";
 import {
   Empty,
   EmptyDescription,
@@ -12,7 +20,10 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "./components/ui/empty";
-import { Input } from "./components/ui/input";
+import { WithTooltip } from "./components/ui/tooltip";
+import { useAgGridTheme } from "./sources/useAgGridTheme";
+
+ModuleRegistry.registerModules([AllCommunityModule]);
 
 /** Case-insensitive match on the title, with untitled chats matching "new chat". */
 export function matchesChatSearch(chat: Chat, query: string): boolean {
@@ -22,13 +33,52 @@ export function matchesChatSearch(chat: Chat, query: string): boolean {
   return title.toLowerCase().includes(trimmed);
 }
 
+type ChatGridContext = {
+  needsAttention: (chatId: string) => boolean;
+};
+
+type CellProps = CustomCellRendererProps<Chat>;
+
+function TitleCellRenderer(props: CellProps) {
+  const chat = props.data!;
+  const context = props.context as ChatGridContext;
+  const title = chat.title?.trim() || "New chat";
+
+  return (
+    <div className="flex h-full min-w-0 items-center gap-2">
+      <MessageCircleMore className="size-4 shrink-0 text-muted-foreground" />
+      <span className="truncate text-sm">{title}</span>
+      {context.needsAttention(chat.id) && (
+        <span
+          className="text-warning ml-1 shrink-0"
+          aria-label={`${title} needs attention`}
+          title="Needs attention"
+        >
+          <CircleAlert aria-hidden="true" className="size-4" />
+        </span>
+      )}
+    </div>
+  );
+}
+
+function CreatedCellRenderer(props: CellProps) {
+  const createdAt = props.data!.created_at;
+  const date = new Date(createdAt);
+  return (
+    <WithTooltip label={format(date, "MMM dd, yyyy HH:mm")}>
+      <time dateTime={createdAt} className="text-sm text-foreground">
+        {format(date, "MMM dd")}
+      </time>
+    </WithTooltip>
+  );
+}
+
 /**
  * Every conversation, searchable.
  *
- * This lives on home rather than beside a conversation. Finding a chat is
- * something you do between conversations, not inside one — offering it from
- * within a chat is what made the rail there a general-purpose list that
- * happened to be mounted next to a specific conversation.
+ * Finding a chat is something you do between conversations, not inside one, so
+ * the table has its own route beside home rather than a place in a
+ * conversation's rail.
  */
 export function ChatExplorer() {
   const navigate = useNavigate();
@@ -36,31 +86,73 @@ export function ChatExplorer() {
   const chatIdsWithPendingPrompts = useChatAttention(
     (state) => state.chatIdsWithPendingPrompts,
   );
-  const deletingChatId = useChatListStore((state) => state.deletingChatId);
   const [query, setQuery] = useState("");
+  const gridTheme = useAgGridTheme();
+  const gridRef = useRef<AgGridReact<Chat>>(null);
 
   const matches = useMemo(
     () => chats.filter((chat) => matchesChatSearch(chat, query)),
     [chats, query],
   );
 
-  return (
-    <div className="flex min-h-0 flex-1 flex-col gap-3">
-      <div className="relative">
-          <Search className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            className="pl-8"
-            placeholder="Search chats"
-            aria-label="Search chats"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-          />
-        </div>
+  const gridContext = useMemo<ChatGridContext>(
+    () => ({ needsAttention: (chatId) => chatIdsWithPendingPrompts.has(chatId) }),
+    [chatIdsWithPendingPrompts],
+  );
 
+  // Cell renderers read their state off `context`, which the grid snapshots
+  // rather than re-reading, so a changed attention set needs the cells redrawn.
+  useEffect(() => {
+    gridRef.current?.api?.refreshCells({ force: true });
+  }, [gridContext]);
+
+  const columnDefs = useMemo<ColDef<Chat>[]>(
+    () => [
+      {
+        headerName: "Title",
+        field: "title",
+        flex: 1,
+        minWidth: 240,
+        cellRenderer: TitleCellRenderer,
+        sortable: true,
+        comparator: (left: string | null, right: string | null) =>
+          (left?.trim() || "New chat").localeCompare(right?.trim() || "New chat", undefined, {
+            sensitivity: "base",
+          }),
+      },
+      {
+        headerName: "Created",
+        field: "created_at",
+        width: 130,
+        cellRenderer: CreatedCellRenderer,
+        sortable: true,
+        comparator: (left: string, right: string) => Date.parse(left) - Date.parse(right),
+      },
+    ],
+    [],
+  );
+
+  const defaultColDef = useMemo<ColDef>(
+    () => ({ resizable: true, suppressMovable: true }),
+    [],
+  );
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-4 px-6 pt-6 pb-6">
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-3">
+        <h1 className="text-lg font-medium text-foreground">All chats</h1>
+        <SearchInput
+          placeholder="Search chats"
+          aria-label="Search chats"
+          value={query}
+          onValueChange={setQuery}
+          className="max-w-md min-w-64 flex-1"
+        />
+      </div>
+
+      <div className="relative min-h-0 flex-1">
         {matches.length === 0 ? (
-          // `flex-1` by default, which on a page this tall reads as a huge
-          // empty box rather than a note.
-          <Empty className="flex-none border">
+          <Empty className="h-full border">
             <EmptyHeader>
               <EmptyMedia variant="icon">
                 <MessageCircleMore />
@@ -74,36 +166,31 @@ export function ChatExplorer() {
             </EmptyHeader>
           </Empty>
         ) : (
-          <ul className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto">
-            {matches.map((chat) => {
-              const title = chat.title?.trim() || "New chat";
-              return (
-                <li key={chat.id}>
-                  <button
-                    type="button"
-                    disabled={deletingChatId !== null}
-                    onClick={() =>
-                      void navigate({ to: "/c/$chatId", params: { chatId: chat.id } })
-                    }
-                    className="flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-2 text-left text-sm transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-50"
-                  >
-                    <MessageCircleMore className="size-4 shrink-0 text-muted-foreground" />
-                    <span className="min-w-0 truncate">{title}</span>
-                    {chatIdsWithPendingPrompts.has(chat.id) && (
-                      <span
-                        className="text-warning ml-auto shrink-0"
-                        aria-label={`${title} needs attention`}
-                        title="Needs attention"
-                      >
-                        <CircleAlert aria-hidden="true" className="size-4" />
-                      </span>
-                    )}
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
+          <div className="size-full">
+            <AgGridReact<Chat>
+              ref={gridRef}
+              theme={gridTheme}
+              context={gridContext}
+              rowData={matches}
+              columnDefs={columnDefs}
+              defaultColDef={defaultColDef}
+              suppressMovableColumns
+              suppressCellFocus
+              suppressRowClickSelection
+              getRowId={(params) => params.data.id}
+              domLayout="normal"
+              rowClass="cursor-pointer"
+              onRowClicked={(event) => {
+                if (!event.data) return;
+                void navigate({
+                  to: "/c/$chatId",
+                  params: { chatId: event.data.id },
+                });
+              }}
+            />
+          </div>
         )}
+      </div>
     </div>
   );
 }

--- a/crates/openwave-desktop/ui/src/ChatHeaderTitle.tsx
+++ b/crates/openwave-desktop/ui/src/ChatHeaderTitle.tsx
@@ -19,9 +19,9 @@ import { WithTooltip } from "@/components/ui/tooltip";
 /**
  * BW-style breadcrumb header: "Chats / chat title".
  *
- * Clicking "Chats" navigates home; clicking the title swaps it for an inline
- * edit field. The ellipsis menu offers Rename and Delete, wired to the shell's
- * existing orchestration.
+ * Clicking "Chats" navigates to the All chats table; clicking the title swaps
+ * it for an inline edit field. The ellipsis menu offers Rename and Delete,
+ * wired to the shell's existing orchestration.
  */
 export function ChatHeaderTitle({ chat }: { chat: Chat }) {
   const navigate = useNavigate();
@@ -42,7 +42,7 @@ export function ChatHeaderTitle({ chat }: { chat: Chat }) {
       <button
         type="button"
         className="shrink-0 font-medium text-muted-foreground hover:underline cursor-pointer"
-        onClick={() => void navigate({ to: "/" })}
+        onClick={() => void navigate({ to: "/chats" })}
       >
         Chats
       </button>

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from "@tanstack/react-router";
 
 import { useApp } from "./AppContext";
 import { attachChatFiles } from "./attachments";
-import { ChatExplorer } from "./ChatExplorer";
 import { useChatListStore } from "./ChatListStore";
 import { Composer, type ComposerImages } from "./Composer";
 import {
@@ -29,6 +28,7 @@ import { useNewChatSettings } from "./NewChatSettings";
 import { PermissionModeMenu } from "./PermissionModeMenu";
 import { RouteFrame } from "./RouteFrame";
 import { HomeSidebar } from "./sidebar/HomeSidebar";
+import { WelcomeState } from "./WelcomeState";
 import type { AttachedFiles } from "./attachments";
 import { MAX_IMAGE_ATTACHMENTS } from "./ImageAttachments";
 
@@ -45,7 +45,6 @@ function isImportedDocument(
 export function HomeRoute() {
   const navigate = useNavigate();
   const { client, models, defaultModelKey } = useApp();
-  const chatsLoaded = useChatListStore((state) => state.chatsLoaded);
   const creatingChat = useChatListStore((state) => state.creatingChat);
   const draft = useComposerDraft(HOME_DRAFT_KEY);
   const setDraft = (text: string) =>
@@ -202,18 +201,10 @@ export function HomeRoute() {
     <RouteFrame sidebar={<HomeSidebar />}>
       <div className="content-container flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden px-[clamp(0.5rem,4%,5rem)]">
         <div className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto">
-          <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 py-10">
-            <div className="space-y-2 text-center">
-              <p className="text-3xl font-normal text-foreground">
-                What are we working on?
-              </p>
-              <p className="text-muted-foreground">
-                Start a chat, or pick up where you left off.
-              </p>
-            </div>
-
-            {chatsLoaded && <ChatExplorer />}
-          </div>
+          {/* The same null state an empty conversation shows: home is where a
+              chat starts, so it greets the same way. Picking a starter prompt
+              fills the composer rather than sending, the way it does in a chat. */}
+          <WelcomeState onSelectPrompt={setDraft} />
         </div>
 
         <div className="z-10 mx-auto w-full max-w-3xl pb-2">

--- a/crates/openwave-desktop/ui/src/WelcomeState.tsx
+++ b/crates/openwave-desktop/ui/src/WelcomeState.tsx
@@ -43,7 +43,7 @@ export function WelcomeState({
       <div className="welcome-copy">
         <h2>How can I help?</h2>
         <p>
-          Ask a question, search sources attached to this chat, or start a task.
+          Ask a question, search attached sources, or start a task.
         </p>
       </div>
       {onSelectPrompt && (

--- a/crates/openwave-desktop/ui/src/router.tsx
+++ b/crates/openwave-desktop/ui/src/router.tsx
@@ -8,12 +8,15 @@ import {
 } from "@tanstack/react-router";
 
 import { AppShell } from "./AppShell";
+import { ChatExplorer } from "./ChatExplorer";
 import { ChatRoute } from "./ChatRoute";
 import { HomeRoute } from "./HomeRoute";
 import { useManagedPolicy } from "./managedPolicy";
 import type { PanelSearch } from "./panel/panelUrl";
+import { RouteFrame } from "./RouteFrame";
 import { SettingsRoute } from "./SettingsRoute";
 import { defaultSettingsPathFor, SETTINGS_SECTIONS } from "./settings/sections";
+import { HomeSidebar } from "./sidebar/HomeSidebar";
 
 const rootRoute = createRootRoute({ component: AppShell });
 
@@ -22,6 +25,26 @@ const homeRoute = createRoute({
   path: "/",
   component: HomeRoute,
 });
+
+/**
+ * The whole chat list as a searchable table. It shares home's rail — nothing
+ * here is scoped to a conversation either.
+ */
+const allChatsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/chats",
+  component: AllChatsRoute,
+});
+
+function AllChatsRoute() {
+  return (
+    <RouteFrame sidebar={<HomeSidebar />}>
+      <div className="content-container min-h-0 w-full min-w-0 flex-1 overflow-hidden">
+        <ChatExplorer />
+      </div>
+    </RouteFrame>
+  );
+}
 
 const chatRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -85,6 +108,7 @@ const settingsSectionRoutes = SETTINGS_SECTIONS.map((section) =>
 
 export const routeTree = rootRoute.addChildren([
   homeRoute,
+  allChatsRoute,
   chatRoute,
   settingsRoute.addChildren([settingsIndexRoute, ...settingsSectionRoutes]),
 ]);

--- a/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
@@ -54,7 +54,7 @@ export function ChatSidebar({ chat }: { chat: Chat }) {
 
   return (
     <SidebarFrame>
-      <SidebarButton onClick={() => void navigate({ to: "/" })}>
+      <SidebarButton onClick={() => void navigate({ to: "/chats" })}>
         <ChevronLeft />
         <span>All chats</span>
         {elsewhereNeedsAttention && (

--- a/crates/openwave-desktop/ui/src/sidebar/HomeSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/HomeSidebar.tsx
@@ -1,14 +1,16 @@
-import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
+import { History, MessagesSquare } from "lucide-react";
 
 import { useApp } from "@/AppContext";
 import { useChatAttention } from "@/ChatAttention";
 import { useChatListStore } from "@/ChatListStore";
 import { NewChatButton } from "./NewChatButton";
 import { RecentChatRow } from "./RecentChatRow";
-import { SidebarSectionTitle, useSidebarWidth } from "./primitives";
+import { SidebarButton, SidebarSectionTitle, useSidebarWidth } from "./primitives";
 import { SidebarFrame } from "./SidebarFrame";
 
-/** How many conversations the rail shows before deferring to the home list. */
+/** How many conversations the rail shows before deferring to the All chats table. */
 const RECENT_CHAT_LIMIT = 8;
 
 /**
@@ -18,6 +20,9 @@ const RECENT_CHAT_LIMIT = 8;
  * of one. The conversation's own controls — its sources, outputs and folders —
  * live on {@link ChatSidebar}, which only exists once there is a conversation
  * for them to act on.
+ *
+ * "Recent" is the rail's own short list; "All chats" opens the full searchable
+ * table in the main area.
  */
 export function HomeSidebar() {
   const navigate = useNavigate();
@@ -34,8 +39,11 @@ export function HomeSidebar() {
     (state) => state.chatIdsWithPendingPrompts,
   );
   const isCompact = useSidebarWidth() === "compact";
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const [recentCollapsed, setRecentCollapsed] = useState(false);
 
   const recentChats = chats.slice(0, RECENT_CHAT_LIMIT);
+  const showRecent = !recentCollapsed && !isCompact && recentChats.length > 0;
 
   return (
     <SidebarFrame>
@@ -45,28 +53,49 @@ export function HomeSidebar() {
         creating={creatingChat}
       />
 
-      {recentChats.length > 0 && (
-        <SidebarSectionTitle className="mt-4">Recent</SidebarSectionTitle>
-      )}
-      <div className={isCompact ? "hidden" : "flex flex-col gap-0.5"} aria-label="Chats">
-        {recentChats.map((chat) => (
-          <RecentChatRow
-            key={chat.id}
-            chat={chat}
-            active={false}
-            needsAttention={chatIdsWithPendingPrompts.has(chat.id)}
-            renaming={renamingChatId === chat.id}
-            renameDraft={renameChatDraft}
-            savingTitle={savingTitle}
-            mutating={deletingChatId !== null || creatingChat}
-            onRenameDraftChange={setRenameDraft}
-            onOpen={() => void navigate({ to: "/c/$chatId", params: { chatId: chat.id } })}
-            onStartRename={() => startRename(chat)}
-            onCommitRename={() => commitRename(chat)}
-            onCancelRename={cancelRename}
-            onDelete={() => deleteChat(chat)}
-          />
-        ))}
+      <SidebarSectionTitle className="mt-4">Chats</SidebarSectionTitle>
+      <div className="flex flex-col gap-0.5">
+        <SidebarButton
+          aria-expanded={!recentCollapsed}
+          onClick={() => setRecentCollapsed((collapsed) => !collapsed)}
+        >
+          <History />
+          <span>Recent</span>
+        </SidebarButton>
+        {showRecent && (
+          <div
+            className="ml-4 flex flex-col gap-0.5 border-l border-border pl-2"
+            aria-label="Recent chats"
+          >
+            {recentChats.map((chat) => (
+              <RecentChatRow
+                key={chat.id}
+                chat={chat}
+                active={false}
+                needsAttention={chatIdsWithPendingPrompts.has(chat.id)}
+                renaming={renamingChatId === chat.id}
+                renameDraft={renameChatDraft}
+                savingTitle={savingTitle}
+                mutating={deletingChatId !== null || creatingChat}
+                onRenameDraftChange={setRenameDraft}
+                onOpen={() => void navigate({ to: "/c/$chatId", params: { chatId: chat.id } })}
+                onStartRename={() => startRename(chat)}
+                onCommitRename={() => commitRename(chat)}
+                onCancelRename={cancelRename}
+                onDelete={() => deleteChat(chat)}
+              />
+            ))}
+          </div>
+        )}
+        <SidebarButton
+          aria-current={pathname === "/chats" ? "page" : undefined}
+          data-active={pathname === "/chats" || undefined}
+          className="data-[active]:bg-muted"
+          onClick={() => void navigate({ to: "/chats" })}
+        >
+          <MessagesSquare />
+          <span>All chats</span>
+        </SidebarButton>
         {chatsError && <p className="px-2 py-1 text-xs text-critical">{chatsError}</p>}
       </div>
     </SidebarFrame>


### PR DESCRIPTION
## What

Home no longer leads with the "What are we working on?" heading plus the chat list. It now shows the same **"How can I help?"** null state an empty conversation shows — starter prompts included, which fill the composer draft exactly as they do inside a chat.

The full chat list moves to a dedicated **All chats** view at `/chats`: an AG Grid table (Title with needs-attention badge, sortable Created column) with the standard `SearchInput`, rendered in the main area and styled with the app's existing `useAgGridTheme`, the same pattern the outputs catalog uses.

The home sidebar is restructured after the projects pattern: a primary New chat button, then a **Chats** section with **Recent** (collapsible group holding the existing 8-row list, rename/delete/attention intact) and an **All chats** tab that opens the table with an active state. The conversation rail's "All chats" back button and the "Chats /" header breadcrumb now land on `/chats`.

## Why

The home page and the chat list were two jobs on one surface: starting a conversation and finding one. Home is where a chat starts, so it should greet the way an empty chat does. Finding a chat is something done between conversations, and a searchable table does that better than a capped list.

## Tests

- `ChatExplorer.dom.test.tsx`: attention marking in the table, and title filtering through to "No matches".
- `AppShell.dom.test.tsx`: home greeting, `/chats` routing from the conversation rail, and grid-scoped search assertions. (The grid is virtualised, so both dom suites stub `getBoundingClientRect` to give it a viewport in jsdom; two shell tests get a 15s timeout because the first mount pays the one-time AG Grid import.)