### PR TITLE
fix(server): raise the turn attempt budget so the retry envelope can bind

### DIFF
--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -99,6 +99,7 @@ impl MigratorTrait for Migrator {
             Box::new(AddLocalApps),
             Box::new(AddAppGrants),
             Box::new(AddToolCallRawArguments),
+            Box::new(RaiseAttemptBudgets),
         ]
     }
 }
@@ -453,6 +454,26 @@ impl MigrationName for AddToolCallRawArguments {
     }
 }
 
+/// Raises the durable attempt budgets of in-flight work from 3 to 5
+/// (issue #1147), matching the `DEFAULT_MAX_ATTEMPTS` constants new rows are
+/// accepted with. Only non-terminal rows move: finished rows keep the budget
+/// they actually ran against, and the raised budget is what lets a parked
+/// `retry_wait` row spend the worker's exponential schedule and wall-clock
+/// envelope instead of failing on the next transient error. Follows the
+/// row-bump pattern of `AddClaimedTurnEffectLeases`; the column default needs
+/// no alter because every accept path writes `max_attempts` explicitly.
+///
+/// The `down` is a deliberate no-op: shrinking a row that has already spent
+/// the extra attempts would strand it with `attempt_count > max_attempts`,
+/// which the shape checks reject.
+struct RaiseAttemptBudgets;
+
+impl MigrationName for RaiseAttemptBudgets {
+    fn name(&self) -> &str {
+        "m20260730_000037_raise_attempt_budgets"
+    }
+}
+
 #[async_trait::async_trait]
 impl MigrationTrait for AddToolCallRawArguments {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
@@ -475,6 +496,34 @@ impl MigrationTrait for AddToolCallRawArguments {
                     .to_owned(),
             )
             .await
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for RaiseAttemptBudgets {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "UPDATE turn_run SET max_attempts = 5 \
+                 WHERE max_attempts = 3 AND status IN \
+                 ('queued', 'running', 'retry_wait', 'resuming', 'waiting_for_client', \
+                  'waiting_for_agent_run', 'cancelling', 'cancelling_client')",
+            )
+            .await?;
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "UPDATE agent_run SET max_attempts = 5 \
+                 WHERE max_attempts = 3 AND status IN \
+                 ('active', 'queued', 'running', 'cancelling', 'waiting', 'retry_wait')",
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
     }
 }
 

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -2497,6 +2497,150 @@ async fn m0024_widens_and_narrows_the_execution_location_domain() {
     );
 }
 
