### PR TITLE
feat(desktop): show a declined tool call as declined

### DIFF
--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -879,6 +879,12 @@ fn tool_activity_from_call(
 ) -> ChatToolActivitySnapshot {
     let status = match call.status {
         crate::model::ToolCallStatus::Completed => ChatToolActivityStatus::Completed,
+        crate::model::ToolCallStatus::Failed
+            if call.error_code.as_deref()
+                == Some(crate::tool::ToolErrorCategory::UserDeclined.as_str()) =>
+        {
+            ChatToolActivityStatus::Denied
+        }
         crate::model::ToolCallStatus::Failed => ChatToolActivityStatus::Failed,
         crate::model::ToolCallStatus::Cancelled => ChatToolActivityStatus::Cancelled,
         crate::model::ToolCallStatus::Pending => {
@@ -1414,6 +1420,28 @@ mod tests {
         );
         assert_eq!(activity.result, None);
         assert!(activity.result_unreadable);
+    }
+
+    /// "You said no" and "the tool broke" are different facts to show a
+    /// reader; folding a decline into `Failed` made history claim a crash.
+    #[test]
+    fn a_declined_call_projects_denied_while_other_failures_stay_failed() {
+        let declined = ToolCallRecord {
+            status: crate::model::ToolCallStatus::Failed,
+            ..terminal_call("exec", Some("user_declined"))
+        };
+        assert_eq!(
+            tool_activity_from_call(declined, None).status,
+            ChatToolActivityStatus::Denied
+        );
+        let crashed = ToolCallRecord {
+            status: crate::model::ToolCallStatus::Failed,
+            ..terminal_call("exec", Some("tool_failed"))
+        };
+        assert_eq!(
+            tool_activity_from_call(crashed, None).status,
+            ChatToolActivityStatus::Failed
+        );
     }
 
     /// Calls that resolved before projections were retained still rebuild the

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -184,6 +184,13 @@ pub enum DeleteProjectOutcome {
 pub enum ChatToolActivityStatus {
     Completed,
     Failed,
+    /// The reader rejected the call's approval, so it never ran.
+    ///
+    /// Durably this is a `Failed` call whose error code says the user
+    /// declined; the projection splits it out because "you said no" and
+    /// "the tool broke" are different facts to show a reader, and folding
+    /// them made a decline indistinguishable from a crash in history.
+    Denied,
     Cancelled,
 }
 

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -276,7 +276,7 @@ describe("tool call lifecycle", () => {
     ]);
     expect(
       rejectedThenCompleted.state.messages.find((m) => m.role === "tool"),
-    ).toMatchObject({ status: "cancelled" });
+    ).toMatchObject({ status: "denied" });
   });
 });
 
@@ -371,7 +371,7 @@ describe("approvals", () => {
       { type: "approval_decided", call_id: "call-1", approved: false },
     ]);
     expect(rejected.state.messages.find((m) => m.role === "tool")).toMatchObject(
-      { status: "cancelled" },
+      { status: "denied" },
     );
   });
 });

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -300,8 +300,8 @@ export function reduceChatSessionEvent(
           messages: updateToolCall(state.messages, event.call_id, (tool) => ({
             ...tool,
             status:
-              tool.status === "cancelled"
-                ? "cancelled"
+              tool.status === "cancelled" || tool.status === "denied"
+                ? tool.status
                 : event.status === "failed"
                   ? "failed"
                   : "completed",
@@ -641,7 +641,7 @@ export function updateApprovalAndToolCall(
     if (message.role === "tool" && message.callId === callId) {
       return {
         ...message,
-        status: approved ? "running" : "cancelled",
+        status: approved ? "running" : "denied",
       };
     }
     return message;

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -1083,6 +1083,7 @@ export function shouldShowAssistantWorking(
       (message.role === "tool" &&
         message.status !== "completed" &&
         message.status !== "failed" &&
+        message.status !== "denied" &&
         message.status !== "cancelled") ||
       (message.role === "approval" && !message.resolved),
   );

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -21,6 +21,7 @@ export type ToolCallStatus =
   | "waiting_approval"
   | "completed"
   | "failed"
+  | "denied"
   | "cancelled";
 
 type ToolCommandCardProps = {
@@ -532,6 +533,16 @@ function statusPresentation(tool: ToolPresentation, status: ToolCallStatus) {
         badge: "Failed",
         label: "Tool could not complete",
         tone: "failed" as const,
+      };
+    case "denied":
+      // The reader said no; the tool did not break. Distinct copy keeps a
+      // decline from reading as either a crash or a cancelled turn.
+      return {
+        icon: "–",
+        title: tool.label,
+        badge: "Declined",
+        label: "Declined",
+        tone: "cancelled" as const,
       };
     case "cancelled":
       return {

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -449,7 +449,7 @@ result_unreadable: boolean, background_agent_run_id?: AgentRunId, status: ChatTo
 /**
  * Fixed lifecycle vocabulary exposed for a historical tool card.
  */
-export type ChatToolActivityStatus = "completed" | "failed" | "cancelled";
+export type ChatToolActivityStatus = "completed" | "failed" | "denied" | "cancelled";
 
 /**
  * One visible transcript plus the durable journal watermark that produced it.


### PR DESCRIPTION
A rejected approval rendered its tool row as **cancelled** in the live stream but as **failed** after reload — the two views disagreed, and neither told the truth: a reader's decline was indistinguishable from a cancelled turn in one and from a tool crash in the other.

- `ChatToolActivityStatus` gains a `denied` variant, projected from a `Failed` call whose stored error code is `user_declined`; the durable record is unchanged, so no migration.
- The reducer marks a rejected approval's tool row `denied` (and keeps it through the trailing `tool_call_completed`), matching what hydration now rebuilds.
- The card shows a "Declined" badge with the muted not-run treatment, distinct from "Failed" and "Not run".

Wire types regenerated; covered by a projection unit test (declined → denied, other failures stay failed) and the updated reducer tests.