### PR TITLE
feat(core): profile-scoped app record with insert-only revisions

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -1322,6 +1322,86 @@ pub mod output_revision {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod app {
+    use sea_orm::entity::prelude::*;
+
+    // The profile-scoped analog of `output`, with the one deliberate
+    // difference that there is no chat foreign key: the profile owns the app
+    // and it outlives every conversation that touched it. As with outputs,
+    // `current_revision_id` and `revision_count` are maintained in the same
+    // transaction that inserts a revision and are deliberately not a foreign
+    // key (the revision table already references `app`; closing the cycle
+    // would order the two inserts against each other for no added safety).
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "app")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub name: String,
+        pub current_revision_id: Uuid,
+        pub revision_count: i32,
+        pub created_at: DateTimeUtc,
+        pub updated_at: DateTimeUtc,
+        pub deleted_at: Option<DateTimeUtc>,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
+pub mod app_revision {
+    use sea_orm::entity::prelude::*;
+
+    // Rows are insert-only. The bundle bytes live under the profile data
+    // directory keyed by (app id, revision id), so a revision row and its
+    // content are both write-once and can never disagree. `chat_id` is
+    // provenance only — deliberately no foreign key, so the revision survives
+    // deletion of the conversation that authored it.
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "app_revision")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub app_id: Uuid,
+        pub ordinal: i32,
+        // Matches the migration's `.json_binary()` (JSONB on Postgres).
+        #[sea_orm(column_type = "JsonBinary")]
+        pub manifest_json: Json,
+        pub byte_len: i64,
+        pub sha256: Vec<u8>,
+        pub turn_id: Option<Uuid>,
+        pub producing_run_id: Option<Uuid>,
+        pub chat_id: Option<Uuid>,
+        pub created_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter)]
+    pub enum Relation {
+        App,
+    }
+
+    impl RelationTrait for Relation {
+        fn def(&self) -> RelationDef {
+            match self {
+                Self::App => Entity::belongs_to(super::app::Entity)
+                    .from(Column::AppId)
+                    .to(super::app::Column::Id)
+                    .into(),
+            }
+        }
+    }
+
+    impl Related<super::app::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::App.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod event {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -96,7 +96,152 @@ impl MigratorTrait for Migrator {
             Box::new(AddLateResultEvidence),
             Box::new(AddPlanRequests),
             Box::new(AddExecFileSnapshots),
+            Box::new(AddLocalApps),
         ]
+    }
+}
+
+/// Adds the profile-scoped local-app record: an `app` row per app plus
+/// insert-only `app_revision` rows pairing a bounded manifest with the length
+/// and digest of write-once bundle bytes.
+///
+/// Follows `output`/`output_revision` with one deliberate difference: there is
+/// no chat foreign key anywhere. The profile owns the app; `chat_id` on a
+/// revision is nullable provenance without a constraint, so an app and its
+/// history survive deletion of the conversation that authored them. Producer
+/// attribution reuses the outputs discipline — `turn_id` XOR
+/// `producing_run_id`, enforced by CHECK. Purely additive, symmetric `down`.
+struct AddLocalApps;
+
+impl MigrationName for AddLocalApps {
+    fn name(&self) -> &str {
+        "m20260730_000037_add_local_apps"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddLocalApps {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(App::Table)
+                    .col(ColumnDef::new(App::Id).uuid().not_null().primary_key())
+                    .col(ColumnDef::new(App::Name).text().not_null())
+                    .col(ColumnDef::new(App::CurrentRevisionId).uuid().not_null())
+                    .col(ColumnDef::new(App::RevisionCount).integer().not_null())
+                    .col(
+                        ColumnDef::new(App::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(App::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(App::DeletedAt).timestamp_with_time_zone())
+                    .check(
+                        Expr::col(App::RevisionCount)
+                            .between(1, crate::local_app::MAX_APP_REVISIONS as i32),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_app_updated")
+                    .table(App::Table)
+                    .col(App::UpdatedAt)
+                    .col(App::Id)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_table(
+                Table::create()
+                    .table(AppRevision::Table)
+                    .col(
+                        ColumnDef::new(AppRevision::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(AppRevision::AppId).uuid().not_null())
+                    .col(ColumnDef::new(AppRevision::Ordinal).integer().not_null())
+                    .col(
+                        ColumnDef::new(AppRevision::ManifestJson)
+                            .json_binary()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AppRevision::ByteLen)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AppRevision::Sha256)
+                            .binary_len(32)
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(AppRevision::TurnId).uuid())
+                    .col(ColumnDef::new(AppRevision::ProducingRunId).uuid())
+                    // Provenance only: no foreign key, so the revision outlives
+                    // the conversation that authored it.
+                    .col(ColumnDef::new(AppRevision::ChatId).uuid())
+                    .col(
+                        ColumnDef::new(AppRevision::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_app_revision_app")
+                            .from_tbl(AppRevision::Table)
+                            .from_col(AppRevision::AppId)
+                            .to_tbl(App::Table)
+                            .to_col(App::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .check(
+                        Expr::col(AppRevision::Ordinal)
+                            .between(1, crate::local_app::MAX_APP_REVISIONS as i32),
+                    )
+                    .check(
+                        Expr::col(AppRevision::ByteLen)
+                            .between(1, crate::local_app::MAX_APP_BUNDLE_BYTES as i64),
+                    )
+                    // A revision records the foreground turn or the background
+                    // run that produced it, never both.
+                    .check(
+                        Expr::col(AppRevision::TurnId)
+                            .is_null()
+                            .or(Expr::col(AppRevision::ProducingRunId).is_null()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_app_revision_ordinal")
+                    .table(AppRevision::Table)
+                    .col(AppRevision::AppId)
+                    .col(AppRevision::Ordinal)
+                    .unique()
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(AppRevision::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(App::Table).to_owned())
+            .await
     }
 }
 
@@ -9088,6 +9233,33 @@ enum OutputRevision {
     Sha256,
     TurnId,
     ProducingRunId,
+    CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum App {
+    Table,
+    Id,
+    Name,
+    CurrentRevisionId,
+    RevisionCount,
+    CreatedAt,
+    UpdatedAt,
+    DeletedAt,
+}
+
+#[derive(DeriveIden)]
+enum AppRevision {
+    Table,
+    Id,
+    AppId,
+    Ordinal,
+    ManifestJson,
+    ByteLen,
+    Sha256,
+    TurnId,
+    ProducingRunId,
+    ChatId,
     CreatedAt,
 }
 

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -23,10 +23,11 @@ use crate::event::{AgentEvent, SequencedEvent};
 #[cfg(test)]
 use crate::id::MessageId;
 use crate::id::{
-    AgentRunId, CallId, ChatId, DocumentId, HostRootId, OutputId, OutputRevisionId, ProjectId,
-    RootAttachmentChangeId, TurnId, TurnSteerId,
+    AgentRunId, AppId, AppRevisionId, CallId, ChatId, DocumentId, HostRootId, OutputId,
+    OutputRevisionId, ProjectId, RootAttachmentChangeId, TurnId, TurnSteerId,
 };
 use crate::image::ImageRef;
+use crate::local_app::{AppRecord, AppRevision, CreateApp, NewAppRevision};
 #[cfg(test)]
 use crate::model::Role;
 use crate::model::{
@@ -605,6 +606,42 @@ impl Store for DbStore {
         updated_at: chrono::DateTime<Utc>,
     ) -> Result<OutputRecord> {
         ops::output::set_current_output_revision(self, output_id, revision_id, updated_at).await
+    }
+
+    async fn create_app(&self, request: &CreateApp) -> Result<AppRecord> {
+        ops::app::create_app(self, request).await
+    }
+
+    async fn append_app_revision(
+        &self,
+        app_id: AppId,
+        revision: &NewAppRevision,
+    ) -> Result<AppRecord> {
+        ops::app::append_app_revision(self, app_id, revision).await
+    }
+
+    async fn get_app(&self, id: AppId) -> Result<Option<AppRecord>> {
+        ops::app::get_app(self, id).await
+    }
+
+    async fn list_apps(&self, limit: u64) -> Result<Vec<AppRecord>> {
+        ops::app::list_apps(self, limit).await
+    }
+
+    async fn list_app_revisions(&self, app_id: AppId) -> Result<Vec<AppRevision>> {
+        ops::app::list_app_revisions(self, app_id).await
+    }
+
+    async fn get_app_revision(&self, id: AppRevisionId) -> Result<Option<AppRevision>> {
+        ops::app::get_app_revision(self, id).await
+    }
+
+    async fn delete_app(&self, id: AppId, deleted_at: chrono::DateTime<Utc>) -> Result<bool> {
+        ops::app::delete_app(self, id, deleted_at).await
+    }
+
+    async fn restore_app(&self, id: AppId, restored_at: chrono::DateTime<Utc>) -> Result<bool> {
+        ops::app::restore_app(self, id, restored_at).await
     }
 
     async fn save_context_checkpoint(

--- a/crates/openwave-core/src/db/ops/app.rs
+++ b/crates/openwave-core/src/db/ops/app.rs
@@ -1,0 +1,423 @@
+//! Profile-scoped local apps and their append-only revision history.
+//!
+//! Mirrors the conversation-output ops with one deliberate difference: there
+//! is no chat anywhere in the record. Serialization of concurrent appends uses
+//! the app row itself as the write lock, and the conversation a revision came
+//! from is nullable provenance rather than ownership.
+//!
+//! Every mutation is keyed by a caller-minted identity so an ambiguous store
+//! response can be retried without creating a second app or a second revision.
+
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder,
+    QuerySelect, Set, TransactionTrait,
+};
+
+use crate::error::{AgentError, Result};
+use crate::id::{AppId, AppRevisionId};
+use crate::local_app::{
+    validate_app_manifest, AppManifest, AppRecord, AppRevision, CreateApp, NewAppRevision,
+    MAX_APP_BUNDLE_BYTES, MAX_APP_REVISIONS,
+};
+
+use super::super::{entities, store_err, DbStore};
+use super::turn::canonical_db_timestamp;
+
+pub(in crate::db) async fn create_app(store: &DbStore, request: &CreateApp) -> Result<AppRecord> {
+    let manifest_json = validate_revision(&request.revision)?;
+    let created_at = canonical_db_timestamp(request.revision.created_at)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    if let Some(existing) = find_app_on(&transaction, request.id).await? {
+        // An exact retry must return the original record rather than fail. A
+        // reused id that describes different content is a caller bug.
+        let exact = exact_app_on(&transaction, &existing, request, created_at).await?;
+        transaction.rollback().await.map_err(store_err)?;
+        return if exact {
+            Ok(existing)
+        } else {
+            Err(AgentError::Store(format!(
+                "app {} already exists with different content",
+                request.id
+            )))
+        };
+    }
+    entities::app::ActiveModel {
+        id: Set(request.id.0),
+        name: Set(request.revision.manifest.name.clone()),
+        current_revision_id: Set(request.revision.id.0),
+        revision_count: Set(1),
+        created_at: Set(created_at),
+        updated_at: Set(created_at),
+        deleted_at: Set(None),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    insert_revision_on(
+        &transaction,
+        request.id,
+        1,
+        &request.revision,
+        manifest_json,
+        created_at,
+    )
+    .await?;
+    let record = require_app_on(&transaction, request.id).await?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(record)
+}
+
+pub(in crate::db) async fn append_app_revision(
+    store: &DbStore,
+    app_id: AppId,
+    revision: &NewAppRevision,
+) -> Result<AppRecord> {
+    let manifest_json = validate_revision(revision)?;
+    let created_at = canonical_db_timestamp(revision.created_at)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    // Take the app row's write lock so two concurrent revisions cannot both
+    // read the same ordinal and race to publish a current revision. There is
+    // no owning chat to lock: the app row itself is the serialization point.
+    if !acquire_app_write_lock(&transaction, app_id).await? {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!("app {app_id} not found")));
+    }
+    let existing = require_app_on(&transaction, app_id).await?;
+    if existing.deleted_at.is_some() {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!("app {app_id} is deleted")));
+    }
+    if let Some(recorded) = find_revision_on(&transaction, revision.id).await? {
+        let exact = recorded.app_id == app_id && revision_matches(&recorded, revision, created_at);
+        transaction.rollback().await.map_err(store_err)?;
+        return if exact {
+            require_app_on(&store.conn, app_id).await
+        } else {
+            Err(AgentError::Store(format!(
+                "app revision {} already exists with different content",
+                revision.id
+            )))
+        };
+    }
+    let ordinal = existing.revision_count + 1;
+    if ordinal > MAX_APP_REVISIONS {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "app {app_id} has reached its {MAX_APP_REVISIONS}-revision limit"
+        )));
+    }
+    insert_revision_on(
+        &transaction,
+        app_id,
+        ordinal,
+        revision,
+        manifest_json,
+        created_at,
+    )
+    .await?;
+    entities::app::ActiveModel {
+        id: Set(app_id.0),
+        // The display name follows the current revision's manifest, so a
+        // revision that renames the app renames the record with it.
+        name: Set(revision.manifest.name.clone()),
+        current_revision_id: Set(revision.id.0),
+        revision_count: Set(i32::try_from(ordinal).map_err(|_| {
+            AgentError::Store("app revision count is outside the database range".into())
+        })?),
+        updated_at: Set(created_at),
+        ..Default::default()
+    }
+    .update(&transaction)
+    .await
+    .map_err(store_err)?;
+    let record = require_app_on(&transaction, app_id).await?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(record)
+}
+
+pub(in crate::db) async fn get_app(store: &DbStore, id: AppId) -> Result<Option<AppRecord>> {
+    find_app_on(&store.conn, id).await
+}
+
+pub(in crate::db) async fn list_apps(store: &DbStore, limit: u64) -> Result<Vec<AppRecord>> {
+    entities::app::Entity::find()
+        .filter(entities::app::Column::DeletedAt.is_null())
+        .order_by_desc(entities::app::Column::UpdatedAt)
+        .order_by_desc(entities::app::Column::Id)
+        .limit(limit)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(app_from_model)
+        .collect()
+}
+
+pub(in crate::db) async fn list_app_revisions(
+    store: &DbStore,
+    app_id: AppId,
+) -> Result<Vec<AppRevision>> {
+    entities::app_revision::Entity::find()
+        .filter(entities::app_revision::Column::AppId.eq(app_id.0))
+        .order_by_desc(entities::app_revision::Column::Ordinal)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(revision_from_model)
+        .collect()
+}
+
+pub(in crate::db) async fn get_app_revision(
+    store: &DbStore,
+    id: AppRevisionId,
+) -> Result<Option<AppRevision>> {
+    find_revision_on(&store.conn, id).await
+}
+
+pub(in crate::db) async fn delete_app(
+    store: &DbStore,
+    id: AppId,
+    deleted_at: chrono::DateTime<chrono::Utc>,
+) -> Result<bool> {
+    let deleted_at = canonical_db_timestamp(deleted_at)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    let Some(existing) = find_app_on(&transaction, id).await? else {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(false);
+    };
+    if existing.deleted_at.is_some() {
+        // Deleting twice is the same durable outcome, not a conflict.
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(true);
+    }
+    entities::app::ActiveModel {
+        id: Set(id.0),
+        deleted_at: Set(Some(deleted_at)),
+        ..Default::default()
+    }
+    .update(&transaction)
+    .await
+    .map_err(store_err)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(true)
+}
+
+pub(in crate::db) async fn restore_app(
+    store: &DbStore,
+    id: AppId,
+    restored_at: chrono::DateTime<chrono::Utc>,
+) -> Result<bool> {
+    let restored_at = canonical_db_timestamp(restored_at)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    let Some(existing) = find_app_on(&transaction, id).await? else {
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(false);
+    };
+    if existing.deleted_at.is_none() {
+        // Restoring a live app is the same durable outcome, not a conflict.
+        transaction.rollback().await.map_err(store_err)?;
+        return Ok(true);
+    }
+    // Clearing the soft-delete is the exact inverse of `delete_app`; the
+    // revision history is untouched. Surfacing the restored app as freshly
+    // updated keeps a reversed deletion visible at the top of the library.
+    entities::app::ActiveModel {
+        id: Set(id.0),
+        deleted_at: Set(None),
+        updated_at: Set(restored_at),
+        ..Default::default()
+    }
+    .update(&transaction)
+    .await
+    .map_err(store_err)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(true)
+}
+
+/// Acquire the shared cross-backend write lock for one app row.
+///
+/// Same shape as the chat/project locks: a self-assigning update serializes
+/// read-then-write decisions (ordinal allocation, current-revision publication)
+/// across server processes.
+async fn acquire_app_write_lock<C>(conn: &C, app_id: AppId) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    let locked = entities::app::Entity::update_many()
+        .col_expr(
+            entities::app::Column::Name,
+            sea_orm::sea_query::Expr::col(entities::app::Column::Name),
+        )
+        .filter(entities::app::Column::Id.eq(app_id.0))
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+    Ok(locked.rows_affected == 1)
+}
+
+/// Validate a revision's manifest and bounds, returning the manifest JSON to
+/// store.
+fn validate_revision(revision: &NewAppRevision) -> Result<serde_json::Value> {
+    let manifest_json = validate_app_manifest(&revision.manifest)
+        .map_err(|message| AgentError::Store(format!("invalid app manifest: {message}")))?;
+    if revision.byte_len == 0 {
+        return Err(AgentError::Store("app bundle is empty".into()));
+    }
+    if revision.byte_len > MAX_APP_BUNDLE_BYTES as u64 {
+        return Err(AgentError::Store(format!(
+            "app bundle is too large (maximum {MAX_APP_BUNDLE_BYTES} bytes)"
+        )));
+    }
+    // A revision records the foreground turn or the background run that
+    // produced it, never both.
+    if revision.turn_id.is_some() && revision.producing_run_id.is_some() {
+        return Err(AgentError::Store(
+            "app revision names both a producing turn and a producing run".into(),
+        ));
+    }
+    Ok(manifest_json)
+}
+
+async fn insert_revision_on<C>(
+    conn: &C,
+    app_id: AppId,
+    ordinal: u32,
+    revision: &NewAppRevision,
+    manifest_json: serde_json::Value,
+    created_at: chrono::DateTime<chrono::Utc>,
+) -> Result<()>
+where
+    C: ConnectionTrait,
+{
+    entities::app_revision::ActiveModel {
+        id: Set(revision.id.0),
+        app_id: Set(app_id.0),
+        ordinal: Set(i32::try_from(ordinal).map_err(|_| {
+            AgentError::Store("app revision ordinal is outside the database range".into())
+        })?),
+        manifest_json: Set(manifest_json),
+        byte_len: Set(i64::try_from(revision.byte_len).map_err(|_| {
+            AgentError::Store("app revision length is outside the database range".into())
+        })?),
+        sha256: Set(revision.sha256.to_vec()),
+        turn_id: Set(revision.turn_id.map(|turn_id| turn_id.0)),
+        producing_run_id: Set(revision.producing_run_id.map(|run_id| run_id.0)),
+        chat_id: Set(revision.chat_id.map(|chat_id| chat_id.0)),
+        created_at: Set(created_at),
+    }
+    .insert(conn)
+    .await
+    .map_err(store_err)?;
+    Ok(())
+}
+
+async fn exact_app_on<C>(
+    conn: &C,
+    stored: &AppRecord,
+    request: &CreateApp,
+    created_at: chrono::DateTime<chrono::Utc>,
+) -> Result<bool>
+where
+    C: ConnectionTrait,
+{
+    if stored.name != request.revision.manifest.name
+        || stored.current_revision != request.revision.id
+        || stored.revision_count != 1
+        || stored.created_at != created_at
+        || stored.updated_at != created_at
+        || stored.deleted_at.is_some()
+    {
+        return Ok(false);
+    }
+    let Some(revision) = find_revision_on(conn, request.revision.id).await? else {
+        return Err(AgentError::Store(
+            "app record has no current revision".into(),
+        ));
+    };
+    Ok(revision.app_id == request.id && revision_matches(&revision, &request.revision, created_at))
+}
+
+fn revision_matches(
+    stored: &AppRevision,
+    request: &NewAppRevision,
+    created_at: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    stored.id == request.id
+        && stored.manifest == request.manifest
+        && stored.byte_len == request.byte_len
+        && stored.sha256 == request.sha256
+        && stored.turn_id == request.turn_id
+        && stored.producing_run_id == request.producing_run_id
+        && stored.chat_id == request.chat_id
+        && stored.created_at == created_at
+}
+
+async fn find_app_on<C>(conn: &C, id: AppId) -> Result<Option<AppRecord>>
+where
+    C: ConnectionTrait,
+{
+    entities::app::Entity::find_by_id(id.0)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .map(app_from_model)
+        .transpose()
+}
+
+async fn require_app_on<C>(conn: &C, id: AppId) -> Result<AppRecord>
+where
+    C: ConnectionTrait,
+{
+    find_app_on(conn, id)
+        .await?
+        .ok_or_else(|| AgentError::Store(format!("app {id} not found")))
+}
+
+async fn find_revision_on<C>(conn: &C, id: AppRevisionId) -> Result<Option<AppRevision>>
+where
+    C: ConnectionTrait,
+{
+    entities::app_revision::Entity::find_by_id(id.0)
+        .one(conn)
+        .await
+        .map_err(store_err)?
+        .map(revision_from_model)
+        .transpose()
+}
+
+fn app_from_model(model: entities::app::Model) -> Result<AppRecord> {
+    Ok(AppRecord {
+        id: AppId(model.id),
+        name: model.name,
+        current_revision: AppRevisionId(model.current_revision_id),
+        revision_count: u32::try_from(model.revision_count)
+            .map_err(|_| AgentError::Store("stored app revision count is negative".into()))?,
+        created_at: model.created_at,
+        updated_at: model.updated_at,
+        deleted_at: model.deleted_at,
+    })
+}
+
+fn revision_from_model(model: entities::app_revision::Model) -> Result<AppRevision> {
+    let sha256: [u8; 32] = model
+        .sha256
+        .try_into()
+        .map_err(|_| AgentError::Store("stored app revision digest is malformed".into()))?;
+    let manifest: AppManifest = serde_json::from_value(model.manifest_json)
+        .map_err(|_| AgentError::Store("stored app manifest is malformed".into()))?;
+    Ok(AppRevision {
+        id: AppRevisionId(model.id),
+        app_id: AppId(model.app_id),
+        ordinal: u32::try_from(model.ordinal)
+            .map_err(|_| AgentError::Store("stored app revision ordinal is negative".into()))?,
+        manifest,
+        byte_len: u64::try_from(model.byte_len)
+            .map_err(|_| AgentError::Store("stored app revision length is negative".into()))?,
+        sha256,
+        turn_id: model.turn_id.map(crate::id::TurnId),
+        producing_run_id: model.producing_run_id.map(crate::id::AgentRunId),
+        chat_id: model.chat_id.map(crate::id::ChatId),
+        created_at: model.created_at,
+    })
+}

--- a/crates/openwave-core/src/db/ops/mod.rs
+++ b/crates/openwave-core/src/db/ops/mod.rs
@@ -6,6 +6,7 @@ use crate::id::{CallId, ChatId, ProjectId, TurnId};
 use super::{entities, store_err};
 
 pub(in crate::db) mod agent_run;
+pub(in crate::db) mod app;
 pub(in crate::db) mod approval;
 pub(in crate::db) mod blob;
 pub(in crate::db) mod chat_prompt;

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -11,6 +11,7 @@ use chrono::{DateTime, Utc};
 use sea_orm::{DatabaseBackend, Statement};
 
 mod agent_run;
+mod app;
 mod context_checkpoint;
 mod delegated_file_read;
 mod message_attachment;

--- a/crates/openwave-core/src/db/tests/app.rs
+++ b/crates/openwave-core/src/db/tests/app.rs
@@ -1,0 +1,244 @@
+use super::*;
+use crate::id::{AgentRunId, AppId, AppRevisionId};
+use crate::local_app::{
+    AppBinding, AppManifest, CreateApp, NewAppRevision, MAX_APP_BUNDLE_BYTES, MAX_APP_REVISIONS,
+};
+
+fn at(second: i64) -> DateTime<Utc> {
+    DateTime::<Utc>::from_timestamp(1_710_000_000 + second, 0).unwrap()
+}
+
+fn digest(seed: u8) -> [u8; 32] {
+    [seed; 32]
+}
+
+fn manifest(name: &str) -> AppManifest {
+    AppManifest {
+        name: name.to_owned(),
+        bindings: vec![AppBinding {
+            server: "sentry".into(),
+            tools: vec!["mcp__sentry__list_issues".into()],
+        }],
+    }
+}
+
+fn revision(seed: u8, second: i64) -> NewAppRevision {
+    NewAppRevision {
+        id: AppRevisionId::new(),
+        manifest: manifest("Sentry triage"),
+        byte_len: u64::from(seed) + 1,
+        sha256: digest(seed),
+        turn_id: None,
+        producing_run_id: None,
+        chat_id: None,
+        created_at: at(second),
+    }
+}
+
+fn create_request(seed: u8) -> CreateApp {
+    CreateApp {
+        id: AppId::new(),
+        revision: revision(seed, 0),
+    }
+}
+
+// Apps are profile-scoped: every test runs against a store with no chat at
+// all, which is itself part of the contract under test.
+
+#[tokio::test]
+async fn an_exact_retry_never_creates_a_second_app_or_revision() {
+    let (_dir, store) = temp_store().await;
+    let request = create_request(1);
+    let created = store.create_app(&request).await.unwrap();
+    assert_eq!(created.id, request.id);
+    assert_eq!(
+        created.name, "Sentry triage",
+        "name comes from the manifest"
+    );
+    assert_eq!(created.current_revision, request.revision.id);
+    assert_eq!(created.revision_count, 1);
+
+    let retried = store.create_app(&request).await.unwrap();
+    assert_eq!(retried, created);
+
+    let second = revision(2, 30);
+    let appended = store
+        .append_app_revision(created.id, &second)
+        .await
+        .unwrap();
+    let appended_again = store
+        .append_app_revision(created.id, &second)
+        .await
+        .unwrap();
+    assert_eq!(appended_again, appended);
+    assert_eq!(appended_again.revision_count, 2);
+    assert_eq!(store.list_apps(10).await.unwrap().len(), 1);
+
+    // The replaced revision stays addressable, and its stored manifest
+    // round-trips intact.
+    let replaced = store
+        .get_app_revision(created.current_revision)
+        .await
+        .unwrap()
+        .expect("the replaced revision is retained");
+    assert_eq!(replaced.ordinal, 1);
+    assert_eq!(replaced.manifest, request.revision.manifest);
+    let revisions = store.list_app_revisions(created.id).await.unwrap();
+    assert_eq!(
+        revisions
+            .iter()
+            .map(|entry| entry.ordinal)
+            .collect::<Vec<_>>(),
+        [2, 1],
+        "revisions list newest first"
+    );
+}
+
+#[tokio::test]
+async fn reusing_an_identity_for_different_content_is_rejected() {
+    let (_dir, store) = temp_store().await;
+    let request = create_request(1);
+    let created = store.create_app(&request).await.unwrap();
+
+    let mut conflicting = request.clone();
+    conflicting.revision.manifest.name = "Other app".into();
+    assert!(store.create_app(&conflicting).await.is_err());
+
+    let second = revision(2, 30);
+    store
+        .append_app_revision(created.id, &second)
+        .await
+        .unwrap();
+    let mut conflicting_revision = second.clone();
+    conflicting_revision.sha256 = digest(9);
+    assert!(store
+        .append_app_revision(created.id, &conflicting_revision)
+        .await
+        .is_err());
+
+    // The rejected retries left exactly the original history behind.
+    assert_eq!(store.list_app_revisions(created.id).await.unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn revision_history_is_bounded_without_losing_content() {
+    let (_dir, store) = temp_store().await;
+    let created = store.create_app(&create_request(1)).await.unwrap();
+    for ordinal in 2..=MAX_APP_REVISIONS {
+        store
+            .append_app_revision(created.id, &revision(2, i64::from(ordinal)))
+            .await
+            .unwrap();
+    }
+
+    // Refusing the write is deliberate: silently dropping the oldest revision
+    // would lose exactly the history this record exists to keep.
+    assert!(store
+        .append_app_revision(created.id, &revision(3, 1_000))
+        .await
+        .is_err());
+    assert_eq!(
+        store.list_app_revisions(created.id).await.unwrap().len() as u32,
+        MAX_APP_REVISIONS
+    );
+}
+
+#[tokio::test]
+async fn a_revision_records_one_producer_and_dangling_conversation_provenance() {
+    let (_dir, store) = temp_store().await;
+
+    // The originating conversation is provenance without a foreign key: this
+    // chat id references no chat row at all and the write still lands, which
+    // is exactly what keeps an app alive after its conversation is deleted.
+    let orphan_chat = ChatId::new();
+    let turn_id = TurnId::new();
+    let mut request = create_request(1);
+    request.revision.turn_id = Some(turn_id);
+    request.revision.chat_id = Some(orphan_chat);
+    let created = store.create_app(&request).await.unwrap();
+
+    let stored = store
+        .get_app_revision(created.current_revision)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.turn_id, Some(turn_id));
+    assert_eq!(stored.chat_id, Some(orphan_chat));
+    assert_eq!(stored.producing_run_id, None);
+
+    // A revision may not name both a producing turn and a producing run.
+    let mut both = revision(2, 30);
+    both.turn_id = Some(TurnId::new());
+    both.producing_run_id = Some(AgentRunId::new());
+    assert!(store.append_app_revision(created.id, &both).await.is_err());
+}
+
+#[tokio::test]
+async fn malformed_manifests_and_out_of_bounds_bundles_are_refused() {
+    let (_dir, store) = temp_store().await;
+
+    // A tool pinned outside its binding's server namespace can never match a
+    // mounted tool, so the store refuses it at the door.
+    let mut foreign_tool = create_request(1);
+    foreign_tool.revision.manifest.bindings[0].tools = vec!["mcp__github__list_issues".into()];
+    assert!(store.create_app(&foreign_tool).await.is_err());
+
+    let mut empty_bundle = create_request(1);
+    empty_bundle.revision.byte_len = 0;
+    assert!(store.create_app(&empty_bundle).await.is_err());
+
+    let mut oversized_bundle = create_request(1);
+    oversized_bundle.revision.byte_len = MAX_APP_BUNDLE_BYTES as u64 + 1;
+    assert!(store.create_app(&oversized_bundle).await.is_err());
+
+    // A manifest over the 64 KiB bound is refused however well-formed it is.
+    let mut oversized_manifest = create_request(1);
+    oversized_manifest.revision.manifest.bindings = (0..2_000)
+        .map(|index| AppBinding {
+            server: format!("server_{index:04}"),
+            tools: vec![format!("mcp__server_{index:04}__tool_padding_padding")],
+        })
+        .collect();
+    assert!(store.create_app(&oversized_manifest).await.is_err());
+
+    assert!(store.list_apps(10).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn deleting_an_app_hides_it_and_refuses_revisions_until_restored() {
+    let (_dir, store) = temp_store().await;
+    let created = store.create_app(&create_request(1)).await.unwrap();
+
+    assert!(store.delete_app(created.id, at(60)).await.unwrap());
+    assert!(
+        store.delete_app(created.id, at(90)).await.unwrap(),
+        "deleting twice is the same durable outcome"
+    );
+    assert!(store.list_apps(10).await.unwrap().is_empty());
+    let record = store.get_app(created.id).await.unwrap().unwrap();
+    assert_eq!(record.deleted_at, Some(at(60)), "the first deletion stands");
+    assert_eq!(
+        store.list_app_revisions(created.id).await.unwrap().len(),
+        1,
+        "revisions are retained through a deletion"
+    );
+    assert!(store
+        .append_app_revision(created.id, &revision(2, 120))
+        .await
+        .is_err());
+
+    assert!(store.restore_app(created.id, at(150)).await.unwrap());
+    assert_eq!(store.list_apps(10).await.unwrap().len(), 1);
+    assert!(store
+        .append_app_revision(created.id, &revision(2, 180))
+        .await
+        .is_ok());
+    assert!(
+        !store.delete_app(AppId::new(), at(60)).await.unwrap(),
+        "an unknown app reports no deletion"
+    );
+    assert!(
+        !store.restore_app(AppId::new(), at(60)).await.unwrap(),
+        "an unknown app reports no restore"
+    );
+}

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -470,6 +470,20 @@ impl OutputRevisionId {
     }
 }
 
+id_type!(
+    /// Identifies one profile-scoped local app across all of its revisions.
+    ///
+    /// Like [`OutputId`] this is a durable opaque handle: possession is not
+    /// authority, and it never encodes a name or a host path. Unlike an
+    /// output, an app has no owning conversation — the profile owns it.
+    AppId
+);
+
+id_type!(
+    /// Identifies one immutable revision of a local app.
+    AppRevisionId
+);
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -47,6 +47,7 @@ pub mod id;
 pub mod image;
 #[cfg(feature = "keychain")]
 pub mod keychain;
+pub mod local_app;
 pub mod model;
 #[cfg(feature = "tools")]
 pub mod output_scan;

--- a/crates/openwave-core/src/local_app.rs
+++ b/crates/openwave-core/src/local_app.rs
@@ -1,0 +1,366 @@
+//! Closed contract for profile-scoped local apps.
+//!
+//! A local app is a profile-owned record with an opaque [`AppId`] and an
+//! ordered history of immutable revisions, following the conversation-output
+//! discipline with one deliberate difference: an app has no owning chat. The
+//! conversation that authored a revision is nullable provenance on the
+//! revision row, so an app outlives every conversation that touched it.
+//!
+//! Each revision pairs an untrusted HTML bundle (bytes on disk, recorded here
+//! as length + digest) with a trusted, structurally validated manifest naming
+//! the mounted MCP tools the app may call.
+
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::deliverable::RevisionProducer;
+use crate::id::{AgentRunId, AppId, AppRevisionId, ChatId, TurnId};
+
+/// Profile-data directory holding immutable app bundle bytes.
+///
+/// Deliberately a profile-level root rather than any conversation's private
+/// scratch: the app record is profile-scoped and its bytes must survive the
+/// originating conversation.
+pub const APPS_DIRECTORY: &str = "apps";
+/// Largest app bundle one revision may record — the same bound as a prefetched
+/// MCP view document.
+pub const MAX_APP_BUNDLE_BYTES: usize = 1024 * 1024;
+/// Largest serialized manifest one revision may record.
+pub const MAX_APP_MANIFEST_BYTES: usize = 64 * 1024;
+/// Largest number of revisions one app retains.
+///
+/// Reaching the bound is a product decision rather than a storage failure: the
+/// store refuses a further revision so no caller can silently lose history.
+pub const MAX_APP_REVISIONS: u32 = 100;
+/// Largest app display name accepted by the manifest.
+pub const MAX_APP_NAME_CHARS: usize = 120;
+/// Provider-safe bound every mounted tool name already obeys, reused verbatim
+/// for manifest bindings so a pinned name can always match a mounted one.
+pub const MAX_MOUNTED_TOOL_NAME_BYTES: usize = 64;
+
+/// Profile-data location of one immutable revision's bundle bytes.
+///
+/// Bundle files are written once and never replaced, so the path is derived
+/// entirely from durable identity — a display name can never steer where
+/// bytes are written or read. Callers resolve it below the profile data
+/// directory, never below any conversation's private scratch.
+#[must_use]
+pub fn app_revision_relative_path(app_id: AppId, revision_id: AppRevisionId) -> PathBuf {
+    PathBuf::from(APPS_DIRECTORY)
+        .join(app_id.to_string())
+        .join(revision_id.to_string())
+}
+
+/// Publish bundle bytes at the write-once derived path under the profile data
+/// directory.
+///
+/// Reuses the immutable-publication primitive the output record uses: atomic,
+/// no-replace, symlink-refusing, and safe to retry with identical bytes.
+#[cfg(feature = "tools")]
+pub async fn publish_app_bundle(
+    profile_dir: &cap_std::fs::Dir,
+    app_id: AppId,
+    revision_id: AppRevisionId,
+    content: &[u8],
+) -> crate::error::Result<()> {
+    use crate::error::AgentError;
+
+    let relative_path = app_revision_relative_path(app_id, revision_id);
+    let profile_dir = profile_dir.try_clone().map_err(|error| {
+        AgentError::Store(format!(
+            "could not open the profile data directory: {error}"
+        ))
+    })?;
+    let content = content.to_vec();
+    tokio::task::spawn_blocking(move || {
+        crate::tools::private_scratch::publish_immutable_file(
+            &profile_dir,
+            &relative_path,
+            &content,
+        )
+    })
+    .await
+    .map_err(|error| AgentError::Store(format!("publication task failed: {error}")))?
+    .map_err(|error| AgentError::Store(format!("could not publish app bundle: {error}")))
+}
+
+/// One profile-owned app and its current revision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppRecord {
+    /// Durable opaque identity, stable across every revision.
+    pub id: AppId,
+    /// Display name, following the current revision's manifest. Not identity.
+    pub name: String,
+    /// Revision currently presented as the app's content.
+    pub current_revision: AppRevisionId,
+    /// Number of retained revisions, always at least one.
+    pub revision_count: u32,
+    /// Creation time of the first revision.
+    pub created_at: DateTime<Utc>,
+    /// Creation time of the current revision.
+    pub updated_at: DateTime<Utc>,
+    /// Set when the user deleted the app. Revisions are retained so a deletion
+    /// stays recoverable.
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+/// One immutable revision of a local app.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppRevision {
+    /// Durable identity, also the profile-data filename of its bundle bytes.
+    pub id: AppRevisionId,
+    /// App this revision belongs to.
+    pub app_id: AppId,
+    /// One-based position in the app's revision history.
+    pub ordinal: u32,
+    /// The trusted manifest: display name and pinned tool bindings.
+    pub manifest: AppManifest,
+    /// Exact byte length of the revision's bundle.
+    pub byte_len: u64,
+    /// SHA-256 of the bundle, used to recognize an exact retry.
+    pub sha256: [u8; 32],
+    /// Turn that produced the revision, when it came from a foreground turn.
+    /// Mutually exclusive with [`AppRevision::producing_run_id`].
+    pub turn_id: Option<TurnId>,
+    /// Background run that produced the revision, when one did. Mutually
+    /// exclusive with [`AppRevision::turn_id`].
+    pub producing_run_id: Option<AgentRunId>,
+    /// Conversation the revision was authored in, recorded as provenance only.
+    ///
+    /// Deliberately not a foreign key: the app is profile-scoped and must
+    /// outlive the conversation, so this id may dangle after a chat deletion.
+    pub chat_id: Option<ChatId>,
+    /// Host-stamped creation time.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Content-identifying fields of a revision whose bundle the caller publishes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewAppRevision {
+    /// Caller-minted identity. Reusing it with the same content is an exact
+    /// retry; reusing it with different content is rejected.
+    pub id: AppRevisionId,
+    /// The revision's manifest, validated structurally by the store.
+    pub manifest: AppManifest,
+    /// Exact byte length of the bundle.
+    pub byte_len: u64,
+    /// SHA-256 of the bundle.
+    pub sha256: [u8; 32],
+    /// Foreground turn that produced the revision, when one did. Mutually
+    /// exclusive with `producing_run_id`.
+    pub turn_id: Option<TurnId>,
+    /// Background run that produced the revision, when one did. Mutually
+    /// exclusive with `turn_id`.
+    pub producing_run_id: Option<AgentRunId>,
+    /// Originating conversation, recorded as nullable provenance.
+    pub chat_id: Option<ChatId>,
+    /// Host-stamped creation time.
+    pub created_at: DateTime<Utc>,
+}
+
+impl NewAppRevision {
+    /// Record the producer that minted this revision into its turn/run fields.
+    #[must_use]
+    pub fn with_producer(mut self, producer: RevisionProducer) -> Self {
+        self.turn_id = producer.turn_id();
+        self.producing_run_id = producer.producing_run_id();
+        self
+    }
+}
+
+/// Request to create an app together with its first revision.
+///
+/// The app's display name comes from the revision's manifest, so the record
+/// and its manifest can never disagree about what the app is called.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateApp {
+    /// Caller-minted identity, so an ambiguous store response can be retried.
+    pub id: AppId,
+    /// The app's first revision.
+    pub revision: NewAppRevision,
+}
+
+/// The trusted half of an app revision: a display name and the exact mounted
+/// tools the app may call.
+///
+/// The manifest — not the bundle — is what the user consents to and what the
+/// host enforces per call, so its shape is closed (`deny_unknown_fields`) and
+/// validated structurally before anything is stored.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AppManifest {
+    /// Display name shown in the transcript card and the Apps library.
+    pub name: String,
+    /// Pinned tool bindings, grouped by configured server namespace.
+    pub bindings: Vec<AppBinding>,
+}
+
+/// The mounted tools one server namespace contributes to an app.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AppBinding {
+    /// Configured server namespace the tools are mounted under.
+    pub server: String,
+    /// Full mounted tool names, each `mcp__{server}__{tool}` under this
+    /// binding's server namespace.
+    pub tools: Vec<String>,
+}
+
+/// Validate an app manifest structurally and return the JSON to store.
+///
+/// Checks the display name, the mounted-tool grammar of every binding, and the
+/// serialized size bound. Tool names must be full mounted names under the
+/// binding's server namespace and fit the provider-safe 64-byte
+/// `[A-Za-z0-9_-]` contract every mounted tool already obeys, so a pinned name
+/// that could never match a mounted tool is refused at the door.
+pub fn validate_app_manifest(manifest: &AppManifest) -> Result<serde_json::Value, String> {
+    validate_app_name(&manifest.name)?;
+    let mut servers = std::collections::HashSet::new();
+    for binding in &manifest.bindings {
+        if binding.server.is_empty() || !is_mounted_name_charset(&binding.server) {
+            return Err(format!(
+                "binding server {:?} must be a non-empty [A-Za-z0-9_-] name",
+                binding.server
+            ));
+        }
+        if !servers.insert(binding.server.as_str()) {
+            return Err(format!("duplicate binding for server {:?}", binding.server));
+        }
+        let prefix = format!("mcp__{}__", binding.server);
+        let mut tools = std::collections::HashSet::new();
+        for tool in &binding.tools {
+            if tool.len() > MAX_MOUNTED_TOOL_NAME_BYTES || !is_mounted_name_charset(tool) {
+                return Err(format!(
+                    "tool {tool:?} must be at most {MAX_MOUNTED_TOOL_NAME_BYTES} bytes of [A-Za-z0-9_-]"
+                ));
+            }
+            match tool.strip_prefix(&prefix) {
+                Some(rest) if !rest.is_empty() => {}
+                _ => {
+                    return Err(format!(
+                        "tool {tool:?} is not a mounted `{prefix}{{tool}}` name under server {:?}",
+                        binding.server
+                    ));
+                }
+            }
+            if !tools.insert(tool.as_str()) {
+                return Err(format!("duplicate tool {tool:?}"));
+            }
+        }
+    }
+    let json =
+        serde_json::to_value(manifest).map_err(|error| format!("unencodable manifest: {error}"))?;
+    let encoded_len = json.to_string().len();
+    if encoded_len > MAX_APP_MANIFEST_BYTES {
+        return Err(format!(
+            "manifest is too large ({encoded_len} bytes, maximum {MAX_APP_MANIFEST_BYTES})"
+        ));
+    }
+    Ok(json)
+}
+
+fn validate_app_name(name: &str) -> Result<(), String> {
+    if name.is_empty() || name.chars().count() > MAX_APP_NAME_CHARS {
+        return Err(format!(
+            "app name must contain between 1 and {MAX_APP_NAME_CHARS} characters"
+        ));
+    }
+    if name.trim() != name {
+        return Err("app name may not have surrounding whitespace".into());
+    }
+    if name.chars().any(char::is_control) {
+        return Err("app name may not contain control characters".into());
+    }
+    Ok(())
+}
+
+fn is_mounted_name_charset(name: &str) -> bool {
+    name.bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundle_paths_are_derived_only_from_durable_identity() {
+        let app_id = AppId::new();
+        let revision_id = AppRevisionId::new();
+        let path = app_revision_relative_path(app_id, revision_id);
+
+        assert_eq!(
+            path,
+            PathBuf::from(APPS_DIRECTORY)
+                .join(app_id.to_string())
+                .join(revision_id.to_string())
+        );
+        assert!(path.is_relative());
+        // The derivation takes no display name at all, so renaming an app can
+        // never steer where bundle bytes are written or read.
+        assert_eq!(
+            path,
+            app_revision_relative_path(app_id, revision_id),
+            "the same identity always resolves to the same path"
+        );
+        assert_ne!(
+            path,
+            app_revision_relative_path(app_id, AppRevisionId::new()),
+            "each revision owns a distinct, write-once path"
+        );
+    }
+
+    #[test]
+    fn manifests_enforce_the_mounted_tool_grammar() {
+        let manifest = |tools: &[&str]| AppManifest {
+            name: "Sentry triage".into(),
+            bindings: vec![AppBinding {
+                server: "sentry".into(),
+                tools: tools.iter().map(|tool| (*tool).to_owned()).collect(),
+            }],
+        };
+
+        assert!(validate_app_manifest(&manifest(&[
+            "mcp__sentry__list_issues",
+            "mcp__sentry__get_issue"
+        ]))
+        .is_ok());
+        // Bindings may be empty: a static app pins no tools.
+        assert!(validate_app_manifest(&AppManifest {
+            name: "Static".into(),
+            bindings: Vec::new(),
+        })
+        .is_ok());
+
+        for tool in [
+            "list_issues",                               // bare name, not mounted
+            "mcp__github__list_issues",                  // mounted under a different server
+            "mcp__sentry__",                             // empty tool segment
+            "mcp__sentry__bad name",                     // charset
+            &format!("mcp__sentry__{}", "x".repeat(64)), // over the 64-byte bound
+        ] {
+            assert!(validate_app_manifest(&manifest(&[tool])).is_err(), "{tool}");
+        }
+        assert!(
+            validate_app_manifest(&manifest(&[
+                "mcp__sentry__list_issues",
+                "mcp__sentry__list_issues"
+            ]))
+            .is_err(),
+            "duplicate pins are refused"
+        );
+
+        for name in ["", " padded ", "line\nbreak", &"x".repeat(121)] {
+            assert!(
+                validate_app_manifest(&AppManifest {
+                    name: (*name).to_owned(),
+                    bindings: Vec::new(),
+                })
+                .is_err(),
+                "{name:?}"
+            );
+        }
+    }
+}

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -29,10 +29,11 @@ use crate::deliverable::{CreateOutput, NewOutputRevision, OutputRecord, OutputRe
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{
-    AgentRunId, CallId, ChatId, DocumentId, MessageId, OutputId, OutputRevisionId, ProjectId,
-    RootAttachmentChangeId, TurnId, TurnSteerId,
+    AgentRunId, AppId, AppRevisionId, CallId, ChatId, DocumentId, MessageId, OutputId,
+    OutputRevisionId, ProjectId, RootAttachmentChangeId, TurnId, TurnSteerId,
 };
 use crate::image::ImageRef;
+use crate::local_app::{AppRecord, AppRevision, CreateApp, NewAppRevision};
 use crate::model::{
     AgentRun, AgentRunInboxEntry, AgentRunResult, AgentRunTier, AgentRunWaitSetCandidate,
     BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus, Chat, ClientToolCallRequest,
@@ -966,6 +967,12 @@ fn output_storage_unavailable<T>() -> Result<T> {
     ))
 }
 
+fn app_storage_unavailable<T>() -> Result<T> {
+    Err(AgentError::Store(
+        "local-app storage is not implemented by this Store".into(),
+    ))
+}
+
 fn context_checkpoint_storage_unavailable<T>() -> Result<T> {
     Err(AgentError::Store(
         "durable context-checkpoint storage is not implemented by this Store".into(),
@@ -1484,6 +1491,75 @@ pub trait Store: Send + Sync {
         _updated_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<OutputRecord> {
         output_storage_unavailable()
+    }
+
+    /// Create a profile-scoped local app together with its first revision.
+    ///
+    /// The caller has already published the bundle bytes under the profile
+    /// data directory at [`crate::local_app::app_revision_relative_path`] and
+    /// supplies their exact length and digest; the manifest is validated
+    /// structurally before anything is stored. Reusing `request.id` with
+    /// identical content returns the original record so an ambiguous store
+    /// response can be retried; reusing it with different content is rejected.
+    async fn create_app(&self, _request: &CreateApp) -> Result<AppRecord> {
+        app_storage_unavailable()
+    }
+
+    /// Append an immutable revision and publish it as the app's current one.
+    ///
+    /// The previous revision is retained and stays addressable by its own id,
+    /// so an update can never destroy the bundle it replaced. Reusing
+    /// `revision.id` with identical content is an exact retry; reaching the
+    /// revision cap refuses the write rather than dropping history.
+    async fn append_app_revision(
+        &self,
+        _app_id: AppId,
+        _revision: &NewAppRevision,
+    ) -> Result<AppRecord> {
+        app_storage_unavailable()
+    }
+
+    /// Fetch one app by opaque id, including a soft-deleted one.
+    async fn get_app(&self, _id: AppId) -> Result<Option<AppRecord>> {
+        app_storage_unavailable()
+    }
+
+    /// List the profile's live apps, most recently updated first.
+    async fn list_apps(&self, _limit: u64) -> Result<Vec<AppRecord>> {
+        app_storage_unavailable()
+    }
+
+    /// List one app's revisions, newest first.
+    async fn list_app_revisions(&self, _app_id: AppId) -> Result<Vec<AppRevision>> {
+        app_storage_unavailable()
+    }
+
+    /// Fetch one app revision by opaque id.
+    async fn get_app_revision(&self, _id: AppRevisionId) -> Result<Option<AppRevision>> {
+        app_storage_unavailable()
+    }
+
+    /// Soft-delete an app, hiding it from the library while retaining its
+    /// revisions. Returns `false` only when the app does not exist; deleting
+    /// an already-deleted app is the same durable outcome, not a conflict.
+    async fn delete_app(
+        &self,
+        _id: AppId,
+        _deleted_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool> {
+        app_storage_unavailable()
+    }
+
+    /// Restore a soft-deleted app, returning it to the library. The exact
+    /// inverse of [`Store::delete_app`]; the revision history is untouched.
+    /// Returns `false` only when the app does not exist; restoring a live app
+    /// is the same durable outcome, not a conflict.
+    async fn restore_app(
+        &self,
+        _id: AppId,
+        _restored_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<bool> {
+        app_storage_unavailable()
     }
 
     /// Persist the next versioned context checkpoint for one conversation.


### PR DESCRIPTION
First slice of the local-apps design (docs/local-apps.md): the durable app record in the product store.

## What changed

- **`app` + `app_revision` tables** (migration `m20260730_000037_add_local_apps`): opaque ids, a non-FK current-revision pointer (same cycle-avoidance as outputs), revision count, soft delete. Revisions are insert-only, carry a bounded manifest (JSONB), the bundle's byte length + SHA-256, producer attribution as turn XOR run (CHECK-enforced), and a unique `(app_id, ordinal)` index. Purely additive, symmetric `down`.
- **The one deliberate divergence from outputs: no chat foreign key anywhere.** The profile owns the app; the originating conversation is nullable provenance on the revision row with no constraint, so an app and its full history survive deletion of the conversation that authored it. A test writes provenance for a chat id that references no chat row to pin exactly that.
- **Store trait ops** mirroring the output surface (`create_app`, `append_app_revision`, `get_app`, `list_apps`, `list_app_revisions`, `get_app_revision`, `delete_app`, `restore_app`), with the same retry-stable identity semantics: reusing an id with identical content returns the original record; different content is refused. The 100-revision cap refuses the write instead of silently dropping history. Concurrent appends serialize on the app row itself (the profile-scoped analog of the chat write lock).
- **Write-once bundle bytes** at `apps/{app_id}/{revision_id}` under the profile data dir — never any conversation's private scratch — derived only from durable identity, published through the same atomic, no-replace, symlink-refusing primitive output revisions use.
- **Structural manifest validation** before anything is stored: closed `{ name, bindings: [{ server, tools[] }] }` shape, every pinned tool required to be a full mounted `mcp__{server}__{tool}` name under its binding's server within the provider-safe 64-byte `[A-Za-z0-9_-]` contract, duplicates refused, manifest ≤ 64 KiB, bundle ≤ 1 MiB.

## Scope

Storage only, per the slice plan — no routes, no tool, no renderer or frame work.

## Tests

Eight, each pinning a decision: retry-stable identity (exact retry returns the original; same id + different content refused), revision-cap refusal, producer XOR + dangling conversation provenance, manifest/bundle bound refusals through the store, delete/restore semantics, the mounted-tool grammar, and the path-derivation property (the derivation takes no display name, so a rename can never steer where bytes land).

Closes #1254

🤖 Generated with [Claude Code](https://claude.com/claude-code)