### PR TITLE
fix(desktop): stall-aware working indicator during a streaming response

### DIFF
--- a/crates/openwave-desktop/ui/src/AssistantWorkingIndicator.test.tsx
+++ b/crates/openwave-desktop/ui/src/AssistantWorkingIndicator.test.tsx
@@ -74,6 +74,38 @@ describe("AssistantWorkingIndicator", () => {
     ).toBe(false);
   });
 
+  it("returns under a partial response when the stream has stalled", () => {
+    const partial: ChatMessage[] = [
+      {
+        id: "assistant-streaming",
+        role: "assistant",
+        text: "Partial response",
+        sources: [],
+      },
+    ];
+
+    expect(shouldShowAssistantWorking(partial, true, 0, true)).toBe(true);
+    // A stall never overrides a more specific live status or a closed turn.
+    expect(
+      shouldShowAssistantWorking(
+        [
+          ...partial,
+          {
+            id: "tool",
+            role: "tool",
+            callId: "call",
+            name: "web_search",
+            status: "running",
+          },
+        ],
+        true,
+        0,
+        true,
+      ),
+    ).toBe(false);
+    expect(shouldShowAssistantWorking(partial, false, 0, true)).toBe(false);
+  });
+
   it("defers to active tool and user-action statuses", () => {
     const runningTool: ChatMessage = {
       id: "tool",

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -21,6 +21,7 @@ import { useTranscriptVisible } from "./TranscriptVisibility";
 import { useFolderAccessRequests } from "./useFolderAccessRequests";
 import { useOutputWritebackRequests } from "./useOutputWritebackRequests";
 import { useToolApprovals } from "./useToolApprovals";
+import { useStreamStalled } from "./useStreamStalled";
 import { useTurnControls } from "./useTurnControls";
 import { usePlanApprovals } from "./usePlanApprovals";
 import { useUserQuestions } from "./useUserQuestions";
@@ -91,6 +92,10 @@ export function ChatView({
   const messages = useChatSessionStore((session) => session.messages);
   const busy = useChatSessionStore((session) => session.busy);
   const activeTurnId = useChatSessionStore((session) => session.activeTurnId);
+  // Every applied stream event advances the seq cursor, so it doubles as the
+  // liveness signal for the stall-aware working indicator.
+  const lastSeq = useChatSessionStore((session) => session.lastSeq);
+  const streamStalled = useStreamStalled(busy, lastSeq);
   const backgroundAgentSpawnKeys = useMemo(
     () =>
       messages.flatMap((message) =>
@@ -288,6 +293,7 @@ export function ChatView({
           onLoadBackgroundAgentActivity={agentRuns.loadActivity}
           onViewBackgroundAgentOutput={onViewOutput}
           busy={busy}
+          streamStalled={streamStalled}
           scrollRef={attachScrollRef}
           contentRef={attachContentRef}
           maskClass={maskClass}

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -192,6 +192,8 @@ type MessageListProps = {
   ) => Promise<AgentActivityHistoryEntry[]>;
   onViewBackgroundAgentOutput?: () => void;
   busy: boolean;
+  /** The live turn's stream has gone quiet — see [useStreamStalled]. */
+  streamStalled?: boolean;
   scrollRef: Ref<HTMLDivElement>;
   /** Attached to the transcript content column so growth can drive auto-follow. */
   contentRef?: RefCallback<HTMLDivElement>;
@@ -261,6 +263,7 @@ export function MessageList({
   onLoadBackgroundAgentActivity = async () => [],
   onViewBackgroundAgentOutput,
   busy,
+  streamStalled = false,
   scrollRef,
   contentRef,
   maskClass,
@@ -427,6 +430,7 @@ export function MessageList({
           outputWritebackRequests.length +
           userQuestionRequests.length +
           planApprovalRequests.length,
+        streamStalled,
       ) && <AssistantWorkingIndicator />}
     </>
   );
@@ -1071,11 +1075,18 @@ export function refusalCopy(
 /**
  * The generic worker indicator fills only gaps where no more specific live or
  * user-action status is already visible. All copy remains renderer-owned.
+ *
+ * A partial assistant response normally suppresses the indicator — the
+ * streaming text is its own liveness signal. `streamStalled` reopens that one
+ * gap: when the live stream has gone quiet mid-response, the indicator
+ * returns under the partial text so a slow model reads differently from a
+ * hung one, and hides again the moment deltas resume.
  */
 export function shouldShowAssistantWorking(
   messages: readonly ChatMessage[],
   busy: boolean,
   pendingFolderAccessCount: number,
+  streamStalled = false,
 ): boolean {
   if (!busy || pendingFolderAccessCount > 0) return false;
   const hasSpecificPendingStatus = messages.some(
@@ -1091,7 +1102,10 @@ export function shouldShowAssistantWorking(
 
   const latest = messages[messages.length - 1];
   if (latest?.role === "assistant") {
-    return latest.text.trim().length === 0 && latest.sources.length === 0;
+    return (
+      streamStalled ||
+      (latest.text.trim().length === 0 && latest.sources.length === 0)
+    );
   }
   if (
     latest?.role === "system" ||

--- a/crates/openwave-desktop/ui/src/useStreamStalled.test.ts
+++ b/crates/openwave-desktop/ui/src/useStreamStalled.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { STREAM_STALL_MS, useStreamStalled } from "./useStreamStalled";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe("useStreamStalled", () => {
+  it("stalls after the quiet period, clears on activity, and ends with the turn", () => {
+    const { result, rerender } = renderHook(
+      ({ busy, seq }) => useStreamStalled(busy, seq),
+      { initialProps: { busy: true, seq: 1 } },
+    );
+
+    expect(result.current).toBe(false);
+    act(() => void vi.advanceTimersByTime(STREAM_STALL_MS));
+    expect(result.current).toBe(true);
+
+    // A delta arrives: the stall clears immediately and the timer restarts.
+    rerender({ busy: true, seq: 2 });
+    expect(result.current).toBe(false);
+    act(() => void vi.advanceTimersByTime(STREAM_STALL_MS - 1));
+    expect(result.current).toBe(false);
+    act(() => void vi.advanceTimersByTime(1));
+    expect(result.current).toBe(true);
+
+    // The turn closes: never stalled while idle, however long it sits.
+    rerender({ busy: false, seq: 2 });
+    expect(result.current).toBe(false);
+    act(() => void vi.advanceTimersByTime(STREAM_STALL_MS * 2));
+    expect(result.current).toBe(false);
+  });
+});

--- a/crates/openwave-desktop/ui/src/useStreamStalled.ts
+++ b/crates/openwave-desktop/ui/src/useStreamStalled.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+/** How long the live stream must go quiet before the turn counts as stalled. */
+export const STREAM_STALL_MS = 2000;
+
+/**
+ * True while a live turn's event stream has gone quiet for [`STREAM_STALL_MS`].
+ *
+ * `activitySeq` is the session's applied-event cursor: every stream event a
+ * turn produces (text and reasoning deltas, tool activity, boundaries)
+ * advances it, so any advance restarts the quiet-period timer and clears the
+ * stall. The timer lives here rather than in the session reducer so the
+ * reducer stays a pure, clock-free state machine.
+ */
+export function useStreamStalled(busy: boolean, activitySeq: number): boolean {
+  const [stalled, setStalled] = useState(false);
+  useEffect(() => {
+    setStalled(false);
+    if (!busy) return;
+    const timer = setTimeout(() => setStalled(true), STREAM_STALL_MS);
+    return () => clearTimeout(timer);
+  }, [busy, activitySeq]);
+  return busy && stalled;
+}


### PR DESCRIPTION
Closes #1183.

`shouldShowAssistantWorking` hides the working indicator as soon as the trailing assistant bubble has any text, so a mid-stream stall shows nothing at all — a slow model is indistinguishable from a hung one. That suppression is deliberate (an always-on loader under every streaming response was rejected when this was split out of #1163), so this takes the stall-aware middle path: while a turn is live, if no stream event arrives for 2 seconds the indicator reappears under the partial text, and it hides again the moment activity resumes.

- `useStreamStalled` owns the timer at the component layer, keyed on `busy` and the session's `lastSeq` cursor — every applied stream event (text/reasoning deltas, tool activity) advances `lastSeq`, so any activity restarts the quiet-period timer. The session reducer stays a pure, clock-free state machine; no reducer changes.
- `shouldShowAssistantWorking` gains an optional `streamStalled` flag that reopens only the partial-response gap. A stall never overrides a more specific live status (running tool, unresolved approval, pending user-action cards) and never shows on a closed turn.
- `ChatView` computes the flag from the session store and threads it into `MessageList`.

Tests: one fake-timer test for the stall/clear/idle contract of the hook, and one for the `shouldShowAssistantWorking` stall gap (shows under stalled partial text, still defers to a running tool, never on an idle turn). The existing "does not compete with a partial assistant response" test still passes unchanged — the default path is untouched.

Verified with `tsc --noEmit` and the touched vitest files (indicator, MessageList, ChatView suites).