### PR TITLE
feat(server): out-of-turn app invoke route with manifest pin enforcement

### DIFF
--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -116,6 +116,22 @@ export type AgentRunStatus = "active" | "queued" | "running" | "cancelling" | "w
 export type AgentRunTier = "foreground" | "background";
 
 /**
+ * The typed refusal body — the `{ kind, message }` shape every route error
+ * carries, with the kind closed so a client never string-matches prose.
+ */
+export type AppInvokeRefusal = { kind: AppInvokeRefusalKind, message: string, };
+
+/**
+ * The stable machine-readable refusals of `POST /apps/{id}/invoke`.
+ *
+ * Unlike the passthrough payloads, the refusal envelope is host-authored and
+ * the renderer must branch on it — `consent_required` is the arm that will
+ * open the grant sheet — so the kind is a closed generated union rather than
+ * a free-form string.
+ */
+export type AppInvokeRefusalKind = "app_not_found" | "not_pinned" | "consent_required" | "unknown_tool";
+
+/**
  * Where the sandboxed iframe should load one app revision from, valid once.
  */
 export type AppViewSession = { frame_path: string, };

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -319,6 +319,11 @@ pub fn app(state: AppState) -> Router {
             "/chats/{chat_id}/calls/{call_id}/mcp-app-payload",
             get(routes::get_mcp_app_payload),
         )
+        .route(
+            "/apps/{id}/invoke",
+            post(routes::post_app_invoke)
+                .layer(DefaultBodyLimit::max(routes::MAX_APP_INVOKE_BODY_BYTES)),
+        )
         .route("/policy", get(routes::get_policy))
         .route("/gateway/status", get(routes::get_gateway_status))
         .route("/gateway/apps", get(routes::get_gateway_apps))

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -44,6 +44,7 @@ use crate::web_search::{
     WebSearchCredentialsInfo,
 };
 
+mod app_invoke;
 pub(crate) mod client_execution;
 mod delegated_file_execution;
 mod document;
@@ -51,6 +52,7 @@ pub(crate) mod image_attachment;
 mod plans;
 mod root_attachment;
 mod user_questions;
+pub use app_invoke::*;
 pub use client_execution::*;
 pub use delegated_file_execution::*;
 pub use document::*;

