### PR TITLE
feat(core): connected-app record with hard-cut MCP absorption and app-keyed bindings

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -241,6 +241,19 @@ impl ToolRegistry {
         self.tools.contains_key(name)
     }
 
+    /// The shared server-side executor registered under `name`, for callers
+    /// that decorate a registration (re-registering under the same name with
+    /// an amended spec) while delegating execution to the original tool.
+    #[must_use]
+    pub fn server_tool(&self, name: &str) -> Option<Arc<dyn Tool>> {
+        match self.tools.get(name)? {
+            RegisteredTool::Server(tool) => Some(tool.clone()),
+            RegisteredTool::Client { .. }
+            | RegisteredTool::ForegroundClient { .. }
+            | RegisteredTool::ForegroundOrchestration { .. } => None,
+        }
+    }
+
     /// Resolve the trusted execution surface for a registered tool name.
     #[must_use]
     pub fn execution(&self, name: &str) -> Option<ToolCallExecution> {

--- a/crates/openwave-core/src/connected_app.rs
+++ b/crates/openwave-core/src/connected_app.rs
@@ -1,0 +1,163 @@
+//! Closed contract for profile-scoped connected apps.
+//!
+//! A connected app is the durable record of an outside integration the
+//! profile can reach: an opaque [`ConnectedAppId`], a display name, a
+//! [`ConnectedAppKind`], and a kind-specific definition. MCP server
+//! definitions are one kind of connected app; a plain REST API with a
+//! credential reference is the other. App manifests and grants bind
+//! capabilities by this record's id, never by a raw server namespace.
+//!
+//! The definition is carried here as bounded JSON: each kind's typed shape,
+//! validation, and fingerprint canonicalization live with the host layer that
+//! owns the kind (the MCP runtime, the REST executor). The store enforces
+//! only what is kind-independent — identity, naming, and bounds.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::id::ConnectedAppId;
+
+/// Largest number of connected apps one profile retains, across kinds. Twice
+/// the MCP server bound (32), leaving the same headroom for REST entries.
+pub const MAX_CONNECTED_APPS: usize = 64;
+/// Largest connected-app display name. For an `mcp_server` app the name is
+/// also the mount namespace, which enforces its own tighter contract.
+pub const MAX_CONNECTED_APP_NAME_CHARS: usize = 120;
+/// Largest serialized kind-specific definition one record may carry. Sized
+/// for a `rest_api` definition holding an ingested operation catalog, well
+/// above any MCP transport config.
+pub const MAX_CONNECTED_APP_DEFINITION_BYTES: usize = 2 * 1024 * 1024;
+
+/// The transport class of a connected app. Closed vocabulary, persisted as
+/// the snake_case string; deliberately the same words the model gateway uses
+/// for its `connected_apps`, so promotion is a translation, not a reframing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectedAppKind {
+    /// An MCP server definition (stdio command, HTTP url, or gateway
+    /// endpoint), absorbed from the pre-record configuration.
+    McpServer,
+    /// A plain REST API: base URL, ingested OpenAPI operation catalog, and an
+    /// optional credential *reference* into the profile secret store. Refused
+    /// entirely on gateway-managed profiles by every write surface.
+    RestApi,
+}
+
+impl ConnectedAppKind {
+    /// The persisted string form of the kind.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::McpServer => "mcp_server",
+            Self::RestApi => "rest_api",
+        }
+    }
+
+    /// Parse the persisted string form back into the closed vocabulary.
+    #[must_use]
+    pub fn parse(kind: &str) -> Option<Self> {
+        match kind {
+            "mcp_server" => Some(Self::McpServer),
+            "rest_api" => Some(Self::RestApi),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for ConnectedAppKind {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// One profile-scoped connected app.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectedApp {
+    /// Durable opaque identity — what app-keyed bindings and grants name.
+    pub id: ConnectedAppId,
+    /// Display name. For an `mcp_server` app this is also the namespace its
+    /// tools mount under (`mcp__{name}__…`).
+    pub name: String,
+    /// Which kind of integration the definition describes.
+    pub kind: ConnectedAppKind,
+    /// Kind-specific definition, validated by the layer that owns the kind
+    /// before it reaches the store. Bounded here so no write path can persist
+    /// an unbounded blob.
+    pub definition: serde_json::Value,
+    /// Creation time of the record.
+    pub created_at: DateTime<Utc>,
+    /// Last time the definition or name changed.
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Validate the kind-independent contract of a connected app record.
+///
+/// Kind-specific validation (transport invariants, catalog shape) happens in
+/// the owning layer before the store is reached; this is the storage door's
+/// backstop on identity, naming, and bounds.
+pub fn validate_connected_app(app: &ConnectedApp) -> Result<(), String> {
+    if app.name.is_empty() || app.name.chars().count() > MAX_CONNECTED_APP_NAME_CHARS {
+        return Err(format!(
+            "connected app name must contain between 1 and {MAX_CONNECTED_APP_NAME_CHARS} characters"
+        ));
+    }
+    if app.name.trim() != app.name {
+        return Err("connected app name may not have surrounding whitespace".into());
+    }
+    if app.name.chars().any(char::is_control) {
+        return Err("connected app name may not contain control characters".into());
+    }
+    if !app.definition.is_object() {
+        return Err("connected app definition must be a JSON object".into());
+    }
+    let encoded_len = app.definition.to_string().len();
+    if encoded_len > MAX_CONNECTED_APP_DEFINITION_BYTES {
+        return Err(format!(
+            "connected app definition is too large ({encoded_len} bytes, \
+             maximum {MAX_CONNECTED_APP_DEFINITION_BYTES})"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kind_strings_round_trip_and_stay_closed() {
+        for kind in [ConnectedAppKind::McpServer, ConnectedAppKind::RestApi] {
+            assert_eq!(ConnectedAppKind::parse(kind.as_str()), Some(kind));
+        }
+        assert_eq!(ConnectedAppKind::parse("oauth_connector"), None);
+    }
+
+    #[test]
+    fn records_enforce_naming_and_definition_bounds() {
+        let app = |name: &str, definition: serde_json::Value| ConnectedApp {
+            id: ConnectedAppId::new(),
+            name: name.into(),
+            kind: ConnectedAppKind::McpServer,
+            definition,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+
+        assert!(validate_connected_app(&app("sentry", serde_json::json!({}))).is_ok());
+        for name in ["", " padded ", "line\nbreak", &"x".repeat(121)] {
+            assert!(validate_connected_app(&app(name, serde_json::json!({}))).is_err());
+        }
+        assert!(
+            validate_connected_app(&app("sentry", serde_json::json!([]))).is_err(),
+            "a definition must be an object"
+        );
+        assert!(
+            validate_connected_app(&app(
+                "sentry",
+                serde_json::json!({ "blob": "x".repeat(MAX_CONNECTED_APP_DEFINITION_BYTES) })
+            ))
+            .is_err(),
+            "an oversized definition is refused at the storage door"
+        );
+    }
+}

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -1370,6 +1370,37 @@ pub mod output_revision {
     impl ActiveModelBehavior for ActiveModel {}
 }
 
+pub mod connected_app {
+    use sea_orm::entity::prelude::*;
+
+    // One row per outside integration the profile can reach. `kind` is the
+    // closed `ConnectedAppKind` vocabulary as text; `definition_json` is the
+    // kind-specific definition, validated and bounded before it gets here.
+    // `(kind, name)` is unique: for `mcp_server` rows the name is the mount
+    // namespace, and two records may not claim one namespace.
+    #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+    #[sea_orm(table_name = "connected_app")]
+    pub struct Model {
+        #[sea_orm(primary_key, auto_increment = false)]
+        pub id: Uuid,
+        pub name: String,
+        pub kind: String,
+        #[sea_orm(column_type = "JsonBinary")]
+        pub definition_json: Json,
+        // Position within the record's kind. The settings surfaces edit an
+        // ordered list, and creation timestamps tie within one save, so the
+        // order is stored rather than inferred.
+        pub position: i32,
+        pub created_at: DateTimeUtc,
+        pub updated_at: DateTimeUtc,
+    }
+
+    #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+    pub enum Relation {}
+
+    impl ActiveModelBehavior for ActiveModel {}
+}
+
 pub mod app {
     use sea_orm::entity::prelude::*;
 

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -105,6 +105,7 @@ impl MigratorTrait for Migrator {
             Box::new(ExtendUserQuestions),
             Box::new(RetainCancelledTurnOutput),
             Box::new(AddSandboxToolCallRetry),
+            Box::new(AddConnectedApps),
         ]
     }
 }
@@ -9249,6 +9250,18 @@ enum AppGrant {
 }
 
 #[derive(DeriveIden)]
+enum ConnectedApp {
+    Table,
+    Id,
+    Name,
+    Kind,
+    DefinitionJson,
+    Position,
+    CreatedAt,
+    UpdatedAt,
+}
+
+#[derive(DeriveIden)]
 enum OutputRevisionCitation {
     Table,
     Id,
@@ -10647,5 +10660,197 @@ impl MigrationTrait for AddSandboxToolCallRetry {
             )
             .await?;
         Ok(())
+    }
+}
+
+/// Introduces the profile-scoped `connected_app` record (docs/connected-apps.md,
+/// #1341) and absorbs the persisted MCP server configuration into it: one
+/// `mcp_server`-kind row per server from the `mcp_servers_v1` setting, which is
+/// then deleted as a source of truth.
+///
+/// The absorption is deliberately a **hard cut**:
+///
+/// - Every `app_grant` row is dropped rather than translated. Grants now name
+///   a connected-app identity instead of a raw server namespace, and consent
+///   given under the old vocabulary is re-asked under the new one — the
+///   affected app simply re-presents its consent sheet on next open.
+/// - Stored app manifests are rewritten from `{server, tools[]}` to
+///   `{app, tools[]}` bindings keyed by the absorbed record's id. A binding
+///   whose server is no longer configured is dropped — narrowing, never
+///   widening, and the invoke gate would have refused it either way.
+///
+/// `down` drops the table and index only. The data cut is irreversible by
+/// design: dropped grants cannot be resurrected (consent must be re-asked
+/// regardless), and rewritten manifests keep the app-keyed vocabulary.
+struct AddConnectedApps;
+
+impl MigrationName for AddConnectedApps {
+    fn name(&self) -> &str {
+        "m20260803_000043_add_connected_apps"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddConnectedApps {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(ConnectedApp::Table)
+                    .col(
+                        ColumnDef::new(ConnectedApp::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(ConnectedApp::Name).string().not_null())
+                    .col(ColumnDef::new(ConnectedApp::Kind).string().not_null())
+                    .col(
+                        ColumnDef::new(ConnectedApp::DefinitionJson)
+                            .json_binary()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(ConnectedApp::Position).integer().not_null())
+                    .col(
+                        ColumnDef::new(ConnectedApp::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(ConnectedApp::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null(),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+        // For `mcp_server` rows the name is the mount namespace; two records
+        // may not claim one namespace. Scoped by kind so a REST entry may
+        // share a display name with a server.
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_connected_app_kind_name")
+                    .table(ConnectedApp::Table)
+                    .col(ConnectedApp::Kind)
+                    .col(ConnectedApp::Name)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        let conn = manager.get_connection();
+        let backend = manager.get_database_backend();
+        let mut ids_by_name = std::collections::BTreeMap::new();
+        let setting = conn
+            .query_one_raw(sea_orm::Statement::from_string(
+                backend,
+                "SELECT value_json FROM setting WHERE key = 'mcp_servers_v1'",
+            ))
+            .await?;
+        if let Some(row) = setting {
+            let config: serde_json::Value = row.try_get("", "value_json")?;
+            let servers = config
+                .get("servers")
+                .and_then(serde_json::Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            let now = chrono::Utc::now();
+            for (position, server) in servers.iter().enumerate() {
+                // The definition row keeps the full server object verbatim
+                // (including its name, which the record's name mirrors), so
+                // the absorption cannot reinterpret any transport field.
+                let Some(name) = server.get("name").and_then(serde_json::Value::as_str) else {
+                    continue;
+                };
+                let id = uuid::Uuid::new_v4();
+                ids_by_name.insert(name.to_owned(), id);
+                manager
+                    .exec_stmt(
+                        Query::insert()
+                            .into_table(ConnectedApp::Table)
+                            .columns([
+                                ConnectedApp::Id,
+                                ConnectedApp::Name,
+                                ConnectedApp::Kind,
+                                ConnectedApp::DefinitionJson,
+                                ConnectedApp::Position,
+                                ConnectedApp::CreatedAt,
+                                ConnectedApp::UpdatedAt,
+                            ])
+                            .values_panic([
+                                id.into(),
+                                name.into(),
+                                "mcp_server".into(),
+                                sea_orm::Value::Json(Some(Box::new(server.clone()))).into(),
+                                (position as i32).into(),
+                                now.into(),
+                                now.into(),
+                            ])
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+        }
+
+        let revisions = conn
+            .query_all_raw(sea_orm::Statement::from_string(
+                backend,
+                "SELECT id, manifest_json FROM app_revision",
+            ))
+            .await?;
+        for row in revisions {
+            let revision_id: uuid::Uuid = row.try_get("", "id")?;
+            let manifest: serde_json::Value = row.try_get("", "manifest_json")?;
+            let Some(bindings) = manifest
+                .get("bindings")
+                .and_then(serde_json::Value::as_array)
+            else {
+                continue;
+            };
+            let translated: Vec<serde_json::Value> = bindings
+                .iter()
+                .filter_map(|binding| {
+                    let Some(server) = binding.get("server").and_then(serde_json::Value::as_str)
+                    else {
+                        // Not the legacy shape; leave it untouched.
+                        return Some(binding.clone());
+                    };
+                    let app_id = ids_by_name.get(server)?;
+                    Some(serde_json::json!({
+                        "app": app_id,
+                        "tools": binding.get("tools").cloned()
+                            .unwrap_or_else(|| serde_json::Value::Array(Vec::new())),
+                    }))
+                })
+                .collect();
+            let mut rewritten = manifest.clone();
+            rewritten["bindings"] = serde_json::Value::Array(translated);
+            if rewritten != manifest {
+                manager
+                    .exec_stmt(
+                        Query::update()
+                            .table(AppRevision::Table)
+                            .value(
+                                AppRevision::ManifestJson,
+                                sea_orm::Value::Json(Some(Box::new(rewritten))),
+                            )
+                            .and_where(Expr::col(AppRevision::Id).eq(revision_id))
+                            .to_owned(),
+                    )
+                    .await?;
+            }
+        }
+
+        conn.execute_unprepared("DELETE FROM app_grant").await?;
+        conn.execute_unprepared("DELETE FROM setting WHERE key = 'mcp_servers_v1'")
+            .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(ConnectedApp::Table).to_owned())
+            .await
     }
 }

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -17,6 +17,7 @@ use sea_orm_migration::MigratorTrait;
 use serde_json::Value;
 
 use crate::approval::{ApprovalDecision, ApprovalRequest, ToolApproval};
+use crate::connected_app::{ConnectedApp, ConnectedAppKind};
 use crate::deliverable::{CreateOutput, NewOutputRevision, OutputRecord, OutputRevision};
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
@@ -672,6 +673,18 @@ impl Store for DbStore {
 
     async fn delete_app_grant(&self, app_id: AppId) -> Result<bool> {
         ops::app::delete_app_grant(self, app_id).await
+    }
+
+    async fn list_connected_apps(&self) -> Result<Vec<ConnectedApp>> {
+        ops::connected_app::list_connected_apps(self).await
+    }
+
+    async fn replace_connected_apps(
+        &self,
+        kind: ConnectedAppKind,
+        apps: &[ConnectedApp],
+    ) -> Result<()> {
+        ops::connected_app::replace_connected_apps(self, kind, apps).await
     }
 
     async fn save_context_checkpoint(

--- a/crates/openwave-core/src/db/ops/connected_app.rs
+++ b/crates/openwave-core/src/db/ops/connected_app.rs
@@ -1,0 +1,137 @@
+//! Profile-scoped connected-app records.
+//!
+//! The write surface mirrors the settings pages that own it: a wholesale
+//! replacement of one kind's complete list, in one transaction, so a
+//! concurrent save can never interleave into a mixed state. Reads return
+//! every kind together — the Connected apps surface lists them side by side
+//! and callers filter by kind.
+
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+};
+
+use crate::connected_app::{
+    validate_connected_app, ConnectedApp, ConnectedAppKind, MAX_CONNECTED_APPS,
+};
+use crate::error::{AgentError, Result};
+use crate::id::ConnectedAppId;
+
+use super::super::{entities, store_err, DbStore};
+use super::turn::canonical_db_timestamp;
+
+pub(in crate::db) async fn list_connected_apps(store: &DbStore) -> Result<Vec<ConnectedApp>> {
+    entities::connected_app::Entity::find()
+        .order_by_asc(entities::connected_app::Column::Kind)
+        .order_by_asc(entities::connected_app::Column::Position)
+        .order_by_asc(entities::connected_app::Column::Id)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(connected_app_from_model)
+        .collect()
+}
+
+pub(in crate::db) async fn replace_connected_apps(
+    store: &DbStore,
+    kind: ConnectedAppKind,
+    apps: &[ConnectedApp],
+) -> Result<()> {
+    if apps.len() > MAX_CONNECTED_APPS {
+        return Err(AgentError::Store(format!(
+            "cannot store more than {MAX_CONNECTED_APPS} connected apps"
+        )));
+    }
+    for app in apps {
+        if app.kind != kind {
+            return Err(AgentError::Store(format!(
+                "connected app {} is {}, not the {kind} this replacement covers",
+                app.id, app.kind
+            )));
+        }
+        validate_connected_app(app)
+            .map_err(|message| AgentError::Store(format!("invalid connected app: {message}")))?;
+    }
+    let transaction = store.conn.begin().await.map_err(store_err)?;
+    let existing: Vec<entities::connected_app::Model> = entities::connected_app::Entity::find()
+        .filter(entities::connected_app::Column::Kind.eq(kind.as_str()))
+        .all(&transaction)
+        .await
+        .map_err(store_err)?;
+    for row in &existing {
+        if !apps.iter().any(|app| app.id.0 == row.id) {
+            entities::connected_app::Entity::delete_by_id(row.id)
+                .exec(&transaction)
+                .await
+                .map_err(store_err)?;
+        }
+    }
+    for (index, app) in apps.iter().enumerate() {
+        // The settings surfaces edit an ordered list; the position within the
+        // kind is part of the stored state.
+        let position = i32::try_from(index)
+            .map_err(|_| AgentError::Store("connected-app position is out of range".into()))?;
+        let updated_at = canonical_db_timestamp(app.updated_at)?;
+        match existing.iter().find(|row| row.id == app.id.0) {
+            Some(row) => {
+                if row.name == app.name
+                    && row.definition_json == app.definition
+                    && row.position == position
+                {
+                    continue;
+                }
+                entities::connected_app::ActiveModel {
+                    id: Set(app.id.0),
+                    name: Set(app.name.clone()),
+                    definition_json: Set(app.definition.clone()),
+                    position: Set(position),
+                    updated_at: Set(
+                        if row.name == app.name && row.definition_json == app.definition {
+                            // A pure reorder is not an edit of what the record is.
+                            row.updated_at
+                        } else {
+                            updated_at
+                        },
+                    ),
+                    ..Default::default()
+                }
+                .update(&transaction)
+                .await
+                .map_err(store_err)?;
+            }
+            None => {
+                entities::connected_app::ActiveModel {
+                    id: Set(app.id.0),
+                    name: Set(app.name.clone()),
+                    kind: Set(kind.as_str().to_owned()),
+                    definition_json: Set(app.definition.clone()),
+                    position: Set(position),
+                    created_at: Set(canonical_db_timestamp(app.created_at)?),
+                    updated_at: Set(updated_at),
+                }
+                .insert(&transaction)
+                .await
+                .map_err(store_err)?;
+            }
+        }
+    }
+    transaction.commit().await.map_err(store_err)?;
+    Ok(())
+}
+
+fn connected_app_from_model(model: entities::connected_app::Model) -> Result<ConnectedApp> {
+    let kind = ConnectedAppKind::parse(&model.kind).ok_or_else(|| {
+        AgentError::Store(format!(
+            "stored connected app has unknown kind {:?}",
+            model.kind
+        ))
+    })?;
+    Ok(ConnectedApp {
+        id: ConnectedAppId(model.id),
+        name: model.name,
+        kind,
+        definition: model.definition_json,
+        created_at: model.created_at,
+        updated_at: model.updated_at,
+    })
+}

--- a/crates/openwave-core/src/db/ops/mod.rs
+++ b/crates/openwave-core/src/db/ops/mod.rs
@@ -12,6 +12,7 @@ pub(in crate::db) mod blob;
 pub(in crate::db) mod chat_prompt;
 pub(in crate::db) mod citation;
 pub(in crate::db) mod client_execution;
+pub(in crate::db) mod connected_app;
 pub(in crate::db) mod context_checkpoint;
 pub(in crate::db) mod conversation;
 pub(in crate::db) mod document;

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -12,6 +12,7 @@ use sea_orm::{DatabaseBackend, Statement};
 
 mod agent_run;
 mod app;
+mod connected_app;
 mod context_checkpoint;
 mod delegated_file_read;
 mod message_attachment;

--- a/crates/openwave-core/src/db/tests/app.rs
+++ b/crates/openwave-core/src/db/tests/app.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::id::{AgentRunId, AppId, AppRevisionId};
+use crate::id::{AgentRunId, AppId, AppRevisionId, ConnectedAppId};
 use crate::local_app::{
     AppBinding, AppManifest, CreateApp, NewAppRevision, MAX_APP_BUNDLE_BYTES, MAX_APP_REVISIONS,
 };
@@ -16,7 +16,7 @@ fn manifest(name: &str) -> AppManifest {
     AppManifest {
         name: name.to_owned(),
         bindings: vec![AppBinding {
-            server: "sentry".into(),
+            app: ConnectedAppId(uuid::Uuid::from_u128(1)),
             tools: vec!["mcp__sentry__list_issues".into()],
         }],
     }
@@ -177,11 +177,11 @@ async fn a_revision_records_one_producer_and_dangling_conversation_provenance() 
 async fn malformed_manifests_and_out_of_bounds_bundles_are_refused() {
     let (_dir, store) = temp_store().await;
 
-    // A tool pinned outside its binding's server namespace can never match a
-    // mounted tool, so the store refuses it at the door.
-    let mut foreign_tool = create_request(1);
-    foreign_tool.revision.manifest.bindings[0].tools = vec!["mcp__github__list_issues".into()];
-    assert!(store.create_app(&foreign_tool).await.is_err());
+    // A pinned name that is not shaped like a mounted tool can never match
+    // one, so the store refuses it at the door.
+    let mut bare_tool = create_request(1);
+    bare_tool.revision.manifest.bindings[0].tools = vec!["list_issues".into()];
+    assert!(store.create_app(&bare_tool).await.is_err());
 
     let mut empty_bundle = create_request(1);
     empty_bundle.revision.byte_len = 0;
@@ -195,7 +195,7 @@ async fn malformed_manifests_and_out_of_bounds_bundles_are_refused() {
     let mut oversized_manifest = create_request(1);
     oversized_manifest.revision.manifest.bindings = (0..2_000)
         .map(|index| AppBinding {
-            server: format!("server_{index:04}"),
+            app: ConnectedAppId::new(),
             tools: vec![format!("mcp__server_{index:04}__tool_padding_padding")],
         })
         .collect();

--- a/crates/openwave-core/src/db/tests/connected_app.rs
+++ b/crates/openwave-core/src/db/tests/connected_app.rs
@@ -1,0 +1,187 @@
+use super::*;
+use crate::connected_app::{ConnectedApp, ConnectedAppKind};
+use crate::id::ConnectedAppId;
+
+fn record(name: &str, kind: ConnectedAppKind, second: i64) -> ConnectedApp {
+    let at = DateTime::<Utc>::from_timestamp(1_710_000_000 + second, 0).unwrap();
+    ConnectedApp {
+        id: ConnectedAppId::new(),
+        name: name.to_owned(),
+        kind,
+        definition: serde_json::json!({ "name": name }),
+        created_at: at,
+        updated_at: at,
+    }
+}
+
+#[tokio::test]
+async fn replacement_is_kind_scoped_and_preserves_record_identity() {
+    let (_dir, store) = temp_store().await;
+    let sentry = record("sentry", ConnectedAppKind::McpServer, 0);
+    let rest = record("Sentry API", ConnectedAppKind::RestApi, 0);
+    store
+        .replace_connected_apps(ConnectedAppKind::McpServer, std::slice::from_ref(&sentry))
+        .await
+        .unwrap();
+    store
+        .replace_connected_apps(ConnectedAppKind::RestApi, std::slice::from_ref(&rest))
+        .await
+        .unwrap();
+
+    // An edit under the same id updates in place and keeps `created_at`; a
+    // replacement listing only the edited record deletes nothing of another
+    // kind.
+    let mut edited = sentry.clone();
+    edited.definition = serde_json::json!({ "name": "sentry", "command": "sentry-mcp" });
+    edited.updated_at = DateTime::<Utc>::from_timestamp(1_710_000_060, 0).unwrap();
+    store
+        .replace_connected_apps(ConnectedAppKind::McpServer, std::slice::from_ref(&edited))
+        .await
+        .unwrap();
+    let apps = store.list_connected_apps().await.unwrap();
+    assert_eq!(apps.len(), 2);
+    let stored = apps.iter().find(|app| app.id == sentry.id).unwrap();
+    assert_eq!(stored.definition, edited.definition);
+    assert_eq!(stored.created_at, sentry.created_at, "identity persists");
+    assert!(
+        apps.iter().any(|app| app.id == rest.id),
+        "kinds are isolated"
+    );
+
+    // An empty replacement clears exactly its kind.
+    store
+        .replace_connected_apps(ConnectedAppKind::McpServer, &[])
+        .await
+        .unwrap();
+    let apps = store.list_connected_apps().await.unwrap();
+    assert_eq!(apps.len(), 1);
+    assert_eq!(apps[0].id, rest.id);
+
+    // A mixed-kind call is a caller bug, refused before any write.
+    assert!(store
+        .replace_connected_apps(ConnectedAppKind::McpServer, std::slice::from_ref(&rest))
+        .await
+        .is_err());
+}
+
+/// The absorption migration is the hard cut docs/connected-apps.md specifies:
+/// persisted MCP servers become `mcp_server` records, stored manifests are
+/// re-keyed onto record ids (dropping bindings to servers that no longer
+/// exist), every pre-existing grant is dropped, and the absorbed setting row
+/// stops being a source of truth.
+#[tokio::test]
+async fn absorption_migrates_servers_rekeys_manifests_and_drops_grants() {
+    let dir = tempfile::tempdir().unwrap();
+    let database = dir.path().join("upgrade.db");
+    let url = format!("sqlite://{}?mode=rwc", database.display());
+    let conn = Database::connect(&url).await.unwrap();
+    let before_absorption = u32::try_from(migration::Migrator::migrations().len() - 1).unwrap();
+    migration::Migrator::up(&conn, Some(before_absorption))
+        .await
+        .unwrap();
+
+    let now = DateTime::<Utc>::from_timestamp(1_710_000_000, 0).unwrap();
+    let app_id = uuid::Uuid::new_v4();
+    let revision_id = uuid::Uuid::new_v4();
+    let seed = |sql: &str, values: Vec<sea_orm::Value>| {
+        conn.execute_raw(Statement::from_sql_and_values(
+            DatabaseBackend::Sqlite,
+            sql,
+            values,
+        ))
+    };
+    seed(
+        "INSERT INTO setting (key, value_json) VALUES ('mcp_servers_v1', ?)",
+        vec![serde_json::json!({
+            "servers": [
+                { "name": "sentry", "command": "sentry-mcp", "enabled": true },
+            ],
+        })
+        .into()],
+    )
+    .await
+    .unwrap();
+    seed(
+        "INSERT INTO app (id, name, current_revision_id, revision_count, created_at, updated_at) \
+         VALUES (?, 'Sentry triage', ?, 1, ?, ?)",
+        vec![app_id.into(), revision_id.into(), now.into(), now.into()],
+    )
+    .await
+    .unwrap();
+    // One binding survives the cut re-keyed; the one naming a server that is
+    // no longer configured is dropped — narrowed, never widened.
+    seed(
+        "INSERT INTO app_revision \
+         (id, app_id, ordinal, manifest_json, byte_len, sha256, created_at) \
+         VALUES (?, ?, 1, ?, 10, ?, ?)",
+        vec![
+            revision_id.into(),
+            app_id.into(),
+            serde_json::json!({
+                "name": "Sentry triage",
+                "bindings": [
+                    { "server": "sentry", "tools": ["mcp__sentry__list_issues"] },
+                    { "server": "gone", "tools": ["mcp__gone__tool"] },
+                ],
+            })
+            .into(),
+            vec![0_u8; 32].into(),
+            now.into(),
+        ],
+    )
+    .await
+    .unwrap();
+    seed(
+        "INSERT INTO app_grant (app_id, bindings_json, created_at) VALUES (?, ?, ?)",
+        vec![
+            app_id.into(),
+            serde_json::json!([{
+                "server": "sentry",
+                "tools": ["mcp__sentry__list_issues"],
+                "fingerprint": "00".repeat(32),
+            }])
+            .into(),
+            now.into(),
+        ],
+    )
+    .await
+    .unwrap();
+
+    migration::Migrator::up(&conn, None).await.unwrap();
+    let store = DbStore { conn };
+
+    let apps = store.list_connected_apps().await.unwrap();
+    assert_eq!(apps.len(), 1);
+    assert_eq!(apps[0].kind, ConnectedAppKind::McpServer);
+    assert_eq!(apps[0].name, "sentry");
+    assert_eq!(
+        apps[0].definition,
+        serde_json::json!({ "name": "sentry", "command": "sentry-mcp", "enabled": true }),
+        "the absorbed definition is the server object verbatim"
+    );
+
+    let revision = store
+        .get_app_revision(crate::id::AppRevisionId(revision_id))
+        .await
+        .unwrap()
+        .expect("the revision row survives the cut");
+    assert_eq!(revision.manifest.bindings.len(), 1);
+    assert_eq!(revision.manifest.bindings[0].app, apps[0].id);
+    assert_eq!(
+        revision.manifest.bindings[0].tools,
+        ["mcp__sentry__list_issues"]
+    );
+
+    assert!(
+        store
+            .get_app_grant(crate::id::AppId(app_id))
+            .await
+            .unwrap()
+            .is_none(),
+        "pre-existing grants are dropped, not translated"
+    );
+    assert!(
+        store.get_setting("mcp_servers_v1").await.unwrap().is_none(),
+        "the absorbed setting row is no longer a source of truth"
+    );
+}

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -494,6 +494,56 @@ impl AppId {
 }
 
 id_type!(
+    /// Identifies one profile-scoped connected app — an outside integration
+    /// (an MCP server, a REST API) a profile can reach.
+    ///
+    /// App-keyed manifest bindings and grants name this identity rather than a
+    /// raw server namespace, so consent follows the record even when display
+    /// names or namespaces change around it.
+    ConnectedAppId
+);
+
+// Ordered so fingerprint maps can key by record id; the macro's derives stop
+// at `Eq` because no other id is used as a map key in sorted collections.
+impl PartialOrd for ConnectedAppId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ConnectedAppId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl ConnectedAppId {
+    const NAMESPACE: Uuid = Uuid::from_u128(0x1f4c_9a70_60fd_4b2e_9a41_c2d1_08e7_5d23);
+
+    /// Derive the boot-stable identity for a server selected by the legacy
+    /// boot file (`OPENWAVE_MCP_CONFIG`), which configures servers without
+    /// persisting records. Deriving from the configured name keeps app grants
+    /// valid across restarts of a boot-file profile; a persisted record keeps
+    /// whatever id it was created with.
+    #[must_use]
+    pub fn for_boot_server(name: &str) -> Self {
+        Self(Uuid::new_v5(&Self::NAMESPACE, name.as_bytes()))
+    }
+}
+
+/// Schema for the one id type the model writes: `create_app` manifests bind
+/// connected apps by id, so the argument schema must carry it.
+impl schemars::JsonSchema for ConnectedAppId {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "ConnectedAppId".into()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        <Uuid as schemars::JsonSchema>::json_schema(generator)
+    }
+}
+
+id_type!(
     /// Identifies one immutable revision of a local app.
     AppRevisionId
 );

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -39,6 +39,7 @@ pub mod cancel;
 pub mod citation;
 pub mod client_tools;
 pub mod config;
+pub mod connected_app;
 pub mod context;
 #[cfg(any(feature = "sqlite", feature = "postgres"))]
 pub mod db;

--- a/crates/openwave-core/src/local_app.rs
+++ b/crates/openwave-core/src/local_app.rs
@@ -16,7 +16,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::deliverable::RevisionProducer;
-use crate::id::{AgentRunId, AppId, AppRevisionId, ChatId, TurnId};
+use crate::id::{AgentRunId, AppId, AppRevisionId, ChatId, ConnectedAppId, TurnId};
 
 /// Stable name of the foreground tool that creates and revises local apps.
 ///
@@ -189,13 +189,13 @@ pub struct CreateApp {
     pub revision: NewAppRevision,
 }
 
-/// The durable consent object for one app: the granted `(server, tools[])`
-/// set, with each bound server pinned to a fingerprint of its definition as it
-/// was configured at consent time.
+/// The durable consent object for one app: the granted `(app, tools[])` set,
+/// with each bound connected app pinned to a fingerprint of its definition as
+/// it was configured at consent time.
 ///
 /// One grant per app, replaced wholesale by a fresh consent and deleted by
 /// revocation. The fingerprint is what keeps consent honest: a Settings edit
-/// can swap the process behind a stable server name, so enforcement compares
+/// can swap the definition behind a stable record, so enforcement compares
 /// the granted fingerprint against the current definition on every invoke and
 /// treats any difference as a stale grant, never as a match.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -203,26 +203,27 @@ pub struct AppGrant {
     /// App the consent belongs to.
     pub app_id: AppId,
     /// The granted bindings, computed by the host from the manifest and the
-    /// server definitions current at consent time — never supplied by a
-    /// renderer.
+    /// connected-app definitions current at consent time — never supplied by
+    /// a renderer.
     pub bindings: Vec<AppGrantBinding>,
     /// Host-stamped consent time.
     pub created_at: DateTime<Utc>,
 }
 
-/// One granted server binding: the tools the user consented to under this
-/// server name, pinned to the definition that name resolved to at consent.
+/// One granted binding: the tools the user consented to under one connected
+/// app, pinned to the definition that record carried at consent.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AppGrantBinding {
-    /// Configured server namespace, matching the manifest binding it covers.
-    pub server: String,
-    /// Full mounted tool names (`mcp__{server}__{tool}`) the grant covers.
+    /// Connected app the consent names, matching the manifest binding it
+    /// covers.
+    pub app: ConnectedAppId,
+    /// Full mounted tool names (`mcp__{namespace}__{tool}`) the grant covers.
     pub tools: Vec<String>,
-    /// SHA-256 fingerprint of the server's definition as configured at consent
-    /// time, computed by the host over a canonical serialization that carries
-    /// configuration *names and structure* only — never environment or token
-    /// values. Persisted as lowercase hex.
+    /// SHA-256 fingerprint of the connected app's definition as configured at
+    /// consent time, computed by the host over a canonical serialization that
+    /// carries configuration *names and structure* only — never environment
+    /// or token values. Persisted as lowercase hex.
     #[serde(with = "hex_fingerprint")]
     pub fingerprint: [u8; 32],
 }
@@ -267,7 +268,7 @@ pub fn validate_app_grant(grant: &AppGrant) -> Result<serde_json::Value, String>
         grant
             .bindings
             .iter()
-            .map(|binding| (binding.server.as_str(), binding.tools.as_slice())),
+            .map(|binding| (binding.app, binding.tools.as_slice())),
     )?;
     serde_json::to_value(&grant.bindings).map_err(|error| format!("unencodable app grant: {error}"))
 }
@@ -286,18 +287,24 @@ pub fn validate_app_grant(grant: &AppGrant) -> Result<serde_json::Value, String>
 pub struct AppManifest {
     /// Display name shown in the transcript card and the Apps library.
     pub name: String,
-    /// Pinned tool bindings, grouped by configured server namespace.
+    /// Pinned tool bindings, grouped by connected app.
     pub bindings: Vec<AppBinding>,
 }
 
-/// The mounted tools one server namespace contributes to an app.
+/// The mounted tools one connected app contributes to a local app.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct AppBinding {
-    /// Configured server namespace the tools are mounted under.
-    pub server: String,
-    /// Full mounted tool names, each `mcp__{server}__{tool}` under this
-    /// binding's server namespace.
+    /// Id of the connected app the tools belong to. The available ids are
+    /// listed in the `create_app` tool description.
+    #[schemars(description = "Id of the connected app these tools belong to.")]
+    pub app: ConnectedAppId,
+    /// Full mounted tool names, each `mcp__{namespace}__{tool}` under the
+    /// bound connected app's namespace.
+    #[schemars(
+        description = "Full mounted tool names (`mcp__{namespace}__{tool}`), all \
+                       under the bound connected app's namespace."
+    )]
     pub tools: Vec<String>,
 }
 
@@ -314,7 +321,7 @@ pub fn validate_app_manifest(manifest: &AppManifest) -> Result<serde_json::Value
         manifest
             .bindings
             .iter()
-            .map(|binding| (binding.server.as_str(), binding.tools.as_slice())),
+            .map(|binding| (binding.app, binding.tools.as_slice())),
     )?;
     let json =
         serde_json::to_value(manifest).map_err(|error| format!("unencodable manifest: {error}"))?;
@@ -327,23 +334,23 @@ pub fn validate_app_manifest(manifest: &AppManifest) -> Result<serde_json::Value
     Ok(json)
 }
 
-/// The binding grammar shared by manifests and grants: valid server names,
-/// no duplicate servers, and every tool a full mounted name under its
-/// binding's server namespace.
+/// The binding grammar shared by manifests and grants: no duplicate connected
+/// apps, and every tool shaped like a full mounted name.
+///
+/// A namespace may itself contain `_`, so a mounted name cannot be split
+/// unambiguously without knowing the namespace — and the bound record lives
+/// behind the store. The grammar here is therefore structural only; the exact
+/// `mcp__{namespace}__` cross-check against the bound connected app's
+/// configuration belongs to the host layers that resolve ids (the
+/// `create_app` door, grant computation, the invoke gate).
 fn validate_binding_set<'a>(
-    bindings: impl Iterator<Item = (&'a str, &'a [String])>,
+    bindings: impl Iterator<Item = (ConnectedAppId, &'a [String])>,
 ) -> Result<(), String> {
-    let mut servers = std::collections::HashSet::new();
-    for (server, binding_tools) in bindings {
-        if server.is_empty() || !is_mounted_name_charset(server) {
-            return Err(format!(
-                "binding server {server:?} must be a non-empty [A-Za-z0-9_-] name"
-            ));
+    let mut apps = std::collections::HashSet::new();
+    for (app, binding_tools) in bindings {
+        if !apps.insert(app) {
+            return Err(format!("duplicate binding for connected app {app}"));
         }
-        if !servers.insert(server) {
-            return Err(format!("duplicate binding for server {server:?}"));
-        }
-        let prefix = format!("mcp__{server}__");
         let mut tools = std::collections::HashSet::new();
         for tool in binding_tools {
             if tool.len() > MAX_MOUNTED_TOOL_NAME_BYTES || !is_mounted_name_charset(tool) {
@@ -351,13 +358,10 @@ fn validate_binding_set<'a>(
                     "tool {tool:?} must be at most {MAX_MOUNTED_TOOL_NAME_BYTES} bytes of [A-Za-z0-9_-]"
                 ));
             }
-            match tool.strip_prefix(&prefix) {
-                Some(rest) if !rest.is_empty() => {}
-                _ => {
-                    return Err(format!(
-                        "tool {tool:?} is not a mounted `{prefix}{{tool}}` name under server {server:?}"
-                    ));
-                }
+            if !is_mounted_name_shape(tool) {
+                return Err(format!(
+                    "tool {tool:?} is not a mounted `mcp__{{namespace}}__{{tool}}` name"
+                ));
             }
             if !tools.insert(tool.as_str()) {
                 return Err(format!("duplicate tool {tool:?}"));
@@ -365,6 +369,31 @@ fn validate_binding_set<'a>(
         }
     }
     Ok(())
+}
+
+/// Whether a name is shaped like `mcp__{namespace}__{tool}` with a non-empty
+/// namespace and tool segment under *some* split — the namespace itself may
+/// contain `_`, so the exact split is only decidable against a configured
+/// record.
+fn is_mounted_name_shape(name: &str) -> bool {
+    let Some(qualified) = name.strip_prefix("mcp__") else {
+        return false;
+    };
+    qualified
+        .match_indices("__")
+        .any(|(index, _)| index > 0 && index + 2 < qualified.len())
+}
+
+/// The bare tool segment of `name` when it is mounted under exactly
+/// `namespace` — the host-side half of the binding grammar, shared by the
+/// `create_app` door, grant computation, and the invoke gate so every layer
+/// applies the same exact-prefix reading.
+#[must_use]
+pub fn mounted_tool_under<'a>(namespace: &str, name: &'a str) -> Option<&'a str> {
+    name.strip_prefix("mcp__")?
+        .strip_prefix(namespace)?
+        .strip_prefix("__")
+        .filter(|tool| !tool.is_empty())
 }
 
 fn validate_app_name(name: &str) -> Result<(), String> {
@@ -420,10 +449,11 @@ mod tests {
 
     #[test]
     fn manifests_enforce_the_mounted_tool_grammar() {
+        let app = ConnectedAppId::new();
         let manifest = |tools: &[&str]| AppManifest {
             name: "Sentry triage".into(),
             bindings: vec![AppBinding {
-                server: "sentry".into(),
+                app,
                 tools: tools.iter().map(|tool| (*tool).to_owned()).collect(),
             }],
         };
@@ -442,8 +472,8 @@ mod tests {
 
         for tool in [
             "list_issues",                               // bare name, not mounted
-            "mcp__github__list_issues",                  // mounted under a different server
             "mcp__sentry__",                             // empty tool segment
+            "mcp____tool",                               // empty namespace segment
             "mcp__sentry__bad name",                     // charset
             &format!("mcp__sentry__{}", "x".repeat(64)), // over the 64-byte bound
         ] {
@@ -457,6 +487,23 @@ mod tests {
             .is_err(),
             "duplicate pins are refused"
         );
+        assert!(
+            validate_app_manifest(&AppManifest {
+                name: "Twice".into(),
+                bindings: vec![
+                    AppBinding {
+                        app,
+                        tools: Vec::new()
+                    },
+                    AppBinding {
+                        app,
+                        tools: Vec::new()
+                    },
+                ],
+            })
+            .is_err(),
+            "duplicate connected-app bindings are refused"
+        );
 
         for name in ["", " padded ", "line\nbreak", &"x".repeat(121)] {
             assert!(
@@ -468,5 +515,20 @@ mod tests {
                 "{name:?}"
             );
         }
+    }
+
+    #[test]
+    fn the_exact_namespace_reading_is_prefix_anchored() {
+        // A namespace may contain `_`, so only the exact-prefix reading is
+        // sound — this is the check the host layers apply once the bound
+        // record's namespace is known.
+        assert_eq!(
+            mounted_tool_under("my_server", "mcp__my_server__tool"),
+            Some("tool")
+        );
+        assert_eq!(mounted_tool_under("my", "mcp__my_server__tool"), None);
+        assert_eq!(mounted_tool_under("sentry", "mcp__github__list"), None);
+        assert_eq!(mounted_tool_under("sentry", "mcp__sentry__"), None);
+        assert_eq!(mounted_tool_under("sentry", "sentry__tool"), None);
     }
 }

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -25,6 +25,7 @@ use serde_json::Value;
 use std::ops::Range;
 
 use crate::approval::{ApprovalDecision, ApprovalRequest, StandingGrant, ToolApproval};
+use crate::connected_app::{ConnectedApp, ConnectedAppKind};
 use crate::deliverable::{CreateOutput, NewOutputRevision, OutputRecord, OutputRevision};
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
@@ -992,6 +993,12 @@ fn app_storage_unavailable<T>() -> Result<T> {
     ))
 }
 
+fn connected_app_storage_unavailable<T>() -> Result<T> {
+    Err(AgentError::Store(
+        "connected-app storage is not implemented by this Store".into(),
+    ))
+}
+
 fn context_checkpoint_storage_unavailable<T>() -> Result<T> {
     Err(AgentError::Store(
         "durable context-checkpoint storage is not implemented by this Store".into(),
@@ -1616,6 +1623,29 @@ pub trait Store: Send + Sync {
     /// revoking twice is the same durable outcome, not a conflict.
     async fn delete_app_grant(&self, _app_id: AppId) -> Result<bool> {
         app_storage_unavailable()
+    }
+
+    /// List every connected app the profile holds, oldest first.
+    ///
+    /// Kind-specific definitions come back as the bounded JSON the owning
+    /// layer stored; callers parse per kind and fail closed per record.
+    async fn list_connected_apps(&self) -> Result<Vec<ConnectedApp>> {
+        connected_app_storage_unavailable()
+    }
+
+    /// Replace the profile's connected apps of one kind wholesale.
+    ///
+    /// Mirrors the settings surfaces that edit a complete list: rows of
+    /// `kind` absent from `apps` are deleted, present ids are updated in
+    /// place (keeping their `created_at`), and new ids are inserted. Records
+    /// of other kinds are untouched. Implementations validate each record's
+    /// kind-independent contract and refuse a mixed-kind call.
+    async fn replace_connected_apps(
+        &self,
+        _kind: ConnectedAppKind,
+        _apps: &[ConnectedApp],
+    ) -> Result<()> {
+        connected_app_storage_unavailable()
     }
 
     /// Persist the next versioned context checkpoint for one conversation.

--- a/crates/openwave-core/src/tools/create_app.rs
+++ b/crates/openwave-core/src/tools/create_app.rs
@@ -19,11 +19,12 @@ use serde_json::Value;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
+use crate::connected_app::ConnectedAppKind;
 use crate::error::Result;
 use crate::id::{AppId, AppRevisionId, TurnId};
 use crate::local_app::{
-    publish_app_bundle, validate_app_manifest, AppManifest, AppRecord, CreateApp, NewAppRevision,
-    MAX_APP_BUNDLE_BYTES,
+    mounted_tool_under, publish_app_bundle, validate_app_manifest, AppManifest, AppRecord,
+    CreateApp, NewAppRevision, MAX_APP_BUNDLE_BYTES,
 };
 use crate::preview::{ResultEntry, ResultEntryKind};
 use crate::storage::Store;
@@ -48,7 +49,9 @@ pub(super) struct Arguments {
     bundle_html: String,
     #[schemars(
         description = "The app's manifest: its display name and the exact mounted \
-                       MCP tools it may call, grouped by server."
+                       MCP tools it may call, grouped by connected app. Each binding \
+                       names a connected app by id (the tool description lists the \
+                       configured ids) and the full mounted tool names under it."
     )]
     manifest: AppManifest,
     #[serde(default)]
@@ -93,6 +96,59 @@ impl CreateAppTool {
             .find(|call| call.id == call_id)
             .map(|call| call.turn_id)
             .ok_or_else(|| ToolOutput::error("this call is not recorded in this conversation"))
+    }
+
+    /// Check that every manifest binding names a configured `mcp_server`
+    /// connected app and that each pinned tool is a mounted name under that
+    /// app's namespace.
+    async fn check_bindings(&self, manifest: &AppManifest) -> std::result::Result<(), String> {
+        if manifest.bindings.is_empty() {
+            return Ok(());
+        }
+        let connected = self
+            .store
+            .list_connected_apps()
+            .await
+            .map_err(|_| "could not read the configured connected apps".to_owned())?;
+        for binding in &manifest.bindings {
+            let Some(app) = connected.iter().find(|app| app.id == binding.app) else {
+                let configured: Vec<String> = connected
+                    .iter()
+                    .filter(|app| app.kind == ConnectedAppKind::McpServer)
+                    .map(|app| format!("{} ({})", app.id, app.name))
+                    .collect();
+                return Err(if configured.is_empty() {
+                    format!(
+                        "connected app {} is not configured, and no connected apps \
+                         are; only an empty bindings list is valid",
+                        binding.app
+                    )
+                } else {
+                    format!(
+                        "connected app {} is not configured; bind one of: {}",
+                        binding.app,
+                        configured.join(", ")
+                    )
+                });
+            };
+            if app.kind != ConnectedAppKind::McpServer {
+                return Err(format!(
+                    "connected app {} ({}) is a {} app; only mcp_server apps \
+                     contribute mounted tools",
+                    app.id, app.name, app.kind
+                ));
+            }
+            for tool in &binding.tools {
+                if mounted_tool_under(&app.name, tool).is_none() {
+                    return Err(format!(
+                        "tool {tool:?} is not mounted under connected app {} — its \
+                         tools are named `mcp__{}__{{tool}}`",
+                        app.id, app.name
+                    ));
+                }
+            }
+        }
+        Ok(())
     }
 
     fn success(record: &AppRecord, ordinal: u32, created: bool) -> ToolOutput {
@@ -142,6 +198,13 @@ impl Tool for CreateAppTool {
             return Ok(ToolOutput::error(format!(
                 "invalid app manifest: {message}"
             )));
+        }
+        // Resolve every binding against the configured connected apps at the
+        // authoring door, so a wrong id or namespace fails here with a
+        // teachable error instead of at the user's first open. The invoke
+        // gate re-checks all of this live; this is legibility, not the gate.
+        if let Err(message) = self.check_bindings(&args.manifest).await {
+            return Ok(ToolOutput::error(message));
         }
         let bundle = args.bundle_html.as_bytes();
         if bundle.is_empty() {
@@ -261,7 +324,7 @@ mod tests {
     use serde_json::json;
 
     use crate::db::DbStore;
-    use crate::id::{CallId, ChatId, TurnId};
+    use crate::id::{CallId, ChatId, ConnectedAppId, TurnId};
     use crate::local_app::app_revision_relative_path;
     use crate::model::{Chat, ToolCallExecution, ToolCallRecord, ToolCallStatus};
     use crate::preview::ToolResultPreview;
@@ -275,6 +338,7 @@ mod tests {
         chat_id: ChatId,
         turn_id: TurnId,
         profile_dir: PathBuf,
+        sentry: ConnectedAppId,
     }
 
     async fn fixture() -> Fixture {
@@ -287,6 +351,22 @@ mod tests {
             .await
             .unwrap(),
         );
+        // One configured connected app for bindings to resolve against.
+        let sentry = ConnectedAppId::new();
+        store
+            .replace_connected_apps(
+                ConnectedAppKind::McpServer,
+                &[crate::connected_app::ConnectedApp {
+                    id: sentry,
+                    name: "sentry".into(),
+                    kind: ConnectedAppKind::McpServer,
+                    definition: json!({ "name": "sentry", "command": "sentry-mcp" }),
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                }],
+            )
+            .await
+            .unwrap();
         let chat = Chat {
             id: ChatId::new(),
             project_id: None,
@@ -314,6 +394,7 @@ mod tests {
             chat_id: chat.id,
             turn_id,
             profile_dir,
+            sentry,
         }
     }
 
@@ -349,13 +430,13 @@ mod tests {
         }
     }
 
-    fn arguments(app_id: Option<Uuid>) -> Value {
+    fn arguments_bound_to(connected: ConnectedAppId, app_id: Option<Uuid>) -> Value {
         let mut arguments = json!({
             "bundle_html": "<!doctype html><h1>Triage</h1>",
             "manifest": {
                 "name": "Sentry triage",
                 "bindings": [
-                    { "server": "sentry", "tools": ["mcp__sentry__list_issues"] }
+                    { "app": connected, "tools": ["mcp__sentry__list_issues"] }
                 ],
             },
         });
@@ -370,7 +451,11 @@ mod tests {
         let fixture = fixture().await;
         let (call_id, ctx) = fixture.recorded_call().await;
 
-        let first = fixture.tool.execute(&ctx, arguments(None)).await.unwrap();
+        let first = fixture
+            .tool
+            .execute(&ctx, arguments_bound_to(fixture.sentry, None))
+            .await
+            .unwrap();
         assert!(!first.is_error, "{}", first.content);
         let app_id = AppId::for_call(call_id);
         assert!(first.content.contains(&app_id.to_string()));
@@ -384,7 +469,11 @@ mod tests {
 
         // Re-executing the exact call reports the same record instead of
         // forking a second app or a second revision.
-        let retried = fixture.tool.execute(&ctx, arguments(None)).await.unwrap();
+        let retried = fixture
+            .tool
+            .execute(&ctx, arguments_bound_to(fixture.sentry, None))
+            .await
+            .unwrap();
         assert!(!retried.is_error, "{}", retried.content);
         assert!(retried.content.contains(&app_id.to_string()));
         assert_eq!(fixture.store.list_apps(10).await.unwrap().len(), 1);
@@ -392,7 +481,7 @@ mod tests {
         assert_eq!(record.revision_count, 1);
 
         // The same call id must not be able to publish different content.
-        let mut different = arguments(None);
+        let mut different = arguments_bound_to(fixture.sentry, None);
         different["bundle_html"] = json!("<!doctype html><h1>Changed</h1>");
         let refused = fixture.tool.execute(&ctx, different).await.unwrap();
         assert!(refused.is_error);
@@ -401,7 +490,10 @@ mod tests {
         let (_, append_ctx) = fixture.recorded_call().await;
         let appended = fixture
             .tool
-            .execute(&append_ctx, arguments(Some(app_id.0)))
+            .execute(
+                &append_ctx,
+                arguments_bound_to(fixture.sentry, Some(app_id.0)),
+            )
             .await
             .unwrap();
         assert!(!appended.is_error, "{}", appended.content);
@@ -414,7 +506,10 @@ mod tests {
         let missing_app = Uuid::new_v4();
         let refused = fixture
             .tool
-            .execute(&wrong_ctx, arguments(Some(missing_app)))
+            .execute(
+                &wrong_ctx,
+                arguments_bound_to(fixture.sentry, Some(missing_app)),
+            )
             .await
             .unwrap();
         assert!(refused.is_error);
@@ -434,7 +529,7 @@ mod tests {
 
         // A manifest pinning a name that could never match a mounted tool.
         let (_, ctx) = fixture.recorded_call().await;
-        let mut bad_manifest = arguments(None);
+        let mut bad_manifest = arguments_bound_to(fixture.sentry, None);
         bad_manifest["manifest"]["bindings"][0]["tools"] = json!(["list_issues"]);
         let refused = fixture.tool.execute(&ctx, bad_manifest).await.unwrap();
         assert!(refused.is_error);
@@ -442,7 +537,7 @@ mod tests {
 
         // An oversized bundle is refused before anything is written.
         let (_, ctx) = fixture.recorded_call().await;
-        let mut oversized = arguments(None);
+        let mut oversized = arguments_bound_to(fixture.sentry, None);
         oversized["bundle_html"] = json!("x".repeat(MAX_APP_BUNDLE_BYTES + 1));
         assert!(
             fixture
@@ -458,7 +553,7 @@ mod tests {
             ToolCtx::without_private_scratch(fixture.chat_id, None).with_call_id(CallId::new());
         let refused = fixture
             .tool
-            .execute(&foreign_ctx, arguments(None))
+            .execute(&foreign_ctx, arguments_bound_to(fixture.sentry, None))
             .await
             .unwrap();
         assert!(refused.is_error);
@@ -470,7 +565,11 @@ mod tests {
     async fn the_projection_carries_the_name_and_ordinal_and_never_the_bundle() {
         let fixture = fixture().await;
         let (_, ctx) = fixture.recorded_call().await;
-        let output = fixture.tool.execute(&ctx, arguments(None)).await.unwrap();
+        let output = fixture
+            .tool
+            .execute(&ctx, arguments_bound_to(fixture.sentry, None))
+            .await
+            .unwrap();
         assert!(!output.is_error, "{}", output.content);
 
         let preview = ToolResultPreview::build(crate::local_app::CREATE_APP_TOOL, &output)

--- a/crates/openwave-core/src/tools/definitions.rs
+++ b/crates/openwave-core/src/tools/definitions.rs
@@ -38,10 +38,13 @@ pub(super) fn create_app() -> ToolSpec {
         crate::local_app::CREATE_APP_TOOL,
         "Publish a local mini-app the user can reopen from their Apps library: a \
          complete self-contained HTML document plus a manifest naming the app and \
-         pinning the exact mounted MCP tools (`mcp__{server}__{tool}` names) it may \
-         call through the host. The app renders in a sandboxed frame with no network \
-         access; pinned tools run only after the user grants them. Pass the app_id \
-         from an earlier create_app result to publish a new revision of that app — \
+         pinning the exact mounted MCP tools it may call through the host. Each \
+         manifest binding names a connected app by its id and lists full mounted \
+         tool names (`mcp__{namespace}__{tool}`) under it; the configured \
+         connected apps and their ids are listed at the end of this description. \
+         The app renders in a sandboxed frame with no network access; pinned \
+         tools run only after the user grants them. Pass the app_id from an \
+         earlier create_app result to publish a new revision of that app — \
          revisions append, never overwrite.",
     )
 }

--- a/crates/openwave-desktop/ui/src/apps/AppConsentSheet.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppConsentSheet.tsx
@@ -40,9 +40,11 @@ export function AppConsentSheet({
       ) : (
         <ul className="flex flex-col gap-2" aria-label="Requested tool access">
           {state.bindings.map((binding) => (
-            <li key={binding.server} className="flex flex-col gap-1">
+            <li key={binding.app} className="flex flex-col gap-1">
               <div className="flex items-center gap-2 text-sm">
-                <span className="font-medium">{binding.server}</span>
+                <span className="font-medium">
+                  {binding.name ?? "Unknown connected app"}
+                </span>
                 {binding.granted && (
                   <span className="text-muted-foreground flex items-center gap-1 text-xs">
                     <ShieldCheck className="size-3" aria-hidden="true" />
@@ -52,7 +54,7 @@ export function AppConsentSheet({
                 {binding.definition_changed && (
                   <span className="text-warning flex items-center gap-1 text-xs">
                     <TriangleAlert className="size-3" aria-hidden="true" />
-                    Server reconfigured since you agreed
+                    Reconfigured since you agreed
                   </span>
                 )}
               </div>

--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
@@ -22,7 +22,8 @@ const GRANTED: AppGrantState = {
   granted: true,
   bindings: [
     {
-      server: "cmd",
+      app: "11111111-1111-4111-8111-111111111111",
+      name: "cmd",
       tools: ["mcp__cmd__doit"],
       granted: true,
       definition_changed: false,
@@ -34,7 +35,8 @@ const STALE: AppGrantState = {
   granted: false,
   bindings: [
     {
-      server: "cmd",
+      app: "11111111-1111-4111-8111-111111111111",
+      name: "cmd",
       tools: ["mcp__cmd__doit"],
       granted: false,
       definition_changed: true,
@@ -123,11 +125,12 @@ describe("AppDetailView", () => {
     const apis = apisWith(STALE);
     render(<AppDetailView appId="app-1" apis={apis} onBack={() => {}} />);
 
-    // The sheet renders the server projection: names, and the marker for a
+    // The sheet renders the server projection: the connected app's display
+    // name and tools, and the marker for a
     // definition that changed since the previous consent.
     expect(await screen.findByText("mcp__cmd__doit")).toBeInTheDocument();
     expect(
-      screen.getByText("Server reconfigured since you agreed"),
+      screen.getByText("Reconfigured since you agreed"),
     ).toBeInTheDocument();
     expect(screen.queryByTitle(/^App:/)).not.toBeInTheDocument();
 

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -141,31 +141,38 @@ revisions: Array<AppRevisionSummary>, };
  */
 export type AppGrantBindingState = { 
 /**
- * Configured server namespace, by name only.
+ * Connected app the manifest binds, by record id.
  */
-server: string, 
+app: ConnectedAppId, 
 /**
- * Full mounted tool names the current manifest pins under this server.
+ * The connected app's display name, absent when no record with that id
+ * is configured — the sheet says so instead of showing a raw id alone.
+ */
+name: string | null, 
+/**
+ * Full mounted tool names the current manifest pins under this app.
  */
 tools: Array<string>, 
 /**
- * Whether the live grant covers every listed tool under this server and
- * the server's current definition still matches the granted fingerprint.
+ * Whether the live grant covers every listed tool under this connected
+ * app and the app's current definition still matches the granted
+ * fingerprint.
  */
 granted: boolean, 
 /**
- * Whether a grant names this server but its definition changed (or
- * disappeared) since consent — the "reconfigured since you agreed"
- * affordance, distinct from a binding that was simply never granted.
+ * Whether a grant names this connected app but its definition changed
+ * (or the record disappeared) since consent — the "reconfigured since
+ * you agreed" affordance, distinct from a binding that was simply never
+ * granted.
  */
 definition_changed: boolean, };
 
 /**
  * Renderer-safe grant state for one app: the consent sheet's whole input.
  *
- * `bindings` follows the app's **current** revision's manifest — names only.
- * The definitions behind the server names, and any environment or token
- * values they select, are deliberately absent from this projection.
+ * `bindings` follows the app's **current** revision's manifest — ids and
+ * names only. The definitions behind the connected apps, and any environment
+ * or token values they select, are deliberately absent from this projection.
  */
 export type AppGrantState = { 
 /**
@@ -176,7 +183,7 @@ export type AppGrantState = {
  */
 granted: boolean, 
 /**
- * The current manifest's bindings, one entry per bound server.
+ * The current manifest's bindings, one entry per bound connected app.
  */
 bindings: Array<AppGrantBindingState>, };
 
@@ -533,6 +540,16 @@ enforcement: Array<CodeExecutionEgressEnforcement>, };
  * A configured code-execution backend.
  */
 export type CodeExecutionProviderKind = "local" | "e2b" | "daytona";
+
+/**
+ * Identifies one profile-scoped connected app — an outside integration
+ * (an MCP server, a REST API) a profile can reach.
+ *
+ * App-keyed manifest bindings and grants name this identity rather than a
+ * raw server namespace, so consent follows the record even when display
+ * names or namespaces change around it.
+ */
+export type ConnectedAppId = string;
 
 /**
  * Conservative, user-inspectable capabilities for one model served by an

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -17,6 +17,9 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use futures::future::join_all;
+use openwave_core::connected_app::{ConnectedApp, ConnectedAppKind};
+use openwave_core::id::ConnectedAppId;
+use openwave_core::local_app::CREATE_APP_TOOL;
 use openwave_core::{AgentError, Result, Store, ToolRegistry};
 use openwave_mcp::{McpClient, McpProbe, MAX_SERVER_NAME_BYTES};
 use serde::{Deserialize, Serialize};
@@ -24,7 +27,6 @@ use tokio::process::Command;
 use tokio::sync::Mutex;
 
 const CONFIG_ENV: &str = "OPENWAVE_MCP_CONFIG";
-const SETTING_KEY: &str = "mcp_servers_v1";
 const MAX_CONFIG_BYTES: u64 = 1024 * 1024;
 pub(crate) const MAX_CONFIG_BODY_BYTES: usize = 1024 * 1024;
 const MAX_SERVERS: usize = 32;
@@ -294,14 +296,16 @@ impl McpServerDefinition {
 }
 
 /// SHA-256 fingerprint of a server definition as configured, the value an app
-/// grant pins each bound server to.
+/// grant pins each bound connected app to.
 ///
 /// The digest is taken over the UTF-8 bytes of a compact JSON object with
 /// **exactly these keys, in exactly this order** (serde serializes struct
 /// fields in declaration order, and every key is always present):
 ///
 /// ```json
-/// {"v":1,
+/// {"v":2,
+///  "kind":"mcp_server",
+///  "namespace":string,
 ///  "transport":"stdio"|"http"|"gateway",
 ///  "command":string|null,
 ///  "args":[string,...],
@@ -318,10 +322,15 @@ impl McpServerDefinition {
 /// values and resolved secrets never enter the canonical form, so the
 /// fingerprint can never be a value oracle. `bearer_token_env_set` records
 /// only whether a bearer name is selected. `cwd` is the configured path,
-/// lossily UTF-8. `name`, `enabled`, and `request_timeout_ms` are deliberately
-/// excluded: the grant binding already keys the fingerprint by server name,
-/// and toggling or re-timing a server does not change *what* the user
-/// consented to run.
+/// lossily UTF-8. The `v:1` form excluded the server name because grants were
+/// keyed by it; app-keyed grants pin a record id instead, so `namespace`
+/// (the configured name, which decides which `mcp__{namespace}__…` mounted
+/// names the binding covers) is now part of what the user consented to.
+/// `kind` roots the form in the connected-app vocabulary so no two kinds can
+/// collide on a canonical serialization. `enabled` and `request_timeout_ms`
+/// stay excluded: toggling or re-timing a server does not change *what* the
+/// user consented to run. Fingerprints are always computed from definition
+/// fields, never from storage.
 ///
 /// **This canonical form is a compatibility surface.** Persisted grants store
 /// the digest; changing the form (or the meaning of any field in it)
@@ -332,6 +341,8 @@ pub(crate) fn definition_fingerprint(definition: &McpServerDefinition) -> [u8; 3
     #[derive(Serialize)]
     struct CanonicalDefinition<'a> {
         v: u32,
+        kind: &'static str,
+        namespace: &'a str,
         transport: &'static str,
         command: Option<&'a str>,
         args: &'a [String],
@@ -348,7 +359,9 @@ pub(crate) fn definition_fingerprint(definition: &McpServerDefinition) -> [u8; 3
     let mut env_from: Vec<&str> = definition.env_from.iter().map(String::as_str).collect();
     env_from.sort_unstable();
     let canonical = CanonicalDefinition {
-        v: 1,
+        v: 2,
+        kind: "mcp_server",
+        namespace: &definition.name,
         transport: if definition.gateway_endpoint.is_some() {
             "gateway"
         } else if definition.url.is_some() {
@@ -415,6 +428,71 @@ pub(crate) struct McpServersInfo {
     pub(crate) servers: Vec<McpServerInfo>,
 }
 
+/// One configured connected app's current namespace and definition
+/// fingerprint, the pair grant enforcement compares per record id.
+pub(crate) struct McpAppFingerprint {
+    /// The configured server name — the namespace its tools mount under.
+    pub(crate) name: String,
+    /// [`definition_fingerprint`] of the current definition.
+    pub(crate) fingerprint: [u8; 32],
+}
+
+/// `create_app` re-registered with the live connected-app roster appended to
+/// its description. Manifest bindings name records by opaque id, which the
+/// model cannot derive from mounted tool names; the roster is where those ids
+/// come from. Everything else delegates to the shared tool.
+struct CreateAppWithRoster {
+    inner: Arc<dyn openwave_core::Tool>,
+    roster: String,
+}
+
+#[async_trait::async_trait]
+impl openwave_core::Tool for CreateAppWithRoster {
+    fn spec(&self) -> openwave_core::ToolSpec {
+        let mut spec = self.inner.spec();
+        spec.description.push_str(&self.roster);
+        spec
+    }
+
+    fn approval_class(&self) -> openwave_core::ApprovalClass {
+        self.inner.approval_class()
+    }
+
+    async fn execute(
+        &self,
+        ctx: &openwave_core::ToolCtx,
+        args: serde_json::Value,
+    ) -> Result<openwave_core::ToolOutput> {
+        self.inner.execute(ctx, args).await
+    }
+}
+
+/// The roster text appended to `create_app`'s description: every configured
+/// `mcp_server` connected app with the id a manifest binding names and the
+/// namespace its mounted tools carry.
+fn connected_app_roster(
+    definitions: &[McpServerDefinition],
+    ids: &BTreeMap<String, ConnectedAppId>,
+) -> String {
+    if definitions.is_empty() {
+        return "\n\nNo connected apps are configured, so only manifests with an \
+                empty bindings list can be created."
+            .to_owned();
+    }
+    let mut roster =
+        String::from("\n\nConfigured connected apps (set each binding's `app` to an id):");
+    for definition in definitions {
+        let Some(id) = ids.get(&definition.name) else {
+            continue;
+        };
+        roster.push_str(&format!(
+            "\n- {id} — {name}: tools are named `mcp__{name}__{{tool}}`",
+            name = definition.name
+        ));
+    }
+    roster
+}
+
 struct ManagedServer {
     client: Option<McpClient>,
     health: McpHealth,
@@ -436,6 +514,11 @@ pub(crate) struct UiViewDocument {
 
 struct RuntimeState {
     definitions: Vec<McpServerDefinition>,
+    /// The connected-app record id behind each configured server name. App
+    /// manifests and grants bind these ids; the id survives edits to the
+    /// definition and dies with the record, so a name-keyed lookup here is
+    /// only ever a projection detail, never the consent key.
+    ids: BTreeMap<String, ConnectedAppId>,
     servers: HashMap<String, ManagedServer>,
 }
 
@@ -471,6 +554,7 @@ impl McpRuntime {
             tools: RwLock::new(base_tools),
             state: Mutex::new(RuntimeState {
                 definitions: Vec::new(),
+                ids: BTreeMap::new(),
                 servers: HashMap::new(),
             }),
             mutation: Mutex::new(()),
@@ -569,7 +653,7 @@ impl McpRuntime {
             torn_down = true;
         }
         if torn_down {
-            let registry = self.registry_for(&state.servers);
+            let registry = self.registry_for(&state);
             *self
                 .tools
                 .write()
@@ -578,36 +662,54 @@ impl McpRuntime {
         torn_down
     }
 
-    /// Load persisted definitions when present, otherwise the legacy boot file.
+    /// Load persisted `mcp_server` connected-app records when present,
+    /// otherwise the legacy boot file.
     ///
     /// A boot file remains fail-closed. Persisted definitions degrade in place
     /// so the Settings UI remains available to repair a missing executable or
     /// selected environment variable.
     pub(crate) async fn initialize(&self, boot: ConfiguredMcpServers) -> Result<()> {
-        match self.store.get_setting(SETTING_KEY).await? {
-            Some(value) => {
-                let config: McpServersConfig = serde_json::from_value(value).map_err(|error| {
-                    AgentError::config(format!("invalid saved MCP config: {error}"))
-                })?;
-                validate_servers(&config.servers)?;
-                self.replace_permissive(config.servers).await;
-                Ok(())
+        let records: Vec<ConnectedApp> = self
+            .store
+            .list_connected_apps()
+            .await?
+            .into_iter()
+            .filter(|record| record.kind == ConnectedAppKind::McpServer)
+            .collect();
+        if !records.is_empty() {
+            let mut ids = BTreeMap::new();
+            let mut definitions = Vec::with_capacity(records.len());
+            for record in records {
+                let mut definition: McpServerDefinition = serde_json::from_value(record.definition)
+                    .map_err(|error| {
+                        AgentError::config(format!(
+                            "invalid saved connected-app definition {:?}: {error}",
+                            record.name
+                        ))
+                    })?;
+                // The record's name is authoritative for the namespace; the
+                // stored definition mirrors it and is repaired if they ever
+                // disagree.
+                definition.name = record.name.clone();
+                ids.insert(record.name, record.id);
+                definitions.push(definition);
             }
-            None => {
-                // The boot file is a host-environment artifact: on a managed
-                // profile it is exactly the channel the lockdown exists to
-                // close, so it is inert rather than partially honored. The
-                // warning is the operator's diagnostic for the silence.
-                if !boot.is_empty() && self.manual_transports_locked().await {
-                    tracing::warn!(
-                        "{CONFIG_ENV} is ignored on a managed profile; \
-                         mount MCP endpoints from the model gateway instead"
-                    );
-                    return Ok(());
-                }
-                self.replace_strict(boot.0, false).await.map(|_| ())
-            }
+            validate_servers(&definitions)?;
+            self.replace_permissive(definitions, ids).await;
+            return Ok(());
         }
+        // The boot file is a host-environment artifact: on a managed
+        // profile it is exactly the channel the lockdown exists to
+        // close, so it is inert rather than partially honored. The
+        // warning is the operator's diagnostic for the silence.
+        if !boot.is_empty() && self.manual_transports_locked().await {
+            tracing::warn!(
+                "{CONFIG_ENV} is ignored on a managed profile; \
+                 mount MCP endpoints from the model gateway instead"
+            );
+            return Ok(());
+        }
+        self.replace_strict(boot.0, false).await.map(|_| ())
     }
 
     /// One prefetched MCP Apps view document, when the named server is
@@ -617,17 +719,27 @@ impl McpRuntime {
         state.servers.get(server)?.ui_views.get(uri).cloned()
     }
 
-    /// The current definition fingerprint of every configured server, by name.
+    /// The current namespace and definition fingerprint of every configured
+    /// connected app, by record id.
     ///
     /// Read live per call — never cached across a request — so grant
-    /// enforcement always compares against the definition a name resolves to
+    /// enforcement always compares against the definition an id resolves to
     /// *now*, including a definition swapped in while the app stayed open.
-    pub(crate) async fn definition_fingerprints(&self) -> BTreeMap<String, [u8; 32]> {
+    pub(crate) async fn app_fingerprints(&self) -> BTreeMap<ConnectedAppId, McpAppFingerprint> {
         let state = self.state.lock().await;
         state
             .definitions
             .iter()
-            .map(|definition| (definition.name.clone(), definition_fingerprint(definition)))
+            .filter_map(|definition| {
+                let id = state.ids.get(&definition.name)?;
+                Some((
+                    *id,
+                    McpAppFingerprint {
+                        name: definition.name.clone(),
+                        fingerprint: definition_fingerprint(definition),
+                    },
+                ))
+            })
             .collect()
     }
 
@@ -732,12 +844,51 @@ impl McpRuntime {
         Ok(self.info().await)
     }
 
+    /// Assign the connected-app record id behind each candidate name: a name
+    /// already configured keeps its record id (so editing a definition
+    /// invalidates grants by fingerprint, not by identity), a new name mints a
+    /// fresh one, and a removed name's record — and with it every binding
+    /// naming its id — simply stops resolving.
+    async fn assign_app_ids(
+        &self,
+        definitions: &[McpServerDefinition],
+    ) -> BTreeMap<String, ConnectedAppId> {
+        let state = self.state.lock().await;
+        definitions
+            .iter()
+            .map(|definition| {
+                let id = state
+                    .ids
+                    .get(&definition.name)
+                    .copied()
+                    .unwrap_or_else(ConnectedAppId::new);
+                (definition.name.clone(), id)
+            })
+            .collect()
+    }
+
     async fn replace_strict(
         &self,
         definitions: Vec<McpServerDefinition>,
         persist: bool,
     ) -> Result<()> {
         validate_servers(&definitions)?;
+        let ids = if persist {
+            self.assign_app_ids(&definitions).await
+        } else {
+            // The legacy boot file configures servers without persisting
+            // records; ids derived from the configured names keep app grants
+            // valid across restarts of a boot-file profile.
+            definitions
+                .iter()
+                .map(|definition| {
+                    (
+                        definition.name.clone(),
+                        ConnectedAppId::for_boot_server(&definition.name),
+                    )
+                })
+                .collect()
+        };
         let gateway = &*self.gateway;
         let locked = self.manual_transports_locked().await;
         let mut servers = HashMap::new();
@@ -809,20 +960,33 @@ impl McpRuntime {
             );
         }
         if persist {
+            let now = chrono::Utc::now();
+            let records: Vec<ConnectedApp> = definitions
+                .iter()
+                .map(|definition| {
+                    Ok(ConnectedApp {
+                        id: ids[&definition.name],
+                        name: definition.name.clone(),
+                        kind: ConnectedAppKind::McpServer,
+                        definition: serde_json::to_value(definition)?,
+                        created_at: now,
+                        updated_at: now,
+                    })
+                })
+                .collect::<Result<_>>()?;
             self.store
-                .set_setting(
-                    SETTING_KEY,
-                    &serde_json::to_value(McpServersConfig {
-                        servers: definitions.clone(),
-                    })?,
-                )
+                .replace_connected_apps(ConnectedAppKind::McpServer, &records)
                 .await?;
         }
-        self.publish(definitions, servers).await;
+        self.publish(definitions, ids, servers).await;
         Ok(())
     }
 
-    async fn replace_permissive(&self, definitions: Vec<McpServerDefinition>) {
+    async fn replace_permissive(
+        &self,
+        definitions: Vec<McpServerDefinition>,
+        ids: BTreeMap<String, ConnectedAppId>,
+    ) {
         let gateway = &*self.gateway;
         let locked = self.manual_transports_locked().await;
         let mut servers = HashMap::new();
@@ -866,17 +1030,19 @@ impl McpRuntime {
             };
             servers.insert(definition.name.clone(), managed);
         }
-        self.publish(definitions, servers).await;
+        self.publish(definitions, ids, servers).await;
     }
 
     async fn publish(
         &self,
         definitions: Vec<McpServerDefinition>,
+        ids: BTreeMap<String, ConnectedAppId>,
         servers: HashMap<String, ManagedServer>,
     ) {
-        let registry = self.registry_for(&servers);
+        let registry = self.registry_with(&definitions, &ids, &servers);
         let mut state = self.state.lock().await;
         state.definitions = definitions;
+        state.ids = ids;
         state.servers = servers;
         *self
             .tools
@@ -884,7 +1050,19 @@ impl McpRuntime {
             .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(registry);
     }
 
-    fn registry_for(&self, servers: &HashMap<String, ManagedServer>) -> ToolRegistry {
+    /// [`registry_with`](Self::registry_with) over the already-published
+    /// state, for the paths that refresh connections without changing the
+    /// configuration.
+    fn registry_for(&self, state: &RuntimeState) -> ToolRegistry {
+        self.registry_with(&state.definitions, &state.ids, &state.servers)
+    }
+
+    fn registry_with(
+        &self,
+        definitions: &[McpServerDefinition],
+        ids: &BTreeMap<String, ConnectedAppId>,
+        servers: &HashMap<String, ManagedServer>,
+    ) -> ToolRegistry {
         let mut registry = self.base_tools.clone();
         for (name, server) in servers {
             if let Some(client) = &server.client {
@@ -897,6 +1075,14 @@ impl McpRuntime {
                     );
                 }
             }
+        }
+        // Manifest bindings name connected apps by record id; the roster on
+        // the `create_app` description is where the model learns those ids.
+        if let Some(inner) = registry.server_tool(CREATE_APP_TOOL) {
+            registry.register(Box::new(CreateAppWithRoster {
+                inner,
+                roster: connected_app_roster(definitions, ids),
+            }));
         }
         registry
     }
@@ -1002,7 +1188,7 @@ impl McpRuntime {
                 server.ui_views = ui_views;
                 server.reconnect_backoff = INITIAL_RECONNECT_BACKOFF;
                 server.epoch = self.fresh_epoch();
-                let registry = self.registry_for(&state.servers);
+                let registry = self.registry_for(&state);
                 *self
                     .tools
                     .write()
@@ -1029,7 +1215,7 @@ impl McpRuntime {
                 } else {
                     return Ok(self.info_locked(&state));
                 }
-                let registry = self.registry_for(&state.servers);
+                let registry = self.registry_for(&state);
                 *self
                     .tools
                     .write()
@@ -1113,7 +1299,7 @@ impl McpRuntime {
             server.ui_views = HashMap::new();
             server.reconnect_backoff = backoff;
         }
-        let registry = self.registry_for(&state.servers);
+        let registry = self.registry_for(&state);
         *self
             .tools
             .write()
@@ -1389,6 +1575,48 @@ mod tests {
         let config: McpServersConfig = serde_json::from_str(json)?;
         validate_servers(&config.servers)?;
         Ok(ConfiguredMcpServers(config.servers))
+    }
+
+    /// Fresh boot-style ids for a test's definitions.
+    fn ids_for(definitions: &[McpServerDefinition]) -> BTreeMap<String, ConnectedAppId> {
+        definitions
+            .iter()
+            .map(|definition| (definition.name.clone(), ConnectedAppId::new()))
+            .collect()
+    }
+
+    /// The persisted `mcp_server` definitions, read back through the
+    /// connected-app record the way `initialize` does.
+    async fn saved_definitions(store: &Arc<dyn Store>) -> Vec<McpServerDefinition> {
+        store
+            .list_connected_apps()
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|record| record.kind == ConnectedAppKind::McpServer)
+            .map(|record| serde_json::from_value(record.definition).unwrap())
+            .collect()
+    }
+
+    /// Persist definitions as connected-app records, the way a settings save
+    /// would, without connecting anything.
+    async fn seed_records(store: &Arc<dyn Store>, definitions: &[McpServerDefinition]) {
+        let now = chrono::Utc::now();
+        let records: Vec<ConnectedApp> = definitions
+            .iter()
+            .map(|definition| ConnectedApp {
+                id: ConnectedAppId::new(),
+                name: definition.name.clone(),
+                kind: ConnectedAppKind::McpServer,
+                definition: serde_json::to_value(definition).unwrap(),
+                created_at: now,
+                updated_at: now,
+            })
+            .collect();
+        store
+            .replace_connected_apps(ConnectedAppKind::McpServer, &records)
+            .await
+            .unwrap();
     }
 
     /// The signed-out stand-in: every resolution demands a session.
@@ -1680,11 +1908,10 @@ mod tests {
         first.await.unwrap().unwrap();
         second.await.unwrap().unwrap();
 
-        let saved: McpServersConfig =
-            serde_json::from_value(store.get_setting(SETTING_KEY).await.unwrap().unwrap()).unwrap();
+        let saved = saved_definitions(&store).await;
         let live = runtime.info().await;
-        assert_eq!(saved.servers[0].name, "second");
-        assert_eq!(live.servers[0].definition, saved.servers[0]);
+        assert_eq!(saved[0].name, "second");
+        assert_eq!(live.servers[0].definition, saved[0]);
     }
 
     #[tokio::test]
@@ -1728,7 +1955,9 @@ mod tests {
         let (runtime, _store, _directory) = test_runtime().await;
         let mut definition = disabled_definition("docs", "/usr/bin/true");
         definition.enabled = true;
-        runtime.replace_permissive(vec![definition]).await;
+        let definitions = vec![definition];
+        let ids = ids_for(&definitions);
+        runtime.replace_permissive(definitions, ids).await;
         let reconnect_lock = runtime
             .state
             .lock()
@@ -1875,7 +2104,10 @@ mod tests {
     async fn signed_out_gateway_mounts_degrade_to_a_sign_in_diagnostic() {
         let (runtime, _store, _directory) = test_runtime().await;
         runtime
-            .replace_permissive(vec![gateway_definition("tools", "tools")])
+            .replace_permissive(
+                vec![gateway_definition("tools", "tools")],
+                ids_for(&[gateway_definition("tools", "tools")]),
+            )
             .await;
         let info = runtime.info().await;
         assert_eq!(info.servers[0].health, McpHealth::Degraded);
@@ -1906,9 +2138,7 @@ mod tests {
             Some("Sign in to the model gateway to reconnect this server.")
         );
         assert_eq!(info.servers[1].health, McpHealth::Disabled);
-        let saved: McpServersConfig =
-            serde_json::from_value(store.get_setting(SETTING_KEY).await.unwrap().unwrap()).unwrap();
-        assert_eq!(saved.servers.len(), 2);
+        assert_eq!(saved_definitions(&store).await.len(), 2);
 
         // A non-gateway failure keeps save-and-verify semantics: reject and
         // change nothing.
@@ -1920,10 +2150,8 @@ mod tests {
             .err()
             .unwrap();
         assert!(error.to_string().contains("failed to start"));
-        let saved: McpServersConfig =
-            serde_json::from_value(store.get_setting(SETTING_KEY).await.unwrap().unwrap()).unwrap();
         assert_eq!(
-            saved.servers.len(),
+            saved_definitions(&store).await.len(),
             2,
             "rejected candidate must not persist"
         );
@@ -2112,16 +2340,7 @@ mod tests {
         let (runtime, store, _directory) = test_runtime().await;
         let mut manual = disabled_definition("private_docs", "/bin/docs");
         manual.enabled = true;
-        store
-            .set_setting(
-                SETTING_KEY,
-                &serde_json::to_value(McpServersConfig {
-                    servers: vec![manual, gateway_definition("tools", "tools")],
-                })
-                .unwrap(),
-            )
-            .await
-            .unwrap();
+        seed_records(&store, &[manual, gateway_definition("tools", "tools")]).await;
         crate::managed_policy::provision(&*store, "https://corp.gateway")
             .await
             .unwrap();
@@ -2162,7 +2381,48 @@ mod tests {
         let boot = parse(r#"{"servers":[{"name":"docs","command":"/bin/docs"}]}"#).unwrap();
         runtime.initialize(boot).await.unwrap();
         assert!(runtime.info().await.servers.is_empty());
-        assert!(store.get_setting(SETTING_KEY).await.unwrap().is_none());
+        assert!(store.list_connected_apps().await.unwrap().is_empty());
+    }
+
+    /// The v:2 canonical-form invariants that keep consent honest: derived
+    /// from definition fields only, never a value oracle, covering the
+    /// namespace (which decides what mounted names a grant reaches), and
+    /// indifferent to toggles that don't change what the user consented to.
+    #[test]
+    fn fingerprints_derive_from_fields_cover_the_namespace_and_leak_no_values() {
+        let mut definition = disabled_definition("docs", "/bin/docs");
+        definition.env.insert("TOKEN".into(), "secret-a".into());
+        let baseline = definition_fingerprint(&definition);
+
+        let mut toggled = definition.clone();
+        toggled.enabled = true;
+        toggled.request_timeout_ms += 1;
+        assert_eq!(
+            definition_fingerprint(&toggled),
+            baseline,
+            "enabling or re-timing is not a change of what the user consented to"
+        );
+
+        let mut rotated = definition.clone();
+        rotated.env.insert("TOKEN".into(), "secret-b".into());
+        assert_eq!(
+            definition_fingerprint(&rotated),
+            baseline,
+            "environment values never enter the canonical form"
+        );
+
+        let mut renamed = definition.clone();
+        renamed.name = "docs2".into();
+        assert_ne!(
+            definition_fingerprint(&renamed),
+            baseline,
+            "app-keyed grants no longer key by name, so the namespace is \
+             part of what a grant pins"
+        );
+
+        let mut swapped = definition.clone();
+        swapped.command = Some("/bin/other".into());
+        assert_ne!(definition_fingerprint(&swapped), baseline);
     }
 
     #[test]

--- a/crates/openwave-server/src/routes/app_grant.rs
+++ b/crates/openwave-server/src/routes/app_grant.rs
@@ -14,18 +14,21 @@ use axum::http::StatusCode;
 use chrono::Utc;
 use serde::Serialize;
 
-use openwave_core::id::AppId;
-use openwave_core::local_app::{AppGrant, AppGrantBinding, AppManifest, AppRecord, AppRevision};
+use openwave_core::id::{AppId, ConnectedAppId};
+use openwave_core::local_app::{
+    mounted_tool_under, AppGrant, AppGrantBinding, AppManifest, AppRecord, AppRevision,
+};
 
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
+use crate::mcp_config::McpAppFingerprint;
 use crate::state::AppState;
 
 /// Renderer-safe grant state for one app: the consent sheet's whole input.
 ///
-/// `bindings` follows the app's **current** revision's manifest — names only.
-/// The definitions behind the server names, and any environment or token
-/// values they select, are deliberately absent from this projection.
+/// `bindings` follows the app's **current** revision's manifest — ids and
+/// names only. The definitions behind the connected apps, and any environment
+/// or token values they select, are deliberately absent from this projection.
 #[derive(Debug, Serialize, ts_rs::TS)]
 pub struct AppGrantState {
     /// Whether a live grant fully covers the current manifest with every
@@ -33,23 +36,28 @@ pub struct AppGrantState {
     /// verdict. When `false`, (re-)consent is required before every pinned
     /// tool is invokable.
     pub granted: bool,
-    /// The current manifest's bindings, one entry per bound server.
+    /// The current manifest's bindings, one entry per bound connected app.
     pub bindings: Vec<AppGrantBindingState>,
 }
 
 /// One current-manifest binding, projected for the consent sheet.
 #[derive(Debug, Serialize, ts_rs::TS)]
 pub struct AppGrantBindingState {
-    /// Configured server namespace, by name only.
-    pub server: String,
-    /// Full mounted tool names the current manifest pins under this server.
+    /// Connected app the manifest binds, by record id.
+    pub app: ConnectedAppId,
+    /// The connected app's display name, absent when no record with that id
+    /// is configured — the sheet says so instead of showing a raw id alone.
+    pub name: Option<String>,
+    /// Full mounted tool names the current manifest pins under this app.
     pub tools: Vec<String>,
-    /// Whether the live grant covers every listed tool under this server and
-    /// the server's current definition still matches the granted fingerprint.
+    /// Whether the live grant covers every listed tool under this connected
+    /// app and the app's current definition still matches the granted
+    /// fingerprint.
     pub granted: bool,
-    /// Whether a grant names this server but its definition changed (or
-    /// disappeared) since consent — the "reconfigured since you agreed"
-    /// affordance, distinct from a binding that was simply never granted.
+    /// Whether a grant names this connected app but its definition changed
+    /// (or the record disappeared) since consent — the "reconfigured since
+    /// you agreed" affordance, distinct from a binding that was simply never
+    /// granted.
     pub definition_changed: bool,
 }
 
@@ -60,7 +68,7 @@ pub async fn get_app_grant_state(
 ) -> Result<Json<AppGrantState>, ServerError> {
     let (app, revision) = current_live_app(&state, app_id).await?;
     let grant = state.store.get_app_grant(app.id).await?;
-    let current = state.mcp.definition_fingerprints().await;
+    let current = state.mcp.app_fingerprints().await;
     Ok(Json(grant_state(
         &revision.manifest,
         grant.as_ref(),
@@ -79,21 +87,35 @@ pub async fn post_app_grant(
     Path(app_id): Path<AppId>,
 ) -> Result<Json<AppGrantState>, ServerError> {
     let (app, revision) = current_live_app(&state, app_id).await?;
-    let current = state.mcp.definition_fingerprints().await;
+    let current = state.mcp.app_fingerprints().await;
     let mut bindings = Vec::with_capacity(revision.manifest.bindings.len());
     for binding in &revision.manifest.bindings {
-        // A binding whose server is not configured cannot be pinned to a
-        // definition, so there is nothing coherent to consent to.
-        let Some(fingerprint) = current.get(&binding.server) else {
+        // A binding whose connected app is not configured cannot be pinned to
+        // a definition, so there is nothing coherent to consent to.
+        let Some(app_fingerprint) = current.get(&binding.app) else {
             return Err(ServerError::conflict(format!(
-                "MCP server {:?} is not configured, so this app cannot be granted",
-                binding.server
+                "connected app {} is not configured, so this app cannot be granted",
+                binding.app
             )));
         };
+        // Nor is there anything coherent when a pinned name is not under the
+        // app's current namespace (the record was renamed after authoring):
+        // the grant would name tools that cannot exist under this app.
+        if let Some(tool) = binding
+            .tools
+            .iter()
+            .find(|tool| mounted_tool_under(&app_fingerprint.name, tool).is_none())
+        {
+            return Err(ServerError::conflict(format!(
+                "tool {tool:?} is not mounted under connected app {:?}, so this \
+                 app cannot be granted",
+                app_fingerprint.name
+            )));
+        }
         bindings.push(AppGrantBinding {
-            server: binding.server.clone(),
+            app: binding.app,
             tools: binding.tools.clone(),
-            fingerprint: *fingerprint,
+            fingerprint: app_fingerprint.fingerprint,
         });
     }
     let grant = AppGrant {
@@ -107,6 +129,17 @@ pub async fn post_app_grant(
         Some(&grant),
         &current,
     )))
+}
+
+/// Whether one granted binding still pins the definition its connected app
+/// carries right now. A missing record is a mismatch, never a match.
+fn fingerprint_current(
+    binding: &AppGrantBinding,
+    current: &std::collections::BTreeMap<ConnectedAppId, McpAppFingerprint>,
+) -> bool {
+    current
+        .get(&binding.app)
+        .is_some_and(|app| app.fingerprint == binding.fingerprint)
 }
 
 /// `DELETE /apps/{id}/grant` — revoke consent.
@@ -155,10 +188,8 @@ async fn current_live_app(
 pub(crate) fn grant_state(
     manifest: &AppManifest,
     grant: Option<&AppGrant>,
-    current: &std::collections::BTreeMap<String, [u8; 32]>,
+    current: &std::collections::BTreeMap<ConnectedAppId, McpAppFingerprint>,
 ) -> AppGrantState {
-    let fingerprint_current =
-        |binding: &AppGrantBinding| current.get(&binding.server) == Some(&binding.fingerprint);
     let bindings: Vec<AppGrantBindingState> = manifest
         .bindings
         .iter()
@@ -167,7 +198,7 @@ pub(crate) fn grant_state(
                 grant
                     .bindings
                     .iter()
-                    .find(|candidate| candidate.server == binding.server)
+                    .find(|candidate| candidate.app == binding.app)
             });
             let covered = granted_binding.is_some_and(|granted| {
                 binding
@@ -176,20 +207,25 @@ pub(crate) fn grant_state(
                     .all(|tool| granted.tools.iter().any(|held| held == tool))
             });
             let definition_changed =
-                granted_binding.is_some_and(|granted| !fingerprint_current(granted));
+                granted_binding.is_some_and(|granted| !fingerprint_current(granted, current));
             AppGrantBindingState {
-                server: binding.server.clone(),
+                app: binding.app,
+                name: current.get(&binding.app).map(|app| app.name.clone()),
                 tools: binding.tools.clone(),
-                granted: covered && granted_binding.is_some_and(fingerprint_current),
+                granted: covered
+                    && granted_binding.is_some_and(|granted| fingerprint_current(granted, current)),
                 definition_changed,
             }
         })
         .collect();
-    // The invoke gate also pins servers the grant names beyond the current
-    // manifest, so the overall verdict does too.
+    // The invoke gate also pins connected apps the grant names beyond the
+    // current manifest, so the overall verdict does too.
     let granted = grant.is_some_and(|grant| {
         bindings.iter().all(|binding| binding.granted)
-            && grant.bindings.iter().all(fingerprint_current)
+            && grant
+                .bindings
+                .iter()
+                .all(|binding| fingerprint_current(binding, current))
     });
     AppGrantState { granted, bindings }
 }

--- a/crates/openwave-server/src/routes/app_invoke.rs
+++ b/crates/openwave-server/src/routes/app_invoke.rs
@@ -209,12 +209,14 @@ fn require_pinned(revision: &AppRevision, tool: &str) -> Result<(), AppInvokeErr
 /// missing or stale grant is a re-prompt, never an error:
 ///
 /// 1. A grant exists for the app.
-/// 2. It covers the invoked `(server, tool)` pair as the *current* revision's
-///    manifest binds it — so a revision that widens the manifest exceeds the
-///    grant by construction, with no special-casing.
-/// 3. Every granted server's current definition fingerprint equals the
-///    granted one. A reconfigured server invalidates the whole grant: consent
-///    named a definition, not a name, and must never outlive it.
+/// 2. It covers the invoked `(connected app, tool)` pair as the *current*
+///    revision's manifest binds it — so a revision that widens the manifest
+///    exceeds the grant by construction, with no special-casing.
+/// 3. Every granted connected app's current definition fingerprint equals the
+///    granted one. A reconfigured or deleted record invalidates the whole
+///    grant: consent named a definition, not a name, and must never outlive
+///    it. The fingerprint covers the namespace too, so a renamed record can
+///    never keep a grant that now describes different mounted names.
 async fn require_app_grant(
     state: &AppState,
     app: &AppRecord,
@@ -229,29 +231,33 @@ async fn require_app_grant(
         )));
     };
     // The pin check has already passed, so exactly one current-manifest
-    // binding names this tool; its server is the namespace the grant must
+    // binding names this tool; its connected app is the record the grant must
     // cover the tool under.
-    let server = revision
+    let connected_app = revision
         .manifest
         .bindings
         .iter()
         .find(|binding| binding.tools.iter().any(|pinned| pinned == tool))
-        .map(|binding| binding.server.as_str())
-        .unwrap_or_default();
-    let covered = grant.bindings.iter().any(|binding| {
-        binding.server == server && binding.tools.iter().any(|granted| granted == tool)
+        .map(|binding| binding.app);
+    let covered = connected_app.is_some_and(|connected_app| {
+        grant.bindings.iter().any(|binding| {
+            binding.app == connected_app && binding.tools.iter().any(|granted| granted == tool)
+        })
     });
     if !covered {
         return Err(consent_required(format!(
             "the app grant does not cover {tool:?}"
         )));
     }
-    let current = state.mcp.definition_fingerprints().await;
+    let current = state.mcp.app_fingerprints().await;
     for binding in &grant.bindings {
-        if current.get(&binding.server) != Some(&binding.fingerprint) {
+        let matches = current
+            .get(&binding.app)
+            .is_some_and(|app| app.fingerprint == binding.fingerprint);
+        if !matches {
             return Err(consent_required(format!(
-                "MCP server {:?} was reconfigured after consent; the grant is stale",
-                binding.server
+                "connected app {} was reconfigured after consent; the grant is stale",
+                binding.app
             )));
         }
     }

--- a/crates/openwave-server/src/routes/app_library.rs
+++ b/crates/openwave-server/src/routes/app_library.rs
@@ -74,7 +74,7 @@ pub async fn get_app_library(
     State(state): State<AppState>,
 ) -> Result<Json<AppLibrary>, ServerError> {
     let records = state.store.list_apps(MAX_LISTED_APPS).await?;
-    let current = state.mcp.definition_fingerprints().await;
+    let current = state.mcp.app_fingerprints().await;
     let mut apps = Vec::with_capacity(records.len());
     for record in records {
         // The same computation the grant surface performs, so the badge is

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -1706,6 +1706,19 @@ async fn json_body<T: DeserializeOwned>(response: axum::response::Response) -> T
     serde_json::from_slice(&bytes).unwrap()
 }
 
+/// The connected-app record id behind one configured server name — how app
+/// fixtures learn what to bind after a `PUT /mcp/servers` created the record.
+async fn connected_app_id(store: &Arc<dyn Store>, name: &str) -> openwave_core::id::ConnectedAppId {
+    store
+        .list_connected_apps()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|record| record.name == name)
+        .map(|record| record.id)
+        .unwrap_or_else(|| panic!("no connected app named {name:?} is configured"))
+}
+
 /// Create a chat and return it.
 async fn make_chat(router: &Router, bearer: &str) -> Chat {
     let response = router

--- a/crates/openwave-server/src/tests/app_grant.rs
+++ b/crates/openwave-server/src/tests/app_grant.rs
@@ -31,7 +31,11 @@ async fn grant_request(
         .unwrap()
 }
 
-async fn create_app_bound_to(store: &Arc<dyn Store>, server: &str, tools: &[&str]) -> AppId {
+async fn create_app_bound_to(
+    store: &Arc<dyn Store>,
+    app: openwave_core::id::ConnectedAppId,
+    tools: &[&str],
+) -> AppId {
     let app_id = AppId::new();
     store
         .create_app(&CreateApp {
@@ -41,7 +45,7 @@ async fn create_app_bound_to(store: &Arc<dyn Store>, server: &str, tools: &[&str
                 manifest: AppManifest {
                     name: "Grant fixture".into(),
                     bindings: vec![AppBinding {
-                        server: server.into(),
+                        app,
                         tools: tools.iter().map(|tool| (*tool).to_owned()).collect(),
                     }],
                 },
@@ -94,7 +98,8 @@ async fn grant_responses_carry_names_only_never_definitions_or_env_values() {
         .await
         .unwrap();
     assert_eq!(put.status(), StatusCode::OK);
-    let app_id = create_app_bound_to(&store, "cmd", &["mcp__cmd__doit"]).await;
+    let cmd = connected_app_id(&store, "cmd").await;
+    let app_id = create_app_bound_to(&store, cmd, &["mcp__cmd__doit"]).await;
 
     let mut responses = Vec::new();
     let state = grant_request(&router, &bearer, "GET", app_id).await;
@@ -132,9 +137,14 @@ async fn grant_responses_carry_names_only_never_definitions_or_env_values() {
     let missing = grant_request(&router, &bearer, "GET", AppId::new()).await;
     assert_eq!(missing.status(), StatusCode::NOT_FOUND);
 
-    // A binding to a server that is not configured cannot be granted: there
-    // is no definition to pin the consent to.
-    let unbound = create_app_bound_to(&store, "ghost", &["mcp__ghost__walk"]).await;
+    // A binding to a connected app that is not configured cannot be granted:
+    // there is no definition to pin the consent to.
+    let unbound = create_app_bound_to(
+        &store,
+        openwave_core::id::ConnectedAppId::new(),
+        &["mcp__ghost__walk"],
+    )
+    .await;
     let refused = grant_request(&router, &bearer, "POST", unbound).await;
     assert_eq!(refused.status(), StatusCode::CONFLICT);
 }

--- a/crates/openwave-server/src/tests/app_invoke.rs
+++ b/crates/openwave-server/src/tests/app_invoke.rs
@@ -93,7 +93,8 @@ fn tool_server_config(address: std::net::SocketAddr) -> crate::mcp_config::McpSe
     .unwrap()
 }
 
-/// Create an app whose current manifest pins exactly `tools` under `srv`.
+/// Create an app whose current manifest pins exactly `tools` under the
+/// connected app the configured `srv` server became.
 async fn create_pinned_app(store: &Arc<dyn Store>, tools: &[&str]) -> AppId {
     let app_id = AppId::new();
     store
@@ -104,7 +105,7 @@ async fn create_pinned_app(store: &Arc<dyn Store>, tools: &[&str]) -> AppId {
                 manifest: AppManifest {
                     name: "Invoke fixture".into(),
                     bindings: vec![AppBinding {
-                        server: "srv".into(),
+                        app: connected_app_id(store, "srv").await,
                         tools: tools.iter().map(|tool| (*tool).to_owned()).collect(),
                     }],
                 },
@@ -393,7 +394,7 @@ async fn a_widened_manifest_requires_fresh_consent_for_the_new_tools() {
                 manifest: AppManifest {
                     name: "Invoke fixture".into(),
                     bindings: vec![AppBinding {
-                        server: "srv".into(),
+                        app: connected_app_id(&store, "srv").await,
                         tools: vec!["mcp__srv__viewer".into(), "mcp__srv__unpinned".into()],
                     }],
                 },

--- a/crates/openwave-server/src/tests/app_library.rs
+++ b/crates/openwave-server/src/tests/app_library.rs
@@ -48,7 +48,7 @@ async fn library_lists_grant_verdicts_and_deletion_removes_the_row() {
                 manifest: AppManifest {
                     name: "Library fixture".into(),
                     bindings: vec![AppBinding {
-                        server: "cmd".into(),
+                        app: connected_app_id(&store, "cmd").await,
                         tools: vec!["mcp__cmd__doit".into()],
                     }],
                 },

--- a/docs/local-apps.md
+++ b/docs/local-apps.md
@@ -31,9 +31,10 @@ An app revision is an untrusted **bundle** and a trusted **manifest**:
   prefetched MCP view). It is assumed hostile: prompt injection anywhere in a
   conversation can author it.
 - The manifest is small, structural JSON: a display name and
-  `bindings: [{ server, tools[] }]` naming mounted tool names under their
-  configured server namespaces. The manifest — not the bundle — is what the
-  user consents to and what the host enforces per call.
+  `bindings: [{ app, tools[] }]` naming mounted tool names under the
+  connected-app records ([connected-apps.md](connected-apps.md)) that
+  contribute them. The manifest — not the bundle — is what the user consents
+  to and what the host enforces per call.
 
 The containment story is inherited from MCP App views and unchanged: the frame
 is served by the host with its own strict CSP (`default-src 'none'`,
@@ -87,9 +88,10 @@ standing grant would silently widen. None of that maps onto a profile-scoped
 app driven by a human click. Local apps therefore get their own consent
 object, designed against the same threat:
 
-- An **app grant** records, per app: the granted `(server, tools[])` set and a
-  **fingerprint of each bound server's definition** (command, args, cwd,
-  selected env names, URL — whatever the transport carries).
+- An **app grant** records, per app: the granted `(app, tools[])` set — keyed
+  by connected-app record id — and a **fingerprint of each bound app's
+  definition** (namespace, command, args, cwd, selected env names, URL —
+  whatever the transport carries).
 - The grant is created by explicit user consent on a sheet that lists every
   binding. It is revocable from the Apps library.
 - Every invoke checks, live: the tool is in the current revision's manifest,


### PR DESCRIPTION
Slice 1 of the REST-bindings epic (#1330), built to the merged design contract in docs/connected-apps.md. Closes #1341.

## What this adds

- **The connected-app record** (`openwave-core::connected_app`): profile-scoped, opaque `ConnectedAppId`, display name, closed `kind` vocabulary (`mcp_server` | `rest_api`), bounded kind-specific definition JSON. Store ops are a kind-scoped wholesale replacement (mirroring the settings surface that owns the list) with stable record identity across edits and an explicit per-kind position, plus `list_connected_apps`.
- **Absorption migration** (`m20260803_000042_add_connected_apps`), a hard cut per the contract:
  - persisted MCP servers (the `mcp_servers_v1` setting) become `mcp_server` records, definitions copied verbatim; the setting row is deleted;
  - **all pre-existing app grants are dropped**, never translated — affected apps re-present the consent sheet on next open;
  - stored app manifests are rewritten from `{server, tools[]}` to `{app, tools[]}` keyed by record id; a binding whose server no longer exists is dropped (narrowed, never widened). No dual-reading compatibility layer exists anywhere in runtime code.
- **App-keyed manifests and grants**: `AppBinding { app, tools[] }`, `AppGrantBinding { app, tools[], fingerprint }`. The core binding grammar is structural only (a namespace may itself contain `_`, so the exact `mcp__{namespace}__` split is only decidable against a record); the exact cross-check lives in the layers that resolve ids — the `create_app` door, grant computation, and the invoke gate — via a shared `mounted_tool_under` helper.
- **Fingerprint `v:2`**: still SHA-256 over a canonical, field-derived form (never storage), now rooted with `kind` and including the `namespace`. v:1 excluded the name because grants keyed by it; app-keyed grants pin a record id, so the namespace — which decides which mounted names a grant reaches — is part of what the user consents to. `enabled`/`request_timeout_ms` stay excluded.
- **Runtime rewiring**: the MCP runtime loads/persists definitions through records, reusing a name's record id on edit (consent invalidates by fingerprint, not identity) and deriving boot-stable ids for the legacy `OPENWAVE_MCP_CONFIG` path. `GET/PUT /settings/mcp-servers` keep their exact wire shape — the Settings phasing is presentation-only, per the doc.
- **Model authoring seam**: `create_app` validates bindings against configured records with teachable errors, and its description now ends with the live roster of connected-app ids (the model cannot derive record ids from mounted tool names). The consent sheet leads with the app's display name.

## Deliberately not here

- `rest_api` is vocabulary only: ingest (#1342, merged), the governed executor (#1343, in review), `{app, operation_ids[]}` bindings (#1344), and Settings CRUD (#1345) are the sibling slices. The managed-profile refusal of the `rest_api` kind ships with its first write surface (#1345), since this slice adds none.
- No hash-stability fixture across the migration, per the contract.

## Tests

- New: absorption-migration round trip on a pre-migration schema (records created verbatim, manifests re-keyed with dead bindings dropped, grants dropped, setting gone); kind-scoped replacement semantics (identity/created_at preserved, kinds isolated, mixed-kind refused); v:2 fingerprint invariants (field-derived, value-oracle-free, namespace-covering, toggle-indifferent); binding-grammar and namespace-anchoring units.
- Reworked to the new vocabulary rather than duplicated: the invoke ladder, grant lifecycle, reconfiguration-invalidates-grant, widened-manifest, library, create_app, and consent-sheet tests all pass unchanged in intent (misc: one store test that asserted cross-namespace pins at the storage door now asserts the structural grammar there, since the namespace cross-check moved to the resolving layers, where existing tests already cover it).

`cargo test -p openwave-core` (558) and `-p openwave-server` (503) green; full UI suite (674) green; wire.ts regenerated; scoped clippy clean. `full-ci` applied — this is a boundary-crossing storage migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)