### PR TITLE
refactor(desktop): consolidate output write-back

### DIFF
--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -35,7 +35,8 @@ pub use host_paths::{
 };
 pub use local::LocalExecutionProvider;
 pub use overlay::{
-    sweep_abandoned_overlays, MaterializedChange, MaterializedChangeKind, OverlayInspector,
+    materialize_file, materialized_file_matches, sweep_abandoned_overlays,
+    MaterializationPrecondition, MaterializedChange, MaterializedChangeKind, OverlayInspector,
     OverlayOutcome, OverlaySlot, PreparedWriteSnapshot, PriorContents, RejectedChange,
     RejectedChangeReason, StagedChange, WriteOverlay, WriteSnapshotSink, OVERLAY_DIR,
 };

--- a/crates/openwave-code-execution/src/overlay.rs
+++ b/crates/openwave-code-execution/src/overlay.rs
@@ -200,6 +200,18 @@ pub enum RejectedChangeReason {
     Unavailable,
 }
 
+/// What the destination must contain when one file is materialized.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaterializationPrecondition {
+    /// No entry may occupy the destination.
+    Absent,
+    /// Any existing regular file may be replaced, with its exact digest
+    /// derived immediately before the conditional mutation.
+    Existing,
+    /// The destination must still contain these exact bytes.
+    Sha256([u8; 32]),
+}
+
 /// Per-file result of applying one overlay.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct OverlayOutcome {
@@ -283,6 +295,66 @@ pub trait WriteSnapshotSink: Send + Sync {
         &self,
         change: StagedChange<'_>,
     ) -> Result<Box<dyn PreparedWriteSnapshot>, String>;
