### PR TITLE
docs: connected-apps umbrella and REST-bindings design; record the MCP Apps view freeze

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,9 @@ Project documentation, versioned alongside the code.
 - [Execution providers and sandbox-resident agent runs](sandbox-providers.md) —
   the run-tier/execution-provider split, reachability and credential
   invariants, and the phased route to detached background agent runs.
+- [Connected apps](connected-apps.md) — the umbrella record for outside
+  integrations: MCP servers as one kind, the planned REST kind with its
+  governed local executor, and the promotion-compatible binding vocabulary.
 - [Local apps](local-apps.md) — agent-generated mini-apps in the profile:
   sandboxed frame rendering, manifest-pinned tool invocation with durable
   consent, and the planned promotion path to gateway shared apps.

--- a/docs/connected-apps.md
+++ b/docs/connected-apps.md
@@ -1,0 +1,126 @@
+# Connected apps
+
+The umbrella for outside integrations a profile can reach: one record class,
+one Settings surface, one consent vocabulary, with per-kind mechanics behind
+it. Today's MCP servers become one *kind* of connected app; this page's main
+job is to specify the second kind — a plain REST API with a credential — and
+the governed executor it requires. Local apps ([local-apps.md](local-apps.md))
+are the first consumer; the design deliberately leaves room for others.
+
+This is the design contract for the REST-bindings epic (#1330). It records
+decisions; the implementation slices are filed against it.
+
+## The record
+
+A **connected app** is a profile-scoped record: opaque id, display name,
+`kind`, and a kind-specific definition. Users think "I connected Sentry" —
+the record is that thought made durable, whatever the transport underneath.
+
+Two kinds initially:
+
+- **`mcp_server`** — today's MCP server definitions, absorbed. The
+  definition is the existing transport config (stdio command/args/env
+  selection, HTTP url, gateway endpoint). Nothing about connection
+  management, discovery bounds, health, or mounting changes; see
+  [mcp-servers.md](mcp-servers.md).
+- **`rest_api`** — a base URL, an OpenAPI document (bounded, ingested once
+  to an operation catalog keyed by `operationId`, mirroring the validation
+  posture the model gateway applies to operator-supplied specs), a
+  credential *reference* into the profile secret store, and a placement
+  (`Authorization: Bearer` or a named header). The credential value never
+  leaves the secret store except inside the executor at request time.
+  Credential-less entries (public APIs) are allowed and still governed.
+
+The vocabulary matches the model gateway's (`connected_apps` with an
+`app_kind` including both REST and MCP kinds) deliberately: a managed
+profile's gateway-served apps and an unmanaged profile's local ones read as
+the same concept, and promotion (below) is a translation, not a reframing.
+The known semantic stretch — a filesystem MCP server is not an "app" in any
+product sense — is accepted for that symmetry, as the gateway accepted it.
+
+## The executor
+
+The `rest_api` kind requires machinery OpenWave does not have today: a
+host-side executor that performs a declared operation against a connected
+app on behalf of a caller. Its guarantees, all server-side and fail-closed:
+
+- The request is validated against the ingested operation catalog — path
+  template, method, parameter shape. Undeclared operations do not execute.
+- The credential is injected by the executor at request time. It is never
+  serialized to the renderer, a frame, a model prompt, or a log.
+- Egress is bounded: DNS resolution pinned per request, private-network
+  and loopback destinations refused, redirects refused, request and
+  response byte counts capped, per-request timeout.
+- Response bounds are sized for interactive UIs, not model context
+  windows — deliberately larger than tool-result clamps.
+
+This is a scoped local analog of the gateway's governed REST tools
+(its ADR 0008), minus multi-user governance — which is exactly why managed
+profiles do not get it (below).
+
+## Bindings key off the app
+
+A local app's manifest binds capabilities of connected apps. The end-state
+vocabulary is app-first:
+
+- `{ app, tools[] }` for `mcp_server` apps — today's `{ server, tools[] }`
+  is the legacy spelling of this, keyed by namespace instead of record id.
+- `{ app, operation_ids[] }` for `rest_api` apps.
+
+Grants, the consent sheet, the invoke route's refusal ladder, and live
+fingerprint invalidation carry over unchanged; only the pinned vocabulary
+and the per-kind fingerprint differ:
+
+- `mcp_server`: the existing canonical definition form (`v:1`, fields not
+  storage — see below).
+- `rest_api`: SHA-256 over base URL + OpenAPI document hash + credential
+  *reference* + placement. Rotating the credential value behind the same
+  reference does not invalidate consent; repointing the reference does.
+
+The consent sheet leads with the app's display name ("Sentry") and lists
+pinned capabilities under it — a legibility improvement over leading with
+mounted tool names.
+
+## Migration invariant: fingerprints survive the absorption
+
+Absorbing MCP definitions into the connected-app record is a forward
+migration of storage, and one invariant is named here so no slice
+improvises it: **the `v:1` server-definition fingerprint is computed from
+definition fields, never from where or how the definition is stored.** A
+migration that preserves fields preserves every existing app grant. If it
+is ever violated, the failure mode is benign by construction — grants go
+stale and users re-consent — but wholesale re-consent churn is a bug, not
+an acceptable cost.
+
+Settings phasing: the MCP servers page remains during the epic; the
+end state is one Connected apps page listing both kinds (per-kind detail —
+health and mounting for MCP, catalog and credential status for REST). The
+phasing is presentation only; the record is authoritative from its first
+slice.
+
+## Consumers
+
+Exactly one in v1: **local-app bindings.** A connected app's catalog is not
+projected to the model as tools. That convergence — OpenWave projecting
+REST catalogs into chat turns the way the gateway does — may be wanted
+later, but it is a separate consent system (the chat approval gate, not app
+grants) and a separate decision, recorded here as deliberately not taken
+rather than drifted into.
+
+## Managed profiles
+
+On a gateway-managed profile the `rest_api` kind is refused entirely: local
+credential entry is what the managed lockdown exists to close, and the
+gateway is the sole governed REST channel — the same posture as BYOK
+provider keys and manual MCP servers. Promotion of a local app with
+`rest_api` bindings translates each binding to a gateway connected-app
+operation set one-to-one; the local record's catalog vocabulary was chosen
+so this is mechanical.
+
+## Non-goals here
+
+- OAuth-brokered kinds (Drive/Box-style source connectors) — the reserved
+  `openwave-connectors` scaffold; a future kind, not part of this epic.
+- Filesystem bindings and their consent posture — #1331.
+- Narrowing which MCP transports are app-bindable — #1332, decided once
+  REST bindings exist.

