### PR TITLE
feat(server): route background runs to containers

### DIFF
--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -4,8 +4,10 @@
 //! port and prints the address and per-launch bearer token it minted, so a local
 //! client (the desktop shell, or a script) can connect. Configuration comes from
 //! the environment via [`Config::from_env`] (`OPENWAVE_PROFILE`,
-//! `OPENWAVE_DATA_DIR`); the model API key comes from `ANTHROPIC_API_KEY`, and
-//! `OPENWAVE_MCP_CONFIG` may name an external stdio-server configuration file.
+//! `OPENWAVE_DATA_DIR`, `OPENWAVE_CONTAINER_EXECUTION_ENABLED`, and
+//! `OPENWAVE_CONTAINER_IMAGE`); the model API key comes from
+//! `ANTHROPIC_API_KEY`, and `OPENWAVE_MCP_CONFIG` may name an external
+//! stdio-server configuration file.
 //!
 //! `openwave mcp <workspace>` serves the built-in read-only filesystem tools over
 //! MCP stdio, confined to the explicit workspace directory.

--- a/crates/openwave-core/src/config.rs
+++ b/crates/openwave-core/src/config.rs
@@ -58,6 +58,15 @@ pub struct Config {
     /// other embeddings leave it absent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exec_scripts_dir: Option<PathBuf>,
+    /// Whether newly spawned background agent runs may execute inside a local
+    /// container when the configured runtime is available. Disabled by default,
+    /// so existing installations keep the in-process scheduler path.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub container_execution_enabled: bool,
+    /// Optional container image override for sandbox-resident agent runs.
+    /// `None` uses the server's documented placeholder image.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_image: Option<String>,
 }
 
 impl Config {
@@ -69,17 +78,23 @@ impl Config {
             keychain_service: None,
             bundle_id: None,
             exec_scripts_dir: None,
+            container_execution_enabled: false,
+            container_image: None,
         }
     }
 
     /// Load from the environment, falling back to sensible defaults:
-    /// `OPENWAVE_PROFILE` (default `desktop`) and `OPENWAVE_DATA_DIR` (default
+    /// `OPENWAVE_PROFILE` (default `desktop`), `OPENWAVE_DATA_DIR` (default
     /// `./.openwave` under the current directory — desktop/CLI clients should set
-    /// this to the platform's app-data location).
+    /// this to the platform's app-data location),
+    /// `OPENWAVE_CONTAINER_EXECUTION_ENABLED` (default `false`), and
+    /// `OPENWAVE_CONTAINER_IMAGE` (defaulting to the server's placeholder image).
     pub fn from_env() -> Result<Self> {
         Self::from_vars(
             std::env::var("OPENWAVE_PROFILE").ok(),
             std::env::var_os("OPENWAVE_DATA_DIR"),
+            std::env::var("OPENWAVE_CONTAINER_EXECUTION_ENABLED").ok(),
+            std::env::var("OPENWAVE_CONTAINER_IMAGE").ok(),
         )
     }
 