+}
+
+/// Materialize one bounded file through the same conditional write and
+/// snapshot protocol used by a turn's overlay.
+///
+/// This is the structured path for trusted callers that already hold a live
+/// grant to `folder` but did not originate from shell edits in an overlay.
+/// `relative` remains root-relative, and every component is opened without
+/// following symlinks.
+pub async fn materialize_file(
+    folder: &Path,
+    relative: &str,
+    content: &[u8],
+    expected: MaterializationPrecondition,
+    snapshots: Option<&dyn WriteSnapshotSink>,
+) -> Result<MaterializedChangeKind, RejectedChangeReason> {
+    if content.len() as u64 > MAX_STAGED_FILE_BYTES {
+        return Err(RejectedChangeReason::StagedFileTooLarge);
+    }
+    let source_dir = resolve_scratch_directory(folder, "", false)
+        .await
+        .ok_or(RejectedChangeReason::Unavailable)?;
+    materialize_file_in(
+        folder,
+        &source_dir,
+        relative,
+        content,
+        expected,
+        snapshots,
+        None,
+    )
+    .await
+}
+
+/// Whether one materialized destination contains the exact expected bytes.
+///
+/// Recovery uses this after a dispatch may have crossed the native boundary.
+/// A missing, non-regular, symlinked, or otherwise unavailable destination is
+/// simply not a match.
+pub async fn materialized_file_matches(
+    folder: &Path,
+    relative: &str,
+    byte_len: u64,
+    sha256: [u8; 32],
+) -> bool {
+    let Some(source_dir) = resolve_scratch_directory(folder, "", false).await else {
+        return false;
+    };
+    let (prefix, name) = split_relative(relative);
+    let Ok(target) = descend(&source_dir, prefix, false).await else {
+        return false;
+    };
+    target
+        .file_stamp(name)
+        .await
+        .is_some_and(|stamp| stamp.len == byte_len)
+        && target
+            .file_sha256(name)
+            .await
+            .is_ok_and(|digest| digest == sha256)
 }
 
 impl WriteOverlay {
@@ -798,30 +870,9 @@ async fn write_back(
     content: &[u8],
 ) -> Result<MaterializedChangeKind, RejectedChangeReason> {
     let relative = join_relative(prefix, name);
-    let target = descend(&slot.source_dir, prefix, true)
-        .await
-        .map_err(|_| RejectedChangeReason::Unavailable)?;
     let expected = manifest.map_or(FilePrecondition::Absent, |entry| {
         FilePrecondition::Sha256(entry.sha256)
     });
-    let observed = observe_prior(&target, name).await?;
-    if observed.precondition != expected {
-        return Err(RejectedChangeReason::Stale);
-    }
-    let snapshot = match snapshots {
-        Some(snapshots) => Some(
-            snapshots
-                .prepare(StagedChange {
-                    folder: &slot.source,
-                    relative: &relative,
-                    prior: observed.prior,
-                    next: Some(content),
-                })
-                .await
-                .map_err(|_| RejectedChangeReason::SnapshotUnavailable)?,
-        ),
-        None => None,
-    };
     // The staged file carries the mode the folder's copy had, so writing it
     // back does not turn a script into a non-executable file or narrow who can
     // read a document the user shares.
@@ -832,6 +883,78 @@ async fn write_back(
         let _ = stamp;
         None
     };
+    materialize_file_in(
+        &slot.source,
+        &slot.source_dir,
+        &relative,
+        content,
+        match expected {
+            FilePrecondition::Absent => MaterializationPrecondition::Absent,
+            FilePrecondition::Sha256(digest) => MaterializationPrecondition::Sha256(digest),
+        },
+        snapshots,
+        mode,
+    )
+    .await
+}
+
+struct ObservedPrior {
+    prior: PriorContents,
+    precondition: FilePrecondition,
+    #[cfg(unix)]
+    mode: Option<u32>,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn materialize_file_in(
+    folder: &Path,
+    source_dir: &ScratchDir,
+    relative: &str,
+    content: &[u8],
+    expected: MaterializationPrecondition,
+    snapshots: Option<&dyn WriteSnapshotSink>,
+    mode: Option<u32>,
+) -> Result<MaterializedChangeKind, RejectedChangeReason> {
+    let (prefix, name) = split_relative(relative);
+    if name.is_empty() {
+        return Err(RejectedChangeReason::Unavailable);
+    }
+    let target = descend(source_dir, prefix, true)
+        .await
+        .map_err(|_| RejectedChangeReason::Unavailable)?;
+    let observed = observe_prior(&target, name).await?;
+    let expected = match expected {
+        MaterializationPrecondition::Absent => FilePrecondition::Absent,
+        MaterializationPrecondition::Existing => match observed.precondition {
+            FilePrecondition::Absent => return Err(RejectedChangeReason::Stale),
+            FilePrecondition::Sha256(digest) => FilePrecondition::Sha256(digest),
+        },
+        MaterializationPrecondition::Sha256(digest) => FilePrecondition::Sha256(digest),
+    };
+    if observed.precondition != expected {
+        return Err(RejectedChangeReason::Stale);
+    }
+    let change = if expected == FilePrecondition::Absent {
+        MaterializedChangeKind::Created
+    } else {
+        MaterializedChangeKind::Overwritten
+    };
+    let snapshot = match snapshots {
+        Some(snapshots) => Some(
+            snapshots
+                .prepare(StagedChange {
+                    folder,
+                    relative,
+                    prior: observed.prior,
+                    next: Some(content),
+                })
+                .await
+                .map_err(|_| RejectedChangeReason::SnapshotUnavailable)?,
+        ),
+        None => None,
+    };
+    #[cfg(unix)]
+    let mode = mode.or(observed.mode);
     let applied = target
         .write_file_with_mode_if_matches(name, content, mode, expected)
         .await
@@ -842,16 +965,7 @@ async fn write_back(
     if let Some(snapshot) = snapshot {
         snapshot.applied();
     }
-    Ok(if manifest.is_some() {
-        MaterializedChangeKind::Overwritten
-    } else {
-        MaterializedChangeKind::Created
-    })
-}
-
-struct ObservedPrior {
-    prior: PriorContents,
-    precondition: FilePrecondition,
+    Ok(change)
 }
 
 /// Read what the user's folder holds for `name` and derive the exact
@@ -865,6 +979,8 @@ async fn observe_prior(
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(ObservedPrior {
                 prior: PriorContents::Absent,
                 precondition: FilePrecondition::Absent,
+                #[cfg(unix)]
+                mode: None,
             }),
             _ => Err(RejectedChangeReason::SnapshotUnavailable),
         },
@@ -878,15 +994,19 @@ async fn observe_prior(
                     byte_len: stamp.len,
                 },
                 precondition: FilePrecondition::Sha256(sha256),
+                #[cfg(unix)]
+                mode: Some(stamp.mode),
             })
         }
