### PR TITLE
feat(core): create_app foreground tool with transcript entry card

### DIFF
--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -479,10 +479,37 @@ id_type!(
     AppId
 );
 
+impl AppId {
+    const NAMESPACE: Uuid = Uuid::from_u128(0xffa3_faf3_1345_4d93_a843_5f92_c996_7331);
+
+    /// Derive the retry-stable app identity for one canonical tool call.
+    ///
+    /// `create_app` mints identity the way the output tools do: from the
+    /// durable call id, so an ambiguous store response retried by the model
+    /// lands on the same app rather than forking a second record.
+    #[must_use]
+    pub fn for_call(call_id: CallId) -> Self {
+        Self(Uuid::new_v5(&Self::NAMESPACE, call_id.as_uuid().as_bytes()))
+    }
+}
+
 id_type!(
     /// Identifies one immutable revision of a local app.
     AppRevisionId
 );
+
+impl AppRevisionId {
+    const NAMESPACE: Uuid = Uuid::from_u128(0xb60b_2034_fb5a_4651_b284_646f_f59b_a069);
+
+    /// Derive the retry-stable revision identity for one canonical tool call.
+    ///
+    /// One call publishes exactly one revision — of a new app or of the app it
+    /// appends to — so the call id alone is the whole identity.
+    #[must_use]
+    pub fn for_call(call_id: CallId) -> Self {
+        Self(Uuid::new_v5(&Self::NAMESPACE, call_id.as_uuid().as_bytes()))
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -214,7 +214,7 @@ pub use tool::{
     ToolErrorCategory, ToolOutput, ToolScratch, ToolSpec, ToolUiView,
 };
 #[cfg(feature = "tools")]
-pub use tools::{ListDir, ReadFile, WriteFile};
+pub use tools::{CreateAppTool, ListDir, ReadFile, WriteFile};
 pub use user_questions::{
     ask_user_questions_tool_spec, validate_ask_user_questions_arguments, AnswerUserQuestions,
     AnswerUserQuestionsRequest, AskUserQuestionsArgs, PendingUserQuestions, UserQuestion,

--- a/crates/openwave-core/src/local_app.rs
+++ b/crates/openwave-core/src/local_app.rs
@@ -18,6 +18,13 @@ use serde::{Deserialize, Serialize};
 use crate::deliverable::RevisionProducer;
 use crate::id::{AgentRunId, AppId, AppRevisionId, ChatId, TurnId};
 
+/// Stable name of the foreground tool that creates and revises local apps.
+///
+/// Lives beside the record contract rather than in the feature-gated tool
+/// module because the renderer projection allowlist needs the name without
+/// pulling in the capability filesystem.
+pub const CREATE_APP_TOOL: &str = "create_app";
+
 /// Profile-data directory holding immutable app bundle bytes.
 ///
 /// Deliberately a profile-level root rather than any conversation's private
@@ -188,7 +195,10 @@ pub struct CreateApp {
 /// The manifest — not the bundle — is what the user consents to and what the
 /// host enforces per call, so its shape is closed (`deny_unknown_fields`) and
 /// validated structurally before anything is stored.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// `JsonSchema` because the `create_app` tool takes the manifest as a typed
+/// argument, so the model sees the exact structural contract the store will
+/// validate.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct AppManifest {
     /// Display name shown in the transcript card and the Apps library.
@@ -198,7 +208,7 @@ pub struct AppManifest {
 }
 
 /// The mounted tools one server namespace contributes to an app.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct AppBinding {
     /// Configured server namespace the tools are mounted under.

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -423,6 +423,9 @@ const ENTRY_TOOLS: &[&str] = &[
     crate::READ_CONNECTED_FILE_TOOL,
     crate::IMPORT_CONNECTED_FILE_TOOL,
     crate::WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
+    // Lists the one app record the call created or revised: name and ordinal
+    // only, never the bundle or the manifest's bindings.
+    crate::local_app::CREATE_APP_TOOL,
 ];
 
 impl ToolResultPreview {

--- a/crates/openwave-core/src/tools/create_app.rs
+++ b/crates/openwave-core/src/tools/create_app.rs
@@ -1,0 +1,484 @@
+//! `create_app` — publish a local mini-app the user can reopen from their
+//! library.
+//!
+//! The tool records a profile-scoped app: an untrusted HTML bundle published
+//! write-once under the profile data directory, paired with a trusted manifest
+//! naming the mounted MCP tools the app may call. Identity follows the output
+//! tools' discipline — the app and revision ids derive from the durable call
+//! id, so a retried call lands on the record it already created instead of
+//! forking a second one.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::error::Result;
+use crate::id::{AppId, AppRevisionId, TurnId};
+use crate::local_app::{
+    publish_app_bundle, validate_app_manifest, AppManifest, AppRecord, CreateApp, NewAppRevision,
+    MAX_APP_BUNDLE_BYTES,
+};
+use crate::preview::{ResultEntry, ResultEntryKind};
+use crate::storage::Store;
+use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
+
+use super::arguments;
+use super::definitions;
+
+/// `create_app` — create a profile-scoped local app or append a revision.
+pub struct CreateAppTool {
+    store: Arc<dyn Store>,
+    profile_data_dir: PathBuf,
+}
+
+#[derive(Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(super) struct Arguments {
+    #[schemars(
+        description = "The complete self-contained HTML document the app renders. \
+                       It runs in a sandboxed frame with no network access."
+    )]
+    bundle_html: String,
+    #[schemars(
+        description = "The app's manifest: its display name and the exact mounted \
+                       MCP tools it may call, grouped by server."
+    )]
+    manifest: AppManifest,
+    #[serde(default)]
+    #[schemars(
+        description = "An app_id returned by an earlier create_app call. Provide it \
+                       to publish a new revision of that app; omit it to create a \
+                       new app."
+    )]
+    app_id: Option<Uuid>,
+}
+
+impl CreateAppTool {
+    /// A tool recording apps in `store` and bundle bytes under the profile
+    /// data directory.
+    #[must_use]
+    pub fn new(store: Arc<dyn Store>, profile_data_dir: PathBuf) -> Self {
+        Self {
+            store,
+            profile_data_dir,
+        }
+    }
+
+    /// Verify the executing call is durably recorded in this conversation and
+    /// return the turn that owns it.
+    ///
+    /// Identity derives from the call id, so the id must be one the host
+    /// minted for this chat — not a value any argument could steer — before it
+    /// is allowed to name profile-scoped records.
+    async fn owned_call_turn(&self, ctx: &ToolCtx) -> std::result::Result<TurnId, ToolOutput> {
+        let Some(call_id) = ctx.call_id else {
+            return Err(ToolOutput::error(
+                "create_app is only available from a recorded agent turn",
+            ));
+        };
+        let calls = self
+            .store
+            .list_tool_calls(ctx.chat_id)
+            .await
+            .map_err(|_| ToolOutput::error("could not verify this call's identity"))?;
+        calls
+            .into_iter()
+            .find(|call| call.id == call_id)
+            .map(|call| call.turn_id)
+            .ok_or_else(|| ToolOutput::error("this call is not recorded in this conversation"))
+    }
+
+    fn success(record: &AppRecord, ordinal: u32, created: bool) -> ToolOutput {
+        let verb = if created {
+            "Created app"
+        } else {
+            "Published a revision of app"
+        };
+        ToolOutput::text(format!(
+            "{verb} {:?} (app_id {}, revision {ordinal}). Pass this app_id to create_app \
+             to publish a further revision.",
+            record.name, record.id,
+        ))
+        .with_entries(vec![ResultEntry::new(
+            ResultEntryKind::Output,
+            record.name.clone(),
+        )
+        .with_meta(format!("revision {ordinal}"))])
+    }
+}
+
+#[async_trait]
+impl Tool for CreateAppTool {
+    fn spec(&self) -> ToolSpec {
+        definitions::create_app()
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        // Publishes durable profile state the user can inspect and delete;
+        // nothing leaves the machine and no pinned tool runs until the user
+        // grants the app its bindings.
+        ApprovalClass::Workspace
+    }
+
+    async fn execute(&self, ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        let args: Arguments = match arguments::parse(args) {
+            Ok(args) => args,
+            Err(output) => return Ok(output),
+        };
+        let turn_id = match self.owned_call_turn(ctx).await {
+            Ok(turn_id) => turn_id,
+            Err(output) => return Ok(output),
+        };
+        // `ctx.call_id` was verified against the durable record just above.
+        let call_id = ctx.call_id.expect("owned_call_turn requires a call id");
+        if let Err(message) = validate_app_manifest(&args.manifest) {
+            return Ok(ToolOutput::error(format!(
+                "invalid app manifest: {message}"
+            )));
+        }
+        let bundle = args.bundle_html.as_bytes();
+        if bundle.is_empty() {
+            return Ok(ToolOutput::error("bundle_html must not be empty"));
+        }
+        if bundle.len() > MAX_APP_BUNDLE_BYTES {
+            return Ok(ToolOutput::error(format!(
+                "bundle_html is {} bytes; the limit is {MAX_APP_BUNDLE_BYTES}",
+                bundle.len()
+            )));
+        }
+
+        // Identity: both ids derive from the durable call id, so re-executing
+        // the same call re-derives the same identities.
+        let revision_id = AppRevisionId::for_call(call_id);
+        let app_id = match args.app_id {
+            Some(app_id) if !app_id.is_nil() => AppId::from(app_id),
+            Some(_) => return Ok(ToolOutput::error("app_id must be a real app id")),
+            None => AppId::for_call(call_id),
+        };
+        // Appending must address an app that exists before any bytes are
+        // published under its id; the store re-checks inside the transaction.
+        if args.app_id.is_some() {
+            match self.store.get_app(app_id).await {
+                Ok(Some(app)) if app.deleted_at.is_none() => {}
+                Ok(Some(_)) => {
+                    return Ok(ToolOutput::error(
+                        "that app was deleted; create a new app instead",
+                    ))
+                }
+                Ok(None) => {
+                    return Ok(ToolOutput::error(
+                        "no app with that app_id; omit app_id to create a new app",
+                    ))
+                }
+                Err(_) => return Ok(ToolOutput::error("could not look up that app")),
+            }
+        }
+
+        let byte_len = bundle.len() as u64;
+        let sha256: [u8; 32] = Sha256::digest(bundle).into();
+        // Recognize an exact retry before writing anything: the same call
+        // republishing the same content reports the record it already made,
+        // while a call id reused for different content is refused.
+        match self.store.get_app_revision(revision_id).await {
+            Ok(Some(recorded)) => {
+                let exact = recorded.app_id == app_id
+                    && recorded.byte_len == byte_len
+                    && recorded.sha256 == sha256
+                    && recorded.manifest == args.manifest;
+                if !exact {
+                    return Ok(ToolOutput::error(
+                        "this call already published a different app revision",
+                    ));
+                }
+                return Ok(match self.store.get_app(app_id).await {
+                    Ok(Some(record)) => {
+                        Self::success(&record, recorded.ordinal, recorded.ordinal == 1)
+                    }
+                    _ => ToolOutput::error("could not read back the app record"),
+                });
+            }
+            Ok(None) => {}
+            Err(_) => return Ok(ToolOutput::error("could not check for an earlier attempt")),
+        }
+
+        // Publish the bundle bytes before recording the row, so a recorded
+        // revision always has its content: the write-once publication re-reads
+        // and byte-compares on collision, making it safe to retry.
+        let profile_dir = match std::fs::create_dir_all(&self.profile_data_dir).and_then(|()| {
+            cap_std::fs::Dir::open_ambient_dir(&self.profile_data_dir, cap_std::ambient_authority())
+        }) {
+            Ok(dir) => dir,
+            Err(_) => {
+                return Ok(ToolOutput::error(
+                    "the profile data directory is unavailable",
+                ))
+            }
+        };
+        if publish_app_bundle(&profile_dir, app_id, revision_id, bundle)
+            .await
+            .is_err()
+        {
+            return Ok(ToolOutput::error("could not publish the app bundle"));
+        }
+
+        let revision = NewAppRevision {
+            id: revision_id,
+            manifest: args.manifest,
+            byte_len,
+            sha256,
+            turn_id: Some(turn_id),
+            producing_run_id: None,
+            chat_id: Some(ctx.chat_id),
+            created_at: Utc::now(),
+        };
+        let recorded = if args.app_id.is_some() {
+            self.store.append_app_revision(app_id, &revision).await
+        } else {
+            self.store
+                .create_app(&CreateApp {
+                    id: app_id,
+                    revision,
+                })
+                .await
+        };
+        Ok(match recorded {
+            Ok(record) => Self::success(&record, record.revision_count, args.app_id.is_none()),
+            Err(error) => ToolOutput::error(format!("could not record the app: {error}")),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use serde_json::json;
+
+    use crate::db::DbStore;
+    use crate::id::{CallId, ChatId, TurnId};
+    use crate::local_app::app_revision_relative_path;
+    use crate::model::{Chat, ToolCallExecution, ToolCallRecord, ToolCallStatus};
+    use crate::preview::ToolResultPreview;
+
+    use super::*;
+
+    struct Fixture {
+        _directory: tempfile::TempDir,
+        store: Arc<DbStore>,
+        tool: CreateAppTool,
+        chat_id: ChatId,
+        turn_id: TurnId,
+        profile_dir: PathBuf,
+    }
+
+    async fn fixture() -> Fixture {
+        let directory = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("create-app.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            reasoning_effort: None,
+            permission_mode: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let turn_id = TurnId::new();
+        store
+            .accept_turn(turn_id, chat.id, "gpt-5", "make an app")
+            .await
+            .unwrap();
+        let profile_dir = directory.path().join("profile-data");
+        let tool = CreateAppTool::new(store.clone(), profile_dir.clone());
+        Fixture {
+            _directory: directory,
+            store,
+            tool,
+            chat_id: chat.id,
+            turn_id,
+            profile_dir,
+        }
+    }
+
+    impl Fixture {
+        /// Record one durable `create_app` call and return the invocation
+        /// context executing it, the way the turn loop would.
+        async fn recorded_call(&self) -> (CallId, ToolCtx) {
+            let call_id = CallId::new();
+            self.store
+                .accept_tool_call(&ToolCallRecord {
+                    id: call_id,
+                    chat_id: self.chat_id,
+                    turn_id: self.turn_id,
+                    provider_id: call_id.to_string(),
+                    name: crate::local_app::CREATE_APP_TOOL.into(),
+                    arguments: json!({}),
+                    execution: ToolCallExecution::Server,
+                    status: ToolCallStatus::Pending,
+                    result: None,
+                    result_preview: None,
+                    error_code: None,
+                    error_detail: None,
+                    client_executor_id: None,
+                    client_lease_expires_at: None,
+                    created_at: Utc::now(),
+                    resolved_at: None,
+                })
+                .await
+                .unwrap();
+            let ctx = ToolCtx::without_private_scratch(self.chat_id, None).with_call_id(call_id);
+            (call_id, ctx)
+        }
+    }
+
+    fn arguments(app_id: Option<Uuid>) -> Value {
+        let mut arguments = json!({
+            "bundle_html": "<!doctype html><h1>Triage</h1>",
+            "manifest": {
+                "name": "Sentry triage",
+                "bindings": [
+                    { "server": "sentry", "tools": ["mcp__sentry__list_issues"] }
+                ],
+            },
+        });
+        if let Some(app_id) = app_id {
+            arguments["app_id"] = json!(app_id);
+        }
+        arguments
+    }
+
+    #[tokio::test]
+    async fn identity_is_retry_stable_and_appends_take_the_app_id() {
+        let fixture = fixture().await;
+        let (call_id, ctx) = fixture.recorded_call().await;
+
+        let first = fixture.tool.execute(&ctx, arguments(None)).await.unwrap();
+        assert!(!first.is_error, "{}", first.content);
+        let app_id = AppId::for_call(call_id);
+        assert!(first.content.contains(&app_id.to_string()));
+        // The bundle bytes are on disk at the identity-derived path before the
+        // record exists to point at them.
+        let bundle_path = fixture.profile_dir.join(app_revision_relative_path(
+            app_id,
+            AppRevisionId::for_call(call_id),
+        ));
+        assert!(bundle_path.is_file());
+
+        // Re-executing the exact call reports the same record instead of
+        // forking a second app or a second revision.
+        let retried = fixture.tool.execute(&ctx, arguments(None)).await.unwrap();
+        assert!(!retried.is_error, "{}", retried.content);
+        assert!(retried.content.contains(&app_id.to_string()));
+        assert_eq!(fixture.store.list_apps(10).await.unwrap().len(), 1);
+        let record = fixture.store.get_app(app_id).await.unwrap().unwrap();
+        assert_eq!(record.revision_count, 1);
+
+        // The same call id must not be able to publish different content.
+        let mut different = arguments(None);
+        different["bundle_html"] = json!("<!doctype html><h1>Changed</h1>");
+        let refused = fixture.tool.execute(&ctx, different).await.unwrap();
+        assert!(refused.is_error);
+
+        // A later call appends to the named app rather than creating one.
+        let (_, append_ctx) = fixture.recorded_call().await;
+        let appended = fixture
+            .tool
+            .execute(&append_ctx, arguments(Some(app_id.0)))
+            .await
+            .unwrap();
+        assert!(!appended.is_error, "{}", appended.content);
+        assert!(appended.content.contains("revision 2"));
+        assert_eq!(fixture.store.list_apps(10).await.unwrap().len(), 1);
+
+        // Appending to an app that does not exist is refused, and refuses
+        // before any bytes could be published under the bogus id.
+        let (wrong_call, wrong_ctx) = fixture.recorded_call().await;
+        let missing_app = Uuid::new_v4();
+        let refused = fixture
+            .tool
+            .execute(&wrong_ctx, arguments(Some(missing_app)))
+            .await
+            .unwrap();
+        assert!(refused.is_error);
+        assert!(refused.content.contains("no app with that app_id"));
+        assert!(!fixture
+            .profile_dir
+            .join(app_revision_relative_path(
+                AppId::from(missing_app),
+                AppRevisionId::for_call(wrong_call),
+            ))
+            .exists());
+    }
+
+    #[tokio::test]
+    async fn refusals_are_tool_errors_not_panics() {
+        let fixture = fixture().await;
+
+        // A manifest pinning a name that could never match a mounted tool.
+        let (_, ctx) = fixture.recorded_call().await;
+        let mut bad_manifest = arguments(None);
+        bad_manifest["manifest"]["bindings"][0]["tools"] = json!(["list_issues"]);
+        let refused = fixture.tool.execute(&ctx, bad_manifest).await.unwrap();
+        assert!(refused.is_error);
+        assert!(refused.content.contains("invalid app manifest"));
+
+        // An oversized bundle is refused before anything is written.
+        let (_, ctx) = fixture.recorded_call().await;
+        let mut oversized = arguments(None);
+        oversized["bundle_html"] = json!("x".repeat(MAX_APP_BUNDLE_BYTES + 1));
+        assert!(
+            fixture
+                .tool
+                .execute(&ctx, oversized)
+                .await
+                .unwrap()
+                .is_error
+        );
+
+        // A call id the conversation never recorded cannot mint identity.
+        let foreign_ctx =
+            ToolCtx::without_private_scratch(fixture.chat_id, None).with_call_id(CallId::new());
+        let refused = fixture
+            .tool
+            .execute(&foreign_ctx, arguments(None))
+            .await
+            .unwrap();
+        assert!(refused.is_error);
+        assert!(refused.content.contains("not recorded"));
+        assert_eq!(fixture.store.list_apps(10).await.unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn the_projection_carries_the_name_and_ordinal_and_never_the_bundle() {
+        let fixture = fixture().await;
+        let (_, ctx) = fixture.recorded_call().await;
+        let output = fixture.tool.execute(&ctx, arguments(None)).await.unwrap();
+        assert!(!output.is_error, "{}", output.content);
+
+        let preview = ToolResultPreview::build(crate::local_app::CREATE_APP_TOOL, &output)
+            .expect("create_app projects an entries card");
+        let json = serde_json::to_string(&preview).unwrap();
+        assert!(json.contains("Sentry triage"));
+        assert!(json.contains("revision 1"));
+        // Renderer-safe: no bundle markup, no manifest bindings, no ids.
+        assert!(!json.contains("doctype"));
+        assert!(!json.contains("mcp__sentry__list_issues"));
+        assert!(!json.contains(&AppId::for_call(ctx.call_id.unwrap()).to_string()));
+    }
+}

--- a/crates/openwave-core/src/tools/definitions.rs
+++ b/crates/openwave-core/src/tools/definitions.rs
@@ -3,7 +3,8 @@
 use crate::tool::ToolSpec;
 
 use super::{
-    list_dir as list_dir_tool, read_file as read_file_tool, write_file as write_file_tool,
+    create_app as create_app_tool, list_dir as list_dir_tool, read_file as read_file_tool,
+    write_file as write_file_tool,
 };
 
 pub(super) const READ_FILE: &str = "read_file";
@@ -29,5 +30,18 @@ pub(super) fn write_file() -> ToolSpec {
         WRITE_FILE,
         "Write a UTF-8 text file into private scratch, creating parent directories. \
          Overwrites an existing file.",
+    )
+}
+
+pub(super) fn create_app() -> ToolSpec {
+    ToolSpec::for_args::<create_app_tool::Arguments>(
+        crate::local_app::CREATE_APP_TOOL,
+        "Publish a local mini-app the user can reopen from their Apps library: a \
+         complete self-contained HTML document plus a manifest naming the app and \
+         pinning the exact mounted MCP tools (`mcp__{server}__{tool}` names) it may \
+         call through the host. The app renders in a sandboxed frame with no network \
+         access; pinned tools run only after the user grants them. Pass the app_id \
+         from an earlier create_app result to publish a new revision of that app — \
+         revisions append, never overwrite.",
     )
 }

--- a/crates/openwave-core/src/tools/mod.rs
+++ b/crates/openwave-core/src/tools/mod.rs
@@ -5,12 +5,14 @@
 //! [`private_scratch`] owns the capability-confined filesystem primitives.
 
 mod arguments;
+mod create_app;
 mod definitions;
 mod list_dir;
 pub(crate) mod private_scratch;
 mod read_file;
 mod write_file;
 
+pub use create_app::CreateAppTool;
 pub use list_dir::ListDir;
 pub use read_file::ReadFile;
 pub use write_file::WriteFile;

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -40,6 +40,7 @@ const WEB_SEARCH_HEADING: &str = "## Public web research";
 const WEB_EXTRACT_HEADING: &str = "## Public web pages";
 const CONNECTED_FOLDERS_HEADING: &str = "## Connected folders";
 const OUTPUTS_HEADING: &str = "## User-visible outputs";
+const APPS_HEADING: &str = "## Local apps";
 const EXECUTION_HEADING: &str = "## Code execution";
 const DELEGATION_HEADING: &str = "## Background delegation";
 const MCP_HEADING: &str = "## External MCP tools";
@@ -261,6 +262,18 @@ pub(crate) fn compose_for_surface(
         );
     }
 
+    if has(openwave_core::local_app::CREATE_APP_TOOL) {
+        push_section(
+            &mut prompt,
+            APPS_HEADING,
+            &[
+                "- Use `create_app` only when the user asks for a reusable interactive view they can reopen later — not for a one-off answer, report, or file.",
+                "- The manifest pins the exact mounted tools the app may call; pin only what the app genuinely needs. The app runs sandboxed with no network access, and its pinned tools run only after the user grants them.",
+                "- To revise an existing app, pass the `app_id` a create_app result reported; revisions append and never overwrite.",
+            ],
+        );
+    }
+
     if has("exec") {
         let mut lines = vec![
             "- Use `exec` for bounded computation or validation when it improves the result."
@@ -417,6 +430,7 @@ mod tests {
             WEB_EXTRACT_HEADING,
             CONNECTED_FOLDERS_HEADING,
             OUTPUTS_HEADING,
+            APPS_HEADING,
             EXECUTION_HEADING,
             DELEGATION_HEADING,
             MCP_HEADING,
@@ -425,6 +439,7 @@ mod tests {
             "`request_folder_access`",
             "`spawn_sandbox_agent`",
             "`web_extract`",
+            "`create_app`",
         ] {
             assert!(
                 !prompt.contains(unavailable),

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -83,8 +83,8 @@ use openwave_core::{
     validate_read_connected_file_arguments, validate_request_folder_access_arguments,
     validate_write_output_to_connected_folder_arguments,
     write_output_to_connected_folder_tool_spec, AgentConfig, AgentError, ApprovalClass, BlobStore,
-    CachingSecretProvider, Config, FsBlobStore, KeychainSecretProvider, ListDir, Profile, ReadFile,
-    Result, SecretProvider, Store, Tool, ToolRegistry, WriteFile,
+    CachingSecretProvider, Config, CreateAppTool, FsBlobStore, KeychainSecretProvider, ListDir,
+    Profile, ReadFile, Result, SecretProvider, Store, Tool, ToolRegistry, WriteFile,
 };
 use resolver::KeyedResolver;
 
@@ -777,6 +777,7 @@ async fn bind_inner(
         foreground_web_search,
         web_extract,
         store.clone(),
+        config.data_dir.clone(),
     );
     let tools = Arc::new(tools);
     let mut state = match client_executor_id {
@@ -934,6 +935,7 @@ fn agent_deps(
     web_search: Box<dyn Tool>,
     web_extract: Box<dyn Tool>,
     source_store: Arc<dyn Store>,
+    profile_data_dir: std::path::PathBuf,
 ) -> (ToolRegistry, AgentConfig) {
     let mut tools = ToolRegistry::new()
         .with(Box::new(ReadFile))
@@ -947,8 +949,9 @@ fn agent_deps(
             source_store.clone(),
         )))
         .with(Box::new(source_tools::ReadToolResultTool::new(
-            source_store,
+            source_store.clone(),
         )))
+        .with(Box::new(CreateAppTool::new(source_store, profile_data_dir)))
         .with(web_search)
         .with(web_extract);
     tools.register_validated_client(

--- a/crates/openwave-server/src/tests/documents.rs
+++ b/crates/openwave-server/src/tests/documents.rs
@@ -1579,6 +1579,7 @@ async fn agent_deps_registers_server_tools_and_closed_foreground_capabilities() 
             Arc::new(MemSecrets::default()),
         )),
         store,
+        dir.path().join("profile-data"),
     );
     assert!(
         config.system_prompt.is_none(),
@@ -1627,6 +1628,10 @@ async fn agent_deps_registers_server_tools_and_closed_foreground_capabilities() 
     assert!(
         !names.iter().any(|n| n == "create_deliverable"),
         "the removed deliverable tool must not reappear; exec's output/ is the creation path"
+    );
+    assert!(
+        names.iter().any(|n| n == "create_app"),
+        "local-app creation tool registered"
     );
     assert!(
         names


### PR DESCRIPTION
Fifth slice of the local-apps design (docs/local-apps.md), building on the app record from #1262. Closes #1258.

## What this adds

- **`create_app` foreground tool** (`crates/openwave-core/src/tools/create_app.rs`): arguments `{ bundle_html, manifest, app_id? }` with `deny_unknown_fields`; the manifest is a typed `AppManifest` so the model sees the exact structural contract the store validates (mounted-name grammar, bounds). The bundle is refused when empty or over the 1 MiB bound.
- **Identity discipline**: `AppId::for_call` / `AppRevisionId::for_call` derive UUIDv5 from the durable call id. The executing call is verified against the conversation's durable call record before it may mint profile-scoped identity, and an exact re-execution of the same call reports the record it already made instead of forking a second app or revision. A call id reused with different content is refused. Appending takes `app_id` and refuses a missing or deleted app before any bytes are published under it.
- **Byte ordering**: the bundle publishes write-once under the profile data directory (re-read + byte-compare on collision, so retries are safe) *before* the row is recorded — a recorded revision always has its content.
- **Transcript card**: reuses the existing `ToolResultPreview::Entries` allowlist path — `create_app` joins `ENTRY_TOOLS` and lists one row: the app's display name with a "revision N" meta. The projection carries name/ordinal only, never bundle content or manifest bindings.
- **Registration**: foreground registry beside the source tools (`agent_deps`), plus a Local apps section of the operating prompt gated on the tool's presence. The prompt's golden identity is unchanged (the representative surface doesn't include `create_app`).

## Deviations from the issue

- The issue's separate `name` argument is dropped: slice 1 made the record's display name follow the manifest, so a second name field could only disagree with it.
- No new `ToolResultPreview` variant and no `RendererToolName` change: the Entries card carries everything this slice needs, so the wire types are untouched and the generated UI types need no regeneration. The dedicated "Open app" affordance (and any richer presentation) belongs to slice 6 as planned; until then the call renders as a generic tool line with the entries card underneath.

## Tests

- Identity retry-stability through the tool: same call re-executed lands on the same record; different content under the same call id is refused; append addresses the named app; a bogus `app_id` is refused with no bytes published.
- Manifest and bounds refusals surface as tool errors, not panics, and an unrecorded call id cannot mint identity.
- The projection carries the name and ordinal and never the bundle markup, manifest tool names, or ids.

Store-level behavior (exact-retry equality, revision caps, soft-delete) is already covered by slice 1's tests and not duplicated here.

Verified locally: `cargo check -p openwave-core -p openwave-server --locked`, the new test module plus the touched neighbors (`preview`, `foreground_prompt`, `agent_deps` registration), scoped clippy (clean) and rustfmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)