### PR TITLE
fix(desktop): converge the updater on the newest published release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4049,6 +4049,7 @@ dependencies = [
  "openwave-host-broker",
  "openwave-server",
  "reqwest 0.12.28",
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -41,6 +41,7 @@ openwave-core = { path = "../openwave-core", default-features = false }
 openwave-host-broker = { path = "../openwave-host-broker" }
 openwave-server = { path = "../openwave-server" }
 reqwest = { workspace = true }
+semver = "=1.0.28"
 sha2 = { workspace = true }
 tauri = { version = "=2.11.5", features = [] }
 tauri-plugin-deep-link = "=2.4.9"

--- a/crates/openwave-desktop/src/updater.rs
+++ b/crates/openwave-desktop/src/updater.rs
@@ -4,6 +4,13 @@
 //! periodically. Updates are downloaded and signature-verified in the
 //! background, but the app bundle is not replaced until an explicit user
 //! restart so the running host and its sidecar always stay on the same version.
+//!
+//! The feed only ever advertises the latest release, so a staged download can
+//! go stale the moment a newer version ships. Every periodic check therefore
+//! re-resolves the feed even while an update is staged and replaces the staged
+//! artifact when the feed has moved on, and the restart path re-resolves once
+//! more at click time so the app never installs an older artifact than the
+//! newest published release it can reach.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
@@ -20,6 +27,8 @@ const UPDATE_CHECK_STARTUP_DELAY: Duration = Duration::from_secs(15);
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const UPDATE_CHECK_ERROR: &str = "Could not check for updates. Try again later.";
 const UPDATE_PREPARE_ERROR: &str = "Could not prepare the update. Try again later.";
+const UPDATE_WITHDRAWN_ERROR: &str =
+    "The downloaded update is no longer published. OpenWave will keep checking.";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -79,6 +88,42 @@ pub(crate) const fn updates_enabled() -> bool {
     cfg!(all(not(debug_assertions), target_os = "macos"))
 }
 
+/// What a fresh look at the feed means for an already-staged artifact.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StagedAction {
+    /// The staged artifact is still the newest published release; keep it.
+    Keep,
+    /// The feed advertises something newer; download and stage that instead.
+    Replace,
+    /// The feed no longer advertises anything newer than the running app
+    /// (the staged release was withdrawn); never install it.
+    Discard,
+}
+
+/// True when `candidate` should supersede the staged version.
+///
+/// Versions are published as semver tags; when either side fails to parse,
+/// the feed is treated as authoritative and any *different* advertised
+/// version replaces the staged one. Equal or older versions never do, so a
+/// check that raced a release cannot downgrade what is already staged.
+fn is_newer(candidate: &str, staged: &str) -> bool {
+    match (
+        semver::Version::parse(candidate),
+        semver::Version::parse(staged),
+    ) {
+        (Ok(candidate), Ok(staged)) => candidate > staged,
+        _ => candidate != staged,
+    }
+}
+
+fn reconcile_staged(feed_version: Option<&str>, staged_version: &str) -> StagedAction {
+    match feed_version {
+        None => StagedAction::Discard,
+        Some(feed) if is_newer(feed, staged_version) => StagedAction::Replace,
+        Some(_) => StagedAction::Keep,
+    }
+}
+
 fn current_update_state(app: &AppHandle) -> DesktopUpdateState {
     app.state::<UpdateManager>()
         .state
@@ -97,48 +142,38 @@ fn set_update_state(app: &AppHandle, next: DesktopUpdateState) {
     }
 }
 
