### PR TITLE
feat(core): commit a cancelled turn's partial prose as its durable output message

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -568,6 +568,13 @@ pub enum AgentTurnOutcome {
     },
     /// The loop observed its cancellation token and stopped cooperatively.
     Cancelled {
+        /// Prose the user was already reading when the stop arrived, prepared
+        /// for durable commit alongside the cancellation. Carried only when
+        /// the cancelled step produced text and no tool calls — a step whose
+        /// calls started was discarded whole under `StreamInterrupted`.
+        output: Option<Message>,
+        /// Ordered lightweight citations authored in the partial text.
+        citations: Vec<AssistantCitationInput>,
         /// Aggregate provider usage for the eventual terminal event.
         usage: Usage,
         /// Model-call steps consumed from the turn-wide execution budget.
@@ -1269,6 +1276,7 @@ impl Agent {
                     total_usage,
                     steps_before,
                     publish_terminal,
+                    None,
                 ));
             }
             if wrap_up {
@@ -1311,6 +1319,7 @@ impl Agent {
                         total_usage,
                         steps_before,
                         publish_terminal,
+                        None,
                     ));
                 }
                 let (mut fitted, reduced) = self.fit_transcript(
@@ -1485,11 +1494,42 @@ impl Agent {
                 if !calls.is_empty() {
                     events.send(AgentEvent::StreamInterrupted);
                 }
+                // The prose the reader was watching survives the stop: a
+                // text-only step hands its partial output to the terminal
+                // commit so reload and the next model turn keep what the user
+                // already saw (#1182). A step whose calls started was
+                // discarded whole just above and stays message-less.
+                let partial = if calls.is_empty() {
+                    let parsed = parse_assistant_citations(&text);
+                    if parsed.content.trim().is_empty() {
+                        None
+                    } else {
+                        let message_id = if publish_terminal {
+                            MessageId::new()
+                        } else {
+                            output_message_id
+                        };
+                        let candidate = AssistantCandidate {
+                            message_id,
+                            content: parsed.content,
+                            citations: parsed.citations,
+                        };
+                        let message = candidate.message(message_id, chat.id, turn_id);
+                        if publish_terminal {
+                            self.append_assistant_exact_retry(&message, &candidate.citations)
+                                .await?;
+                        }
+                        Some((message, candidate.citations))
+                    }
+                } else {
+                    None
+                };
                 return Ok(self.finish_cancelled(
                     events,
                     total_usage,
                     steps_used,
                     publish_terminal,
+                    partial,
                 ));
             }
             if matches!(stream_end, StreamEnd::Steered) {
@@ -1694,11 +1734,16 @@ impl Agent {
                 // arrives before sealing still continues the turn.
                 loop {
                     if self.cancel.is_cancelled() {
+                        // The answer is fully formed here; a cancel that races
+                        // the completion fence keeps it rather than discarding
+                        // a finished reply the user watched stream (#1182).
                         return Ok(self.finish_cancelled(
                             events,
                             total_usage,
                             steps_used,
                             publish_terminal,
+                            (!output.content.trim().is_empty())
+                                .then(|| (output.clone(), candidate.citations.clone())),
                         ));
                     }
                     if self
@@ -1822,6 +1867,7 @@ impl Agent {
                         total_usage,
                         steps_used,
                         publish_terminal,
+                        None,
                     ));
                 }
             }
@@ -1852,6 +1898,7 @@ impl Agent {
                         total_usage,
                         steps_used,
                         publish_terminal,
+                        None,
                     ));
                 }
             }
@@ -1877,6 +1924,7 @@ impl Agent {
                         total_usage,
                         steps_used,
                         publish_terminal,
+                        None,
                     ));
                 }
             }
