### PR TITLE
feat(server): resolve a typed principal and executor capability at the auth boundary

### DIFF
--- a/crates/openwave-server/src/auth.rs
+++ b/crates/openwave-server/src/auth.rs
@@ -19,6 +19,7 @@ use axum::http::{
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 
+use crate::principal::{AuthContext, Principal};
 use crate::state::AppState;
 
 /// Handshake subprotocol the server selects when the client offered it.
@@ -40,13 +41,21 @@ pub const CLIENT_EXECUTOR_HEADER: HeaderName =
 /// `Sec-WebSocket-Protocol: openwave-token.<token>`.
 pub async fn require_token(
     State(state): State<AppState>,
-    request: Request,
+    mut request: Request,
     next: Next,
 ) -> Response {
     let presented = extract_token(request.headers());
 
     match presented {
         Some(token) if constant_time_eq(token.as_bytes(), state.token.as_bytes()) => {
+            // The per-launch bearer is loopback-only and handed to one client,
+            // so the verified caller *is* the local owner. This is the only
+            // place a principal is minted; handlers learn it through the
+            // fail-closed `AuthContext` extractor.
+            request.extensions_mut().insert(AuthContext {
+                principal: Principal::LocalOwner,
+                client_executor: false,
+            });
             next.run(request).await
         }
         _ => StatusCode::UNAUTHORIZED.into_response(),
@@ -54,9 +63,14 @@ pub async fn require_token(
 }
 
 /// Require the second credential held only by the trusted native host.
+///
+/// The credential is a capability, not a principal: it marks the bit on the
+/// [`AuthContext`] the bearer middleware already attached, and fails closed if
+/// no context is present — the native credential alone names nobody and must
+/// never admit a request by itself.
 pub async fn require_client_executor_token(
     State(state): State<AppState>,
-    request: Request,
+    mut request: Request,
     next: Next,
 ) -> Response {
     let presented = request
@@ -67,6 +81,13 @@ pub async fn require_client_executor_token(
         Some(token)
             if constant_time_eq(token.as_bytes(), state.client_executor_token.as_bytes()) =>
         {
+            let Some(auth) = request.extensions().get::<AuthContext>().copied() else {
+                return StatusCode::UNAUTHORIZED.into_response();
+            };
+            request.extensions_mut().insert(AuthContext {
+                client_executor: true,
+                ..auth
+            });
             next.run(request).await
         }
         _ => StatusCode::UNAUTHORIZED.into_response(),

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -35,6 +35,7 @@ mod mcp_config;
 mod model_registry;
 mod model_roles;
 mod pairing;
+mod principal;
 mod provider;
 mod providers;
 mod resolver;

--- a/crates/openwave-server/src/principal.rs
+++ b/crates/openwave-server/src/principal.rs
@@ -1,0 +1,140 @@
+//! Who is asking — resolved once at the authentication boundary.
+//!
+//! The per-launch credentials in [`crate::auth`] are capability checks: they
+//! prove the caller was handed a secret by this process, not who the caller
+//! is. This module gives request handling a typed answer to "who is asking"
+//! so authorization can grow from "the token is valid" to "this principal may
+//! see this row" without re-plumbing the request path (#853).
+//!
+//! Two rules are load-bearing:
+//!
+//! - **The context is attached only by the auth middleware.** [`AuthContext`]
+//!   is an extractor that fails closed: a handler that asks for it on a route
+//!   the auth layer does not cover gets `401`, never a defaulted identity.
+//! - **The client-executor credential is a capability, not a principal.** It
+//!   marks a bit on an existing context; it cannot conjure an identity on its
+//!   own. [`ClientExecutor`] types that requirement into handler signatures so
+//!   it survives router refactors.
+
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use axum::http::StatusCode;
+
+/// The authenticated identity a request acts as.
+///
+/// Today the only inhabitant is the single local owner: the desktop bearer is
+/// per-launch and loopback-only, so whoever presents it is the one person at
+/// the machine. A shared deployment adds a variant whose token names a user;
+/// nothing downstream may assume `LocalOwner` is the only case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Principal {
+    /// The one person at the machine, authenticated by the per-launch bearer.
+    LocalOwner,
+}
+
+/// The authentication result the middleware attaches to a verified request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AuthContext {
+    /// Who the request acts as.
+    pub principal: Principal,
+    /// Whether the request also presented the native client-executor
+    /// credential. Host authority (claiming delegated work, touching the
+    /// filesystem), not identity — it never widens what `principal` may see.
+    pub client_executor: bool,
+}
+
+impl<S: Send + Sync> FromRequestParts<S> for AuthContext {
+    /// Absence means the auth middleware never ran for this route — an
+    /// unauthenticated request, as far as any identity consumer is concerned.
+    type Rejection = StatusCode;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<AuthContext>()
+            .copied()
+            .ok_or(StatusCode::UNAUTHORIZED)
+    }
+}
+
+/// Proof the request presented the native client-executor credential on top of
+/// an authenticated principal.
+///
+/// Handlers on the native-only surface take this so the requirement is part of
+/// the handler's type, not only of which router it happens to be mounted on.
+/// When owner-scoped queries land, this grows the principal the capability was
+/// granted on; until a consumer exists it stays a bare proof token.
+#[derive(Debug, Clone, Copy)]
+pub struct ClientExecutor;
+
+impl<S: Send + Sync> FromRequestParts<S> for ClientExecutor {
+    type Rejection = StatusCode;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let auth = AuthContext::from_request_parts(parts, state).await?;
+        if auth.client_executor {
+            Ok(Self)
+        } else {
+            Err(StatusCode::UNAUTHORIZED)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::get;
+    use axum::Router;
+    use tower::ServiceExt;
+
+    /// The boundary contract: a route the auth middleware does not cover
+    /// cannot observe an identity — the extractors fail closed instead of
+    /// defaulting to the local owner.
+    #[tokio::test]
+    async fn extractors_fail_closed_without_the_auth_middleware() {
+        let app = Router::new()
+            .route("/principal", get(|_auth: AuthContext| async { "leaked" }))
+            .route(
+                "/capability",
+                get(|_executor: ClientExecutor| async { "leaked" }),
+            );
+
+        for uri in ["/principal", "/capability"] {
+            let response = app
+                .clone()
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::UNAUTHORIZED,
+                "{uri} must reject when no middleware attached a context"
+            );
+        }
+    }
+
+    /// A principal without the native credential is not a client executor.
+    #[tokio::test]
+    async fn capability_is_not_implied_by_identity() {
+        let app = Router::new()
+            .route("/", get(|_executor: ClientExecutor| async { "leaked" }))
+            .layer(axum::middleware::from_fn(
+                |mut request: Request<Body>, next: axum::middleware::Next| async move {
+                    request.extensions_mut().insert(AuthContext {
+                        principal: Principal::LocalOwner,
+                        client_executor: false,
+                    });
+                    next.run(request).await
+                },
+            ));
+
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/openwave-server/src/routes/client_execution.rs
+++ b/crates/openwave-server/src/routes/client_execution.rs
@@ -21,6 +21,7 @@ use openwave_core::{
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
+use crate::principal::ClientExecutor;
 use crate::state::AppState;
 
 const CLIENT_EXECUTION_LEASE: Duration = Duration::seconds(60);
@@ -210,6 +211,7 @@ pub async fn list_pending_output_writebacks(
 /// Native-only authoritative pending work used by the trusted executor.
 pub async fn list_pending_client_executions_raw(
     State(state): State<AppState>,
+    _executor: ClientExecutor,
     Path(id): Path<ChatId>,
 ) -> Result<Json<Vec<ToolCallRecord>>, ServerError> {
     ensure_chat(&state, id).await?;
@@ -268,6 +270,7 @@ fn renderer_output_writeback_request(
 /// `POST .../{call_id}/claim` — atomically acquire or recover one exact claim.
 pub async fn claim_client_execution(
     State(state): State<AppState>,
+    _executor: ClientExecutor,
     Path((id, call_id)): Path<(ChatId, CallId)>,
     Json(body): Json<ClaimClientExecution>,
 ) -> Result<Json<ClaimedClientExecution>, ServerError> {
@@ -307,6 +310,7 @@ pub async fn claim_client_execution(
 /// repeated request can extend the lease again from its new server receive time.
 pub async fn heartbeat_client_execution(
     State(state): State<AppState>,
+    _executor: ClientExecutor,
     Path((id, call_id)): Path<(ChatId, CallId)>,
     Json(body): Json<HeartbeatClientExecution>,
 ) -> Result<Json<ClientExecutionHeartbeat>, ServerError> {
@@ -342,6 +346,7 @@ pub async fn heartbeat_client_execution(
 /// with the first committed result.
 pub async fn resolve_client_execution(
     State(state): State<AppState>,
+    _executor: ClientExecutor,
     Path((id, call_id)): Path<(ChatId, CallId)>,
     Json(body): Json<ResolveClientExecution>,
 ) -> Result<Json<ResolvedClientExecution>, ServerError> {

--- a/crates/openwave-server/src/routes/delegated_file_execution.rs
+++ b/crates/openwave-server/src/routes/delegated_file_execution.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
+use crate::principal::ClientExecutor;
 use crate::state::AppState;
 
 const DELEGATED_FILE_EXECUTION_LEASE: Duration = Duration::seconds(60);
@@ -111,6 +112,7 @@ pub struct ResolvedDelegatedFileRead {
 
 pub async fn list_pending_delegated_file_reads(
     State(state): State<AppState>,
+    _executor: ClientExecutor,
 ) -> Result<Json<Vec<PendingDelegatedFileRead>>, ServerError> {
     let pending = state
         .store
@@ -127,6 +129,7 @@ pub async fn list_pending_delegated_file_reads(
 
 pub async fn claim_delegated_file_read(
     State(state): State<AppState>,
+    _executor: ClientExecutor,
     Path(call_id): Path<CallId>,
     Json(body): Json<ClaimDelegatedFileReadBody>,
 ) -> Result<Json<ClaimedDelegatedFileRead>, ServerError> {
@@ -163,6 +166,7 @@ pub async fn claim_delegated_file_read(
 
 pub async fn heartbeat_delegated_file_read(
     State(state): State<AppState>,
+    _executor: ClientExecutor,
     Path(call_id): Path<CallId>,
     Json(body): Json<DelegatedFileLeaseBody>,
 ) -> Result<Json<DelegatedFileHeartbeat>, ServerError> {
@@ -184,6 +188,7 @@ pub async fn heartbeat_delegated_file_read(
 
 pub async fn resolve_delegated_file_read(
     State(state): State<AppState>,
+    _executor: ClientExecutor,
     Path(call_id): Path<CallId>,
     Json(body): Json<ResolveDelegatedFileReadBody>,
 ) -> Result<Json<ResolvedDelegatedFileRead>, ServerError> {

--- a/crates/openwave-server/src/routes/root_attachment.rs
+++ b/crates/openwave-server/src/routes/root_attachment.rs
@@ -17,6 +17,7 @@ use uuid::Uuid;
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path, Query};
+use crate::principal::ClientExecutor;
 use crate::state::AppState;
 
 const DEFAULT_PENDING_LIMIT: u64 = 64;
@@ -132,6 +133,7 @@ pub struct PendingRootAttachmentChanges {
 /// Begin or recover one exact product-side attachment intent.
 pub async fn begin_root_attachment_change(
     State(state): State<AppState>,
+    _executor: ClientExecutor,
     Path((chat_id, change_id)): Path<(ChatId, RootAttachmentChangeId)>,
     Json(body): Json<BeginRootAttachmentChangeBody>,
 ) -> Result<Json<BegunRootAttachmentChange>, ServerError> {
@@ -199,6 +201,7 @@ pub async fn begin_root_attachment_change(
 /// List awaiting work owned by this app-private native executor.
 pub async fn list_pending_root_attachment_changes(
     State(state): State<AppState>,
+    _executor: ClientExecutor,
     Query(query): Query<PendingRootAttachmentChangesQuery>,
 ) -> Result<Json<PendingRootAttachmentChanges>, ServerError> {
     let limit = query.limit.unwrap_or(DEFAULT_PENDING_LIMIT);
@@ -220,6 +223,7 @@ pub async fn list_pending_root_attachment_changes(
 /// Finish or recover one exact product-side attachment change.
 pub async fn finish_root_attachment_change(
     State(state): State<AppState>,
+    _executor: ClientExecutor,
     Path(change_id): Path<RootAttachmentChangeId>,
     Json(body): Json<FinishRootAttachmentChangeBody>,
 ) -> Result<Json<FinishedRootAttachmentChange>, ServerError> {

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -2476,3 +2476,105 @@ async fn client_execution_api_validates_scope_identity_and_terminal_payloads() {
     .await;
     assert_eq!(oversized.status(), StatusCode::BAD_REQUEST);
 }
+
+/// The native-only surface requires a principal, not just the capability:
+/// presenting only the client-executor credential names nobody and is
+/// rejected before any handler runs.
+#[tokio::test]
+async fn client_executor_credential_alone_is_rejected() {
+    let (router, _token, _store, _dir) = test_app().await;
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .uri("/sandbox-file-reads/pending")
+                .header(
+                    crate::auth::CLIENT_EXECUTOR_HEADER,
+                    crate::state::TEST_CLIENT_EXECUTOR_TOKEN,
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// The auth middleware is the one place a principal is minted: the bearer
+/// resolves to the local owner without the executor capability, the native
+/// credential upgrades the capability bit on that principal, and the
+/// capability alone cannot reach a handler. Probes the real middlewares in
+/// the production layering (bearer outermost).
+#[tokio::test]
+async fn auth_middleware_resolves_principal_and_capability() {
+    use crate::principal::{AuthContext, Principal};
+
+    let (_app, token, state, _store, _dir) = test_app_with_state().await;
+    let whoami = |auth: AuthContext| async move {
+        format!(
+            "{}|{}",
+            matches!(auth.principal, Principal::LocalOwner),
+            auth.client_executor
+        )
+    };
+    let native = axum::Router::new()
+        .route("/native", axum::routing::get(whoami))
+        .route_layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            crate::auth::require_client_executor_token,
+        ));
+    let probe = axum::Router::new()
+        .route("/whoami", axum::routing::get(whoami))
+        .merge(native)
+        .route_layer(axum::middleware::from_fn_with_state(
+            state,
+            crate::auth::require_token,
+        ));
+    let bearer = format!("Bearer {token}");
+
+    let request = |uri: &str, with_executor: bool| {
+        let mut builder = Request::builder()
+            .uri(uri)
+            .header(header::AUTHORIZATION, &bearer);
+        if with_executor {
+            builder = builder.header(
+                crate::auth::CLIENT_EXECUTOR_HEADER,
+                crate::state::TEST_CLIENT_EXECUTOR_TOKEN,
+            );
+        }
+        builder.body(Body::empty()).unwrap()
+    };
+
+    let response = probe
+        .clone()
+        .oneshot(request("/whoami", false))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), 1024).await.unwrap();
+    assert_eq!(&body[..], b"true|false", "bearer resolves the local owner");
+
+    let response = probe
+        .clone()
+        .oneshot(request("/native", false))
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "a principal without the native credential lacks the capability"
+    );
+
+    let response = probe
+        .clone()
+        .oneshot(request("/native", true))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), 1024).await.unwrap();
+    assert_eq!(
+        &body[..],
+        b"true|true",
+        "the native credential marks the capability on the same principal"
+    );
+}


### PR DESCRIPTION
Slice 1 of the authorization sequence planned on #853 (see the plan comment there). Does not close the issue — it is the gate for the whole track.

Today the two per-launch credentials in `auth.rs` are pure capability checks: they prove the caller holds a secret this process minted, and nothing downstream of the middleware knows who is asking. The "who" question has no representation at all, so per-principal authorization has nowhere to attach.

This PR gives the request path a typed answer without touching storage or behavior:

- **`principal.rs`**: `Principal` (single `LocalOwner` variant today, `#[non_exhaustive]`) and `AuthContext { principal, client_executor }`. `require_token` mints the context after verifying the bearer — the per-launch loopback bearer belongs to the one person at the machine, so the verified caller *is* the local owner. This is the only place a principal is created.
- **Fail-closed extraction**: `AuthContext` is an axum extractor that answers 401 when no middleware attached a context. A handler that asks "who is asking" on a route accidentally mounted outside the auth layer cannot observe a defaulted identity.
- **Capability, not principal**: `require_client_executor_token` now marks the capability bit on an *existing* context and rejects when none is present — the native credential alone names nobody and can no longer be a self-sufficient admission path, encoding the credential-boundary rule from #853. The native-only handlers (delegated file reads, client executions, root-attachment changes) take a `ClientExecutor` extractor, so the requirement is part of the handler's type rather than only of which router it happens to be mounted on.

No storage schema, wire type, or observable behavior changes; every existing route answers exactly as before.

Tests are boundary contracts only: the extractors fail closed without the middleware; the capability is not implied by identity; the native credential alone is rejected on a real native route; and the production middleware layering resolves `LocalOwner` and the capability bit correctly.

Next slice: token verification maps credential → named principal so a shared profile's token identifies a user (desktop stays `LocalOwner`), then owner attribution and scoped queries behind the `Store` trait.
