### PR TITLE
fix(desktop): keep the app shell up when the chat list fails to load

### DIFF
--- a/crates/openwave-desktop/ui/src/AppContext.tsx
+++ b/crates/openwave-desktop/ui/src/AppContext.tsx
@@ -27,6 +27,8 @@ export type AppContextValue = {
   defaultModelKey: string | null;
   providers: ProviderInfo[];
   refreshCatalog: () => Promise<void>;
+  /** Reload the chat list after a failed fetch — the rail's retry. */
+  refreshChats: () => Promise<void>;
   status: string;
   setStatus: (next: string | ((current: string) => string)) => void;
   /** Start a conversation and open it. Fenced against a second in-flight create. */

--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -207,7 +207,7 @@ beforeEach(() => {
   usePendingPrompts.setState({ chatId: null, userQuestions: [], folderAccess: [] });
   // The stores outlive a test file's renders, so a chat list left behind would
   // decide the next test's routing before its own boot ever ran.
-  useChatListStore.setState({ chats: [], chatsLoaded: false });
+  useChatListStore.setState({ chats: [], chatsLoaded: false, chatsError: null });
   useUiStore.setState({ sidebarCollapsed: false });
 });
 afterEach(() => {
@@ -261,6 +261,30 @@ describe("app shell", () => {
     await mountApp({ at: "/chats" });
 
     expect(await screen.findByText("No chats yet")).toBeInTheDocument();
+  });
+
+  it("keeps the shell up with a retryable list when loading chats fails", async () => {
+    listChats.mockRejectedValue(new Error("database is locked"));
+    const user = userEvent.setup();
+    const { router } = await mountApp({ at: "/c/chat-1" });
+
+    // A list failure is not a boot failure: the models and providers fetched
+    // fine, so the shell stands and the failure is reported where the list
+    // would be. The settled load also frees the deep link to redirect home
+    // rather than wait on a fetch that already failed.
+    expect(await screen.findByText("How can I help?")).toBeInTheDocument();
+    await waitFor(() => expect(router.state.location.pathname).toBe("/"));
+    expect(
+      await screen.findByText(/Could not load chats/),
+    ).toBeInTheDocument();
+
+    listChats.mockResolvedValue(chats);
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(
+      (await screen.findAllByRole("button", { name: "Roadmap" })).length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText(/Could not load chats/)).not.toBeInTheDocument();
   });
 
   it("starts a conversation from the home composer and sends what was written", async () => {

--- a/crates/openwave-desktop/ui/src/AppShell.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.tsx
@@ -136,16 +136,14 @@ export function AppShell() {
     let cancelled = false;
     void (async () => {
       try {
-        const [catalog, providerList, existingChats] = await Promise.all([
+        const [catalog, providerList] = await Promise.all([
           client.listModels(),
           client.listProviders(),
-          client.listChats(),
         ]);
         if (cancelled) return;
         setModels(catalog.models);
         setDefaultModelKey(resolvedRoleKey(catalog.roles, "chat"));
         setProviders(providerList.providers);
-        chatListActions.setChats(existingChats);
       } catch (err) {
         if (!cancelled) setBootError(String(err));
       }
@@ -154,6 +152,40 @@ export function AppShell() {
       cancelled = true;
     };
   }, [client, info]);
+
+  // The chat list loads apart from the catalog: a failure here is a sidebar
+  // problem, not a boot problem, and must not take down a shell the catalog
+  // already stood up. The store hears about the failure so the gate that
+  // sends a stale deep link home settles instead of waiting on a fetch that
+  // already failed, and the rail shows the error with a way to retry.
+  useEffect(() => {
+    if (!client || !info) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const existingChats = await client.listChats();
+        if (!cancelled) chatListActions.setChats(existingChats);
+      } catch (err) {
+        if (!cancelled) {
+          chatListActions.failChatsLoad(`Could not load chats: ${String(err)}`);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, info]);
+
+  /** Reload the chat list after a failed fetch — the rail's retry calls this. */
+  async function refreshChats() {
+    if (!client) return;
+    try {
+      chatListActions.setChats(await client.listChats());
+      chatListActions.setChatsError(null);
+    } catch (err) {
+      chatListActions.failChatsLoad(`Could not load chats: ${String(err)}`);
+    }
+  }
 
   async function refreshCatalog() {
     if (!client) return;
@@ -321,6 +353,7 @@ export function AppShell() {
           defaultModelKey,
           providers,
           refreshCatalog,
+          refreshChats,
           status,
           setStatus,
           newChat: () => void onNewChat(),

--- a/crates/openwave-desktop/ui/src/ChatListStore.ts
+++ b/crates/openwave-desktop/ui/src/ChatListStore.ts
@@ -37,6 +37,13 @@ export type ChatListStore = {
    */
   derivedTitleChatId: string | null;
   setChats: (chats: Chat[]) => void;
+  /**
+   * Record that fetching the list failed. The load is still settled — the
+   * gate that sends a stale deep link home keys on having asked, not on
+   * having rows, and must not wait on a fetch that already failed. Whatever
+   * list is in hand stays: a failed refresh is no reason to blank it.
+   */
+  failChatsLoad: (error: string) => void;
   /** Replace a chat in the list by id. */
   replaceChat: (chat: Chat) => void;
   /** Take a title the server derived, and mark it as newly arrived. */
@@ -65,6 +72,7 @@ export function createChatListStore() {
     savingTitle: false,
     derivedTitleChatId: null,
     setChats: (chats) => set({ chats, chatsLoaded: true }),
+    failChatsLoad: (error) => set({ chatsLoaded: true, chatsError: error }),
     replaceChat: (chat) =>
       set((state) => ({
         chats: state.chats.map((item) => (item.id === chat.id ? chat : item)),

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -479,7 +479,13 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     chatListActions.replaceChat(await client.patchChatPermissionMode(chatId, mode));
   }
 
-  if (!chat) return <div className="routed-surface-loading" />;
+  // Shown while the list fetch or the redirect above settles — a blank frame
+  // still needs a name so it is not silent to a screen reader.
+  if (!chat) {
+    return (
+      <div className="routed-surface-loading" role="status" aria-label="Loading chat" />
+    );
+  }
 
   function renderPanel(panel: PanelContent, position: "left" | "right" | "chat", visible: boolean) {
     if (panel.type === "chat") {

--- a/crates/openwave-desktop/ui/src/sidebar/HomeSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/HomeSidebar.tsx
@@ -26,7 +26,7 @@ const RECENT_CHAT_LIMIT = 8;
  */
 export function HomeSidebar() {
   const navigate = useNavigate();
-  const { newChat, deleteChat, startRename, commitRename, cancelRename } = useApp();
+  const { newChat, deleteChat, startRename, commitRename, cancelRename, refreshChats } = useApp();
   const chats = useChatListStore((state) => state.chats);
   const chatsError = useChatListStore((state) => state.chatsError);
   const creatingChat = useChatListStore((state) => state.creatingChat);
@@ -96,7 +96,18 @@ export function HomeSidebar() {
           <MessagesSquare />
           <span>All chats</span>
         </SidebarButton>
-        {chatsError && <p className="px-2 py-1 text-xs text-critical">{chatsError}</p>}
+        {chatsError && (
+          <div className="flex flex-col gap-1 px-2 py-1">
+            <p className="text-xs text-critical">{chatsError}</p>
+            <button
+              type="button"
+              className="self-start text-xs text-muted-foreground underline-offset-2 hover:underline"
+              onClick={() => void refreshChats()}
+            >
+              Retry
+            </button>
+          </div>
+        )}
       </div>
     </SidebarFrame>
   );


### PR DESCRIPTION
Closes #1119

## The decision

A chat-list-only failure is not a boot error. Boot previously fetched models, providers, and chats in one `Promise.all`, so a failed `listChats` set `bootError` and replaced the whole window with the boot error screen — discarding a shell whose catalog fetches had succeeded. Now the chat list loads in its own effect:

- The catalog (models/providers) keeps the boot-error behavior; those failures still take the shell down.
- A failed `listChats` records the failure in the chat-list store via a new `failChatsLoad` action, which sets `chatsError` **and** marks `chatsLoaded`. Marking the load settled matters: the `chatsLoaded` gate from #1115 keys on having *asked*, not on having rows, so a deep link to a conversation now redirects home instead of waiting forever on a fetch that already failed. The list already in hand is kept — a failed refresh is no reason to blank it.

## What the shell shows now

The app comes up normally on home. The home rail shows `Could not load chats: …` where the list would be, with a **Retry** button that re-fetches through a new `refreshChats` on the app context. A successful retry populates the list and clears the error.

## Smaller fixes folded in

- `ChatRoute`'s loading frame was a bare `routed-surface-loading` div with no text and no role while the redirect effect settled — an unlabeled blank frame. It now carries `role="status"` and `aria-label="Loading chat"`.
- The `eslint-disable react-hooks/exhaustive-deps` on the first-message effect (`ChatRoute.tsx`) was examined and left in place: it hides no stale-closure bug. The effect only fires on transitions of `chat`/`chatId`/`hydrated`, and at that moment the `sendMessage` closure is from the latest render; `firstMessageActions.take(chatId)` consumes the pending message, so a re-run cannot double-send. Listing `sendMessage` (recreated every render) would re-run the effect on every render for no benefit.

## Tests

One new shell DOM test earns its place per the repo's test bar: it pins the decision itself — a failed `listChats` still renders the shell (not the boot error screen), settles the deep-link redirect, and the rail's retry recovers the list. It would fail on any regression that put the chat list back on the boot-error path.

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm test` — 92 files, 655 tests, all pass
- `pnpm build` — succeeds
