### PR TITLE
feat(router): carry Anthropic reasoning blocks within a turn

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1351,6 +1351,9 @@ impl Agent {
             };
             let mut text = String::new();
             let mut calls: Vec<PendingCall> = Vec::new();
+            // Reasoning blocks captured from this step's stream, replayed on
+            // the later steps of this turn and dropped when the turn ends.
+            let mut reasoning: Vec<Value> = Vec::new();
             let mut by_index: HashMap<u32, usize> = HashMap::new();
             let mut stop_reason = StopReason::EndTurn;
             let mut refusal_details: Option<RefusalDetails> = None;
@@ -1384,6 +1387,9 @@ impl Agent {
                     }
                     ProviderEvent::ReasoningDelta { text: delta } => {
                         streamed_events.send(AgentEvent::ReasoningDelta { text: delta });
+                    }
+                    ProviderEvent::ReasoningBlock { data } => {
+                        reasoning.push(data);
                     }
                     ProviderEvent::ToolCallStarted { index, id, name } => {
                         let call_id = CallId::new();
@@ -1566,6 +1572,11 @@ impl Agent {
                 transcript.push(ChatMessage {
                     role: Role::Assistant,
                     content: blocks,
+                    // The step's reasoning rides its assistant message for the
+                    // rest of the turn. A steer, cancel, or broken stream
+                    // discarded `reasoning` along with the step before here,
+                    // so nothing partial ever reaches the transcript.
+                    reasoning: std::mem::take(&mut reasoning),
                 });
             }
 
@@ -1897,6 +1908,7 @@ impl Agent {
             // next step never sees a request it cannot account for.
             transcript.push(ChatMessage {
                 role: Role::User,
+                reasoning: Vec::new(),
                 content: calls
                     .iter()
                     .zip(outputs)
@@ -2334,6 +2346,7 @@ impl Agent {
                 content: vec![ContentBlock::Text {
                     text: msg.content.clone(),
                 }],
+                reasoning: Vec::new(),
             });
             events.send(AgentEvent::UserSteered {
                 message_id,
@@ -2376,6 +2389,7 @@ impl Agent {
                 content: vec![ContentBlock::Text {
                     text: steer.content.clone(),
                 }],
+                reasoning: Vec::new(),
             });
             events.send_committed(event_ordinal, event)?;
         }
@@ -3061,6 +3075,7 @@ impl Agent {
                         content: output.content,
                         is_error: true,
                     }],
+                    reasoning: Vec::new(),
                 });
                 continue;
             }
