### PR TITLE
fix(exec): make overlay limits fail closed

### DIFF
--- a/crates/openwave-code-execution/src/host_paths.rs
+++ b/crates/openwave-code-execution/src/host_paths.rs
@@ -25,7 +25,7 @@
 //! caller reaching for `join`.
 
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt};
@@ -286,6 +286,17 @@ impl ScratchDir {
         })
         .await
         .unwrap_or(false)
+    }
+
+    /// Read a symlink target without following it.
+    ///
+    /// Used only to compare inert overlay entries before and after an exec
+    /// command. The containing directory stays descriptor-pinned, so a renamed
+    /// parent cannot redirect the observation elsewhere.
+    pub async fn read_link(&self, name: &str) -> io::Result<PathBuf> {
+        let name = single_component(name)?;
+        self.blocking(move |directory| directory.read_link(&name))
+            .await
     }
 
     /// Open `name` as a child directory, refusing a symlink at that component.

--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -35,9 +35,9 @@ pub use host_paths::{
 };
 pub use local::LocalExecutionProvider;
 pub use overlay::{
-    sweep_abandoned_overlays, MaterializedChange, MaterializedChangeKind, OverlayOutcome,
-    OverlaySlot, PreparedWriteSnapshot, PriorContents, RejectedChange, RejectedChangeReason,
-    StagedChange, WriteOverlay, WriteSnapshotSink, OVERLAY_DIR,
+    sweep_abandoned_overlays, MaterializedChange, MaterializedChangeKind, OverlayInspector,
+    OverlayOutcome, OverlaySlot, PreparedWriteSnapshot, PriorContents, RejectedChange,
+    RejectedChangeReason, StagedChange, WriteOverlay, WriteSnapshotSink, OVERLAY_DIR,
 };
 pub use preview::{scan_preview_directory, PreviewScan};
 pub use remote::RemoteSessionPool;

--- a/crates/openwave-code-execution/src/overlay.rs
+++ b/crates/openwave-code-execution/src/overlay.rs
@@ -46,9 +46,10 @@
 //! it can rename directories under the paths this module would otherwise walk;
 //! pinning means the directory acted on is the directory that was checked.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use openwave_core::MAX_EXEC_SNAPSHOT_BYTES;
 use sha2::{Digest as _, Sha256};
@@ -76,6 +77,9 @@ const MAX_OVERLAY_DEPTH: usize = 24;
 /// Ceiling on one staged file's size when it is written back.
 const MAX_STAGED_FILE_BYTES: u64 = 64 * 1_024 * 1_024;
 
+/// Maximum paths included in one model-visible overlay note.
+const MAX_REPORTED_INERT_PATHS: usize = 8;
+
 /// What one regular file in the staged copy looked like before exec ran.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ManifestEntry {
