### PR TITLE
feat(sandbox): enforce local Docker egress by network topology and a policy proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4133,6 +4133,7 @@ dependencies = [
  "async-trait",
  "libc",
  "openwave-core",
+ "openwave-egress",
  "openwave-sandbox-protocol",
  "schemars 1.2.2",
  "serde",

--- a/crates/openwave-sandbox-agent/Cargo.toml
+++ b/crates/openwave-sandbox-agent/Cargo.toml
@@ -20,6 +20,9 @@ openwave-sandbox-protocol = { path = "../openwave-sandbox-protocol" }
 # provider vocabulary, not the host-side persistence stack. `default-features =
 # false` keeps sea-orm, the keychain, and the fs tools out of the container image.
 openwave-core = { path = "../openwave-core", default-features = false }
+# Destination hygiene for the egress-proxy mode: dependency-free by charter, so
+# it costs the container image nothing.
+openwave-egress = { path = "../openwave-egress" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "process", "time"] }
 async-trait = { workspace = true }
 serde = { workspace = true }

--- a/crates/openwave-sandbox-agent/Dockerfile
+++ b/crates/openwave-sandbox-agent/Dockerfile
@@ -3,7 +3,9 @@
 # Packages the `openwave-sandbox-agent` binary: the sandbox-side transport
 # server plus the in-container agent loop. The container's entrypoint runs the
 # agent server on the listener port the host dials (default 8080, publishable by
-# the local container backend in issue #874).
+# the local container backend in issue #874). The same image has a second face:
+# run with the `egress-proxy` argument it serves the sandbox's network boundary
+# from its own dual-homed container (see `sandbox_docker` in openwave-server).
 #
 # Build context is the WORKSPACE ROOT, so the whole Cargo workspace and the
 # committed Cargo.lock are visible to a `--locked` build:

