### PR TITLE
feat(core): single bounded retry for transient sandbox web-search failures

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -766,6 +766,7 @@ pub mod sandbox_tool_call {
         pub park_claim_count: i32,
         pub executor_lease_token: Option<Uuid>,
         pub executor_lease_expires_at: Option<DateTimeUtc>,
+        pub retry_at: Option<DateTimeUtc>,
         pub created_at: DateTimeUtc,
         pub resolved_at: Option<DateTimeUtc>,
     }

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -104,6 +104,7 @@ impl MigratorTrait for Migrator {
             Box::new(AddChatNetworkPolicy),
             Box::new(ExtendUserQuestions),
             Box::new(RetainCancelledTurnOutput),
+            Box::new(AddSandboxToolCallRetry),
         ]
     }
 }
@@ -4244,139 +4245,166 @@ async fn create_turn_agent_run_wait_set_tables(manager: &SchemaManager<'_>) -> R
         .await
 }
 
+/// The `sandbox_tool_call` table, shared between its creating migration and
+/// the retry-state rebuild migration so the two definitions cannot drift.
+/// `table` is the physical table to create — the canonical one on creation, a
+/// scratch alias during a SQLite rebuild. `retry` selects the status domain:
+/// the original, or widened with `retry_wait` plus the `retry_at` column that
+/// parks one classified-transient failure for its single bounded retry
+/// (#1224).
+/// The status domain of `sandbox_tool_call`. Strict: the original vocabulary.
+/// Widened (#1224): `retry_wait` parks one classified-transient failure until
+/// its single bounded retry becomes claimable.
+fn sandbox_tool_call_status_check(retry: bool) -> SimpleExpr {
+    let mut valid_status = vec![
+        SandboxToolCallStatus::Accepted.as_str(),
+        SandboxToolCallStatus::Claimed.as_str(),
+        SandboxToolCallStatus::Completed.as_str(),
+        SandboxToolCallStatus::Failed.as_str(),
+        SandboxToolCallStatus::Cancelled.as_str(),
+    ];
+    if retry {
+        valid_status.insert(2, SandboxToolCallStatus::RetryWait.as_str());
+    }
+    Expr::col(SandboxToolCall::Status).is_in(valid_status)
+}
+
+fn sandbox_tool_call_table<T>(table: T, retry: bool) -> TableCreateStatement
+where
+    T: IntoTableRef + Clone,
+{
+    let mut statement = Table::create();
+    statement
+        .table(table.clone())
+        .if_not_exists()
+        .col(
+            ColumnDef::new(SandboxToolCall::Id)
+                .uuid()
+                .not_null()
+                .primary_key(),
+        )
+        .col(
+            ColumnDef::new(SandboxToolCall::AgentRunId)
+                .uuid()
+                .not_null(),
+        )
+        .col(ColumnDef::new(SandboxToolCall::ChatId).uuid().not_null())
+        .col(
+            ColumnDef::new(SandboxToolCall::AgentRunDepth)
+                .small_integer()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(SandboxToolCall::ProviderId)
+                .text()
+                .not_null(),
+        )
+        .col(ColumnDef::new(SandboxToolCall::Name).text().not_null())
+        .col(
+            ColumnDef::new(SandboxToolCall::Arguments)
+                .json_binary()
+                .not_null(),
+        )
+        .col(ColumnDef::new(SandboxToolCall::Status).text().not_null())
+        .col(
+            ColumnDef::new(SandboxToolCall::ParkLeaseToken)
+                .uuid()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(SandboxToolCall::ParkAttemptCount)
+                .integer()
+                .not_null(),
+        )
+        .col(
+            ColumnDef::new(SandboxToolCall::ParkClaimCount)
+                .integer()
+                .not_null(),
+        )
+        .col(ColumnDef::new(SandboxToolCall::ExecutorLeaseToken).uuid())
+        .col(ColumnDef::new(SandboxToolCall::ExecutorLeaseExpiresAt).timestamp_with_time_zone());
+    if retry {
+        statement.col(ColumnDef::new(SandboxToolCall::RetryAt).timestamp_with_time_zone());
+    }
+    statement
+        .col(
+            ColumnDef::new(SandboxToolCall::CreatedAt)
+                .timestamp_with_time_zone()
+                .not_null(),
+        )
+        .col(ColumnDef::new(SandboxToolCall::ResolvedAt).timestamp_with_time_zone())
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_sandbox_tool_call_run")
+                .from_tbl(table.clone())
+                .from_col(SandboxToolCall::AgentRunId)
+                .from_col(SandboxToolCall::ChatId)
+                .from_col(SandboxToolCall::AgentRunDepth)
+                .to_tbl(AgentRun::Table)
+                .to_col(AgentRun::Id)
+                .to_col(AgentRun::ChatId)
+                .to_col(AgentRun::Depth)
+                .on_delete(ForeignKeyAction::Restrict),
+        )
+        .foreign_key(
+            ForeignKey::create()
+                .name("fk_sandbox_tool_call_park_claim")
+                .from_tbl(table.clone())
+                .from_col(SandboxToolCall::ParkLeaseToken)
+                .from_col(SandboxToolCall::AgentRunId)
+                .from_col(SandboxToolCall::ParkAttemptCount)
+                .from_col(SandboxToolCall::ParkClaimCount)
+                .to_tbl(AgentRunClaim::Table)
+                .to_col(AgentRunClaim::Token)
+                .to_col(AgentRunClaim::AgentRunId)
+                .to_col(AgentRunClaim::AttemptCount)
+                .to_col(AgentRunClaim::ClaimCount)
+                .on_delete(ForeignKeyAction::Restrict),
+        )
+        .check(Expr::col(SandboxToolCall::AgentRunDepth).eq(1))
+        .check(Expr::col(SandboxToolCall::ParkAttemptCount).gte(1))
+        .check(
+            Expr::col(SandboxToolCall::ParkClaimCount)
+                .gte(Expr::col(SandboxToolCall::ParkAttemptCount)),
+        )
+        .check(sandbox_tool_call_status_check(retry))
+        .check(
+            Expr::col(SandboxToolCall::ResolvedAt)
+                .is_null()
+                .or(Expr::col(SandboxToolCall::ResolvedAt)
+                    .gte(Expr::col(SandboxToolCall::CreatedAt))),
+        );
+    statement.to_owned()
+}
+
+/// Every index `sandbox_tool_call` carries, for its creating migration and
+/// for recreation after a SQLite table rebuild.
+fn sandbox_tool_call_indexes() -> Vec<IndexCreateStatement> {
+    vec![
+        Index::create()
+            .name("idx_sandbox_tool_call_run")
+            .table(SandboxToolCall::Table)
+            .col(SandboxToolCall::AgentRunId)
+            .col(SandboxToolCall::CreatedAt)
+            .to_owned(),
+        Index::create()
+            .name("idx_sandbox_tool_call_recovery")
+            .table(SandboxToolCall::Table)
+            .col(SandboxToolCall::Status)
+            .col(SandboxToolCall::ExecutorLeaseExpiresAt)
+            .col(SandboxToolCall::CreatedAt)
+            .col(SandboxToolCall::Id)
+            .to_owned(),
+    ]
+}
+
 async fn create_sandbox_tool_call_tables(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
     manager
-        .create_table(
-            Table::create()
-                .table(SandboxToolCall::Table)
-                .if_not_exists()
-                .col(
-                    ColumnDef::new(SandboxToolCall::Id)
-                        .uuid()
-                        .not_null()
-                        .primary_key(),
-                )
-                .col(
-                    ColumnDef::new(SandboxToolCall::AgentRunId)
-                        .uuid()
-                        .not_null(),
-                )
-                .col(ColumnDef::new(SandboxToolCall::ChatId).uuid().not_null())
-                .col(
-                    ColumnDef::new(SandboxToolCall::AgentRunDepth)
-                        .small_integer()
-                        .not_null(),
-                )
-                .col(
-                    ColumnDef::new(SandboxToolCall::ProviderId)
-                        .text()
-                        .not_null(),
-                )
-                .col(ColumnDef::new(SandboxToolCall::Name).text().not_null())
-                .col(
-                    ColumnDef::new(SandboxToolCall::Arguments)
-                        .json_binary()
-                        .not_null(),
-                )
-                .col(ColumnDef::new(SandboxToolCall::Status).text().not_null())
-                .col(
-                    ColumnDef::new(SandboxToolCall::ParkLeaseToken)
-                        .uuid()
-                        .not_null(),
-                )
-                .col(
-                    ColumnDef::new(SandboxToolCall::ParkAttemptCount)
-                        .integer()
-                        .not_null(),
-                )
-                .col(
-                    ColumnDef::new(SandboxToolCall::ParkClaimCount)
-                        .integer()
-                        .not_null(),
-                )
-                .col(ColumnDef::new(SandboxToolCall::ExecutorLeaseToken).uuid())
-                .col(
-                    ColumnDef::new(SandboxToolCall::ExecutorLeaseExpiresAt)
-                        .timestamp_with_time_zone(),
-                )
-                .col(
-                    ColumnDef::new(SandboxToolCall::CreatedAt)
-                        .timestamp_with_time_zone()
-                        .not_null(),
-                )
-                .col(ColumnDef::new(SandboxToolCall::ResolvedAt).timestamp_with_time_zone())
-                .foreign_key(
-                    ForeignKey::create()
-                        .name("fk_sandbox_tool_call_run")
-                        .from_tbl(SandboxToolCall::Table)
-                        .from_col(SandboxToolCall::AgentRunId)
-                        .from_col(SandboxToolCall::ChatId)
-                        .from_col(SandboxToolCall::AgentRunDepth)
-                        .to_tbl(AgentRun::Table)
-                        .to_col(AgentRun::Id)
-                        .to_col(AgentRun::ChatId)
-                        .to_col(AgentRun::Depth)
-                        .on_delete(ForeignKeyAction::Restrict),
-                )
-                .foreign_key(
-                    ForeignKey::create()
-                        .name("fk_sandbox_tool_call_park_claim")
-                        .from_tbl(SandboxToolCall::Table)
-                        .from_col(SandboxToolCall::ParkLeaseToken)
-                        .from_col(SandboxToolCall::AgentRunId)
-                        .from_col(SandboxToolCall::ParkAttemptCount)
-                        .from_col(SandboxToolCall::ParkClaimCount)
-                        .to_tbl(AgentRunClaim::Table)
-                        .to_col(AgentRunClaim::Token)
-                        .to_col(AgentRunClaim::AgentRunId)
-                        .to_col(AgentRunClaim::AttemptCount)
-                        .to_col(AgentRunClaim::ClaimCount)
-                        .on_delete(ForeignKeyAction::Restrict),
-                )
-                .check(Expr::col(SandboxToolCall::AgentRunDepth).eq(1))
-                .check(Expr::col(SandboxToolCall::ParkAttemptCount).gte(1))
-                .check(
-                    Expr::col(SandboxToolCall::ParkClaimCount)
-                        .gte(Expr::col(SandboxToolCall::ParkAttemptCount)),
-                )
-                .check(Expr::col(SandboxToolCall::Status).is_in([
-                    SandboxToolCallStatus::Accepted.as_str(),
-                    SandboxToolCallStatus::Claimed.as_str(),
-                    SandboxToolCallStatus::Completed.as_str(),
-                    SandboxToolCallStatus::Failed.as_str(),
-                    SandboxToolCallStatus::Cancelled.as_str(),
-                ]))
-                .check(
-                    Expr::col(SandboxToolCall::ResolvedAt)
-                        .is_null()
-                        .or(Expr::col(SandboxToolCall::ResolvedAt)
-                            .gte(Expr::col(SandboxToolCall::CreatedAt))),
-                )
-                .to_owned(),
-        )
+        .create_table(sandbox_tool_call_table(SandboxToolCall::Table, false))
         .await?;
-    manager
-        .create_index(
-            Index::create()
-                .name("idx_sandbox_tool_call_run")
-                .table(SandboxToolCall::Table)
-                .col(SandboxToolCall::AgentRunId)
-                .col(SandboxToolCall::CreatedAt)
-                .to_owned(),
-        )
-        .await?;
-    manager
-        .create_index(
-            Index::create()
-                .name("idx_sandbox_tool_call_recovery")
-                .table(SandboxToolCall::Table)
-                .col(SandboxToolCall::Status)
-                .col(SandboxToolCall::ExecutorLeaseExpiresAt)
-                .col(SandboxToolCall::CreatedAt)
-                .col(SandboxToolCall::Id)
-                .to_owned(),
-        )
-        .await?;
+    for index in sandbox_tool_call_indexes() {
+        manager.create_index(index).await?;
+    }
     manager
         .create_table(
             Table::create()
@@ -9514,7 +9542,7 @@ enum TurnAgentRunWaitMember {
     Open,
 }
 
-#[derive(DeriveIden)]
+#[derive(DeriveIden, Clone, Copy)]
 enum SandboxToolCall {
     Table,
     Id,
@@ -9530,6 +9558,7 @@ enum SandboxToolCall {
     ParkClaimCount,
     ExecutorLeaseToken,
     ExecutorLeaseExpiresAt,
+    RetryAt,
     CreatedAt,
     ResolvedAt,
 }
@@ -10470,6 +10499,152 @@ impl MigrationTrait for RetainCancelledTurnOutput {
                  EXECUTE 'ALTER TABLE turn_run DROP CONSTRAINT chk_turn_run_terminal_output'; \
                  END $$;"
             ))
+            .await?;
+        Ok(())
+    }
+}
+
+const SANDBOX_TOOL_CALL_REBUILD: &str = "sandbox_tool_call_rebuild";
+
+/// Rebuild `sandbox_tool_call` on SQLite with the chosen retry domain.
+///
+/// The status check is an anonymous CHECK from the creating migration, and
+/// SQLite cannot drop or alter one in place — the sanctioned path is a
+/// scratch-table rebuild, the same shape `turn_run` uses for its terminal
+/// output domain. Other tables' foreign keys reference `sandbox_tool_call` by
+/// name and survive the drop-and-rename under `PRAGMA foreign_keys=OFF`.
+async fn rebuild_sandbox_tool_call_sqlite_retry(
+    manager: &SchemaManager<'_>,
+    retry: bool,
+) -> Result<(), DbErr> {
+    let columns = "id, agent_run_id, chat_id, agent_run_depth, provider_id, name, arguments, \
+         status, park_lease_token, park_attempt_count, park_claim_count, executor_lease_token, \
+         executor_lease_expires_at, created_at, resolved_at";
+    let mut statements = vec![
+        "PRAGMA foreign_keys=OFF".to_owned(),
+        "BEGIN IMMEDIATE".to_owned(),
+        sandbox_tool_call_table(Alias::new(SANDBOX_TOOL_CALL_REBUILD), retry)
+            .to_string(SqliteQueryBuilder),
+        format!(
+            "INSERT INTO {SANDBOX_TOOL_CALL_REBUILD} ({columns}) \
+             SELECT {columns} FROM sandbox_tool_call"
+        ),
+        "DROP TABLE sandbox_tool_call".to_owned(),
+        format!("ALTER TABLE {SANDBOX_TOOL_CALL_REBUILD} RENAME TO sandbox_tool_call"),
+    ];
+    statements.extend(
+        sandbox_tool_call_indexes()
+            .iter()
+            .map(|index| index.to_string(SqliteQueryBuilder)),
+    );
+    statements.push("COMMIT".to_owned());
+    statements.push("PRAGMA foreign_keys=ON".to_owned());
+    manager
+        .get_connection()
+        .execute_unprepared(&format!("{};", statements.join(";\n")))
+        .await?;
+    Ok(())
+}
+
+/// Refuse to narrow the sandbox-tool status domain while any call still
+/// carries retry state, so a rollback fails up front with the actual problem
+/// named instead of stranding a half-rebuilt schema.
+async fn reject_down_with_sandbox_retry_rows(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let conn = manager.get_connection();
+    let backend = manager.get_database_backend();
+    let remaining = conn
+        .query_one_raw(sea_orm::Statement::from_string(
+            backend,
+            "SELECT COUNT(*) AS remaining FROM sandbox_tool_call \
+             WHERE status = 'retry_wait' OR retry_at IS NOT NULL",
+        ))
+        .await?;
+    let remaining = match remaining {
+        Some(row) => row.try_get::<i64>("", "remaining")?,
+        None => 0,
+    };
+    if remaining > 0 {
+        return Err(DbErr::Custom(format!(
+            "cannot narrow sandbox_tool_call's status domain: {remaining} call(s) carry \
+             retry state; let those calls settle before rolling this migration back"
+        )));
+    }
+    Ok(())
+}
+
+/// A sandbox tool call whose provider failed transiently gets one bounded
+/// retry (#1224). The creating migration pinned the status vocabulary in an
+/// anonymous CHECK on `sandbox_tool_call`; this widens that domain with
+/// `retry_wait` and adds the `retry_at` column that parks the call until its
+/// single retry becomes claimable.
+struct AddSandboxToolCallRetry;
+
+impl MigrationName for AddSandboxToolCallRetry {
+    fn name(&self) -> &str {
+        "m20260803_000042_add_sandbox_tool_call_retry"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddSandboxToolCallRetry {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() == DatabaseBackend::Sqlite {
+            return rebuild_sandbox_tool_call_sqlite_retry(manager, true).await;
+        }
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(SandboxToolCall::Table)
+                    .add_column(ColumnDef::new(SandboxToolCall::RetryAt).timestamp_with_time_zone())
+                    .to_owned(),
+            )
+            .await?;
+        // The check is anonymous, so locate it by definition. Add the widened
+        // constraint before dropping the strict one so no window exists in
+        // which the status column is unconstrained.
+        let widened = render_postgres_check(sandbox_tool_call_status_check(true));
+        manager
+            .get_connection()
+            .execute_unprepared(&format!(
+                "DO $$ DECLARE strict_name text; BEGIN \
+                 SELECT conname INTO strict_name FROM pg_constraint \
+                 WHERE conrelid = 'sandbox_tool_call'::regclass AND contype = 'c' \
+                 AND pg_get_constraintdef(oid) LIKE '%accepted%'; \
+                 IF strict_name IS NULL THEN \
+                 RAISE EXCEPTION 'sandbox_tool_call status check not found'; END IF; \
+                 EXECUTE $q$ALTER TABLE sandbox_tool_call ADD CONSTRAINT \
+                 chk_sandbox_tool_call_retry_status CHECK ({widened})$q$; \
+                 EXECUTE format('ALTER TABLE sandbox_tool_call DROP CONSTRAINT %I', strict_name); \
+                 END $$;"
+            ))
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        reject_down_with_sandbox_retry_rows(manager).await?;
+        if manager.get_database_backend() == DatabaseBackend::Sqlite {
+            return rebuild_sandbox_tool_call_sqlite_retry(manager, false).await;
+        }
+        let strict = render_postgres_check(sandbox_tool_call_status_check(false));
+        manager
+            .get_connection()
+            .execute_unprepared(&format!(
+                "DO $$ BEGIN \
+                 EXECUTE $q$ALTER TABLE sandbox_tool_call ADD CONSTRAINT \
+                 chk_sandbox_tool_call_status CHECK ({strict})$q$; \
+                 EXECUTE 'ALTER TABLE sandbox_tool_call DROP CONSTRAINT \
+                 chk_sandbox_tool_call_retry_status'; \
+                 END $$;"
+            ))
+            .await?;
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(SandboxToolCall::Table)
+                    .drop_column(SandboxToolCall::RetryAt)
+                    .to_owned(),
+            )
             .await?;
         Ok(())
     }

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -58,8 +58,8 @@ use crate::storage::{
     ParkTurnForAgentRunInboxOutcome, ParkTurnForAgentRunWaitSetOutcome,
     ParkTurnForClientCallOutcome, RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome,
     RequestToolApprovalOutcome, RequestTurnCancellationOutcome, ResolveSandboxToolCallOutcome,
-    ResolveToolCallOutcome, ResumeTurnForAgentRunWaitSetOutcome, Store,
-    SubmitAgentRunResultOutcome, TurnLeaseFence,
+    ResolveToolCallOutcome, ResumeTurnForAgentRunWaitSetOutcome, RetrySandboxToolCallOutcome,
+    Store, SubmitAgentRunResultOutcome, TurnLeaseFence,
 };
 
 mod ops;
