### PR TITLE
feat(skills): authored document skills for DOCX, XLSX, PPTX, and charts

### DIFF
--- a/crates/openwave-code-execution/src/skills.rs
+++ b/crates/openwave-code-execution/src/skills.rs
@@ -369,11 +369,25 @@ Instructions live here.\n";
             .filter(|entry| entry.path().is_dir())
             .count();
         let skills = load_builtin_skills(&source);
-        assert!(!skills.is_empty(), "no bundled skills were loaded");
         assert_eq!(
             skills.len(),
             directories,
             "a bundled skill failed strict parsing"
+        );
+        // The curated document set. A missing name means a skill silently
+        // dropped out of the staged catalog.
+        assert_eq!(
+            skills
+                .iter()
+                .map(|skill| skill.package.name.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "charts",
+                "pdf-documents",
+                "presentations",
+                "spreadsheets",
+                "word-documents",
+            ]
         );
         for skill in &skills {
             assert!(

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -135,7 +135,13 @@ fn exec_scripts_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
 }
 
 fn exec_skills_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
-    const REQUIRED_SKILLS: [&str; 1] = ["pdf-documents"];
+    const REQUIRED_SKILLS: [&str; 5] = [
+        "charts",
+        "pdf-documents",
+        "presentations",
+        "spreadsheets",
+        "word-documents",
+    ];
     let directory = app
         .path()
         .resource_dir()

--- a/skills/charts/SKILL.md
+++ b/skills/charts/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: charts
+description: Render charts with matplotlib to PNG (or SVG for vector) in output/ — readable sizing, labels, and legends, inspected before delivery.
+deps: { python: ["matplotlib==3.10.0"] }
+---
+
+# Charts
+
+Produce chart deliverables with **matplotlib**. Follow every section below
+before declaring a chart done.
+
+## Installing the library
+
+Install the pinned dependency with its own `exec` call — commands have a
+bounded wall clock, and one `pip` invocation per package stays inside it:
+
+```
+python3 -m pip install --user matplotlib==3.10.0
+```
+
+Installs work only when this chat's network policy allows package managers,
+and they persist for the rest of the conversation. If an install is refused
+by policy, do not retry: tell the user to enable the package-manager network
+policy for this chat, and offer the closest result you can produce without
+the library (the summarized data as a table, or an SVG you write by hand
+for a simple chart) — only with their knowledge, never as a silent
+substitution. If a dependency cannot be installed at all, say so plainly
+instead of quietly delivering a lesser format.
+
+## Rendering
+
+- Use the non-interactive backend — set `matplotlib.use("Agg")` before
+  importing `pyplot` — and save with `fig.savefig(...)`; never call
+  `plt.show()` in the sandbox.
+- Render PNG by default. When the user asks for a vector or print-ready
+  graphic, save SVG (and provide PNG alongside it unless they only want the
+  vector).
+- Size for reading, not for thumbnails: around `figsize=(10, 6)` at
+  `dpi=150` for a standalone PNG, and `bbox_inches="tight"` so labels are
+  not clipped.
+
+## Readability
+
+- Every chart gets a title, axis labels with units, and — whenever more
+  than one series is plotted — a legend with meaningful names.
+- Rotate or thin dense tick labels rather than letting them collide;
+  format large numbers with thousands separators or scaled units.
+- Prefer one clear message per chart over a crowded multi-axis figure;
+  produce several charts when the data carries several stories.
+- Use color plus a second cue (marker or line style) to distinguish series,
+  and keep font sizes at 10pt equivalent or larger after export.
+
+## Saving deliverables
+
+Save finished charts in `output/` — files there are published to the user
+as durable outputs. Writing the same filename again publishes a new version
+of the same output, so keep the filename stable when revising and change it
+only when the user asks for a distinct chart. When a chart accompanies a
+document deliverable (a report embedding the figure), save both files in
+`output/`: the document and the standalone chart image.
+
+## Validation before declaring done
+
+PNG and SVG land in `output/` where you can see them directly in the exec
+result flow — inspect the rendered image before presenting it: no clipped
+or colliding labels, a legend that matches the series, axes that start
+where you intended, and text large enough to read at natural size. Fix the
+plotting code rather than accepting a flawed render. Only declare the chart
+done after it reads correctly.

--- a/skills/presentations/SKILL.md
+++ b/skills/presentations/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: presentations
+description: Build PowerPoint (PPTX) decks with python-pptx — layouts, placeholders, in-bounds geometry, overflow-free text — with visual QA before delivery.
+deps: { python: ["python-pptx==1.0.2"] }
+---
+
+# Presentations
+
+Produce PPTX deliverables with **python-pptx**. Follow every section below
+before declaring a deck done.
+
+## Installing the library
+
+Install the pinned dependency with its own `exec` call — commands have a
+bounded wall clock, and one `pip` invocation per package stays inside it:
+
+```
+python3 -m pip install --user python-pptx==1.0.2
+```
+
+Installs work only when this chat's network policy allows package managers,
+and they persist for the rest of the conversation. If an install is refused
+by policy, do not retry: tell the user to enable the package-manager network
+policy for this chat, and offer the closest format you can produce without
+the library (a markdown outline of the deck) — only with their knowledge,
+never as a silent substitution. If a dependency cannot be installed at all,
+say so plainly instead of quietly delivering a lesser format.
+
+## Structure and layouts
+
+- Default structure: a title slide, then title-and-content slides — one idea
+  per slide. Use `prs.slide_layouts[0]` for the title slide and
+  `prs.slide_layouts[1]` (Title and Content) for body slides.
+- Fill the layout's placeholders (`slide.shapes.title`,
+  `slide.placeholders[1]`) instead of free-floating text boxes; placeholders
+  carry the theme's fonts and positions for free.
+- Add bullets through the content placeholder's `text_frame`: first bullet
+  on `text_frame.paragraphs[0]`, subsequent ones via `add_paragraph()`,
+  with `paragraph.level` for sub-bullets.
+
+## Geometry and overflow
+
+- The default slide is 13.33 x 7.5 inches (16:9). Any shape you position
+  manually must satisfy `left + width <= slide width` and
+  `top + height <= slide height` — compute positions with `Inches(...)`
+  rather than guessing EMUs, and never let images or boxes hang off the
+  slide edge.
+- Avoid text overflow by writing less text, not by shrinking fonts:
+  at most about 6 bullets per slide and about 12 words per bullet. When
+  content does not fit, split the slide. Keep body text at 18pt or larger;
+  a slide that needs 12pt text is a document, not a slide.
+
+## Consistency
+
+- Keep one font family and a small, consistent color palette across the
+  deck; set them through the layout placeholders and reuse the same
+  `RGBColor` constants everywhere rather than styling each slide ad hoc.
+- Images: preserve aspect ratio by setting only width or only height, and
+  keep them inside the slide bounds.
+
+## Saving deliverables
+
+Save the finished deck in `output/` — files there are published to the user
+as durable outputs. Writing the same filename again publishes a new version
+of the same output, so keep the filename stable when revising and change it
+only when the user asks for a distinct deck.
+
+## Validation before declaring done
+
+1. Reopen the saved file — `pptx.Presentation("output/<file>.pptx")` — and
+   confirm the slide count and that each slide's title and body text are
+   what you intended. A file that fails to reopen is not a deliverable.
+2. When LibreOffice is available in the sandbox, render slides for a visual
+   check with the bundled helper:
+   `python3 .openwave/exec-scripts/render_office.py output/<file>.pptx`
+   (images land in `preview/`; at most 3 are returned per exec call).
+   Inspect for clipped text, overlapping shapes, and anything crossing the
+   slide edge, and fix the generator rather than accepting a flawed slide.
+   If the helper reports LibreOffice is missing, rely on the reopen check
+   and say the visual pass was not possible.
+
+Only declare the deck done after validation passes.

