### PR TITLE
fix(router): keep request URLs out of client-visible provider errors

### DIFF
--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -38,10 +38,6 @@ const STRUCTURED_OUTPUT_TOOL_DESCRIPTION: &str =
     "Return the result of this request. Call this once, with the whole answer in \
      its arguments, and write nothing else.";
 
-fn provider_err(err: impl std::fmt::Display) -> AgentError {
-    AgentError::Provider(err.to_string())
-}
-
 /// A [`ModelProvider`] for Anthropic's Messages API.
 #[derive(Clone)]
 pub struct AnthropicProvider {
@@ -115,7 +111,10 @@ impl ModelProvider for AnthropicProvider {
             .json(&body)
             .send()
             .await
-            .map_err(provider_err)?;
+            // reqwest's display includes the URL, and a gateway URL can carry
+            // tenant-identifying parts; `AgentError` strings reach the client
+            // via TurnFailed. Only the fact of a failed request surfaces.
+            .map_err(|_| AgentError::Provider("anthropic request failed".into()))?;
 
         // Surface non-2xx without the raw body — it can echo key material, and
         // `AgentError` strings reach the client via TurnFailed. Status (+ a
@@ -148,9 +147,9 @@ impl ModelProvider for AnthropicProvider {
                     Ok(chunk) => chunk,
                     Err(error) => {
                         yield ProviderEvent::Failed {
-                            error: ProviderErrorInfo::provider(format!(
-                                "anthropic stream ended early: {error}"
-                            )),
+                            error: ProviderErrorInfo::provider(
+                                error.client_message("anthropic"),
+                            ),
                         };
                         return;
                     }

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -215,14 +215,7 @@ impl ModelProvider for GeminiProvider {
                     // carries no such thing and is worth surfacing.
                     Err(error) => {
                         yield ProviderEvent::Failed {
-                            error: ProviderErrorInfo::provider(match error {
-                                crate::http::StreamFailure::Deadline(_) => {
-                                    format!("gemini stream ended early: {error}")
-                                }
-                                crate::http::StreamFailure::Transport(_) => {
-                                    "gemini stream ended early".to_string()
-                                }
-                            }),
+                            error: ProviderErrorInfo::provider(error.client_message("gemini")),
                         };
                         return;
                     }

--- a/crates/openwave-router/src/http.rs
+++ b/crates/openwave-router/src/http.rs
@@ -164,6 +164,23 @@ impl<E: std::fmt::Display> std::fmt::Display for StreamFailure<E> {
     }
 }
 
+impl<E: std::fmt::Display> StreamFailure<E> {
+    /// The client-safe form of the failure: only the deadline text is ours.
+    ///
+    /// A transport error's `Display` is reqwest's, and reqwest includes the
+    /// request URL — a Vertex URL carries the project id, and any gateway URL
+    /// may carry tenant-identifying parts. These strings reach the client
+    /// through `ProviderEvent::Failed` and `TurnFailed`, so a transport
+    /// failure reports only the fact of an early end.
+    #[must_use]
+    pub fn client_message(&self, provider: &str) -> String {
+        match self {
+            Self::Deadline(_) => format!("{provider} stream ended early: {self}"),
+            Self::Transport(_) => format!("{provider} stream ended early"),
+        }
+    }
+}
+
 /// Cap the total duration of a provider byte stream.
 ///
 /// The returned stream forwards items unchanged until `ceiling` elapses, then
@@ -239,5 +256,25 @@ mod tests {
             other => panic!("expected a deadline failure, got {other:?}"),
         };
         assert_eq!(message, "exceeded the 120s stream duration limit");
+    }
+
+    #[test]
+    fn the_client_message_keeps_the_transport_error_and_its_url_out() {
+        // reqwest's error display includes the request URL; a Vertex URL
+        // carries the project id, and these strings reach the client.
+        let transport = StreamFailure::Transport(
+            "error sending request for url (https://us-central1-aiplatform.googleapis.com/v1/projects/secret-project/): connection closed".to_string(),
+        );
+        let message = transport.client_message("gemini");
+        assert_eq!(message, "gemini stream ended early");
+        assert!(!message.contains("http"), "{message}");
+        assert!(!message.contains("secret-project"), "{message}");
+
+        // The deadline text is our own and says why the stream was cut.
+        let deadline = StreamFailure::<String>::Deadline(Duration::from_secs(3600));
+        assert_eq!(
+            deadline.client_message("anthropic"),
+            "anthropic stream ended early: exceeded the 3600s stream duration limit"
+        );
     }
 }

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -30,10 +30,6 @@ use crate::sse::{
 const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
 const DEFAULT_MAX_TOKENS: u32 = 4096;
 
-fn provider_err(err: impl std::fmt::Display) -> AgentError {
-    AgentError::Provider(err.to_string())
-}
-
 /// A [`ModelProvider`] for any OpenAI-compatible Chat Completions endpoint.
 #[derive(Clone)]
 pub struct OpenAiCompatProvider {
@@ -105,7 +101,10 @@ impl ModelProvider for OpenAiCompatProvider {
             .json(&body)
             .send()
             .await
-            .map_err(provider_err)?;
+            // reqwest's display includes the URL, and a gateway URL can carry
+            // tenant-identifying parts; `AgentError` strings reach the client
+            // via TurnFailed. Only the fact of a failed request surfaces.
+            .map_err(|_| AgentError::Provider("openai-compat request failed".into()))?;
 
         let status = response.status();
         if !status.is_success() {
@@ -135,9 +134,9 @@ impl ModelProvider for OpenAiCompatProvider {
                     Ok(chunk) => chunk,
                     Err(error) => {
                         yield ProviderEvent::Failed {
-                            error: ProviderErrorInfo::provider(format!(
-                                "stream ended early: {error}"
-                            )),
+                            error: ProviderErrorInfo::provider(
+                                error.client_message("openai-compat"),
+                            ),
                         };
                         return;
                     }


### PR DESCRIPTION
Closes #1145

Stacked on #1272 (same adapter sites); retargets to `main` automatically once that lands.

## What

`anthropic.rs` and `openai_compat.rs` interpolated the raw `reqwest` error into client-visible failure messages, and reqwest's `Display` includes the request URL. `gemini.rs` already suppresses it for exactly this reason — a Vertex URL carries the project id extracted from the secret key file — and any gateway URL can carry tenant-identifying parts. These strings reach the client through `TurnFailed`, so both adapters now match Gemini's direction:

- A `send()` failure reports only `"<provider> request failed"` (the per-adapter `provider_err` helper that formatted the reqwest error is gone).
- A mid-stream transport failure reports only the early end. The Gemini adapter's hand-rolled `Deadline`/`Transport` match is now a shared `StreamFailure::client_message(provider)` helper in `http.rs` that all three adapters use; the deadline text is our own and still surfaces ("exceeded the 3600s stream duration limit").

This reuses the intent behind `sse.rs`'s client-safe error construction (nothing untrusted forwarded) rather than inventing a new mechanism; no behavior changes other than the message text, and the error kind is unchanged (`provider`).

## Tests

- `http::tests::the_client_message_keeps_the_transport_error_and_its_url_out` — regression for the leak: a transport error whose text contains a Vertex-style URL produces a client message with no URL and no project id; the deadline arm keeps its own explanatory text.

Verified: `cargo test -p openwave-router --locked` (74 passed), `cargo clippy -p openwave-core -p openwave-router --all-targets --locked -- -D warnings`, `cargo fmt --check`.
