### PR TITLE
feat(core): sanity-check binary output bytes before publishing

### DIFF
--- a/crates/openwave-core/src/db/tests/output.rs
+++ b/crates/openwave-core/src/db/tests/output.rs
@@ -763,11 +763,21 @@ mod output_scan {
         write_output_file(scratch.path(), "binary.md", b"text\xff\xfe");
         write_output_file(scratch.path(), ".hidden.md", b"# Plumbing");
         write_output_file(scratch.path(), "nested/index.html", b"<html></html>");
+        write_output_file(scratch.path(), "fake.pdf", b"<html>not a pdf</html>");
+        write_output_file(scratch.path(), "real.pdf", b"%PDF-1.7 minimal");
 
         let scan = sync(&store, &dir, chat.id, CallId::new(), 0).await;
 
-        assert_eq!(scan.entries.len(), 1);
-        assert_eq!(scan.entries[0].filename, "good.md");
+        let published: Vec<&str> = scan
+            .entries
+            .iter()
+            .map(|entry| entry.filename.as_str())
+            .collect();
+        assert_eq!(published, ["good.md", "real.pdf"]);
+        assert!(scan
+            .notes
+            .iter()
+            .any(|note| note.contains("fake.pdf") && note.contains("not a PDF")));
         assert!(scan.notes.iter().any(|note| note.contains("empty.md")));
         assert!(scan
             .notes

--- a/crates/openwave-core/src/output_scan.rs
+++ b/crates/openwave-core/src/output_scan.rs
@@ -305,6 +305,52 @@ fn read_output_candidates(scratch: &Dir) -> (Vec<ScanCandidate>, Vec<String>) {
     (candidates, notes)
 }
 
+/// Refuse a binary candidate whose bytes do not start with its extension's
+/// unambiguous format signature, so a mislabeled file (HTML saved as
+/// `report.pdf`) becomes a note the model can act on instead of a broken
+/// preview.
+///
+/// Only formats with a fixed magic number are checked; extensions without one
+/// (and anything that classified as text) publish exactly as before. Office
+/// formats are ZIP containers, so they share the ZIP check. An empty-archive
+/// end-of-central-directory record (`PK\x05\x06`) counts as a valid ZIP: it is
+/// a real, well-formed archive, and whether it opens as a useful office file
+/// is fidelity validation, which stays out of scope until a
+/// conversion-capable runtime exists.
+fn check_binary_signature(name: &str, content: &[u8]) -> std::result::Result<(), String> {
+    fn is_zip(content: &[u8]) -> bool {
+        content.starts_with(b"PK\x03\x04") || content.starts_with(b"PK\x05\x06")
+    }
+
+    let Some((_, extension)) = name.rsplit_once('.') else {
+        return Ok(());
+    };
+    let (matches, format) = match extension.to_ascii_lowercase().as_str() {
+        "pdf" => (content.starts_with(b"%PDF-"), "PDF"),
+        "docx" => (is_zip(content), "DOCX"),
+        "xlsx" => (is_zip(content), "XLSX"),
+        "xlsm" => (is_zip(content), "XLSM"),
+        "pptx" => (is_zip(content), "PPTX"),
+        "zip" => (is_zip(content), "ZIP archive"),
+        "png" => (content.starts_with(b"\x89PNG\r\n\x1a\n"), "PNG"),
+        "jpg" | "jpeg" => (content.starts_with(b"\xff\xd8\xff"), "JPEG"),
+        "webp" => (
+            content.len() >= 12 && content.starts_with(b"RIFF") && &content[8..12] == b"WEBP",
+            "WebP",
+        ),
+        "gif" => (
+            content.starts_with(b"GIF87a") || content.starts_with(b"GIF89a"),
+            "GIF",
+        ),
+        _ => return Ok(()),
+    };
+    if matches {
+        Ok(())
+    } else {
+        Err(format!("the bytes are not a {format}"))
+    }
+}
+
 /// Read one file and classify it as a text deliverable or binary artifact.
 fn classify_candidate(directory: &Dir, name: &str) -> std::result::Result<ScanCandidate, String> {
     validate_portable_filename(name).map_err(str::to_owned)?;
@@ -347,9 +393,12 @@ fn classify_candidate(directory: &Dir, name: &str) -> std::result::Result<ScanCa
             }
             DeliverableKind::Text
         }
-        None => DeliverableKind::Binary {
-            media_type: binary_media_type_for_extension(name).to_owned(),
-        },
+        None => {
+            check_binary_signature(name, &content)?;
+            DeliverableKind::Binary {
+                media_type: binary_media_type_for_extension(name).to_owned(),
+            }
+        }
     };
     Ok(ScanCandidate {
         filename: name.to_owned(),


### PR DESCRIPTION
Closes #1314. Part of #1310.

The exec output scan classified files under `output/` by extension alone, so `report.pdf` containing HTML was published and previewed as a PDF, and a truncated DOCX landed silently. This adds a dependency-free content check at classification time (`classify_candidate`), limited to extensions whose format has an unambiguous signature:

- `.pdf` — `%PDF-` header
- `.docx` / `.xlsx` / `.xlsm` / `.pptx` / `.zip` — ZIP local-file header `PK\x03\x04`; the empty-archive end-of-central-directory record `PK\x05\x06` counts as a valid ZIP, since it is a real (if useless) archive and fidelity validation stays out of scope
- `.png`, `.jpg`/`.jpeg`, `.webp`, `.gif` — their signatures

A mismatch publishes nothing and becomes a note in the existing scan-notes mechanism (`output/report.pdf was not published: the bytes are not a PDF`), so the model regenerates instead of the user discovering a broken file. Text-classified and unknown/octet-stream extensions are untouched.

Extended `unacceptable_files_become_notes_without_failing_the_scan` to cover a mismatched claimed-PDF being refused with a note while a well-formed PDF still publishes.