-        Some(_) => {
+        Some(stamp) => {
             let bytes = match target.read_file(name).await {
                 Ok(bytes) => bytes,
                 Err(error) if error.kind() == io::ErrorKind::NotFound => {
                     return Ok(ObservedPrior {
                         prior: PriorContents::Absent,
                         precondition: FilePrecondition::Absent,
+                        #[cfg(unix)]
+                        mode: None,
                     });
                 }
                 Err(_) => return Err(RejectedChangeReason::SnapshotUnavailable),
@@ -895,6 +1015,8 @@ async fn observe_prior(
             Ok(ObservedPrior {
                 prior: PriorContents::Bytes(bytes),
                 precondition: FilePrecondition::Sha256(sha256),
+                #[cfg(unix)]
+                mode: Some(stamp.mode),
             })
         }
     }
@@ -1268,6 +1390,66 @@ mod tests {
                 },
             }))
         }
+    }
+
+    /// Trusted structured writes use the same prior-byte snapshot, conditional
+    /// publication, and recovery digest as overlay changes.
+    #[tokio::test]
+    async fn direct_materialization_shares_the_overlay_write_contract() {
+        let granted = tempfile::tempdir().unwrap();
+        std::fs::create_dir(granted.path().join("published")).unwrap();
+        std::fs::write(granted.path().join("published/report.txt"), "original").unwrap();
+        let sink = RecordingSink {
+            refuse: None,
+            seen: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+        };
+
+        assert_eq!(
+            materialize_file(
+                granted.path(),
+                "published/report.txt",
+                b"revision",
+                MaterializationPrecondition::Existing,
+                Some(&sink),
+            )
+            .await,
+            Ok(MaterializedChangeKind::Overwritten)
+        );
+        assert_eq!(
+            *sink.seen.lock().unwrap(),
+            vec![Recorded {
+                relative: "published/report.txt".to_owned(),
+                prior: PriorContents::Bytes(b"original".to_vec()),
+                next: Some(b"revision".to_vec()),
+            }]
+        );
+        let digest: [u8; 32] = Sha256::digest(b"revision").into();
+        assert!(
+            materialized_file_matches(
+                granted.path(),
+                "published/report.txt",
+                b"revision".len() as u64,
+                digest,
+            )
+            .await
+        );
+
+        assert_eq!(
+            materialize_file(
+                granted.path(),
+                "published/report.txt",
+                b"must-not-clobber",
+                MaterializationPrecondition::Absent,
+                Some(&sink),
+            )
+            .await,
+            Err(RejectedChangeReason::Stale)
+        );
+        assert_eq!(
+            std::fs::read(granted.path().join("published/report.txt")).unwrap(),
+            b"revision"
+        );
+        assert_eq!(sink.seen.lock().unwrap().len(), 1);
     }
 
     /// The bytes a change destroys reach the journal before the folder is

--- a/crates/openwave-desktop/src/client_execution/output_writeback.rs
+++ b/crates/openwave-desktop/src/client_execution/output_writeback.rs
@@ -7,21 +7,19 @@
 
 use std::collections::HashSet;
 
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use openwave_code_execution::{
+    MaterializationPrecondition, MaterializedChangeKind, RejectedChangeReason,
+};
 use openwave_core::{
     CallId, ChatId, HostRootId, OutputWriteMode, ToolCallRecord, WriteOutputToConnectedFolderArgs,
     WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
 };
-use openwave_host_broker::{
-    ErrorCode, OperationEnvelope, OperationRequest, OperationResult, RelativePath, RootId,
-    WriteApproval, WriteFileMode, WriteFileRequest, PROTOCOL_VERSION,
-};
+use openwave_host_broker::RelativePath;
 use serde::Deserialize;
 use tauri::{AppHandle, Manager, State};
 use uuid::Uuid;
 
 use crate::{
-    broker::BrokerClientError,
     deliverables::{read_output_revision_bytes, require_exact_revision, require_live_output},
     host_access::HostAccess,
 };
@@ -295,17 +293,6 @@ async fn execute_receipt(
     {
         return Err("local control plane returned a stale write-back claim".to_owned());
     }
-    let context = match state.context(receipt.chat_id.0).await {
-        Ok(context) => context,
-        Err(_) => {
-            return terminalize(
-                state,
-                &mut receipt,
-                unavailable("output_writeback_authority_unavailable"),
-            )
-            .await;
-        }
-    };
     let store = state
         .store()
         .ok_or_else(|| "OpenWave is still starting".to_owned())?;
@@ -338,6 +325,33 @@ async fn execute_receipt(
         )
         .await;
     }
