### PR TITLE
chore: add scoped pre-commit checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+git diff --cached --check
+
+if ! git diff --cached --quiet --diff-filter=ACMR -- '*.rs'; then
+  cargo fmt --all --check
+fi
+
+if ! git diff --cached --quiet --diff-filter=ACMR -- \
+  ':(glob)crates/openwave-desktop/ui/**/*.ts' \
+  ':(glob)crates/openwave-desktop/ui/**/*.tsx'; then
+  pnpm --dir crates/openwave-desktop/ui exec tsc --noEmit
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,9 @@ scripts/clean-worktree-artifacts.sh --worktree ../finished-task --yes
 cargo fmt --all --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
+
+# Optional fast checks for staged files
+git config core.hooksPath .githooks
 ```
 
 The Rust toolchain is pinned in [`rust-toolchain.toml`](rust-toolchain.toml);


### PR DESCRIPTION
## Summary

- add a dependency-free, opt-in pre-commit hook
- check staged whitespace on every commit
- run Rust formatting and UI type-checking only when matching files are staged
- document the one-line hook setup

## Verification

- `sh -n .githooks/pre-commit`
- `.githooks/pre-commit`
- `cargo fmt --all --check`