@@ -3133,6 +3148,7 @@ impl Agent {
             });
             transcript.push(ChatMessage {
                 role: Role::User,
+                reasoning: Vec::new(),
                 content: tool_result_blocks(
                     call.provider_id,
                     self.tool_result_for_model(&output.content, call.call_id),
@@ -3398,7 +3414,7 @@ impl Agent {
                         return None;
                     }
                 }
-                ProviderEvent::ReasoningDelta { .. } => {}
+                ProviderEvent::ReasoningDelta { .. } | ProviderEvent::ReasoningBlock { .. } => {}
                 ProviderEvent::Usage(reported) => {
                     usage = usage.checked_add(reported)?;
                 }
@@ -3816,6 +3832,7 @@ fn user_message_with_attachments(
     ChatMessage {
         role: message.role,
         content,
+        reasoning: Vec::new(),
     }
 }
 
@@ -4025,6 +4042,9 @@ fn push_tool_batch(
         out.push(ChatMessage {
             role: Role::Assistant,
             content: blocks,
+            // Rebuilt from the store, which holds no reasoning: replaying
+            // nothing is the valid degradation.
+            reasoning: Vec::new(),
         });
     }
     let results: Vec<ContentBlock> = batch
@@ -4052,6 +4072,7 @@ fn push_tool_batch(
         out.push(ChatMessage {
             role: Role::User,
             content: results,
+            reasoning: Vec::new(),
         });
     }
 }
@@ -4258,6 +4279,62 @@ mod tests {
                 .push(req.tools.iter().map(|tool| tool.name.clone()).collect());
             let events = if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
                 vec![
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: "call_1".into(),
+                        name: "read_file".into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: r#"{"path":"note.txt"}"#.into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ]
+            } else {
+                vec![
+                    ProviderEvent::TextDelta {
+                        text: "done".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ]
+            };
+            Ok(stream::iter(events).boxed())
+        }
+    }
+
+    /// Streams a reasoning block beside its tool call, then answers,
+    /// recording the reasoning each request carried.
+    struct ReasoningRecordingProvider {
+        calls: AtomicUsize,
+        seen: Arc<Mutex<Vec<Vec<Value>>>>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for ReasoningRecordingProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("fake")
+        }
+
+        async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            self.seen.lock().unwrap().push(
+                req.messages
+                    .iter()
+                    .flat_map(|message| message.reasoning.iter().cloned())
+                    .collect(),
+            );
+            let events = if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                vec![
+                    ProviderEvent::ReasoningBlock {
+                        data: serde_json::json!({
+                            "type": "thinking",
+                            "thinking": "plan: read the note first",
+                            "signature": "sig-1",
+                        }),
+                    },
                     ProviderEvent::ToolCallStarted {
                         index: 0,
                         id: "call_1".into(),
@@ -5949,6 +6026,75 @@ mod tests {
         assert_eq!(advertised.len(), 2, "one tool step, then the wrap-up");
         assert!(!advertised[0].is_empty());
         assert!(advertised[1].is_empty());
+    }
+
+    /// A reasoning block streamed on one step must ride the step's assistant
+    /// message — verbatim and whole — into the next step's request, and must
+    /// stay in-memory: nothing about it reaches the durable record, so a turn
+    /// rebuilt from the store degrades to sending no reasoning.
+    #[tokio::test]
+    async fn reasoning_blocks_ride_later_steps_of_the_same_turn() {
+        let workspace = tempfile::tempdir().unwrap();
+        std::fs::write(workspace.path().join("note.txt"), "secret").unwrap();
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            reasoning_effort: None,
+            permission_mode: None,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let agent = Agent::new(
+            Arc::new(ReasoningRecordingProvider {
+                calls: AtomicUsize::new(0),
+                seen: seen.clone(),
+            }),
+            Arc::new(ToolRegistry::new().with(Box::new(ReadFile))),
+            store.clone(),
+            AgentConfig {
+                model: "fake".into(),
+                tool_scratch: Some(tool_scratch(workspace.path())),
+                ..Default::default()
+            },
+        );
+
+        let (tx, rx) = unbounded();
+        agent.run_turn(&chat, "read note.txt", &tx).await.unwrap();
+        drop(tx);
+        let events: Vec<AgentEvent> = rx.collect().await;
+        assert!(
+            matches!(events.last(), Some(AgentEvent::TurnCompleted { .. })),
+            "{events:?}"
+        );
+
+        let block = serde_json::json!({
+            "type": "thinking",
+            "thinking": "plan: read the note first",
+            "signature": "sig-1",
+        });
+        let seen = seen.lock().unwrap().clone();
+        assert_eq!(seen.len(), 2, "one tool step, then the answer step");
+        assert!(seen[0].is_empty(), "nothing to replay on the first call");
+        assert_eq!(
+            seen[1],
+            vec![block],
+            "the block reaches the next step exactly as streamed"
+        );
     }
 
     #[tokio::test]
@@ -9070,6 +9216,7 @@ mod tests {
                     name: "read_file".into(),
                     input: serde_json::json!({"path": "decision.md"}),
                 }],
+                reasoning: Vec::new(),
             },
             ChatMessage {
                 role: Role::User,
@@ -9078,6 +9225,7 @@ mod tests {
                     content: "the durable decision".into(),
                     is_error: false,
                 }],
+                reasoning: Vec::new(),
             },
             ChatMessage::text(Role::User, "Continue from the decision."),
         ];
