### PR TITLE
fix(approvals): keep recovered approval choices valid

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -2767,10 +2767,11 @@ impl Agent {
                 tool_name: call.name.clone(),
                 class: approval_class,
                 kind,
-                grant_scopes: kind
-                    .is_standing_grantable()
-                    .then(|| GrantScope::ladder_for(&call.name, &arguments))
-                    .unwrap_or_default(),
+                grant_scopes: if kind.is_standing_grantable() {
+                    GrantScope::ladder_for(&call.name, &arguments)
+                } else {
+                    Vec::new()
+                },
                 preview,
                 summary,
             };

--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -34,7 +34,7 @@ use crate::agent_tools::{
 };
 use crate::approval::{
     ApprovalDecision, ApprovalGate, ApprovalJournalIdentity, ApprovalRequest,
-    ApprovalRequiredPublication, RefuseGate, StandingGrants, ToolApprovalKind,
+    ApprovalRequiredPublication, GrantScope, RefuseGate, StandingGrants, ToolApprovalKind,
 };
 use crate::cancel::CancelToken;
 use crate::citation::{parse_assistant_citations, AssistantCitationInput};
@@ -2767,6 +2767,10 @@ impl Agent {
                 tool_name: call.name.clone(),
                 class: approval_class,
                 kind,
+                grant_scopes: kind
+                    .is_standing_grantable()
+                    .then(|| GrantScope::ladder_for(&call.name, &arguments))
+                    .unwrap_or_default(),
                 preview,
                 summary,
             };

--- a/crates/openwave-core/src/db/ops/approval.rs
+++ b/crates/openwave-core/src/db/ops/approval.rs
@@ -191,15 +191,6 @@ pub(in crate::db) async fn request_and_append_event(
             "approval journal identity must be valid".into(),
         ));
     }
-    let event = AgentEvent::ApprovalRequired {
-        auto_judging: request.auto_judge,
-        call_id: request.call_id,
-        tool_name: request.tool_name.clone(),
-        class: request.class,
-        kind: request.kind,
-        preview: request.preview.clone(),
-        summary: request.summary.clone(),
-    };
     let transaction = store.conn.begin().await.map_err(store_err)?;
     if !acquire_chat_write_lock(&transaction, request.chat_id).await?
         || !acquire_turn_write_lock(&transaction, request.turn_id).await?