--- a/crates/openwave-sandbox-agent/src/egress.rs
+++ b/crates/openwave-sandbox-agent/src/egress.rs
@@ -1,0 +1,566 @@
+//! The `egress-proxy` mode: the dual-homed side of the local Docker sandbox's
+//! network boundary.
+//!
+//! The sandbox container's only network is an internal bridge with no route
+//! out; this proxy is the one container attached to both that bridge and a
+//! network with external reach. It serves two listeners:
+//!
+//! - **CONNECT egress** ([`DEFAULT_EGRESS_LISTEN`]): a CONNECT-only HTTP proxy
+//!   with the same contract as the native local adapter's loopback broker
+//!   (`openwave-code-execution`'s `network` module). TLS stays end to end; the
+//!   proxy decides only the requested `host:port` against the compiled
+//!   [`SandboxNetworkPolicy`], resolves the name *outside* the sandbox, refuses
+//!   private/loopback/link-local answers (any private answer poisons the whole
+//!   name, so resolver ordering cannot reopen a DNS-rebinding path), audits the
+//!   decision, and relays bytes. Plain absolute-form HTTP is not implemented:
+//!   plaintext egress is simply denied, as on the native path.
+//! - **Transport relay** ([`DEFAULT_RELAY_LISTEN`]): a raw TCP relay to the
+//!   sandbox container's supervisor port. A port published on a container whose
+//!   only network is internal is not reachable from the host, so the host dials
+//!   this proxy's published loopback port instead; the per-run transport secret
+//!   still gates attach exactly as before.
+//!
+//! The policy is enforcement configuration, not advice: the sandbox's
+//! `HTTP(S)_PROXY` environment merely points compliant tools here, while a
+//! command that ignores it has no route anywhere. The policy arrives compiled
+//! ([`POLICY_ENV`]) — destination classes already expanded to exact hosts by
+//! the host — and an absent or malformed value means deny-all, never open.
+
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::time::Duration;
+
+use openwave_egress::EgressDestination;
+use openwave_sandbox_protocol::SandboxNetworkPolicy;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{lookup_host, TcpListener, TcpStream};
+use tokio::task::JoinSet;
+
+/// Environment variable carrying the compiled [`SandboxNetworkPolicy`] as JSON.
+/// Must match the name the local Docker backend injects.
+pub const POLICY_ENV: &str = "OPENWAVE_EGRESS_POLICY";
+/// Environment variable overriding the CONNECT listener address.
+pub const EGRESS_LISTEN_ENV: &str = "OPENWAVE_EGRESS_LISTEN";
+/// Environment variable overriding the transport-relay listener address.
+pub const RELAY_LISTEN_ENV: &str = "OPENWAVE_RELAY_LISTEN";
+/// Environment variable naming the relay's upstream — the sandbox container's
+/// supervisor endpoint on the internal network, as `host:port`. Absent means no
+/// relay is served.
+pub const RELAY_TARGET_ENV: &str = "OPENWAVE_RELAY_TARGET";
+
+/// Default CONNECT listener. The sandbox reaches it over the internal network;
+/// it is never published to the host.
+pub const DEFAULT_EGRESS_LISTEN: &str = "0.0.0.0:3128";
+/// Default relay listener; the backend publishes this port to host loopback.
+pub const DEFAULT_RELAY_LISTEN: &str = "0.0.0.0:8080";
+
+const MAX_CONNECT_HEADERS: usize = 16 * 1024;
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How this proxy serves, resolved from the environment.
+#[derive(Debug, Clone)]
+pub struct EgressProxyConfig {
+    /// The compiled policy every CONNECT is decided against.
+    pub policy: SandboxNetworkPolicy,
+    /// The CONNECT listener address.
+    pub egress_listen: String,
+    /// The transport-relay listener address.
+    pub relay_listen: String,
+    /// The relay's upstream `host:port`, or `None` to serve no relay.
+    pub relay_target: Option<String>,
+}
+
+impl EgressProxyConfig {
+    /// Resolve the configuration from process environment. A missing or
+    /// malformed policy is deny-all — the proxy must fail closed, never open —
+    /// and the malformed case is logged so the misconfiguration is visible.
+    #[must_use]
+    pub fn from_env() -> Self {
+        let policy = match std::env::var(POLICY_ENV) {
+            Ok(raw) => match serde_json::from_str::<SandboxNetworkPolicy>(&raw) {
+                Ok(policy) => policy,
+                Err(_) => {
+                    eprintln!(
+                        "openwave-sandbox-agent egress-proxy: {POLICY_ENV} is malformed; \
+                         denying all egress (fail closed)"
+                    );
+                    SandboxNetworkPolicy::deny_all()
+                }
+            },
+            Err(_) => SandboxNetworkPolicy::deny_all(),
+        };
+        Self {
+            policy,
+            egress_listen: std::env::var(EGRESS_LISTEN_ENV)
+                .unwrap_or_else(|_| DEFAULT_EGRESS_LISTEN.to_owned()),
+            relay_listen: std::env::var(RELAY_LISTEN_ENV)
+                .unwrap_or_else(|_| DEFAULT_RELAY_LISTEN.to_owned()),
+            relay_target: std::env::var(RELAY_TARGET_ENV)
+                .ok()
+                .filter(|target| !target.is_empty()),
+        }
+    }
+}
+
+/// A bound egress proxy: both listeners are held, so a caller that observed
+/// [`bind`](Self::bind) succeed knows the ports are its own before serving.
+pub struct EgressProxy {
+    egress: TcpListener,
+    relay: Option<(TcpListener, String)>,
+    policy: SandboxNetworkPolicy,
+}
+
+impl EgressProxy {
+    /// Bind both listeners.
+    pub async fn bind(config: EgressProxyConfig) -> io::Result<Self> {
+        let egress = TcpListener::bind(&config.egress_listen).await?;
+        let relay = match config.relay_target {
+            Some(target) => Some((TcpListener::bind(&config.relay_listen).await?, target)),
+            None => None,
+        };
+        Ok(Self {
+            egress,
+            relay,
+            policy: config.policy,
+        })
+    }
+
+    /// The bound CONNECT listener address.
+    pub fn egress_addr(&self) -> io::Result<SocketAddr> {
+        self.egress.local_addr()
+    }
+
+    /// The bound relay listener address, when a relay target is configured.
+    pub fn relay_addr(&self) -> Option<io::Result<SocketAddr>> {
+        self.relay
+            .as_ref()
+            .map(|(listener, _)| listener.local_addr())
+    }
+
+    /// Serve both listeners until the process ends.
+    pub async fn serve(self) {
+        let Self {
+            egress,
+            relay,
+            policy,
+        } = self;
+        match relay {
+            Some((listener, target)) => {
+                tokio::join!(serve_egress(egress, policy), serve_relay(listener, target));
+            }
+            None => serve_egress(egress, policy).await,
+        }
+    }
+}
+
+async fn serve_egress(listener: TcpListener, policy: SandboxNetworkPolicy) {
+    let mut connections = JoinSet::new();
+    loop {
+        tokio::select! {
+            accepted = listener.accept() => {
+                let Ok((stream, peer)) = accepted else {
+                    break;
+                };
+                let policy = policy.clone();
+                connections.spawn(async move {
+                    if let Err(error) = handle_connect(stream, &policy).await {
+                        eprintln!("egress-proxy: connection from {peer} ended: {error}");
+                    }
+                });
+            }
+            Some(_) = connections.join_next(), if !connections.is_empty() => {}
+        }
+    }
+}
+
+async fn serve_relay(listener: TcpListener, target: String) {
+    let mut connections = JoinSet::new();
+    loop {
+        tokio::select! {
+            accepted = listener.accept() => {
+                let Ok((stream, _)) = accepted else {
+                    break;
+                };
+                let target = target.clone();
+                connections.spawn(async move {
+                    let mut client = stream;
+                    let upstream = tokio::time::timeout(
+                        CONNECT_TIMEOUT,
+                        TcpStream::connect(target.as_str()),
+                    )
+                    .await;
+                    match upstream {
+                        Ok(Ok(mut upstream)) => {
+                            let _ = tokio::io::copy_bidirectional(&mut client, &mut upstream).await;
+                        }
+                        _ => {
+                            eprintln!("egress-proxy: relay upstream {target} is unreachable");
+                        }
+                    }
+                });
+            }
+            Some(_) = connections.join_next(), if !connections.is_empty() => {}
+        }
+    }
+}
+
+async fn handle_connect(
+    mut client: TcpStream,
+    policy: &SandboxNetworkPolicy,
+) -> Result<(), io::Error> {
+    let request = match read_connect_request(&mut client).await {
+        Ok(request) => request,
+        Err(reason) => {
+            audit(None, None, false, reason);
+            reject(&mut client, 400, "Bad Request").await?;
+            return Ok(());
+        }
+    };
+    let (host, port) = match parse_authority(&request.authority) {
+        Some(target) => target,
+        None => {
+            audit(None, None, false, "invalid CONNECT authority");
+            reject(&mut client, 400, "Bad Request").await?;
+            return Ok(());
+        }
+    };
+    if !policy_permits(policy, &host, port) {
+        audit(
+            Some(&host),
+            Some(port),
+            false,
+            "destination denied by policy",
+        );
+        reject(&mut client, 403, "Forbidden").await?;
+        return Ok(());
+    }
+
+    let addresses = match resolve_public(&host, port).await {
+        Ok(addresses) => addresses,
+        Err(reason) => {
+            audit(Some(&host), Some(port), false, reason);
+            reject(&mut client, 403, "Forbidden").await?;
+            return Ok(());
+        }
+    };
+    let upstream = match connect_any(&addresses).await {
+        Ok(stream) => stream,
+        Err(_) => {
+            audit(Some(&host), Some(port), false, "upstream connection failed");
+            reject(&mut client, 502, "Bad Gateway").await?;
+            return Ok(());
+        }
+    };
+    audit(Some(&host), Some(port), true, "destination allowed");
+    client
+        .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        .await?;
+    let mut upstream = upstream;
+    let _ = tokio::io::copy_bidirectional(&mut client, &mut upstream).await?;
+    Ok(())
+}
+
+struct ConnectRequest {
+    authority: String,
+}
+
+async fn read_connect_request(stream: &mut TcpStream) -> Result<ConnectRequest, &'static str> {
+    let mut bytes = Vec::with_capacity(1024);
+    let mut buffer = [0_u8; 1024];
+    loop {
+        if bytes.len() >= MAX_CONNECT_HEADERS {
+            return Err("CONNECT headers exceed the size limit");
+        }
+        let read = stream
+            .read(&mut buffer)
+            .await
+            .map_err(|_| "could not read CONNECT request")?;
+        if read == 0 {
+            return Err("CONNECT request ended before its headers");
+        }
+        bytes.extend_from_slice(&buffer[..read]);
+        if bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+    }
+    let text = String::from_utf8(bytes).map_err(|_| "CONNECT headers are not UTF-8")?;
+    let line = text
+        .split("\r\n")
+        .next()
+        .ok_or("CONNECT request line is absent")?;
+    let mut parts = line.split_whitespace();
+    let method = parts.next().ok_or("CONNECT method is absent")?;
+    let authority = parts.next().ok_or("CONNECT authority is absent")?;
+    let version = parts.next().ok_or("CONNECT version is absent")?;
+    if parts.next().is_some() || method != "CONNECT" || !matches!(version, "HTTP/1.0" | "HTTP/1.1")
+    {
+        return Err("only HTTP CONNECT is accepted");
+    }
+    Ok(ConnectRequest {
+        authority: authority.to_owned(),
+    })
+}
+
+fn parse_authority(authority: &str) -> Option<(String, u16)> {
+    if let Some(rest) = authority.strip_prefix('[') {
+        let (host, port) = rest.split_once("]:")?;
+        let port = port.parse::<u16>().ok().filter(|port| *port != 0)?;
+        return Some((host.to_ascii_lowercase(), port));
+    }
+    let (host, port) = authority.rsplit_once(':')?;
+    if host.is_empty() || host.contains(':') {
+        return None;
+    }
+    let port = port.parse::<u16>().ok().filter(|port| *port != 0)?;
+    Some((host.trim_end_matches('.').to_ascii_lowercase(), port))
+}
+
+/// Whether the compiled policy admits `host:port`. The destination must also be
+/// a well-formed public name or address encoding ([`EgressDestination`]), so an
+/// alternate IP spelling cannot slip past the exact-host comparison.
+fn policy_permits(policy: &SandboxNetworkPolicy, host: &str, port: u16) -> bool {
+    if EgressDestination::parse(host).is_err() {
+        return false;
+    }
+    policy.permits(host, port)
+}
+
+async fn resolve_public(host: &str, port: u16) -> Result<Vec<SocketAddr>, &'static str> {
+    if let Ok(address) = host.parse::<IpAddr>() {
+        if is_restricted(address) {
+            return Err("private, loopback, or link-local target");
+        }
+        return Ok(vec![SocketAddr::new(address, port)]);
+    }
+    let addresses = lookup_host((host, port))
+        .await
+        .map_err(|_| "destination DNS lookup failed")?
+        .collect::<Vec<_>>();
+    if addresses.is_empty() {
+        return Err("destination DNS lookup returned no addresses");
+    }
+    // Refuse the whole name when any answer is private. Selecting just a public
+    // answer would make the decision depend on resolver ordering and reopen a
+    // DNS-rebinding path on the next connection.
+    if addresses.iter().any(|address| is_restricted(address.ip())) {
+        return Err("destination resolved to private, loopback, or link-local space");
+    }
+    Ok(addresses)
+}
+
+async fn connect_any(addresses: &[SocketAddr]) -> io::Result<TcpStream> {
+    let mut last = io::Error::new(io::ErrorKind::NotFound, "no upstream address");
+    for address in addresses {
+        match tokio::time::timeout(CONNECT_TIMEOUT, TcpStream::connect(address)).await {
+            Ok(Ok(stream)) => return Ok(stream),
+            Ok(Err(error)) => last = error,
+            Err(_) => last = io::Error::new(io::ErrorKind::TimedOut, "upstream connect timed out"),
+        }
+    }
+    Err(last)
+}
+
+fn is_restricted(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => {
+            address.is_private()
+                || address.is_loopback()
+                || address.is_link_local()
+                || address.is_unspecified()
+                || address.is_multicast()
+                || in_v4_block(address, [100, 64, 0, 0], 10)
+                || in_v4_block(address, [198, 18, 0, 0], 15)
+        }
+        IpAddr::V6(address) => {
+            address.is_loopback()
+                || address.is_unspecified()
+                || address.is_multicast()
+                || in_v6_prefix(address, 0xfc00, 7)
+                || in_v6_prefix(address, 0xfe80, 10)
+                || address
+                    .to_ipv4_mapped()
+                    .is_some_and(|mapped| is_restricted(IpAddr::V4(mapped)))
+        }
+    }
+}
+
+fn in_v4_block(address: Ipv4Addr, network: [u8; 4], prefix: u32) -> bool {
+    let mask = u32::MAX << (32 - prefix);
+    u32::from(address) & mask == u32::from(Ipv4Addr::from(network)) & mask
+}
+
+fn in_v6_prefix(address: Ipv6Addr, network: u16, prefix: u32) -> bool {
+    let mask = u16::MAX << (16 - prefix);
+    address.segments()[0] & mask == network & mask
+}
+
+async fn reject(stream: &mut TcpStream, code: u16, reason: &str) -> io::Result<()> {
+    stream
+        .write_all(
+            format!("HTTP/1.1 {code} {reason}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n")
+                .as_bytes(),
+        )
+        .await
+}
+
+fn audit(host: Option<&str>, port: Option<u16>, allowed: bool, reason: &'static str) {
+    eprintln!(
+        "egress-proxy: {} {}:{} ({reason})",
+        if allowed { "allow" } else { "deny" },
+        host.unwrap_or("<invalid>"),
+        port.unwrap_or_default(),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn allowlist(hosts: &[&str], https_only: &[&str]) -> SandboxNetworkPolicy {
+        SandboxNetworkPolicy {
+            allow_all_public: false,
+            allowed_hosts: hosts.iter().map(|host| (*host).to_owned()).collect(),
+            https_only_hosts: https_only.iter().map(|host| (*host).to_owned()).collect(),
+        }
+    }
+
+    #[test]
+    fn compiled_policy_is_exact_and_port_scoped() {
+        let policy = allowlist(&["api.example.com"], &["pypi.org"]);
+        assert!(policy_permits(&policy, "api.example.com", 8443));
+        assert!(policy_permits(&policy, "pypi.org", 443));
+        // The https-only class never opens other ports, and exact matching
+        // never widens to subdomains or lookalikes.
+        assert!(!policy_permits(&policy, "pypi.org", 80));
+        assert!(!policy_permits(&policy, "sub.api.example.com", 8443));
+        assert!(!policy_permits(&policy, "evil-pypi.org", 443));
+        // Deny-all denies, open passes hygiene but stays name-validated.
+        assert!(!policy_permits(
+            &SandboxNetworkPolicy::deny_all(),
+            "example.com",
+            443
+        ));
+        assert!(policy_permits(
+            &SandboxNetworkPolicy::open(),
+            "example.com",
+            443
+        ));
+        assert!(!policy_permits(
+            &SandboxNetworkPolicy::open(),
+            "not a host",
+            443
+        ));
+    }
+
+    #[test]
+    fn private_and_local_address_families_are_restricted() {
+        for address in [
+            "127.0.0.1",
+            "10.0.0.1",
+            "172.16.0.1",
+            "192.168.0.1",
+            "169.254.169.254",
+            "100.64.0.1",
+            "::1",
+            "fe80::1",
+            "fc00::1",
+            "::ffff:127.0.0.1",
+        ] {
+            let address: IpAddr = address.parse().unwrap();
+            assert!(is_restricted(address), "{address} was not restricted");
+        }
+        assert!(!is_restricted("8.8.8.8".parse().unwrap()));
+    }
+
+    #[test]
+    fn a_malformed_or_absent_policy_denies_everything() {
+        let deny: SandboxNetworkPolicy = Default::default();
+        assert!(deny.denies_everything());
+        // The env parser's fallback is this same deny-all value; the fallback
+        // itself is exercised through `from_env` only in-process, so pin the
+        // property the fallback relies on.
+        assert!(!policy_permits(&deny, "example.com", 443));
+    }
+
+    async fn connect_via(proxy: SocketAddr, authority: &str) -> String {
+        let mut stream = TcpStream::connect(proxy).await.unwrap();
+        stream
+            .write_all(
+                format!("CONNECT {authority} HTTP/1.1\r\nHost: {authority}\r\n\r\n").as_bytes(),
+            )
+            .await
+            .unwrap();
+        let mut response = vec![0_u8; 128];
+        let read = stream.read(&mut response).await.unwrap();
+        String::from_utf8_lossy(&response[..read]).into_owned()
+    }
+
+    /// The whole deny path, end to end over real sockets: a policy-denied name
+    /// is 403, and even an Open policy refuses loopback — the two refusals the
+    /// container's confinement depends on.
+    #[tokio::test]
+    async fn proxy_denies_by_policy_and_refuses_private_space() {
+        let proxy = EgressProxy::bind(EgressProxyConfig {
+            policy: SandboxNetworkPolicy::deny_all(),
+            egress_listen: "127.0.0.1:0".to_owned(),
+            relay_listen: "127.0.0.1:0".to_owned(),
+            relay_target: None,
+        })
+        .await
+        .unwrap();
+        let addr = proxy.egress_addr().unwrap();
+        tokio::spawn(proxy.serve());
+        assert!(connect_via(addr, "example.com:443")
+            .await
+            .starts_with("HTTP/1.1 403"));
+
+        let open = EgressProxy::bind(EgressProxyConfig {
+            policy: SandboxNetworkPolicy::open(),
+            egress_listen: "127.0.0.1:0".to_owned(),
+            relay_listen: "127.0.0.1:0".to_owned(),
+            relay_target: None,
+        })
+        .await
+        .unwrap();
+        let addr = open.egress_addr().unwrap();
+        tokio::spawn(open.serve());
+        assert!(connect_via(addr, "127.0.0.1:9")
+            .await
+            .starts_with("HTTP/1.1 403"));
+        assert!(connect_via(addr, "not-connect")
+            .await
+            .starts_with("HTTP/1.1 400"));
+    }
+
+    /// The relay forwards raw bytes to its configured upstream — the property
+    /// the host's attach transport rides on.
+    #[tokio::test]
+    async fn relay_forwards_to_the_configured_upstream() {
+        let upstream = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let upstream_addr = upstream.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = upstream.accept().await.unwrap();
+            let mut buffer = [0_u8; 5];
+            stream.read_exact(&mut buffer).await.unwrap();
+            assert_eq!(&buffer, b"hello");
+            stream.write_all(b"world").await.unwrap();
+        });
+
+        let proxy = EgressProxy::bind(EgressProxyConfig {
+            policy: SandboxNetworkPolicy::deny_all(),
+            egress_listen: "127.0.0.1:0".to_owned(),
+            relay_listen: "127.0.0.1:0".to_owned(),
+            relay_target: Some(upstream_addr.to_string()),
+        })
+        .await
+        .unwrap();
+        let relay_addr = proxy.relay_addr().unwrap().unwrap();
+        tokio::spawn(proxy.serve());
+
+        let mut client = TcpStream::connect(relay_addr).await.unwrap();
+        client.write_all(b"hello").await.unwrap();
+        let mut buffer = [0_u8; 5];
+        client.read_exact(&mut buffer).await.unwrap();
+        assert_eq!(&buffer, b"world");
+    }
+}

