### PR TITLE
fix(server): back off worker lane retries when the store is unavailable

### DIFF
--- a/crates/openwave-server/src/blob_retirement_worker.rs
+++ b/crates/openwave-server/src/blob_retirement_worker.rs
@@ -9,7 +9,7 @@ use openwave_core::{AgentError, BlobRetirement, BlobRetirementStatus, BlobStore,
 use tokio::sync::Notify;
 use uuid::Uuid;
 
-use crate::retry::{RetryAttempt, RetrySchedule};
+use crate::retry::{LaneBackoff, RetryAttempt, RetrySchedule};
 use crate::state::BlobWriteGuard;
 
 #[derive(Debug, Clone, Copy)]
@@ -20,6 +20,9 @@ pub(crate) struct BlobRetirementWorkerConfig {
     idle_min: Duration,
     idle_cap: Duration,
     failure_delay: Duration,
+    /// Ceiling on the lane's own backoff after consecutive iteration errors,
+    /// so a store outage is not polled at a fixed rate forever.
+    failure_delay_cap: Duration,
 }
 
 impl Default for BlobRetirementWorkerConfig {
@@ -42,6 +45,7 @@ impl Default for BlobRetirementWorkerConfig {
             idle_min: Duration::from_millis(250),
             idle_cap: Duration::from_secs(5),
             failure_delay: Duration::from_secs(1),
+            failure_delay_cap: Duration::from_secs(30),
         }
     }
 }
