### PR TITLE
feat(server): log cache token counters when a turn resolves

### DIFF
--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -1022,6 +1022,19 @@ impl TurnWorker {
                                     if let Some(event) = resolution.terminal_event {
                                         self.publish(turn.chat_id, event);
                                     }
+                                    // The cache counters are the only way to
+                                    // see prompt caching work or silently stop:
+                                    // a miss never errors, it just costs more.
+                                    // Logged with the durable field names so the
+                                    // line is greppable across turns.
+                                    eprintln!(
+                                        "openwave: turn {} resolved usage input_tokens={} output_tokens={} cache_read_input_tokens={} cache_creation_input_tokens={}",
+                                        turn.id,
+                                        total_usage.input_tokens,
+                                        total_usage.output_tokens,
+                                        total_usage.cache_read_input_tokens,
+                                        total_usage.cache_creation_input_tokens,
+                                    );
                                     return Ok(TurnWorkerOutcome::Completed(turn.id));
                                 }
                                 CompleteTurnRunOutcome::SteerPending(_)


### PR DESCRIPTION
## Summary

PR #1153 made `cache_read_input_tokens` and `cache_creation_input_tokens` carry real values for the first time, but nothing reads them — there was no way to observe whether prompt caching works or silently stops. A cache miss is invisible by construction: nothing errors, the request just costs more.

This adds the lightest durable observability that fits the codebase's conventions: a log line at the turn worker's completion point (which covers both `TurnCompleted` and `TurnRefused`), emitting the turn's final usage with the durable field names so it is greppable:

```
openwave: turn <id> resolved usage input_tokens=… output_tokens=… cache_read_input_tokens=… cache_creation_input_tokens=…
```

This matches the surrounding `eprintln!("openwave: turn {} …")` convention already used in `turn_worker.rs` (e.g. the `operating_prompt` line at turn start).

Closes #1156

## Test plan

- `cargo test -p openwave-server --locked` — 482 passed
- `cargo clippy -p openwave-server --all-targets --locked -- -D warnings` — clean
- `cargo fmt --check` — clean

No new test: this is a debug log line, not a behavioral contract; per the repo's test philosophy a test pinning stderr text would break on every wording tweak without ever catching a defect.