+    let Some(materializer) = state.staged_folders() else {
+        return terminalize(
+            state,
+            &mut receipt,
+            unavailable("output_writeback_authority_unavailable"),
+        )
+        .await;
+    };
+    let path = RelativePath::parse(&receipt.relative_path)
+        .map_err(|_| "invalid output write-back destination".to_owned())?;
+    if receipt.phase == FolderOperationPhase::DispatchStarted {
+        let resolution = if materializer
+            .connected_file_matches(
+                receipt.chat_id,
+                receipt.root_id,
+                path.as_str(),
+                receipt.byte_len,
+                receipt.sha256,
+            )
+            .await
+        {
+            completed(&receipt)
+        } else {
+            unavailable("output_writeback_ambiguous_native_failure")
+        };
+        return terminalize(state, &mut receipt, resolution).await;
+    }
 
     let scratch_root = crate::data_dir(app)?.join("scratch");
     let (output, revision) =
@@ -359,17 +373,6 @@ async fn execute_receipt(
         .await
         .map_err(|_| "could not read immutable output revision".to_owned())??
     };
-    let root_id = RootId::from_uuid(*receipt.root_id.as_uuid())
-        .map_err(|_| "invalid connected-root identity".to_owned())?;
-    let path = RelativePath::parse(&receipt.relative_path)
-        .map_err(|_| "invalid output write-back destination".to_owned())?;
-    let mode = match receipt.mode {
-        OutputWriteMode::Create => WriteFileMode::Create,
-        OutputWriteMode::Replace => WriteFileMode::Replace,
-    };
-    let approval = receipt
-        .approval_id
-        .map(|approval_id| WriteApproval { approval_id });
 
     client
         .heartbeat(receipt.chat_id, receipt.call_id, receipt.lease_token)
