### PR TITLE
fix(core): refuse to complete an in-process turn on an empty response

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1585,11 +1585,22 @@ impl Agent {
                     self.append_assistant_exact_retry(&output, &candidate.citations)
                         .await?;
                 }
+                // The in-process driver mirrors the worker's emptiness
+                // detection (#1208): a final response with neither text nor a
+                // tool call is not an answer, and completing on it reports a
+                // successful turn that produced nothing. The disposition stays
+                // where the worker owns it — there is no attempt budget here,
+                // so instead of rescheduling the turn simply fails. Refusals
+                // are exempt for the same reason the worker gives: the refusal
+                // is the outcome and stays meaningful with no prose behind it.
+                let empty_final = publish_terminal && refusal.is_none() && text.trim().is_empty();
                 // Drain steers until the inbox is quiet, then complete. A steer
                 // that arrives as the stream finished must continue the turn
                 // rather than race a TurnCompleted. `try_complete` holds the
                 // queue lock across the empty-check and terminal emit so a
-                // concurrent push cannot 202 and then be orphaned.
+                // concurrent push cannot 202 and then be orphaned — the
+                // emptiness failure rides the same fence, so a steer that
+                // arrives before sealing still continues the turn.
                 loop {
                     if self.cancel.is_cancelled() {
                         return Ok(self.finish_cancelled(
@@ -1629,14 +1640,21 @@ impl Agent {
                                     usage: total_usage,
                                     refusal,
                                 });
-                            } else {
+                            } else if !empty_final {
                                 events.send(AgentEvent::TurnCompleted {
                                     usage: total_usage,
                                     stop_reason,
                                 });
                             }
+                            // An empty final response emits nothing here; the
+                            // error below surfaces as TurnFailed.
                         }
                     }) {
+                        if empty_final {
+                            return Err(AgentError::msg(
+                                "the model returned neither text nor a tool call",
+                            ));
+                        }
                         return Ok(AgentTurnOutcome::Completed {
                             output,
                             citations: candidate.citations.clone(),
@@ -7535,6 +7553,81 @@ mod tests {
         assert!(
             matches!((started, interrupted), (Some(a), Some(b)) if a < b),
             "the started call is marked discarded by the refusal"
+        );
+    }
+
+    /// The in-process driver must not report success for a turn whose final
+    /// model response has neither text nor a tool call: the caller gets a
+    /// blank turn with nothing to act on and no error to explain it. The
+    /// worker refuses the same response (its disposition is to retry while
+    /// budgets allow); the in-process driver has no attempt accounting, so
+    /// the turn fails instead of completing.
+    #[tokio::test]
+    async fn an_empty_model_response_does_not_complete_an_in_process_turn() {
+        struct EmptyProvider;
+
+        #[async_trait]
+        impl ModelProvider for EmptyProvider {
+            fn id(&self) -> ProviderId {
+                ProviderId::new("empty")
+            }
+
+            async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+                Ok(stream::iter(vec![ProviderEvent::Stop {
+                    reason: StopReason::EndTurn,
+                }])
+                .boxed())
+            }
+        }
+
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            reasoning_effort: None,
+            permission_mode: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let agent = Agent::new(
+            Arc::new(EmptyProvider),
+            Arc::new(ToolRegistry::new()),
+            store,
+            AgentConfig {
+                model: "fake".into(),
+                ..Default::default()
+            },
+        );
+
+        let (tx, rx) = unbounded();
+        let result = agent.run_turn(&chat, "say something", &tx).await;
+        drop(tx);
+        let events: Vec<AgentEvent> = rx.collect().await;
+
+        assert!(result.is_err());
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event, AgentEvent::TurnCompleted { .. })),
+            "an empty response must not complete the turn"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, AgentEvent::TurnFailed { .. })),
+            "the failure surfaces as TurnFailed"
         );
     }
 


### PR DESCRIPTION
## What changed

PR #1208 (issue #1100) made the worker refuse to complete a turn when the model's final response has neither text nor a tool call. That fix lives in `crates/openwave-server/src/turn_worker.rs` — the product path. The in-process path in `crates/openwave-core/src/agent.rs` (`publish_terminal`, used when the agent is driven directly, e.g. from the CLI) still emitted `TurnCompleted` for the same empty candidate, so a CLI run could report a successful turn that produced nothing — behaving differently from the worker for no principled reason.

The in-process completion point now mirrors the worker's **detection**: when the final candidate has no text and is not a refusal, the turn fails instead of completing — no `TurnCompleted` is emitted, and the error surfaces as `TurnFailed` through `run_turn_inner`'s existing error path.

## Placement decision

The issue asked whether the emptiness rule belongs in the agent loop so both drivers inherit it. I kept the **disposition** in the worker and shared only the **detection**, per the issue's own analysis: the worker's disposition (reschedule while step/attempt budgets remain, fail as `max_steps_exceeded` once spent) depends on accounting the worker owns, and the in-process driver has no budgets to consult — its only honest disposition is to fail the turn. Splitting "is this empty" into a shared helper would couple the two paths over a one-line predicate (`refusal.is_none() && text.trim().is_empty()`) while leaving both call sites doing entirely different things with the result, so the detection is simply mirrored with a comment linking them.

Two details worth noting:

- The check rides the steer queue's `try_complete` fence: a steer that arrives before sealing still continues the turn (the empty candidate is superseded); only a turn that genuinely ends on the empty response fails.
- Refusals stay exempt, matching the worker — the refusal is the outcome and remains meaningful with no prose behind it.

## Test

One behavior test, per the repo's test philosophy: an in-process turn driven end to end whose provider returns an empty final response must not complete as success — it asserts `run_turn` errors, no `TurnCompleted` is emitted, and the failure surfaces as `TurnFailed`. Verified to fail without the fix.

Closes #1210