--- a/crates/openwave-server/src/routes/app_invoke.rs
+++ b/crates/openwave-server/src/routes/app_invoke.rs
@@ -1,0 +1,268 @@
+//! `POST /apps/{id}/invoke` — out-of-turn invocation of a local app's pinned
+//! MCP tools.
+//!
+//! The first tool execution outside a model turn: the sandboxed app frame
+//! posts a call to the trusted renderer, the renderer forwards it here on its
+//! bearer, and the server performs the same dispatch a turn would — registry
+//! snapshot, `Tool::execute` — minus the turn. Enforcement is entirely
+//! server-side and fails closed, in a fixed order: the app must exist with a
+//! current revision, the requested tool must be pinned in that revision's
+//! manifest bindings, and a live app grant must cover the call. The grant
+//! store does not exist yet, so the grant gate refuses every invoke today and
+//! the route ships dark.
+//!
+//! Chat approval gates, permission modes, and plan mode deliberately do not
+//! apply: there is no chat. The app grant is the whole policy.
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::{Deserialize, Serialize};
+
+use openwave_core::id::AppId;
+use openwave_core::local_app::{AppRecord, AppRevision};
+use openwave_core::{AgentError, ChatId, ToolCtx};
+
+use crate::error::ServerError;
+use crate::extract::{Json, Path};
+use crate::state::AppState;
+
+/// Body bound for an invoke request: a mounted tool name plus its opaque
+/// arguments. Generous for a tool call, far below the MCP client's own 2 MiB
+/// JSON-RPC frame bound so an admitted request can always be forwarded.
+pub(crate) const MAX_APP_INVOKE_BODY_BYTES: usize = 256 * 1024;
+
+/// Body of `POST /apps/{id}/invoke`.
+///
+/// `arguments` is opaque passthrough JSON authored inside the sandboxed app
+/// frame. The server hands it to the mounted tool verbatim and the renderer
+/// never interprets it, so — like [`super::McpAppPayload`] — this request has
+/// a hand-written TS twin rather than a generated wire type: the generator's
+/// precision guard rightly refuses `any`-shaped fields.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AppInvokeRequest {
+    /// Full mounted name (`mcp__{server}__{tool}`) of the pinned tool to run.
+    pub tool: String,
+    /// Opaque arguments for the tool, passed through untouched.
+    #[serde(default)]
+    pub arguments: serde_json::Value,
+}
+
+/// Result of a granted invoke, packaged for the sandboxed app frame.
+///
+/// Deliberately not a generated wire type, for the same reason as the
+/// request: `structured_content` is opaque passthrough the renderer forwards
+/// to the frame without reading. Both halves have already crossed the MCP
+/// client's result clamp, so nothing here exceeds the 1 MiB call-result bound.
+#[derive(Debug, PartialEq, Serialize)]
+pub struct AppInvokeResult {
+    /// The call result's text content, clamped by the MCP client.
+    pub content: String,
+    /// The call's structured content, absent when the server sent none or the
+    /// clamp dropped an oversized payload (the text then carries a marker).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub structured_content: Option<serde_json::Value>,
+    /// Whether the external tool reported its own failure.
+    pub is_error: bool,
+}
+
+/// The stable machine-readable refusals of `POST /apps/{id}/invoke`.
+///
+/// Unlike the passthrough payloads, the refusal envelope is host-authored and
+/// the renderer must branch on it — `consent_required` is the arm that will
+/// open the grant sheet — so the kind is a closed generated union rather than
+/// a free-form string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+pub enum AppInvokeRefusalKind {
+    /// No live app with this id.
+    AppNotFound,
+    /// The requested tool is not pinned in the current revision's manifest.
+    NotPinned,
+    /// The pinned tool is not covered by a live app grant.
+    ConsentRequired,
+    /// The pinned name does not resolve to a mounted MCP tool right now.
+    UnknownTool,
+}
+
+/// The typed refusal body — the `{ kind, message }` shape every route error
+/// carries, with the kind closed so a client never string-matches prose.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct AppInvokeRefusal {
+    pub kind: AppInvokeRefusalKind,
+    pub message: String,
+}
+
+impl AppInvokeRefusal {
+    fn status(&self) -> StatusCode {
+        match self.kind {
+            AppInvokeRefusalKind::AppNotFound => StatusCode::NOT_FOUND,
+            AppInvokeRefusalKind::NotPinned | AppInvokeRefusalKind::ConsentRequired => {
+                StatusCode::FORBIDDEN
+            }
+            // The manifest pin exists but nothing mounted answers to it — a
+            // conflict with current MCP state, not a bad request.
+            AppInvokeRefusalKind::UnknownTool => StatusCode::CONFLICT,
+        }
+    }
+}
+
+/// Invoke failure: a typed refusal, or an ordinary server-side failure.
+#[derive(Debug)]
+pub enum AppInvokeError {
+    Refused(AppInvokeRefusal),
+    Failed(ServerError),
+}
+
+impl AppInvokeError {
+    fn refused(kind: AppInvokeRefusalKind, message: impl Into<String>) -> Self {
+        Self::Refused(AppInvokeRefusal {
+            kind,
+            message: message.into(),
+        })
+    }
+}
+
+impl From<AgentError> for AppInvokeError {
+    fn from(error: AgentError) -> Self {
+        Self::Failed(error.into())
+    }
+}
+
+impl IntoResponse for AppInvokeError {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Refused(refusal) => (refusal.status(), axum::Json(refusal)).into_response(),
+            Self::Failed(error) => error.into_response(),
+        }
+    }
+}
+
+/// `POST /apps/{id}/invoke` — execute one of the app's pinned mounted MCP
+/// tools outside any model turn.
+///
+/// Enforcement order is fixed and fails closed: the app record first, then
+/// the manifest pin, then the grant gate, and only then dispatch. Every check
+/// runs server-side against stored state, so nothing the renderer asserts can
+/// widen what a call reaches.
+pub async fn post_app_invoke(
+    State(state): State<AppState>,
+    Path(app_id): Path<AppId>,
+    Json(request): Json<AppInvokeRequest>,
+) -> Result<Json<AppInvokeResult>, AppInvokeError> {
+    let (app, revision) = current_app_revision(&state, app_id).await?;
+    require_pinned(&revision, &request.tool)?;
+    require_app_grant(&state, &app, &revision, &request.tool).await?;
+    dispatch_mounted_tool(&state, &request.tool, request.arguments)
+        .await
+        .map(Json)
+}
+
+/// Resolve a live app and its current revision, or refuse as absent.
+///
+/// A deleted app refuses identically to a missing one: soft-deletion removes
+/// the app from every renderer surface, so it must remove it from this one.
+async fn current_app_revision(
+    state: &AppState,
+    app_id: AppId,
+) -> Result<(AppRecord, AppRevision), AppInvokeError> {
+    let absent = || {
+        AppInvokeError::refused(
+            AppInvokeRefusalKind::AppNotFound,
+            format!("no app {app_id}"),
+        )
+    };
+    let app = state.store.get_app(app_id).await?.ok_or_else(absent)?;
+    if app.deleted_at.is_some() {
+        return Err(absent());
+    }
+    // A live app always points at a stored revision; if the record is ever
+    // inconsistent, fail closed as absent rather than dispatch unpinned.
+    let revision = state
+        .store
+        .get_app_revision(app.current_revision)
+        .await?
+        .ok_or_else(absent)?;
+    Ok((app, revision))
+}
+
+/// Refuse any tool the current revision's manifest does not pin.
+fn require_pinned(revision: &AppRevision, tool: &str) -> Result<(), AppInvokeError> {
+    let pinned = revision
+        .manifest
+        .bindings
+        .iter()
+        .any(|binding| binding.tools.iter().any(|pinned| pinned == tool));
+    if pinned {
+        return Ok(());
+    }
+    Err(AppInvokeError::refused(
+        AppInvokeRefusalKind::NotPinned,
+        format!("{tool:?} is not pinned in this app's current manifest"),
+    ))
+}
+
+/// The consent gate, evaluated after the pin check and before dispatch.
+///
+/// The grant store does not exist yet, so this refuses every invoke and the
+/// route ships dark. The grants slice replaces only this function's body —
+/// checking the live grant's `(server, tools)` cover and the bound server's
+/// definition fingerprint — while the route's enforcement order stays fixed.
+async fn require_app_grant(
+    _state: &AppState,
+    _app: &AppRecord,
+    _revision: &AppRevision,
+    tool: &str,
+) -> Result<(), AppInvokeError> {
+    Err(AppInvokeError::refused(
+        AppInvokeRefusalKind::ConsentRequired,
+        format!("no live app grant covers {tool:?}"),
+    ))
+}
+
+/// Resolve a pinned name against the current MCP snapshot and execute it.
+///
+/// This route invokes mounted MCP tools only. The name must carry the mounted
+/// `mcp__{server}__{tool}` shape — which no built-in server tool does — and
+/// must resolve to a server-executed registration; a client-executed contract
+/// has no executor here and refuses. The execution context is deliberately
+/// inert: no chat owns this call and no scratch is attached, so even though
+/// `McpTool::execute` ignores its context, nothing dispatched from here could
+/// reach a workspace capability. Results cross back through the MCP client's
+/// own 1 MiB call-result clamp.
+pub(crate) async fn dispatch_mounted_tool(
+    state: &AppState,
+    tool_name: &str,
+    arguments: serde_json::Value,
+) -> Result<AppInvokeResult, AppInvokeError> {
+    let unknown = || {
+        AppInvokeError::refused(
+            AppInvokeRefusalKind::UnknownTool,
+            format!("{tool_name:?} is not a mounted MCP tool"),
+        )
+    };
+    if !is_mounted_mcp_name(tool_name) {
+        return Err(unknown());
+    }
+    let registry = state.mcp.snapshot();
+    let tool = registry.get(tool_name).ok_or_else(unknown)?;
+    let ctx = ToolCtx::without_private_scratch(ChatId::new(), None);
+    let output = tool.execute(&ctx, arguments).await?;
+    Ok(AppInvokeResult {
+        content: output.content,
+        structured_content: output.data,
+        is_error: output.is_error,
+    })
+}
+
+/// Whether a name has the mounted `mcp__{server}__{tool}` shape.
+///
+/// The same grammar the manifest validator enforces on pins; repeated here so
+/// dispatch is independently safe when driven without the pin check.
+fn is_mounted_mcp_name(name: &str) -> bool {
+    name.strip_prefix("mcp__").is_some_and(|rest| {
+        rest.split_once("__")
+            .is_some_and(|(server, tool)| !server.is_empty() && !tool.is_empty())
+    })
+}

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -34,6 +34,7 @@ use serde::de::DeserializeOwned;
 use tokio::sync::Notify;
 use tower::ServiceExt;
 
