### PR TITLE
feat(server): governed REST executor with pinned, bounded egress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4166,6 +4166,7 @@ dependencies = [
  "chrono",
  "futures",
  "image",
+ "jsonschema",
  "libc",
  "openwave-code-execution",
  "openwave-connectors",

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -29,6 +29,11 @@ futures = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+# The governed REST executor's pinned per-request egress client.
+reqwest = { workspace = true }
+# Catalog-declared parameter and body schemas validated per request in the
+# governed REST executor.
+jsonschema = { workspace = true }
 # Output-constraint schemas for the host's own model calls, e.g. chat titling.
 schemars = { workspace = true }
 uuid = { workspace = true }
@@ -73,5 +78,4 @@ openwave-sandbox-agent = { path = "../openwave-sandbox-agent" }
 sea-orm = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "time", "sync"] }
 tower = { version = "=0.5.3", features = ["util"] }
-reqwest = { workspace = true }
 tokio-tungstenite = "=0.30.0"

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -42,6 +42,10 @@ mod principal;
 mod provider;
 mod providers;
 mod resolver;
+/// Governed executor performing one declared operation of a `rest_api`
+/// connected app: catalog validation before any I/O, pinned bounded egress,
+/// request-time credential injection.
+pub mod rest_executor;
 mod retry;
 mod routes;
 mod sandbox_admission;

