### PR TITLE
feat(code-execution): explicit file staging for managed sandboxes, scoped output/preview pull

### DIFF
--- a/crates/openwave-code-execution/src/daytona.rs
+++ b/crates/openwave-code-execution/src/daytona.rs
@@ -12,13 +12,14 @@ use crate::http::{decode_bounded_json, download_bounded_file, multipart_file};
 use crate::output::{Capture, StreamKind};
 use crate::remote::{
     connect_remote_workspace, create_remote_workspace, destroy_remote_workspace, execute_remote,
-    with_remote_session, RemoteSandboxAdapter, RemoteSession, RemoteSessionError,
-    RemoteSessionPool, RemoteWorkspaceAdapter,
+    stage_remote_file, with_remote_session, RemoteSandboxAdapter, RemoteSession,
+    RemoteSessionError, RemoteSessionPool, RemoteWorkspaceAdapter,
 };
 use crate::{
     CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest,
-    CodeExecutionResponse, ExecutionWorkspaceId, WorkspaceFileEntry, WorkspaceFilePath,
-    WorkspaceLifecycle, WorkspaceListing, MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES,
+    CodeExecutionResponse, ExecutionWorkspaceId, StagedUpload, WorkspaceFileEntry,
+    WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, MAX_WORKSPACE_FILE_BYTES,
+    MAX_WORKSPACE_LIST_ENTRIES,
 };
 
 const DAYTONA_API_BASE: &str = "https://app.daytona.io/api";
@@ -642,6 +643,18 @@ impl WorkspaceLifecycle for DaytonaExecutionProvider {
             |adapter, session| async move { adapter.upload_file(&session, path, content).await },
         )
         .await