@@ -10609,6 +10757,7 @@ mod tests {
             ChatMessage {
                 role: Role::Assistant,
                 content: assistant,
+                ..
             } if matches!(
                 &assistant[..],
                 [ContentBlock::ToolUse { id, name, .. }]

--- a/crates/openwave-core/src/context.rs
+++ b/crates/openwave-core/src/context.rs
@@ -180,9 +180,23 @@ const fn is_compressible(block: &ContentBlock) -> bool {
     !matches!(block, ContentBlock::Image { .. })
 }
 
-/// Estimate tokens for a full message (role overhead + blocks).
+/// Estimate tokens for a message's opaque reasoning side channel.
+///
+/// Reasoning accumulates as ordinary history on keep-all models, so it must
+/// be counted wherever the content is. The blocks are provider JSON, so the
+/// estimate runs over their serialized form.
+fn estimate_reasoning_tokens(msg: &ChatMessage) -> usize {
+    msg.reasoning
+        .iter()
+        .map(|block| estimate_tokens(&block.to_string()))
+        .sum()
+}
+
+/// Estimate tokens for a full message (role overhead + reasoning + blocks).
 pub fn estimate_message_tokens(msg: &ChatMessage) -> usize {
-    ROLE_OVERHEAD + msg.content.iter().map(estimate_block_tokens).sum::<usize>()
+    ROLE_OVERHEAD
+        + estimate_reasoning_tokens(msg)
+        + msg.content.iter().map(estimate_block_tokens).sum::<usize>()
 }
 
 /// Estimate tokens for an entire transcript.
@@ -294,10 +308,15 @@ struct Entry {
     kept: bool,
 }
 
-/// Minimum viable token size for a message: role overhead + each block at the
-/// floor.
+/// Minimum viable token size for a message: role overhead + reasoning in full
+/// + each block at the floor.
+///
+/// Reasoning is charged like an image: replay validity is all-or-nothing per
+/// message, so a floor that promised to shrink it would be one the serializer
+/// cannot keep.
 fn message_floor(msg: &ChatMessage, content_floor: usize) -> usize {
     ROLE_OVERHEAD
+        + estimate_reasoning_tokens(msg)
         + msg
             .content
             .iter()
@@ -446,7 +465,12 @@ fn mark_pair_kept(
 // ── Truncation ─────────────────────────────────────────────────────
 
 fn truncate_message(msg: &ChatMessage, target_tokens: usize) -> ChatMessage {
-    let available = target_tokens.saturating_sub(ROLE_OVERHEAD);
+    // Reasoning is never truncated or partially dropped — a shrunken thinking
+    // block would fail the provider's replay validation, so the side channel
+    // keeps its full cost and only the content blocks split what remains.
+    let available = target_tokens
+        .saturating_sub(ROLE_OVERHEAD)
+        .saturating_sub(estimate_reasoning_tokens(msg));
     if msg.content.is_empty() {
         return msg.clone();
     }
@@ -487,6 +511,9 @@ fn truncate_message(msg: &ChatMessage, target_tokens: usize) -> ChatMessage {
     ChatMessage {
         role: msg.role,
         content: blocks,
+        // The signed reasoning prefix is untouched by content truncation, so
+        // it survives whole with the message.
+        reasoning: msg.reasoning.clone(),
     }
 }
 
@@ -605,6 +632,11 @@ fn merge_adjacent_roles(messages: &mut Vec<ChatMessage>) {
     while i + 1 < messages.len() {
         if messages[i].role == messages[i + 1].role {
             let next = messages.remove(i + 1);
+            // The absorbed message's reasoning cannot ride along: appending
+            // its content after the surviving message's blocks would move its
+            // thinking prefix away from the front, and partial or reordered
+            // replay is worse than none. The surviving message keeps its own
+            // reasoning, which still prefixes its own content.
             messages[i].content.extend(next.content);
         } else {
             i += 1;
@@ -691,6 +723,7 @@ mod tests {
                 name: name.into(),
                 input: json!({ "arg": args }),
             }],
+            reasoning: Vec::new(),
         }
     }
 
@@ -702,6 +735,7 @@ mod tests {
                 content: content.into(),
                 is_error: false,
             }],
+            reasoning: Vec::new(),
         }
     }
 
@@ -714,6 +748,61 @@ mod tests {
         let (result, reduced) = fit_to_budget(&msgs, budget, 500);
         assert!(!reduced);
         assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn reasoning_rides_its_message_whole_through_reduction() {
+        // Reasoning accumulates as ordinary history on keep-all models, so it
+        // is counted — and reduction either keeps the message with every
+        // block intact or drops the message entirely. Shrinking or partially
+        // dropping blocks would break the provider's replay validation.
+        let reasoning = vec![
+            json!({"type": "thinking", "thinking": "p".repeat(300), "signature": "sig"}),
+            json!({"type": "redacted_thinking", "data": "blob"}),
+        ];
+        let mut thinking_step = assistant_msg(&"calling a tool ".repeat(50));
+        thinking_step.reasoning = reasoning.clone();
+
+        let mut silent_step = thinking_step.clone();
+        silent_step.reasoning = Vec::new();
+        assert!(
+            estimate_message_tokens(&thinking_step) > estimate_message_tokens(&silent_step),
+            "reasoning tokens must be counted"
+        );
+
+        // A budget that keeps the message but shrinks its text leaves every
+        // reasoning block byte-identical.
+        let messages = vec![user_msg("start"), thinking_step.clone()];
+        let full = estimate_transcript_tokens(&messages);
+        let floor_with_user =
+            estimate_message_tokens(&messages[0]) + message_floor(&thinking_step, 100);
+        let (fitted, reduced) = fit_to_budget(&messages, (full + floor_with_user) / 2, 100);
+        assert!(reduced);
+        let fitted_step = fitted
+            .iter()
+            .find(|message| message.role == Role::Assistant)
+            .expect("the step fits under this budget");
+        assert_eq!(
+            fitted_step.reasoning, reasoning,
+            "truncation never touches the blocks"
+        );
+        assert!(
+            estimate_message_tokens(fitted_step) < estimate_message_tokens(&thinking_step),
+            "the text took the shrink"
+        );
+
+        // A budget that cannot pay the floor — reasoning is charged in full,
+        // like an image — drops the whole message rather than some blocks.
+        let drop_budget = estimate_message_tokens(&messages[0]) + 10;
+        let (fitted, _) = fit_to_budget(&messages, drop_budget, 100);
+        assert!(
+            fitted.iter().all(|message| message.reasoning.is_empty()),
+            "no partial reasoning survives: {fitted:?}"
+        );
+        assert!(
+            fitted.iter().all(|message| message.role != Role::Assistant),
+            "the step went with its reasoning: {fitted:?}"
+        );
     }
 
     #[test]
@@ -746,6 +835,7 @@ mod tests {
         let msg = ChatMessage {
             role: Role::User,
             content: blocks,
+            reasoning: Vec::new(),
         };
         // Callers never allocate below the message's irreducible overhead floor
         // (role + each block's fixed envelope); test at and above it.
@@ -773,6 +863,7 @@ mod tests {
                     text: format!("chunk {i} ").repeat(30),
                 })
                 .collect(),
+            reasoning: Vec::new(),
         };
         let msgs = vec![
             user_msg("kick off the conversation here"),
@@ -980,6 +1071,7 @@ mod tests {
         ChatMessage {
             role: Role::User,
             content: vec![image_block(width, height)],
+            reasoning: Vec::new(),
         }
     }
 
@@ -1081,6 +1173,7 @@ mod tests {
                 },
                 image_block(400, 300),
             ],
+            reasoning: Vec::new(),
         }];
         messages.extend((0..10).map(|index| assistant_msg(&format!("message {index}"))));
         messages.push(ChatMessage {
@@ -1093,6 +1186,7 @@ mod tests {
                 },
                 image_block(800, 600),
             ],
+            reasoning: Vec::new(),
         });
 
         evict_old_tool_result_images(&mut messages, TOOL_RESULT_IMAGE_MESSAGE_WINDOW);