--- a/docs/local-apps.md
+++ b/docs/local-apps.md
@@ -153,6 +153,18 @@ Local stdio and HTTP servers run under whatever authority the user configured
 them with. That is the existing local trust model, unchanged — an app adds no
 authority to a server the user already mounted.
 
+## Beyond MCP bindings
+
+Mounted MCP tools are the first binding vocabulary, not the last. The
+accepted next step ([connected-apps.md](connected-apps.md), tracked by
+#1330) makes MCP servers one *kind* of a broader connected-app record and
+adds a `rest_api` kind — a base URL, an ingested OpenAPI catalog, and a
+secret-store credential — executed through a governed local egress layer.
+App manifests then gain a sibling binding kind, `{ app, operation_ids[] }`,
+with the grant, consent-sheet, and invoke machinery on this page carried
+over unchanged. Until that lands, MCP tools remain the only callable
+surface.
+
 ## The authorization gate
 
 The invoke route rides the per-launch loopback bearer, which is a capability

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -97,6 +97,17 @@ output still never reach the renderer.
 Views are served from memory and refreshed on reconnect. If a view cannot be
 fetched, its card degrades to a reconnect hint; the tool itself is unaffected.
 
+The view surface is deliberately frozen at this scope. The bridge answers
+`ui/initialize` with empty host capabilities and refuses every other request:
+a view renders one call's delivered payload and never initiates calls, which
+is why it is safe to run with no consent surface of its own. Any future
+view-initiated interactivity must ride the local-app grant machinery
+([local-apps.md](local-apps.md)) rather than a new approval door. Revisit
+point on record: once local apps and gateway promotion have shipped, if the
+gateway's inline console remains the only `ui://` producer in practice and a
+promoted app covers its use case, deprecating this surface is the recorded
+default — it would remove a special case, not a subsystem.
+
 ## Headless bootstrap
 
 `openwave serve` can still read an initial configuration from the JSON file


### PR DESCRIPTION
Step 1 of #1330 (kept open — this PR is the epic's design contract, not its implementation), and the whole of #1333.

**docs/connected-apps.md (new):** the umbrella record for outside integrations, as settled in design discussion:
- One profile-scoped connected-app record; `mcp_server` (today's definitions, absorbed) and `rest_api` (base URL + ingested OpenAPI catalog + secret-store credential reference + placement) as the initial kinds. Vocabulary deliberately matches the model gateway's.
- The governed local executor's guarantees for the REST kind: catalog validation, request-time credential injection that never reaches renderer/frame/model, pinned + bounded egress, UI-sized response bounds.
- App-first binding vocabulary (`{app, tools[]}` / `{app, operation_ids[]}`) with per-kind fingerprints; grants/consent/invoke machinery unchanged.
- Named migration invariant: `v:1` definition fingerprints are computed from fields, not storage — absorption must not stale existing grants.
- Exactly one consumer in v1 (local-app bindings; no model projection — recorded as a decision, not drift), and the managed-profile posture: `rest_api` refused locally, gateway is the sole governed REST channel.

**docs/local-apps.md:** "Beyond MCP bindings" pointer section.

**docs/mcp-servers.md:** records the MCP App views display-only freeze (empty host capabilities are intentional; any future view interactivity rides app grants) and the deprecation revisit point. Closes #1333.

**docs/README.md:** index entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)