### PR TITLE
feat(exec): move staged deletes to native trash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,7 +2731,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -3984,6 +3984,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tracing",
+ "trash",
  "ts-rs",
  "uuid",
 ]
@@ -6498,8 +6499,8 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
 ]
@@ -6586,7 +6587,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6685,7 +6686,7 @@ dependencies = [
  "tracing",
  "url",
  "windows-registry",
- "windows-result",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -6823,7 +6824,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -6848,7 +6849,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -7363,6 +7364,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "trash"
+version = "5.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7602e0c7d66ec2d92a8c917219fbc7894039efa2063b9064260110828a356f46"
+dependencies = [
+ "libc",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "once_cell",
+ "percent-encoding",
+ "scopeguard",
+ "urlencoding",
+ "windows 0.56.0",
+]
+
+[[package]]
 name = "tray-icon"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7585,6 +7603,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"
@@ -7898,10 +7922,10 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
- "windows-core",
- "windows-implement",
- "windows-interface",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
 ]
 
 [[package]]
@@ -7922,8 +7946,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.19",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7986,12 +8010,22 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+dependencies = [
+ "windows-core 0.56.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -8003,7 +8037,19 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+dependencies = [
+ "windows-implement 0.56.0",
+ "windows-interface 0.56.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8012,10 +8058,10 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
- "windows-result",
+ "windows-result 0.3.4",
  "windows-strings",
 ]
 
@@ -8025,9 +8071,20 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -8035,6 +8092,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8070,7 +8138,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
 ]
 
@@ -8081,8 +8149,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link 0.1.3",
- "windows-result",
+ "windows-result 0.3.4",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8456,8 +8533,8 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,4 +73,5 @@ libc = "=0.2.189"
 async-stream = "=0.3.6"
 axum = { version = "=0.8.9", features = ["ws"] }
 tempfile = "=3.27.0"
+trash = { version = "=5.2.6", default-features = false, features = ["coinit_apartmentthreaded"] }
 zip = { version = "=8.6.0", default-features = false, features = ["deflate-flate2"] }

--- a/crates/openwave-code-execution/Cargo.toml
+++ b/crates/openwave-code-execution/Cargo.toml
@@ -27,6 +27,7 @@ sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "net", "process", "rt", "sync", "time"] }
 tracing = "=0.1.44"