@@ -90,7 +105,12 @@ impl Config {
     /// An **empty** value is treated as unset: a caller that exports
     /// `OPENWAVE_DATA_DIR=` (or an empty profile) gets the documented defaults,
     /// not an empty path rooted at the current directory.
-    fn from_vars(profile: Option<String>, data_dir: Option<OsString>) -> Result<Self> {
+    fn from_vars(
+        profile: Option<String>,
+        data_dir: Option<OsString>,
+        container_execution_enabled: Option<String>,
+        container_image: Option<String>,
+    ) -> Result<Self> {
         let profile = match profile.filter(|value| !value.is_empty()).as_deref() {
             None | Some("desktop") => Profile::Desktop,
             Some("self_host" | "selfhost") => Profile::SelfHost,
@@ -102,12 +122,24 @@ impl Config {
                 .map_err(|e| AgentError::config(format!("no working directory: {e}")))?
                 .join(".openwave"),
         };
+        let container_execution_enabled =
+            match container_execution_enabled.filter(|value| !value.is_empty()) {
+                None => false,
+                Some(value) => value.parse::<bool>().map_err(|_| {
+                    AgentError::config(format!(
+                        "invalid OPENWAVE_CONTAINER_EXECUTION_ENABLED: {value}"
+                    ))
+                })?,
+            };
+        let container_image = container_image.filter(|value| !value.is_empty());
         Ok(Self {
             profile,
             data_dir,
             keychain_service: None,
             bundle_id: None,
             exec_scripts_dir: None,
+            container_execution_enabled,
+            container_image,
         })
     }
 
@@ -125,6 +157,10 @@ impl Config {
                 .map_err(|_| AgentError::config("OPENWAVE_DATABASE_URL is required for self-host")),
         }
     }
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[cfg(test)]
@@ -151,7 +187,7 @@ mod tests {
     fn empty_data_dir_var_falls_back_to_the_default() {
         // `OPENWAVE_DATA_DIR=` (set but empty) must behave like unset, not point
         // the store at `openwave.db` in the current directory.
-        let config = Config::from_vars(None, Some(OsString::new())).unwrap();
+        let config = Config::from_vars(None, Some(OsString::new()), None, None).unwrap();
         let expected = std::env::current_dir().unwrap().join(".openwave");
         assert_eq!(config.data_dir, expected);
         assert_eq!(config.profile, Profile::Desktop);
@@ -159,21 +195,32 @@ mod tests {
 
     #[test]
     fn empty_profile_var_defaults_to_desktop() {
-        let config = Config::from_vars(Some(String::new()), Some(OsString::from("/data"))).unwrap();
+        let config = Config::from_vars(
+            Some(String::new()),
+            Some(OsString::from("/data")),
+            None,
+            None,
+        )
+        .unwrap();
         assert_eq!(config.profile, Profile::Desktop);
     }
 
     #[test]
     fn explicit_vars_are_honored() {
-        let config =
-            Config::from_vars(Some("self_host".into()), Some(OsString::from("/data"))).unwrap();
+        let config = Config::from_vars(
+            Some("self_host".into()),
+            Some(OsString::from("/data")),
+            None,
+            None,
+        )
+        .unwrap();
         assert_eq!(config.profile, Profile::SelfHost);
         assert_eq!(config.data_dir, PathBuf::from("/data"));
     }
 
     #[test]
     fn unknown_profile_var_is_an_error() {
-        assert!(Config::from_vars(Some("bogus".into()), None).is_err());
+        assert!(Config::from_vars(Some("bogus".into()), None, None, None).is_err());
     }
 
     #[test]
@@ -188,5 +235,32 @@ mod tests {
         let config = serde_json::from_str::<Config>(r#"{"data_dir":"/data"}"#).unwrap();
         assert_eq!(config.keychain_service, None);
         assert_eq!(config.exec_scripts_dir, None);
+        assert!(!config.container_execution_enabled);
+        assert_eq!(config.container_image, None);
+    }
+
+    #[test]
+    fn container_execution_defaults_off_without_changing_default_json() {
+        let config = Config::desktop("/data");
+        let json = serde_json::to_value(config).unwrap();
+        assert_eq!(json.get("container_execution_enabled"), None);
+        assert_eq!(json.get("container_image"), None);
+    }
+
+    #[test]
+    fn container_execution_vars_are_validated_and_honored() {
+        let config = Config::from_vars(
+            None,
+            Some(OsString::from("/data")),
+            Some("true".into()),
+            Some("openwave-sandbox-agent:dev".into()),
+        )
+        .unwrap();
+        assert!(config.container_execution_enabled);
+        assert_eq!(
+            config.container_image.as_deref(),
+            Some("openwave-sandbox-agent:dev")
+        );
+        assert!(Config::from_vars(None, None, Some("yes".into()), None).is_err());
     }
 }

--- a/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
+++ b/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
@@ -11,9 +11,8 @@ use crate::agent_tools::{
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::model::{
-    AgentRun, AgentRunExecutionLocation, SandboxSpawnCheckpoint, SandboxSpawnCheckpointRequest,
-    ToolCallExecution, ToolCallRecord, ToolCallStatus, TurnCheckpointProgress, TurnRunStatus,
-    TurnSteerStatus,
+    AgentRun, SandboxSpawnCheckpoint, SandboxSpawnCheckpointRequest, ToolCallExecution,
+    ToolCallRecord, ToolCallStatus, TurnCheckpointProgress, TurnRunStatus, TurnSteerStatus,
 };
 use crate::storage::{AdmitSandboxAgentRunOutcome, CheckpointSandboxSpawnOutcome};
 use crate::{AgentRunId, ChatId, ToolOutput};
@@ -176,7 +175,7 @@ where
         request.call_id,
         &arguments.task,
         arguments.resource.as_ref(),
-        AgentRunExecutionLocation::InProcess,
+        request.execution_location,
         request.lease_token,
         request.expected_steer_revision,
         AgentRun::DEFAULT_MAX_OUTSTANDING_CHILDREN,

--- a/crates/openwave-core/src/db/tests/delegated_file_read.rs
+++ b/crates/openwave-core/src/db/tests/delegated_file_read.rs
@@ -73,6 +73,7 @@ async fn delegated_sandbox(
             model_steps: 1,
             usage: Usage::default(),
         },
+        execution_location: crate::AgentRunExecutionLocation::InProcess,
     };
     let child = match store
         .checkpoint_sandbox_spawn(&request, Utc::now())

--- a/crates/openwave-core/src/db/tests/sandbox_spawn_checkpoint.rs
+++ b/crates/openwave-core/src/db/tests/sandbox_spawn_checkpoint.rs
@@ -69,6 +69,7 @@ fn request(
         .unwrap(),
         event_ordinal: ordinal,
         progress,
+        execution_location: crate::AgentRunExecutionLocation::InProcess,
     }
 }
 
@@ -265,6 +266,78 @@ async fn nonblocking_spawn_commits_one_atomic_yield_and_exact_retry_survives_rec
             .unwrap()
             .resource,
         None
+    );
+}
+
+#[tokio::test]
+async fn container_checkpoint_matches_standalone_container_admission_shape() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn, lease) = running_turn(&store, chat.id).await;
+    let mut checkpoint_request = request(
+        &turn,
+        lease,
+        CallId::new(),
+        "research one container fact",
+        2,
+        progress(),
+    );
+    checkpoint_request.execution_location = crate::AgentRunExecutionLocation::Container;
+    let checkpoint_child = match store
+        .checkpoint_sandbox_spawn(&checkpoint_request, Utc::now())
+        .await
+        .unwrap()
+        .unwrap()
+    {
+        CheckpointSandboxSpawnOutcome::Checkpointed { child, .. } => child,
+        outcome => panic!("unexpected container checkpoint outcome: {outcome:?}"),
+    };
+
+    let (_standalone_dir, standalone_store) = temp_store().await;
+    let standalone_chat = sample_chat();
+    standalone_store
+        .create_chat(&standalone_chat)
+        .await
+        .unwrap();
+    let (standalone_turn, standalone_lease) =
+        running_turn(&standalone_store, standalone_chat.id).await;
+    let standalone_child = match standalone_store
+        .admit_sandbox_container_agent_run(
+            standalone_turn.id,
+            CallId::new(),
+            "research one container fact",
+            standalone_lease,
+            standalone_turn.steer_revision,
+            AgentRun::MAX_CONCURRENCY_LIMIT,
+            Utc::now(),
+        )
+        .await
+        .unwrap()
+        .unwrap()
+    {
+        crate::AdmitSandboxAgentRunOutcome::Accepted { child, .. } => child,
+        outcome => panic!("unexpected standalone container admission: {outcome:?}"),
+    };
+
+    assert_eq!(
+        checkpoint_child.execution_location,
+        crate::AgentRunExecutionLocation::Container
+    );
+    assert_eq!(checkpoint_child.max_attempts, 1);
+    assert_eq!(
+        checkpoint_child.execution_location,
+        standalone_child.execution_location
+    );
+    assert_eq!(checkpoint_child.input, standalone_child.input);
+    assert_eq!(
+        checkpoint_child.attempt_count,
+        standalone_child.attempt_count
+    );
+    assert_eq!(checkpoint_child.max_attempts, standalone_child.max_attempts);
+    assert_eq!(
+        checkpoint_child.deadline_at.unwrap() - checkpoint_child.created_at,
+        standalone_child.deadline_at.unwrap() - standalone_child.created_at
     );
 }
 

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1015,6 +1015,7 @@ pub struct AgentRun {
     /// scheduler.
     pub tier: AgentRunTier,
     /// Where the run's loop executes.
+    #[serde(default)]
     pub execution_location: AgentRunExecutionLocation,
     /// Explicit bounded hierarchy depth. OpenWave v1 permits only zero or one.
     pub depth: u8,
@@ -1155,6 +1156,9 @@ pub struct SandboxSpawnCheckpointRequest {
     pub result: String,
     pub event_ordinal: i32,
     pub progress: TurnCheckpointProgress,
+    /// Host-resolved execution location for the child admitted by this atomic
+    /// checkpoint. Existing callers use the in-process default.
+    pub execution_location: AgentRunExecutionLocation,
 }
 
 /// Immutable final text submitted by one exact sandbox worker lease.
@@ -1351,11 +1355,12 @@ impl AgentRunTier {
 /// Every run executes inside the OpenWave server process today. A run
 /// executing inside an execution provider's boundary adds a variant here
 /// rather than a second meaning to [`AgentRunTier`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum AgentRunExecutionLocation {
     /// The loop runs inside the OpenWave server process.
+    #[default]
     InProcess,
     /// The loop runs inside a sandbox-resident container, host-driven over the
     /// versioned sandbox-agent wire protocol. The in-process scheduler does not

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -437,6 +437,7 @@ fn postgres_spawn_checkpoint_request(
                 cache_creation_input_tokens: 1,
             },
         },
+        execution_location: openwave_core::AgentRunExecutionLocation::InProcess,
     }
 }
 

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -703,7 +703,8 @@ async fn bind_inner(
     // approvals are durable, while one process still owns the complete data
     // directory and its worker set.
     let instance_lock = InstanceLock::acquire(&config)?;
-    let sandbox_spawn_execution_location = sandbox_admission::resolve_execution_location(&config);
+    let sandbox_container_admission = sandbox_admission::resolve(&config);
+    let sandbox_spawn_execution_location = sandbox_container_admission.execution_location;
     let store = connect_store(&config).await?;
     let secrets = secret_provider(&config);
     // The product boot path is where this platform's OS-managed (MDM) policy
@@ -856,15 +857,10 @@ async fn bind_inner(
             sandbox_web_search_worker::SandboxWebSearchWorkerConfig::default(),
         );
     let sandbox_container_run_worker = {
-        // Issue #1230 replaces this constructor gate with the profile flag.
-        // Keep it false in this slice so admission routing and configuration
-        // remain independently reviewable.
-        let container_execution_enabled = false;
-        let backend = Arc::new(sandbox_docker::DockerSandboxBackend::with_defaults());
-        let enabled = container_execution_enabled && backend.is_available();
+        let enabled = sandbox_container_admission.enabled();
         sandbox_container_run_worker::SandboxContainerRunWorker::new(
             state.store.clone(),
-            backend,
+            sandbox_container_admission.backend,
             state.resolver.clone(),
             state.agent_run_wake.clone(),
             enabled,

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -39,6 +39,7 @@ mod providers;
 mod resolver;
 mod retry;
 mod routes;
+mod sandbox_admission;
 mod sandbox_agent_run_worker;
 pub mod sandbox_container_run;
 mod sandbox_container_run_worker;
@@ -702,6 +703,7 @@ async fn bind_inner(
     // approvals are durable, while one process still owns the complete data
     // directory and its worker set.
     let instance_lock = InstanceLock::acquire(&config)?;
+    let sandbox_spawn_execution_location = sandbox_admission::resolve_execution_location(&config);
     let store = connect_store(&config).await?;
     let secrets = secret_provider(&config);
     // The product boot path is where this platform's OS-managed (MDM) policy
@@ -824,7 +826,10 @@ async fn bind_inner(
         state.agent_run_wake.clone(),
         state.agent_config.clone(),
         Some(state.config.data_dir.join("scratch")),
-        turn_worker::TurnWorkerConfig::default(),
+        turn_worker::TurnWorkerConfig {
+            sandbox_spawn_execution_location,
+            ..turn_worker::TurnWorkerConfig::default()
+        },
     )
     .with_blobs(state.blobs.clone())
     .with_mcp_runtime(state.mcp.clone())

--- a/crates/openwave-server/src/sandbox_admission.rs
+++ b/crates/openwave-server/src/sandbox_admission.rs
@@ -5,15 +5,35 @@
 //! execution location is copied into the turn worker and remains fixed for the
 //! life of that server process.
 
+use std::sync::Arc;
+
 use openwave_core::{AgentRunExecutionLocation, Config};
 
 use crate::sandbox_docker::{DockerConfig, DockerSandboxBackend};
 
-/// Resolve where this server process admits newly spawned background runs.
-pub(crate) fn resolve_execution_location(config: &Config) -> AgentRunExecutionLocation {
-    let backend = DockerSandboxBackend::new(docker_config(config));
+/// Container backend and admission route resolved once during server startup.
+pub(crate) struct SandboxContainerAdmission {
+    pub(crate) backend: Arc<DockerSandboxBackend>,
+    pub(crate) execution_location: AgentRunExecutionLocation,
+}
+
+impl SandboxContainerAdmission {
+    /// Whether both configuration and runtime availability selected containers.
+    pub(crate) fn enabled(&self) -> bool {
+        self.execution_location == AgentRunExecutionLocation::Container
+    }
+}
+
+/// Resolve the backend and fixed location for this server process.
+pub(crate) fn resolve(config: &Config) -> SandboxContainerAdmission {
+    let backend = Arc::new(DockerSandboxBackend::new(docker_config(config)));
     let backend_available = config.container_execution_enabled && backend.is_available();
-    execution_location(config.container_execution_enabled, backend_available)
+    let execution_location =
+        execution_location(config.container_execution_enabled, backend_available);
+    SandboxContainerAdmission {
+        backend,
+        execution_location,
+    }
 }
 
 /// Apply the routing decision independently from capability detection.

--- a/crates/openwave-server/src/sandbox_admission.rs
+++ b/crates/openwave-server/src/sandbox_admission.rs
@@ -1,0 +1,70 @@
+//! Startup-time routing for newly admitted background agent runs.
+//!
+//! The container runtime is a detected capability, but checking it belongs at
+//! process assembly rather than at every model-authored spawn. The resolved
+//! execution location is copied into the turn worker and remains fixed for the
+//! life of that server process.
+
+use openwave_core::{AgentRunExecutionLocation, Config};
+
+use crate::sandbox_docker::{DockerConfig, DockerSandboxBackend};
+
+/// Resolve where this server process admits newly spawned background runs.
+pub(crate) fn resolve_execution_location(config: &Config) -> AgentRunExecutionLocation {
+    let backend = DockerSandboxBackend::new(docker_config(config));
+    let backend_available = config.container_execution_enabled && backend.is_available();
+    execution_location(config.container_execution_enabled, backend_available)
+}
+
+/// Apply the routing decision independently from capability detection.
+fn execution_location(
+    container_execution_enabled: bool,
+    backend_available: bool,
+) -> AgentRunExecutionLocation {
+    if container_execution_enabled && backend_available {
+        AgentRunExecutionLocation::Container
+    } else {
+        AgentRunExecutionLocation::InProcess
+    }
+}
+
+/// Build the Docker configuration shared by admission detection and the
+/// container worker service. An absent override retains the adapter's
+/// documented placeholder image.
+pub(crate) fn docker_config(config: &Config) -> DockerConfig {
+    let mut docker = DockerConfig::default();
+    if let Some(image) = &config.container_image {
+        docker.image.clone_from(image);
+    }
+    docker
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sandbox_container_routing_requires_enablement_and_availability() {
+        assert_eq!(
+            execution_location(true, true),
+            AgentRunExecutionLocation::Container
+        );
+        assert_eq!(
+            execution_location(false, true),
+            AgentRunExecutionLocation::InProcess
+        );
+        assert_eq!(
+            execution_location(true, false),
+            AgentRunExecutionLocation::InProcess
+        );
+    }
+
+    #[test]
+    fn sandbox_container_image_only_overrides_the_docker_default_when_set() {
+        let mut config = Config::desktop("/data");
+        assert_eq!(docker_config(&config).image, DockerConfig::default().image);
+
+        config.container_image = Some("openwave-sandbox-agent:dev".into());
+        assert_eq!(docker_config(&config).image, "openwave-sandbox-agent:dev");
+    }
+}

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -3066,6 +3066,7 @@ mod tests {
                         model_steps: 1,
                         usage: Usage::default(),
                     },
+                    execution_location: openwave_core::AgentRunExecutionLocation::InProcess,
                 },
                 Utc::now(),
             )

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -849,6 +849,7 @@ async fn committed_steer_event_recovers_when_cancellation_wins_ambiguous_respons
             failure_delay: Duration::from_millis(5),
             retry: fast_retry_schedule(),
             max_concurrency: 1,
+            sandbox_spawn_execution_location: openwave_core::AgentRunExecutionLocation::InProcess,
         },
     );
     let router = app(state);

--- a/crates/openwave-server/src/tests/sandbox.rs
+++ b/crates/openwave-server/src/tests/sandbox.rs
@@ -445,6 +445,7 @@ async fn delegated_file_routes_are_native_only_and_expose_only_exact_broker_auth
                     model_steps: 1,
                     usage: Usage::default(),
                 },