--- a/crates/openwave-core/src/provider.rs
+++ b/crates/openwave-core/src/provider.rs
@@ -82,6 +82,20 @@ pub struct ChatMessage {
     pub role: Role,
     /// The ordered content blocks.
     pub content: Vec<ContentBlock>,
+    /// Reasoning blocks the model produced in the step this message came
+    /// from, captured from the live stream for verbatim replay on the later
+    /// steps of the same turn.
+    ///
+    /// A side channel, not content: serde never reads or writes it, so no
+    /// stored transcript or wire request changes shape. The blocks are opaque
+    /// provider values kept in emission order and kept whole — a message
+    /// replays either all of them or none, because a provider that validates
+    /// replay (Anthropic) rejects rearranged, edited, or partially dropped
+    /// reasoning. Only an assistant message built from a live provider stream
+    /// carries any; a message rebuilt from the store has none and degrades to
+    /// sending no reasoning, which is always a valid shape.
+    #[serde(default, skip)]
+    pub reasoning: Vec<Value>,
 }
 
 impl ChatMessage {
@@ -90,6 +104,7 @@ impl ChatMessage {
         Self {
             role,
             content: vec![ContentBlock::Text { text: text.into() }],
+            reasoning: Vec::new(),
         }
     }
 }
@@ -368,6 +383,19 @@ pub enum ProviderEvent {
     ReasoningDelta {
         /// The reasoning fragment.
         text: String,
+    },
+    /// One reasoning block, complete and opaque, as the provider emitted it.
+    ///
+    /// Where `ReasoningDelta` is display text, this is the replayable
+    /// artifact (an Anthropic `thinking` or `redacted_thinking` block,
+    /// signature included). `data` is the block exactly as the provider
+    /// accepts it back; consumers must not parse, filter, or reorder it,
+    /// because replay validity depends on the blocks matching what the model
+    /// generated. Carried in-memory for one turn at most — it is never
+    /// journaled or persisted.
+    ReasoningBlock {
+        /// The provider-native block, replayed verbatim.
+        data: Value,
     },
     /// A tool call has begun; name and id are known.
     ToolCallStarted {

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -298,28 +298,57 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         // as a long silent pause before the answer. `summarized` is what makes
         // the reasoning stream the renderer already draws worth drawing.
         //
-        // Rebuilt history deliberately replays no thinking blocks at all.
-        // Adaptive mode relaxes turn validation for exactly this case: no
-        // assistant turn has to begin with a thinking block, and history
-        // assembled from mixed sources needs none reinserted, so sending zero
-        // of them consistently is a valid shape. The 400 lives in *partial*
-        // replay — within the latest assistant message the consecutive
-        // thinking blocks must match what the model generated verbatim,
-        // `redacted_thinking` included, so a future fix that stores and
-        // filters on `type == "thinking"` would introduce errors we do not
-        // have today. What omission costs is reasoning continuity across tool
-        // steps, worst on Opus 4.7 and later where inter-tool reasoning lands
-        // entirely in thinking blocks. It also keeps history portable: blocks
-        // are bound to the model that produced them and a chat can switch
-        // models mid-conversation, where a foreign block is ignored rather
-        // than rejected and so only wastes input tokens. See #1200 for the
-        // in-turn-only recovery of the lost quality.
+        // Reasoning captured from this turn's own stream rides back on the
+        // assistant messages that produced it (see `attach_reasoning_blocks`),
+        // restoring the model's inter-tool plan continuity. Anything rebuilt
+        // from the store — a retry, a resumed turn, an older chat — still
+        // replays no thinking blocks at all. Adaptive mode relaxes turn
+        // validation for exactly that case: no assistant turn has to begin
+        // with a thinking block, and history assembled from mixed sources
+        // needs none reinserted, so sending zero of them is always a valid
+        // shape. The 400 lives in *partial* replay — within the latest
+        // assistant message the consecutive thinking blocks must match what
+        // the model generated verbatim, `redacted_thinking` included, which
+        // is why capture and replay below keep the raw blocks whole rather
+        // than filtering on `type == "thinking"`. Omission also keeps history
+        // portable: blocks are bound to the model that produced them and a
+        // chat can switch models mid-conversation, where a foreign block is
+        // ignored rather than rejected and so only wastes input tokens.
         body["thinking"] = json!({ "type": "adaptive", "display": "summarized" });
         if let Some(effort) = req.reasoning_effort {
             body["output_config"] = json!({ "effort": effort.as_str() });
         }
+        attach_reasoning_blocks(&mut body, req);
     }
     Ok(body)
+}
+
+/// Replay the turn's captured reasoning blocks ahead of the content of the
+/// assistant messages that produced them.
+///
+/// Anthropic validates the consecutive thinking prefix of an assistant
+/// message against what the model generated, so the blocks go back exactly
+/// as captured: whole, in stream order, and block-type-agnostic. A
+/// `redacted_thinking` block rides along untouched — filtering on
+/// `type == "thinking"` would split the prefix and fail the request. This
+/// runs only on a request that actually thinks (see the caller): replaying
+/// reasoning into a request with thinking off buys nothing and risks a
+/// shape the API rejects, while omission is always valid.
+fn attach_reasoning_blocks(body: &mut Value, req: &ChatRequest) {
+    let Some(messages) = body.get_mut("messages").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for (message, wire) in req.messages.iter().zip(messages.iter_mut()) {
+        if message.reasoning.is_empty() {
+            continue;
+        }
+        let Some(content) = wire.get_mut("content").and_then(Value::as_array_mut) else {
+            continue;
+        };
+        let mut combined = message.reasoning.clone();
+        combined.append(content);
+        *content = combined;
+    }
 }
 
 /// The breakpoint marker. Five-minute TTL: an agentic turn's model calls land
