### PR TITLE
feat(core): coach the model when an approval is declined

### DIFF
--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -372,6 +372,15 @@ pub struct ToolApproval {
 }
 
 impl ToolApproval {
+    /// Reject reason when the reader gave none.
+    ///
+    /// The model reads this verbatim, so it carries the recovery guidance a
+    /// silent reader would otherwise leave implicit: retrying the exact call
+    /// just re-asks the question the reader already answered.
+    pub const DEFAULT_REJECT_REASON: &'static str = "The user declined to approve this action. \
+        Do not retry the same action; propose a different approach, ask the user why, or \
+        continue without it.";
+
     /// Maximum stored reject-reason bytes.
     pub const MAX_REASON_BYTES: usize = 1024;
 
@@ -397,7 +406,7 @@ impl ToolApproval {
                 reason: self
                     .reason
                     .clone()
-                    .unwrap_or_else(|| "user denied approval".into()),
+                    .unwrap_or_else(|| Self::DEFAULT_REJECT_REASON.into()),
             }),
         }
     }

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -3123,7 +3123,9 @@ pub async fn post_approval(
                 .reason
                 .map(|reason| reason.trim().to_owned())
                 .filter(|reason| !reason.is_empty())
-                .unwrap_or_else(|| "user denied approval".into()),
+                .unwrap_or_else(|| {
+                    openwave_core::ToolApproval::DEFAULT_REJECT_REASON.into()
+                }),
         },
     };
     if body.grant.is_some() && !matches!(&decision, ApprovalDecision::Approve) {

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -3123,9 +3123,7 @@ pub async fn post_approval(
                 .reason
                 .map(|reason| reason.trim().to_owned())
                 .filter(|reason| !reason.is_empty())
-                .unwrap_or_else(|| {
-                    openwave_core::ToolApproval::DEFAULT_REJECT_REASON.into()
-                }),
+                .unwrap_or_else(|| openwave_core::ToolApproval::DEFAULT_REJECT_REASON.into()),
         },
     };
     if body.grant.is_some() && !matches!(&decision, ApprovalDecision::Approve) {


### PR DESCRIPTION
A rejected approval with no reader-supplied reason fed the model the bare string `user denied approval`, which models routinely answer by retrying the exact same call. The shared default now lives on `ToolApproval::DEFAULT_REJECT_REASON` and tells the model not to retry the same action — propose a different approach, ask the user why, or continue without it. A reader-supplied reason still passes through verbatim, and the durable-recovery path uses the same default.