--- a/crates/openwave-sandbox-agent/src/exec.rs
+++ b/crates/openwave-sandbox-agent/src/exec.rs
@@ -14,15 +14,22 @@
 //! that whole group, a captured-output cap, and rlimit ceilings — so a
 //! runaway or wedged command is contained by resource bounds, not left to run.
 //!
-//! # NOT YET FOR CREDENTIAL-BEARING WORK
+//! # Egress
 //!
-//! A command run here can make network calls. The design routes egress through
-//! the sandbox supervisor (credential separation + an egress proxy), which is a
-//! **stub** in this crate. Nothing here reaches host authority — the containment
-//! above holds — but egress *from the container* is not yet externally enforced.
-//! This tool surface must not be routed to production credential-bearing work
-//! until externally-enforced egress (the run's egress policy applied to the
-//! container's network) and the transport-auth gate land. See the crate docs.
+//! Egress is enforced from *outside* this process, never in here: this tool
+//! shares a failure domain with the commands it runs, so nothing it could do
+//! would count as a boundary. On the local Docker backend the boundary is
+//! network topology (`openwave-server`'s `sandbox_docker`): the container's
+//! only network is an internal bridge with no route out, and the one
+//! dual-homed egress proxy (this binary's `egress-proxy` mode, see the
+//! [`egress`](crate::egress) module) enforces the chat's compiled network
+//! policy — deny by default — with `HTTP(S)_PROXY` in this environment
+//! pointing compliant tools at it. A command that ignores the proxy has no
+//! route anywhere.
+//!
+//! That guarantee belongs to the provisioning backend, not to this crate: an
+//! operator who runs the agent image by hand, on a network of their own
+//! choosing, gets exactly that network's reach and no policy enforcement.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;

--- a/crates/openwave-sandbox-agent/src/lib.rs
+++ b/crates/openwave-sandbox-agent/src/lib.rs
@@ -6,23 +6,27 @@
 //! [`openwave_sandbox_protocol`] wire contract. It is the primary consumer of
 //! that protocol's sandbox-side transport.
 //!
-//! Three components, and their separation is the point:
+//! Four components, and their separation is the point:
 //!
 //! - the [`supervisor`] owns the transport listener (and, as a documented stub,
-//!   the credential/egress boundary) — the non-agent component;
+//!   the credential boundary) — the non-agent component;
 //! - the [`agent`] loop drives the run: model inference dialed back to the host
 //!   over reverse RPC, a sandbox-resident [`tools`] registry, the event stream,
 //!   and a final result;
 //! - the [`model`] client turns each model step into a host-proxied reverse call,
-//!   so **no model credential ever lives in the container**.
+//!   so **no model credential ever lives in the container**;
+//! - the [`egress`] proxy is the binary's second face: it runs in its *own*
+//!   dual-homed container — never beside the agent, whose failure domain it
+//!   must not share — enforcing the run's compiled network policy and relaying
+//!   the host's transport into the otherwise-unroutable sandbox.
 //!
 //! The sandbox-resident tool surface — [`exec`], [`fs`], and the closed
 //! [`tools`] registry that pins them — runs *inside* the container. That
 //! in-container execution is the containment: model output can only move the
-//! sandbox. Egress from the container is not yet externally enforced (the
-//! supervisor's egress proxy is a stub), so this surface must not be routed to
-//! production credential-bearing work until that enforcement and the
-//! transport-auth gate land.
+//! sandbox. Egress is enforced from outside it: on the local Docker backend the
+//! sandbox's only network is an internal bridge, and the egress-proxy container
+//! is its single, policy-checked way out (see [`exec`]'s module docs for what
+//! that does and does not guarantee).
 //!
 //! # UNSTABLE
 //!
@@ -30,6 +34,7 @@
 //! named release.
 
 pub mod agent;
+pub mod egress;
 pub mod exec;
 pub mod fs;
 pub mod model;
@@ -37,6 +42,7 @@ pub mod supervisor;
 pub mod tools;
 
 pub use agent::{run_agent, AgentRunError};
+pub use egress::{EgressProxy, EgressProxyConfig};
 pub use exec::{ExecTool, EXEC_TOOL};
 pub use fs::{
     ListDirTool, ReadFileTool, WriteFileTool, LIST_DIR_TOOL, READ_FILE_TOOL, WRITE_FILE_TOOL,

--- a/crates/openwave-sandbox-agent/src/main.rs
+++ b/crates/openwave-sandbox-agent/src/main.rs
@@ -40,7 +40,7 @@
 use std::env;
 use std::time::Duration;
 
-use openwave_sandbox_agent::{run_agent, Supervisor};
+use openwave_sandbox_agent::{run_agent, EgressProxy, EgressProxyConfig, Supervisor};
 use openwave_sandbox_protocol::{reverse::Capability, SandboxRun, TransportSecret};
 
 /// Default listener address; the container publishes this port.
@@ -67,6 +67,13 @@ async fn main() {
 }
 
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    // The same binary is the image's second face: `egress-proxy` serves the
+    // sandbox's network boundary from the one dual-homed container instead of
+    // running the agent loop. It honors the same lifetime cap, so a proxy whose
+    // host never returns dies on its own exactly like a stranded sandbox.
+    if env::args().nth(1).as_deref() == Some("egress-proxy") {
+        return run_egress_proxy().await;
+    }
     let listen = env::var("OPENWAVE_SANDBOX_LISTEN").unwrap_or_else(|_| DEFAULT_LISTEN.to_owned());
     let workspace =
         env::var("OPENWAVE_SANDBOX_WORKSPACE").unwrap_or_else(|_| DEFAULT_WORKSPACE.to_owned());
@@ -115,6 +122,32 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         () = lifetime_elapsed(cap) => {
             let secs = cap.unwrap_or_default().as_secs();
             eprintln!("openwave-sandbox-agent: lifetime cap of {secs}s reached; exiting");
+        }
+    }
+    Ok(())
+}
+
+/// Serve the egress-proxy mode until the lifetime cap (if any) elapses.
+async fn run_egress_proxy() -> Result<(), Box<dyn std::error::Error>> {
+    let config = EgressProxyConfig::from_env();
+    if config.policy.denies_everything() {
+        eprintln!("openwave-sandbox-agent egress-proxy: policy denies all egress");
+    }
+    let proxy = EgressProxy::bind(config).await?;
+    eprintln!(
+        "openwave-sandbox-agent egress-proxy listening on {} (relay: {})",
+        proxy.egress_addr()?,
+        match proxy.relay_addr() {
+            Some(addr) => addr?.to_string(),
+            None => "off".to_owned(),
+        }
+    );
+    let cap = lifetime_cap(env::var(LIFETIME_CAP_ENV).ok().as_deref());
+    tokio::select! {
+        () = proxy.serve() => {}
+        () = lifetime_elapsed(cap) => {
+            let secs = cap.unwrap_or_default().as_secs();
+            eprintln!("openwave-sandbox-agent egress-proxy: lifetime cap of {secs}s reached; exiting");
         }
     }
     Ok(())

--- a/crates/openwave-sandbox-protocol/src/conformance.rs
+++ b/crates/openwave-sandbox-protocol/src/conformance.rs
@@ -126,6 +126,7 @@ fn provision_request() -> ProvisionRequest {
         run_id: RunId::new(),
         tag: crate::ids::SandboxTag::new(),
         lifetime_cap_secs: None,
+        network_policy: Default::default(),
     }
 }
 