@@ -95,6 +99,11 @@ pub struct OverlaySlot {
     overlay_dir: ScratchDir,
     /// Every regular file the copy started with, by overlay-relative path.
     manifest: BTreeMap<String, ManifestEntry>,
+    /// Directory names present when staging began.
+    directories: Arc<BTreeSet<String>>,
+    /// Symlinks and exotic entries present when staging began. A symlink's
+    /// target is retained so replacing it in place is still observable.
+    inert: Arc<BTreeMap<String, Option<PathBuf>>>,
 }
 
 impl std::fmt::Debug for OverlaySlot {
@@ -128,6 +137,21 @@ impl OverlaySlot {
 pub struct WriteOverlay {
     home: PathBuf,
     slots: Vec<OverlaySlot>,
+}
+
+/// An owned, descriptor-pinned view used to report overlay changes after an
+/// exec command without holding the server's overlay registry lock.
+#[derive(Debug, Clone)]
+pub struct OverlayInspector {
+    slots: Vec<OverlayInspectionSlot>,
+}
+
+#[derive(Debug, Clone)]
+struct OverlayInspectionSlot {
+    source: PathBuf,
+    directory: ScratchDir,
+    directories: Arc<BTreeSet<String>>,
+    inert: Arc<BTreeMap<String, Option<PathBuf>>>,
 }
 
 /// A staged change that passed its precondition and reached the granted folder.
@@ -265,10 +289,9 @@ impl WriteOverlay {
     /// Stage `sources` under a fresh per-turn home inside `scratch_root`.
     ///
     /// A source that cannot be copied — unreadable, too large, or a name that
-    /// something already occupies — is simply not staged. It keeps direct write
-    /// access, which is what it had before this module existed, so a folder
-    /// this cannot handle degrades to the previous behavior instead of losing
-    /// the agent's writes.
+    /// something already occupies — is left out of the returned slots. The
+    /// caller must then fail its write grant closed; this layer never grants
+    /// access to the source itself.
     pub async fn prepare(scratch_root: &Path, scope: &str, sources: &[PathBuf]) -> Option<Self> {
         if sources.is_empty() || scope.is_empty() || scope.contains('/') {
             return None;
@@ -291,7 +314,7 @@ impl WriteOverlay {
                 None => {
                     tracing::warn!(
                         source = %source.display(),
-                        "exec write overlay could not stage a granted folder; writes stay direct"
+                        "exec write overlay could not stage a granted folder"
                     );
                 }
             }
@@ -307,6 +330,25 @@ impl WriteOverlay {
     #[must_use]
     pub fn slots(&self) -> &[OverlaySlot] {
         &self.slots
+    }
+
+    /// Take a cheap owned view that can report changes which write-back cannot
+    /// apply. The inspection uses the same pinned directories and manifest as
+    /// materialization, so its warning cannot be redirected through a symlink.
+    #[must_use]
+    pub fn inspector(&self) -> OverlayInspector {
+        OverlayInspector {
+            slots: self
+                .slots
+                .iter()
+                .map(|slot| OverlayInspectionSlot {
+                    source: slot.source.clone(),
+                    directory: slot.overlay_dir.clone(),
+                    directories: Arc::clone(&slot.directories),
+                    inert: Arc::clone(&slot.inert),
+                })
+                .collect(),
+        }
     }
 
     /// Apply every staged change to the real folders and drop the overlay.
@@ -370,7 +412,20 @@ async fn stage_one(
     let overlay_dir = home_dir.open_dir(name).await.ok()?;
 
     let mut manifest = BTreeMap::new();
-    if !record_manifest(&overlay_dir, "", &mut manifest, 0).await {
+    let mut directories = BTreeSet::new();
+    let mut inert = BTreeMap::new();
+    let mut entries = 0;
+    if !record_manifest(
+        &overlay_dir,
+        "",
+        &mut manifest,
+        &mut directories,
+        &mut inert,
+        &mut entries,
+        0,
+    )
+    .await
+    {
         let _ = tokio::fs::remove_dir_all(&destination).await;
         return None;
     }
@@ -380,6 +435,8 @@ async fn stage_one(
         source_dir,
         overlay_dir,
         manifest,
+        directories: Arc::new(directories),
+        inert: Arc::new(inert),
     })
 }
 
@@ -394,6 +451,9 @@ async fn record_manifest(
     directory: &ScratchDir,
     prefix: &str,
     manifest: &mut BTreeMap<String, ManifestEntry>,
+    directories: &mut BTreeSet<String>,
+    inert: &mut BTreeMap<String, Option<PathBuf>>,
+    entry_count: &mut usize,
     depth: usize,
 ) -> bool {
     if depth > MAX_OVERLAY_DEPTH {
@@ -403,9 +463,10 @@ async fn record_manifest(
         return false;
     };
     for ScratchEntry { name, kind } in entries {
-        if manifest.len() >= MAX_OVERLAY_ENTRIES {
+        if *entry_count >= MAX_OVERLAY_ENTRIES {
             return false;
         }
+        *entry_count += 1;
         let relative = join_relative(prefix, &name);
         match kind {
             ScratchEntryKind::File => {
@@ -417,19 +478,195 @@ async fn record_manifest(
                 }
             }
             ScratchEntryKind::Directory => {
+                directories.insert(relative.clone());
                 let Ok(child) = directory.open_dir(&name).await else {
                     continue;
                 };
-                if !Box::pin(record_manifest(&child, &relative, manifest, depth + 1)).await {
+                if !Box::pin(record_manifest(
+                    &child,
+                    &relative,
+                    manifest,
+                    directories,
+                    inert,
+                    entry_count,
+                    depth + 1,
+                ))
+                .await
+                {
                     return false;
                 }
             }
             // Symlinks and everything exotic are copied by the clone but never
-            // walked, written back, or deleted. They are inert.
-            ScratchEntryKind::Other => {}
+            // walked, written back, or deleted. Retaining their identity lets
+            // the exec result say so if the command changes one.
+            ScratchEntryKind::Other => {
+                inert.insert(relative, directory.read_link(&name).await.ok());
+            }
         }
     }
     true
+}
+
+impl OverlayInspector {
+    /// Model-visible notes for changes that overlay materialization cannot
+    /// apply. Empty means every observed change is representable.
+    pub async fn notes(self) -> Vec<String> {
+        let mut notes = Vec::new();
+        for slot in self.slots {
+            let mut observed = ObservedOverlay::default();
+            if !inspect_directory(&slot.directory, "", &mut observed, 0).await {
+                notes.push(format!(
+                    "staged folder {}: OpenWave could not inspect all staged changes; some writes may not be applied",
+                    quoted_path(&slot.source)
+                ));
+                continue;
+            }
+
+            if !observed.oversized.is_empty() {
+                notes.push(format_inert_note(
+                    &slot.source,
+                    &observed.oversized,
+                    "exceed the 64 MiB write-back limit; content changes to them will not be applied",
+                ));
+            }
+
+            let empty_created = observed
+                .directories
+                .difference(&slot.directories)
+                .filter(|directory| !has_descendant_file(directory, &observed.files))
+                .cloned()
+                .collect::<Vec<_>>();
+            if !empty_created.is_empty() {
+                notes.push(format_inert_note(
+                    &slot.source,
+                    &empty_created,
+                    "are new empty directories; empty-directory changes are not applied",
+                ));
+            }
+
+            let removed_directories = slot
+                .directories
+                .difference(&observed.directories)
+                .cloned()
+                .collect::<Vec<_>>();
+            if !removed_directories.is_empty() {
+                notes.push(format_inert_note(
+                    &slot.source,
+                    &removed_directories,
+                    "were removed in staging; directory removals are not applied",
+                ));
+            }
+
+            let changed_inert = slot
+                .inert
+                .keys()
+                .chain(observed.inert.keys())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .filter(|path| slot.inert.get(*path) != observed.inert.get(*path))
+                .cloned()
+                .collect::<Vec<_>>();
+            if !changed_inert.is_empty() {
+                notes.push(format_inert_note(
+                    &slot.source,
+                    &changed_inert,
+                    "are symlink or unsupported-entry changes and will not be applied",
+                ));
+            }
+        }
+        notes
+    }
+}
+
+#[derive(Default)]
+struct ObservedOverlay {
+    files: BTreeSet<String>,
+    directories: BTreeSet<String>,
+    inert: BTreeMap<String, Option<PathBuf>>,
+    oversized: Vec<String>,
+}
+
+async fn inspect_directory(
+    directory: &ScratchDir,
+    prefix: &str,
+    observed: &mut ObservedOverlay,
+    depth: usize,
+) -> bool {
+    if depth > MAX_OVERLAY_DEPTH {
+        return false;
+    }
+    let Ok(entries) = directory.entries().await else {
+        return false;
+    };
+    for ScratchEntry { name, kind } in entries {
+        if observed.files.len() + observed.directories.len() + observed.inert.len()
+            >= MAX_OVERLAY_ENTRIES
+        {
+            return false;
+        }
+        let relative = join_relative(prefix, &name);
+        match kind {
+            ScratchEntryKind::File => {
+                observed.files.insert(relative.clone());
+                let Some(stamp) = directory.file_stamp(&name).await else {
+                    return false;
+                };
+                if stamp.len > MAX_STAGED_FILE_BYTES {
+                    observed.oversized.push(relative);
+                }
+            }
+            ScratchEntryKind::Directory => {
+                observed.directories.insert(relative.clone());
+                let Ok(child) = directory.open_dir(&name).await else {
+                    return false;
+                };
+                if !Box::pin(inspect_directory(&child, &relative, observed, depth + 1)).await {
+                    return false;
+                }
+            }
+            ScratchEntryKind::Other => {
+                observed
+                    .inert
+                    .insert(relative, directory.read_link(&name).await.ok());
+            }
+        }
+    }
+    true
+}
+
+fn has_descendant_file(directory: &str, files: &BTreeSet<String>) -> bool {
+    let prefix = format!("{directory}/");
+    files
+        .range(prefix.clone()..)
+        .next()
+        .is_some_and(|file| file.starts_with(&prefix))
+}
+
+fn format_inert_note(folder: &Path, paths: &[String], consequence: &str) -> String {
+    let shown = paths
+        .iter()
+        .take(MAX_REPORTED_INERT_PATHS)
+        .map(|path| quoted(path))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let omitted = paths.len().saturating_sub(MAX_REPORTED_INERT_PATHS);
+    let suffix = if omitted == 0 {
+        String::new()
+    } else {
+        format!(" (and {omitted} more)")
+    };
+    format!(
+        "staged folder {}: {shown}{suffix} {consequence}",
+        quoted_path(folder)
+    )
+}
+
+fn quoted_path(path: &Path) -> String {
+    quoted(&path.display().to_string())
+}
+
+fn quoted(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"<unprintable>\"".to_owned())
 }
 
 async fn apply_directory(
@@ -950,6 +1187,42 @@ mod tests {
             std::fs::read_to_string(granted.path().join("kept.txt")).unwrap(),
             "kept"
         );
+    }
+
+    /// Unsupported staging effects must ride the exec result while the model
+    /// can still react, rather than appearing only in a host log after the turn.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn inert_and_oversized_changes_are_reported_before_write_back() {
+        use std::os::unix::fs::symlink;
+
+        let granted = tempfile::tempdir().unwrap();
+        let (_scratch, overlay) = overlay_for(granted.path()).await;
+        let staged = overlay.slots()[0].overlay().to_path_buf();
+        std::fs::create_dir(staged.join("empty")).unwrap();
+        symlink("target.txt", staged.join("shortcut")).unwrap();
+        std::fs::File::create(staged.join("oversized.bin"))
+            .unwrap()
+            .set_len(MAX_STAGED_FILE_BYTES + 1)
+            .unwrap();
+
+        let notes = overlay.inspector().notes().await.join("\n");
+        assert!(notes.contains("\"oversized.bin\" exceed the 64 MiB write-back limit"));
+        assert!(notes.contains("\"empty\" are new empty directories"));
+        assert!(notes.contains("\"shortcut\" are symlink or unsupported-entry changes"));
+
+        let outcome = overlay.materialize(None).await;
+        assert_eq!(
+            outcome.rejected,
+            vec![RejectedChange {
+                folder: granted.path().to_path_buf(),
+                relative: "oversized.bin".to_owned(),
+                reason: RejectedChangeReason::StagedFileTooLarge,
+            }]
+        );
+        assert!(!granted.path().join("empty").exists());
+        assert!(!granted.path().join("shortcut").exists());
+        assert!(!granted.path().join("oversized.bin").exists());
     }
 
     #[derive(Debug, PartialEq, Eq)]

--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -182,6 +182,7 @@ impl openwave_server::code_execution::ExecFolderGrantResolver for DesktopExecFol
                     // once it knows which folders it will stage. The broker
                     // answers about authority and nothing else.
                     overlay: None,
+                    staging_unavailable: false,
                 })
             })
             .collect()

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -134,6 +134,12 @@ pub struct ResolvedExecFolderGrant {
     /// Set by the server after the broker answers, never by the broker: it is
     /// a property of the turn, not of the attachment.
     pub overlay: Option<PathBuf>,
+    /// The broker granted writes, but this turn could not stage them safely.
+    ///
+    /// Such a folder is deliberately downgraded to read-only. Keeping the
+    /// reason distinct lets the operating prompt explain the restriction
+    /// instead of presenting it as ordinary read-only authority.
+    pub staging_unavailable: bool,
 }
 
 /// Native-only bridge from product root attachments to live broker authority.
@@ -805,8 +811,9 @@ impl ConfiguredCodeExecutionProvider {
     /// Stage this turn's writes for every writable granted folder.
     ///
     /// Called once, when the turn resolves the grants it will show the model.
-    /// A folder that cannot be staged keeps direct write access, which is the
-    /// behavior it had before staging existed.
+    /// A folder that cannot be staged is downgraded to read-only for this turn:
+    /// silently restoring direct writes would remove the overlay precisely for
+    /// the largest or most unusual folders.
     async fn open_write_overlay(
         &self,
         chat: ChatId,
@@ -822,6 +829,10 @@ impl ConfiguredCodeExecutionProvider {
         let scope = chat.to_string();
         let Some(overlay) = WriteOverlay::prepare(&self.scratch_root, &scope, &writable).await
         else {
+            for grant in grants.iter_mut().filter(|grant| grant.writable) {
+                grant.writable = false;
+                grant.staging_unavailable = true;
+            }
             return;
         };
         let mut staged_roots = HashMap::new();
@@ -833,6 +844,13 @@ impl ConfiguredCodeExecutionProvider {
                 grant.overlay = Some(slot.overlay().to_path_buf());
                 staged_roots.insert(grant.root_id, slot.overlay().to_path_buf());
             }
+        }
+        for grant in grants
+            .iter_mut()
+            .filter(|grant| grant.writable && grant.overlay.is_none())
+        {
+            grant.writable = false;
+            grant.staging_unavailable = true;
         }
         self.write_overlays
             .lock()
@@ -930,6 +948,14 @@ impl ConfiguredCodeExecutionProvider {
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    fn overlay_inspector(&self, chat: ChatId) -> Option<openwave_code_execution::OverlayInspector> {
+        self.write_overlays
+            .lock()
+            .expect("write overlay registry is not poisoned")
+            .get(&chat)
+            .map(|staged| staged.overlay.inspector())
     }
 
     async fn resolve_chat_folder_grants(
@@ -1067,6 +1093,33 @@ impl ConfiguredCodeExecutionProvider {
     }
 }
 
+fn exec_folder_grant_for_turn(
+    grant: ResolvedExecFolderGrant,
+    staged: &HashMap<PathBuf, PathBuf>,
+) -> std::result::Result<ExecFolderGrant, CodeExecutionError> {
+    let overlay = grant
+        .writable
+        .then(|| staged.get(&grant.path))
+        .flatten()
+        .cloned();
+    // A live broker write grant is necessary but no longer sufficient: this
+    // turn must also have staged the folder. Missing staging fails closed
+    // instead of quietly restoring unrestricted writes to the real root.
+    let writable = grant.writable && overlay.is_some();
+    let resolved = ExecFolderGrant::new(
+        grant.path,
+        if writable {
+            ExecFolderAccess::ReadWrite
+        } else {
+            ExecFolderAccess::ReadOnly
+        },
+    )?;
+    match overlay {
+        Some(overlay) => resolved.staged_at(overlay),
+        None => Ok(resolved),
+    }
+}
+
 #[async_trait]
 impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
     async fn execute(
@@ -1109,22 +1162,7 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
                 .resolve_chat_folder_grants(&chat)
                 .await?
                 .into_iter()
-                .map(|grant| {
-                    let writable = grant.writable;
-                    let overlay = writable.then(|| staged.get(&grant.path)).flatten().cloned();
-                    let resolved = ExecFolderGrant::new(
-                        grant.path,
-                        if writable {
-                            ExecFolderAccess::ReadWrite
-                        } else {
-                            ExecFolderAccess::ReadOnly
-                        },
-                    )?;
-                    match overlay {
-                        Some(overlay) => resolved.staged_at(overlay),
-                        None => Ok(resolved),
-                    }
-                })
+                .map(|grant| exec_folder_grant_for_turn(grant, &staged))
                 .collect::<std::result::Result<Vec<_>, _>>()?;
             request = request.with_folder_grants(grants)?;
         }
@@ -1161,7 +1199,17 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
         };
         let Some(lifecycle) = lifecycle else {
             sync::validate_staged_paths(&host_dir, &request.files).await?;
-            return provider.execute(request).await;
+            let inspector = request
+                .workspace_id
+                .as_str()
+                .parse::<ChatId>()
+                .ok()
+                .and_then(|chat| self.overlay_inspector(chat));
+            let mut response = provider.execute(request).await?;
+            if let Some(inspector) = inspector {
+                response.sync_notes.extend(inspector.notes().await);
+            }
+            return Ok(response);
         };
         // A staging that fails outright fails the execution: a listed path
         // that does not exist, an over-bound expansion, or an unreachable
@@ -1644,6 +1692,7 @@ mod tests {
                 path: folder.path().to_path_buf(),
                 writable: false,
                 overlay: None,
+                staging_unavailable: false,
             }],
         });
         let provider = ConfiguredCodeExecutionProvider::new(
@@ -1679,6 +1728,7 @@ mod tests {
                 path: folder.path().to_path_buf(),
                 writable: true,
                 overlay: None,
+                staging_unavailable: false,
             }],
         });
         let (store, _database) = test_store().await;