@@ -552,6 +581,15 @@ struct StreamState {
     output_block: Option<u32>,
     /// Whether any *other* tool call was announced this stream.
     saw_other_tool_call: bool,
+    /// Reasoning blocks in flight, keyed by content-block index.
+    ///
+    /// A `thinking` block opens empty at `content_block_start` and accumulates
+    /// `thinking_delta` text and the terminal `signature_delta` until
+    /// `content_block_stop` closes it; a `redacted_thinking` block arrives
+    /// whole at the start. The raw JSON is the state — never a parsed struct
+    /// — so a block goes back out byte-identical to what the model produced,
+    /// whatever fields a future API revision adds.
+    pending_reasoning: std::collections::HashMap<u32, Value>,
     /// Set once the stream has terminalized on an in-band error, so no later
     /// frame can append events after the failure.
     terminal: bool,
@@ -615,30 +653,37 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
         Some("content_block_start") => {
             let index = u32_at(data, "index");
             let block = data.get("content_block");
-            if block.and_then(|b| b.get("type")).and_then(Value::as_str) == Some("tool_use") {
-                let block = block.unwrap();
-                let name = str_at(block, "name");
-                state.open_tool_blocks.insert(index);
-                // The synthetic output tool is the request's own scaffolding.
-                // Announcing it as a tool call would hand consumers a call they
-                // never advertised and cannot answer.
-                if state.output_tool.as_deref() == Some(name.as_str()) {
-                    state.output_block = Some(index);
-                    return Vec::new();
+            match block.and_then(|b| b.get("type")).and_then(Value::as_str) {
+                Some("tool_use") => {
+                    let block = block.unwrap();
+                    let name = str_at(block, "name");
+                    state.open_tool_blocks.insert(index);
+                    // The synthetic output tool is the request's own scaffolding.
+                    // Announcing it as a tool call would hand consumers a call they
+                    // never advertised and cannot answer.
+                    if state.output_tool.as_deref() == Some(name.as_str()) {
+                        state.output_block = Some(index);
+                        return Vec::new();
+                    }
+                    state.saw_other_tool_call = true;
+                    vec![ProviderEvent::ToolCallStarted {
+                        index,
+                        id: str_at(block, "id"),
+                        name,
+                    }]
                 }
-                state.saw_other_tool_call = true;
-                vec![ProviderEvent::ToolCallStarted {
-                    index,
-                    id: str_at(block, "id"),
-                    name,
-                }]
-            } else {
-                Vec::new()
+                // A thinking block opens (usually empty) and is filled by
+                // deltas; a redacted one arrives complete. Both are captured
+                // raw and emitted once they close — capturing is whole-block
+                // or nothing, so a partial block can never be replayed.
+                Some("thinking" | "redacted_thinking") => {
+                    state
+                        .pending_reasoning
+                        .insert(index, block.unwrap().clone());
+                    Vec::new()
+                }
+                _ => Vec::new(),
             }
-        }
-        Some("content_block_stop") => {
-            state.open_tool_blocks.remove(&u32_at(data, "index"));
-            Vec::new()
         }
         Some("content_block_delta") => {
             let index = u32_at(data, "index");
@@ -650,9 +695,22 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                 Some("text_delta") => vec![ProviderEvent::TextDelta {
                     text: str_at(delta, "text"),
                 }],
-                Some("thinking_delta") => vec![ProviderEvent::ReasoningDelta {
-                    text: str_at(delta, "thinking"),
-                }],
+                Some("thinking_delta") => {
+                    if let Some(block) = state.pending_reasoning.get_mut(&index) {
+                        append_str_field(block, "thinking", &str_at(delta, "thinking"));
+                    }
+                    vec![ProviderEvent::ReasoningDelta {
+                        text: str_at(delta, "thinking"),
+                    }]
+                }
+                // The signature is what makes the block replayable; without
+                // it the thinking text is display-only.
+                Some("signature_delta") => {
+                    if let Some(block) = state.pending_reasoning.get_mut(&index) {
+                        block["signature"] = json!(str_at(delta, "signature"));
+                    }
+                    Vec::new()
+                }
                 // A constrained response is JSON in a tool call's arguments;
                 // every other provider streams it as text, so it becomes text
                 // here too and consumers stay provider-blind.
@@ -665,12 +723,15 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                     index,
                     fragment: str_at(delta, "partial_json"),
                 }],
-                // `signature_delta` and `redacted_thinking` fall through here
-                // on purpose: they are only useful for replaying thinking
-                // blocks, which the request built above deliberately does not
-                // do. Capturing them here alone would not enable replay and
-                // would tempt the partial-replay bug described there.
                 _ => Vec::new(),
+            }
+        }
+        Some("content_block_stop") => {
+            let index = u32_at(data, "index");
+            state.open_tool_blocks.remove(&index);
+            match state.pending_reasoning.remove(&index) {
+                Some(block) => vec![ProviderEvent::ReasoningBlock { data: block }],
+                None => Vec::new(),
             }
         }
         Some("message_delta") => {
@@ -739,6 +800,17 @@ fn str_at(value: &Value, key: &str) -> String {
         .and_then(Value::as_str)
         .unwrap_or_default()
         .to_string()
+}
+
+/// Append `fragment` to the string at `key` in a raw JSON block.
+fn append_str_field(block: &mut Value, key: &str, fragment: &str) {
+    let mut text = block
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    text.push_str(fragment);
+    block[key] = json!(text);
 }
 
 /// What a provider `stop_reason` means for the step that was streaming.
@@ -890,6 +962,7 @@ mod tests {
                     input: json!({"path": format!("f{i}.rs")}),
                 })
                 .collect(),
