### PR TITLE
feat(server): durable app grants pinned to server-definition fingerprints

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -1402,6 +1402,50 @@ pub mod app_revision {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod app_grant {
+    use sea_orm::entity::prelude::*;
+
+    // At most one grant per app — the app id is the primary key — replaced
+    // wholesale by a fresh consent and deleted by revocation. The bindings
+    // column carries the granted `(server, tools[])` set with each server's
+    // definition fingerprint, in the serde shape of
+    // `Vec<crate::local_app::AppGrantBinding>`.
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "app_grant")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub app_id: Uuid,
+        // Matches the migration's `.json_binary()` (JSONB on Postgres).
+        #[sea_orm(column_type = "JsonBinary")]
+        pub bindings_json: Json,
+        pub created_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter)]
+    pub enum Relation {
+        App,
+    }
+
+    impl RelationTrait for Relation {
+        fn def(&self) -> RelationDef {
+            match self {
+                Self::App => Entity::belongs_to(super::app::Entity)
+                    .from(Column::AppId)
+                    .to(super::app::Column::Id)
+                    .into(),
+            }
+        }
+    }
+
+    impl Related<super::app::Entity> for Entity {
+        fn to() -> RelationDef {
+            Relation::App.def()
+        }
+    }
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod event {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -97,6 +97,7 @@ impl MigratorTrait for Migrator {
             Box::new(AddPlanRequests),
             Box::new(AddExecFileSnapshots),
             Box::new(AddLocalApps),
+            Box::new(AddAppGrants),
         ]
     }
 }