@@ -2475,17 +2523,31 @@ impl Agent {
 
     /// Emit the cancellation terminal event and end the turn as a (non-error)
     /// success — the client asked for the stop, so it isn't a `TurnFailed`.
+    ///
+    /// `partial` carries prose the user was already reading so the worker can
+    /// commit it durably with the cancellation; losing it made the next turn
+    /// continue as though the answer was never given (#1182).
     fn finish_cancelled(
         &self,
         events: &EventSink<'_>,
         usage: Usage,
         model_steps: usize,
         publish_terminal_event: bool,
+        partial: Option<(Message, Vec<AssistantCitationInput>)>,
     ) -> AgentTurnOutcome {
         if publish_terminal_event {
             events.send(AgentEvent::TurnCancelled { usage });
         }
-        AgentTurnOutcome::Cancelled { usage, model_steps }
+        let (output, citations) = match partial {
+            Some((message, citations)) => (Some(message), citations),
+            None => (None, Vec::new()),
+        };
+        AgentTurnOutcome::Cancelled {
+            output,
+            citations,
+            usage,
+            model_steps,
+        }
     }
 
     /// Drain the steer inbox into the transcript. Returns whether any messages
@@ -6256,6 +6318,8 @@ mod tests {
         assert_eq!(
             outcome,
             AgentTurnOutcome::Cancelled {
+                output: None,
+                citations: Vec::new(),
                 usage: Usage::default(),
                 model_steps: 0,
             }
@@ -6274,6 +6338,8 @@ mod tests {
                 cancellation_token,
                 Utc::now(),
                 Usage::default(),
+                None,
+                &[],
             )
             .await
             .unwrap()
@@ -6301,6 +6367,8 @@ mod tests {
                 cancellation_token,
                 cancellation_claimed_at + chrono::Duration::hours(1),
                 Usage::default(),
+                None,
+                &[],
             )
             .await
             .unwrap()
@@ -10093,15 +10161,12 @@ mod tests {
         handle.await.unwrap();
 
         assert!(cancelled, "a mid-stream cancel ends the turn as cancelled");
-        // The partial assistant text of the preempted step is discarded, not stored.
-        let roles: Vec<Role> = store
-            .list_messages(chat_id)
-            .await
-            .unwrap()
-            .iter()
-            .map(|m| m.role)
-            .collect();
-        assert_eq!(roles, vec![Role::User]);
+        // The prose the reader was already watching commits durably with the
+        // cancellation, so the next model turn sees what was said (#1182).
+        let messages = store.list_messages(chat_id).await.unwrap();
+        let roles: Vec<Role> = messages.iter().map(|m| m.role).collect();
+        assert_eq!(roles, vec![Role::User, Role::Assistant]);
+        assert_eq!(messages[1].content, "partial");
     }
 
     struct ToolCallStallProvider;

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -103,6 +103,7 @@ impl MigratorTrait for Migrator {
             Box::new(RaiseAttemptBudgets),
             Box::new(AddChatNetworkPolicy),
             Box::new(ExtendUserQuestions),
+            Box::new(RetainCancelledTurnOutput),
         ]
     }
 }
@@ -4766,463 +4767,12 @@ impl MigrationTrait for Init {
             .execute_unprepared("INSERT INTO turn_claim_lock (id) VALUES (1)")
             .await?;
 
-        let valid_turn_status = Expr::col(TurnRun::Status).is_in([
-            TurnRunStatus::Queued.as_str(),
-            TurnRunStatus::Running.as_str(),
-            TurnRunStatus::Cancelling.as_str(),
-            TurnRunStatus::WaitingForClient.as_str(),
-            TurnRunStatus::WaitingForAgentRun.as_str(),
-            TurnRunStatus::CancellingClient.as_str(),
-            TurnRunStatus::Resuming.as_str(),
-            TurnRunStatus::RetryWait.as_str(),
-            TurnRunStatus::Completed.as_str(),
-            TurnRunStatus::Failed.as_str(),
-            TurnRunStatus::Cancelled.as_str(),
-        ]);
-        let active_lease = Expr::col(TurnRun::Status)
-            .is_in([
-                TurnRunStatus::Running.as_str(),
-                TurnRunStatus::Cancelling.as_str(),
-            ])
-            .and(Expr::col(TurnRun::LeaseToken).is_not_null())
-            .and(Expr::col(TurnRun::LeaseExpiresAt).is_not_null());
-        let no_lease = Expr::col(TurnRun::Status)
-            .ne(TurnRunStatus::Running.as_str())
-            .and(Expr::col(TurnRun::Status).ne(TurnRunStatus::Cancelling.as_str()))
-            .and(Expr::col(TurnRun::LeaseToken).is_null())
-            .and(Expr::col(TurnRun::LeaseExpiresAt).is_null());
-        let completed_output = Expr::col(TurnRun::Status)
-            .eq(TurnRunStatus::Completed.as_str())
-            .and(Expr::col(TurnRun::OutputMessageId).is_not_null());
-        let no_output = Expr::col(TurnRun::Status)
-            .ne(TurnRunStatus::Completed.as_str())
-            .and(Expr::col(TurnRun::OutputMessageId).is_null());
-        let terminal_finished = Expr::col(TurnRun::Status)
-            .is_in([
-                TurnRunStatus::Completed.as_str(),
-                TurnRunStatus::Failed.as_str(),
-                TurnRunStatus::Cancelled.as_str(),
-            ])
-            .and(Expr::col(TurnRun::FinishedAt).is_not_null());
-        let nonterminal_unfinished = Expr::col(TurnRun::Status)
-            .is_in([
-                TurnRunStatus::Queued.as_str(),
-                TurnRunStatus::Running.as_str(),
-                TurnRunStatus::Cancelling.as_str(),
-                TurnRunStatus::WaitingForClient.as_str(),
-                TurnRunStatus::WaitingForAgentRun.as_str(),
-                TurnRunStatus::CancellingClient.as_str(),
-                TurnRunStatus::Resuming.as_str(),
-                TurnRunStatus::RetryWait.as_str(),
-            ])
-            .and(Expr::col(TurnRun::FinishedAt).is_null());
-        let queued_attempt = Expr::col(TurnRun::Status)
-            .eq(TurnRunStatus::Queued.as_str())
-            .and(Expr::col(TurnRun::AttemptCount).eq(0))
-            .and(Expr::col(TurnRun::ClaimCount).eq(0))
-            .and(Expr::col(TurnRun::StartedAt).is_null());
-        let leased_attempt = Expr::col(TurnRun::Status)
-            .is_in([
-                TurnRunStatus::Running.as_str(),
-                TurnRunStatus::Cancelling.as_str(),
-            ])
-            .and(Expr::col(TurnRun::AttemptCount).gte(1))
-            .and(Expr::col(TurnRun::StartedAt).is_not_null());
-        let retryable_attempt = Expr::col(TurnRun::Status)
-            .eq(TurnRunStatus::RetryWait.as_str())
-            .and(Expr::col(TurnRun::AttemptCount).gte(1))
-            .and(Expr::col(TurnRun::AttemptCount).lt(Expr::col(TurnRun::MaxAttempts)))
-            .and(Expr::col(TurnRun::StartedAt).is_not_null());
-        let continuation_checkpoint_attempt = Expr::col(TurnRun::Status)
-            .is_in([
-                TurnRunStatus::WaitingForClient.as_str(),
-                TurnRunStatus::WaitingForAgentRun.as_str(),
-                TurnRunStatus::CancellingClient.as_str(),
-                TurnRunStatus::Resuming.as_str(),
-            ])
-            .and(Expr::col(TurnRun::AttemptCount).gte(1))
-            .and(Expr::col(TurnRun::StartedAt).is_not_null());
-        let resolved_attempt = Expr::col(TurnRun::Status)
-            .is_in([
-                TurnRunStatus::Completed.as_str(),
-                TurnRunStatus::Failed.as_str(),
-            ])
-            .and(Expr::col(TurnRun::AttemptCount).gte(1))
-            .and(Expr::col(TurnRun::StartedAt).is_not_null());
-        let cancelled_attempt = Expr::col(TurnRun::Status)
-            .eq(TurnRunStatus::Cancelled.as_str())
-            .and(
-                Expr::col(TurnRun::AttemptCount)
-                    .eq(0)
-                    .and(Expr::col(TurnRun::ClaimCount).eq(0))
-                    .and(Expr::col(TurnRun::StartedAt).is_null())
-                    .or(Expr::col(TurnRun::AttemptCount)
-                        .gte(1)
-                        .and(Expr::col(TurnRun::StartedAt).is_not_null())),
-            );
-        let failure_has_error = Expr::col(TurnRun::Status)
-            .is_in([
-                TurnRunStatus::RetryWait.as_str(),
-                TurnRunStatus::Failed.as_str(),
-            ])
-            .and(Expr::col(TurnRun::LastErrorCode).is_not_null());
-        let success_has_no_error = Expr::col(TurnRun::Status)
-            .is_in([
-                TurnRunStatus::Queued.as_str(),
-                TurnRunStatus::Running.as_str(),
-                TurnRunStatus::Cancelling.as_str(),
-                TurnRunStatus::WaitingForClient.as_str(),
-                TurnRunStatus::WaitingForAgentRun.as_str(),
-                TurnRunStatus::CancellingClient.as_str(),
-                TurnRunStatus::Resuming.as_str(),
-                TurnRunStatus::Completed.as_str(),
-                TurnRunStatus::Cancelled.as_str(),
-            ])
-            .and(Expr::col(TurnRun::LastErrorCode).is_null())
-            .and(Expr::col(TurnRun::LastErrorDetail).is_null());
-        let coherent_steer_generation = Expr::col(TurnRun::SteerRevision)
-            .eq(0)
-            .and(Expr::col(TurnRun::LastSteerAppliedAt).is_null())
-            .or(Expr::col(TurnRun::SteerRevision)
-                .gte(1)
-                .and(Expr::col(TurnRun::LastSteerAppliedAt).is_not_null()));
-
         manager
-            .create_table(
-                Table::create()
-                    .table(TurnRun::Table)
-                    .if_not_exists()
-                    .col(ColumnDef::new(TurnRun::Id).uuid().not_null().primary_key())
-                    .col(ColumnDef::new(TurnRun::ChatId).uuid().not_null())
-                    .col(ColumnDef::new(TurnRun::AgentRunId).uuid().not_null())
-                    .col(
-                        ColumnDef::new(TurnRun::AgentRunDepth)
-                            .small_integer()
-                            .not_null()
-                            .default(0),
-                    )
-                    .col(ColumnDef::new(TurnRun::InputMessageId).uuid().not_null())
-                    .col(ColumnDef::new(TurnRun::OutputMessageId).uuid())
-                    .col(
-                        ColumnDef::new(TurnRun::Model)
-                            .string_len(crate::model::TurnRun::MAX_MODEL_LEN as u32)
-                            .not_null(),
-                    )
-                    .col(
-                        ColumnDef::new(TurnRun::Status)
-                            .string_len(32)
-                            .not_null()
-                            .default(TurnRunStatus::Queued.as_str()),
-                    )
-                    .col(
-                        ColumnDef::new(TurnRun::AttemptCount)
-                            .integer()
-                            .not_null()
-                            .default(0),
-                    )
-                    .col(
-                        ColumnDef::new(TurnRun::MaxAttempts)
-                            .integer()
-                            .not_null()
-                            .default(crate::model::TurnRun::DEFAULT_MAX_ATTEMPTS),
-                    )
-                    .col(
-                        ColumnDef::new(TurnRun::ClaimCount)
-                            .integer()
-                            .not_null()
-                            .default(0),
-                    )
-                    .col(
-                        ColumnDef::new(TurnRun::ModelSteps)
-                            .integer()
-                            .not_null()
-                            .default(0),
-                    )
-                    .col(
-                        ColumnDef::new(TurnRun::InputTokens)
-                            .big_integer()
-                            .not_null()
-                            .default(0),
-                    )
-                    .col(
-                        ColumnDef::new(TurnRun::OutputTokens)
-                            .big_integer()
-                            .not_null()
-                            .default(0),
-                    )
-                    .col(
-                        ColumnDef::new(TurnRun::CacheReadInputTokens)
-                            .big_integer()
-                            .not_null()
-                            .default(0),
-                    )
-                    .col(
-                        ColumnDef::new(TurnRun::CacheCreationInputTokens)
-                            .big_integer()
-                            .not_null()
-                            .default(0),
-                    )
-                    .col(
-                        ColumnDef::new(TurnRun::AvailableAt)
-                            .timestamp_with_time_zone()
-                            .not_null(),
-                    )
-                    .col(ColumnDef::new(TurnRun::LeaseToken).uuid())
-                    .col(ColumnDef::new(TurnRun::LeaseExpiresAt).timestamp_with_time_zone())
-                    .col(ColumnDef::new(TurnRun::StartedAt).timestamp_with_time_zone())
-                    .col(ColumnDef::new(TurnRun::FinishedAt).timestamp_with_time_zone())
-                    .col(
-                        ColumnDef::new(TurnRun::LastErrorCode)
-                            .string_len(crate::model::TurnRun::MAX_ERROR_CODE_LEN as u32),
-                    )
-                    .col(
-                        ColumnDef::new(TurnRun::LastErrorDetail)
-                            .string_len(crate::model::TurnRun::MAX_ERROR_DETAIL_LEN as u32),
-                    )
-                    .col(
-                        ColumnDef::new(TurnRun::SteerRevision)
-                            .big_integer()
-                            .not_null()
-                            .default(0),
-                    )
-                    .col(ColumnDef::new(TurnRun::LastSteerAppliedAt).timestamp_with_time_zone())
-                    .col(
-                        ColumnDef::new(TurnRun::CreatedAt)
-                            .timestamp_with_time_zone()
-                            .not_null(),
-                    )
-                    .col(
-                        ColumnDef::new(TurnRun::UpdatedAt)
-                            .timestamp_with_time_zone()
-                            .not_null(),
-                    )
-                    .foreign_key(
-                        ForeignKey::create()
-                            .name("fk_turn_run_chat")
-                            .from(TurnRun::Table, TurnRun::ChatId)
-                            .to(Chat::Table, Chat::Id)
-                            .on_delete(ForeignKeyAction::Cascade),
-                    )
-                    .foreign_key(
-                        ForeignKey::create()
-                            .name("fk_turn_run_foreground_agent")
-                            .from_tbl(TurnRun::Table)
-                            .from_col(TurnRun::AgentRunId)
-                            .from_col(TurnRun::ChatId)
-                            .from_col(TurnRun::AgentRunDepth)
-                            .to_tbl(AgentRun::Table)
-                            .to_col(AgentRun::Id)
-                            .to_col(AgentRun::ChatId)
-                            .to_col(AgentRun::Depth)
-                            .on_delete(ForeignKeyAction::Restrict),
-                    )
-                    .foreign_key(
-                        ForeignKey::create()
-                            .name("fk_turn_run_input_message")
-                            .from_tbl(TurnRun::Table)
-                            .from_col(TurnRun::InputMessageId)
-                            .from_col(TurnRun::ChatId)
-                            .from_col(TurnRun::Id)
-                            .to_tbl(Message::Table)
-                            .to_col(Message::Id)
-                            .to_col(Message::ChatId)
-                            .to_col(Message::TurnId)
-                            .on_delete(ForeignKeyAction::Restrict),
-                    )
-                    .foreign_key(
-                        ForeignKey::create()
-                            .name("fk_turn_run_output_message")
-                            .from_tbl(TurnRun::Table)
-                            .from_col(TurnRun::OutputMessageId)
-                            .from_col(TurnRun::ChatId)
-                            .from_col(TurnRun::Id)
-                            .to_tbl(Message::Table)
-                            .to_col(Message::Id)
-                            .to_col(Message::ChatId)
-                            .to_col(Message::TurnId)
-                            .on_delete(ForeignKeyAction::Restrict),
-                    )
-                    .foreign_key(
-                        ForeignKey::create()
-                            .name("fk_turn_run_live_claim")
-                            .from_tbl(TurnRun::Table)
-                            .from_col(TurnRun::LeaseToken)
-                            .from_col(TurnRun::Id)
-                            .from_col(TurnRun::AttemptCount)
-                            .from_col(TurnRun::ClaimCount)
-                            .to_tbl(TurnClaim::Table)
-                            .to_col(TurnClaim::Token)
-                            .to_col(TurnClaim::TurnId)
-                            .to_col(TurnClaim::AttemptCount)
-                            .to_col(TurnClaim::ClaimCount)
-                            .on_delete(ForeignKeyAction::Restrict),
-                    )
-                    .check(
-                        Func::char_length(Expr::col(TurnRun::Model))
-                            .between(1, crate::model::TurnRun::MAX_MODEL_LEN as i32),
-                    )
-                    .check(Expr::col(TurnRun::AgentRunDepth).eq(0))
-                    .check(valid_turn_status)
-                    .check(
-                        Expr::col(TurnRun::AttemptCount)
-                            .gte(0)
-                            .and(Expr::col(TurnRun::MaxAttempts).gte(1))
-                            .and(
-                                Expr::col(TurnRun::AttemptCount)
-                                    .lte(Expr::col(TurnRun::MaxAttempts)),
-                            ),
-                    )
-                    .check(Expr::col(TurnRun::ClaimCount).gte(Expr::col(TurnRun::AttemptCount)))
-                    .check(active_lease.or(no_lease))
-                    .check(completed_output.or(no_output))
-                    .check(terminal_finished.or(nonterminal_unfinished))
-                    .check(
-                        queued_attempt
-                            .or(leased_attempt)
-                            .or(continuation_checkpoint_attempt)
-                            .or(retryable_attempt)
-                            .or(resolved_attempt)
-                            .or(cancelled_attempt),
-                    )
-                    .check(failure_has_error.or(success_has_no_error))
-                    .check(
-                        Expr::col(TurnRun::LastErrorCode)
-                            .is_null()
-                            .or(Func::char_length(Expr::col(TurnRun::LastErrorCode))
-                                .between(1, crate::model::TurnRun::MAX_ERROR_CODE_LEN as i32)),
-                    )
-                    .check(
-                        Expr::col(TurnRun::LastErrorDetail)
-                            .is_null()
-                            .or(Func::char_length(Expr::col(TurnRun::LastErrorDetail))
-                                .between(1, crate::model::TurnRun::MAX_ERROR_DETAIL_LEN as i32)),
-                    )
-                    .check(Expr::col(TurnRun::SteerRevision).gte(0))
-                    .check(coherent_steer_generation)
-                    .check(
-                        Expr::col(TurnRun::ModelSteps)
-                            .gte(0)
-                            .and(Expr::col(TurnRun::ModelSteps).lte(i64::from(i32::MAX)))
-                            .and(Expr::col(TurnRun::InputTokens).gte(0))
-                            .and(Expr::col(TurnRun::InputTokens).lte(i64::from(u32::MAX)))
-                            .and(Expr::col(TurnRun::OutputTokens).gte(0))
-                            .and(Expr::col(TurnRun::OutputTokens).lte(i64::from(u32::MAX)))
-                            .and(Expr::col(TurnRun::CacheReadInputTokens).gte(0))
-                            .and(Expr::col(TurnRun::CacheReadInputTokens).lte(i64::from(u32::MAX)))
-                            .and(Expr::col(TurnRun::CacheCreationInputTokens).gte(0))
-                            .and(
-                                Expr::col(TurnRun::CacheCreationInputTokens)
-                                    .lte(i64::from(u32::MAX)),
-                            ),
-                    )
-                    .check(
-                        Expr::col(TurnRun::LastSteerAppliedAt)
-                            .is_null()
-                            .or(Expr::col(TurnRun::LastSteerAppliedAt)
-                                .gte(Expr::col(TurnRun::CreatedAt))
-                                .and(
-                                    Expr::col(TurnRun::LastSteerAppliedAt)
-                                        .lte(Expr::col(TurnRun::UpdatedAt)),
-                                )),
-                    )
-                    .to_owned(),
-            )
+            .create_table(turn_run_table(TurnRun::Table, false))
             .await?;
-
-        manager
-            .create_index(
-                Index::create()
-                    .name("idx_turn_run_chat_identity")
-                    .table(TurnRun::Table)
-                    .col(TurnRun::ChatId)
-                    .col(TurnRun::Id)
-                    .unique()
-                    .to_owned(),
-            )
-            .await?;
-        manager
-            .create_index(
-                Index::create()
-                    .name("idx_turn_run_input_message")
-                    .table(TurnRun::Table)
-                    .col(TurnRun::InputMessageId)
-                    .unique()
-                    .to_owned(),
-            )
-            .await?;
-        manager
-            .create_index(
-                Index::create()
-                    .name("idx_turn_run_one_active")
-                    .table(TurnRun::Table)
-                    .col(TurnRun::ChatId)
-                    .unique()
-                    .and_where(Expr::col(TurnRun::Status).is_in([
-                        TurnRunStatus::Queued.as_str(),
-                        TurnRunStatus::Running.as_str(),
-                        TurnRunStatus::Cancelling.as_str(),
-                        TurnRunStatus::WaitingForClient.as_str(),
-                        TurnRunStatus::WaitingForAgentRun.as_str(),
-                        TurnRunStatus::CancellingClient.as_str(),
-                        TurnRunStatus::Resuming.as_str(),
-                        TurnRunStatus::RetryWait.as_str(),
-                    ]))
-                    .to_owned(),
-            )
-            .await?;
-        manager
-            .create_index(
-                Index::create()
-                    .name("idx_turn_run_due")
-                    .table(TurnRun::Table)
-                    .col(TurnRun::Status)
-                    .col(TurnRun::AvailableAt)
-                    .col(TurnRun::CreatedAt)
-                    .to_owned(),
-            )
-            .await?;
-        manager
-            .create_index(
-                Index::create()
-                    .name("idx_turn_run_lease_token")
-                    .table(TurnRun::Table)
-                    .col(TurnRun::LeaseToken)
-                    .unique()
-                    .to_owned(),
-            )
-            .await?;
-        manager
-            .create_index(
-                Index::create()
-                    .name("idx_turn_run_stale_lease")
-                    .table(TurnRun::Table)
-                    .col(TurnRun::Status)
-                    .col(TurnRun::LeaseExpiresAt)
-                    .to_owned(),
-            )
-            .await?;
-        manager
-            .create_index(
-                Index::create()
-                    .name("idx_turn_run_history")
-                    .table(TurnRun::Table)
-                    .col(TurnRun::ChatId)
-                    .col(TurnRun::CreatedAt)
-                    .to_owned(),
-            )
-            .await?;
-        manager
-            .create_index(
-                Index::create()
-                    .name("idx_turn_run_admission_owner")
-                    .table(TurnRun::Table)
-                    .col(TurnRun::Id)
-                    .col(TurnRun::ChatId)
-                    .col(TurnRun::AgentRunId)
-                    .unique()
-                    .to_owned(),
-            )
-            .await?;
+        for index in turn_run_indexes() {
+            manager.create_index(index).await?;
+        }
 
         manager
             .create_table(
@@ -10130,7 +9680,7 @@ enum MessageIdentity {
     Owner,
 }
 
-#[derive(DeriveIden)]
+#[derive(DeriveIden, Clone, Copy)]
 enum TurnRun {
     Table,
     Id,
@@ -10345,4 +9895,582 @@ enum Event {
     Terminal,
     Payload,
     CreatedAt,
+}
+
+/// The `turn_run` table, shared between `Init` and the cancelled-output
+/// rebuild migration so the two definitions cannot drift. `table` is the
+/// physical table to create — the canonical one in `Init`, a scratch alias
+/// during a SQLite rebuild. `cancelled_output` selects the terminal-output
+/// domain: strict, or widened so a cancelled turn keeps the partial prose it
+/// had already streamed (#1182).
+fn turn_run_table<T>(table: T, cancelled_output: bool) -> TableCreateStatement
+where
+    T: IntoTableRef + Clone,
+{
+    let valid_turn_status = Expr::col(TurnRun::Status).is_in([
+        TurnRunStatus::Queued.as_str(),
+        TurnRunStatus::Running.as_str(),
+        TurnRunStatus::Cancelling.as_str(),
+        TurnRunStatus::WaitingForClient.as_str(),
+        TurnRunStatus::WaitingForAgentRun.as_str(),
+        TurnRunStatus::CancellingClient.as_str(),
+        TurnRunStatus::Resuming.as_str(),
+        TurnRunStatus::RetryWait.as_str(),
+        TurnRunStatus::Completed.as_str(),
+        TurnRunStatus::Failed.as_str(),
+        TurnRunStatus::Cancelled.as_str(),
+    ]);
+    let active_lease = Expr::col(TurnRun::Status)
+        .is_in([
+            TurnRunStatus::Running.as_str(),
+            TurnRunStatus::Cancelling.as_str(),
+        ])
+        .and(Expr::col(TurnRun::LeaseToken).is_not_null())
+        .and(Expr::col(TurnRun::LeaseExpiresAt).is_not_null());
+    let no_lease = Expr::col(TurnRun::Status)
+        .ne(TurnRunStatus::Running.as_str())
+        .and(Expr::col(TurnRun::Status).ne(TurnRunStatus::Cancelling.as_str()))
+        .and(Expr::col(TurnRun::LeaseToken).is_null())
+        .and(Expr::col(TurnRun::LeaseExpiresAt).is_null());
+    let terminal_finished = Expr::col(TurnRun::Status)
+        .is_in([
+            TurnRunStatus::Completed.as_str(),
+            TurnRunStatus::Failed.as_str(),
+            TurnRunStatus::Cancelled.as_str(),
+        ])
+        .and(Expr::col(TurnRun::FinishedAt).is_not_null());
+    let nonterminal_unfinished = Expr::col(TurnRun::Status)
+        .is_in([
+            TurnRunStatus::Queued.as_str(),
+            TurnRunStatus::Running.as_str(),
+            TurnRunStatus::Cancelling.as_str(),
+            TurnRunStatus::WaitingForClient.as_str(),
+            TurnRunStatus::WaitingForAgentRun.as_str(),
+            TurnRunStatus::CancellingClient.as_str(),
+            TurnRunStatus::Resuming.as_str(),
+            TurnRunStatus::RetryWait.as_str(),
+        ])
+        .and(Expr::col(TurnRun::FinishedAt).is_null());
+    let queued_attempt = Expr::col(TurnRun::Status)
+        .eq(TurnRunStatus::Queued.as_str())
+        .and(Expr::col(TurnRun::AttemptCount).eq(0))
+        .and(Expr::col(TurnRun::ClaimCount).eq(0))
+        .and(Expr::col(TurnRun::StartedAt).is_null());
+    let leased_attempt = Expr::col(TurnRun::Status)
+        .is_in([
+            TurnRunStatus::Running.as_str(),
+            TurnRunStatus::Cancelling.as_str(),
+        ])
+        .and(Expr::col(TurnRun::AttemptCount).gte(1))
+        .and(Expr::col(TurnRun::StartedAt).is_not_null());
+    let retryable_attempt = Expr::col(TurnRun::Status)
+        .eq(TurnRunStatus::RetryWait.as_str())
+        .and(Expr::col(TurnRun::AttemptCount).gte(1))
+        .and(Expr::col(TurnRun::AttemptCount).lt(Expr::col(TurnRun::MaxAttempts)))
+        .and(Expr::col(TurnRun::StartedAt).is_not_null());
+    let continuation_checkpoint_attempt = Expr::col(TurnRun::Status)
+        .is_in([
+            TurnRunStatus::WaitingForClient.as_str(),
+            TurnRunStatus::WaitingForAgentRun.as_str(),
+            TurnRunStatus::CancellingClient.as_str(),
+            TurnRunStatus::Resuming.as_str(),
+        ])
+        .and(Expr::col(TurnRun::AttemptCount).gte(1))
+        .and(Expr::col(TurnRun::StartedAt).is_not_null());
+    let resolved_attempt = Expr::col(TurnRun::Status)
+        .is_in([
+            TurnRunStatus::Completed.as_str(),
+            TurnRunStatus::Failed.as_str(),
+        ])
+        .and(Expr::col(TurnRun::AttemptCount).gte(1))
+        .and(Expr::col(TurnRun::StartedAt).is_not_null());
+    let cancelled_attempt = Expr::col(TurnRun::Status)
+        .eq(TurnRunStatus::Cancelled.as_str())
+        .and(
+            Expr::col(TurnRun::AttemptCount)
+                .eq(0)
+                .and(Expr::col(TurnRun::ClaimCount).eq(0))
+                .and(Expr::col(TurnRun::StartedAt).is_null())
+                .or(Expr::col(TurnRun::AttemptCount)
+                    .gte(1)
+                    .and(Expr::col(TurnRun::StartedAt).is_not_null())),
+        );
+    let failure_has_error = Expr::col(TurnRun::Status)
+        .is_in([
+            TurnRunStatus::RetryWait.as_str(),
+            TurnRunStatus::Failed.as_str(),
+        ])
+        .and(Expr::col(TurnRun::LastErrorCode).is_not_null());
+    let success_has_no_error = Expr::col(TurnRun::Status)
+        .is_in([
+            TurnRunStatus::Queued.as_str(),
+            TurnRunStatus::Running.as_str(),
+            TurnRunStatus::Cancelling.as_str(),
+            TurnRunStatus::WaitingForClient.as_str(),
+            TurnRunStatus::WaitingForAgentRun.as_str(),
+            TurnRunStatus::CancellingClient.as_str(),
+            TurnRunStatus::Resuming.as_str(),
+            TurnRunStatus::Completed.as_str(),
+            TurnRunStatus::Cancelled.as_str(),
+        ])
+        .and(Expr::col(TurnRun::LastErrorCode).is_null())
+        .and(Expr::col(TurnRun::LastErrorDetail).is_null());
+    let coherent_steer_generation = Expr::col(TurnRun::SteerRevision)
+        .eq(0)
+        .and(Expr::col(TurnRun::LastSteerAppliedAt).is_null())
+        .or(Expr::col(TurnRun::SteerRevision)
+            .gte(1)
+            .and(Expr::col(TurnRun::LastSteerAppliedAt).is_not_null()));
+
+    Table::create()
+        .table(table.clone())
+        .col(ColumnDef::new(TurnRun::Id).uuid().not_null().primary_key())
+        .col(ColumnDef::new(TurnRun::ChatId).uuid().not_null())
+        .col(ColumnDef::new(TurnRun::AgentRunId).uuid().not_null())
+        .col(
+            ColumnDef::new(TurnRun::AgentRunDepth)
+                .small_integer()
+                .not_null()
+                .default(0),
+        )
+        .col(ColumnDef::new(TurnRun::InputMessageId).uuid().not_null())
+        .col(ColumnDef::new(TurnRun::OutputMessageId).uuid())
+        .col(
+            ColumnDef::new(TurnRun::Model)
+                .string_len(crate::model::TurnRun::MAX_MODEL_LEN as u32)
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(TurnRun::Status)
+                .string_len(32)
+                .not_null()
+                .default(TurnRunStatus::Queued.as_str()),
+        )
+        .col(
+            ColumnDef::new(TurnRun::AttemptCount)
+                .integer()
+                .not_null()
+                .default(0),
+        )
+        .col(
+            ColumnDef::new(TurnRun::MaxAttempts)
+                .integer()
+                .not_null()
+                .default(crate::model::TurnRun::DEFAULT_MAX_ATTEMPTS),
+        )
+        .col(
+            ColumnDef::new(TurnRun::ClaimCount)
+                .integer()
+                .not_null()
+                .default(0),
+        )
+        .col(
+            ColumnDef::new(TurnRun::ModelSteps)
+                .integer()
+                .not_null()
+                .default(0),
+        )
+        .col(
+            ColumnDef::new(TurnRun::InputTokens)
+                .big_integer()
+                .not_null()
+                .default(0),
+        )
+        .col(
+            ColumnDef::new(TurnRun::OutputTokens)
+                .big_integer()
+                .not_null()
+                .default(0),
+        )
+        .col(
+            ColumnDef::new(TurnRun::CacheReadInputTokens)
+                .big_integer()
+                .not_null()
+                .default(0),
+        )
+        .col(
+            ColumnDef::new(TurnRun::CacheCreationInputTokens)
+                .big_integer()
+                .not_null()
+                .default(0),
+        )
+        .col(
+            ColumnDef::new(TurnRun::AvailableAt)
+                .timestamp_with_time_zone()
+                .not_null(),
+        )
+        .col(ColumnDef::new(TurnRun::LeaseToken).uuid())
+        .col(ColumnDef::new(TurnRun::LeaseExpiresAt).timestamp_with_time_zone())
+        .col(ColumnDef::new(TurnRun::StartedAt).timestamp_with_time_zone())
+        .col(ColumnDef::new(TurnRun::FinishedAt).timestamp_with_time_zone())
+        .col(
+            ColumnDef::new(TurnRun::LastErrorCode)
+                .string_len(crate::model::TurnRun::MAX_ERROR_CODE_LEN as u32),
+        )
+        .col(
+            ColumnDef::new(TurnRun::LastErrorDetail)
+                .string_len(crate::model::TurnRun::MAX_ERROR_DETAIL_LEN as u32),
+        )
+        .col(
+            ColumnDef::new(TurnRun::SteerRevision)
+                .big_integer()
+                .not_null()
+                .default(0),
+        )
+        .col(ColumnDef::new(TurnRun::LastSteerAppliedAt).timestamp_with_time_zone())
+        .col(
+            ColumnDef::new(TurnRun::CreatedAt)
+                .timestamp_with_time_zone()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(TurnRun::UpdatedAt)
+                .timestamp_with_time_zone()
+                .not_null(),
+        )
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_turn_run_chat")
+                .from(table.clone(), TurnRun::ChatId)
+                .to(Chat::Table, Chat::Id)
+                .on_delete(ForeignKeyAction::Cascade),
+        )
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_turn_run_foreground_agent")
+                .from_tbl(table.clone())
+                .from_col(TurnRun::AgentRunId)
+                .from_col(TurnRun::ChatId)
+                .from_col(TurnRun::AgentRunDepth)
+                .to_tbl(AgentRun::Table)
+                .to_col(AgentRun::Id)
+                .to_col(AgentRun::ChatId)
+                .to_col(AgentRun::Depth)
+                .on_delete(ForeignKeyAction::Restrict),
+        )
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_turn_run_input_message")
+                .from_tbl(table.clone())
+                .from_col(TurnRun::InputMessageId)
+                .from_col(TurnRun::ChatId)
+                .from_col(TurnRun::Id)
+                .to_tbl(Message::Table)
+                .to_col(Message::Id)
+                .to_col(Message::ChatId)
+                .to_col(Message::TurnId)
+                .on_delete(ForeignKeyAction::Restrict),
+        )
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_turn_run_output_message")
+                .from_tbl(table.clone())
+                .from_col(TurnRun::OutputMessageId)
+                .from_col(TurnRun::ChatId)
+                .from_col(TurnRun::Id)
+                .to_tbl(Message::Table)
+                .to_col(Message::Id)
+                .to_col(Message::ChatId)
+                .to_col(Message::TurnId)
+                .on_delete(ForeignKeyAction::Restrict),
+        )
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_turn_run_live_claim")
+                .from_tbl(table.clone())
+                .from_col(TurnRun::LeaseToken)
+                .from_col(TurnRun::Id)
+                .from_col(TurnRun::AttemptCount)
+                .from_col(TurnRun::ClaimCount)
+                .to_tbl(TurnClaim::Table)
+                .to_col(TurnClaim::Token)
+                .to_col(TurnClaim::TurnId)
+                .to_col(TurnClaim::AttemptCount)
+                .to_col(TurnClaim::ClaimCount)
+                .on_delete(ForeignKeyAction::Restrict),
+        )
+        .check(
+            Func::char_length(Expr::col(TurnRun::Model))
+                .between(1, crate::model::TurnRun::MAX_MODEL_LEN as i32),
+        )
+        .check(Expr::col(TurnRun::AgentRunDepth).eq(0))
+        .check(valid_turn_status)
+        .check(
+            Expr::col(TurnRun::AttemptCount)
+                .gte(0)
+                .and(Expr::col(TurnRun::MaxAttempts).gte(1))
+                .and(Expr::col(TurnRun::AttemptCount).lte(Expr::col(TurnRun::MaxAttempts))),
+        )
+        .check(Expr::col(TurnRun::ClaimCount).gte(Expr::col(TurnRun::AttemptCount)))
+        .check(active_lease.or(no_lease))
+        .check(turn_run_terminal_output_check(cancelled_output))
+        .check(terminal_finished.or(nonterminal_unfinished))
+        .check(
+            queued_attempt
+                .or(leased_attempt)
+                .or(continuation_checkpoint_attempt)
+                .or(retryable_attempt)
+                .or(resolved_attempt)
+                .or(cancelled_attempt),
+        )
+        .check(failure_has_error.or(success_has_no_error))
+        .check(
+            Expr::col(TurnRun::LastErrorCode)
+                .is_null()
+                .or(Func::char_length(Expr::col(TurnRun::LastErrorCode))
+                    .between(1, crate::model::TurnRun::MAX_ERROR_CODE_LEN as i32)),
+        )
+        .check(
+            Expr::col(TurnRun::LastErrorDetail)
+                .is_null()
+                .or(Func::char_length(Expr::col(TurnRun::LastErrorDetail))
+                    .between(1, crate::model::TurnRun::MAX_ERROR_DETAIL_LEN as i32)),
+        )
+        .check(Expr::col(TurnRun::SteerRevision).gte(0))
+        .check(coherent_steer_generation)
+        .check(
+            Expr::col(TurnRun::ModelSteps)
+                .gte(0)
+                .and(Expr::col(TurnRun::ModelSteps).lte(i64::from(i32::MAX)))
+                .and(Expr::col(TurnRun::InputTokens).gte(0))
+                .and(Expr::col(TurnRun::InputTokens).lte(i64::from(u32::MAX)))
+                .and(Expr::col(TurnRun::OutputTokens).gte(0))
+                .and(Expr::col(TurnRun::OutputTokens).lte(i64::from(u32::MAX)))
+                .and(Expr::col(TurnRun::CacheReadInputTokens).gte(0))
+                .and(Expr::col(TurnRun::CacheReadInputTokens).lte(i64::from(u32::MAX)))
+                .and(Expr::col(TurnRun::CacheCreationInputTokens).gte(0))
+                .and(Expr::col(TurnRun::CacheCreationInputTokens).lte(i64::from(u32::MAX))),
+        )
+        .check(
+            Expr::col(TurnRun::LastSteerAppliedAt)
+                .is_null()
+                .or(Expr::col(TurnRun::LastSteerAppliedAt)
+                    .gte(Expr::col(TurnRun::CreatedAt))
+                    .and(
+                        Expr::col(TurnRun::LastSteerAppliedAt).lte(Expr::col(TurnRun::UpdatedAt)),
+                    )),
+        )
+        .to_owned()
+}
+
+/// The terminal-output domain of `turn_run`. Strict: only a completed turn
+/// carries an output message. Widened (#1182): a cancelled turn may also
+/// carry one — the partial prose it had already streamed — or none, when the
+/// cancel arrived before any text.
+fn turn_run_terminal_output_check(cancelled_output: bool) -> SimpleExpr {
+    let completed_output = Expr::col(TurnRun::Status)
+        .eq(TurnRunStatus::Completed.as_str())
+        .and(Expr::col(TurnRun::OutputMessageId).is_not_null());
+    if cancelled_output {
+        completed_output
+            .or(Expr::col(TurnRun::Status).eq(TurnRunStatus::Cancelled.as_str()))
+            .or(Expr::col(TurnRun::Status)
+                .is_not_in([
+                    TurnRunStatus::Completed.as_str(),
+                    TurnRunStatus::Cancelled.as_str(),
+                ])
+                .and(Expr::col(TurnRun::OutputMessageId).is_null()))
+    } else {
+        let no_output = Expr::col(TurnRun::Status)
+            .ne(TurnRunStatus::Completed.as_str())
+            .and(Expr::col(TurnRun::OutputMessageId).is_null());
+        completed_output.or(no_output)
+    }
+}
+
+/// Every index `turn_run` carries, for `Init` and for recreation after a
+/// SQLite table rebuild.
+fn turn_run_indexes() -> Vec<IndexCreateStatement> {
+    vec![
+        Index::create()
+            .name("idx_turn_run_chat_identity")
+            .table(TurnRun::Table)
+            .col(TurnRun::ChatId)
+            .col(TurnRun::Id)
+            .unique()
+            .to_owned(),
+        Index::create()
+            .name("idx_turn_run_input_message")
+            .table(TurnRun::Table)
+            .col(TurnRun::InputMessageId)
+            .unique()
+            .to_owned(),
+        Index::create()
+            .name("idx_turn_run_one_active")
+            .table(TurnRun::Table)
+            .col(TurnRun::ChatId)
+            .unique()
+            .and_where(Expr::col(TurnRun::Status).is_in([
+                TurnRunStatus::Queued.as_str(),
+                TurnRunStatus::Running.as_str(),
+                TurnRunStatus::Cancelling.as_str(),
+                TurnRunStatus::WaitingForClient.as_str(),
+                TurnRunStatus::WaitingForAgentRun.as_str(),
+                TurnRunStatus::CancellingClient.as_str(),
+                TurnRunStatus::Resuming.as_str(),
+                TurnRunStatus::RetryWait.as_str(),
+            ]))
+            .to_owned(),
+        Index::create()
+            .name("idx_turn_run_due")
+            .table(TurnRun::Table)
+            .col(TurnRun::Status)
+            .col(TurnRun::AvailableAt)
+            .col(TurnRun::CreatedAt)
+            .to_owned(),
+        Index::create()
+            .name("idx_turn_run_lease_token")
+            .table(TurnRun::Table)
+            .col(TurnRun::LeaseToken)
+            .unique()
+            .to_owned(),
+        Index::create()
+            .name("idx_turn_run_stale_lease")
+            .table(TurnRun::Table)
+            .col(TurnRun::Status)
+            .col(TurnRun::LeaseExpiresAt)
+            .to_owned(),
+        Index::create()
+            .name("idx_turn_run_history")
+            .table(TurnRun::Table)
+            .col(TurnRun::ChatId)
+            .col(TurnRun::CreatedAt)
+            .to_owned(),
+        Index::create()
+            .name("idx_turn_run_admission_owner")
+            .table(TurnRun::Table)
+            .col(TurnRun::Id)
+            .col(TurnRun::ChatId)
+            .col(TurnRun::AgentRunId)
+            .unique()
+            .to_owned(),
+    ]
+}
+
+const TURN_RUN_REBUILD: &str = "turn_run_rebuild";
+
+/// Rebuild `turn_run` on SQLite with the chosen terminal-output domain.
+///
+/// The output check is an anonymous CHECK from `Init`, and SQLite cannot drop
+/// or alter one in place — the sanctioned path is a scratch-table rebuild, the
+/// same shape the container-location migration uses for `agent_run`. Other
+/// tables' foreign keys reference `turn_run` by name and survive the
+/// drop-and-rename under `PRAGMA foreign_keys=OFF`.
+async fn rebuild_turn_run_sqlite_output(
+    manager: &SchemaManager<'_>,
+    cancelled_output: bool,
+) -> Result<(), DbErr> {
+    let columns = "id, chat_id, agent_run_id, agent_run_depth, input_message_id, \
+         output_message_id, model, status, attempt_count, max_attempts, claim_count, \
+         model_steps, input_tokens, output_tokens, cache_read_input_tokens, \
+         cache_creation_input_tokens, available_at, lease_token, lease_expires_at, \
+         started_at, finished_at, last_error_code, last_error_detail, steer_revision, \
+         last_steer_applied_at, created_at, updated_at";
+    let mut statements = vec![
+        "PRAGMA foreign_keys=OFF".to_owned(),
+        "BEGIN IMMEDIATE".to_owned(),
+        turn_run_table(Alias::new(TURN_RUN_REBUILD), cancelled_output)
+            .to_string(SqliteQueryBuilder),
+        format!("INSERT INTO {TURN_RUN_REBUILD} ({columns}) SELECT {columns} FROM turn_run"),
+        "DROP TABLE turn_run".to_owned(),
+        format!("ALTER TABLE {TURN_RUN_REBUILD} RENAME TO turn_run"),
+    ];
+    statements.extend(
+        turn_run_indexes()
+            .iter()
+            .map(|index| index.to_string(SqliteQueryBuilder)),
+    );
+    statements.push("COMMIT".to_owned());
+    statements.push("PRAGMA foreign_keys=ON".to_owned());
+    manager
+        .get_connection()
+        .execute_unprepared(&format!("{};", statements.join(";\n")))
+        .await?;
+    Ok(())
+}
+
+/// Refuse to narrow the terminal-output domain while any cancelled turn still
+/// carries an output message, so a rollback fails up front with the actual
+/// problem named instead of stranding a half-rebuilt schema.
+async fn reject_down_with_cancelled_output_rows(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let conn = manager.get_connection();
+    let backend = manager.get_database_backend();
+    let remaining = conn
+        .query_one_raw(sea_orm::Statement::from_string(
+            backend,
+            "SELECT COUNT(*) AS remaining FROM turn_run \
+             WHERE status = 'cancelled' AND output_message_id IS NOT NULL",
+        ))
+        .await?;
+    let remaining = match remaining {
+        Some(row) => row.try_get::<i64>("", "remaining")?,
+        None => 0,
+    };
+    if remaining > 0 {
+        return Err(DbErr::Custom(format!(
+            "cannot narrow turn_run's output domain: {remaining} cancelled turn(s) retain \
+             partial output; delete those messages before rolling this migration back"
+        )));
+    }
+    Ok(())
+}
+
+/// A cancelled turn keeps the partial prose it had already streamed as its
+/// durable output message (#1182). The `Init` schema pinned "only a completed
+/// turn carries an output message" in a CHECK on `turn_run`; this widens that
+/// domain to let cancelled turns carry one too.
+struct RetainCancelledTurnOutput;
+
+impl MigrationName for RetainCancelledTurnOutput {
+    fn name(&self) -> &str {
+        "m20260731_000041_retain_cancelled_turn_output"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for RetainCancelledTurnOutput {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() == DatabaseBackend::Sqlite {
+            return rebuild_turn_run_sqlite_output(manager, true).await;
+        }
+        // The check is anonymous, so locate it by definition. Add the widened
+        // constraint before dropping the strict one so no window exists in
+        // which the output column is unconstrained.
+        let widened = render_postgres_check(turn_run_terminal_output_check(true));
+        manager
+            .get_connection()
+            .execute_unprepared(&format!(
+                "DO $$ DECLARE strict_name text; BEGIN \
+                 SELECT conname INTO strict_name FROM pg_constraint \
+                 WHERE conrelid = 'turn_run'::regclass AND contype = 'c' \
+                 AND pg_get_constraintdef(oid) LIKE '%output_message_id%'; \
+                 IF strict_name IS NULL THEN \
+                 RAISE EXCEPTION 'turn_run output check not found'; END IF; \
+                 EXECUTE $q$ALTER TABLE turn_run ADD CONSTRAINT \
+                 chk_turn_run_terminal_output CHECK ({widened})$q$; \
+                 EXECUTE format('ALTER TABLE turn_run DROP CONSTRAINT %I', strict_name); \
+                 END $$;"
+            ))
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        reject_down_with_cancelled_output_rows(manager).await?;
+        if manager.get_database_backend() == DatabaseBackend::Sqlite {
+            return rebuild_turn_run_sqlite_output(manager, false).await;
+        }
+        let strict = render_postgres_check(turn_run_terminal_output_check(false));
+        manager
+            .get_connection()
+            .execute_unprepared(&format!(
+                "DO $$ BEGIN \
+                 EXECUTE $q$ALTER TABLE turn_run ADD CONSTRAINT \
+                 chk_turn_run_completed_output CHECK ({strict})$q$; \
+                 EXECUTE 'ALTER TABLE turn_run DROP CONSTRAINT chk_turn_run_terminal_output'; \
+                 END $$;"
+            ))
+            .await?;
+        Ok(())
+    }
 }

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1457,9 +1457,19 @@ impl Store for DbStore {
         lease_token: uuid::Uuid,
         now: chrono::DateTime<Utc>,
         usage: Usage,
+        output: Option<&Message>,
+        citations: &[crate::AssistantCitationInput],
     ) -> Result<Option<JournaledTurnOutcome<FinishTurnCancellationOutcome>>> {
-        ops::turn::finish_turn_cancellation_and_append_event(self, id, lease_token, now, usage)
-            .await
+        ops::turn::finish_turn_cancellation_and_append_event(
+            self,
+            id,
+            lease_token,
+            now,
+            usage,
+            output,
+            citations,
+        )
+        .await
     }
 
     async fn park_turn_for_client_tool_call(

--- a/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
@@ -419,32 +419,46 @@ pub(in crate::db) async fn finish_turn_cancellation(
     now: chrono::DateTime<Utc>,
 ) -> Result<Option<FinishTurnCancellationOutcome>> {
     Ok(
-        finish_turn_cancellation_inner(store, id, lease_token, now, None)
+        finish_turn_cancellation_inner(store, id, lease_token, now, None, None, &[])
             .await?
             .map(|resolution| resolution.outcome),
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(in crate::db) async fn finish_turn_cancellation_and_append_event(
     store: &DbStore,
     id: TurnId,
     lease_token: uuid::Uuid,
     now: chrono::DateTime<Utc>,
     usage: Usage,
+    output: Option<&Message>,
+    citations: &[crate::AssistantCitationInput],
 ) -> Result<Option<JournaledTurnOutcome<FinishTurnCancellationOutcome>>> {
     let event = AgentEvent::TurnCancelled { usage };
-    finish_turn_cancellation_inner(store, id, lease_token, now, Some(&event)).await
+    finish_turn_cancellation_inner(store, id, lease_token, now, Some(&event), output, citations)
+        .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn finish_turn_cancellation_inner(
     store: &DbStore,
     id: TurnId,
     lease_token: uuid::Uuid,
     now: chrono::DateTime<Utc>,
     terminal_event: Option<&AgentEvent>,
+    output: Option<&Message>,
+    citations: &[crate::AssistantCitationInput],
 ) -> Result<Option<JournaledTurnOutcome<FinishTurnCancellationOutcome>>> {
     if lease_token.is_nil() {
         return Err(AgentError::Store("turn lease token must not be nil".into()));
+    }
+    // The prose a cancelled turn already streamed commits with the same
+    // transition (#1182). An empty output is not a message.
+    let output = output.filter(|output| !output.content.is_empty());
+    if let Some(output) = output {
+        validate_turn_output(id, lease_token, output)?;
+        super::super::super::citation::validate_assistant_message(output, citations)?;
     }
     let now = canonical_db_timestamp(now)?;
     let journal_chat_id = journal_chat_id(store, id, terminal_event.is_some()).await?;
@@ -512,7 +526,49 @@ async fn finish_turn_cancellation_inner(
         .await?;
     super::super::super::plan::close_pending_for_terminal_turn_on(&transaction, id, now).await?;
 
-    let cancelled = entities::turn_run::Entity::update_many()
+    // Commit the partial output under the cancelled turn before the status
+    // flip so the message row and the terminal transition land atomically —
+    // the same shape as a completed turn's output.
+    let output_message_id = match output {
+        Some(output) => {
+            if output.chat_id.0 != turn.chat_id {
+                return Err(AgentError::Store(format!(
+                    "turn {id} output belongs to a different chat"
+                )));
+            }
+            if !reserve_message_identity_on(
+                &transaction,
+                output.id,
+                output.chat_id,
+                output.turn_id,
+                MESSAGE_IDENTITY_OWNER_MESSAGE,
+            )
+            .await?
+            {
+                return Err(AgentError::Store(format!(
+                    "turn output message identity {} is already reserved",
+                    output.id
+                )));
+            }
+            let message = entities::message::ActiveModel {
+                id: Set(output.id.0),
+                chat_id: Set(output.chat_id.0),
+                turn_id: Set(output.turn_id.0),
+                seq: Set(next_message_seq_on(&transaction, output.chat_id).await?),
+                role: Set("assistant".into()),
+                content: Set(output.content.clone()),
+                turn_lease_token: Set(Some(lease_token)),
+                created_at: Set(canonical_db_timestamp(output.created_at)?),
+            };
+            message.insert(&transaction).await.map_err(store_err)?;
+            super::super::super::citation::insert_for_message_on(&transaction, output, citations)
+                .await?;
+            Some(output.id.0)
+        }
+        None => None,
+    };
+
+    let mut cancelled = entities::turn_run::Entity::update_many()
         .col_expr(
             entities::turn_run::Column::Status,
             sea_orm::sea_query::Expr::value(TurnRunStatus::Cancelled.as_str()),
@@ -532,7 +588,14 @@ async fn finish_turn_cancellation_inner(
         .col_expr(
             entities::turn_run::Column::UpdatedAt,
             sea_orm::sea_query::Expr::value(now),
-        )
+        );
+    if let Some(message_id) = output_message_id {
+        cancelled = cancelled.col_expr(
+            entities::turn_run::Column::OutputMessageId,
+            sea_orm::sea_query::Expr::value(Some(message_id)),
+        );
+    }
+    let cancelled = cancelled
         .filter(entities::turn_run::Column::Id.eq(id.0))
         .filter(entities::turn_run::Column::Status.eq(TurnRunStatus::Cancelling.as_str()))
         .filter(entities::turn_run::Column::AttemptCount.eq(claim.attempt_count))

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -6690,7 +6690,14 @@ async fn running_turn_cancellation_holds_the_chat_until_exact_worker_acknowledge
         ..Usage::default()
     };
     let journaled = store
-        .finish_turn_cancellation_and_append_event(turn.id, token, acknowledged_at, usage)
+        .finish_turn_cancellation_and_append_event(
+            turn.id,
+            token,
+            acknowledged_at,
+            usage,
+            None,
+            &[],
+        )
         .await
         .unwrap()
         .unwrap();
@@ -6711,6 +6718,8 @@ async fn running_turn_cancellation_holds_the_chat_until_exact_worker_acknowledge
             token,
             acknowledged_at + chrono::Duration::hours(1),
             usage,
+            None,
+            &[],
         )
         .await
         .unwrap()
@@ -6726,6 +6735,8 @@ async fn running_turn_cancellation_holds_the_chat_until_exact_worker_acknowledge
             token,
             acknowledged_at + chrono::Duration::hours(1),
             Usage::default(),
+            None,
+            &[],
         )
         .await
         .is_err());
@@ -6820,6 +6831,8 @@ async fn claim_scan_terminalizes_an_expired_cancelling_lease() {
             token,
             expires_at + chrono::Duration::hours(1),
             Usage::default(),
+            None,
+            &[],
         )
         .await
         .unwrap()
@@ -10284,6 +10297,8 @@ async fn message_less_terminal_turns_rebuild_partial_text_and_reasoning() {
             cancelled_lease,
             cancellation_requested_at + chrono::Duration::seconds(1),
             Usage::default(),
+            None,
+            &[],
         )
         .await
         .unwrap()
@@ -10396,5 +10411,134 @@ async fn message_less_terminal_turns_rebuild_partial_text_and_reasoning() {
             "considering failure".into(),
             Some("provider".into()),
         )
+    );
+}
+
+/// A cancellation acknowledged with partial output commits it as the turn's
+/// durable assistant message in the same transition (#1182): the transcript
+/// serves the prose from the message row rather than rebuilding journal
+/// deltas, and the next turn's context (built from message rows) includes it.
+#[tokio::test]
+async fn cancellation_with_partial_output_commits_a_durable_message() {
+    use crate::event::AgentEvent;
+    use crate::provider::Usage;
+
+    let (_dir, store) = temp_store().await;
+
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "claude", "stop this")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    let lease = uuid::Uuid::new_v4();
+    store
+        .claim_turn_run(
+            lease,
+            accepted.available_at,
+            accepted.available_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .expect("accepted turn is claimable");
+    store
+        .append_turn_event(
+            chat.id,
+            turn_id,
+            lease,
+            1,
+            accepted.available_at,
+            &AgentEvent::TextDelta {
+                text: "the answer so far".into(),
+            },
+        )
+        .await
+        .unwrap()
+        .expect("a live attempt may journal its visible stream");
+    let requested_at = accepted.available_at + chrono::Duration::seconds(1);
+    store
+        .request_turn_cancellation(turn_id, requested_at)
+        .await
+        .unwrap()
+        .expect("running cancellation is accepted");
+
+    let output = Message {
+        id: MessageId::new(),
+        chat_id: chat.id,
+        turn_id,
+        role: Role::Assistant,
+        content: "the answer so far".into(),
+        created_at: requested_at,
+    };
+    store
+        .finish_turn_cancellation_and_append_event(
+            turn_id,
+            lease,
+            requested_at + chrono::Duration::seconds(1),
+            Usage::default(),
+            Some(&output),
+            &[],
+        )
+        .await
+        .unwrap()
+        .expect("worker acknowledges cancellation with output");
+
+    let transcript = store.get_chat_transcript(chat.id).await.unwrap().unwrap();
+    let snapshot = transcript
+        .terminal_turns
+        .last()
+        .expect("cancelled turn remains in the transcript");
+    assert_eq!(
+        (
+            snapshot.status.clone(),
+            snapshot.message_id,
+            snapshot.partial_content.as_str(),
+        ),
+        (
+            crate::storage::ChatTerminalTurnStatus::Cancelled,
+            Some(output.id),
+            "",
+        ),
+        "the committed message, not the journal rebuild, carries the prose"
+    );
+    let committed = transcript
+        .messages
+        .iter()
+        .find(|message| message.id == output.id)
+        .expect("partial output is a durable message");
+    assert_eq!(
+        (committed.role, committed.content.as_str()),
+        (Role::Assistant, "the answer so far")
+    );
+
+    // An exact retry of the same acknowledgement stays idempotent.
+    store
+        .finish_turn_cancellation_and_append_event(
+            turn_id,
+            lease,
+            requested_at + chrono::Duration::seconds(2),
+            Usage::default(),
+            Some(&output),
+            &[],
+        )
+        .await
+        .unwrap()
+        .expect("exact cancellation retry recovers");
+    assert_eq!(
+        store
+            .list_messages(chat.id)
+            .await
+            .unwrap()
+            .iter()
+            .filter(|message| message.role == Role::Assistant)
+            .count(),
+        1,
+        "a retried acknowledgement must not duplicate the output message"
     );
 }

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -2607,12 +2607,19 @@ pub trait Store: Send + Sync {
     ///
     /// Exact ambiguous retries recover both the cancelled turn and the same
     /// journal sequence, including the usage recorded by the original worker.
+    ///
+    /// `output` carries the prose the cancelled turn had already streamed; a
+    /// non-empty output commits as the turn's durable assistant message in the
+    /// same transaction, so reload and the next model turn keep what the user
+    /// was reading when they stopped the run (#1182).
     async fn finish_turn_cancellation_and_append_event(
         &self,
         _id: TurnId,
         _lease_token: uuid::Uuid,
         _now: chrono::DateTime<chrono::Utc>,
         _usage: Usage,
+        _output: Option<&Message>,
+        _citations: &[crate::AssistantCitationInput],
     ) -> Result<Option<JournaledTurnOutcome<FinishTurnCancellationOutcome>>> {
         turn_storage_unavailable()
     }

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -2564,6 +2564,8 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
             cancellation_token,
             acknowledged_at,
             usage,
+            None,
+            &[],
         )
         .await
         .unwrap()
@@ -2580,6 +2582,8 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
             cancellation_token,
             acknowledged_at + Duration::hours(1),
             usage,
+            None,
+            &[],
         )
         .await
         .unwrap()

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.test.ts
@@ -478,6 +478,56 @@ describe("terminal transcript presentation", () => {
     });
   });
 
