### PR TITLE
fix(agent): resolve started tool calls on cancel

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -833,7 +833,8 @@ impl<'a, 'b> AssistantStreamEventFilter<'a, 'b> {
     }
 
     fn discard(&mut self) {
-        // Nothing is buffered.
+        // Nothing is buffered — the discard itself is the separately-sent
+        // `StreamInterrupted` event, not anything this hook does.
     }
 }
 
@@ -1442,6 +1443,15 @@ impl Agent {
             // the left arm of the nested select). Also catch a cancel that raced
             // the final stream event.
             if matches!(stream_end, StreamEnd::Cancelled) || self.cancel.is_cancelled() {
+                // Calls that started before the cancel were already journaled,
+                // so terminalizing silently would leave replay and live clients
+                // holding a call that never resolves. Mark them discarded the
+                // way the refusal path does — but only when calls had actually
+                // started, because the marker also clears streamed prose and a
+                // cancel with prose alone deliberately retains it.
+                if !calls.is_empty() {
+                    events.send(AgentEvent::StreamInterrupted);
+                }
                 return Ok(self.finish_cancelled(
                     events,
                     total_usage,
@@ -9101,6 +9111,122 @@ mod tests {
             .map(|m| m.role)
             .collect();
         assert_eq!(roles, vec![Role::User]);
+    }
+
+    struct ToolCallStallProvider;
+
+    #[async_trait]
+    impl ModelProvider for ToolCallStallProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("tool-stall")
+        }
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let head = stream::iter(vec![
+                ProviderEvent::TextDelta {
+                    text: "partial".into(),
+                },
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "call-0".into(),
+                    name: "echo".into(),
+                },
+            ]);
+            Ok(head.chain(stream::pending()).boxed())
+        }
+    }
+
+    /// A cancel that lands after `ToolCallStarted` was already journaled must
+    /// mark the call discarded, or replay and live clients hold a call that
+    /// never resolves. The marker is conditional — a cancel with only partial
+    /// prose must not send it, because replay clears visible assistant text on
+    /// the marker and cancellation deliberately retains that prose.
+    #[tokio::test]
+    async fn cancel_after_a_tool_call_starts_does_not_leave_it_dangling() {
+        let (store, chat, _workspace) = cancel_test_chat().await;
+
+        let cancel = CancelToken::new();
+        let agent = Agent::new(
+            Arc::new(ToolCallStallProvider),
+            Arc::new(ToolRegistry::new()),
+            store,
+            AgentConfig {
+                model: "tool-stall".into(),
+                ..Default::default()
+            },
+        )
+        .with_cancel(cancel.clone());
+
+        let (tx, mut rx) = unbounded();
+        let handle = tokio::spawn(async move {
+            let _ = agent.run_turn(&chat, "go", &tx).await;
+        });
+
+        // Cancel the instant the started call is visible; the stream then
+        // stalls, so only the cancel can end the turn.
+        let mut events = Vec::new();
+        while let Some(event) = rx.next().await {
+            if matches!(event, AgentEvent::ToolCallStarted { .. }) {
+                cancel.cancel();
+            }
+            events.push(event);
+        }
+        handle.await.unwrap();
+
+        let started = events
+            .iter()
+            .position(|e| matches!(e, AgentEvent::ToolCallStarted { .. }));
+        let interrupted = events
+            .iter()
+            .position(|e| matches!(e, AgentEvent::StreamInterrupted));
+        let cancelled = events
+            .iter()
+            .position(|e| matches!(e, AgentEvent::TurnCancelled { .. }));
+        assert!(
+            matches!((started, interrupted, cancelled), (Some(a), Some(b), Some(c)) if a < b && b < c),
+            "the started call is marked discarded before the turn terminalizes: {events:?}"
+        );
+
+        // The other half of the contract: with no started tool call the marker
+        // stays unsent, so the partial prose the client already showed survives.
+        let (store, chat, _workspace) = cancel_test_chat().await;
+        let cancel = CancelToken::new();
+        let agent = Agent::new(
+            Arc::new(StallProvider),
+            Arc::new(ToolRegistry::new()),
+            store,
+            AgentConfig {
+                model: "stall".into(),
+                ..Default::default()
+            },
+        )
+        .with_cancel(cancel.clone());
+
+        let (tx, mut rx) = unbounded();
+        let handle = tokio::spawn(async move {
+            let _ = agent.run_turn(&chat, "go", &tx).await;
+        });
+
+        let mut events = Vec::new();
+        while let Some(event) = rx.next().await {
+            if matches!(event, AgentEvent::TextDelta { .. }) {
+                cancel.cancel();
+            }
+            events.push(event);
+        }
+        handle.await.unwrap();
+
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::TurnCancelled { .. })),
+            "a prose-only cancel still ends the turn as cancelled"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::StreamInterrupted)),
+            "a cancel with no started tool call keeps the partial prose"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Defect

`finish_cancelled` terminalizes a turn without emitting `StreamInterrupted`. When a cancel lands after `ToolCallStarted` was already journaled, clients and journal replay are left holding a tool call that started and never resolves — the same defect #1117 fixed for the refusal path (follow-up from #1072).

## Fix

`StreamInterrupted` carries two meanings that pull in opposite directions: the contract comment states that cancellation retains malformed or incomplete marker-like prose exactly, while replay honors the discard literally (`lifecycle.rs` clears visible assistant text on the marker). Emitting the marker unconditionally on cancel would wipe partial prose that cancellation deliberately preserves.

#1117 resolved this for refusal by emitting the marker only when tool calls had actually started. The same argument applies unchanged to cancel, so this PR applies the same conditional in the post-stream cancel branch: send `StreamInterrupted` before `finish_cancelled` only when `calls` is non-empty.

## Test

`cancel_after_a_tool_call_starts_does_not_leave_it_dangling` pins both halves:

1. A cancel observed after `ToolCallStarted` emits `StreamInterrupted` between the started call and `TurnCancelled`, so the call is not left dangling.
2. A prose-only cancel sends no marker, so the partial text the client already showed survives — this is the half that makes the naive unconditional fix wrong.

Verified the test fails without the fix (the `ToolCallStarted` → `StreamInterrupted` → `TurnCancelled` ordering assertion) and passes with it.

## Deliberately out of scope

- The issue floats a larger redesign — a distinct marker for unresolved tool calls, separate from `StreamInterrupted`'s prose-discard semantics. Not done here; flagged rather than assumed, per the issue.
- The `AssistantStreamEventFilter::finish()`/`discard()` footgun (both are no-ops, so discard semantics live entirely in the separately-sent event) is settled with a one-line comment on `discard()` rather than a refactor.
- Cancel arriving *between* sequential tool executions can leave later sibling calls unresolved; that's a separate shape from the stream-cancel branch fixed here and is left for a follow-up if it proves out.

Closes #1120
