### PR TITLE
feat(server): managed permission-mode ceiling for MDM-managed installs

### DIFF
--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1039,7 +1039,12 @@ impl ReasoningEffort {
 /// Persisted per chat as the token from [`Self::as_str`] and read at turn
 /// start, like the model selection: changing it mid-turn applies from the
 /// next turn, and a reopened chat runs the way it ran before.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+///
+/// The declaration order is ascending autonomy, and the derived `Ord` relies
+/// on it: `Plan < Ask < Auto < Allow`, matching [`Self::ALL`]. Managed-policy
+/// ceilings compare modes with it, so a new variant must slot into this
+/// scale, not just onto the end of the list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum PermissionMode {
     /// The agent explores read-only and designs a plan instead of acting.

--- a/crates/openwave-desktop/ui/src/PermissionModeMenu.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/PermissionModeMenu.dom.test.tsx
@@ -2,6 +2,8 @@
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, expect, it, vi } from "vitest";
+import type { ManagedPolicy } from "./api";
+import { ManagedPolicyContext } from "./managedPolicy";
 import { PermissionModeMenu } from "./PermissionModeMenu";
 
 afterEach(() => {
@@ -24,4 +26,36 @@ it("applies the chosen mode and closes", async () => {
   await waitFor(() =>
     expect(screen.queryByRole("menuitem", { name: /Allow all/ })).not.toBeInTheDocument(),
   );
+});
+
+/**
+ * #923: a managed permission-mode ceiling renders over-ceiling modes as
+ * locked — visible but unselectable — and a stored mode above the ceiling
+ * displays as the ceiling the turn actually runs under.
+ */
+it("locks modes above a managed ceiling", async () => {
+  const capped: ManagedPolicy = {
+    managed: false,
+    source: "unmanaged",
+    misconfigured: false,
+    permission_mode_ceiling: "ask",
+  };
+  const onChange = vi.fn();
+  render(
+    <ManagedPolicyContext.Provider value={capped}>
+      <PermissionModeMenu value="allow" onChange={onChange} />
+    </ManagedPolicyContext.Provider>,
+  );
+
+  // The over-ceiling stored mode reads as its clamped effective mode.
+  await userEvent.click(screen.getByRole("button", { name: "Permissions: Ask" }));
+  const locked = await screen.findByRole("menuitem", { name: /Allow all/ });
+  expect(locked).toHaveAttribute("aria-disabled", "true");
+  expect(locked).toHaveTextContent("Locked by your organization's policy.");
+  expect(
+    screen.getByRole("menuitem", { name: /Plan/ }),
+  ).not.toHaveAttribute("aria-disabled", "true");
+
+  await userEvent.click(locked);
+  expect(onChange).not.toHaveBeenCalled();
 });

--- a/crates/openwave-desktop/ui/src/PermissionModeMenu.tsx
+++ b/crates/openwave-desktop/ui/src/PermissionModeMenu.tsx
@@ -1,12 +1,14 @@
 import {
   Check,
   ChevronDown,
+  Lock,
   NotebookPen,
   ShieldCheck,
   Sparkles,
   Zap,
 } from "lucide-react";
 import type { PermissionMode } from "./api";
+import { useManagedPolicy } from "./managedPolicy";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -69,6 +71,11 @@ const PERMISSION_MODE_SCALE: {
 /** The stored mode a chat runs under when none is set. */
 export const DEFAULT_PERMISSION_MODE: PermissionMode = "ask";
 
+/** Position on the autonomy scale, for comparing a mode against a ceiling. */
+function autonomyRank(mode: PermissionMode): number {
+  return PERMISSION_MODE_SCALE.findIndex((option) => option.value === mode);
+}
+
 export function permissionModeOption(mode: PermissionMode | null) {
   const value = mode ?? DEFAULT_PERMISSION_MODE;
   return (
@@ -87,6 +94,13 @@ export function permissionModeOption(mode: PermissionMode | null) {
  * background: the row reads as one set of controls, and the one that has been
  * dialed up should stand out within it without becoming a second kind of
  * object.
+ *
+ * A managed profile may assert a permission-mode ceiling. Modes above it
+ * render locked — decided elsewhere rather than silently missing — and the
+ * server enforces the same ceiling at the chat routes and the turn gate, so
+ * this is legibility, not the lockdown itself. A stored mode already above
+ * the ceiling displays as the ceiling, matching what the turn actually runs
+ * under.
  */
 export function PermissionModeMenu({
   value,
@@ -97,7 +111,14 @@ export function PermissionModeMenu({
   disabled?: boolean;
   onChange: (mode: PermissionMode) => void | Promise<void>;
 }) {
-  const current = permissionModeOption(value);
+  const ceiling = useManagedPolicy().permission_mode_ceiling ?? null;
+  const ceilingRank = ceiling === null ? null : autonomyRank(ceiling);
+  const overCeiling = (mode: PermissionMode) =>
+    ceilingRank !== null && autonomyRank(mode) > ceilingRank;
+  const effective = overCeiling(value ?? DEFAULT_PERMISSION_MODE)
+    ? ceiling
+    : value;
+  const current = permissionModeOption(effective);
   const CurrentIcon = current.icon;
   return (
     <DropdownMenu>
@@ -121,11 +142,12 @@ export function PermissionModeMenu({
       <DropdownMenuContent align="end" side="top" className="w-72">
         {PERMISSION_MODE_SCALE.map((option) => {
           const selected = current.value === option.value;
+          const locked = overCeiling(option.value);
           const OptionIcon = option.icon;
           return (
             <DropdownMenuItem
               key={option.value}
-              disabled={disabled}
+              disabled={disabled || locked}
               onSelect={() => {
                 if (selected) return;
                 void onChange(option.value);
@@ -137,17 +159,23 @@ export function PermissionModeMenu({
                   <OptionIcon
                     className={cn(
                       "size-4",
-                      option.elevated
+                      option.elevated && !locked
                         ? "text-warning-foreground"
                         : "text-muted-foreground",
                     )}
                   />
                   {option.label}
                 </span>
-                {selected && <Check className="size-4" />}
+                {locked ? (
+                  <Lock aria-label="Locked" className="size-4" />
+                ) : (
+                  selected && <Check className="size-4" />
+                )}
               </div>
               <span className="text-muted-foreground pl-6 text-xs">
-                {option.description}
+                {locked
+                  ? "Locked by your organization's policy."
+                  : option.description}
               </span>
             </DropdownMenuItem>
           );

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -761,7 +761,15 @@ misconfigured: boolean,
  * [`resolve`] always leaves it `None` — and only ever present while the
  * profile is unmanaged.
  */
-pending_gateway_url?: string, };
+pending_gateway_url?: string, 
+/**
+ * The highest permission mode any chat may run under, when the OS policy
+ * asserts one. A ceiling, not a fixed mode: the reader may always pick a
+ * stricter mode, and clearing back to the default is always allowed.
+ * Asserted per key, so it binds even when no gateway URL is deployed and
+ * the profile is otherwise unmanaged.
+ */
+permission_mode_ceiling?: PermissionMode, };
 
 /**
  * Which authority asserted the active policy.
@@ -1008,6 +1016,11 @@ export type PendingUserQuestions = { call_id: CallId, turn_id: TurnId, questions
  * Persisted per chat as the token from [`Self::as_str`] and read at turn
  * start, like the model selection: changing it mid-turn applies from the
  * next turn, and a reopened chat runs the way it ran before.
+ *
+ * The declaration order is ascending autonomy, and the derived `Ord` relies
+ * on it: `Plan < Ask < Auto < Allow`, matching [`Self::ALL`]. Managed-policy
+ * ceilings compare modes with it, so a new variant must slot into this
+ * scale, not just onto the end of the list.
  */
 export type PermissionMode = "plan" | "ask" | "auto" | "allow";
 

--- a/crates/openwave-server/src/managed_policy.rs
+++ b/crates/openwave-server/src/managed_policy.rs
@@ -19,7 +19,7 @@ use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use openwave_core::{AgentError, Config, Result, Store};
+use openwave_core::{AgentError, Config, PermissionMode, Result, Store};
 use serde::{Deserialize, Serialize};
 
 const SETTING_KEY: &str = "managed_policy_v1";
@@ -27,6 +27,12 @@ const SETTING_KEY: &str = "managed_policy_v1";
 /// The key every OS artifact stores the asserted URL under: the Windows
 /// registry value and the macOS managed-preferences key share this name.
 const MANAGED_GATEWAY_URL_KEY: &str = "GatewayURL";
+
+/// The key an OS artifact stores the permission-mode ceiling under, shared by
+/// the Windows registry value and the macOS managed-preferences key. The value
+/// is a mode token (`plan`, `ask`, `auto`, `allow`); a chat may run at or
+/// below it, never above.
+const MANAGED_PERMISSION_MODE_KEY: &str = "MaximumPermissionMode";
 
 /// Which authority asserted the active policy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
@@ -62,6 +68,14 @@ pub(crate) struct ManagedPolicy {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub(crate) pending_gateway_url: Option<String>,
+    /// The highest permission mode any chat may run under, when the OS policy
+    /// asserts one. A ceiling, not a fixed mode: the reader may always pick a
+    /// stricter mode, and clearing back to the default is always allowed.
+    /// Asserted per key, so it binds even when no gateway URL is deployed and
+    /// the profile is otherwise unmanaged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub(crate) permission_mode_ceiling: Option<PermissionMode>,
 }
 
 impl ManagedPolicy {
@@ -74,7 +88,27 @@ impl ManagedPolicy {
             source,
             misconfigured: true,
             pending_gateway_url: None,
+            permission_mode_ceiling: None,
         }
+    }
+
+    /// Clamp a chat's stored mode to the asserted ceiling. `None` reads as
+    /// the default (`Ask`), same as everywhere else the stored mode is
+    /// interpreted, so a ceiling below the default binds unset chats too.
+    pub(crate) fn clamp_permission_mode(
+        &self,
+        mode: Option<PermissionMode>,
+    ) -> Option<PermissionMode> {
+        match self.permission_mode_ceiling {
+            Some(ceiling) if mode.unwrap_or(PermissionMode::Ask) > ceiling => Some(ceiling),
+            _ => mode,
+        }
+    }
+
+    /// Whether the reader may select `mode` under this policy.
+    pub(crate) fn permits_permission_mode(&self, mode: PermissionMode) -> bool {
+        self.permission_mode_ceiling
+            .is_none_or(|ceiling| mode <= ceiling)
     }
 }
 
@@ -88,6 +122,15 @@ pub(crate) trait OsPolicySource: Send + Sync {
     /// artifact exists but cannot be read or decoded — [`resolve`] projects
     /// that as a misconfigured managed profile, never as unmanaged.
     fn gateway_url(&self) -> Result<Option<String>>;
+
+    /// The OS-asserted permission-mode ceiling, when the platform declares
+    /// one. Same error contract as [`Self::gateway_url`]: `Err` means an
+    /// artifact exists but its assertion cannot be honored — [`resolve`]
+    /// fails that closed by clamping to the default mode rather than
+    /// dropping the ceiling.
+    fn permission_mode_ceiling(&self) -> Result<Option<PermissionMode>> {
+        Ok(None)
+    }
 }
 
 /// The source that asserts nothing: non-desktop platforms, embeddings without
@@ -185,6 +228,34 @@ impl ManagedPreferencesSource {
             trusted_owner: 0,
         }
     }
+
+    /// Search the channels for one key's value, in precedence order.
+    ///
+    /// A broken channel falls through instead of aborting the search: an
+    /// unreadable user-channel artifact must not hide the device-channel
+    /// policy the organization actually deployed. Misconfigured is reported
+    /// only when no channel yields a usable value and at least one had a
+    /// present-but-broken artifact. Each key searches the channels
+    /// independently, matching CFPreferences' per-key domain search.
+    fn channel_value<T>(&self, extract: impl Fn(&[u8]) -> Result<Option<T>>) -> Result<Option<T>> {
+        let mut broken = None;
+        for path in &self.paths {
+            let outcome = trusted_plist_bytes(path, self.trusted_owner)
+                .and_then(|bytes| bytes.as_deref().map_or(Ok(None), &extract));
+            match outcome {
+                Ok(Some(value)) => return Ok(Some(value)),
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::warn!("managed-preferences channel skipped: {error}");
+                    broken.get_or_insert(error);
+                }
+            }
+        }
+        match broken {
+            Some(error) => Err(error),
+            None => Ok(None),
+        }
+    }
 }
 
 /// The account name of the effective uid, from the user database rather than
@@ -240,39 +311,24 @@ impl OsPolicySource for ManagedPreferencesSource {
     // If OpenWave ever adopts the App Sandbox, this must move to the
     // sandbox-safe CFPreferences API.
     fn gateway_url(&self) -> Result<Option<String>> {
-        let mut broken = None;
-        for path in &self.paths {
-            // A broken channel falls through instead of aborting the search:
-            // an unreadable user-channel artifact must not hide the
-            // device-channel policy the organization actually deployed.
-            // Misconfigured is reported only when no channel yields a usable
-            // value and at least one had a present-but-broken artifact.
-            match managed_plist_channel(path, self.trusted_owner) {
-                Ok(Some(url)) => return Ok(Some(url)),
-                Ok(None) => {}
-                Err(error) => {
-                    tracing::warn!("managed-preferences channel skipped: {error}");
-                    broken.get_or_insert(error);
-                }
-            }
-        }
-        match broken {
-            Some(error) => Err(error),
-            None => Ok(None),
-        }
+        self.channel_value(gateway_url_from_managed_plist)
+    }
+
+    fn permission_mode_ceiling(&self) -> Result<Option<PermissionMode>> {
+        self.channel_value(permission_mode_from_managed_plist)
     }
 }
 
-/// Read one managed-preferences channel: an absent file (or absent key) is
-/// `None`. Only a file owned by `trusted_owner` (root in production) is
-/// honored — MDM materializes these as root, and a plist planted by an
-/// unprivileged user must never assert device policy. Ownership is taken
-/// from the opened handle, so the check and the read cannot be raced apart.
+/// Read one managed-preferences channel's bytes: an absent file is `None`.
+/// Only a file owned by `trusted_owner` (root in production) is honored —
+/// MDM materializes these as root, and a plist planted by an unprivileged
+/// user must never assert device policy. Ownership is taken from the opened
+/// handle, so the check and the read cannot be raced apart.
 // Portable so unit tests exercise it on every platform; the production
 // caller is the macOS reader.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 #[cfg_attr(not(unix), allow(unused_variables))]
-fn managed_plist_channel(path: &Path, trusted_owner: u32) -> Result<Option<String>> {
+fn trusted_plist_bytes(path: &Path, trusted_owner: u32) -> Result<Option<Vec<u8>>> {
     use std::io::Read;
 
     let mut file = match std::fs::File::open(path) {
@@ -311,16 +367,16 @@ fn managed_plist_channel(path: &Path, trusted_owner: u32) -> Result<Option<Strin
             path.display()
         ))
     })?;
-    // A domain that forces other keys without GatewayURL asserts no gateway
-    // in this channel.
-    gateway_url_from_managed_plist(&bytes)
+    Ok(Some(bytes))
 }
 
-/// Extract `GatewayURL` from a managed-preferences plist (binary or XML).
-/// Split from the reader so the format is unit-testable without a profile.
+/// Extract one string key from a managed-preferences plist (binary or XML).
+/// A domain that forces other keys without this one asserts nothing for it
+/// in this channel — `None`, not an error. Split from the reader so the
+/// format is unit-testable without a profile.
 // Live via the reader only where the platform wires it; tested everywhere.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-fn gateway_url_from_managed_plist(bytes: &[u8]) -> Result<Option<String>> {
+fn string_from_managed_plist(bytes: &[u8], key: &str) -> Result<Option<String>> {
     let value = plist::Value::from_reader(std::io::Cursor::new(bytes))
         .map_err(|_| AgentError::config("managed preferences plist is unreadable"))?;
     let Some(dictionary) = value.as_dictionary() else {
@@ -328,15 +384,32 @@ fn gateway_url_from_managed_plist(bytes: &[u8]) -> Result<Option<String>> {
             "managed preferences plist is not a dictionary",
         ));
     };
-    match dictionary.get(MANAGED_GATEWAY_URL_KEY) {
+    match dictionary.get(key) {
         None => Ok(None),
         Some(value) => match value.as_string() {
-            Some(url) => asserted_gateway_url(url).map(Some),
-            None => Err(AgentError::config(
-                "managed preferences GatewayURL is not a string",
-            )),
+            Some(raw) => Ok(Some(raw.to_owned())),
+            None => Err(AgentError::config(format!(
+                "managed preferences {key} is not a string"
+            ))),
         },
     }
+}
+
+/// Extract and validate `GatewayURL` from a managed-preferences plist.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn gateway_url_from_managed_plist(bytes: &[u8]) -> Result<Option<String>> {
+    string_from_managed_plist(bytes, MANAGED_GATEWAY_URL_KEY)?
+        .map(|raw| asserted_gateway_url(&raw))
+        .transpose()
+}
+
+/// Extract and validate `MaximumPermissionMode` from a managed-preferences
+/// plist.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn permission_mode_from_managed_plist(bytes: &[u8]) -> Result<Option<PermissionMode>> {
+    string_from_managed_plist(bytes, MANAGED_PERMISSION_MODE_KEY)?
+        .map(|raw| asserted_permission_mode(&raw))
+        .transpose()
 }
 
 /// Machine policy from the Windows registry:
@@ -347,32 +420,47 @@ fn gateway_url_from_managed_plist(bytes: &[u8]) -> Result<Option<String>> {
 #[cfg(windows)]
 pub(crate) struct RegistryPolicySource;
 
+/// Read one string value from the machine policy key. An absent key or
+/// absent value asserts no policy for that name.
+#[cfg(windows)]
+fn registry_policy_value(name: &str) -> Result<Option<String>> {
+    // KEY_WOW64_64KEY pins the native 64-bit view: policy lives in the
+    // real Policies hive, and a future 32-bit build must not be silently
+    // redirected to Wow6432Node.
+    let key = match winreg::RegKey::predef(winreg::enums::HKEY_LOCAL_MACHINE)
+        .open_subkey_with_flags(
+            r"Software\Policies\Brightwave\OpenWave",
+            winreg::enums::KEY_READ | winreg::enums::KEY_WOW64_64KEY,
+        ) {
+        Ok(key) => key,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(AgentError::config(format!(
+                "managed policy registry key is unreadable: {error}"
+            )))
+        }
+    };
+    match key.get_value::<String, _>(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(AgentError::config(format!(
+            "managed policy registry value is unreadable: {error}"
+        ))),
+    }
+}
+
 #[cfg(windows)]
 impl OsPolicySource for RegistryPolicySource {
     fn gateway_url(&self) -> Result<Option<String>> {
-        // KEY_WOW64_64KEY pins the native 64-bit view: policy lives in the
-        // real Policies hive, and a future 32-bit build must not be silently
-        // redirected to Wow6432Node.
-        let key = match winreg::RegKey::predef(winreg::enums::HKEY_LOCAL_MACHINE)
-            .open_subkey_with_flags(
-                r"Software\Policies\Brightwave\OpenWave",
-                winreg::enums::KEY_READ | winreg::enums::KEY_WOW64_64KEY,
-            ) {
-            Ok(key) => key,
-            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
-            Err(error) => {
-                return Err(AgentError::config(format!(
-                    "managed policy registry key is unreadable: {error}"
-                )))
-            }
-        };
-        match key.get_value::<String, _>(MANAGED_GATEWAY_URL_KEY) {
-            Ok(value) => asserted_gateway_url(&value).map(Some),
-            Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
-            Err(error) => Err(AgentError::config(format!(
-                "managed policy registry value is unreadable: {error}"
-            ))),
-        }
+        registry_policy_value(MANAGED_GATEWAY_URL_KEY)?
+            .map(|raw| asserted_gateway_url(&raw))
+            .transpose()
+    }
+
+    fn permission_mode_ceiling(&self) -> Result<Option<PermissionMode>> {
+        registry_policy_value(MANAGED_PERMISSION_MODE_KEY)?
+            .map(|raw| asserted_permission_mode(&raw))
+            .transpose()
     }
 }
 
@@ -391,8 +479,10 @@ impl PolicyFileSource {
     }
 }
 
-impl OsPolicySource for PolicyFileSource {
-    fn gateway_url(&self) -> Result<Option<String>> {
+impl PolicyFileSource {
+    /// Read and decode the policy file; an absent file asserts nothing.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    fn read(&self) -> Result<Option<PolicyFilePayload>> {
         let bytes = match std::fs::read(&self.path) {
             Ok(bytes) => bytes,
             Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
@@ -403,22 +493,54 @@ impl OsPolicySource for PolicyFileSource {
                 )))
             }
         };
-        gateway_url_from_policy_json(&bytes).map(Some)
+        decode_policy_json(&bytes).map(Some)
     }
 }
 
+impl OsPolicySource for PolicyFileSource {
+    fn gateway_url(&self) -> Result<Option<String>> {
+        self.read()?
+            .and_then(|file| file.gateway_url)
+            .map(|raw| asserted_gateway_url(&raw))
+            .transpose()
+    }
+
+    fn permission_mode_ceiling(&self) -> Result<Option<PermissionMode>> {
+        self.read()?
+            .and_then(|file| file.maximum_permission_mode)
+            .map(|raw| asserted_permission_mode(&raw))
+            .transpose()
+    }
+}
+
+/// The policy-file payload: `{"gateway_url": "https://…",
+/// "maximum_permission_mode": "ask"}`, each key optional but at least one
+/// required.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[derive(Deserialize)]
+struct PolicyFilePayload {
+    #[serde(default)]
+    gateway_url: Option<String>,
+    #[serde(default)]
+    maximum_permission_mode: Option<String>,
+}
+
 /// Decode the policy-file payload. Split from the reader so the format is
-/// testable without a filesystem.
+/// testable without a filesystem. A present file that names none of the
+/// recognized keys is a misconfiguration, not "no policy" — a deployed
+/// artifact whose keys are misspelled must fail closed, never read as the
+/// open experience.
 // Live via the reader only where the platform wires it; tested everywhere.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-fn gateway_url_from_policy_json(bytes: &[u8]) -> Result<String> {
-    #[derive(Deserialize)]
-    struct PolicyFile {
-        gateway_url: String,
-    }
-    let file: PolicyFile = serde_json::from_slice(bytes)
+fn decode_policy_json(bytes: &[u8]) -> Result<PolicyFilePayload> {
+    let file: PolicyFilePayload = serde_json::from_slice(bytes)
         .map_err(|_| AgentError::config("managed policy file is not the expected JSON shape"))?;
-    asserted_gateway_url(&file.gateway_url)
+    if file.gateway_url.is_none() && file.maximum_permission_mode.is_none() {
+        return Err(AgentError::config(
+            "managed policy file names no recognized policy keys",
+        ));
+    }
+    Ok(file)
 }
 
 /// The shared shape check for a value read from any OS artifact: registry
@@ -433,6 +555,19 @@ fn asserted_gateway_url(raw: &str) -> Result<String> {
         ));
     }
     Ok(value.to_string())
+}
+
+/// The shared token check for a permission-mode ceiling read from any OS
+/// artifact: trimmed, then held to the chat-mode vocabulary. Anything else —
+/// including blank — is a misconfiguration, never silently ignored.
+fn asserted_permission_mode(raw: &str) -> Result<PermissionMode> {
+    let value = raw.trim();
+    PermissionMode::from_str(value).ok_or_else(|| {
+        AgentError::config(format!(
+            "managed policy asserts an unknown permission mode {value:?}; \
+             expected one of plan, ask, auto, allow"
+        ))
+    })
 }
 
 /// The durable provisioned state, stored as one setting.
@@ -456,6 +591,30 @@ struct ProvisionedPolicy {
 /// removal becomes visible on the next `/policy` read without an app
 /// restart, and the artifacts are tiny.
 pub(crate) async fn resolve(
+    store: &dyn Store,
+    os_policy: &dyn OsPolicySource,
+) -> Result<ManagedPolicy> {
+    let mut policy = resolve_gateway(store, os_policy).await?;
+    // The ceiling is asserted per key, independent of the gateway verdict: an
+    // MDM profile can cap the mode without deploying a gateway URL, and the
+    // cap rides on whatever policy the gateway resolution produced. A broken
+    // ceiling value fails closed to the default mode — `Auto`/`Allow` stay
+    // locked out — rather than open or by bricking the profile.
+    policy.permission_mode_ceiling = match os_policy.permission_mode_ceiling() {
+        Ok(ceiling) => ceiling,
+        Err(error) => {
+            tracing::warn!(
+                "OS-managed permission-mode ceiling is present but unusable: {error}; \
+                 clamping to the default mode"
+            );
+            Some(PermissionMode::Ask)
+        }
+    };
+    Ok(policy)
+}
+
+/// The gateway half of [`resolve`]: managed verdict, URL, and authority.
+async fn resolve_gateway(
     store: &dyn Store,
     os_policy: &dyn OsPolicySource,
 ) -> Result<ManagedPolicy> {
@@ -487,6 +646,7 @@ pub(crate) async fn resolve(
         source: ManagedPolicySource::Unmanaged,
         misconfigured: false,
         pending_gateway_url: None,
+        permission_mode_ceiling: None,
     })
 }
 
@@ -500,6 +660,7 @@ fn asserted(source: ManagedPolicySource, gateway_url: &str) -> ManagedPolicy {
             source,
             misconfigured: false,
             pending_gateway_url: None,
+            permission_mode_ceiling: None,
         },
         Err(error) => {
             tracing::warn!("{source:?}-asserted gateway URL fails the contract: {error}");
@@ -725,6 +886,23 @@ mod tests {
         assert!(policy.managed && !policy.misconfigured);
         assert_eq!(policy.source, ManagedPolicySource::Os);
         assert_eq!(policy.gateway_url.as_deref(), Some("https://corp.gateway/"));
+        assert_eq!(policy.permission_mode_ceiling, None);
+
+        // The ceiling is per key: a file asserting only the mode cap leaves
+        // the gateway side unmanaged, and one asserting both carries both.
+        std::fs::write(&path, br#"{ "maximum_permission_mode": "ask" }"#).unwrap();
+        let policy = resolve(&*store, &reader).await.unwrap();
+        assert!(!policy.managed);
+        assert_eq!(policy.permission_mode_ceiling, Some(PermissionMode::Ask));
+
+        std::fs::write(
+            &path,
+            br#"{ "gateway_url": "https://corp.gateway", "maximum_permission_mode": "auto" }"#,
+        )
+        .unwrap();
+        let policy = resolve(&*store, &reader).await.unwrap();
+        assert!(policy.managed && !policy.misconfigured);
+        assert_eq!(policy.permission_mode_ceiling, Some(PermissionMode::Auto));
 
         for corrupt in [&b"not json"[..], br#"{ "gateway": "wrong shape" }"#] {
             std::fs::write(&path, corrupt).unwrap();
@@ -783,6 +961,77 @@ mod tests {
         ] {
             assert!(gateway_url_from_managed_plist(broken).is_err());
         }
+
+        // The mode ceiling shares the extraction path: same trimming, absent
+        // key is `None`, and a token outside the mode vocabulary refuses.
+        let capped = xml("<key>MaximumPermissionMode</key><string> auto </string>");
+        assert_eq!(
+            permission_mode_from_managed_plist(capped.as_bytes()).unwrap(),
+            Some(PermissionMode::Auto)
+        );
+        assert_eq!(
+            permission_mode_from_managed_plist(unrelated.as_bytes()).unwrap(),
+            None
+        );
+        let unknown = xml("<key>MaximumPermissionMode</key><string>yolo</string>");
+        assert!(permission_mode_from_managed_plist(unknown.as_bytes()).is_err());
+    }
+
+    /// The ceiling's failure direction: a present-but-broken assertion clamps
+    /// to the default mode instead of dropping the ceiling (open) or bricking
+    /// the profile, and a valid one rides on the resolved policy whatever the
+    /// gateway verdict was.
+    #[tokio::test]
+    async fn a_broken_ceiling_fails_closed_to_the_default_mode() {
+        struct CeilingOnly(Result<Option<PermissionMode>>);
+
+        impl OsPolicySource for CeilingOnly {
+            fn gateway_url(&self) -> Result<Option<String>> {
+                Ok(None)
+            }
+            fn permission_mode_ceiling(&self) -> Result<Option<PermissionMode>> {
+                match &self.0 {
+                    Ok(value) => Ok(*value),
+                    Err(error) => Err(AgentError::config(error.to_string())),
+                }
+            }
+        }
+
+        let (store, _directory) = test_store().await;
+        let policy = resolve(&*store, &CeilingOnly(Ok(Some(PermissionMode::Ask))))
+            .await
+            .unwrap();
+        assert!(!policy.managed);
+        assert_eq!(policy.permission_mode_ceiling, Some(PermissionMode::Ask));
+
+        let policy = resolve(
+            &*store,
+            &CeilingOnly(Err(AgentError::config("artifact present but unreadable"))),
+        )
+        .await
+        .unwrap();
+        assert_eq!(policy.permission_mode_ceiling, Some(PermissionMode::Ask));
+
+        // The clamp the gate applies: over-ceiling comes down (including the
+        // unset default when the ceiling sits below it), at-or-below stays
+        // the reader's choice.
+        assert_eq!(
+            policy.clamp_permission_mode(Some(PermissionMode::Allow)),
+            Some(PermissionMode::Ask)
+        );
+        assert_eq!(
+            policy.clamp_permission_mode(Some(PermissionMode::Plan)),
+            Some(PermissionMode::Plan)
+        );
+        assert_eq!(policy.clamp_permission_mode(None), None);
+        let plan_capped = ManagedPolicy {
+            permission_mode_ceiling: Some(PermissionMode::Plan),
+            ..policy
+        };
+        assert_eq!(
+            plan_capped.clamp_permission_mode(None),
+            Some(PermissionMode::Plan)
+        );
     }
 
     /// The channel-fallthrough decision, end to end through resolution: a

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -924,6 +924,36 @@ async fn has_api_key(secrets: &dyn SecretProvider) -> bool {
     false
 }
 
+/// Refuse selecting a permission mode above the managed ceiling.
+///
+/// The picker-facing half of the lockdown: the authoritative clamp lives at
+/// the turn gate, which also catches chats whose stored mode predates the
+/// policy. Selecting a mode at or below the ceiling stays open — the policy
+/// names a maximum, not a fixed mode.
+async fn refuse_permission_mode_over_ceiling(
+    state: &AppState,
+    requested: Option<PermissionMode>,
+) -> Result<(), ServerError> {
+    let Some(mode) = requested else {
+        return Ok(());
+    };
+    let policy = crate::managed_policy::resolve(&*state.store, &*state.os_policy).await?;
+    if !policy.permits_permission_mode(mode) {
+        return Err(ServerError::conflict_kind(
+            "permission_mode_locked",
+            format!(
+                "permission mode `{}` exceeds the maximum this managed profile allows (`{}`)",
+                mode.as_str(),
+                policy
+                    .permission_mode_ceiling
+                    .unwrap_or(PermissionMode::Allow)
+                    .as_str()
+            ),
+        ));
+    }
+    Ok(())
+}
+
 /// Refuse a BYOK credential write on a managed profile.
 ///
 /// The gateway session is a managed profile's only model credential; stored
@@ -1386,6 +1416,7 @@ pub async fn create_chat(
     if let Some(model) = body.model.as_mut() {
         *model = validate_model_selection(&state, model, false).await?;
     }
+    refuse_permission_mode_over_ceiling(&state, body.permission_mode).await?;
     crate::code_execution::normalize_network_policy(&mut body.network_policy)?;
     let chat = Chat {
         id: ChatId::new(),
@@ -1441,6 +1472,10 @@ pub async fn patch_chat(
     if let Some(policy) = body.network_policy.as_mut() {
         crate::code_execution::normalize_network_policy(policy)?;
     }
+    // A `null` (clear back to the default) is always allowed: the ceiling
+    // caps what the reader may select, and the turn gate clamps whatever the
+    // default resolves to.
+    refuse_permission_mode_over_ceiling(&state, body.permission_mode.flatten()).await?;
     let title = body.title.map(normalize_chat_title).transpose()?;
 
     let mut chat = state

--- a/crates/openwave-server/src/tests/conversations.rs
+++ b/crates/openwave-server/src/tests/conversations.rs
@@ -1365,3 +1365,74 @@ async fn patch_chat_rejects_empty_model_and_unknown_chat() {
     .await;
     assert_eq!(missing.status(), StatusCode::NOT_FOUND);
 }
+
+/// #923: a managed permission-mode ceiling refuses over-ceiling selections
+/// at the picker routes — create and patch alike — while stricter modes stay
+/// the reader's choice. The ceiling names a maximum, never a fixed mode.
+#[tokio::test]
+async fn a_managed_ceiling_locks_over_ceiling_permission_modes() {
+    struct CappedAtAsk;
+    impl crate::managed_policy::OsPolicySource for CappedAtAsk {
+        fn gateway_url(&self) -> openwave_core::Result<Option<String>> {
+            Ok(None)
+        }
+        fn permission_mode_ceiling(
+            &self,
+        ) -> openwave_core::Result<Option<openwave_core::PermissionMode>> {
+            Ok(Some(openwave_core::PermissionMode::Ask))
+        }
+    }
+
+    let (dir, store) = temp_db_store("ceiling.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state.os_policy = Arc::new(CappedAtAsk);
+    let bearer = format!("Bearer {}", state.token.clone());
+    let router = app(state);
+
+    let chat = make_chat(&router, &bearer).await;
+    let refused = patch_chat(
+        &router,
+        &bearer,
+        chat.id,
+        serde_json::json!({"permission_mode": "auto"}),
+    )
+    .await;
+    assert_eq!(refused.status(), StatusCode::CONFLICT);
+
+    let stricter = patch_chat(
+        &router,
+        &bearer,
+        chat.id,
+        serde_json::json!({"permission_mode": "plan"}),
+    )
+    .await;
+    assert_eq!(stricter.status(), StatusCode::OK);
+
+    let over_ceiling_creation = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/chats")
+                .header(header::AUTHORIZATION, &bearer)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"permission_mode": "allow"}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(over_ceiling_creation.status(), StatusCode::CONFLICT);
+}

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -533,7 +533,7 @@ impl TurnWorker {
                 )
                 .await;
         }
-        let Some(chat) = self.store.get_chat(turn.chat_id).await? else {
+        let Some(mut chat) = self.store.get_chat(turn.chat_id).await? else {
             return self
                 .record_failure(
                     &turn,
@@ -545,6 +545,13 @@ impl TurnWorker {
                 )
                 .await;
         };
+        // A managed permission-mode ceiling binds at the gate, not only the
+        // picker: a stored mode that predates the policy, or one written past
+        // the route check, is clamped here before anything downstream reads
+        // it. Resolved per turn, like the model, so an MDM push takes effect
+        // on the next turn without a restart.
+        let managed = crate::managed_policy::resolve(&*self.store, &*self.os_policy).await?;
+        chat.permission_mode = managed.clamp_permission_mode(chat.permission_mode);
         let exec_folders = match self.exec_folder_context.as_ref() {
             Some(provider) => match provider.folder_grants_for_chat(&chat, turn.id).await {
                 Ok(folders) => folders,


### PR DESCRIPTION
An administrator who has locked BYOK providers and the MCP surface on an MDM-managed install still had no say over the per-chat permission mode. This adds a managed policy field for it, resolved as a **ceiling rather than a fixed mode**: the policy names the maximum mode any chat may run under, and the reader may always choose a stricter one. Clearing back to the default stays allowed; the default itself is clamped when the ceiling sits below it.

What changed:

- `ManagedPolicy` gains an optional `permission_mode_ceiling`, read by all three OS policy sources under one shared token check (`plan`/`ask`/`auto`/`allow`): the macOS managed-preferences key and Windows registry value `MaximumPermissionMode`, and `maximum_permission_mode` in the Linux policy file. The ceiling is asserted per key — CFPreferences-style — so it binds even when no gateway URL is deployed; the Linux file's `gateway_url` becomes optional accordingly, while a file naming no recognized keys still fails closed as misconfigured. A present-but-invalid ceiling value fails closed to the default mode (`ask`) instead of dropping the ceiling or bricking the profile.
- `PermissionMode` derives `Ord` on its existing ascending-autonomy declaration order (`plan < ask < auto < allow`), which the clamp and the route check compare against.
- **Enforcement at the gate, not only the picker**: the turn worker resolves the policy per turn and clamps the chat's stored mode before the surface freeze and the agent's approval gate read it, so a mode that predates the policy — or was written around the routes — cannot outrun the ceiling. `POST /chats` and `PATCH /chats/{id}` additionally refuse an over-ceiling selection with a `permission_mode_locked` conflict, so the picker gets a real error rather than a silently ignored write.
- The composer's mode menu renders over-ceiling modes as locked — visible, disabled, "Locked by your organization's policy" — via the existing `useManagedPolicy` context, and displays a stored over-ceiling mode as the ceiling the turn actually runs under. Wire types regenerated.

Out of scope, deliberately: whether standing grants made above the ceiling stay honored under lockdown. Grants are per-chat consent the reader gave, a separate question from the mode; this slice clamps the mode only, and the grants question is left as a follow-up on the issue.

Closes #923