@@ -91,20 +95,27 @@ impl BlobRetirementWorker {
 
     pub(crate) async fn run(self) {
         let mut idle_delay = self.config.idle_min;
+        let mut failure_backoff =
+            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
         loop {
             match self.run_once().await {
                 Ok(BlobRetirementWorkerOutcome::Idle) => {
+                    failure_backoff.reset();
                     tokio::select! {
                         _ = tokio::time::sleep(idle_delay) => {}
                         _ = self.wake.notified() => {}
                     }
                     idle_delay = idle_delay.saturating_mul(2).min(self.config.idle_cap);
                 }
-                Ok(_) => idle_delay = self.config.idle_min,
+                Ok(_) => {
+                    failure_backoff.reset();
+                    idle_delay = self.config.idle_min;
+                }
                 Err(error) => {
                     eprintln!("openwave: blob retirement worker iteration failed: {error}");
+                    let delay = failure_backoff.next_delay();
                     tokio::select! {
-                        _ = tokio::time::sleep(self.config.failure_delay) => {}
+                        _ = tokio::time::sleep(delay) => {}
                         _ = self.wake.notified() => {}
                     }
                 }
@@ -344,6 +355,7 @@ mod tests {
             idle_min: Duration::from_millis(1),
             idle_cap: Duration::from_millis(5),
             failure_delay: Duration::from_millis(1),
+            failure_delay_cap: Duration::from_millis(5),
         }
     }
 

--- a/crates/openwave-server/src/retry.rs
+++ b/crates/openwave-server/src/retry.rs
@@ -112,11 +112,68 @@ impl RetrySchedule {
     /// Exponential wait for the attempt that just failed, capped at
     /// `max_delay`. Attempt one waits `initial`.
     fn backoff(self, attempt_count: i32) -> Duration {
-        let doublings = u32::try_from(attempt_count.saturating_sub(1)).unwrap_or(0);
-        self.initial
-            .checked_mul(1_u32.checked_shl(doublings.min(31)).unwrap_or(u32::MAX))
-            .unwrap_or(self.max_delay)
-            .min(self.max_delay)
+        backoff(
+            self.initial,
+            self.max_delay,
+            u32::try_from(attempt_count.max(1)).unwrap_or(1),
+        )
+    }
+}
+
+/// Exponential wait capped at `max_delay`; the first failure waits `initial`.
+fn backoff(initial: Duration, max_delay: Duration, consecutive_failures: u32) -> Duration {
+    let doublings = consecutive_failures.saturating_sub(1).min(31);
+    initial
+        .checked_mul(1_u32 << doublings)
+        .unwrap_or(max_delay)
+        .min(max_delay)
+}
+
+/// Consecutive-failure backoff for a worker lane's own iteration errors.
+///
+/// A lane error — the store refusing a claim or a scan, for instance — has no
+/// work item behind it: no row id to seed jitter from and no attempt budget,
+/// because the lane loop is infinite by design. All it needs is to stop
+/// polling a struggling store at a fixed rate forever. The failure count
+/// therefore lives in the lane loop rather than the database: each failure
+/// doubles the wait up to a ceiling, one successful iteration resets it, and
+/// the jitter seed is drawn once per lane so lanes that failed together do
+/// not recover in lockstep.
+#[derive(Debug, Clone)]
+pub(crate) struct LaneBackoff {
+    seed: uuid::Uuid,
+    consecutive_failures: u32,
+    initial: Duration,
+    max_delay: Duration,
+}
+
+impl LaneBackoff {
+    pub(crate) fn new(initial: Duration, max_delay: Duration) -> Self {
+        assert!(!initial.is_zero());
+        assert!(initial <= max_delay);
+        Self {
+            seed: uuid::Uuid::new_v4(),
+            consecutive_failures: 0,
+            initial,
+            max_delay,
+        }
+    }
+
+    /// One successful iteration ends the failure episode.
+    pub(crate) fn reset(&mut self) {
+        self.consecutive_failures = 0;
+    }
+
+    /// The wait before the lane iterates again after another failure:
+    /// `initial` doubled per consecutive failure, capped at `max_delay`, and
+    /// jittered into the top half.
+    pub(crate) fn next_delay(&mut self) -> Duration {
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        jitter(
+            backoff(self.initial, self.max_delay, self.consecutive_failures),
+            self.seed,
+            i32::try_from(self.consecutive_failures).unwrap_or(i32::MAX),
+        )
     }
 }
 
@@ -200,5 +257,30 @@ mod tests {
         assert!(schedule
             .next_attempt_at(failed(4, start), None, start)
             .is_none());
+    }
+
+    /// A lane error has no row id and no attempt budget, so its backoff is
+    /// the loop-held counter: waits must still grow past the old flat delay,
+    /// never exceed the ceiling no matter how long the store stays down, and
+    /// one success must return the lane to its initial wait.
+    #[test]
+    fn lane_backoff_grows_caps_and_resets() {
+        let mut lane = LaneBackoff::new(Duration::from_millis(100), Duration::from_millis(800));
+
+        for base in [100, 200, 400, 800, 800, 800] {
+            let waited = lane.next_delay().as_millis();
+            assert!(
+                (base / 2..=base).contains(&waited),
+                "waited {waited}ms, expected {}..={base}ms",
+                base / 2
+            );
+        }
+
+        lane.reset();
+        let waited = lane.next_delay().as_millis();
+        assert!(
+            (50..=100).contains(&waited),
+            "after reset waited {waited}ms, expected 50..=100ms"
+        );
     }
 }

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -29,7 +29,7 @@ use tokio::sync::Notify;
 
 use crate::bus::EventBus;
 use crate::resolver::ProviderResolver;
-use crate::retry::{RetryAttempt, RetrySchedule};
+use crate::retry::{LaneBackoff, RetryAttempt, RetrySchedule};
 use crate::state::SandboxAttemptGuard;
 
 /// Fixed instruction set for the initial isolated executor.
@@ -48,6 +48,9 @@ pub(crate) struct SandboxAgentRunWorkerConfig {
     idle_min: Duration,
     idle_cap: Duration,
     failure_delay: Duration,
+    /// Ceiling on the lane's own backoff after consecutive iteration errors,
+    /// so a store outage is not polled at a fixed rate forever.
+    failure_delay_cap: Duration,
     retry: RetrySchedule,
     max_concurrency: usize,
     max_running_global: u32,
@@ -65,6 +68,7 @@ impl Default for SandboxAgentRunWorkerConfig {
             idle_min: Duration::from_millis(250),
             idle_cap: Duration::from_secs(5),
             failure_delay: Duration::from_secs(1),
+            failure_delay_cap: Duration::from_secs(30),
             // A parent turn may be waiting on this run, but nothing it retries
             // recovers in milliseconds: a sandbox that is still provisioning,
             // a provider that just refused, a delegated resource that has not
@@ -198,10 +202,12 @@ impl SandboxAgentRunWorker {
         for _ in 0..self.config.max_concurrency {
             lanes.spawn(self.clone().run_lane());
         }
+        let mut restart_backoff =
+            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
         while let Some(result) = lanes.join_next().await {
             if let Err(error) = result {
                 eprintln!("openwave: sandbox agent worker lane stopped: {error}");
-                tokio::time::sleep(self.config.failure_delay).await;
+                tokio::time::sleep(restart_backoff.next_delay()).await;
             }
             lanes.spawn(self.clone().run_lane());
         }
@@ -209,20 +215,27 @@ impl SandboxAgentRunWorker {
 
     async fn run_lane(self) {
         let mut idle_delay = self.config.idle_min;
+        let mut failure_backoff =
+            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
         loop {
             match self.run_once().await {
                 Ok(SandboxAgentRunWorkerOutcome::Idle) => {
+                    failure_backoff.reset();
                     tokio::select! {
                         _ = tokio::time::sleep(idle_delay) => {}
                         _ = self.wake.notified() => {}
                     }
                     idle_delay = idle_delay.saturating_mul(2).min(self.config.idle_cap);
                 }
-                Ok(_) => idle_delay = self.config.idle_min,
+                Ok(_) => {
+                    failure_backoff.reset();
+                    idle_delay = self.config.idle_min;
+                }
                 Err(error) => {
                     eprintln!("openwave: sandbox agent worker iteration failed: {error}");
+                    let delay = failure_backoff.next_delay();
                     tokio::select! {
-                        _ = tokio::time::sleep(self.config.failure_delay) => {}
+                        _ = tokio::time::sleep(delay) => {}
                         _ = self.wake.notified() => {}
                     }
                 }

--- a/crates/openwave-server/src/sandbox_web_search_worker.rs
+++ b/crates/openwave-server/src/sandbox_web_search_worker.rs
@@ -19,6 +19,7 @@ use openwave_web_search::{
 };
 use tokio::sync::Notify;
 
+use crate::retry::LaneBackoff;
 use crate::state::SandboxAttemptGuard;
 use crate::web_search;
 
@@ -66,6 +67,9 @@ pub(crate) struct SandboxWebSearchWorkerConfig {
     idle_min: Duration,
     idle_cap: Duration,
     failure_delay: Duration,
+    /// Ceiling on the lane's own backoff after consecutive iteration errors,
+    /// so a store outage is not polled at a fixed rate forever.
+    failure_delay_cap: Duration,
     max_concurrency: usize,
 }
 
@@ -79,6 +83,7 @@ impl Default for SandboxWebSearchWorkerConfig {
             idle_min: Duration::from_millis(250),
             idle_cap: Duration::from_secs(5),
             failure_delay: Duration::from_secs(1),
+            failure_delay_cap: Duration::from_secs(30),
             max_concurrency: 2,
         }
     }
@@ -156,10 +161,12 @@ impl SandboxWebSearchWorker {
         for _ in 0..self.config.max_concurrency {
             lanes.spawn(self.clone().run_lane());
         }
+        let mut restart_backoff =
+            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
         while let Some(result) = lanes.join_next().await {
             if let Err(error) = result {
                 eprintln!("openwave: sandbox web-search worker lane stopped: {error}");
-                tokio::time::sleep(self.config.failure_delay).await;
+                tokio::time::sleep(restart_backoff.next_delay()).await;
             }
             lanes.spawn(self.clone().run_lane());
         }
@@ -167,20 +174,27 @@ impl SandboxWebSearchWorker {
 
     async fn run_lane(self) {
         let mut idle_delay = self.config.idle_min;
+        let mut failure_backoff =
+            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
         loop {
             match self.run_once().await {
                 Ok(SandboxWebSearchWorkerOutcome::Idle) => {
+                    failure_backoff.reset();
                     tokio::select! {
                         _ = tokio::time::sleep(idle_delay) => {}
                         _ = self.wake.notified() => {}
                     }
                     idle_delay = idle_delay.saturating_mul(2).min(self.config.idle_cap);
                 }
-                Ok(_) => idle_delay = self.config.idle_min,
+                Ok(_) => {
+                    failure_backoff.reset();
+                    idle_delay = self.config.idle_min;
+                }
                 Err(error) => {
                     eprintln!("openwave: sandbox web-search worker iteration failed: {error}");
+                    let delay = failure_backoff.next_delay();
                     tokio::select! {
-                        _ = tokio::time::sleep(self.config.failure_delay) => {}
+                        _ = tokio::time::sleep(delay) => {}
                         _ = self.wake.notified() => {}
                     }
                 }

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -847,6 +847,7 @@ async fn committed_steer_event_recovers_when_cancellation_wins_ambiguous_respons
             idle_min: Duration::from_millis(5),
             idle_cap: Duration::from_millis(20),
             failure_delay: Duration::from_millis(5),
+            failure_delay_cap: Duration::from_millis(20),
             retry: fast_retry_schedule(),
             max_concurrency: 1,
             sandbox_spawn_execution_location: openwave_core::AgentRunExecutionLocation::InProcess,

--- a/crates/openwave-server/src/tests/workers.rs
+++ b/crates/openwave-server/src/tests/workers.rs
@@ -644,6 +644,7 @@ async fn worker_recovers_ambiguous_claim_and_completion_with_exact_receipts() {
             // lease even when a loaded test host delays the retry task.
             lease: Duration::from_secs(5 * 60),
             failure_delay: Duration::from_millis(10),
+            failure_delay_cap: Duration::from_millis(40),
             retry: fast_retry_schedule(),
             max_concurrency: 1,
             ..turn_worker::TurnWorkerConfig::default()
@@ -945,6 +946,7 @@ async fn worker_renews_a_near_expiry_ambiguous_claim_before_execution() {
             idle_min: Duration::from_millis(10),
             idle_cap: Duration::from_millis(20),
             failure_delay: Duration::from_millis(10),
+            failure_delay_cap: Duration::from_millis(40),
             retry: fast_retry_schedule(),
             max_concurrency: 1,
             sandbox_spawn_execution_location: openwave_core::AgentRunExecutionLocation::InProcess,
@@ -1039,6 +1041,7 @@ async fn worker_heartbeats_while_event_journaling_is_blocked() {
             idle_min: Duration::from_millis(10),
             idle_cap: Duration::from_millis(20),
             failure_delay: Duration::from_millis(10),
+            failure_delay_cap: Duration::from_millis(40),
             retry: fast_retry_schedule(),
             max_concurrency: 1,
             sandbox_spawn_execution_location: openwave_core::AgentRunExecutionLocation::InProcess,

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -30,7 +30,7 @@ use crate::bus::EventBus;
 use crate::chat_titling::ChatTitler;
 use crate::mcp_config::McpRuntime;
 use crate::resolver::ProviderResolver;
-use crate::retry::{RetryAttempt, RetrySchedule};
+use crate::retry::{LaneBackoff, RetryAttempt, RetrySchedule};
 use crate::state::TurnGuard;
 
 #[derive(Debug, Clone, Copy)]
@@ -41,6 +41,9 @@ pub(crate) struct TurnWorkerConfig {
     pub(crate) idle_min: Duration,
     pub(crate) idle_cap: Duration,
     pub(crate) failure_delay: Duration,
+    /// Ceiling on the lane's own backoff after consecutive iteration errors,
+    /// so a store outage is not polled at a fixed rate forever.
+    pub(crate) failure_delay_cap: Duration,
     pub(crate) retry: RetrySchedule,
     pub(crate) max_concurrency: usize,
     /// Startup-resolved location for every background child admitted by this
@@ -57,6 +60,7 @@ impl Default for TurnWorkerConfig {
             idle_min: Duration::from_millis(250),
             idle_cap: Duration::from_secs(5),
             failure_delay: Duration::from_secs(1),
+            failure_delay_cap: Duration::from_secs(30),
             // A user is watching this turn: start retrying in well under a
             // second, and give up after ten minutes rather than hold a chat
             // open longer than anyone waits.
@@ -378,6 +382,8 @@ impl TurnWorker {
     pub(crate) async fn run(self) {
         let mut turns = tokio::task::JoinSet::new();
         let mut idle_delay = self.config.idle_min;
+        let mut failure_backoff =
+            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
         let mut pending_claim_token = None;
         loop {
             let mut scan_failed = false;
@@ -415,8 +421,9 @@ impl TurnWorker {
             }
 
             let delay = if scan_failed {
-                self.config.failure_delay
+                failure_backoff.next_delay()
             } else {
+                failure_backoff.reset();
                 idle_delay
             };
             tokio::select! {


### PR DESCRIPTION
## Summary

All four durable worker lanes (turn, sandbox agent run, blob retirement, sandbox web search) slept a flat one second after an unexpected iteration error — a store failure rather than a work-item failure. An unavailable or overloaded database was therefore polled at 1 Hz by every lane, forever, with no backoff, jitter, or ceiling.

- Adds `LaneBackoff` to `crates/openwave-server/src/retry.rs`, reusing the existing capped-exponential + top-half jitter primitives from `RetrySchedule`. A lane error has no row id and no attempt budget, so the counter lives in the lane loop: each consecutive failure doubles the wait from the existing one-second `failure_delay` up to a new 30-second `failure_delay_cap`, one successful iteration resets it, and one jitter seed is drawn per lane so the four lanes do not recover in lockstep.
- Wires it into the iteration-error path of all four lanes, and into the lane-restart path of the two multi-lane workers (sandbox agent run, sandbox web search), where a repeatedly stopping lane had the same fixed-rate restart loop.
- Per-item exact-request retries (ambiguous-commit recovery in `retry_after` and the wait-set resume loop) are unchanged — those are item-scoped, not lane iteration errors.

## Verification

- `cargo test -p openwave-server retry --locked` — 5 passed, including the new `lane_backoff_grows_caps_and_resets` (waits grow past the old flat delay, hold at the ceiling, and reset after one success).
- `cargo test -p openwave-server worker --locked` — 81 passed.
- `cargo test -p openwave-server --locked -- blob_retirement sandbox_web_search` — 12 passed.
- `cargo clippy -p openwave-server --all-targets --locked -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `cargo check -p openwave-server --locked` — clean, no lockfile changes.

Closes #1226