@@ -380,44 +383,28 @@ async fn execute_receipt(
         .receipts
         .save_output_writeback(&receipt)
         .map_err(private_receipt_error)?;
-    let operation = OperationEnvelope {
-        protocol_version: PROTOCOL_VERSION,
-        request_id: openwave_host_broker::RequestId::new(),
-        context: context.execution,
-        request: OperationRequest::WriteFile(WriteFileRequest {
-            operation_id: receipt.operation_id,
-            root_id,
-            path,
-            mode,
-            approval,
-            content_base64: BASE64.encode(&bytes),
-            bytes: bytes.len(),
-            sha256: receipt.sha256,
-        }),
+    let expected = match receipt.mode {
+        OutputWriteMode::Create => MaterializationPrecondition::Absent,
+        OutputWriteMode::Replace => MaterializationPrecondition::Existing,
     };
-    let resolution = match state.broker.operation(operation).await {
-        Ok(OperationResult::WriteFile(result))
-            if result.operation_id == receipt.operation_id
-                && result.bytes as u64 == receipt.byte_len
-                && result.replaced == matches!(receipt.mode, OutputWriteMode::Replace) =>
-        {
-            StoredResolution::Completed {
-                result: format!(
-                    "Published output {} revision {} to the connected folder.",
-                    receipt.output_id, receipt.revision_id
-                ),
-                rows: Some(serde_json::json!({
-                    "entries": [openwave_core::ResultEntry::new(
-                        openwave_core::ResultEntryKind::Output,
-                        file_name(&receipt.relative_path),
-                    )
-                    .with_detail(receipt.relative_path.clone())
-                    .with_meta(openwave_core::format_bytes(receipt.byte_len))],
-                })),
-            }
-        }
-        Ok(_) => unavailable("output_writeback_broker_protocol"),
-        Err(error) => broker_resolution(&error),
+    let expected_change = match receipt.mode {
+        OutputWriteMode::Create => MaterializedChangeKind::Created,
+        OutputWriteMode::Replace => MaterializedChangeKind::Overwritten,
+    };
+    let resolution = match materializer
+        .materialize_connected_file(
+            receipt.chat_id,
+            claim.call.turn_id,
+            receipt.root_id,
+            path.as_str(),
+            &bytes,
+            expected,
+        )
+        .await
+    {
+        Ok(change) if change == expected_change => completed(&receipt),
+        Ok(_) => unavailable("output_writeback_materialization_protocol"),
+        Err(reason) => materialization_resolution(receipt.mode, reason),
     };
     terminalize(state, &mut receipt, resolution).await
 }
@@ -502,21 +489,37 @@ fn unavailable(code: &str) -> StoredResolution {
     }
 }
 
-fn broker_resolution(error: &BrokerClientError) -> StoredResolution {
-    let code = match error {
-        BrokerClientError::Broker {
-            code: ErrorCode::AlreadyExists,
-            ..
-        } => "output_writeback_destination_exists",
-        BrokerClientError::Broker {
-            code: ErrorCode::Denied | ErrorCode::InvalidRoot,
-            ..
-        } => "output_writeback_authority_unavailable",
-        BrokerClientError::Broker {
-            code: ErrorCode::AmbiguousWrite,
-            ..
-        } => "output_writeback_ambiguous_native_failure",
-        _ => "output_writeback_unavailable",
+fn completed(receipt: &OutputWritebackReceipt) -> StoredResolution {
+    StoredResolution::Completed {
+        result: format!(
+            "Published output {} revision {} to the connected folder.",
+            receipt.output_id, receipt.revision_id
+        ),
+        rows: Some(serde_json::json!({
+            "entries": [openwave_core::ResultEntry::new(
+                openwave_core::ResultEntryKind::Output,
+                file_name(&receipt.relative_path),
+            )
+            .with_detail(receipt.relative_path.clone())
+            .with_meta(openwave_core::format_bytes(receipt.byte_len))],
+        })),
+    }
+}
+
+fn materialization_resolution(
+    mode: OutputWriteMode,
+    reason: RejectedChangeReason,
+) -> StoredResolution {
+    let code = match (mode, reason) {
+        (OutputWriteMode::Create, RejectedChangeReason::Stale) => {
+            "output_writeback_destination_exists"
+        }
+        (OutputWriteMode::Replace, RejectedChangeReason::Stale) => {
+            "output_writeback_destination_changed"
+        }
+        (_, RejectedChangeReason::SnapshotUnavailable) => "output_writeback_snapshot_unavailable",
+        (_, RejectedChangeReason::StagedFileTooLarge) => "output_writeback_source_unavailable",
+        (_, RejectedChangeReason::Unavailable) => "output_writeback_unavailable",
     };
     unavailable(code)
 }

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -18,10 +18,11 @@ use openwave_code_execution::{
     CodeExecutionProviderKind, CodeExecutionRequest, CodeExecutionResponse, DaytonaCredential,
     DaytonaExecutionProvider, E2BCredential, E2BExecutionProvider, ExecFolderAccess,
     ExecFolderGrant, ExecutionId, ExecutionWorkspaceId, LocalExecutionProvider,
-    OutputArtifactEntry, OutputArtifactScan, OutputArtifactStatus, PreviewScan, RemoteSessionPool,
-    StagedUpload, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, WriteOverlay,
-    WriteSnapshotSink, DAYTONA_CREDENTIAL_KEY, DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES,
-    E2B_CREDENTIAL_KEY, PACKAGE_MANAGER_DOMAINS,
+    MaterializationPrecondition, MaterializedChangeKind, OutputArtifactEntry, OutputArtifactScan,
+    OutputArtifactStatus, PreviewScan, RejectedChangeReason, RemoteSessionPool, StagedUpload,
+    WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, WriteOverlay, WriteSnapshotSink,
+    DAYTONA_CREDENTIAL_KEY, DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES, E2B_CREDENTIAL_KEY,
+    PACKAGE_MANAGER_DOMAINS,
 };
 use openwave_core::{
     exec_attachment_file_name, BlobStore, CallId, Chat, ChatId, HostRootId,
@@ -709,17 +710,41 @@ struct StagedTurn {
 /// the same turn consults this first, so the model is never shown two versions
 /// of one folder.
 ///
-/// The broker is deliberately not involved. Staging is a property of the turn,
-/// and the broker knows nothing about turns; it stays the authority on whether
-/// a folder may be read at all.
+/// The broker knows nothing about turn staging, but remains the live authority
+/// behind every root resolution. Structured publications resolve that
+/// authority again immediately before entering the shared materializer.
+#[async_trait]
 pub trait StagedFolders: Send + Sync {
     /// The staged copy of `root_id` for this chat's current turn, if the turn
     /// stages that folder. `None` covers every case where the user's folder is
     /// still the only view — no turn in flight, a read-only grant, or a folder
     /// the overlay could not stage.
     fn staged_root(&self, chat: ChatId, root_id: HostRootId) -> Option<PathBuf>;
+
+    /// Publish one trusted file through the same conditional materializer and
+    /// turn journal as an overlay write.
+    async fn materialize_connected_file(
+        &self,
+        chat: ChatId,
+        turn: TurnId,
+        root_id: HostRootId,
+        relative: &str,
+        content: &[u8],
+        expected: MaterializationPrecondition,
+    ) -> std::result::Result<MaterializedChangeKind, RejectedChangeReason>;
+
+    /// Reconcile an interrupted publication against its exact content.
+    async fn connected_file_matches(
+        &self,
+        chat: ChatId,
+        root_id: HostRootId,
+        relative: &str,
+        byte_len: u64,
+        sha256: [u8; 32],
+    ) -> bool;
 }
 
+#[async_trait]
 impl StagedFolders for ConfiguredCodeExecutionProvider {
     fn staged_root(&self, chat: ChatId, root_id: HostRootId) -> Option<PathBuf> {
         self.write_overlays
@@ -729,6 +754,63 @@ impl StagedFolders for ConfiguredCodeExecutionProvider {
             .staged_roots
             .get(&root_id)
             .cloned()
+    }
+
+    async fn materialize_connected_file(
+        &self,
+        chat: ChatId,
+        turn: TurnId,
+        root_id: HostRootId,
+        relative: &str,
+        content: &[u8],
+        expected: MaterializationPrecondition,
+    ) -> std::result::Result<MaterializedChangeKind, RejectedChangeReason> {
+        let folder = self.writable_connected_root(chat, root_id).await?;
+        let snapshots =
+            self.blobs
+                .as_ref()
+                .zip(self.blob_writes.as_ref())
+                .map(|(blobs, blob_writes)| {
+                    TurnSnapshotSink::new(self.store.clone(), blobs.clone(), blob_writes.clone())
+                });
+        let result = openwave_code_execution::materialize_file(
+            &folder,
+            relative,
+            content,
+            expected,
+            snapshots
+                .as_ref()
+                .map(|sink| sink as &dyn WriteSnapshotSink),
+        )
+        .await;
+        if result.is_ok() {
+            if let Some(sink) = snapshots {
+                if let Err(error) = sink.commit(chat, turn).await {
+                    tracing::error!(
+                        chat = %chat,
+                        turn = %turn,
+                        %error,
+                        "could not journal a connected-folder publication; undo is unavailable"
+                    );
+                }
+            }
+        }
+        result
+    }
+
+    async fn connected_file_matches(
+        &self,
+        chat: ChatId,
+        root_id: HostRootId,
+        relative: &str,
+        byte_len: u64,
+        sha256: [u8; 32],
+    ) -> bool {
+        let Ok(folder) = self.writable_connected_root(chat, root_id).await else {
+            return false;
+        };
+        openwave_code_execution::materialized_file_matches(&folder, relative, byte_len, sha256)
+            .await
     }
 }
 
@@ -1010,6 +1092,26 @@ impl ConfiguredCodeExecutionProvider {
             }
         }
         Ok(ordered)
+    }
+
+    async fn writable_connected_root(
+        &self,
+        chat_id: ChatId,
+        root_id: HostRootId,
+    ) -> std::result::Result<PathBuf, RejectedChangeReason> {
+        let chat = self
+            .store
+            .get_chat(chat_id)
+            .await
+            .map_err(|_| RejectedChangeReason::Unavailable)?
+            .ok_or(RejectedChangeReason::Unavailable)?;
+        self.resolve_chat_folder_grants(&chat)
+            .await
+            .map_err(|_| RejectedChangeReason::Unavailable)?
+            .into_iter()
+            .find(|grant| grant.root_id == root_id && grant.writable)
+            .map(|grant| grant.path)
+            .ok_or(RejectedChangeReason::Unavailable)
     }
 
     /// Resolve the currently selected adapter at the last boundary before use.


### PR DESCRIPTION
## Summary

- extract the staged overlay materializer into a shared single-file write path
- route deliverable publications through live root resolution, digest CAS, and prior-byte snapshot journaling
- reconcile interrupted publications by exact immutable revision digest while preserving create/no-clobber and replacement approval behavior

## Tests

- `cargo check -p openwave-code-execution -p openwave-server -p openwave-desktop --locked`
- `cargo test -p openwave-code-execution --locked overlay::tests`
- `cargo clippy -p openwave-code-execution -p openwave-server -p openwave-desktop --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`

Closes #1081