### PR TITLE
feat(desktop): show published outputs on the exec card and refresh the catalog

### DIFF
--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -351,6 +351,7 @@ mod tests {
                     stdout: "on branch main".into(),
                     stderr: String::new(),
                     images: Vec::new(),
+                    outputs: Vec::new(),
                 }),
             },
             AgentEvent::TurnCompleted {

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -356,6 +356,12 @@ pub enum ToolResultPreview {
         /// Preview images emitted by the command, in model-facing priority order.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         images: Vec<crate::ImageRef>,
+        /// Durable outputs the command's `output/` files created or updated.
+        /// Files that still match their published version are not news and are
+        /// not listed. Defaulted so exec rows persisted before the field
+        /// existed read back unchanged.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        outputs: Vec<ResultEntry>,
     },
     /// Web search is available after the reader chooses and configures a
     /// provider. Carries no model- or provider-authored text.
@@ -453,6 +459,7 @@ impl ToolResultPreview {
                     stdout: stream(data.get("stdout")),
                     stderr: stream(data.get("stderr")),
                     images: output.images.clone(),
+                    outputs: exec_output_entries(data.get("outputs")),
                 })
             }
             // Only an external MCP proxy can carry a view declaration, and a
@@ -561,6 +568,33 @@ fn web_capability_tool(tool_name: &str) -> bool {
 /// line the reader cannot interpret. `detail` and `meta` are genuinely
 /// optional, so one that clamps away to nothing simply goes missing rather than
 /// taking its row with it.
+/// Project the exec tool's published-output rows into bounded entries.
+///
+/// The tool's data lists every scanned file; only the ones that created or
+/// updated a durable output are a result worth a row. Malformed rows are
+/// dropped rather than degrading the whole preview, matching how listed
+/// entries behave elsewhere.
+fn exec_output_entries(value: Option<&Value>) -> Vec<ResultEntry> {
+    let Some(rows) = value.and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    rows.iter()
+        .filter_map(|row| {
+            let status = row.get("status")?.as_str()?;
+            if status != "created" && status != "updated" {
+                return None;
+            }
+            let label = clamp(row.get("filename")?.as_str()?, MAX_RESULT_ENTRY_CHARS)?;
+            let version = row.get("version")?.as_u64()?;
+            Some(
+                ResultEntry::new(ResultEntryKind::Output, label)
+                    .with_meta(format!("v{version} · {status}")),
+            )
+        })
+        .take(MAX_RESULT_ENTRIES)
+        .collect()
+}
+
 fn result_entry(value: &Value) -> Option<ResultEntry> {
     Some(ResultEntry {
         kind: serde_json::from_value(value.get("kind")?.clone()).ok()?,
@@ -843,6 +877,55 @@ mod tests {
                 cwd: ".".into(),
             })
         );
+    }
+
+    /// The exec card lists the durable outputs the command published. Only
+    /// created/updated files are rows — an unchanged file is not news — and a
+    /// stored exec preview from before the field existed reads back unchanged.
+    #[test]
+    fn exec_result_lists_published_outputs_and_old_rows_read_back() {
+        let output = output_with_data(serde_json::json!({
+            "exit_code": 0,
+            "outputs": [
+                { "filename": "report.md", "version": 3, "status": "updated" },
+                { "filename": "chart.png", "version": 1, "status": "created" },
+                { "filename": "data.csv", "version": 2, "status": "unchanged" },
+                { "filename": 7, "version": "x", "status": "created" },
+            ],
+        }));
+        let Some(ToolResultPreview::Exec { outputs, .. }) =
+            ToolResultPreview::build("exec", &output)
+        else {
+            panic!("exec projects a result");
+        };
+        assert_eq!(
+            outputs
+                .iter()
+                .map(|entry| (entry.label.as_str(), entry.meta.as_deref()))
+                .collect::<Vec<_>>(),
+            [
+                ("report.md", Some("v3 · updated")),
+                ("chart.png", Some("v1 · created")),
+            ]
+        );
+        assert!(outputs
+            .iter()
+            .all(|entry| entry.kind == ResultEntryKind::Output));
+
+        // A pre-outputs journal row deserializes with the field defaulted.
+        let stored: ToolResultPreview = serde_json::from_value(serde_json::json!({
+            "tool": "exec",
+            "exit_code": 0,
+            "timed_out": false,
+            "output_truncated": false,
+            "stdout": "ok",
+            "stderr": "",
+        }))
+        .unwrap();
+        let ToolResultPreview::Exec { outputs, .. } = stored else {
+            panic!("stored exec row");
+        };
+        assert!(outputs.is_empty());
     }
 
     #[test]
@@ -1173,6 +1256,7 @@ mod tests {
                 stdout: "line one\nline two\n".into(),
                 stderr: "boom\n".into(),
                 images: Vec::new(),
+                outputs: Vec::new(),
             })
         );
         assert!(result.unwrap().has_output());