+            reasoning: Vec::new(),
         });
         messages.push(ChatMessage {
             role: Role::User,
@@ -900,6 +973,7 @@ mod tests {
                     is_error: false,
                 })
                 .collect(),
+            reasoning: Vec::new(),
         });
         let req = ChatRequest {
             provider: Some(ProviderId::new("anthropic")),
@@ -1268,6 +1342,126 @@ mod tests {
     }
 
     #[test]
+    fn reasoning_blocks_are_captured_whole_and_opaque() {
+        let out = run(&[
+            json!({"type": "content_block_start", "index": 0, "content_block": {"type": "thinking", "thinking": ""}}),
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "plan: "}}),
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "thinking_delta", "thinking": "read first"}}),
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "signature_delta", "signature": "sig-1"}}),
+            json!({"type": "content_block_stop", "index": 0}),
+            // A redacted block arrives complete and must round-trip untouched:
+            // filtering capture on `type == "thinking"` would drop it and
+            // split the message's reasoning prefix on replay.
+            json!({"type": "content_block_start", "index": 1, "content_block": {"type": "redacted_thinking", "data": "opaque-blob"}}),
+            json!({"type": "content_block_stop", "index": 1}),
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                ProviderEvent::ReasoningDelta {
+                    text: "plan: ".into()
+                },
+                ProviderEvent::ReasoningDelta {
+                    text: "read first".into()
+                },
+                ProviderEvent::ReasoningBlock {
+                    data: json!({
+                        "type": "thinking",
+                        "thinking": "plan: read first",
+                        "signature": "sig-1",
+                    }),
+                },
+                ProviderEvent::ReasoningBlock {
+                    data: json!({
+                        "type": "redacted_thinking",
+                        "data": "opaque-blob",
+                    }),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn captured_reasoning_is_replayed_verbatim_ahead_of_its_content() {
+        let reasoning = vec![
+            json!({"type": "thinking", "thinking": "plan: read first", "signature": "sig-1"}),
+            json!({"type": "redacted_thinking", "data": "opaque-blob"}),
+        ];
+        let mut req = reasoning_request("claude-opus-5", None);
+        req.messages = vec![
+            ChatMessage::text(Role::User, "hi"),
+            ChatMessage {
+                role: Role::Assistant,
+                content: vec![
+                    ContentBlock::Text {
+                        text: "checking".into(),
+                    },
+                    ContentBlock::ToolUse {
+                        id: "toolu_1".into(),
+                        name: "read_file".into(),
+                        input: json!({"path": "a"}),
+                    },
+                ],
+                reasoning: reasoning.clone(),
+            },
+            ChatMessage {
+                role: Role::User,
+                content: vec![ContentBlock::ToolResult {
+                    tool_use_id: "toolu_1".into(),
+                    content: "ok".into(),
+                    is_error: false,
+                }],
+                reasoning: Vec::new(),
+            },
+        ];
+        let body = build_request_json(&req).unwrap();
+        let content = body["messages"][1]["content"].as_array().unwrap();
+        assert_eq!(
+            content[..2],
+            reasoning[..],
+            "the blocks go back byte-identical, redacted included"
+        );
+        assert_eq!(content[2]["type"], "text");
+        assert_eq!(content[3]["type"], "tool_use");
+        // The transcript-tail breakpoint still lands on the true tail.
+        assert_eq!(
+            body["messages"][2]["content"][0]["cache_control"],
+            ephemeral_cache_control()
+        );
+    }
+
+    #[test]
+    fn reasoning_is_omitted_when_the_request_does_not_think() {
+        // A constrained request cannot think (forced tool), so the replay
+        // stays off entirely: omission is always valid, and blocks sent to a
+        // non-thinking request would be a shape the API has not promised.
+        let mut req = reasoning_request("claude-opus-5", None);
+        req.response_format = Some(ResponseFormat::JsonSchema {
+            name: "note".into(),
+            schema: json!({
+                "type": "object",
+                "properties": { "body": { "type": "string" } },
+                "required": ["body"],
+            }),
+        });
+        req.messages.push(ChatMessage {
+            role: Role::Assistant,
+            content: vec![ContentBlock::Text {
+                text: "checking".into(),
+            }],
+            reasoning: vec![json!({"type": "thinking", "thinking": "t", "signature": "s"})],
+        });
+        req.messages.push(ChatMessage::text(Role::User, "go on"));
+        let body = build_request_json(&req).unwrap();
+        assert!(body.get("thinking").is_none());
+        assert_eq!(
+            body["messages"][1]["content"].as_array().unwrap().len(),
+            1,
+            "no reasoning block is attached: {body}"
+        );
+    }
+
+    #[test]
     fn maps_stop_reasons() {
         use StopOutcome::{Interrupted, Reason};
         assert_eq!(map_stop_reason("tool_use"), Reason(StopReason::ToolUse));
@@ -1380,6 +1574,7 @@ mod tests {
             messages: vec![ChatMessage {
                 role: Role::User,
                 content,
+                reasoning: Vec::new(),
             }],
             tools: vec![],
             max_tokens: None,

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -981,6 +981,7 @@ mod tests {
                         input: json!({"path": "two"}),
                     },
                 ],
+                reasoning: Vec::new(),
             },
             ChatMessage {
                 role: Role::User,
@@ -989,6 +990,7 @@ mod tests {
                     content: "one".into(),
                     is_error: false,
                 }],
+                reasoning: Vec::new(),
             },
             ChatMessage {
                 role: Role::User,
@@ -997,6 +999,7 @@ mod tests {
                     content: "two".into(),
                     is_error: false,
                 }],