--- a/crates/openwave-sandbox-protocol/src/lib.rs
+++ b/crates/openwave-sandbox-protocol/src/lib.rs
@@ -76,7 +76,8 @@ pub use protocol::{
     MAX_MODEL_COMPLETION_BYTES, MAX_MODEL_PROMPT_BYTES, PROTOCOL_VERSION,
 };
 pub use provisioning::{
-    BackendError, ProvisionRequest, SandboxAddress, SandboxBackend, SandboxHandle, TransportSecret,
+    BackendError, ProvisionRequest, SandboxAddress, SandboxBackend, SandboxHandle,
+    SandboxNetworkPolicy, TransportSecret,
 };
 pub use reverse::{
     Capability, CapabilityResponder, ControlFrame, GrantSet, ModelInferenceParams,

--- a/crates/openwave-sandbox-protocol/src/provisioning.rs
+++ b/crates/openwave-sandbox-protocol/src/provisioning.rs
@@ -49,6 +49,77 @@ pub struct ProvisionRequest {
     /// outside the sandbox. `None` means the backend cannot cap lifetime, which
     /// (per the design) makes the run attached-only.
     pub lifetime_cap_secs: Option<u64>,
+    /// The egress the sandbox is granted, in the compiled deny-by-default form.
+    /// Absent on the wire means [`SandboxNetworkPolicy::deny_all`], so a caller
+    /// that predates the field provisions a sandbox with no egress rather than
+    /// an unrestricted one.
+    #[serde(default)]
+    pub network_policy: SandboxNetworkPolicy,
+}
+
+/// The egress a provisioned sandbox may perform, compiled by the host into a
+/// closed allowlist before it reaches a backend.
+///
+/// This is deliberately *not* the host's own policy vocabulary: destination
+/// classes (for example the package-manager registry set) are expanded by the
+/// host into exact hosts, so an enforcement point — a backend, or the egress
+/// proxy a backend stands up — needs no class knowledge and no dependency
+/// beyond this crate. The default is deny-everything.
+///
+/// A destination is permitted when [`permits`](Self::permits) says so; private,
+/// loopback, and link-local address space is the enforcement point's own
+/// obligation to refuse regardless of this policy.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SandboxNetworkPolicy {
+    /// Permit every public destination. Enforcement points must still refuse
+    /// private, loopback, and link-local address space.
+    #[serde(default)]
+    pub allow_all_public: bool,
+    /// Exact lowercase DNS hosts permitted on any port. Never wildcards: the
+    /// host refuses wildcard entries at compile time rather than shipping them.
+    #[serde(default)]
+    pub allowed_hosts: Vec<String>,
+    /// Exact lowercase DNS hosts permitted on port 443 only — the compiled
+    /// expansion of a registry destination class.
+    #[serde(default)]
+    pub https_only_hosts: Vec<String>,
+}
+
+impl SandboxNetworkPolicy {
+    /// The deny-everything policy (also `Default`).
+    #[must_use]
+    pub fn deny_all() -> Self {
+        Self::default()
+    }
+
+    /// Permit every public destination.
+    #[must_use]
+    pub fn open() -> Self {
+        Self {
+            allow_all_public: true,
+            allowed_hosts: Vec::new(),
+            https_only_hosts: Vec::new(),
+        }
+    }
+
+    /// Whether this policy denies every destination.
+    #[must_use]
+    pub fn denies_everything(&self) -> bool {
+        !self.allow_all_public && self.allowed_hosts.is_empty() && self.https_only_hosts.is_empty()
+    }
+
+    /// Whether `host:port` is permitted. `host` is matched case-insensitively
+    /// against the exact entries; no wildcard or suffix matching exists here.
+    #[must_use]
+    pub fn permits(&self, host: &str, port: u16) -> bool {
+        if self.allow_all_public {
+            return true;
+        }
+        let matches = |entry: &String| entry.eq_ignore_ascii_case(host);
+        self.allowed_hosts.iter().any(matches)
+            || (port == 443 && self.https_only_hosts.iter().any(matches))
+    }
 }
 
 /// An opaque, backend-specific handle to a provisioned sandbox.

--- a/crates/openwave-sandbox-protocol/tests/wire_format.rs
+++ b/crates/openwave-sandbox-protocol/tests/wire_format.rs
@@ -324,9 +324,31 @@ fn provisioning_wire_shapes() {
         run_id: RunId::new(),
         tag: SandboxTag::new(),
         lifetime_cap_secs: Some(3600),
+        network_policy: openwave_sandbox_protocol::SandboxNetworkPolicy {
+            allow_all_public: false,
+            allowed_hosts: vec!["api.example.com".to_owned()],
+            https_only_hosts: vec!["pypi.org".to_owned()],
+        },
     };
     roundtrip(&request);
-    golden(&request, &[("/lifetime_cap_secs", json!(3600))]);
+    golden(
+        &request,
+        &[
+            ("/lifetime_cap_secs", json!(3600)),
+            ("/network_policy/allowed_hosts/0", json!("api.example.com")),
+            ("/network_policy/https_only_hosts/0", json!("pypi.org")),
+        ],
+    );
+
+    // A request that predates the policy field deserializes to deny-all, so an
+    // older caller provisions a no-egress sandbox rather than an open one.
+    let legacy: ProvisionRequest = serde_json::from_value(json!({
+        "run_id": RunId::new(),
+        "tag": SandboxTag::new(),
+        "lifetime_cap_secs": null,
+    }))
+    .unwrap();
+    assert!(legacy.network_policy.denies_everything());
 
     let handle = SandboxHandle {
         reference: "container-abc".to_owned(),

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -55,7 +55,7 @@ use openwave_sandbox_protocol::{
         ReverseResult, RunProvenance,
     },
     AttachRequest, BackendError, CapabilityHost, ConnectError, ProvisionRequest, SandboxAddress,
-    SandboxBackend, SandboxHandle, SandboxTag, WireClient,
+    SandboxBackend, SandboxHandle, SandboxNetworkPolicy, SandboxTag, WireClient,
 };
 use tokio::net::TcpStream;
 use uuid::Uuid;
