### PR TITLE
feat(desktop): persist composer attachments per chat

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -14,7 +14,11 @@ import { ChatHeaderTitle } from "./ChatHeaderTitle";
 import { reconcilePendingApprovalCards } from "./ApprovalHistory";
 import { loadChatApprovalHydration } from "./ChatApprovalHydration";
 import { useChatListStore } from "./ChatListStore";
-import { useComposerDraft, useComposerDrafts } from "./ComposerDrafts";
+import {
+  useComposerAttachments,
+  useComposerDraft,
+  useComposerDrafts,
+} from "./ComposerDrafts";
 import { ChatSessionController } from "./ChatSessionController";
 import {
   applyTerminalHydration,
@@ -103,8 +107,8 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   const busy = useChatSessionStore((session) => session.busy);
   const [hydrated, setHydrated] = useState(false);
   const draft = useComposerDraft(chatId);
+  const files = useComposerAttachments(chatId).files;
   const [attaching, setAttaching] = useState(false);
-  const [files, setFiles] = useState<ImportedDocument[]>([]);
   const [attachError, setAttachError] = useState<string | null>(null);
   const images = useImageAttachments(client, chatId);
   const handleEventRef = useRef<(event: SequencedEvent) => void>(() => {});
@@ -268,6 +272,14 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     composerDraftActions.setDraft(chatId, next);
   }
 
+  function setComposerFiles(
+    update: (current: readonly ImportedDocument[]) => ImportedDocument[],
+  ) {
+    const current =
+      useComposerDrafts.getState().attachments[chatId]?.files ?? [];
+    composerDraftActions.setFiles(chatId, update(current));
+  }
+
   async function onSend() {
     await sendMessage(draft.trim());
   }
@@ -374,7 +386,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
       // reader has queued for their *next* message.
       if (fromComposer) {
         images.clear();
-        setFiles([]);
+        setComposerFiles(() => []);
       }
     } catch (err) {
       // Nothing was accepted, so the message has to go back to where it can be
@@ -442,7 +454,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     );
     images.adopt(imagesToAdopt);
     if (filesToAdopt.length > 0) {
-      setFiles((current) => [...current, ...filesToAdopt]);
+      setComposerFiles((current) => [...current, ...filesToAdopt]);
     }
     if (
       imagesToAdopt.length + filesToAdopt.length <
@@ -503,7 +515,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
               attaching,
               onAttach: hasNativeHost() ? onAttach : undefined,
               onRemove: (documentId) =>
-                setFiles((current) =>
+                setComposerFiles((current) =>
                   current.filter((file) => file.documentId !== documentId),
                 ),
             }}

