### PR TITLE
fix(router): carry a classified error on ProviderEvent::Failed

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -39,7 +39,7 @@ use crate::approval::{
 use crate::cancel::CancelToken;
 use crate::citation::{parse_assistant_citations, AssistantCitationInput};
 use crate::context;
-use crate::error::{AgentError, Result};
+use crate::error::{AgentError, ProviderErrorInfo, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{AgentRunId, CallId, ChatId, MessageId, TurnId};
 use crate::image::{ImageAttachments, ImageData, ImageRef};
@@ -1361,7 +1361,7 @@ impl Agent {
                 Done,
                 Cancelled,
                 Steered,
-                Failed(String),
+                Failed(ProviderErrorInfo),
             }
             let mut streamed_events = AssistantStreamEventFilter::new(events);
             let stream_end = loop {
@@ -1418,7 +1418,7 @@ impl Agent {
                         stop_reason = StopReason::Refusal;
                         refusal_details = Some(details);
                     }
-                    ProviderEvent::Failed { message } => break StreamEnd::Failed(message),
+                    ProviderEvent::Failed { error } => break StreamEnd::Failed(error),
                 }
             };
             if matches!(stream_end, StreamEnd::Steered | StreamEnd::Failed(_)) {
@@ -1432,11 +1432,11 @@ impl Agent {
             }
             // A stream that broke mid-flight left this step's tool-call
             // arguments possibly truncated mid-JSON. Nothing here is safe to
-            // act on, and nothing was persisted, so fail the turn under a
-            // retryable provider code rather than executing the fragment.
-            if let StreamEnd::Failed(message) = stream_end {
+            // act on, and nothing was persisted, so fail the turn under the
+            // classified provider error rather than executing the fragment.
+            if let StreamEnd::Failed(error) = stream_end {
                 events.send(AgentEvent::StreamInterrupted);
-                return Err(AgentError::Provider(message));
+                return Err(error.into_agent_error());
             }
             // Prefer cancel when both cancel and interrupt are ready (cancel is
             // the left arm of the nested select). Also catch a cancel that raced
@@ -7628,6 +7628,84 @@ mod tests {
                 .iter()
                 .any(|event| matches!(event, AgentEvent::TurnFailed { .. })),
             "the failure surfaces as TurnFailed"
+        );
+    }
+
+    /// A mid-stream provider failure must keep the classification the
+    /// equivalent HTTP-status failure would have had: an in-band overload
+    /// surfaces to the client as `overloaded`, not the generic `provider`.
+    #[tokio::test]
+    async fn a_mid_stream_failure_reaches_the_client_with_its_classification() {
+        struct OverloadedProvider;
+
+        #[async_trait]
+        impl ModelProvider for OverloadedProvider {
+            fn id(&self) -> ProviderId {
+                ProviderId::new("overloaded")
+            }
+
+            async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+                Ok(stream::iter(vec![
+                    ProviderEvent::TextDelta {
+                        text: "partial".into(),
+                    },
+                    ProviderEvent::Failed {
+                        error: ProviderErrorInfo::from_error(&AgentError::Overloaded(
+                            "anthropic returned 500 (overloaded_error)".into(),
+                        )),
+                    },
+                ])
+                .boxed())
+            }
+        }
+
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            reasoning_effort: None,
+            permission_mode: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let agent = Agent::new(
+            Arc::new(OverloadedProvider),
+            Arc::new(ToolRegistry::new()),
+            store,
+            AgentConfig {
+                model: "fake".into(),
+                ..Default::default()
+            },
+        );
+
+        let (tx, rx) = unbounded();
+        let result = agent.run_turn(&chat, "say something", &tx).await;
+        drop(tx);
+        let events: Vec<AgentEvent> = rx.collect().await;
+
+        assert_eq!(
+            result.unwrap_err().kind(),
+            "overloaded",
+            "the turn fails under the classified kind"
+        );
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                AgentEvent::TurnFailed { error } if error.kind == "overloaded"
+            )),
+            "the classification reaches the client on TurnFailed"
         );
     }
 

--- a/crates/openwave-core/src/error.rs
+++ b/crates/openwave-core/src/error.rs
@@ -169,6 +169,70 @@ impl AgentError {
     }
 }
 