+/// The attempt-budget raise (issue #1147) is a persisted-value contract: rows
+/// still in flight under the old budget of three must come out of the
+/// migration with the raised budget, while terminal rows keep the budget they
+/// actually ran against.
+#[tokio::test]
+async fn m0037_raises_attempt_budgets_only_for_in_flight_runs() {
+    use sea_orm_migration::MigratorTrait;
+
+    let dir = tempfile::tempdir().unwrap();
+    let url = format!(
+        "sqlite://{}?mode=rwc",
+        dir.path().join("attempt-budget-upgrade.db").display()
+    );
+    let conn = Database::connect(&url).await.unwrap();
+    let raise_index = migration::Migrator::migrations()
+        .iter()
+        .position(|migration| migration.name() == "m20260730_000037_raise_attempt_budgets")
+        .expect("the attempt-budget migration is registered");
+    migration::Migrator::up(&conn, Some(raise_index as u32))
+        .await
+        .unwrap();
+
+    // Rows accepted under the old budget of three. Foreign keys stay off on
+    // this connection so no chat/message parent rows are needed; only the
+    // budget bump is under test. The literal 5 below is what the frozen
+    // migration writes, deliberately not re-derived from the constants.
+    conn.execute_unprepared("PRAGMA foreign_keys=OFF")
+        .await
+        .unwrap();
+    // One chat per row: turn_run allows a single active turn per chat, and
+    // the parent/agent rows the keys would point at are deliberately absent.
+    let queued_turn = TurnId::new();
+    let retry_turn = TurnId::new();
+    let failed_turn = TurnId::new();
+    conn.execute_unprepared(&format!(
+        "INSERT INTO turn_run \
+         (id, chat_id, agent_run_id, agent_run_depth, input_message_id, model, status, \
+          attempt_count, max_attempts, claim_count, available_at, started_at, finished_at, \
+          last_error_code, created_at, updated_at) \
+         VALUES \
+         (X'{queued_turn}', X'{queued_chat}', X'{queued_agent}', 0, X'{queued_msg}', \
+          'test-model', 'queued', 0, 3, 0, '2026-07-01 00:00:00+00:00', NULL, NULL, NULL, \
+          '2026-07-01 00:00:00+00:00', '2026-07-01 00:00:00+00:00'), \
+         (X'{retry_turn}', X'{retry_chat}', X'{retry_agent}', 0, X'{retry_msg}', \
+          'test-model', 'retry_wait', 2, 3, 2, '2026-07-01 00:01:00+00:00', \
+          '2026-07-01 00:00:30+00:00', NULL, 'overloaded', \
+          '2026-07-01 00:00:00+00:00', '2026-07-01 00:01:00+00:00'), \
+         (X'{failed_turn}', X'{failed_chat}', X'{failed_agent}', 0, X'{failed_msg}', \
+          'test-model', 'failed', 3, 3, 3, '2026-07-01 00:02:00+00:00', \
+          '2026-07-01 00:00:30+00:00', '2026-07-01 00:02:00+00:00', 'overloaded', \
+          '2026-07-01 00:00:00+00:00', '2026-07-01 00:02:00+00:00');",
+        queued_turn = queued_turn.0.simple(),
+        retry_turn = retry_turn.0.simple(),
+        failed_turn = failed_turn.0.simple(),
+        queued_chat = ChatId::new().0.simple(),
+        retry_chat = ChatId::new().0.simple(),
+        failed_chat = ChatId::new().0.simple(),
+        queued_agent = AgentRunId::foreground_for_chat(ChatId::new()).0.simple(),
+        retry_agent = AgentRunId::foreground_for_chat(ChatId::new()).0.simple(),
+        failed_agent = AgentRunId::foreground_for_chat(ChatId::new()).0.simple(),
+        queued_msg = MessageId::new().0.simple(),
+        retry_msg = MessageId::new().0.simple(),
+        failed_msg = MessageId::new().0.simple(),
+    ))
+    .await
+    .unwrap();
+
+    let queued_call = CallId::new();
+    let retry_call = CallId::new();
+    let failed_call = CallId::new();
+    let foreground_id = AgentRunId::foreground_for_chat(ChatId::new());
+    let queued_run = AgentRunId::sandbox_for_spawn_call(queued_call);
+    let retry_run = AgentRunId::sandbox_for_spawn_call(retry_call);
+    let failed_run = AgentRunId::sandbox_for_spawn_call(failed_call);
+    conn.execute_unprepared(&format!(
+        "INSERT INTO agent_run \
+         (id, chat_id, parent_id, parent_depth, spawn_call_id, tier, execution_location, \
+          depth, status, input, attempt_count, max_attempts, claim_count, available_at, \
+          deadline_at, started_at, finished_at, last_error_code, created_at, updated_at) \
+         VALUES \
+         (X'{foreground}', X'{foreground_chat}', NULL, NULL, NULL, 'foreground', \
+          'in_process', 0, 'active', NULL, 0, 0, 0, '2026-07-01 00:00:00+00:00', NULL, \
+          NULL, NULL, NULL, '2026-07-01 00:00:00+00:00', '2026-07-01 00:00:00+00:00'), \
+         (X'{queued_run}', X'{queued_chat}', X'{foreground}', 0, X'{queued_call}', \
+          'background', 'in_process', 1, 'queued', 'legacy delegated task', 0, 3, 0, \
+          '2026-07-01 00:00:00+00:00', '2026-07-01 00:30:00+00:00', NULL, NULL, NULL, \
+          '2026-07-01 00:00:00+00:00', '2026-07-01 00:00:00+00:00'), \
+         (X'{retry_run}', X'{retry_chat}', X'{foreground}', 0, X'{retry_call}', \
+          'background', 'in_process', 1, 'retry_wait', 'legacy delegated task', 1, 3, 1, \
+          '2026-07-01 00:01:00+00:00', '2026-07-01 00:30:00+00:00', \
+          '2026-07-01 00:00:30+00:00', NULL, 'overloaded', \
+          '2026-07-01 00:00:00+00:00', '2026-07-01 00:01:00+00:00'), \
+         (X'{failed_run}', X'{failed_chat}', X'{foreground}', 0, X'{failed_call}', \
+          'background', 'in_process', 1, 'failed', 'legacy delegated task', 3, 3, 3, \
+          '2026-07-01 00:02:00+00:00', '2026-07-01 00:30:00+00:00', \
+          '2026-07-01 00:00:30+00:00', '2026-07-01 00:02:00+00:00', 'overloaded', \
+          '2026-07-01 00:00:00+00:00', '2026-07-01 00:02:00+00:00');",
+        foreground = foreground_id.0.simple(),
+        foreground_chat = ChatId::new().0.simple(),
+        queued_chat = ChatId::new().0.simple(),
+        retry_chat = ChatId::new().0.simple(),
+        failed_chat = ChatId::new().0.simple(),
+        queued_run = queued_run.0.simple(),
+        retry_run = retry_run.0.simple(),
+        failed_run = failed_run.0.simple(),
+        queued_call = queued_call.0.simple(),
+        retry_call = retry_call.0.simple(),
+        failed_call = failed_call.0.simple(),
+    ))
+    .await
+    .unwrap();
+
+    migration::Migrator::up(&conn, None).await.unwrap();
+
+    let store = DbStore { conn };
+    for (turn, expected) in [(queued_turn, 5), (retry_turn, 5), (failed_turn, 3)] {
+        assert_eq!(
+            store
+                .get_turn_run(turn)
+                .await
+                .unwrap()
+                .unwrap()
+                .max_attempts,
+            expected
+        );
+    }
+    for (run, expected) in [
+        (queued_run, 5),
+        (retry_run, 5),
+        (failed_run, 3),
+        (foreground_id, 0),
+    ] {
+        assert_eq!(
+            store
+                .get_agent_run(run)
+                .await
+                .unwrap()
+                .unwrap()
+                .max_attempts,
+            expected
+        );
+    }
+}
+
 #[tokio::test]
 async fn m0011_preserves_legacy_documents_as_conversationless() {
     let dir = tempfile::tempdir().unwrap();

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1197,8 +1197,11 @@ impl AgentRun {
     pub const MAX_INPUT_LEN: usize = 65_536;
     /// Maximum persisted model identifier length.
     pub const MAX_MODEL_LEN: usize = TurnRun::MAX_MODEL_LEN;
-    /// Default failure-attempt budget for sandboxed work.
-    pub const DEFAULT_MAX_ATTEMPTS: i32 = 3;
+    /// Default failure-attempt budget for sandboxed work. Five attempts give
+    /// the worker's exponential schedule and the provider's `Retry-After`
+    /// room to stretch waits toward the run's wall-clock envelope; at three
+    /// the budget was gone before either could bind.
+    pub const DEFAULT_MAX_ATTEMPTS: i32 = 5;
     /// Default wall-clock budget for one sandbox run.
     pub const DEFAULT_MAX_DURATION: chrono::Duration = chrono::Duration::hours(1);
     /// Largest accepted scheduler concurrency bound.
@@ -1737,8 +1740,12 @@ pub struct TurnRun {
 
 impl TurnRun {
     /// New turns retry transient failures while per-attempt effect provenance
-    /// prevents ambiguous tool work from being replayed.
-    pub const DEFAULT_MAX_ATTEMPTS: i32 = 3;
+    /// prevents ambiguous tool work from being replayed. Five attempts give
+    /// the turn worker's exponential schedule and the provider's
+    /// `Retry-After` room to stretch waits toward the ten-minute envelope; at
+    /// three the budget was gone in about a second of backoff unless a hint
+    /// stretched a wait.
+    pub const DEFAULT_MAX_ATTEMPTS: i32 = 5;
     /// Maximum persisted model identifier length.
     pub const MAX_MODEL_LEN: usize = 512;
     /// Maximum persisted machine-readable error code length.

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -72,8 +72,8 @@ impl Default for SandboxAgentRunWorkerConfig {
             // A parent turn may be waiting on this run, but nothing it retries
             // recovers in milliseconds: a sandbox that is still provisioning,
             // a provider that just refused, a delegated resource that has not
-            // appeared yet. Retrying inside a second only spends one of three
-            // attempts on the same unfinished state, so the first wait is five
+            // appeared yet. Retrying inside a second only spends an attempt
+            // on the same unfinished state, so the first wait is five
             // seconds. The envelope matches the run's own wall-clock deadline,
             // which the database already enforces.
             retry: RetrySchedule::new(
@@ -2575,16 +2575,14 @@ mod tests {
             .finish_agent_run_cancellation(second, claimed.lease_token.unwrap())
             .await
             .unwrap();
-        tokio::time::sleep(Duration::from_millis(300)).await;
-        assert_eq!(
-            worker.run_once().await.unwrap(),
-            SandboxAgentRunWorkerOutcome::RetryScheduled(first)
-        );
-        tokio::time::sleep(Duration::from_millis(300)).await;
-        assert_eq!(
-            worker.run_once().await.unwrap(),
-            SandboxAgentRunWorkerOutcome::Failed(first)
-        );
+        // Each remaining attempt parks in retry-wait until the durable
+        // budget is spent and the run fails terminally.
+        let mut outcome = SandboxAgentRunWorkerOutcome::RetryScheduled(first);
+        for _ in 1..openwave_core::AgentRun::DEFAULT_MAX_ATTEMPTS {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            outcome = worker.run_once().await.unwrap();
+        }
+        assert_eq!(outcome, SandboxAgentRunWorkerOutcome::Failed(first));
         let terminal = store.get_agent_run(first).await.unwrap().unwrap();
         assert_eq!(terminal.status, AgentRunStatus::Failed);
         let inbox = store


### PR DESCRIPTION
Closes #1147

## Correction: which constant, and what value

The parity audit and #1086 cited `DEFAULT_MAX_ATTEMPTS = 5` at `model.rs:584`. That constant belongs to `BlobRetirement` (deletion claims) and is unrelated to turns. The turn's budget is `TurnRun::DEFAULT_MAX_ATTEMPTS` and it was **3**; `AgentRun` has a third one, also 3, playing the same role for background sandbox runs (it feeds the same `RetryAttempt.max_attempts` in the sandbox agent-run worker). Both are now 5.

## Direction chosen: raise the budget, keep the envelope

The retry schedule from #1137 is correct but mostly unreachable at a budget of 3:

- Turn worker (250ms initial, doubling, 100s ceiling, 600s envelope): three attempts means waits of ~250ms and ~500ms — the budget is spent in about a second. Only a provider `Retry-After` honored inside the envelope ever stretched a wait.
- Sandbox agent-run worker (5s initial, 60s ceiling, 1h envelope): three attempts means waits of 5s and 10s.

With 5 attempts there are four retries instead of two, so backoff and provider hints have room to stretch toward the envelope before the failure goes terminal. The alternative the issue offers — shrinking the envelope to match the budget — would make the wall-clock deadline honest but leave any transient provider overload longer than ~1s fatal to a turn a user is watching; that seemed strictly worse.

## Token-cost tradeoff

Each turn attempt replays model work, so the two extra attempts are real spend, not just latency: a turn that keeps failing transiently now costs up to 5 model replays before failing terminally (likewise two extra sandbox executions for a background run). The spend stays bounded by the 600s / 1h wall-clock envelopes, and a `Retry-After` longer than the remaining envelope is refused outright, so the extra budget is only spent inside the window someone is actually waiting. The prior art points the same direction: the codebase and its audit documents had already assumed 5; 3 was the drift.

## Migration story

`max_attempts` is written explicitly on every accept path, so the constants govern new rows only, and the `turn_run.max_attempts` column default moves automatically for fresh databases (SQLite cannot alter a column default in place, and the default never fires in practice since inserts always set the value). Existing in-flight rows are bumped by `m20260730_000037_raise_attempt_budgets`, following the `AddClaimedTurnEffectLeases` precedent: non-terminal `turn_run` and `agent_run` rows with `max_attempts = 3` go to 5; terminal rows keep the budget they ran against; foreground rows (0) and container runs (1) are untouched. The `down` is a deliberate no-op — shrinking a row that already spent the extra attempts would strand it with `attempt_count > max_attempts`, which the shape checks reject.

## Tests

- New `m0037_raises_attempt_budgets_only_for_in_flight_runs` migration test (sqlite, following the m0021 pattern): seeds pre-migration queued/retry_wait/failed turns and foreground/queued/retry_wait/failed agent runs, then asserts in-flight rows come out at 5 while terminal and foreground rows are unchanged.
- `immediate_failures_release_capacity_then_deliver_a_terminal_parent_receipt` no longer hard-codes the old default's three-beat structure; it drives attempts symbolically until the durable budget is spent.

Verified locally: `cargo test -p openwave-core --locked` (525 passed), `cargo test -p openwave-server --locked` (482 passed), `cargo clippy -p openwave-core -p openwave-server --all-targets --locked -- -D warnings`, `cargo fmt --all --check`.
