### PR TITLE
fix(desktop): make ToolActivityGroup derivation total

### DIFF
--- a/crates/openwave-desktop/ui/src/ToolActivityGroup.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolActivityGroup.dom.test.tsx
@@ -1,12 +1,20 @@
 // @vitest-environment jsdom
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { ToolActivityGroup } from "./ToolActivityGroup";
+import { ToolActivityGroup, type ToolActivity } from "./ToolActivityGroup";
 
 afterEach(() => {
   cleanup();
   vi.useRealTimers();
+  vi.restoreAllMocks();
 });
 
 describe("ToolActivityGroup rail animation", () => {
@@ -54,5 +62,46 @@ describe("ToolActivityGroup rail animation", () => {
 
     // Row titles are plain text — present in full without advancing any timer.
     expect(screen.getByText("Reading a file")).toBeTruthy();
+  });
+});
+
+describe("an activity that cannot be read", () => {
+  it("costs its own row, not the phase's other row or its cards", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    // Reading this activity throws while the group derives its rows — in the
+    // group's own body, outside the rail's boundary, so it used to fall to
+    // the phase's backstop and take the phase's cards down with it.
+    const unreadable = {
+      id: "broken",
+      status: "completed",
+      get name(): never {
+        throw new Error("unreadable activity projection");
+      },
+    } as unknown as ToolActivity;
+
+    render(
+      <ToolActivityGroup
+        groupIndex={0}
+        activities={[
+          { id: "read", name: "read_file", status: "completed" },
+          unreadable,
+        ]}
+      >
+        <p>a card that must stay reachable</p>
+      </ToolActivityGroup>,
+    );
+
+    // The cards below the rail are the part a reader may have to act on.
+    expect(screen.getByText("a card that must stay reachable")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button"));
+    // The row beside the unreadable one renders; the unreadable one says so
+    // in place rather than vanishing or taking the rail down. (The phase line
+    // also reads "Read a file", so the row is found inside the rail itself.)
+    const rail = within(screen.getByRole("list"));
+    expect(rail.getByText("Read a file")).toBeTruthy();
+    expect(
+      rail.getAllByText("This step could not be displayed.").length,
+    ).toBe(1);
   });
 });