+mod app_invoke;
 mod chat_titling;
 mod configuration;
 mod conversations;

--- a/crates/openwave-server/src/tests/app_invoke.rs
+++ b/crates/openwave-server/src/tests/app_invoke.rs
@@ -1,0 +1,362 @@
+//! `POST /apps/{id}/invoke`: server-side enforcement and MCP dispatch.
+
+use super::*;
+
+use openwave_core::id::{AppId, AppRevisionId};
+use openwave_core::local_app::{AppBinding, AppManifest, CreateApp, NewAppRevision};
+use serde_json::json;
+
+/// The MCP client's call-result bound and the marker its clamp leaves.
+const CALL_RESULT_CLAMP_BYTES: usize = 1024 * 1024;
+const CLAMP_MARKER: &str = "[truncated: MCP result exceeded 1 MiB]";
+
+/// What one invoke against the fake external server observed.
+#[derive(Default)]
+struct ToolServerLog {
+    calls: AtomicUsize,
+    last_arguments: Mutex<Option<serde_json::Value>>,
+}
+
+/// A loopback Streamable-HTTP MCP server mounting `viewer` and `unpinned`,
+/// whose `tools/call` answers with the given content and structured payload.
+async fn spawn_tool_server(
+    log: Arc<ToolServerLog>,
+    content: String,
+    structured: serde_json::Value,
+) -> std::net::SocketAddr {
+    use axum::routing::post as axum_post;
+
+    let handler = move |body: String| {
+        let log = log.clone();
+        let content = content.clone();
+        let structured = structured.clone();
+        async move {
+            let request: serde_json::Value = serde_json::from_str(&body).unwrap();
+            let id = request.get("id").cloned().unwrap_or_default();
+            let result = match request["method"].as_str().unwrap_or_default() {
+                "initialize" => json!({
+                    "protocolVersion": openwave_mcp::PROTOCOL_VERSION,
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "invoke-fixture", "version": "1"}
+                }),
+                "tools/list" => json!({
+                    "tools": [
+                        {
+                            "name": "viewer",
+                            "description": "The pinned tool",
+                            "inputSchema": {"type": "object"}
+                        },
+                        {
+                            "name": "unpinned",
+                            "description": "Mounted but never pinned",
+                            "inputSchema": {"type": "object"}
+                        }
+                    ]
+                }),
+                "tools/call" => {
+                    log.calls.fetch_add(1, Ordering::SeqCst);
+                    *log.last_arguments.lock().unwrap() =
+                        Some(request["params"]["arguments"].clone());
+                    json!({
+                        "content": [{"type": "text", "text": content}],
+                        "structuredContent": structured,
+                        "isError": false
+                    })
+                }
+                _ => json!({}),
+            };
+            (
+                [("content-type", "application/json")],
+                json!({"jsonrpc": "2.0", "id": id, "result": result}).to_string(),
+            )
+        }
+    };
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, Router::new().route("/mcp", axum_post(handler)))
+            .await
+            .unwrap();
+    });
+    address
+}
+
+fn tool_server_config(address: std::net::SocketAddr) -> crate::mcp_config::McpServersConfig {
+    serde_json::from_value(json!({
+        "servers": [{
+            "name": "srv",
+            "url": format!("http://{address}/mcp"),
+            "request_timeout_ms": 30_000,
+            "enabled": true
+        }]
+    }))
+    .unwrap()
+}
+
+/// Create an app whose current manifest pins exactly `tools` under `srv`.
+async fn create_pinned_app(store: &Arc<dyn Store>, tools: &[&str]) -> AppId {
+    let app_id = AppId::new();
+    store
+        .create_app(&CreateApp {
+            id: app_id,
+            revision: NewAppRevision {
+                id: AppRevisionId::new(),
+                manifest: AppManifest {
+                    name: "Invoke fixture".into(),
+                    bindings: vec![AppBinding {
+                        server: "srv".into(),
+                        tools: tools.iter().map(|tool| (*tool).to_owned()).collect(),
+                    }],
+                },
+                byte_len: 1,
+                sha256: [0; 32],
+                turn_id: None,
+                producing_run_id: None,
+                chat_id: None,
+                created_at: chrono::Utc::now(),
+            },
+        })
+        .await
+        .unwrap();
+    app_id
+}
+
+async fn invoke(
+    router: &Router,
+    bearer: &str,
+    app_id: AppId,
+    body: serde_json::Value,
+) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/apps/{app_id}/invoke"))
+                .header("authorization", bearer)
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+/// The route's whole enforcement ladder, fail-closed at every rung: a missing
+/// or deleted app is 404, an unpinned or non-MCP name is refused before the
+/// gate, and — the dark-ship property — even a perfectly pinned tool on a
+/// mounted, healthy server is refused with `consent_required` and the external
+/// server never sees a `tools/call`.
+#[tokio::test]
+async fn every_invoke_is_refused_before_dispatch_until_grants_exist() {
+    let log = Arc::new(ToolServerLog::default());
+    let address = spawn_tool_server(log.clone(), "ok".into(), json!({})).await;
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let put = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/mcp/servers")
+                .header("authorization", &bearer)
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({"servers": [{
+                        "name": "srv",
+                        "url": format!("http://{address}/mcp"),
+                        "request_timeout_ms": 30_000,
+                        "enabled": true
+                    }]})
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(put.status(), StatusCode::OK);
+    let app_id = create_pinned_app(&store, &["mcp__srv__viewer"]).await;
+
+    let refusal = |status: StatusCode, kind: &str| (status, kind.to_owned());
+    let cases = [
+        // No such app: refused before anything is inspected.
+        (
+            AppId::new(),
+            json!({"tool": "mcp__srv__viewer"}),
+            refusal(StatusCode::NOT_FOUND, "app_not_found"),
+        ),
+        // Mounted and healthy, but the manifest never pinned it.
+        (
+            app_id,
+            json!({"tool": "mcp__srv__unpinned"}),
+            refusal(StatusCode::FORBIDDEN, "not_pinned"),
+        ),
+        // A non-MCP name can never be pinned by a validated manifest.
+        (
+            app_id,
+            json!({"tool": "read_file"}),
+            refusal(StatusCode::FORBIDDEN, "not_pinned"),
+        ),
+        // The dark ship: pinned, mounted, healthy — still refused, because no
+        // grant store exists yet.
+        (
+            app_id,
+            json!({"tool": "mcp__srv__viewer", "arguments": {"q": "open"}}),
+            refusal(StatusCode::FORBIDDEN, "consent_required"),
+        ),
+    ];
+    for (target, body, (status, kind)) in cases {
+        let response = invoke(&router, &bearer, target, body.clone()).await;
+        assert_eq!(response.status(), status, "{body}");
+        let info: AgentErrorInfo = json_body(response).await;
+        assert_eq!(info.kind, kind, "{body}");
+    }
+
+    // A soft-deleted app refuses identically to a missing one.
+    store.delete_app(app_id, chrono::Utc::now()).await.unwrap();
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"tool": "mcp__srv__viewer"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    assert_eq!(
+        log.calls.load(Ordering::SeqCst),
+        0,
+        "no refusal path may reach the external server"
+    );
+}
+
+async fn dispatch_state(
+    base: ToolRegistry,
+    address: std::net::SocketAddr,
+) -> (AppState, tempfile::TempDir) {
+    let (dir, store) = temp_db_store("app-invoke.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(base),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state
+        .mcp
+        .replace(tool_server_config(address))
+        .await
+        .unwrap();
+    (state, dir)
+}
+
+/// With the consent gate out of the way (dispatch driven directly, which is
+/// exactly what a granted invoke will do), a pinned name round-trips to the
+/// external server: arguments pass through verbatim, the oversized text comes
+/// back clamped with the client's marker, and the structured payload crosses
+/// as untouched passthrough JSON.
+#[tokio::test]
+async fn gate_opened_dispatch_round_trips_clamped_opaque_results() {
+    let log = Arc::new(ToolServerLog::default());
+    let structured = json!({"rows": [{"id": 7, "status": "open"}]});
+    let address = spawn_tool_server(
+        log.clone(),
+        "x".repeat(CALL_RESULT_CLAMP_BYTES + 64),
+        structured.clone(),
+    )
+    .await;
+    let (state, _dir) = dispatch_state(ToolRegistry::new(), address).await;
+
+    let arguments = json!({"q": "open", "nested": {"limit": 3}});
+    let result =
+        crate::routes::dispatch_mounted_tool(&state, "mcp__srv__viewer", arguments.clone())
+            .await
+            .unwrap();
+
+    assert_eq!(log.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        log.last_arguments.lock().unwrap().clone(),
+        Some(arguments),
+        "arguments must cross to the server verbatim"
+    );
+    assert!(result.content.len() <= CALL_RESULT_CLAMP_BYTES);
+    assert!(
+        result.content.ends_with(CLAMP_MARKER),
+        "the clamp marker must survive to the invoke result"
+    );
+    assert_eq!(
+        result.structured_content,
+        Some(structured),
+        "structured content is opaque passthrough"
+    );
+    assert!(!result.is_error);
+}
+
+/// Even driven with the gate open, dispatch executes mounted MCP tools only:
+/// a built-in server tool, a client-executed contract (including one hiding
+/// under a mounted-looking name), and an unmounted name are all refused.
+#[tokio::test]
+async fn gate_opened_dispatch_refuses_every_non_mcp_surface() {
+    struct BaseTool;
+
+    #[async_trait]
+    impl Tool for BaseTool {
+        fn spec(&self) -> ToolSpec {
+            ToolSpec {
+                name: "innocent_tool".into(),
+                description: "a built-in server tool".into(),
+                input_schema: json!({"type": "object"}),
+            }
+        }
+        fn approval_class(&self) -> ApprovalClass {
+            ApprovalClass::ReadOnly
+        }
+        async fn execute(
+            &self,
+            _ctx: &ToolCtx,
+            _args: serde_json::Value,
+        ) -> openwave_core::Result<ToolOutput> {
+            panic!("the invoke route must never execute a built-in tool");
+        }
+    }
+
+    let log = Arc::new(ToolServerLog::default());
+    let address = spawn_tool_server(log.clone(), "ok".into(), json!({})).await;
+    let mut base = ToolRegistry::new();
+    base.register(Box::new(BaseTool));
+    base.register_client(
+        ToolSpec {
+            name: "mcp__srv__client_owned".into(),
+            description: "client-executed contract".into(),
+            input_schema: json!({"type": "object"}),
+        },
+        ApprovalClass::ReadOnly,
+    );
+    let (state, _dir) = dispatch_state(base, address).await;
+
+    for name in [
+        "innocent_tool",
+        "mcp__srv__client_owned",
+        "mcp__srv__missing",
+        "mcp____tool",
+        "mcp__srv__",
+    ] {
+        let error = crate::routes::dispatch_mounted_tool(&state, name, json!({}))
+            .await
+            .expect_err(name);
+        match error {
+            crate::routes::AppInvokeError::Refused(refusal) => assert_eq!(
+                refusal.kind,
+                crate::routes::AppInvokeRefusalKind::UnknownTool,
+                "{name}"
+            ),
+            other => panic!("{name}: expected a typed refusal, got {other:?}"),
+        }
+    }
+    assert_eq!(log.calls.load(Ordering::SeqCst), 0);
+}

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -320,6 +320,11 @@ mod tests {
         // validators narrow *from* — see the aliases in api.ts.
         generate::collect_from::<crate::routes::PendingApprovalSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::StandingGrantSnapshot>(&cfg, &mut out);
+        // The app-invoke refusal envelope. The invoke payloads themselves are
+        // opaque passthrough for the sandboxed frame and stay hand-written;
+        // only the refusal is generated, because the renderer branches on its
+        // closed kind (`consent_required` opens the grant sheet).
+        generate::collect_from::<crate::routes::AppInvokeRefusal>(&cfg, &mut out);
         generate::collect_from::<openwave_core::PendingUserQuestions>(&cfg, &mut out);
         generate::collect_from::<openwave_core::PendingPlanApproval>(&cfg, &mut out);
         generate::collect_from::<openwave_core::PlanDecisionChoice>(&cfg, &mut out);


### PR DESCRIPTION
Third slice of `docs/local-apps.md`, on top of #1262: `POST /apps/{id}/invoke` on the renderer bearer — the first tool execution outside a model turn — shipping dark until the grants slice lands.

## What this adds

- **The route** (`routes/app_invoke.rs`, registered on the main token-guarded API router): body names a mounted tool (`mcp__{server}__{tool}`) and opaque arguments, bounded at 256 KiB.
- **Server-side enforcement, fail closed, fixed order:**
  1. the app exists, is live, and has a current revision (`app_not_found`, 404);
  2. the tool is pinned in that revision's manifest bindings (`not_pinned`, 403);
  3. a live app grant covers the call — the grant store doesn't exist yet, so this gate refuses **every** invoke (`consent_required`, 403). It is a single seam (`require_app_grant`) whose body the grants slice (#1257) replaces; the route's ordering never moves.
- **Dispatch** (behind the gate, implemented and tested with the gate driven open): current `McpRuntime` snapshot → `ToolRegistry::get` → `Tool::execute` with a chat-less, scratch-less `ToolCtx`. Mounted MCP tools only — built-in server tools, client-executed contracts (even under mounted-looking names), and unmounted names refuse with `unknown_tool` (409). Results cross back through the MCP client's existing 1 MiB call-result clamp.
- **Renderer-safety split:** request arguments and results are opaque passthrough for the sandboxed frame (the documented `McpAppPayload` exception — hand-written twin, never generated, renderer never interprets). The refusal envelope *is* typed and generated (`AppInvokeRefusal` / `AppInvokeRefusalKind` in `wire.ts`) so the renderer branches on a closed kind — `consent_required` is what will open the grant sheet.

Explicitly out of scope, per the design doc: chat approval gate, permission modes, plan mode (no chat exists — the app grant is the whole policy), the grant store (#1257), and all renderer/bridge work (slice 6).

## Tests

Three tests, each multi-arm to keep the harness cost paid once:

- `every_invoke_is_refused_before_dispatch_until_grants_exist` — the enforcement ladder end to end over HTTP against a real loopback MCP server: missing app 404, mounted-but-unpinned refused, non-MCP name refused, deleted app 404, and the dark-ship property: a pinned tool on a healthy mounted server still refuses `consent_required` and the external server never sees a `tools/call`.
- `gate_opened_dispatch_round_trips_clamped_opaque_results` — dispatch driven directly (what a granted invoke will do): arguments cross verbatim, oversized text comes back clamped with the client's marker, structured content passes through untouched.
- `gate_opened_dispatch_refuses_every_non_mcp_surface` — built-in server tool, client-executed contract, and unmounted names all refuse `unknown_tool` even with the gate open.

Verified with `cargo check -p openwave-server --locked`, the new test module, scoped clippy (`--all-targets`, clean), and rustfmt. Wire types regenerated by the checked-in generator test.

Closes #1256

🤖 Generated with [Claude Code](https://claude.com/claude-code)