### PR TITLE
fix(router): fail a stream that closes silently mid-tool-call

### DIFF
--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -172,6 +172,12 @@ impl ModelProvider for AnthropicProvider {
                     }
                 }
             }
+            // A stream that closes with a tool call's argument JSON still open
+            // was truncated — a clean TCP close carries no transport error.
+            // Fail the step rather than committing the fragment as a finish.
+            if let Some(event) = end_of_stream(&state) {
+                yield event;
+            }
         };
         Ok(Box::pin(stream))
     }
@@ -521,6 +527,30 @@ struct StreamState {
     /// Set once the stream has terminalized on an in-band error, so no later
     /// frame can append events after the failure.
     terminal: bool,
+    /// Tool-use content blocks still open — started, not yet stopped. Their
+    /// argument JSON is incomplete until `content_block_stop` arrives.
+    open_tool_blocks: std::collections::HashSet<u32>,
+    /// Set once the provider reported how the message ended (a stop, a
+    /// refusal, or an interrupting failure). Without it a silent close is
+    /// indistinguishable from a finished message on the wire.
+    finished: bool,
+}
+
+/// What a silent end of the byte stream means.
+///
+/// Anthropic closes every healthy message with a `message_delta` carrying a
+/// `stop_reason`, so a stream that ends without one and with a tool call's
+/// argument JSON still open was truncated: a clean TCP close mid-response
+/// carries no transport error, and committing the fragment would hand
+/// `parse_args` a cut-off call. Text alone keeps the clean-end reading the
+/// agent loop already gives an exhausted stream.
+fn end_of_stream(state: &StreamState) -> Option<ProviderEvent> {
+    if state.terminal || state.finished || state.open_tool_blocks.is_empty() {
+        return None;
+    }
+    Some(ProviderEvent::Failed {
+        error: ProviderErrorInfo::provider("anthropic stream ended mid-tool-call"),
+    })
 }
 
 fn u32_at(value: &Value, key: &str) -> u32 {
@@ -560,6 +590,7 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
             if block.and_then(|b| b.get("type")).and_then(Value::as_str) == Some("tool_use") {
                 let block = block.unwrap();
                 let name = str_at(block, "name");
+                state.open_tool_blocks.insert(index);
                 // The synthetic output tool is the request's own scaffolding.
                 // Announcing it as a tool call would hand consumers a call they
                 // never advertised and cannot answer.
@@ -576,6 +607,10 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
             } else {
                 Vec::new()
             }
+        }
+        Some("content_block_stop") => {
+            state.open_tool_blocks.remove(&u32_at(data, "index"));
+            Vec::new()
         }
         Some("content_block_delta") => {
             let index = u32_at(data, "index");
@@ -625,6 +660,9 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                 .and_then(|d| d.get("stop_reason"))
                 .and_then(Value::as_str)
             {
+                // However the message ended, the provider said it ended: a
+                // later silent close is no longer truncation evidence.
+                state.finished = true;
                 let mut reason = match map_stop_reason(reason) {
                     StopOutcome::Reason(reason) => reason,
                     // Whatever streamed before this stop is a fragment, so no
@@ -1018,6 +1056,57 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn a_silent_close_with_an_open_tool_call_fails_the_stream() {
+        // A clean TCP close mid-response carries no transport error and no
+        // stop_reason. With a tool call's argument JSON still open the stream
+        // was truncated, so the adapter must not let the fragment read as a
+        // finished turn. This changes behavior on streams that reported
+        // success before — the remaining silent-close route after the
+        // transport-error and in-band-error paths were closed.
+        let mut state = StreamState::default();
+        let out: Vec<ProviderEvent> = [
+            json!({"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "read_file"}}),
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\"path\":\"a"}}),
+        ]
+        .iter()
+        .flat_map(|frame| normalize(frame, &mut state))
+        .collect();
+        assert!(matches!(
+            out.last(),
+            Some(ProviderEvent::ToolCallArgsDelta { .. })
+        ));
+        let ending = end_of_stream(&state).expect("an open tool call fails the stream");
+        assert!(
+            matches!(
+                &ending,
+                ProviderEvent::Failed { error } if error.kind == "provider"
+            ),
+            "expected a failure, got {ending:?}"
+        );
+
+        // Once the block stops and the provider reports a stop_reason, the
+        // close is clean and the end-of-stream check stays silent.
+        let mut state = StreamState::default();
+        for frame in [
+            json!({"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "read_file"}}),
+            json!({"type": "content_block_stop", "index": 0}),
+            json!({"type": "message_delta", "delta": {"stop_reason": "tool_use"}}),
+        ] {
+            let _ = normalize(&frame, &mut state);
+        }
+        assert!(end_of_stream(&state).is_none());
+
+        // Text alone keeps the clean-end reading an exhausted stream already
+        // had: no tool-call arguments exist that truncation could corrupt.
+        let mut state = StreamState::default();
+        let _ = normalize(
+            &json!({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hi"}}),
+            &mut state,
+        );
+        assert!(end_of_stream(&state).is_none());
     }
 
     #[test]

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -158,16 +158,10 @@ impl ModelProvider for OpenAiCompatProvider {
                     }
                 }
             }
-            // Emit a Stop if the stream ended without a finish_reason (some
-            // local servers omit it on clean close).
+            // The stream ended without a finish_reason (some local servers
+            // omit it on clean close).
             if !state.stopped && !state.terminal {
-                yield ProviderEvent::Stop {
-                    reason: if state.saw_tool_call {
-                        StopReason::ToolUse
-                    } else {
-                        StopReason::EndTurn
-                    },
-                };
+                yield state.end_of_stream();
             }
         };
         Ok(Box::pin(stream))
@@ -419,10 +413,31 @@ struct StreamState {
     tool_calls: std::collections::BTreeMap<u32, ToolCallBuf>,
     usage: Usage,
     stopped: bool,
-    saw_tool_call: bool,
     /// Set once the stream has terminalized on an in-band error. It suppresses
-    /// both later frames and the synthetic end-of-stream `Stop` below.
+    /// both later frames and the synthetic end-of-stream event below.
     terminal: bool,
+}
+
+impl StreamState {
+    /// What the end of the byte stream means when no `finish_reason` arrived.
+    ///
+    /// Some local servers omit `finish_reason` on a clean close, so text alone
+    /// still gets the synthetic `Stop`. An *announced* tool call is different:
+    /// a silently dropped connection is indistinguishable from an omitted
+    /// `finish_reason` on the wire, and the call's argument JSON may be
+    /// truncated mid-value, so the conservative reading fails the step rather
+    /// than committing the fragment as a finished call.
+    fn end_of_stream(&self) -> ProviderEvent {
+        if self.tool_calls.values().any(|call| call.started) {
+            ProviderEvent::Failed {
+                error: ProviderErrorInfo::provider("openai-compat stream ended mid-tool-call"),
+            }
+        } else {
+            ProviderEvent::Stop {
+                reason: StopReason::EndTurn,
+            }
+        }
+    }
 }
 
 #[derive(Default)]
@@ -534,7 +549,6 @@ fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
                 // never invent a synthetic id. Flush any buffered args after.
                 if !buf.started && !buf.id.is_empty() && !buf.name.is_empty() {
                     buf.started = true;
-                    state.saw_tool_call = true;
                     events.push(ProviderEvent::ToolCallStarted {
                         index,
                         id: buf.id.clone(),
@@ -805,6 +819,47 @@ mod tests {
         // truncated tool call would be handed on under a clean `Stop`.
         assert!(state.terminal);
         assert!(!state.stopped);
+    }
+
+    #[test]
+    fn a_silent_close_mid_tool_call_fails_instead_of_stopping_cleanly() {
+        // A clean TCP close mid-response carries no transport error and no
+        // finish_reason. An announced tool call whose argument stream never
+        // closed is truncation evidence, so the end-of-stream fallback fails
+        // the step rather than committing the fragment. This changes behavior
+        // on streams that reported success before: a complete call whose
+        // server dropped only `finish_reason` now fails too — the two are
+        // indistinguishable on the wire.
+        let mut state = StreamState::default();
+        let out: Vec<ProviderEvent> = [
+            json!({"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"read_file","arguments":"{\"pa"}}]}}]}),
+        ]
+        .iter()
+        .flat_map(|chunk| normalize(chunk, &mut state))
+        .collect();
+        assert!(matches!(
+            out.last(),
+            Some(ProviderEvent::ToolCallArgsDelta { .. })
+        ));
+        let ending = state.end_of_stream();
+        assert!(
+            matches!(
+                &ending,
+                ProviderEvent::Failed { error } if error.kind == "provider"
+            ),
+            "expected a failure, got {ending:?}"
+        );
+
+        // Text alone keeps the synthetic `Stop`: some local servers omit
+        // `finish_reason` on every clean close.
+        let mut state = StreamState::default();
+        let _ = normalize(&json!({"choices":[{"delta":{"content":"hi"}}]}), &mut state);
+        assert_eq!(
+            state.end_of_stream(),
+            ProviderEvent::Stop {
+                reason: StopReason::EndTurn
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #1124

Stacked on #1274 (same adapter sites); retargets as the stack lands.

## What

Neither the Anthropic nor the OpenAI-compatible adapter had a positive "the provider said it finished" signal, so a stream that died with a clean TCP close mid-response — no transport error, no `finish_reason` / `stop_reason` — was reported as a normal end of turn, and a tool call's truncated argument JSON could reach `parse_args` as if complete. This was the remaining silent-close route after #1083/#1084 closed the transport-error and in-band-error paths.

- **OpenAI-compatible:** the synthetic end-of-stream `Stop` now fires only when no announced tool call is mid-flight. A `ToolCallBuf` that was announced (`ToolCallStarted` emitted) but never closed out by a `finish_reason` is strong evidence of truncation, so the adapter yields `ProviderEvent::Failed` and the agent loop discards the step instead of committing the fragment. The decision moved into a testable `StreamState::end_of_stream`.
- **Anthropic:** the adapter previously derived its stop entirely from `message_delta.stop_reason` and never observed the end of the stream. It now tracks open tool-use content blocks (`content_block_start` without the matching `content_block_stop`, including the synthetic structured-output block) and whether any `stop_reason` arrived; a stream that closes with a tool block still open and no stop received yields `ProviderEvent::Failed`.

## Behavior change — called out plainly

This deliberately changes behavior on streams that **currently report success**: a genuinely complete tool call whose server dropped *only* the terminal frame now fails too, because a dropped connection and a dropped `finish_reason` are indistinguishable on the wire. The failure is the retryable `provider` kind, so the turn retries rather than losing data. Text-only silent closes keep the clean-end reading they already had — some local servers omit `finish_reason` on every clean close, and there is no argument JSON that truncation could corrupt.

## Tests

- `openai_compat::tests::a_silent_close_mid_tool_call_fails_instead_of_stopping_cleanly` — a silently closed stream with an announced, unclosed tool call fails; text alone still synthesizes `Stop`.
- `anthropic::tests::a_silent_close_with_an_open_tool_call_fails_the_stream` — an open tool block at close fails the stream; a stopped block plus `stop_reason`, or text alone, stays silent.

Verified: `cargo test -p openwave-router --locked` (76 passed), `cargo clippy -p openwave-core -p openwave-router -p openwave-server --all-targets --locked -- -D warnings`, `cargo check -p openwave-core -p openwave-server --locked`, `cargo fmt --check`.
