### PR TITLE
fix(core): close all built-in tool argument objects with deny_unknown_fields

### DIFF
--- a/crates/openwave-core/src/tools/list_dir.rs
+++ b/crates/openwave-core/src/tools/list_dir.rs
@@ -15,6 +15,7 @@ use super::private_scratch::{list_directory, relative_path};
 pub struct ListDir;
 
 #[derive(Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub(super) struct Arguments {
     #[serde(default)]
     #[schemars(

--- a/crates/openwave-core/src/tools/read_file.rs
+++ b/crates/openwave-core/src/tools/read_file.rs
@@ -15,6 +15,7 @@ use super::private_scratch::{file_name, line_count, read_utf8_file, relative_pat
 pub struct ReadFile;
 
 #[derive(Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub(super) struct Arguments {
     #[schemars(description = "Private-scratch-relative file path.")]
     path: String,

--- a/crates/openwave-core/src/tools/tests.rs
+++ b/crates/openwave-core/src/tools/tests.rs
@@ -73,7 +73,8 @@ async fn built_in_tool_schemas_preserve_their_provider_contracts() {
                     "description": "Private-scratch-relative file path."
                 }
             },
-            "required": ["path"]
+            "required": ["path"],
+            "additionalProperties": false
         })
     );
     assert_eq!(
@@ -85,7 +86,8 @@ async fn built_in_tool_schemas_preserve_their_provider_contracts() {
                     "type": "string",
                     "description": "Private-scratch-relative directory (optional)."
                 }
-            }
+            },
+            "additionalProperties": false
         })
     );
     assert_eq!(
@@ -102,9 +104,25 @@ async fn built_in_tool_schemas_preserve_their_provider_contracts() {
                     "description": "File contents to write."
                 }
             },
-            "required": ["path", "content"]
+            "required": ["path", "content"],
+            "additionalProperties": false
         })
     );
+}
+
+#[tokio::test]
+async fn unknown_arguments_are_refused_not_ignored() {
+    let output = ReadFile
+        .execute(
+            &ToolCtx::without_private_scratch(ChatId::new(), None),
+            json!({"path": "note.txt", "encoding": "utf-8"}),
+        )
+        .await
+        .unwrap();
+
+    assert!(output.is_error);
+    assert!(output.content.contains("invalid arguments:"));
+    assert!(output.content.contains("unknown field"));
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/tools/write_file.rs
+++ b/crates/openwave-core/src/tools/write_file.rs
@@ -15,6 +15,7 @@ use super::private_scratch::{file_name, relative_path, write_utf8_file};
 pub struct WriteFile;
 
 #[derive(Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub(super) struct Arguments {
     #[schemars(description = "Private-scratch-relative file path.")]
     path: String,


### PR DESCRIPTION
`read_file`, `list_dir`, and `write_file` were the only typed tool arguments in the crate without `#[serde(deny_unknown_fields)]`; every other site already closes its object. This adds the attribute to those three, so all built-ins now follow one principle: closed argument objects.

The rationale: a stray field in a tool call is almost always the model hallucinating a parameter that silently does nothing. Closing the object turns that into the same model-facing `invalid arguments` refusal (with the expected schema echoed back) that other tools already produce via `tools::arguments::parse`, giving the model a chance to correct itself instead of quietly getting less than it asked for. The advertised schemas gain `additionalProperties: false` accordingly.

Tests: updated the provider-contract schema assertions for the new `additionalProperties: false`, and added one behavior test pinning that an unknown field is refused through the standard malformed-arguments path (one test, not one per tool — the mechanism is shared).

Closes #1158