--- a/skills/spreadsheets/SKILL.md
+++ b/skills/spreadsheets/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: spreadsheets
+description: Build Excel (XLSX) workbooks with openpyxl — live formulas, number formats, layout — re-inspected with the bundled analyzer before delivery.
+deps: { python: ["openpyxl==3.1.5"] }
+---
+
+# Spreadsheets
+
+Produce XLSX deliverables with **openpyxl**. Follow every section below
+before declaring a workbook done.
+
+## Installing the library
+
+Install the pinned dependency with its own `exec` call — commands have a
+bounded wall clock, and one `pip` invocation per package stays inside it:
+
+```
+python3 -m pip install --user openpyxl==3.1.5
+```
+
+Installs work only when this chat's network policy allows package managers,
+and they persist for the rest of the conversation. If an install is refused
+by policy, do not retry: tell the user to enable the package-manager network
+policy for this chat, and offer the closest format you can produce without
+the library (CSV) — only with their knowledge, never as a silent
+substitution. If a dependency cannot be installed at all, say so plainly
+instead of quietly delivering a lesser format.
+
+## Formulas: the hard rule
+
+**Write live formulas, never precomputed values, in any cell that represents
+a calculation.** A total cell gets `=SUM(B2:B13)`, not the number you
+computed in Python. A spreadsheet with baked-in values silently goes stale
+the moment the user edits an input, which defeats the reason they asked for
+a spreadsheet.
+
+openpyxl writes formulas but **does not calculate them** — the file carries
+the formula text and Excel computes it on open. Two consequences:
+
+- You cannot read a formula's result back in a later exec; do not try to
+  "verify" totals by reopening the file. Compute the expected value in
+  Python for your own checking if needed.
+- Any calculated value the user must see in the conversation should also be
+  stated in chat, since you cannot read it from the file and they may not
+  open the workbook immediately.
+
+## Layout conventions
+
+- Give columns real number formats: currency `#,##0.00`, percentages
+  `0.0%`, dates `yyyy-mm-dd` — via `cell.number_format`. Never leave money
+  as bare floats.
+- Size columns to their content with `worksheet.column_dimensions["A"].width`;
+  unreadably narrow columns are a defect.
+- Freeze the header row (`worksheet.freeze_panes = "A2"`) on any sheet the
+  user will scroll.
+- Bold the header row and keep one table per sheet; split unrelated data
+  into multiple named sheets (`workbook.create_sheet("Assumptions")`)
+  instead of stacking tables.
+
+## Saving deliverables
+
+Save the finished workbook in `output/` — files there are published to the
+user as durable outputs. Writing the same filename again publishes a new
+version of the same output, so keep the filename stable when revising and
+change it only when the user asks for a distinct workbook. Outputs above
+the 16 MiB ceiling are refused: keep workbooks lean (no embedded raw data
+dumps that a summary sheet serves better), and if the data genuinely cannot
+fit, tell the user and deliver a trimmed workbook plus the raw data as CSV.
+
+## Validation before declaring done
+
+Re-inspect the saved file with the bundled analyzer:
+
+```
+python3 .openwave/exec-scripts/analyze_xlsx.py output/<file>.xlsx
+```
+
+It prints each sheet's dimensions and sample rows and writes sheet
+thumbnails into `preview/` (at most 3 images are returned per exec call).
+Check that every expected sheet exists, headers and sample rows look right,
+and the thumbnails show a readable layout. Only declare the workbook done
+after this inspection passes.

