### PR TITLE
ci: make heavyweight PR validation opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,11 +149,11 @@ jobs:
             exit 0
           fi
 
-          # `rust` gates the lanes that cover every crate: rustfmt, clippy, and
-          # the openwave-desktop tests. `workspace` gates the lanes that cover
-          # everything *except* openwave-desktop, so it can stay false when a
-          # change cannot reach them. `workspace` implies `rust`; the gate below
-          # asserts that.
+          # `rust` gates rustfmt plus the full-CI lanes that cover every crate:
+          # clippy and the openwave-desktop tests. `workspace` gates the full-CI
+          # lanes that cover everything *except* openwave-desktop, so it can
+          # stay false when a change cannot reach them. `workspace` implies
+          # `rust`; the gate below asserts that.
           rust=false
           sandbox_container=false
           ui=false
@@ -162,7 +162,7 @@ jobs:
             > "$RUNNER_TEMP/changed-files"
           while IFS= read -r -d '' file; do
             case "$file" in
-              *.md|docs/*|assets/*|LICENSE|NOTICE) ;;
+              *.md|docs/*|assets/*|.githooks/*|LICENSE|NOTICE) ;;
               .github/workflows/ci.yml)
                 rust=true
                 sandbox_container=true
@@ -253,7 +253,9 @@ jobs:
   lint:
     name: clippy
     needs: changes
-    if: ${{ needs.changes.outputs.rust == 'true' }}
+    # Keep the default greenfield PR gate fast. Add `full-ci` for pre-merge
+    # validation; pushes to main and scheduled/manual runs always pay this cost.
+    if: ${{ needs.changes.outputs.rust == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -304,7 +306,7 @@ jobs:
   desktop:
     name: desktop test
     needs: changes
-    if: ${{ needs.changes.outputs.rust == 'true' }}
+    if: ${{ needs.changes.outputs.rust == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -346,7 +348,7 @@ jobs:
   test:
     name: test
     needs: changes
-    if: ${{ needs.changes.outputs.workspace == 'true' }}
+    if: ${{ needs.changes.outputs.workspace == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -389,7 +391,7 @@ jobs:
   postgres:
     name: postgres state machine
     needs: changes
-    if: ${{ needs.changes.outputs.workspace == 'true' }}
+    if: ${{ needs.changes.outputs.workspace == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:
@@ -494,7 +496,7 @@ jobs:
   ui:
     name: desktop UI
     needs: changes
-    if: ${{ needs.changes.outputs.ui == 'true' }}
+    if: ${{ needs.changes.outputs.ui == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,19 +128,22 @@ Coverage percentage is not a goal and is not tracked. Confidence is.
 
 ## Let CI do the heavy verification
 
-CI is the gate, and for anything it runs at all it runs *more* than you can
-locally. Re-running the full workspace suite before every push buys nothing and
-costs minutes on each iteration. Push early and let the lanes work while you
-keep going.
+During active greenfield development, pull requests use a deliberately fast
+default gate. Full validation remains automatic after merge and on scheduled or
+manual runs; add the `full-ci` label when a change warrants full validation
+before merge. Re-running the full workspace suite before every push buys little
+and costs minutes on each iteration. Run a cheap relevant subset locally, push
+early, and let the configured lanes work while you keep going.
 
 The change-scope gate in [`.github/workflows/ci.yml`](.github/workflows/ci.yml)
 is the whole rule, and it is coarse on purpose:
 
-- Any changed file outside `*.md`, `docs/`, `assets/`, `LICENSE`, `NOTICE`, and
-  `crates/openwave-desktop/ui/` marks the change **Rust** — including
-  `Cargo.toml` and `Cargo.lock`. That runs rustfmt, clippy (`--all-targets
-  -D warnings`), and the desktop tests. Every cargo invocation passes `--locked`,
-  so a lockfile drift fails there too.
+- Any changed file outside `*.md`, `docs/`, `assets/`, `.githooks/`, `LICENSE`,
+  `NOTICE`, and `crates/openwave-desktop/ui/` marks the change **Rust** —
+  including `Cargo.toml` and `Cargo.lock`. That always runs rustfmt. With
+  `full-ci`, and automatically outside pull requests, it also runs clippy
+  (`--all-targets -D warnings`) and the desktop tests. Every Cargo invocation
+  passes `--locked`, so a lockfile drift fails there too.
 - A Rust change also marks the **workspace** scope, which adds the headless
   workspace tests plus the PostgreSQL turn-state lane, unless every changed file
   is one of `openwave-desktop`'s own sources. Nothing in the workspace depends on
@@ -148,11 +151,12 @@ is the whole rule, and it is coarse on purpose:
   cannot see such a change. `ui/src/generated/` is not covered by the carve-out
   because its staleness check lives in `openwave-server`.
 - Any file under `crates/openwave-desktop/ui/` marks it **UI**, which runs
-  `pnpm test` and `pnpm build` as two fixed parallel jobs.
-- Branch protection requires the pull-request gate jobs directly. Conditional
-  jobs report a successful skip when their scope is false; the always-running
-  change detector rejects impossible narrower-scope combinations before those
-  jobs consume them. There is no serial aggregate wrapper after the slowest job.
+  `pnpm test` and `pnpm build` together during full CI.
+- Branch protection requires the pull-request jobs directly. Heavy jobs report
+  a successful skip on ordinary pull requests and become active when the
+  `full-ci` label is added. The always-running change detector rejects
+  impossible narrower-scope combinations before conditional jobs consume them.
+  There is no serial aggregate wrapper after the slowest job.
 - The heavyweight `sandbox-resident container e2e` lane is scoped separately on
   merges to `main`. It runs when the sandbox agent/protocol, container driver,
   Dockerfile, or dependency/toolchain inputs change. A weekly scheduled run and
@@ -161,15 +165,16 @@ is the whole rule, and it is coarse on purpose:
   post-merge/scheduled lane proves the Docker packaging and container network
   boundary.
 
-So a scoped skip is not a coverage hole, and duplicating those lanes locally is
-wasted time. Run a cheap subset for fast feedback on what you actually touched —
-`cargo check -p <crate>`, the one test module you changed, `tsc` — and push.
+An ordinary pull request's heavy-job skips are the intended fast path, backed by
+full validation on `main`. For risky or boundary-crossing changes, add
+`full-ci` and wait for the applicable lanes. Run a cheap subset for fast local
+feedback on what you actually touched — `cargo check -p <crate>`, the one test
+module you changed, `tsc` — and push.
 
-**The real trap is a PR that got no CI at all.** A conflicting PR runs nothing
-but the trivial policy checks, so "no checks failed" reads green while nothing
-was verified. Judge by whether every applicable required job is present and
-passed, not by the absence of red. `gh pr checks <n>` shows the truth; rebase a
-conflicting PR before believing anything about it.
+**The real trap is confusing the fast gate with full validation.** When a PR has
+`full-ci`, judge by whether every applicable job is present and passed, not by
+the absence of red. A conflicting PR runs nothing but trivial policy checks;
+rebase it before believing its status. `gh pr checks <n>` shows the truth.
 
 Enable auto-merge (`gh pr merge <n> --squash --auto --delete-branch`) so a PR
 lands the moment its lanes go green instead of waiting for you to come back.

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -92,21 +92,25 @@ test("workflow container images are pinned by digest", () => {
   assert.doesNotMatch(workflows["ci.yml"], /gitleaks\/gitleaks:latest/);
 });
 
-test("Rust CI requires the same PostgreSQL lane on pull requests and main", () => {
+test("heavy CI is opt-in on pull requests and automatic elsewhere", () => {
   const ci = workflows["ci.yml"];
   const changes = workflowJob(ci, "changes");
+  const fmt = workflowJob(ci, "fmt");
   const postgres = workflowJob(ci, "postgres");
   const testJob = workflowJob(ci, "test");
+  const fullCiGate =
+    /github\.event_name != 'pull_request' \|\| contains\(github\.event\.pull_request\.labels\.\*\.name, 'full-ci'\)/;
 
   assert.match(
     ci,
     /^on:\n  push:\n    branches: \[main\]\n  pull_request:/m,
   );
+  assert.match(
+    ci,
+    /pull_request:\n\s+types:\n\s+\[[^\]]*labeled, unlabeled[^\]]*\]/,
+  );
   assert.doesNotMatch(ci, /^  build:$/m);
-  // Scoped to the lanes that skip openwave-desktop, but still never exempted
-  // from pull requests.
-  assert.match(postgres, /if:.*needs\.changes\.outputs\.workspace == 'true'/);
-  assert.doesNotMatch(postgres, /github\.event_name != 'pull_request'/);
+  assert.doesNotMatch(fmt, /full-ci/);
   assert.match(postgres, /OPENWAVE_REQUIRE_POSTGRES_TEST: "true"/);
   // The narrower `workspace` scope must imply the `rust` one. Without this the
   // crate-coverage lanes could be gated on a scope that never ran for them.
@@ -116,6 +120,16 @@ test("Rust CI requires the same PostgreSQL lane on pull requests and main", () =
   );
   assert.doesNotMatch(ci, /^  rust:$/m);
   assert.doesNotMatch(ci, /name: fmt · clippy · build · test/);
+
+  for (const job of [
+    workflowJob(ci, "lint"),
+    workflowJob(ci, "desktop"),
+    testJob,
+    postgres,
+    workflowJob(ci, "ui"),
+  ]) {
+    assert.match(job, fullCiGate);
+  }
 
   for (const job of [
     workflowJob(ci, "lint"),
@@ -138,6 +152,7 @@ test("Rust CI requires the same PostgreSQL lane on pull requests and main", () =
   );
   assert.doesNotMatch(ci, /^  parsers:$/m);
   assert.doesNotMatch(ci, /outputs\.parsers|echo "parsers=/);
+  assert.match(changes, /\*\.md\|docs\/\*\|assets\/\*\|\.githooks\/\*/);
 
   const desktop = workflowJob(ci, "desktop");
   assert.match(


### PR DESCRIPTION
## Summary

- keep policy, secret scanning, change detection, and rustfmt in the default pull-request gate
- run Clippy, Rust tests, PostgreSQL tests, and UI validation on pull requests only when labeled `full-ci`
- continue full validation automatically on `main`, scheduled runs, and manual dispatches
- exclude tracked Git hooks from Rust change scope

This is a temporary greenfield-development policy intended to reduce merge latency while the cost of repairing `main` remains low.

## Verification

- `cargo fmt --all --check`
- `node --test scripts/*.test.mjs`