### PR TITLE
test(core): follow sandbox claim attempt budget

### DIFF
--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -1365,14 +1365,17 @@ async fn sandbox_claims_are_exact_reclaimable_and_heartbeatable() {
         .await
         .unwrap());
 
-    force_expired_agent_lease(&store, child_id).await;
-    let third_token = uuid::Uuid::new_v4();
-    let third = store
-        .claim_agent_run(third_token, Duration::minutes(1), 2, 1)
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(third.attempt_count, 3);
+    let mut latest = second;
+    while latest.attempt_count < latest.max_attempts {
+        force_expired_agent_lease(&store, child_id).await;
+        let next = store
+            .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 2, 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(next.attempt_count, latest.attempt_count + 1);
+        latest = next;
+    }
 
     force_expired_agent_lease(&store, child_id).await;
     let exhausted_scan = uuid::Uuid::new_v4();


### PR DESCRIPTION
## Summary

- exhaust the sandbox run’s persisted attempt budget before checking lease-expiry terminalization
- preserve the exact exhausted-scan assertion and production scheduler semantics
- remove the stale assumption that sandbox runs always have three attempts after the default budget was raised to five

## Verification

- `cargo test -p openwave-core db::tests::agent_run::sandbox_claims_are_exact_reclaimable_and_heartbeatable --locked -- --exact`
- `cargo clippy -p openwave-core --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`

Closes #1294.