### PR TITLE
feat(approvals): name the file a gated workspace write will touch

### DIFF
--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -75,6 +75,14 @@ pub enum ToolActionPreview {
     /// both what leaves the device and where the request goes — so the card
     /// shows it whole.
     WebExtract { url: String },
+    /// A file write inside the chat's private workspace. The path is the
+    /// resource under review — which file the call will create or replace —
+    /// and deliberately the only field: the content is not projected, so the
+    /// card names the target without carrying a document across the boundary.
+    WriteFile {
+        /// Workspace-relative destination path, never a host path.
+        path: String,
+    },
 }
 
 impl ToolActionPreview {
@@ -115,6 +123,13 @@ impl ToolActionPreview {
                     arguments.get("url")?.as_str()?.trim(),
                     MAX_ACTION_FIELD_CHARS,
                 )?,
+            }),
+            // A workspace write gated in Ask mode names the file it will touch.
+            // The content stays behind the boundary: the resource is the path,
+            // and the card's job is to say where the write lands, not to
+            // preview a document.
+            "write_file" => Some(Self::WriteFile {
+                path: clamp(arguments.get("path")?.as_str()?, MAX_ACTION_FIELD_CHARS)?,
             }),
             _ => None,
         }
@@ -168,6 +183,12 @@ impl ToolActionPreview {
                 .get("url")
                 .and_then(Value::as_str)
                 .is_some_and(|url| survives_clamp(url.trim())),
+            // Deliberately not exact: the preview names the path and omits the
+            // content, so it can never reproduce the call. A workspace write is
+            // one-shot anyway (its standing "yes" is the chat's Auto mode), and
+            // keeping it inexact means no narrow grant or judge candidacy can
+            // ever be built from a projection that lost the document.
+            "write_file" => false,
             // A tool with no variant projects nothing, so there is nothing a
             // narrower scope could name — and claiming otherwise would invite a
             // narrow grant with nothing to narrow to.
@@ -934,10 +955,7 @@ mod tests {
     #[test]
     fn only_tools_with_a_variant_project_anything() {
         for (tool, arguments) in [
-            (
-                "write_file",
-                serde_json::json!({ "path": "/Users/private" }),
-            ),
+            ("read_file", serde_json::json!({ "path": "notes.md" })),
             ("mcp__server__tool", serde_json::json!({ "any": "thing" })),
         ] {
             assert_eq!(ToolActionPreview::build(tool, &arguments), None);
@@ -959,6 +977,38 @@ mod tests {
                 None
             );
         }
+    }
+
+    /// A gated workspace write names the file it will touch, and nothing else.
+    ///
+    /// The card used to ask about "files in this chat's workspace" without
+    /// saying which one. The projection carries the path — the resource under
+    /// review — and deliberately not the content, so the action can never be
+    /// exactly describable: no narrow grant and no judge candidacy can be
+    /// built from a projection that lost the document.
+    #[test]
+    fn a_workspace_write_names_its_path_but_is_never_exact() {
+        let arguments = json!({ "path": "reports/q3.md", "content": "private document body" });
+        let preview = ToolActionPreview::build("write_file", &arguments);
+        assert_eq!(
+            preview,
+            Some(ToolActionPreview::WriteFile {
+                path: "reports/q3.md".into()
+            })
+        );
+        // Wire shape: the serialized preview carries the path and never the
+        // content, whatever the arguments held.
+        let json = serde_json::to_string(&preview.unwrap()).unwrap();
+        assert_eq!(json, r#"{"tool":"write_file","path":"reports/q3.md"}"#);
+        assert!(!ToolActionPreview::describes_exactly(
+            "write_file",
+            &arguments
+        ));
+        // Malformed arguments project nothing rather than an empty card.
+        assert_eq!(
+            ToolActionPreview::build("write_file", &json!({ "content": "x" })),
+            None
+        );
     }
 
     #[test]

--- a/crates/openwave-desktop/ui/src/ApprovalCard.tsx
+++ b/crates/openwave-desktop/ui/src/ApprovalCard.tsx
@@ -245,6 +245,9 @@ export function approvalAsk(
   if (preview?.tool === "exec") {
     return { title: "Run this command?", summaryLine: summary };
   }
+  if (preview?.tool === "write_file") {
+    return { title: "Write this file?", summaryLine: summary };
+  }
   return { title: summary, summaryLine: null };
 }
 
@@ -385,7 +388,9 @@ function spokenAction(preview: ToolActionPreview): string {
       ? [preview.command, ...preview.args].join(" ")
       : preview.tool === "web_extract"
         ? preview.url
-        : preview.query;
+        : preview.tool === "write_file"
+          ? preview.path
+          : preview.query;
   return spoken.length > SPOKEN_ACTION_CHARS
     ? `${spoken.slice(0, SPOKEN_ACTION_CHARS).trimEnd()}\u2026`
     : spoken;

--- a/crates/openwave-desktop/ui/src/ToolPreview.test.ts
+++ b/crates/openwave-desktop/ui/src/ToolPreview.test.ts
@@ -42,6 +42,19 @@ describe("toolPreviewPresentation", () => {
   });
 });
 
+describe("workspace write previews", () => {
+  it("names the file the write will land on", () => {
+    // The Ask-mode card used to ask about workspace files without saying
+    // which one; the path is the resource under review.
+    const write = toolPreviewPresentation({
+      tool: "write_file",
+      path: "reports/q3.md",
+    });
+    expect(write.headline).toBe("reports/q3.md");
+    expect(write.detail).toContain("this chat's workspace");
+  });
+});
+
 describe("search previews", () => {
   const unfiltered = {
     domains: [] as string[],

--- a/crates/openwave-desktop/ui/src/ToolPreview.tsx
+++ b/crates/openwave-desktop/ui/src/ToolPreview.tsx
@@ -40,6 +40,15 @@ export function toolPreviewPresentation(
       .join("\n");
     return { headline, detail };
   }
+  if (preview.tool === "write_file") {
+    // The path is the resource under review: the card says where the write
+    // lands, and the content deliberately never crosses the boundary.
+    const headline = preview.path;
+    return {
+      headline,
+      detail: `${headline}\n# written into this chat's workspace`,
+    };
+  }
   if (preview.tool === "web_extract") {
     // The URL is the whole action: what leaves the device and where the
     // request goes are the same string, so the card shows it unabridged.

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1367,14 +1367,18 @@ start_published_at: string | null,
 /**
  * Latest publication date the search will accept.
  */
-end_published_at: string | null, } | { "tool": "web_extract", url: string, };
+end_published_at: string | null, } | { "tool": "web_extract", url: string, } | { "tool": "write_file", 
+/**
+ * Workspace-relative destination path, never a host path.
+ */
+path: string, };
 
 /**
  * Closed immutable consent semantics stored with each approval request.
  *
  * Each presentable variant names the egress a human is consenting to, so the
  * renderer can describe the action without ever seeing the model-authored
- * summary or arguments. `Unsupported` is the fail-closed default: a Sensitive
+ * arguments. `Unsupported` is the fail-closed default: a Sensitive
  * action the server can only reject, never approve.
  */
 export type ToolApprovalKind = "search_may_share_query_and_excerpts" | "web_search_may_share_query" | "web_extract_may_fetch_url" | "exec_may_run_networked_command" | "external_mcp_may_call_server" | "workspace_may_modify_files" | "unsupported";

--- a/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
@@ -45,6 +45,11 @@ export function grantScopeLabel(
       if (scope.tool === "web_extract") {
         return scope.url;
       }
+      // Workspace writes are never standing-grantable, so no stored grant can
+      // carry this scope today; named anyway so the vocabulary stays total.
+      if (scope.tool === "write_file") {
+        return scope.path;
+      }
       return `“${scope.query}”`;
     }
     case "any_args_for":

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -682,15 +682,15 @@ mod tests {
                 output: ToolOutput::text("private result").with_data(serde_json::json!({
                     "stdout": "private stream",
                 })),
-                // `write_file` projects neither an action nor a result, so
-                // nothing about it may cross — not the output text, and not
-                // the structured payload beside it.
+                // `read_file` projects neither an action nor an opted-in
+                // result here, so nothing about it may cross — not the output
+                // text, and not the structured payload beside it.
                 action: ToolActionPreview::build(
-                    "write_file",
+                    "read_file",
                     &serde_json::json!({ "path": "private/path" }),
                 ),
                 result: ToolResultPreview::build(
-                    "write_file",
+                    "read_file",
                     &ToolOutput::text("private result")
                         .with_data(serde_json::json!({ "stdout": "private stream" })),
                 ),
@@ -709,15 +709,15 @@ mod tests {
             event: AgentEvent::ApprovalRequired {
                 auto_judging: false,
                 call_id: CallId::new(),
-                tool_name: "write_file".into(),
-                class: ApprovalClass::Workspace,
-                kind: ToolApprovalKind::Unsupported,
+                tool_name: "mcp__server__tool".into(),
+                class: ApprovalClass::Sensitive,
+                kind: ToolApprovalKind::ExternalMcpMayCallServer,
                 grant_scopes: Vec::new(),
                 // A tool with no variant projects nothing, so the card has no
                 // action to show; the desktop renders its own canned ask from
                 // the approval kind.
                 preview: ToolActionPreview::build(
-                    "write_file",
+                    "mcp__server__tool",
                     &serde_json::json!({ "path": "private/path" }),
                 ),
             },
@@ -725,6 +725,31 @@ mod tests {
         let json = serde_json::to_string(&projected).unwrap();
         assert!(!json.contains("preview"));
         assert!(!json.contains("private"));
+    }
+
+    /// A gated workspace write names the file it is about to touch. The path
+    /// crosses because it is the resource under review; the content never
+    /// does — it is not part of the projection at all.
+    #[test]
+    fn a_workspace_write_approval_carries_the_path_and_not_the_content() {
+        let projected = RendererSequencedEvent::from(&SequencedEvent {
+            seq: 11,
+            event: AgentEvent::ApprovalRequired {
+                auto_judging: false,
+                call_id: CallId::new(),
+                tool_name: "write_file".into(),
+                class: ApprovalClass::Workspace,
+                kind: ToolApprovalKind::WorkspaceMayModifyFiles,
+                grant_scopes: Vec::new(),
+                preview: ToolActionPreview::build(
+                    "write_file",
+                    &serde_json::json!({ "path": "reports/q3.md", "content": "private body" }),
+                ),
+            },
+        });
+        let json = serde_json::to_string(&projected).unwrap();
+        assert!(json.contains("reports/q3.md"), "{json}");
+        assert!(!json.contains("private body"), "{json}");
     }
 
     /// Consent to an action you cannot see is not consent, and for a web search


### PR DESCRIPTION
Slice 1 of the one-vocabulary track planned on #939 (does not close it).

A `write_file` call parked in Ask mode rendered a card that asked about "files in this chat's workspace" without saying which file — the one gated tool whose card named no target. `ToolActionPreview` gains a `WriteFile { path }` variant: the workspace-relative path is the resource under review, and the approval card, tool preview, and grant-scope label now render it.

Deliberate boundaries:

- The content never crosses. The preview carries only the path, and `describes_exactly` stays `false` for `write_file` — a projection that lost the document can never seed a narrow standing grant or judge candidacy.
- No enforcement change. `WorkspaceMayModifyFiles` remains neither standing-grantable nor auto-judgeable, so the grant ladder, analyzer floor, and Auto-mode judge are untouched; the card gains information, not new buttons.
- Recovery is automatic: previews are rebuilt from the stored tool name and canonical arguments, so parked cards from before this change pick up the path on replay.

Tests: one wire-shape contract in `preview.rs` (path crosses, content cannot, malformed args project nothing), one renderer-boundary contract in `event_projection.rs` (the approval event carries the path and not the body), and the UI presentation case in `ToolPreview.test.ts`. The two projection tests that used `write_file` as their example of "a tool that projects nothing" now use `read_file` and an external MCP name, which keeps their original closed-boundary assertions intact.

`full-ci`: the `ToolActionPreview` wire union changed (regenerated `ui/src/generated/wire.ts`).