### PR TITLE
fix(desktop): complete system transcript fixture

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -39,6 +39,7 @@ describe("terminal transcript presentation", () => {
           role: "system",
           content: "User restored output 'report.md' to the content of version 1.",
           created_at: "2026-07-30T12:00:00Z",
+          citations: [],
         },
       ],
       tool_activity: [],


### PR DESCRIPTION
Adds the required empty citation list to the durable system-message fixture. This keeps the fixture aligned with the generated transcript wire type and restores the macOS release-cache type-check.

Verified with `pnpm test` and `pnpm build` in `crates/openwave-desktop/ui`.