### PR TITLE
fix(desktop): 40px titlebar and plain chat-explorer rows for BW parity

### DIFF
--- a/crates/openwave-desktop/tauri.conf.json
+++ b/crates/openwave-desktop/tauri.conf.json
@@ -29,7 +29,7 @@
         "dragDropEnabled": true,
         "trafficLightPosition": {
           "x": 16,
-          "y": 23
+          "y": 17
         }
       }
     ],

--- a/crates/openwave-desktop/ui/src/ChatExplorer.tsx
+++ b/crates/openwave-desktop/ui/src/ChatExplorer.tsx
@@ -46,7 +46,6 @@ function TitleCellRenderer(props: CellProps) {
 
   return (
     <div className="flex h-full min-w-0 items-center gap-2">
-      <MessageCircleMore className="size-4 shrink-0 text-muted-foreground" />
       <span className="truncate text-sm">{title}</span>
       {context.needsAttention(chat.id) && (
         <span

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -1365,7 +1365,7 @@ body {
 }
 
 .titlebar {
-  flex: 0 0 52px;
+  flex: 0 0 40px;
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -1405,7 +1405,7 @@ body {
   top: 0;
   left: 0;
   right: 0;
-  height: 52px;
+  height: 40px;
   z-index: 50;
 }
 


### PR DESCRIPTION
Closes the two chrome differences left over from the parity sweep (#757):

- The titlebar strip drops from 52px to 40px to match BW, in both `.titlebar` and the `.window-drag-strip` stand-in used by full-window surfaces. `trafficLightPosition.y` moves 23 → 17, preserving the lights' existing offset relative to the strip's vertical center as it shrinks (the center moves up 6px, so the lights do too). `x` is unchanged.
- Chat-explorer rows lose the leading chat-bubble icon: it was identical on every row, distinguished nothing, and cost title width in a narrow rail. The empty-state illustration keeps the icon.

The traffic-light position needs an on-screen check in the packaged app before this merges — lights landing off-center reads as broken.

Closes #791