### PR TITLE
feat(server): serve local-app revisions through the view-frame machinery

### DIFF
--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -116,6 +116,11 @@ export type AgentRunStatus = "active" | "queued" | "running" | "cancelling" | "w
 export type AgentRunTier = "foreground" | "background";
 
 /**
+ * Where the sandboxed iframe should load one app revision from, valid once.
+ */
+export type AppViewSession = { frame_path: string, };
+
+/**
  * The approval policy class a tool declares for itself.
  *
  * Policy maps class → auto-approve / ask / deny. In v1: `ReadOnly` and

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -54,6 +54,7 @@ pub mod secret_rehome;
 mod source_tools;
 mod state;
 mod turn_worker;
+mod view_frames;
 /// Host-owned, inert web-search configuration and provider selection.
 pub mod web_search;
 mod wire_types;
@@ -311,6 +312,10 @@ pub fn app(state: AppState) -> Router {
             post(routes::post_mcp_view_session),
         )
         .route(
+            "/apps/{id}/view-session",
+            post(routes::post_app_view_session),
+        )
+        .route(
             "/chats/{chat_id}/calls/{call_id}/mcp-app-payload",
             get(routes::get_mcp_app_payload),
         )
@@ -456,9 +461,11 @@ pub fn app(state: AppState) -> Router {
         ]);
 
     // Reached by capability (single-use token), not by bearer: iframes send
-    // no headers. See `routes::get_mcp_view_frame`.
+    // no headers. See `routes::get_mcp_view_frame` and
+    // `routes::get_app_view_frame`.
     let view_frames = Router::new()
         .route("/mcp/view-frames/{token}", get(routes::get_mcp_view_frame))
+        .route("/apps/view-frames/{token}", get(routes::get_app_view_frame))
         .with_state(frame_state);
 
     Router::new()

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -39,10 +39,6 @@ const HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 const INITIALIZATION_TIMEOUT: Duration = Duration::from_secs(10);
 const INITIAL_RECONNECT_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(30);
-/// How long a minted view-frame token stays redeemable. One iframe load
-/// consumes it; a remount mints a fresh one.
-const VIEW_FRAME_TOKEN_TTL: Duration = Duration::from_secs(60);
-const MAX_VIEW_FRAME_TOKENS: usize = 64;
 
 /// The diagnostic every manual (command/url) server carries while managed
 /// policy holds. The definitions stay persisted — inert, not deleted — so an
@@ -381,8 +377,6 @@ pub(crate) struct McpRuntime {
     /// path and stays open.
     os_policy: Arc<dyn crate::managed_policy::OsPolicySource>,
     next_epoch: AtomicU64,
-    /// Outstanding single-use view-frame tokens: token → (server, uri, minted).
-    view_frame_tokens: Mutex<HashMap<uuid::Uuid, (String, String, std::time::Instant)>>,
 }
 
 impl McpRuntime {
@@ -404,7 +398,6 @@ impl McpRuntime {
             gateway,
             os_policy,
             next_epoch: AtomicU64::new(1),
-            view_frame_tokens: Mutex::new(HashMap::new()),
         }
     }
 
@@ -542,38 +535,6 @@ impl McpRuntime {
     pub(crate) async fn ui_view_document(&self, server: &str, uri: &str) -> Option<UiViewDocument> {
         let state = self.state.lock().await;
         state.servers.get(server)?.ui_views.get(uri).cloned()
-    }
-
-    /// Mint a single-use, short-lived token addressing one prefetched view.
-    ///
-    /// An iframe cannot carry the API bearer, so the frame route is reached
-    /// by capability instead: the authenticated renderer trades its bearer
-    /// for a token here, and the unauthenticated frame route redeems it
-    /// exactly once within [`VIEW_FRAME_TOKEN_TTL`].
-    pub(crate) async fn mint_view_frame(&self, server: &str, uri: &str) -> Option<uuid::Uuid> {
-        self.ui_view_document(server, uri).await?;
-        let token = uuid::Uuid::new_v4();
-        let mut tokens = self.view_frame_tokens.lock().await;
-        let now = std::time::Instant::now();
-        tokens.retain(|_, (_, _, minted)| now.duration_since(*minted) < VIEW_FRAME_TOKEN_TTL);
-        if tokens.len() >= MAX_VIEW_FRAME_TOKENS {
-            return None;
-        }
-        tokens.insert(token, (server.to_string(), uri.to_string(), now));
-        Some(token)
-    }
-
-    /// Redeem a frame token, consuming it.
-    pub(crate) async fn take_view_frame(&self, token: uuid::Uuid) -> Option<UiViewDocument> {
-        let (server, uri) = {
-            let mut tokens = self.view_frame_tokens.lock().await;
-            let (server, uri, minted) = tokens.remove(&token)?;
-            if minted.elapsed() >= VIEW_FRAME_TOKEN_TTL {
-                return None;
-            }
-            (server, uri)
-        };
-        self.ui_view_document(&server, &uri).await
     }
 
     /// One immutable tool surface for a live turn.
@@ -1996,21 +1957,6 @@ mod tests {
         assert_eq!(view.html, "<html>fixture view</html>");
         assert_eq!(view.mime_type.as_deref(), Some("text/html;profile=mcp-app"));
 
-        // Frame tokens are single-use capabilities over the prefetched view.
-        let token = runtime
-            .mint_view_frame("gateway", "ui://fixture/app.html")
-            .await
-            .expect("declared view mints a frame token");
-        let redeemed = runtime
-            .take_view_frame(token)
-            .await
-            .expect("first redemption serves the document");
-        assert_eq!(redeemed.html, "<html>fixture view</html>");
-        assert!(runtime.take_view_frame(token).await.is_none());
-        assert!(runtime
-            .mint_view_frame("gateway", "ui://fixture/other.html")
-            .await
-            .is_none());
         assert!(runtime
             .ui_view_document("gateway", "ui://fixture/other.html")
             .await

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -15,6 +15,8 @@ use serde::{Deserialize, Serialize};
 use std::path::Path as FsPath;
 use tokio::sync::broadcast::error::RecvError;
 
+use openwave_core::id::{AppId, AppRevisionId};
+use openwave_core::local_app::app_revision_relative_path;
 use openwave_core::{
     AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentError, AgentRun, AgentRunExecutionLocation,
     AgentRunStatus, AgentRunTier, ApprovalDecision, CallId, Chat, ChatId, DeleteChatOutcome,
@@ -36,6 +38,7 @@ use crate::mcp_config::{McpServersConfig, McpServersInfo};
 use crate::model_roles::{self, ModelRole};
 use crate::providers::{self, ProviderCredential, ProviderInfo, ProviderKind, ProviderUpdate};
 use crate::state::AppState;
+use crate::view_frames::ViewFrameSource;
 use crate::web_search::{
     self, WebSearchConfigInfo, WebSearchConfigUpdate, WebSearchCredentialReadiness,
     WebSearchCredentialsInfo,
@@ -276,9 +279,15 @@ pub async fn post_mcp_view_session(
     Path(name): Path<String>,
     Json(body): Json<McpViewSessionRequest>,
 ) -> Result<Json<McpViewSession>, ServerError> {
+    if state.mcp.ui_view_document(&name, &body.uri).await.is_none() {
+        return Err(ServerError::not_found("no such MCP App view"));
+    }
     let token = state
-        .mcp
-        .mint_view_frame(&name, &body.uri)
+        .view_frames
+        .mint(ViewFrameSource::McpView {
+            server: name,
+            uri: body.uri,
+        })
         .await
         .ok_or_else(|| ServerError::not_found("no such MCP App view"))?;
     Ok(Json(McpViewSession {
@@ -313,9 +322,20 @@ pub async fn get_mcp_view_frame(
     State(state): State<AppState>,
     Path(token): Path<uuid::Uuid>,
 ) -> Response {
-    let Some(document) = state.mcp.take_view_frame(token).await else {
+    let Some(ViewFrameSource::McpView { server, uri }) = state.view_frames.take(token).await else {
         return StatusCode::NOT_FOUND.into_response();
     };
+    let Some(document) = state.mcp.ui_view_document(&server, &uri).await else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    view_frame_response(document.html)
+}
+
+/// The one response shape every sandboxed view frame is served with,
+/// whatever its source: the document's own strict Content-Security-Policy
+/// (inline script and style may run; every network direction is shut) plus
+/// the no-sniff/no-referrer/no-store envelope.
+fn view_frame_response(body: impl Into<axum::body::Body>) -> Response {
     (
         [
             ("content-type", "text/html; charset=utf-8"),
@@ -331,9 +351,98 @@ pub async fn get_mcp_view_frame(
             ("referrer-policy", "no-referrer"),
             ("cache-control", "no-store"),
         ],
-        document.html,
+        body.into(),
     )
         .into_response()
+}
+
+/// `POST /apps/{id}/view-session` — trade the API bearer for a single-use
+/// frame token addressing one stored local-app revision.
+///
+/// The same capability trade as [`post_mcp_view_session`], for the same
+/// reason: the sandboxed iframe cannot carry the bearer. Serves the app's
+/// current revision unless the body pins one, which must belong to the app.
+/// A soft-deleted app mints nothing until it is restored — deletion removes
+/// the open affordance, not just the library row.
+pub async fn post_app_view_session(
+    State(state): State<AppState>,
+    Path(id): Path<AppId>,
+    Json(body): Json<AppViewSessionRequest>,
+) -> Result<Json<AppViewSession>, ServerError> {
+    let app = state
+        .store
+        .get_app(id)
+        .await?
+        .filter(|app| app.deleted_at.is_none())
+        .ok_or_else(|| ServerError::not_found(format!("app {id} not found")))?;
+    let revision_id = match body.revision {
+        Some(revision_id) => {
+            state
+                .store
+                .get_app_revision(revision_id)
+                .await?
+                .filter(|revision| revision.app_id == id)
+                .ok_or_else(|| {
+                    ServerError::not_found(format!("app revision {revision_id} not found"))
+                })?
+                .id
+        }
+        None => app.current_revision,
+    };
+    let token = state
+        .view_frames
+        .mint(ViewFrameSource::AppRevision {
+            app_id: id,
+            revision_id,
+        })
+        .await
+        .ok_or_else(|| {
+            ServerError::conflict("too many outstanding view frames; retry in a moment")
+        })?;
+    Ok(Json(AppViewSession {
+        frame_path: format!("/apps/view-frames/{token}"),
+    }))
+}
+
+#[derive(Deserialize, ts_rs::TS)]
+pub struct AppViewSessionRequest {
+    /// Revision to serve; the app's current revision when omitted.
+    revision: Option<AppRevisionId>,
+}
+
+/// Where the sandboxed iframe should load one app revision from, valid once.
+#[derive(Serialize, ts_rs::TS)]
+pub struct AppViewSession {
+    frame_path: String,
+}
+
+/// `GET /apps/view-frames/{token}` — redeem a frame token for one stored
+/// app revision's bundle.
+///
+/// The exact contract of [`get_mcp_view_frame`] — unauthenticated, reached
+/// only by an unguessable single-use token, served under the same strict
+/// policy — differing only in where the document comes from: app bundles are
+/// write-once bytes under the profile data directory, loaded by durable
+/// identity instead of re-resolved against a live MCP session.
+pub async fn get_app_view_frame(
+    State(state): State<AppState>,
+    Path(token): Path<uuid::Uuid>,
+) -> Response {
+    let Some(ViewFrameSource::AppRevision {
+        app_id,
+        revision_id,
+    }) = state.view_frames.take(token).await
+    else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let path = state
+        .config
+        .data_dir
+        .join(app_revision_relative_path(app_id, revision_id));
+    match tokio::fs::read(&path).await {
+        Ok(bundle) => view_frame_response(bundle),
+        Err(_) => StatusCode::NOT_FOUND.into_response(),
+    }
 }
 
 /// `POST /mcp/servers/{name}/reconnect` — explicitly establish a fresh session,

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -18,6 +18,7 @@ use crate::approvals::ApprovalBroker;
 use crate::bus::EventBus;
 use crate::mcp_config::McpRuntime;
 use crate::resolver::ProviderResolver;
+use crate::view_frames::ViewFrameTokens;
 
 /// The state cloned into each handler: the boot config, the durable store, the
 /// agent's dependencies (provider + tools + tuning), the per-launch bearer token,
@@ -40,6 +41,9 @@ pub struct AppState {
     pub tools: Arc<ToolRegistry>,
     /// Runtime-managed MCP connections and immutable per-turn tool snapshots.
     pub(crate) mcp: Arc<McpRuntime>,
+    /// Outstanding single-use tokens redeemed by the sandboxed view frames —
+    /// prefetched MCP views and stored local-app revisions alike.
+    pub(crate) view_frames: Arc<ViewFrameTokens>,
     /// The signed-in model-gateway session handle (sign-in, model sync,
     /// per-request tokens). The production assembly in `bind_inner` replaces
     /// this with the resolver's instance — refresh rotation is serialized
@@ -149,6 +153,7 @@ impl AppState {
             secrets,
             tools,
             mcp,
+            view_frames: Arc::default(),
             gateway,
             os_policy,
             turn_job_wake: Arc::new(Notify::new()),

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -2058,3 +2058,127 @@ async fn mcp_view_frames_are_single_use_capabilities_with_their_own_csp() {
         .unwrap();
     assert_eq!(replay.status(), StatusCode::NOT_FOUND);
 }
+
+/// Stored local-app revisions ride the same frame contract as MCP views:
+/// bearer-guarded minting, unauthenticated single-use redemption, the same
+/// strict CSP — with the document loaded from the revision's write-once
+/// profile bytes instead of a live MCP session, and a soft-deleted app
+/// minting nothing.
+#[tokio::test]
+async fn app_view_frames_serve_stored_revisions_under_the_same_contract() {
+    use openwave_core::id::{AppId, AppRevisionId};
+    use openwave_core::local_app::{
+        app_revision_relative_path, AppManifest, CreateApp, NewAppRevision,
+    };
+
+    let (router, token, store, dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+
+    let app_id = AppId::new();
+    let revision_id = AppRevisionId::new();
+    let bundle = b"<html><script>renderApp()</script></html>".to_vec();
+    store
+        .create_app(&CreateApp {
+            id: app_id,
+            revision: NewAppRevision {
+                id: revision_id,
+                manifest: AppManifest {
+                    name: "Fixture app".into(),
+                    bindings: Vec::new(),
+                },
+                byte_len: bundle.len() as u64,
+                sha256: [7u8; 32],
+                turn_id: None,
+                producing_run_id: None,
+                chat_id: None,
+                created_at: chrono::Utc::now(),
+            },
+        })
+        .await
+        .unwrap();
+    let bundle_path = dir
+        .path()
+        .join(app_revision_relative_path(app_id, revision_id));
+    std::fs::create_dir_all(bundle_path.parent().unwrap()).unwrap();
+    std::fs::write(&bundle_path, &bundle).unwrap();
+
+    let mint = |id: AppId, authorization: Option<&str>| {
+        let mut request = Request::builder()
+            .method("POST")
+            .uri(format!("/apps/{id}/view-session"))
+            .header("content-type", "application/json");
+        if let Some(authorization) = authorization {
+            request = request.header("authorization", authorization);
+        }
+        request.body(Body::from("{}")).unwrap()
+    };
+
+    // Minting requires the bearer and an existing app.
+    let unauthenticated = router.clone().oneshot(mint(app_id, None)).await.unwrap();
+    assert_eq!(unauthenticated.status(), StatusCode::UNAUTHORIZED);
+    let unknown = router
+        .clone()
+        .oneshot(mint(AppId::new(), Some(&bearer)))
+        .await
+        .unwrap();
+    assert_eq!(unknown.status(), StatusCode::NOT_FOUND);
+
+    let minted = router
+        .clone()
+        .oneshot(mint(app_id, Some(&bearer)))
+        .await
+        .unwrap();
+    assert_eq!(minted.status(), StatusCode::OK);
+    let session: serde_json::Value = json_body(minted).await;
+    let frame_path = session["frame_path"].as_str().unwrap().to_string();
+    assert!(frame_path.starts_with("/apps/view-frames/"));
+
+    // The frame redeems once, without auth, under the same strict policy the
+    // MCP view frame carries.
+    let frame = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(&frame_path)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(frame.status(), StatusCode::OK);
+    let csp = frame
+        .headers()
+        .get("content-security-policy")
+        .and_then(|value| value.to_str().ok())
+        .unwrap();
+    assert!(csp.contains("default-src 'none'"));
+    assert!(csp.contains("script-src 'unsafe-inline'"));
+    assert!(csp.contains("connect-src 'none'"));
+    assert_eq!(
+        frame
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok()),
+        Some("text/html; charset=utf-8")
+    );
+    let body = to_bytes(frame.into_body(), 2 * 1024 * 1024).await.unwrap();
+    assert_eq!(body.as_ref(), bundle.as_slice());
+
+    // Replay is refused: the capability is spent.
+    let replay = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(&frame_path)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(replay.status(), StatusCode::NOT_FOUND);
+
+    // A soft-deleted app mints nothing until restored.
+    assert!(store.delete_app(app_id, chrono::Utc::now()).await.unwrap());
+    let deleted = router.oneshot(mint(app_id, Some(&bearer))).await.unwrap();
+    assert_eq!(deleted.status(), StatusCode::NOT_FOUND);
+}

--- a/crates/openwave-server/src/view_frames.rs
+++ b/crates/openwave-server/src/view_frames.rs
@@ -1,0 +1,132 @@
+//! Single-use tokens behind the sandboxed view frames.
+//!
+//! An iframe cannot carry the API bearer, so frame documents are reached by
+//! capability instead: the authenticated renderer trades its bearer for a
+//! short-lived token at a mint route, and the unauthenticated frame route
+//! redeems the token exactly once. The table is its own small piece of app
+//! state rather than part of the MCP runtime because tokens address stored
+//! local-app revisions as well as prefetched MCP views, and the MCP runtime
+//! has no other reason to be involved in app frames.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use openwave_core::id::{AppId, AppRevisionId};
+use tokio::sync::Mutex;
+
+/// How long a minted view-frame token stays redeemable. One iframe load
+/// consumes it; a remount mints a fresh one.
+const VIEW_FRAME_TOKEN_TTL: Duration = Duration::from_secs(60);
+/// Bound on outstanding tokens, so a mint loop cannot grow the table.
+const MAX_VIEW_FRAME_TOKENS: usize = 64;
+
+/// What one frame token addresses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ViewFrameSource {
+    /// A prefetched MCP Apps view, re-resolved against the live runtime at
+    /// redemption so a server that dropped its view stops serving it.
+    McpView {
+        /// Configured server namespace the view was prefetched from.
+        server: String,
+        /// Declared view URI under that server.
+        uri: String,
+    },
+    /// A stored local-app revision, addressed by durable identity only.
+    /// Redemption loads the revision's write-once bundle bytes.
+    AppRevision {
+        /// App the revision belongs to.
+        app_id: AppId,
+        /// Exact revision to serve.
+        revision_id: AppRevisionId,
+    },
+}
+
+/// Outstanding single-use view-frame tokens.
+#[derive(Default)]
+pub(crate) struct ViewFrameTokens {
+    tokens: Mutex<HashMap<uuid::Uuid, (ViewFrameSource, Instant)>>,
+}
+
+impl ViewFrameTokens {
+    /// Mint a token addressing `source`, sweeping expired tokens first.
+    /// Returns `None` at the outstanding-token bound.
+    pub(crate) async fn mint(&self, source: ViewFrameSource) -> Option<uuid::Uuid> {
+        let token = uuid::Uuid::new_v4();
+        let mut tokens = self.tokens.lock().await;
+        let now = Instant::now();
+        tokens.retain(|_, (_, minted)| now.duration_since(*minted) < VIEW_FRAME_TOKEN_TTL);
+        if tokens.len() >= MAX_VIEW_FRAME_TOKENS {
+            return None;
+        }
+        tokens.insert(token, (source, now));
+        Some(token)
+    }
+
+    /// Redeem a token, consuming it. An expired token is consumed too: the
+    /// capability is spent by presentation, whether or not it was served.
+    pub(crate) async fn take(&self, token: uuid::Uuid) -> Option<ViewFrameSource> {
+        let mut tokens = self.tokens.lock().await;
+        let (source, minted) = tokens.remove(&token)?;
+        if minted.elapsed() >= VIEW_FRAME_TOKEN_TTL {
+            return None;
+        }
+        Some(source)
+    }
+
+    #[cfg(test)]
+    async fn backdate(&self, token: uuid::Uuid, age: Duration) {
+        let mut tokens = self.tokens.lock().await;
+        if let Some((_, minted)) = tokens.get_mut(&token) {
+            *minted = Instant::now() - age;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The parts of the capability contract the HTTP tests cannot reach:
+    /// expiry refuses service but still consumes the token, and the
+    /// outstanding set is bounded with expired tokens swept at mint.
+    #[tokio::test]
+    async fn tokens_are_single_use_bounded_and_expire() {
+        let tokens = ViewFrameTokens::default();
+        let source = ViewFrameSource::McpView {
+            server: "gateway".into(),
+            uri: "ui://fixture/app.html".into(),
+        };
+
+        let token = tokens.mint(source.clone()).await.unwrap();
+        assert_eq!(tokens.take(token).await, Some(source.clone()));
+        assert_eq!(
+            tokens.take(token).await,
+            None,
+            "redemption spends the token"
+        );
+
+        let expired = tokens.mint(source.clone()).await.unwrap();
+        tokens.backdate(expired, VIEW_FRAME_TOKEN_TTL).await;
+        assert_eq!(
+            tokens.take(expired).await,
+            None,
+            "an expired token is never served, and presenting it spends it"
+        );
+
+        let mut outstanding = Vec::new();
+        for _ in 0..MAX_VIEW_FRAME_TOKENS {
+            outstanding.push(tokens.mint(source.clone()).await.unwrap());
+        }
+        assert!(
+            tokens.mint(source.clone()).await.is_none(),
+            "the outstanding set is bounded"
+        );
+        for token in outstanding {
+            tokens.backdate(token, VIEW_FRAME_TOKEN_TTL).await;
+        }
+        assert!(
+            tokens.mint(source).await.is_some(),
+            "expired tokens are swept at mint rather than counted forever"
+        );
+    }
+}

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -349,6 +349,7 @@ mod tests {
         // it — and the renderer uses it on its own as the PUT body shape.
         generate::collect_from::<crate::mcp_config::McpServerDefinition>(&cfg, &mut out);
         generate::collect_from::<crate::routes::McpViewSession>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::AppViewSession>(&cfg, &mut out);
         generate::collect_from::<crate::gateway_runtime::GatewayStatus>(&cfg, &mut out);
         generate::collect_from::<crate::managed_policy::ManagedPolicy>(&cfg, &mut out);
         generate::collect_from::<crate::gateway_runtime::GatewayApps>(&cfg, &mut out);


### PR DESCRIPTION
Second slice of the local-apps design (docs/local-apps.md), building on #1262.

## What changed

- **Token table lifted off `McpRuntime`** into a small dedicated `ViewFrameTokens` type in `AppState` (`view_frames.rs`), with a `ViewFrameSource` enum: a prefetched MCP view addressed by `(server, uri)`, or a stored app revision addressed by durable `(app_id, revision_id)`. The MCP runtime is no longer involved in frame tokens.
- **MCP behavior unchanged**: `POST /mcp/servers/{name}/view-session` still requires the prefetched view to exist before minting, `GET /mcp/view-frames/{token}` still re-resolves the view against the live runtime at redemption, and the 60s TTL / 64-outstanding-token bounds carry over verbatim.
- **App frames**: `POST /apps/{id}/view-session` (bearer-guarded) verifies the app exists and is not soft-deleted, defaults to the current revision (an explicit `revision` in the body must belong to the app), and returns the frame path. `GET /apps/view-frames/{token}` redeems once, unauthenticated, loading the write-once bundle bytes at `apps/{app_id}/{revision_id}` under the profile data dir and serving them through the same response helper as MCP frames — identical strict CSP (`default-src 'none'; … connect-src 'none'`) and header envelope.
- **Wire type**: `AppViewSession` registered and the generated `wire.ts` refreshed.

## Tests

- The existing HTTP contract test `mcp_view_frames_are_single_use_capabilities_with_their_own_csp` is untouched and passes — the MCP contract did not move.
- New HTTP contract test `app_view_frames_serve_stored_revisions_under_the_same_contract`: bearer-guarded mint, 404 for unknown and soft-deleted apps, unauthenticated single-use redemption, exact bundle bytes, shared CSP, replay 404.
- New unit test on the lifted table covers what HTTP tests cannot reach: an expired token is consumed without being served, the outstanding set is bounded, and expired tokens are swept at mint.
- Removed the mint/take assertions from the `McpRuntime` unit test (`declared_views_are_prefetched…`): they asserted the token table that no longer lives there; single use and replay remain covered end to end by the HTTP contract test, and the prefetch assertions stay.

Verified scoped per CLAUDE.md: `cargo check -p openwave-server --locked`, the touched test modules (`view_frames`, `mcp_config`, both frame contract tests), `cargo clippy -p openwave-server --all-targets`, `cargo fmt`.

Closes #1255

🤖 Generated with [Claude Code](https://claude.com/claude-code)