### PR TITLE
feat(desktop): view office, PDF, and code outputs inline

### DIFF
--- a/crates/openwave-desktop/src/deliverables.rs
+++ b/crates/openwave-desktop/src/deliverables.rs
@@ -9,6 +9,8 @@
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
 use cap_fs_ext::{DirExt as _, FollowSymlinks, OpenOptionsFollowExt};
 use cap_std::ambient_authority;
 use cap_std::fs::{Dir, OpenOptions};
@@ -88,6 +90,9 @@ pub(crate) struct DeliverablePreview {
     /// Lets the detail panel gate its version-history affordance without a
     /// second catalog fetch.
     revision_count: u32,
+    /// The revision this preview (or empty binary placeholder) was built from,
+    /// so an inline viewer can address the same immutable bytes.
+    revision_id: OutputRevisionId,
     content: String,
     truncated: bool,
 }
@@ -98,6 +103,28 @@ pub(crate) struct OutputRevisionRequest {
     chat_id: Uuid,
     output_id: OutputId,
     revision_id: OutputRevisionId,
+}
+
+/// Read one revision's full bytes for an inline viewer.
+///
+/// `revision_id` is optional: omit it to read the output's current revision.
+/// Bytes travel as base64 so they share one IPC argument with identity — the
+/// same shape pasted images use — rather than as a JSON number array.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct DeliverableFileRequest {
+    chat_id: Uuid,
+    output_id: OutputId,
+    revision_id: Option<OutputRevisionId>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DeliverableFile {
+    output_id: OutputId,
+    revision_id: OutputRevisionId,
+    media_type: String,
+    content_base64: String,
 }
 
 /// One row of an output's version history, oldest ordinal highest in the list.
@@ -173,6 +200,51 @@ pub(crate) async fn read_deliverable(
     revision_preview(&app, chat_id, &output, &revision).await
 }
 