-async fn perform_update_check(app: &AppHandle) {
-    set_update_state(
-        app,
-        DesktopUpdateState {
-            status: DesktopUpdateStatus::Checking,
-            ..DesktopUpdateState::idle()
-        },
-    );
+fn staged_version(app: &AppHandle) -> Option<String> {
+    app.state::<UpdateManager>()
+        .staged
+        .lock()
+        .expect("staged update mutex poisoned")
+        .as_ref()
+        .map(|staged| staged.update.version.clone())
+}
 
-    let updater = match app.updater() {
-        Ok(updater) => updater,
-        Err(error) => {
-            eprintln!("openwave-desktop: could not initialize updater: {error}");
-            return set_update_state(app, DesktopUpdateState::failed(UPDATE_CHECK_ERROR));
-        }
-    };
+fn store_staged(app: &AppHandle, staged: Option<StagedUpdate>) {
+    *app.state::<UpdateManager>()
+        .staged
+        .lock()
+        .expect("staged update mutex poisoned") = staged;
+}
 
-    let update = match updater.check().await {
-        Ok(Some(update)) => update,
-        Ok(None) => return set_update_state(app, DesktopUpdateState::idle()),
-        Err(error) => {
-            eprintln!("openwave-desktop: update check failed: {error}");
-            return set_update_state(app, DesktopUpdateState::failed(UPDATE_CHECK_ERROR));
-        }
-    };
-
+async fn download_and_stage(app: &AppHandle, update: Update, silent: bool) -> bool {
     let version = Some(update.version.clone());
-    set_update_state(
-        app,
-        DesktopUpdateState {
-            status: DesktopUpdateStatus::Downloading,
-            version: version.clone(),
-            ..DesktopUpdateState::idle()
-        },
-    );
+    if !silent {
+        set_update_state(
+            app,
+            DesktopUpdateState {
+                status: DesktopUpdateStatus::Downloading,
+                version: version.clone(),
+                ..DesktopUpdateState::idle()
+            },
+        );
+    }
 
     match update.download(|_chunk, _total| {}, || {}).await {
         Ok(bytes) => {
-            *app.state::<UpdateManager>()
-                .staged
-                .lock()
-                .expect("staged update mutex poisoned") = Some(StagedUpdate { update, bytes });
+            store_staged(app, Some(StagedUpdate { update, bytes }));
             set_update_state(
                 app,
                 DesktopUpdateState {
@@ -147,10 +182,79 @@ async fn perform_update_check(app: &AppHandle) {
                     ..DesktopUpdateState::idle()
                 },
             );
+            true
         }
         Err(error) => {
             eprintln!("openwave-desktop: update download failed: {error}");
-            set_update_state(app, DesktopUpdateState::failed(UPDATE_PREPARE_ERROR));
+            // A silent refresh keeps the previously staged (older but valid)
+            // update on download failure instead of surfacing an error over a
+            // still-installable state.
+            if !silent {
+                set_update_state(app, DesktopUpdateState::failed(UPDATE_PREPARE_ERROR));
+            }
+            false
+        }
+    }
+}
+
+async fn perform_update_check(app: &AppHandle) {
+    // When an update is already staged the periodic re-check runs silently:
+    // the visible state stays `Ready` (the banner keeps showing the staged
+    // version) unless the feed has actually moved on.
+    let staged = staged_version(app);
+    let silent = staged.is_some();
+
+    if !silent {
+        set_update_state(
+            app,
+            DesktopUpdateState {
+                status: DesktopUpdateStatus::Checking,
+                ..DesktopUpdateState::idle()
+            },
+        );
+    }
+
+    let updater = match app.updater() {
+        Ok(updater) => updater,
+        Err(error) => {
+            eprintln!("openwave-desktop: could not initialize updater: {error}");
+            if !silent {
+                set_update_state(app, DesktopUpdateState::failed(UPDATE_CHECK_ERROR));
+            }
+            return;
+        }
+    };
+
+    let update = match updater.check().await {
+        Ok(update) => update,
+        Err(error) => {
+            eprintln!("openwave-desktop: update check failed: {error}");
+            if !silent {
+                set_update_state(app, DesktopUpdateState::failed(UPDATE_CHECK_ERROR));
+            }
+            return;
+        }
+    };
+
+    match staged {
+        None => match update {
+            Some(update) => {
+                download_and_stage(app, update, false).await;
+            }
+            None => set_update_state(app, DesktopUpdateState::idle()),
+        },
+        Some(staged) => {
+            match reconcile_staged(update.as_ref().map(|u| u.version.as_str()), &staged) {
+                StagedAction::Keep => {}
+                StagedAction::Replace => {
+                    let update = update.expect("replace implies an advertised update");
+                    download_and_stage(app, update, true).await;
+                }
+                StagedAction::Discard => {
+                    store_staged(app, None);
+                    set_update_state(app, DesktopUpdateState::idle());
+                }
+            }
         }
     }
 }
@@ -160,24 +264,12 @@ async fn run_update_check(app: AppHandle) -> DesktopUpdateState {
         return current_update_state(&app);
     }
 
+    if app
+        .state::<UpdateManager>()
+        .busy
+        .swap(true, Ordering::AcqRel)
     {
-        let manager = app.state::<UpdateManager>();
-        if manager.busy.swap(true, Ordering::AcqRel) {
-            return current_update_state(&app);
-        }
-
-        let update_is_staged = matches!(
-            manager
-                .state
-                .lock()
-                .expect("update state mutex poisoned")
-                .status,
-            DesktopUpdateStatus::Downloading | DesktopUpdateStatus::Ready
-        );
-        if update_is_staged {
-            manager.busy.store(false, Ordering::Release);
-            return current_update_state(&app);
-        }
+        return current_update_state(&app);
     }
 
     perform_update_check(&app).await;
@@ -214,6 +306,53 @@ fn can_restart(state: &DesktopUpdateState, has_staged_update: bool) -> bool {
     state.enabled && state.status == DesktopUpdateStatus::Ready && has_staged_update
 }
 
+/// Re-resolves the feed at install time so a restart that raced a release
+/// installs the newest published artifact, not the one that happened to be
+/// staged when the button appeared. Falls back to the staged artifact when
+/// the feed is unreachable — it is still an upgrade — but refuses to install
+/// a release the feed has withdrawn.
+async fn resolve_latest_for_install(
+    app: &AppHandle,
+    staged: StagedUpdate,
+) -> Result<StagedUpdate, String> {
+    let updater = match app.updater() {
+        Ok(updater) => updater,
+        Err(error) => {
+            eprintln!("openwave-desktop: could not initialize updater: {error}");
+            return Ok(staged);
+        }
+    };
+
+    let update = match updater.check().await {
+        Ok(update) => update,
+        Err(error) => {
+            eprintln!("openwave-desktop: install-time update check failed: {error}");
+            return Ok(staged);
+        }
+    };
+
+    match reconcile_staged(
+        update.as_ref().map(|u| u.version.as_str()),
+        &staged.update.version,
+    ) {
+        StagedAction::Keep => Ok(staged),
+        StagedAction::Replace => {
+            let update = update.expect("replace implies an advertised update");
+            match update.download(|_chunk, _total| {}, || {}).await {
+                Ok(bytes) => Ok(StagedUpdate { update, bytes }),
+                Err(error) => {
+                    eprintln!("openwave-desktop: install-time update download failed: {error}");
+                    Ok(staged)
+                }
+            }
+        }
+        StagedAction::Discard => {
+            set_update_state(app, DesktopUpdateState::idle());
+            Err(UPDATE_WITHDRAWN_ERROR.to_owned())
+        }
+    }
+}
+
 #[tauri::command]
 pub(crate) async fn restart_for_update(app: AppHandle) -> Result<(), String> {
     let staged = {
@@ -228,6 +367,26 @@ pub(crate) async fn restart_for_update(app: AppHandle) -> Result<(), String> {
             return Err("no update is ready to install".to_owned());
         }
         staged.take().expect("ready update must have staged bytes")
+    };
+
+    // Block the background loop from starting a new check while the install
+    // proceeds; on success the process restarts, and every error path below
+    // returns through `release_busy`.
+    let was_busy = app
+        .state::<UpdateManager>()
+        .busy
+        .swap(true, Ordering::AcqRel);
+
+    let staged = match resolve_latest_for_install(&app, staged).await {
+        Ok(staged) => staged,
+        Err(message) => {
+            if !was_busy {
+                app.state::<UpdateManager>()
+                    .busy
+                    .store(false, Ordering::Release);
+            }
+            return Err(message);
+        }
     };
 
     // Once the bundle is replaced, every new sidecar process would come from
@@ -287,5 +446,50 @@ mod tests {
         state.status = DesktopUpdateStatus::Ready;
         state.enabled = false;
         assert!(!can_restart(&state, true));
+    }
+
+    #[test]
+    fn a_newer_release_replaces_the_staged_artifact() {
+        // The double-release window: v0.4.1 was staged, v0.4.2 shipped before
+        // the user acted. The stale artifact must be replaced, never installed.
+        assert_eq!(
+            reconcile_staged(Some("0.4.2"), "0.4.1"),
+            StagedAction::Replace
+        );
+        assert_eq!(
+            reconcile_staged(Some("1.0.0"), "0.9.9"),
+            StagedAction::Replace
+        );
+    }
+
+    #[test]
+    fn the_staged_artifact_is_kept_when_still_newest() {
+        assert_eq!(reconcile_staged(Some("0.4.1"), "0.4.1"), StagedAction::Keep);
+        // A check that raced a release and resolved the *older* feed must not
+        // downgrade what is already staged.
+        assert_eq!(reconcile_staged(Some("0.4.0"), "0.4.1"), StagedAction::Keep);
+        assert_eq!(
+            reconcile_staged(Some("0.4.2-rc.1"), "0.4.2"),
+            StagedAction::Keep
+        );
+    }
+
+    #[test]
+    fn a_withdrawn_release_is_discarded_not_installed() {
+        assert_eq!(reconcile_staged(None, "0.4.1"), StagedAction::Discard);
+    }
+
+    #[test]
+    fn unparseable_versions_defer_to_the_feed() {
+        // The feed is authoritative when tags are not semver: any different
+        // advertised version replaces the staged one, an identical one stays.
+        assert_eq!(
+            reconcile_staged(Some("build-124"), "build-123"),
+            StagedAction::Replace
+        );
+        assert_eq!(
+            reconcile_staged(Some("build-123"), "build-123"),
+            StagedAction::Keep
+        );
     }
 }


### PR DESCRIPTION
## The stale-update race

The feed at `downloads.brightwave.io/openwave/latest.json` only ever advertises the latest release, but the updater treated a staged download as final:

- `run_update_check` short-circuited whenever the state was `Downloading`/`Ready`, so once vN was staged the app never looked at the feed again — the banner pinned the first version it saw and the user could be shown "update to vN" long after vN+1 shipped.
- `restart_for_update` installed whatever bytes were staged, with no re-resolution at click time, so a restart that raced a release installed the older artifact.

## What changed

- **Periodic checks re-resolve while staged.** The staged-update short-circuit is gone. When an update is already staged, the re-check runs silently (state stays `Ready`, the banner does not flap every five minutes) and reconciles against the fresh feed:
  - feed advertises something newer → download and replace the staged artifact, then re-emit `Ready` with the new version (the sidebar banner and settings panel read live event state, so they refresh on their own);
  - feed advertises the same version → keep the staged bytes, no re-download;
  - feed advertises nothing newer than the running app (release withdrawn) → drop the staged artifact and return to idle rather than install a pulled release.
- **The restart click re-resolves once more.** `restart_for_update` checks the feed again before installing: a newer release is downloaded and installed instead of the stale artifact; an unreachable feed falls back to the staged artifact (still an upgrade); a withdrawn release aborts the install.
- **No downgrades in the double-release window.** A check that started before a release landed and resolved the older feed can never replace a newer staged artifact: replacement requires the advertised version to compare strictly newer (semver; for unparseable tags the feed is authoritative and any different version replaces).
- The restart path takes the checker's busy flag so the background loop cannot start a competing download mid-install.

## Tests

`reconcile_staged` is the pure decision point both paths share; unit tests pin the double-release replace, the no-downgrade rule (including a pre-release racing a stable tag), the withdrawn-release discard, and the unparseable-tag fallback. The plumbing against the real signed feed (download, signature verification, install) is exercised only by a live release cycle and is unchanged apart from when it runs.

Adds `semver = "=1.0.28"` to the desktop crate, matching what the lockfile already resolves (lock diff is the dependency edge only).