+/// The stream-carrying form of a classified provider failure.
+///
+/// [`AgentError`] is not `Serialize`, but [`crate::provider::ProviderEvent`]
+/// is, and its `Failed` variant must carry the classification through the
+/// event stream so a mid-stream failure reaches the client under the same kind
+/// as the equivalent HTTP-status failure. This is that projection: the `kind`
+/// the client ultimately branches on, plus the client-safe message *without*
+/// the variant's `Display` prefix, so [`ProviderErrorInfo::into_agent_error`]
+/// rebuilds the classified error instead of doubling the prefix.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderErrorInfo {
+    /// Machine-readable category — one of the provider-failure
+    /// [`AgentError::kind`] values.
+    pub kind: String,
+    /// Client-safe description, free of provider payload text and URLs.
+    pub message: String,
+}
+
+impl ProviderErrorInfo {
+    /// Project a provider failure into its stream-carrying form.
+    pub fn from_error(error: &AgentError) -> Self {
+        let message = match error {
+            AgentError::Provider(message)
+            | AgentError::Authentication(message)
+            | AgentError::InvalidRequest(message)
+            | AgentError::Refusal(message)
+            | AgentError::PromptTooLong(message) => message.clone(),
+            AgentError::RateLimited(failure) | AgentError::Overloaded(failure) => {
+                failure.to_string()
+            }
+            other => other.to_string(),
+        };
+        Self {
+            kind: error.kind().to_string(),
+            message,
+        }
+    }
+
+    /// A plain `provider`-kind failure with a client-safe message.
+    pub fn provider(message: impl Into<String>) -> Self {
+        Self {
+            kind: "provider".to_string(),
+            message: message.into(),
+        }
+    }
+
+    /// Rebuild the classified error for the consumer that fails the turn.
+    ///
+    /// A mid-stream failure carries no `Retry-After` header, so the throttling
+    /// variants rebuild without a hint and the retry schedule falls back to
+    /// its own backoff.
+    pub fn into_agent_error(self) -> AgentError {
+        match self.kind.as_str() {
+            "authentication" => AgentError::Authentication(self.message),
+            "rate_limited" => AgentError::RateLimited(self.message.into()),
+            "overloaded" => AgentError::Overloaded(self.message.into()),
+            "invalid_request" => AgentError::InvalidRequest(self.message),
+            "refusal" => AgentError::Refusal(self.message),
+            "prompt_too_long" => AgentError::PromptTooLong(self.message),
+            _ => AgentError::Provider(self.message),
+        }
+    }
+}
+
 /// The wire-facing representation of an error.
 ///
 /// [`AgentError`] itself is not `Serialize` (it wraps non-serializable source
@@ -205,5 +269,40 @@ mod tests {
         let info: AgentErrorInfo = (&AgentError::msg("boom")).into();
         let json = serde_json::to_string(&info).unwrap();
         assert_eq!(serde_json::from_str::<AgentErrorInfo>(&json).unwrap(), info);
+    }
+
+    #[test]
+    fn provider_error_info_roundtrips_the_classification() {
+        for (error, kind) in [
+            (AgentError::Provider("p".into()), "provider"),
+            (AgentError::Authentication("a".into()), "authentication"),
+            (AgentError::RateLimited("r".into()), "rate_limited"),
+            (AgentError::Overloaded("o".into()), "overloaded"),
+            (AgentError::InvalidRequest("i".into()), "invalid_request"),
+            (AgentError::Refusal("no".into()), "refusal"),
+            (AgentError::PromptTooLong("long".into()), "prompt_too_long"),
+        ] {
+            let info = ProviderErrorInfo::from_error(&error);
+            assert_eq!(info.kind, kind);
+            let rebuilt = info.into_agent_error();
+            assert_eq!(rebuilt.kind(), kind);
+            assert_eq!(rebuilt.to_string(), error.to_string());
+        }
+        // The throttling variants rebuild without a retry hint: a mid-stream
+        // failure never saw the response's headers.
+        assert!(
+            AgentError::RateLimited(ProviderFailure::new("r", Some(Duration::from_secs(5))))
+                .retry_after()
+                .is_some()
+        );
+        assert!(
+            ProviderErrorInfo::from_error(&AgentError::RateLimited(ProviderFailure::new(
+                "r",
+                Some(Duration::from_secs(5))
+            )))
+            .into_agent_error()
+            .retry_after()
+            .is_none()
+        );
     }
 }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -125,7 +125,7 @@ pub use deliverable_acceptance::{
     accept_workspace_artifact, merge_agent_run_result, restore_output_to_revision,
     AgentResultOutputMerge, WorkspaceArtifactProposal,
 };
