### PR TITLE
fix(core): build openwave-core without the tools feature

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -2334,7 +2334,7 @@ impl Agent {
         }
         let outputs = self
             .store
-            .list_outputs(chat.id, crate::output_scan::OUTPUT_LOOKUP_LIMIT)
+            .list_outputs(chat.id, crate::OUTPUT_LOOKUP_LIMIT)
             .await?;
         let Some(output) = outputs
             .iter()

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -23,6 +23,13 @@ pub const VERSION: &str = match option_env!("OPENWAVE_VERSION") {
     None => env!("CARGO_PKG_VERSION"),
 };
 
+/// Upper bound on the filename lookup when matching files to existing
+/// outputs. Far above the catalog's own display cap. Shared between the
+/// output scan and the agent's filename resolution for output write-backs so
+/// both match the same window; it lives here, ungated, because the agent
+/// compiles without the `tools` feature the scan is behind.
+pub(crate) const OUTPUT_LOOKUP_LIMIT: u64 = 1_000;
+
 pub mod agent;
 pub mod agent_tools;
 pub mod approval;

--- a/crates/openwave-core/src/output_scan.rs
+++ b/crates/openwave-core/src/output_scan.rs
@@ -38,11 +38,6 @@ pub const EXEC_OUTPUT_DIRECTORY: &str = "output";
 /// rather than silently ignored.
 pub const MAX_OUTPUT_SCAN_FILES: usize = 64;
 
-/// Upper bound on the filename lookup when matching scan files to existing
-/// outputs. Far above the catalog's own display cap. Shared with the agent's
-/// filename resolution for output write-backs so both match the same window.
-pub(crate) const OUTPUT_LOOKUP_LIMIT: u64 = 1_000;
-
 /// What one scanned file did to the output record.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputSyncStatus {
@@ -114,7 +109,9 @@ pub async fn sync_output_directory(
     }
 
     // One lookup serves every candidate: the newest live output per filename.
-    let existing = store.list_outputs(chat_id, OUTPUT_LOOKUP_LIMIT).await?;
+    let existing = store
+        .list_outputs(chat_id, crate::OUTPUT_LOOKUP_LIMIT)
+        .await?;
 
     for candidate in candidates {
         match record_candidate(


### PR DESCRIPTION
The agent's output write-back filename resolution references `output_scan::OUTPUT_LOOKUP_LIMIT`, but `output_scan` is behind the `tools` feature while the referencing code compiles unconditionally. Any build of `openwave-core` without that feature fails with E0433: isolated `cargo check -p openwave-code-execution` (which depends on the crate with default features off) and the PostgreSQL turn-state lane, which is currently red on `main` (https://github.com/brightwave-inc/openwave/actions/runs/30661973878). Workspace-wide invocations unify features, which is how the introducing PR stayed green.

Moves the shared constant to the crate root, ungated, referenced from both the scan and the agent. No behavior change.

Verified with `cargo check -p openwave-core --no-default-features --features sqlite`, `cargo check -p openwave-code-execution`, and the output_scan test module.

Closes #1325