### PR TITLE
feat(server): resolve self-host tokens to named principals at the auth boundary

### DIFF
--- a/crates/openwave-core/src/config.rs
+++ b/crates/openwave-core/src/config.rs
@@ -72,6 +72,13 @@ pub struct Config {
     /// `None` uses the server's documented placeholder image.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub container_image: Option<String>,
+    /// Path to the self-host profile's static bearer-token file, mapping each
+    /// token to the user it authenticates (format documented in the server's
+    /// auth module). Consulted only by [`Profile::SelfHost`], which requires
+    /// it; the desktop profile authenticates with its per-launch bearer and
+    /// ignores this.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_tokens_file: Option<PathBuf>,
 }
 
 impl Config {
@@ -86,6 +93,7 @@ impl Config {
             exec_skills_dir: None,
             container_execution_enabled: false,
             container_image: None,
+            auth_tokens_file: None,
         }
     }
 
@@ -93,14 +101,17 @@ impl Config {
     /// `OPENWAVE_PROFILE` (default `desktop`), `OPENWAVE_DATA_DIR` (default
     /// `./.openwave` under the current directory — desktop/CLI clients should set
     /// this to the platform's app-data location),
-    /// `OPENWAVE_CONTAINER_EXECUTION_ENABLED` (default `false`), and
-    /// `OPENWAVE_CONTAINER_IMAGE` (defaulting to the server's placeholder image).
+    /// `OPENWAVE_CONTAINER_EXECUTION_ENABLED` (default `false`),
+    /// `OPENWAVE_CONTAINER_IMAGE` (defaulting to the server's placeholder
+    /// image), and `OPENWAVE_AUTH_TOKENS_FILE` (self-host only; required
+    /// there).
     pub fn from_env() -> Result<Self> {
         Self::from_vars(
             std::env::var("OPENWAVE_PROFILE").ok(),
             std::env::var_os("OPENWAVE_DATA_DIR"),
             std::env::var("OPENWAVE_CONTAINER_EXECUTION_ENABLED").ok(),
             std::env::var("OPENWAVE_CONTAINER_IMAGE").ok(),
+            std::env::var_os("OPENWAVE_AUTH_TOKENS_FILE"),
         )
     }
 
@@ -116,6 +127,7 @@ impl Config {
         data_dir: Option<OsString>,
         container_execution_enabled: Option<String>,
         container_image: Option<String>,
+        auth_tokens_file: Option<OsString>,
     ) -> Result<Self> {
         let profile = match profile.filter(|value| !value.is_empty()).as_deref() {
             None | Some("desktop") => Profile::Desktop,
@@ -138,6 +150,9 @@ impl Config {
                 })?,
             };
         let container_image = container_image.filter(|value| !value.is_empty());
+        let auth_tokens_file = auth_tokens_file
+            .filter(|path| !path.is_empty())
+            .map(PathBuf::from);
         Ok(Self {
             profile,
             data_dir,
@@ -147,6 +162,7 @@ impl Config {
             exec_skills_dir: None,
             container_execution_enabled,
             container_image,
+            auth_tokens_file,
         })
     }
 
@@ -194,7 +210,7 @@ mod tests {
     fn empty_data_dir_var_falls_back_to_the_default() {
         // `OPENWAVE_DATA_DIR=` (set but empty) must behave like unset, not point
         // the store at `openwave.db` in the current directory.
-        let config = Config::from_vars(None, Some(OsString::new()), None, None).unwrap();
+        let config = Config::from_vars(None, Some(OsString::new()), None, None, None).unwrap();
         let expected = std::env::current_dir().unwrap().join(".openwave");
         assert_eq!(config.data_dir, expected);
         assert_eq!(config.profile, Profile::Desktop);
@@ -205,6 +221,7 @@ mod tests {
         let config = Config::from_vars(
             Some(String::new()),
             Some(OsString::from("/data")),
+            None,
             None,
             None,
         )
@@ -219,15 +236,20 @@ mod tests {
             Some(OsString::from("/data")),
             None,
             None,
+            Some(OsString::from("/etc/openwave/tokens")),
         )
         .unwrap();
         assert_eq!(config.profile, Profile::SelfHost);
         assert_eq!(config.data_dir, PathBuf::from("/data"));
+        assert_eq!(
+            config.auth_tokens_file,
+            Some(PathBuf::from("/etc/openwave/tokens"))
+        );
     }
 
     #[test]
     fn unknown_profile_var_is_an_error() {
-        assert!(Config::from_vars(Some("bogus".into()), None, None, None).is_err());
+        assert!(Config::from_vars(Some("bogus".into()), None, None, None, None).is_err());
     }
 
     #[test]
@@ -245,6 +267,7 @@ mod tests {
         assert_eq!(config.exec_skills_dir, None);
         assert!(!config.container_execution_enabled);
         assert_eq!(config.container_image, None);
+        assert_eq!(config.auth_tokens_file, None);
     }
 
     #[test]
@@ -262,6 +285,7 @@ mod tests {
             Some(OsString::from("/data")),
             Some("true".into()),
             Some("openwave-sandbox-agent:dev".into()),
+            None,
         )
         .unwrap();
         assert!(config.container_execution_enabled);
@@ -269,6 +293,6 @@ mod tests {
             config.container_image.as_deref(),
             Some("openwave-sandbox-agent:dev")
         );
-        assert!(Config::from_vars(None, None, Some("yes".into()), None).is_err());
+        assert!(Config::from_vars(None, None, Some("yes".into()), None, None).is_err());
     }
 }

--- a/crates/openwave-server/src/auth.rs
+++ b/crates/openwave-server/src/auth.rs
@@ -1,15 +1,43 @@
-//! Bearer-token authentication for the local API.
+//! Bearer-token authentication for the API.
 //!
-//! The server binds to loopback with a per-launch token (see [`AppState`]); a
-//! middleware layer rejects any request that doesn't present it. It's the one
-//! thing standing between the agent and any other local process that finds the
-//! port, so the check is mandatory on every non-health route.
+//! Which credentials authenticate depends on the boot [`Profile`]:
+//!
+//! - **Desktop** binds to loopback with a per-launch token (see [`AppState`]);
+//!   whoever presents it is the one person at the machine, so it resolves to
+//!   [`Principal::LocalOwner`]. It's the one thing standing between the agent
+//!   and any other local process that finds the port, so the check is
+//!   mandatory on every non-health route.
+//! - **Self-host** authenticates with static named bearer tokens from an
+//!   operator-maintained file ([`TokenMap`]); each token names the configured
+//!   user it belongs to, resolved to [`Principal::User`]. The per-launch token
+//!   names nobody on a shared deployment and is not accepted there — a
+//!   credential that names no one is rejected at this middleware (#853).
+//!
+//! # Self-host token file
+//!
+//! `OPENWAVE_AUTH_TOKENS_FILE` points at a plain-text file, one mapping per
+//! line — `<user-id> <token>`, whitespace-separated. Blank lines and lines
+//! starting with `#` are ignored. A user may hold several tokens (rotation);
+//! a token may name only one user, and duplicates fail the load. Tokens are
+//! opaque secrets matched exactly (no hashing scheme to misconfigure): at
+//! least 16 characters from `[A-Za-z0-9._~-]`, so they stay valid in both the
+//! `Authorization` header and the WebSocket subprotocol below. Generate them
+//! with e.g. `openssl rand -hex 32`. Gateway-derived identity (#578) later
+//! replaces this file behind the same credential-to-principal seam.
+//!
+//! ```text
+//! # user-id  token
+//! alice  4f9c0e9b2d5a4c1e8f7b6a5d4c3b2a1f
+//! bob    0123456789abcdef0123456789abcdef
+//! ```
 //!
 //! Browsers can't set an `Authorization` header on a WebSocket upgrade, so on
 //! upgrade requests the token is also accepted via `Sec-WebSocket-Protocol` as
 //! `openwave-token.<token>` (alongside the handshake subprotocol `openwave-v1`).
 //! Non-browser clients keep using `Authorization: Bearer`. Subprotocol auth is
 //! ignored on ordinary HTTP requests.
+
+use std::path::Path;
 
 use axum::extract::{Request, State};
 use axum::http::{
@@ -18,8 +46,9 @@ use axum::http::{
 };
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
+use openwave_core::{AgentError, Profile, Result};
 
-use crate::principal::{AuthContext, Principal};
+use crate::principal::{AuthContext, Principal, UserId};
 use crate::state::AppState;
 
 /// Handshake subprotocol the server selects when the client offered it.
@@ -36,29 +65,143 @@ pub const WS_TOKEN_SUBPROTOCOL_PREFIX: &str = "openwave-token.";
 pub const CLIENT_EXECUTOR_HEADER: HeaderName =
     HeaderName::from_static("x-openwave-client-executor");
 
-/// Reject requests without a valid bearer token — from
+/// Reject requests whose bearer token does not resolve to a principal — from
 /// `Authorization: Bearer <token>`, or (on WebSocket upgrades only)
 /// `Sec-WebSocket-Protocol: openwave-token.<token>`.
+///
+/// This is the only place a principal is minted; handlers learn it through
+/// the fail-closed `AuthContext` extractor.
 pub async fn require_token(
     State(state): State<AppState>,
     mut request: Request,
     next: Next,
 ) -> Response {
-    let presented = extract_token(request.headers());
+    let resolved =
+        extract_token(request.headers()).and_then(|presented| resolve_principal(&state, presented));
 
-    match presented {
-        Some(token) if constant_time_eq(token.as_bytes(), state.token.as_bytes()) => {
-            // The per-launch bearer is loopback-only and handed to one client,
-            // so the verified caller *is* the local owner. This is the only
-            // place a principal is minted; handlers learn it through the
-            // fail-closed `AuthContext` extractor.
+    match resolved {
+        Some(principal) => {
             request.extensions_mut().insert(AuthContext {
-                principal: Principal::LocalOwner,
+                principal,
                 client_executor: false,
             });
             next.run(request).await
         }
-        _ => StatusCode::UNAUTHORIZED.into_response(),
+        None => StatusCode::UNAUTHORIZED.into_response(),
+    }
+}
+
+/// Map the presented credential to WHO is asking, per the boot profile.
+///
+/// `None` is a 401: a token that names no one admits no one. Unknown future
+/// profiles resolve nobody until they choose an authenticator — fail closed,
+/// never defaulted to the local owner.
+fn resolve_principal(state: &AppState, presented: &str) -> Option<Principal> {
+    match state.config.profile {
+        // The per-launch bearer is loopback-only and handed to one client, so
+        // the verified caller *is* the local owner.
+        Profile::Desktop => constant_time_eq(presented.as_bytes(), state.token.as_bytes())
+            .then_some(Principal::LocalOwner),
+        // Every self-host credential names a configured user. The per-launch
+        // bearer is deliberately not consulted: on a shared deployment it
+        // names nobody, so it authenticates nobody.
+        Profile::SelfHost => state
+            .principal_tokens
+            .resolve(presented)
+            .map(Principal::User),
+        _ => None,
+    }
+}
+
+/// The self-host profile's static credential-to-principal mapping.
+///
+/// Loaded once at boot from the operator's token file (format in the module
+/// docs). This is the seam a future authenticator (gateway-derived identity,
+/// #578) replaces: whatever verifies the credential, the middleware's output
+/// stays "which [`UserId`] is asking".
+#[derive(Debug, Default)]
+pub struct TokenMap {
+    /// `(token, user)` pairs; tokens are unique, users may repeat.
+    entries: Vec<(Box<str>, UserId)>,
+}
+
+/// Tokens shorter than this are refused at load: a guessable credential names
+/// someone without authenticating them.
+const MIN_TOKEN_LEN: usize = 16;
+
+impl TokenMap {
+    /// Load and validate the token file at `path`.
+    pub fn load(path: &Path) -> Result<Self> {
+        let text = std::fs::read_to_string(path).map_err(|e| {
+            AgentError::config(format!(
+                "failed to read auth tokens file {}: {e}",
+                path.display()
+            ))
+        })?;
+        Self::parse(&text)
+    }
+
+    /// Parse the token-file format. Rejects malformed lines, invalid ids,
+    /// weak or header-unsafe tokens, duplicate tokens, and a file that names
+    /// nobody — an empty authenticator must fail loudly at boot, not admit
+    /// nobody silently.
+    pub fn parse(text: &str) -> Result<Self> {
+        let mut entries: Vec<(Box<str>, UserId)> = Vec::new();
+        for (index, raw) in text.lines().enumerate() {
+            let line_no = index + 1;
+            let line = raw.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let mut fields = line.split_whitespace();
+            let (Some(user), Some(token), None) = (fields.next(), fields.next(), fields.next())
+            else {
+                return Err(AgentError::config(format!(
+                    "auth tokens file line {line_no}: expected `<user-id> <token>`"
+                )));
+            };
+            let user = UserId::new(user)
+                .map_err(|e| AgentError::config(format!("auth tokens file line {line_no}: {e}")))?;
+            // Never echo the token itself into an error message.
+            let token_ok = token.len() >= MIN_TOKEN_LEN
+                && token
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'~' | b'-'));
+            if !token_ok {
+                return Err(AgentError::config(format!(
+                    "auth tokens file line {line_no}: token must be at least {MIN_TOKEN_LEN} \
+                     characters from [A-Za-z0-9._~-]"
+                )));
+            }
+            if entries
+                .iter()
+                .any(|(existing, _)| existing.as_ref() == token)
+            {
+                return Err(AgentError::config(format!(
+                    "auth tokens file line {line_no}: duplicate token"
+                )));
+            }
+            entries.push((token.into(), user));
+        }
+        if entries.is_empty() {
+            return Err(AgentError::config(
+                "auth tokens file names no principals; a self-host server nobody can \
+                 authenticate to must not start",
+            ));
+        }
+        Ok(Self { entries })
+    }
+
+    /// The user the presented credential names, if any. Exact match; every
+    /// entry is compared in constant time regardless of where a match lands.
+    pub fn resolve(&self, presented: &str) -> Option<UserId> {
+        let mut resolved = None;
+        for (token, user) in &self.entries {
+            if constant_time_eq(token.as_bytes(), presented.as_bytes()) && resolved.is_none() {
+                resolved = Some(user.clone());
+            }
+        }
+        resolved
     }
 }
 
@@ -81,7 +224,7 @@ pub async fn require_client_executor_token(
         Some(token)
             if constant_time_eq(token.as_bytes(), state.client_executor_token.as_bytes()) =>
         {
-            let Some(auth) = request.extensions().get::<AuthContext>().copied() else {
+            let Some(auth) = request.extensions().get::<AuthContext>().cloned() else {
                 return StatusCode::UNAUTHORIZED.into_response();
             };
             request.extensions_mut().insert(AuthContext {
@@ -175,6 +318,50 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 mod tests {
     use super::*;
     use axum::http::HeaderValue;
+
+    #[test]
+    fn token_map_parses_the_documented_format_and_resolves_exactly() {
+        let map = TokenMap::parse(
+            "# staff\n\nalice aaaaaaaaaaaaaaaa\nbob\tbbbbbbbbbbbbbbbb\nalice cccccccccccccccc\n",
+        )
+        .unwrap();
+        let alice = UserId::new("alice").unwrap();
+        assert_eq!(map.resolve("aaaaaaaaaaaaaaaa"), Some(alice.clone()));
+        assert_eq!(
+            map.resolve("cccccccccccccccc"),
+            Some(alice),
+            "a user may hold several tokens"
+        );
+        assert_eq!(
+            map.resolve("bbbbbbbbbbbbbbbb"),
+            Some(UserId::new("bob").unwrap())
+        );
+        assert_eq!(map.resolve("dddddddddddddddd"), None);
+        assert_eq!(
+            map.resolve("aaaaaaaaaaaaaaa"),
+            None,
+            "prefixes do not match"
+        );
+    }
+
+    #[test]
+    fn token_map_rejects_files_that_cannot_name_someone_safely() {
+        for (text, why) in [
+            ("", "names nobody"),
+            ("# only comments\n", "names nobody"),
+            ("alice\n", "missing token"),
+            ("alice aaaaaaaaaaaaaaaa extra\n", "trailing field"),
+            ("alice short\n", "guessably short token"),
+            ("alice aaaaaaaa,aaaaaaaa\n", "header-unsafe token character"),
+            ("al!ce aaaaaaaaaaaaaaaa\n", "invalid user id"),
+            (
+                "alice aaaaaaaaaaaaaaaa\nbob aaaaaaaaaaaaaaaa\n",
+                "one token must name one user",
+            ),
+        ] {
+            assert!(TokenMap::parse(text).is_err(), "{why}: {text:?}");
+        }
+    }
 
     #[test]
     fn extracts_bearer_authorization() {

--- a/crates/openwave-server/src/principal.rs
+++ b/crates/openwave-server/src/principal.rs
@@ -16,25 +16,66 @@
 //!   own. [`ClientExecutor`] types that requirement into handler signatures so
 //!   it survives router refactors.
 
+use std::fmt;
+use std::sync::Arc;
+
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 use axum::http::StatusCode;
+use openwave_core::{AgentError, Result};
 
 /// The authenticated identity a request acts as.
 ///
-/// Today the only inhabitant is the single local owner: the desktop bearer is
-/// per-launch and loopback-only, so whoever presents it is the one person at
-/// the machine. A shared deployment adds a variant whose token names a user;
-/// nothing downstream may assume `LocalOwner` is the only case.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// The desktop bearer is per-launch and loopback-only, so whoever presents it
+/// is the one person at the machine — [`Principal::LocalOwner`]. On the shared
+/// self-host profile every credential names a configured user instead
+/// ([`Principal::User`]); a token that names no one is rejected at the
+/// middleware, and the local-owner identity does not exist there. Nothing
+/// downstream may assume `LocalOwner` is the only case.
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Principal {
     /// The one person at the machine, authenticated by the per-launch bearer.
     LocalOwner,
+    /// A named user on a shared deployment, resolved from a configured
+    /// credential (today the self-host token file — see [`crate::auth`]).
+    User(UserId),
+}
+
+/// The operator-assigned identifier of a named user on a shared deployment.
+///
+/// Validated at construction: 1–64 ASCII characters from `[A-Za-z0-9._@-]`.
+/// The id is an identity label, not a secret — it appears in config files and
+/// (in later slices) owner columns, so it is kept greppable and log-safe.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct UserId(Arc<str>);
+
+impl UserId {
+    /// Validate and intern a user id.
+    pub fn new(id: &str) -> Result<Self> {
+        let valid = !id.is_empty()
+            && id.len() <= 64
+            && id
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'@' | b'-'));
+        if valid {
+            Ok(Self(id.into()))
+        } else {
+            Err(AgentError::config(format!(
+                "invalid user id {id:?}: expected 1-64 characters from [A-Za-z0-9._@-]"
+            )))
+        }
+    }
+}
+
+impl fmt::Display for UserId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
 }
 
 /// The authentication result the middleware attaches to a verified request.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuthContext {
     /// Who the request acts as.
     pub principal: Principal,
@@ -53,7 +94,7 @@ impl<S: Send + Sync> FromRequestParts<S> for AuthContext {
         parts
             .extensions
             .get::<AuthContext>()
-            .copied()
+            .cloned()
             .ok_or(StatusCode::UNAUTHORIZED)
     }
 }

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 
 use openwave_core::{
     AgentConfig, AgentError, AgentRunId, BlobStore, CallId, CancelToken, ChatId, Config,
-    FsBlobStore, Result, SecretProvider, SteerInbox, Store, ToolRegistry, TurnId,
+    FsBlobStore, Profile, Result, SecretProvider, SteerInbox, Store, ToolRegistry, TurnId,
 };
 use tokio::sync::{Notify, Semaphore};
 use uuid::Uuid;
@@ -71,7 +71,13 @@ pub struct AppState {
     /// Per-turn agent tuning (model, limits, …).
     pub agent_config: AgentConfig,
     /// The secret every request must present as `Authorization: Bearer <token>`.
+    /// Authenticates the local owner on the desktop profile; on self-host it
+    /// names nobody and admits nobody.
     pub token: Arc<str>,
+    /// The self-host profile's named bearer tokens (credential → user).
+    /// Loaded from `Config::auth_tokens_file` at assembly; empty on desktop,
+    /// where `require_token` never consults it.
+    pub(crate) principal_tokens: Arc<crate::auth::TokenMap>,
     /// A second per-launch secret required for native-only operations.
     pub(crate) client_executor_token: Arc<str>,
     /// Stable private identity owning native attachment reconciliation work.
@@ -112,7 +118,7 @@ impl AppState {
             agent_config,
             Uuid::new_v4(),
         )
-        .expect("a generated client executor id is non-nil");
+        .expect("state assembly with a generated executor id only fails on a self-host config whose token file is missing or invalid");
         state.root_attachment_routes_enabled = false;
         state
     }
@@ -132,6 +138,23 @@ impl AppState {
         if client_executor_id.is_nil() {
             return Err(AgentError::config("client executor id must not be nil"));
         }
+        // Resolve the profile's principal-naming credentials up front, so a
+        // self-host server that could authenticate nobody fails assembly
+        // instead of starting and rejecting every request.
+        let principal_tokens = match config.profile {
+            Profile::SelfHost => {
+                let path = config.auth_tokens_file.as_deref().ok_or_else(|| {
+                    AgentError::config(
+                        "self-host requires OPENWAVE_AUTH_TOKENS_FILE (named bearer tokens \
+                         mapping token to user; see the auth module docs)",
+                    )
+                })?;
+                Arc::new(crate::auth::TokenMap::load(path)?)
+            }
+            // Desktop (and any future single-user embedding) authenticates
+            // with the per-launch bearer only.
+            _ => Arc::default(),
+        };
         let blobs: Arc<dyn BlobStore> = Arc::new(FsBlobStore::new(config.data_dir.join("blobs")));
         let blob_writes = Arc::new(BlobWriteGuard::new(config.data_dir.join("blob-locks")));
         let os_policy: Arc<dyn crate::managed_policy::OsPolicySource> =
@@ -165,6 +188,7 @@ impl AppState {
             file_preview_permits: Arc::new(Semaphore::new(2)),
             agent_config,
             token: Uuid::new_v4().to_string().into(),
+            principal_tokens,
             client_executor_token: mint_client_executor_token(),
             client_executor_id,
             root_attachment_routes_enabled: true,

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -2578,3 +2578,83 @@ async fn auth_middleware_resolves_principal_and_capability() {
         "the native credential marks the capability on the same principal"
     );
 }
+
+/// The self-host boundary contract: the middleware resolves WHO from the
+/// configured named tokens — a named token yields its user, an unknown token
+/// answers 401, and the per-launch bearer (which names nobody on a shared
+/// profile) is rejected too.
+#[tokio::test]
+async fn self_host_tokens_resolve_named_principals() {
+    use crate::principal::{AuthContext, Principal};
+
+    let (dir, store) = temp_db_store("self-host-auth.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let tokens_file = dir.path().join("tokens");
+    std::fs::write(&tokens_file, "# staff\nalice aaaaaaaaaaaaaaaa\n").unwrap();
+    let mut config = Config::desktop(dir.path());
+    config.profile = openwave_core::Profile::SelfHost;
+    config.auth_tokens_file = Some(tokens_file);
+    let state = AppState::new(
+        config,
+        store,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let launch_bearer = state.token.clone();
+
+    let whoami = |auth: AuthContext| async move {
+        match auth.principal {
+            Principal::User(user) => user.to_string(),
+            other => format!("unexpected principal {other:?}"),
+        }
+    };
+    let probe = axum::Router::new()
+        .route("/whoami", axum::routing::get(whoami))
+        .route_layer(axum::middleware::from_fn_with_state(
+            state,
+            crate::auth::require_token,
+        ));
+    let request = |bearer: &str| {
+        Request::builder()
+            .uri("/whoami")
+            .header(header::AUTHORIZATION, format!("Bearer {bearer}"))
+            .body(Body::empty())
+            .unwrap()
+    };
+
+    let response = probe
+        .clone()
+        .oneshot(request("aaaaaaaaaaaaaaaa"))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), 1024).await.unwrap();
+    assert_eq!(&body[..], b"alice", "the named token identifies its user");
+
+    let response = probe
+        .clone()
+        .oneshot(request("bbbbbbbbbbbbbbbb"))
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "a token the file does not name admits no one"
+    );
+
+    let response = probe
+        .clone()
+        .oneshot(request(&launch_bearer))
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "the per-launch bearer names nobody on a shared profile"
+    );
+}


### PR DESCRIPTION
Slice 2 of the authorization sequence planned on #853 (does not close the issue — it is the gate for the whole track). Slice 1 (#1338) gave the request path a typed `AuthContext`; this slice makes the credential answer WHO is asking.

- **`resolve_principal` in `auth.rs`**: `require_token` now maps the presented bearer to a principal per the boot profile. Desktop is unchanged — the per-launch loopback bearer resolves to `Principal::LocalOwner`. Self-host resolves against a static named-token map, and — deliberately — does not consult the per-launch bearer at all: on a shared deployment that token names nobody, so it authenticates nobody. Unknown future profiles resolve nobody (fail closed), never a defaulted local owner.
- **`TokenMap`**: the self-host profile's credential→principal mapping, loaded once at state assembly from an operator-maintained file (`OPENWAVE_AUTH_TOKENS_FILE`; format documented in the module docs: `<user-id> <token>` per line, `#` comments). Tokens are opaque secrets matched exactly in constant time — no hashing scheme to misconfigure. The load rejects malformed lines, guessably short or header/subprotocol-unsafe tokens, a token naming two users, and a file that names nobody, so a self-host server nobody can authenticate to fails assembly instead of starting and rejecting everything. Parse errors never echo the token. This map is the seam gateway-derived identity (#578) later swaps in behind: whatever verifies the credential, the middleware's output stays "which user is asking".
- **`Principal::User(UserId)`** joins `LocalOwner`; `UserId` is a validated, log-safe operator-assigned id (1–64 chars of `[A-Za-z0-9._@-]`). `AuthContext` drops `Copy` for the owned id, nothing else about slice 1's extractors changes.
- **`Config.auth_tokens_file`** (`OPENWAVE_AUTH_TOKENS_FILE`) follows the existing env→config pattern; additive and skipped when absent, so serialized configs are unchanged. Self-host still cannot boot end to end — `connect_store` continues to reject the profile until the owner-scoped store lands — but the authenticator it will boot with is now real and tested.

No storage, wire type, or desktop-observable behavior changes.

Tests are boundary contracts: a named token resolves to its user through the real middleware, an unknown token and the per-launch bearer both 401 on self-host, the token-file parser rejects everything it must, and the existing slice-1 layering test pins the desktop path.

Next slice: owner attribution and principal-scoped queries behind the `Store` trait, with desktop rows backfilled to the local owner.