--- a/skills/word-documents/SKILL.md
+++ b/skills/word-documents/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: word-documents
+description: Create Word (DOCX) documents with python-docx — headings, styles, tables, page setup — validated by reopening before delivery.
+deps: { python: ["python-docx==1.1.2"] }
+---
+
+# Word documents
+
+Produce DOCX deliverables with **python-docx**. Follow every section below
+before declaring a document done.
+
+## When DOCX is the right format
+
+Reach for DOCX when the user will edit, print, or share the document in
+Word — a report, letter, proposal, or anything with real formatting.
+When the user just needs readable text they will consume in the chat or a
+plain file, a markdown output serves them better than a DOCX: say so and
+offer the simpler format instead of defaulting to Word.
+
+## Installing the library
+
+Install the pinned dependency with its own `exec` call — commands have a
+bounded wall clock, and one `pip` invocation per package stays inside it:
+
+```
+python3 -m pip install --user python-docx==1.1.2
+```
+
+Installs work only when this chat's network policy allows package managers,
+and they persist for the rest of the conversation. If an install is refused
+by policy, do not retry: tell the user to enable the package-manager network
+policy for this chat, and offer the closest format you can produce without
+the library (markdown or HTML) — only with their knowledge, never as a
+silent substitution. If a dependency cannot be installed at all, say so
+plainly instead of quietly delivering a lesser format.
+
+## Building documents from scratch
+
+- Start from `docx.Document()` and compose with `add_heading(...)`,
+  `add_paragraph(...)`, `add_table(...)`, and `add_picture(...)`.
+- Use the built-in styles (`Heading 1`..`Heading 3`, `Title`, `List Bullet`,
+  `List Number`, `Quote`) rather than hand-formatting runs; consistent styles
+  are what make the document editable for the user afterwards.
+- Reserve direct run formatting (`bold`, `italic`, `font.size`) for emphasis
+  inside a paragraph, not for imitating headings.
+- Tables: create with explicit dimensions, put header text in the first row,
+  and apply a table style (for example `Light Grid Accent 1`) so borders
+  render. Populate cells via `table.cell(row, col).text`.
+- Page setup lives on `document.sections[0]`: page size, orientation
+  (`WD_ORIENT.LANDSCAPE` for wide tables), and margins via `Inches(...)`.
+- Add page breaks with `add_page_break()` between major parts rather than
+  padding with empty paragraphs.
+
+## Saving deliverables
+
+Save the finished document in `output/` — files there are published to the
+user as durable outputs. Writing the same filename again publishes a new
+version of the same output, so keep the filename stable when revising and
+change it only when the user asks for a distinct document.
+
+## Validation before declaring done
+
+1. Reopen the saved file with the library — `docx.Document("output/<file>.docx")`
+   — and walk its paragraphs and tables to confirm the structure you meant
+   to write is actually there (headings present, table dimensions right,
+   no empty required sections). A file that fails to reopen is not a
+   deliverable.
+2. When LibreOffice is available in the sandbox, render pages for a visual
+   check with the bundled helper:
+   `python3 .openwave/exec-scripts/render_office.py output/<file>.docx`
+   (images land in `preview/`; at most 3 are returned per exec call). If the
+   helper reports LibreOffice is missing, rely on the reopen check and say
+   the visual pass was not possible.
+
+Only declare the document done after validation passes.


