### PR TITLE
fix(sandbox-agent): rate-limit immediate retries in the accept loop

### DIFF
--- a/crates/openwave-sandbox-agent/src/supervisor.rs
+++ b/crates/openwave-sandbox-agent/src/supervisor.rs
@@ -34,6 +34,15 @@ const ACCEPT_BACKOFF_MIN: Duration = Duration::from_millis(5);
 /// reason that never clears retries at a steady, cheap rate instead of spinning.
 const ACCEPT_BACKOFF_MAX: Duration = Duration::from_secs(1);
 
+/// How many consecutive per-connection accept failures are retried immediately
+/// before they join the backoff. Immediate retry is the right call for the
+/// common case — a paused accept would let one aborted dial delay a real host's
+/// attach — but unbounded immediate retry lets a peer that aborts its dials in
+/// a tight loop keep the accept loop spinning. An ordinary reconnect aborts a
+/// dial or two at a time and never comes near this limit, so normal attaches
+/// stay immediate.
+const PER_CONNECTION_BURST_LIMIT: u32 = 100;
+
 /// The credential and egress boundary the supervisor owns — a documented stub.
 ///
 /// In the full design the agent addresses a connected service with an opaque
@@ -119,7 +128,10 @@ impl Supervisor {
 /// - A per-connection error (the peer went away between the SYN and the accept,
 ///   or the syscall was interrupted) says nothing about the listener. The failed
 ///   connection is dropped and the next one accepted immediately; pausing here
-///   would let one aborted dial delay a real host's attach.
+///   would let one aborted dial delay a real host's attach. Up to
+///   [`PER_CONNECTION_BURST_LIMIT`] of these in a row retry immediately; past
+///   the limit they are paced by the backoff below, so a peer aborting its
+///   dials in a tight loop cannot keep the loop spinning.
 /// - Anything else — descriptor exhaustion above all — is a condition of the
 ///   process or the host, not of one connection, and retrying it in a tight loop
 ///   would spin a core. Those back off exponentially to
@@ -129,17 +141,24 @@ where
     L: Accept,
 {
     let mut backoff = ACCEPT_BACKOFF_MIN;
+    let mut per_connection_errors = 0;
     loop {
         match listener.accept().await {
             Ok(stream) => {
                 backoff = ACCEPT_BACKOFF_MIN;
+                per_connection_errors = 0;
                 let run = run.clone();
                 tokio::spawn(async move {
                     let _ = serve_connection(stream, run).await;
                 });
             }
-            Err(error) if is_per_connection(&error) => {}
-            Err(_) => {
+            Err(error) => {
+                if is_per_connection(&error) {
+                    per_connection_errors += 1;
+                    if per_connection_errors <= PER_CONNECTION_BURST_LIMIT {
+                        continue;
+                    }
+                }
                 tokio::time::sleep(backoff).await;
                 backoff = (backoff * 2).min(ACCEPT_BACKOFF_MAX);
             }
@@ -181,7 +200,10 @@ impl Accept for TcpListener {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::VecDeque, sync::Mutex};
+    use std::{
+        collections::VecDeque,
+        sync::{Arc, Mutex},
+    };
 
     use openwave_sandbox_protocol::{
         protocol::{AttachRequest, HandshakeResponse, PROTOCOL_VERSION},
@@ -189,18 +211,24 @@ mod tests {
     };
     use tokio::io::{split, BufReader, DuplexStream};
 
-    use super::{io, serve_accepted, Accept, Duration, SandboxRun};
+    use super::{io, serve_accepted, Accept, Duration, SandboxRun, PER_CONNECTION_BURST_LIMIT};
 
     /// A listener that hands out a scripted sequence of accept outcomes and then
-    /// stops producing connections, as an idle listener does.
+    /// stops producing connections, as an idle listener does. Every `accept`
+    /// call's instant is recorded so a test can see how the calls were paced.
     struct ScriptedListener {
         steps: Mutex<VecDeque<io::Result<DuplexStream>>>,
+        accepted_at: Arc<Mutex<Vec<tokio::time::Instant>>>,
     }
 
     impl Accept for ScriptedListener {
         type Stream = DuplexStream;
 
         async fn accept(&self) -> io::Result<DuplexStream> {
+            self.accepted_at
+                .lock()
+                .expect("clock lock")
+                .push(tokio::time::Instant::now());
             let step = self.steps.lock().expect("script lock").pop_front();
             match step {
                 Some(step) => step,
@@ -225,6 +253,7 @@ mod tests {
                 Err(io::Error::other("too many open files")),
                 Ok(sandbox_side),
             ])),
+            accepted_at: Arc::new(Mutex::new(Vec::new())),
         };
         let secret = TransportSecret::new("accept-loop-test");
         let run = SandboxRun::new([], Some(secret.clone()));
@@ -252,6 +281,51 @@ mod tests {
                 WireFrame::Handshake(HandshakeResponse::Accepted(_))
             ),
             "expected the attach to be accepted, got {answered:?}"
+        );
+    }
+
+    /// A peer that aborts its dials in a tight loop must not keep the accept
+    /// loop spinning: the first [`PER_CONNECTION_BURST_LIMIT`] consecutive
+    /// per-connection failures still retry immediately — a normal reconnect
+    /// never comes near the limit — and the ones past it are paced by the
+    /// backoff. The paused clock shows both halves from the recorded accept
+    /// instants without costing wall time.
+    #[tokio::test(start_paused = true)]
+    async fn a_storm_of_aborted_dials_is_rate_limited() {
+        let burst = PER_CONNECTION_BURST_LIMIT as usize;
+        let aborts = burst + 3;
+        let listener = ScriptedListener {
+            steps: Mutex::new(VecDeque::from_iter(
+                (0..aborts).map(|_| Err(io::Error::from(io::ErrorKind::ConnectionAborted))),
+            )),
+            accepted_at: Arc::new(Mutex::new(Vec::new())),
+        };
+        let accepted_at = listener.accepted_at.clone();
+        let run = SandboxRun::new([], None);
+        tokio::spawn(serve_accepted(listener, run));
+
+        // Give the paused clock room to run well past the paced retries.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let stamps = accepted_at.lock().expect("clock lock");
+        // One stamp past the script is the accept that parks once it is spent;
+        // it lands only after the last paced retry's backoff has elapsed.
+        assert!(
+            stamps.len() > aborts,
+            "every scripted abort was accepted and dropped"
+        );
+        // Aborts within the burst limit cost no time at all.
+        assert_eq!(
+            stamps[burst - 1],
+            stamps[0],
+            "aborts up to the limit must retry immediately"
+        );
+        // Aborts past it are spaced by the growing backoff: the three paced
+        // retries wait 5ms, 10ms, and 20ms between them.
+        let storm_span = stamps[aborts] - stamps[0];
+        assert!(
+            storm_span >= Duration::from_millis(35),
+            "aborts past the limit must wait out the backoff, got {storm_span:?} across {aborts} aborts"
         );
     }
 }


### PR DESCRIPTION
The hardened accept loop from #1146 backs off exponentially (5ms to 1s) on ambiguous errors like descriptor exhaustion, but per-connection error classes (`ConnectionAborted`, `ConnectionReset`, `ConnectionRefused`, `Interrupted`) retry immediately by design — one aborted dial says nothing about the listener, and pausing would let it delay a real host's attach. Right for the common case, but a local peer that connects and aborts in a tight loop can keep the accept loop spinning.

**What changed:** the loop now counts consecutive per-connection errors. The first 100 in a row still retry immediately — an ordinary reconnect aborts a dial or two at a time and never comes near the limit — and past the limit the streak joins the same exponential backoff as listener-wide failures, so a storm of aborted dials paces itself instead of hot-spinning. The streak (and the backoff) resets on the first accepted connection, so normal attaches stay immediate. One counter, no new state machines.

**Threshold choice:** 100 is deliberately generous — far above anything a legitimate reconnect produces, low enough that a hostile peer is throttled within milliseconds of sustained abuse. At the 1s backoff ceiling a persistent storm costs one accept attempt per second.

**Test:** one behavior test, driven end to end on a paused clock: a scripted listener storms aborted dials at the accept loop, and the recorded accept instants show the in-limit retries costing no time and the ones past the limit spaced by the growing backoff. A regression here would fail in a way we'd act on.

Note: `cargo clippy -p openwave-sandbox-agent --all-targets --locked -- -D warnings` fails on `origin/main` itself (feature-gated dead code in `openwave-core` when built with `default-features = false`); the CI invocation `cargo clippy --workspace --all-targets --locked -- -D warnings` passes with this change.

Closes #1150