+                reasoning: Vec::new(),
             },
         ];
         let body = build_request_json(&request(messages)).unwrap();
@@ -1038,6 +1041,7 @@ mod tests {
                 },
                 ContentBlock::Image { image },
             ],
+            reasoning: Vec::new(),
         }]);
         req.images.insert(
             image.blob_id,
@@ -1056,6 +1060,7 @@ mod tests {
         let req = request(vec![ChatMessage {
             role: Role::User,
             content: vec![ContentBlock::Image { image: png_ref(9) }],
+            reasoning: Vec::new(),
         }]);
         let err = build_request_json(&req).unwrap_err();
         assert!(err.to_string().contains("no hydrated bytes"), "{err}");

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -748,6 +748,7 @@ mod tests {
                     input: json!({"path": "a"}),
                 },
             ],
+            reasoning: Vec::new(),
         };
         let mut out = Vec::new();
         extend_openai_messages(&mut out, &msg, &ImageAttachments::new()).unwrap();
@@ -767,6 +768,7 @@ mod tests {
                 content: "ok".into(),
                 is_error: false,
             }],
+            reasoning: Vec::new(),
         };
         let mut out = Vec::new();
         extend_openai_messages(&mut out, &msg, &ImageAttachments::new()).unwrap();
@@ -994,6 +996,7 @@ mod tests {
                 },
                 ContentBlock::Image { image },
             ],
+            reasoning: Vec::new(),
         };
 
         let mut out = Vec::new();
@@ -1014,6 +1017,7 @@ mod tests {
         let msg = ChatMessage {
             role: Role::User,
             content: vec![ContentBlock::Image { image: png_ref(9) }],
+            reasoning: Vec::new(),
         };
         let mut out = Vec::new();
         let err = extend_openai_messages(&mut out, &msg, &ImageAttachments::new()).unwrap_err();
@@ -1038,6 +1042,7 @@ mod tests {
                 },
                 ContentBlock::Image { image },
             ],
+            reasoning: Vec::new(),
         };
 
         let mut out = Vec::new();

--- a/crates/openwave-server/src/approval_judge.rs
+++ b/crates/openwave-server/src/approval_judge.rs
@@ -401,7 +401,9 @@ async fn request_verdict(
                     return Err(AgentError::msg("judge completion exceeded its bound"));
                 }
             }
-            ProviderEvent::ReasoningDelta { .. } | ProviderEvent::Usage(_) => {}
+            ProviderEvent::ReasoningDelta { .. }
+            | ProviderEvent::ReasoningBlock { .. }
+            | ProviderEvent::Usage(_) => {}
             ProviderEvent::Stop {
                 reason: StopReason::EndTurn | StopReason::MaxTokens | StopReason::StopSequence,
             } => completed = true,

