### PR TITLE
feat(desktop): support skipping and multi-select user questions

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -10967,9 +10967,10 @@ mod tests {
         let answer = crate::AnswerUserQuestions {
             answers: vec![crate::UserQuestionAnswer {
                 question_id: "target".into(),
-                option_id: Some("staging".into()),
-                free_form: None,
+                selected_option_ids: vec!["staging".into()],
+                custom_answer: None,
             }],
+            additional_user_context: None,
         };
         let calls = vec![ToolCallRecord {
             id: CallId::new(),

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -1017,6 +1017,7 @@ pub mod user_question_request {
         pub event_seq: i64,
         pub asked_at: DateTimeUtc,
         pub resolved_at: Option<DateTimeUtc>,
+        pub additional_user_context: Option<String>,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -1040,10 +1041,15 @@ pub mod user_question {
         pub prompt: String,
         #[sea_orm(column_type = "JsonBinary")]
         pub options: Json,
+        pub question_type: String,
         pub allow_free_form: bool,
         pub answer_option_id: Option<String>,
         pub answer_free_form: Option<String>,
         pub answered_at: Option<DateTimeUtc>,
+        #[sea_orm(column_type = "JsonBinary")]
+        pub answer_selected_option_ids: Option<Json>,
+        pub answer_custom_answer: Option<String>,
+        pub response_recorded_at: Option<DateTimeUtc>,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -101,6 +101,7 @@ impl MigratorTrait for Migrator {
             Box::new(AddToolCallRawArguments),
             Box::new(RaiseAttemptBudgets),
             Box::new(AddChatNetworkPolicy),
+            Box::new(ExtendUserQuestions),
         ]
     }
 }
@@ -144,6 +145,123 @@ impl MigrationTrait for AddChatNetworkPolicy {
             )
             .await?;
         Ok(())
+    }
+}
+
+/// Extends the first question checkpoint with skip, multi-select, and
+/// additional-context support without rewriting already answered rows.
+///
+/// The original scalar answer columns remain as the compatibility projection
+/// for databases created before this migration. New answers use the explicit
+/// response columns, which can represent selected options plus custom text and
+/// an explicit skipped question.
+struct ExtendUserQuestions;
+
+impl MigrationName for ExtendUserQuestions {
+    fn name(&self) -> &str {
+        "m20260730_000040_extend_user_questions"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for ExtendUserQuestions {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(UserQuestionRequest::Table)
+                    .add_column(
+                        ColumnDef::new(UserQuestionRequest::AdditionalUserContext)
+                            .string_len(crate::MAX_ADDITIONAL_USER_CONTEXT_CHARS as u32),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(UserQuestion::Table)
+                    .add_column(
+                        ColumnDef::new(UserQuestion::QuestionType)
+                            .string_len(16)
+                            .not_null()
+                            .default(crate::UserQuestionType::SingleSelect.as_str()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(UserQuestion::Table)
+                    .add_column(ColumnDef::new(UserQuestion::AnswerSelectedOptionIds).json_binary())
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(UserQuestion::Table)
+                    .add_column(
+                        ColumnDef::new(UserQuestion::AnswerCustomAnswer)
+                            .string_len(crate::MAX_FREE_FORM_ANSWER_CHARS as u32),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(UserQuestion::Table)
+                    .add_column(
+                        ColumnDef::new(UserQuestion::ResponseRecordedAt).timestamp_with_time_zone(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(UserQuestion::Table)
+                    .drop_column(UserQuestion::ResponseRecordedAt)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(UserQuestion::Table)
+                    .drop_column(UserQuestion::AnswerCustomAnswer)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(UserQuestion::Table)
+                    .drop_column(UserQuestion::AnswerSelectedOptionIds)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(UserQuestion::Table)
+                    .drop_column(UserQuestion::QuestionType)
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(UserQuestionRequest::Table)
+                    .drop_column(UserQuestionRequest::AdditionalUserContext)
+                    .to_owned(),
+            )
+            .await
     }
 }
 
@@ -10075,6 +10193,7 @@ enum UserQuestionRequest {
     EventSeq,
     AskedAt,
     ResolvedAt,
+    AdditionalUserContext,
 }
 
 #[derive(DeriveIden)]
@@ -10101,10 +10220,14 @@ enum UserQuestion {
     Header,
     Prompt,
     Options,
+    QuestionType,
     AllowFreeForm,
     AnswerOptionId,
     AnswerFreeForm,
     AnsweredAt,
+    AnswerSelectedOptionIds,
+    AnswerCustomAnswer,
+    ResponseRecordedAt,
 }
 
 #[derive(DeriveIden)]

--- a/crates/openwave-core/src/db/ops/user_question.rs
+++ b/crates/openwave-core/src/db/ops/user_question.rs
@@ -48,6 +48,7 @@ where
         event_seq: Set(seq),
         asked_at: Set(asked_at),
         resolved_at: Set(None),
+        additional_user_context: Set(None),
     }
     .insert(conn)
     .await
@@ -61,10 +62,14 @@ where
             header: Set(question.header),
             prompt: Set(question.question),
             options: Set(serde_json::to_value(question.options)?),
+            question_type: Set(question.question_type.as_str().into()),
             allow_free_form: Set(question.allow_free_form),
             answer_option_id: Set(None),
             answer_free_form: Set(None),
             answered_at: Set(None),
+            answer_selected_option_ids: Set(None),
+            answer_custom_answer: Set(None),
+            response_recorded_at: Set(None),
         }
         .insert(conn)
         .await
@@ -273,9 +278,21 @@ pub(in crate::db) async fn answer(
     let result = serde_json::to_string(&canonical)?;
 
     if question_request.status == UserQuestionRequestStatus::Answered.as_str() {
-        let exact = stored_answers_match(&questions, &canonical)
+        let result_matches = if questions
+            .iter()
+            .all(|question| question.response_recorded_at.is_some())
+        {
+            call.result.as_deref() == Some(result.as_str())
+        } else {
+            // Before the extension, the result used scalar `option_id` /
+            // `free_form` fields. The compatibility columns below still prove
+            // the semantic answer exactly; requiring byte-identical new JSON
+            // would turn an equivalent retry after upgrade into a conflict.
+            call.result.is_some()
+        };
+        let exact = stored_answers_match(&question_request, &questions, &canonical)?
             && call.status == ToolCallStatus::Completed.as_str()
-            && call.result.as_deref() == Some(result.as_str());
+            && result_matches;
         if !exact {
             transaction.commit().await.map_err(store_err)?;
             return Ok(AnswerUserQuestionsOutcome::AnswerConflict);
@@ -319,16 +336,27 @@ pub(in crate::db) async fn answer(
         .max(call.created_at)
         .max(turn.updated_at);
 
-    for (model, answer) in questions.iter().zip(canonical.answers.iter()) {
+    let answers_by_id: HashMap<_, _> = canonical
+        .answers
+        .iter()
+        .map(|answer| (answer.question_id.as_str(), answer))
+        .collect();
+    for model in &questions {
+        let answer = answers_by_id.get(model.question_id.as_str());
         let mut active: entities::user_question::ActiveModel = model.clone().into();
-        active.answer_option_id = Set(answer.option_id.clone());
-        active.answer_free_form = Set(answer.free_form.clone());
-        active.answered_at = Set(Some(answered_at));
+        active.answer_selected_option_ids = Set(Some(serde_json::to_value(
+            answer
+                .map(|answer| answer.selected_option_ids.as_slice())
+                .unwrap_or_default(),
+        )?));
+        active.answer_custom_answer = Set(answer.and_then(|answer| answer.custom_answer.clone()));
+        active.response_recorded_at = Set(Some(answered_at));
         active.update(&transaction).await.map_err(store_err)?;
     }
     let mut active_request: entities::user_question_request::ActiveModel = question_request.into();
     active_request.status = Set(UserQuestionRequestStatus::Answered.as_str().into());
     active_request.resolved_at = Set(Some(answered_at));
+    active_request.additional_user_context = Set(canonical.additional_user_context.clone());
     active_request
         .update(&transaction)
         .await
@@ -496,6 +524,15 @@ fn questions_from_models(models: &[entities::user_question::Model]) -> Result<Ve
                 header: model.header.clone(),
                 question: model.prompt.clone(),
                 options: serde_json::from_value(model.options.clone())?,
+                question_type: match model.question_type.as_str() {
+                    "single_select" => crate::UserQuestionType::SingleSelect,
+                    "multi_select" => crate::UserQuestionType::MultiSelect,
+                    _ => {
+                        return Err(AgentError::Store(
+                            "durable question has an unknown question type".into(),
+                        ));
+                    }
+                },
                 allow_free_form: model.allow_free_form,
             };
             if !question.is_well_formed() {
@@ -512,45 +549,97 @@ fn canonical_answers(
     questions: &[entities::user_question::Model],
     supplied: &crate::AnswerUserQuestions,
 ) -> Result<Option<crate::AnswerUserQuestions>> {
-    if questions.len() != supplied.answers.len() {
-        return Ok(None);
-    }
     let by_id: HashMap<_, _> = supplied
         .answers
         .iter()
         .map(|answer| (answer.question_id.as_str(), answer))
         .collect();
-    let mut answers = Vec::with_capacity(questions.len());
+    let mut answers = Vec::with_capacity(supplied.answers.len());
     for question in questions {
         let Some(answer) = by_id.get(question.question_id.as_str()) else {
-            return Ok(None);
+            continue;
         };
         let options: Vec<crate::UserQuestionOption> =
             serde_json::from_value(question.options.clone())?;
-        let valid = match (&answer.option_id, &answer.free_form) {
-            (Some(option_id), None) => options.iter().any(|option| option.id == *option_id),
-            (None, Some(_)) => question.allow_free_form,
+        let selections_are_valid = answer
+            .selected_option_ids
+            .iter()
+            .all(|option_id| options.iter().any(|option| option.id == *option_id));
+        let custom_is_valid = answer.custom_answer.is_none() || question.allow_free_form;
+        let selection_shape_is_valid = match question.question_type.as_str() {
+            "single_select" => {
+                (answer.selected_option_ids.len() == 1 && answer.custom_answer.is_none())
+                    || (answer.selected_option_ids.is_empty() && answer.custom_answer.is_some())
+            }
+            "multi_select" => true,
             _ => false,
         };
-        if !valid {
+        if !selections_are_valid || !custom_is_valid || !selection_shape_is_valid {
             return Ok(None);
         }
         answers.push((*answer).clone());
     }
-    Ok(Some(crate::AnswerUserQuestions { answers }))
+    if answers.len() != supplied.answers.len() {
+        return Ok(None);
+    }
+    Ok(Some(crate::AnswerUserQuestions {
+        answers,
+        additional_user_context: supplied.additional_user_context.clone(),
+    }))
 }
 
 fn stored_answers_match(
+    request: &entities::user_question_request::Model,
     questions: &[entities::user_question::Model],
     expected: &crate::AnswerUserQuestions,
-) -> bool {
-    questions
+) -> Result<bool> {
+    if request.additional_user_context != expected.additional_user_context {
+        return Ok(false);
+    }
+    let expected_by_id: HashMap<_, _> = expected
+        .answers
         .iter()
-        .zip(expected.answers.iter())
-        .all(|(question, answer)| {
-            question.question_id == answer.question_id
-                && question.answer_option_id == answer.option_id
-                && question.answer_free_form == answer.free_form
-                && question.answered_at.is_some()
-        })
+        .map(|answer| (answer.question_id.as_str(), answer))
+        .collect();
+    for question in questions {
+        let expected_answer = expected_by_id.get(question.question_id.as_str());
+        if question.response_recorded_at.is_some() {
+            let stored_option_ids: Vec<String> = question
+                .answer_selected_option_ids
+                .clone()
+                .map(serde_json::from_value)
+                .transpose()?
+                .unwrap_or_default();
+            if stored_option_ids
+                != expected_answer
+                    .map(|answer| answer.selected_option_ids.clone())
+                    .unwrap_or_default()
+                || question.answer_custom_answer
+                    != expected_answer.and_then(|answer| answer.custom_answer.clone())
+            {
+                return Ok(false);
+            }
+            continue;
+        }
+
+        // Rows answered before the extension used exactly one of the original
+        // scalar columns. Keep exact retries recoverable after upgrading.
+        let Some(expected_answer) = expected_answer else {
+            return Ok(false);
+        };
+        let legacy_matches = match (
+            &question.answer_option_id,
+            &question.answer_free_form,
+            expected_answer.selected_option_ids.as_slice(),
+            &expected_answer.custom_answer,
+        ) {
+            (Some(stored), None, [expected], None) => stored == expected,
+            (None, Some(stored), [], Some(expected)) => stored == expected,
+            _ => false,
+        };
+        if !legacy_matches || question.answered_at.is_none() {
+            return Ok(false);
+        }
+    }
+    Ok(true)
 }

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -4636,12 +4636,14 @@ async fn park_test_user_questions(
                         {"id": "staging", "label": "Staging", "description": "Deploy for internal verification."},
                         {"id": "production", "label": "Production", "description": "Deploy to customers."}
                     ],
-                    "allow_free_form": false
+                    "question_type": "multi_select",
+                    "allow_free_form": true
                 },
                 {
                     "id": "note",
                     "header": "Note",
                     "question": "Anything else I should know?",
+                    "question_type": "single_select",
                     "allow_free_form": true
                 }
             ]
@@ -4683,18 +4685,12 @@ async fn park_test_user_questions(
 
 fn sample_user_answers() -> crate::AnswerUserQuestions {
     crate::AnswerUserQuestions {
-        answers: vec![
-            crate::UserQuestionAnswer {
-                question_id: "target".into(),
-                option_id: Some("staging".into()),
-                free_form: None,
-            },
-            crate::UserQuestionAnswer {
-                question_id: "note".into(),
-                option_id: None,
-                free_form: Some("Keep the rollout reversible.".into()),
-            },
-        ],
+        answers: vec![crate::UserQuestionAnswer {
+            question_id: "target".into(),
+            selected_option_ids: vec!["staging".into(), "production".into()],
+            custom_answer: Some("Start with a canary.".into()),
+        }],
+        additional_user_context: Some("Keep the rollout reversible.".into()),
     }
 }
 
@@ -4838,18 +4834,12 @@ async fn user_questions_survive_reconnect_and_answer_exactly_once() {
     );
     let contradictory = crate::AnswerUserQuestionsRequest {
         answers: crate::AnswerUserQuestions {
-            answers: vec![
-                crate::UserQuestionAnswer {
-                    question_id: "target".into(),
-                    option_id: Some("production".into()),
-                    free_form: None,
-                },
-                crate::UserQuestionAnswer {
-                    question_id: "note".into(),
-                    option_id: None,
-                    free_form: Some("Keep the rollout reversible.".into()),
-                },
-            ],
+            answers: vec![crate::UserQuestionAnswer {
+                question_id: "target".into(),
+                selected_option_ids: vec!["production".into()],
+                custom_answer: None,
+            }],
+            additional_user_context: Some("Keep the rollout reversible.".into()),
         },
         ..answer_request
     };
@@ -4913,9 +4903,10 @@ async fn user_question_answer_validation_and_cancellation_are_closed() {
         answers: crate::AnswerUserQuestions {
             answers: vec![crate::UserQuestionAnswer {
                 question_id: "target".into(),
-                option_id: Some("not-an-option".into()),
-                free_form: None,
+                selected_option_ids: vec!["not-an-option".into()],
+                custom_answer: None,
             }],
+            additional_user_context: None,
         },
     };
     assert_eq!(

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -218,8 +218,9 @@ pub use tools::{CreateAppTool, ListDir, ReadFile, WriteFile};
 pub use user_questions::{
     ask_user_questions_tool_spec, validate_ask_user_questions_arguments, AnswerUserQuestions,
     AnswerUserQuestionsRequest, AskUserQuestionsArgs, PendingUserQuestions, UserQuestion,
-    UserQuestionAnswer, UserQuestionOption, UserQuestionRequestStatus, ASK_USER_QUESTIONS_TOOL,
-    MAX_FREE_FORM_ANSWER_CHARS, MAX_QUESTION_HEADER_CHARS, MAX_QUESTION_ID_CHARS,
-    MAX_QUESTION_OPTIONS, MAX_QUESTION_OPTION_DESCRIPTION_CHARS, MAX_QUESTION_OPTION_ID_CHARS,
+    UserQuestionAnswer, UserQuestionOption, UserQuestionRequestStatus, UserQuestionType,
+    ASK_USER_QUESTIONS_TOOL, MAX_ADDITIONAL_USER_CONTEXT_CHARS, MAX_FREE_FORM_ANSWER_CHARS,
+    MAX_QUESTION_HEADER_CHARS, MAX_QUESTION_ID_CHARS, MAX_QUESTION_OPTIONS,
+    MAX_QUESTION_OPTION_DESCRIPTION_CHARS, MAX_QUESTION_OPTION_ID_CHARS,
     MAX_QUESTION_OPTION_LABEL_CHARS, MAX_QUESTION_PROMPT_CHARS, MAX_USER_QUESTIONS,
 };

--- a/crates/openwave-core/src/user_questions.rs
+++ b/crates/openwave-core/src/user_questions.rs
@@ -26,8 +26,30 @@ pub const MAX_QUESTION_OPTION_ID_CHARS: usize = 64;
 pub const MAX_QUESTION_OPTION_LABEL_CHARS: usize = 80;
 pub const MAX_QUESTION_OPTION_DESCRIPTION_CHARS: usize = 240;
 pub const MAX_FREE_FORM_ANSWER_CHARS: usize = 2_000;
+pub const MAX_ADDITIONAL_USER_CONTEXT_CHARS: usize = 2_000;
 
-/// One mutually exclusive answer choice.
+/// Whether the reader may select one option or several independent options.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema, ts_rs::TS,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum UserQuestionType {
+    #[default]
+    SingleSelect,
+    MultiSelect,
+}
+
+impl UserQuestionType {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SingleSelect => "single_select",
+            Self::MultiSelect => "multi_select",
+        }
+    }
+}
+
+/// One selectable answer choice.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, ts_rs::TS)]
 #[serde(deny_unknown_fields)]
 #[schemars(description = "")]
@@ -63,6 +85,8 @@ pub struct UserQuestion {
     #[serde(default)]
     #[schemars(length(max = MAX_QUESTION_OPTIONS))]
     pub options: Vec<UserQuestionOption>,
+    #[serde(default)]
+    pub question_type: UserQuestionType,
     #[serde(default)]
     pub allow_free_form: bool,
 }
@@ -106,26 +130,35 @@ impl AskUserQuestionsArgs {
     }
 }
 
-/// One exact answer. Exactly one of `option_id` and `free_form` is populated.
+/// One supplied answer. Omitted questions are explicitly skipped.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct UserQuestionAnswer {
     pub question_id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub selected_option_ids: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub option_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub free_form: Option<String>,
+    pub custom_answer: Option<String>,
 }
 
 impl UserQuestionAnswer {
     #[must_use]
     pub fn shape_is_well_formed(&self) -> bool {
-        valid_text(&self.question_id, MAX_QUESTION_ID_CHARS)
-            && match (&self.option_id, &self.free_form) {
-                (Some(option), None) => valid_text(option, MAX_QUESTION_OPTION_ID_CHARS),
-                (None, Some(answer)) => valid_free_form(answer),
-                _ => false,
-            }
+        if !valid_text(&self.question_id, MAX_QUESTION_ID_CHARS)
+            || self.selected_option_ids.len() > MAX_QUESTION_OPTIONS
+            || (self.selected_option_ids.is_empty() && self.custom_answer.is_none())
+            || self
+                .custom_answer
+                .as_deref()
+                .is_some_and(|answer| !valid_free_form(answer))
+        {
+            return false;
+        }
+        let mut option_ids = HashSet::with_capacity(self.selected_option_ids.len());
+        self.selected_option_ids.iter().all(|option_id| {
+            valid_text(option_id, MAX_QUESTION_OPTION_ID_CHARS)
+                && option_ids.insert(option_id.as_str())
+        })
     }
 }
 
@@ -134,12 +167,19 @@ impl UserQuestionAnswer {
 #[serde(deny_unknown_fields)]
 pub struct AnswerUserQuestions {
     pub answers: Vec<UserQuestionAnswer>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub additional_user_context: Option<String>,
 }
 
 impl AnswerUserQuestions {
     #[must_use]
     pub fn shape_is_well_formed(&self) -> bool {
-        if self.answers.is_empty() || self.answers.len() > MAX_USER_QUESTIONS {
+        if self.answers.len() > MAX_USER_QUESTIONS
+            || self
+                .additional_user_context
+                .as_deref()
+                .is_some_and(|context| !valid_additional_context(context))
+        {
             return false;
         }
         let mut ids = HashSet::with_capacity(self.answers.len());
@@ -201,7 +241,7 @@ pub fn validate_ask_user_questions_arguments(arguments: &Value) -> bool {
 pub fn ask_user_questions_tool_spec() -> ToolSpec {
     ToolSpec::for_args::<AskUserQuestionsArgs>(
         ASK_USER_QUESTIONS_TOOL,
-        "Pause the current foreground turn and ask the user up to three short structured questions. Use stable question and option IDs. Options are mutually exclusive; enable allow_free_form only when a custom answer is useful. Call this tool alone, with no assistant text or sibling tools.",
+        "Pause the current foreground turn and ask the user up to three short structured questions. Use stable question and option IDs. Set question_type to single_select only when options are mutually exclusive; otherwise use multi_select. Enable allow_free_form when a custom answer is useful. The user may skip any or all questions, so proceed with reasonable defaults for omissions. Call this tool alone, with no assistant text or sibling tools.",
     )
 }
 
@@ -214,6 +254,14 @@ fn valid_text(value: &str, max_chars: usize) -> bool {
 fn valid_free_form(value: &str) -> bool {
     !value.trim().is_empty()
         && value.chars().count() <= MAX_FREE_FORM_ANSWER_CHARS
+        && !value
+            .chars()
+            .any(|character| character.is_control() && !matches!(character, '\n' | '\t'))
+}
+
+fn valid_additional_context(value: &str) -> bool {
+    !value.trim().is_empty()
+        && value.chars().count() <= MAX_ADDITIONAL_USER_CONTEXT_CHARS
         && !value
             .chars()
             .any(|character| character.is_control() && !matches!(character, '\n' | '\t'))
@@ -290,6 +338,10 @@ mod tests {
             MAX_QUESTION_OPTION_DESCRIPTION_CHARS
         );
         // What omitting an optional field means is part of the contract.
+        assert_eq!(
+            question["properties"]["question_type"]["default"],
+            "single_select"
+        );
         assert_eq!(question["properties"]["allow_free_form"]["default"], false);
         assert_eq!(
             question["properties"]["options"]["default"],
@@ -317,28 +369,33 @@ mod tests {
     }
 
     #[test]
-    fn answers_require_exactly_one_value() {
+    fn answers_are_bounded_unique_and_may_be_skipped() {
         let option = UserQuestionAnswer {
             question_id: "target".into(),
-            option_id: Some("staging".into()),
-            free_form: None,
+            selected_option_ids: vec!["staging".into()],
+            custom_answer: None,
         };
         assert!(option.shape_is_well_formed());
         assert!(!UserQuestionAnswer {
-            free_form: Some("both".into()),
-            ..option
+            selected_option_ids: vec!["staging".into(), "staging".into()],
+            ..option.clone()
         }
         .shape_is_well_formed());
         assert!(UserQuestionAnswer {
             question_id: "note".into(),
-            option_id: None,
-            free_form: Some("First line\nSecond line".into()),
+            selected_option_ids: vec!["staging".into(), "production".into()],
+            custom_answer: Some("First line\nSecond line".into()),
         }
         .shape_is_well_formed());
         assert!(!UserQuestionAnswer {
             question_id: "note".into(),
-            option_id: None,
-            free_form: Some("unsafe\0answer".into()),
+            selected_option_ids: Vec::new(),
+            custom_answer: Some("unsafe\0answer".into()),
+        }
+        .shape_is_well_formed());
+        assert!(AnswerUserQuestions {
+            answers: Vec::new(),
+            additional_user_context: None,
         }
         .shape_is_well_formed());
     }

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -3595,9 +3595,10 @@ async fn postgres_user_questions_resume_exactly_and_serialize_with_cancellation(
     let answers = AnswerUserQuestions {
         answers: vec![UserQuestionAnswer {
             question_id: "target".into(),
-            option_id: Some("staging".into()),
-            free_form: None,
+            selected_option_ids: vec!["staging".into()],
+            custom_answer: None,
         }],
+        additional_user_context: None,
     };
     let answer_request = AnswerUserQuestionsRequest {
         chat_id: chat.id,

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -138,6 +138,7 @@ describe("ChatView", () => {
               header: "Scope",
               question: "Which quarter?",
               options: [],
+              questionType: "single_select",
               allowFreeForm: true,
             },
           ],

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -301,7 +301,6 @@ export function ChatView({
             outputWritebacks.cancel(callId, turnId)
           }
           onAnswerUserQuestions={userQuestions.answer}
-          onUserQuestionsCancel={userQuestions.cancel}
           onSelectPrompt={onSelectPrompt}
           onRetryTurn={onRetryTurn}
           hydrated={hydrated}

--- a/crates/openwave-desktop/ui/src/MessageList.isolation.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.isolation.dom.test.tsx
@@ -124,6 +124,7 @@ describe("a continuation card that cannot render", () => {
               options: [
                 { id: "o1", label: "Staging", description: "the shared one" },
               ],
+              questionType: "single_select",
               allowFreeForm: false,
             },
           ],

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -210,8 +210,8 @@ type MessageListProps = {
   onAnswerUserQuestions?: (
     callId: string,
     answers: UserQuestionAnswer[],
+    additionalUserContext?: string,
   ) => void;
-  onUserQuestionsCancel?: (turnId: string) => void;
   decidingPlanCalls?: Set<string>;
   planApprovalErrors?: Record<string, string>;
   onPlanDecision?: (callId: string, decision: PlanDecision) => void;
@@ -264,7 +264,6 @@ export function MessageList({
   planApprovalErrors = {},
   onPlanDecision = () => undefined,
   onPlanCancel = () => undefined,
-  onUserQuestionsCancel = () => undefined,
   onSelectPrompt,
   onRetryTurn,
   hydrated = true,
@@ -383,10 +382,13 @@ export function MessageList({
             request={request}
             working={answeringQuestionCalls.has(request.callId)}
             error={userQuestionErrors[request.callId]}
-            onAnswer={(answers) =>
-              onAnswerUserQuestions(request.callId, answers)
+            onAnswer={(answers, additionalUserContext) =>
+              onAnswerUserQuestions(
+                request.callId,
+                answers,
+                additionalUserContext,
+              )
             }
-            onCancel={() => onUserQuestionsCancel(request.turnId)}
           />,
         ),
       )}

--- a/crates/openwave-desktop/ui/src/UserQuestionsCard.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/UserQuestionsCard.dom.test.tsx
@@ -27,20 +27,22 @@ const request = {
           description: "Deploy to customers.",
         },
       ],
-      allowFreeForm: false,
+      questionType: "multi_select" as const,
+      allowFreeForm: true,
     },
     {
       id: "note",
       header: "Note",
       question: "Anything else?",
       options: [],
+      questionType: "single_select" as const,
       allowFreeForm: true,
     },
   ],
 };
 
 describe("UserQuestionsCard", () => {
-  it("submits every exact answer without creating chat text", async () => {
+  it("submits multi-select, partial answers, and additional context together", async () => {
     const user = userEvent.setup();
     const onAnswer = vi.fn();
     render(
@@ -49,41 +51,68 @@ describe("UserQuestionsCard", () => {
         working={false}
         error={undefined}
         onAnswer={onAnswer}
-        onCancel={vi.fn()}
       />,
     );
     expect(
       screen.queryByRole("button", { name: "Continue" }),
     ).not.toBeInTheDocument();
     await user.click(screen.getByLabelText(/Staging/));
+    await user.click(screen.getByLabelText(/Production/));
+    await user.type(
+      screen.getByRole("textbox", { name: "Other answer" }),
+      "Start with a canary.",
+    );
     await user.click(screen.getByRole("button", { name: "Next" }));
     const submit = screen.getByRole("button", { name: "Continue" });
-    expect(submit).toBeDisabled();
-    await user.type(screen.getByRole("textbox"), "Keep it reversible.");
     expect(submit).toBeEnabled();
+    await user.type(
+      screen.getByRole("textbox", { name: "Additional context" }),
+      "Keep it reversible.",
+    );
     await user.click(submit);
-    expect(onAnswer).toHaveBeenCalledWith([
-      { questionId: "target", optionId: "staging" },
-      { questionId: "note", freeForm: "Keep it reversible." },
-    ]);
+    expect(onAnswer).toHaveBeenCalledWith(
+      [
+        {
+          questionId: "target",
+          selectedOptionIds: ["staging", "production"],
+          customAnswer: "Start with a canary.",
+        },
+      ],
+      "Keep it reversible.",
+    );
   });
 
-  it("keeps cancellation explicit and disables mutation while sending", async () => {
+  it("skips all questions without cancelling the turn", async () => {
     const user = userEvent.setup();
-    const onCancel = vi.fn();
+    const onAnswer = vi.fn();
+    render(
+      <UserQuestionsCard
+        request={request}
+        working={false}
+        error={undefined}
+        onAnswer={onAnswer}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Skip questions" }));
+    expect(onAnswer).toHaveBeenCalledWith([]);
+  });
+
+  it("disables submission while sending", async () => {
+    const user = userEvent.setup();
+    const onAnswer = vi.fn();
     render(
       <UserQuestionsCard
         request={request}
         working
         error="Retry safely"
-        onAnswer={vi.fn()}
-        onCancel={onCancel}
+        onAnswer={onAnswer}
       />,
     );
     expect(screen.getByRole("alert")).toHaveTextContent("Retry safely");
-    const cancel = screen.getByRole("button", { name: "Cancel turn" });
-    expect(cancel).toBeDisabled();
-    await user.click(cancel);
-    expect(onCancel).not.toHaveBeenCalled();
+    const skip = screen.getByRole("button", { name: "Skip questions" });
+    expect(skip).toBeDisabled();
+    await user.click(skip);
+    expect(onAnswer).not.toHaveBeenCalled();
   });
 });

--- a/crates/openwave-desktop/ui/src/UserQuestionsCard.tsx
+++ b/crates/openwave-desktop/ui/src/UserQuestionsCard.tsx
@@ -6,56 +6,93 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 
-type DraftAnswer =
-  | { kind: "option"; value: string }
-  | { kind: "free_form"; value: string };
+type DraftAnswer = {
+  selectedOptionIds: string[];
+  customAnswer?: string;
+};
 
 export function UserQuestionsCard({
   request,
   working,
   error,
   onAnswer,
-  onCancel,
 }: {
   request: PendingUserQuestions;
   working: boolean;
   error: string | undefined;
-  onAnswer: (answers: UserQuestionAnswer[]) => void;
-  onCancel: () => void;
+  onAnswer: (
+    answers: UserQuestionAnswer[],
+    additionalUserContext?: string,
+  ) => void;
 }) {
   const [drafts, setDrafts] = useState<Record<string, DraftAnswer>>({});
   const [currentPage, setCurrentPage] = useState(0);
+  const [additionalContext, setAdditionalContext] = useState("");
   const answers = useMemo(
     () =>
       request.questions.flatMap<UserQuestionAnswer>((question) => {
         const draft = drafts[question.id];
-        if (!draft || !draft.value.trim()) return [];
+        if (!draft) return [];
+        const customAnswer = draft.customAnswer?.trim();
+        if (draft.selectedOptionIds.length === 0 && !customAnswer) return [];
         return [
-          draft.kind === "option"
-            ? { questionId: question.id, optionId: draft.value }
-            : { questionId: question.id, freeForm: draft.value.trim() },
+          {
+            questionId: question.id,
+            selectedOptionIds: draft.selectedOptionIds,
+            ...(customAnswer ? { customAnswer } : {}),
+          },
         ];
       }),
     [drafts, request.questions],
   );
-  const complete = answers.length === request.questions.length;
   const currentQuestion =
     request.questions[Math.min(currentPage, request.questions.length - 1)];
   if (!currentQuestion) return null;
-  const currentDraft = drafts[currentQuestion.id];
+  const currentDraft = drafts[currentQuestion.id] ?? {
+    selectedOptionIds: [],
+  };
+  const isMultiSelect = currentQuestion.questionType === "multi_select";
   const isLastPage = currentPage === request.questions.length - 1;
 
-  const chooseOption = (questionId: string, optionId: string) =>
+  const chooseSingleOption = (questionId: string, optionId: string) =>
     setDrafts((current) => ({
       ...current,
-      [questionId]: { kind: "option", value: optionId },
+      [questionId]: { selectedOptionIds: [optionId] },
     }));
 
-  const updateFreeForm = (questionId: string, value: string) =>
-    setDrafts((current) => ({
-      ...current,
-      [questionId]: { kind: "free_form", value },
-    }));
+  const toggleOption = (questionId: string, optionId: string) =>
+    setDrafts((current) => {
+      const draft = current[questionId] ?? { selectedOptionIds: [] };
+      return {
+        ...current,
+        [questionId]: {
+          ...draft,
+          selectedOptionIds: draft.selectedOptionIds.includes(optionId)
+            ? draft.selectedOptionIds.filter((id) => id !== optionId)
+            : [...draft.selectedOptionIds, optionId],
+        },
+      };
+    });
+
+  const updateCustomAnswer = (
+    questionId: string,
+    value: string | undefined,
+  ) =>
+    setDrafts((current) => {
+      const draft = current[questionId] ?? { selectedOptionIds: [] };
+      return {
+        ...current,
+        [questionId]: {
+          selectedOptionIds: isMultiSelect ? draft.selectedOptionIds : [],
+          ...(value === undefined ? {} : { customAnswer: value }),
+        },
+      };
+    });
+
+  const submitAnswers = () => {
+    const context = additionalContext.trim();
+    onAnswer(answers, context || undefined);
+  };
 
   return (
     <section
@@ -73,6 +110,7 @@ export function UserQuestionsCard({
             className="mt-1 text-[15px] leading-5 font-semibold break-words"
           >
             {currentQuestion.question}
+            {isMultiSelect && " Select all that apply."}
           </h3>
         </div>
         <Button
@@ -80,9 +118,9 @@ export function UserQuestionsCard({
           variant="ghost"
           size="icon-xs"
           disabled={working}
-          onClick={onCancel}
-          aria-label="Cancel turn"
-          title="Cancel turn"
+          onClick={() => onAnswer([])}
+          aria-label="Skip questions"
+          title="Skip questions"
           className="text-muted-foreground shrink-0"
         >
           <X aria-hidden="true" />
@@ -91,14 +129,12 @@ export function UserQuestionsCard({
 
       {currentQuestion.options.length > 0 && (
         <div
-          role="radiogroup"
+          role={isMultiSelect ? "group" : "radiogroup"}
           aria-label={currentQuestion.header}
           className="grid gap-1"
         >
           {currentQuestion.options.map((option) => {
-            const selected =
-              currentDraft?.kind === "option" &&
-              currentDraft.value === option.id;
+            const selected = currentDraft.selectedOptionIds.includes(option.id);
             return (
               <label
                 key={option.id}
@@ -109,12 +145,14 @@ export function UserQuestionsCard({
                 )}
               >
                 <input
-                  type="radio"
+                  type={isMultiSelect ? "checkbox" : "radio"}
                   name={`${request.callId}-${currentQuestion.id}`}
                   checked={selected}
                   disabled={working}
                   onChange={() =>
-                    chooseOption(currentQuestion.id, option.id)
+                    isMultiSelect
+                      ? toggleOption(currentQuestion.id, option.id)
+                      : chooseSingleOption(currentQuestion.id, option.id)
                   }
                   className="accent-foreground mt-0.5 size-[18px] shrink-0"
                 />
@@ -139,26 +177,31 @@ export function UserQuestionsCard({
               )}
             >
               <input
-                type="radio"
+                type={isMultiSelect ? "checkbox" : "radio"}
                 name={`${request.callId}-${currentQuestion.id}`}
-                checked={currentDraft?.kind === "free_form"}
+                checked={currentDraft.customAnswer !== undefined}
                 disabled={working}
-                onChange={() => updateFreeForm(currentQuestion.id, "")}
+                onChange={(event) =>
+                  updateCustomAnswer(
+                    currentQuestion.id,
+                    event.target.checked
+                      ? (currentDraft.customAnswer ?? "")
+                      : undefined,
+                  )
+                }
                 className="accent-foreground size-[18px] shrink-0"
               />
               <Input
                 type="text"
                 maxLength={2000}
-                value={
-                  currentDraft?.kind === "free_form" ? currentDraft.value : ""
-                }
+                value={currentDraft.customAnswer ?? ""}
                 onFocus={() => {
-                  if (currentDraft?.kind !== "free_form") {
-                    updateFreeForm(currentQuestion.id, "");
+                  if (currentDraft.customAnswer === undefined) {
+                    updateCustomAnswer(currentQuestion.id, "");
                   }
                 }}
                 onChange={(event) =>
-                  updateFreeForm(currentQuestion.id, event.target.value)
+                  updateCustomAnswer(currentQuestion.id, event.target.value)
                 }
                 disabled={working}
                 aria-label="Other answer"
@@ -175,11 +218,9 @@ export function UserQuestionsCard({
           <Textarea
             maxLength={2000}
             rows={3}
-            value={
-              currentDraft?.kind === "free_form" ? currentDraft.value : ""
-            }
+            value={currentDraft.customAnswer ?? ""}
             onChange={(event) =>
-              updateFreeForm(currentQuestion.id, event.target.value)
+              updateCustomAnswer(currentQuestion.id, event.target.value)
             }
             disabled={working}
             aria-label={currentQuestion.header}
@@ -187,6 +228,17 @@ export function UserQuestionsCard({
             className="min-h-16 resize-y rounded-[10px] py-2.5 text-sm focus-visible:border-foreground focus-visible:ring-0 focus-visible:ring-offset-0"
           />
         )}
+
+      <Textarea
+        maxLength={2000}
+        rows={2}
+        value={additionalContext}
+        onChange={(event) => setAdditionalContext(event.target.value)}
+        disabled={working}
+        aria-label="Additional context"
+        placeholder="Additional context (optional)"
+        className="min-h-14 resize-y rounded-[10px] py-2.5 text-sm focus-visible:border-foreground focus-visible:ring-0 focus-visible:ring-offset-0"
+      />
 
       {request.questions.length > 1 && (
         <div
@@ -236,8 +288,8 @@ export function UserQuestionsCard({
           <Button
             type="button"
             size="sm"
-            disabled={working || !complete}
-            onClick={() => onAnswer(answers)}
+            disabled={working}
+            onClick={submitAnswers}
           >
             {working ? "Sending…" : "Continue"}
             {!working && <CornerDownLeft aria-hidden="true" />}

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -202,6 +202,7 @@ describe("parsePendingUserQuestions", () => {
             description: "Deploy for internal verification.",
           },
         ],
+        question_type: "multi_select",
         allow_free_form: true,
       },
     ],
@@ -224,6 +225,7 @@ describe("parsePendingUserQuestions", () => {
               description: "Deploy for internal verification.",
             },
           ],
+          questionType: "multi_select",
           allowFreeForm: true,
         },
       ],
@@ -252,6 +254,12 @@ describe("parsePendingUserQuestions", () => {
       parsePendingUserQuestions({
         ...safe,
         questions: [{ ...safe.questions[0], header: "Target\u0085hidden" }],
+      }),
+    ).toBeNull();
+    expect(
+      parsePendingUserQuestions({
+        ...safe,
+        questions: [{ ...safe.questions[0], question_type: "ranked" }],
       }),
     ).toBeNull();
   });

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -58,6 +58,7 @@ import {
   type PendingUserQuestions as WirePendingUserQuestions,
   type UserQuestion as WireUserQuestion,
   type UserQuestionOption as WireUserQuestionOption,
+  type UserQuestionType as WireUserQuestionType,
   type ChatTerminalTurnSnapshot,
   type ChatToolActivitySnapshot,
   type ChatToolActivityStatus,
@@ -531,6 +532,7 @@ export type UserQuestion = {
   header: string;
   question: string;
   options: UserQuestionOption[];
+  questionType: WireUserQuestionType;
   allowFreeForm: boolean;
 };
 
@@ -544,8 +546,8 @@ export type PendingUserQuestions = {
 
 export type UserQuestionAnswer = {
   questionId: string;
-  optionId?: string;
-  freeForm?: string;
+  selectedOptionIds: string[];
+  customAnswer?: string;
 };
 
 /** Closed renderer projection of one durable plan continuation. */
@@ -1476,6 +1478,7 @@ export class ApiClient {
     chatId: string,
     callId: string,
     answers: UserQuestionAnswer[],
+    additionalUserContext?: string,
   ): Promise<void> {
     await this.json(`/chats/${chatId}/questions/${callId}/answer`, {
       method: "POST",
@@ -1483,13 +1486,14 @@ export class ApiClient {
       body: JSON.stringify({
         answers: answers.map((answer) => ({
           question_id: answer.questionId,
-          ...(answer.optionId === undefined
+          selected_option_ids: answer.selectedOptionIds,
+          ...(answer.customAnswer === undefined
             ? {}
-            : { option_id: answer.optionId }),
-          ...(answer.freeForm === undefined
-            ? {}
-            : { free_form: answer.freeForm }),
+            : { custom_answer: answer.customAnswer }),
         })),
+        ...(additionalUserContext === undefined
+          ? {}
+          : { additional_user_context: additionalUserContext }),
       }),
     });
   }
@@ -1745,6 +1749,7 @@ export function parsePendingUserQuestions(
         "header",
         "question",
         "options",
+        "question_type",
         "allow_free_form",
       ]) ||
       !nonEmptyBounded(item.id, 64) ||
@@ -1753,6 +1758,8 @@ export function parsePendingUserQuestions(
       !nonEmptyBounded(item.question, 500) ||
       !Array.isArray(item.options) ||
       item.options.length > 5 ||
+      (item.question_type !== "single_select" &&
+        item.question_type !== "multi_select") ||
       typeof item.allow_free_form !== "boolean" ||
       (item.options.length === 0 && !item.allow_free_form)
     ) {
@@ -1784,6 +1791,7 @@ export function parsePendingUserQuestions(
       header: item.header,
       question: item.question,
       options,
+      questionType: item.question_type,
       allowFreeForm: item.allow_free_form,
     });
   }

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1422,12 +1422,17 @@ export type TurnId = string;
 /**
  * One bounded question shown to the user.
  */
-export type UserQuestion = { id: string, header: string, question: string, options: Array<UserQuestionOption>, allow_free_form: boolean, };
+export type UserQuestion = { id: string, header: string, question: string, options: Array<UserQuestionOption>, question_type: UserQuestionType, allow_free_form: boolean, };
 
 /**
- * One mutually exclusive answer choice.
+ * One selectable answer choice.
  */
 export type UserQuestionOption = { id: string, label: string, description: string, };
+
+/**
+ * Whether the reader may select one option or several independent options.
+ */
+export type UserQuestionType = "single_select" | "multi_select";
 
 /**
  * Public state returned by the local API. It intentionally reports only

--- a/crates/openwave-desktop/ui/src/useUserQuestions.test.ts
+++ b/crates/openwave-desktop/ui/src/useUserQuestions.test.ts
@@ -37,7 +37,6 @@ function deferred<T>() {
 function stubClient(overrides: Record<string, unknown> = {}) {
   return {
     answerUserQuestions: vi.fn().mockResolvedValue(undefined),
-    cancel: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   } as unknown as ApiClient;
 }
@@ -72,24 +71,33 @@ describe("useUserQuestions", () => {
     });
   });
 
-  it("cancels the turn that owns a request", async () => {
+  it("forwards additional context with partial answers", async () => {
     const client = stubClient();
     seedQuestions("chat-1", [pending("call-9", "turn-9")]);
     const { result } = renderHook(() => useUserQuestions(client, "chat-1"));
     await waitFor(() => expect(result.current.requests).toHaveLength(1));
 
-    await act(async () => result.current.cancel("turn-9"));
+    act(() =>
+      result.current.answer(
+        "call-9",
+        [
+          {
+            questionId: "scope",
+            selectedOptionIds: ["desktop"],
+          },
+        ],
+        "Keep the interaction compact.",
+      ),
+    );
 
-    expect(client.cancel).toHaveBeenCalledWith("chat-1", "turn-9");
-  });
-
-  it("ignores a cancel for a turn it has no request for", async () => {
-    const client = stubClient();
-    const { result } = renderHook(() => useUserQuestions(client, "chat-1"));
-
-    await act(async () => result.current.cancel("turn-unknown"));
-
-    expect(client.cancel).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(client.answerUserQuestions).toHaveBeenCalledWith(
+        "chat-1",
+        "call-9",
+        [{ questionId: "scope", selectedOptionIds: ["desktop"] }],
+        "Keep the interaction compact.",
+      ),
+    );
   });
 
   it("does not report a failure onto the conversation that replaced it", async () => {

--- a/crates/openwave-desktop/ui/src/useUserQuestions.ts
+++ b/crates/openwave-desktop/ui/src/useUserQuestions.ts
@@ -7,8 +7,11 @@ export type UserQuestions = {
   requests: PendingUserQuestions[];
   answering: Set<string>;
   errors: Record<string, string>;
-  answer: (callId: string, answers: UserQuestionAnswer[]) => void;
-  cancel: (turnId: string) => void;
+  answer: (
+    callId: string,
+    answers: UserQuestionAnswer[],
+    additionalUserContext?: string,
+  ) => void;
 };
 
 /**
@@ -78,29 +81,26 @@ export function useUserQuestions(
     }
   }
 
-  function answer(callId: string, answers: UserQuestionAnswer[]) {
+  function answer(
+    callId: string,
+    answers: UserQuestionAnswer[],
+    additionalUserContext?: string,
+  ) {
     if (!client || !chatId || answeringRef.current.has(callId)) return;
     const startedChatId = chatId;
     void send(
       callId,
       startedChatId,
-      () => client.answerUserQuestions(startedChatId, callId, answers),
+      () =>
+        client.answerUserQuestions(
+          startedChatId,
+          callId,
+          answers,
+          additionalUserContext,
+        ),
       (err) => `Could not send your answer: ${String(err)}`,
     );
   }
 
-  function cancel(turnId: string) {
-    if (!client || !chatId) return;
-    const request = requests.find((candidate) => candidate.turnId === turnId);
-    if (!request || answeringRef.current.has(request.callId)) return;
-    const startedChatId = chatId;
-    void send(
-      request.callId,
-      startedChatId,
-      () => client.cancel(startedChatId, turnId),
-      (err) => `Could not cancel the turn: ${String(err)}`,
-    );
-  }
-
-  return { requests, answering, errors, answer, cancel };
+  return { requests, answering, errors, answer };
 }

--- a/crates/openwave-server/src/routes/user_questions.rs
+++ b/crates/openwave-server/src/routes/user_questions.rs
@@ -83,7 +83,7 @@ pub async fn answer_user_questions(
         }
         AnswerUserQuestionsOutcome::InvalidAnswer => {
             return Err(ServerError::bad_request(
-                "answers must cover every question exactly once and select a valid option or allowed free-form answer",
+                "answers must name known questions and contain valid selections or allowed custom answers",
             ));
         }
         AnswerUserQuestionsOutcome::Unavailable => {

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -1120,6 +1120,13 @@ async fn park_user_questions_for_route_test(
                     {"id": "staging", "label": "Staging", "description": "Deploy for internal verification."},
                     {"id": "production", "label": "Production", "description": "Deploy to customers."}
                 ],
+                "question_type": "multi_select",
+                "allow_free_form": true
+            }, {
+                "id": "note",
+                "header": "Note",
+                "question": "Anything else?",
+                "question_type": "single_select",
                 "allow_free_form": true
             }]
         }),
@@ -1223,6 +1230,7 @@ async fn user_question_api_is_renderer_safe_exact_and_not_native_claimable() {
     assert_eq!(pending[0]["call_id"], call.id.to_string());
     assert_eq!(pending[0]["turn_id"], turn_id.to_string());
     assert_eq!(pending[0]["questions"][0]["id"], "target");
+    assert_eq!(pending[0]["questions"][0]["question_type"], "multi_select");
     let serialized = pending.to_string();
     for private in [
         "provider-question",
@@ -1272,13 +1280,21 @@ async fn user_question_api_is_renderer_safe_exact_and_not_native_claimable() {
         &bearer,
         &answer_uri,
         serde_json::json!({
-            "answers": [{"question_id": "target", "option_id": "unknown"}]
+            "answers": [{
+                "question_id": "target",
+                "selected_option_ids": ["unknown"]
+            }]
         }),
     )
     .await;
     assert_eq!(invalid.status(), StatusCode::BAD_REQUEST);
     let answer = serde_json::json!({
-        "answers": [{"question_id": "target", "option_id": "staging"}]
+        "answers": [{
+            "question_id": "target",
+            "selected_option_ids": ["staging", "production"],
+            "custom_answer": "Start with a canary."
+        }],
+        "additional_user_context": "Keep the rollout reversible."
     });
     let first = post_json(&router, &bearer, &answer_uri, answer.clone()).await;
     assert_eq!(first.status(), StatusCode::OK);
@@ -1297,7 +1313,11 @@ async fn user_question_api_is_renderer_safe_exact_and_not_native_claimable() {
         &bearer,
         &answer_uri,
         serde_json::json!({
-            "answers": [{"question_id": "target", "option_id": "production"}]
+            "answers": [{
+                "question_id": "target",
+                "selected_option_ids": ["production"]
+            }],
+            "additional_user_context": "Keep the rollout reversible."
         }),
     )
     .await;
@@ -1337,7 +1357,7 @@ async fn user_question_answer_announces_the_completion_live_once() {
     let mut live = state.events.subscribe(chat.id);
     let answer_uri = format!("/chats/{}/questions/{}/answer", chat.id, call.id);
     let answer = serde_json::json!({
-        "answers": [{"question_id": "target", "option_id": "staging"}]
+        "answers": []
     });
     let answered = post_json(&router, &bearer, &answer_uri, answer.clone()).await;
     assert_eq!(answered.status(), StatusCode::OK);


### PR DESCRIPTION
## Summary

- let readers skip all or some agent questions while the parked turn continues
- add single-select and multi-select wire semantics, additive custom answers, and optional overall context
- persist the extended response shape with an additive migration while retaining compatibility with existing scalar answer rows
- align the desktop card with Alpha: checkbox multi-select, Select all that apply guidance, optional context, and a close control that skips instead of cancelling

## Testing

- `cargo test -p openwave-core user_question --locked --no-fail-fast`
- `cargo test -p openwave-server user_question --locked --no-fail-fast`
- `UPDATE_WIRE_TYPES=1 cargo test -p openwave-server wire_types::tests::the_generated_bindings_are_current --locked`
- `pnpm exec vitest run src/UserQuestionsCard.dom.test.tsx src/useUserQuestions.test.ts src/api.test.ts src/ChatView.dom.test.tsx src/MessageList.isolation.dom.test.tsx`
- `pnpm exec tsc --noEmit`
- `cargo fmt --all -- --check`
- `git diff --check`

## Test changes

- replaced cancellation-only question-card and hook assertions with skip-path and additional-context coverage because closing a question card now resumes the turn instead of cancelling it

Closes #704