@@ -1031,6 +1031,15 @@ impl Store for DbStore {
         lease_duration: chrono::Duration,
     ) -> Result<Option<chrono::Duration>> {
         ops::sandbox_tool::heartbeat_sandbox_tool_call(self, id, lease_token, lease_duration).await
+    }
+
+    async fn retry_sandbox_tool_call(
+        &self,
+        id: CallId,
+        lease_token: uuid::Uuid,
+        delay: chrono::Duration,
+    ) -> Result<RetrySandboxToolCallOutcome> {
+        ops::sandbox_tool::retry_sandbox_tool_call(self, id, lease_token, delay).await
     }
 
     async fn resolve_sandbox_tool_call(

--- a/crates/openwave-core/src/db/ops/sandbox_tool.rs
+++ b/crates/openwave-core/src/db/ops/sandbox_tool.rs
@@ -16,7 +16,7 @@ use crate::model::{
 };
 use crate::storage::{
     ClaimDelegatedFileReadOutcome, ClaimSandboxToolCallOutcome, ParkSandboxToolCallOutcome,
-    ResolveSandboxToolCallOutcome,
+    ResolveSandboxToolCallOutcome, RetrySandboxToolCallOutcome,
 };
 
 use super::super::{entities, store_err, DbStore};
@@ -117,6 +117,7 @@ pub(in crate::db) async fn park_agent_run_for_sandbox_tool_call(
         park_claim_count: Set(run.claim_count),
         executor_lease_token: Set(None),
         executor_lease_expires_at: Set(None),
+        retry_at: Set(None),
         created_at: Set(now),
         resolved_at: Set(None),
     }
@@ -370,7 +371,9 @@ async fn claim_sandbox_tool_call_matching(
         transaction.commit().await.map_err(store_err)?;
         return Ok(ClaimSandboxToolCallOutcome::Unavailable);
     }
-    if existing.status != SandboxToolCallStatus::Accepted.as_str() {
+    let due_retry = existing.status == SandboxToolCallStatus::RetryWait.as_str()
+        && existing.retry_at.is_some_and(|retry_at| retry_at <= now);
+    if existing.status != SandboxToolCallStatus::Accepted.as_str() && !due_retry {
         transaction.commit().await.map_err(store_err)?;
         return Ok(ClaimSandboxToolCallOutcome::Unavailable);
     }
@@ -682,6 +685,85 @@ pub(in crate::db) async fn resolve_sandbox_tool_call(
     Ok(ResolveSandboxToolCallOutcome::Resolved)
 }
 
+/// Park a claimed sandbox tool call for its single bounded retry (#1224).
+///
+/// The call moves to `retry_wait` under the exact live executor lease, keeps
+/// no lease of its own, and becomes claimable again once `retry_at` passes.
+/// Its waiting sandbox run is untouched — no receipt exists yet, so nothing
+/// resumes. `retry_at` doubles as the spent-retry marker: it is set exactly
+/// once, and a call that already carries one cannot be parked again.
+pub(in crate::db) async fn retry_sandbox_tool_call(
+    store: &DbStore,
+    id: CallId,
+    lease_token: uuid::Uuid,
+    delay: Duration,
+) -> Result<RetrySandboxToolCallOutcome> {
+    if id.0.is_nil() || lease_token.is_nil() || delay < Duration::zero() {
+        return Err(AgentError::Store(
+            "invalid sandbox tool retry request".into(),
+        ));
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    acquire_agent_run_claim_lock(&transaction).await?;
+    let now = database_now(&transaction).await?;
+    if entities::sandbox_tool_call_receipt::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+        .is_some()
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(RetrySandboxToolCallOutcome::LeaseLost);
+    }
+    let Some(call) = entities::sandbox_tool_call::Entity::find_by_id(id.0)
+        .one(&transaction)
+        .await
+        .map_err(store_err)?
+    else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(RetrySandboxToolCallOutcome::LeaseLost);
+    };
+    if call.status != SandboxToolCallStatus::Claimed.as_str()
+        || call.executor_lease_token != Some(lease_token)
+        || call
+            .executor_lease_expires_at
+            .is_none_or(|expiry| expiry <= now)
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(RetrySandboxToolCallOutcome::LeaseLost);
+    }
+    if call.retry_at.is_some() {
+        // The single retry is already spent. Executors decide terminal versus
+        // retry from the claimed call's own retry marker, so reaching this is
+        // an invariant breach worth surfacing, not a schedulable state.
+        return Err(AgentError::Store(
+            "sandbox tool call retry budget exhausted".into(),
+        ));
+    }
+    let Some(run) = find_by_id_on(&transaction, AgentRunId(call.agent_run_id)).await? else {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(RetrySandboxToolCallOutcome::LeaseLost);
+    };
+    if run.chat_id != call.chat_id
+        || run.status != AgentRunStatus::Waiting.as_str()
+        || run.deadline_at.is_none_or(|deadline| deadline <= now)
+    {
+        transaction.commit().await.map_err(store_err)?;
+        return Ok(RetrySandboxToolCallOutcome::LeaseLost);
+    }
+    let retry_at = now
+        .checked_add_signed(delay)
+        .ok_or_else(|| AgentError::Store("sandbox tool retry overflows database time".into()))?;
+    let mut active: entities::sandbox_tool_call::ActiveModel = call.into();
+    active.status = Set(SandboxToolCallStatus::RetryWait.as_str().into());
+    active.executor_lease_token = Set(None);
+    active.executor_lease_expires_at = Set(None);
+    active.retry_at = Set(Some(retry_at));
+    active.update(&transaction).await.map_err(store_err)?;
+    transaction.commit().await.map_err(store_err)?;
+    Ok(RetrySandboxToolCallOutcome::Scheduled)
+}
+
 pub(in crate::db) async fn resolve_delegated_file_read(
     store: &DbStore,
     id: CallId,
@@ -928,6 +1010,11 @@ pub(in crate::db) async fn list_sandbox_tool_call_candidates(
                     entities::sandbox_tool_call::Column::Status
                         .eq(SandboxToolCallStatus::Claimed.as_str())
                         .and(entities::sandbox_tool_call::Column::ExecutorLeaseExpiresAt.lte(now)),
+                )
+                .add(
+                    entities::sandbox_tool_call::Column::Status
+                        .eq(SandboxToolCallStatus::RetryWait.as_str())
+                        .and(entities::sandbox_tool_call::Column::RetryAt.lte(now)),
                 ),
         )
         .order_by_asc(entities::sandbox_tool_call::Column::CreatedAt)
