### PR TITLE
feat(desktop): preview binary document changes

### DIFF
--- a/crates/openwave-desktop/ui/src/ChangeSummaryCard.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChangeSummaryCard.dom.test.tsx
@@ -6,7 +6,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient, ExecFileChangeSummary } from "./api";
 import { ChangeSummaryCard } from "./ChangeSummaryCard";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
 
 const files: ExecFileChangeSummary[] = [
   {
@@ -18,6 +21,7 @@ const files: ExecFileChangeSummary[] = [
     rejection_reason: null,
     undo: "available",
     diff: "--- before\n+++ after\n@@ -1 +1 @@\n-old\n+new\n",
+    binary_preview: null,
   },
   {
     snapshot_id: "rejected:1",
@@ -28,6 +32,7 @@ const files: ExecFileChangeSummary[] = [
     rejection_reason: "stale",
     undo: "not_available",
     diff: null,
+    binary_preview: null,
   },
   {
     snapshot_id: "rejected:2",
@@ -38,6 +43,7 @@ const files: ExecFileChangeSummary[] = [
     rejection_reason: "trash_unavailable",
     undo: "not_available",
     diff: null,
+    binary_preview: null,
   },
 ];
 
@@ -45,6 +51,7 @@ describe("ChangeSummaryCard", () => {
   it("separates rejected writes and updates one file after undo", async () => {
     const user = userEvent.setup();
     const client = {
+      getFileChangePreview: vi.fn(),
       undoFileChange: vi.fn().mockResolvedValue({
         snapshot_id: "snapshot-1",
         folder_name: "Project",
@@ -54,7 +61,7 @@ describe("ChangeSummaryCard", () => {
       undoTurnFileChanges: vi.fn(),
     } satisfies Pick<
       ApiClient,
-      "undoFileChange" | "undoTurnFileChanges"
+      "getFileChangePreview" | "undoFileChange" | "undoTurnFileChanges"
     >;
 
     render(
@@ -87,5 +94,63 @@ describe("ChangeSummaryCard", () => {
       ),
     );
     expect(screen.getByRole("button", { name: "Undone" })).toBeDisabled();
+  });
+
+  it("loads server-selected document revisions only when the preview opens", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn(() => "blob:document-preview"),
+      revokeObjectURL: vi.fn(),
+    });
+    const client = {
+      getFileChangePreview: vi
+        .fn()
+        .mockResolvedValue(new Blob(["png"], { type: "image/png" })),
+      undoFileChange: vi.fn(),
+      undoTurnFileChanges: vi.fn(),
+    } satisfies Pick<
+      ApiClient,
+      "getFileChangePreview" | "undoFileChange" | "undoTurnFileChanges"
+    >;
+    const workbook: ExecFileChangeSummary = {
+      snapshot_id: "snapshot-workbook",
+      folder_name: "Project",
+      relative_path: "forecast.xlsx",
+      classification: "applied",
+      change: "overwritten",
+      rejection_reason: null,
+      undo: "available",
+      diff: null,
+      binary_preview: {
+        format: "xlsx",
+        before: "available",
+        after: "available",
+      },
+    };
+
+    render(
+      <ChangeSummaryCard
+        client={client}
+        chatId="chat-1"
+        turnId="turn-1"
+        files={[workbook]}
+      />,
+    );
+
+    expect(client.getFileChangePreview).not.toHaveBeenCalled();
+    await user.click(screen.getByText("Before and after preview"));
+    await waitFor(() =>
+      expect(client.getFileChangePreview).toHaveBeenCalledTimes(2),
+    );
+    expect(client.getFileChangePreview).toHaveBeenCalledWith(
+      "chat-1",
+      "turn-1",
+      "snapshot-workbook",
+      "before",
+      expect.any(AbortSignal),
+    );
+    expect(
+      await screen.findByAltText("After preview of forecast.xlsx"),
+    ).toHaveAttribute("src", "blob:document-preview");
   });
 });

--- a/crates/openwave-desktop/ui/src/ChangeSummaryCard.tsx
+++ b/crates/openwave-desktop/ui/src/ChangeSummaryCard.tsx
@@ -1,15 +1,23 @@
 import { useEffect, useMemo, useState } from "react";
-import { AlertTriangle, Check, FileText, RotateCcw } from "lucide-react";
+import {
+  AlertTriangle,
+  Check,
+  FileImage,
+  FileText,
+  Loader2,
+  RotateCcw,
+} from "lucide-react";
 import type {
   ApiClient,
   ExecFileChangeSummary,
   ExecFileUndoOutcome,
 } from "./api";
+import type { ExecFilePreviewAvailability } from "./generated/wire";
 import { cn } from "./lib/utils";
 
 type ChangeClient = Pick<
   ApiClient,
-  "undoFileChange" | "undoTurnFileChanges"
+  "getFileChangePreview" | "undoFileChange" | "undoTurnFileChanges"
 >;
 
 type Props = {
@@ -53,6 +61,19 @@ export function ChangeSummaryCard({ client, chatId, turnId, files }: Props) {
               : status === "stale"
                 ? "stale"
                 : "not_available",
+          binary_preview: file.binary_preview
+            ? {
+                ...file.binary_preview,
+                after:
+                  status === "stale"
+                    ? "stale"
+                    : status === "restored" ||
+                        status === "deleted" ||
+                        status === "already_undone"
+                      ? "unavailable"
+                      : file.binary_preview.after,
+              }
+            : null,
         };
       }),
     );
@@ -130,6 +151,9 @@ export function ChangeSummaryCard({ client, chatId, turnId, files }: Props) {
             file={file}
             working={working.has(file.snapshot_id)}
             onUndo={() => void undoOne(file)}
+            client={client}
+            chatId={chatId}
+            turnId={turnId}
           />
         ))}
       </div>
@@ -146,10 +170,16 @@ function FileChangeRow({
   file,
   working,
   onUndo,
+  client,
+  chatId,
+  turnId,
 }: {
   file: ExecFileChangeSummary;
   working: boolean;
   onUndo: () => void;
+  client: ChangeClient;
+  chatId: string;
+  turnId: string;
 }) {
   const rejected = file.classification === "rejected";
   return (
@@ -188,6 +218,20 @@ function FileChangeRow({
         )}
       </div>
       {file.diff && <TextDiff diff={file.diff} />}
+      {file.binary_preview && (
+        <BinaryPreview
+          client={client}
+          chatId={chatId}
+          turnId={turnId}
+          file={file}
+          preview={file.binary_preview}
+        />
+      )}
+      {!rejected && !file.diff && !file.binary_preview && (
+        <p className="ml-6 mt-2 text-xs text-muted-foreground">
+          No change preview is available for this file type or revision.
+        </p>
+      )}
     </div>
   );
 }
@@ -220,6 +264,168 @@ function TextDiff({ diff }: { diff: string }) {
         ))}
       </pre>
     </details>