--- a/crates/openwave-server/src/chat_titling.rs
+++ b/crates/openwave-server/src/chat_titling.rs
@@ -307,7 +307,9 @@ async fn request_title(
                     return Err(AgentError::msg("titling completion exceeded its bound"));
                 }
             }
-            ProviderEvent::ReasoningDelta { .. } | ProviderEvent::Usage(_) => {}
+            ProviderEvent::ReasoningDelta { .. }
+            | ProviderEvent::ReasoningBlock { .. }
+            | ProviderEvent::Usage(_) => {}
             ProviderEvent::Stop {
                 reason: StopReason::EndTurn | StopReason::MaxTokens | StopReason::StopSequence,
             } => completed = true,

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -1089,6 +1089,7 @@ async fn sandbox_request(
                 name: call.name.clone(),
                 input: call.arguments.clone(),
             }],
+            reasoning: Vec::new(),
         });
         messages.push(ChatMessage {
             role: Role::User,
@@ -1097,6 +1098,7 @@ async fn sandbox_request(
                 content: receipt.result,
                 is_error: receipt.status != SandboxToolCallStatus::Completed,
             }],
+            reasoning: Vec::new(),
         });
     }
     Ok(ChatRequest {
@@ -1297,7 +1299,11 @@ async fn complete_sandbox_task(
                     "sandbox agent model declined the request (category: {category})"
                 )));
             }
-            ProviderEvent::ReasoningDelta { .. } | ProviderEvent::Usage(_) => {}
+            // Reasoning blocks exist for in-turn replay, which this minimal
+            // loop does not do; dropping them degrades to pre-replay behavior.
+            ProviderEvent::ReasoningDelta { .. }
+            | ProviderEvent::ReasoningBlock { .. }
+            | ProviderEvent::Usage(_) => {}
             // The stream broke mid-flight, so `text` and `arguments` are both
             // possibly truncated. Fail under the classified provider error
             // instead of treating the fragment as a result.


### PR DESCRIPTION
Closes #1200.

## Why

On Opus 4.7/4.8/5 — including the default model — all inter-tool reasoning lands in thinking blocks. Today we replay none of them, so across an agentic turn the model re-derives its plan from scratch at every tool step. The #1091 spike concluded replay is a quality improvement, not a correctness requirement; this is the optional recovery of that quality, in the cheap shape the issue scoped: **in-turn only, no persistence**.

## What changes

- `ProviderEvent::ReasoningBlock { data }` carries one completed reasoning block as an opaque `serde_json::Value` — the block exactly as the provider accepts it back.
- The Anthropic adapter captures blocks raw: `content_block_start` opens a `thinking` block (or carries a whole `redacted_thinking`), `thinking_delta` text and the previously-unhandled `signature_delta` accumulate onto the raw JSON, and `content_block_stop` closes it and emits the event.
- The agent loop buffers the events per step and attaches them to that step's assistant message on `ChatMessage.reasoning` — a **serde-skipped side channel**, so no DB table, no migration, no wire-type change, no `ContentBlock` persisted-shape change. The buffer lives exactly as long as the in-memory transcript and is dropped at turn end.
- Outbound, the adapter prepends the captured blocks verbatim to the content of the assistant messages that produced them — but only on a request that actually thinks (a forced-tool/constrained request cannot, and omission is always valid).

## The two hazards from the spike, as requirements

1. **Opaque, block-type-agnostic storage.** Blocks are raw JSON end to end — never parsed into a "text + signature" struct, never filtered on `type == "thinking"`, never reordered, never partially dropped. `redacted_thinking` round-trips untouched (there is a test proving it); filtering would split the consecutive thinking prefix and produce the 400 the spike warned about.
2. **Context accounting.** `context::` counts reasoning tokens in every estimate, charges them in full like an image (a floor that promised to shrink them would be one the serializer cannot keep), and never splits a message's blocks: truncation shrinks only the content and leaves the signed prefix byte-identical; a message that does not fit is dropped whole; a role merge drops the absorbed message's reasoning rather than move it off the front.

## What degrades to today's behavior

Retry paths, resumed turns, checkpoints, and older history all rebuild from the store, which holds no reasoning — they replay nothing, exactly as today, which remains a valid shape (adaptive mode requires no thinking prefix). The sandbox subagent loop, chat titling, and the approval judge do not replay either; they now ignore the new event explicitly.

## Verification

- `cargo test -p openwave-router -p openwave-core --locked` — 538 + 76 passed, including new tests:
  - capture round-trip of an opaque thinking block (text + signature) and a `redacted_thinking` block through the stream parser;
  - re-serialization prepends the blocks byte-identical, and omits them when the request does not think;
  - end-to-end agent turn: a block streamed on step 0 rides the step's assistant message into step 1's request;
  - context reduction counts reasoning and never splits it — truncation keeps blocks whole, an unaffordable message drops whole.
- `cargo clippy -p openwave-core -p openwave-router -p openwave-server --all-targets --locked -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.

Not verified: behavior against the live Anthropic API (no credentials here); the replay shape is covered at the request-builder level instead.
