### PR TITLE
fix(exec): raise the local sandbox open-files limit to 512

### DIFF
--- a/crates/openwave-code-execution/src/local.rs
+++ b/crates/openwave-code-execution/src/local.rs
@@ -47,7 +47,10 @@ const TERMINATE_GRACE: Duration = Duration::from_millis(250);
 #[cfg(target_os = "macos")]
 const MAX_WRITTEN_FILE_BYTES: u64 = 16 * 1_024 * 1_024;
 #[cfg(target_os = "macos")]
-const MAX_OPEN_FILES: u64 = 64;
+// Roomy enough for interpreters, package installs, and office-format
+// libraries that open many archive members at once; still far below the
+// system default, so a descriptor leak dies quickly.
+const MAX_OPEN_FILES: u64 = 512;
 
 /// Native local execution rooted at OpenWave's private per-chat scratch.
 pub struct LocalExecutionProvider {


### PR DESCRIPTION
Part of #1310.

`RLIMIT_NOFILE=64` starves legitimate workloads: a `pip install --user` (now a supported path under the package-managers network policy) opens wheels, sockets, and metadata files concurrently, and office-format libraries open many ZIP archive members at once — both hit EMFILE before doing anything unreasonable. 512 leaves them room while staying far below the system default, so a descriptor leak still dies quickly.

Verified with `cargo check -p openwave-code-execution`; no test pins the old value.