### PR TITLE
fix(desktop): stretch home content to the panel slot height

### DIFF
--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -257,7 +257,10 @@ export function HomeRoute() {
 
   function homeContent() {
     return (
-      <div className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden px-[clamp(0.5rem,4%,5rem)]">
+      // The panel slot this sits in is a plain block, so nothing stretches
+      // the column to the slot's height — it has to claim it itself, the
+      // same way .chat-pane does.
+      <div className="flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden px-[clamp(0.5rem,4%,5rem)]">
         <div className="flex min-h-0 flex-1 items-center justify-center overflow-y-auto">
           {/* The same null state an empty conversation shows: home is where a
               chat starts, so it greets the same way. Picking a starter prompt


### PR DESCRIPTION
The home route's content column relied on `flex-1` to fill the panel, but the react-resizable-panels slot it renders into is a plain block — the same trap `.chat-pane` documents and fixes with `height: 100%`. With nothing stretching it, the column collapsed to content height: the welcome state hugged the top of the window and the composer sat directly under it instead of pinning to the bottom, so the home null state no longer matched an empty chat.

Claim the slot height with `h-full` (and drop the inert `flex-1`) so the welcome centers and the composer pins to the bottom, matching the chat's empty state.