@@ -219,6 +210,20 @@ pub(in crate::db) async fn request_and_append_event(
         .await
         .map_err(store_err)?
         .expect("locked tool call exists");
+    let event = AgentEvent::ApprovalRequired {
+        auto_judging: request.auto_judge,
+        call_id: request.call_id,
+        tool_name: request.tool_name.clone(),
+        class: request.class,
+        kind: request.kind,
+        grant_scopes: request
+            .kind
+            .is_standing_grantable()
+            .then(|| GrantScope::ladder_for(&call.name, &call.arguments))
+            .unwrap_or_default(),
+        preview: request.preview.clone(),
+        summary: request.summary.clone(),
+    };
     let turn = entities::turn_run::Entity::find_by_id(request.turn_id.0)
         .one(&transaction)
         .await

--- a/crates/openwave-core/src/db/ops/approval.rs
+++ b/crates/openwave-core/src/db/ops/approval.rs
@@ -216,11 +216,11 @@ pub(in crate::db) async fn request_and_append_event(
         tool_name: request.tool_name.clone(),
         class: request.class,
         kind: request.kind,
-        grant_scopes: request
-            .kind
-            .is_standing_grantable()
-            .then(|| GrantScope::ladder_for(&call.name, &call.arguments))
-            .unwrap_or_default(),
+        grant_scopes: if request.kind.is_standing_grantable() {
+            GrantScope::ladder_for(&call.name, &call.arguments)
+        } else {
+            Vec::new()
+        },
         preview: request.preview.clone(),
         summary: request.summary.clone(),
     };

--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -86,6 +86,14 @@ pub enum AgentEvent {
         /// The approval class that triggered the prompt.
         class: ApprovalClass,
         kind: crate::approval::ToolApprovalKind,
+        /// The complete standing-grant ladder this exact call cleared.
+        ///
+        /// Empty means approving once is the only affirmative choice. The
+        /// renderer must not reconstruct broader rungs from the approval kind:
+        /// command policy can refuse every standing grant for an interpreter
+        /// while still allowing one explicit human approval.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        grant_scopes: Vec<crate::approval::GrantScope>,
         /// Closed projection of what the call will do, when its tool has one.
         /// Absent on journal rows written before previews existed.
         #[serde(default)]
@@ -311,6 +319,7 @@ mod tests {
                 tool_name: "exec".into(),
                 class: ApprovalClass::Sensitive,
                 kind: crate::approval::ToolApprovalKind::ExecMayRunNetworkedCommand,
+                grant_scopes: Vec::new(),
                 preview: Some(crate::preview::ToolActionPreview::Exec {
                     command: "git".into(),
                     args: vec!["status".into()],

--- a/crates/openwave-desktop/ui/src/ApprovalCard.tsx
+++ b/crates/openwave-desktop/ui/src/ApprovalCard.tsx
@@ -28,8 +28,8 @@ type ApprovalCardProps = {
   canRemember: boolean;
   /** How far a remembered answer will reach, for the option labels. */
   grantScope?: GrantScopeName;
-  /** Token counts of the prefix rungs the server will honor for this call. */
-  prefixRungs?: readonly number[];
+  /** Complete standing-grant ladder the server will honor for this call. */
+  grantRungs?: readonly ApprovalGrantRung[];
   /** The Auto-mode judge is deciding. Advisory only: the card stays live. */
   autoJudging?: boolean;
   deciding: boolean;
@@ -60,7 +60,7 @@ export function ApprovalCard({
   canApprove,
   canRemember,
   grantScope = "chat",
-  prefixRungs = [],
+  grantRungs = [],
   autoJudging,
   deciding,
   error,
@@ -73,7 +73,7 @@ export function ApprovalCard({
     canRemember,
     expanded,
     grantScope,
-    prefixRungs,
+    grantRungs,
   );
   const [highlight, setHighlight] = useState(0);
   const rowRefs = useRef<Array<HTMLDivElement | null>>([]);
@@ -271,7 +271,7 @@ export function approvalOptions(
   canRemember: boolean,
   expanded = false,
   scope: GrantScopeName = "chat",
-  prefixRungs: readonly number[] = [],
+  grantRungs: readonly ApprovalGrantRung[] = [],
 ): ApprovalOption[] {
   if (!canApprove) return [declineOption()];
 
@@ -288,7 +288,7 @@ export function approvalOptions(
     },
   ];
 
-  const grants = canRemember ? grantLadder(preview, scope, prefixRungs) : [];
+  const grants = canRemember ? grantLadder(preview, scope, grantRungs) : [];
   const visible = expanded ? grants : grants.slice(0, INLINE_GRANTS);
   options.push(...visible);
   if (grants.length > visible.length) {
@@ -319,48 +319,54 @@ function declineOption(): ApprovalOption {
 export function grantLadder(
   preview: ToolActionPreview | null,
   scope: GrantScopeName = "chat",
-  prefixRungs: readonly number[] = [],
+  grantRungs: readonly ApprovalGrantRung[] = [],
 ): ApprovalOption[] {
   // The label names the level the server will actually write. A chat filed
   // under a project grants across it, and saying "this chat" while writing
   // something wider is the one thing a consent label must never do.
   const where = scope === "project" ? "in this project" : "in this chat";
-  const wholeTool: ApprovalOption = {
-    kind: "decide",
-    key: "whole-tool",
-    label:
-      preview?.tool === "exec"
-        ? `Yes, and don't ask again about commands ${where}`
-        : `Yes, and don't ask again ${where}`,
-    decision: "approve",
-    grant: "whole_tool",
-  };
-  if (!preview) return [wholeTool];
-
-  const exact: ApprovalOption = {
-    kind: "decide",
-    key: "exact",
-    label: `Yes, and always allow exactly \u201c${spokenAction(preview)}\u201d`,
-    decision: "approve",
-    grant: "exact_action",
-  };
-  if (preview.tool !== "exec") {
-    return [exact, wholeTool];
-  }
-  // Which token runs may be granted is the server's answer, not a guess made
-  // here: a command the analyzer would never auto-run under a prefix rule has
-  // none, and offering one anyway would promise something the gate refuses.
-  const argv = [preview.command, ...preview.args];
-  const prefixes: ApprovalOption[] = prefixRungs
-    .filter((tokens) => tokens > 0 && tokens <= argv.length)
-    .map((tokens) => ({
-      kind: "decide",
-      key: `prefix-${tokens}`,
-      label: `Yes, and always allow any \u201c${argv.slice(0, tokens).join(" ")}\u201d command`,
-      decision: "approve",
-      grant: { command_prefix: { tokens } },
-    }));
-  return [exact, ...prefixes, wholeTool];
+  return grantRungs.flatMap((grant): ApprovalOption[] => {
+    if (grant === "whole_tool") {
+      return [
+        {
+          kind: "decide",
+          key: "whole-tool",
+          label:
+            preview?.tool === "exec"
+              ? `Yes, and don't ask again about commands ${where}`
+              : `Yes, and don't ask again ${where}`,
+          decision: "approve",
+          grant,
+        },
+      ];
+    }
+    if (grant === "exact_action") {
+      return preview
+        ? [
+            {
+              kind: "decide",
+              key: "exact",
+              label: `Yes, and always allow exactly \u201c${spokenAction(preview)}\u201d`,
+              decision: "approve",
+              grant,
+            },
+          ]
+        : [];
+    }
+    if (preview?.tool !== "exec") return [];
+    const argv = [preview.command, ...preview.args];
+    const tokens = grant.command_prefix.tokens;
+    if (tokens < 1 || tokens > argv.length) return [];
+    return [
+      {
+        kind: "decide",
+        key: `prefix-${tokens}`,
+        label: `Yes, and always allow any \u201c${argv.slice(0, tokens).join(" ")}\u201d command`,
+        decision: "approve",
+        grant,
+      },
+    ];
+  });
 }
 
 /** How much of an action fits in one row of the option list. */

--- a/crates/openwave-desktop/ui/src/ApprovalHistory.test.ts
+++ b/crates/openwave-desktop/ui/src/ApprovalHistory.test.ts
@@ -13,7 +13,7 @@ const pending = {
   preview: null,
   canApprove: true,
   canRemember: true,
-  prefixRungs: [],
+  grantRungs: ["whole_tool" as const],
   autoJudgeStatus: null,
 };
 
@@ -38,7 +38,7 @@ describe("reconcilePendingApprovalCards", () => {
         canApprove: true,
         canRemember: true,
         autoJudging: false,
-        prefixRungs: [],
+        grantRungs: ["whole_tool"],
       },
     ]);
   });
@@ -68,8 +68,33 @@ describe("reconcilePendingApprovalCards", () => {
     expect(stale).toEqual([{ id: "message-new", role: "user", text: "new chat" }]);
   });
 
-  it("upserts a replayed live requirement by call id", () => {
-    const once = upsertPendingApprovalCard([], pending);
-    expect(upsertPendingApprovalCard(once, pending)).toEqual(once);
+  it("moves a hydrated card behind earlier events when its live frame replays", () => {
+    const hydrated = upsertPendingApprovalCard(
+      [{ id: "user", role: "user", text: "run it" }],
+      pending,
+    );
+    const withEarlierReplay = [
+      ...hydrated,
+      {
+        id: "thought",
+        role: "assistant" as const,
+        text: "",
+        reasoning: "checking the command",
+        sources: [],
+      },
+    ];
+
+    expect(upsertPendingApprovalCard(withEarlierReplay, pending, true)).toEqual([
+      { id: "user", role: "user", text: "run it" },
+      {
+        id: "thought",
+        role: "assistant",
+        text: "",
+        reasoning: "checking the command",
+        sources: [],
+      },
+      expect.objectContaining({ role: "tool", callId: "call-search" }),
+      expect.objectContaining({ role: "approval", callId: "call-search" }),
+    ]);
   });
 });

--- a/crates/openwave-desktop/ui/src/ApprovalHistory.ts
+++ b/crates/openwave-desktop/ui/src/ApprovalHistory.ts
@@ -24,7 +24,7 @@ export function reconcilePendingApprovalCards(
     next = upsertPendingApprovalCard(next, {
       ...approval,
       autoJudging: approval.autoJudgeStatus === "judging",
-      prefixRungs: approval.prefixRungs,
+      grantRungs: approval.grantRungs,
     });
   }
   return next;
@@ -38,10 +38,19 @@ export function upsertPendingApprovalCard(
   > &
     Partial<Pick<PendingToolApproval, "preview">> & {
       autoJudging?: boolean;
-      prefixRungs?: readonly number[];
+      grantRungs?: ReadonlyArray<PendingToolApproval["grantRungs"][number]>;
     },
+  moveToEnd = false,
 ): ChatMessage[] {
-    let next = messages;
+    let next = moveToEnd
+      ? messages.filter(
+          (message) =>
+            !(
+              (message.role === "tool" || message.role === "approval") &&
+              message.callId === approval.callId
+            ),
+        )
+      : messages;
     const presentation = toolApprovalPresentation(approval.approval);
     const preview = approval.preview ?? null;
     const toolIndex = next.findIndex(
@@ -86,7 +95,7 @@ export function upsertPendingApprovalCard(
       canApprove: approval.canApprove && presentation.canApprove,
       canRemember: approval.canRemember && presentation.canRemember,
       autoJudging: approval.autoJudging ?? false,
-      prefixRungs: approval.prefixRungs ?? [],
+      grantRungs: approval.grantRungs ?? [],
     };
     if (cardIndex >= 0) {
       next = next.map((message, index) => (index === cardIndex ? card : message));

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -113,7 +113,7 @@ describe("turn_started", () => {
       {
         type: "approval_required",
         auto_judging: false,
-        prefix_rungs: [],
+        grant_rungs: [],
         call_id: "call-approved",
         action: "search",
         approval: "search_may_share_query_and_excerpts",
@@ -237,7 +237,7 @@ describe("tool call lifecycle", () => {
       {
         type: "approval_required",
       auto_judging: false,
-      prefix_rungs: [],
+      grant_rungs: [],
         call_id: "call-1",
         action: "search",
         approval: "search_may_share_query_and_excerpts",
@@ -265,7 +265,7 @@ describe("tool call lifecycle", () => {
       {
         type: "approval_required",
       auto_judging: false,
-      prefix_rungs: [],
+      grant_rungs: [],
         call_id: "call-1",
         action: "search",
         approval: "search_may_share_query_and_excerpts",
@@ -332,7 +332,7 @@ describe("approvals", () => {
   const APPROVAL: AgentEvent = {
     type: "approval_required",
       auto_judging: false,
-      prefix_rungs: [],
+      grant_rungs: [],
     call_id: "call-1",
     action: "search",
     approval: "search_may_share_query_and_excerpts",
@@ -524,7 +524,7 @@ describe("terminal events", () => {
       {
         type: "approval_required",
       auto_judging: false,
-      prefix_rungs: [],
+      grant_rungs: [],
         call_id: "call-1",
         action: "search",
         approval: "search_may_share_query_and_excerpts",

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -243,19 +243,23 @@ export function reduceChatSessionEvent(
         state: {
           ...state,
           provisionalToolCallIds,
-          messages: upsertPendingApprovalCard(state.messages, {
-            callId: event.call_id,
-            action: event.action,
-            approval: event.approval,
-            // Validated here rather than trusted: the socket frame is the one
-            // place a preview arrives without having gone through the HTTP
-            // recovery parser.
-            preview: parseToolActionPreview(event.preview),
-            canApprove: approval.canApprove,
-            canRemember: approval.canRemember,
-            autoJudging: event.auto_judging,
-            prefixRungs: event.prefix_rungs,
-          }),
+          messages: upsertPendingApprovalCard(
+            state.messages,
+            {
+              callId: event.call_id,
+              action: event.action,
+              approval: event.approval,
+              // Validated here rather than trusted: the socket frame is the one
+              // place a preview arrives without having gone through the HTTP
+              // recovery parser.
+              preview: parseToolActionPreview(event.preview),
+              canApprove: approval.canApprove,
+              canRemember: event.grant_rungs.length > 0,
+              autoJudging: event.auto_judging,
+              grantRungs: event.grant_rungs,
+            },
+            true,
+          ),
         },
         effects,
       };

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -19,6 +19,7 @@ function card(overrides: Partial<Parameters<typeof ApprovalCard>[0]> = {}) {
       preview={null}
       canApprove
       canRemember
+      grantRungs={["exact_action", "whole_tool"]}
       deciding={false}
       onDecide={noop}
       {...overrides}
@@ -150,6 +151,25 @@ describe("approval card interactions", () => {
     ).toEqual([ONCE, "2.No, don't allow this"]);
   });
 
+  it("offers an interpreter command once when policy supplies no grant rung", () => {
+    render(
+      card({
+        preview: {
+          tool: "exec",
+          command: "python3",
+          args: ["-c", "import pptx"],
+          cwd: ".",
+        },
+        canRemember: false,
+        grantRungs: [],
+      }),
+    );
+
+    expect(
+      screen.getAllByRole("option").map((option) => option.textContent),
+    ).toEqual(["1.Yes, run it once", "2.No, don't allow this"]);
+  });
+
   it("hides the broader grants behind one more keystroke", async () => {
     const user = userEvent.setup();
     const onDecide = vi.fn();
@@ -162,8 +182,12 @@ describe("approval card interactions", () => {
           args: ["test"],
           cwd: ".",
         },
-        // Both prefix rungs the server offers for `cargo test`.
-        prefixRungs: [2, 1],
+        grantRungs: [
+          "exact_action",
+          { command_prefix: { tokens: 2 } },
+          { command_prefix: { tokens: 1 } },
+          "whole_tool",
+        ],
       }),
     );
 

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -108,8 +108,8 @@ export type ChatMessage =
       canRemember: boolean;
       /** The Auto-mode judge is deciding; the card stays fully actionable. */
       autoJudging?: boolean;
-      /** Prefix rungs the server will honor for this call. */
-      prefixRungs?: readonly number[];
+      /** Complete standing-grant ladder the server will honor for this call. */
+      grantRungs?: readonly ApprovalGrantRung[];
       resolved?: boolean;
     }
   | { id: string; role: "error"; text: string }
@@ -765,7 +765,7 @@ function surfacedCard(entry: ChatMessage, context: CardContext): ReactNode {
         canRemember={entry.canRemember}
         grantScope={approvalState?.grantScope ?? "chat"}
         autoJudging={entry.autoJudging ?? false}
-        prefixRungs={entry.prefixRungs ?? []}
+        grantRungs={entry.grantRungs ?? []}
         deciding={
           approvalState?.decidingApprovalCalls.has(entry.callId) ?? false
         }

--- a/crates/openwave-desktop/ui/src/WireFixtures.test.ts
+++ b/crates/openwave-desktop/ui/src/WireFixtures.test.ts
@@ -40,8 +40,11 @@ describe("validators against real server output", () => {
       preview: { tool: "exec", command: "git", args: ["status"], cwd: "." },
       canApprove: true,
       canRemember: true,
-      // The fixture is real server output: `git` is a one-token prefix rung.
-      prefixRungs: [1],
+      grantRungs: [
+        "exact_action",
+        { command_prefix: { tokens: 1 } },
+        "whole_tool",
+      ],
       autoJudgeStatus: null,
     });
   });

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -266,6 +266,7 @@ describe("pending approval recovery", () => {
     class: "sensitive",
     can_approve: true,
     can_remember: true,
+    grant_rungs: ["whole_tool"],
   };
 
   it("parses only the closed renderer projection", () => {
@@ -278,12 +279,16 @@ describe("pending approval recovery", () => {
       preview: null,
       canApprove: true,
       canRemember: true,
-      prefixRungs: [],
+      grantRungs: ["whole_tool"],
       autoJudgeStatus: null,
     });
     expect(parsePendingToolApproval({ ...safe, arguments: { query: "private" } })).toBeNull();
     expect(parsePendingToolApproval({ ...safe, can_approve: false })).toBeNull();
     expect(parsePendingToolApproval({ ...safe, action: "private_plugin" })).toBeNull();
+    expect(parsePendingToolApproval({ ...safe, grant_rungs: [] })).toBeNull();
+    expect(
+      parsePendingToolApproval({ ...safe, grant_rungs: ["unknown_scope"] }),
+    ).toBeNull();
   });
 
   it("recovers the command an exec approval is granting", () => {
@@ -379,6 +384,7 @@ describe("pending approval recovery", () => {
         action: "other",
         approval: "external_mcp_may_call_server",
         can_remember: false,
+        grant_rungs: [],
       }),
     ).toMatchObject({
       action: "other",
@@ -391,6 +397,7 @@ describe("pending approval recovery", () => {
         ...safe,
         action: "other",
         approval: "external_mcp_may_call_server",
+        grant_rungs: [],
       }),
     ).toBeNull();
   });
@@ -403,6 +410,7 @@ describe("pending approval recovery", () => {
         approval: "unsupported",
         can_approve: false,
         can_remember: false,
+        grant_rungs: [],
       }),
     ).toMatchObject({ action: "wait_for_agents", canApprove: false });
     expect(
@@ -412,6 +420,7 @@ describe("pending approval recovery", () => {
         approval: "unsupported",
         can_approve: false,
         can_remember: false,
+        grant_rungs: [],
       }),
     ).toBeNull();
   });
@@ -424,6 +433,7 @@ describe("pending approval recovery", () => {
         approval: "unsupported",
         can_approve: false,
         can_remember: false,
+        grant_rungs: [],
       }),
     ).toMatchObject({ action: "read_delegated_file", canApprove: false });
     expect(
@@ -433,6 +443,7 @@ describe("pending approval recovery", () => {
         approval: "unsupported",
         can_approve: false,
         can_remember: false,
+        grant_rungs: [],
       }),
     ).toBeNull();
   });

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -1,5 +1,6 @@
 import {
   RENDERER_TOOL_NAMES,
+  type ApprovalGrantRung,
   type ApprovalClass,
   type AssistantCitationSnapshot,
   type CitationLocator as WireCitationLocator,
@@ -69,6 +70,7 @@ import {
 
 export type {
   ApprovalClass,
+  ApprovalGrantRung,
   GrantLevel,
   GrantScope,
   StandingGrantSnapshot,
@@ -407,18 +409,6 @@ export function isApprovableKind(kind: RendererApprovalKind): boolean {
   );
 }
 
-/**
- * How wide a standing grant to remember, narrowest first.
- *
- * The renderer only names the rung. The server builds the concrete grant from
- * the arguments the call is parked on, so a grant can never describe a broader
- * action than the one the human was shown.
- */
-export type ApprovalGrantRung =
-  | "exact_action"
-  | { command_prefix: { tokens: number } }
-  | "whole_tool";
-
 /** Approval kinds whose authority is stable enough to remember by tool name. */
 export function isRememberableKind(kind: RendererApprovalKind): boolean {
   return isApprovableKind(kind) && kind !== "external_mcp_may_call_server";
@@ -435,8 +425,8 @@ export type PendingToolApproval = {
   preview: ToolActionPreview | null;
   canApprove: boolean;
   canRemember: boolean;
-  /** Token counts of the prefix rungs the server will honor for this call. */
-  prefixRungs: number[];
+  /** Complete standing-grant ladder the server will honor for this call. */
+  grantRungs: ApprovalGrantRung[];
   /** Where the Auto-mode judge stands, or null when no judge was engaged. */
   autoJudgeStatus: "judging" | "approved" | "declined" | null;
 };
@@ -1748,7 +1738,7 @@ const PENDING_APPROVAL_KEYS = [
   "preview",
   "can_approve",
   "can_remember",
-  "prefix_rungs",
+  "grant_rungs",
   "auto_judge_status",
 ] as const satisfies readonly (keyof PendingApprovalSnapshot)[];
 
@@ -1773,15 +1763,10 @@ export function parsePendingToolApproval(
     typeof value.can_approve !== "boolean" ||
     value.can_approve !== isApprovableKind(value.approval) ||
     typeof value.can_remember !== "boolean" ||
-    value.can_remember !== isRememberableKind(value.approval) ||
-    // Absent reads as "no prefix rungs", which is the safe answer: the card
-    // offers nothing it was not told about.
-    (value.prefix_rungs !== undefined &&
-      (!Array.isArray(value.prefix_rungs) ||
-        value.prefix_rungs.some(
-          (tokens) =>
-            typeof tokens !== "number" || !Number.isInteger(tokens) || tokens < 1,
-        ))) ||
+    !Array.isArray(value.grant_rungs) ||
+    value.grant_rungs.some((rung) => parseApprovalGrantRung(rung) === null) ||
+    (value.grant_rungs.length > 0 && !isRememberableKind(value.approval)) ||
+    value.can_remember !== (value.grant_rungs.length > 0) ||
     !(
       value.auto_judge_status === undefined ||
       value.auto_judge_status === "judging" ||
@@ -1800,9 +1785,29 @@ export function parsePendingToolApproval(
     preview: parseToolActionPreview(value.preview),
     canApprove: value.can_approve,
     canRemember: value.can_remember,
-    prefixRungs: (value.prefix_rungs as number[] | undefined) ?? [],
+    grantRungs: value.grant_rungs.map(
+      (rung) => parseApprovalGrantRung(rung) as ApprovalGrantRung,
+    ),
     autoJudgeStatus: value.auto_judge_status ?? null,
   };
+}
+
+function parseApprovalGrantRung(value: unknown): ApprovalGrantRung | null {
+  if (value === "exact_action" || value === "whole_tool") return value;
+  if (
+    !isRecord(value) ||
+    Object.keys(value).length !== 1 ||
+    !isRecord(value.command_prefix) ||
+    Object.keys(value.command_prefix).length !== 1
+  ) {
+    return null;
+  }
+  const tokens = value.command_prefix.tokens;
+  return typeof tokens === "number" &&
+    Number.isInteger(tokens) &&
+    tokens > 0
+    ? { command_prefix: { tokens } }
+    : null;
 }
 
 /**

--- a/crates/openwave-desktop/ui/src/generated/fixtures.ts
+++ b/crates/openwave-desktop/ui/src/generated/fixtures.ts
@@ -15,8 +15,14 @@ export const PENDING_APPROVAL = {
   "can_approve": true,
   "can_remember": true,
   "class": "sensitive",
-  "prefix_rungs": [
-    1
+  "grant_rungs": [
+    "exact_action",
+    {
+      "command_prefix": {
+        "tokens": 1
+      }
+    },
+    "whole_tool"
   ],
   "preview": {
     "args": [
@@ -36,7 +42,7 @@ export const PENDING_APPROVAL_WITHOUT_PREVIEW = {
   "can_approve": false,
   "can_remember": false,
   "class": "read_only",
-  "prefix_rungs": [],
+  "grant_rungs": [],
   "turn_id": "00000000-0000-0000-0000-000000000002"
 } as const;
 

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -125,6 +125,15 @@ export type AgentRunTier = "foreground" | "background";
 export type ApprovalClass = "read_only" | "workspace" | "sensitive";
 
 /**
+ * How wide a standing grant the human chose, narrowest first.
+ *
+ * The renderer names a rung; the server builds the concrete grant from the
+ * arguments the call is parked on. A grant can therefore only ever describe
+ * the action that was actually under review.
+ */
+export type ApprovalGrantRung = "exact_action" | { "command_prefix": { tokens: number, } } | "whole_tool";
+
+/**
  * Opaque renderer identity for one assistant-message citation.
  */
 export type AssistantCitationId = string;
@@ -747,15 +756,13 @@ export type PendingApprovalSnapshot = { call_id: CallId, turn_id: TurnId, action
  */
 preview?: ToolActionPreview, can_approve: boolean, can_remember: boolean, 
 /**
- * Token counts of the command-prefix rungs this call may be granted at,
- * narrowest first.
+ * Complete standing-grant ladder for this exact call, narrowest first.
  *
- * Derived server-side, because whether a prefix rung exists at all is a
- * question only the analyzer can answer — a wrapper has none. The
- * renderer slices the action's own tokens to these lengths for the
- * labels rather than deciding for itself what to offer.
+ * Empty means only one-shot approval is available. The renderer receives
+ * the whole ladder because command policy may refuse exact and whole-tool
+ * grants as well as prefixes.
  */
-prefix_rungs: Array<number>, 
+grant_rungs: Array<ApprovalGrantRung>, 
 /**
  * Where the Auto-mode judge stands, when one was engaged. Absent means
  * no judge ever owned this card.
@@ -903,10 +910,10 @@ export type RendererAgentEvent = { "type": "turn_started", turn_id: TurnId, } | 
  */
 auto_judging: boolean, 
 /**
- * Token counts of the command-prefix rungs on offer, narrowest
- * first. Empty when the action has none.
+ * Complete standing-grant ladder for this exact call, narrowest first.
+ * Empty means only one-shot approval is available.
  */
-prefix_rungs: Array<number>, 
+grant_rungs: Array<ApprovalGrantRung>, 
 /**
  * The one deliberate opening in this boundary. A human cannot consent
  * to a command they are not shown, so a tool may project a closed,

--- a/crates/openwave-server/src/approvals.rs
+++ b/crates/openwave-server/src/approvals.rs
@@ -192,26 +192,26 @@ fn grant_scope(
 ) -> Option<GrantScope> {
     use crate::routes::ApprovalGrantRung;
     use openwave_core::ToolActionPreview;
-    if matches!(rung, ApprovalGrantRung::WholeTool) {
-        return Some(GrantScope::WholeTool);
-    }
     // A narrow rung names the action, and the preview it would be named from is
     // clamped for display. Naming one from a clamped preview would authorize
     // every other call that clamps to the same text, so an approximate
     // description is refused rather than turned into standing authority.
-    if !action_is_exact {
-        return None;
-    }
-    match (rung, action?) {
-        (ApprovalGrantRung::WholeTool, _) => Some(GrantScope::WholeTool),
-        (ApprovalGrantRung::ExactAction, action) => Some(GrantScope::ExactAction(action.clone())),
-        (ApprovalGrantRung::CommandPrefix { tokens }, action @ ToolActionPreview::Exec { .. }) => {
-            command_prefix_scope(action, tokens)
+    let candidate = match (rung, action) {
+        (ApprovalGrantRung::WholeTool, _) => GrantScope::WholeTool,
+        (ApprovalGrantRung::ExactAction, Some(action)) if action_is_exact => {
+            GrantScope::ExactAction(action.clone())
         }
-        // Only a command has a token run to name, so no other action can
-        // reach the rung between exact and whole-tool.
-        (ApprovalGrantRung::CommandPrefix { .. }, _) => None,
-    }
+        (
+            ApprovalGrantRung::CommandPrefix { tokens },
+            Some(action @ ToolActionPreview::Exec { .. }),
+        ) if action_is_exact => command_prefix_scope(action, tokens)?,
+        _ => return None,
+    };
+    let available = match action {
+        Some(action) => GrantScope::ladder_for_action(action),
+        None => vec![GrantScope::WholeTool],
+    };
+    available.contains(&candidate).then_some(candidate)
 }
 
 /// Rebuild a prefix rung from the parked call rather than from the request.
@@ -1244,6 +1244,57 @@ mod tests {
             request.kind,
             &json!({})
         ));
+    }
+
+    #[tokio::test]
+    async fn an_interpreter_call_cannot_resolve_with_a_grant_the_floor_refuses() {
+        let (store, request) = setup_with_arguments(
+            "exec",
+            json!({
+                "command": "python3",
+                "args": ["-c", "import pptx"],
+                "cwd": ".",
+            }),
+        )
+        .await;
+        let broker = ApprovalBroker::new(store.clone());
+        let _pending = broker.register(request.clone(), None).await;
+
+        for rung in [
+            crate::routes::ApprovalGrantRung::ExactAction,
+            crate::routes::ApprovalGrantRung::WholeTool,
+        ] {
+            assert_eq!(
+                broker
+                    .resolve_with_grant(
+                        request.chat_id,
+                        request.call_id,
+                        ApprovalDecision::Approve,
+                        Some(rung),
+                    )
+                    .await
+                    .unwrap(),
+                ResolveApprovalOutcome::GrantNotAvailable
+            );
+            assert_eq!(
+                store
+                    .get_tool_call_approval(request.call_id)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .status,
+                openwave_core::ToolApprovalStatus::Pending
+            );
+        }
+
+        // A human may still approve this exact invocation once.
+        assert_eq!(
+            broker
+                .resolve(request.chat_id, request.call_id, ApprovalDecision::Approve)
+                .await
+                .unwrap(),
+            ResolveApprovalOutcome::Resolved
+        );
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -121,10 +121,10 @@ pub(crate) enum RendererAgentEvent {
         /// automatically" hint.
         #[serde(default)]
         auto_judging: bool,
-        /// Token counts of the command-prefix rungs on offer, narrowest
-        /// first. Empty when the action has none.
+        /// Complete standing-grant ladder for this exact call, narrowest first.
+        /// Empty means only one-shot approval is available.
         #[serde(default)]
-        prefix_rungs: Vec<usize>,
+        grant_rungs: Vec<crate::routes::ApprovalGrantRung>,
         /// The one deliberate opening in this boundary. A human cannot consent
         /// to a command they are not shown, so a tool may project a closed,
         /// field-by-field view of the action under review. Tools without one
@@ -266,6 +266,7 @@ impl From<&SequencedEvent> for RendererSequencedEvent {
                 tool_name,
                 class,
                 kind,
+                grant_scopes,
                 preview,
                 ..
             } => RendererAgentEvent::ApprovalRequired {
@@ -274,10 +275,7 @@ impl From<&SequencedEvent> for RendererSequencedEvent {
                 approval: *kind,
                 class: *class,
                 auto_judging: *auto_judging,
-                prefix_rungs: preview
-                    .as_ref()
-                    .map(crate::routes::prefix_rung_lengths)
-                    .unwrap_or_default(),
+                grant_rungs: crate::routes::grant_rungs_from_scopes(grant_scopes, true),
                 preview: preview.clone(),
             },
             AgentEvent::ApprovalDecided { call_id, approved } => {
@@ -388,6 +386,7 @@ mod tests {
                 tool_name: "provider_tool_with_secret".into(),
                 class: ApprovalClass::Sensitive,
                 kind: ToolApprovalKind::Unsupported,
+                grant_scopes: Vec::new(),
                 preview: None,
                 summary: "upload /Users/private/document.txt".into(),
             },
@@ -536,6 +535,14 @@ mod tests {
                 tool_name: "exec".into(),
                 class: ApprovalClass::Sensitive,
                 kind: ToolApprovalKind::ExecMayRunNetworkedCommand,
+                grant_scopes: openwave_core::GrantScope::ladder_for(
+                    "exec",
+                    &serde_json::json!({
+                        "command": "cargo",
+                        "args": ["test", "--workspace"],
+                        "cwd": "checkout",
+                    }),
+                ),
                 preview: ToolActionPreview::build(
                     "exec",
                     &serde_json::json!({
@@ -555,6 +562,37 @@ mod tests {
         assert!(json.contains(r#""cwd":"checkout""#));
         // The preview replaces the model-authored summary; it does not join it.
         assert!(!json.contains("private model-authored summary"));
+    }
+
+    #[test]
+    fn interpreter_approval_projects_no_remembered_grant_choices() {
+        let projected = RendererSequencedEvent::from(&SequencedEvent {
+            seq: 11,
+            event: AgentEvent::ApprovalRequired {
+                auto_judging: false,
+                call_id: CallId::new(),
+                tool_name: "exec".into(),
+                class: ApprovalClass::Sensitive,
+                kind: ToolApprovalKind::ExecMayRunNetworkedCommand,
+                grant_scopes: Vec::new(),
+                preview: ToolActionPreview::build(
+                    "exec",
+                    &serde_json::json!({
+                        "command": "python3",
+                        "args": ["-c", "import pptx"],
+                        "cwd": ".",
+                    }),
+                ),
+                summary: "run an interpreter".into(),
+            },
+        });
+
+        let encoded = serde_json::to_value(projected).unwrap();
+        assert_eq!(
+            encoded["event"]["grant_rungs"],
+            serde_json::json!([]),
+            "only one-shot approval may be presented"
+        );
     }
 
     #[test]
@@ -674,6 +712,7 @@ mod tests {
                 tool_name: "write_file".into(),
                 class: ApprovalClass::Workspace,
                 kind: ToolApprovalKind::Unsupported,
+                grant_scopes: Vec::new(),
                 // A tool with no variant projects nothing, so the card has no
                 // action to show and the summary is all that crosses.
                 preview: ToolActionPreview::build(
@@ -702,6 +741,13 @@ mod tests {
                 tool_name: "web_search".into(),
                 class: ApprovalClass::Sensitive,
                 kind: ToolApprovalKind::WebSearchMayShareQuery,
+                grant_scopes: openwave_core::GrantScope::ladder_for(
+                    "web_search",
+                    &serde_json::json!({
+                        "query": "quarterly filings",
+                        "max_results": 5,
+                    }),
+                ),
                 preview: ToolActionPreview::build(
                     "web_search",
                     &serde_json::json!({ "query": "quarterly filings", "max_results": 5 }),
@@ -782,6 +828,7 @@ mod tests {
                 tool_name: "search".into(),
                 class: ApprovalClass::Sensitive,
                 kind: ToolApprovalKind::SearchMayShareQueryAndExcerpts,
+                grant_scopes: vec![openwave_core::GrantScope::WholeTool],
                 preview: None,
                 summary: "private query and document title".into(),
             },
@@ -802,6 +849,7 @@ mod tests {
                 tool_name: "web_search".into(),
                 class: ApprovalClass::Sensitive,
                 kind: ToolApprovalKind::WebSearchMayShareQuery,
+                grant_scopes: Vec::new(),
                 preview: None,
                 summary: "private query and domain filters".into(),
             },
@@ -823,6 +871,7 @@ mod tests {
                 tool_name: "mcp__private_server__private_tool".into(),
                 class: ApprovalClass::Sensitive,
                 kind: ToolApprovalKind::ExternalMcpMayCallServer,
+                grant_scopes: Vec::new(),
                 preview: None,
                 summary: "private model-authored arguments".into(),
             },

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -2555,7 +2555,7 @@ pub struct ApprovalBody {
 /// The renderer names a rung; the server builds the concrete grant from the
 /// arguments the call is parked on. A grant can therefore only ever describe
 /// the action that was actually under review.
-#[derive(Debug, Clone, Copy, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum ApprovalGrantRung {
     /// Exactly the action the card showed.
@@ -2607,14 +2607,12 @@ pub(crate) struct PendingApprovalSnapshot {
     pub preview: Option<openwave_core::ToolActionPreview>,
     pub can_approve: bool,
     pub can_remember: bool,
-    /// Token counts of the command-prefix rungs this call may be granted at,
-    /// narrowest first.
+    /// Complete standing-grant ladder for this exact call, narrowest first.
     ///
-    /// Derived server-side, because whether a prefix rung exists at all is a
-    /// question only the analyzer can answer — a wrapper has none. The
-    /// renderer slices the action's own tokens to these lengths for the
-    /// labels rather than deciding for itself what to offer.
-    pub prefix_rungs: Vec<usize>,
+    /// Empty means only one-shot approval is available. The renderer receives
+    /// the whole ladder because command policy may refuse exact and whole-tool
+    /// grants as well as prefixes.
+    pub grant_rungs: Vec<ApprovalGrantRung>,
     /// Where the Auto-mode judge stands, when one was engaged. Absent means
     /// no judge ever owned this card.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2625,35 +2623,61 @@ pub(crate) struct PendingApprovalSnapshot {
 impl PendingApprovalSnapshot {
     fn from_approval(approval: openwave_core::ToolApproval) -> Self {
         let kind = approval.kind;
+        let grant_rungs =
+            approval_grant_rungs(kind, approval.preview.as_ref(), approval.action_is_exact);
         Self {
             call_id: approval.call_id,
             turn_id: approval.turn_id,
             action: openwave_core::RendererToolName::from(approval.tool_name.as_str()),
             approval: kind,
             class: approval.class,
-            prefix_rungs: approval
-                .preview
-                .as_ref()
-                .map(prefix_rung_lengths)
-                .unwrap_or_default(),
             preview: approval.preview,
             can_approve: kind.is_approvable(),
-            can_remember: kind.is_standing_grantable(),
+            can_remember: !grant_rungs.is_empty(),
+            grant_rungs,
             auto_judge_status: approval.auto_judge_status,
         }
     }
 }
 
-/// The command-prefix rungs on offer for an action, as token counts.
-///
-/// Empty for anything that is not a command, and for a command the analyzer
-/// would not auto-run under a prefix rule however it were granted.
-pub(crate) fn prefix_rung_lengths(action: &openwave_core::ToolActionPreview) -> Vec<usize> {
-    openwave_core::GrantScope::ladder_for_action(action)
-        .into_iter()
+/// Renderer names for the complete standing-grant ladder of one approval.
+pub(crate) fn approval_grant_rungs(
+    kind: openwave_core::ToolApprovalKind,
+    action: Option<&openwave_core::ToolActionPreview>,
+    action_is_exact: bool,
+) -> Vec<ApprovalGrantRung> {
+    if !kind.is_standing_grantable() {
+        return Vec::new();
+    }
+    let scopes = match action {
+        Some(action) => openwave_core::GrantScope::ladder_for_action(action),
+        None => vec![openwave_core::GrantScope::WholeTool],
+    };
+    grant_rungs_from_scopes(&scopes, action_is_exact)
+}
+
+pub(crate) fn grant_rungs_from_scopes(
+    scopes: &[openwave_core::GrantScope],
+    action_is_exact: bool,
+) -> Vec<ApprovalGrantRung> {
+    scopes
+        .iter()
         .filter_map(|scope| match scope {
-            openwave_core::GrantScope::CommandPrefix { tokens } => Some(tokens.len()),
-            _ => None,
+            openwave_core::GrantScope::ExactAction(_) if action_is_exact => {
+                Some(ApprovalGrantRung::ExactAction)
+            }
+            openwave_core::GrantScope::ExactAction(_) => None,
+            openwave_core::GrantScope::CommandPrefix { tokens } => {
+                Some(ApprovalGrantRung::CommandPrefix {
+                    tokens: tokens.len(),
+                })
+            }
+            openwave_core::GrantScope::WholeTool => Some(ApprovalGrantRung::WholeTool),
+            // Retained for old durable grants; the current ladder names the
+            // same authority as a one-token command prefix.
+            openwave_core::GrantScope::AnyArgsFor { .. } => {
+                Some(ApprovalGrantRung::CommandPrefix { tokens: 1 })
+            }
         })
         .collect()
 }

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -555,7 +555,11 @@ mod tests {
             }),
             can_approve: true,
             can_remember: true,
-            prefix_rungs: vec![1],
+            grant_rungs: vec![
+                crate::routes::ApprovalGrantRung::ExactAction,
+                crate::routes::ApprovalGrantRung::CommandPrefix { tokens: 1 },
+                crate::routes::ApprovalGrantRung::WholeTool,
+            ],
         };
         // The same shape with the omittable field absent, because "the key is
         // missing" is a distinct case the validator has to survive and the one
@@ -570,7 +574,7 @@ mod tests {
             preview: None,
             can_approve: false,
             can_remember: false,
-            prefix_rungs: Vec::new(),
+            grant_rungs: Vec::new(),
         };
 
         let folder_access = crate::routes::client_execution::PendingFolderAccessRequest {


### PR DESCRIPTION
## Summary

- carry the complete server-authoritative standing-grant ladder through live and recovered approval projections
- validate a requested remembered grant against the same ladder before consuming the pending approval
- place a hydrated approval card at its replayed event position so earlier thought and tool activity stays above it

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p openwave-server the_generated_bindings_are_current --locked`
- `cargo test -p openwave-server the_validator_fixtures_are_current --locked`
- `cargo test -p openwave-server interpreter_approval --locked`
- `cargo test -p openwave-server an_interpreter_call --locked`
- `pnpm test` (651 tests)
- `pnpm exec vite build`

## Baseline note

`pnpm build` still reports the existing missing `citations` field in `ChatTranscriptPresentation.test.ts`; the same TypeScript error is present in the successful `main` CI log because the parallel shell command currently masks the build exit status.