@@ -241,6 +242,66 @@ impl MigrationTrait for AddLocalApps {
             .await?;
         manager
             .drop_table(Table::drop().table(App::Table).to_owned())
+            .await
+    }
+}
+
+/// Adds the durable app-grant consent record: at most one row per app — the
+/// app id is the primary key — carrying the granted `(server, tools[])`
+/// bindings with each bound server's definition fingerprint as JSON.
+///
+/// The grant is host-computed policy, replaced wholesale by a fresh consent
+/// and deleted by revocation, so the table needs no history and no surrogate
+/// identity. Cascade delete follows the app row: a grant never outlives the
+/// thing it consented to. Purely additive, symmetric `down`.
+struct AddAppGrants;
+
+impl MigrationName for AddAppGrants {
+    fn name(&self) -> &str {
+        "m20260730_000038_add_app_grants"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddAppGrants {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(AppGrant::Table)
+                    .col(
+                        ColumnDef::new(AppGrant::AppId)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(AppGrant::BindingsJson)
+                            .json_binary()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(AppGrant::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .foreign_key(
+                        ForeignKey::create()
+                            .name("fk_app_grant_app")
+                            .from_tbl(AppGrant::Table)
+                            .from_col(AppGrant::AppId)
+                            .to_tbl(App::Table)
+                            .to_col(App::Id)
+                            .on_delete(ForeignKeyAction::Cascade),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(AppGrant::Table).to_owned())
             .await
     }
 }
@@ -9260,6 +9321,14 @@ enum AppRevision {
     TurnId,
     ProducingRunId,
     ChatId,
+    CreatedAt,
+}
+
+#[derive(DeriveIden)]
+enum AppGrant {
+    Table,
+    AppId,
+    BindingsJson,
     CreatedAt,
 }
 

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -27,7 +27,7 @@ use crate::id::{
     OutputRevisionId, ProjectId, RootAttachmentChangeId, TurnId, TurnSteerId,
 };
 use crate::image::ImageRef;
-use crate::local_app::{AppRecord, AppRevision, CreateApp, NewAppRevision};
+use crate::local_app::{AppGrant, AppRecord, AppRevision, CreateApp, NewAppRevision};
 #[cfg(test)]
 use crate::model::Role;
 use crate::model::{
@@ -642,6 +642,18 @@ impl Store for DbStore {
 
     async fn restore_app(&self, id: AppId, restored_at: chrono::DateTime<Utc>) -> Result<bool> {
         ops::app::restore_app(self, id, restored_at).await
+    }
+
+    async fn put_app_grant(&self, grant: &AppGrant) -> Result<()> {
+        ops::app::put_app_grant(self, grant).await
+    }
+
+    async fn get_app_grant(&self, app_id: AppId) -> Result<Option<AppGrant>> {
+        ops::app::get_app_grant(self, app_id).await
+    }
+
+    async fn delete_app_grant(&self, app_id: AppId) -> Result<bool> {
+        ops::app::delete_app_grant(self, app_id).await
     }
 
     async fn save_context_checkpoint(

--- a/crates/openwave-core/src/db/ops/app.rs
+++ b/crates/openwave-core/src/db/ops/app.rs
@@ -16,8 +16,8 @@ use sea_orm::{
 use crate::error::{AgentError, Result};
 use crate::id::{AppId, AppRevisionId};
 use crate::local_app::{
-    validate_app_manifest, AppManifest, AppRecord, AppRevision, CreateApp, NewAppRevision,
-    MAX_APP_BUNDLE_BYTES, MAX_APP_REVISIONS,
+    validate_app_grant, validate_app_manifest, AppGrant, AppGrantBinding, AppManifest, AppRecord,
+    AppRevision, CreateApp, NewAppRevision, MAX_APP_BUNDLE_BYTES, MAX_APP_REVISIONS,
 };
 
 use super::super::{entities, store_err, DbStore};
@@ -233,6 +233,74 @@ pub(in crate::db) async fn restore_app(
     .map_err(store_err)?;
     transaction.commit().await.map_err(store_err)?;
     Ok(true)
+}
+
+pub(in crate::db) async fn put_app_grant(store: &DbStore, grant: &AppGrant) -> Result<()> {
+    let bindings_json = validate_app_grant(grant)
+        .map_err(|message| AgentError::Store(format!("invalid app grant: {message}")))?;
+    let created_at = canonical_db_timestamp(grant.created_at)?;
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    // The app row's write lock serializes replacement of the single grant row
+    // the same way it serializes revision appends.
+    if !acquire_app_write_lock(&transaction, grant.app_id).await? {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!("app {} not found", grant.app_id)));
+    }
+    let existing = require_app_on(&transaction, grant.app_id).await?;
+    if existing.deleted_at.is_some() {
+        transaction.rollback().await.map_err(store_err)?;
+        return Err(AgentError::Store(format!(
+            "app {} is deleted",
+            grant.app_id
+        )));
+    }
+    // A fresh consent replaces the whole grant: there is at most one per app.
+    entities::app_grant::Entity::delete_many()
+        .filter(entities::app_grant::Column::AppId.eq(grant.app_id.0))
+        .exec(&transaction)
+        .await
+        .map_err(store_err)?;
+    entities::app_grant::ActiveModel {
+        app_id: Set(grant.app_id.0),
+        bindings_json: Set(bindings_json),
+        created_at: Set(created_at),
+    }
+    .insert(&transaction)
+    .await
+    .map_err(store_err)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(())
+}
+
+pub(in crate::db) async fn get_app_grant(
+    store: &DbStore,
+    app_id: AppId,
+) -> Result<Option<AppGrant>> {
+    entities::app_grant::Entity::find_by_id(app_id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .map(grant_from_model)
+        .transpose()
+}
+
+pub(in crate::db) async fn delete_app_grant(store: &DbStore, app_id: AppId) -> Result<bool> {
+    let deleted = entities::app_grant::Entity::delete_many()
+        .filter(entities::app_grant::Column::AppId.eq(app_id.0))
+        .exec(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(deleted.rows_affected > 0)
+}
+
+fn grant_from_model(model: entities::app_grant::Model) -> Result<AppGrant> {
+    let bindings: Vec<AppGrantBinding> = serde_json::from_value(model.bindings_json)
+        .map_err(|_| AgentError::Store("stored app grant is malformed".into()))?;
+    Ok(AppGrant {
+        app_id: AppId(model.app_id),
+        bindings,
+        created_at: model.created_at,
+    })
 }
 
 /// Acquire the shared cross-backend write lock for one app row.

--- a/crates/openwave-core/src/local_app.rs
+++ b/crates/openwave-core/src/local_app.rs
@@ -189,6 +189,89 @@ pub struct CreateApp {
     pub revision: NewAppRevision,
 }
 
+/// The durable consent object for one app: the granted `(server, tools[])`
+/// set, with each bound server pinned to a fingerprint of its definition as it
+/// was configured at consent time.
+///
+/// One grant per app, replaced wholesale by a fresh consent and deleted by
+/// revocation. The fingerprint is what keeps consent honest: a Settings edit
+/// can swap the process behind a stable server name, so enforcement compares
+/// the granted fingerprint against the current definition on every invoke and
+/// treats any difference as a stale grant, never as a match.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppGrant {
+    /// App the consent belongs to.
+    pub app_id: AppId,
+    /// The granted bindings, computed by the host from the manifest and the
+    /// server definitions current at consent time — never supplied by a
+    /// renderer.
+    pub bindings: Vec<AppGrantBinding>,
+    /// Host-stamped consent time.
+    pub created_at: DateTime<Utc>,
+}
+
+/// One granted server binding: the tools the user consented to under this
+/// server name, pinned to the definition that name resolved to at consent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AppGrantBinding {
+    /// Configured server namespace, matching the manifest binding it covers.
+    pub server: String,
+    /// Full mounted tool names (`mcp__{server}__{tool}`) the grant covers.
+    pub tools: Vec<String>,
+    /// SHA-256 fingerprint of the server's definition as configured at consent
+    /// time, computed by the host over a canonical serialization that carries
+    /// configuration *names and structure* only — never environment or token
+    /// values. Persisted as lowercase hex.
+    #[serde(with = "hex_fingerprint")]
+    pub fingerprint: [u8; 32],
+}
+
+/// Lowercase-hex persistence for a grant binding's definition fingerprint.
+mod hex_fingerprint {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(bytes: &[u8; 32], serializer: S) -> Result<S::Ok, S::Error> {
+        use std::fmt::Write as _;
+
+        let mut text = String::with_capacity(64);
+        for byte in bytes {
+            let _ = write!(text, "{byte:02x}");
+        }
+        serializer.serialize_str(&text)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<[u8; 32], D::Error> {
+        let text = String::deserialize(deserializer)?;
+        let malformed = || serde::de::Error::custom("malformed definition fingerprint");
+        if text.len() != 64 || !text.is_ascii() {
+            return Err(malformed());
+        }
+        let mut bytes = [0_u8; 32];
+        for (index, byte) in bytes.iter_mut().enumerate() {
+            *byte =
+                u8::from_str_radix(&text[2 * index..2 * index + 2], 16).map_err(|_| malformed())?;
+        }
+        Ok(bytes)
+    }
+}
+
+/// Validate a grant's bindings structurally and return the JSON to store.
+///
+/// A grant is host-computed from an already-validated manifest, so this is the
+/// same binding grammar [`validate_app_manifest`] enforces — repeated at the
+/// storage door so no other write path can persist a binding the manifest
+/// validator would have refused.
+pub fn validate_app_grant(grant: &AppGrant) -> Result<serde_json::Value, String> {
+    validate_binding_set(
+        grant
+            .bindings
+            .iter()
+            .map(|binding| (binding.server.as_str(), binding.tools.as_slice())),
+    )?;
+    serde_json::to_value(&grant.bindings).map_err(|error| format!("unencodable app grant: {error}"))
+}
+
 /// The trusted half of an app revision: a display name and the exact mounted
 /// tools the app may call.
 ///
@@ -227,39 +310,12 @@ pub struct AppBinding {
 /// that could never match a mounted tool is refused at the door.
 pub fn validate_app_manifest(manifest: &AppManifest) -> Result<serde_json::Value, String> {
     validate_app_name(&manifest.name)?;
-    let mut servers = std::collections::HashSet::new();
-    for binding in &manifest.bindings {
-        if binding.server.is_empty() || !is_mounted_name_charset(&binding.server) {
-            return Err(format!(
-                "binding server {:?} must be a non-empty [A-Za-z0-9_-] name",
-                binding.server
-            ));
-        }
-        if !servers.insert(binding.server.as_str()) {
-            return Err(format!("duplicate binding for server {:?}", binding.server));
-        }
-        let prefix = format!("mcp__{}__", binding.server);
-        let mut tools = std::collections::HashSet::new();
-        for tool in &binding.tools {
-            if tool.len() > MAX_MOUNTED_TOOL_NAME_BYTES || !is_mounted_name_charset(tool) {
-                return Err(format!(
-                    "tool {tool:?} must be at most {MAX_MOUNTED_TOOL_NAME_BYTES} bytes of [A-Za-z0-9_-]"
-                ));
-            }
-            match tool.strip_prefix(&prefix) {
-                Some(rest) if !rest.is_empty() => {}
-                _ => {
-                    return Err(format!(
-                        "tool {tool:?} is not a mounted `{prefix}{{tool}}` name under server {:?}",
-                        binding.server
-                    ));
-                }
-            }
-            if !tools.insert(tool.as_str()) {
-                return Err(format!("duplicate tool {tool:?}"));
-            }
-        }
-    }
+    validate_binding_set(
+        manifest
+            .bindings
+            .iter()
+            .map(|binding| (binding.server.as_str(), binding.tools.as_slice())),
+    )?;
     let json =
         serde_json::to_value(manifest).map_err(|error| format!("unencodable manifest: {error}"))?;
     let encoded_len = json.to_string().len();
@@ -269,6 +325,46 @@ pub fn validate_app_manifest(manifest: &AppManifest) -> Result<serde_json::Value
         ));
     }
     Ok(json)
+}
+
+/// The binding grammar shared by manifests and grants: valid server names,
+/// no duplicate servers, and every tool a full mounted name under its
+/// binding's server namespace.
+fn validate_binding_set<'a>(
+    bindings: impl Iterator<Item = (&'a str, &'a [String])>,
+) -> Result<(), String> {
+    let mut servers = std::collections::HashSet::new();
+    for (server, binding_tools) in bindings {
+        if server.is_empty() || !is_mounted_name_charset(server) {
+            return Err(format!(
+                "binding server {server:?} must be a non-empty [A-Za-z0-9_-] name"
+            ));
+        }
+        if !servers.insert(server) {
+            return Err(format!("duplicate binding for server {server:?}"));
+        }
+        let prefix = format!("mcp__{server}__");
+        let mut tools = std::collections::HashSet::new();
+        for tool in binding_tools {
+            if tool.len() > MAX_MOUNTED_TOOL_NAME_BYTES || !is_mounted_name_charset(tool) {
+                return Err(format!(
+                    "tool {tool:?} must be at most {MAX_MOUNTED_TOOL_NAME_BYTES} bytes of [A-Za-z0-9_-]"
+                ));
+            }
+            match tool.strip_prefix(&prefix) {
+                Some(rest) if !rest.is_empty() => {}
+                _ => {
+                    return Err(format!(
+                        "tool {tool:?} is not a mounted `{prefix}{{tool}}` name under server {server:?}"
+                    ));
+                }
+            }
+            if !tools.insert(tool.as_str()) {
+                return Err(format!("duplicate tool {tool:?}"));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn validate_app_name(name: &str) -> Result<(), String> {

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -33,7 +33,7 @@ use crate::id::{
     OutputRevisionId, ProjectId, RootAttachmentChangeId, TurnId, TurnSteerId,
 };
 use crate::image::ImageRef;
-use crate::local_app::{AppRecord, AppRevision, CreateApp, NewAppRevision};
+use crate::local_app::{AppGrant, AppRecord, AppRevision, CreateApp, NewAppRevision};
 use crate::model::{
     AgentRun, AgentRunInboxEntry, AgentRunResult, AgentRunTier, AgentRunWaitSetCandidate,
     BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus, Chat, ClientToolCallRequest,
@@ -1559,6 +1559,27 @@ pub trait Store: Send + Sync {
         _id: AppId,
         _restored_at: chrono::DateTime<chrono::Utc>,
     ) -> Result<bool> {
+        app_storage_unavailable()
+    }
+
+    /// Record explicit user consent for one app, replacing any previous grant.
+    ///
+    /// The grant is host-computed from the app's current manifest and the
+    /// server definitions current at consent time; implementations validate
+    /// its bindings with the manifest grammar and refuse a missing or deleted
+    /// app. There is at most one grant per app.
+    async fn put_app_grant(&self, _grant: &AppGrant) -> Result<()> {
+        app_storage_unavailable()
+    }
+
+    /// Fetch one app's grant, when the user has consented and not revoked.
+    async fn get_app_grant(&self, _app_id: AppId) -> Result<Option<AppGrant>> {
+        app_storage_unavailable()
+    }
+
+    /// Revoke one app's grant. Returns `false` when no grant existed;
+    /// revoking twice is the same durable outcome, not a conflict.
+    async fn delete_app_grant(&self, _app_id: AppId) -> Result<bool> {
         app_storage_unavailable()
     }
 

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -116,6 +116,50 @@ export type AgentRunStatus = "active" | "queued" | "running" | "cancelling" | "w
 export type AgentRunTier = "foreground" | "background";
 
 /**
+ * One current-manifest binding, projected for the consent sheet.
+ */
+export type AppGrantBindingState = { 
+/**
+ * Configured server namespace, by name only.
+ */
+server: string, 
+/**
+ * Full mounted tool names the current manifest pins under this server.
+ */
+tools: Array<string>, 
+/**
+ * Whether the live grant covers every listed tool under this server and
+ * the server's current definition still matches the granted fingerprint.
+ */
+granted: boolean, 
+/**
+ * Whether a grant names this server but its definition changed (or
+ * disappeared) since consent — the "reconfigured since you agreed"
+ * affordance, distinct from a binding that was simply never granted.
+ */
+definition_changed: boolean, };
+
+/**
+ * Renderer-safe grant state for one app: the consent sheet's whole input.
+ *
+ * `bindings` follows the app's **current** revision's manifest — names only.
+ * The definitions behind the server names, and any environment or token
+ * values they select, are deliberately absent from this projection.
+ */
+export type AppGrantState = { 
+/**
+ * Whether a live grant fully covers the current manifest with every
+ * bound definition unchanged since consent — the "no sheet needed"
+ * verdict. When `false`, (re-)consent is required before every pinned
+ * tool is invokable.
+ */
+granted: boolean, 
+/**
+ * The current manifest's bindings, one entry per bound server.
+ */
+bindings: Array<AppGrantBindingState>, };
+
+/**
  * The typed refusal body — the `{ kind, message }` shape every route error
  * carries, with the kind closed so a client never string-matches prose.
  */

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -324,6 +324,12 @@ pub fn app(state: AppState) -> Router {
             post(routes::post_app_invoke)
                 .layer(DefaultBodyLimit::max(routes::MAX_APP_INVOKE_BODY_BYTES)),
         )
+        .route(
+            "/apps/{id}/grant",
+            get(routes::get_app_grant_state)
+                .post(routes::post_app_grant)
+                .delete(routes::delete_app_grant),
+        )
         .route("/policy", get(routes::get_policy))
         .route("/gateway/status", get(routes::get_gateway_status))
         .route("/gateway/apps", get(routes::get_gateway_apps))

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -293,6 +293,86 @@ impl McpServerDefinition {
     }
 }
 
+/// SHA-256 fingerprint of a server definition as configured, the value an app
+/// grant pins each bound server to.
+///
+/// The digest is taken over the UTF-8 bytes of a compact JSON object with
+/// **exactly these keys, in exactly this order** (serde serializes struct
+/// fields in declaration order, and every key is always present):
+///
+/// ```json
+/// {"v":1,
+///  "transport":"stdio"|"http"|"gateway",
+///  "command":string|null,
+///  "args":[string,...],
+///  "cwd":string|null,
+///  "env_names":[string,...],
+///  "env_from":[string,...],
+///  "url":string|null,
+///  "bearer_token_env_set":bool,
+///  "gateway_endpoint":string|null}
+/// ```
+///
+/// `env_names` is the sorted *names* of the literal `env` entries and
+/// `env_from` the sorted selected parent-environment names — configuration
+/// values and resolved secrets never enter the canonical form, so the
+/// fingerprint can never be a value oracle. `bearer_token_env_set` records
+/// only whether a bearer name is selected. `cwd` is the configured path,
+/// lossily UTF-8. `name`, `enabled`, and `request_timeout_ms` are deliberately
+/// excluded: the grant binding already keys the fingerprint by server name,
+/// and toggling or re-timing a server does not change *what* the user
+/// consented to run.
+///
+/// **This canonical form is a compatibility surface.** Persisted grants store
+/// the digest; changing the form (or the meaning of any field in it)
+/// invalidates every existing grant and must bump `v`.
+pub(crate) fn definition_fingerprint(definition: &McpServerDefinition) -> [u8; 32] {
+    use sha2::Digest as _;
+
+    #[derive(Serialize)]
+    struct CanonicalDefinition<'a> {
+        v: u32,
+        transport: &'static str,
+        command: Option<&'a str>,
+        args: &'a [String],
+        cwd: Option<String>,
+        env_names: Vec<&'a str>,
+        env_from: Vec<&'a str>,
+        url: Option<&'a str>,
+        bearer_token_env_set: bool,
+        gateway_endpoint: Option<&'a str>,
+    }
+
+    let mut env_names: Vec<&str> = definition.env.keys().map(String::as_str).collect();
+    env_names.sort_unstable();
+    let mut env_from: Vec<&str> = definition.env_from.iter().map(String::as_str).collect();
+    env_from.sort_unstable();
+    let canonical = CanonicalDefinition {
+        v: 1,
+        transport: if definition.gateway_endpoint.is_some() {
+            "gateway"
+        } else if definition.url.is_some() {
+            "http"
+        } else {
+            "stdio"
+        },
+        command: definition.command.as_deref(),
+        args: &definition.args,
+        cwd: definition
+            .cwd
+            .as_ref()
+            .map(|cwd| cwd.to_string_lossy().into_owned()),
+        env_names,
+        env_from,
+        url: definition.url.as_deref(),
+        bearer_token_env_set: definition.bearer_token_env.is_some(),
+        gateway_endpoint: definition.gateway_endpoint.as_deref(),
+    };
+    let bytes = serde_json::to_vec(&canonical)
+        .expect("a canonical definition serializes infallibly to JSON");
+    sha2::Sha256::digest(&bytes).into()
+}
+
 const fn default_request_timeout_ms() -> u64 {
     DEFAULT_REQUEST_TIMEOUT_MS
 }
@@ -535,6 +615,20 @@ impl McpRuntime {
     pub(crate) async fn ui_view_document(&self, server: &str, uri: &str) -> Option<UiViewDocument> {
         let state = self.state.lock().await;
         state.servers.get(server)?.ui_views.get(uri).cloned()
+    }
+
+    /// The current definition fingerprint of every configured server, by name.
+    ///
+    /// Read live per call — never cached across a request — so grant
+    /// enforcement always compares against the definition a name resolves to
+    /// *now*, including a definition swapped in while the app stayed open.
+    pub(crate) async fn definition_fingerprints(&self) -> BTreeMap<String, [u8; 32]> {
+        let state = self.state.lock().await;
+        state
+            .definitions
+            .iter()
+            .map(|definition| (definition.name.clone(), definition_fingerprint(definition)))
+            .collect()
     }
 
     /// One immutable tool surface for a live turn.

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -44,6 +44,7 @@ use crate::web_search::{
     WebSearchCredentialsInfo,
 };
 
+mod app_grant;
 mod app_invoke;
 pub(crate) mod client_execution;
 mod delegated_file_execution;
@@ -52,6 +53,7 @@ pub(crate) mod image_attachment;
 mod plans;
 mod root_attachment;
 mod user_questions;
+pub use app_grant::*;
 pub use app_invoke::*;
 pub use client_execution::*;
 pub use delegated_file_execution::*;

--- a/crates/openwave-server/src/routes/app_grant.rs
+++ b/crates/openwave-server/src/routes/app_grant.rs
@@ -1,0 +1,194 @@
+//! `/apps/{id}/grant` — the renderer-facing surface of the app-grant consent
+//! object: read grant state, record consent, revoke.
+//!
+//! The renderer never supplies grant content. Consent (`POST`) is a bare
+//! affirmative — the server computes the grant from the app's *current*
+//! manifest and the server definitions *current* at that moment, so a stale
+//! sheet can never grant tools the manifest no longer pins or pin a
+//! definition that has since changed. State (`GET`) is renderer-safe
+//! metadata: server and tool *names* with coverage/staleness booleans, never
+//! definitions and never environment values.
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use chrono::Utc;
+use serde::Serialize;
+
+use openwave_core::id::AppId;
+use openwave_core::local_app::{AppGrant, AppGrantBinding, AppManifest, AppRecord, AppRevision};
+
+use crate::error::ServerError;
+use crate::extract::{Json, Path};
+use crate::state::AppState;
+
+/// Renderer-safe grant state for one app: the consent sheet's whole input.
+///
+/// `bindings` follows the app's **current** revision's manifest — names only.
+/// The definitions behind the server names, and any environment or token
+/// values they select, are deliberately absent from this projection.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct AppGrantState {
+    /// Whether a live grant fully covers the current manifest with every
+    /// bound definition unchanged since consent — the "no sheet needed"
+    /// verdict. When `false`, (re-)consent is required before every pinned
+    /// tool is invokable.
+    pub granted: bool,
+    /// The current manifest's bindings, one entry per bound server.
+    pub bindings: Vec<AppGrantBindingState>,
+}
+
+/// One current-manifest binding, projected for the consent sheet.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct AppGrantBindingState {
+    /// Configured server namespace, by name only.
+    pub server: String,
+    /// Full mounted tool names the current manifest pins under this server.
+    pub tools: Vec<String>,
+    /// Whether the live grant covers every listed tool under this server and
+    /// the server's current definition still matches the granted fingerprint.
+    pub granted: bool,
+    /// Whether a grant names this server but its definition changed (or
+    /// disappeared) since consent — the "reconfigured since you agreed"
+    /// affordance, distinct from a binding that was simply never granted.
+    pub definition_changed: bool,
+}
+
+/// `GET /apps/{id}/grant` — the app's current grant state.
+pub async fn get_app_grant_state(
+    State(state): State<AppState>,
+    Path(app_id): Path<AppId>,
+) -> Result<Json<AppGrantState>, ServerError> {
+    let (app, revision) = current_live_app(&state, app_id).await?;
+    let grant = state.store.get_app_grant(app.id).await?;
+    let current = state.mcp.definition_fingerprints().await;
+    Ok(Json(grant_state(
+        &revision.manifest,
+        grant.as_ref(),
+        &current,
+    )))
+}
+
+/// `POST /apps/{id}/grant` — record explicit user consent.
+///
+/// The request carries no body: consent is only ever "yes to what the server
+/// shows right now". The grant is computed here from the current revision's
+/// manifest and the current definition fingerprints, then replaces any
+/// previous grant wholesale.
+pub async fn post_app_grant(
+    State(state): State<AppState>,
+    Path(app_id): Path<AppId>,
+) -> Result<Json<AppGrantState>, ServerError> {
+    let (app, revision) = current_live_app(&state, app_id).await?;
+    let current = state.mcp.definition_fingerprints().await;
+    let mut bindings = Vec::with_capacity(revision.manifest.bindings.len());
+    for binding in &revision.manifest.bindings {
+        // A binding whose server is not configured cannot be pinned to a
+        // definition, so there is nothing coherent to consent to.
+        let Some(fingerprint) = current.get(&binding.server) else {
+            return Err(ServerError::conflict(format!(
+                "MCP server {:?} is not configured, so this app cannot be granted",
+                binding.server
+            )));
+        };
+        bindings.push(AppGrantBinding {
+            server: binding.server.clone(),
+            tools: binding.tools.clone(),
+            fingerprint: *fingerprint,
+        });
+    }
+    let grant = AppGrant {
+        app_id: app.id,
+        bindings,
+        created_at: Utc::now(),
+    };
+    state.store.put_app_grant(&grant).await?;
+    Ok(Json(grant_state(
+        &revision.manifest,
+        Some(&grant),
+        &current,
+    )))
+}
+
+/// `DELETE /apps/{id}/grant` — revoke consent.
+///
+/// Idempotent, and deliberately available for a soft-deleted app too:
+/// revocation is fail-safe and must never be blocked by library state. The
+/// next invoke refuses with `consent_required`.
+pub async fn delete_app_grant(
+    State(state): State<AppState>,
+    Path(app_id): Path<AppId>,
+) -> Result<StatusCode, ServerError> {
+    if state.store.get_app(app_id).await?.is_none() {
+        return Err(ServerError::not_found(format!("no app {app_id}")));
+    }
+    state.store.delete_app_grant(app_id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Resolve a live app and its current revision, or 404.
+///
+/// A soft-deleted app answers as missing on the consent surface, exactly as
+/// it does on invoke.
+async fn current_live_app(
+    state: &AppState,
+    app_id: AppId,
+) -> Result<(AppRecord, AppRevision), ServerError> {
+    let absent = || ServerError::not_found(format!("no app {app_id}"));
+    let app = state.store.get_app(app_id).await?.ok_or_else(absent)?;
+    if app.deleted_at.is_some() {
+        return Err(absent());
+    }
+    let revision = state
+        .store
+        .get_app_revision(app.current_revision)
+        .await?
+        .ok_or_else(absent)?;
+    Ok((app, revision))
+}
+
+/// Project grant state against the current manifest and current definitions.
+///
+/// The same three checks the invoke gate applies, evaluated for the whole
+/// manifest: `granted` is true exactly when every pinned tool would pass the
+/// gate right now.
+fn grant_state(
+    manifest: &AppManifest,
+    grant: Option<&AppGrant>,
+    current: &std::collections::BTreeMap<String, [u8; 32]>,
+) -> AppGrantState {
+    let fingerprint_current =
+        |binding: &AppGrantBinding| current.get(&binding.server) == Some(&binding.fingerprint);
+    let bindings: Vec<AppGrantBindingState> = manifest
+        .bindings
+        .iter()
+        .map(|binding| {
+            let granted_binding = grant.and_then(|grant| {
+                grant
+                    .bindings
+                    .iter()
+                    .find(|candidate| candidate.server == binding.server)
+            });
+            let covered = granted_binding.is_some_and(|granted| {
+                binding
+                    .tools
+                    .iter()
+                    .all(|tool| granted.tools.iter().any(|held| held == tool))
+            });
+            let definition_changed =
+                granted_binding.is_some_and(|granted| !fingerprint_current(granted));
+            AppGrantBindingState {
+                server: binding.server.clone(),
+                tools: binding.tools.clone(),
+                granted: covered && granted_binding.is_some_and(fingerprint_current),
+                definition_changed,
+            }
+        })
+        .collect();
+    // The invoke gate also pins servers the grant names beyond the current
+    // manifest, so the overall verdict does too.
+    let granted = grant.is_some_and(|grant| {
+        bindings.iter().all(|binding| binding.granted)
+            && grant.bindings.iter().all(fingerprint_current)
+    });
+    AppGrantState { granted, bindings }
+}

--- a/crates/openwave-server/src/routes/app_invoke.rs
+++ b/crates/openwave-server/src/routes/app_invoke.rs
@@ -7,9 +7,9 @@
 //! snapshot, `Tool::execute` — minus the turn. Enforcement is entirely
 //! server-side and fails closed, in a fixed order: the app must exist with a
 //! current revision, the requested tool must be pinned in that revision's
-//! manifest bindings, and a live app grant must cover the call. The grant
-//! store does not exist yet, so the grant gate refuses every invoke today and
-//! the route ships dark.
+//! manifest bindings, and a live app grant must cover the call — including
+//! that every granted server's current definition still matches the
+//! fingerprint recorded at consent.
 //!
 //! Chat approval gates, permission modes, and plan mode deliberately do not
 //! apply: there is no chat. The app grant is the whole policy.
@@ -205,20 +205,57 @@ fn require_pinned(revision: &AppRevision, tool: &str) -> Result<(), AppInvokeErr
 
 /// The consent gate, evaluated after the pin check and before dispatch.
 ///
-/// The grant store does not exist yet, so this refuses every invoke and the
-/// route ships dark. The grants slice replaces only this function's body —
-/// checking the live grant's `(server, tools)` cover and the bound server's
-/// definition fingerprint — while the route's enforcement order stays fixed.
+/// Three checks, all live and all fail-closed to `consent_required` — a
+/// missing or stale grant is a re-prompt, never an error:
+///
+/// 1. A grant exists for the app.
+/// 2. It covers the invoked `(server, tool)` pair as the *current* revision's
+///    manifest binds it — so a revision that widens the manifest exceeds the
+///    grant by construction, with no special-casing.
+/// 3. Every granted server's current definition fingerprint equals the
+///    granted one. A reconfigured server invalidates the whole grant: consent
+///    named a definition, not a name, and must never outlive it.
 async fn require_app_grant(
-    _state: &AppState,
-    _app: &AppRecord,
-    _revision: &AppRevision,
+    state: &AppState,
+    app: &AppRecord,
+    revision: &AppRevision,
     tool: &str,
 ) -> Result<(), AppInvokeError> {
-    Err(AppInvokeError::refused(
-        AppInvokeRefusalKind::ConsentRequired,
-        format!("no live app grant covers {tool:?}"),
-    ))
+    let consent_required =
+        |message: String| AppInvokeError::refused(AppInvokeRefusalKind::ConsentRequired, message);
+    let Some(grant) = state.store.get_app_grant(app.id).await? else {
+        return Err(consent_required(format!(
+            "no live app grant covers {tool:?}"
+        )));
+    };
+    // The pin check has already passed, so exactly one current-manifest
+    // binding names this tool; its server is the namespace the grant must
+    // cover the tool under.
+    let server = revision
+        .manifest
+        .bindings
+        .iter()
+        .find(|binding| binding.tools.iter().any(|pinned| pinned == tool))
+        .map(|binding| binding.server.as_str())
+        .unwrap_or_default();
+    let covered = grant.bindings.iter().any(|binding| {
+        binding.server == server && binding.tools.iter().any(|granted| granted == tool)
+    });
+    if !covered {
+        return Err(consent_required(format!(
+            "the app grant does not cover {tool:?}"
+        )));
+    }
+    let current = state.mcp.definition_fingerprints().await;
+    for binding in &grant.bindings {
+        if current.get(&binding.server) != Some(&binding.fingerprint) {
+            return Err(consent_required(format!(
+                "MCP server {:?} was reconfigured after consent; the grant is stale",
+                binding.server
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Resolve a pinned name against the current MCP snapshot and execute it.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -34,6 +34,7 @@ use serde::de::DeserializeOwned;
 use tokio::sync::Notify;
 use tower::ServiceExt;
 
+mod app_grant;
 mod app_invoke;
 mod chat_titling;
 mod configuration;

--- a/crates/openwave-server/src/tests/app_grant.rs
+++ b/crates/openwave-server/src/tests/app_grant.rs
@@ -1,0 +1,145 @@
+//! `/apps/{id}/grant`: the renderer-facing consent surface.
+//!
+//! The lifecycle (consent → invoke → revoke, staleness on reconfiguration,
+//! widened-manifest re-consent) is covered end to end in
+//! [`super::app_invoke`]; this module pins the projection contract — what the
+//! grant endpoints may and may not put on the wire.
+
+use super::*;
+
+use openwave_core::id::{AppId, AppRevisionId};
+use openwave_core::local_app::{AppBinding, AppManifest, CreateApp, NewAppRevision};
+use serde_json::json;
+
+async fn grant_request(
+    router: &Router,
+    bearer: &str,
+    method: &str,
+    app_id: AppId,
+) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(method)
+                .uri(format!("/apps/{app_id}/grant"))
+                .header("authorization", bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn create_app_bound_to(store: &Arc<dyn Store>, server: &str, tools: &[&str]) -> AppId {
+    let app_id = AppId::new();
+    store
+        .create_app(&CreateApp {
+            id: app_id,
+            revision: NewAppRevision {
+                id: AppRevisionId::new(),
+                manifest: AppManifest {
+                    name: "Grant fixture".into(),
+                    bindings: vec![AppBinding {
+                        server: server.into(),
+                        tools: tools.iter().map(|tool| (*tool).to_owned()).collect(),
+                    }],
+                },
+                byte_len: 1,
+                sha256: [0; 32],
+                turn_id: None,
+                producing_run_id: None,
+                chat_id: None,
+                created_at: chrono::Utc::now(),
+            },
+        })
+        .await
+        .unwrap();
+    app_id
+}
+
+/// The consent surface carries names only. A command server's definition —
+/// executable, arguments, literal environment values, selected environment
+/// names — must never appear in any grant response, asserted on the raw
+/// serialized JSON rather than a parsed projection so nothing can hide in an
+/// unmodeled field. Also pins the 404 for an unknown app and the conflict for
+/// a binding whose server is not configured (nothing coherent to consent to).
+#[tokio::test]
+async fn grant_responses_carry_names_only_never_definitions_or_env_values() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    // A disabled stdio server never spawns, so the definition can carry
+    // conspicuously secret-shaped configuration for the leak assertions.
+    let put = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/mcp/servers")
+                .header("authorization", &bearer)
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({"servers": [{
+                        "name": "cmd",
+                        "command": "/opt/secret-location/docs-mcp",
+                        "args": ["--secret-flag"],
+                        "env": {"LITERAL_NAME": "literal-value-hunter2"},
+                        "env_from": ["PARENT_SECRET_NAME"],
+                        "enabled": false
+                    }]})
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(put.status(), StatusCode::OK);
+    let app_id = create_app_bound_to(&store, "cmd", &["mcp__cmd__doit"]).await;
+
+    let mut responses = Vec::new();
+    let state = grant_request(&router, &bearer, "GET", app_id).await;
+    assert_eq!(state.status(), StatusCode::OK);
+    responses.push(("GET", body_string(state).await));
+    let consented = grant_request(&router, &bearer, "POST", app_id).await;
+    assert_eq!(consented.status(), StatusCode::OK);
+    responses.push(("POST", body_string(consented).await));
+
+    for (method, body) in &responses {
+        assert!(
+            body.contains("\"cmd\"") && body.contains("mcp__cmd__doit"),
+            "{method}: the sheet needs server and tool names: {body}"
+        );
+        for leaked in [
+            "secret-location",
+            "docs-mcp",
+            "--secret-flag",
+            "literal-value-hunter2",
+            "LITERAL_NAME",
+            "PARENT_SECRET_NAME",
+        ] {
+            assert!(
+                !body.contains(leaked),
+                "{method}: {leaked:?} must not reach the renderer: {body}"
+            );
+        }
+    }
+    let before: serde_json::Value = serde_json::from_str(&responses[0].1).unwrap();
+    assert_eq!(before["granted"], json!(false));
+    let after: serde_json::Value = serde_json::from_str(&responses[1].1).unwrap();
+    assert_eq!(after["granted"], json!(true));
+
+    // An unknown app is 404 on the whole surface.
+    let missing = grant_request(&router, &bearer, "GET", AppId::new()).await;
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+
+    // A binding to a server that is not configured cannot be granted: there
+    // is no definition to pin the consent to.
+    let unbound = create_app_bound_to(&store, "ghost", &["mcp__ghost__walk"]).await;
+    let refused = grant_request(&router, &bearer, "POST", unbound).await;
+    assert_eq!(refused.status(), StatusCode::CONFLICT);
+}
+
+async fn body_string(response: axum::response::Response) -> String {
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}

--- a/crates/openwave-server/src/tests/app_invoke.rs
+++ b/crates/openwave-server/src/tests/app_invoke.rs
@@ -121,6 +121,61 @@ async fn create_pinned_app(store: &Arc<dyn Store>, tools: &[&str]) -> AppId {
     app_id
 }
 
+/// Configure the mounted server set to one `srv` at `address` over the API.
+async fn put_srv(router: &Router, bearer: &str, address: std::net::SocketAddr) {
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/mcp/servers")
+                .header("authorization", bearer)
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({"servers": [{
+                        "name": "srv",
+                        "url": format!("http://{address}/mcp"),
+                        "request_timeout_ms": 30_000,
+                        "enabled": true
+                    }]})
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// Send one of the body-less grant requests (`GET`, `POST` consent, `DELETE`).
+async fn grant_request(
+    router: &Router,
+    bearer: &str,
+    method: &str,
+    app_id: AppId,
+) -> axum::response::Response {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(method)
+                .uri(format!("/apps/{app_id}/grant"))
+                .header("authorization", bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+/// Record consent for the app and assert the resulting state is fully granted.
+async fn consent(router: &Router, bearer: &str, app_id: AppId) {
+    let response = grant_request(router, bearer, "POST", app_id).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let state: serde_json::Value = json_body(response).await;
+    assert_eq!(state["granted"], json!(true));
+}
+
 async fn invoke(
     router: &Router,
     bearer: &str,
@@ -144,37 +199,16 @@ async fn invoke(
 
 /// The route's whole enforcement ladder, fail-closed at every rung: a missing
 /// or deleted app is 404, an unpinned or non-MCP name is refused before the
-/// gate, and — the dark-ship property — even a perfectly pinned tool on a
-/// mounted, healthy server is refused with `consent_required` and the external
-/// server never sees a `tools/call`.
+/// gate, and — the fail-closed default — even a perfectly pinned tool on a
+/// mounted, healthy server is refused with `consent_required` until the user
+/// consents, and the external server never sees a `tools/call`.
 #[tokio::test]
-async fn every_invoke_is_refused_before_dispatch_until_grants_exist() {
+async fn every_invoke_is_refused_before_dispatch_without_a_grant() {
     let log = Arc::new(ToolServerLog::default());
     let address = spawn_tool_server(log.clone(), "ok".into(), json!({})).await;
     let (router, token, store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");
-    let put = router
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("PUT")
-                .uri("/mcp/servers")
-                .header("authorization", &bearer)
-                .header("content-type", "application/json")
-                .body(Body::from(
-                    json!({"servers": [{
-                        "name": "srv",
-                        "url": format!("http://{address}/mcp"),
-                        "request_timeout_ms": 30_000,
-                        "enabled": true
-                    }]})
-                    .to_string(),
-                ))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(put.status(), StatusCode::OK);
+    put_srv(&router, &bearer, address).await;
     let app_id = create_pinned_app(&store, &["mcp__srv__viewer"]).await;
 
     let refusal = |status: StatusCode, kind: &str| (status, kind.to_owned());
@@ -197,8 +231,8 @@ async fn every_invoke_is_refused_before_dispatch_until_grants_exist() {
             json!({"tool": "read_file"}),
             refusal(StatusCode::FORBIDDEN, "not_pinned"),
         ),
-        // The dark ship: pinned, mounted, healthy — still refused, because no
-        // grant store exists yet.
+        // Pinned, mounted, healthy — still refused, because the user never
+        // consented. No grant, no call.
         (
             app_id,
             json!({"tool": "mcp__srv__viewer", "arguments": {"q": "open"}}),
@@ -228,6 +262,191 @@ async fn every_invoke_is_refused_before_dispatch_until_grants_exist() {
         0,
         "no refusal path may reach the external server"
     );
+}
+
+/// The grant lifecycle end to end over the API: consent opens the gate and a
+/// granted invoke round-trips to the external server; revocation closes it on
+/// the very next invoke, and the refusal is `consent_required` — a re-prompt,
+/// not an error.
+#[tokio::test]
+async fn consent_opens_the_gate_and_revocation_closes_it() {
+    let log = Arc::new(ToolServerLog::default());
+    let address = spawn_tool_server(log.clone(), "ok".into(), json!({})).await;
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    put_srv(&router, &bearer, address).await;
+    let app_id = create_pinned_app(&store, &["mcp__srv__viewer"]).await;
+
+    consent(&router, &bearer, app_id).await;
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"tool": "mcp__srv__viewer", "arguments": {"q": "open"}}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let result: serde_json::Value = json_body(response).await;
+    assert_eq!(result["content"], json!("ok"));
+    assert_eq!(log.calls.load(Ordering::SeqCst), 1);
+
+    let revoked = grant_request(&router, &bearer, "DELETE", app_id).await;
+    assert_eq!(revoked.status(), StatusCode::NO_CONTENT);
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"tool": "mcp__srv__viewer"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let info: AgentErrorInfo = json_body(response).await;
+    assert_eq!(info.kind, "consent_required");
+    assert_eq!(
+        log.calls.load(Ordering::SeqCst),
+        1,
+        "a revoked grant must stop the next call before dispatch"
+    );
+}
+
+/// The property that makes MCP approvals per-call in chats, preserved here
+/// without per-call friction: a Settings edit can swap the process behind a
+/// stable server name, so a reconfigured definition invalidates the grant. The
+/// granted invoke works; after the definition changes the same invoke refuses
+/// with `consent_required` and the state projection flags the server as
+/// changed; a fresh consent re-pins to the new definition.
+#[tokio::test]
+async fn reconfiguring_a_bound_server_invalidates_the_grant() {
+    let log = Arc::new(ToolServerLog::default());
+    let address = spawn_tool_server(log.clone(), "first".into(), json!({})).await;
+    let swapped_log = Arc::new(ToolServerLog::default());
+    let swapped = spawn_tool_server(swapped_log.clone(), "second".into(), json!({})).await;
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    put_srv(&router, &bearer, address).await;
+    let app_id = create_pinned_app(&store, &["mcp__srv__viewer"]).await;
+
+    consent(&router, &bearer, app_id).await;
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"tool": "mcp__srv__viewer"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // The same name now resolves to a different process.
+    put_srv(&router, &bearer, swapped).await;
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"tool": "mcp__srv__viewer"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let info: AgentErrorInfo = json_body(response).await;
+    assert_eq!(info.kind, "consent_required");
+    assert_eq!(
+        swapped_log.calls.load(Ordering::SeqCst),
+        0,
+        "the swapped-in server must not be reached under the stale grant"
+    );
+    let state = grant_request(&router, &bearer, "GET", app_id).await;
+    let state: serde_json::Value = json_body(state).await;
+    assert_eq!(state["granted"], json!(false));
+    assert_eq!(state["bindings"][0]["definition_changed"], json!(true));
+
+    consent(&router, &bearer, app_id).await;
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"tool": "mcp__srv__viewer"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(swapped_log.calls.load(Ordering::SeqCst), 1);
+}
+
+/// A revision that widens the manifest exceeds the grant by construction: the
+/// new tool refuses with `consent_required` while the already-granted tool
+/// keeps working, with no widening-specific mechanism anywhere. Re-consent is
+/// computed from the server's current state — the renderer's bare "yes"
+/// cannot name tools — so afterwards the new tool is invokable.
+#[tokio::test]
+async fn a_widened_manifest_requires_fresh_consent_for_the_new_tools() {
+    let log = Arc::new(ToolServerLog::default());
+    let address = spawn_tool_server(log.clone(), "ok".into(), json!({})).await;
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    put_srv(&router, &bearer, address).await;
+    let app_id = create_pinned_app(&store, &["mcp__srv__viewer"]).await;
+    consent(&router, &bearer, app_id).await;
+
+    store
+        .append_app_revision(
+            app_id,
+            &NewAppRevision {
+                id: AppRevisionId::new(),
+                manifest: AppManifest {
+                    name: "Invoke fixture".into(),
+                    bindings: vec![AppBinding {
+                        server: "srv".into(),
+                        tools: vec!["mcp__srv__viewer".into(), "mcp__srv__unpinned".into()],
+                    }],
+                },
+                byte_len: 1,
+                sha256: [0; 32],
+                turn_id: None,
+                producing_run_id: None,
+                chat_id: None,
+                created_at: chrono::Utc::now(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"tool": "mcp__srv__unpinned"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let info: AgentErrorInfo = json_body(response).await;
+    assert_eq!(info.kind, "consent_required");
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"tool": "mcp__srv__viewer"}),
+    )
+    .await;
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "tools within the granted set stay invokable"
+    );
+    let state = grant_request(&router, &bearer, "GET", app_id).await;
+    let state: serde_json::Value = json_body(state).await;
+    assert_eq!(
+        state["granted"],
+        json!(false),
+        "the widened manifest must re-prompt on next open"
+    );
+
+    consent(&router, &bearer, app_id).await;
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"tool": "mcp__srv__unpinned"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
 }
 
 async fn dispatch_state(

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -325,6 +325,9 @@ mod tests {
         // only the refusal is generated, because the renderer branches on its
         // closed kind (`consent_required` opens the grant sheet).
         generate::collect_from::<crate::routes::AppInvokeRefusal>(&cfg, &mut out);
+        // The grant-state projection the consent sheet renders: server and
+        // tool names with coverage/staleness booleans, never definitions.
+        generate::collect_from::<crate::routes::AppGrantState>(&cfg, &mut out);
         generate::collect_from::<openwave_core::PendingUserQuestions>(&cfg, &mut out);
         generate::collect_from::<openwave_core::PendingPlanApproval>(&cfg, &mut out);
         generate::collect_from::<openwave_core::PlanDecisionChoice>(&cfg, &mut out);


### PR DESCRIPTION
Fourth local-apps slice: the durable consent object behind `POST /apps/{id}/invoke`, replacing the always-refuse grant seam from #1268 with real policy. Closes #1257.

## Grant record

One grant per app in the product store (`app_grant`, app id as primary key, cascade with the app row): the consented `(server, tools[])` set, with each bound server pinned to a SHA-256 fingerprint of its definition as configured. The canonical serialization the digest covers is documented on `definition_fingerprint` in `mcp_config.rs` and is a compatibility surface — fixed key order, versioned (`"v":1`), carrying command, args, cwd, sorted env *names* (literal and selected — values never enter the form), url, bearer-token-env presence, and transport kind. `name`, `enabled`, and `request_timeout_ms` are deliberately excluded: the binding already keys by name, and toggling or re-timing a server does not change what the user consented to run.

## Enforcement

Only the body of `require_app_grant` changed; the route's refusal ladder and error envelope are untouched. Three live checks, all failing closed to `consent_required` (a re-prompt, never an error): the grant exists, it covers the invoked `(server, tool)` as the *current* revision binds it, and every granted server's current definition fingerprint equals the granted one. A Settings edit that swaps the process behind a stable server name therefore invalidates the grant — the property that makes MCP approvals per-call in chats, preserved without per-call friction. A revision that widens the manifest exceeds the grant by construction; no widening-specific mechanism exists.

## Renderer surface

`GET/POST/DELETE /apps/{id}/grant` (renderer bearer):

- **GET** projects grant state for the consent sheet: the current manifest's bindings with per-server coverage and definition-changed staleness — names and booleans only, never definitions and never environment values.
- **POST** records consent as a bare affirmative: the grant is computed server-side from the current manifest and current definition fingerprints, so a stale sheet cannot grant tools the manifest no longer pins. A binding to an unconfigured server refuses with a conflict — there is no definition to pin consent to.
- **DELETE** revokes; the next invoke refuses. Available for a soft-deleted app too, since revocation must never be blocked by library state.

`AppGrantState` / `AppGrantBindingState` are generated wire types; `wire.ts` regenerated with the checked-in generator.

## Tests

- Consent opens the gate end to end (external server sees the call) and revocation closes it before dispatch on the next invoke.
- Reconfiguring a bound server (same name, different process) refuses with `consent_required`, never reaches the swapped-in server, surfaces `definition_changed` on GET, and re-consent re-pins.
- A widened manifest refuses the new tool, keeps granted tools invokable, reports `granted: false`, and re-consent (recomputed server-side) opens it.
- Grant responses carry names only — asserted on the raw serialized JSON against the executable path, args, literal env values, and selected env names of a command server; plus the 404 and unconfigured-server conflict arms.

The pre-existing enforcement-ladder test now reads as the no-grant default rather than the dark-ship seam; no tests were removed.

Based on #1268 (`feat/local-apps-3-invoke`); retarget to `main` once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)