### PR TITLE
feat(desktop): apps library, consent sheet, and the app open flow

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -35,6 +35,7 @@ import { ChatView } from "./ChatView";
 import type { RetryableTurn } from "./MessageList";
 import type { TranscriptFileAttachment } from "./TranscriptFileAttachments";
 import type { TranscriptImageAttachment } from "./ImageAttachments";
+import { AppsPanel } from "./apps/AppsPanel";
 import { OutputDetailRoot } from "./outputs/OutputDetailRoot";
 import { OutputsView } from "./outputs/OutputsView";
 import { DocumentDetailRoot } from "./document-detail/DocumentDetailRoot";
@@ -625,6 +626,8 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             <FoldersView chat={chat!} />
           </PanelFrame>
         );
+      case "apps":
+        return <AppsPanel panel={panel} position={side} />;
     }
   }
 

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -26,6 +26,10 @@ import {
 import { ModelMenu, ReasoningEffortMenu } from "./ModelMenu";
 import { modelForSelection } from "./ModelSelection";
 import { useNewChatSettings } from "./NewChatSettings";
+import { AppsPanel } from "./apps/AppsPanel";
+import { PanelLayout } from "./panel/PanelLayout";
+import type { LayoutState, PanelContent } from "./panel/panelTypes";
+import { useLayoutState } from "./panel/usePanelNav";
 import { PermissionModeMenu } from "./PermissionModeMenu";
 import { RouteFrame } from "./RouteFrame";
 import { HomeSidebar } from "./sidebar/HomeSidebar";
@@ -232,9 +236,25 @@ export function HomeRoute() {
         }
       : undefined;
 
-  return (
-    <RouteFrame sidebar={<HomeSidebar />}>
-      <div className="content-container flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden px-[clamp(0.5rem,4%,5rem)]">
+  // Home hosts panels the way a conversation does, but only the ones that
+  // mean something outside a chat — today, the Apps library. Anything else in
+  // the URL collapses back to home alone rather than rendering a panel whose
+  // content is scoped to a conversation this route does not have.
+  const layout = homeLayout(useLayoutState());
+
+  function renderPanel(
+    panel: PanelContent,
+    position: "left" | "right" | "chat",
+  ) {
+    if (panel.type === "apps" && position !== "chat") {
+      return <AppsPanel panel={panel} position={position} />;
+    }
+    return homeContent();
+  }
+
+  function homeContent() {
+    return (
+      <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden px-[clamp(0.5rem,4%,5rem)]">
         <div className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto">
           {/* The same null state an empty conversation shows: home is where a
               chat starts, so it greets the same way. Picking a starter prompt
@@ -311,6 +331,29 @@ export function HomeRoute() {
           />
         </div>
       </div>
+    );
+  }
+
+  return (
+    <RouteFrame sidebar={<HomeSidebar />}>
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <PanelLayout layout={layout} renderPanel={renderPanel} />
+      </div>
     </RouteFrame>
   );
+}
+
+/**
+ * The layouts home is willing to host: itself alone, or itself beside the
+ * Apps library. A URL naming any conversation-scoped panel is a stale or
+ * hand-edited link; it lands on plain home rather than an empty panel.
+ */
+function homeLayout(layout: LayoutState): LayoutState {
+  if (layout.mode === "single") return { mode: "single", panel: { type: "chat" } };
+  const supported = (panel: PanelContent) =>
+    panel.type === "chat" || panel.type === "apps";
+  if (!supported(layout.left) || !supported(layout.right)) {
+    return { mode: "single", panel: { type: "chat" } };
+  }
+  return layout;
 }

--- a/crates/openwave-desktop/ui/src/McpAppBridge.test.ts
+++ b/crates/openwave-desktop/ui/src/McpAppBridge.test.ts
@@ -12,7 +12,10 @@ const PAYLOAD: McpAppPayload = {
   is_error: false,
 };
 
-function harness(theme: "light" | "dark" = "dark") {
+function harness(
+  theme: "light" | "dark" = "dark",
+  invokeTool?: Parameters<typeof createMcpAppBridge>[0]["invokeTool"],
+) {
   const postMessage = vi.fn();
   const frame = { postMessage } as unknown as Window;
   const onHeight = vi.fn();
@@ -21,6 +24,7 @@ function harness(theme: "light" | "dark" = "dark") {
     frame: () => frame,
     theme: () => currentTheme,
     onHeight,
+    invokeTool,
   });
   const fromView = (data: unknown, source: unknown = frame) =>
     bridge.handleMessage({ data, source } as MessageEvent);
@@ -117,6 +121,31 @@ describe("createMcpAppBridge", () => {
     fromView({ jsonrpc: "2.0", method: "notifications/message", params: { level: "info" } });
     fromView({ jsonrpc: "2.0", method: "ui/notifications/request-teardown" });
     expect(sent()).toHaveLength(1);
+  });
+
+  it("refuses tools/call without an invoker, and undeclared methods with one", () => {
+    // The transcript card wires no invoker: tools/call stays method-not-found
+    // there, exactly as before the app-open flow existed.
+    const bare = harness();
+    bare.fromView({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "mcp__cmd__doit", arguments: {} },
+    });
+    expect(bare.sent()).toEqual([
+      { jsonrpc: "2.0", id: 1, error: { code: -32601, message: "Method not found" } },
+    ]);
+
+    // Wiring the invoker declares tools/call and nothing else: any other
+    // method still fails closed rather than acquiring a handler by accident.
+    const invokeTool = vi.fn();
+    const wired = harness("dark", invokeTool);
+    wired.fromView({ jsonrpc: "2.0", id: 2, method: "resources/read", params: {} });
+    expect(wired.sent()).toEqual([
+      { jsonrpc: "2.0", id: 2, error: { code: -32601, message: "Method not found" } },
+    ]);
+    expect(invokeTool).not.toHaveBeenCalled();
   });
 
   it("answers ping and clamps size-changed heights", () => {

--- a/crates/openwave-desktop/ui/src/McpAppBridge.ts
+++ b/crates/openwave-desktop/ui/src/McpAppBridge.ts
@@ -18,9 +18,19 @@
 
 export const MCP_APPS_PROTOCOL_VERSION = "2026-01-26";
 
-import type { McpAppPayload } from "./api";
+import { AppInvokeRefusalError, type AppInvokeResult, type McpAppPayload } from "./api";
 
 export type { McpAppPayload };
+
+/**
+ * Executes one tool call on the embedded view's behalf. Local-app hosts wire
+ * this to `POST /apps/{id}/invoke`; both the arguments and the result are
+ * opaque passthrough the bridge forwards without interpreting. A rejection
+ * becomes a JSON-RPC error reply — a typed [`AppInvokeRefusalError`] keeps
+ * its machine-readable kind in `error.data` (the refusal envelope is
+ * host-authored, so surfacing it is not interpretation).
+ */
+export type AppToolInvoker = (tool: string, args: unknown) => Promise<AppInvokeResult>;
 
 const MIN_FRAME_HEIGHT = 160;
 const MAX_FRAME_HEIGHT = 800;
@@ -41,6 +51,13 @@ export function createMcpAppBridge(options: {
    * buffered handshake state — survives a theme change. */
   theme: () => "light" | "dark";
   onHeight?: (height: number) => void;
+  /**
+   * When present, the view may call `tools/call` and the bridge forwards it
+   * here. Absent — the MCP App transcript card — `tools/call` refuses with
+   * method-not-found exactly as before: a view only gets the methods its
+   * host deliberately declared.
+   */
+  invokeTool?: AppToolInvoker;
 }): McpAppBridge {
   let viewInitialized = false;
   let payload: McpAppPayload | null = null;
@@ -107,6 +124,58 @@ export function createMcpAppBridge(options: {
         case "ping":
           post({ jsonrpc: "2.0", id, result: {} });
           break;
+        case "tools/call": {
+          const invoke = options.invokeTool;
+          if (!invoke) {
+            post({
+              jsonrpc: "2.0",
+              id,
+              error: { code: -32601, message: "Method not found" },
+            });
+            break;
+          }
+          const params = isRecord(message.params) ? message.params : {};
+          const tool = typeof params.name === "string" ? params.name : null;
+          if (!tool) {
+            post({
+              jsonrpc: "2.0",
+              id,
+              error: { code: -32602, message: "tools/call needs a string name" },
+            });
+            break;
+          }
+          // The reply is asynchronous; `post` already refuses after dispose,
+          // so a result landing after unmount goes nowhere.
+          void invoke(tool, params.arguments).then(
+            (result) =>
+              post({
+                jsonrpc: "2.0",
+                id,
+                result: {
+                  content: [{ type: "text", text: result.content }],
+                  ...(result.structured_content === undefined ||
+                  result.structured_content === null
+                    ? {}
+                    : { structuredContent: result.structured_content }),
+                  isError: result.is_error,
+                },
+              }),
+            (error: unknown) =>
+              post({
+                jsonrpc: "2.0",
+                id,
+                error:
+                  error instanceof AppInvokeRefusalError
+                    ? {
+                        code: -32000,
+                        message: error.message,
+                        data: { kind: error.kind },
+                      }
+                    : { code: -32000, message: String(error) },
+              }),
+          );
+          break;
+        }
         default:
           // Fail closed but politely: the view sees a rejected promise, not
           // a hung request or a torn-down connection.

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -1,5 +1,11 @@
 import {
   RENDERER_TOOL_NAMES,
+  type AppDetail as WireAppDetail,
+  type AppGrantState as WireAppGrantState,
+  type AppInvokeRefusalKind,
+  type AppLibrary as WireAppLibrary,
+  type AppSummary as WireAppSummary,
+  type AppViewSession,
   type ApprovalGrantRung,
   type ApprovalClass,
   type AssistantCitationSnapshot,
@@ -395,6 +401,58 @@ export type McpAppPayload = {
   structured_content?: unknown;
   is_error: boolean;
 };
+
+/** The Apps library listing: every live local app, newest activity first. */
+export type AppLibrary = WireAppLibrary;
+
+/** One Apps library row. */
+export type AppSummary = WireAppSummary;
+
+/** One app's detail: summary fields plus its revision history. */
+export type AppDetail = WireAppDetail;
+
+/** Renderer-safe grant state for one app: the consent sheet's whole input. */
+export type AppGrantState = WireAppGrantState;
+
+/** A single-use frame address for one stored app revision. */
+export type AppViewSessionInfo = AppViewSession;
+
+/**
+ * Result of a granted app invoke, forwarded verbatim to the sandboxed frame.
+ *
+ * Hand-written on purpose, like [`McpAppPayload`] and for the same reason:
+ * `structured_content` is opaque passthrough the renderer never interprets,
+ * which the wire-type generator's precision guard refuses.
+ */
+export type AppInvokeResult = {
+  content: string;
+  structured_content?: unknown;
+  is_error: boolean;
+};
+
+export type { AppInvokeRefusalKind };
+
+const APP_INVOKE_REFUSAL_KINDS: readonly AppInvokeRefusalKind[] = [
+  "app_not_found",
+  "not_pinned",
+  "consent_required",
+  "unknown_tool",
+];
+
+/**
+ * A typed refusal from `POST /apps/{id}/invoke`: the one invoke failure the
+ * renderer branches on (`consent_required` re-opens the grant sheet) rather
+ * than merely reporting.
+ */
+export class AppInvokeRefusalError extends Error {
+  constructor(
+    readonly kind: AppInvokeRefusalKind,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AppInvokeRefusalError";
+  }
+}
 
 
 /** Approval kinds a human may approve from the renderer. */
@@ -850,6 +908,100 @@ export class ApiClient {
       `/chats/${encodeURIComponent(chatId)}/calls/${encodeURIComponent(callId)}/mcp-app-payload`,
       { headers: this.headers() },
     );
+  }
+
+  listApps(): Promise<AppLibrary> {
+    return this.json("/apps", { headers: this.headers() });
+  }
+
+  getApp(appId: string): Promise<AppDetail> {
+    return this.json(`/apps/${encodeURIComponent(appId)}`, {
+      headers: this.headers(),
+    });
+  }
+
+  deleteApp(appId: string): Promise<void> {
+    return this.json(`/apps/${encodeURIComponent(appId)}`, {
+      method: "DELETE",
+      headers: this.headers(),
+    });
+  }
+
+  getAppGrant(appId: string): Promise<AppGrantState> {
+    return this.json(`/apps/${encodeURIComponent(appId)}/grant`, {
+      headers: this.headers(),
+    });
+  }
+
+  /**
+   * Record consent. Deliberately body-less: consent is only ever "yes to what
+   * the server shows right now" — the server recomputes the grant from the
+   * current manifest and definitions, so a stale sheet can never widen it.
+   */
+  consentAppGrant(appId: string): Promise<AppGrantState> {
+    return this.json(`/apps/${encodeURIComponent(appId)}/grant`, {
+      method: "POST",
+      headers: this.headers(),
+    });
+  }
+
+  revokeAppGrant(appId: string): Promise<void> {
+    return this.json(`/apps/${encodeURIComponent(appId)}/grant`, {
+      method: "DELETE",
+      headers: this.headers(),
+    });
+  }
+
+  /** Trade the bearer for a single-use iframe address for one app revision. */
+  createAppViewFrame(appId: string): Promise<AppViewSession> {
+    return this.json(`/apps/${encodeURIComponent(appId)}/view-session`, {
+      method: "POST",
+      headers: this.headers(true),
+      body: JSON.stringify({}),
+    });
+  }
+
+  /**
+   * Execute one of an app's pinned tools outside any turn. `args` and the
+   * result are opaque passthrough between the sandboxed frame and the server;
+   * a typed refusal surfaces as {@link AppInvokeRefusalError} so the caller
+   * can branch on `consent_required` without string-matching prose.
+   */
+  async invokeApp(
+    appId: string,
+    tool: string,
+    args: unknown,
+  ): Promise<AppInvokeResult> {
+    const response = await fetch(
+      `${this.baseUrl}/apps/${encodeURIComponent(appId)}/invoke`,
+      {
+        method: "POST",
+        headers: this.headers(true),
+        body: JSON.stringify({ tool, arguments: args }),
+      },
+    );
+    if (!response.ok) {
+      let refusal: unknown;
+      try {
+        refusal = await response.clone().json();
+      } catch {
+        /* not a typed refusal; fall through to the generic error */
+      }
+      if (
+        typeof refusal === "object" &&
+        refusal !== null &&
+        "kind" in refusal &&
+        "message" in refusal &&
+        APP_INVOKE_REFUSAL_KINDS.includes(
+          (refusal as { kind: AppInvokeRefusalKind }).kind,
+        )
+      ) {
+        const typed = refusal as { kind: AppInvokeRefusalKind; message: string };
+        throw new AppInvokeRefusalError(typed.kind, String(typed.message));
+      }
+      await throwIfNotOk(response);
+    }
+    return (await response.json()) as AppInvokeResult;
   }
 
   createProject(title: string): Promise<Project> {

--- a/crates/openwave-desktop/ui/src/apps/AppConsentSheet.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppConsentSheet.tsx
@@ -1,0 +1,90 @@
+import { ShieldAlert, ShieldCheck, TriangleAlert, Wrench } from "lucide-react";
+
+import type { AppGrantState } from "@/api";
+import { Button } from "@/components/ui/button";
+
+/**
+ * The consent sheet: exactly what the server's grant projection says, and a
+ * single affirmative.
+ *
+ * The sheet never composes what is being granted — the server recomputes the
+ * grant from the app's current manifest and the definitions current at that
+ * moment, so consenting here is only ever "yes to what is shown". A server
+ * whose definition changed since a previous consent carries a visible marker:
+ * consent named a definition, not a name, and must not silently survive it.
+ */
+export function AppConsentSheet({
+  state,
+  busy,
+  error,
+  onConsent,
+}: {
+  state: AppGrantState;
+  busy: boolean;
+  error: string | null;
+  onConsent: () => void;
+}) {
+  return (
+    <section
+      className="bg-background mx-4 flex flex-col gap-3 rounded-lg border p-4"
+      aria-label="App access consent"
+    >
+      <div className="flex items-center gap-2">
+        <ShieldAlert className="text-warning size-4 shrink-0" aria-hidden="true" />
+        <h2 className="text-sm font-medium">This app needs your permission</h2>
+      </div>
+      {state.bindings.length === 0 ? (
+        <p className="text-muted-foreground text-sm">
+          This app requests no tool access.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2" aria-label="Requested tool access">
+          {state.bindings.map((binding) => (
+            <li key={binding.server} className="flex flex-col gap-1">
+              <div className="flex items-center gap-2 text-sm">
+                <span className="font-medium">{binding.server}</span>
+                {binding.granted && (
+                  <span className="text-muted-foreground flex items-center gap-1 text-xs">
+                    <ShieldCheck className="size-3" aria-hidden="true" />
+                    granted
+                  </span>
+                )}
+                {binding.definition_changed && (
+                  <span className="text-warning flex items-center gap-1 text-xs">
+                    <TriangleAlert className="size-3" aria-hidden="true" />
+                    Server reconfigured since you agreed
+                  </span>
+                )}
+              </div>
+              <ul className="flex flex-col gap-0.5">
+                {binding.tools.map((tool) => (
+                  <li
+                    key={tool}
+                    className="text-muted-foreground flex items-center gap-1.5 pl-1 text-xs"
+                  >
+                    <Wrench className="size-3 shrink-0" aria-hidden="true" />
+                    <span className="truncate font-mono">{tool}</span>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+      <p className="text-muted-foreground text-xs">
+        The app can call only these tools, only while you have it open. You can
+        revoke this at any time from the app&rsquo;s page.
+      </p>
+      {error && (
+        <p className="text-critical text-sm" role="alert">
+          {error}
+        </p>
+      )}
+      <div>
+        <Button size="sm" disabled={busy} onClick={onConsent}>
+          Allow access
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AppDetail, AppGrantState } from "@/api";
+import { AppDetailView } from "./AppDetailView";
+import type { AppsApis } from "./appsApis";
+
+const DETAIL: AppDetail = {
+  id: "app-1",
+  name: "Fixture app",
+  created_at: "2026-07-01T00:00:00Z",
+  updated_at: "2026-07-02T00:00:00Z",
+  current_revision: "rev-2",
+  revisions: [
+    { id: "rev-2", ordinal: 2, created_at: "2026-07-02T00:00:00Z" },
+    { id: "rev-1", ordinal: 1, created_at: "2026-07-01T00:00:00Z" },
+  ],
+};
+
+const GRANTED: AppGrantState = {
+  granted: true,
+  bindings: [
+    {
+      server: "cmd",
+      tools: ["mcp__cmd__doit"],
+      granted: true,
+      definition_changed: false,
+    },
+  ],
+};
+
+const STALE: AppGrantState = {
+  granted: false,
+  bindings: [
+    {
+      server: "cmd",
+      tools: ["mcp__cmd__doit"],
+      granted: false,
+      definition_changed: true,
+    },
+  ],
+};
+
+function apisWith(grant: AppGrantState): AppsApis {
+  return {
+    baseUrl: "http://127.0.0.1:7777",
+    list: vi.fn().mockResolvedValue({ apps: [] }),
+    get: vi.fn().mockResolvedValue(DETAIL),
+    deleteApp: vi.fn().mockResolvedValue(undefined),
+    grantState: vi.fn().mockResolvedValue(grant),
+    consent: vi.fn().mockResolvedValue(GRANTED),
+    revoke: vi.fn().mockResolvedValue(undefined),
+    viewSession: vi
+      .fn()
+      .mockResolvedValue({ frame_path: "/apps/view-frames/token-1" }),
+    invoke: vi
+      .fn()
+      .mockResolvedValue({
+        content: '{"ok":true}',
+        structured_content: { ok: true },
+        is_error: false,
+      }),
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AppDetailView", () => {
+  it("opens a granted app and drives one invoke round trip through the bridge", async () => {
+    const apis = apisWith(GRANTED);
+    render(<AppDetailView appId="app-1" apis={apis} onBack={() => {}} />);
+
+    // Granted: no sheet, the sandboxed frame mounts at the single-use address.
+    const frame = (await screen.findByTitle(
+      "App: Fixture app",
+    )) as HTMLIFrameElement;
+    expect(apis.viewSession).toHaveBeenCalledWith("app-1");
+    expect(frame).toHaveAttribute(
+      "src",
+      "http://127.0.0.1:7777/apps/view-frames/token-1",
+    );
+    expect(frame).toHaveAttribute("sandbox", "allow-scripts");
+    expect(frame.getAttribute("sandbox")).not.toContain("allow-same-origin");
+
+    // The frame asks for a tool call; the parent forwards it to the invoke
+    // route and posts the result back — both directions opaque passthrough.
+    const contentWindow = frame.contentWindow!;
+    const posted = vi.spyOn(contentWindow, "postMessage");
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: {
+          jsonrpc: "2.0",
+          id: 3,
+          method: "tools/call",
+          params: { name: "mcp__cmd__doit", arguments: { q: 1 } },
+        },
+        source: contentWindow,
+      }),
+    );
+    await waitFor(() => expect(posted).toHaveBeenCalled());
+    expect(apis.invoke).toHaveBeenCalledWith("app-1", "mcp__cmd__doit", {
+      q: 1,
+    });
+    expect(posted).toHaveBeenCalledWith(
+      {
+        jsonrpc: "2.0",
+        id: 3,
+        result: {
+          content: [{ type: "text", text: '{"ok":true}' }],
+          structuredContent: { ok: true },
+          isError: false,
+        },
+      },
+      "*",
+    );
+  });
+
+  it("gates an ungranted app behind the sheet, marks staleness, and consents body-less", async () => {
+    const apis = apisWith(STALE);
+    render(<AppDetailView appId="app-1" apis={apis} onBack={() => {}} />);
+
+    // The sheet renders the server projection: names, and the marker for a
+    // definition that changed since the previous consent.
+    expect(await screen.findByText("mcp__cmd__doit")).toBeInTheDocument();
+    expect(
+      screen.getByText("Server reconfigured since you agreed"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTitle(/^App:/)).not.toBeInTheDocument();
+
+    // Consent is a bare affirmative — the client method carries only the app
+    // id, so a stale sheet can never author what gets granted — and the
+    // server's fresh verdict is what opens the frame.
+    fireEvent.click(screen.getByRole("button", { name: "Allow access" }));
+    expect(apis.consent).toHaveBeenCalledWith("app-1");
+    expect(await screen.findByTitle("App: Fixture app")).toBeInTheDocument();
+  });
+});

--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
@@ -1,0 +1,222 @@
+import { ChevronLeft, ShieldCheck, Trash2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import type { AppDetail, AppGrantState } from "@/api";
+import { PanelSecondaryHeader } from "@/components/PanelHeader";
+import { Button } from "@/components/ui/button";
+import { AppConsentSheet } from "./AppConsentSheet";
+import { AppFrame } from "./AppFrame";
+import { friendlyAppsError, updatedLabel } from "./AppsView";
+import type { AppsApis } from "./appsApis";
+
+/**
+ * One app, as the panel addressed `apps.{appId}`: the running frame (behind
+ * its consent gate), the grant controls, the revision history, and deletion.
+ *
+ * The open flow is a consent check first, always: the server's grant verdict
+ * decides whether the frame mounts or the sheet renders, and the frame's own
+ * `consent_required` refusals fold back into the same gate — the sheet is the
+ * one way through, and the server recomputes what it grants.
+ */
+export function AppDetailView({
+  appId,
+  apis,
+  onBack,
+}: {
+  appId: string;
+  apis: AppsApis;
+  /** Return to the `apps` list panel; also where deletion lands. */
+  onBack: () => void;
+}) {
+  const [detail, setDetail] = useState<AppDetail | null>(null);
+  const [grant, setGrant] = useState<AppGrantState | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    const generation = ++generationRef.current;
+    setDetail(null);
+    setGrant(null);
+    setLoadError(null);
+    setActionError(null);
+    void (async () => {
+      try {
+        const [loadedDetail, loadedGrant] = await Promise.all([
+          apis.get(appId),
+          apis.grantState(appId),
+        ]);
+        if (generation !== generationRef.current) return;
+        setDetail(loadedDetail);
+        setGrant(loadedGrant);
+      } catch (caught) {
+        if (generation !== generationRef.current) return;
+        setLoadError(friendlyAppsError(caught, "Could not load this app."));
+      }
+    })();
+    return () => {
+      generationRef.current += 1;
+    };
+  }, [apis, appId]);
+
+  async function onConsent() {
+    setBusy(true);
+    setActionError(null);
+    try {
+      setGrant(await apis.consent(appId));
+    } catch (caught) {
+      setActionError(friendlyAppsError(caught, "Could not record consent."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onRevoke() {
+    setBusy(true);
+    setActionError(null);
+    try {
+      await apis.revoke(appId);
+      setGrant(await apis.grantState(appId));
+    } catch (caught) {
+      setActionError(friendlyAppsError(caught, "Could not revoke access."));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // A mid-session consent_required refusal (revocation elsewhere, or a
+  // server reconfigured underneath the grant) drops the frame back behind
+  // the sheet with the server's fresh projection.
+  async function onConsentRequired() {
+    try {
+      setGrant(await apis.grantState(appId));
+    } catch {
+      setGrant((current) => (current ? { ...current, granted: false } : current));
+    }
+  }
+
+  async function onDelete() {
+    setBusy(true);
+    setActionError(null);
+    try {
+      await apis.deleteApp(appId);
+      onBack();
+    } catch (caught) {
+      setActionError(friendlyAppsError(caught, "Could not delete this app."));
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <PanelSecondaryHeader showBorder={false} className="pr-1 pl-2">
+        <Button variant="ghost" size="icon-sm" onClick={onBack}>
+          <ChevronLeft className="size-4" />
+          <span className="sr-only">Back to apps</span>
+        </Button>
+        <h1 className="min-w-0 truncate text-lg font-medium">
+          {detail?.name ?? "App"}
+        </h1>
+      </PanelSecondaryHeader>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pt-4 pb-4">
+        {loadError && (
+          <p className="text-critical mx-4 text-sm" role="alert">
+            {loadError}
+          </p>
+        )}
+        {!loadError && (!detail || !grant) && (
+          <p className="text-muted-foreground mx-4 text-sm" role="status">
+            Loading app…
+          </p>
+        )}
+
+        {detail && grant && (
+          <>
+            {grant.granted ? (
+              <AppFrame
+                appId={appId}
+                name={detail.name}
+                apis={apis}
+                onConsentRequired={() => void onConsentRequired()}
+              />
+            ) : (
+              <AppConsentSheet
+                state={grant}
+                busy={busy}
+                error={actionError}
+                onConsent={() => void onConsent()}
+              />
+            )}
+
+            {grant.granted && (
+              <section className="mx-4 flex flex-col gap-2" aria-label="Access">
+                <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
+                  <ShieldCheck className="size-3.5 shrink-0" aria-hidden="true" />
+                  <span>
+                    Allowed to call{" "}
+                    {grant.bindings
+                      .flatMap((binding) => binding.tools)
+                      .join(", ") || "no tools"}
+                  </span>
+                </div>
+                {actionError && (
+                  <p className="text-critical text-sm" role="alert">
+                    {actionError}
+                  </p>
+                )}
+                <div>
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    disabled={busy}
+                    onClick={() => void onRevoke()}
+                  >
+                    Revoke access
+                  </Button>
+                </div>
+              </section>
+            )}
+
+            <section className="mx-4 flex flex-col gap-1" aria-label="Revisions">
+              <h2 className="text-sm font-medium">
+                {detail.revisions.length === 1
+                  ? "1 revision"
+                  : `${detail.revisions.length} revisions`}
+              </h2>
+              <ul className="flex flex-col gap-0.5">
+                {detail.revisions.map((revision) => (
+                  <li
+                    key={revision.id}
+                    className="text-muted-foreground flex items-center gap-2 text-xs"
+                  >
+                    <span className="tabular-nums">
+                      Revision {revision.ordinal}
+                    </span>
+                    <span>{updatedLabel(revision.created_at)}</span>
+                    {revision.id === detail.current_revision && (
+                      <span className="text-foreground">current</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+
+            <section className="mx-4" aria-label="Delete app">
+              <Button
+                variant="outline"
+                size="xs"
+                disabled={busy}
+                onClick={() => void onDelete()}
+              >
+                <Trash2 className="size-3.5" aria-hidden="true" />
+                Delete app
+              </Button>
+            </section>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/apps/AppFrame.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppFrame.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from "react";
+
+import { AppInvokeRefusalError } from "@/api";
+import { createMcpAppBridge, type McpAppBridge } from "@/McpAppBridge";
+import { useTheme } from "@/theme";
+import type { AppsApis } from "./appsApis";
+
+/**
+ * The running app: one stored revision in the same sandbox the MCP App card
+ * uses — `sandbox="allow-scripts"` without `allow-same-origin`, so the bundle
+ * runs with an opaque origin and no reach into OpenWave's DOM, storage, or
+ * bearer — plus the host bridge with the tool-call leg wired in. The frame
+ * posts `tools/call`; the bridge forwards it to the bearer-authenticated
+ * invoke route and posts the result back, both directions opaque passthrough.
+ *
+ * A `consent_required` refusal mid-session (revoked, or a server reconfigured
+ * while the app was open) is reported upward so the host can re-present the
+ * consent sheet; the frame itself just sees a rejected call.
+ */
+type FrameState =
+  | { kind: "loading" }
+  | { kind: "unavailable" }
+  | { kind: "ready"; url: string };
+
+const DEFAULT_FRAME_HEIGHT = 384;
+
+export function AppFrame({
+  appId,
+  name,
+  apis,
+  onConsentRequired,
+}: {
+  appId: string;
+  /** Display name, for the frame's accessible title only. */
+  name: string;
+  apis: AppsApis;
+  onConsentRequired?: () => void;
+}) {
+  const { resolved: resolvedTheme } = useTheme();
+  const [state, setState] = useState<FrameState>({ kind: "loading" });
+  const [frameHeight, setFrameHeight] = useState(DEFAULT_FRAME_HEIGHT);
+  const frameRef = useRef<HTMLIFrameElement | null>(null);
+  const bridgeRef = useRef<McpAppBridge | null>(null);
+
+  const themeRef = useRef(resolvedTheme);
+  themeRef.current = resolvedTheme;
+  const onConsentRequiredRef = useRef(onConsentRequired);
+  onConsentRequiredRef.current = onConsentRequired;
+
+  // One bridge per mount, created before the frame's document runs — the
+  // same ordering contract as McpAppCard, for the same reason.
+  useEffect(() => {
+    const bridge = createMcpAppBridge({
+      frame: () => frameRef.current?.contentWindow ?? null,
+      theme: () => themeRef.current,
+      onHeight: setFrameHeight,
+      invokeTool: async (tool, args) => {
+        try {
+          return await apis.invoke(appId, tool, args);
+        } catch (error) {
+          if (
+            error instanceof AppInvokeRefusalError &&
+            error.kind === "consent_required"
+          ) {
+            onConsentRequiredRef.current?.();
+          }
+          throw error;
+        }
+      },
+    });
+    bridgeRef.current = bridge;
+    window.addEventListener("message", bridge.handleMessage);
+    return () => {
+      window.removeEventListener("message", bridge.handleMessage);
+      bridge.dispose();
+      bridgeRef.current = null;
+    };
+  }, [apis, appId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ kind: "loading" });
+    // The bundle is served by the host under its own strict CSP; the address
+    // is a single-use capability because an iframe cannot carry the bearer.
+    apis
+      .viewSession(appId)
+      .then((session) => {
+        if (cancelled) return;
+        setState({ kind: "ready", url: apis.baseUrl + session.frame_path });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ kind: "unavailable" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [apis, appId]);
+
+  return (
+    <div className="bg-background mx-4 overflow-hidden rounded-lg border">
+      {state.kind === "loading" && (
+        <p className="text-muted-foreground p-3 text-xs">Opening app…</p>
+      )}
+      {state.kind === "unavailable" && (
+        <p className="text-muted-foreground p-3 text-xs">
+          This app could not be opened. Its stored revision may be missing —
+          try again, or delete the app.
+        </p>
+      )}
+      {state.kind === "ready" && (
+        <iframe
+          ref={frameRef}
+          title={`App: ${name}`}
+          src={state.url}
+          sandbox="allow-scripts"
+          referrerPolicy="no-referrer"
+          className="w-full border-0"
+          style={{ height: frameHeight }}
+        />
+      )}
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/apps/AppsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppsPanel.tsx
@@ -1,0 +1,44 @@
+import { useMemo } from "react";
+
+import { useApp } from "@/AppContext";
+import { PanelFrame } from "@/panel/PanelFrame";
+import type { PanelContent } from "@/panel/panelTypes";
+import { usePanelNav } from "@/panel/usePanelNav";
+import { AppDetailView } from "./AppDetailView";
+import { AppsView } from "./AppsView";
+import { appsApisFromClient } from "./appsApis";
+
+/**
+ * The `apps` panel: the library list, or — addressed `apps.{appId}` — one
+ * app's detail with the open flow. Hosted by the home route (the library's
+ * primary home) and available beside a conversation like any other
+ * navigation panel.
+ */
+export function AppsPanel({
+  panel,
+  position,
+}: {
+  panel: Extract<PanelContent, { type: "apps" }>;
+  position: "left" | "right";
+}) {
+  const { client } = useApp();
+  const { openPanel } = usePanelNav();
+  const apis = useMemo(() => appsApisFromClient(client), [client]);
+
+  return (
+    <PanelFrame position={position} spaceBetween>
+      {panel.appId ? (
+        <AppDetailView
+          appId={panel.appId}
+          apis={apis}
+          onBack={() => openPanel({ type: "apps" })}
+        />
+      ) : (
+        <AppsView
+          apis={apis}
+          onOpen={(appId) => openPanel({ type: "apps", appId })}
+        />
+      )}
+    </PanelFrame>
+  );
+}

--- a/crates/openwave-desktop/ui/src/apps/AppsView.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppsView.tsx
@@ -1,0 +1,168 @@
+import { LayoutGrid, RotateCwIcon, ShieldCheck } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import type { AppSummary } from "@/api";
+import { PanelSecondaryHeader } from "@/components/PanelHeader";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { WithTooltip } from "@/components/ui/tooltip";
+import type { AppsApis } from "./appsApis";
+
+/**
+ * The Apps library, as the panel addressed `apps`.
+ *
+ * Profile-scoped rather than conversation-scoped: an app outlives every chat
+ * that touched it, which is why this list hangs off the home rail instead of
+ * a conversation's. Picking a row opens `apps.{appId}` — the detail panel
+ * with the running app, its consent state, and its history.
+ */
+export function AppsView({
+  onOpen,
+  apis,
+}: {
+  /** Navigate to the `apps.{appId}` panel contract. */
+  onOpen: (appId: string) => void;
+  apis: AppsApis;
+}) {
+  const [apps, setApps] = useState<AppSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const generationRef = useRef(0);
+
+  async function refresh(showLoading = false) {
+    const generation = ++generationRef.current;
+    if (showLoading) setLoading(true);
+    setError(null);
+    try {
+      const library = await apis.list();
+      if (generation !== generationRef.current) return;
+      setApps(library.apps);
+    } catch (caught) {
+      if (generation !== generationRef.current) return;
+      setError(friendlyAppsError(caught, "Could not load your apps."));
+    } finally {
+      if (generation === generationRef.current) setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void refresh(true);
+    return () => {
+      generationRef.current += 1;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [apis]);
+
+  const hasApps = apps.length > 0;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <PanelSecondaryHeader showBorder={false} className="pr-1 pl-4">
+        <h1 className="text-lg font-medium">Apps</h1>
+        <span className="grow" />
+        <div className="pr-2">
+          <WithTooltip label="Refresh">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              disabled={loading}
+              onClick={() => void refresh(true)}
+            >
+              <RotateCwIcon className="size-4" />
+              <span className="sr-only">Refresh</span>
+            </Button>
+          </WithTooltip>
+        </div>
+      </PanelSecondaryHeader>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-2 pt-4">
+        {error && (
+          <div
+            className="mx-4 flex shrink-0 items-center justify-between gap-3 rounded-md bg-critical-background px-3 py-2 text-sm text-critical-foreground-muted"
+            role="alert"
+          >
+            <span>{error}</span>
+            <Button
+              variant="outline"
+              size="xs"
+              className="shrink-0"
+              onClick={() => void refresh(true)}
+            >
+              Try again
+            </Button>
+          </div>
+        )}
+
+        {loading && !hasApps ? (
+          <p className="px-4 text-sm text-muted-foreground" role="status">
+            Loading your apps…
+          </p>
+        ) : !hasApps ? (
+          <Empty>
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <LayoutGrid />
+              </EmptyMedia>
+              <EmptyTitle>No apps yet</EmptyTitle>
+              <EmptyDescription>
+                Ask OpenWave to build a mini app in a conversation. What it
+                creates lives here — reopen it any time without re-running the
+                chat.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <ul className="flex flex-col gap-0.5 overflow-y-auto px-3" aria-label="Apps">
+            {apps.map((app) => (
+              <li key={app.id}>
+                <button
+                  type="button"
+                  className="hover:bg-muted flex w-full items-center gap-2 rounded-md p-2 text-left text-sm transition-colors"
+                  onClick={() => onOpen(app.id)}
+                >
+                  <LayoutGrid
+                    className="text-muted-foreground size-4 shrink-0"
+                    aria-hidden="true"
+                  />
+                  <span className="min-w-0 flex-1 truncate">{app.name}</span>
+                  {app.granted && (
+                    <Badge variant="outline" className="shrink-0 gap-1">
+                      <ShieldCheck className="size-3" aria-hidden="true" />
+                      Granted
+                    </Badge>
+                  )}
+                  <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+                    {revisionCountLabel(app.revision_count)} ·{" "}
+                    {updatedLabel(app.updated_at)}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function revisionCountLabel(count: number): string {
+  return count === 1 ? "1 revision" : `${count} revisions`;
+}
+
+/** The row's freshness, as a plain local date; time-of-day is noise here. */
+export function updatedLabel(updatedAt: string): string {
+  const date = new Date(updatedAt);
+  return Number.isNaN(date.getTime()) ? "" : date.toLocaleDateString();
+}
+
+export function friendlyAppsError(error: unknown, fallback: string): string {
+  const message = String(error).replace(/^Error:\s*/, "").trim();
+  return message && message.length <= 240 ? message : fallback;
+}

--- a/crates/openwave-desktop/ui/src/apps/appsApis.ts
+++ b/crates/openwave-desktop/ui/src/apps/appsApis.ts
@@ -1,0 +1,41 @@
+import type {
+  ApiClient,
+  AppDetail,
+  AppGrantState,
+  AppInvokeResult,
+  AppLibrary,
+  AppViewSessionInfo,
+} from "@/api";
+
+/**
+ * Everything the Apps library surfaces call on the server, as one injectable
+ * object — the {@link import("@/outputs/OutputsView").OutputsApis} pattern,
+ * so list, detail, consent, and the open flow are drivable in tests without
+ * a network.
+ */
+export type AppsApis = {
+  /** The API origin; frame paths from a view session resolve against it. */
+  baseUrl: string;
+  list(): Promise<AppLibrary>;
+  get(appId: string): Promise<AppDetail>;
+  deleteApp(appId: string): Promise<void>;
+  grantState(appId: string): Promise<AppGrantState>;
+  consent(appId: string): Promise<AppGrantState>;
+  revoke(appId: string): Promise<void>;
+  viewSession(appId: string): Promise<AppViewSessionInfo>;
+  invoke(appId: string, tool: string, args: unknown): Promise<AppInvokeResult>;
+};
+
+export function appsApisFromClient(client: ApiClient): AppsApis {
+  return {
+    baseUrl: client.baseUrl,
+    list: () => client.listApps(),
+    get: (appId) => client.getApp(appId),
+    deleteApp: (appId) => client.deleteApp(appId),
+    grantState: (appId) => client.getAppGrant(appId),
+    consent: (appId) => client.consentAppGrant(appId),
+    revoke: (appId) => client.revokeAppGrant(appId),
+    viewSession: (appId) => client.createAppViewFrame(appId),
+    invoke: (appId, tool, args) => client.invokeApp(appId, tool, args),
+  };
+}

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -116,6 +116,27 @@ export type AgentRunStatus = "active" | "queued" | "running" | "cancelling" | "w
 export type AgentRunTier = "foreground" | "background";
 
 /**
+ * One app's detail: the summary fields plus its revision history.
+ */
+export type AppDetail = { id: AppId, name: string, 
+/**
+ * Creation time of the first revision.
+ */
+created_at: string, 
+/**
+ * Creation time of the current revision.
+ */
+updated_at: string, 
+/**
+ * Revision currently presented as the app's content.
+ */
+current_revision: AppRevisionId, 
+/**
+ * Every retained revision, newest first.
+ */
+revisions: Array<AppRevisionSummary>, };
+
+/**
  * One current-manifest binding, projected for the consent sheet.
  */
 export type AppGrantBindingState = { 
@@ -160,6 +181,15 @@ granted: boolean,
 bindings: Array<AppGrantBindingState>, };
 
 /**
+ * Identifies one profile-scoped local app across all of its revisions.
+ *
+ * Like [`OutputId`] this is a durable opaque handle: possession is not
+ * authority, and it never encodes a name or a host path. Unlike an
+ * output, an app has no owning conversation — the profile owns it.
+ */
+export type AppId = string;
+
+/**
  * The typed refusal body — the `{ kind, message }` shape every route error
  * carries, with the kind closed so a client never string-matches prose.
  */
@@ -174,6 +204,49 @@ export type AppInvokeRefusal = { kind: AppInvokeRefusalKind, message: string, };
  * a free-form string.
  */
 export type AppInvokeRefusalKind = "app_not_found" | "not_pinned" | "consent_required" | "unknown_tool";
+
+/**
+ * The library listing: every live app, newest activity first.
+ */
+export type AppLibrary = { apps: Array<AppSummary>, };
+
+/**
+ * Identifies one immutable revision of a local app.
+ */
+export type AppRevisionId = string;
+
+/**
+ * One revision row: identity and position only. The manifest and the
+ * bundle's content address stay server-side.
+ */
+export type AppRevisionSummary = { id: AppRevisionId, 
+/**
+ * One-based position in the app's revision history.
+ */
+ordinal: number, created_at: string, };
+
+/**
+ * One library row.
+ */
+export type AppSummary = { id: AppId, 
+/**
+ * Display name, following the current revision's manifest.
+ */
+name: string, 
+/**
+ * Number of retained revisions, always at least one.
+ */
+revision_count: number, 
+/**
+ * Creation time of the current revision.
+ */
+updated_at: string, 
+/**
+ * Whether a live grant fully covers the app right now — the same
+ * verdict `GET /apps/{id}/grant` reports, so the library badge and the
+ * consent sheet can never disagree.
+ */
+granted: boolean, };
 
 /**
  * Where the sandboxed iframe should load one app revision from, valid once.

--- a/crates/openwave-desktop/ui/src/panel/panelTypes.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelTypes.ts
@@ -13,7 +13,9 @@ export type PanelContent =
    */
   | { type: "document"; documentId: string; citationId?: string }
   | { type: "outputs"; outputId?: string }
-  | { type: "folders" };
+  | { type: "folders" }
+  /** The Apps library; an app id turns the list into that app's detail. */
+  | { type: "apps"; appId?: string };
 
 export type PanelType = PanelContent["type"];
 
@@ -48,6 +50,7 @@ export function isContentPanel(panel: PanelContent): boolean {
     case "chat":
     case "outputs":
     case "folders":
+    case "apps":
       return false;
     case "document":
       return true;

--- a/crates/openwave-desktop/ui/src/panel/panelUrl.test.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelUrl.test.ts
@@ -13,6 +13,8 @@ describe("panel URLs", () => {
     expect(parsePanelSegment("chat")).toEqual({ type: "chat" });
     expect(parsePanelSegment("outputs")).toEqual({ type: "outputs" });
     expect(parsePanelSegment("folders")).toEqual({ type: "folders" });
+    expect(parsePanelSegment("apps")).toEqual({ type: "apps" });
+    expect(parsePanelSegment("apps.app-1")).toEqual({ type: "apps", appId: "app-1" });
     expect(parsePanelSegment("document.doc-1")).toEqual({
       type: "document",
       documentId: "doc-1",

--- a/crates/openwave-desktop/ui/src/panel/panelUrl.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelUrl.ts
@@ -19,6 +19,8 @@ import {
  *   outputs
  *   outputs.{outputId}
  *   folders
+ *   apps
+ *   apps.{appId}
  *
  * Only the first separator picks the panel type; what follows is read by that
  * panel and nothing else. Output navigation carries the durable opaque output
@@ -43,6 +45,8 @@ export function parsePanelSegment(segment: string): PanelContent | null {
       return id ? parseDocumentTarget(id) : null;
     case "outputs":
       return id ? { type: "outputs", outputId: id } : { type: "outputs" };
+    case "apps":
+      return id ? { type: "apps", appId: id } : { type: "apps" };
     default:
       return null;
   }
@@ -73,6 +77,8 @@ export function encodePanelSegment(panel: PanelContent): string {
         : `document.${panel.documentId}`;
     case "outputs":
       return panel.outputId ? `outputs.${panel.outputId}` : "outputs";
+    case "apps":
+      return panel.appId ? `apps.${panel.appId}` : "apps";
   }
 }
 

--- a/crates/openwave-desktop/ui/src/panel/usePanelNav.ts
+++ b/crates/openwave-desktop/ui/src/panel/usePanelNav.ts
@@ -25,12 +25,18 @@ export function usePanelNav() {
   const { chatId } = useParams({ strict: false }) as { chatId?: string };
 
   function go(next: LayoutState) {
-    if (!chatId) return;
-    void navigate({
-      to: "/c/$chatId",
-      params: { chatId },
-      search: searchFromLayout(next),
-    });
+    // Panels live beside a conversation when there is one; outside any
+    // conversation the home route hosts them (the Apps library), and its bare
+    // URL is the single-layout collapse the same way a chat's is.
+    if (chatId) {
+      void navigate({
+        to: "/c/$chatId",
+        params: { chatId },
+        search: searchFromLayout(next),
+      });
+    } else {
+      void navigate({ to: "/", search: searchFromLayout(next) });
+    }
   }
 
   return {

--- a/crates/openwave-desktop/ui/src/router.tsx
+++ b/crates/openwave-desktop/ui/src/router.tsx
@@ -23,6 +23,14 @@ const rootRoute = createRootRoute({ component: AppShell });
 const homeRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/",
+  // Home hosts panels the way a conversation does — the Apps library opens
+  // beside the composer — so it reads the same layout params. Which panel
+  // types home actually accepts is decided by HomeRoute, not the URL parser.
+  validateSearch: (search: Record<string, unknown>): PanelSearch => ({
+    left: typeof search.left === "string" ? search.left : undefined,
+    right: typeof search.right === "string" ? search.right : undefined,
+    fullscreen: typeof search.fullscreen === "string" ? search.fullscreen : undefined,
+  }),
   component: HomeRoute,
 });
 

--- a/crates/openwave-desktop/ui/src/sidebar/HomeSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/HomeSidebar.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { History, MessagesSquare } from "lucide-react";
+import { useNavigate, useRouterState, useSearch } from "@tanstack/react-router";
+import { History, LayoutGrid, MessagesSquare } from "lucide-react";
 
 import { useApp } from "@/AppContext";
 import { useChatAttention } from "@/ChatAttention";
@@ -40,7 +40,15 @@ export function HomeSidebar() {
   );
   const isCompact = useSidebarWidth() === "compact";
   const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const search = useSearch({ strict: false }) as { left?: string; right?: string };
   const [recentCollapsed, setRecentCollapsed] = useState(false);
+
+  // The Apps library lives on home; the entry is "current" when either slot
+  // holds it, list or detail alike.
+  const holdsApps = (segment: string | undefined) =>
+    segment === "apps" || segment?.startsWith("apps.") === true;
+  const appsOpen =
+    pathname === "/" && (holdsApps(search.left) || holdsApps(search.right));
 
   const recentChats = chats.slice(0, RECENT_CHAT_LIMIT);
   const showRecent = !recentCollapsed && !isCompact && recentChats.length > 0;
@@ -109,6 +117,19 @@ export function HomeSidebar() {
           </div>
         )}
       </div>
+
+      {/* Apps are profile-scoped — they outlive every conversation — so their
+          library belongs on the chat-free rail, opening as a panel on home. */}
+      <SidebarSectionTitle className="mt-4">Library</SidebarSectionTitle>
+      <SidebarButton
+        aria-current={appsOpen ? "page" : undefined}
+        data-active={appsOpen || undefined}
+        className="data-[active]:bg-muted"
+        onClick={() => void navigate({ to: "/", search: { left: "apps" } })}
+      >
+        <LayoutGrid />
+        <span>Apps</span>
+      </SidebarButton>
     </SidebarFrame>
   );
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -330,6 +330,11 @@ pub fn app(state: AppState) -> Router {
                 .post(routes::post_app_grant)
                 .delete(routes::delete_app_grant),
         )
+        .route("/apps", get(routes::get_app_library))
+        .route(
+            "/apps/{id}",
+            get(routes::get_app_detail).delete(routes::delete_app),
+        )
         .route("/policy", get(routes::get_policy))
         .route("/gateway/status", get(routes::get_gateway_status))
         .route("/gateway/apps", get(routes::get_gateway_apps))

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -46,6 +46,7 @@ use crate::web_search::{
 
 mod app_grant;
 mod app_invoke;
+mod app_library;
 pub(crate) mod client_execution;
 mod delegated_file_execution;
 mod document;
@@ -55,6 +56,7 @@ mod root_attachment;
 mod user_questions;
 pub use app_grant::*;
 pub use app_invoke::*;
+pub use app_library::*;
 pub use client_execution::*;
 pub use delegated_file_execution::*;
 pub use document::*;

--- a/crates/openwave-server/src/routes/app_grant.rs
+++ b/crates/openwave-server/src/routes/app_grant.rs
@@ -150,8 +150,9 @@ async fn current_live_app(
 ///
 /// The same three checks the invoke gate applies, evaluated for the whole
 /// manifest: `granted` is true exactly when every pinned tool would pass the
-/// gate right now.
-fn grant_state(
+/// gate right now. Shared with the library listing so its granted badge is
+/// this verdict rather than a reimplementation of it.
+pub(crate) fn grant_state(
     manifest: &AppManifest,
     grant: Option<&AppGrant>,
     current: &std::collections::BTreeMap<String, [u8; 32]>,

--- a/crates/openwave-server/src/routes/app_library.rs
+++ b/crates/openwave-server/src/routes/app_library.rs
@@ -1,0 +1,151 @@
+//! `/apps` — the Apps library's renderer surface: list, detail, delete.
+//!
+//! Everything here is a renderer-safe projection over the profile's app
+//! records: names, counts, timestamps, and the grant verdict. Manifest
+//! bindings, bundle bytes, and server definitions never cross this surface —
+//! the consent sheet reads its own projection from `/apps/{id}/grant`, and
+//! the bundle is only ever served through the single-use frame route.
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use openwave_core::id::{AppId, AppRevisionId};
+
+use crate::error::ServerError;
+use crate::extract::{Json, Path};
+use crate::state::AppState;
+
+/// How many library rows one listing returns. The library is a personal
+/// shelf, not a search surface; a bound this size is unreachable in practice
+/// and exists so a runaway profile cannot make the route unbounded.
+const MAX_LISTED_APPS: u64 = 100;
+
+/// The library listing: every live app, newest activity first.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct AppLibrary {
+    pub apps: Vec<AppSummary>,
+}
+
+/// One library row.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct AppSummary {
+    pub id: AppId,
+    /// Display name, following the current revision's manifest.
+    pub name: String,
+    /// Number of retained revisions, always at least one.
+    pub revision_count: u32,
+    /// Creation time of the current revision.
+    pub updated_at: DateTime<Utc>,
+    /// Whether a live grant fully covers the app right now — the same
+    /// verdict `GET /apps/{id}/grant` reports, so the library badge and the
+    /// consent sheet can never disagree.
+    pub granted: bool,
+}
+
+/// One app's detail: the summary fields plus its revision history.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct AppDetail {
+    pub id: AppId,
+    pub name: String,
+    /// Creation time of the first revision.
+    pub created_at: DateTime<Utc>,
+    /// Creation time of the current revision.
+    pub updated_at: DateTime<Utc>,
+    /// Revision currently presented as the app's content.
+    pub current_revision: AppRevisionId,
+    /// Every retained revision, newest first.
+    pub revisions: Vec<AppRevisionSummary>,
+}
+
+/// One revision row: identity and position only. The manifest and the
+/// bundle's content address stay server-side.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct AppRevisionSummary {
+    pub id: AppRevisionId,
+    /// One-based position in the app's revision history.
+    pub ordinal: u32,
+    pub created_at: DateTime<Utc>,
+}
+
+/// `GET /apps` — the library listing.
+pub async fn get_app_library(
+    State(state): State<AppState>,
+) -> Result<Json<AppLibrary>, ServerError> {
+    let records = state.store.list_apps(MAX_LISTED_APPS).await?;
+    let current = state.mcp.definition_fingerprints().await;
+    let mut apps = Vec::with_capacity(records.len());
+    for record in records {
+        // The same computation the grant surface performs, so the badge is
+        // the invoke gate's verdict rather than a cached approximation. An
+        // app whose current revision cannot be read fails closed: it lists,
+        // but never as granted.
+        let granted = match state
+            .store
+            .get_app_revision(record.current_revision)
+            .await?
+        {
+            Some(revision) => {
+                let grant = state.store.get_app_grant(record.id).await?;
+                super::grant_state(&revision.manifest, grant.as_ref(), &current).granted
+            }
+            None => false,
+        };
+        apps.push(AppSummary {
+            id: record.id,
+            name: record.name,
+            revision_count: record.revision_count,
+            updated_at: record.updated_at,
+            granted,
+        });
+    }
+    Ok(Json(AppLibrary { apps }))
+}
+
+/// `GET /apps/{id}` — one live app's detail. A soft-deleted app answers as
+/// missing, exactly as it does on every other renderer surface.
+pub async fn get_app_detail(
+    State(state): State<AppState>,
+    Path(id): Path<AppId>,
+) -> Result<Json<AppDetail>, ServerError> {
+    let absent = || ServerError::not_found(format!("no app {id}"));
+    let app = state.store.get_app(id).await?.ok_or_else(absent)?;
+    if app.deleted_at.is_some() {
+        return Err(absent());
+    }
+    let revisions = state
+        .store
+        .list_app_revisions(id)
+        .await?
+        .into_iter()
+        .map(|revision| AppRevisionSummary {
+            id: revision.id,
+            ordinal: revision.ordinal,
+            created_at: revision.created_at,
+        })
+        .collect();
+    Ok(Json(AppDetail {
+        id: app.id,
+        name: app.name,
+        created_at: app.created_at,
+        updated_at: app.updated_at,
+        current_revision: app.current_revision,
+        revisions,
+    }))
+}
+
+/// `DELETE /apps/{id}` — soft-delete one app.
+///
+/// Revisions and the grant are retained so the deletion stays recoverable;
+/// what deletion removes is every open affordance — the library row, frame
+/// minting, and invoke all refuse a deleted app server-side.
+pub async fn delete_app(
+    State(state): State<AppState>,
+    Path(id): Path<AppId>,
+) -> Result<StatusCode, ServerError> {
+    if !state.store.delete_app(id, Utc::now()).await? {
+        return Err(ServerError::not_found(format!("no app {id}")));
+    }
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -36,6 +36,7 @@ use tower::ServiceExt;
 
 mod app_grant;
 mod app_invoke;
+mod app_library;
 mod chat_titling;
 mod configuration;
 mod conversations;

--- a/crates/openwave-server/src/tests/app_library.rs
+++ b/crates/openwave-server/src/tests/app_library.rs
@@ -1,0 +1,126 @@
+//! `/apps` library surface: listing, detail, and deletion.
+
+use super::*;
+
+use openwave_core::id::{AppId, AppRevisionId};
+use openwave_core::local_app::{AppBinding, AppManifest, CreateApp, NewAppRevision};
+use serde_json::json;
+
+/// The library lifecycle in one pass: the listing carries renderer-safe rows
+/// whose `granted` badge is the grant surface's own verdict, the detail lists
+/// revision history, and deletion removes the app from every one of those
+/// surfaces while staying idempotent server-side state.
+#[tokio::test]
+async fn library_lists_grant_verdicts_and_deletion_removes_the_row() {
+    let (router, token, store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+
+    // A disabled stdio server never spawns but still carries a definition
+    // fingerprint, which is all a grant pins.
+    let put = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/mcp/servers")
+                .header("authorization", &bearer)
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({"servers": [{
+                        "name": "cmd",
+                        "command": "/usr/local/bin/fixture-mcp",
+                        "enabled": false
+                    }]})
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(put.status(), StatusCode::OK);
+
+    let app_id = AppId::new();
+    store
+        .create_app(&CreateApp {
+            id: app_id,
+            revision: NewAppRevision {
+                id: AppRevisionId::new(),
+                manifest: AppManifest {
+                    name: "Library fixture".into(),
+                    bindings: vec![AppBinding {
+                        server: "cmd".into(),
+                        tools: vec!["mcp__cmd__doit".into()],
+                    }],
+                },
+                byte_len: 1,
+                sha256: [0; 32],
+                turn_id: None,
+                producing_run_id: None,
+                chat_id: None,
+                created_at: chrono::Utc::now(),
+            },
+        })
+        .await
+        .unwrap();
+
+    let request = |method: &str, uri: String| {
+        router.clone().oneshot(
+            Request::builder()
+                .method(method)
+                .uri(uri)
+                .header("authorization", &bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+    };
+
+    // Ungranted at first; the listing carries the projection fields and never
+    // the manifest's bindings.
+    let listed = request("GET", "/apps".into()).await.unwrap();
+    assert_eq!(listed.status(), StatusCode::OK);
+    let body = body_string(listed).await;
+    assert!(
+        !body.contains("bindings") && !body.contains("mcp__cmd__doit"),
+        "the listing must not carry manifest bindings: {body}"
+    );
+    let library: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(library["apps"][0]["name"], json!("Library fixture"));
+    assert_eq!(library["apps"][0]["revision_count"], json!(1));
+    assert_eq!(library["apps"][0]["granted"], json!(false));
+
+    // Consent flips the listing's verdict — same computation, same answer.
+    let consented = request("POST", format!("/apps/{app_id}/grant"))
+        .await
+        .unwrap();
+    assert_eq!(consented.status(), StatusCode::OK);
+    let listed = request("GET", "/apps".into()).await.unwrap();
+    let library: serde_json::Value = serde_json::from_str(&body_string(listed).await).unwrap();
+    assert_eq!(library["apps"][0]["granted"], json!(true));
+
+    // Detail lists the revision history.
+    let detail = request("GET", format!("/apps/{app_id}")).await.unwrap();
+    assert_eq!(detail.status(), StatusCode::OK);
+    let detail: serde_json::Value = serde_json::from_str(&body_string(detail).await).unwrap();
+    assert_eq!(detail["name"], json!("Library fixture"));
+    assert_eq!(detail["revisions"][0]["ordinal"], json!(1));
+    assert_eq!(detail["revisions"][0]["id"], detail["current_revision"]);
+
+    // Deletion removes the app from the library and the detail surface.
+    let deleted = request("DELETE", format!("/apps/{app_id}")).await.unwrap();
+    assert_eq!(deleted.status(), StatusCode::NO_CONTENT);
+    let listed = request("GET", "/apps".into()).await.unwrap();
+    let library: serde_json::Value = serde_json::from_str(&body_string(listed).await).unwrap();
+    assert_eq!(library["apps"], json!([]));
+    let detail = request("GET", format!("/apps/{app_id}")).await.unwrap();
+    assert_eq!(detail.status(), StatusCode::NOT_FOUND);
+    // An unknown app 404s; re-deleting the soft-deleted one stays idempotent.
+    let missing = request("DELETE", format!("/apps/{}", AppId::new()))
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+}
+
+async fn body_string(response: axum::response::Response) -> String {
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -328,6 +328,10 @@ mod tests {
         // The grant-state projection the consent sheet renders: server and
         // tool names with coverage/staleness booleans, never definitions.
         generate::collect_from::<crate::routes::AppGrantState>(&cfg, &mut out);
+        // The Apps library projections: names, counts, timestamps, and the
+        // grant verdict — never manifests, bundles, or definitions.
+        generate::collect_from::<crate::routes::AppLibrary>(&cfg, &mut out);
+        generate::collect_from::<crate::routes::AppDetail>(&cfg, &mut out);
         generate::collect_from::<openwave_core::PendingUserQuestions>(&cfg, &mut out);
         generate::collect_from::<openwave_core::PendingPlanApproval>(&cfg, &mut out);
         generate::collect_from::<openwave_core::PlanDecisionChoice>(&cfg, &mut out);

--- a/docs/local-apps.md
+++ b/docs/local-apps.md
@@ -67,7 +67,7 @@ rows and bytes are keyed to a chat — so apps get their own record:
   directory — write-once, path derived only from durable identity, symlink-
   refusing, never under any conversation's private scratch.
 
-`create_app` mints identity the way `create_deliverable` does: ids derived
+`create_app` follows the outputs record's identity discipline: ids derived
 from the durable tool-call id, so an ambiguous store response retries into the
 same record instead of a duplicate. Authoring always happens inside a turn, so
 call identity exists; it is only *invocation* that happens outside one.


### PR DESCRIPTION
Final MVP slice of docs/local-apps.md (builds on #1267 frame serving, #1268 invoke, #1276 grants). Closes #1259

## What this adds

**Server — a small renderer-safe library surface.** Slices 1–5 shipped no listing route, so this adds `GET /apps` (id, name, revision count, updated-at, and a `granted` verdict computed by the same `grant_state` projection the grant endpoints use — the badge and the sheet can never disagree), `GET /apps/{id}` (summary plus revision history), and `DELETE /apps/{id}` (soft-delete; revisions and grant retained, every open affordance already refuses a deleted app server-side). Names, counts, and timestamps only — manifests, bundles, and definitions never cross this surface. Registered in `wire_types.rs`, `wire.ts` regenerated.

**Panel plumbing.** `PanelContent` gains `{type: "apps", appId?}` (a navigation panel, like outputs), with the `apps` / `apps.{id}` URL grammar. Home hosts panels for the first time: the home route gains the same `validateSearch` as the chat route, `usePanelNav` collapses to `/` when there is no chat, and `HomeRoute` renders the existing `PanelLayout` with the welcome/composer content in the chat slot. Conversation-scoped panel types in a home URL collapse back to plain home rather than rendering an empty panel. The chat route renders the same apps panel, since the type is now part of the layout vocabulary.

**Entry point.** A "Library / Apps" button on the chat-free `HomeSidebar`, active when either slot holds the apps panel.

**List + detail.** On the `OutputsView` pattern with an injectable `AppsApis` object (`appsApisFromClient` builds the default). Detail shows the running app (behind its consent gate), the granted tool set with revoke, the revision history, and delete.

**Consent sheet.** Renders `GET /apps/{id}/grant` verbatim — server and tool names, plus a visible "Server reconfigured since you agreed" marker per binding with `definition_changed`. Consent is a body-less `POST`: the server recomputes the grant from the current manifest and definitions, so a stale sheet can never author what gets granted.

**The open flow.** Grant verdict → `POST /apps/{id}/view-session` → sandboxed iframe (`sandbox="allow-scripts"`, same contract as `McpAppCard`) → bridge. A `consent_required` refusal mid-session folds the frame back behind the sheet with a fresh server projection.

## Bridge design choice: extended, not a sibling

`createMcpAppBridge` gains an optional `invokeTool` dependency rather than a parallel app-bridge. The protocol surface is genuinely shared (initialize/ping/size-changed/notifications), and the one behavioral fork is exactly the capability boundary we want explicit: without an invoker — the MCP App transcript card, unchanged — `tools/call` still answers `-32601`; with one, the frame's `{tool, arguments}` forwards to `POST /apps/{id}/invoke` and the result posts back, both directions opaque passthrough (the `McpAppPayload` posture; the invoke request/result stay hand-written TS). A typed refusal keeps its machine-readable kind in JSON-RPC `error.data` — host-authored, so surfacing it is not interpretation.

## Tests

- Server: one lifecycle test — listing projects renderer-safe rows whose `granted` flag flips with consent, detail lists revisions, deletion removes the row and 404s the detail (and no manifest bindings leak into the listing body).
- DOM: one open-flow round trip (granted app → sandboxed frame → frame `tools/call` postMessage → bridge → mocked `invoke` → result posted back), and one consent-gate test (staleness marker renders, body-less consent, frame opens on the fresh verdict).
- Bridge: `tools/call` without an invoker still refuses `-32601`, and wiring an invoker declares `tools/call` and nothing else.
- Grammar: `apps` / `apps.{id}` cases added to the existing panel-URL contract test.

## Doc fix

`docs/local-apps.md` said `create_app` mints identity "the way `create_deliverable` does"; that tool no longer exists after the files-first outputs migration, so the sentence now references the outputs record's identity discipline directly.

## Follow-up

The `create_app` transcript card is the generic Entries card and its `ResultEntry` rows carry no app id (label + "revision N" meta only), so an "Open app" affordance from the card needs the entries vocabulary to carry a target — a general rework of that projection, not a local hook. Left out of this slice deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)