@@ -357,9 +357,11 @@ impl SandboxContainerRunner {
         // Resolve the run's model through the host's registry BEFORE any
         // container exists, and fail closed if it does not resolve: the in-process
         // worker gates every egress on the registry, and a container run must
-        // egress under the same policy rather than a looser one.
-        let config = match self.resolve_model_config(&run).await {
-            Ok(config) => config,
+        // egress under the same policy rather than a looser one. The chat's
+        // network policy is compiled here too — the sandbox's egress proxy
+        // enforces exactly the authority the owning conversation granted.
+        let (config, network_policy) = match self.resolve_model_config(&run).await {
+            Ok(resolved) => resolved,
             Err(error) => {
                 return self
                     .fail(
@@ -393,6 +395,7 @@ impl SandboxContainerRunner {
                         // A local container has no external lifetime cap, which
                         // is why the run is attached-only.
                         lifetime_cap_secs: None,
+                        network_policy,
                     })
                     .await;
                 match provisioned {
@@ -470,11 +473,16 @@ impl SandboxContainerRunner {
     }
 
     /// Resolve the run's frozen model selection into an egress config under the
-    /// host's model-registry policy, exactly as the in-process worker does.
+    /// host's model-registry policy, exactly as the in-process worker does, and
+    /// compile the owning chat's network policy into the closed form the
+    /// sandbox backend enforces.
     ///
     /// Fails closed: an absent or unregistered model refuses the run rather than
     /// egressing on an empty or unvetted selection.
-    async fn resolve_model_config(&self, run: &AgentRun) -> Result<AgentConfig> {
+    async fn resolve_model_config(
+        &self,
+        run: &AgentRun,
+    ) -> Result<(AgentConfig, SandboxNetworkPolicy)> {
         let Some(model) = run.model.clone().filter(|model| !model.is_empty()) else {
             return Err(AgentError::config(
                 "container agent run has no frozen model selection",
@@ -501,7 +509,8 @@ impl SandboxContainerRunner {
             config.model = model;
             config.reasoning_effort = chat.reasoning_effort;
         }
-        Ok(config)
+        let network_policy = crate::sandbox_docker::compile_network_policy(&chat.network_policy);
+        Ok((config, network_policy))
     }
 
     async fn attach_and_drive(

--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -1597,6 +1597,9 @@ async fn docker_container_conforms_at_the_transport_boundary() {
             run_id,
             tag: SandboxTag::new(),
             lifetime_cap_secs: None,
+            // Deny-all egress: the attach transport must work through the
+            // proxy's relay even when the sandbox is granted no egress at all.
+            network_policy: Default::default(),
         })
         .await
         .expect("provisioning a conformance container succeeds");

--- a/crates/openwave-server/src/sandbox_docker.rs
+++ b/crates/openwave-server/src/sandbox_docker.rs
@@ -53,10 +53,31 @@
 //! memory and process count. See [`SandboxHardening`] for what each of those buys
 //! and where the writable surface is.
 //!
-//! What is *not* enforced here: egress. A command inside the container can still
-//! reach the network, and no proxy or network policy constrains it on this
-//! backend. That gap is disclosed on the in-container exec tool itself and is a
-//! separate piece of work.
+//! # Egress enforcement
+//!
+//! Egress is enforced by network topology, not by anything inside the sandbox
+//! container (whose `--cap-drop ALL` profile stays intact). Each provisioning
+//! creates an *internal* Docker network — no route out — as the sandbox
+//! container's only network, and stands up a second container from the same
+//! image running the agent binary's `egress-proxy` mode. Only the proxy is
+//! dual-homed: created on the default bridge (outbound reach plus a
+//! loopback-published host port) and then connected onto the internal network
+//! under the [`EGRESS_PROXY_ALIAS`] name. The sandbox's `HTTP(S)_PROXY`
+//! environment points compliant tools at the proxy; a command that ignores it
+//! has no route anywhere.
+//!
+//! The proxy enforces the run's compiled [`SandboxNetworkPolicy`] (deny by
+//! default, delivered as JSON in its environment) with the same CONNECT-only
+//! contract as the native local adapter's loopback broker, and it also carries
+//! the host-to-agent transport: a port published on a container whose only
+//! network is internal is not reachable from the host, so the proxy's published
+//! port TCP-relays to the sandbox's supervisor across the internal network and
+//! [`address`](SandboxBackend::address) resolves the proxy's port. The per-run
+//! transport secret still gates attach.
+//!
+//! Residual: engines differ on whether the embedded DNS resolver forwards
+//! external lookups from internal networks; where an older engine does, name
+//! lookups (not payload connections) can leak. Not closed here.
 //!
 //! # The image is not verified
 //!
@@ -81,9 +102,11 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
 use async_trait::async_trait;
+use openwave_core::NetworkPolicy;
+use openwave_egress::DomainPattern;
 use openwave_sandbox_protocol::{
     BackendError, ProvisionRequest, RunId, SandboxAddress, SandboxBackend, SandboxHandle,
-    SandboxTag, TransportSecret,
+    SandboxNetworkPolicy, SandboxTag, TransportSecret,
 };
 use tokio::process::Command;
 use uuid::Uuid;
@@ -102,6 +125,24 @@ pub const LIFETIME_CAP_ENV: &str = "OPENWAVE_SANDBOX_LIFETIME_CAP_SECS";
 /// Go-template that lists a tagged container's id and correlation tag, tab-separated.
 /// Kept in sync with [`RUN_TAG_LABEL`] by a unit test.
 const TAG_LIST_FORMAT: &str = "{{.ID}}\t{{.Label \"openwave.run-tag\"}}";
+/// Go-template that lists a tagged network's name and correlation tag,
+/// tab-separated. Kept in sync with [`RUN_TAG_LABEL`] by the same unit test.
+const NETWORK_TAG_LIST_FORMAT: &str = "{{.Name}}\t{{.Label \"openwave.run-tag\"}}";
+
+/// The DNS name the sandbox reaches the egress proxy under on the internal
+/// network, and the host the sandbox's `HTTP(S)_PROXY` environment names.
+pub const EGRESS_PROXY_ALIAS: &str = "openwave-egress";
+/// The in-proxy CONNECT listener port. Kept in sync with the agent binary's
+/// `egress-proxy` default; never published to the host.
+const EGRESS_PROXY_PORT: u16 = 3128;
+/// Environment variable carrying the compiled egress policy (JSON) into the
+/// proxy container. Kept in sync with the agent's constant of the same name.
+const EGRESS_POLICY_ENV: &str = "OPENWAVE_EGRESS_POLICY";
+/// Environment variable overriding the proxy's transport-relay listener.
+const RELAY_LISTEN_ENV: &str = "OPENWAVE_RELAY_LISTEN";
+/// Environment variable naming the relay's upstream — the sandbox container's
+/// supervisor endpoint on the internal network.
+const RELAY_TARGET_ENV: &str = "OPENWAVE_RELAY_TARGET";
 
 /// The default runtime binary, resolved on `PATH`.
 const DEFAULT_BINARY: &str = "docker";
@@ -142,6 +183,11 @@ const DEFAULT_PIDS_LIMIT: u32 = 512;
 const DEFAULT_TMPFS_OPTIONS: &str = "rw,exec,nosuid,nodev,size=1g";
 
 const RUNTIME_UNAVAILABLE: &str = "container runtime is unavailable";
+const NETWORK_CREATE_FAILED: &str = "could not create the sandbox's internal network";
+const PROXY_RUN_FAILED: &str = "could not start the sandbox egress proxy";
+const PROXY_CONNECT_FAILED: &str = "could not attach the egress proxy to the sandbox network";
+const NETWORK_REMOVE_FAILED: &str = "could not remove the sandbox network";
+const NETWORK_LIST_FAILED: &str = "could not list sandbox networks";
 const RUNTIME_SPAWN_FAILED: &str = "could not invoke the container runtime";
 const RUN_FAILED: &str = "could not start the sandbox container";
 const PORT_LOOKUP_FAILED: &str = "could not resolve the sandbox's published port";
@@ -164,6 +210,11 @@ pub struct DockerConfig {
     /// entrypoint. Empty means the image's default is used — the real agent image
     /// needs no override; tests pass a trivial port-holding command.
     pub command: Vec<String>,
+    /// A command (and arguments) for the egress-proxy container, overriding the
+    /// image's entrypoint. Empty means the image's entrypoint runs with the
+    /// `egress-proxy` argument — the real agent image's second face; tests on
+    /// stand-in images pass a trivial port-holding command.
+    pub proxy_command: Vec<String>,
     /// The absolute lifetime cap, in seconds, applied to a provisioning request
     /// that names none of its own. `None` disables the fallback, leaving a
     /// capless request uncapped; a request's own
@@ -181,6 +232,7 @@ impl Default for DockerConfig {
             image: DEFAULT_IMAGE.to_owned(),
             listener_port: DEFAULT_LISTENER_PORT,
             command: Vec::new(),
+            proxy_command: Vec::new(),
             lifetime_cap_secs: Some(DEFAULT_LIFETIME_CAP_SECS),
             hardening: SandboxHardening::default(),
         }
@@ -351,12 +403,108 @@ impl DockerSandboxBackend {
     }
 }
 
+impl DockerSandboxBackend {
+    /// Run one runtime invocation whose only interesting outcome is success.
+    async fn invoke(&self, args: &[String], failure: &str) -> Result<Vec<u8>, BackendError> {
+        let mut command = self.command();
+        command.args(args);
+        let output = command
+            .output()
+            .await
+            .map_err(|_| BackendError::Provision(RUNTIME_SPAWN_FAILED.to_owned()))?;
+        if !output.status.success() {
+            return Err(BackendError::Provision(failure.to_owned()));
+        }
+        Ok(output.stdout)
+    }
+
+    /// Best-effort removal of whatever a failed provisioning half-made. The
+    /// caller still enqueues the durable teardown obligation, so the tag sweep
+    /// re-covers anything this pass could not confirm.
+    async fn unwind_provision(&self, tag: SandboxTag) {
+        let _ = self.remove(&proxy_name(tag)).await;
+        let _ = self.remove_network(tag).await;
+    }
+
+    /// `docker network rm`, treating a missing network as success.
+    async fn remove_network(&self, tag: SandboxTag) -> Result<(), BackendError> {
+        let mut command = self.command();
+        command.args(["network", "rm", &network_name(tag)]);
+        let output = command
+            .output()
+            .await
+            .map_err(|_| BackendError::Teardown(RUNTIME_SPAWN_FAILED.to_owned()))?;
+        if output.status.success() || is_no_such_network(&output.stderr) {
+            Ok(())
+        } else {
+            Err(BackendError::Teardown(NETWORK_REMOVE_FAILED.to_owned()))
+        }
+    }
+
+    /// List every network carrying the correlation-tag label, with its tag parsed.
+    async fn list_tagged_networks(&self) -> Result<Vec<(String, SandboxTag)>, BackendError> {
+        let mut command = self.command();
+        command.args([
+            "network",
+            "ls",
+            "--filter",
+            &format!("label={RUN_TAG_LABEL}"),
+            "--format",
+            NETWORK_TAG_LIST_FORMAT,
+        ]);
+        let output = command
+            .output()
+            .await
+            .map_err(|_| BackendError::Teardown(RUNTIME_SPAWN_FAILED.to_owned()))?;
+        if !output.status.success() {
+            return Err(BackendError::Teardown(NETWORK_LIST_FAILED.to_owned()));
+        }
+        Ok(parse_network_tag_listing(&output.stdout))
+    }
+}
+
 #[async_trait]
 impl SandboxBackend for DockerSandboxBackend {
     async fn provision(&self, request: ProvisionRequest) -> Result<SandboxHandle, BackendError> {
         if !self.is_available() {
             return Err(BackendError::Provision(RUNTIME_UNAVAILABLE.to_owned()));
         }
+        let tag = request.tag;
+        let cap = effective_lifetime_cap(&self.config, &request);
+        let policy_json = serde_json::to_string(&request.network_policy)
+            .map_err(|_| BackendError::Provision(RUN_FAILED.to_owned()))?;
+
+        // 1. The internal network — the sandbox's only network, with no route
+        //    out. Tagged so the orphan sweep reclaims it with the containers.
+        self.invoke(&network_create_args(tag), NETWORK_CREATE_FAILED)
+            .await?;
+
+        // 2. The egress proxy, on the default bridge: outbound reach, the
+        //    loopback-published transport port, and the compiled policy in its
+        //    environment.
+        if let Err(error) = self
+            .invoke(
+                &proxy_run_args(&self.config, tag, request.run_id, cap, &policy_json),
+                PROXY_RUN_FAILED,
+            )
+            .await
+        {
+            self.unwind_provision(tag).await;
+            return Err(error);
+        }
+
+        // 3. Dual-home the proxy onto the internal network under the alias the
+        //    sandbox's HTTP(S)_PROXY environment names.
+        if let Err(error) = self
+            .invoke(&proxy_connect_args(tag), PROXY_CONNECT_FAILED)
+            .await
+        {
+            self.unwind_provision(tag).await;
+            return Err(error);
+        }
+
+        // 4. The sandbox itself, confined to the internal network.
+        //
         // Docker enforces no lifetime cap from outside the container, and neither
         // can this process: a host-side timer dies with the host, which is the very
         // failure that strands a container. The cap therefore rides into the
@@ -364,12 +512,7 @@ impl SandboxBackend for DockerSandboxBackend {
         // docs for why that is an absolute cap and not an idle timeout.
         let secret = Uuid::new_v4().to_string();
         let mut command = self.command();
-        command.args(run_args(
-            &self.config,
-            request.tag,
-            request.run_id,
-            effective_lifetime_cap(&self.config, &request),
-        ));
+        command.args(run_args(&self.config, tag, request.run_id, cap));
         // Set the secret on the runtime CLI's own environment and pass it through with
         // a valueless `--env`, so it never appears in this process's argv. The
         // delegated task never travels here at all: it arrives in the run-init
@@ -379,16 +522,16 @@ impl SandboxBackend for DockerSandboxBackend {
         let output = command
             .output()
             .await
-            .map_err(|_| BackendError::Provision(RUNTIME_SPAWN_FAILED.to_owned()))?;
-        if !output.status.success() {
+            .map_err(|_| BackendError::Provision(RUNTIME_SPAWN_FAILED.to_owned()));
+        let reference = match output {
+            Ok(output) if output.status.success() => parse_container_id(&output.stdout),
+            _ => None,
+        };
+        let Some(reference) = reference else {
+            self.unwind_provision(tag).await;
             return Err(BackendError::Provision(RUN_FAILED.to_owned()));
-        }
-        let reference = parse_container_id(&output.stdout)
-            .ok_or_else(|| BackendError::Provision(RUN_FAILED.to_owned()))?;
-        Ok(SandboxHandle {
-            reference,
-            tag: request.tag,
-        })
+        };
+        Ok(SandboxHandle { reference, tag })
     }
 
     async fn address(&self, handle: &SandboxHandle) -> Result<SandboxAddress, BackendError> {
@@ -400,12 +543,18 @@ impl SandboxBackend for DockerSandboxBackend {
         // unit-testable without a daemon), and it does not depend on `docker port`'s
         // line format. The publish is loopback-only, so the binding's host IP is
         // 127.0.0.1 and `base_url` names it directly.
+        //
+        // The published port lives on the *proxy* container: the sandbox's only
+        // network is internal, so its own port could not be published, and the
+        // proxy relays the transport across the internal network. The proxy's
+        // deterministic name is a pure function of the handle's tag, so this
+        // remains recoverable after a host restart.
         let mut command = self.command();
         command.args([
             "inspect",
             "--format",
             "{{json .NetworkSettings.Ports}}",
-            &handle.reference,
+            &proxy_name(handle.tag),
         ]);
         let output = command
             .output()
@@ -431,7 +580,11 @@ impl SandboxBackend for DockerSandboxBackend {
         if !self.is_available() {
             return Err(BackendError::Teardown(RUNTIME_UNAVAILABLE.to_owned()));
         }
-        self.remove(&handle.reference).await
+        // Containers before the network: a network with attached containers
+        // refuses removal. Each step is idempotent on "already gone".
+        self.remove(&handle.reference).await?;
+        self.remove(&proxy_name(handle.tag)).await?;
+        self.remove_network(handle.tag).await
     }
 
     /// Reclaim orphaned containers: destroy every tagged container whose
@@ -453,6 +606,8 @@ impl SandboxBackend for DockerSandboxBackend {
         }
         let mut reclaimed = Vec::new();
         let mut unconfirmed = false;
+        // The egress-proxy containers carry the same tag label, so one listing
+        // covers both halves of a run's pair.
         for handle in self.list_tagged().await? {
             if live_tags.contains(&handle.tag) {
                 continue;
@@ -460,6 +615,16 @@ impl SandboxBackend for DockerSandboxBackend {
             if self.remove(&handle.reference).await.is_ok() {
                 reclaimed.push(handle);
             } else {
+                unconfirmed = true;
+            }
+        }
+        // Networks after their containers, for the same attachment reason as
+        // `destroy`.
+        for (_, tag) in self.list_tagged_networks().await? {
+            if live_tags.contains(&tag) {
+                continue;
+            }
+            if self.remove_network(tag).await.is_err() {
                 unconfirmed = true;
             }
         }
@@ -481,23 +646,206 @@ fn effective_lifetime_cap(config: &DockerConfig, request: &ProvisionRequest) -> 
         .filter(|secs| *secs > 0)
 }
 
-/// The `docker run` argument vector for one provisioning. Factored out so the
-/// label, publish, and env-passthrough composition is testable without a runtime.
+/// The per-run internal network's name — a pure function of the tag, so
+/// teardown and restart recovery need no extra state.
+fn network_name(tag: SandboxTag) -> String {
+    format!("openwave-net-{tag}")
+}
+
+/// The per-run egress-proxy container's name.
+fn proxy_name(tag: SandboxTag) -> String {
+    format!("openwave-egress-{tag}")
+}
+
+/// The per-run sandbox container's name: the DNS name the proxy's transport
+/// relay dials on the internal network.
+fn sandbox_name(tag: SandboxTag) -> String {
+    format!("openwave-sbx-{tag}")
+}
+
+/// Compile a chat's provider-neutral [`NetworkPolicy`] into the closed,
+/// class-expanded form a sandbox backend enforces.
+///
+/// Persisted policies are already normalized (exact lowercase hosts, no
+/// wildcards), but the filter here is defensive rather than trusting: an entry
+/// that fails to parse as an exact domain pattern is dropped — narrowing, never
+/// widening — instead of shipped to the enforcement point.
+pub(crate) fn compile_network_policy(policy: &NetworkPolicy) -> SandboxNetworkPolicy {
+    let package_domains = || {
+        openwave_code_execution::PACKAGE_MANAGER_DOMAINS
+            .iter()
+            .map(|domain| (*domain).to_owned())
+            .collect::<Vec<_>>()
+    };
+    match policy {
+        NetworkPolicy::Off => SandboxNetworkPolicy::deny_all(),
+        NetworkPolicy::Open => SandboxNetworkPolicy::open(),
+        NetworkPolicy::PackageManagers => SandboxNetworkPolicy {
+            allow_all_public: false,
+            allowed_hosts: Vec::new(),
+            https_only_hosts: package_domains(),
+        },
+        NetworkPolicy::AllowedHosts {
+            allowed_hosts,
+            package_managers,
+        } => SandboxNetworkPolicy {
+            allow_all_public: false,
+            allowed_hosts: allowed_hosts
+                .iter()
+                .filter(|host| !host.starts_with("*."))
+                .filter_map(|host| DomainPattern::parse(host).ok().map(|_| host.to_owned()))
+                .collect(),
+            https_only_hosts: if *package_managers {
+                package_domains()
+            } else {
+                Vec::new()
+            },
+        },
+    }
+}
+
+/// The `docker network create` argument vector for one provisioning: an
+/// *internal* network — no route out — tagged for the orphan sweep.
+fn network_create_args(tag: SandboxTag) -> Vec<String> {
+    vec![
+        "network".to_owned(),
+        "create".to_owned(),
+        "--internal".to_owned(),
+        "--label".to_owned(),
+        format!("{RUN_TAG_LABEL}={tag}"),
+        network_name(tag),
+    ]
+}
+
+/// The `docker run` argument vector for the egress-proxy container. It runs on
+/// the default bridge (outbound reach) with the transport port published to
+/// host loopback and the compiled policy in its environment; a later
+/// `network connect` dual-homes it onto the internal network.
+fn proxy_run_args(
+    config: &DockerConfig,
+    tag: SandboxTag,
+    run_id: RunId,
+    lifetime_cap_secs: Option<u64>,
+    policy_json: &str,
+) -> Vec<String> {
+    let mut args = vec![
+        "run".to_owned(),
+        "-d".to_owned(),
+        "--name".to_owned(),
+        proxy_name(tag),
+        "--label".to_owned(),
+        format!("{RUN_TAG_LABEL}={tag}"),
+        "--label".to_owned(),
+        format!("{RUN_ID_LABEL}={run_id}"),
+        "--env".to_owned(),
+        format!("{EGRESS_POLICY_ENV}={policy_json}"),
+        "--env".to_owned(),
+        format!("{RELAY_LISTEN_ENV}=0.0.0.0:{}", config.listener_port),
+        "--env".to_owned(),
+        format!(
+            "{RELAY_TARGET_ENV}={}:{}",
+            sandbox_name(tag),
+            config.listener_port
+        ),
+    ];
+    // The proxy dies on its own exactly like a stranded sandbox.
+    if let Some(secs) = lifetime_cap_secs {
+        args.push("--env".to_owned());
+        args.push(format!("{LIFETIME_CAP_ENV}={secs}"));
+    }
+    args.extend(proxy_hardening_args(&config.hardening));
+    args.extend([
+        "--publish".to_owned(),
+        format!("127.0.0.1::{}", config.listener_port),
+        config.image.clone(),
+    ]);
+    if config.proxy_command.is_empty() {
+        args.push("egress-proxy".to_owned());
+    } else {
+        args.extend(config.proxy_command.iter().cloned());
+    }
+    args
+}
+
+/// The proxy's confinement: the sandbox profile minus the writable surface —
+/// the proxy writes nothing — and minus `--init`, since it never spawns
+/// children. It is trusted code, but it faces the untrusted network on one side
+/// and the untrusted sandbox on the other, so it keeps the non-root,
+/// no-capability, read-only, ceiling-bounded profile.
+fn proxy_hardening_args(hardening: &SandboxHardening) -> Vec<String> {
+    let mut args = Vec::new();
+    if let Some(user) = &hardening.user {
+        args.extend(["--user".to_owned(), user.clone()]);
+    }
+    if hardening.drop_capabilities {
+        args.extend(["--cap-drop".to_owned(), "ALL".to_owned()]);
+    }
+    if hardening.no_new_privileges {
+        args.extend([
+            "--security-opt".to_owned(),
+            "no-new-privileges:true".to_owned(),
+        ]);
+    }
+    if hardening.read_only_rootfs {
+        args.push("--read-only".to_owned());
+    }
+    if let Some(memory) = &hardening.memory_limit {
+        args.extend(["--memory".to_owned(), memory.clone()]);
+    }
+    if let Some(pids) = hardening.pids_limit {
+        args.extend(["--pids-limit".to_owned(), pids.to_string()]);
+    }
+    args
+}
+
+/// The `docker network connect` argument vector that dual-homes the proxy onto
+/// the internal network under the alias the sandbox's proxy environment names.
+fn proxy_connect_args(tag: SandboxTag) -> Vec<String> {
+    vec![
+        "network".to_owned(),
+        "connect".to_owned(),
+        "--alias".to_owned(),
+        EGRESS_PROXY_ALIAS.to_owned(),
+        network_name(tag),
+        proxy_name(tag),
+    ]
+}
+
+/// The `docker run` argument vector for the sandbox container. Factored out so
+/// the label, network, and env-passthrough composition is testable without a
+/// runtime.
 fn run_args(
     config: &DockerConfig,
     tag: SandboxTag,
     run_id: RunId,
     lifetime_cap_secs: Option<u64>,
 ) -> Vec<String> {
+    let proxy_url = format!("http://{EGRESS_PROXY_ALIAS}:{EGRESS_PROXY_PORT}");
     let mut args = vec![
         "run".to_owned(),
         "-d".to_owned(),
+        "--name".to_owned(),
+        sandbox_name(tag),
+        // The sandbox's ONLY network: internal, so a command that ignores the
+        // proxy environment has no route anywhere. No port is published here —
+        // it could not reach the host anyway; the proxy relays the transport.
+        "--network".to_owned(),
+        network_name(tag),
         "--label".to_owned(),
         format!("{RUN_TAG_LABEL}={tag}"),
         "--label".to_owned(),
         format!("{RUN_ID_LABEL}={run_id}"),
         "--env".to_owned(),
         TRANSPORT_SECRET_ENV.to_owned(),
+        // Convenience for compliant tools; the topology is the enforcement.
+        "--env".to_owned(),
+        format!("HTTP_PROXY={proxy_url}"),
+        "--env".to_owned(),
+        format!("HTTPS_PROXY={proxy_url}"),
+        "--env".to_owned(),
+        format!("http_proxy={proxy_url}"),
+        "--env".to_owned(),
+        format!("https_proxy={proxy_url}"),
     ];
     args.extend(hardening_args(&config.hardening));
     // Unlike the secret, the cap is not sensitive, so it travels as
@@ -507,11 +855,7 @@ fn run_args(
         args.push("--env".to_owned());
         args.push(format!("{LIFETIME_CAP_ENV}={secs}"));
     }
-    args.extend([
-        "--publish".to_owned(),
-        format!("127.0.0.1::{}", config.listener_port),
-        config.image.clone(),
-    ]);
+    args.push(config.image.clone());
     args.extend(config.command.iter().cloned());
     args
 }
@@ -628,12 +972,37 @@ fn parse_tag_listing(stdout: &[u8]) -> Vec<SandboxHandle> {
         .collect()
 }
 
+/// Parse the name/tag pairs from the network tag-listing template's output.
+fn parse_network_tag_listing(stdout: &[u8]) -> Vec<(String, SandboxTag)> {
+    let text = String::from_utf8_lossy(stdout);
+    text.lines()
+        .filter_map(|line| {
+            let (name, tag) = line.trim().split_once('\t')?;
+            let (name, tag) = (name.trim(), tag.trim());
+            if name.is_empty() {
+                return None;
+            }
+            let tag = tag.parse::<SandboxTag>().ok()?;
+            Some((name.to_owned(), tag))
+        })
+        .collect()
+}
+
 /// Whether a runtime error names a container that does not exist — the idempotent
 /// case for destroy, and the unknown-handle case for address. Covers both Docker
 /// (`No such container`) and podman (`no such container` / `no such object`).
 fn is_no_such_container(stderr: &[u8]) -> bool {
     let text = String::from_utf8_lossy(stderr).to_ascii_lowercase();
     text.contains("no such container") || text.contains("no such object")
+}
+
+/// Whether a runtime error names a network that does not exist — the idempotent
+/// case for network removal, across Docker and podman phrasings.
+fn is_no_such_network(stderr: &[u8]) -> bool {
+    let text = String::from_utf8_lossy(stderr).to_ascii_lowercase();
+    text.contains("no such network")
+        || text.contains("network not found")
+        || text.contains("unable to find network")
 }
 
 /// Resolve a runtime binary the way a shell would: an explicit path is checked as
@@ -698,6 +1067,7 @@ mod tests {
             run_id: RunId::new(),
             tag: SandboxTag::new(),
             lifetime_cap_secs: None,
+            network_policy: Default::default(),
         };
         assert!(matches!(
             backend.provision(request).await,
@@ -724,7 +1094,7 @@ mod tests {
     }
 
     #[test]
-    fn run_args_stamp_the_tag_publish_the_port_and_append_the_command() {
+    fn run_args_stamp_the_tag_confine_the_network_and_append_the_command() {
         let tag = SandboxTag::new();
         let run_id = RunId::new();
         let config = DockerConfig {
@@ -745,7 +1115,23 @@ mod tests {
         assert!(args
             .iter()
             .all(|arg| !arg.contains(TRANSPORT_SECRET_ENV) || arg == TRANSPORT_SECRET_ENV));
-        assert!(args.contains(&"127.0.0.1::9000".to_owned()));
+
+        // The sandbox's only network is the per-run internal network, and it
+        // publishes NO port: the proxy relays the transport, and a published
+        // port here would be dead weight at best.
+        let network_at = args.iter().position(|arg| arg == "--network").unwrap();
+        assert_eq!(args[network_at + 1], network_name(tag));
+        assert!(!args.iter().any(|arg| arg == "--publish"));
+        // Compliant tools are pointed at the proxy by every spelling.
+        for var in ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"] {
+            assert!(args.contains(&format!(
+                "{var}=http://{EGRESS_PROXY_ALIAS}:{EGRESS_PROXY_PORT}"
+            )));
+        }
+        // The deterministic name is what the proxy's relay dials.
+        let name_at = args.iter().position(|arg| arg == "--name").unwrap();
+        assert_eq!(args[name_at + 1], sandbox_name(tag));
+
         // The image precedes the container command.
         let image_at = args
             .iter()
@@ -763,6 +1149,109 @@ mod tests {
         // the container would read as "expire now".
         let uncapped = run_args(&config, tag, run_id, None);
         assert!(uncapped.iter().all(|arg| !arg.contains(LIFETIME_CAP_ENV)));
+    }
+
+    /// The proxy container is the only dual-homed, host-published piece, and it
+    /// carries the compiled policy. Every property here is invisible at runtime
+    /// if silently dropped, so each is pinned.
+    #[test]
+    fn proxy_and_network_args_compose_the_egress_topology() {
+        let tag = SandboxTag::new();
+        let run_id = RunId::new();
+        let config = DockerConfig {
+            listener_port: 9000,
+            image: "example/image:tag".to_owned(),
+            ..DockerConfig::default()
+        };
+
+        // The network is internal — the property the whole boundary rests on.
+        let net = network_create_args(tag);
+        assert!(net.contains(&"--internal".to_owned()));
+        assert!(net.contains(&format!("{RUN_TAG_LABEL}={tag}")));
+        assert_eq!(net.last().unwrap(), &network_name(tag));
+
+        let policy = r#"{"allow_all_public":false}"#;
+        let args = proxy_run_args(&config, tag, run_id, Some(900), policy);
+        // Published to host loopback: this is the transport's front door.
+        assert!(args.contains(&"127.0.0.1::9000".to_owned()));
+        // Policy, relay wiring, and the lifetime cap ride the environment.
+        assert!(args.contains(&format!("{EGRESS_POLICY_ENV}={policy}")));
+        assert!(args.contains(&format!("{RELAY_LISTEN_ENV}=0.0.0.0:9000")));
+        assert!(args.contains(&format!("{RELAY_TARGET_ENV}={}:9000", sandbox_name(tag))));
+        assert!(args.contains(&format!("{LIFETIME_CAP_ENV}=900")));
+        // The default command is the agent image's second face.
+        assert_eq!(args.last().unwrap(), "egress-proxy");
+        // The proxy keeps the non-root, no-capability, read-only profile.
+        assert!(args.contains(&"--cap-drop".to_owned()));
+        assert!(args.contains(&"--read-only".to_owned()));
+        // It is tagged for the sweep and deterministically named for recovery.
+        assert!(args.contains(&format!("{RUN_TAG_LABEL}={tag}")));
+        assert!(args.contains(&proxy_name(tag)));
+
+        // A test image without the agent binary can stand in a port-holder.
+        let stand_in = DockerConfig {
+            proxy_command: vec!["nc".to_owned(), "-l".to_owned()],
+            ..config.clone()
+        };
+        let args = proxy_run_args(&stand_in, tag, run_id, None, policy);
+        assert_eq!(args.last().unwrap(), "-l");
+
+        // The connect dual-homes the proxy under the alias the sandbox's proxy
+        // environment names.
+        let connect = proxy_connect_args(tag);
+        assert_eq!(
+            connect,
+            vec![
+                "network".to_owned(),
+                "connect".to_owned(),
+                "--alias".to_owned(),
+                EGRESS_PROXY_ALIAS.to_owned(),
+                network_name(tag),
+                proxy_name(tag),
+            ]
+        );
+    }
+
+    /// Host-side policy compilation: classes expand to exact hosts, deny stays
+    /// deny, and nothing ever widens.
+    #[test]
+    fn network_policy_compiles_to_the_closed_sandbox_form() {
+        assert!(compile_network_policy(&NetworkPolicy::Off).denies_everything());
+
+        let open = compile_network_policy(&NetworkPolicy::Open);
+        assert!(open.allow_all_public);
+
+        let packages = compile_network_policy(&NetworkPolicy::PackageManagers);
+        assert!(!packages.allow_all_public);
+        assert!(packages.allowed_hosts.is_empty());
+        assert!(packages
+            .https_only_hosts
+            .iter()
+            .any(|host| host == "pypi.org"));
+        assert!(packages.permits("pypi.org", 443));
+        assert!(!packages.permits("pypi.org", 80));
+
+        let custom = compile_network_policy(&NetworkPolicy::AllowedHosts {
+            allowed_hosts: vec![
+                "api.example.com".to_owned(),
+                // Defensive: wildcards and malformed entries are dropped, not
+                // shipped — narrowing, never widening.
+                "*.unsafe.example".to_owned(),
+                "not a host".to_owned(),
+            ],
+            package_managers: true,
+        });
+        assert_eq!(custom.allowed_hosts, vec!["api.example.com".to_owned()]);
+        assert!(custom.permits("crates.io", 443));
+        assert!(!custom.permits("x.unsafe.example", 443));
+    }
+
+    #[test]
+    fn network_tag_listing_parser_keeps_valid_tags() {
+        let tag = SandboxTag::new();
+        let stdout = format!("openwave-net-{tag}\t{tag}\nother-net\tnot-a-uuid\n");
+        let networks = parse_network_tag_listing(stdout.as_bytes());
+        assert_eq!(networks, vec![(network_name(tag), tag)]);
     }
 
     /// Every confinement control reaches the argv. A container missing them
@@ -817,6 +1306,7 @@ mod tests {
             run_id: RunId::new(),
             tag: SandboxTag::new(),
             lifetime_cap_secs,
+            network_policy: Default::default(),
         };
         let config = DockerConfig::default();
         assert_eq!(config.lifetime_cap_secs, Some(DEFAULT_LIFETIME_CAP_SECS));
@@ -845,6 +1335,7 @@ mod tests {
     #[test]
     fn tag_list_format_tracks_the_label_constant() {
         assert!(TAG_LIST_FORMAT.contains(RUN_TAG_LABEL));
+        assert!(NETWORK_TAG_LIST_FORMAT.contains(RUN_TAG_LABEL));
     }
 
     #[test]
@@ -916,6 +1407,16 @@ mod tests {
             // published port keeps a real listener behind it; `|| sleep 1` avoids a
             // busy spin if a listen attempt ever fails.
             command: vec![
+                "sh".to_owned(),
+                "-c".to_owned(),
+                "while true; do nc -l -p 8080 || sleep 1; done".to_owned(),
+            ],
+            // The stand-in image has no agent binary, so the egress-proxy
+            // container holds its published port the same way. Reachability of
+            // the published port then proves the topology stood up (network,
+            // dual-homed proxy, sandbox), not the relay's forwarding — that is
+            // the sandbox-resident e2e lane's to prove.
+            proxy_command: vec![
                 "sh".to_owned(),
                 "-c".to_owned(),
                 "while true; do nc -l -p 8080 || sleep 1; done".to_owned(),
@@ -999,6 +1500,7 @@ mod tests {
                 run_id: RunId::new(),
                 tag: live_tag,
                 lifetime_cap_secs: None,
+                network_policy: Default::default(),
             })
             .await
             .expect("provision live container");
@@ -1010,6 +1512,7 @@ mod tests {
                 run_id: RunId::new(),
                 tag: orphan_tag,
                 lifetime_cap_secs: None,
+                network_policy: Default::default(),
             })
             .await
             .expect("provision orphan container");

--- a/crates/openwave-server/src/sandbox_docker.rs
+++ b/crates/openwave-server/src/sandbox_docker.rs
@@ -997,11 +997,13 @@ fn is_no_such_container(stderr: &[u8]) -> bool {
 }
 
 /// Whether a runtime error names a network that does not exist — the idempotent
-/// case for network removal, across Docker and podman phrasings.
+/// case for network removal. Docker phrases it `network <name> not found` (the
+/// name sits between the words, so the match is on the bare suffix); podman
+/// uses `unable to find network` / `no such network`.
 fn is_no_such_network(stderr: &[u8]) -> bool {
     let text = String::from_utf8_lossy(stderr).to_ascii_lowercase();
     text.contains("no such network")
-        || text.contains("network not found")
+        || text.contains("not found")
         || text.contains("unable to find network")
 }
 
@@ -1391,6 +1393,23 @@ mod tests {
         assert!(is_no_such_container(b"Error: No such container: abc"));
         assert!(is_no_such_container(b"error: no such object abc"));
         assert!(!is_no_such_container(b"Error: container is restarting"));
+    }
+
+    /// The missing-network phrasings that make repeated teardown idempotent.
+    /// Docker interpolates the name between "network" and "not found", which is
+    /// exactly the case a stricter phrase match gets wrong.
+    #[test]
+    fn missing_network_is_recognized_across_runtimes() {
+        assert!(is_no_such_network(
+            b"Error response from daemon: network openwave-net-abc not found"
+        ));
+        assert!(is_no_such_network(b"Error: no such network abc"));
+        assert!(is_no_such_network(
+            b"Error: unable to find network with name or ID abc: network not found"
+        ));
+        assert!(!is_no_such_network(
+            b"Error response from daemon: network openwave-net-abc has active endpoints"
+        ));
     }
 
     // --- Live-Docker tests, skipped cleanly when no runtime is present. ---


### PR DESCRIPTION
Closes #1189. Implements the egress-proxy architecture from the issue's design discussion (see the design comment there): the local Docker sandbox's egress is now denied by network topology and granted only through a policy-enforcing proxy, with no `NET_ADMIN` and no change to #1187's `--cap-drop ALL` / `no-new-privileges` profile.

## Topology (per provisioning)

- The backend creates an **internal** Docker network (no route out), labeled with the run's correlation tag, as the sandbox container's only network. The sandbox's published port is gone (it could not reach the host from an internal network anyway) and its environment points compliant tools at `HTTP(S)_PROXY=http://openwave-egress:3128`. The env vars are convenience; the topology is the enforcement — a command that ignores the proxy has no route anywhere.
- A second container from the same sandbox-agent image runs the binary's new `egress-proxy` mode and is the only dual-homed piece: created on the default bridge (outbound reach plus a loopback-published host port), then `network connect --alias openwave-egress`ed onto the internal network. It runs under the same hardening (non-root, cap-drop ALL, no-new-privileges, read-only rootfs, memory/pids ceilings) and honors the same in-container lifetime cap, so a stranded proxy dies on its own.

## The proxy

Reuses the CONNECT-only broker contract the native local adapter already ships (`openwave-code-execution`'s `network` module) rather than adding any third-party proxy: TLS stays end to end, the proxy decides only `host:port` against the compiled policy, resolves the name outside the sandbox, refuses private/loopback/link-local answers (any private answer poisons the whole name, closing the DNS-rebinding angle), audits every decision, and relays bytes. Plain absolute-form HTTP is not implemented — plaintext egress is simply denied, as on the native path.

The proxy also carries the host-to-agent transport: its published loopback port TCP-relays to the sandbox's supervisor across the internal network, `address()` resolves the proxy's port, and the per-run transport secret still gates attach.

## Policy

The run's owning chat's `NetworkPolicy` is compiled host-side into a closed, class-expanded `SandboxNetworkPolicy` carried on `ProvisionRequest` (new defaulted field; the default is deny-all, so a caller that predates the field provisions a no-egress sandbox). `Off` denies; `PackageManagers` expands to the exact registry set, 443 only; `AllowedHosts` ships exact hosts (wildcard or malformed entries are dropped, narrowing); `Open` allows public destinations with private space still refused. Teardown and the orphan sweep now reclaim the proxy container and the network alongside the sandbox, and the disclosures in `exec.rs`, the agent crate docs, the Dockerfile, and the backend module docs are rewritten to match.

## Testing

- Loopback integration tests drive the proxy over real sockets: policy-denied CONNECT is 403, loopback is refused even under an Open policy, malformed requests are 400, and the relay forwards bytes to its upstream.
- Unit tests pin the wire shape (including the legacy-request deny-all default), the policy compilation, the argv composition of the network/proxy/sandbox trio (a silently dropped flag is invisible at runtime), and the network tag-listing parser.
- What only the post-merge `sandbox-resident container e2e` lane (or a manual run) can prove: the real topology — that an internal network actually blocks direct egress, that the alias resolves, and that the published-through-proxy transport attaches. The existing e2e test now exercises the relay implicitly under a deny-all policy; #1346 tracks adding an explicit deny/allow egress probe to that lane, plus the residual that some engines forward external DNS lookups from internal networks.