### PR TITLE
test(desktop): pin the transcript image content-type contract

### DIFF
--- a/crates/openwave-desktop/ui/src/TranscriptImageAttachments.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/TranscriptImageAttachments.dom.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TranscriptImageAttachments } from "./TranscriptImageAttachments";
+
+// Registered before cleanup so the LIFO afterEach order unmounts (revoking
+// the stubbed object URL) before the URL global is restored.
+afterEach(() => vi.unstubAllGlobals());
+afterEach(cleanup);
+
+// The renderer pins a cross-boundary contract: it only draws the image when
+// the served Content-Type matches the media type in the transcript record.
+const image = {
+  attachmentId: "attachment-1",
+  mediaType: "image/png",
+  width: 320,
+  height: 240,
+};
+
+describe("TranscriptImageAttachments served content type", () => {
+  it("renders the image when the served blob type matches the transcript record", async () => {
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn(() => "blob:transcript-image"),
+      revokeObjectURL: vi.fn(),
+    });
+    const client = {
+      getChatImageAttachment: vi.fn(
+        async () => new Blob(["pixels"], { type: "image/png" }),
+      ),
+    };
+    render(
+      <TranscriptImageAttachments
+        client={client}
+        chatId="chat-1"
+        images={[image]}
+      />,
+    );
+
+    const rendered = await screen.findByRole("img", {
+      name: "Attached image 1: 320 by 240 pixels",
+    });
+    expect(rendered).toHaveAttribute("src", "blob:transcript-image");
+  });
+
+  it("shows the unavailable state when the served blob type disagrees with the transcript record", async () => {
+    const createObjectURL = vi.fn(() => "blob:transcript-image");
+    vi.stubGlobal("URL", { createObjectURL, revokeObjectURL: vi.fn() });
+    const client = {
+      getChatImageAttachment: vi.fn(
+        async () => new Blob(["pixels"], { type: "application/octet-stream" }),
+      ),
+    };
+    render(
+      <TranscriptImageAttachments
+        client={client}
+        chatId="chat-1"
+        images={[image]}
+      />,
+    );
+
+    expect(
+      await screen.findByText("Attached image unavailable"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(createObjectURL).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #1225

## What

Adds `TranscriptImageAttachments.dom.test.tsx`, a jsdom component test pinning the content-type contract in `ChatImage`:

- **Types agree** — the served blob's type matches the transcript record's `mediaType`, and the image renders from an object URL.
- **Types disagree** (e.g. a server change resolves the route to `application/octet-stream`) — the component shows the unavailable state and never creates an object URL.

## Why

`TranscriptImageAttachments.tsx` compares the served `Content-Type` against the transcript record and refuses to draw the image when they differ. Until now nothing on the TS side exercised that check (the existing `MessageList.dom.test.tsx` image test only covers the matching path through `MessageBubble`), so a server change that altered the served type would have blanked every transcript image with no failing test pointing at the cause. The served type itself is already pinned by the server's end-to-end coverage; this closes the renderer-side gap.

One harness detail: the file registers `vi.unstubAllGlobals` before `cleanup` so vitest's LIFO `afterEach` order unmounts the component — which revokes the stubbed object URL — before the `URL` global is restored.

Test-only change: one new file, no dependency or lockfile changes. Verified with the scoped vitest run, the full `pnpm test` (92 files / 653 tests), and `tsc --noEmit`.