@@ -967,6 +1054,11 @@ pub(in crate::db) async fn list_sandbox_tool_call_candidates_named(
                     entities::sandbox_tool_call::Column::Status
                         .eq(SandboxToolCallStatus::Claimed.as_str())
                         .and(entities::sandbox_tool_call::Column::ExecutorLeaseExpiresAt.lte(now)),
+                )
+                .add(
+                    entities::sandbox_tool_call::Column::Status
+                        .eq(SandboxToolCallStatus::RetryWait.as_str())
+                        .and(entities::sandbox_tool_call::Column::RetryAt.lte(now)),
                 ),
         )
         .order_by_asc(entities::sandbox_tool_call::Column::CreatedAt)
@@ -1007,6 +1099,7 @@ where
         .filter(entities::sandbox_tool_call::Column::Status.is_in([
             SandboxToolCallStatus::Accepted.as_str(),
             SandboxToolCallStatus::Claimed.as_str(),
+            SandboxToolCallStatus::RetryWait.as_str(),
         ]))
         .all(conn)
         .await
@@ -1261,6 +1354,7 @@ fn call_from_model(model: entities::sandbox_tool_call::Model) -> Result<SandboxT
         park_claim_count: model.park_claim_count,
         executor_lease_token: model.executor_lease_token,
         executor_lease_expires_at: model.executor_lease_expires_at,