+                execution_location: openwave_core::AgentRunExecutionLocation::InProcess,
             },
             chrono::Utc::now(),
         )

--- a/crates/openwave-server/src/tests/workers.rs
+++ b/crates/openwave-server/src/tests/workers.rs
@@ -493,6 +493,128 @@ async fn concurrent_message_retry_converges_across_a_model_setting_race() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn sandbox_container_routing_preserves_in_process_task_and_deadline_shape() {
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("container.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let provider = Arc::new(SandboxRoundTripProvider::default());
+    let mut tools = ToolRegistry::new();
+    tools.register_foreground_agent_orchestration();
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(provider)),
+        Arc::new(MemSecrets::default()),
+        Arc::new(tools),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    spawn_turn_worker_with_config(
+        &state,
+        turn_worker::TurnWorkerConfig {
+            sandbox_spawn_execution_location: openwave_core::AgentRunExecutionLocation::Container,
+            ..turn_worker::TurnWorkerConfig::default()
+        },
+    );
+    let router = app(state);
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    assert_eq!(
+        send_message(&router, &bearer, chat.id, "delegate this").await,
+        StatusCode::ACCEPTED
+    );
+    let container_child = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if let Some(child) = store
+                .list_agent_runs(chat.id)
+                .await
+                .unwrap()
+                .into_iter()
+                .find(|run| run.parent_id.is_some())
+            {
+                break child;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("foreground spawn should admit a container child");
+    assert_eq!(
+        container_child.execution_location,
+        openwave_core::AgentRunExecutionLocation::Container
+    );
+    assert_eq!(
+        container_child.input.as_deref(),
+        Some("Return the first child result.")
+    );
+
+    let (_reference_dir, reference_store) = temp_db_store("in-process-reference.db").await;
+    let reference_store: Arc<dyn Store> = Arc::new(reference_store);
+    let reference_chat = Chat {
+        id: ChatId::new(),
+        project_id: None,
+        title: Some("in-process reference".into()),
+        model: Some("fake".into()),
+        reasoning_effort: None,
+        permission_mode: None,
+        attachment_revision: 0,
+        root_attachments: Vec::new(),
+        created_at: chrono::Utc::now(),
+    };
+    reference_store.create_chat(&reference_chat).await.unwrap();
+    let reference_turn_id = TurnId::new();
+    reference_store
+        .accept_turn(
+            reference_turn_id,
+            reference_chat.id,
+            "fake",
+            "reference admission",
+        )
+        .await
+        .unwrap();
+    let reference_lease = uuid::Uuid::new_v4();
+    let now = chrono::Utc::now();
+    let reference_turn = reference_store
+        .claim_turn_run(reference_lease, now, now + chrono::Duration::minutes(5))
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    let in_process_child = match reference_store
+        .admit_sandbox_agent_run(
+            reference_turn.id,
+            CallId::new(),
+            "Return the first child result.",
+            reference_lease,
+            reference_turn.steer_revision,
+            openwave_core::AgentRun::MAX_CONCURRENCY_LIMIT,
+            chrono::Utc::now(),
+        )
+        .await
+        .unwrap()
+        .unwrap()
+    {
+        openwave_core::AdmitSandboxAgentRunOutcome::Accepted { child, .. } => child,
+        outcome => panic!("unexpected in-process reference admission: {outcome:?}"),
+    };
+
+    assert_eq!(container_child.input, in_process_child.input);
+    assert_eq!(
+        container_child.deadline_at.unwrap() - container_child.created_at,
+        in_process_child.deadline_at.unwrap() - in_process_child.created_at
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn worker_recovers_ambiguous_claim_and_completion_with_exact_receipts() {
     let dir = tempfile::tempdir().unwrap();
     let inner: Arc<dyn Store> = Arc::new(
@@ -825,6 +947,7 @@ async fn worker_renews_a_near_expiry_ambiguous_claim_before_execution() {
             failure_delay: Duration::from_millis(10),
             retry: fast_retry_schedule(),
             max_concurrency: 1,
+            sandbox_spawn_execution_location: openwave_core::AgentRunExecutionLocation::InProcess,
         },
     );
     let token = state.token.clone();
@@ -918,6 +1041,7 @@ async fn worker_heartbeats_while_event_journaling_is_blocked() {
             failure_delay: Duration::from_millis(10),
             retry: fast_retry_schedule(),
             max_concurrency: 1,
+            sandbox_spawn_execution_location: openwave_core::AgentRunExecutionLocation::InProcess,
         },
     );
     let token = state.token.clone();

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -15,7 +15,7 @@ use chrono::Utc;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver};
 use futures::StreamExt;
 use openwave_core::{
-    Agent, AgentConfig, AgentError, AgentEvent, AgentRunWaitCondition,
+    Agent, AgentConfig, AgentError, AgentEvent, AgentRunExecutionLocation, AgentRunWaitCondition,
     AgentRunWaitSetCheckpointRequest, AgentTurnOutcome, BlobStore, CheckpointSandboxSpawnOutcome,
     ClaimedAgentEvent, CompleteTurnRunOutcome, ForegroundAgentWaitRequest, MessageId,
     ParkTurnForAgentRunWaitSetOutcome, ParkTurnForClientCallOutcome, RecordTurnFailureOutcome,
@@ -43,6 +43,9 @@ pub(crate) struct TurnWorkerConfig {
     pub(crate) failure_delay: Duration,
     pub(crate) retry: RetrySchedule,
     pub(crate) max_concurrency: usize,
+    /// Startup-resolved location for every background child admitted by this
+    /// worker. Capability detection never runs in the spawn path.
+    pub(crate) sandbox_spawn_execution_location: AgentRunExecutionLocation,
 }
 
 impl Default for TurnWorkerConfig {
@@ -63,6 +66,7 @@ impl Default for TurnWorkerConfig {
                 Duration::from_secs(600),
             ),
             max_concurrency: 4,
+            sandbox_spawn_execution_location: AgentRunExecutionLocation::InProcess,
         }
     }
 }
@@ -1450,6 +1454,7 @@ impl TurnWorker {
                         })?,
                         event_ordinal: ordinal,
                         progress,
+                        execution_location: self.config.sandbox_spawn_execution_location,
                     };
                     let mut checkpoint_heartbeat = AbortOnDrop(tokio::spawn(
                         self.clone()


### PR DESCRIPTION
## Summary

- add default-off container execution configuration with an optional image override
- resolve Docker availability once at startup, share the configured backend with the container worker, and route spawn admission to containers only when enabled and available
- preserve the atomic spawn checkpoint and in-process default, with row-shape parity and loopback end-to-end coverage

## Verification

- cargo test -p openwave-server --locked sandbox
- cargo test -p openwave-core --locked db::
- cargo clippy -p openwave-server -p openwave-core --all-targets --locked -- -D warnings
- cargo fmt -p openwave-server -p openwave-core -- --check

Closes #1230