+  it("keeps the cancellation notice on a cancelled turn that committed its partial output", () => {
+    const presented = presentChatTranscript({
+      messages: [
+        {
+          id: "question",
+          role: "user",
+          content: "Long question",
+          created_at: "2026-07-19T10:00:00Z",
+          citations: [],
+        },
+        {
+          id: "partial-answer",
+          role: "assistant",
+          content: "The answer so far",
+          created_at: "2026-07-19T10:00:30Z",
+          citations: [],
+        },
+      ],
+      tool_activity: [],
+      terminal_turns: [
+        {
+          turn_id: "turn-cancelled",
+          message_id: "partial-answer",
+          status: "cancelled",
+          partial_content: "",
+          reasoning: "Considering the first approach",
+          file_changes: [],
+          finished_at: "2026-07-19T10:01:00Z",
+        },
+      ],
+      last_event_seq: 20,
+    });
+
+    expect(
+      presented.messages.map((message) => [message.id, message.role]),
+    ).toEqual([
+      ["question", "user"],
+      ["partial-answer", "assistant"],
+      ["cancellation:partial-answer", "system"],
+    ]);
+    expect(presented.messages[1]).toMatchObject({
+      text: "The answer so far",
+      reasoning: "Considering the first approach",
+    });
+    expect(presented.messages[2]).toMatchObject({
+      text: TURN_CANCELLED_NOTICE,
+    });
+    expect(presented.messageIds).toEqual(new Set(["question", "partial-answer"]));
+  });
+
   it("uses renderer-owned copy that distinguishes an incomplete refusal", () => {
     expect(refusalCopy("cyber", false)).toBe(
       "The model declined this response because it matched the cyber safety category.",

--- a/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
+++ b/crates/openwave-desktop/ui/src/ChatTranscriptPresentation.ts
@@ -109,17 +109,31 @@ export function presentChatTranscript(
           createdAt: entry.createdAt,
           reasoning: entry.reasoning,
         } satisfies ChatMessage;
-        return entry.refusal
-          ? [
-              assistant,
-              {
-                id: `refusal:${entry.id}`,
-                role: "refusal",
-                category: entry.refusal.category,
-                partialOutput: entry.refusal.partial_output,
-              } satisfies ChatMessage,
-            ]
-          : [assistant];
+        if (entry.refusal) {
+          return [
+            assistant,
+            {
+              id: `refusal:${entry.id}`,
+              role: "refusal",
+              category: entry.refusal.category,
+              partialOutput: entry.refusal.partial_output,
+            } satisfies ChatMessage,
+          ];
+        }
+        // A cancelled turn that committed its partial prose renders as an
+        // ordinary assistant message, but the stop the user asked for still
+        // gets the same notice a message-less cancellation shows.
+        if (entry.interrupted) {
+          return [
+            assistant,
+            {
+              id: `cancellation:${entry.id}`,
+              role: "system",
+              text: TURN_CANCELLED_NOTICE,
+            } satisfies ChatMessage,
+          ];
+        }
+        return [assistant];
       }
       return [
         {

--- a/crates/openwave-desktop/ui/src/TranscriptHistory.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptHistory.ts
@@ -26,6 +26,11 @@ export type HydratedTranscriptEntry =
       refusal?: RendererRefusal;
       /** The turn's presentable reasoning summary, on assistant entries. */
       reasoning?: string;
+      /**
+       * The turn was cancelled after this assistant message's prose streamed;
+       * the partial output is durable but the stop still needs its notice.
+       */
+      interrupted?: boolean;
     }
   | {
       id: string;
@@ -117,6 +122,9 @@ export function hydrateTranscriptHistory(
           message.role === "assistant" ? terminalTurn?.refusal : undefined,
         reasoning:
           message.role === "assistant" ? terminalTurn?.reasoning : undefined,
+        interrupted:
+          message.role === "assistant" &&
+          terminalTurn?.status === "cancelled",
       };
     }),
     ...toolActivity.map((activity) => ({

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -1191,6 +1191,8 @@ impl Store for PauseTerminalStore {
         lease_token: uuid::Uuid,
         now: chrono::DateTime<chrono::Utc>,
         usage: Usage,
+        output: Option<&openwave_core::Message>,
+        citations: &[openwave_core::AssistantCitationInput],
     ) -> Result<
         Option<openwave_core::JournaledTurnOutcome<openwave_core::FinishTurnCancellationOutcome>>,
     > {
@@ -1201,7 +1203,14 @@ impl Store for PauseTerminalStore {
             self.terminalize_expired_turn(id).await?;
         }
         self.inner
-            .finish_turn_cancellation_and_append_event(id, lease_token, now, usage)
+            .finish_turn_cancellation_and_append_event(
+                id,
+                lease_token,
+                now,
+                usage,
+                output,
+                citations,
+            )
             .await
     }
     async fn append_turn_event(

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -860,8 +860,21 @@ impl TurnWorker {
                         ),
                     }
                     drop(active);
+                    // A cancel that raced the drive still keeps the prose the
+                    // cancelled outcome carried out of the loop.
+                    let partial = match drive_result {
+                        Ok(AgentTurnOutcome::Cancelled {
+                            output, citations, ..
+                        }) => output.map(|message| (message, citations)),
+                        _ => None,
+                    };
                     return self
-                        .acknowledge_cancellation(&turn, lease_token, total_usage)
+                        .acknowledge_cancellation_with_output(
+                            &turn,
+                            lease_token,
+                            total_usage,
+                            partial,
+                        )
                         .await;
                 }
                 LeaseState::Lost => return Ok(TurnWorkerOutcome::LeaseLost(turn.id)),
@@ -1857,7 +1870,12 @@ impl TurnWorker {
                     continuation_heartbeat.abort_and_wait().await;
                     continue;
                 }
-                Ok(AgentTurnOutcome::Cancelled { usage, .. }) => {
+                Ok(AgentTurnOutcome::Cancelled {
+                    output,
+                    citations,
+                    usage,
+                    ..
+                }) => {
                     match checked_usage_sum(total_usage, usage) {
                         Ok(total) => total_usage = total,
                         Err(error) => eprintln!(
@@ -1867,7 +1885,12 @@ impl TurnWorker {
                     }
                     drop(active);
                     return self
-                        .acknowledge_cancellation(&turn, lease_token, total_usage)
+                        .acknowledge_cancellation_with_output(
+                            &turn,
+                            lease_token,
+                            total_usage,
+                            output.map(|message| (message, citations)),
+                        )
                         .await;
                 }
                 Ok(AgentTurnOutcome::Failed {
@@ -2164,11 +2187,37 @@ impl TurnWorker {
         lease_token: uuid::Uuid,
         usage: openwave_core::Usage,
     ) -> Result<TurnWorkerOutcome> {
+        self.acknowledge_cancellation_with_output(turn, lease_token, usage, None)
+            .await
+    }
+
+    /// Acknowledge a cancellation, committing any partial prose the cancelled
+    /// agent loop carried out as the turn's durable output (#1182).
+    async fn acknowledge_cancellation_with_output(
+        &self,
+        turn: &TurnRun,
+        lease_token: uuid::Uuid,
+        usage: openwave_core::Usage,
+        output: Option<(
+            openwave_core::Message,
+            Vec<openwave_core::AssistantCitationInput>,
+        )>,
+    ) -> Result<TurnWorkerOutcome> {
         let terminal_event = AgentEvent::TurnCancelled { usage };
         loop {
             match self
                 .store
-                .finish_turn_cancellation_and_append_event(turn.id, lease_token, Utc::now(), usage)
+                .finish_turn_cancellation_and_append_event(
+                    turn.id,
+                    lease_token,
+                    Utc::now(),
+                    usage,
+                    output.as_ref().map(|(message, _)| message),
+                    output
+                        .as_ref()
+                        .map(|(_, citations)| citations.as_slice())
+                        .unwrap_or(&[]),
+                )
                 .await
             {
                 Ok(Some(resolution)) => {


### PR DESCRIPTION
A cancelled turn persisted no assistant text at all: streamed prose existed only as journal `TextDelta` rows, which the renderer rebuilds on reload (#1220) but the model never sees — `rebuild_transcript_with_boundary` reads durable message rows only. So the next turn continued as though the answer the user was reading (and often cancelled *because* it was sufficient, or wrong-direction) was never said. The user and model ended up with different views of the same conversation.

This makes the partial output durable:

- **Agent loop** — `AgentTurnOutcome::Cancelled` now carries `output`/`citations`. A mid-stream cancel on a text-only step parses citations and hands the partial message out; a cancel that races the completion fence keeps the fully formed answer. A step whose tool calls had started stays message-less — that step is already discarded whole under `StreamInterrupted` semantics (#1266), and this change deliberately preserves that boundary.
- **Store** — `finish_turn_cancellation_and_append_event` accepts the optional output and commits the message row, its citations, and `output_message_id` in the same transaction as the `Cancelling → Cancelled` flip, mirroring the completed/refused commit shape. Exact retries stay idempotent via the early replay branch.
- **Schema** — `Init` pinned `(completed ⟺ output_message_id)` in an anonymous CHECK on `turn_run`, so this ships a migration widening the domain to let cancelled turns carry an output. SQLite cannot alter an anonymous CHECK, so the migration rebuilds `turn_run` scratch-table-style (the `agent_run` container-location precedent); to keep the definitions from drifting, the table/check/index definitions are extracted into helpers shared by `Init` and the rebuild. PostgreSQL swaps the constraint in place (add-widened-then-drop-strict, located by definition since it was anonymous), and `down` refuses while any cancelled turn still carries output rather than stranding a half-narrowed schema.
- **Projection/UI** — a message-bearing cancelled turn now serves its prose from the message row (the `#1220` journal rebuild stays for message-less cancels and failures), and the presentation attaches the existing "Response cancelled" notice to the committed message, which previously existed only on message-less terminal turns. Model context needs no wiring: message rows already flow into the next turn's prompt.

Tests: extended `cancel_mid_stream_preempts_the_model_call` to the new contract (the partial commits instead of vanishing); new `cancellation_with_partial_output_commits_a_durable_message` covering the atomic commit, the projection flip to the message row, and ack idempotency; new presentation test pinning assistant-bubble-plus-notice for a message-bearing cancelled turn. The `#1266` conditional-marker test and the `#1220` journal-rebuild test pass unchanged, as do the full core (551) and server (498) suites, `tsc`, and the UI suites.

Labelled `full-ci` for the postgres turn-state lane, since the migration has a distinct PostgreSQL path.

Closes #1182