--- a/crates/openwave-desktop/ui/src/ComposerDrafts.test.ts
+++ b/crates/openwave-desktop/ui/src/ComposerDrafts.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createComposerDraftStore,
+  useComposerDrafts,
+} from "./ComposerDrafts";
+import type { ImageAttachment } from "./ImageAttachments";
+
+const READY_IMAGE: ImageAttachment = {
+  id: "local-1",
+  name: "chart.png",
+  byteLen: 4,
+  uploadedBytes: 4,
+  status: "ready",
+  previewUrl: "blob:preview",
+  attachmentId: "1c2f1a44-2f3b-4a1e-9f0a-2b6d5c4e3a21",
+  mediaType: "image/png",
+  width: 800,
+  height: 600,
+  error: null,
+};
+
+const QUEUED_IMAGE: ImageAttachment = {
+  ...READY_IMAGE,
+  id: "local-2",
+  status: "queued",
+  attachmentId: null,
+};
+
+const IMPORTED_FILE = {
+  documentId: "doc-1",
+  displayName: "notes.pdf",
+  mediaType: "application/pdf",
+  byteLen: 10,
+};
+
+beforeEach(() => {
+  useComposerDrafts.setState({ drafts: {}, attachments: {} });
+  window.sessionStorage.clear();
+});
+
+describe("composer draft attachments", () => {
+  it("restores only what a reload can honestly re-send", () => {
+    const store = useComposerDrafts.getState();
+    store.setImages("chat-1", [READY_IMAGE, QUEUED_IMAGE]);
+    store.setFiles("chat-1", [IMPORTED_FILE]);
+
+    // A fresh store is what the next load of the page gets.
+    const restored = createComposerDraftStore().getState().attachments["chat-1"];
+    expect(restored.files).toEqual([IMPORTED_FILE]);
+    // The published image re-sends as-is; the queued one was a promise to
+    // move bytes no storage can hold, so no chip comes back for it.
+    expect(restored.images).toHaveLength(1);
+    expect(restored.images[0]).toMatchObject({
+      name: "chart.png",
+      status: "ready",
+      attachmentId: READY_IMAGE.attachmentId,
+      // Object URLs die with the page; the restored chip falls back to
+      // format and geometry.
+      previewUrl: null,
+    });
+  });
+
+  it("forgets text and attachments together, in the session too", () => {
+    const store = useComposerDrafts.getState();
+    store.setDraft("chat-1", "half a thought");
+    store.setImages("chat-1", [READY_IMAGE]);
+    store.clearDraft("chat-1");
+
+    expect(useComposerDrafts.getState().drafts["chat-1"]).toBeUndefined();
+    expect(useComposerDrafts.getState().attachments["chat-1"]).toBeUndefined();
+
+    const restored = createComposerDraftStore().getState();
+    expect(restored.drafts["chat-1"]).toBeUndefined();
+    expect(restored.attachments["chat-1"]).toBeUndefined();
+  });
+});

--- a/crates/openwave-desktop/ui/src/ComposerDrafts.ts
+++ b/crates/openwave-desktop/ui/src/ComposerDrafts.ts
@@ -1,12 +1,20 @@
 import { create } from "zustand";
 
+import type { ImportedDocument } from "./documents";
+import type { ImageAttachment } from "./ImageAttachments";
+
 const KEY_PREFIX = "composer_";