+    }
+
+    async fn stage_workspace_file(
+        &self,
+        workspace: &ExecutionWorkspaceId,
+        path: &WorkspaceFilePath,
+        content: &[u8],
+    ) -> Result<StagedUpload, CodeExecutionError> {
+        if content.len() > MAX_WORKSPACE_FILE_BYTES {
+            return Err(CodeExecutionError::WorkspaceFileTooLarge);
+        }
+        stage_remote_file(self, &self.pool, workspace.as_str(), path, content).await
     }
 
     async fn get_workspace_file(

--- a/crates/openwave-code-execution/src/e2b.rs
+++ b/crates/openwave-code-execution/src/e2b.rs
@@ -17,13 +17,14 @@ use crate::http::{decode_bounded_json, download_bounded_file, multipart_file};
 use crate::output::{Capture, StreamKind};
 use crate::remote::{
     connect_remote_workspace, create_remote_workspace, destroy_remote_workspace, execute_remote,
-    with_remote_session, RemoteSandboxAdapter, RemoteSession, RemoteSessionError,
-    RemoteSessionPool, RemoteWorkspaceAdapter,
+    stage_remote_file, with_remote_session, RemoteSandboxAdapter, RemoteSession,
+    RemoteSessionError, RemoteSessionPool, RemoteWorkspaceAdapter,
 };
 use crate::{
     CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest,
-    CodeExecutionResponse, ExecutionWorkspaceId, WorkspaceFileEntry, WorkspaceFilePath,
-    WorkspaceLifecycle, WorkspaceListing, MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES,
+    CodeExecutionResponse, ExecutionWorkspaceId, StagedUpload, WorkspaceFileEntry,
+    WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, MAX_WORKSPACE_FILE_BYTES,
+    MAX_WORKSPACE_LIST_ENTRIES,
 };
 
 const E2B_API_BASE: &str = "https://api.e2b.app";
@@ -547,6 +548,18 @@ impl WorkspaceLifecycle for E2BExecutionProvider {
         .await
     }
 
+    async fn stage_workspace_file(
+        &self,
+        workspace: &ExecutionWorkspaceId,
+        path: &WorkspaceFilePath,
+        content: &[u8],
+    ) -> Result<StagedUpload, CodeExecutionError> {
+        if content.len() > MAX_WORKSPACE_FILE_BYTES {
+            return Err(CodeExecutionError::WorkspaceFileTooLarge);
+        }
+        stage_remote_file(self, &self.pool, workspace.as_str(), path, content).await
+    }
+
     async fn get_workspace_file(
         &self,
         workspace: &ExecutionWorkspaceId,
@@ -1021,6 +1034,7 @@ mod tests {
         connects: AtomicUsize,
         starts: AtomicUsize,
         deletes: AtomicUsize,
+        uploads: AtomicUsize,
         create_body: StdMutex<Option<Value>>,
         start_bodies: StdMutex<Vec<Vec<u8>>>,
         api_keys: StdMutex<Vec<String>>,
@@ -1036,6 +1050,7 @@ mod tests {
                 connects: AtomicUsize::new(0),
                 starts: AtomicUsize::new(0),
                 deletes: AtomicUsize::new(0),
+                uploads: AtomicUsize::new(0),
                 create_body: StdMutex::new(None),
                 start_bodies: StdMutex::new(Vec::new()),
                 api_keys: StdMutex::new(Vec::new()),
@@ -1205,6 +1220,7 @@ mod tests {
     ) -> axum::http::StatusCode {
         assert_eq!(query["username"], "user");
         assert_eq!(header_value(&headers, "x-access-token"), "access-123");
+        state.uploads.fetch_add(1, Ordering::SeqCst);
         let content = multipart_content(&headers, &body);
         state
             .files
@@ -1406,6 +1422,40 @@ mod tests {
         assert!(!provider.connect_workspace(&workspace).await.unwrap());
         provider.destroy_workspace(&workspace).await.unwrap();
         assert_eq!(state.deletes.load(Ordering::SeqCst), 1);
+        server.abort();
+    }
+
+    /// A reused sandbox session skips re-uploading content it already holds,
+    /// re-uploads changed content, and forgets everything once the sandbox is
+    /// destroyed — a successor sandbox must be staged from scratch.
+    #[tokio::test]
+    async fn e2b_staging_skips_content_the_live_sandbox_already_has() {
+        let (provider, state, server) = mock_provider(ProcessMode::Complete, None).await;
+        let workspace = ExecutionWorkspaceId::parse("workspace-stage").unwrap();
+        let path = WorkspaceFilePath::parse("build_deck.py").unwrap();
+
+        let staged = |content: &'static [u8]| {
+            let provider = &provider;
+            let workspace = &workspace;
+            let path = &path;
+            async move {
+                provider
+                    .stage_workspace_file(workspace, path, content)
+                    .await
+                    .unwrap()
+            }
+        };
+
+        assert_eq!(staged(b"v1").await, crate::StagedUpload::Uploaded);
+        assert_eq!(staged(b"v1").await, crate::StagedUpload::AlreadyCurrent);
+        assert_eq!(state.uploads.load(Ordering::SeqCst), 1);
+
+        assert_eq!(staged(b"v2").await, crate::StagedUpload::Uploaded);
+        assert_eq!(state.uploads.load(Ordering::SeqCst), 2);
+
+        provider.destroy_workspace(&workspace).await.unwrap();
+        assert_eq!(staged(b"v2").await, crate::StagedUpload::Uploaded);
+        assert_eq!(state.uploads.load(Ordering::SeqCst), 3);
         server.abort();
     }
 

--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -42,10 +42,11 @@ pub use tool::{ExecTool, EXEC_TOOL_NAME};
 pub use types::{
     CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest,
     CodeExecutionResponse, ExecFolderAccess, ExecFolderGrant, ExecutionId, ExecutionWorkspaceId,
-    OutputArtifactEntry, OutputArtifactScan, OutputArtifactStatus, WorkspaceFileEntry,
-    WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, MAX_ARGUMENTS, MAX_ARGUMENT_BYTES,
-    MAX_CAPTURE_BYTES, MAX_COMMAND_BYTES, MAX_CWD_BYTES, MAX_EXEC_FOLDER_GRANTS,
-    MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES, MAX_WORKSPACE_PATH_BYTES,
+    OutputArtifactEntry, OutputArtifactScan, OutputArtifactStatus, StagedUpload,
+    WorkspaceFileEntry, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, MAX_ARGUMENTS,
+    MAX_ARGUMENT_BYTES, MAX_CAPTURE_BYTES, MAX_COMMAND_BYTES, MAX_CWD_BYTES,
+    MAX_EXEC_FOLDER_GRANTS, MAX_STAGED_PATHS, MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES,
+    MAX_WORKSPACE_PATH_BYTES,
 };
 
 /// Stable workspace-relative location populated by hosts that ship the

--- a/crates/openwave-code-execution/src/remote.rs
+++ b/crates/openwave-code-execution/src/remote.rs
@@ -2,12 +2,13 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use sha2::{Digest as _, Sha256};
 use tokio::sync::Mutex;
 
 use crate::receipt::{request_fingerprint, BeginExecution, ExecutionReceipt};
 use crate::{
     CodeExecutionError, CodeExecutionProviderKind, CodeExecutionRequest, CodeExecutionResponse,
-    WorkspaceFilePath, WorkspaceListing,
+    StagedUpload, WorkspaceFilePath, WorkspaceListing,
 };
 
 /// Shared process-local sessions and idempotency receipts for managed sandboxes.
@@ -20,6 +21,15 @@ pub struct RemoteSessionPool {
 struct PoolState {
     sessions: HashMap<SessionKey, Arc<Mutex<Option<RemoteSession>>>>,
     receipts: HashMap<ReceiptKey, ExecutionReceipt>,
+    /// Content digests of files already staged into each workspace's live
+    /// sandbox, bound to the exact sandbox instance they were uploaded to. A
+    /// recreated sandbox never inherits digests from its predecessor.
+    staged: HashMap<SessionKey, StagedDigests>,
+}
+
+struct StagedDigests {
+    sandbox_id: String,
+    digests: HashMap<String, [u8; 32]>,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -155,6 +165,52 @@ impl RemoteSessionPool {
             .or_insert_with(|| Arc::new(Mutex::new(None)))
             .clone()
     }
+
+    /// Whether the live sandbox `sandbox_id` already holds `path` with exactly
+    /// this content, according to what previous stagings recorded.
+    async fn staged_is_current(
+        &self,
+        key: &SessionKey,
+        sandbox_id: &str,
+        path: &str,
+        digest: &[u8; 32],
+    ) -> bool {
+        let state = self.state.lock().await;
+        state.staged.get(key).is_some_and(|staged| {
+            staged.sandbox_id == sandbox_id && staged.digests.get(path) == Some(digest)
+        })
+    }
+
+    /// Record that `path` with `digest` was just uploaded to `sandbox_id`.
+    /// Digests recorded against a different sandbox instance are discarded:
+    /// their staged state belongs to a sandbox that no longer serves this key.
+    async fn record_staged(
+        &self,
+        key: &SessionKey,
+        sandbox_id: &str,
+        path: String,
+        digest: [u8; 32],
+    ) {
+        let mut state = self.state.lock().await;
+        let staged = state
+            .staged
+            .entry(key.clone())
+            .or_insert_with(|| StagedDigests {
+                sandbox_id: sandbox_id.to_owned(),
+                digests: HashMap::new(),
+            });
+        if staged.sandbox_id != sandbox_id {
+            staged.sandbox_id = sandbox_id.to_owned();
+            staged.digests.clear();
+        }
+        staged.digests.insert(path, digest);
+    }
+
+    /// Forget everything staged for this key. Called when the sandbox is
+    /// destroyed, so a successor sandbox starts from an empty ledger.
+    async fn clear_staged(&self, key: &SessionKey) {
+        self.state.lock().await.staged.remove(key);
+    }
 }
 
 pub(crate) async fn execute_remote(
@@ -222,6 +278,43 @@ where
         }
         Err(RemoteSessionError::Provider(error)) => Err(error),
     }
+}
+
+/// Stage one file into the chat's remote sandbox, skipping the upload when
+/// the pool remembers the live sandbox already holds identical content.
+///
+/// The digest check and the record both happen inside the per-chat session
+/// lock, so the sandbox instance the ledger is bound to is exactly the one the
+/// upload targeted.
+pub(crate) async fn stage_remote_file<A>(
+    adapter: &A,
+    pool: &RemoteSessionPool,
+    workspace_id: &str,
+    path: &WorkspaceFilePath,
+    content: &[u8],
+) -> Result<StagedUpload, CodeExecutionError>
+where
+    A: RemoteWorkspaceAdapter + ?Sized,
+{
+    let key = SessionKey {
+        provider: adapter.kind(),
+        credential: adapter.credential_fingerprint(),
+        workspace_id: workspace_id.to_owned(),
+    };
+    let digest: [u8; 32] = Sha256::digest(content).into();
+    with_remote_session(adapter, pool, workspace_id, |adapter, session| async move {
+        if pool
+            .staged_is_current(&key, &session.sandbox_id, path.as_str(), &digest)
+            .await
+        {
+            return Ok(StagedUpload::AlreadyCurrent);
+        }
+        adapter.upload_file(&session, path, content).await?;
+        pool.record_staged(&key, &session.sandbox_id, path.as_str().to_owned(), digest)
+            .await;
+        Ok(StagedUpload::Uploaded)
+    })
+    .await
 }
 
 async fn connected_session<A>(
@@ -310,6 +403,11 @@ pub(crate) async fn destroy_remote_workspace<A>(
 where
     A: RemoteWorkspaceAdapter + ?Sized,
 {
+    let key = SessionKey {
+        provider: adapter.kind(),
+        credential: adapter.credential_fingerprint(),
+        workspace_id: workspace_id.to_owned(),
+    };
     let slot = pool
         .session(
             adapter.kind(),
@@ -322,7 +420,10 @@ where
         return Ok(());
     };
     match adapter.destroy_sandbox(&session).await {
-        Ok(()) => Ok(()),
+        Ok(()) => {
+            pool.clear_staged(&key).await;
+            Ok(())
+        }
         Err(error) => {
             *slot = Some(session);
             Err(error)

--- a/crates/openwave-code-execution/src/sync.rs
+++ b/crates/openwave-code-execution/src/sync.rs
@@ -1,43 +1,50 @@
-//! Mirror a host directory into a durable workspace and back.
+//! Explicit file staging between host scratch and a managed workspace.
 //!
 //! Remote sandboxes have their own filesystem, but the model is shown one
 //! path vocabulary: the file tools and `exec` both speak private-scratch
-//! relative paths. The host keeps that story true by pushing the chat's
-//! scratch into the workspace before a command runs and pulling the workspace
-//! back afterwards, so a file written by either side is visible to the other.
+//! relative paths. The host keeps that story true by staging exactly the
+//! paths the model listed on the call into the workspace before the command
+//! runs, and by pulling only the `output/` and `preview/` subtrees back
+//! afterwards — the two directories whose contents feed the host-side output
+//! and preview scans.
 //!
-//! The mirror is additive in both directions: a file deleted on one side is
-//! not deleted on the other. Everything a sync leaves behind — oversized
-//! files, dependency trees, truncated listings — is reported in the
-//! [`SyncReport`], never skipped silently.
+//! Staging is loud, never silent: a listed path that does not exist, is a
+//! symlink, or expands past the per-call file bound fails the call with an
+//! error naming the path. Only per-entry conditions discovered *inside* a
+//! listed directory (a dependency tree, a nested symlink, an oversized file)
+//! degrade into notes in the [`SyncReport`], because the entry beside them can
+//! still be staged usefully.
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use crate::host_paths::{
-    resolve_scratch_directory, try_resolve_scratch_directory, ScratchDir, ScratchEntryKind,
-    ScratchRefusal,
+    try_resolve_scratch_directory, ScratchDir, ScratchEntryKind, ScratchRefusal,
 };
 use crate::{
-    CodeExecutionError, ExecutionWorkspaceId, WorkspaceFilePath, WorkspaceLifecycle,
+    CodeExecutionError, ExecutionWorkspaceId, StagedUpload, WorkspaceFilePath, WorkspaceLifecycle,
     MAX_WORKSPACE_FILE_BYTES,
 };
 
-/// The most files one direction of a sync will transfer before stopping and
-/// saying so. A workspace that grows a dependency tree past the skip list
-/// should degrade into a bounded transfer plus a note, not an unbounded copy.
-pub const MAX_SYNC_FILES: usize = 256;
+/// The most files one call's listed paths may expand to. Crossing it fails the
+/// call loudly rather than truncating the staged set: a bounded set the model
+/// chose is useful, a silently incomplete one produces baffling not-found
+/// errors inside the sandbox.
+pub const MAX_STAGED_FILES: usize = 256;
 
-/// The most notes one direction of a sync will carry before collapsing
-/// repeats into a summary line. Notes are rendered into the model-facing tool
-/// result, so a tree full of skipped entries must not push unbounded prose
-/// into the model's context: the first note of each distinct reason is always
-/// kept, and anything past the limit with an already-shown reason becomes a
-/// count.
+/// The workspace subtrees pulled back to host scratch after a command.
+pub const PULLED_DIRS: &[&str] = &["output", "preview"];
+
+/// The most notes one sync direction will carry before collapsing repeats
+/// into a summary line. Notes are rendered into the model-facing tool result,
+/// so a tree full of skipped entries must not push unbounded prose into the
+/// model's context: the first note of each distinct reason is always kept, and
+/// anything past the limit with an already-shown reason becomes a count.
 pub const MAX_SYNC_NOTES: usize = 32;
 
-/// Directory names never mirrored in either direction: version control and
-/// dependency trees that are large, regenerable, and meaningless to copy
-/// between the host and a sandbox.
+/// Directory names never staged or pulled: version control and dependency
+/// trees that are large, regenerable, and meaningless to copy between the host
+/// and a sandbox.
 const SKIPPED_DIRS: &[&str] = &[".git", ".venv", "__pycache__", "node_modules"];
 
 /// What one direction of a sync transferred, and everything it left behind.
@@ -79,61 +86,170 @@ impl SyncReport {
     }
 }
 
-/// Push every eligible file under `host_dir` into the workspace.
+/// One host file a staging pass would upload, pinned to the directory it was
+/// judged in so the entry read is the entry that was checked.
+struct StagedFile {
+    path: WorkspaceFilePath,
+    dir: ScratchDir,
+    name: String,
+}
+
+/// Validate the listed paths without transferring anything: every path must
+/// exist under `host_dir`, none may be or cross a symlink, and the expansion
+/// must stay within [`MAX_STAGED_FILES`].
 ///
-/// A missing `host_dir` pushes nothing: the chat simply has no scratch yet.
+/// The local provider calls this so a bad `files` entry fails identically on
+/// every provider, even though scratch is already its filesystem.
+pub async fn validate_staged_paths(
+    host_dir: &Path,
+    listed: &[WorkspaceFilePath],
+) -> Result<(), CodeExecutionError> {
+    resolve_staged_files(host_dir, listed).await.map(|_| ())
+}
+
+/// Stage exactly the listed paths into the workspace, expanding directories
+/// recursively. Nothing outside the listed set is transferred.
 ///
-/// The walk is descriptor-relative from a pinned root, the same discipline the
-/// pull applies to its writes: directories are opened with symlink following
-/// disabled as they are discovered, and files are read through the directory
-/// they were listed in, so an entry swapped for a symlink between the listing
-/// and the read is refused rather than followed.
-///
-/// Every host-side failure — an unreadable file, a directory the walk cannot
-/// list — is reported against the entry it belongs to and the push continues.
-/// One permission-denied file in an attached folder should cost the agent that
-/// file, not the whole workspace.
-pub async fn push_host_dir(
+/// Unchanged files may be skipped by a backend that remembers its live
+/// session's staged content; the report counts only real transfers.
+pub async fn stage_listed_paths(
     lifecycle: &dyn WorkspaceLifecycle,
     workspace: &ExecutionWorkspaceId,
     host_dir: &Path,
+    listed: &[WorkspaceFilePath],
 ) -> Result<SyncReport, CodeExecutionError> {
-    let mut report = SyncReport::default();
-    let Some(root) = resolve_scratch_directory(host_dir, "", false).await else {
-        return Ok(report);
-    };
-    let mut stack: Vec<(ScratchDir, String)> = vec![(root, String::new())];
-    let mut files: Vec<(WorkspaceFilePath, ScratchDir, String)> = Vec::new();
-    while let Some((dir, prefix)) = stack.pop() {
-        let listed = if prefix.is_empty() {
-            "the private scratch root".to_owned()
-        } else {
-            format!("{prefix}/")
+    let (files, mut report) = resolve_staged_files(host_dir, listed).await?;
+    for staged in files {
+        let content = match staged.dir.read_file(&staged.name).await {
+            Ok(content) => content,
+            Err(error) => {
+                tracing::debug!(
+                    "staged file '{}' could not be read: {error}",
+                    staged.path.as_str()
+                );
+                report.skip(
+                    "could not be read from the host",
+                    format!(
+                        "not staged: {} could not be read from the host ({error})",
+                        staged.path.as_str()
+                    ),
+                );
+                continue;
+            }
         };
+        match lifecycle
+            .stage_workspace_file(workspace, &staged.path, &content)
+            .await
+        {
+            Ok(StagedUpload::Uploaded) => report.transferred += 1,
+            Ok(StagedUpload::AlreadyCurrent) => {}
+            Err(error) if aborts_the_sync(&error) => return Err(error),
+            Err(error) => {
+                tracing::warn!(
+                    "staged file '{}' was rejected by the workspace: {error}",
+                    staged.path.as_str()
+                );
+                report.skip(
+                    "rejected by the workspace",
+                    format!(
+                        "not staged: {} was rejected by the workspace ({error})",
+                        staged.path.as_str()
+                    ),
+                );
+            }
+        }
+    }
+    Ok(report.finish("staged"))
+}
+
+/// Resolve the listed paths into the concrete files a staging would upload.
+///
+/// Failures on the listed paths themselves are errors that name the path;
+/// conditions inside an expanded directory become notes.
+async fn resolve_staged_files(
+    host_dir: &Path,
+    listed: &[WorkspaceFilePath],
+) -> Result<(Vec<StagedFile>, SyncReport), CodeExecutionError> {
+    let mut report = SyncReport::default();
+    let mut files: Vec<StagedFile> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for path in listed {
+        let (parent_rel, name) = path
+            .as_str()
+            .rsplit_once('/')
+            .map_or(("", path.as_str()), |(parent, name)| (parent, name));
+        let parent = try_resolve_scratch_directory(host_dir, parent_rel, false)
+            .await
+            .map_err(|refusal| listed_path_error(path, refusal))?;
+        if parent.is_symlink(name).await {
+            return Err(CodeExecutionError::InvalidRequest(format!(
+                "staged path '{}' is a symlink; symlinks are never staged",
+                path.as_str()
+            )));
+        }
+        if let Ok(dir) = parent.open_dir(name).await {
+            expand_directory(dir, path, &mut files, &mut seen, &mut report).await?;
+        } else {
+            let Some(stamp) = parent.file_stamp(name).await else {
+                return Err(CodeExecutionError::InvalidRequest(format!(
+                    "staged path '{}' does not exist in the chat's files",
+                    path.as_str()
+                )));
+            };
+            if stamp.len > MAX_WORKSPACE_FILE_BYTES as u64 {
+                return Err(CodeExecutionError::InvalidRequest(format!(
+                    "staged path '{}' exceeds the {MAX_WORKSPACE_FILE_BYTES}-byte file limit",
+                    path.as_str()
+                )));
+            }
+            if seen.insert(path.as_str().to_owned()) {
+                files.push(StagedFile {
+                    path: path.clone(),
+                    dir: parent,
+                    name: name.to_owned(),
+                });
+            }
+        }
+        if files.len() > MAX_STAGED_FILES {
+            return Err(staging_bound_error(path, files.len()));
+        }
+    }
+    Ok((files, report))
+}
+
+/// Walk one listed directory, collecting its stageable files.
+///
+/// Crossing [`MAX_STAGED_FILES`] mid-walk fails immediately — continuing would
+/// only enumerate a tree the call has already refused to transfer.
+async fn expand_directory(
+    root: ScratchDir,
+    listed: &WorkspaceFilePath,
+    files: &mut Vec<StagedFile>,
+    seen: &mut HashSet<String>,
+    report: &mut SyncReport,
+) -> Result<(), CodeExecutionError> {
+    let mut stack: Vec<(ScratchDir, String)> = vec![(root, listed.as_str().to_owned())];
+    while let Some((dir, prefix)) = stack.pop() {
         let entries = match dir.entries().await {
             Ok(entries) => entries,
             Err(error) => {
-                tracing::warn!("private scratch directory '{listed}' could not be listed: {error}");
+                tracing::warn!("staged directory '{prefix}/' could not be listed: {error}");
                 report.skip(
                     "could not be listed",
-                    format!("not pushed: {listed} could not be listed ({error})"),
+                    format!("not staged: {prefix}/ could not be listed ({error})"),
                 );
                 continue;
             }
         };
         for entry in entries {
             let name = entry.name;
-            let relative = if prefix.is_empty() {
-                name.clone()
-            } else {
-                format!("{prefix}/{name}")
-            };
+            let relative = format!("{prefix}/{name}");
             match entry.kind {
                 ScratchEntryKind::Directory => {
                     if SKIPPED_DIRS.contains(&name.as_str()) {
                         report.skip(
                             "dependency or VCS tree",
-                            format!("not pushed: {relative}/ (dependency or VCS tree)"),
+                            format!("not staged: {relative}/ (dependency or VCS tree)"),
                         );
                         continue;
                     }
@@ -144,23 +260,20 @@ pub async fn push_host_dir(
                         Ok(child) => stack.push((child, relative)),
                         Err(error) => {
                             tracing::warn!(
-                                "private scratch directory '{relative}/' could not be entered: {error}"
+                                "staged directory '{relative}/' could not be entered: {error}"
                             );
                             report.skip(
                                 "could not be listed",
-                                format!("not pushed: {relative}/ could not be listed ({error})"),
+                                format!("not staged: {relative}/ could not be listed ({error})"),
                             );
                         }
                     }
                 }
                 ScratchEntryKind::File => {
                     let Some(stamp) = dir.file_stamp(&name).await else {
-                        tracing::debug!(
-                            "private scratch entry '{relative}' vanished or is unreadable"
-                        );
                         report.skip(
                             "could not be inspected",
-                            format!("not pushed: {relative} could not be inspected"),
+                            format!("not staged: {relative} could not be inspected"),
                         );
                         continue;
                     };
@@ -168,7 +281,7 @@ pub async fn push_host_dir(
                         report.skip(
                             "exceeds the file limit",
                             format!(
-                                "not pushed: {relative} exceeds the {MAX_WORKSPACE_FILE_BYTES}-byte file limit"
+                                "not staged: {relative} exceeds the {MAX_WORKSPACE_FILE_BYTES}-byte file limit"
                             ),
                         );
                         continue;
@@ -176,11 +289,20 @@ pub async fn push_host_dir(
                     let Ok(path) = WorkspaceFilePath::parse(&relative) else {
                         report.skip(
                             "not a valid workspace path",
-                            format!("not pushed: {relative} is not a valid workspace path"),
+                            format!("not staged: {relative} is not a valid workspace path"),
                         );
                         continue;
                     };
-                    files.push((path, dir.clone(), name));
+                    if seen.insert(path.as_str().to_owned()) {
+                        files.push(StagedFile {
+                            path,
+                            dir: dir.clone(),
+                            name,
+                        });
+                    }
+                    if files.len() > MAX_STAGED_FILES {
+                        return Err(staging_bound_error(listed, files.len()));
+                    }
                 }
                 // The symlink question only decides which note to write;
                 // nothing here traverses the entry either way.
@@ -188,86 +310,65 @@ pub async fn push_host_dir(
                     if dir.is_symlink(&name).await {
                         report.skip(
                             "is a symlink",
-                            format!("not pushed: {relative} is a symlink"),
+                            format!("not staged: {relative} is a symlink"),
                         );
                     }
                 }
             }
         }
     }
-    files.sort_by(|a, b| a.0.as_str().cmp(b.0.as_str()));
-    let overflow = files.len().saturating_sub(MAX_SYNC_FILES);
-    if overflow > 0 {
-        report.skip(
-            "beyond the file sync limit",
-            format!(
-                "not pushed: {overflow} more file(s) beyond the {MAX_SYNC_FILES}-file sync limit"
-            ),
-        );
-    }
-    for (path, dir, name) in files.into_iter().take(MAX_SYNC_FILES) {
-        let content = match dir.read_file(&name).await {
-            Ok(content) => content,
-            Err(error) => {
-                tracing::debug!(
-                    "private scratch file '{}' could not be read: {error}",
-                    path.as_str()
-                );
-                report.skip(
-                    "could not be read from the host",
-                    format!(
-                        "not pushed: {} could not be read from the host ({error})",
-                        path.as_str()
-                    ),
-                );
-                continue;
-            }
-        };
-        match lifecycle
-            .put_workspace_file(workspace, &path, &content)
-            .await
-        {
-            Ok(()) => report.transferred += 1,
-            Err(error) if aborts_the_sync(&error) => return Err(error),
-            Err(error) => {
-                tracing::warn!(
-                    "private scratch file '{}' was rejected by the workspace: {error}",
-                    path.as_str()
-                );
-                report.skip(
-                    "rejected by the workspace",
-                    format!(
-                        "not pushed: {} was rejected by the workspace ({error})",
-                        path.as_str()
-                    ),
-                );
-            }
-        }
-    }
-    Ok(report.finish("pushed"))
+    Ok(())
 }
 
-/// Pull every eligible workspace file into `host_dir`, writing only files
-/// whose content actually differs from the host copy.
-pub async fn pull_into_host_dir(
+fn staging_bound_error(listed: &WorkspaceFilePath, count: usize) -> CodeExecutionError {
+    CodeExecutionError::InvalidRequest(format!(
+        "staging '{}' expands the staged set past the {MAX_STAGED_FILES}-file bound \
+         ({count}+ files); list fewer or more specific paths",
+        listed.as_str()
+    ))
+}
+
+fn listed_path_error(path: &WorkspaceFilePath, refusal: ScratchRefusal) -> CodeExecutionError {
+    let reason = match refusal {
+        ScratchRefusal::Escape => "escapes the chat's files",
+        ScratchRefusal::SymlinkedComponent => "crosses a symlink",
+        ScratchRefusal::NotADirectory | ScratchRefusal::Unavailable => {
+            "does not exist in the chat's files"
+        }
+    };
+    CodeExecutionError::InvalidRequest(format!("staged path '{}' {reason}", path.as_str()))
+}
+
+/// Pull the `output/` and `preview/` subtrees back into `host_dir`, writing
+/// only files whose content actually differs from the host copy. Nothing
+/// outside those two directories is read back: intermediates the command
+/// created stay in the sandbox for later commands in the same session.
+pub async fn pull_result_dirs(
     lifecycle: &dyn WorkspaceLifecycle,
     workspace: &ExecutionWorkspaceId,
     host_dir: &Path,
 ) -> Result<SyncReport, CodeExecutionError> {
     let mut report = SyncReport::default();
-    let mut stack: Vec<Option<WorkspaceFilePath>> = vec![None];
+    let mut stack: Vec<WorkspaceFilePath> = PULLED_DIRS
+        .iter()
+        .filter_map(|root| WorkspaceFilePath::parse(*root).ok())
+        .collect();
     let mut files: Vec<WorkspaceFilePath> = Vec::new();
     while let Some(dir) = stack.pop() {
-        let listing = lifecycle
-            .list_workspace_files(workspace, dir.as_ref())
-            .await?;
+        let listing = match lifecycle.list_workspace_files(workspace, Some(&dir)).await {
+            Ok(listing) => listing,
+            // A workspace with no output/ or preview/ yet has nothing to pull;
+            // a directory that vanished mid-walk means the same.
+            Err(CodeExecutionError::WorkspaceFileNotFound) => continue,
+            Err(error) => return Err(error),
+        };
         if listing.truncated {
-            let shown = dir
-                .as_ref()
-                .map_or("the workspace root", WorkspaceFilePath::as_str);
             report.skip(
                 "listing was truncated",
-                format!("not fully pulled: the listing of {shown} was truncated"),
+                format!(
+                    "not fully pulled: the listing of {} was truncated",
+                    dir.as_str()
+                ),
             );
         }
         for entry in listing.entries {
@@ -281,6 +382,22 @@ pub async fn pull_into_host_dir(
                 );
                 continue;
             };
+            // Scope, not just containment: only output/ and preview/ come
+            // back, even if the backend lists something else.
+            if !PULLED_DIRS.iter().any(|root| {
+                path.as_str()
+                    .strip_prefix(root)
+                    .is_some_and(|rest| rest.starts_with('/'))
+            }) {
+                report.skip(
+                    "outside the pulled directories",
+                    format!(
+                        "not pulled: {} is outside output/ and preview/",
+                        path.as_str()
+                    ),
+                );
+                continue;
+            }
             if entry.directory {
                 if SKIPPED_DIRS.contains(&path.file_name()) {
                     report.skip(
@@ -288,7 +405,7 @@ pub async fn pull_into_host_dir(
                         format!("not pulled: {}/ (dependency or VCS tree)", path.as_str()),
                     );
                 } else {
-                    stack.push(Some(path));
+                    stack.push(path);
                 }
                 continue;
             }
@@ -309,16 +426,16 @@ pub async fn pull_into_host_dir(
         }
     }
     files.sort_by(|a, b| a.as_str().cmp(b.as_str()));
-    let overflow = files.len().saturating_sub(MAX_SYNC_FILES);
+    let overflow = files.len().saturating_sub(MAX_STAGED_FILES);
     if overflow > 0 {
         report.skip(
             "beyond the file sync limit",
             format!(
-                "not pulled: {overflow} more file(s) beyond the {MAX_SYNC_FILES}-file sync limit"
+                "not pulled: {overflow} more file(s) beyond the {MAX_STAGED_FILES}-file sync limit"
             ),
         );
     }
-    let files: Vec<WorkspaceFilePath> = files.into_iter().take(MAX_SYNC_FILES).collect();
+    let files: Vec<WorkspaceFilePath> = files.into_iter().take(MAX_STAGED_FILES).collect();
     if files.is_empty() {
         return Ok(report.finish("pulled"));
     }
@@ -388,10 +505,10 @@ pub async fn pull_into_host_dir(
 /// directories.
 ///
 /// Local exec is confined to this same scratch tree, so it can plant
-/// `<scratch>/out -> ~/.ssh` and wait for a pull: `create_dir_all` and a plain
-/// `write` both follow a symlinked *parent*, and the pull's host write is not
-/// sandboxed. Handing back a descriptor rather than a path also closes the
-/// window between the walk and the write, which a process still running in
+/// `<scratch>/output -> ~/.ssh` and wait for a pull: `create_dir_all` and a
+/// plain `write` both follow a symlinked *parent*, and the pull's host write
+/// is not sandboxed. Handing back a descriptor rather than a path also closes
+/// the window between the walk and the write, which a process still running in
 /// scratch could otherwise use to swap the verified directory for a symlink.
 async fn host_parent_dir(
     host_dir: &Path,
@@ -430,12 +547,12 @@ fn refuse(report: &mut SyncReport, path: &WorkspaceFilePath, refusal: ScratchRef
 /// Whether one file's provider-side failure should end the whole sync.
 ///
 /// A file that is missing, oversized, or rejected on its own merits is this
-/// file's problem: the sync reports it and keeps going, which is what the
-/// module promises. A provider that is unreachable or misconfigured is every
-/// remaining file's problem too, and degrading it into a few hundred identical
-/// notes would hide a real failure from the caller.
+/// file's problem: the sync reports it and keeps going. A provider that is
+/// unreachable or misconfigured is every remaining file's problem too, and
+/// degrading it into a few hundred identical notes would hide a real failure
+/// from the caller.
 ///
-/// Only provider-side errors reach here. The push's other failures are
+/// Only provider-side errors reach here. The staging's other failures are
 /// host-side — an unreadable file, a directory that vanished mid-walk — and
 /// those are per-entry by nature: the next entry has every chance of
 /// succeeding, so none of them are ever fatal.
@@ -474,7 +591,8 @@ mod tests {
     #[derive(Default)]
     struct FakeWorkspace {
         files: Mutex<BTreeMap<String, Vec<u8>>>,
-        /// Extra listing rows returned verbatim, for hostile-backend cases.
+        /// Extra rows returned verbatim from the `output/` listing, for
+        /// hostile-backend cases.
         planted: Mutex<Vec<WorkspaceFileEntry>>,
     }
 
@@ -564,7 +682,7 @@ mod tests {
                     }
                 }
             }
-            if path.is_none() {
+            if path.map(WorkspaceFilePath::as_str) == Some("output") {
                 entries.extend(self.planted.lock().unwrap().drain(..));
             }
             Ok(WorkspaceListing {
@@ -578,76 +696,262 @@ mod tests {
         ExecutionWorkspaceId::parse("chat-1".to_owned()).unwrap()
     }
 
+    fn paths(listed: &[&str]) -> Vec<WorkspaceFilePath> {
+        listed
+            .iter()
+            .map(|path| WorkspaceFilePath::parse(*path).unwrap())
+            .collect()
+    }
+
     #[tokio::test]
-    async fn round_trips_host_scratch_through_the_workspace() {
+    async fn stages_exactly_the_listed_paths_and_expands_directories() {
         let host = tempfile::tempdir().unwrap();
-        std::fs::write(host.path().join("a.txt"), "host a").unwrap();
-        std::fs::create_dir_all(host.path().join("sub")).unwrap();
-        std::fs::write(host.path().join("sub/b.txt"), "host b").unwrap();
-        std::fs::create_dir_all(host.path().join(".git")).unwrap();
-        std::fs::write(host.path().join(".git/config"), "never").unwrap();
+        std::fs::write(host.path().join("a.txt"), "listed file").unwrap();
+        std::fs::write(host.path().join("junk.txt"), "never listed").unwrap();
+        std::fs::create_dir_all(host.path().join("sub/nested")).unwrap();
+        std::fs::write(host.path().join("sub/b.txt"), "in listed dir").unwrap();
+        std::fs::write(host.path().join("sub/nested/c.txt"), "nested").unwrap();
+        std::fs::create_dir_all(host.path().join("sub/node_modules")).unwrap();
+        std::fs::write(host.path().join("sub/node_modules/dep.js"), "never").unwrap();
 
         let fake = FakeWorkspace::default();
-        let pushed = push_host_dir(&fake, &workspace_id(), host.path())
-            .await
-            .unwrap();
-        assert_eq!(pushed.transferred, 2);
-        assert_eq!(fake.get("a.txt").unwrap(), b"host a");
-        assert_eq!(fake.get("sub/b.txt").unwrap(), b"host b");
-        assert!(fake.get(".git/config").is_none());
-        assert_eq!(
-            pushed.notes,
-            vec!["not pushed: .git/ (dependency or VCS tree)"]
-        );
+        let report = stage_listed_paths(
+            &fake,
+            &workspace_id(),
+            host.path(),
+            &paths(&["a.txt", "sub"]),
+        )
+        .await
+        .unwrap();
 
-        // The sandbox edits one file and creates another; the pull mirrors
-        // both back and leaves the unchanged file alone.
-        fake.insert("a.txt", b"sandbox a");
-        fake.insert("out/c.txt", b"sandbox c");
-        let pulled = pull_into_host_dir(&fake, &workspace_id(), host.path())
-            .await
-            .unwrap();
-        assert_eq!(pulled.transferred, 2, "{:?}", pulled.notes);
+        assert_eq!(report.transferred, 3, "{:?}", report.notes);
+        assert_eq!(fake.get("a.txt").unwrap(), b"listed file");
+        assert_eq!(fake.get("sub/b.txt").unwrap(), b"in listed dir");
+        assert_eq!(fake.get("sub/nested/c.txt").unwrap(), b"nested");
+        assert!(fake.get("junk.txt").is_none(), "unlisted files never move");
+        assert!(fake.get("sub/node_modules/dep.js").is_none());
         assert_eq!(
-            std::fs::read(host.path().join("a.txt")).unwrap(),
-            b"sandbox a"
-        );
-        assert_eq!(
-            std::fs::read(host.path().join("out/c.txt")).unwrap(),
-            b"sandbox c"
-        );
-        assert_eq!(
-            std::fs::read(host.path().join("sub/b.txt")).unwrap(),
-            b"host b"
+            report.notes,
+            vec!["not staged: sub/node_modules/ (dependency or VCS tree)"]
         );
     }
 
     #[tokio::test]
-    async fn pull_rejects_paths_that_escape_the_host_directory() {
+    async fn a_missing_listed_path_fails_naming_it() {
+        let host = tempfile::tempdir().unwrap();
+        std::fs::write(host.path().join("present.txt"), "here").unwrap();
+        let fake = FakeWorkspace::default();
+
+        let error = stage_listed_paths(
+            &fake,
+            &workspace_id(),
+            host.path(),
+            &paths(&["present.txt", "build_deck.py"]),
+        )
+        .await
+        .unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("build_deck.py"), "{message}");
+        assert!(message.contains("does not exist"), "{message}");
+        // The same contract holds for the validation-only entry point the
+        // local provider uses.
+        let local = validate_staged_paths(host.path(), &paths(&["build_deck.py"]))
+            .await
+            .unwrap_err();
+        assert!(local.to_string().contains("build_deck.py"));
+    }
+
+    #[tokio::test]
+    async fn expansion_past_the_bound_fails_naming_the_listed_path() {
+        let host = tempfile::tempdir().unwrap();
+        let cache = host.path().join("cache");
+        std::fs::create_dir_all(&cache).unwrap();
+        for index in 0..=MAX_STAGED_FILES {
+            std::fs::write(cache.join(format!("f{index:04}")), "x").unwrap();
+        }
+        let fake = FakeWorkspace::default();
+
+        let error = stage_listed_paths(&fake, &workspace_id(), host.path(), &paths(&["cache"]))
+            .await
+            .unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("'cache'"), "{message}");
+        assert!(message.contains(&MAX_STAGED_FILES.to_string()), "{message}");
+        // Loud means loud: nothing was uploaded from a refused staging.
+        assert!(fake.files.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn an_oversized_listed_file_fails_and_an_oversized_nested_file_is_noted() {
+        let host = tempfile::tempdir().unwrap();
+        let oversized = std::fs::File::create(host.path().join("big.bin")).unwrap();
+        oversized
+            .set_len(MAX_WORKSPACE_FILE_BYTES as u64 + 1)
+            .unwrap();
+        std::fs::create_dir_all(host.path().join("data")).unwrap();
+        std::fs::write(host.path().join("data/ok.txt"), "fits").unwrap();
+        let nested = std::fs::File::create(host.path().join("data/huge.bin")).unwrap();
+        nested.set_len(MAX_WORKSPACE_FILE_BYTES as u64 + 1).unwrap();
+        let fake = FakeWorkspace::default();
+
+        let error = stage_listed_paths(&fake, &workspace_id(), host.path(), &paths(&["big.bin"]))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("big.bin"), "{error}");
+
+        let report = stage_listed_paths(&fake, &workspace_id(), host.path(), &paths(&["data"]))
+            .await
+            .unwrap();
+        assert_eq!(report.transferred, 1, "{:?}", report.notes);
+        assert_eq!(fake.get("data/ok.txt").unwrap(), b"fits");
+        assert!(fake.get("data/huge.bin").is_none());
+        assert!(report
+            .notes
+            .iter()
+            .any(|note| note.contains("data/huge.bin") && note.contains("file limit")));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_listed_symlink_fails_and_a_nested_symlink_is_noted() {
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret"), b"host secret").unwrap();
+        let host = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(outside.path().join("secret"), host.path().join("link"))
+            .unwrap();
+        std::fs::create_dir_all(host.path().join("data")).unwrap();
+        std::fs::write(host.path().join("data/real.txt"), "real").unwrap();
+        std::os::unix::fs::symlink(outside.path().join("secret"), host.path().join("data/link"))
+            .unwrap();
+        let fake = FakeWorkspace::default();
+
+        let error = stage_listed_paths(&fake, &workspace_id(), host.path(), &paths(&["link"]))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("'link'"), "{error}");
+        assert!(error.to_string().contains("symlink"), "{error}");
+
+        // A listed path that reaches through a symlinked directory fails too.
+        std::os::unix::fs::symlink(outside.path(), host.path().join("dir-link")).unwrap();
+        let error = stage_listed_paths(
+            &fake,
+            &workspace_id(),
+            host.path(),
+            &paths(&["dir-link/secret"]),
+        )
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains("dir-link/secret"), "{error}");
+
+        let report = stage_listed_paths(&fake, &workspace_id(), host.path(), &paths(&["data"]))
+            .await
+            .unwrap();
+        assert_eq!(report.transferred, 1, "{:?}", report.notes);
+        assert!(fake.get("data/link").is_none());
+        assert!(report
+            .notes
+            .iter()
+            .any(|note| note.contains("data/link") && note.contains("is a symlink")));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn staging_notes_an_unreadable_nested_file_and_keeps_going() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let host = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(host.path().join("docs")).unwrap();
+        std::fs::write(host.path().join("docs/readable.txt"), b"attached brief").unwrap();
+        let denied = host.path().join("docs/denied.txt");
+        std::fs::write(&denied, b"secret").unwrap();
+        std::fs::set_permissions(&denied, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let fake = FakeWorkspace::default();
+
+        let report = stage_listed_paths(&fake, &workspace_id(), host.path(), &paths(&["docs"]))
+            .await
+            .unwrap();
+
+        assert_eq!(report.transferred, 1, "{:?}", report.notes);
+        assert_eq!(fake.get("docs/readable.txt").unwrap(), b"attached brief");
+        assert!(fake.get("docs/denied.txt").is_none());
+        assert!(report
+            .notes
+            .iter()
+            .any(|note| note.contains("denied.txt") && note.contains("could not be read")));
+    }
+
+    #[tokio::test]
+    async fn pull_touches_only_output_and_preview() {
+        let host = tempfile::tempdir().unwrap();
+        let fake = FakeWorkspace::default();
+        fake.insert("output/report.csv", b"rows");
+        fake.insert("output/sub/extra.txt", b"nested output");
+        fake.insert("preview/overview.png", b"pixels");
+        fake.insert("scratch-root.txt", b"intermediate");
+        fake.insert("work/data.bin", b"intermediate");
+
+        let pulled = pull_result_dirs(&fake, &workspace_id(), host.path())
+            .await
+            .unwrap();
+
+        assert_eq!(pulled.transferred, 3, "{:?}", pulled.notes);
+        assert_eq!(
+            std::fs::read(host.path().join("output/report.csv")).unwrap(),
+            b"rows"
+        );
+        assert_eq!(
+            std::fs::read(host.path().join("output/sub/extra.txt")).unwrap(),
+            b"nested output"
+        );
+        assert_eq!(
+            std::fs::read(host.path().join("preview/overview.png")).unwrap(),
+            b"pixels"
+        );
+        assert!(!host.path().join("scratch-root.txt").exists());
+        assert!(!host.path().join("work").exists());
+        // Unchanged content is not rewritten on a second pull.
+        let again = pull_result_dirs(&fake, &workspace_id(), host.path())
+            .await
+            .unwrap();
+        assert_eq!(again.transferred, 0, "{:?}", again.notes);
+    }
+
+    #[tokio::test]
+    async fn pull_rejects_listing_rows_that_escape_or_leave_the_pulled_scope() {
         let parent = tempfile::tempdir().unwrap();
         let host = parent.path().join("scratch");
         std::fs::create_dir_all(&host).unwrap();
 
         let fake = FakeWorkspace::default();
+        fake.insert("secrets.txt", b"root file the backend should not offer");
         fake.planted.lock().unwrap().push(WorkspaceFileEntry {
             path: "../escape.txt".into(),
             directory: false,
             size_bytes: Some(4),
         });
         fake.planted.lock().unwrap().push(WorkspaceFileEntry {
-            path: "big.bin".into(),
+            path: "secrets.txt".into(),
+            directory: false,
+            size_bytes: Some(4),
+        });
+        fake.planted.lock().unwrap().push(WorkspaceFileEntry {
+            path: "output/big.bin".into(),
             directory: false,
             size_bytes: Some(MAX_WORKSPACE_FILE_BYTES as u64 + 1),
         });
 
-        let pulled = pull_into_host_dir(&fake, &workspace_id(), &host)
+        let pulled = pull_result_dirs(&fake, &workspace_id(), &host)
             .await
             .unwrap();
         assert_eq!(pulled.transferred, 0);
         assert!(!parent.path().join("escape.txt").exists());
-        assert_eq!(pulled.notes.len(), 2, "{:?}", pulled.notes);
+        assert!(!host.join("secrets.txt").exists());
+        assert_eq!(pulled.notes.len(), 3, "{:?}", pulled.notes);
         assert!(pulled.notes[0].contains("not a valid workspace path"));
-        assert!(pulled.notes[1].contains("file limit"));
+        assert!(pulled.notes[1].contains("outside output/ and preview/"));
+        assert!(pulled.notes[2].contains("file limit"));
     }
 
     #[cfg(unix)]
@@ -658,12 +962,12 @@ mod tests {
         let host = tempfile::tempdir().unwrap();
         // Local exec is confined to the scratch directory but can create
         // entries in it, including a symlink aimed at a host directory.
-        std::os::unix::fs::symlink(outside.path(), host.path().join("out")).unwrap();
+        std::os::unix::fs::symlink(outside.path(), host.path().join("output")).unwrap();
 
         let fake = FakeWorkspace::default();
-        fake.insert("out/authorized_keys", b"attacker key");
+        fake.insert("output/authorized_keys", b"attacker key");
 
-        let pulled = pull_into_host_dir(&fake, &workspace_id(), host.path())
+        let pulled = pull_result_dirs(&fake, &workspace_id(), host.path())
             .await
             .unwrap();
 
@@ -673,7 +977,7 @@ mod tests {
             b"host secret"
         );
         assert!(pulled.notes.iter().any(|note| {
-            note.contains("out/authorized_keys") && note.contains("symlinked parent directory")
+            note.contains("output/authorized_keys") && note.contains("symlinked parent directory")
         }));
     }
 
@@ -686,79 +990,54 @@ mod tests {
         // nothing: the planted entry would never be surfaced.
         std::fs::write(outside.path().join("config"), b"same bytes").unwrap();
         let host = tempfile::tempdir().unwrap();
-        std::os::unix::fs::symlink(outside.path().join("config"), host.path().join("config"))
-            .unwrap();
+        std::fs::create_dir_all(host.path().join("output")).unwrap();
+        std::os::unix::fs::symlink(
+            outside.path().join("config"),
+            host.path().join("output/config"),
+        )
+        .unwrap();
 
         let fake = FakeWorkspace::default();
-        fake.insert("config", b"same bytes");
+        fake.insert("output/config", b"same bytes");
 
-        let pulled = pull_into_host_dir(&fake, &workspace_id(), host.path())
+        let pulled = pull_result_dirs(&fake, &workspace_id(), host.path())
             .await
             .unwrap();
 
         assert_eq!(pulled.transferred, 0, "{:?}", pulled.notes);
-        assert!(pulled
-            .notes
-            .iter()
-            .any(|note| { note.contains("config") && note.contains("is a symlink on the host") }));
+        assert!(pulled.notes.iter().any(|note| {
+            note.contains("output/config") && note.contains("is a symlink on the host")
+        }));
         assert_eq!(
             std::fs::read(outside.path().join("config")).unwrap(),
             b"same bytes"
         );
-        assert!(std::fs::symlink_metadata(host.path().join("config"))
+        assert!(std::fs::symlink_metadata(host.path().join("output/config"))
             .unwrap()
             .file_type()
             .is_symlink());
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn push_reports_a_symlink_and_never_pushes_its_target() {
-        let outside = tempfile::tempdir().unwrap();
-        std::fs::write(outside.path().join("secret"), b"host secret").unwrap();
-        let host = tempfile::tempdir().unwrap();
-        std::os::unix::fs::symlink(outside.path().join("secret"), host.path().join("link"))
-            .unwrap();
-        std::os::unix::fs::symlink(outside.path(), host.path().join("dir-link")).unwrap();
-
-        let fake = FakeWorkspace::default();
-        let pushed = push_host_dir(&fake, &workspace_id(), host.path())
-            .await
-            .unwrap();
-
-        assert_eq!(pushed.transferred, 0, "{:?}", pushed.notes);
-        assert!(fake.get("link").is_none());
-        assert!(fake.get("dir-link/secret").is_none());
-        assert!(pushed
-            .notes
-            .iter()
-            .any(|note| note.contains("link") && note.contains("is a symlink")));
-        assert!(pushed
-            .notes
-            .iter()
-            .any(|note| note.contains("dir-link") && note.contains("is a symlink")));
     }
 
     #[tokio::test]
     async fn pull_reports_an_unreadable_file_and_keeps_going() {
         let host = tempfile::tempdir().unwrap();
         let fake = FakeWorkspace::default();
-        fake.insert("kept.txt", b"sandbox output");
+        fake.insert("output/kept.txt", b"sandbox output");
         // A backend that omits the size passes the oversize filter and can
         // still refuse the download; older E2B envd and Daytona both do.
         fake.planted.lock().unwrap().push(WorkspaceFileEntry {
-            path: "huge.bin".into(),
+            path: "output/huge.bin".into(),
             directory: false,
             size_bytes: None,
         });
 
-        let pulled = pull_into_host_dir(&fake, &workspace_id(), host.path())
+        let pulled = pull_result_dirs(&fake, &workspace_id(), host.path())
             .await
             .unwrap();
 
         assert_eq!(pulled.transferred, 1, "{:?}", pulled.notes);
         assert_eq!(
-            std::fs::read(host.path().join("kept.txt")).unwrap(),
+            std::fs::read(host.path().join("output/kept.txt")).unwrap(),
             b"sandbox output"
         );
         assert!(pulled
@@ -768,85 +1047,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn preview_files_are_mirrored_and_keep_the_per_file_cap() {
-        let host = tempfile::tempdir().unwrap();
-        let fake = FakeWorkspace::default();
-        fake.insert("preview/overview.png", b"pixels");
-        fake.planted.lock().unwrap().push(WorkspaceFileEntry {
-            path: "preview/too-large.png".into(),
-            directory: false,
-            size_bytes: Some(MAX_WORKSPACE_FILE_BYTES as u64 + 1),
-        });
-
-        let pulled = pull_into_host_dir(&fake, &workspace_id(), host.path())
-            .await
-            .unwrap();
-
-        assert_eq!(
-            std::fs::read(host.path().join("preview/overview.png")).unwrap(),
-            b"pixels"
-        );
-        assert_eq!(pulled.transferred, 1);
-        assert!(pulled
-            .notes
-            .iter()
-            .any(|note| { note.contains("preview/too-large.png") && note.contains("file limit") }));
-    }
-
-    #[tokio::test]
-    async fn attached_documents_are_pushed_with_the_per_file_cap() {
-        let host = tempfile::tempdir().unwrap();
-        let documents = host.path().join("documents");
-        std::fs::create_dir_all(&documents).unwrap();
-        std::fs::write(documents.join("brief.pdf"), b"pdf bytes").unwrap();
-        let oversized = std::fs::File::create(documents.join("oversized.pdf")).unwrap();
-        oversized
-            .set_len(MAX_WORKSPACE_FILE_BYTES as u64 + 1)
-            .unwrap();
-        let fake = FakeWorkspace::default();
-
-        let pushed = push_host_dir(&fake, &workspace_id(), host.path())
-            .await
-            .unwrap();
-
-        assert_eq!(fake.get("documents/brief.pdf").unwrap(), b"pdf bytes");
-        assert!(fake.get("documents/oversized.pdf").is_none());
-        assert_eq!(pushed.transferred, 1);
-        assert!(pushed.notes.iter().any(|note| {
-            note.contains("documents/oversized.pdf") && note.contains("file limit")
-        }));
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn push_reports_an_unreadable_file_and_keeps_going() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let host = tempfile::tempdir().unwrap();
-        std::fs::write(host.path().join("readable.txt"), b"attached brief").unwrap();
-        let denied = host.path().join("denied.txt");
-        std::fs::write(&denied, b"secret").unwrap();
-        std::fs::set_permissions(&denied, std::fs::Permissions::from_mode(0o000)).unwrap();
-        let fake = FakeWorkspace::default();
-
-        let pushed = push_host_dir(&fake, &workspace_id(), host.path())
-            .await
-            .unwrap();
-
-        assert_eq!(pushed.transferred, 1, "{:?}", pushed.notes);
-        assert_eq!(fake.get("readable.txt").unwrap(), b"attached brief");
-        assert!(fake.get("denied.txt").is_none());
-        assert!(pushed
-            .notes
-            .iter()
-            .any(|note| note.contains("denied.txt") && note.contains("could not be read")));
-    }
-
-    #[tokio::test]
     async fn pull_caps_sync_notes_and_preserves_distinct_reasons() {
         let host = tempfile::tempdir().unwrap();
         let fake = FakeWorkspace::default();
-        fake.insert("kept.txt", b"sandbox output");
+        fake.insert("output/kept.txt", b"sandbox output");
         // A hostile listing can produce a skip note per entry; the report must
         // stay bounded without losing a reason that only appears late.
         for i in 0..40 {
@@ -858,13 +1062,13 @@ mod tests {
         }
         for i in 0..2 {
             fake.planted.lock().unwrap().push(WorkspaceFileEntry {
-                path: format!("big-{i}.bin"),
+                path: format!("output/big-{i}.bin"),
                 directory: false,
                 size_bytes: Some(MAX_WORKSPACE_FILE_BYTES as u64 + 1),
             });
         }
 
-        let pulled = pull_into_host_dir(&fake, &workspace_id(), host.path())
+        let pulled = pull_result_dirs(&fake, &workspace_id(), host.path())
             .await
             .unwrap();
 
@@ -878,29 +1082,6 @@ mod tests {
         assert_eq!(
             pulled.notes.last().unwrap(),
             &format!("not pulled: 9 more note(s) beyond the {MAX_SYNC_NOTES}-note sync limit")
-        );
-    }
-
-    #[tokio::test]
-    async fn bundled_document_helpers_are_not_on_the_sync_skip_list() {
-        let host = tempfile::tempdir().unwrap();
-        let helper = host
-            .path()
-            .join(crate::DOCUMENT_SCRIPTS_DIR)
-            .join("render_pdf.py");
-        std::fs::create_dir_all(helper.parent().unwrap()).unwrap();
-        std::fs::write(&helper, b"print('render')").unwrap();
-        let fake = FakeWorkspace::default();
-
-        let pushed = push_host_dir(&fake, &workspace_id(), host.path())
-            .await
-            .unwrap();
-
-        assert_eq!(pushed.transferred, 1);
-        assert!(pushed.notes.is_empty());
-        assert_eq!(
-            fake.get(".openwave/exec-scripts/render_pdf.py").unwrap(),
-            b"print('render')"
         );
     }
 }

--- a/crates/openwave-code-execution/src/tool.rs
+++ b/crates/openwave-code-execution/src/tool.rs
@@ -7,7 +7,7 @@ use serde_json::{json, Value};
 
 use crate::{
     CodeExecutionProvider, CodeExecutionRequest, ExecutionId, ExecutionWorkspaceId, MAX_ARGUMENTS,
-    MAX_COMMAND_BYTES, MAX_CWD_BYTES,
+    MAX_COMMAND_BYTES, MAX_CWD_BYTES, MAX_STAGED_PATHS,
 };
 
 pub const EXEC_TOOL_NAME: &str = "exec";
@@ -32,6 +32,8 @@ struct ExecArguments {
     args: Vec<String>,
     #[serde(default = "default_cwd")]
     cwd: String,
+    #[serde(default)]
+    files: Vec<String>,
 }
 
 fn default_cwd() -> String {
@@ -45,31 +47,37 @@ impl Tool for ExecTool {
             name: EXEC_TOOL_NAME.into(),
             description: "Run one executable with an argument vector in the configured isolated \
                           execution provider. No shell parses the arguments unless you explicitly \
-                          invoke a shell. The local provider blocks network and user-data access \
-                          outside private chat scratch plus any current host-resolved folder \
-                          grants listed in the operating context; folder paths are host state, \
-                          never tool arguments. Managed cloud sandboxes (E2B, Daytona) \
-                          have the chat's private scratch mirrored in before the command runs and \
-                          mirrored back after, so files from write_file are visible here and \
-                          files this command writes are visible to read_file. Every provider \
-                          returns bounded stdout/stderr. Files you save in output/ are published \
-                          to the user automatically as durable outputs. To update an output you \
-                          already published, save to the same filename in output/ — it becomes a \
-                          new version of the same output in place; you never track output ids. \
-                          For visual review, save up to three \
-                          PNG, JPEG, or WebP images in preview/; overview, grid, thumbnail, page, \
-                          and slide filenames are prioritized; preview images are for your own \
-                          review and never become outputs. \
-                          When bundled document helpers are present, invoke them directly from \
-                          .openwave/exec-scripts. Examples: command python3 with args \
+                          invoke a shell. The local provider runs directly in the chat's private \
+                          scratch and blocks network and user-data access outside it plus any \
+                          current host-resolved folder grants listed in the operating context; \
+                          folder paths are host state, never tool arguments. Managed cloud \
+                          sandboxes (E2B, Daytona) see ONLY the scratch paths you list in the \
+                          'files' argument, plus whatever earlier commands in the same sandbox \
+                          session created. List every file or directory the command reads — \
+                          including files you just wrote with write_file and attached documents \
+                          under documents/ — or the command will not find them there. A listed \
+                          directory stages recursively; a listed path that does not exist fails \
+                          the call on every provider. Every provider returns bounded \
+                          stdout/stderr. Files you save in output/ are published to the user \
+                          automatically as durable outputs; output/ and preview/ are copied back \
+                          for you and need never be listed. To update an output you already \
+                          published, save to the same filename in output/ — it becomes a new \
+                          version of the same output in place; you never track output ids. For \
+                          visual review, save up to three PNG, JPEG, or WebP images in preview/; \
+                          overview, grid, thumbnail, page, and slide filenames are prioritized; \
+                          preview images are for your own review and never become outputs. When \
+                          bundled document helpers are present, invoke them directly from \
+                          .openwave/exec-scripts (always available without listing them). \
+                          Examples: command python3 with args \
                           [\".openwave/exec-scripts/render_pdf.py\", \"documents/report.pdf\", \
-                          \"--pages\", \"1-2\"]; command python3 with args \
-                          [\".openwave/exec-scripts/extract_pdf_figures.py\", \
-                          \"documents/report.pdf\"]; or command python3 with args \
-                          [\".openwave/exec-scripts/analyze_xlsx.py\", \
-                          \"documents/model.xlsx\"]. Each helper writes visual review files to \
-                          preview/ and prints a concise summary; a missing Python or document \
-                          dependency is reported as a command error."
+                          \"--pages\", \"1-2\"] and files [\"documents/report.pdf\"]; command \
+                          python3 with args [\".openwave/exec-scripts/extract_pdf_figures.py\", \
+                          \"documents/report.pdf\"] and files [\"documents/report.pdf\"]; or \
+                          command python3 with args [\".openwave/exec-scripts/analyze_xlsx.py\", \
+                          \"documents/model.xlsx\"] and files [\"documents/model.xlsx\"]. Each \
+                          helper writes visual review files to preview/ and prints a concise \
+                          summary; a missing Python or document dependency is reported as a \
+                          command error."
                 .into(),
             input_schema: json!({
                 "type": "object",
@@ -92,6 +100,12 @@ impl Tool for ExecTool {
                         "minLength": 1,
                         "maxLength": MAX_CWD_BYTES,
                         "description": "Private-scratch-relative working directory (defaults to '.')."
+                    },
+                    "files": {
+                        "type": "array",
+                        "maxItems": MAX_STAGED_PATHS,
+                        "items": { "type": "string" },
+                        "description": "Scratch-relative files or directories staged into a managed sandbox before the command runs; directories stage recursively. Managed sandboxes see only these paths (plus what earlier commands in the session created); a path that does not exist fails the call on every provider."
                     }
                 },
                 "required": ["command"]
@@ -131,7 +145,9 @@ impl Tool for ExecTool {
             arguments.command,
             arguments.args,
             arguments.cwd,
-        ) {
+        )
+        .and_then(|request| request.with_staged_files(arguments.files))
+        {
             Ok(request) => request,
             Err(error) => return Ok(ToolOutput::error(error.to_string())),
         };
@@ -305,7 +321,7 @@ mod tests {
         let output = tool
             .execute(
                 &ctx,
-                json!({"command": "/bin/echo", "args": ["ok"], "cwd": "."}),
+                json!({"command": "/bin/echo", "args": ["ok"], "cwd": ".", "files": ["data/in.csv"]}),
             )
             .await
             .unwrap();
@@ -316,6 +332,20 @@ mod tests {
         assert_eq!(request.execution_id.as_str(), call_id.to_string());
         assert_eq!(request.workspace_id.as_str(), chat_id.to_string());
         assert_eq!(request.command, "/bin/echo");
+        assert_eq!(request.files.len(), 1);
+        assert_eq!(request.files[0].as_str(), "data/in.csv");
+
+        // A traversal in the model-listed staged set is refused before any
+        // provider sees the request, and the error names the path.
+        let refused = tool
+            .execute(
+                &ctx,
+                json!({"command": "/bin/echo", "files": ["../escape"]}),
+            )
+            .await
+            .unwrap();
+        assert!(refused.is_error);
+        assert!(refused.content.contains("../escape"), "{}", refused.content);
     }
 
     #[test]
@@ -325,6 +355,8 @@ mod tests {
         let spec = tool.spec();
         assert_eq!(spec.name, EXEC_TOOL_NAME);
         assert_eq!(spec.input_schema["additionalProperties"], false);
+        assert!(spec.input_schema["properties"]["files"].is_object());
+        assert!(spec.description.contains("'files'"));
         assert!(spec.description.contains("preview/"));
         assert!(spec.description.contains(".openwave/exec-scripts"));
         assert!(spec.description.contains("render_pdf.py"));

--- a/crates/openwave-code-execution/src/types.rs
+++ b/crates/openwave-code-execution/src/types.rs
@@ -20,6 +20,8 @@ pub const MAX_WORKSPACE_FILE_BYTES: usize = openwave_core::MAX_EXEC_WORKSPACE_FI
 pub const MAX_WORKSPACE_PATH_BYTES: usize = 1_024;
 /// Maximum entries returned by one workspace listing.
 pub const MAX_WORKSPACE_LIST_ENTRIES: usize = 256;
+/// Maximum scratch-relative paths one `exec` call may list for staging.
+pub const MAX_STAGED_PATHS: usize = 64;
 /// Maximum host-resolved folder grants carried by one local execution.
 pub const MAX_EXEC_FOLDER_GRANTS: usize = 32;
 const MAX_EXEC_FOLDER_PATH_BYTES: usize = 4_096;
@@ -158,6 +160,16 @@ pub struct WorkspaceListing {
     pub truncated: bool,
 }
 
+/// Whether staging one file moved bytes or found the live session current.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StagedUpload {
+    /// The bytes were transferred into the workspace.
+    Uploaded,
+    /// The backend's live session already held identical content; nothing was
+    /// transferred.
+    AlreadyCurrent,
+}
+
 /// Optional durable-workspace capability beside [`CodeExecutionProvider::execute`].
 ///
 /// This is a host-internal surface: nothing here is model-facing, and no
@@ -192,6 +204,22 @@ pub trait WorkspaceLifecycle: Send + Sync {
         path: &WorkspaceFilePath,
         content: &[u8],
     ) -> Result<(), CodeExecutionError>;
+
+    /// Stage one bounded file for the next command.
+    ///
+    /// Backends that reuse a live session may skip the transfer when that
+    /// session already holds identical content from a previous staging. The
+    /// default always uploads, which is correct for backends with no session
+    /// memory.
+    async fn stage_workspace_file(
+        &self,
+        workspace: &ExecutionWorkspaceId,
+        path: &WorkspaceFilePath,
+        content: &[u8],
+    ) -> Result<StagedUpload, CodeExecutionError> {
+        self.put_workspace_file(workspace, path, content).await?;
+        Ok(StagedUpload::Uploaded)
+    }
 
     /// Read one bounded file.
     async fn get_workspace_file(
@@ -236,6 +264,15 @@ pub struct CodeExecutionRequest {
     pub arguments: Vec<String>,
     #[serde(default = "default_cwd")]
     pub cwd: String,
+    /// Scratch-relative files or directories the model asked to stage into a
+    /// managed sandbox before the command runs. Directories stage recursively.
+    ///
+    /// Model-facing, unlike `folder_grants`: it rides the canonical tool call,
+    /// so a replay with a different staged set is an identity conflict. The
+    /// local provider stages nothing — scratch is its filesystem — but the
+    /// listed paths are validated identically on every provider.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<WorkspaceFilePath>,
     /// Host-resolved folder authority for the local adapter.
     ///
     /// The model-facing tool always constructs this empty. The configured host
@@ -313,10 +350,28 @@ impl CodeExecutionRequest {
             command: command.into(),
             arguments,
             cwd: cwd.into(),
+            files: Vec::new(),
             folder_grants: Vec::new(),
         };
         request.validate()?;
         Ok(request)
+    }
+
+    /// Install the model-listed staged paths, validating each and naming the
+    /// first offender rather than reporting a bare "invalid".
+    pub fn with_staged_files(mut self, files: Vec<String>) -> Result<Self, CodeExecutionError> {
+        self.files = files
+            .into_iter()
+            .map(|path| {
+                WorkspaceFilePath::parse(&path).map_err(|_| {
+                    CodeExecutionError::InvalidRequest(format!(
+                        "invalid staged path '{path}': paths must be scratch-relative with no traversal"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        self.validate()?;
+        Ok(self)
     }
 
     /// Revalidate public/deserialized fields at the provider boundary.
@@ -354,6 +409,22 @@ impl CodeExecutionRequest {
             return Err(CodeExecutionError::InvalidRequest(
                 "invalid working directory".into(),
             ));
+        }
+        if self.files.len() > MAX_STAGED_PATHS {
+            return Err(CodeExecutionError::InvalidRequest(format!(
+                "too many staged paths: {} listed, at most {MAX_STAGED_PATHS} allowed",
+                self.files.len()
+            )));
+        }
+        for file in &self.files {
+            // Transparent deserialization bypasses the parse-time checks, so
+            // the boundary re-proves each path is its own normalized form.
+            if !WorkspaceFilePath::parse(file.as_str()).is_ok_and(|parsed| &parsed == file) {
+                return Err(CodeExecutionError::InvalidRequest(format!(
+                    "invalid staged path '{}'",
+                    file.as_str()
+                )));
+            }
         }
         if self.folder_grants.len() > MAX_EXEC_FOLDER_GRANTS {
             return Err(CodeExecutionError::InvalidRequest(

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -19,8 +19,9 @@ use openwave_code_execution::{
     DaytonaExecutionProvider, E2BCredential, E2BExecutionProvider, ExecFolderAccess,
     ExecFolderGrant, ExecutionId, ExecutionWorkspaceId, LocalExecutionProvider,
     OutputArtifactEntry, OutputArtifactScan, OutputArtifactStatus, PreviewScan, RemoteSessionPool,
-    WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, WriteOverlay, WriteSnapshotSink,
-    DAYTONA_CREDENTIAL_KEY, DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES, E2B_CREDENTIAL_KEY,
+    StagedUpload, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, WriteOverlay,
+    WriteSnapshotSink, DAYTONA_CREDENTIAL_KEY, DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES,
+    E2B_CREDENTIAL_KEY,
 };
 use openwave_core::{
     exec_attachment_file_name, BlobStore, CallId, Chat, ChatId, HostRootId,
@@ -1060,34 +1061,45 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
             materialize_chat_attachments(&*self.store, blobs, chat_id, &host_dir).await?;
         }
         // A remote sandbox has its own filesystem, but the model is shown one
-        // path vocabulary across the file tools and exec. Mirror the chat's
-        // private scratch into the workspace before the command and back out
-        // after it, so a file written by either side is visible to the other.
-        // The local provider already runs inside scratch; mirroring there
-        // would only copy the directory onto itself.
+        // path vocabulary across the file tools and exec. Stage exactly the
+        // paths the model listed on this call into the workspace before the
+        // command, and pull only output/ and preview/ back out afterwards —
+        // the two directories the host output and preview scans read. The
+        // local provider already runs inside scratch, so nothing is staged
+        // there, but the listed paths are validated identically so a bad path
+        // fails the same way on every provider.
         let lifecycle = match kind {
             CodeExecutionProviderKind::Local => None,
             _ => provider.workspace_lifecycle(),
         };
         let Some(lifecycle) = lifecycle else {
+            sync::validate_staged_paths(&host_dir, &request.files).await?;
             return provider.execute(request).await;
         };
-        // A push that fails outright fails the execution: if the workspace is
-        // unreachable, running against files the model believes are present
-        // would answer with misleading not-found errors. Files the push had to
-        // leave behind individually ride along as notes instead, so the model
-        // learns its workspace is incomplete rather than starting with nothing.
-        let mut notes = sync::push_host_dir(lifecycle, &request.workspace_id, &host_dir)
-            .await?
-            .notes;
+        // A staging that fails outright fails the execution: a listed path
+        // that does not exist, an over-bound expansion, or an unreachable
+        // workspace would otherwise surface as a baffling not-found inside the
+        // sandbox. Entries a listed directory had to leave behind individually
+        // ride along as notes instead.
+        let mut staged_paths = implicit_staged_paths(self.document_scripts_source.is_some());
+        staged_paths.extend(request.files.iter().cloned());
+        let mut notes =
+            sync::stage_listed_paths(lifecycle, &request.workspace_id, &host_dir, &staged_paths)
+                .await?
+                .notes;
         let mut response = provider.execute(request.clone()).await?;
         // A failed pull keeps the execution's output — the command did run —
         // and says the host copies are stale instead of failing the call.
-        match sync::pull_into_host_dir(lifecycle, &request.workspace_id, &host_dir).await {
+        match sync::pull_result_dirs(lifecycle, &request.workspace_id, &host_dir).await {
             Ok(pulled) => notes.extend(pulled.notes),
             Err(error) => notes.push(format!(
-                "workspace files were not copied back to private scratch: {error}"
+                "output files were not copied back to private scratch: {error}"
             )),
+        }
+        // A failed command plus an empty or thin staged set usually means the
+        // command's inputs were never listed; one bounded line points there.
+        if response.timed_out || response.exit_code != Some(0) {
+            notes.push(staged_set_note(&request.files));
         }
         response.sync_notes.extend(notes);
         Ok(response)
@@ -1179,6 +1191,47 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
     // this late-binding wrapper depends on the configuration read at call
     // time, which the synchronous trait flag cannot express. Host callers use
     // [`ConfiguredCodeExecutionProvider::workspace`] instead.
+}
+
+/// Host infrastructure staged into every managed workspace regardless of the
+/// model's listed set: the conventional-directory markers that make `output/`
+/// and `preview/` exist remotely so commands can write into them, and the
+/// bundled document helpers the tool description tells the model to invoke
+/// without listing. All of it is host-authored, bounded, and digest-skipped on
+/// a reused session.
+fn implicit_staged_paths(with_document_scripts: bool) -> Vec<WorkspaceFilePath> {
+    let mut paths = vec![
+        "output/.openwave-directory".to_owned(),
+        "preview/.openwave-directory".to_owned(),
+    ];
+    if with_document_scripts {
+        paths.push(DOCUMENT_SCRIPTS_DIR.to_owned());
+    }
+    paths
+        .into_iter()
+        .filter_map(|path| WorkspaceFilePath::parse(path).ok())
+        .collect()
+}
+
+/// One bounded line naming what this call staged, appended to a failed managed
+/// command so a missing-input failure points at the `files` argument.
+fn staged_set_note(files: &[WorkspaceFilePath]) -> String {
+    const SHOWN: usize = 8;
+    if files.is_empty() {
+        return "staged: none — list the files the command needs in the exec 'files' argument"
+            .into();
+    }
+    let shown: Vec<&str> = files
+        .iter()
+        .take(SHOWN)
+        .map(WorkspaceFilePath::as_str)
+        .collect();
+    let mut note = format!("staged: {}", shown.join(", "));
+    let omitted = files.len().saturating_sub(SHOWN);
+    if omitted > 0 {
+        note.push_str(&format!(" (+{omitted} more)"));
+    }
+    note
 }
 
 async fn materialize_chat_attachments(
@@ -1293,9 +1346,9 @@ async fn prepare_execution_directories(
             .await
             .ok_or_else(unavailable)?;
         if mirrored {
-            // The sync protocol mirrors files rather than empty directories.
-            // A hidden zero-byte marker makes the conventional directories
-            // exist in managed workspaces without becoming a user artifact.
+            // Staging transfers files rather than empty directories. A hidden
+            // zero-byte marker makes the conventional directories exist in
+            // managed workspaces without becoming a user artifact.
             directory
                 .write_file(".openwave-directory", &[])
                 .await
@@ -1401,6 +1454,19 @@ impl WorkspaceLifecycle for ConfiguredWorkspace {
     ) -> std::result::Result<(), CodeExecutionError> {
         self.lifecycle()?
             .put_workspace_file(workspace, path, content)
+            .await
+    }
+
+    async fn stage_workspace_file(
+        &self,
+        workspace: &ExecutionWorkspaceId,
+        path: &WorkspaceFilePath,
+        content: &[u8],
+    ) -> std::result::Result<StagedUpload, CodeExecutionError> {
+        // Delegated rather than left to the trait default so the selected
+        // backend's session memory is not bypassed by the wrapper.
+        self.lifecycle()?
+            .stage_workspace_file(workspace, path, content)
             .await
     }
 

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -146,6 +146,8 @@ A request contains:
 - an opaque workspace ID derived from the chat;
 - one executable and argument vector (not an implicitly parsed shell string);
 - one private-workspace-relative current directory;
+- an optional bounded list of scratch-relative files or directories to stage
+  into a managed sandbox before the command runs;
 - for native local execution only, a bounded set of absolute folder paths
   resolved by the host from the chat's current root attachments.
 
@@ -284,6 +286,43 @@ The provider adapters own only their control-plane and command transports:
   and argv element before dispatch and prefixes the result with `exec`. Shell
   metacharacters therefore remain argument data. A caller that deliberately
   needs a shell must still name `/bin/sh` and `-c` explicitly.
+
+### File staging
+
+A managed sandbox has its own filesystem, so the host moves files between the
+chat's private scratch and the sandbox around each command. The contract is
+explicit, not a mirror:
+
+- **Only listed paths go in.** The `exec` call's `files` argument names the
+  scratch-relative files or directories (up to 64 paths) the command needs;
+  directories stage recursively. Nothing else in scratch is uploaded — a file
+  written with `write_file` or a materialized attachment under `documents/` is
+  visible to a managed command only if listed. The host also stages a fixed
+  set of infrastructure on its own: the hidden markers that make `output/` and
+  `preview/` exist remotely, and the bundled document helpers under
+  `.openwave/exec-scripts`.
+- **Failures are loud, never silent.** A listed path that does not exist, is a
+  symlink, or expands past the 256-file staging bound fails the call with an
+  error naming the path. The local provider validates the listed paths the
+  same way even though it stages nothing, so a bad path fails identically on
+  every provider. Only per-entry conditions found *inside* a listed directory
+  (a dependency tree, a nested symlink, an oversized file) degrade into
+  bounded sync notes in the tool result. The per-file transfer cap applies in
+  both directions.
+- **Unchanged files are not re-uploaded.** The session pool remembers a
+  content digest per staged path for the live sandbox instance and skips
+  identical content on later commands in the same session. The memory is bound
+  to the exact sandbox: a recreated or destroyed sandbox starts from an empty
+  ledger and is staged again.
+- **Only `output/` and `preview/` come back.** After the command, the host
+  pulls those two subtrees into scratch — they feed the output-versioning and
+  preview-image scans — validating every returned path and refusing anything
+  the backend lists outside them. Intermediates the command wrote elsewhere
+  stay in the sandbox for later commands in the same session.
+
+When a managed command fails, the sync notes include one bounded `staged:`
+line naming what was staged (or pointing at the `files` argument when nothing
+was), so a missing-input failure is diagnosable from the tool result.
 
 Managed credentials remain in the OS secret store and never enter configuration,
 tool arguments, logs, or renderer responses. Remote API endpoints are fixed by

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -123,9 +123,13 @@ interface; server-owned source tools use it too.
 ## Code execution
 
 Command execution lives in `openwave-code-execution`, not in core. Its `exec`
-tool accepts one executable, direct argument vector, and private-scratch-relative
-working directory. The host—not the model—selects the provider and timeout
-through `GET`/`PUT /code-execution`.
+tool accepts one executable, direct argument vector, private-scratch-relative
+working directory, and an optional bounded `files` list naming the scratch
+paths to stage into a managed sandbox before the command runs — managed
+sandboxes see only the listed paths (plus what earlier commands in the same
+session created), and only `output/` and `preview/` are copied back afterwards.
+The host—not the model—selects the provider and timeout through
+`GET`/`PUT /code-execution`.
 
 The provider contract includes both the canonical tool-call ID and an opaque
 chat workspace ID. The former is an idempotency key; the latter lets the local


### PR DESCRIPTION
Managed-provider exec currently mirrors the entire per-chat scratch directory into the remote sandbox before every command and mirrors the whole tree back after, capped at 256 files with alphabetical truncation and one sequential upload per file. In production this produced two failures at once: a 153 ms command spent ~3 minutes of wall clock syncing at ~4 uploads/sec, and a file the agent had just written (`build_deck.py`) was silently dropped because 530 junk cache files sorted before it alphabetically — the command then failed with a baffling `FileNotFoundError`. The implicit "mirror everything" contract is the root problem, so this replaces it with explicit staging.

## The new contract

- **`exec` gains an optional `files` argument** (up to 64 scratch-relative paths, files or directories; directories stage recursively). Before a managed command runs, exactly these paths are staged into the sandbox at the same relative locations. Nothing else is uploaded. The host also stages a fixed set of its own infrastructure: the hidden `output/`/`preview/` directory markers and the bundled `.openwave/exec-scripts` helpers, so helper invocations keep working without being listed.
- **Bounded and loud, never silent.** A listed path that does not exist, is a symlink, or expands past the 256-file bound fails the call with an error naming the path and the count. Per-entry conditions found *inside* a listed directory (dependency trees, nested symlinks, oversized files) degrade into the existing bounded sync notes. The per-file byte cap is unchanged.
- **Local provider validates identically.** Scratch is its filesystem, so nothing is staged, but the listed paths are checked the same way — a bad path fails the same way on every provider.
- **Pull only `output/` and `preview/`.** After the command, only those two subtrees are reconciled back to host scratch (they feed the existing output-versioning and preview scans, which are unchanged). Returned paths are validated and anything the backend lists outside the two subtrees is refused with a note. The whole-tree pull is gone.
- **Digest-based skip on reused sandboxes.** The remote session pool remembers a sha256 per staged path, bound to the exact sandbox instance; identical content is not re-uploaded on later commands in the same session. A recreated or destroyed sandbox starts from an empty ledger and is staged again. The check and the record happen under the per-chat session lock, so the ledger can never describe a different sandbox than the upload targeted.
- **Guiding errors.** When a managed command fails, the sync notes carry one bounded `staged:` line naming what was staged (or pointing at the `files` argument when nothing was), so missing-input failures are diagnosable from the tool result.
- The `files` list rides the canonical request, so replaying an execution ID with a different staged set is an identity conflict like any other argument change.

The exec tool description and schema are rewritten for the new mental model, and `docs/code-execution.md` / `docs/tools.md` now describe staging instead of mirroring.

## Removed tests

Each old sync test asserting the whole-tree mirror was replaced rather than kept alongside:

- `round_trips_host_scratch_through_the_workspace` — asserted the mirror-everything contract this PR removes; replaced by `stages_exactly_the_listed_paths_and_expands_directories` and `pull_touches_only_output_and_preview`.
- `pull_rejects_paths_that_escape_the_host_directory` — folded into `pull_rejects_listing_rows_that_escape_or_leave_the_pulled_scope`, which keeps the escape and oversize rows and adds the new outside-`output//preview/` refusal.
- `push_reports_a_symlink_and_never_pushes_its_target` — symlinks are now a loud error when listed and a note when nested; replaced by `a_listed_symlink_fails_and_a_nested_symlink_is_noted`.
- `attached_documents_are_pushed_with_the_per_file_cap` — attachments are no longer auto-pushed (they must be listed); the per-file cap is covered by `an_oversized_listed_file_fails_and_an_oversized_nested_file_is_noted`.
- `preview_files_are_mirrored_and_keep_the_per_file_cap` — preview reconciliation and its cap are covered by `pull_touches_only_output_and_preview` and the oversize row above.
- `push_reports_an_unreadable_file_and_keeps_going` — became `staging_notes_an_unreadable_nested_file_and_keeps_going`.
- `bundled_document_helpers_are_not_on_the_sync_skip_list` — the sync skip-list no longer decides whether helpers move; they are staged explicitly as host infrastructure by the server wiring.

The symlinked-parent, destination-symlink, unreadable-pull, and notes-cap tests were adapted in place to the `output/` scope. New coverage: exact-set staging, missing/over-bound/symlink listed-path errors naming the path, scoped pull, and an E2B mock-server test that a reused session skips unchanged content, re-uploads changed content, and re-stages after destroy.

Verified with `cargo check`/`clippy`/`test -p openwave-code-execution --locked` and `cargo check -p openwave-server --locked --all-targets` plus the server `code_execution` test module; no lockfile changes.
