### PR TITLE
fix(protocol): deflake superseded-peer ack cursor test

### DIFF
--- a/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
@@ -621,11 +621,31 @@ mod tests {
             attach(first_host, &secret, EventCursor::START).await;
 
         // The host reconnects; the second connection becomes the live one while
-        // the first is still readable.
+        // the first is still readable. `attach` returning proves only that the
+        // handshake completed on the test side, so before touching the first
+        // connection, a ping-pong on the second proves its serve loop — which
+        // runs only after the connection is installed as live — is up.
         let (second_host, second_sandbox) = tokio::io::duplex(4096);
         tokio::spawn(super::serve_connection(second_sandbox, run.clone()));
-        let (_second_reader, _second_writer) =
+        let (mut second_reader, mut second_writer) =
             attach(second_host, &secret, EventCursor::START).await;
+        write_frame(
+            &mut second_writer,
+            &WireFrame::Control(ControlFrame::Ping { nonce: 0 }),
+        )
+        .await
+        .expect("send ping on the live connection");
+        let pong = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            read_frame(&mut second_reader),
+        )
+        .await
+        .expect("the live connection is served")
+        .expect("pong");
+        assert!(matches!(
+            pong,
+            WireFrame::Control(ControlFrame::Pong { nonce: 0 })
+        ));
 
         // The stale peer acknowledges. A ping behind it, answered on the same
         // connection, proves the ack was processed before we assert.


### PR DESCRIPTION
## Summary

`wire::sandbox::tests::a_superseded_peer_cannot_advance_the_acknowledged_cursor` raced under CI load: it inferred the second connection was live from `attach` returning, but that only proves the handshake completed on the test side. The spawned `serve_connection` task installs the connection as live on its own schedule, so the stale first connection's ack could be processed while the first connection was still live — legitimately moving the acked cursor to 5 and failing the assertion.

The fix is the ordering signal the issue suggests: ping-pong on the **second** connection before sending the stale ack on the first. The serve loop that answers the ping runs only after the connection is installed as the run's live connection, so the pong is a positive signal that the first connection is already superseded. The existing ping-behind-the-ack on the first connection is kept — it still proves the ack was processed before the assertion.

No production behavior changes.

## Verification

- `cargo test -p openwave-sandbox-protocol a_superseded_peer_cannot_advance_the_acknowledged_cursor --locked` — 6/6 runs pass (initial build + 5 repeats)
- `cargo test -p openwave-sandbox-protocol --locked` — all 66 tests pass
- `cargo check -p openwave-sandbox-protocol --locked` — clean
- `cargo fmt --all -- --check` — clean

Closes #1216