-pub use error::{AgentError, AgentErrorInfo, ProviderFailure, Result};
+pub use error::{AgentError, AgentErrorInfo, ProviderErrorInfo, ProviderFailure, Result};
 pub use event::{AgentEvent, SequencedEvent};
 pub use id::{
     AgentRunId, AssistantCitationId, CallId, ChatId, ChunkId, DocumentId, HostRootId,

--- a/crates/openwave-core/src/provider.rs
+++ b/crates/openwave-core/src/provider.rs
@@ -408,9 +408,13 @@ pub enum ProviderEvent {
     /// particular may be truncated mid-value. Consumers must discard the
     /// partial step and treat the completion as failed rather than acting on
     /// it.
+    ///
+    /// The payload is classified the way the equivalent HTTP-status failure
+    /// would be, so a mid-stream overload or rate limit surfaces to the client
+    /// under that kind rather than the generic `provider`.
     Failed {
-        /// Why the stream broke, for the turn's failure detail.
-        message: String,
+        /// Why the stream broke, classified for the turn's failure detail.
+        error: crate::error::ProviderErrorInfo,
     },
 }
 
@@ -503,6 +507,17 @@ mod tests {
         };
         let json = serde_json::to_string(&ev).unwrap();
         assert_eq!(serde_json::from_str::<ProviderEvent>(&json).unwrap(), ev);
+
+        let failed = ProviderEvent::Failed {
+            error: crate::error::ProviderErrorInfo::from_error(
+                &crate::error::AgentError::Overloaded("p returned 529 (overloaded_error)".into()),
+            ),
+        };
+        let json = serde_json::to_string(&failed).unwrap();
+        assert_eq!(
+            serde_json::from_str::<ProviderEvent>(&json).unwrap(),
+            failed
+        );
     }
 
     #[test]

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -12,7 +12,7 @@ use serde_json::{json, Value};
 
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine as _;
-use openwave_core::error::{AgentError, Result};
+use openwave_core::error::{AgentError, ProviderErrorInfo, Result};
 use openwave_core::provider::{
     ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, RefusalDetails,
     ResponseFormat, StopReason, ToolChoice, Usage,
@@ -21,7 +21,8 @@ use openwave_core::tool::{strict_json_schema, OptionalProperties};
 use openwave_core::{ImageAttachments, Role};
 
 use crate::sse::{
-    classify_provider_error, drain_frames, frame_data, read_bounded_error_body, safe_in_band_error,
+    classify_in_band_error, classify_provider_error, drain_frames, frame_data,
+    read_bounded_error_body,
 };
 
 const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
@@ -147,7 +148,9 @@ impl ModelProvider for AnthropicProvider {
                     Ok(chunk) => chunk,
                     Err(error) => {
                         yield ProviderEvent::Failed {
-                            message: format!("anthropic stream ended early: {error}"),
+                            error: ProviderErrorInfo::provider(format!(
+                                "anthropic stream ended early: {error}"
+                            )),
                         };
                         return;
                     }
@@ -538,7 +541,10 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
         Some("error") => {
             state.terminal = true;
             vec![ProviderEvent::Failed {
-                message: safe_in_band_error("anthropic", data.get("error").unwrap_or(data)),
+                error: ProviderErrorInfo::from_error(&classify_in_band_error(
+                    "anthropic",
+                    data.get("error").unwrap_or(data),
+                )),
             }]
         }
         Some("message_start") => {
@@ -629,7 +635,7 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                     // any tool call inside it — as a finished answer.
                     StopOutcome::Interrupted(message) => {
                         events.push(ProviderEvent::Failed {
-                            message: message.into(),
+                            error: ProviderErrorInfo::provider(message),
                         });
                         return events;
                     }
@@ -974,7 +980,10 @@ mod tests {
                     text: "partial".into()
                 },
                 ProviderEvent::Failed {
-                    message: "anthropic returned 500 (overloaded_error)".into()
+                    error: ProviderErrorInfo {
+                        kind: "overloaded".into(),
+                        message: "anthropic returned 500 (overloaded_error)".into(),
+                    },
                 },
             ]
         );
@@ -1004,8 +1013,9 @@ mod tests {
                     ..Usage::default()
                 }),
                 ProviderEvent::Failed {
-                    message: "anthropic: the model's context window was exceeded mid-response"
-                        .into(),
+                    error: ProviderErrorInfo::provider(
+                        "anthropic: the model's context window was exceeded mid-response",
+                    ),
                 },
             ]
         );

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -17,7 +17,7 @@ use futures::stream::{BoxStream, StreamExt};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use openwave_core::error::{AgentError, Result};
+use openwave_core::error::{AgentError, ProviderErrorInfo, Result};
 use openwave_core::provider::{
     ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, RefusalDetails,
     ResponseFormat, StopReason, ToolChoice, Usage,
@@ -27,8 +27,8 @@ use openwave_core::{ImageAttachments, ReasoningEffort, Role};
 
 use crate::google_auth::{valid_resource_segment, valid_vertex_location};
 use crate::sse::{
-    classify_provider_error, drain_frames, frame_data_raw, read_bounded_error_body,
-    safe_in_band_error,
+    classify_in_band_error, classify_provider_error, drain_frames, frame_data_raw,
+    read_bounded_error_body,
 };
 use crate::BearerTokenSource;
 
@@ -215,14 +215,14 @@ impl ModelProvider for GeminiProvider {
                     // carries no such thing and is worth surfacing.
                     Err(error) => {
                         yield ProviderEvent::Failed {
-                            message: match error {
+                            error: ProviderErrorInfo::provider(match error {
                                 crate::http::StreamFailure::Deadline(_) => {
                                     format!("gemini stream ended early: {error}")
                                 }
                                 crate::http::StreamFailure::Transport(_) => {
                                     "gemini stream ended early".to_string()
                                 }
-                            },
+                            }),
                         };
                         return;
                     }
@@ -236,7 +236,9 @@ impl ModelProvider for GeminiProvider {
                         Ok(data) => data,
                         Err(_) => {
                             yield ProviderEvent::Failed {
-                                message: "gemini returned an invalid stream frame".to_string(),
+                                error: ProviderErrorInfo::provider(
+                                    "gemini returned an invalid stream frame",
+                                ),
                             };
                             return;
                         }
@@ -256,7 +258,9 @@ impl ModelProvider for GeminiProvider {
                         Ok(data) => data,
                         Err(_) => {
                             yield ProviderEvent::Failed {
-                                message: "gemini returned an invalid stream frame".to_string(),
+                                error: ProviderErrorInfo::provider(
+                                    "gemini returned an invalid stream frame",
+                                ),
                             };
                             return;
                         }
@@ -657,7 +661,7 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
     if let Some(error) = data.get("error") {
         state.terminal = true;
         return vec![ProviderEvent::Failed {
-            message: safe_in_band_error("gemini", error),
+            error: ProviderErrorInfo::from_error(&classify_in_band_error("gemini", error)),
         }];
     }
     if let Some(block_reason) = data
@@ -719,7 +723,9 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                 else {
                     state.terminal = true;
                     events.push(ProviderEvent::Failed {
-                        message: "gemini returned a malformed function call".to_string(),
+                        error: ProviderErrorInfo::provider(
+                            "gemini returned a malformed function call",
+                        ),
                     });
                     return events;
                 };
@@ -739,7 +745,9 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                 if !args.is_object() {
                     state.terminal = true;
                     events.push(ProviderEvent::Failed {
-                        message: "gemini returned non-object function arguments".to_string(),
+                        error: ProviderErrorInfo::provider(
+                            "gemini returned non-object function arguments",
+                        ),
                     });
                     return events;
                 }
@@ -790,7 +798,7 @@ fn finish_candidate(reason: &str, state: &mut StreamState, events: &mut Vec<Prov
         }
         "MALFORMED_FUNCTION_CALL" | "UNEXPECTED_TOOL_CALL" => {
             events.push(ProviderEvent::Failed {
-                message: "gemini rejected a function call".to_string(),
+                error: ProviderErrorInfo::provider("gemini rejected a function call"),
             });
         }
         "MAX_TOKENS" => events.push(ProviderEvent::Stop {
@@ -1141,7 +1149,10 @@ mod tests {
         assert_eq!(
             failed,
             vec![ProviderEvent::Failed {
-                message: "gemini returned 401".into(),
+                error: ProviderErrorInfo {
+                    kind: "authentication".into(),
+                    message: "gemini returned 401".into(),
+                },
             }]
         );
     }

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -14,7 +14,7 @@ use base64::Engine as _;
 use futures::stream::{BoxStream, StreamExt};
 use serde_json::{json, Value};
 
-use openwave_core::error::{AgentError, Result};
+use openwave_core::error::{AgentError, ProviderErrorInfo, Result};
 use openwave_core::provider::{
     ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, ResponseFormat,
     StopReason, ToolChoice, Usage,
@@ -23,7 +23,8 @@ use openwave_core::tool::{strict_json_schema, OptionalProperties};
 use openwave_core::{ImageAttachments, Role};
 
 use crate::sse::{
-    classify_provider_error, drain_frames, frame_data, read_bounded_error_body, safe_in_band_error,
+    classify_in_band_error, classify_provider_error, drain_frames, frame_data,
+    read_bounded_error_body,
 };
 
 const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
@@ -134,7 +135,9 @@ impl ModelProvider for OpenAiCompatProvider {
                     Ok(chunk) => chunk,
                     Err(error) => {
                         yield ProviderEvent::Failed {
-                            message: format!("stream ended early: {error}"),
+                            error: ProviderErrorInfo::provider(format!(
+                                "stream ended early: {error}"
+                            )),
                         };
                         return;
                     }
@@ -446,7 +449,7 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
     if let Some(error) = data.get("error") {
         state.terminal = true;
         return vec![ProviderEvent::Failed {
-            message: safe_in_band_error("openai-compat", error),
+            error: ProviderErrorInfo::from_error(&classify_in_band_error("openai-compat", error)),
         }];
     }
 
@@ -792,7 +795,10 @@ mod tests {
                     fragment: "{\"pa".into(),
                 },
                 ProviderEvent::Failed {
-                    message: "openai-compat returned 500 (server_error)".into(),
+                    error: ProviderErrorInfo {
+                        kind: "overloaded".into(),
+                        message: "openai-compat returned 500 (server_error)".into(),
+                    },
                 },
             ]
         );

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -121,30 +121,29 @@ pub fn safe_http_error(provider: &str, status: u16, body: &str) -> String {
     }
 }
 
-/// Build a client-safe message for an error delivered *inside* a 200 stream.
+/// Classify an error delivered *inside* a 200 stream — the in-band counterpart
+/// of [`classify_provider_error`].
 ///
 /// Providers can accept a request, start streaming, and then emit an error
-/// frame instead of finishing. There is no HTTP status to report in that case:
-/// some providers carry a numeric `code` (Gemini), others only a stable
-/// enum-style `type` / `code` token (Anthropic, OpenAI-compatible). As with
-/// [`safe_http_error`], nothing else from the untrusted payload is forwarded —
-/// these strings reach the client through `TurnFailed`.
-pub fn safe_in_band_error(provider: &str, error: &serde_json::Value) -> String {
+/// frame instead of finishing. The status is the numeric `code` some providers
+/// send (Gemini), defaulting to 500 when the frame carries only a stable
+/// enum-style `type`/`code` token (Anthropic, OpenAI-compatible). The kind
+/// mapping and the client-safe message are the HTTP path's own — nothing from
+/// the untrusted payload is forwarded beyond a vetted code token — so an
+/// in-band `overloaded_error` surfaces exactly like the 529 that never started
+/// streaming. A stream that accepted the request has no `Retry-After` header
+/// to honor, so the throttling kinds carry no hint.
+pub fn classify_in_band_error(
+    provider: &str,
+    error: &serde_json::Value,
+) -> openwave_core::error::AgentError {
     let status = error
         .get("code")
         .and_then(serde_json::Value::as_u64)
         .and_then(|code| u16::try_from(code).ok())
         .filter(|code| (100..=599).contains(code))
         .unwrap_or(500);
-    let detail = error
-        .get("type")
-        .or_else(|| error.get("code"))
-        .and_then(serde_json::Value::as_str)
-        .filter(|code| safe_error_code(code));
-    match detail {
-        Some(code) => format!("{provider} returned {status} ({code})"),
-        None => format!("{provider} returned {status}"),
-    }
+    classify_provider_error(provider, status, &error.to_string(), None)
 }
 
 /// Accept only a compact enum-style token. Error fields come from an
@@ -364,6 +363,33 @@ mod tests {
             ),
             AgentError::Refusal(_)
         ));
+    }
+
+    #[test]
+    fn in_band_error_classifies_like_the_http_status_path() {
+        use openwave_core::error::AgentError;
+        // The Anthropic overloaded frame arrives inside a 200 stream, so there
+        // is no status to read — the stable `type` token must still land on
+        // the same kind as the 529 that never started streaming.
+        let error = serde_json::json!({"type": "overloaded_error", "message": "Overloaded"});
+        assert!(matches!(
+            classify_in_band_error("anthropic", &error),
+            AgentError::Overloaded(_)
+        ));
+        // A numeric `code` (Gemini's shape) is the in-band status.
+        let error = serde_json::json!({"code": 401, "message": "bad key"});
+        assert!(matches!(
+            classify_in_band_error("gemini", &error),
+            AgentError::Authentication(_)
+        ));
+        // Nothing provider-supplied rides into the client-visible message.
+        let error = serde_json::json!({
+            "code": "rate_limit_error",
+            "message": "slow down, key sk-secret"
+        });
+        let classified = classify_in_band_error("openai-compat", &error);
+        assert!(matches!(classified, AgentError::RateLimited(_)));
+        assert!(!classified.to_string().contains("sk-secret"));
     }
 
     #[test]

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -1299,9 +1299,9 @@ async fn complete_sandbox_task(
             }
             ProviderEvent::ReasoningDelta { .. } | ProviderEvent::Usage(_) => {}
             // The stream broke mid-flight, so `text` and `arguments` are both
-            // possibly truncated. Fail under the retryable provider code
+            // possibly truncated. Fail under the classified provider error
             // instead of treating the fragment as a result.
-            ProviderEvent::Failed { message } => return Err(AgentError::Provider(message)),
+            ProviderEvent::Failed { error } => return Err(error.into_agent_error()),
             _ => {
                 return Err(AgentError::msg(
                     "sandbox agent provider emitted an unsupported event",

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -235,8 +235,11 @@ impl CapabilityResponder for HostModelProxy {
         while let Some(event) = stream.next().await {
             match event {
                 ProviderEvent::TextDelta { text } => completion.push_str(&text),
-                ProviderEvent::Failed { message } => {
-                    eprintln!("openwave: host model proxy inference failed: {message}");
+                ProviderEvent::Failed { error } => {
+                    eprintln!(
+                        "openwave: host model proxy inference failed: {}",
+                        error.message
+                    );
                     return Response::Error(ErrorResponse::new(
                         ErrorCode::Internal,
                         "host model inference failed",


### PR DESCRIPTION
Closes #1125

## What

`ProviderEvent::Failed` carried only a `String`, so the in-band error path could never reach `classify_provider_error`: a mid-stream failure surfaced to the client as kind `"provider"` where the equivalent HTTP-status failure surfaced as `"overloaded"` or `"rate_limited"`. The variant now carries a `ProviderErrorInfo` (new in `openwave-core::error`): the classified `kind` plus the client-safe message, in a form the `Serialize`/`Deserialize` event enum can hold (`AgentError` itself is not serializable).

- `sse::classify_in_band_error` classifies an error frame delivered inside a 200 stream through the same kind mapping as the HTTP-status path (`classify_provider_error`), with the frame's numeric `code` (Gemini's shape) as the status, defaulting to 500. It replaces `safe_in_band_error`, whose redaction intent it inherits via `safe_http_error` — nothing but a vetted code token from the untrusted payload is forwarded.
- Anthropic, OpenAI-compat, and Gemini in-band error frames are classified through it; transport/malformed-stream failures carry kind `"provider"` as before.
- Consumers (`agent.rs`, `sandbox_agent_run_worker.rs`, `sandbox_container_run.rs`) rebuild the `AgentError` from the payload via `ProviderErrorInfo::into_agent_error` instead of wrapping a string in `AgentError::Provider`. A mid-stream failure never saw response headers, so the throttling variants rebuild without a `Retry-After` hint — the retry schedule keeps its own backoff, unchanged from today.

## Wire contract

`ProviderEvent` does not cross a process boundary — it is produced and consumed in-process; the client sees `AgentEvent::TurnFailed` with `AgentErrorInfo`, which is unchanged in shape (the `kind` value is now correct for in-band failures). The event's serialized form change (`message` → `error`) is internal and covered by a roundtrip test.

## Tests

- `error::tests::provider_error_info_roundtrips_the_classification` — kind and message survive the project/rebuild round trip; retry hints intentionally do not.
- `sse::tests::in_band_error_classifies_like_the_http_status_path` — an in-band `overloaded_error` lands on `Overloaded`, a numeric 401 on `Authentication`, and no provider payload text reaches the message.
- `agent::tests::a_mid_stream_failure_reaches_the_client_with_its_classification` — end to end: a provider stream that fails mid-flight surfaces `TurnFailed` with kind `"overloaded"`.
- Existing adapter tests updated to assert the classified kind on in-band failures.

Verified: `cargo test -p openwave-router --locked` (73 passed), `cargo test -p openwave-core --locked --lib` (526 passed), `cargo clippy -p openwave-core -p openwave-router -p openwave-server --all-targets --locked -- -D warnings`, `cargo fmt --check`.
