### PR TITLE
docs: local apps design — sandboxed mini-apps over mounted MCP tools

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,9 @@ Project documentation, versioned alongside the code.
 - [Execution providers and sandbox-resident agent runs](sandbox-providers.md) —
   the run-tier/execution-provider split, reachability and credential
   invariants, and the phased route to detached background agent runs.
+- [Local apps](local-apps.md) — agent-generated mini-apps in the profile:
+  sandboxed frame rendering, manifest-pinned tool invocation with durable
+  consent, and the planned promotion path to gateway shared apps.
 - [The OpenWave ↔ model gateway boundary](gateway-boundary.md) — how a profile
   becomes gateway-managed (pairing, policy tiers, sessions) and what crosses
   the wire once it is.

--- a/docs/local-apps.md
+++ b/docs/local-apps.md
@@ -1,0 +1,207 @@
+# Local apps
+
+Agent-generated mini-apps that live in the profile: a bounded HTML document
+rendered in the sandboxed view-frame machinery, plus a manifest that pins the
+exact mounted MCP tools the app may call. The user asks for "a Sentry triage
+view" once; the result is a durable, revisable surface they can reopen from the
+sidebar instead of a conversation they re-run.
+
+This page is the design overview for the local-first slice. Sharing is
+deliberately out of scope: the eventual sharing plane is a model gateway
+("promotion", sketched at the end), not any peer-to-peer exchange.
+
+## Product flow
+
+1. In a conversation, the foreground agent calls `create_app` with a name, an
+   HTML bundle, and a manifest naming the tools the app uses. The transcript
+   shows an app card; revisions of the same app append, never overwrite.
+2. The user opens the app — from the card or from an **Apps** library on the
+   home sidebar. First open (and any open after the app's tool needs change)
+   presents a consent sheet listing exactly which servers and tools the app may
+   call. Consent is per-app, durable, and revocable from the library.
+3. The app renders in a sandboxed frame and drives its pinned tools through the
+   host. Results render however the app likes; the app never holds a
+   credential and has no network of its own.
+
+## Two parts, two trust levels
+
+An app revision is an untrusted **bundle** and a trusted **manifest**:
+
+- The bundle is model-authored HTML/JS/CSS, at most 1 MiB (the same bound as a
+  prefetched MCP view). It is assumed hostile: prompt injection anywhere in a
+  conversation can author it.
+- The manifest is small, structural JSON: a display name and
+  `bindings: [{ server, tools[] }]` naming mounted tool names under their
+  configured server namespaces. The manifest — not the bundle — is what the
+  user consents to and what the host enforces per call.
+
+The containment story is inherited from MCP App views and unchanged: the frame
+is served by the host with its own strict CSP (`default-src 'none'`,
+`connect-src 'none'`), sandboxed `allow-scripts` only, opaque origin. The
+bundle cannot fetch, cannot reach OpenWave's DOM, storage, bearer token, or
+IPC, and cannot talk to anything except its parent via `postMessage`. A
+malicious bundle can render lies; it cannot exfiltrate, and it cannot call
+anything the manifest did not pin and the user did not grant.
+
+Because the frame's CSP forbids all network, the app **never calls the host
+API directly**. Every tool call is a `postMessage` to the parent; the trusted
+renderer forwards it to the bearer-authenticated invoke route and posts the
+result back. The renderer treats both directions as opaque passthrough JSON —
+the same posture as the existing MCP App payload, and for the same reason:
+canonical tool arguments and results are model- and remote-authored content
+the renderer must never interpret.
+
+## The app record
+
+Apps follow the durable-output discipline but are **profile-scoped**: an app
+outlives the conversation that created it. Outputs cannot express this — their
+rows and bytes are keyed to a chat — so apps get their own record:
+
+- An `app` row: opaque id, display name, current revision, revision count,
+  soft-delete. No chat foreign key; the profile owns it.
+- Insert-only `app_revision` rows: opaque id, one-based ordinal, manifest
+  JSON (bounded), bundle byte length and SHA-256, and producer attribution
+  (the turn or run that authored it, plus the originating conversation as
+  provenance). Revisions are capped; reaching the cap refuses the write.
+- Bundle bytes at `apps/{app id}/{revision id}` under the profile data
+  directory — write-once, path derived only from durable identity, symlink-
+  refusing, never under any conversation's private scratch.
+
+`create_app` mints identity the way `create_deliverable` does: ids derived
+from the durable tool-call id, so an ambiguous store response retries into the
+same record instead of a duplicate. Authoring always happens inside a turn, so
+call identity exists; it is only *invocation* that happens outside one.
+
+## Invocation and consent
+
+Invocation is new host surface: the first tool execution outside a model turn.
+The route (`POST /apps/{id}/invoke`, renderer bearer) resolves the current
+tool registry snapshot and executes the named tool — mechanically the same
+dispatch a turn performs, minus the turn.
+
+What it deliberately does **not** reuse is the chat approval gate. That gate
+is enforced inside the foreground agent loop, scoped to a chat and its
+permission mode, and MCP calls are approvable per-call precisely because a
+Settings edit can swap the process behind a stable namespace — a name-based
+standing grant would silently widen. None of that maps onto a profile-scoped
+app driven by a human click. Local apps therefore get their own consent
+object, designed against the same threat:
+
+- An **app grant** records, per app: the granted `(server, tools[])` set and a
+  **fingerprint of each bound server's definition** (command, args, cwd,
+  selected env names, URL — whatever the transport carries).
+- The grant is created by explicit user consent on a sheet that lists every
+  binding. It is revocable from the Apps library.
+- Every invoke checks, live: the tool is in the current revision's manifest,
+  the manifest entry is covered by the grant, **and** the bound server's
+  current definition still matches the granted fingerprint. A reconfigured
+  server invalidates the grant and the next open re-prompts, so consent can
+  never outlive the thing it named — the exact property that makes per-call
+  approval mandatory in chats, preserved without per-call friction.
+- A revision that changes the manifest exceeds the grant by construction and
+  re-prompts.
+
+Chat permission modes and plan mode do not apply: there is no chat. The grant
+is the whole policy, and it fails closed — no grant, no call, and an
+ungranted or unpinned tool name is refused server-side regardless of what the
+renderer asked for.
+
+This does widen what the renderer bearer can do: today the renderer can only
+approve model-initiated calls; with apps it can initiate granted ones. The
+widening is bounded — the server enforces pin + grant + fingerprint, so a
+compromised renderer gains only the tool set some installed app pinned and
+the user granted — and the bearer already reaches settings, credentials, and
+policy surfaces, so this is not a new class of authority (see the
+authorization gate below).
+
+Results are clamped by the existing MCP result bounds before they cross to
+the renderer, and cross it as opaque passthrough.
+
+## Frame serving
+
+The view-frame machinery serves app revisions through the same mint/redeem
+shape: the renderer trades its bearer for a single-use, minute-lived frame
+token; the unauthenticated frame route redeems it once and serves the
+document with the strict CSP. Two changes from today's implementation:
+
+- The token payload grows a source: a prefetched MCP view addressed by
+  `(server, uri)`, or an app revision addressed by durable identity.
+- The token table moves off the MCP runtime into its own small type in app
+  state; the MCP runtime has no other reason to be involved in app frames.
+
+The frame's opaque origin means an app has no storage of its own. v1 apps are
+stateless: they refetch through their tools on open. A state primitive is a
+deliberate non-goal until something real needs it.
+
+## Acting on gateway-backed servers
+
+Bindings name mounted servers of any transport — local stdio, remote HTTP,
+or gateway endpoints — uniformly. When a binding resolves to a gateway
+endpoint, calls carry the user's per-endpoint `mcp:<slug>` bearer, so the
+gateway authenticates the person: its live entitlement checks apply, its
+audit and content-free usage ledgers attribute the call to that user, and the
+client name rides as `openwave`. Local apps are already governed and
+attributed for gateway-backed bindings with zero gateway-side work.
+
+One boundary follows from the gateway's design rather than ours:
+gateway-attested endpoints refuse session-token calls that lack a
+model-emitted observation, so local apps can act only on Direct endpoints
+today. Promotion (below) is what lifts that, because a promoted app's calls
+are brokered by the gateway itself.
+
+Local stdio and HTTP servers run under whatever authority the user configured
+them with. That is the existing local trust model, unchanged — an app adds no
+authority to a server the user already mounted.
+
+## The authorization gate
+
+The invoke route rides the per-launch loopback bearer, which is a capability
+check on the local process, not a principal (#853). That is the correct
+posture for the single-user desktop and the wrong one for anything shared.
+Local apps inherit it knowingly: nothing here adds per-user authorization,
+and #853 remains the recorded gate before any deployment that puts more than
+one person behind one server — apps included.
+
+## Promotion: planned for, not built
+
+A later step can promote a local app to a **shared app** on a model gateway,
+where a team-scoped copy is stored, served, and brokered by the gateway under
+each viewer's own entitlements. Three properties keep that door open without
+building anything now:
+
+- **The binding vocabulary maps.** A gateway-endpoint binding translates
+  mechanically to the gateway's manifest vocabulary (endpoint slug, proxied
+  operation set). Promotion walks the bindings and refuses with a precise
+  list when any binding is not gateway-resolvable — an app bound to a local
+  stdio server cannot promote, by construction.
+- **Revision identity carries.** Digests, ordinals, and producer provenance
+  become the published revision's provenance.
+- **Attestation flips from limitation to benefit.** Once the gateway brokers
+  the calls, attested apps become reachable — a concrete reason to promote
+  beyond sharing itself.
+
+Nothing in the local design depends on promotion shipping.
+
+## Non-goals
+
+- **No server component.** A local app is a client over governed tool calls;
+  anything that needs computation is the agent's job, in a conversation.
+- **No background execution.** An app runs while the user is looking at it.
+  Autonomous behavior has no viewer to attribute and is a gateway-side
+  service-principal question, deferred there too.
+- **No peer-to-peer sharing.** The gateway is the sharing plane.
+- **No app state primitive** until a real app needs one.
+
+## Slices
+
+1. App record: `app` + `app_revision` tables, store ops, write-once bundle
+   bytes under the profile `apps/` root.
+2. Frame serving for app revisions: token source enum, token table lifted off
+   the MCP runtime, same CSP and single-use contract.
+3. Invoke route: bearer-guarded, registry-snapshot dispatch, manifest pin
+   enforcement, clamped opaque results.
+4. App grants: the consent object, server-definition fingerprints, live
+   invalidation, consent sheet, revocation.
+5. `create_app` tool and transcript card.
+6. Apps library: home-sidebar entry, panel type, list/detail views, the open
+   flow wiring frame + bridge + invoke together.


### PR DESCRIPTION
Adds [docs/local-apps.md](docs/local-apps.md): the design for profile-scoped, agent-generated mini-apps rendered in the existing sandboxed view-frame machinery, calling mounted MCP tools through a new bearer-guarded invoke route gated by durable, fingerprint-pinned consent — plus the planned (unbuilt) promotion path to gateway shared apps.

Every seam claim was verified against current code before writing: frame CSP forbids direct fetch (all app I/O rides the postMessage bridge), the chat approval gate is in-loop and chat-scoped (hence the distinct app-grant consent object), and outputs are chat-keyed (hence the profile-scoped app record).

MVP slices tracked as #1254–#1259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)