+        retry_at: model.retry_at,
         created_at: model.created_at,
         resolved_at: model.resolved_at,
     })
@@ -1284,6 +1378,7 @@ fn status_from_db(value: &str) -> Result<SandboxToolCallStatus> {
     match value {
         "accepted" => Ok(SandboxToolCallStatus::Accepted),
         "claimed" => Ok(SandboxToolCallStatus::Claimed),
+        "retry_wait" => Ok(SandboxToolCallStatus::RetryWait),
         "completed" => Ok(SandboxToolCallStatus::Completed),
         "failed" => Ok(SandboxToolCallStatus::Failed),
         "cancelled" => Ok(SandboxToolCallStatus::Cancelled),

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -214,8 +214,8 @@ pub use storage::{
     ParkTurnForClientCallOutcome, PendingChatPrompt, RecordTurnFailureOutcome,
     RequestAgentRunCancellationOutcome, RequestToolApprovalOutcome, RequestTurnCancellationOutcome,
     ResolveSandboxToolCallOutcome, ResolveToolCallOutcome, ResumeTurnForAgentRunWaitSetOutcome,
-    SandboxProvision, SandboxProvisionState, SecretProvider, Store, SubmitAgentRunResultOutcome,
-    TurnLeaseFence, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
+    RetrySandboxToolCallOutcome, SandboxProvision, SandboxProvisionState, SecretProvider, Store,
+    SubmitAgentRunResultOutcome, TurnLeaseFence, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
 };
 pub use tool::{
     input_schema_for, strict_json_schema, ApprovalClass, OptionalProperties, Tool, ToolCtx,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1703,6 +1703,10 @@ impl SandboxToolCallRequest {
 pub enum SandboxToolCallStatus {
     Accepted,
     Claimed,
+    /// A classified-transient failure parked awaiting its single bounded
+    /// retry. The call becomes claimable again once `retry_at` passes; a
+    /// second failure resolves terminally.
+    RetryWait,
     Completed,
     Failed,
     Cancelled,
@@ -1714,6 +1718,7 @@ impl SandboxToolCallStatus {
         match self {
             Self::Accepted => "accepted",
             Self::Claimed => "claimed",
+            Self::RetryWait => "retry_wait",
             Self::Completed => "completed",
             Self::Failed => "failed",
             Self::Cancelled => "cancelled",
@@ -1741,6 +1746,10 @@ pub struct SandboxToolCall {
     pub park_claim_count: i32,
     pub executor_lease_token: Option<Uuid>,
     pub executor_lease_expires_at: Option<DateTime<Utc>>,
+    /// When the call's single bounded retry becomes claimable. Set exactly
+    /// once, by the transient failure that scheduled the retry, and kept
+    /// through the second attempt as the spent-retry marker.
+    pub retry_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub resolved_at: Option<DateTime<Utc>>,
 }

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -419,6 +419,17 @@ pub enum ClaimDelegatedFileReadOutcome {
     Unavailable,
 }
 
+/// Result of parking a claimed sandbox tool call for its single bounded retry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetrySandboxToolCallOutcome {
+    /// The call is parked in `retry_wait` and becomes claimable at its
+    /// `retry_at`. Its waiting sandbox run is untouched.
+    Scheduled,
+    /// The lease no longer authorizes the call — cancellation, expiry, a
+    /// terminal receipt, or a competing executor already won.
+    LeaseLost,
+}
+
 /// Result of resolving sandbox tool work under its exact executor lease.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResolveSandboxToolCallOutcome {
@@ -2064,6 +2075,21 @@ pub trait Store: Send + Sync {
         _lease_token: uuid::Uuid,
         _lease_duration: chrono::Duration,
     ) -> Result<Option<chrono::Duration>> {
+        agent_run_storage_unavailable()
+    }
+
+    /// Park a claimed sandbox tool call for its single bounded retry under
+    /// the exact live executor lease. The call moves to `retry_wait` with a
+    /// `retry_at` of the database clock plus `delay`, releases its executor
+    /// lease, and becomes claimable again once `retry_at` passes; its waiting
+    /// sandbox run is untouched. A call that already spent its retry cannot be
+    /// parked again — that is an executor invariant breach, not a race.
+    async fn retry_sandbox_tool_call(
+        &self,
+        _id: CallId,
+        _lease_token: uuid::Uuid,
+        _delay: chrono::Duration,
+    ) -> Result<RetrySandboxToolCallOutcome> {
         agent_run_storage_unavailable()
     }
 

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1970,7 +1970,9 @@ fn sandbox_activity(calls: &[SandboxToolCall]) -> Option<AgentActivitySnapshot> 
         _ => return None,
     };
     let status = match call.status {
-        SandboxToolCallStatus::Accepted => AgentActivityStatus::Waiting,
+        SandboxToolCallStatus::Accepted | SandboxToolCallStatus::RetryWait => {
+            AgentActivityStatus::Waiting
+        }
         SandboxToolCallStatus::Claimed => AgentActivityStatus::Running,
         SandboxToolCallStatus::Completed
         | SandboxToolCallStatus::Failed
@@ -2034,7 +2036,9 @@ fn sandbox_activity_history_item(call: &SandboxToolCall) -> Option<AgentActivity
     // admitted. `resolved_at` is always present once terminal, but fall back to
     // the creation time rather than dropping a settled step from the timeline.
     let (outcome, at) = match call.status {
-        SandboxToolCallStatus::Accepted => (AgentActivityOutcome::Waiting, call.created_at),
+        SandboxToolCallStatus::Accepted | SandboxToolCallStatus::RetryWait => {
+            (AgentActivityOutcome::Waiting, call.created_at)
+        }
         SandboxToolCallStatus::Claimed => (AgentActivityOutcome::Running, call.created_at),
         SandboxToolCallStatus::Completed => (
             AgentActivityOutcome::Completed,

--- a/crates/openwave-server/src/sandbox_web_search_worker.rs
+++ b/crates/openwave-server/src/sandbox_web_search_worker.rs
@@ -14,8 +14,8 @@ use openwave_core::{
     AgentError, ClaimSandboxToolCallOutcome, Result, SandboxToolCall, Store, ToolCallResolution,
 };
 use openwave_web_search::{
-    request_from_tool_arguments, WebSearchProvider, WebSearchRequest, WebSearchResponse,
-    MAX_OUTPUT_BYTES,
+    request_from_tool_arguments, WebSearchError, WebSearchProvider, WebSearchRequest,
+    WebSearchResponse, MAX_OUTPUT_BYTES,
 };
 use tokio::sync::Notify;
 
@@ -70,6 +70,10 @@ pub(crate) struct SandboxWebSearchWorkerConfig {
     /// Ceiling on the lane's own backoff after consecutive iteration errors,
     /// so a store outage is not polled at a fixed rate forever.
     failure_delay_cap: Duration,
+    /// Backoff before a classified-transient provider failure's single bounded
+    /// retry becomes claimable. This work sits inside a foreground turn the
+    /// user is waiting on, so the whole envelope stays within a few seconds.
+    retry_delay: Duration,
     max_concurrency: usize,
 }
 
@@ -84,6 +88,7 @@ impl Default for SandboxWebSearchWorkerConfig {
             idle_cap: Duration::from_secs(5),
             failure_delay: Duration::from_secs(1),
             failure_delay_cap: Duration::from_secs(30),
+            retry_delay: Duration::from_secs(2),
             max_concurrency: 2,
         }
     }
@@ -93,6 +98,9 @@ impl Default for SandboxWebSearchWorkerConfig {
 pub(crate) enum SandboxWebSearchWorkerOutcome {
     Idle,
     Resolved(openwave_core::CallId),
+    /// A classified-transient provider failure parked the call in
+    /// `retry_wait`; it becomes claimable again after its short backoff.
+    RetryScheduled(openwave_core::CallId),
     LeaseLost(openwave_core::CallId),
 }
 
@@ -301,10 +309,19 @@ impl SandboxWebSearchWorker {
                                 None => return Ok(SandboxWebSearchWorkerOutcome::LeaseLost(call.id)),
                                 Some(result) => match result {
                                     Ok(Ok(response)) => serialize_response(response),
-                                    Ok(Err(_)) => failed_resolution(
-                                        "web_search_failed",
-                                        "Web search could not complete.",
-                                    ),
+                                    Ok(Err(error)) => {
+                                        if transient_provider_failure(&error)
+                                            && call.retry_at.is_none()
+                                        {
+                                            return self
+                                                .schedule_retry(call.id, lease_token)
+                                                .await;
+                                        }
+                                        failed_resolution(
+                                            "web_search_failed",
+                                            "Web search could not complete.",
+                                        )
+                                    }
                                     Err(_) => failed_resolution(
                                         "web_search_timed_out",
                                         "Web search did not complete before its sandbox lease expired.",
@@ -332,6 +349,42 @@ impl SandboxWebSearchWorker {
                 Ok(SandboxWebSearchWorkerOutcome::LeaseLost(call.id))
             }
         }
+    }
+
+    /// Park the call for its single bounded retry instead of writing a
+    /// terminal failure receipt. Only a first-attempt classified-transient
+    /// failure reaches here; the durable `retry_at` marker makes the second
+    /// attempt terminal on any failure.
+    async fn schedule_retry(
+        &self,
+        id: openwave_core::CallId,
+        lease_token: uuid::Uuid,
+    ) -> Result<SandboxWebSearchWorkerOutcome> {
+        match self
+            .store
+            .retry_sandbox_tool_call(id, lease_token, chrono_duration(self.config.retry_delay)?)
+            .await?
+        {
+            openwave_core::RetrySandboxToolCallOutcome::Scheduled => {
+                self.wake.notify_one();
+                Ok(SandboxWebSearchWorkerOutcome::RetryScheduled(id))
+            }
+            openwave_core::RetrySandboxToolCallOutcome::LeaseLost => {
+                Ok(SandboxWebSearchWorkerOutcome::LeaseLost(id))
+            }
+        }
+    }
+}
+
+/// Whether a provider failure is worth the single bounded retry: a transport
+/// fault (including a timed-out request), a provider 5xx, or a rate limit.
+/// Configuration and request failures recur on the next call and resolve
+/// terminally at once.
+fn transient_provider_failure(error: &WebSearchError) -> bool {
+    match error {
+        WebSearchError::Transport(_) | WebSearchError::RateLimited(_) => true,
+        WebSearchError::HttpStatus { status, .. } => (500..=599).contains(status),
+        _ => false,
     }
 }
 
@@ -406,6 +459,32 @@ mod tests {
     struct FakeProvider {
         requests: Mutex<Vec<WebSearchRequest>>,
         response: WebSearchResponse,
+    }
+
+    struct FlakyProvider {
+        failures: Mutex<Vec<WebSearchError>>,
+        requests: std::sync::atomic::AtomicUsize,
+        response: WebSearchResponse,
+    }
+
+    #[async_trait]
+    impl WebSearchProvider for FlakyProvider {
+        fn kind(&self) -> WebSearchProviderKind {
+            WebSearchProviderKind::Exa
+        }
+
+        async fn search(
+            &self,
+            _request: WebSearchRequest,
+        ) -> std::result::Result<WebSearchResponse, WebSearchError> {
+            self.requests.fetch_add(1, Ordering::SeqCst);
+            let mut failures = self.failures.lock().unwrap();
+            if failures.is_empty() {
+                Ok(self.response.clone())
+            } else {
+                Err(failures.remove(0))
+            }
+        }
     }
 
     struct DropMarker(Arc<AtomicBool>);
@@ -629,6 +708,126 @@ mod tests {
                 .status,
             AgentRunStatus::RetryWait
         );
+    }
+
+    #[tokio::test]
+    async fn transient_failure_retries_once_then_second_failure_terminalizes() {
+        let (store, _dir) = test_store().await;
+        let call = checkpoint(
+            &store,
+            WEB_SEARCH_TOOL,
+            serde_json::json!({"query":"flaky"}),
+        )
+        .await;
+        let provider = Arc::new(FlakyProvider {
+            failures: Mutex::new(vec![
+                WebSearchError::HttpStatus {
+                    provider: WebSearchProviderKind::Exa,
+                    status: 503,
+                },
+                WebSearchError::Transport("connection reset".into()),
+            ]),
+            requests: std::sync::atomic::AtomicUsize::new(0),
+            response: WebSearchResponse::new(WebSearchProviderKind::Exa, Vec::new()),
+        });
+        let fake = Arc::new(FakeSearch {
+            resolution: Ok(Some(provider.clone())),
+        });
+        // A zero backoff keeps the test fast; the schedule itself is durable.
+        let worker = SandboxWebSearchWorker::with_search(
+            store.clone(),
+            fake,
+            Arc::new(Notify::new()),
+            SandboxWebSearchWorkerConfig {
+                retry_delay: Duration::ZERO,
+                ..SandboxWebSearchWorkerConfig::default()
+            },
+        );
+        // The first transient failure parks the call instead of writing a
+        // terminal receipt, and the sandbox stays parked on its checkpoint.
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            SandboxWebSearchWorkerOutcome::RetryScheduled(call.id)
+        );
+        let parked = store.get_sandbox_tool_call(call.id).await.unwrap().unwrap();
+        assert_eq!(
+            parked.status,
+            openwave_core::SandboxToolCallStatus::RetryWait
+        );
+        assert!(parked.retry_at.is_some());
+        assert!(store
+            .get_sandbox_tool_call_receipt(call.id)
+            .await
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            store
+                .get_agent_run(call.agent_run_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            AgentRunStatus::Waiting
+        );
+        // The single retry is spent, so the second transient failure resolves
+        // terminally and resumes the sandbox with the failure receipt.
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            SandboxWebSearchWorkerOutcome::Resolved(call.id)
+        );
+        let receipt = store
+            .get_sandbox_tool_call_receipt(call.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(receipt.status, openwave_core::SandboxToolCallStatus::Failed);
+        assert_eq!(receipt.error_code.as_deref(), Some("web_search_failed"));
+        assert_eq!(provider.requests.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            store
+                .get_agent_run(call.agent_run_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            AgentRunStatus::RetryWait
+        );
+    }
+
+    #[tokio::test]
+    async fn non_transient_failure_never_spends_the_retry() {
+        let (store, _dir) = test_store().await;
+        let call = checkpoint(
+            &store,
+            WEB_SEARCH_TOOL,
+            serde_json::json!({"query":"quota"}),
+        )
+        .await;
+        let provider = Arc::new(FlakyProvider {
+            failures: Mutex::new(vec![WebSearchError::QuotaExhausted(
+                WebSearchProviderKind::Exa,
+            )]),
+            requests: std::sync::atomic::AtomicUsize::new(0),
+            response: WebSearchResponse::new(WebSearchProviderKind::Exa, Vec::new()),
+        });
+        let fake = Arc::new(FakeSearch {
+            resolution: Ok(Some(provider.clone())),
+        });
+        assert_eq!(
+            worker(store.clone(), fake).run_once().await.unwrap(),
+            SandboxWebSearchWorkerOutcome::Resolved(call.id)
+        );
+        assert_eq!(
+            store
+                .get_sandbox_tool_call_receipt(call.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .error_code
+                .as_deref(),
+            Some("web_search_failed")
+        );
+        assert_eq!(provider.requests.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
A sandbox web search that failed transiently — provider 5xx, a rate limit, a transport fault — wrote a terminal failure receipt at once, so a single 503 cost the delegated task its only search. #1148 gave the other durable workers a real retry schedule; sandbox tool calls had nowhere to park one.

## What changed

- `sandbox_tool_call` gains a `retry_wait` status and a `retry_at` column, mirroring the turn-level retry-wait shape. A classified-transient provider failure parks the claimed call in `retry_wait` under its exact executor lease instead of resolving it; the waiting sandbox run is untouched because no receipt exists yet.
- The call becomes claimable again once `retry_at` passes (candidate listing and the claim path both admit a due retry). `retry_at` doubles as the spent-retry marker: it is set exactly once, so the second attempt resolves terminally on any failure, exactly as before. The store refuses a second park as an invariant breach.
- Classification in the web-search worker: transport faults (including a timed-out request), provider 5xx, and rate limits are transient; credential, quota, and request failures recur on the next call and terminalize at once. The backoff is 2s — this work sits inside a foreground turn the user is waiting on, so the envelope stays within a few seconds.
- Run-level cancellation/terminalization sweeps include `retry_wait` so a cancel cannot strand a parked retry.

## Migration

The status domain was pinned in an anonymous CHECK by the creating migration, so `m20260803_000042_add_sandbox_tool_call_retry` follows the `turn_run` pattern from m20260731_000041: a scratch-table rebuild on SQLite (table builder and indexes extracted into shared helpers so the definitions cannot drift) and a named-constraint swap plus `ADD COLUMN` on PostgreSQL. `down` refuses while any call still carries retry state.

## Tests

One behavior-driven worker test drives a real checkpoint through transient failure → durable `retry_wait` (no receipt, run still waiting) → second failure → terminal `web_search_failed` receipt and resumed run, asserting exactly two provider requests; a second covers that a non-transient failure never spends the retry. Existing worker and sandbox suites pass unchanged.

Closes #1224