@@ -1195,6 +1279,7 @@ mod tests {
                 stdout: String::new(),
                 stderr: String::new(),
                 images: Vec::new(),
+                outputs: Vec::new(),
             }
         );
         assert!(!result.has_output());

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -280,6 +280,54 @@ describe("tool call lifecycle", () => {
   });
 });
 
+describe("published outputs", () => {
+  it("signals an outputs refresh when an exec call published files", () => {
+    const execResult = {
+      tool: "exec" as const,
+      exit_code: 0,
+      timed_out: false,
+      output_truncated: false,
+      stdout: "",
+      stderr: "",
+      outputs: [
+        {
+          kind: "output" as const,
+          label: "report.md",
+          detail: null,
+          meta: "v2 · updated",
+          media_type: null,
+        },
+      ],
+    };
+    const { effects } = play([
+      TURN,
+      { type: "tool_call_started", call_id: "exec-1", name: "exec" },
+      {
+        type: "tool_call_completed",
+        call_id: "exec-1",
+        status: "completed",
+        result: execResult,
+      },
+    ]);
+    expect(effects).toContainEqual({ type: "refresh_output_writebacks" });
+
+    // A command that published nothing moves nothing.
+    const quiet = play([
+      TURN,
+      { type: "tool_call_started", call_id: "exec-2", name: "exec" },
+      {
+        type: "tool_call_completed",
+        call_id: "exec-2",
+        status: "completed",
+        result: { ...execResult, outputs: [] },
+      },
+    ]);
+    expect(quiet.effects).not.toContainEqual({
+      type: "refresh_output_writebacks",
+    });
+  });
+});
+
 describe("approvals", () => {
   const APPROVAL: AgentEvent = {
     type: "approval_required",

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -278,6 +278,17 @@ export function reduceChatSessionEvent(
     case "tool_call_completed": {
       const provisionalToolCallIds = new Set(state.provisionalToolCallIds);
       provisionalToolCallIds.delete(event.call_id);
+      // An exec call that published durable outputs changes the Outputs
+      // catalog; the sidebar count and outputs panel refresh on the same
+      // signal the writeback flow uses. The preview only lists created and
+      // updated files, so any row at all means the catalog moved.
+      const completedResult = parseToolResultPreview(event.result);
+      if (
+        completedResult?.tool === "exec" &&
+        (completedResult.outputs?.length ?? 0) > 0
+      ) {
+        effects.push({ type: "refresh_output_writebacks" });
+      }
       return {
         state: {
           ...state,
@@ -295,7 +306,7 @@ export function reduceChatSessionEvent(
             // A call approved by a standing grant never had an approval card,
             // so completion is the first time the action itself arrives.
             preview: parseToolActionPreview(event.action) ?? tool.preview,
-            result: parseToolResultPreview(event.result),
+            result: completedResult,
           })),
         },
         effects,

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -1,4 +1,4 @@
-import { Check, Clock, Terminal, X } from "lucide-react";
+import { Check, Clock, FileOutput, Terminal, X } from "lucide-react";
 import {
   isRendererToolName,
   type ExecResultPreview,
@@ -245,6 +245,7 @@ export function ToolCommandCard({
   const running = presentation.tone === "running";
   const output = commandOutput(result);
   const images = result?.images ?? [];
+  const outputs = result?.outputs ?? [];
   // A command that finished silently has nothing to tab between, and a
   // "Command / Output → no output" pair reads as confusing noise.
   const tabbed = running || output !== null || images.length > 0;
@@ -256,7 +257,7 @@ export function ToolCommandCard({
       title={command.headline}
       titleClassName="font-mono"
       badge={<ToolStatusBadge presentation={presentation} result={result} />}
-      defaultExpanded={running || images.length > 0}
+      defaultExpanded={running || images.length > 0 || outputs.length > 0}
     >
       {tabbed ? (
         <Tabs defaultValue="output">
@@ -315,6 +316,22 @@ export function ToolCommandCard({
             {command.detail}
           </ScrollableContainer>
         </div>
+      )}
+      {outputs.length > 0 && (
+        <ul className="flex flex-col gap-0.5 px-2 pb-1.5" aria-label="Published outputs">
+          {outputs.map((entry) => (
+            <li
+              key={`${entry.label} ${entry.meta ?? ""}`}
+              className="text-muted-foreground flex items-center gap-1.5 text-xs"
+            >
+              <FileOutput className="size-3.5 shrink-0" aria-hidden="true" />
+              <span className="truncate">{entry.label}</span>
+              {entry.meta && (
+                <span className="text-2xs shrink-0 tabular-nums">{entry.meta}</span>
+              )}
+            </li>
+          ))}
+        </ul>
       )}
     </ToolCardShell>
   );

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -844,6 +844,7 @@ describe("parseToolResultPreview closed results", () => {
       exitCode: 0,
       timedOut: false,
       outputTruncated: false,
+      outputs: [],
       stdout: "ok",
       stderr: "",
       images: [

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -318,6 +318,8 @@ export type ToolResultPreview =
         width: number;
         height: number;
       }[];
+      /** Durable outputs the command's output/ files created or updated. */
+      outputs?: ResultEntry[];
     }
   | {
       /** Web search is available after the reader configures a provider. */
@@ -1988,9 +1990,23 @@ export function parseToolResultPreview(
     };
   }
   if (value.tool !== "exec") return null;
-  const { exit_code, timed_out, output_truncated, stdout, stderr, images }: UncheckedExecResult =
-    value;
+  const {
+    exit_code,
+    timed_out,
+    output_truncated,
+    stdout,
+    stderr,
+    images,
+    outputs,
+  }: UncheckedExecResult = value;
   const imageValues = images ?? [];
+  const outputValues = outputs ?? [];
+  if (!Array.isArray(outputValues)) return null;
+  // Like listed entries, a malformed output row is dropped rather than
+  // poisoning the whole preview: the rows are display hints, not authority.
+  const parsedOutputs = outputValues
+    .map(parseResultEntry)
+    .filter((entry): entry is ResultEntry => entry !== null);
   if (
     (exit_code !== null && typeof exit_code !== "number") ||
     typeof timed_out !== "boolean" ||
@@ -2032,6 +2048,7 @@ export function parseToolResultPreview(
     stdout,
     stderr,
     images: parsedImages,
+    outputs: parsedOutputs,
   };
 }
 

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1164,7 +1164,14 @@ output_truncated: boolean, stdout: string, stderr: string,
 /**
  * Preview images emitted by the command, in model-facing priority order.
  */
-images?: Array<ImageRef>, } | { "tool": "web_search_provider_required" } | { "tool": "mcp_app", 
+images?: Array<ImageRef>, 
+/**
+ * Durable outputs the command's `output/` files created or updated.
+ * Files that still match their published version are not news and are
+ * not listed. Defaulted so exec rows persisted before the field
+ * existed read back unchanged.
+ */
+outputs?: Array<ResultEntry>, } | { "tool": "web_search_provider_required" } | { "tool": "mcp_app", 
 /**
  * The configured MCP server namespace that serves the view.
  */

--- a/crates/openwave-desktop/ui/src/outputs/OutputsView.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputsView.tsx
@@ -25,6 +25,7 @@ import {
   PICKER_HOLDERS,
   useNativePickerLatch,
 } from "@/NativePickerLatch";
+import { useRefreshSignals } from "@/RefreshSignals";
 import { OutputsTable } from "./OutputsTable";
 
 export type OutputsApis = {
@@ -75,6 +76,9 @@ export function OutputsView({
   } | null>(null);
   const [countSuffix, setCountSuffix] = useState("");
   const generationRef = useRef(0);
+  // Bumped when the event stream reports the catalog moved — an exec call
+  // publishing outputs, or a writeback resolving.
+  const outputsRevision = useRefreshSignals((store) => store.outputWritebacks);
 
   async function refresh(showLoading = false) {
     const generation = ++generationRef.current;
@@ -102,6 +106,13 @@ export function OutputsView({
       generationRef.current += 1;
     };
   }, [chatId, apis]);
+
+  // A signal bump means the catalog moved server-side; re-list in place
+  // without blanking what is already on screen.
+  useEffect(() => {
+    if (outputsRevision === 0) return;
+    void refresh();
+  }, [outputsRevision]);
 
   const onSave = useCallback(
     async (output: DeliverableSummary) => {

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -33,8 +33,10 @@ use ts_rs::TS;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TS)]
 #[serde(untagged)]
 pub(crate) enum RendererChatFrame {
-    /// A journaled turn event at its sequence.
-    Event(RendererSequencedEvent),
+    /// A journaled turn event at its sequence. Boxed: an event frame carries
+    /// tool previews and dwarfs a metadata frame, and every frame is built
+    /// once and serialized, so the indirection costs nothing on the hot path.
+    Event(Box<RendererSequencedEvent>),
     /// Chat state that changed outside the journal.
     Metadata(RendererChatMetadata),
 }

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -2998,7 +2998,7 @@ async fn replay_after(
 async fn send_event(socket: &mut WebSocket, event: &SequencedEvent) -> Result<(), axum::Error> {
     send_frame(
         socket,
-        &RendererChatFrame::Event(RendererSequencedEvent::from(event)),
+        &RendererChatFrame::Event(Box::new(RendererSequencedEvent::from(event))),
     )
     .await
 }

--- a/crates/openwave-server/src/tests/image_attachment.rs
+++ b/crates/openwave-server/src/tests/image_attachment.rs
@@ -587,6 +587,7 @@ async fn a_tool_preview_is_fetchable_only_through_its_chat() {
             height: 480,
             byte_len: bytes.len() as u64,
         }],
+        outputs: Vec::new(),
     };
     store
         .resolve_server_tool_call_with_artifacts(


### PR DESCRIPTION
Two gaps left over from the files-first outputs series (#1173/#1196):

- **The exec transcript card now lists the outputs a command published.** `ToolResultPreview::Exec` gains an `outputs` list of the existing `ResultEntry` rows (kind `output`, e.g. `report.md — v3 · updated`), projected from the tool's structured data. Only created/updated files become rows — an unchanged file is not news. The field is `#[serde(default, skip_serializing_if = ...)]`, so every exec preview persisted before this deserializes unchanged (the projection layer flips to `result_unreadable` on parse failure, which made the default load-bearing, and the test pins it). The card renders the rows under the command/output tabs and expands by default when files were published.
- **The Outputs catalog and sidebar count refresh when exec publishes files.** The session reducer pushes the existing `refresh_output_writebacks` effect when a completed exec result carries output rows — same client-side pattern the writeback flow uses, no new wire traffic — and `OutputsView` now subscribes to that signal (it previously refreshed only on mount or manual reload), re-listing in place without blanking the table.

Wire types regenerated; the hand-written renderer union and parser are widened with the same drop-malformed-rows policy as listed entries.

Tests: Rust projection contract (created/updated rows only, malformed rows dropped, pre-field rows read back), reducer effect contract (rows → refresh, empty → no refresh), and the updated api parser expectation.