### PR TITLE
fix(core): explain what the output scan refused to publish

### DIFF
--- a/crates/openwave-core/src/db/ops/output.rs
+++ b/crates/openwave-core/src/db/ops/output.rs
@@ -119,7 +119,7 @@ pub(in crate::db) async fn append_output_revision(
     if ordinal > MAX_OUTPUT_REVISIONS {
         transaction.rollback().await.map_err(store_err)?;
         return Err(AgentError::Store(format!(
-            "output {output_id} has reached its {MAX_OUTPUT_REVISIONS}-revision limit"
+            "output {output_id} has reached its {MAX_OUTPUT_REVISIONS}-revision limit; save the file under a new filename to publish further changes"
         )));
     }
     insert_revision_on(&transaction, output_id, ordinal, revision, created_at).await?;

--- a/crates/openwave-core/src/db/tests/output.rs
+++ b/crates/openwave-core/src/db/tests/output.rs
@@ -625,9 +625,9 @@ mod output_scan {
     }
 
     fn write_output_file(scratch: &std::path::Path, name: &str, content: &[u8]) {
-        let directory = scratch.join(EXEC_OUTPUT_DIRECTORY);
-        std::fs::create_dir_all(&directory).unwrap();
-        std::fs::write(directory.join(name), content).unwrap();
+        let path = scratch.join(EXEC_OUTPUT_DIRECTORY).join(name);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, content).unwrap();
     }
 
     #[tokio::test]
@@ -762,6 +762,7 @@ mod output_scan {
         );
         write_output_file(scratch.path(), "binary.md", b"text\xff\xfe");
         write_output_file(scratch.path(), ".hidden.md", b"# Plumbing");
+        write_output_file(scratch.path(), "nested/index.html", b"<html></html>");
 
         let scan = sync(&store, &dir, chat.id, CallId::new(), 0).await;
 
@@ -777,6 +778,10 @@ mod output_scan {
             .iter()
             .any(|note| note.contains("binary.md") && note.contains("UTF-8")));
         assert!(!scan.notes.iter().any(|note| note.contains(".hidden.md")));
+        assert!(scan
+            .notes
+            .iter()
+            .any(|note| note.contains("nested") && note.contains("top level")));
     }
 
     #[tokio::test]
@@ -800,7 +805,10 @@ mod output_scan {
         write_output_file(scratch.path(), "fresh.md", b"# Lands anyway");
         let scan = sync(&store, &dir, chat.id, CallId::new(), 500).await;
 
-        assert!(scan.notes.iter().any(|note| note.contains("capped.md")));
+        assert!(scan
+            .notes
+            .iter()
+            .any(|note| note.contains("capped.md") && note.contains("new filename")));
         assert_eq!(scan.entries.len(), 1);
         assert_eq!(scan.entries[0].filename, "fresh.md");
         assert_eq!(scan.entries[0].status, OutputSyncStatus::Created);

--- a/crates/openwave-core/src/output_scan.rs
+++ b/crates/openwave-core/src/output_scan.rs
@@ -272,19 +272,19 @@ fn read_output_candidates(scratch: &Dir) -> (Vec<ScanCandidate>, Vec<String>) {
             notes.push("a file with a non-UTF-8 name was ignored".into());
             continue;
         };
-        let is_regular_file = entry
-            .metadata()
-            .map(|metadata| metadata.is_file())
-            .unwrap_or(false);
-        if !is_regular_file {
-            // Subdirectories and symlinks are outside the outputs contract;
-            // dotfiles are workspace plumbing. Neither warrants a note.
-            continue;
-        }
         if name.starts_with('.') {
+            // Dotfiles are workspace plumbing and never publishable.
             continue;
         }
-        names.push(name);
+        match entry.metadata().map(|metadata| metadata.file_type()) {
+            Ok(file_type) if file_type.is_file() => names.push(name),
+            Ok(file_type) if file_type.is_dir() => notes.push(format!(
+                "output/{name}/ was not published: only files directly in output/ become outputs; save each file at the top level or produce a single archive"
+            )),
+            _ => notes.push(format!(
+                "output/{name} was not published: it is not a regular file"
+            )),
+        }
     }
     names.sort();
     if names.len() > MAX_OUTPUT_SCAN_FILES {


### PR DESCRIPTION
Part of #1310.

Two silent traps in the outputs contract now speak up:

- A subdirectory under `output/` was skipped with no note, so a model that writes `output/report/index.html` plus assets gets zero outputs and zero explanation — and nothing in the result hints why. Directories and other non-regular files now produce a note naming the fix (save files at the top level or produce a single archive). Dotfiles stay silent: they are workspace plumbing (`output/.openwave-directory` lives there).
- The 100-revision refusal named the cap but not the recovery; the note now tells the model to save the file under a new filename.

Extended the existing note tests rather than adding new ones: the unacceptable-files test grows a nested-directory case, and the revision-cap test now pins the recovery hint.