+const ATTACHMENTS_PREFIX = "composer_attachments_";
 
 /** The home composer's draft, written before a chat exists to hold it. */
 export const HOME_DRAFT_KEY = "home";
 
 function storageKeyFor(key: string): string {
   return `${KEY_PREFIX}${key}`;
+}
+
+function attachmentsStorageKeyFor(key: string): string {
+  return `${ATTACHMENTS_PREFIX}${key}`;
 }
 
 function readStoredDrafts(): Record<string, string> {
@@ -34,8 +42,129 @@ function writeStoredDraft(key: string, text: string): void {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /**
- * What is typed but not yet sent, kept per composer.
+ * What one composer's attachment strip holds but has not sent.
+ *
+ * `pendingChatId` is written by the home composer alone. Home attaches files
+ * before a chat exists, so a chat is created silently to publish them to, and
+ * its id has to survive with the attachments — a restored draft without it
+ * would offer images no chat will accept. A chat's own composer leaves it
+ * null: its key is the chat id already.
+ */
+export type ComposerAttachmentDraft = {
+  images: ImageAttachment[];
+  files: ImportedDocument[];
+  pendingChatId: string | null;
+};
+
+export const EMPTY_ATTACHMENT_DRAFT: ComposerAttachmentDraft = {
+  images: [],
+  files: [],
+  pendingChatId: null,
+};
+
+function isEmptyAttachmentDraft(draft: ComposerAttachmentDraft): boolean {
+  return (
+    draft.images.length === 0 &&
+    draft.files.length === 0 &&
+    draft.pendingChatId === null
+  );
+}
+
+/**
+ * Only what a reload can honestly restore goes into the session. A published
+ * image is server identity plus geometry, so it re-sends as-is; a queued or
+ * failed one is a promise to move bytes the renderer holds in a `File`, which
+ * no storage can keep — restoring its chip would offer a retry with nothing
+ * behind it. Object URLs die with the page, so restored chips fall back to
+ * format and geometry the way host-picked images always do.
+ */
+function storableDraft(
+  draft: ComposerAttachmentDraft,
+): ComposerAttachmentDraft {
+  return {
+    images: draft.images
+      .filter((image) => image.status === "ready" && image.attachmentId !== null)
+      .map((image) => ({ ...image, previewUrl: null })),
+    files: draft.files,
+    pendingChatId: draft.pendingChatId,
+  };
+}
+
+function parseStoredAttachmentDraft(value: string): ComposerAttachmentDraft | null {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!isRecord(parsed)) return null;
+    const images = (Array.isArray(parsed.images) ? parsed.images : [])
+      .filter(
+        (image): image is ImageAttachment =>
+          isRecord(image) &&
+          image.status === "ready" &&
+          typeof image.attachmentId === "string",
+      )
+      .map((image) => ({ ...image, previewUrl: null }));
+    const files = (Array.isArray(parsed.files) ? parsed.files : []).filter(
+      (file): file is ImportedDocument =>
+        isRecord(file) &&
+        typeof file.documentId === "string" &&
+        typeof file.displayName === "string",
+    );
+    return {
+      images,
+      files,
+      pendingChatId:
+        typeof parsed.pendingChatId === "string" ? parsed.pendingChatId : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function readStoredAttachmentDrafts(): Record<string, ComposerAttachmentDraft> {
+  const drafts: Record<string, ComposerAttachmentDraft> = {};
+  try {
+    const storage = window.sessionStorage;
+    for (let index = 0; index < storage.length; index += 1) {
+      const name = storage.key(index);
+      if (!name?.startsWith(ATTACHMENTS_PREFIX)) continue;
+      const value = storage.getItem(name);
+      if (!value) continue;
+      const draft = parseStoredAttachmentDraft(value);
+      if (draft && !isEmptyAttachmentDraft(draft)) {
+        drafts[name.slice(ATTACHMENTS_PREFIX.length)] = draft;
+      }
+    }
+  } catch {
+    // A composer with no memory still works; an unreadable store is not fatal.
+  }
+  return drafts;
+}
+
+function writeStoredAttachmentDraft(
+  key: string,
+  draft: ComposerAttachmentDraft,
+): void {
+  try {
+    if (isEmptyAttachmentDraft(draft)) {
+      window.sessionStorage.removeItem(attachmentsStorageKeyFor(key));
+    } else {
+      window.sessionStorage.setItem(
+        attachmentsStorageKeyFor(key),
+        JSON.stringify(storableDraft(draft)),
+      );
+    }
+  } catch {
+    // Persisting a draft is best-effort; the session still holds it.
+  }
+}
+
+/**
+ * What a composer is holding but has not sent, kept per composer: the typed
+ * text and the attachment strip.
  *
  * The chat route is remounted per conversation, so a draft held in the route
  * dies the moment you look at another chat — which is exactly when people
@@ -49,27 +178,65 @@ function writeStoredDraft(key: string, text: string): void {
  */
 export type ComposerDraftStore = {
   drafts: Record<string, string>;
+  attachments: Record<string, ComposerAttachmentDraft>;
   setDraft: (key: string, text: string) => void;
+  /**
+   * Forget a composer's whole draft — text, attachments, everything. For when
+   * the chat the draft belonged to no longer exists to send it to.
+   */
   clearDraft: (key: string) => void;
+  setImages: (key: string, images: ImageAttachment[]) => void;
+  setFiles: (key: string, files: ImportedDocument[]) => void;
+  setPendingChatId: (key: string, chatId: string | null) => void;
 };
 
 export function createComposerDraftStore() {
-  return create<ComposerDraftStore>()((set) => ({
-    drafts: readStoredDrafts(),
-    setDraft: (key, text) => {
-      writeStoredDraft(key, text);
-      set((state) => ({ drafts: { ...state.drafts, [key]: text } }));
-    },
-    clearDraft: (key) => {
-      writeStoredDraft(key, "");
+  return create<ComposerDraftStore>()((set, get) => {
+    function updateAttachments(
+      key: string,
+      change: (current: ComposerAttachmentDraft) => ComposerAttachmentDraft,
+    ): void {
+      const next = change(
+        get().attachments[key] ?? EMPTY_ATTACHMENT_DRAFT,
+      );
+      writeStoredAttachmentDraft(key, next);
       set((state) => {
-        if (!(key in state.drafts)) return state;
-        const drafts = { ...state.drafts };
-        delete drafts[key];
-        return { drafts };
+        const attachments = { ...state.attachments };
+        if (isEmptyAttachmentDraft(next)) delete attachments[key];
+        else attachments[key] = next;
+        return { attachments };
       });
-    },
-  }));
+    }
+
+    return {
+      drafts: readStoredDrafts(),
+      attachments: readStoredAttachmentDrafts(),
+      setDraft: (key, text) => {
+        writeStoredDraft(key, text);
+        set((state) => ({ drafts: { ...state.drafts, [key]: text } }));
+      },
+      clearDraft: (key) => {
+        writeStoredDraft(key, "");
+        writeStoredAttachmentDraft(key, EMPTY_ATTACHMENT_DRAFT);
+        set((state) => {
+          const drafts = { ...state.drafts };
+          delete drafts[key];
+          const attachments = { ...state.attachments };
+          delete attachments[key];
+          return { drafts, attachments };
+        });
+      },
+      setImages: (key, images) =>
+        updateAttachments(key, (current) => ({ ...current, images })),
+      setFiles: (key, files) =>
+        updateAttachments(key, (current) => ({ ...current, files })),
+      setPendingChatId: (key, chatId) =>
+        updateAttachments(key, (current) => ({
+          ...current,
+          pendingChatId: chatId,
+        })),
+    };
+  });
 }
 
 export const useComposerDrafts = createComposerDraftStore();
@@ -77,4 +244,11 @@ export const useComposerDrafts = createComposerDraftStore();
 /** This composer's unsent text, restored from a previous visit if there is one. */
 export function useComposerDraft(key: string): string {
   return useComposerDrafts((state) => state.drafts[key] ?? "");
+}
+
+/** This composer's unsent attachments, restored from a previous visit if there are any. */
+export function useComposerAttachments(key: string): ComposerAttachmentDraft {
+  return useComposerDrafts(
+    (state) => state.attachments[key] ?? EMPTY_ATTACHMENT_DRAFT,
+  );
 }

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 
 import { useApp } from "./AppContext";
@@ -7,6 +7,7 @@ import { useChatListStore } from "./ChatListStore";
 import { Composer, type ComposerImages } from "./Composer";
 import {
   HOME_DRAFT_KEY,
+  useComposerAttachments,
   useComposerDraft,
   useComposerDrafts,
 } from "./ComposerDrafts";
@@ -55,22 +56,56 @@ export function HomeRoute() {
 
   // A chat created silently when the user attaches files before typing. The
   // chat exists on the server so files can upload, but the user stays on the
-  // home page until they send.
-  const [pendingChatId, setPendingChatId] = useState<string | null>(null);
-  const [pendingImages, setPendingImages] = useState<ImageAttachment[]>([]);
-  const [pendingFiles, setPendingFiles] = useState<ImportedDocument[]>([]);
+  // home page until they send. The id is part of the home draft: without it a
+  // restored attachment strip would publish to a chat nobody remembers.
+  const attachments = useComposerAttachments(HOME_DRAFT_KEY);
+  const pendingChatId = attachments.pendingChatId;
+  const pendingImages = attachments.images;
+  const pendingFiles = attachments.files;
   const [attaching, setAttaching] = useState(false);
   const [attachError, setAttachError] = useState<string | null>(null);
 
+  const chats = useChatListStore((state) => state.chats);
+  const chatsLoaded = useChatListStore((state) => state.chatsLoaded);
+
+  // A restored home draft may point at a chat that no longer exists — deleted
+  // in another window since the attachments were published to it. Those images
+  // and files can never send, so drop them; the text stands on its own.
+  useEffect(() => {
+    if (!chatsLoaded || !pendingChatId) return;
+    if (chats.some((chat) => chat.id === pendingChatId)) return;
+    composerDraftActions.setPendingChatId(HOME_DRAFT_KEY, null);
+    composerDraftActions.setImages(HOME_DRAFT_KEY, []);
+    composerDraftActions.setFiles(HOME_DRAFT_KEY, []);
+  }, [chatsLoaded, chats, pendingChatId]);
+
+  function setPendingImages(
+    update: (current: readonly ImageAttachment[]) => ImageAttachment[],
+  ) {
+    const current =
+      useComposerDrafts.getState().attachments[HOME_DRAFT_KEY]?.images ?? [];
+    composerDraftActions.setImages(HOME_DRAFT_KEY, update(current));
+  }
+
+  function setPendingFiles(
+    update: (current: readonly ImportedDocument[]) => ImportedDocument[],
+  ) {
+    const current =
+      useComposerDrafts.getState().attachments[HOME_DRAFT_KEY]?.files ?? [];
+    composerDraftActions.setFiles(HOME_DRAFT_KEY, update(current));
+  }
+
   async function ensurePendingChat(): Promise<string> {
-    if (pendingChatId) return pendingChatId;
+    const existing =
+      useComposerDrafts.getState().attachments[HOME_DRAFT_KEY]?.pendingChatId;
+    if (existing) return existing;
     const created = await client.createChat(newChat.model ?? undefined, null, {
       reasoningEffort: newChat.reasoningEffort,
       permissionMode: newChat.permissionMode,
     });
     chatListActions.prependChat(created);
     chatListActions.setChatsError(null);
-    setPendingChatId(created.id);
+    composerDraftActions.setPendingChatId(HOME_DRAFT_KEY, created.id);
     return created.id;
   }
 
@@ -171,12 +206,12 @@ export function HomeRoute() {
         images: pendingImages,
         files: pendingFiles,
       });
-      setDraft("");
-      setPendingChatId(null);
-      setPendingImages([]);
-      setPendingFiles([]);
-      setAttachError(null);
+      // Clear the home draft only once navigation has committed. If it throws,
+      // the message lives only in the FirstMessage store with no composer
+      // showing it — the draft has to stay where the reader can see and
+      // resend it.
       await navigate({ to: "/c/$chatId", params: { chatId } });
+      composerDraftActions.clearDraft(HOME_DRAFT_KEY);
     } catch (err) {
       setError(`Could not start a chat: ${String(err)}`);
     } finally {

--- a/crates/openwave-desktop/ui/src/useImageAttachments.test.ts
+++ b/crates/openwave-desktop/ui/src/useImageAttachments.test.ts
@@ -3,6 +3,7 @@ import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ApiClient } from "./api";
+import { useComposerDrafts } from "./ComposerDrafts";
 import { useImageAttachments } from "./useImageAttachments";
 
 const ATTACHMENT_ID = "1c2f1a44-2f3b-4a1e-9f0a-2b6d5c4e3a21";
@@ -80,6 +81,10 @@ function png(name = "chart.png"): File {
 }
 
 beforeEach(() => {
+  // The attachments live in the module-level draft store now, so each test
+  // starts it empty rather than inheriting the last test's chips.
+  useComposerDrafts.setState({ drafts: {}, attachments: {} });
+  window.sessionStorage.clear();
   FakeUpload.opened = [];
   hasNativeHost.mockReturnValue(false);
   publishChatImage.mockReset();
@@ -210,6 +215,40 @@ describe("useImageAttachments", () => {
     );
     expect(FakeUpload.opened).toHaveLength(0);
     expect(publishChatImage).toHaveBeenCalledWith("chat-1", expect.any(File));
+  });
+
+  it("keeps the strip across the remount a chat switch causes", async () => {
+    const first = renderHook(() => useImageAttachments(client, "chat-1"));
+
+    act(() => first.result.current.attachFiles([png()]));
+    await waitFor(() => expect(FakeUpload.opened).toHaveLength(1));
+    act(() => FakeUpload.opened[0].finish(201, PUBLISHED));
+    await waitFor(() =>
+      expect(first.result.current.attachments[0].status).toBe("ready"),
+    );
+
+    first.unmount();
+    const second = renderHook(() => useImageAttachments(client, "chat-1"));
+    expect(second.result.current.attachments[0]).toMatchObject({
+      name: "chart.png",
+      status: "ready",
+      attachmentId: ATTACHMENT_ID,
+    });
+
+    // A chat the reader switched away from mid-upload lands ready when they
+    // return, rather than dying with the unmounted route.
+    act(() => second.result.current.attachFiles([png("later.png")]));
+    await waitFor(() => expect(FakeUpload.opened).toHaveLength(2));
+    second.unmount();
+    act(() => FakeUpload.opened[1].finish(201, PUBLISHED));
+
+    const third = renderHook(() => useImageAttachments(client, "chat-1"));
+    await waitFor(() =>
+      expect(third.result.current.attachments[1]).toMatchObject({
+        name: "later.png",
+        status: "ready",
+      }),
+    );
   });
 
   it("forgets everything once a turn has carried it", async () => {

--- a/crates/openwave-desktop/ui/src/useImageAttachments.ts
+++ b/crates/openwave-desktop/ui/src/useImageAttachments.ts
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
 import type { ApiClient } from "./api";
 import { publishChatImage } from "./attachments";
+import { useComposerDrafts } from "./ComposerDrafts";
 import { hasNativeHost } from "./host";
 import {
   imageAttachmentName,
@@ -32,6 +33,75 @@ export type ImageAttachmentControls = {
   clear: () => void;
 };
 
+const NO_IMAGES: ImageAttachment[] = [];
+
+/**
+ * The bytes behind the chips, which no store can hold.
+ *
+ * The attachment list itself lives in the composer draft store, so it survives
+ * the route remount that every chat switch causes. What cannot go there — the
+ * `File` a retry re-reads, the upload to abort, the preview's object URL — is
+ * kept here per conversation, for exactly as long as the draft it belongs to.
+ */
+type ImageBacking = {
+  files: Map<string, File>;
+  aborts: Map<string, AbortController>;
+  previews: Map<string, string>;
+};
+
+const backingByChat = new Map<string, ImageBacking>();
+
+function backingFor(chatId: string): ImageBacking {
+  let backing = backingByChat.get(chatId);
+  if (!backing) {
+    backing = { files: new Map(), aborts: new Map(), previews: new Map() };
+    backingByChat.set(chatId, backing);
+  }
+  return backing;
+}
+
+function forgetBacking(chatId: string, id: string): void {
+  const backing = backingByChat.get(chatId);
+  if (!backing) return;
+  backing.aborts.get(id)?.abort();
+  backing.aborts.delete(id);
+  const preview = backing.previews.get(id);
+  if (preview) URL.revokeObjectURL(preview);
+  backing.previews.delete(id);
+  backing.files.delete(id);
+}
+
+/**
+ * Hand every object URL and in-flight upload for one conversation back. An
+ * object URL outlives the element that rendered it, so it has to be handed
+ * back explicitly — but only when the draft itself is gone. Revoking on
+ * unmount would destroy the very thing the store just kept.
+ */
+function releaseBacking(chatId: string): void {
+  const backing = backingByChat.get(chatId);
+  if (!backing) return;
+  for (const controller of backing.aborts.values()) controller.abort();
+  for (const url of backing.previews.values()) URL.revokeObjectURL(url);
+  backingByChat.delete(chatId);
+}
+
+// A draft entry that disappears entirely — the chat was deleted, its composer
+// cleared from outside the route — takes its backing with it. Removals the
+// hook performs itself are forgotten one id at a time instead.
+useComposerDrafts.subscribe((state, previous) => {
+  for (const chatId of Object.keys(previous.attachments)) {
+    if (!(chatId in state.attachments)) releaseBacking(chatId);
+  }
+});
+
+function setComposerImages(
+  chatId: string,
+  change: (current: readonly ImageAttachment[]) => ImageAttachment[],
+): void {
+  const current = useComposerDrafts.getState().attachments[chatId]?.images ?? [];
+  useComposerDrafts.getState().setImages(chatId, change(current));
+}
+
 /**
  * The images waiting on one conversation's composer.
  *
@@ -42,57 +112,28 @@ export type ImageAttachmentControls = {
  * pixels to preview. Both land in the same list, so removal, retry, and send
  * gating cannot behave differently depending on how the image got here.
  *
- * The `File` behind each upload is kept until the attachment leaves the list.
- * That is what makes retry a retry, rather than an invitation to go and find
- * the file again.
+ * The list is the conversation's composer draft, so switching chats and coming
+ * back finds the strip as it was left — including an upload that finished
+ * while the reader was looking at another chat. The `File` behind each upload
+ * is kept until the attachment leaves the list. That is what makes retry a
+ * retry, rather than an invitation to go and find the file again.
  */
 export function useImageAttachments(
   client: ApiClient,
   chatId: string,
 ): ImageAttachmentControls {
-  const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
+  const attachments = useComposerDrafts(
+    (state) => state.attachments[chatId]?.images ?? NO_IMAGES,
+  );
   const [error, setError] = useState<string | null>(null);
   const attachmentsRef = useRef<ImageAttachment[]>([]);
-  const filesRef = useRef(new Map<string, File>());
-  const abortsRef = useRef(new Map<string, AbortController>());
-  const previewsRef = useRef(new Map<string, string>());
-  const mountedRef = useRef(true);
 
   attachmentsRef.current = attachments;
-
-  // An object URL outlives the element that rendered it, so it has to be handed
-  // back explicitly. Closing a conversation with images attached would otherwise
-  // pin their bytes in memory for the life of the window, and an upload nobody
-  // is waiting for would keep running.
-  useEffect(() => {
-    mountedRef.current = true;
-    const aborts = abortsRef.current;
-    const previews = previewsRef.current;
-    const files = filesRef.current;
-    return () => {
-      mountedRef.current = false;
-      for (const controller of aborts.values()) controller.abort();
-      for (const url of previews.values()) URL.revokeObjectURL(url);
-      aborts.clear();
-      previews.clear();
-      files.clear();
-    };
-  }, [chatId]);
 
   function update(
     change: (current: readonly ImageAttachment[]) => ImageAttachment[],
   ) {
-    if (!mountedRef.current) return;
-    setAttachments((current) => change(current));
-  }
-
-  function forget(id: string) {
-    abortsRef.current.get(id)?.abort();
-    abortsRef.current.delete(id);
-    const preview = previewsRef.current.get(id);
-    if (preview) URL.revokeObjectURL(preview);
-    previewsRef.current.delete(id);
-    filesRef.current.delete(id);
+    setComposerImages(chatId, change);
   }
 
   /**
@@ -122,10 +163,11 @@ export function useImageAttachments(
   }
 
   async function upload(id: string) {
-    const file = filesRef.current.get(id);
+    const backing = backingFor(chatId);
+    const file = backing.files.get(id);
     if (!file) return;
     const controller = new AbortController();
-    abortsRef.current.set(id, controller);
+    backing.aborts.set(id, controller);
     update((current) => withUploadStarted(current, id));
     try {
       const published = await publish(id, file, controller.signal);
@@ -136,7 +178,7 @@ export function useImageAttachments(
       if (err instanceof DOMException && err.name === "AbortError") return;
       update((current) => withUploadFailed(current, id, failureText(err)));
     } finally {
-      abortsRef.current.delete(id);
+      backing.aborts.delete(id);
     }
   }
 
@@ -148,12 +190,13 @@ export function useImageAttachments(
       return;
     }
     setError(null);
+    const backing = backingFor(chatId);
     const now = new Date();
     const queued = files.map((file) => {
       const id = crypto.randomUUID();
-      filesRef.current.set(id, file);
+      backing.files.set(id, file);
       const previewUrl = URL.createObjectURL(file);
-      previewsRef.current.set(id, previewUrl);
+      backing.previews.set(id, previewUrl);
       return queuedImageAttachment(id, {
         name: imageAttachmentName(file, now),
         byteLen: file.size,
@@ -181,7 +224,7 @@ export function useImageAttachments(
     adopt,
     attachFiles,
     remove: (id) => {
-      forget(id);
+      forgetBacking(chatId, id);
       update((current) => withoutAttachment(current, id));
     },
     retry: (id) => {
@@ -189,7 +232,9 @@ export function useImageAttachments(
       void upload(id);
     },
     clear: () => {
-      for (const attachment of attachmentsRef.current) forget(attachment.id);
+      for (const attachment of attachmentsRef.current) {
+        forgetBacking(chatId, attachment.id);
+      }
       update(() => []);
       setError(null);
     },


### PR DESCRIPTION
## What survives a chat switch now

#1136 made composer *text* survive chat switches and reloads; this extends the same store-plus-sessionStorage idiom to the attachment strip, so the text no longer outlives its attachments:

- **`ChatRoute`** — imported files move from route-local `useState` into the composer draft store (keyed by chat id), and `useImageAttachments` keeps its image list there instead of in the hook. Switching chats and coming back — or reloading — finds the strip as it was left, including an upload that finished while you were looking at another chat.
- **`HomeRoute`** — pending images, pending files, and the silently created pending chat id move into the store under the home key. The id has to persist with the attachments: they were published to that chat, and a restored strip without it would offer images no chat will accept.

Persistence scope matches the text drafts (session-scoped). Only what a reload can honestly re-send goes into `sessionStorage`: published images (server id + geometry) and imported documents. Queued or failed uploads stay in memory only — their chips survive a chat switch, but a reload cannot restore the `File` bytes behind a retry, so no phantom chips come back. Object URLs are dropped on persist; restored chips fall back to format and geometry, the way host-picked images always render.

The byte-level backing (`File` handles for retry, abort controllers, preview object URLs) lives in a per-chat map released only when the draft itself goes away — removal, a successful send, or the draft being cleared — rather than on route unmount, which would destroy exactly what the store just kept.

## Smaller fixes folded in

- **`startChat` clears the home draft only after `await navigate` commits.** Previously a thrown navigation left the message only in the `FirstMessage` store with no composer showing it — the same class of bug #1106 fixed, on a narrower path. Now a failed navigation leaves the draft (text and attachments) where the reader can see and resend it.
- **Deleting a chat clears its attachment draft along with its text draft** (same `clearDraft` call in `AppShell`).
- **A restored home draft whose pending chat no longer exists** (deleted in another window) drops its unsendable attachments once the chat list loads; the text stands on its own.

## Not fixed (noted per the issue)

**A chat deleted in another window leaves its draft behind in this one.** `sessionStorage` is per-tab, so the store idiom has no cross-window channel to invalidate through, and the chat's *text* draft already behaves this way. The store now at least funnels same-window deletion (and the home pending-chat case above) through one clear path. There is no "focus-item" state in these routes; nothing to port there.

## Tests

- `useImageAttachments.test.ts`: the strip — including an upload that completes mid-switch — survives the remount a chat switch causes.
- `ComposerDrafts.test.ts` (new): a fresh store restores only what a reload can honestly re-send (published images, imported files; queued images dropped, object URLs nulled), and `clearDraft` forgets text and attachments in memory and in the session.

Full `pnpm test` (657 tests) and `pnpm build` pass.

Closes #1139