+/// Return one revision's complete bytes for an inline viewer (office, PDF, image).
+///
+/// Unlike [`read_deliverable`], this is not capped to a text preview and is not
+/// limited to curated text media types — viewers that already draw source
+/// documents reuse the same engines against these bytes.
+#[tauri::command]
+pub(crate) async fn read_deliverable_file(
+    app: AppHandle,
+    host_access: State<'_, HostAccess>,
+    request: DeliverableFileRequest,
+) -> Result<DeliverableFile, String> {
+    let chat_id = resolve_conversation_scope(&host_access, request.chat_id).await?;
+    let (output, revision) = match request.revision_id {
+        None => require_live_output(host_access.store(), chat_id, request.output_id).await?,
+        Some(revision_id) => {
+            let (output, _) =
+                require_live_output(host_access.store(), chat_id, request.output_id).await?;
+            let store = host_access
+                .store()
+                .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+            let revision = store
+                .get_output_revision(revision_id)
+                .await
+                .map_err(|_| "Could not load that version".to_owned())?
+                .filter(|revision| revision.output_id == output.id)
+                .ok_or_else(|| "That version does not belong to this output".to_owned())?;
+            (output, revision)
+        }
+    };
+    let scratch_root = crate::data_dir(&app)?.join("scratch");
+    let read_output = output.clone();
+    let read_revision = revision.clone();
+    let bytes = tauri::async_runtime::spawn_blocking(move || {
+        read_output_revision_bytes(&scratch_root, chat_id, &read_output, &read_revision)
+    })
+    .await
+    .map_err(|_| "Could not open that output".to_owned())??;
+    Ok(DeliverableFile {
+        output_id: output.id,
+        revision_id: revision.id,
+        media_type: output.media_type.clone(),
+        content_base64: BASE64.encode(bytes),
+    })
+}
+
 /// Build the bounded preview of one exact revision's content.
 async fn revision_preview(
     app: &AppHandle,
@@ -180,14 +252,16 @@ async fn revision_preview(
     output: &OutputRecord,
     revision: &OutputRevision,
 ) -> Result<DeliverablePreview, String> {
-    // Binary artifacts have no inline preview; the renderer keys its placeholder
-    // off the media type, so the response carries identity without content.
+    // Binary artifacts have no inline text preview; the renderer keys its
+    // viewer (or export-only placeholder) off the media type, and uses
+    // `revision_id` to fetch the full bytes when a viewer can draw them.
     if !media_type_is_text(&output.media_type) {
         return Ok(DeliverablePreview {
             output_id: output.id,
             filename: output.filename.clone(),
             media_type: output.media_type.clone(),
             revision_count: output.revision_count,
+            revision_id: revision.id,
             content: String::new(),
             truncated: false,
         });
@@ -200,7 +274,7 @@ async fn revision_preview(
     })
     .await
     .map_err(|_| "Could not preview that output".to_owned())??;
-    preview_from_bytes(output, bytes)
+    preview_from_bytes(output, revision, bytes)
 }
 
 /// List an output's version history, newest revision first.
@@ -646,7 +720,11 @@ pub(crate) fn read_output_revision_bytes(
     Ok(bytes)
 }
 
-fn preview_from_bytes(output: &OutputRecord, bytes: Vec<u8>) -> Result<DeliverablePreview, String> {
+fn preview_from_bytes(
+    output: &OutputRecord,
+    revision: &OutputRevision,
+    bytes: Vec<u8>,
+) -> Result<DeliverablePreview, String> {
     let text =
         String::from_utf8(bytes).map_err(|_| "Output is not a supported text file".to_owned())?;
     if text.contains('\0')
@@ -662,6 +740,7 @@ fn preview_from_bytes(output: &OutputRecord, bytes: Vec<u8>) -> Result<Deliverab
         filename: output.filename.clone(),
         media_type: output.media_type.clone(),
         revision_count: output.revision_count,
+        revision_id: revision.id,
         content,
         truncated,
     })

--- a/crates/openwave-desktop/src/deliverables.rs
+++ b/crates/openwave-desktop/src/deliverables.rs
@@ -1007,8 +1007,9 @@ mod tests {
         assert_eq!(summary.size_bytes, content.len() as u64);
         assert_eq!(summary.revision_count, 1);
 
-        let preview = preview_from_bytes(&output, content.to_vec()).unwrap();
+        let preview = preview_from_bytes(&output, &revision, content.to_vec()).unwrap();
         assert_eq!(preview.output_id, output.id);
+        assert_eq!(preview.revision_id, revision.id);
         assert_eq!(preview.content, "# Brief");
         let serialized = serde_json::to_value(preview).unwrap();
         assert_eq!(
@@ -1024,6 +1025,7 @@ mod tests {
                 "mediaType",
                 "outputId",
                 "revisionCount",
+                "revisionId",
                 "truncated"
             ]
         );

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -190,6 +190,7 @@ pub fn run() {
             documents::export_library_document,
             deliverables::list_deliverables,
             deliverables::read_deliverable,
+            deliverables::read_deliverable_file,
             deliverables::export_deliverable,
             deliverables::restore_output,
             deliverables::list_output_revisions,

--- a/crates/openwave-desktop/ui/src/components/document/document-details.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/document-details.tsx
@@ -18,6 +18,7 @@ import {
   hasOriginalViewer,
 } from "@/document/DocumentViewer";
 import type { SheetHighlightRange } from "@/document/UniverSpreadsheetViewer";
+import { documentFileSource } from "@/document/useFileDownload";
 import { cn } from "@/lib/utils";
 import {
   CITATION_MARK_CLASS,
@@ -117,6 +118,7 @@ export function DocumentDetails({
   const { client } = useApp();
   const type = baseMediaType(info.media_type);
   const structured = structuredKind(type);
+  const source = documentFileSource(client, chatId, info.document_id);
 
   return (
     <div className="flex min-h-0 grow flex-col overflow-hidden">
@@ -124,9 +126,7 @@ export function DocumentDetails({
         <>
           {hasOriginalViewer(type) ? (
             <DocumentViewer
-              client={client}
-              chatId={chatId}
-              documentId={info.document_id}
+              source={source}
               mediaType={type}
               targetPage={targetPage}
               citationCellRange={citationCellRange}
@@ -134,25 +134,19 @@ export function DocumentDetails({
             />
           ) : type.startsWith("image/") ? (
             <ImageViewer
-              client={client}
-              chatId={chatId}
-              documentID={info.document_id}
+              source={source}
               className="bg-page-background grow"
             />
           ) : structured !== null ? (
             <Suspense fallback={<ViewerLoading />}>
               {structured === "json" ? (
                 <JsonViewer
-                  client={client}
-                  chatId={chatId}
-                  documentID={info.document_id}
+                  source={source}
                   className="grow"
                 />
               ) : (
                 <XmlViewer
-                  client={client}
-                  chatId={chatId}
-                  documentID={info.document_id}
+                  source={source}
                   className="grow"
                 />
               )}
@@ -162,9 +156,7 @@ export function DocumentDetails({
             // extracted out of those: the text of record is the file, so the
             // citation's own offsets address what the viewer draws.
             <MarkdownViewer
-              client={client}
-              chatId={chatId}
-              documentID={info.document_id}
+              source={source}
               targetLines={targetLines}
               markdown={type === "text/markdown"}
               className="bg-page-background grow"

--- a/crates/openwave-desktop/ui/src/components/document/image-viewer.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/image-viewer.tsx
@@ -2,27 +2,26 @@ import { Loader2Icon } from "lucide-react";
 import type { HTMLAttributes } from "react";
 import { useEffect, useState } from "react";
 
-import type { ApiClient } from "@/api";
-import { useFileDownload } from "@/document/useFileDownload";
+import {
+  useFileDownload,
+  type FileBytesSource,
+} from "@/document/useFileDownload";
 import { cn } from "@/lib/utils";
 import { FileDownloadProgressIndicator } from "./FileDownloadProgress";
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
-  client: Pick<ApiClient, "getChatDocumentFile">;
-  chatId: string;
-  documentID: string;
+  source: FileBytesSource;
 }
 
 export function ImageViewer({
-  client,
-  chatId,
-  documentID,
+  source,
   className,
   ...restProps
 }: Props) {
   const [imageError, setImageError] = useState(false);
   const [imageUrl, setImageUrl] = useState<string | null>(null);
-  const fileDownload = useFileDownload(client, chatId, documentID, {
+  const fileId = source.id;
+  const fileDownload = useFileDownload(source, {
     parseAs: "blob",
   });
 
@@ -38,7 +37,7 @@ export function ImageViewer({
   // Reset error state on document change
   useEffect(() => {
     setImageError(false);
-  }, [documentID]);
+  }, [fileId]);
 
   if (fileDownload.isLoading) {
     return (

--- a/crates/openwave-desktop/ui/src/components/document/json-viewer.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/json-viewer.tsx
@@ -17,14 +17,16 @@ import {
   useState,
 } from "react";
 
-import type { ApiClient } from "@/api";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { useFileDownload } from "@/document/useFileDownload";
+import {
+  useFileDownload,
+  type FileBytesSource,
+} from "@/document/useFileDownload";
 import { cn } from "@/lib/utils";
 import { FileDownloadProgressIndicator } from "./FileDownloadProgress";
 
@@ -112,22 +114,18 @@ function isContainer(value: unknown): boolean {
 // ---------------------------------------------------------------------------
 
 interface JsonViewerProps extends HTMLAttributes<HTMLDivElement> {
-  client: Pick<ApiClient, "getChatDocumentFile">;
-  chatId: string;
-  documentID: string;
+  source: FileBytesSource;
   /** Glom-style dot-notation path to highlight, e.g. "items.0.invoice_number" */
   highlightPath?: string;
 }
 
 export function JsonViewer({
-  client,
-  chatId,
-  documentID,
+  source,
   highlightPath,
   className,
   ...props
 }: JsonViewerProps) {
-  const fileDownload = useFileDownload(client, chatId, documentID, {
+  const fileDownload = useFileDownload(source, {
     parseAs: "text",
   });
 

--- a/crates/openwave-desktop/ui/src/components/document/markdown-viewer.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/markdown-viewer.tsx
@@ -2,8 +2,10 @@ import { FileIcon, Loader2Icon } from "lucide-react";
 import type { HTMLAttributes } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import type { ApiClient } from "@/api";
-import { useFileDownload } from "@/document/useFileDownload";
+import {
+  useFileDownload,
+  type FileBytesSource,
+} from "@/document/useFileDownload";
 import { cn } from "@/lib/utils";
 import { extractHeadings } from "@/markdownHeadings";
 import { MessageMarkdown } from "@/MessageMarkdown";
@@ -58,9 +60,7 @@ export function splitIntoChunks(text: string, chunkSize: number): string[] {
 }
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
-  client: Pick<ApiClient, "getChatDocumentFile">;
-  chatId: string;
-  documentID: string;
+  source: FileBytesSource;
   /** Model-authored line range to reveal when a citation led here. */
   targetLines?: Readonly<{ start: number; end: number }>;
   /** Render the file as markdown rather than as the text it literally is. */
@@ -69,9 +69,7 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
 
 /** Text-shaped originals: markdown rendered, everything else as written. */
 export function MarkdownViewer({
-  client,
-  chatId,
-  documentID,
+  source,
   targetLines,
   markdown = false,
   className,
@@ -80,7 +78,7 @@ export function MarkdownViewer({
   const containerRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
-  const fileDownload = useFileDownload(client, chatId, documentID, {
+  const fileDownload = useFileDownload(source, {
     parseAs: "text",
   });
   const fullContent = fileDownload.data ?? "";

--- a/crates/openwave-desktop/ui/src/components/document/xml-viewer.tsx
+++ b/crates/openwave-desktop/ui/src/components/document/xml-viewer.tsx
@@ -16,14 +16,16 @@ import {
   useState,
 } from "react";
 
-import type { ApiClient } from "@/api";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { useFileDownload } from "@/document/useFileDownload";
+import {
+  useFileDownload,
+  type FileBytesSource,
+} from "@/document/useFileDownload";
 import { cn } from "@/lib/utils";
 import { FileDownloadProgressIndicator } from "./FileDownloadProgress";
 
@@ -190,22 +192,18 @@ function getAttributes(el: Element): [string, string][] {
 // ---------------------------------------------------------------------------
 
 interface XmlViewerProps extends HTMLAttributes<HTMLDivElement> {
-  client: Pick<ApiClient, "getChatDocumentFile">;
-  chatId: string;
-  documentID: string;
+  source: FileBytesSource;
   /** XPath expression to highlight, e.g. "/root/items/item[1]" */
   highlightPath?: string;
 }
 
 export function XmlViewer({
-  client,
-  chatId,
-  documentID,
+  source,
   highlightPath,
   className,
   ...props
 }: XmlViewerProps) {
-  const fileDownload = useFileDownload(client, chatId, documentID, {
+  const fileDownload = useFileDownload(source, {
     parseAs: "text",
   });
 

--- a/crates/openwave-desktop/ui/src/deliverables.test.ts
+++ b/crates/openwave-desktop/ui/src/deliverables.test.ts
@@ -5,6 +5,7 @@ vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
 
 import {
   exportDeliverable,
+  parseDeliverableFile,
   parseDeliverablePreview,
   parseDeliverablesCatalog,
   parseOutputExportResult,
@@ -166,12 +167,32 @@ describe("deliverable renderer projections", () => {
   });
 
   it("rejects canonical paths, missing opaque ids, and oversized previews", () => {
+    expect(
+      parseDeliverablePreview({
+        outputId,
+        filename: "brief.md",
+        mediaType: "text/markdown",
+        revisionCount: 1,
+        revisionId,
+        content: "safe",
+        truncated: false,
+      }),
+    ).toEqual({
+      outputId,
+      filename: "brief.md",
+      mediaType: "text/markdown",
+      revisionCount: 1,
+      revisionId,
+      content: "safe",
+      truncated: false,
+    });
     expect(() =>
       parseDeliverablePreview({
         outputId,
         filename: "brief.md",
         mediaType: "text/markdown",
         revisionCount: 1,
+        revisionId,
         content: "safe",
         truncated: false,
         path: "/private/scratch/brief.md",
@@ -182,6 +203,7 @@ describe("deliverable renderer projections", () => {
         filename: "brief.md",
         mediaType: "text/markdown",
         revisionCount: 1,
+        revisionId,
         content: "safe",
         truncated: false,
       }),
@@ -192,6 +214,7 @@ describe("deliverable renderer projections", () => {
         filename: "brief.md",
         mediaType: "text/markdown",
         revisionCount: 1,
+        revisionId,
         content: "x".repeat(100_001),
         truncated: true,
       }),
@@ -255,5 +278,40 @@ describe("deliverable renderer projections", () => {
     });
     expect(invokeMock).toHaveBeenCalledTimes(2);
     expect(invokeMock.mock.calls[1]?.[1]).toEqual(invokeMock.mock.calls[0]?.[1]);
+  });
+
+  it("decodes a pathless output file payload and rejects empty or oversized ones", () => {
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    const contentBase64 = btoa(String.fromCharCode(...bytes));
+    expect(
+      parseDeliverableFile({
+        outputId,
+        revisionId,
+        mediaType: "image/png",
+        contentBase64,
+      }),
+    ).toEqual({
+      outputId,
+      revisionId,
+      mediaType: "image/png",
+      bytes,
+    });
+    expect(() =>
+      parseDeliverableFile({
+        outputId,
+        revisionId,
+        mediaType: "image/png",
+        contentBase64: "",
+      }),
+    ).toThrow("Invalid output file response");
+    expect(() =>
+      parseDeliverableFile({
+        outputId,
+        revisionId,
+        mediaType: "image/png",
+        contentBase64,
+        path: "/private/scratch/chart.png",
+      }),
+    ).toThrow("Invalid output file response");
   });
 });

--- a/crates/openwave-desktop/ui/src/deliverables.ts
+++ b/crates/openwave-desktop/ui/src/deliverables.ts
@@ -23,8 +23,18 @@ export type DeliverablePreview = {
   filename: string;
   mediaType: string;
   revisionCount: number;
+  /** Revision this preview was built from — keys the inline file viewer. */
+  revisionId: string;
   content: string;
   truncated: boolean;
+};
+
+/** One revision's complete bytes, for inline viewers (office, PDF, image). */
+export type DeliverableFile = {
+  outputId: string;
+  revisionId: string;
+  mediaType: string;
+  bytes: Uint8Array;
 };
 
 export type OutputExportResult =
@@ -45,7 +55,7 @@ export type OutputExportResult =
         | "ambiguous_native_failure";
     };
 
-/** The curated model-authored text types, which are the only previewable ones. */
+/** The curated model-authored text types (bounded text preview + size ceiling). */
 export type TextDeliverableMediaType =
   | "text/markdown"
   | "text/plain"
@@ -87,6 +97,25 @@ export async function readDeliverable(
 ): Promise<DeliverablePreview> {
   return parseDeliverablePreview(
     await invoke("read_deliverable", { request: { chatId, outputId } }),
+  );
+}
+
+/**
+ * Load one revision's complete bytes for an inline viewer.
+ *
+ * Omit `revisionId` to read the current revision. Unlike
+ * {@link readDeliverable}, this is not a capped text preview and works for
+ * binary artifacts the document engines can draw.
+ */
+export async function readDeliverableFile(
+  chatId: string,
+  outputId: string,
+  revisionId?: string,
+): Promise<DeliverableFile> {
+  return parseDeliverableFile(
+    await invoke("read_deliverable_file", {
+      request: { chatId, outputId, revisionId: revisionId ?? null },
+    }),
   );
 }
 
@@ -251,6 +280,7 @@ export function parseDeliverablePreview(value: unknown): DeliverablePreview {
       "filename",
       "mediaType",
       "revisionCount",
+      "revisionId",
       "content",
       "truncated",
     ]) ||
@@ -261,6 +291,7 @@ export function parseDeliverablePreview(value: unknown): DeliverablePreview {
     !Number.isSafeInteger(value.revisionCount) ||
     value.revisionCount < 1 ||
     value.revisionCount > MAX_OUTPUT_REVISIONS ||
+    !isOpaqueId(value.revisionId) ||
     typeof value.content !== "string" ||
     [...value.content].length > MAX_PREVIEW_CHARACTERS ||
     value.content.includes("\0") ||
@@ -273,9 +304,60 @@ export function parseDeliverablePreview(value: unknown): DeliverablePreview {
     filename: value.filename,
     mediaType: value.mediaType,
     revisionCount: value.revisionCount,
+    revisionId: value.revisionId,
     content: value.content,
     truncated: value.truncated,
   };
+}
+
+export function parseDeliverableFile(value: unknown): DeliverableFile {
+  if (
+    !isExactRecord(value, [
+      "outputId",
+      "revisionId",
+      "mediaType",
+      "contentBase64",
+    ]) ||
+    !isOpaqueId(value.outputId) ||
+    !isOpaqueId(value.revisionId) ||
+    !isDeliverableMediaType(value.mediaType) ||
+    typeof value.contentBase64 !== "string" ||
+    value.contentBase64.length === 0
+  ) {
+    throw new Error("Invalid output file response");
+  }
+  let bytes: Uint8Array;
+  try {
+    bytes = decodeBase64(value.contentBase64);
+  } catch {
+    throw new Error("Invalid output file response");
+  }
+  if (bytes.byteLength === 0 || bytes.byteLength > deliverableByteCeiling(value.mediaType)) {
+    throw new Error("Invalid output file response");
+  }
+  return {
+    outputId: value.outputId,
+    revisionId: value.revisionId,
+    mediaType: value.mediaType,
+    bytes,
+  };
+}
+
+/**
+ * Decode base64 in chunks so a 16 MB artifact does not blow the argument stack
+ * the way a single `Uint8Array.from(..., charCodeAt)` would.
+ */
+function decodeBase64(encoded: string): Uint8Array {
+  const binary = atob(encoded);
+  const bytes = new Uint8Array(binary.length);
+  const chunkSize = 0x8000;
+  for (let offset = 0; offset < binary.length; offset += chunkSize) {
+    const end = Math.min(offset + chunkSize, binary.length);
+    for (let i = offset; i < end; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+  }
+  return bytes;
 }
 
 export function parseOutputExportResult(

--- a/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/document-detail/DocumentDetailRoot.dom.test.tsx
@@ -24,13 +24,13 @@ vi.mock("@/document/PdfViewer", async () => {
   const { usePdfPageState } = await import("@/document/usePdfPageState");
   return {
     PdfViewer: ({
-      documentId,
+      source,
       targetPage,
     }: {
-      documentId: string;
+      source: { id: string };
       targetPage?: number;
     }) => {
-      const { currentPage, setCurrentPage } = usePdfPageState(documentId, {
+      const { currentPage, setCurrentPage } = usePdfPageState(source.id, {
         numPages: 20,
         targetPage,
       });

--- a/crates/openwave-desktop/ui/src/document/DocumentViewer.tsx
+++ b/crates/openwave-desktop/ui/src/document/DocumentViewer.tsx
@@ -12,8 +12,8 @@
 import { lazy, Suspense } from "react";
 import { Loader2Icon } from "lucide-react";
 
-import type { ApiClient } from "@/api";
 import type { SheetHighlightRange } from "@/document/UniverSpreadsheetViewer";
+import type { FileBytesSource } from "@/document/useFileDownload";
 
 // pdf.js is a large dependency and most sessions never open a PDF, so it is
 // fetched from the app bundle on first use rather than at startup.
@@ -87,9 +87,7 @@ export function isGridOriginalViewer(mediaType: string): boolean {
 }
 
 interface DocumentViewerProps {
-  client: Pick<ApiClient, "getChatDocumentFile">;
-  chatId: string;
-  documentId: string;
+  source: FileBytesSource;
   mediaType: string;
   /** Open on this page the first time it is requested for this document. */
   targetPage?: number;
@@ -102,9 +100,7 @@ interface DocumentViewerProps {
 }
 
 export function DocumentViewer({
-  client,
-  chatId,
-  documentId,
+  source,
   mediaType,
   targetPage,
   citationCellRange,
@@ -116,9 +112,7 @@ export function DocumentViewer({
     return (
       <ViewerBoundary>
         <PdfViewer
-          client={client}
-          chatId={chatId}
-          documentId={documentId}
+          source={source}
           targetPage={targetPage}
           className={className}
         />
@@ -130,10 +124,8 @@ export function DocumentViewer({
     return (
       <ViewerBoundary>
         <UniverSpreadsheetViewer
-          key={documentId}
-          client={client}
-          chatId={chatId}
-          documentId={documentId}
+          key={source.id}
+          source={source}
           highlightRange={citationCellRange}
           isCsv={DELIMITED_TEXT_MEDIA_TYPES.has(type)}
           className={className}
@@ -146,10 +138,8 @@ export function DocumentViewer({
     return (
       <ViewerBoundary>
         <UniverDocumentViewer
-          key={documentId}
-          client={client}
-          chatId={chatId}
-          documentId={documentId}
+          key={source.id}
+          source={source}
           className={className}
         />
       </ViewerBoundary>

--- a/crates/openwave-desktop/ui/src/document/PdfViewer.tsx
+++ b/crates/openwave-desktop/ui/src/document/PdfViewer.tsx
@@ -14,11 +14,13 @@ import { Document, Page, pdfjs } from "react-pdf";
 // security policy. Vite emits the file and rewrites this to its final URL.
 import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
 
-import type { ApiClient } from "@/api";
 import { FileDownloadProgressIndicator } from "@/components/document/FileDownloadProgress";
 import { Button } from "@/components/ui/button";
 import { useRegisterPdfControls } from "@/document/PdfControlsContext";
-import { useFileDownload } from "@/document/useFileDownload";
+import {
+  useFileDownload,
+  type FileBytesSource,
+} from "@/document/useFileDownload";
 import { usePdfPageState } from "@/document/usePdfPageState";
 import { useWheelPageNavigation } from "@/document/useWheelPageNavigation";
 import { useZoom } from "@/document/useZoom";
@@ -28,9 +30,7 @@ import { cn } from "@/lib/utils";
 pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
-  client: Pick<ApiClient, "getChatDocumentFile">;
-  chatId: string;
-  documentId: string;
+  source: FileBytesSource;
   /** Open on this page the first time it is requested for this document. */
   targetPage?: number;
   /** Render the toolbar at a smaller scale. */
@@ -56,9 +56,7 @@ function PdfPage({ pageNumber, width }: { pageNumber: number; width: number }) {
  * and page-at-a-time is what makes wheel and arrow paging mean anything.
  */
 export function PdfViewer({
-  client,
-  chatId,
-  documentId,
+  source,
   targetPage,
   compact,
   className,
@@ -75,8 +73,9 @@ export function PdfViewer({
 
   const [renderFailed, setRenderFailed] = useState(false);
   const [numPages, setNumPages] = useState(0);
+  const fileId = source.id;
 
-  const { data, error, progress } = useFileDownload(client, chatId, documentId, {
+  const { data, error, progress } = useFileDownload(source, {
     parseAs: "arrayBuffer",
   });
   const loadFailed = renderFailed || error !== null;
@@ -86,7 +85,7 @@ export function PdfViewer({
     setScale(100);
     setRenderFailed(false);
     setNumPages(0);
-  }, [documentId, setScale]);
+  }, [fileId, setScale]);
 
   const pdfFile = useMemo(() => {
     if (!data) return null;
@@ -95,7 +94,7 @@ export function PdfViewer({
     return { data: new Uint8Array(data) };
   }, [data]);
 
-  const { currentPage, setCurrentPage } = usePdfPageState(documentId, {
+  const { currentPage, setCurrentPage } = usePdfPageState(fileId, {
     numPages,
     targetPage,
   });
@@ -283,7 +282,7 @@ export function PdfViewer({
       {/* Scrollable page area */}
       <div className="relative min-h-0 flex-1 overflow-scroll" ref={setContainerRef}>
         <Document
-          key={documentId}
+          key={fileId}
           file={pdfFile ?? undefined}
           onLoadSuccess={({ numPages }) => setNumPages(numPages)}
           onLoadError={() => setRenderFailed(true)}

--- a/crates/openwave-desktop/ui/src/document/UniverDocumentViewer.tsx
+++ b/crates/openwave-desktop/ui/src/document/UniverDocumentViewer.tsx
@@ -7,11 +7,10 @@ import { Loader2Icon } from "lucide-react";
 import type { HTMLAttributes } from "react";
 import { useEffect, useRef, useState } from "react";
 
-import type { ApiClient } from "@/api";
 import { cn } from "@/lib/utils";
 import { docxToUniver } from "./docx-to-univer";
 import { FileDownloadProgressIndicator } from "@/components/document/FileDownloadProgress";
-import { useFileDownload } from "./useFileDownload";
+import { useFileDownload, type FileBytesSource } from "./useFileDownload";
 
 // The MODERN flavor hardcodes page width to 595/0.75 ≈ 793px. To fill the
 // container we CSS-scale the render canvas so its pixel width matches the
@@ -30,9 +29,7 @@ const UNIVER_VIEWER_STYLES = `
 `;
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
-  client: Pick<ApiClient, "getChatDocumentFile">;
-  chatId: string;
-  documentId: string;
+  source: FileBytesSource;
 }
 
 /**
@@ -43,9 +40,7 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
  * of viewing one locally.
  */
 export default function UniverDocumentViewer({
-  client,
-  chatId,
-  documentId,
+  source,
   className,
   ...restProps
 }: Props) {
@@ -53,8 +48,9 @@ export default function UniverDocumentViewer({
   const univerRef = useRef<FUniver | null>(null);
   const [errorType, setErrorType] = useState<"parse" | "load" | null>(null);
   const [isReady, setIsReady] = useState(false);
+  const fileId = source.id;
 
-  const fileDownload = useFileDownload(client, chatId, documentId, {
+  const fileDownload = useFileDownload(source, {
     parseAs: "arrayBuffer",
   });
 
@@ -129,7 +125,7 @@ export default function UniverDocumentViewer({
         univerRef.current = null;
       }
     };
-  }, [fileDownload.data, documentId]);
+  }, [fileDownload.data, fileId]);
 
   useEffect(() => {
     if (fileDownload.error) setErrorType("load");

--- a/crates/openwave-desktop/ui/src/document/UniverSpreadsheetViewer.tsx
+++ b/crates/openwave-desktop/ui/src/document/UniverSpreadsheetViewer.tsx
@@ -13,14 +13,13 @@ import { Loader2Icon } from "lucide-react";
 import type { HTMLAttributes, ReactNode } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import type { ApiClient } from "@/api";
 import { cn } from "@/lib/utils";
 import { useTheme } from "@/theme";
 import UniverFormulaWorker from "@/workers/univer-formula.worker?worker&inline";
 import { SpreadsheetShortcutsInfoBar } from "./SpreadsheetShortcutsInfo";
 import { parseCellAddress } from "./spreadsheet";
 import { FileDownloadProgressIndicator } from "@/components/document/FileDownloadProgress";
-import { useFileDownload } from "./useFileDownload";
+import { useFileDownload, type FileBytesSource } from "./useFileDownload";
 import { useUniverWorker } from "./useUniverWorker";
 
 /** A cell range a citation points at, resolved against a named or indexed sheet. */
@@ -32,9 +31,7 @@ export interface SheetHighlightRange {
 }
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
-  client: Pick<ApiClient, "getChatDocumentFile">;
-  chatId: string;
-  documentId: string;
+  source: FileBytesSource;
   highlightRange?: SheetHighlightRange;
   /** When true, skip the XLSX-only style pass — a CSV has none. */
   isCsv?: boolean;
@@ -57,9 +54,7 @@ interface UniverInstance {
  * navigation, selection, and the formula engine's own writes through.
  */
 export default function UniverSpreadsheetViewer({
-  client,
-  chatId,
-  documentId,
+  source,
   highlightRange,
   isCsv,
   className,
@@ -74,6 +69,7 @@ export default function UniverSpreadsheetViewer({
   const { resolved: resolvedTheme } = useTheme();
   const resolvedThemeRef = useRef(resolvedTheme);
   resolvedThemeRef.current = resolvedTheme;
+  const fileId = source.id;
 
   // Sync dark mode with Univer.
   useEffect(() => {
@@ -93,7 +89,7 @@ export default function UniverSpreadsheetViewer({
     };
   }, []);
 
-  const fileDownload = useFileDownload(client, chatId, documentId, {
+  const fileDownload = useFileDownload(source, {
     parseAs: "arrayBuffer",
   });
 
@@ -211,7 +207,7 @@ export default function UniverSpreadsheetViewer({
     let disposed = false;
 
     univerWorker
-      .parseWorkbook(fileDownload.data, documentId, { isCsv })
+      .parseWorkbook(fileDownload.data, fileId, { isCsv })
       .then(({ workbookData }) => {
         if (disposed || !containerRef.current) return;
 
@@ -314,7 +310,7 @@ export default function UniverSpreadsheetViewer({
         univerInstanceRef.current = null;
       }
     };
-  }, [fileDownload.data, documentId, isCsv, univerWorker]);
+  }, [fileDownload.data, fileId, isCsv, univerWorker]);
 
   // Apply a highlight that arrives after the canvas is up; one that arrives
   // before it is applied by the canvas poll above.

--- a/crates/openwave-desktop/ui/src/document/useFileDownload.ts
+++ b/crates/openwave-desktop/ui/src/document/useFileDownload.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import type { ApiClient, FileDownloadProgress } from "@/api";
+import { readDeliverableFile } from "@/deliverables";
 
 /** How a viewer wants the bytes handed to it. */
 export type FileDownloadFormat = "arrayBuffer" | "text" | "blob";
@@ -15,29 +16,53 @@ type Decoded<F extends FileDownloadFormat> = F extends "text"
 type StoredFile = { bytes: Uint8Array; contentType: string | null };
 
 /**
- * How many bytes of source documents may be held at once.
+ * Fetch one file's bytes for a viewer. Progress is optional — Tauri-backed
+ * sources load in one shot and have nothing to report.
+ */
+export type FileBytesFetcher = (
+  signal: AbortSignal,
+  onProgress?: (progress: FileDownloadProgress) => void,
+) => Promise<{ bytes: Uint8Array; contentType: string | null }>;
+
+/**
+ * Where a viewer gets its bytes, and how they are addressed in the cache.
+ *
+ * Sources and outputs both draw with the same engines; they differ only in
+ * how the bytes are fetched. `id` is the stable identity UI state (page,
+ * remount keys) keys off; `cacheKey` must change whenever the bytes would.
+ */
+export type FileBytesSource = {
+  id: string;
+  cacheKey: string;
+  fetch: FileBytesFetcher;
+};
+
+/**
+ * How many bytes of viewed files may be held at once.
  *
  * The budget is on total bytes rather than on entries because the cost being
  * bounded is memory: a cap of "ten documents" treats a 12 MB workbook and a
- * 4 KB note as the same thing. A source cannot exceed 16 MB — the import limit
- * both the server and the renderer enforce — so 64 MB holds four of the largest
- * files a reader can open, or dozens of ordinary ones. That is generous for an
- * access pattern of "the source I am reading, and the one before it", while
- * still being small next to what a desktop renderer already occupies, and it no
- * longer grows with the length of the session.
+ * 4 KB note as the same thing. A source or binary output cannot exceed 16 MB
+ * — the import / acceptance limit both the server and the renderer enforce —
+ * so 64 MB holds four of the largest files a reader can open, or dozens of
+ * ordinary ones. That is generous for an access pattern of "the file I am
+ * reading, and the one before it", while still being small next to what a
+ * desktop renderer already occupies, and it no longer grows with the length
+ * of the session.
  */
 const MAX_CACHED_BYTES = 64 * 1024 * 1024;
 
 /**
- * Source documents' original bytes, held across viewer mounts.
+ * Viewed files' original bytes, held across viewer mounts.
  *
- * A document's content is immutable once imported — replacing a file produces a
- * new document with a new id — so a cache hit can never be stale. It earns its
- * place because the panel unmounts the viewer whenever the reader switches
- * between the original and the extracted text: without the cache, every flip
- * back re-downloads the whole file and redraws from a spinner.
+ * A source document's content is immutable once imported — replacing a file
+ * produces a new document with a new id — so a cache hit can never be stale.
+ * An output revision is likewise write-once. The cache earns its place
+ * because the panel unmounts the viewer whenever the reader switches between
+ * views: without it, every flip back re-downloads the whole file and redraws
+ * from a spinner.
  *
- * Eviction is least-recently-*read*, not least-recently-inserted: the document a
+ * Eviction is least-recently-*read*, not least-recently-inserted: the file a
  * reader keeps flipping back to is the one worth keeping, however long ago it
  * was downloaded.
  */
@@ -116,40 +141,78 @@ export type FileDownload<F extends FileDownloadFormat> = {
   contentType: string | null;
   /**
    * How far the transfer has got, or null when there is nothing to report — a
-   * small file, a response that never declared its length, or a cache hit,
-   * which is instant and has no transfer to report on.
+   * small file, a response that never declared its length, a cache hit, or a
+   * one-shot IPC load with no streaming progress.
    */
   progress: FileDownloadProgress | null;
 };
 
-/**
- * Download one source's original bytes, for every viewer that draws them.
- *
- * The file is addressed by document id inside its conversation, never by a host
- * path, so a viewer can draw the file the reader imported without the renderer
- * learning where on disk it came from. The client is passed in rather than
- * pulled from context so the hook can be driven without a provider, and so a
- * viewer's dependencies are visible in its props.
- */
-export function useFileDownload<F extends FileDownloadFormat>(
+/** Bytes of one imported source document, addressed by document id. */
+export function documentFileSource(
   client: Pick<ApiClient, "getChatDocumentFile">,
   chatId: string,
   documentId: string,
+): FileBytesSource {
+  return {
+    id: documentId,
+    cacheKey: `document/${chatId}/${documentId}`,
+    fetch: (signal, onProgress) =>
+      client.getChatDocumentFile(chatId, documentId, signal, onProgress),
+  };
+}
+
+/**
+ * Bytes of one output revision in private scratch.
+ *
+ * `revisionId` is required so the cache key names immutable content: omitting
+ * it and keying on "current" would serve a stale revision after an update.
+ */
+export function outputFileSource(
+  chatId: string,
+  outputId: string,
+  revisionId: string,
+): FileBytesSource {
+  return {
+    id: `${outputId}/${revisionId}`,
+    cacheKey: `output/${chatId}/${outputId}/${revisionId}`,
+    fetch: async (signal) => {
+      const file = await readDeliverableFile(chatId, outputId, revisionId);
+      if (signal.aborted) {
+        throw new DOMException("The operation was aborted.", "AbortError");
+      }
+      return { bytes: file.bytes, contentType: file.mediaType };
+    },
+  };
+}
+
+/**
+ * Download one file's original bytes, for every viewer that draws them.
+ *
+ * The source is passed in rather than pulled from context so the hook can be
+ * driven without a provider, and so a viewer's dependencies are visible in
+ * its props. Sources and outputs share the cache and the decode path.
+ */
+export function useFileDownload<F extends FileDownloadFormat>(
+  source: FileBytesSource,
   options: { parseAs: F },
 ): FileDownload<F> {
   const { parseAs } = options;
-  const key = `${chatId}/${documentId}`;
+  const { cacheKey, fetch } = source;
   const [file, setFile] = useState<StoredFile | null>(
-    () => byteCache.get(key) ?? null,
+    () => byteCache.get(cacheKey) ?? null,
   );
   const [error, setError] = useState<Error | null>(null);
   const [isLoading, setIsLoading] = useState(file === null);
   const [progress, setProgress] = useState<FileDownloadProgress | null>(null);
   const requestRef = useRef(0);
+  // Keep the latest fetch without re-running the effect when the caller
+  // rebuilds an otherwise-identical source object each render.
+  const fetchRef = useRef(fetch);
+  fetchRef.current = fetch;
 
   useEffect(() => {
     const request = ++requestRef.current;
-    const cached = byteCache.get(key);
+    const cached = byteCache.get(cacheKey);
     if (cached) {
       setFile(cached);
       setError(null);
@@ -166,9 +229,7 @@ export function useFileDownload<F extends FileDownloadFormat>(
 
     void (async () => {
       try {
-        const downloaded = await client.getChatDocumentFile(
-          chatId,
-          documentId,
+        const downloaded = await fetchRef.current(
           controller.signal,
           (next) => {
             if (!controller.signal.aborted && request === requestRef.current) {
@@ -177,7 +238,7 @@ export function useFileDownload<F extends FileDownloadFormat>(
           },
         );
         if (request !== requestRef.current) return;
-        byteCache.set(key, downloaded);
+        byteCache.set(cacheKey, downloaded);
         setFile(downloaded);
       } catch (err) {
         if (controller.signal.aborted || request !== requestRef.current) return;
@@ -191,7 +252,7 @@ export function useFileDownload<F extends FileDownloadFormat>(
     })();
 
     return () => controller.abort();
-  }, [client, chatId, documentId, key]);
+  }, [cacheKey]);
 
   const data = useMemo(() => {
     if (!file) return null;

--- a/crates/openwave-desktop/ui/src/outputs/CodeViewer.test.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/CodeViewer.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CodeViewer, codeLanguageForMediaType } from "./CodeViewer";
+
+describe("CodeViewer", () => {
+  it("maps curated media types to highlight languages", () => {
+    expect(codeLanguageForMediaType("application/json")).toBe("json");
+    expect(codeLanguageForMediaType("text/html")).toBe("xml");
+    expect(codeLanguageForMediaType("text/plain")).toBe("plaintext");
+  });
+
+  it("highlights JSON without treating it as markdown prose", () => {
+    render(
+      <CodeViewer
+        mediaType="application/json"
+        content={'{\n  "title": "Findings"\n}'}
+      />,
+    );
+    expect(screen.queryByRole("heading", { name: "Findings" })).toBeNull();
+    expect(screen.getByText('"title"')).toBeVisible();
+    expect(document.querySelector(".hljs-string")).not.toBeNull();
+  });
+
+  it("keeps content that contains fence markers intact", () => {
+    const content = "before\n```\nstill source\n```\nafter";
+    render(<CodeViewer mediaType="text/plain" content={content} />);
+    expect(screen.getByText(/still source/)).toBeVisible();
+    expect(screen.getByText(/before/)).toBeVisible();
+    expect(screen.getByText(/after/)).toBeVisible();
+  });
+});

--- a/crates/openwave-desktop/ui/src/outputs/CodeViewer.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/CodeViewer.tsx
@@ -1,0 +1,53 @@
+import { useMemo } from "react";
+import ReactMarkdown from "react-markdown";
+import rehypeHighlight from "rehype-highlight";
+
+/**
+ * Fence long enough that no run of backticks inside `content` can close it.
+ * Markdown fences match the longest opening run, so stretching past the
+ * content's longest run is enough — no escaping of the body.
+ */
+function fence(language: string, content: string): string {
+  let ticks = "```";
+  while (content.includes(ticks)) ticks += "`";
+  return `${ticks}${language}\n${content}\n${ticks}`;
+}
+
+/** Highlight language for a curated text output's media type. */
+export function codeLanguageForMediaType(mediaType: string): string {
+  switch (mediaType.split(";", 1)[0]!.trim().toLowerCase()) {
+    case "application/json":
+      return "json";
+    case "text/html":
+      return "xml";
+    default:
+      return "plaintext";
+  }
+}
+
+/**
+ * Syntax-highlighted source view for curated text outputs that are not
+ * markdown (JSON, HTML-as-source, plain text).
+ *
+ * Reuses the chat fence highlighter and the `.message-markdown` token colors
+ * so an output and a fenced block in the transcript read the same.
+ */
+export function CodeViewer({
+  content,
+  mediaType,
+}: {
+  content: string;
+  mediaType: string;
+}) {
+  const language = codeLanguageForMediaType(mediaType);
+  const markdown = useMemo(
+    () => fence(language, content),
+    [language, content],
+  );
+
+  return (
+    <div className="message-markdown code-viewer">
+      <ReactMarkdown rehypePlugins={[rehypeHighlight]}>{markdown}</ReactMarkdown>
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/outputs/OutputContent.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputContent.tsx
@@ -1,0 +1,96 @@
+/**
+ * How one output revision is drawn in the detail panel.
+ *
+ * Formats that already have a source-document viewer reuse those engines
+ * against private scratch bytes. Curated text without a dedicated engine stays
+ * on the bounded preview string. Everything else offers export only.
+ */
+import { Suspense } from "react";
+import { Loader2Icon } from "lucide-react";
+
+import { ImageViewer } from "@/components/document/image-viewer";
+import {
+  DocumentViewer,
+  hasOriginalViewer,
+} from "@/document/DocumentViewer";
+import { outputFileSource } from "@/document/useFileDownload";
+import {
+  isTextDeliverableMediaType,
+  type DeliverablePreview,
+} from "@/deliverables";
+import { MessageMarkdown } from "@/MessageMarkdown";
+import { CodeViewer } from "./CodeViewer";
+
+function normalizeMediaType(mediaType: string): string {
+  return mediaType.split(";", 1)[0]!.trim().toLowerCase();
+}
+
+export function OutputContent({
+  chatId,
+  preview,
+}: {
+  chatId: string;
+  preview: DeliverablePreview;
+}) {
+  const type = normalizeMediaType(preview.mediaType);
+  const source = outputFileSource(chatId, preview.outputId, preview.revisionId);
+
+  if (hasOriginalViewer(type)) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <Suspense fallback={<ViewerLoading />}>
+          <DocumentViewer
+            source={source}
+            mediaType={type}
+            className="bg-page-background min-h-0 grow p-4 pt-2"
+          />
+        </Suspense>
+      </div>
+    );
+  }
+
+  if (type.startsWith("image/")) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <ImageViewer source={source} className="bg-page-background grow" />
+      </div>
+    );
+  }
+
+  if (!isTextDeliverableMediaType(type)) {
+    return (
+      <div className="min-h-0 flex-1 overflow-auto p-6">
+        <p className="text-sm text-muted-foreground" role="status">
+          No preview for this file type. Save as… exports the file.
+        </p>
+      </div>
+    );
+  }
+
+  // CSV is handled above via Univer. Markdown renders as prose; other curated
+  // text gets a syntax-highlighted source view.
+  return (
+    <div className="min-h-0 flex-1 overflow-auto p-6">
+      <div className="mx-auto max-w-4xl">
+        {type === "text/markdown" ? (
+          <MessageMarkdown>{preview.content}</MessageMarkdown>
+        ) : (
+          <CodeViewer content={preview.content} mediaType={type} />
+        )}
+        {preview.truncated && (
+          <p className="mt-6 text-xs text-muted-foreground">
+            Preview truncated. Saving writes the complete file.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ViewerLoading() {
+  return (
+    <div className="flex grow items-center justify-center">
+      <Loader2Icon className="size-6 animate-spin text-muted-foreground" />
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.dom.test.tsx
@@ -8,6 +8,22 @@ import type { DeliverablePreview, OutputRevisionInfo } from "@/deliverables";
 import { renderWithRouter } from "@/test/router";
 import { OutputDetailRoot, type OutputDetailApis } from "./OutputDetailRoot";
 
+vi.mock("@/components/document/image-viewer", () => ({
+  ImageViewer: () => <div>Image preview</div>,
+}));
+
+vi.mock("@/document/DocumentViewer", async () => {
+  const actual = await vi.importActual<typeof import("@/document/DocumentViewer")>(
+    "@/document/DocumentViewer",
+  );
+  return {
+    ...actual,
+    DocumentViewer: ({ mediaType }: { mediaType: string }) => (
+      <div>Document preview ({mediaType})</div>
+    ),
+  };
+});
+
 afterEach(cleanup);
 
 const outputId = "550062d4-2528-5cc6-90f8-a788e119bf36";
@@ -21,6 +37,7 @@ function preview(overrides: Partial<DeliverablePreview> = {}): DeliverablePrevie
     filename: "Research brief.md",
     mediaType: "text/markdown",
     revisionCount: 1,
+    revisionId,
     content: "# Findings\n\nGrounded.",
     truncated: false,
     ...overrides,
@@ -120,9 +137,9 @@ describe("OutputDetailRoot", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent("output not found");
   });
 
-  // Non-markdown outputs are source text, not prose: rendering a CSV as markdown
-  // would eat its structure.
-  it("renders a delimited output as text rather than as markdown", async () => {
+  // CSV shares the spreadsheet viewer with xlsx — never markdown, which would
+  // eat its structure into headings.
+  it("renders a delimited output in the spreadsheet viewer", async () => {
     const apis = detailApis({
       read: vi.fn().mockResolvedValue(
         preview({
@@ -135,9 +152,8 @@ describe("OutputDetailRoot", () => {
     });
     await openOutput(apis);
 
-    expect(await screen.findByText(/# not a heading,2/)).toBeVisible();
+    expect(await screen.findByText("Document preview (text/csv)")).toBeVisible();
     expect(screen.queryByRole("heading", { name: "not a heading,2" })).toBeNull();
-    expect(screen.getByText(/Saving writes the complete file/)).toBeVisible();
   });
 
   // Alpha parity: the history affordance is invisible until an output actually
@@ -207,14 +223,50 @@ describe("OutputDetailRoot", () => {
     expect(apis.restoreRevision).not.toHaveBeenCalled();
   });
 
-  // Binary artifacts arrive with empty content; the panel offers export rather
-  // than an inline rendering it cannot produce.
-  it("offers export instead of a preview for a binary artifact", async () => {
+  it("draws an image output with the shared image viewer", async () => {
     const apis = detailApis({
       read: vi.fn().mockResolvedValue(
         preview({
           filename: "chart.png",
           mediaType: "image/png",
+          content: "",
+        }),
+      ),
+    });
+    await openOutput(apis);
+
+    expect(await screen.findByText("Image preview")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Save as…" })).toBeEnabled();
+  });
+
+  it("draws an office output with the shared document viewer", async () => {
+    const apis = detailApis({
+      read: vi.fn().mockResolvedValue(
+        preview({
+          filename: "model.xlsx",
+          mediaType:
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          content: "",
+        }),
+      ),
+    });
+    await openOutput(apis);
+
+    expect(
+      await screen.findByText(
+        "Document preview (application/vnd.openxmlformats-officedocument.spreadsheetml.sheet)",
+      ),
+    ).toBeVisible();
+  });
+
+  // Formats with no viewer still arrive with empty content; the panel offers
+  // export rather than an inline rendering it cannot produce.
+  it("offers export instead of a preview for an unsupported binary artifact", async () => {
+    const apis = detailApis({
+      read: vi.fn().mockResolvedValue(
+        preview({
+          filename: "bundle.zip",
+          mediaType: "application/zip",
           content: "",
         }),
       ),

--- a/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputDetailRoot.tsx
@@ -9,7 +9,6 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { WithTooltip } from "@/components/ui/tooltip";
 import {
   exportDeliverable,
-  isTextDeliverableMediaType,
   listOutputRevisions,
   readDeliverable,
   readOutputRevision,
@@ -20,7 +19,6 @@ import {
   type OutputRevisionInfo,
   type OutputRevisionsCatalog,
 } from "@/deliverables";
-import { MessageMarkdown } from "@/MessageMarkdown";
 import {
   PICKER_BUSY_MESSAGE,
   PICKER_HOLDERS,
@@ -29,6 +27,7 @@ import {
 import { PanelFrame } from "@/panel/PanelFrame";
 import type { PanelPosition } from "@/panel/panelTypes";
 import { usePanelNav } from "@/panel/usePanelNav";
+import { OutputContent } from "./OutputContent";
 import { outputTypeLabel } from "./outputFormat";
 import { exportFailureMessage, friendlyOutputError } from "./OutputsView";
 
@@ -349,26 +348,7 @@ export function OutputDetailRoot({
           <div className="shrink-0 px-6 pt-4 text-xs text-muted-foreground">
             {outputTypeLabel(viewing.mediaType)}
           </div>
-          <div className="min-h-0 flex-1 overflow-auto p-6">
-            <div className="mx-auto max-w-4xl">
-              {!isTextDeliverableMediaType(viewing.mediaType) ? (
-                <p className="text-sm text-muted-foreground" role="status">
-                  No preview for this file type. Save as… exports the file.
-                </p>
-              ) : viewing.mediaType === "text/markdown" ? (
-                <MessageMarkdown>{viewing.content}</MessageMarkdown>
-              ) : (
-                <pre className="font-mono text-xs break-words whitespace-pre-wrap">
-                  {viewing.content}
-                </pre>
-              )}
-              {viewing.truncated && (
-                <p className="mt-6 text-xs text-muted-foreground">
-                  Preview truncated. Saving writes the complete file.
-                </p>
-              )}
-            </div>
-          </div>
+          <OutputContent chatId={chatId} preview={viewing} />
         </>
       ) : (
         <p className="p-6 text-sm text-muted-foreground" role="status">

--- a/docs/deliverables.md
+++ b/docs/deliverables.md
@@ -32,11 +32,16 @@ symlinks rather than following them.
 - Filenames are one portable ASCII component, at most 120 characters.
 - Content is valid UTF-8, non-empty, and at most 512 KiB.
 - The catalog returns the newest 100 valid output files.
-- Previews return at most 100,000 Unicode characters. Export always uses the
-  complete file.
+- Text previews return at most 100,000 Unicode characters. Export always uses
+  the complete file.
+- Formats with an inline viewer — spreadsheets and CSV (Univer), Word documents
+  (Univer), PDFs, and images — load the revision's complete bytes through a
+  separate native read and reuse the same engines as source documents.
 - Markdown previews use the same safe renderer as assistant messages: raw HTML,
   local-file links, executable URL schemes, and remote image loads are not
-  rendered. HTML outputs are shown as text rather than executed.
+  rendered. Plain text, JSON, and HTML outputs use a syntax-highlighted source
+  view (HTML is never executed). Unsupported binary types (for example ZIP)
+  remain export-only.
 
 The output directory is a capability-confined child of private per-chat
 scratch. Native reads reject symlinks and non-regular or oversized files.


### PR DESCRIPTION
## Summary
- Add `read_deliverable_file` so output revisions can load full bytes for inline viewers, and carry `revisionId` on previews for cache keys.
- Generalize `useFileDownload` around a shared `FileBytesSource` so source and output panels reuse Univer, pdf.js, and image viewers.
- Dispatch Outputs detail through `OutputContent`, with a syntax-highlighted `CodeViewer` for plain/JSON/HTML text.

## Test plan
- [ ] Open an xlsx/csv/docx/PDF/image output and confirm it renders in Outputs (not “No preview”).
- [ ] Open a markdown output and confirm prose rendering still works; open JSON/HTML/plain and confirm highlighted source view.
- [ ] Open a ZIP (or other unsupported binary) and confirm export-only placeholder remains.
- [ ] Preview an older revision of a binary/office output, then restore; confirm the viewer tracks the selected revision.
- [ ] Flip a source document between original and extracted views and confirm downloads still cache/work.


Made with [Cursor](https://cursor.com)