### PR TITLE
feat(server): tell the model when the user restores an output version

### DIFF
--- a/crates/openwave-core/src/db/tests/output.rs
+++ b/crates/openwave-core/src/db/tests/output.rs
@@ -932,6 +932,21 @@ mod restore {
                 .unwrap();
         assert_eq!(retried.revision_count, 3);
         assert_eq!(retried.current_revision, restored.current_revision);
+
+        // The restore leaves the model a durable host note — a System message
+        // the next turn's transcript picks up — and the no-op retry does not
+        // repeat it.
+        let notes: Vec<_> = store
+            .list_messages(chat.id)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|message| message.role == crate::model::Role::System)
+            .collect();
+        assert_eq!(notes.len(), 1);
+        assert!(notes[0].content.contains("restored output 'report.md'"));
+        assert!(notes[0].content.contains("version 1"));
+        assert!(notes[0].content.contains("v3"));
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/deliverable_acceptance.rs
+++ b/crates/openwave-core/src/deliverable_acceptance.rs
@@ -280,7 +280,7 @@ pub async fn restore_output_to_revision(
     .map_err(|error| AgentError::Store(format!("restore publication task failed: {error}")))?
     .map_err(|error| AgentError::Store(format!("could not publish restored revision: {error}")))?;
 
-    store
+    let restored = store
         .append_output_revision(
             output.id,
             &NewOutputRevision {
@@ -293,7 +293,31 @@ pub async fn restore_output_to_revision(
                 created_at: now,
             },
         )
-        .await
+        .await?;
+
+    // A host note tells the model what the user did between turns, so its next
+    // turn re-reads the file instead of overwriting the restore with stale
+    // context. The next `load_transcript` picks the `System` message up; the
+    // adapters serialize it as ordinary user-context text. Best-effort: the
+    // restore has already committed, and a lost note must not fail it.
+    let _ = store
+        .append_message(&crate::model::Message {
+            id: crate::id::MessageId::new(),
+            chat_id,
+            // No turn produced this; messages carry no turn foreign key, so a
+            // fresh id is an inert marker rather than a claim on turn state.
+            turn_id: crate::id::TurnId::new(),
+            role: crate::model::Role::System,
+            content: format!(
+                "User restored output '{}' to the content of version {} \
+                 (now the latest version, v{}). Re-read output/{} before \
+                 relying on or changing it.",
+                output.filename, target.ordinal, restored.revision_count, output.filename
+            ),
+            created_at: now,
+        })
+        .await;
+    Ok(restored)
 }
 
 /// Read and verify one revision's bytes from the conversation's private

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -29,6 +29,32 @@ const transcript: ChatTranscript = {
 };
 
 describe("terminal transcript presentation", () => {
+  // A durable host note — "User restored output …" — renders as the subtle
+  // inline system notice, never as a user or assistant bubble.
+  it("presents a host-authored system note as an inline notice", () => {
+    const presented = presentChatTranscript({
+      messages: [
+        {
+          id: "host-note-1",
+          role: "system",
+          content: "User restored output 'report.md' to the content of version 1.",
+          created_at: "2026-07-30T12:00:00Z",
+        },
+      ],
+      tool_activity: [],
+      cancellations: [],
+      last_event_seq: 2,
+    });
+
+    expect(presented.messages).toEqual([
+      {
+        id: "host-note-1",
+        role: "system",
+        text: "User restored output 'report.md' to the content of version 1.",
+      },
+    ]);
+  });
+
   it("keeps a historical spawn bound to its durable child", () => {
     const presented = presentChatTranscript({
       messages: [],

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
@@ -57,6 +57,18 @@ export function presentChatTranscript(
           } satisfies ChatMessage,
         ];
       }
+      // A durable host-authored note — "User restored output 'report.md'…" —
+      // written for the model between turns. Shown as the same subtle inline
+      // notice a cancellation uses, never as a user or assistant bubble.
+      if (entry.role === "system") {
+        return [
+          {
+            id: entry.id,
+            role: "system",
+            text: entry.text,
+          } satisfies ChatMessage,
+        ];
+      }
       if (entry.role === "assistant") {
         const assistant = {
           id: entry.id,

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1223,7 +1223,7 @@ width: number, height: number, };
  * makes a new [`Role`] variant a decision in [`Self::for_transcript`] instead of
  * something that silently appears in the transcript.
  */
-export type TranscriptRole = "user" | "assistant";
+export type TranscriptRole = "user" | "assistant" | "system";
 
 /**
  * Why a turn failed, closed and coarse enough to be stable.

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1336,6 +1336,10 @@ pub struct ChatTranscript {
 pub enum TranscriptRole {
     User,
     Assistant,
+    /// A durable host-authored note — e.g. "User restored output 'report.md'…"
+    /// — written between turns so the model's next turn learns what happened.
+    /// Shown as a subtle inline notice, never as a user or assistant bubble.
+    System,
 }
 
 impl TranscriptRole {
@@ -1344,7 +1348,8 @@ impl TranscriptRole {
         match role {
             Role::User => Some(Self::User),
             Role::Assistant => Some(Self::Assistant),
-            Role::System | Role::Tool => None,
+            Role::System => Some(Self::System),
+            Role::Tool => None,
         }
     }
 }


### PR DESCRIPTION
Closes #1199.

When a user restores an old output version between turns, the agent had no way to learn about it — its next turn could overwrite the restore with stale context. This adds the model-facing counterpart to the renderer event journal: a durable, host-authored note in the conversation itself.

**Mechanism.** `restore_output_to_revision` now appends a `Role::System` message after the restore commits: *"User restored output 'report.md' to the content of version 1 (now the latest version, v3). Re-read output/report.md before relying on or changing it."* The next turn's `load_transcript` picks it up like any persisted message, and all three provider adapters already serialize mid-transcript `System` as ordinary user-context text (the documented checkpoint contract). The note is best-effort — a committed restore never fails over it — carries no turn claim (messages have no turn foreign key), and the idempotent no-op/retry paths don't repeat it.

**Visibility.** `TranscriptRole` gains a `System` variant, so the transcript route now returns host notes and the renderer shows them with the existing subtle inline system-notice styling (the same treatment as a cancellation notice) — not as a user or assistant bubble. Previously `Role::System` was filtered at the route; the only producer of durable system messages is this note, so nothing else starts appearing.

Known limitation, deliberate: a turn already running when the restore happens loads its transcript once at start and won't see the note until the next turn; an open chat window shows it after the next transcript hydration. Both match the "between turns" scope of #1199.

Tests: restore contract asserts exactly one System note with the filename and versions (and none repeated on the idempotent retry); presentation test pins the system-notice rendering; wire types regenerated.