+trash = { workspace = true }
 uuid = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -36,9 +36,10 @@ pub use host_paths::{
 pub use local::LocalExecutionProvider;
 pub use overlay::{
     materialize_file, materialized_file_matches, sweep_abandoned_overlays,
-    MaterializationPrecondition, MaterializedChange, MaterializedChangeKind, OverlayInspector,
-    OverlayOutcome, OverlaySlot, PreparedWriteSnapshot, PriorContents, RejectedChange,
-    RejectedChangeReason, StagedChange, WriteOverlay, WriteSnapshotSink, OVERLAY_DIR,
+    MaterializationPrecondition, MaterializedChange, MaterializedChangeKind, NativeTrash,
+    OverlayInspector, OverlayOutcome, OverlaySlot, PreparedWriteSnapshot, PriorContents,
+    RejectedChange, RejectedChangeReason, StagedChange, TrashSink, WriteOverlay, WriteSnapshotSink,
+    OVERLAY_DIR,
 };
 pub use preview::{scan_preview_directory, PreviewScan};
 pub use remote::RemoteSessionPool;

--- a/crates/openwave-code-execution/src/overlay.rs
+++ b/crates/openwave-code-execution/src/overlay.rs
@@ -196,6 +196,8 @@ pub enum RejectedChangeReason {
     SnapshotUnavailable,
     /// The staged file exceeds the write-back ceiling.
     StagedFileTooLarge,
+    /// A recoverable copy could not be placed in the operating system's trash.
+    TrashUnavailable,
     /// A filesystem operation failed or found an unsupported entry.
     Unavailable,
 }
@@ -357,6 +359,31 @@ pub async fn materialized_file_matches(
             .is_ok_and(|digest| digest == sha256)
 }
 
+/// Destination for the recoverable copy made before a granted-root deletion.
+///
+/// Production uses [`NativeTrash`]. The trait keeps native Trash/Recycle Bin
+/// side effects out of contract tests while exercising the same ordering:
+/// trash must accept the verified copy before the real file can be unlinked.
+#[async_trait::async_trait]
+pub trait TrashSink: Send + Sync {
+    /// Move `path` into this trash destination.
+    async fn trash(&self, path: &Path) -> Result<(), String>;
+}
+
+/// The current user's native Trash, Recycle Bin, or FreeDesktop trash.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NativeTrash;
+
+#[async_trait::async_trait]
+impl TrashSink for NativeTrash {
+    async fn trash(&self, path: &Path) -> Result<(), String> {
+        let path = path.to_path_buf();
+        tokio::task::spawn_blocking(move || trash::delete(path).map_err(|error| error.to_string()))
+            .await
+            .map_err(|_| "native trash operation did not complete".to_owned())?
+    }
+}
+
 impl WriteOverlay {
     /// Stage `sources` under a fresh per-turn home inside `scratch_root`.
     ///
@@ -433,7 +460,21 @@ impl WriteOverlay {
     /// leaving the remainder unapplied would strand work the agent believes it
     /// finished.
     pub async fn materialize(self, snapshots: Option<&dyn WriteSnapshotSink>) -> OverlayOutcome {
+        self.materialize_with_trash(snapshots, &NativeTrash).await
+    }
+
+    /// Apply staged changes with an explicit trash destination.
+    ///
+    /// This is the same operation as [`WriteOverlay::materialize`]; callers
+    /// that need deterministic isolation from the user's native trash can
+    /// supply a test destination.
+    pub async fn materialize_with_trash(
+        self,
+        snapshots: Option<&dyn WriteSnapshotSink>,
+        trash: &dyn TrashSink,
+    ) -> OverlayOutcome {
         let mut outcome = OverlayOutcome::default();
+        let trash_staging = self.home.join(".trash-staging");
         for slot in &self.slots {
             let mut seen = Vec::new();
             apply_directory(
@@ -446,7 +487,7 @@ impl WriteOverlay {
                 &mut outcome,
             )
             .await;
-            apply_deletions(slot, snapshots, &seen, &mut outcome).await;
+            apply_deletions(slot, snapshots, trash, &trash_staging, &seen, &mut outcome).await;
         }
         self.discard().await;
         outcome
@@ -1029,6 +1070,8 @@ async fn observe_prior(
 async fn apply_deletions(
     slot: &OverlaySlot,
     snapshots: Option<&dyn WriteSnapshotSink>,
+    trash: &dyn TrashSink,
+    trash_staging: &Path,
     seen: &[String],
     outcome: &mut OverlayOutcome,
 ) {
@@ -1072,6 +1115,18 @@ async fn apply_deletions(
             },
             None => None,
         };
+        let trashed = match stage_trash_copy(&target, name, expected, trash_staging).await {
+            Ok(trashed) => trashed,
+            Err(reason) => {
+                outcome.rejected(slot, relative, reason);
+                continue;
+            }
+        };
+        if trash.trash(&trashed).await.is_err() {
+            let _ = tokio::fs::remove_file(&trashed).await;
+            outcome.rejected(slot, relative, RejectedChangeReason::TrashUnavailable);
+            continue;
+        }
         match target.remove_file_if_matches(name, expected).await {
             Ok(true) => {
                 if let Some(snapshot) = snapshot {
@@ -1083,6 +1138,69 @@ async fn apply_deletions(
             Err(_) => outcome.rejected(slot, relative, RejectedChangeReason::Unavailable),
         }
     }
+}
+
+/// Copy one still-matching source file to private staging for native trash.
+///
+/// Native trash APIs are path-based. The granted root is deliberately not:
+/// every mutation there is descriptor-relative so a renamed directory or
+/// planted symlink cannot redirect it. Copying through a no-follow file handle
+/// bridges those models without reopening the granted path. The digest of the
+/// copied bytes is verified before the path-based native API sees them, and
+/// the original is checked again at the eventual unlink boundary.
+async fn stage_trash_copy(
+    source: &ScratchDir,
+    name: &str,
+    expected: FilePrecondition,
+    trash_staging: &Path,
+) -> Result<PathBuf, RejectedChangeReason> {
+    let FilePrecondition::Sha256(expected) = expected else {
+        return Err(RejectedChangeReason::Unavailable);
+    };
+    let source = source
+        .open_file(name)
+        .await
+        .map_err(|_| RejectedChangeReason::Unavailable)?;
+    let name = name.to_owned();
+    let trash_staging = trash_staging.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        use std::io::{Read as _, Write as _};
+
+        let item_home = trash_staging.join(uuid::Uuid::new_v4().to_string());
+        std::fs::create_dir_all(&item_home).map_err(|_| RejectedChangeReason::TrashUnavailable)?;
+        let path = item_home.join(name);
+        let mut destination = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .map_err(|_| RejectedChangeReason::TrashUnavailable)?;
+        let mut source = source;
+        let mut digest = Sha256::new();
+        let mut buffer = [0_u8; 64 * 1_024];
+        loop {
+            let read = source
+                .read(&mut buffer)
+                .map_err(|_| RejectedChangeReason::Unavailable)?;
+            if read == 0 {
+                break;
+            }
+            digest.update(&buffer[..read]);
+            destination
+                .write_all(&buffer[..read])
+                .map_err(|_| RejectedChangeReason::TrashUnavailable)?;
+        }
+        destination
+            .sync_all()
+            .map_err(|_| RejectedChangeReason::TrashUnavailable)?;
+        let copied: [u8; 32] = digest.finalize().into();
+        if copied != expected {
+            let _ = std::fs::remove_file(&path);
+            return Err(RejectedChangeReason::Stale);
+        }
+        Ok(path)
+    })
+    .await
+    .map_err(|_| RejectedChangeReason::TrashUnavailable)?
 }
 
 /// Open `relative` under `directory` one pinned component at a time.
@@ -1201,6 +1319,30 @@ fn split_relative(relative: &str) -> (&str, &str) {
 mod tests {
     use super::*;
 
+    #[derive(Default)]
+    struct RecordingTrash {
+        files: std::sync::Mutex<Vec<(String, Vec<u8>)>>,
+        fail: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl TrashSink for RecordingTrash {
+        async fn trash(&self, path: &Path) -> Result<(), String> {
+            if self.fail {
+                return Err("trash unavailable".into());
+            }
+            let name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| "trash name is not UTF-8".to_owned())?
+                .to_owned();
+            let bytes = std::fs::read(path).map_err(|error| error.to_string())?;
+            std::fs::remove_file(path).map_err(|error| error.to_string())?;
+            self.files.lock().unwrap().push((name, bytes));
+            Ok(())
+        }
+    }
+
     async fn overlay_for(source: &Path) -> (tempfile::TempDir, WriteOverlay) {
         let scratch = tempfile::tempdir().unwrap();
         let overlay = WriteOverlay::prepare(scratch.path(), "chat", &[source.to_path_buf()])
@@ -1251,7 +1393,8 @@ mod tests {
         );
         assert!(granted.path().join("nested/data.csv").exists());
 
-        let outcome = overlay.materialize(None).await;
+        let trash = RecordingTrash::default();
+        let outcome = overlay.materialize_with_trash(None, &trash).await;
         assert_eq!(outcome.rejected, Vec::new());
         assert_eq!(outcome.written.len(), 3);
         assert_eq!(
@@ -1275,6 +1418,10 @@ mod tests {
             "fresh"
         );
         assert!(!granted.path().join("nested/data.csv").exists());
+        assert_eq!(
+            *trash.files.lock().unwrap(),
+            vec![("data.csv".to_owned(), b"a,b".to_vec())]
+        );
 
         // A file written back keeps the mode it had rather than becoming a
         // private host-owned file the user can no longer share.
@@ -1299,7 +1446,8 @@ mod tests {
         let (_scratch, overlay) = overlay_for(granted.path()).await;
         std::fs::write(granted.path().join("arrived-later.txt"), "user").unwrap();
 
-        let outcome = overlay.materialize(None).await;
+        let trash = RecordingTrash::default();
+        let outcome = overlay.materialize_with_trash(None, &trash).await;
         assert_eq!(outcome, OverlayOutcome::default());
         assert_eq!(
             std::fs::read_to_string(granted.path().join("arrived-later.txt")).unwrap(),
@@ -1474,7 +1622,8 @@ mod tests {
             refuse: Some("precious.md".into()),
             seen: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         };
-        let outcome = overlay.materialize(Some(&sink)).await;
+        let trash = RecordingTrash::default();
+        let outcome = overlay.materialize_with_trash(Some(&sink), &trash).await;
         assert_eq!(outcome.written.len(), 3);
         assert_eq!(
             outcome.rejected,
@@ -1515,6 +1664,42 @@ mod tests {
         );
     }
 
+    /// A native trash failure is a per-file rejection, never permission to
+    /// fall back to the irreversible unlink this feature replaces.
+    #[tokio::test]
+    async fn a_trash_failure_leaves_the_granted_file_and_snapshot_unapplied() {
+        let granted = tempfile::tempdir().unwrap();
+        std::fs::write(granted.path().join("gone.txt"), "keep me").unwrap();
+
+        let (_scratch, overlay) = overlay_for(granted.path()).await;
+        std::fs::remove_file(overlay.slots()[0].overlay().join("gone.txt")).unwrap();
+
+        let sink = RecordingSink {
+            refuse: None,
+            seen: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+        };
+        let trash = RecordingTrash {
+            fail: true,
+            ..RecordingTrash::default()
+        };
+        let outcome = overlay.materialize_with_trash(Some(&sink), &trash).await;
+
+        assert_eq!(outcome.written, Vec::new());
+        assert_eq!(
+            outcome.rejected,
+            vec![RejectedChange {
+                folder: granted.path().to_path_buf(),
+                relative: "gone.txt".to_owned(),
+                reason: RejectedChangeReason::TrashUnavailable,
+            }]
+        );
+        assert_eq!(
+            std::fs::read_to_string(granted.path().join("gone.txt")).unwrap(),
+            "keep me"
+        );
+        assert!(sink.seen.lock().unwrap().is_empty());
+    }
+
     /// A user edit after the overlay is prepared wins every conflict: an
     /// overwrite, a delete, and a create collision are each rejected rather
     /// than replacing bytes the agent never saw.
@@ -1547,7 +1732,8 @@ mod tests {
         std::fs::write(granted.path().join("gone.txt"), "user edit").unwrap();
         std::fs::write(granted.path().join("fresh.txt"), "user file").unwrap();
 
-        let outcome = overlay.materialize(None).await;
+        let trash = RecordingTrash::default();
+        let outcome = overlay.materialize_with_trash(None, &trash).await;
         assert_eq!(outcome.written, Vec::new());
         assert_eq!(
             outcome
@@ -1620,7 +1806,8 @@ mod tests {
             target: target.clone(),
             applied: std::sync::Arc::clone(&applied),
         };
-        let outcome = overlay.materialize(Some(&sink)).await;
+        let trash = RecordingTrash::default();
+        let outcome = overlay.materialize_with_trash(Some(&sink), &trash).await;
 
         assert_eq!(outcome.written, Vec::new());
         assert_eq!(

--- a/crates/openwave-desktop/src/client_execution/output_writeback.rs
+++ b/crates/openwave-desktop/src/client_execution/output_writeback.rs
@@ -519,6 +519,7 @@ fn materialization_resolution(
         }
         (_, RejectedChangeReason::SnapshotUnavailable) => "output_writeback_snapshot_unavailable",
         (_, RejectedChangeReason::StagedFileTooLarge) => "output_writeback_source_unavailable",
+        (_, RejectedChangeReason::TrashUnavailable) => "output_writeback_unavailable",
         (_, RejectedChangeReason::Unavailable) => "output_writeback_unavailable",
     };
     unavailable(code)

--- a/crates/openwave-server/src/exec_write_snapshot.rs
+++ b/crates/openwave-server/src/exec_write_snapshot.rs
@@ -377,10 +377,27 @@ mod tests {
     use std::collections::BTreeMap;
 
     use chrono::Utc;
-    use openwave_code_execution::WriteOverlay;
+    use openwave_code_execution::{TrashSink, WriteOverlay};
     use openwave_core::{Chat, DbStore, FsBlobStore};
 
     use crate::state::BlobWriteGuard;
+
+    struct TestTrash(std::sync::Mutex<Vec<(String, Vec<u8>)>>);
+
+    #[async_trait::async_trait]
+    impl TrashSink for TestTrash {
+        async fn trash(&self, path: &Path) -> Result<(), String> {
+            let name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| "trash name is not UTF-8".to_owned())?
+                .to_owned();
+            let bytes = std::fs::read(path).map_err(|error| error.to_string())?;
+            std::fs::remove_file(path).map_err(|error| error.to_string())?;
+            self.0.lock().unwrap().push((name, bytes));
+            Ok(())
+        }
+    }
 
     /// The issue contract: the turn journal survives process state, and undo
     /// restores overwritten/deleted bytes while removing a file the turn made.
@@ -433,9 +450,14 @@ mod tests {
         std::fs::write(staged.join("created.txt"), b"new file").unwrap();
         std::fs::remove_file(staged.join("removed.txt")).unwrap();
 
-        let materialized = overlay.materialize(Some(&sink)).await;
+        let trash = TestTrash(std::sync::Mutex::new(Vec::new()));
+        let materialized = overlay.materialize_with_trash(Some(&sink), &trash).await;
         assert_eq!(materialized.written.len(), 3);
         assert!(materialized.rejected.is_empty());
+        assert_eq!(
+            *trash.0.lock().unwrap(),
+            vec![("removed.txt".to_owned(), b"bring me back".to_vec())]
+        );
         sink.commit(chat.id, turn_id).await.unwrap();
         assert_eq!(
             std::fs::read(granted.join("notes.md")).unwrap(),


### PR DESCRIPTION
Closes #1080

Stacked on #1291.

## Summary

- place a digest-verified private copy of every staged deletion in the native OS Trash/Recycle Bin before unlinking the granted-root file
- preserve descriptor-relative confinement and recheck the source digest at the unlink boundary; native-trash failures are explicit per-file rejections and never fall back to unlink
- keep #1077 content-addressed blob snapshots as the deterministic, restart-safe undo source

## Platform tradeoff

The exact-pinned `trash` dependency targets macOS Trash, Windows Recycle Bin, and FreeDesktop-compliant trash implementations. Native trash restore/list capabilities are not uniform across those platforms, so OpenWave undo does not discover or restore the OS trash item; it restores the durable blob with the existing absence/digest precondition. To keep granted-root access descriptor-confined, the path-based native API receives a verified private copy, which means the OS trash item records that private staging origin rather than the mutable granted-root path. The item remains visible and recoverable from native trash, while deterministic one-click undo stays platform-independent.

## Verification

- `cargo test -p openwave-code-execution overlay::tests --locked`
- `cargo test -p openwave-server a_turns_journaled_file_changes_undo_after_restart --locked`
- `cargo clippy -p openwave-code-execution --all-targets --no-deps --locked -- -D warnings`
- `cargo clippy -p openwave-server --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`