@@ -1692,6 +1742,44 @@ mod tests {
             .resolve_chat_folder_grants(&chat)
             .await
             .is_err());
+    }
+
+    /// A tree outside the overlay's bounded contract must lose exec write
+    /// access rather than regaining direct access to the user's real folder.
+    #[tokio::test]
+    async fn a_folder_that_cannot_be_staged_fails_closed_and_stays_visible() {
+        let (store, _database) = test_store().await;
+        let scratch = tempfile::tempdir().unwrap();
+        let folder = tempfile::tempdir().unwrap();
+        let mut nested = folder.path().to_path_buf();
+        for depth in 0..30 {
+            nested.push(format!("level-{depth}"));
+            std::fs::create_dir(&nested).unwrap();
+        }
+        let root_id = HostRootId::from_uuid(Uuid::new_v4()).unwrap();
+        let provider = ConfiguredCodeExecutionProvider::new(
+            Arc::new(store),
+            Arc::new(NoSecrets),
+            scratch.path(),
+        );
+        let mut grants = vec![ResolvedExecFolderGrant {
+            root_id,
+            path: folder.path().to_path_buf(),
+            writable: true,
+            overlay: None,
+            staging_unavailable: false,
+        }];
+
+        provider
+            .open_write_overlay(ChatId::new(), TurnId::new(), &mut grants)
+            .await;
+
+        assert!(!grants[0].writable);
+        assert!(grants[0].staging_unavailable);
+        assert!(grants[0].overlay.is_none());
+        let effective = exec_folder_grant_for_turn(grants.remove(0), &HashMap::new()).unwrap();
+        assert_eq!(effective.access, ExecFolderAccess::ReadOnly);
+        assert!(effective.writable_path().is_none());
     }
 
     /// The files-first creation path end to end at the provider seam: a file

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -294,25 +294,36 @@ pub(crate) fn compose_for_surface(
             let mut any_staged = false;
             for folder in exec_folders.iter().take(MAX_LISTED_EXEC_FOLDER_GRANTS) {
                 let path = quoted(&folder.path);
-                match (&folder.overlay, folder.writable) {
-                    (Some(overlay), true) => {
+                match (
+                    &folder.overlay,
+                    folder.writable,
+                    folder.staging_unavailable,
+                ) {
+                    (Some(overlay), true, false) => {
                         any_staged = true;
                         lines.push(format!(
                             "- read-write folder: {path}, staged at {}",
                             quoted(overlay)
                         ));
                     }
-                    (_, true) => lines.push(format!("- read-write folder: {path}")),
-                    (_, false) => lines.push(format!("- read-only folder: {path}")),
+                    (_, _, true) => lines.push(format!(
+                        "- write unavailable folder: {path} (OpenWave could not stage it safely for this turn; use connected-folder tools if a write is needed)"
+                    )),
+                    (_, true, false) => lines.push(format!("- read-write folder: {path}")),
+                    (_, false, false) => lines.push(format!("- read-only folder: {path}")),
                 }
             }
             if any_staged {
                 lines.push(
-                    "- A staged folder is writable only at its staged path, which holds a complete copy of the folder made for this turn. Read and edit the copy exactly as you would the folder itself; the changes are applied to the real folder when the turn ends."
+                    "- A staged folder is writable only at its staged path, which holds a copy of the folder made for this turn. Read and edit the copy exactly as you would the folder itself; regular-file changes are applied to the real folder when the turn ends, including when the turn is cancelled. A crash or abandoned turn discards them."
                         .to_owned(),
                 );
                 lines.push(
                     "- When you tell the user about a file in a staged folder, name it by the folder's own path, not the staged path."
+                        .to_owned(),
+                );
+                lines.push(
+                    "- Empty-directory and symlink changes cannot be applied from staging. OpenWave reports those, and files over the write-back limit, in the exec result."
                         .to_owned(),
                 );
             }
@@ -552,6 +563,7 @@ mod tests {
                 path: format!("/Users/example/grant-{index}").into(),
                 writable: index < 2,
                 overlay: (index == 0).then(|| "/scratch/.exec-overlays/chat/staged".into()),
+                staging_unavailable: index == 1,
             })
             .collect::<Vec<_>>();
         let prompt = compose_for_surface(&[spec("exec")], &folders, false);
@@ -559,9 +571,12 @@ mod tests {
         assert!(prompt.contains(
             "read-write folder: \"/Users/example/grant-0\", staged at \"/scratch/.exec-overlays/chat/staged\""
         ));
-        // An unstaged writable grant must not be described as staged.
-        assert!(prompt.contains("read-write folder: \"/Users/example/grant-1\"\n"));
+        assert!(prompt.contains(
+            "write unavailable folder: \"/Users/example/grant-1\" (OpenWave could not stage it safely"
+        ));
         assert!(prompt.contains("read-only folder: \"/Users/example/grant-2\""));
+        assert!(prompt.contains("including when the turn is cancelled"));
+        assert!(prompt.contains("Empty-directory and symlink changes cannot be applied"));
         assert!(prompt.contains("2 additional granted folder(s) are omitted"));
         assert!(!prompt.contains("/Users/example/grant-12"));
         assert!(prompt.contains("Revocation applies to the next invocation"));


### PR DESCRIPTION
## Summary

- downgrade writable folder grants to read-only when per-turn staging cannot safely cover the folder, and explain that restriction in the operating prompt
- report oversized files plus inert empty-directory and symlink changes in the next exec result while the model can still react
- state the existing cancellation contract explicitly: graceful cancellation applies staged regular-file changes, while abandoned work is discarded

## Verification

- `cargo check -p openwave-code-execution -p openwave-server -p openwave-desktop --locked`
- `cargo clippy -p openwave-code-execution -p openwave-server -p openwave-desktop --all-targets --locked -- -D warnings`
- `cargo test -p openwave-code-execution overlay::tests::inert_and_oversized_changes_are_reported_before_write_back --locked`
- `cargo test -p openwave-server code_execution::tests::a_folder_that_cannot_be_staged_fails_closed_and_stays_visible --locked`
- `cargo test -p openwave-server foreground_prompt::tests::exec_folder_context_lists_modes_and_bounds_host_paths --locked`

Closes #1219.