--- a/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
+++ b/crates/openwave-desktop/ui/src/ToolActivityGroup.tsx
@@ -55,6 +55,8 @@ export function ToolActivityGroup({
   groupIndex,
   children,
 }: ToolActivityGroupProps) {
+  // Total by construction: an activity that throws while being read costs its
+  // own row, leaving the rail and the cards below it standing.
   const safeActivities = normalizeActivities(activities);
 
   // The rail reads model-shaped data through several defensive parsers; the
@@ -107,12 +109,18 @@ function ToolActivityRail({
   activities: safeActivities,
   groupIndex,
 }: {
-  activities: ToolActivity[];
+  activities: (ToolActivity | null)[];
   groupIndex: number;
 }) {
   const [expanded, setExpanded] = useState(false);
   const contentId = `tool-activity-group-${groupIndex}`;
-  const summary = toolActivityGroupPresentation(safeActivities);
+  // The phase line speaks only for the rows that could be read; an unreadable
+  // one is a gap in the rail, not a claim about what the agent did.
+  const summary = toolActivityGroupPresentation(
+    safeActivities.filter(
+      (activity): activity is ToolActivity => activity !== null,
+    ),
+  );
   // The phase line types itself out once when the phase first goes live, then
   // updates instantly as calls settle and nudge the wording — re-typing on
   // every change reads as a stutter, and a settled phase should never animate.
@@ -156,15 +164,25 @@ function ToolActivityRail({
           {/* One boundary per row, not one per phase: a result this build
               cannot render should cost its own line and leave the rest of the
               rail — and the cards under it — standing. */}
-          {safeActivities.map((activity, index) => (
-            <ErrorBoundary
-              key={activity.id ?? `position:${index}`}
-              resetKey={rowSignature(activity)}
-              fallback={<ToolActivityUnavailable role="listitem" />}
-            >
-              <ToolActivityRow activity={activity} />
-            </ErrorBoundary>
-          ))}
+          {safeActivities.map((activity, index) =>
+            activity === null ? (
+              // An activity that could not even be read. It says so in place
+              // rather than leaving a gap, which would read as a step that
+              // never happened — a different and untrue claim.
+              <ToolActivityUnavailable
+                key={`position:${index}`}
+                role="listitem"
+              />
+            ) : (
+              <ErrorBoundary
+                key={activity.id ?? `position:${index}`}
+                resetKey={rowSignature(activity)}
+                fallback={<ToolActivityUnavailable role="listitem" />}
+              >
+                <ToolActivityRow activity={activity} />
+              </ErrorBoundary>
+            ),
+          )}
         </div>
       )}
     </>
@@ -194,19 +212,32 @@ export function ToolActivityUnavailable({
  *
  * A row that threw is retried when its call moves on or its result arrives,
  * and left alone while the transcript re-renders around it.
+ *
+ * Total: the rail's signature is computed in the group's own body, outside
+ * the rail's boundary, and the preview and result an activity carries are
+ * still the projection's own references — a read that throws there costs the
+ * row's place in the signature, not the phase.
  */
 function rowSignature(activity: ToolActivity): string {
-  return [
-    activity.name,
-    activity.status,
-    activity.resultUnreadable === true ? "unreadable" : "",
-    activity.preview?.tool ?? "",
-    activity.result?.tool ?? "",
-  ].join(" ");
+  try {
+    return [
+      activity.name,
+      activity.status,
+      activity.resultUnreadable === true ? "unreadable" : "",
+      activity.preview?.tool ?? "",
+      activity.result?.tool ?? "",
+    ].join(" ");
+  } catch {
+    return "unreadable";
+  }
 }
 
-function railSignature(activities: readonly ToolActivity[]): string {
-  return activities.map(rowSignature).join("|");
+function railSignature(activities: readonly (ToolActivity | null)[]): string {
+  return activities
+    .map((activity) =>
+      activity === null ? "unreadable" : rowSignature(activity),
+    )
+    .join("|");
 }
 
 function ToolActivityRow({ activity }: { activity: ToolActivity }) {
@@ -403,40 +434,60 @@ function joinWithOxford(lead: string, appendages: string[]): string {
   return `${lead}, ${head}, and ${appendages[appendages.length - 1]}`;
 }
 
-function normalizeActivities(activities: unknown): ToolActivity[] {
+/**
+ * The activities, reduced to plain data the rail can read without throwing.
+ *
+ * `null` marks one that threw while being read — retained projections can
+ * carry getters this build no longer agrees with. It stays in the list as a
+ * placeholder row rather than being dropped: a gap reads as a step that never
+ * happened, which is a different and untrue claim. Reading happens here, in
+ * the group's own body outside the rail's boundary, so a throw that escaped
+ * would fall to the phase's backstop and take the phase's cards down with it;
+ * per activity, the damage stops at the row.
+ */
+function normalizeActivities(activities: unknown): (ToolActivity | null)[] {
   if (!Array.isArray(activities)) return [];
   return activities.flatMap((activity) => {
-    const candidate = activity as Record<string, unknown> | null;
-    if (
-      candidate === null ||
-      typeof candidate !== "object" ||
-      typeof candidate.name !== "string" ||
-      typeof candidate.status !== "string"
-    ) {
-      return [];
+    try {
+      const normalized = normalizeActivity(activity);
+      return normalized === null ? [] : [normalized];
+    } catch (error) {
+      console.error("tool activity could not be read", error);
+      return [null];
     }
-    return [
-      {
-        // Carried through rather than dropped: it is what keys the row.
-        ...(typeof candidate.id === "string" && candidate.id.length > 0
-          ? { id: candidate.id }
-          : {}),
-        name: candidate.name,
-        status: candidate.status as ToolCallStatus,
-        // Already validated field by field at the API boundary; carried here
-        // so the expanded row can say what the call did and what it found.
-        ...(typeof candidate.preview === "object"
-          ? { preview: candidate.preview as ToolActionPreview | null }
-          : {}),
-        ...(typeof candidate.result === "object"
-          ? { result: candidate.result as ToolResultPreview | null }
-          : {}),
-        ...(typeof candidate.resultUnreadable === "boolean"
-          ? { resultUnreadable: candidate.resultUnreadable }
-          : {}),
-      },
-    ];
   });
+}
+
+/** One activity as plain data, or `null` when it is not shaped like one. */
+function normalizeActivity(activity: unknown): ToolActivity | null {
+  const candidate = activity as Record<string, unknown> | null;
+  if (
+    candidate === null ||
+    typeof candidate !== "object" ||
+    typeof candidate.name !== "string" ||
+    typeof candidate.status !== "string"
+  ) {
+    return null;
+  }
+  return {
+    // Carried through rather than dropped: it is what keys the row.
+    ...(typeof candidate.id === "string" && candidate.id.length > 0
+      ? { id: candidate.id }
+      : {}),
+    name: candidate.name,
+    status: candidate.status as ToolCallStatus,
+    // Already validated field by field at the API boundary; carried here
+    // so the expanded row can say what the call did and what it found.
+    ...(typeof candidate.preview === "object"
+      ? { preview: candidate.preview as ToolActionPreview | null }
+      : {}),
+    ...(typeof candidate.result === "object"
+      ? { result: candidate.result as ToolResultPreview | null }
+      : {}),
+    ...(typeof candidate.resultUnreadable === "boolean"
+      ? { resultUnreadable: candidate.resultUnreadable }
+      : {}),
+  };
 }
 
 function lowercaseFirst(value: string): string {


### PR DESCRIPTION
## What could throw

`ToolActivityGroup` called `normalizeActivities(activities)` and `railSignature(...)` in its own component body, *outside* the rail's inner error boundary. The activities arrive as transcript entries — retained projections that can carry getters this build no longer agrees with — so reading one there could throw.

## What it cost before

A throw in the group body is not caught by the rail's boundary (it never gets to render); it falls through to the phase's backstop boundary in `groupMessageItems`, taking the whole phase down — including the cards below the rail, one of which can be the pending decision the turn is waiting on.

## What it costs now

The derivation is total, mirroring the card-list construction fix in #1201:

- Each activity is read inside its own `try` in `normalizeActivities`. One that throws stays in the rail as a "This step could not be displayed." placeholder row rather than vanishing — a gap would read as a step that never happened, a different and untrue claim. One unreadable activity costs one row.
- `rowSignature` is total too: the `preview`/`result` an activity carries through normalization are still the projection's own references, and the rail's `resetKey` signature is computed in the group body.
- The phase line now speaks only for the rows that could be read; the cards below the rail render regardless.

## Looked at, left alone

The `parked` / `activities` / `spawns` derivations in `groupMessageItems` noted in the issue: plain field reads on entries the already-total `surfacedCards` walks first, a much lower risk profile, and hardening them is not the same cheap shape — out of scope here to keep the diff focused.

## Test

One DOM test drives an activity with a throwing `name` getter through `ToolActivityGroup` and asserts the phase's other row renders, the unreadable one says so in place, and the card below the rail survives.

Closes #1202