### PR DESCRIPTION
Stacked on #1321 (the skill-package mechanism); will be retargeted to `main` and rebased once the base lands.

Authors the remaining four curated document skills, each following the pdf-documents structure with one shared contract across all five: pinned `python3 -m pip install --user` one package per exec call (with an explicit user-facing path when the network policy refuses installs), `output/` publication and same-filename versioning, a preview QA loop (`render_office.py` for DOCX/PPTX where LibreOffice is available, `analyze_xlsx.py` for workbooks, PDF page renders via `render_pdf.py`, direct inspection for chart images), and honest degradation — say what's missing and offer the closest capable format only with the user's knowledge, never a silent substitution.

- **word-documents** — python-docx `1.1.2`: new documents from scratch with built-in styles, tables, and page setup; validation by reopening the saved file; guidance on when plain markdown serves the user better than DOCX.
- **spreadsheets** — openpyxl `3.1.5`: hard rule that calculation cells carry live formulas, never precomputed values, plus the consequence that openpyxl does not calculate — so values the user must see are also stated in chat; number formats, column widths, freeze panes, multiple sheets, and the 16 MiB output ceiling.
- **presentations** — python-pptx `1.0.2`: layouts and placeholder use, shape geometry kept within slide bounds, overflow avoided with shorter bullets rather than shrunken fonts, consistent fonts/colors, title+content default structure.
- **charts** — matplotlib `3.10.0`: PNG by default and SVG when vector is asked for, saved into `output/`; readable sizing/dpi/labels/legends; when a chart accompanies a document, both files are saved.

The bundled-skill parser sweep now pins the curated five-name set — every authored file must pass the strict parser or the test fails — and the desktop resource check requires all five skills in the bundle.

Closes #1312