--- a/crates/openwave-server/src/rest_executor.rs
+++ b/crates/openwave-server/src/rest_executor.rs
@@ -237,7 +237,10 @@ impl fmt::Debug for RestTransportRequest {
             .debug_struct("RestTransportRequest")
             .field("method", &self.method)
             .field("url", &self.url.as_str())
-            .field("addresses", &format_args!("<{} vetted>", self.addresses.len()))
+            .field(
+                "addresses",
+                &format_args!("<{} vetted>", self.addresses.len()),
+            )
             .field(
                 "headers",
                 &self
@@ -605,10 +608,7 @@ fn admit_base_url(base_url: &str) -> Result<Url, RestExecuteError> {
 
 /// Join the admitted base URL's path prefix with the substituted operation
 /// path and attach the encoded query.
-fn assemble_url(
-    base: &Url,
-    rendered: &RenderedParameters,
-) -> Result<Url, RestExecuteError> {
+fn assemble_url(base: &Url, rendered: &RenderedParameters) -> Result<Url, RestExecuteError> {
     let mut url = base.clone();
     let prefix = base.path().trim_end_matches('/');
     let operation_path = if rendered.path.starts_with('/') {
@@ -742,7 +742,12 @@ fn is_header_token(name: &str) -> bool {
 fn is_routing_or_framing_header(lowercase: &str) -> bool {
     matches!(
         lowercase,
-        "host" | "content-length" | "transfer-encoding" | "connection" | "te" | "trailer"
+        "host"
+            | "content-length"
+            | "transfer-encoding"
+            | "connection"
+            | "te"
+            | "trailer"
             | "upgrade"
             | "expect"
     ) || lowercase.starts_with("proxy-")
@@ -1318,7 +1323,15 @@ mod tests {
         // (case-insensitively), as is a non-token name; `Authorization` is
         // reachable only as an explicit placement, and a benign named header
         // is fine.
-        for name in ["Host", "content-LENGTH", "Transfer-Encoding", "Connection", "Proxy-Authorization", "Content-Type", "not a token"] {
+        for name in [
+            "Host",
+            "content-LENGTH",
+            "Transfer-Encoding",
+            "Connection",
+            "Proxy-Authorization",
+            "Content-Type",
+            "not a token",
+        ] {
             let refused = run(
                 &transport,
                 FakeResolver(vec![PUBLIC_V4]),
@@ -1390,7 +1403,10 @@ mod tests {
         for (base_url, expected) in [
             ("http://api.example.com", "scheme must be https"),
             ("https://u:p@api.example.com", "URL must not carry userinfo"),
-            ("https://api.example.com/#frag", "URL must not carry a fragment"),
+            (
+                "https://api.example.com/#frag",
+                "URL must not carry a fragment",
+            ),
             ("https://api.example.com/?q=1", "URL must not carry a query"),
             ("not a url", "URL is not valid"),
         ] {
@@ -1611,7 +1627,12 @@ mod tests {
             Some(Duration::from_secs(600)),
         ] {
             executor
-                .execute(&target(None), &catalog(), &get_issue(full_parameters()), asked)
+                .execute(
+                    &target(None),
+                    &catalog(),
+                    &get_issue(full_parameters()),
+                    asked,
+                )
                 .await
                 .unwrap();
         }

--- a/crates/openwave-server/src/rest_executor.rs
+++ b/crates/openwave-server/src/rest_executor.rs
@@ -1,0 +1,1623 @@
+//! Governed REST executor: perform one declared operation against a
+//! `rest_api` connected app on behalf of a caller.
+//!
+//! The executor is the only code that turns a caller's operation request into
+//! bytes on the wire, and every guarantee it makes is server-side and
+//! fail-closed:
+//!
+//! - The request is validated against the ingested
+//!   [`OperationCatalog`](crate::openapi_catalog::OperationCatalog) *before any
+//!   I/O* — an undeclared operation, an undeclared parameter, a missing
+//!   required parameter, or a value outside its declared schema refuses the
+//!   request outright. The catalog, not the caller, decides what is
+//!   executable.
+//! - Egress mirrors the native web-search fetcher's posture: the base URL is
+//!   admitted (https only, no userinfo, no fragment), the host's DNS answer is
+//!   resolved and vetted per request with the same denied-network list, the
+//!   connection is pinned to exactly the vetted addresses, redirects are never
+//!   followed, and request and response byte counts and wall time are capped.
+//!   Unlike the web-search policy, an explicit port is allowed — a REST base
+//!   URL may legitimately pin one — and refusals distinguish an unresolvable
+//!   host from a denied address, because the base URL is operator
+//!   configuration rather than a model-chosen name; resolved addresses are
+//!   still never echoed.
+//! - The credential is a *reference* into the profile secret store. Its value
+//!   is resolved only here, at request time, injected as a header, and never
+//!   appears in `Debug` output, error text, or logs — the transport request's
+//!   `Debug` impl redacts every header value, and transport failures are
+//!   stripped of URLs before their message is kept.
+//!
+//! Response bounds are sized for interactive UIs, not model context windows —
+//! deliberately larger than the MCP tool-result clamp — per the connected-apps
+//! design (`docs/connected-apps.md`).
+//!
+//! This slice is standalone: inputs are plain values ([`RestApiTarget`],
+//! [`RestOperationRequest`]); wiring to the connected-app record arrives in
+//! later slices.
+
+use std::fmt;
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use thiserror::Error;
+
+use openwave_core::SecretProvider;
+use openwave_web_search::admit_fetch_address;
+
+use crate::openapi_catalog::{CatalogOperation, HttpMethod, OperationCatalog, ParameterLocation};
+
+/// Largest JSON-serialized request body sent, in bytes. Matches the
+/// app-invoke route's body bound so a binding cannot smuggle more through the
+/// executor than the invoke surface accepts.
+pub const MAX_REST_REQUEST_BODY_BYTES: usize = 256 * 1024;
+/// Largest response body retained, in bytes. Deliberately larger than the
+/// 1 MiB MCP tool-result clamp: responses feed interactive UIs, not model
+/// context windows.
+pub const MAX_REST_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
+/// Longest base URL accepted, in bytes.
+pub const MAX_REST_BASE_URL_BYTES: usize = 2048;
+/// Longest rendered path or query parameter value, in bytes. With the
+/// catalog's parameter-count bound this caps the assembled URL.
+pub const MAX_REST_PARAMETER_VALUE_BYTES: usize = 4 * 1024;
+/// Longest header parameter value, in bytes. Headers travel uncompressed on
+/// every hop, so their bound is tighter than the URL parameters'.
+pub const MAX_REST_HEADER_VALUE_BYTES: usize = 1024;
+/// Shortest per-request timeout a caller may ask for.
+pub const MIN_REST_TIMEOUT: Duration = Duration::from_secs(1);
+/// Longest per-request timeout a caller may ask for.
+pub const MAX_REST_TIMEOUT: Duration = Duration::from_secs(60);
+/// Timeout used when the caller does not supply one.
+pub const DEFAULT_REST_TIMEOUT: Duration = Duration::from_secs(30);
+/// The honest, distinct user agent every executed operation announces.
+pub const REST_EXECUTOR_USER_AGENT: &str =
+    "OpenWaveConnectedApp/1.0 (+https://github.com/brightwave-inc/openwave)";
+
+/// The REST API one operation executes against: where to send the request and
+/// which stored credential (if any) authenticates it.
+///
+/// The base URL may carry a path prefix (`https://api.example.com/v2`); the
+/// operation's path template appends to it. Credential-less targets (public
+/// APIs) execute through exactly the same governed path.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RestApiTarget {
+    /// Base URL the operation path appends to. Admitted per request; https
+    /// only, no userinfo, no fragment, explicit ports allowed.
+    pub base_url: String,
+    /// Stored credential reference and placement, when the API needs one.
+    pub credential: Option<RestCredential>,
+}
+
+/// A credential *reference*: the profile secret-store key and where the value
+/// goes. The value itself is resolved from the store only inside the
+/// executor, at request time — it never travels in this type.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RestCredential {
+    /// Profile secret-store key holding the credential value.
+    pub secret_name: String,
+    /// Header the resolved value is injected into.
+    pub placement: CredentialPlacement,
+}
+
+/// Where the resolved credential value is placed on the request.
+///
+/// Externally tagged and closed: `"bearer"` or `{"header": "X-Api-Key"}`; an
+/// unknown variant refuses to deserialize. A named header must be a valid
+/// header token and may name `Authorization` explicitly, but never a header
+/// the executor owns or that alters routing (see [`RestExecuteError::ForbiddenHeader`]).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialPlacement {
+    /// `Authorization: Bearer {value}`.
+    Bearer,
+    /// `{name}: {value}` for an explicitly named header.
+    Header(String),
+}
+
+/// One caller-supplied operation request, validated against the catalog
+/// before anything else happens.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RestOperationRequest {
+    /// The catalog `operationId` to execute.
+    pub operation_id: String,
+    /// Supplied parameter values as a JSON object of name → value. Every name
+    /// must be declared by the operation; values must be JSON scalars.
+    pub parameters: Value,
+    /// JSON request body, only when the operation declares one.
+    pub body: Option<Value>,
+}
+
+/// The bounded response of one executed operation, returned verbatim —
+/// including redirect statuses, which the executor reports rather than
+/// follows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RestOperationResponse {
+    /// HTTP status code.
+    pub status: u16,
+    /// Raw `Content-Type` header value, when present.
+    pub content_type: Option<String>,
+    /// Response body, at most [`MAX_REST_RESPONSE_BYTES`].
+    pub body: Vec<u8>,
+}
+
+/// Why one operation request was refused or failed.
+///
+/// Closed, one variant per refusal class, and deliberately quiet: no variant
+/// ever carries the credential value, a resolved address, or unbounded
+/// attacker-controlled text. Parameter and header names are echoed because
+/// they come from the caller's own request or the operator's own catalog and
+/// are byte-bounded by ingest.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum RestExecuteError {
+    #[error("operation {operation_id} is not declared by the connected app")]
+    UnknownOperation { operation_id: String },
+    #[error("request parameters must be a JSON object of parameter name to value")]
+    ParametersNotAnObject,
+    #[error("parameter {name} is not declared by the operation")]
+    UndeclaredParameter { name: String },
+    #[error("required parameter {name} was not supplied")]
+    MissingParameter { name: String },
+    #[error("parameter {name} does not match its declared schema")]
+    InvalidParameter { name: String },
+    #[error("parameter {name} cannot be carried in its declared location")]
+    UnrepresentableParameter { name: String },
+    #[error("header {name} may not be set by a parameter or credential placement")]
+    ForbiddenHeader { name: String },
+    #[error("the operation does not declare a request body")]
+    UndeclaredBody,
+    #[error("the operation requires a request body")]
+    MissingBody,
+    #[error("request body does not match the declared schema")]
+    InvalidBody,
+    #[error("request body exceeds {} bytes", MAX_REST_REQUEST_BODY_BYTES)]
+    BodyTooLarge,
+    #[error("connected app base URL is not admissible: {reason}")]
+    InadmissibleBaseUrl { reason: &'static str },
+    /// The host resolved, but to address space the executor refuses to dial.
+    /// Which address it was stays inside the check that refused it.
+    #[error("connected app address is not an allowed destination")]
+    DeniedAddress,
+    #[error("connected app host could not be resolved")]
+    UnresolvableHost,
+    #[error("connected app credential is not present in the secret store")]
+    MissingCredential,
+    #[error("connected app credential could not be read from the secret store")]
+    SecretStoreUnavailable,
+    /// The stored value cannot travel as a header (control bytes or
+    /// non-ASCII). Refused here so it can never reach a transport error that
+    /// might echo it.
+    #[error("connected app credential value cannot be carried in a header")]
+    UnusableCredential,
+    #[error("response exceeded {} bytes", MAX_REST_RESPONSE_BYTES)]
+    ResponseTooLarge,
+    #[error("request exceeded its time budget")]
+    Timeout,
+    #[error("request transport failed: {0}")]
+    Transport(String),
+}
+
+/// One fully validated, vetted outbound request handed to the transport.
+///
+/// By the time this exists, every refusal has already happened: the URL is
+/// admitted and assembled, the addresses are the vetted resolution of its
+/// host, and the headers include the resolved credential. Implementations
+/// must connect only to `addresses` and never follow redirects.
+#[derive(Clone)]
+pub struct RestTransportRequest {
+    /// HTTP method of the declared operation.
+    pub method: HttpMethod,
+    /// Fully assembled request URL.
+    pub url: Url,
+    /// Vetted addresses the connection must be pinned to. Empty only for an
+    /// IP-literal host already admitted by the URL check — the literal is
+    /// then in the URL itself.
+    pub addresses: Vec<IpAddr>,
+    /// Header name/value pairs, including the injected credential.
+    pub headers: Vec<(String, String)>,
+    /// JSON-serialized request body, when the operation carries one.
+    pub body: Option<Vec<u8>>,
+    /// Whole-request wall-time budget, already clamped.
+    pub timeout: Duration,
+}
+
+impl fmt::Debug for RestTransportRequest {
+    /// Header values are redacted wholesale: one of them is the resolved
+    /// credential, and `Debug` output flows into logs and error context that
+    /// must never carry it. Names are kept — they are configuration, and they
+    /// are what a diagnostic needs.
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RestTransportRequest")
+            .field("method", &self.method)
+            .field("url", &self.url.as_str())
+            .field("addresses", &format_args!("<{} vetted>", self.addresses.len()))
+            .field(
+                "headers",
+                &self
+                    .headers
+                    .iter()
+                    .map(|(name, _)| (name.as_str(), "***"))
+                    .collect::<Vec<_>>(),
+            )
+            .field("body_bytes", &self.body.as_ref().map(Vec::len))
+            .field("timeout", &self.timeout)
+            .finish()
+    }
+}
+
+/// Transport seam: dispatch one vetted request. Implementations must pin the
+/// connection to the request's addresses (which rules out an ambient proxy —
+/// a proxied connection dials the proxy, not the vetted address), refuse to
+/// follow redirects, and cap the retained body at
+/// [`MAX_REST_RESPONSE_BYTES`].
+#[async_trait]
+pub trait RestTransport: Send + Sync {
+    async fn execute(
+        &self,
+        request: &RestTransportRequest,
+    ) -> Result<RestOperationResponse, RestExecuteError>;
+}
+
+/// Fresh DNS resolution for one host, called once per executed request so the
+/// vetting always judges the answer the connection will actually use.
+#[async_trait]
+pub trait RestHostResolver: Send + Sync {
+    async fn resolve(&self, host: &str) -> Result<Vec<IpAddr>, RestExecuteError>;
+}
+
+/// The governed executor, backed by an injected transport, resolver, and
+/// secret store. It has no default constructor: the host must explicitly
+/// decide the transport policy and where credentials come from.
+pub struct RestExecutor<T, R> {
+    transport: T,
+    resolver: R,
+    secrets: Arc<dyn SecretProvider>,
+}
+
+impl<T: RestTransport, R: RestHostResolver> RestExecutor<T, R> {
+    pub fn new(transport: T, resolver: R, secrets: Arc<dyn SecretProvider>) -> Self {
+        Self {
+            transport,
+            resolver,
+            secrets,
+        }
+    }
+
+    /// Execute one declared operation, or refuse.
+    ///
+    /// All catalog validation happens before any I/O — before DNS, before the
+    /// secret store is read, before a connection exists. `timeout` is clamped
+    /// to `[`[`MIN_REST_TIMEOUT`]`, `[`MAX_REST_TIMEOUT`]`]` and defaults to
+    /// [`DEFAULT_REST_TIMEOUT`].
+    pub async fn execute(
+        &self,
+        target: &RestApiTarget,
+        catalog: &OperationCatalog,
+        request: &RestOperationRequest,
+        timeout: Option<Duration>,
+    ) -> Result<RestOperationResponse, RestExecuteError> {
+        let Some(operation) = catalog.operations.get(&request.operation_id) else {
+            return Err(RestExecuteError::UnknownOperation {
+                operation_id: request.operation_id.clone(),
+            });
+        };
+
+        // The header the credential placement will write, decided up front so
+        // parameter validation can refuse a declared header that collides
+        // with it: the executor owns that header for this request.
+        let placement_header = match target.credential.as_ref().map(|c| &c.placement) {
+            None => None,
+            Some(CredentialPlacement::Bearer) => Some("authorization".to_owned()),
+            Some(CredentialPlacement::Header(name)) => {
+                require_placement_header_name(name)?;
+                Some(name.to_ascii_lowercase())
+            }
+        };
+
+        let rendered = render_parameters(operation, request, placement_header.as_deref())?;
+        let body_bytes = serialize_body(operation, request)?;
+
+        let base = admit_base_url(&target.base_url)?;
+        let url = assemble_url(&base, &rendered)?;
+
+        // Vet the destination. A domain host is resolved freshly and every
+        // answer must clear the denied-network list — refusing the whole name
+        // when any answer is private, because picking just a public answer
+        // would make admission depend on resolver ordering and reopen a DNS
+        // rebinding path on the connection that follows.
+        let addresses = match url.domain() {
+            Some(domain) => {
+                let resolved = self.resolver.resolve(domain).await?;
+                if resolved.is_empty() {
+                    return Err(RestExecuteError::UnresolvableHost);
+                }
+                if resolved
+                    .iter()
+                    .any(|address| admit_fetch_address(*address).is_err())
+                {
+                    return Err(RestExecuteError::DeniedAddress);
+                }
+                resolved
+            }
+            None => {
+                // `admit_base_url` guaranteed a host, so a non-domain host is
+                // an IP literal (the URL parser normalizes decimal, hex, and
+                // octal encodings into one). It was admitted there; the
+                // transport dials the literal itself.
+                Vec::new()
+            }
+        };
+
+        let mut headers = rendered.headers;
+        if body_bytes.is_some() {
+            headers.push(("content-type".to_owned(), "application/json".to_owned()));
+        }
+        // The credential value exists only from here to the transport call:
+        // resolved at request time, placed as a header, never stored, never
+        // formatted.
+        if let Some(credential) = &target.credential {
+            let value = self
+                .secrets
+                .get_secret(&credential.secret_name)
+                .await
+                .map_err(|_| RestExecuteError::SecretStoreUnavailable)?
+                .ok_or(RestExecuteError::MissingCredential)?;
+            if value.is_empty() || !is_printable_ascii(&value) {
+                return Err(RestExecuteError::UnusableCredential);
+            }
+            let (name, value) = match &credential.placement {
+                CredentialPlacement::Bearer => {
+                    ("authorization".to_owned(), format!("Bearer {value}"))
+                }
+                CredentialPlacement::Header(name) => (name.to_ascii_lowercase(), value),
+            };
+            headers.push((name, value));
+        }
+
+        let timeout = timeout
+            .unwrap_or(DEFAULT_REST_TIMEOUT)
+            .clamp(MIN_REST_TIMEOUT, MAX_REST_TIMEOUT);
+
+        let transport_request = RestTransportRequest {
+            method: operation.method,
+            url,
+            addresses,
+            headers,
+            body: body_bytes,
+            timeout,
+        };
+        let response = self.transport.execute(&transport_request).await?;
+        // Custom transports are held to the same cap as the real one.
+        if response.body.len() > MAX_REST_RESPONSE_BYTES {
+            return Err(RestExecuteError::ResponseTooLarge);
+        }
+        Ok(response)
+    }
+}
+
+/// Parameters rendered into their wire locations.
+struct RenderedParameters {
+    /// Substituted, percent-encoded operation path (template placeholders
+    /// resolved).
+    path: String,
+    /// Fully encoded query pairs, in declaration order.
+    query: Vec<(String, String)>,
+    /// Header parameters (names lowercased), before the credential joins.
+    headers: Vec<(String, String)>,
+}
+
+fn render_parameters(
+    operation: &CatalogOperation,
+    request: &RestOperationRequest,
+    placement_header: Option<&str>,
+) -> Result<RenderedParameters, RestExecuteError> {
+    let Some(supplied) = request.parameters.as_object() else {
+        return Err(RestExecuteError::ParametersNotAnObject);
+    };
+    // Undeclared names refuse before anything is rendered: the catalog is the
+    // whole vocabulary, and a name it does not declare must not reach the
+    // wire in any location.
+    for name in supplied.keys() {
+        if !operation
+            .parameters
+            .iter()
+            .any(|parameter| parameter.name == *name)
+        {
+            return Err(RestExecuteError::UndeclaredParameter { name: name.clone() });
+        }
+    }
+
+    let mut path_values: Vec<(String, String)> = Vec::new();
+    let mut query: Vec<(String, String)> = Vec::new();
+    let mut headers: Vec<(String, String)> = Vec::new();
+    for parameter in &operation.parameters {
+        let Some(value) = supplied.get(&parameter.name) else {
+            if parameter.required {
+                return Err(RestExecuteError::MissingParameter {
+                    name: parameter.name.clone(),
+                });
+            }
+            continue;
+        };
+        if let Some(schema) = &parameter.schema {
+            // Catalog schemas are self-contained by ingest, so no resolver is
+            // configured; a schema that still fails to compile refuses the
+            // request rather than waving the value through.
+            let valid = jsonschema::validator_for(schema)
+                .map(|validator| validator.is_valid(value))
+                .unwrap_or(false);
+            if !valid {
+                return Err(RestExecuteError::InvalidParameter {
+                    name: parameter.name.clone(),
+                });
+            }
+        }
+        // Only JSON scalars render into a URL or header deterministically;
+        // arrays, objects, and null are refused rather than guessed at.
+        let Some(text) = scalar_text(value) else {
+            return Err(RestExecuteError::UnrepresentableParameter {
+                name: parameter.name.clone(),
+            });
+        };
+        match parameter.location {
+            ParameterLocation::Path | ParameterLocation::Query => {
+                if text.len() > MAX_REST_PARAMETER_VALUE_BYTES {
+                    return Err(RestExecuteError::UnrepresentableParameter {
+                        name: parameter.name.clone(),
+                    });
+                }
+                if parameter.location == ParameterLocation::Path {
+                    // A value that *is* a dot segment cannot be carried:
+                    // URL parsers (this one and the server's) decode every
+                    // encoding of `.` / `..` and apply dot-segment removal,
+                    // so it would rewrite the path instead of traveling as a
+                    // value. Everything else — including values merely
+                    // *containing* `/` or `..` — is percent-encoded and
+                    // travels verbatim.
+                    if text == "." || text == ".." {
+                        return Err(RestExecuteError::UnrepresentableParameter {
+                            name: parameter.name.clone(),
+                        });
+                    }
+                    path_values.push((parameter.name.clone(), text));
+                } else {
+                    query.push((
+                        percent_encode_strict(&parameter.name),
+                        percent_encode_strict(&text),
+                    ));
+                }
+            }
+            ParameterLocation::Header => {
+                // A declared header still faces the forbidden-name check: a
+                // spec must not be able to declare `Host` as a "parameter",
+                // and nothing may write the header the credential placement
+                // owns for this request.
+                require_header_parameter_name(&parameter.name, placement_header)?;
+                if text.len() > MAX_REST_HEADER_VALUE_BYTES || !is_printable_ascii(&text) {
+                    return Err(RestExecuteError::UnrepresentableParameter {
+                        name: parameter.name.clone(),
+                    });
+                }
+                headers.push((parameter.name.to_ascii_lowercase(), text));
+            }
+        }
+    }
+
+    let path = substitute_path_template(&operation.path_template, &path_values)?;
+    Ok(RenderedParameters {
+        path,
+        query,
+        headers,
+    })
+}
+
+fn serialize_body(
+    operation: &CatalogOperation,
+    request: &RestOperationRequest,
+) -> Result<Option<Vec<u8>>, RestExecuteError> {
+    let declared = operation.request_body.as_ref();
+    match (declared, request.body.as_ref()) {
+        (None, None) => Ok(None),
+        (None, Some(_)) => Err(RestExecuteError::UndeclaredBody),
+        (Some(declared), None) => {
+            if declared.required {
+                return Err(RestExecuteError::MissingBody);
+            }
+            Ok(None)
+        }
+        (Some(declared), Some(body)) => {
+            if let Some(schema) = &declared.schema {
+                let valid = jsonschema::validator_for(schema)
+                    .map(|validator| validator.is_valid(body))
+                    .unwrap_or(false);
+                if !valid {
+                    return Err(RestExecuteError::InvalidBody);
+                }
+            }
+            let bytes = serde_json::to_vec(body).map_err(|_| RestExecuteError::InvalidBody)?;
+            if bytes.len() > MAX_REST_REQUEST_BODY_BYTES {
+                return Err(RestExecuteError::BodyTooLarge);
+            }
+            Ok(Some(bytes))
+        }
+    }
+}
+
+/// Admit an operator-configured base URL, or say precisely why not.
+///
+/// Same shape as the web-search admission with one deliberate difference: an
+/// explicit port is allowed, because a REST base URL may pin one; default-port
+/// normalization (`:443` disappearing) is left to the URL parser. A fragment
+/// or a query is refused rather than stripped — a base URL is configuration,
+/// and configuration that cannot mean anything should be corrected, not
+/// silently rewritten.
+fn admit_base_url(base_url: &str) -> Result<Url, RestExecuteError> {
+    let refuse = |reason| Err(RestExecuteError::InadmissibleBaseUrl { reason });
+    if base_url.len() > MAX_REST_BASE_URL_BYTES {
+        return refuse("URL exceeds the byte limit");
+    }
+    let Ok(parsed) = Url::parse(base_url) else {
+        return refuse("URL is not valid");
+    };
+    if parsed.scheme() != "https" {
+        return refuse("scheme must be https");
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return refuse("URL must not carry userinfo");
+    }
+    if parsed.fragment().is_some() {
+        return refuse("URL must not carry a fragment");
+    }
+    if parsed.query().is_some() {
+        return refuse("URL must not carry a query");
+    }
+    match parsed.host_str() {
+        None | Some("") => return refuse("URL has no host"),
+        Some(_) => {}
+    }
+    // An IP-literal host — in any encoding the URL parser dials as an
+    // address — is vetted against the denied-network list right here; a
+    // DNS-named host is vetted after resolution instead.
+    if parsed.domain().is_none() {
+        let literal = parsed
+            .host_str()
+            .unwrap_or_default()
+            .trim_start_matches('[')
+            .trim_end_matches(']');
+        match literal.parse::<IpAddr>() {
+            Ok(address) => {
+                if admit_fetch_address(address).is_err() {
+                    return Err(RestExecuteError::DeniedAddress);
+                }
+            }
+            Err(_) => return refuse("URL host is not a name or address"),
+        }
+    }
+    Ok(parsed)
+}
+
+/// Join the admitted base URL's path prefix with the substituted operation
+/// path and attach the encoded query.
+fn assemble_url(
+    base: &Url,
+    rendered: &RenderedParameters,
+) -> Result<Url, RestExecuteError> {
+    let mut url = base.clone();
+    let prefix = base.path().trim_end_matches('/');
+    let operation_path = if rendered.path.starts_with('/') {
+        rendered.path.clone()
+    } else {
+        format!("/{}", rendered.path)
+    };
+    let assembled = format!("{prefix}{operation_path}");
+    url.set_path(&assembled);
+    // Backstop against dot-segment collapse the per-value refusal did not
+    // see (a template-borne `..`, say): if normalization changed the path's
+    // segment structure, the request would not go where the catalog and base
+    // URL said, so it does not go anywhere.
+    let expected_segments = assembled.split('/').skip(1).count();
+    if url.path_segments().map(Iterator::count) != Some(expected_segments) {
+        return Err(RestExecuteError::InadmissibleBaseUrl {
+            reason: "assembled request path did not survive URL normalization",
+        });
+    }
+    if !rendered.query.is_empty() {
+        let joined = rendered
+            .query
+            .iter()
+            .map(|(name, value)| format!("{name}={value}"))
+            .collect::<Vec<_>>()
+            .join("&");
+        url.set_query(Some(&joined));
+    }
+    Ok(url)
+}
+
+/// Substitute `{name}` placeholders with pre-rendered values, percent-encoding
+/// everything outside the unreserved set — so a hostile value cannot introduce
+/// a `/`, a `..` segment, a `?`, or a `#` into the request target. Encoding,
+/// not rejection, is the policy: the value survives verbatim on the server
+/// side while the URL structure stays fixed.
+fn substitute_path_template(
+    template: &str,
+    values: &[(String, String)],
+) -> Result<String, RestExecuteError> {
+    let mut substituted = String::with_capacity(template.len());
+    let mut rest = template;
+    while let Some(start) = rest.find('{') {
+        substituted.push_str(&rest[..start]);
+        let Some(length) = rest[start..].find('}') else {
+            // Ingest refuses malformed templates; an unterminated brace that
+            // somehow survives is kept literal rather than guessed at.
+            substituted.push_str(&rest[start..]);
+            return Ok(substituted);
+        };
+        let name = &rest[start + 1..start + length];
+        let Some((_, value)) = values.iter().find(|(candidate, _)| candidate == name) else {
+            return Err(RestExecuteError::MissingParameter {
+                name: name.to_owned(),
+            });
+        };
+        substituted.push_str(&percent_encode_strict(value));
+        rest = &rest[start + length + 1..];
+    }
+    substituted.push_str(rest);
+    Ok(substituted)
+}
+
+/// Percent-encode every byte outside RFC 3986's unreserved set. Stricter than
+/// a component encoder needs to be, which is the point: nothing a value can
+/// contain survives as URL structure.
+fn percent_encode_strict(value: &str) -> String {
+    use std::fmt::Write as _;
+
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(byte as char);
+            }
+            other => {
+                let _ = write!(encoded, "%{other:02X}");
+            }
+        }
+    }
+    encoded
+}
+
+/// The one deterministic text rendering of a JSON scalar; `None` for
+/// anything that has no single obvious wire form.
+fn scalar_text(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => Some(text.clone()),
+        Value::Number(number) => Some(number.to_string()),
+        Value::Bool(flag) => Some(flag.to_string()),
+        Value::Null | Value::Array(_) | Value::Object(_) => None,
+    }
+}
+
+/// Printable ASCII only (0x20..=0x7E): refuses the control bytes that would
+/// smuggle header folding or CRLF injection, and non-ASCII that transports
+/// encode inconsistently.
+fn is_printable_ascii(value: &str) -> bool {
+    value.bytes().all(|byte| (0x20..=0x7E).contains(&byte))
+}
+
+/// RFC 7230 token charset for header names.
+fn is_header_token(name: &str) -> bool {
+    !name.is_empty()
+        && name.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric()
+                || matches!(
+                    byte,
+                    b'!' | b'#'
+                        | b'$'
+                        | b'%'
+                        | b'&'
+                        | b'\''
+                        | b'*'
+                        | b'+'
+                        | b'-'
+                        | b'.'
+                        | b'^'
+                        | b'_'
+                        | b'`'
+                        | b'|'
+                        | b'~'
+                )
+        })
+}
+
+/// Headers that alter routing or message framing, refused everywhere: neither
+/// a credential placement nor a declared header parameter may set them,
+/// because a request that rewrites its own destination or framing escapes the
+/// vetting that admitted it.
+fn is_routing_or_framing_header(lowercase: &str) -> bool {
+    matches!(
+        lowercase,
+        "host" | "content-length" | "transfer-encoding" | "connection" | "te" | "trailer"
+            | "upgrade"
+            | "expect"
+    ) || lowercase.starts_with("proxy-")
+}
+
+/// Headers the executor writes itself. A parameter may not shadow them;
+/// `Authorization` is reachable only through an explicit credential
+/// placement.
+fn is_executor_owned_header(lowercase: &str) -> bool {
+    matches!(lowercase, "authorization" | "content-type" | "user-agent")
+}
+
+/// Admit a credential placement's named header: token charset, no routing or
+/// framing header, no executor-owned header — except `Authorization`, which a
+/// placement (and only a placement) may name explicitly.
+fn require_placement_header_name(name: &str) -> Result<(), RestExecuteError> {
+    let refuse = || {
+        Err(RestExecuteError::ForbiddenHeader {
+            name: name.to_owned(),
+        })
+    };
+    if !is_header_token(name) {
+        return refuse();
+    }
+    let lowercase = name.to_ascii_lowercase();
+    if is_routing_or_framing_header(&lowercase) {
+        return refuse();
+    }
+    if is_executor_owned_header(&lowercase) && lowercase != "authorization" {
+        return refuse();
+    }
+    Ok(())
+}
+
+/// Admit a declared header parameter's name: token charset, no routing or
+/// framing header, no executor-owned header (including `Authorization`), and
+/// never the header the credential placement owns for this request.
+fn require_header_parameter_name(
+    name: &str,
+    placement_header: Option<&str>,
+) -> Result<(), RestExecuteError> {
+    let refuse = || {
+        Err(RestExecuteError::ForbiddenHeader {
+            name: name.to_owned(),
+        })
+    };
+    if !is_header_token(name) {
+        return refuse();
+    }
+    let lowercase = name.to_ascii_lowercase();
+    if is_routing_or_framing_header(&lowercase) || is_executor_owned_header(&lowercase) {
+        return refuse();
+    }
+    if placement_header == Some(lowercase.as_str()) {
+        return refuse();
+    }
+    Ok(())
+}
+
+/// REST transport that builds one pinned `reqwest` client per request.
+///
+/// Building per request is what lets the connection be pinned: the vetted
+/// addresses are installed as the host's only resolution, so the connect
+/// cannot re-resolve to something the vetting never saw.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ReqwestRestTransport;
+
+#[async_trait]
+impl RestTransport for ReqwestRestTransport {
+    async fn execute(
+        &self,
+        request: &RestTransportRequest,
+    ) -> Result<RestOperationResponse, RestExecuteError> {
+        use futures::StreamExt;
+
+        let mut builder = reqwest::Client::builder()
+            // Load-bearing, not tidiness: reqwest defaults to discovering a
+            // proxy from `HTTPS_PROXY`/`ALL_PROXY` and system configuration,
+            // and a proxied connection dials the *proxy* — the pinned
+            // addresses below are never consulted, so the deny list and the
+            // per-request vetting silently become advisory, a loopback proxy
+            // becomes reachable, and proxy userinfo would be turned into a
+            // `Proxy-Authorization` header on the request. Removing this line
+            // removes the address pinning.
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .https_only(true)
+            .user_agent(REST_EXECUTOR_USER_AGENT)
+            .connect_timeout(request.timeout.min(Duration::from_secs(10)))
+            .timeout(request.timeout);
+        if let Some(domain) = request.url.domain() {
+            let port = request.url.port_or_known_default().unwrap_or(443);
+            let pinned: Vec<std::net::SocketAddr> = request
+                .addresses
+                .iter()
+                .map(|address| std::net::SocketAddr::new(*address, port))
+                .collect();
+            builder = builder.resolve_to_addrs(domain, &pinned);
+        }
+        let client = builder.build().map_err(transport_failure)?;
+        let mut outbound = client.request(reqwest_method(request.method), request.url.clone());
+        for (name, value) in &request.headers {
+            outbound = outbound.header(name.as_str(), value.as_str());
+        }
+        if let Some(body) = &request.body {
+            outbound = outbound.body(body.clone());
+        }
+        let response = outbound.send().await.map_err(transport_failure)?;
+        let status = response.status().as_u16();
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(ToOwned::to_owned);
+        // An honest oversized Content-Length is refused before a byte is
+        // read; a lying one is caught by the check-before-extend below, so it
+        // never turns into an unbounded allocation either way.
+        if response
+            .content_length()
+            .is_some_and(|length| length > MAX_REST_RESPONSE_BYTES as u64)
+        {
+            return Err(RestExecuteError::ResponseTooLarge);
+        }
+        let mut body = Vec::new();
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(transport_failure)?;
+            push_bounded(&mut body, &chunk)?;
+        }
+        Ok(RestOperationResponse {
+            status,
+            content_type,
+            body,
+        })
+    }
+}
+
+/// Retain one streamed chunk, refusing the response the moment it would cross
+/// [`MAX_REST_RESPONSE_BYTES`] — before the bytes are kept, so a lying
+/// `Content-Length` never turns into an unbounded allocation.
+fn push_bounded(body: &mut Vec<u8>, chunk: &[u8]) -> Result<(), RestExecuteError> {
+    if body.len().saturating_add(chunk.len()) > MAX_REST_RESPONSE_BYTES {
+        return Err(RestExecuteError::ResponseTooLarge);
+    }
+    body.extend_from_slice(chunk);
+    Ok(())
+}
+
+/// Map a transport failure without letting it carry anything sensitive: the
+/// URL (which reqwest embeds in its messages) is stripped before the text is
+/// kept, and a timeout is told apart so callers can act on it.
+fn transport_failure(error: reqwest::Error) -> RestExecuteError {
+    if error.is_timeout() {
+        return RestExecuteError::Timeout;
+    }
+    RestExecuteError::Transport(error.without_url().to_string())
+}
+
+fn reqwest_method(method: HttpMethod) -> reqwest::Method {
+    match method {
+        HttpMethod::Get => reqwest::Method::GET,
+        HttpMethod::Put => reqwest::Method::PUT,
+        HttpMethod::Post => reqwest::Method::POST,
+        HttpMethod::Delete => reqwest::Method::DELETE,
+        HttpMethod::Patch => reqwest::Method::PATCH,
+        HttpMethod::Head => reqwest::Method::HEAD,
+        HttpMethod::Options => reqwest::Method::OPTIONS,
+    }
+}
+
+/// Host resolver backed by the operating system's resolver.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TokioRestHostResolver;
+
+#[async_trait]
+impl RestHostResolver for TokioRestHostResolver {
+    async fn resolve(&self, host: &str) -> Result<Vec<IpAddr>, RestExecuteError> {
+        let resolved = tokio::net::lookup_host((host, 443))
+            .await
+            .map_err(|_| RestExecuteError::UnresolvableHost)?;
+        let mut addresses = Vec::new();
+        for address in resolved.map(|socket| socket.ip()) {
+            if !addresses.contains(&address) {
+                addresses.push(address);
+            }
+        }
+        Ok(addresses)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, HashMap};
+    use std::sync::Mutex;
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::openapi_catalog::{CatalogParameter, CatalogRequestBody};
+
+    const SECRET_VALUE: &str = "sk-live-URXvXW0hVqzJm";
+    const PUBLIC_V4: IpAddr = IpAddr::V4(std::net::Ipv4Addr::new(93, 184, 216, 34));
+    const PRIVATE_V4: IpAddr = IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 5));
+
+    struct FakeSecrets(HashMap<String, String>);
+
+    impl FakeSecrets {
+        fn with(name: &str, value: &str) -> Arc<Self> {
+            Arc::new(Self(HashMap::from([(name.to_owned(), value.to_owned())])))
+        }
+
+        fn empty() -> Arc<Self> {
+            Arc::new(Self(HashMap::new()))
+        }
+    }
+
+    #[async_trait]
+    impl SecretProvider for FakeSecrets {
+        async fn get_secret(&self, key: &str) -> openwave_core::Result<Option<String>> {
+            Ok(self.0.get(key).cloned())
+        }
+
+        async fn set_secret(&self, _key: &str, _value: &str) -> openwave_core::Result<()> {
+            Ok(())
+        }
+
+        async fn delete_secret(&self, _key: &str) -> openwave_core::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct FakeTransport {
+        requests: Mutex<Vec<RestTransportRequest>>,
+        response: Result<RestOperationResponse, RestExecuteError>,
+    }
+
+    impl FakeTransport {
+        fn ok() -> Self {
+            Self::respond(Ok(RestOperationResponse {
+                status: 200,
+                content_type: Some("application/json".to_owned()),
+                body: b"{}".to_vec(),
+            }))
+        }
+
+        fn respond(response: Result<RestOperationResponse, RestExecuteError>) -> Self {
+            Self {
+                requests: Mutex::new(Vec::new()),
+                response,
+            }
+        }
+
+        fn sole_request(&self) -> RestTransportRequest {
+            let requests = self.requests.lock().unwrap();
+            assert_eq!(requests.len(), 1, "expected exactly one dispatched request");
+            requests[0].clone()
+        }
+
+        fn request_count(&self) -> usize {
+            self.requests.lock().unwrap().len()
+        }
+    }
+
+    #[async_trait]
+    impl RestTransport for &FakeTransport {
+        async fn execute(
+            &self,
+            request: &RestTransportRequest,
+        ) -> Result<RestOperationResponse, RestExecuteError> {
+            self.requests.lock().unwrap().push(request.clone());
+            self.response.clone()
+        }
+    }
+
+    struct FakeResolver(Vec<IpAddr>);
+
+    #[async_trait]
+    impl RestHostResolver for FakeResolver {
+        async fn resolve(&self, _host: &str) -> Result<Vec<IpAddr>, RestExecuteError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    fn catalog() -> OperationCatalog {
+        let operations = BTreeMap::from([
+            (
+                "getIssue".to_owned(),
+                CatalogOperation {
+                    operation_id: "getIssue".to_owned(),
+                    method: HttpMethod::Get,
+                    path_template: "/repos/{owner}/issues/{number}".to_owned(),
+                    parameters: vec![
+                        CatalogParameter {
+                            name: "owner".to_owned(),
+                            location: ParameterLocation::Path,
+                            required: true,
+                            schema: Some(json!({"type": "string"})),
+                        },
+                        CatalogParameter {
+                            name: "number".to_owned(),
+                            location: ParameterLocation::Path,
+                            required: true,
+                            schema: None,
+                        },
+                        CatalogParameter {
+                            name: "state".to_owned(),
+                            location: ParameterLocation::Query,
+                            required: false,
+                            schema: Some(json!({"type": "string", "enum": ["open", "closed"]})),
+                        },
+                        CatalogParameter {
+                            name: "x-request-tag".to_owned(),
+                            location: ParameterLocation::Header,
+                            required: false,
+                            schema: None,
+                        },
+                    ],
+                    request_body: None,
+                },
+            ),
+            (
+                "createIssue".to_owned(),
+                CatalogOperation {
+                    operation_id: "createIssue".to_owned(),
+                    method: HttpMethod::Post,
+                    path_template: "/issues".to_owned(),
+                    parameters: Vec::new(),
+                    request_body: Some(CatalogRequestBody {
+                        required: true,
+                        schema: Some(json!({
+                            "type": "object",
+                            "required": ["title"],
+                            "properties": {"title": {"type": "string"}}
+                        })),
+                    }),
+                },
+            ),
+            (
+                "hostHeader".to_owned(),
+                CatalogOperation {
+                    operation_id: "hostHeader".to_owned(),
+                    method: HttpMethod::Get,
+                    path_template: "/ping".to_owned(),
+                    parameters: vec![CatalogParameter {
+                        name: "Host".to_owned(),
+                        location: ParameterLocation::Header,
+                        required: true,
+                        schema: None,
+                    }],
+                    request_body: None,
+                },
+            ),
+        ]);
+        OperationCatalog {
+            document_sha256: "0".repeat(64),
+            operations,
+        }
+    }
+
+    fn target(credential: Option<RestCredential>) -> RestApiTarget {
+        RestApiTarget {
+            base_url: "https://api.example.com/v2".to_owned(),
+            credential,
+        }
+    }
+
+    fn bearer(secret_name: &str) -> Option<RestCredential> {
+        Some(RestCredential {
+            secret_name: secret_name.to_owned(),
+            placement: CredentialPlacement::Bearer,
+        })
+    }
+
+    fn get_issue(parameters: Value) -> RestOperationRequest {
+        RestOperationRequest {
+            operation_id: "getIssue".to_owned(),
+            parameters,
+            body: None,
+        }
+    }
+
+    fn full_parameters() -> Value {
+        json!({"owner": "octocat", "number": 42})
+    }
+
+    async fn run(
+        transport: &FakeTransport,
+        resolver: FakeResolver,
+        secrets: Arc<FakeSecrets>,
+        target: &RestApiTarget,
+        request: &RestOperationRequest,
+    ) -> Result<RestOperationResponse, RestExecuteError> {
+        RestExecutor::new(transport, resolver, secrets)
+            .execute(target, &catalog(), request, None)
+            .await
+    }
+
+    #[tokio::test]
+    async fn catalog_validation_refuses_before_any_io() {
+        let transport = FakeTransport::ok();
+        let cases: Vec<(RestOperationRequest, RestExecuteError)> = vec![
+            (
+                RestOperationRequest {
+                    operation_id: "deleteEverything".to_owned(),
+                    parameters: json!({}),
+                    body: None,
+                },
+                RestExecuteError::UnknownOperation {
+                    operation_id: "deleteEverything".to_owned(),
+                },
+            ),
+            (
+                get_issue(json!([1, 2])),
+                RestExecuteError::ParametersNotAnObject,
+            ),
+            (
+                get_issue(json!({"owner": "octocat", "number": 1, "verbose": true})),
+                RestExecuteError::UndeclaredParameter {
+                    name: "verbose".to_owned(),
+                },
+            ),
+            (
+                get_issue(json!({"owner": "octocat"})),
+                RestExecuteError::MissingParameter {
+                    name: "number".to_owned(),
+                },
+            ),
+            (
+                get_issue(json!({"owner": 7, "number": 1})),
+                RestExecuteError::InvalidParameter {
+                    name: "owner".to_owned(),
+                },
+            ),
+            (
+                get_issue(json!({"owner": "octocat", "number": 1, "state": "wontfix"})),
+                RestExecuteError::InvalidParameter {
+                    name: "state".to_owned(),
+                },
+            ),
+            (
+                get_issue(json!({"owner": "octocat", "number": {"nested": true}})),
+                RestExecuteError::UnrepresentableParameter {
+                    name: "number".to_owned(),
+                },
+            ),
+            (
+                RestOperationRequest {
+                    operation_id: "getIssue".to_owned(),
+                    parameters: full_parameters(),
+                    body: Some(json!({"stray": true})),
+                },
+                RestExecuteError::UndeclaredBody,
+            ),
+            (
+                RestOperationRequest {
+                    operation_id: "createIssue".to_owned(),
+                    parameters: json!({}),
+                    body: None,
+                },
+                RestExecuteError::MissingBody,
+            ),
+            (
+                RestOperationRequest {
+                    operation_id: "createIssue".to_owned(),
+                    parameters: json!({}),
+                    body: Some(json!({"title": 7})),
+                },
+                RestExecuteError::InvalidBody,
+            ),
+            (
+                RestOperationRequest {
+                    operation_id: "createIssue".to_owned(),
+                    parameters: json!({}),
+                    body: Some(json!({
+                        "title": "x".repeat(MAX_REST_REQUEST_BODY_BYTES)
+                    })),
+                },
+                RestExecuteError::BodyTooLarge,
+            ),
+        ];
+        for (request, expected) in cases {
+            let refused = run(
+                &transport,
+                FakeResolver(vec![PUBLIC_V4]),
+                FakeSecrets::empty(),
+                &target(None),
+                &request,
+            )
+            .await
+            .unwrap_err();
+            assert_eq!(refused, expected);
+        }
+        assert_eq!(
+            transport.request_count(),
+            0,
+            "a refused request must never reach the transport"
+        );
+    }
+
+    #[tokio::test]
+    async fn hostile_path_parameters_are_encoded_not_traversed() {
+        let transport = FakeTransport::ok();
+        run(
+            &transport,
+            FakeResolver(vec![PUBLIC_V4]),
+            FakeSecrets::empty(),
+            &target(None),
+            &get_issue(json!({
+                "owner": "../../../admin?x=1#frag",
+                "number": "weiß/ソ",
+                "state": "open",
+            })),
+        )
+        .await
+        .unwrap();
+        let dispatched = transport.sole_request();
+        // The url crate decodes `%2E` back to a literal dot, which is why a
+        // pure dot-segment value is refused below; the mixed hostile value
+        // stays a single opaque segment either way.
+        assert_eq!(
+            dispatched.url.as_str(),
+            "https://api.example.com/v2/repos/..%2F..%2F..%2Fadmin%3Fx%3D1%23frag\
+             /issues/wei%C3%9F%2F%E3%82%BD?state=open"
+        );
+        // The hostile value introduced no new path segments and no query or
+        // fragment of its own.
+        assert_eq!(dispatched.url.path_segments().unwrap().count(), 5);
+
+        // A value that *is* `..` would survive encoding as a real dot
+        // segment and pop its parent, so it is refused outright.
+        let refused = run(
+            &transport,
+            FakeResolver(vec![PUBLIC_V4]),
+            FakeSecrets::empty(),
+            &target(None),
+            &get_issue(json!({"owner": "..", "number": 1})),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            refused,
+            RestExecuteError::UnrepresentableParameter {
+                name: "owner".to_owned()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn forbidden_headers_are_refused_for_parameters_and_placements() {
+        // A spec-declared `Host` header parameter never reaches the wire.
+        let transport = FakeTransport::ok();
+        let refused = run(
+            &transport,
+            FakeResolver(vec![PUBLIC_V4]),
+            FakeSecrets::empty(),
+            &target(None),
+            &RestOperationRequest {
+                operation_id: "hostHeader".to_owned(),
+                parameters: json!({"Host": "evil.internal"}),
+                body: None,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(
+            refused,
+            RestExecuteError::ForbiddenHeader {
+                name: "Host".to_owned()
+            }
+        );
+
+        // Placements: routing/framing and executor-owned names are refused
+        // (case-insensitively), as is a non-token name; `Authorization` is
+        // reachable only as an explicit placement, and a benign named header
+        // is fine.
+        for name in ["Host", "content-LENGTH", "Transfer-Encoding", "Connection", "Proxy-Authorization", "Content-Type", "not a token"] {
+            let refused = run(
+                &transport,
+                FakeResolver(vec![PUBLIC_V4]),
+                FakeSecrets::with("k", SECRET_VALUE),
+                &target(Some(RestCredential {
+                    secret_name: "k".to_owned(),
+                    placement: CredentialPlacement::Header(name.to_owned()),
+                })),
+                &get_issue(full_parameters()),
+            )
+            .await
+            .unwrap_err();
+            assert!(
+                matches!(refused, RestExecuteError::ForbiddenHeader { .. }),
+                "{name} was not refused"
+            );
+        }
+        assert_eq!(transport.request_count(), 0);
+        for name in ["Authorization", "X-Api-Key", "Cookie"] {
+            run(
+                &transport,
+                FakeResolver(vec![PUBLIC_V4]),
+                FakeSecrets::with("k", SECRET_VALUE),
+                &target(Some(RestCredential {
+                    secret_name: "k".to_owned(),
+                    placement: CredentialPlacement::Header(name.to_owned()),
+                })),
+                &get_issue(full_parameters()),
+            )
+            .await
+            .unwrap_or_else(|error| panic!("{name} placement refused: {error}"));
+        }
+    }
+
+    #[tokio::test]
+    async fn address_vetting_is_all_or_nothing() {
+        let transport = FakeTransport::ok();
+        let refused = run(
+            &transport,
+            FakeResolver(vec![PUBLIC_V4, PRIVATE_V4]),
+            FakeSecrets::empty(),
+            &target(None),
+            &get_issue(full_parameters()),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(refused, RestExecuteError::DeniedAddress);
+        assert_eq!(
+            transport.request_count(),
+            0,
+            "a partially private resolution must never be dialed"
+        );
+
+        let refused = run(
+            &transport,
+            FakeResolver(Vec::new()),
+            FakeSecrets::empty(),
+            &target(None),
+            &get_issue(full_parameters()),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(refused, RestExecuteError::UnresolvableHost);
+    }
+
+    #[tokio::test]
+    async fn base_url_admission_allows_ports_and_refuses_the_rest() {
+        let transport = FakeTransport::ok();
+        for (base_url, expected) in [
+            ("http://api.example.com", "scheme must be https"),
+            ("https://u:p@api.example.com", "URL must not carry userinfo"),
+            ("https://api.example.com/#frag", "URL must not carry a fragment"),
+            ("https://api.example.com/?q=1", "URL must not carry a query"),
+            ("not a url", "URL is not valid"),
+        ] {
+            let refused = run(
+                &transport,
+                FakeResolver(vec![PUBLIC_V4]),
+                FakeSecrets::empty(),
+                &RestApiTarget {
+                    base_url: base_url.to_owned(),
+                    credential: None,
+                },
+                &get_issue(full_parameters()),
+            )
+            .await
+            .unwrap_err();
+            assert_eq!(
+                refused,
+                RestExecuteError::InadmissibleBaseUrl { reason: expected },
+                "{base_url}"
+            );
+        }
+        // A loopback IP literal is refused as a destination, not as a URL.
+        let refused = run(
+            &transport,
+            FakeResolver(vec![PUBLIC_V4]),
+            FakeSecrets::empty(),
+            &RestApiTarget {
+                base_url: "https://127.0.0.1:8443".to_owned(),
+                credential: None,
+            },
+            &get_issue(full_parameters()),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(refused, RestExecuteError::DeniedAddress);
+        assert_eq!(transport.request_count(), 0);
+
+        // An explicit non-default port is allowed — a REST base URL may pin
+        // one — and survives into the dispatched URL.
+        run(
+            &transport,
+            FakeResolver(vec![PUBLIC_V4]),
+            FakeSecrets::empty(),
+            &RestApiTarget {
+                base_url: "https://api.example.com:8443/v2".to_owned(),
+                credential: None,
+            },
+            &get_issue(full_parameters()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            transport.sole_request().url.as_str(),
+            "https://api.example.com:8443/v2/repos/octocat/issues/42"
+        );
+    }
+
+    #[tokio::test]
+    async fn redirects_are_reported_not_followed() {
+        let transport = FakeTransport::respond(Ok(RestOperationResponse {
+            status: 302,
+            content_type: None,
+            body: Vec::new(),
+        }));
+        let response = run(
+            &transport,
+            FakeResolver(vec![PUBLIC_V4]),
+            FakeSecrets::empty(),
+            &target(None),
+            &get_issue(full_parameters()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(response.status, 302);
+        assert_eq!(
+            transport.request_count(),
+            1,
+            "a redirect status must not trigger a second request"
+        );
+    }
+
+    #[tokio::test]
+    async fn oversized_transport_response_is_refused() {
+        // The executor holds custom transports to the same cap as the real
+        // one; the real transport's own cap is push_bounded, tested below.
+        let transport = FakeTransport::respond(Ok(RestOperationResponse {
+            status: 200,
+            content_type: None,
+            body: vec![0; MAX_REST_RESPONSE_BYTES + 1],
+        }));
+        let refused = run(
+            &transport,
+            FakeResolver(vec![PUBLIC_V4]),
+            FakeSecrets::empty(),
+            &target(None),
+            &get_issue(full_parameters()),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(refused, RestExecuteError::ResponseTooLarge);
+    }
+
+    #[test]
+    fn push_bounded_refuses_before_retaining_a_lying_chunk() {
+        let mut body = vec![0_u8; MAX_REST_RESPONSE_BYTES - 1];
+        assert_eq!(
+            push_bounded(&mut body, &[0, 0]).unwrap_err(),
+            RestExecuteError::ResponseTooLarge
+        );
+        // The over-cap chunk was refused before extending, not truncated in.
+        assert_eq!(body.len(), MAX_REST_RESPONSE_BYTES - 1);
+        assert!(push_bounded(&mut body, &[0]).is_ok());
+    }
+
+    #[tokio::test]
+    async fn credential_is_injected_and_never_rendered() {
+        // Bearer placement.
+        let transport = FakeTransport::ok();
+        run(
+            &transport,
+            FakeResolver(vec![PUBLIC_V4]),
+            FakeSecrets::with("sentry_token", SECRET_VALUE),
+            &target(bearer("sentry_token")),
+            &get_issue(json!({"owner": "octocat", "number": 1, "x-request-tag": "t-1"})),
+        )
+        .await
+        .unwrap();
+        let dispatched = transport.sole_request();
+        assert!(dispatched
+            .headers
+            .contains(&("authorization".to_owned(), format!("Bearer {SECRET_VALUE}"))));
+        assert!(dispatched
+            .headers
+            .contains(&("x-request-tag".to_owned(), "t-1".to_owned())));
+        // Debug output redacts every header value: the credential must not
+        // survive into logs through an incidental {:?}.
+        let debugged = format!("{dispatched:?}");
+        assert!(!debugged.contains(SECRET_VALUE), "{debugged}");
+        assert!(debugged.contains("authorization"), "{debugged}");
+
+        // Named-header placement.
+        let transport = FakeTransport::ok();
+        run(
+            &transport,
+            FakeResolver(vec![PUBLIC_V4]),
+            FakeSecrets::with("sentry_token", SECRET_VALUE),
+            &target(Some(RestCredential {
+                secret_name: "sentry_token".to_owned(),
+                placement: CredentialPlacement::Header("X-Api-Key".to_owned()),
+            })),
+            &get_issue(full_parameters()),
+        )
+        .await
+        .unwrap();
+        assert!(transport
+            .sole_request()
+            .headers
+            .contains(&("x-api-key".to_owned(), SECRET_VALUE.to_owned())));
+
+        // A transport failure's full rendering never echoes the credential.
+        let transport = FakeTransport::respond(Err(RestExecuteError::Transport(
+            "connection reset by peer".to_owned(),
+        )));
+        let error = run(
+            &transport,
+            FakeResolver(vec![PUBLIC_V4]),
+            FakeSecrets::with("sentry_token", SECRET_VALUE),
+            &target(bearer("sentry_token")),
+            &get_issue(full_parameters()),
+        )
+        .await
+        .unwrap_err();
+        let rendered = format!("{error} / {error:?}");
+        assert!(!rendered.contains(SECRET_VALUE), "{rendered}");
+    }
+
+    #[tokio::test]
+    async fn missing_secret_is_a_distinct_refusal() {
+        let transport = FakeTransport::ok();
+        let refused = run(
+            &transport,
+            FakeResolver(vec![PUBLIC_V4]),
+            FakeSecrets::empty(),
+            &target(bearer("absent_token")),
+            &get_issue(full_parameters()),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(refused, RestExecuteError::MissingCredential);
+        assert_eq!(transport.request_count(), 0);
+
+        // A secret that cannot travel as a header is refused before the
+        // transport, not surfaced as a transport failure that might echo it.
+        let refused = run(
+            &transport,
+            FakeResolver(vec![PUBLIC_V4]),
+            FakeSecrets::with("k", "line\nbreak"),
+            &target(bearer("k")),
+            &get_issue(full_parameters()),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(refused, RestExecuteError::UnusableCredential);
+        assert_eq!(transport.request_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn timeout_is_clamped_and_defaulted() {
+        let transport = FakeTransport::ok();
+        let executor = RestExecutor::new(
+            &transport,
+            FakeResolver(vec![PUBLIC_V4]),
+            FakeSecrets::empty(),
+        );
+        for asked in [
+            None,
+            Some(Duration::from_millis(5)),
+            Some(Duration::from_secs(600)),
+        ] {
+            executor
+                .execute(&target(None), &catalog(), &get_issue(full_parameters()), asked)
+                .await
+                .unwrap();
+        }
+        let requests = transport.requests.lock().unwrap();
+        assert_eq!(requests[0].timeout, DEFAULT_REST_TIMEOUT);
+        assert_eq!(requests[1].timeout, MIN_REST_TIMEOUT);
+        assert_eq!(requests[2].timeout, MAX_REST_TIMEOUT);
+    }
+}


### PR DESCRIPTION
Slice 3 of the connected-apps REST-bindings epic (#1330), per the executor contract in `docs/connected-apps.md` ("The executor"). Stacks on the operation catalog from #1348 (now merged), so this targets `main`.

Closes #1343

## What this adds

`openwave_server::rest_executor` — a host-side executor performing one declared operation of a `rest_api` connected app, standalone in this slice (plain-value inputs; wiring to the connected-app record arrives in later slices). Every guarantee is server-side and fail-closed:

- **Catalog validation before any I/O.** The operation must exist in the ingested `OperationCatalog`; every supplied parameter must be declared and every required one supplied; catalog-declared JSON schemas are enforced per request (`jsonschema`, no resolvers — ingest already made schemas self-contained); bodies only where declared, required where declared required, schema-checked, and capped at 256 KiB (matching the app-invoke body bound).
- **Egress mirrors the web-search fetcher's posture.** Base URL admitted https-only with no userinfo/fragment/query — explicit ports allowed, unlike the fetch policy, since a REST base URL may pin one. DNS is resolved and vetted per request against the shared `admit_fetch_address` deny list, refusing the whole name if *any* answer is denied (anti-rebinding); the per-request reqwest client is pinned to the vetted addresses, proxy-free, redirect-free. Redirects are returned to the caller as ordinary bounded responses, never followed. Responses stream against a 4 MiB cap with check-before-extend, so a lying `Content-Length` never allocates. Timeouts clamp to [1s, 60s], default 30s.
- **Hostile path parameters encode, not traverse.** Values are percent-encoded outside the unreserved set; a value that *is* `.`/`..` is refused (URL parsers dot-normalize every encoding of it), with a structural backstop refusing any assembled path that normalization rewrites.
- **Header hygiene.** Placement and declared header names must be RFC 7230 tokens; routing/framing headers (`Host`, `Content-Length`, `Transfer-Encoding`, `Connection`, `Proxy-*`, …) are refused everywhere, executor-owned headers refused for parameters, and `Authorization` is reachable only as an explicit named-header placement.
- **Credential redaction.** The credential is a secret-store *reference*, resolved only at request time; the transport request's hand-written `Debug` redacts all header values, transport failures are URL-stripped (`reqwest::Error::without_url`), a missing secret is a distinct refusal, and a value that cannot travel as a header is refused before it can reach an error path.

Transport and resolver are trait seams (`RestTransport`, `RestHostResolver`) with the pinned `ReqwestRestTransport` / `TokioRestHostResolver` as the real implementations; tests drive the executor with fakes — no live network.

`openwave-server` gains `reqwest` (moved up from dev-dependencies) and `jsonschema` (already a workspace dependency); the lockfile diff is one dependency-edge line, no version changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