+  );
+}
+
+function BinaryPreview({
+  client,
+  chatId,
+  turnId,
+  file,
+  preview,
+}: {
+  client: ChangeClient;
+  chatId: string;
+  turnId: string;
+  file: ExecFileChangeSummary;
+  preview: NonNullable<ExecFileChangeSummary["binary_preview"]>;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <details
+      className="ml-6 mt-2"
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+    >
+      <summary className="flex cursor-pointer select-none items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground">
+        <FileImage size={13} aria-hidden="true" />
+        Before and after preview
+      </summary>
+      <div className="mt-2 grid gap-2 md:grid-cols-2">
+        <RevisionPreview
+          client={client}
+          chatId={chatId}
+          turnId={turnId}
+          snapshotId={file.snapshot_id}
+          revision="before"
+          availability={preview.before}
+          active={open}
+          fileName={file.relative_path}
+        />
+        <RevisionPreview
+          client={client}
+          chatId={chatId}
+          turnId={turnId}
+          snapshotId={file.snapshot_id}
+          revision="after"
+          availability={preview.after}
+          active={open}
+          fileName={file.relative_path}
+        />
+      </div>
+    </details>
+  );
+}
+
+type LoadedRevision =
+  | { status: "idle" | "loading" }
+  | { status: "loaded"; url: string }
+  | { status: "error"; message: string };
+
+function RevisionPreview({
+  client,
+  chatId,
+  turnId,
+  snapshotId,
+  revision,
+  availability,
+  active,
+  fileName,
+}: {
+  client: ChangeClient;
+  chatId: string;
+  turnId: string;
+  snapshotId: string;
+  revision: "before" | "after";
+  availability: ExecFilePreviewAvailability;
+  active: boolean;
+  fileName: string;
+}) {
+  const [loaded, setLoaded] = useState<LoadedRevision>({ status: "idle" });
+
+  useEffect(() => {
+    if (!active || availability !== "available") {
+      setLoaded({ status: "idle" });
+      return;
+    }
+    const controller = new AbortController();
+    let objectUrl: string | null = null;
+    setLoaded({ status: "loading" });
+    void client
+      .getFileChangePreview(
+        chatId,
+        turnId,
+        snapshotId,
+        revision,
+        controller.signal,
+      )
+      .then((blob) => {
+        objectUrl = URL.createObjectURL(blob);
+        setLoaded({ status: "loaded", url: objectUrl });
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        const message =
+          error instanceof Error
+            ? error.message.replace(/^\d+:\s*/, "")
+            : "Preview unavailable.";
+        setLoaded({ status: "error", message });
+      });
+    return () => {
+      controller.abort();
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [
+    active,
+    availability,
+    chatId,
+    client,
+    revision,
+    snapshotId,
+    turnId,
+  ]);
+
+  const label = revision === "before" ? "Before" : "After";
+  return (
+    <figure className="overflow-hidden rounded-md border border-border bg-muted/20">
+      <figcaption className="border-b border-border px-2 py-1.5 text-[11px] font-medium text-muted-foreground">
+        {label}
+      </figcaption>
+      <div className="flex min-h-36 items-center justify-center p-2">
+        {availability === "empty" ? (
+          <p className="text-xs text-muted-foreground">
+            {revision === "before" ? "No previous file" : "File deleted"}
+          </p>
+        ) : availability === "stale" ? (
+          <PreviewNotice>Changed again; preview unavailable</PreviewNotice>
+        ) : availability === "too_large" ? (
+          <PreviewNotice>Too large to preview</PreviewNotice>
+        ) : availability === "unavailable" ? (
+          <PreviewNotice>Preview unavailable</PreviewNotice>
+        ) : loaded.status === "loaded" ? (
+          <img
+            className="max-h-80 w-full object-contain"
+            src={loaded.url}
+            alt={`${label} preview of ${fileName}`}
+          />
+        ) : loaded.status === "error" ? (
+          <PreviewNotice>{loaded.message}</PreviewNotice>
+        ) : (
+          <Loader2
+            className="animate-spin text-muted-foreground"
+            size={18}
+            aria-label={`Loading ${revision} preview`}
+          />
+        )}
+      </div>
+    </figure>
+  );
+}
+
+function PreviewNotice({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="max-w-48 text-center text-xs text-muted-foreground">
+      {children}
+    </p>
   );
 }
 

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -232,7 +232,7 @@ type MessageListProps = {
   imageClient?: Pick<ApiClient, "getChatImageAttachment">;
   changeClient?: Pick<
     ApiClient,
-    "undoFileChange" | "undoTurnFileChanges"
+    "getFileChangePreview" | "undoFileChange" | "undoTurnFileChanges"
   >;
 };
 
@@ -521,7 +521,7 @@ export function groupMessageItems(
   chatId?: string,
   changeClient?: Pick<
     ApiClient,
-    "undoFileChange" | "undoTurnFileChanges"
+    "getFileChangePreview" | "undoFileChange" | "undoTurnFileChanges"
   >,
   backgroundAgents: {
     runs: AgentRun[];
@@ -890,7 +890,7 @@ function MessageBubbleImpl({
   chatId?: string;
   changeClient?: Pick<
     ApiClient,
-    "undoFileChange" | "undoTurnFileChanges"
+    "getFileChangePreview" | "undoFileChange" | "undoTurnFileChanges"
   >;
   /** Present only on the transcript's newest retryable failure. */
   onRetry?: () => void;

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -1144,6 +1144,19 @@ export class ApiClient {
     );
   }
 
+  getFileChangePreview(
+    chatId: string,
+    turnId: string,
+    snapshotId: string,
+    revision: "before" | "after",
+    signal?: AbortSignal,
+  ): Promise<Blob> {
+    return this.blob(
+      `/chats/${encodeURIComponent(chatId)}/turns/${encodeURIComponent(turnId)}/file-changes/${encodeURIComponent(snapshotId)}/preview/${revision}`,
+      signal,
+    );
+  }
+
   private async blob(path: string, signal?: AbortSignal): Promise<Blob> {
     const response = await fetch(`${this.baseUrl}${path}`, {
       headers: this.headers(),

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -593,6 +593,11 @@ export type EgressConfig = { "mode": "open" } | { "mode": "allowlist", domains: 
 export type EgressEnforcementStatus = "boundary" | "conditional_boundary" | "applied_with_gaps" | "unconfirmed";
 
 /**
+ * Renderer-safe selection metadata; bytes remain behind the scoped endpoint.
+ */
+export type ExecFileBinaryPreview = { format: ExecFilePreviewFormat, before: ExecFilePreviewAvailability, after: ExecFilePreviewAvailability, };
+
+/**
  * Renderer-owned classification of one journal row.
  */
 export type ExecFileChangeClassification = "applied" | "rejected";
@@ -604,9 +609,20 @@ export type ExecFileChangeKind = "created" | "overwritten" | "deleted";
 
 /**
  * One renderer-safe row in a terminal turn's file-change summary, including a
- * bounded unified diff when both revisions are text.
+ * bounded unified diff when both revisions are text or a binary preview
+ * selector whose bytes remain behind the scoped preview endpoint.
  */
-export type ExecFileChangeSummary = { snapshot_id: string, folder_name: string, relative_path: string, classification: ExecFileChangeClassification, change: ExecFileChangeKind | null, rejection_reason: ExecFileRejectionReason | null, undo: ExecFileUndoAvailability, diff: string | null, };
+export type ExecFileChangeSummary = { snapshot_id: string, folder_name: string, relative_path: string, classification: ExecFileChangeClassification, change: ExecFileChangeKind | null, rejection_reason: ExecFileRejectionReason | null, undo: ExecFileUndoAvailability, diff: string | null, binary_preview: ExecFileBinaryPreview | null, };
+
+/**
+ * Whether one side of a binary before/after comparison can be requested.
+ */
+export type ExecFilePreviewAvailability = "available" | "empty" | "stale" | "too_large" | "unavailable";
+
+/**
+ * A binary format handled by the bundled #1056 document renderer.
+ */
+export type ExecFilePreviewFormat = "pdf" | "docx" | "xlsx";
 
 /**
  * Why one staged file was left out of the user's folder.

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -51,6 +51,8 @@ plist = "=1.10.0"
 tracing = "=0.1.44"
 # Bounded unified diffs for the post-turn connected-folder change summary.
 similar = "=2.7.0"
+# Private, automatically removed inputs and outputs for ephemeral document previews.
+tempfile = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 # Effective-uid account lookup (getpwuid_r) for the macOS managed-preferences
@@ -72,4 +74,3 @@ tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time
 tower = { version = "=0.5.3", features = ["util"] }
 reqwest = { workspace = true }
 tokio-tungstenite = "=0.30.0"
-tempfile = "=3.27.0"

--- a/crates/openwave-server/src/error.rs
+++ b/crates/openwave-server/src/error.rs
@@ -101,6 +101,42 @@ impl ServerError {
         }
     }
 
+    /// A `415 Unsupported Media Type` with a route-specific stable kind.
+    pub(crate) fn unsupported_media_type_kind(
+        kind: &'static str,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            status: StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            info: AgentErrorInfo {
+                kind: kind.to_owned(),
+                message: message.into(),
+            },
+        }
+    }
+
+    /// A `422 Unprocessable Entity` with a route-specific stable kind.
+    pub(crate) fn unprocessable_kind(kind: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            info: AgentErrorInfo {
+                kind: kind.to_owned(),
+                message: message.into(),
+            },
+        }
+    }
+
+    /// A `429 Too Many Requests` with a route-specific stable kind.
+    pub(crate) fn too_many_requests_kind(kind: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            info: AgentErrorInfo {
+                kind: kind.to_owned(),
+                message: message.into(),
+            },
+        }
+    }
+
     /// A `500 Internal Server Error` for an unexpected server-side failure that
     /// isn't an [`AgentError`] (for example, another subsystem fault). Carries a stable
     /// `kind` so a client sees the same `{ kind, message }` shape as any error.

--- a/crates/openwave-server/src/exec_write_snapshot.rs
+++ b/crates/openwave-server/src/exec_write_snapshot.rs
@@ -18,6 +18,7 @@
 
 use std::path::Path;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use openwave_code_execution::{
     try_resolve_scratch_directory, FilePrecondition, PreparedWriteSnapshot, PriorContents,
@@ -25,7 +26,8 @@ use openwave_code_execution::{
 };
 use openwave_core::{
     BlobStore, ChatId, DocumentSourceBlob, ExecFileChange, ExecFileRejectionReason,
-    ExecFileSnapshot, ExecFileSnapshotRecord, ExecUndoState, Store, TurnId,
+    ExecFileSnapshot, ExecFileSnapshotRecord, ExecUndoState, ImageMediaType, Store, TurnId,
+    MAX_EXEC_WORKSPACE_FILE_BYTES,
 };
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
@@ -268,8 +270,69 @@ pub(crate) enum ExecFileUndoAvailability {
     NotAvailable,
 }
 
+/// A binary format handled by the bundled #1056 document renderer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ExecFilePreviewFormat {
+    Pdf,
+    Docx,
+    Xlsx,
+}
+
+impl ExecFilePreviewFormat {
+    fn for_path(path: &str) -> Option<Self> {
+        match Path::new(path)
+            .extension()
+            .and_then(|extension| extension.to_str())?
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "pdf" => Some(Self::Pdf),
+            "docx" => Some(Self::Docx),
+            "xlsx" => Some(Self::Xlsx),
+            _ => None,
+        }
+    }
+
+    fn helper(self) -> &'static str {
+        match self {
+            Self::Pdf => "render_pdf.py",
+            Self::Docx => "render_office.py",
+            Self::Xlsx => "analyze_xlsx.py",
+        }
+    }
+
+    fn extension(self) -> &'static str {
+        match self {
+            Self::Pdf => "pdf",
+            Self::Docx => "docx",
+            Self::Xlsx => "xlsx",
+        }
+    }
+}
+
+/// Whether one side of a binary before/after comparison can be requested.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ExecFilePreviewAvailability {
+    Available,
+    Empty,
+    Stale,
+    TooLarge,
+    Unavailable,
+}
+
+/// Renderer-safe selection metadata; bytes remain behind the scoped endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, TS)]
+pub(crate) struct ExecFileBinaryPreview {
+    pub format: ExecFilePreviewFormat,
+    pub before: ExecFilePreviewAvailability,
+    pub after: ExecFilePreviewAvailability,
+}
+
 /// One renderer-safe row in a terminal turn's file-change summary, including a
-/// bounded unified diff when both revisions are text.
+/// bounded unified diff when both revisions are text or a binary preview
+/// selector whose bytes remain behind the scoped preview endpoint.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, TS)]
 pub(crate) struct ExecFileChangeSummary {
     pub snapshot_id: String,
@@ -280,9 +343,12 @@ pub(crate) struct ExecFileChangeSummary {
     pub rejection_reason: Option<ExecFileRejectionReason>,
     pub undo: ExecFileUndoAvailability,
     pub diff: Option<String>,
+    pub binary_preview: Option<ExecFileBinaryPreview>,
 }
 
 const MAX_TEXT_DIFF_BYTES: u64 = 512 * 1_024;
+const MAX_FILE_PREVIEW_INPUT_BYTES: u64 = MAX_EXEC_WORKSPACE_FILE_BYTES as u64;
+const FILE_PREVIEW_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Build durable change summaries grouped by turn without exposing host paths.
 pub(crate) async fn list_file_change_summaries(
@@ -311,6 +377,7 @@ pub(crate) async fn list_file_change_summaries(
                 rejection_reason: Some(rejection.file.reason),
                 undo: ExecFileUndoAvailability::NotAvailable,
                 diff: None,
+                binary_preview: None,
             });
     }
     for files in by_turn.values_mut() {
@@ -332,7 +399,8 @@ async fn summarize_applied_change(
         ExecFileChange::Deleted => ExecFileChangeKind::Deleted,
     };
     let (undo, current) = inspect_current_change(blobs, &snapshot).await;
-    let diff = if undo == ExecFileUndoAvailability::Available {
+    let binary_preview = binary_preview_for(&snapshot, undo);
+    let diff = if binary_preview.is_none() && undo == ExecFileUndoAvailability::Available {
         text_diff(blobs, &snapshot, current.as_deref()).await
     } else {
         None
@@ -346,7 +414,46 @@ async fn summarize_applied_change(
         rejection_reason: None,
         undo,
         diff,
+        binary_preview,
     }
+}
+
+fn binary_preview_for(
+    snapshot: &ExecFileSnapshot,
+    undo: ExecFileUndoAvailability,
+) -> Option<ExecFileBinaryPreview> {
+    let format = ExecFilePreviewFormat::for_path(&snapshot.file.relative_path)?;
+    let before = match snapshot.file.change {
+        ExecFileChange::Created => ExecFilePreviewAvailability::Empty,
+        ExecFileChange::Overwritten | ExecFileChange::Deleted => {
+            if snapshot.file.prior_blob_id.is_none() {
+                ExecFilePreviewAvailability::Unavailable
+            } else if snapshot
+                .file
+                .prior_byte_len
+                .is_some_and(|byte_len| byte_len > MAX_FILE_PREVIEW_INPUT_BYTES)
+            {
+                ExecFilePreviewAvailability::TooLarge
+            } else {
+                ExecFilePreviewAvailability::Available
+            }
+        }
+    };
+    let after = match snapshot.file.change {
+        ExecFileChange::Deleted => ExecFilePreviewAvailability::Empty,
+        ExecFileChange::Created | ExecFileChange::Overwritten => match undo {
+            ExecFileUndoAvailability::Available | ExecFileUndoAvailability::NotAvailable => {
+                ExecFilePreviewAvailability::Available
+            }
+            ExecFileUndoAvailability::Stale => ExecFilePreviewAvailability::Stale,
+            ExecFileUndoAvailability::AlreadyUndone => ExecFilePreviewAvailability::Unavailable,
+        },
+    };
+    Some(ExecFileBinaryPreview {
+        format,
+        before,
+        after,
+    })
 }
 
 async fn inspect_current_change(
@@ -454,6 +561,215 @@ async fn text_diff(
             .header("before", "after")
             .to_string(),
     )
+}
+
+/// Which immutable side of a journaled change the renderer requested.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ExecFilePreviewRevision {
+    Before,
+    After,
+}
+
+/// One ephemeral, already-bounded raster result from the bundled renderer.
+pub(crate) struct RenderedExecFilePreview {
+    pub media_type: ImageMediaType,
+    pub width: u32,
+    pub height: u32,
+    pub bytes: Vec<u8>,
+}
+
+/// Safe failure vocabulary for the renderer-facing preview endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExecFilePreviewError {
+    NotFound,
+    Unsupported,
+    Empty,
+    Stale,
+    TooLarge,
+    Unavailable,
+    RenderFailed,
+}
+
+pub(crate) struct ExecFilePreviewRequest<'a> {
+    pub chat_id: ChatId,
+    pub turn_id: TurnId,
+    pub snapshot_id: uuid::Uuid,
+    pub revision: ExecFilePreviewRevision,
+    pub scripts_dir: Option<&'a Path>,
+    pub temp_root: &'a Path,
+}
+
+/// Authorize, select, and render one revision without publishing a reusable
+/// file or image identity. All filesystem paths remain server-side.
+pub(crate) async fn render_file_change_preview(
+    store: &dyn Store,
+    blobs: &dyn BlobStore,
+    request: ExecFilePreviewRequest<'_>,
+) -> Result<RenderedExecFilePreview, ExecFilePreviewError> {
+    let snapshot = store
+        .list_exec_file_snapshots(request.chat_id)
+        .await
+        .map_err(|_| ExecFilePreviewError::Unavailable)?
+        .into_iter()
+        .find(|snapshot| snapshot.turn_id == request.turn_id && snapshot.id == request.snapshot_id)
+        .ok_or(ExecFilePreviewError::NotFound)?;
+    let format = ExecFilePreviewFormat::for_path(&snapshot.file.relative_path)
+        .ok_or(ExecFilePreviewError::Unsupported)?;
+    let bytes = match request.revision {
+        ExecFilePreviewRevision::Before => preview_before_bytes(blobs, &snapshot).await?,
+        ExecFilePreviewRevision::After => preview_after_bytes(&snapshot).await?,
+    };
+    let scripts_dir = request
+        .scripts_dir
+        .ok_or(ExecFilePreviewError::Unavailable)?;
+    render_document_bytes(format, bytes, scripts_dir, request.temp_root).await
+}
+
+async fn preview_before_bytes(
+    blobs: &dyn BlobStore,
+    snapshot: &ExecFileSnapshot,
+) -> Result<Vec<u8>, ExecFilePreviewError> {
+    if snapshot.file.change == ExecFileChange::Created {
+        return Err(ExecFilePreviewError::Empty);
+    }
+    if snapshot
+        .file
+        .prior_byte_len
+        .is_some_and(|byte_len| byte_len > MAX_FILE_PREVIEW_INPUT_BYTES)
+    {
+        return Err(ExecFilePreviewError::TooLarge);
+    }
+    load_prior_bytes(blobs, snapshot)
+        .await
+        .ok_or(ExecFilePreviewError::Unavailable)
+}
+
+async fn preview_after_bytes(snapshot: &ExecFileSnapshot) -> Result<Vec<u8>, ExecFilePreviewError> {
+    if snapshot.file.change == ExecFileChange::Deleted {
+        return Err(ExecFilePreviewError::Empty);
+    }
+    let expected = snapshot
+        .file
+        .new_sha256
+        .as_deref()
+        .and_then(parse_sha256)
+        .ok_or(ExecFilePreviewError::Unavailable)?;
+    let Some((prefix, name)) = split_journal_path(&snapshot.file.relative_path) else {
+        return Err(ExecFilePreviewError::Unavailable);
+    };
+    let folder = Path::new(&snapshot.file.folder_path);
+    if !folder.is_absolute() {
+        return Err(ExecFilePreviewError::Unavailable);
+    }
+    let parent = try_resolve_scratch_directory(folder, prefix, false)
+        .await
+        .map_err(|_| ExecFilePreviewError::Stale)?;
+    match current_digest(&parent, name).await {
+        Ok(Some(digest)) if digest == expected => {}
+        Ok(_) => return Err(ExecFilePreviewError::Stale),
+        Err(()) => return Err(ExecFilePreviewError::Unavailable),
+    }
+    let mut file = parent.open_file(name).await.map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            ExecFilePreviewError::Stale
+        } else {
+            ExecFilePreviewError::Unavailable
+        }
+    })?;
+    let byte_len = file
+        .metadata()
+        .map_err(|_| ExecFilePreviewError::Unavailable)?
+        .len();
+    if byte_len > MAX_FILE_PREVIEW_INPUT_BYTES {
+        return Err(ExecFilePreviewError::TooLarge);
+    }
+    let bytes = tokio::task::spawn_blocking(move || {
+        use std::io::Read as _;
+        let mut bytes = Vec::with_capacity(usize::try_from(byte_len).unwrap_or_default());
+        file.read_to_end(&mut bytes).map(|_| bytes)
+    })
+    .await
+    .map_err(|_| ExecFilePreviewError::Unavailable)?
+    .map_err(|_| ExecFilePreviewError::Unavailable)?;
+    if sha256(&bytes) != expected {
+        return Err(ExecFilePreviewError::Stale);
+    }
+    Ok(bytes)
+}
+
+async fn render_document_bytes(
+    format: ExecFilePreviewFormat,
+    bytes: Vec<u8>,
+    scripts_dir: &Path,
+    temp_root: &Path,
+) -> Result<RenderedExecFilePreview, ExecFilePreviewError> {
+    tokio::fs::create_dir_all(temp_root)
+        .await
+        .map_err(|_| ExecFilePreviewError::Unavailable)?;
+    let temporary = tempfile::Builder::new()
+        .prefix("file-preview-")
+        .tempdir_in(temp_root)
+        .map_err(|_| ExecFilePreviewError::Unavailable)?;
+    let input = temporary
+        .path()
+        .join(format!("revision.{}", format.extension()));
+    let output = temporary.path().join("preview");
+    tokio::fs::create_dir(&output)
+        .await
+        .map_err(|_| ExecFilePreviewError::Unavailable)?;
+    tokio::fs::write(&input, bytes)
+        .await
+        .map_err(|_| ExecFilePreviewError::Unavailable)?;
+
+    let helper = scripts_dir.join(format.helper());
+    if !helper.is_file() {
+        return Err(ExecFilePreviewError::Unavailable);
+    }
+    run_document_helper(&helper, &input, &output, temporary.path()).await?;
+
+    let scan = tokio::task::spawn_blocking(move || {
+        openwave_code_execution::scan_preview_directory(&output)
+    })
+    .await
+    .map_err(|_| ExecFilePreviewError::RenderFailed)?;
+    let (image, data) = scan
+        .images
+        .into_iter()
+        .next()
+        .ok_or(ExecFilePreviewError::RenderFailed)?;
+    Ok(RenderedExecFilePreview {
+        media_type: image.media_type,
+        width: image.width,
+        height: image.height,
+        bytes: data.bytes().to_vec(),
+    })
+}
+
+async fn run_document_helper(
+    helper: &Path,
+    input: &Path,
+    output: &Path,
+    working_directory: &Path,
+) -> Result<(), ExecFilePreviewError> {
+    for python in ["python3", "python"] {
+        let mut command = tokio::process::Command::new(python);
+        command
+            .arg(helper)
+            .arg(input)
+            .arg("--preview-dir")
+            .arg(output)
+            .current_dir(working_directory)
+            .kill_on_drop(true);
+        match tokio::time::timeout(FILE_PREVIEW_TIMEOUT, command.output()).await {
+            Ok(Ok(completed)) if completed.status.success() => return Ok(()),
+            Ok(Err(error)) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Ok(Ok(_)) | Ok(Err(_)) | Err(_) => {
+                return Err(ExecFilePreviewError::RenderFailed);
+            }
+        }
+    }
+    Err(ExecFilePreviewError::Unavailable)
 }
 
 fn display_folder_name(folder_path: &str) -> String {
@@ -629,8 +945,11 @@ mod tests {
     use std::collections::BTreeMap;
 
     use chrono::Utc;
+    use image::{DynamicImage, ImageFormat, Rgb, RgbImage};
     use openwave_code_execution::{TrashSink, WriteOverlay};
-    use openwave_core::{Chat, DbStore, ExecFileRejectionRecord, FsBlobStore};
+    use openwave_core::{
+        Chat, DbStore, ExecFileRejectionRecord, ExecFileSnapshotRecord, FsBlobStore,
+    };
 
     use crate::state::BlobWriteGuard;
 
@@ -791,5 +1110,140 @@ mod tests {
             .files
             .iter()
             .all(|file| file.status == ExecFileUndoStatus::AlreadyUndone));
+    }
+
+    /// The binary-preview contract crosses the durable journal, retained blob,
+    /// digest-guarded granted-root file, bundled helper, and bounded image scan.
+    #[tokio::test]
+    async fn a_workbook_change_renders_distinct_before_and_after_previews() {
+        if !["python3", "python"].iter().any(|python| {
+            std::process::Command::new(python)
+                .arg("--version")
+                .output()
+                .is_ok_and(|output| output.status.success())
+        }) {
+            return;
+        }
+
+        let home = tempfile::tempdir().unwrap();
+        let database = home.path().join("openwave.db");
+        let database_url = format!("sqlite://{}?mode=rwc", database.display());
+        let granted = home.path().join("granted");
+        let scripts = home.path().join("scripts");
+        std::fs::create_dir_all(&granted).unwrap();
+        std::fs::create_dir_all(&scripts).unwrap();
+
+        let store = DbStore::connect(&database_url).await.unwrap();
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            reasoning_effort: None,
+            permission_mode: None,
+            network_policy: Default::default(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let blobs = FsBlobStore::new(home.path().join("blobs"));
+        let before = b"old workbook bytes";
+        let after = b"new workbook bytes";
+        let prior = DocumentSourceBlob::from_bytes(before);
+        blobs.put(prior.id, before.to_vec()).await.unwrap();
+        std::fs::write(granted.join("forecast.xlsx"), after).unwrap();
+        let turn_id = TurnId::new();
+        store
+            .record_exec_file_snapshots(
+                chat.id,
+                turn_id,
+                &[ExecFileSnapshotRecord {
+                    folder_path: granted.display().to_string(),
+                    relative_path: "forecast.xlsx".into(),
+                    change: ExecFileChange::Overwritten,
+                    prior_blob_id: Some(prior.id),
+                    prior_byte_len: Some(prior.byte_len),
+                    new_sha256: Some(sha256_hex(after)),
+                    undo: ExecUndoState::Available,
+                }],
+            )
+            .await
+            .unwrap();
+        let snapshot = store
+            .list_exec_file_snapshots(chat.id)
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        let summary = list_file_change_summaries(&store, &blobs, chat.id)
+            .await
+            .unwrap();
+        assert_eq!(
+            summary[&turn_id][0].binary_preview,
+            Some(ExecFileBinaryPreview {
+                format: ExecFilePreviewFormat::Xlsx,
+                before: ExecFilePreviewAvailability::Available,
+                after: ExecFilePreviewAvailability::Available,
+            })
+        );
+        assert!(summary[&turn_id][0].diff.is_none());
+
+        write_preview_fixture(&scripts.join("old.png"), [180, 20, 20]);
+        write_preview_fixture(&scripts.join("new.png"), [20, 20, 180]);
+        std::fs::write(
+            scripts.join("analyze_xlsx.py"),
+            r#"import shutil
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).read_bytes()
+output = Path(sys.argv[sys.argv.index("--preview-dir") + 1])
+output.mkdir(parents=True, exist_ok=True)
+fixture = "old.png" if source == b"old workbook bytes" else "new.png"
+shutil.copyfile(Path(__file__).with_name(fixture), output / "overview-grid.png")
+"#,
+        )
+        .unwrap();
+
+        let before_preview = render_file_change_preview(
+            &store,
+            &blobs,
+            ExecFilePreviewRequest {
+                chat_id: chat.id,
+                turn_id,
+                snapshot_id: snapshot.id,
+                revision: ExecFilePreviewRevision::Before,
+                scripts_dir: Some(&scripts),
+                temp_root: &home.path().join("preview-temp"),
+            },
+        )
+        .await
+        .unwrap();
+        let after_preview = render_file_change_preview(
+            &store,
+            &blobs,
+            ExecFilePreviewRequest {
+                chat_id: chat.id,
+                turn_id,
+                snapshot_id: snapshot.id,
+                revision: ExecFilePreviewRevision::After,
+                scripts_dir: Some(&scripts),
+                temp_root: &home.path().join("preview-temp"),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(before_preview.media_type, ImageMediaType::Png);
+        assert_eq!(after_preview.media_type, ImageMediaType::Png);
+        assert_ne!(before_preview.bytes, after_preview.bytes);
+    }
+
+    fn write_preview_fixture(path: &Path, color: [u8; 3]) {
+        DynamicImage::ImageRgb8(RgbImage::from_pixel(4, 2, Rgb(color)))
+            .save_with_format(path, ImageFormat::Png)
+            .unwrap();
     }
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -413,6 +413,10 @@ pub fn app(state: AppState) -> Router {
             post(routes::post_undo_one_file_change),
         )
         .route(
+            "/chats/{chat_id}/turns/{turn_id}/file-changes/{snapshot_id}/preview/{revision}",
+            get(routes::get_file_change_preview),
+        )
+        .route(
             "/chats/{id}/client-executions/pending",
             get(routes::list_pending_folder_access_requests),
         )

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -4,9 +4,10 @@
 //! submodule; settings, providers, projects, chats, and event streaming remain
 //! here.
 
+use axum::body::Body;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
-use axum::http::StatusCode;
+use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
 use cap_std::ambient_authority;
 use cap_std::fs::Dir;
@@ -34,8 +35,9 @@ use crate::code_execution::{
 use crate::error::ServerError;
 use crate::event_projection::{RendererChatFrame, RendererChatMetadata, RendererSequencedEvent};
 use crate::exec_write_snapshot::{
-    list_file_change_summaries, undo_one_file_change, undo_turn_file_changes,
-    ExecFileChangeSummary, ExecFileUndoOutcome, ExecTurnUndoOutcome,
+    list_file_change_summaries, render_file_change_preview, undo_one_file_change,
+    undo_turn_file_changes, ExecFileChangeSummary, ExecFilePreviewError, ExecFilePreviewRequest,
+    ExecFilePreviewRevision, ExecFileUndoOutcome, ExecTurnUndoOutcome,
 };
 use crate::extract::{Json, Path, Query};
 use crate::mcp_config::{McpServersConfig, McpServersInfo};
@@ -683,6 +685,93 @@ pub async fn post_undo_one_file_change(
         .await?
         .map(Json)
         .ok_or_else(|| ServerError::not_found("no retained file change for this turn"))
+}
+
+/// `GET /chats/{chat_id}/turns/{turn_id}/file-changes/{snapshot_id}/preview/{revision}`
+/// — render one authorized journal revision without exposing source bytes,
+/// paths, or a reusable document identity.
+pub async fn get_file_change_preview(
+    State(state): State<AppState>,
+    Path((chat_id, turn_id, snapshot_id, revision)): Path<(
+        ChatId,
+        TurnId,
+        uuid::Uuid,
+        ExecFilePreviewRevision,
+    )>,
+) -> Result<Response, ServerError> {
+    if state.store.get_chat(chat_id).await?.is_none() {
+        return Err(ServerError::not_found(format!("chat {chat_id} not found")));
+    }
+    let _permit = state
+        .file_preview_permits
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_| {
+            ServerError::too_many_requests_kind(
+                "file_preview_busy",
+                "Document preview rendering is busy; try again shortly.",
+            )
+        })?;
+    let rendered = render_file_change_preview(
+        &*state.store,
+        &*state.blobs,
+        ExecFilePreviewRequest {
+            chat_id,
+            turn_id,
+            snapshot_id,
+            revision,
+            scripts_dir: state.config.exec_scripts_dir.as_deref(),
+            temp_root: &state.config.data_dir.join("file-preview-temp"),
+        },
+    )
+    .await
+    .map_err(file_preview_error)?;
+    let byte_len = rendered.bytes.len();
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, rendered.media_type.as_str())
+        .header(header::CONTENT_LENGTH, byte_len.to_string())
+        .header(header::CACHE_CONTROL, "no-store")
+        .header(header::X_CONTENT_TYPE_OPTIONS, "nosniff")
+        .header(header::CONTENT_SECURITY_POLICY, SERVED_BYTES_CONTENT_POLICY)
+        .header(header::REFERRER_POLICY, "no-referrer")
+        .header(header::CONTENT_DISPOSITION, "inline")
+        .header("x-openwave-preview-width", rendered.width.to_string())
+        .header("x-openwave-preview-height", rendered.height.to_string())
+        .body(Body::from(rendered.bytes))
+        .map_err(|_| ServerError::internal("failed to build document preview response"))
+}
+
+fn file_preview_error(error: ExecFilePreviewError) -> ServerError {
+    match error {
+        ExecFilePreviewError::NotFound => {
+            ServerError::not_found("No file change with that identity exists in this turn.")
+        }
+        ExecFilePreviewError::Unsupported => ServerError::unsupported_media_type_kind(
+            "file_preview_unsupported",
+            "No visual preview is available for this file type.",
+        ),
+        ExecFilePreviewError::Empty => ServerError::unprocessable_kind(
+            "file_preview_empty",
+            "This side of the change has no file.",
+        ),
+        ExecFilePreviewError::Stale => ServerError::conflict_kind(
+            "file_preview_stale",
+            "The file changed again; its after preview is no longer available.",
+        ),
+        ExecFilePreviewError::TooLarge => ServerError::unprocessable_kind(
+            "file_preview_too_large",
+            "This revision is too large to preview.",
+        ),
+        ExecFilePreviewError::Unavailable => ServerError::unprocessable_kind(
+            "file_preview_unavailable",
+            "This revision is no longer available to preview.",
+        ),
+        ExecFilePreviewError::RenderFailed => ServerError::unprocessable_kind(
+            "file_preview_failed",
+            "OpenWave could not render this revision on this device.",
+        ),
+    }
 }
 
 /// Maximum API-key size accepted by the local credential endpoint. This is

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -11,7 +11,7 @@ use openwave_core::{
     AgentConfig, AgentError, AgentRunId, BlobStore, CallId, CancelToken, ChatId, Config,
     FsBlobStore, Result, SecretProvider, SteerInbox, Store, ToolRegistry, TurnId,
 };
-use tokio::sync::Notify;
+use tokio::sync::{Notify, Semaphore};
 use uuid::Uuid;
 
 use crate::approvals::ApprovalBroker;
@@ -66,6 +66,8 @@ pub struct AppState {
     pub(crate) blob_retirement_wake: Arc<Notify>,
     /// Coordinates source publication and retirement across server processes.
     pub(crate) blob_writes: Arc<BlobWriteGuard>,
+    /// Bounds expensive document renderers used by post-turn binary previews.
+    pub(crate) file_preview_permits: Arc<Semaphore>,
     /// Per-turn agent tuning (model, limits, …).
     pub agent_config: AgentConfig,
     /// The secret every request must present as `Authorization: Bearer <token>`.
@@ -160,6 +162,7 @@ impl AppState {
             agent_run_wake: Arc::new(Notify::new()),
             blob_retirement_wake: Arc::new(Notify::new()),
             blob_writes,
+            file_preview_permits: Arc::new(Semaphore::new(2)),
             agent_config,
             token: Uuid::new_v4().to_string().into(),
             client_executor_token: mint_client_executor_token(),


### PR DESCRIPTION
## What and why

The post-turn change summary now recognizes `.docx`, `.xlsx`, and `.pdf` changes and offers lazy before/after visual previews instead of attempting text diffs. The preview endpoint is scoped to the chat, turn, and journal snapshot: it reads only the retained prior blob or digest-matching current granted-root bytes, materializes them in a private temporary directory, invokes the bundled #1056 helper, and returns only the bounded raster selected by the existing exec preview scanner.

Empty, stale, oversized, unsupported, busy, missing-renderer, and render-failed states remain explicit in the summary. Rendering is limited to two concurrent jobs with a 20-second process timeout, inputs use the existing 16 MiB exec-workspace ceiling, outputs use the existing image dimension/byte scanner, and no path, raw document bytes, persistent document row, or reusable preview identity crosses the renderer boundary.

This PR is stacked on #1297, which is stacked on #1291. Its base is `thet/change-summary-ui` until the earlier slice lands.

## Tests

- `cargo fmt --all -- --check`
- `cargo check -p openwave-server --locked`
- `cargo clippy -p openwave-server --all-targets --locked -- -D warnings`
- `cargo test -p openwave-server exec_write_snapshot::tests::a_workbook_change_renders_distinct_before_and_after_previews --locked`
- `cargo test -p openwave-server wire_types::tests::the_generated_bindings_are_current --locked`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run src/ChangeSummaryCard.dom.test.tsx`
- `pnpm test` (95 files, 663 tests)
- `pnpm build`

No tests were removed.

Closes #1079