### PR TITLE
test(sandbox): prove egress deny/allow through the proxy on the container e2e lane

### DIFF
--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -1758,3 +1758,164 @@ async fn docker_container_conforms_at_the_transport_boundary() {
         .await
         .expect("tearing the conformance container down succeeds");
 }
+
+/// Run one Python probe inside the sandbox container and return its first
+/// stdout line. The probe scripts are written to always exit 0 and print a
+/// marker, so a failure is a wrong marker (with the probe's own diagnostics in
+/// it), not an opaque non-zero exit.
+async fn exec_probe(container: &str, script: &str) -> String {
+    let output = tokio::process::Command::new("docker")
+        .args(["exec", container, "python3", "-c", script])
+        .output()
+        .await
+        .expect("docker exec runs");
+    assert!(
+        output.status.success(),
+        "probe exited non-zero: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_owned()
+}
+
+/// The egress boundary on a real container: only the topology can prove that
+/// the internal network actually has no route out, that the proxy's alias
+/// resolves from the sandbox, and that the proxy's verdicts are what a command
+/// inside the boundary observes. The loopback integration tests already prove
+/// the proxy's protocol; this proves the wiring around it:
+///
+/// 1. a direct connection to a public address — ignoring `HTTP(S)_PROXY` —
+///    fails: the internal network has no route anywhere;
+/// 2. a CONNECT to a policy-denied destination is refused with a 403;
+/// 3. a CONNECT to the policy's allowed host flows end to end (the proxy
+///    resolves the name host-side and splices a real upstream connection);
+/// 4. an external DNS lookup inside the sandbox fails — the embedded resolver
+///    answers only the internal network's own names, and the sandbox's
+///    upstream is the blackhole `sandbox_docker` configures.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires a Docker daemon, the agent image, and outbound network reach; run explicitly or in the Docker CI lane"]
+async fn docker_egress_boundary_denies_and_allows_through_the_proxy() {
+    use crate::sandbox_docker::{
+        sandbox_name, DockerConfig, DockerSandboxBackend, EGRESS_PROXY_ALIAS, EGRESS_PROXY_PORT,
+    };
+    use openwave_sandbox_protocol::SandboxNetworkPolicy;
+
+    let Some(image) = build_agent_image().await else {
+        return;
+    };
+
+    // The one host the policy allows, on 443 only. A stable public site the CI
+    // runner can reach; the allowed probe needs real outbound connectivity.
+    const ALLOWED_HOST: &str = "example.com";
+    const DENIED_HOST: &str = "denied.example";
+
+    let backend = DockerSandboxBackend::new(DockerConfig {
+        image: image.to_owned(),
+        ..DockerConfig::default()
+    });
+    let tag = SandboxTag::new();
+    let handle = backend
+        .provision(ProvisionRequest {
+            run_id: RunId::new(),
+            tag,
+            lifetime_cap_secs: None,
+            network_policy: SandboxNetworkPolicy {
+                allow_all_public: false,
+                allowed_hosts: Vec::new(),
+                https_only_hosts: vec![ALLOWED_HOST.to_owned()],
+            },
+        })
+        .await
+        .expect("provisioning the egress-probe sandbox succeeds");
+    let sandbox = sandbox_name(tag);
+
+    // A CONNECT probe: dial the proxy by its alias (retrying while the proxy
+    // container finishes starting), issue one CONNECT, print the status line.
+    let connect_probe = |host: &str| {
+        format!(
+            r#"
+import socket, time
+last = None
+for _ in range(30):
+    try:
+        s = socket.create_connection(("{EGRESS_PROXY_ALIAS}", {EGRESS_PROXY_PORT}), timeout=5)
+        break
+    except OSError as error:
+        last = error
+        time.sleep(1)
+else:
+    print(f"PROXY UNREACHABLE {{last}}")
+    raise SystemExit(0)
+s.settimeout(30)
+s.sendall(b"CONNECT {host}:443 HTTP/1.1\r\nHost: {host}:443\r\n\r\n")
+print(s.recv(64).decode("latin1").splitlines()[0])
+"#
+        )
+    };
+
+    let checks = tokio::time::timeout(Duration::from_secs(180), async {
+        // 1. The topology itself: a command that ignores the proxy environment
+        // has no route to a public address, well-known or otherwise.
+        let direct = exec_probe(
+            &sandbox,
+            r#"
+import socket
+try:
+    socket.create_connection(("1.1.1.1", 443), timeout=10)
+    print("REACHED")
+except OSError as error:
+    print(f"BLOCKED {error}")
+"#,
+        )
+        .await;
+        assert!(
+            direct.starts_with("BLOCKED"),
+            "direct egress must have no route: {direct}"
+        );
+
+        // 2. The proxy refuses a policy-denied destination before touching it.
+        let denied = exec_probe(&sandbox, &connect_probe(DENIED_HOST)).await;
+        assert!(
+            denied.starts_with("HTTP/1.1 403"),
+            "a denied CONNECT must be refused with 403: {denied}"
+        );
+
+        // 3. The allowed destination flows end to end through the proxy.
+        let allowed = exec_probe(&sandbox, &connect_probe(ALLOWED_HOST)).await;
+        assert!(
+            allowed.starts_with("HTTP/1.1 200"),
+            "an allowed CONNECT must be established: {allowed}"
+        );
+
+        // 4. The name-lookup side channel: an external lookup inside the
+        // sandbox fails, because the proxy resolves destinations host-side and
+        // the sandbox's own upstream is a blackhole.
+        let lookup = exec_probe(
+            &sandbox,
+            &format!(
+                r#"
+import socket
+try:
+    socket.getaddrinfo("{ALLOWED_HOST}", 443)
+    print("RESOLVED")
+except OSError as error:
+    print(f"UNRESOLVED {{error}}")
+"#
+            ),
+        )
+        .await;
+        assert!(
+            lookup.starts_with("UNRESOLVED"),
+            "an external DNS lookup inside the sandbox must fail: {lookup}"
+        );
+    })
+    .await;
+
+    // A failed assertion above leaks the trio in a local run, exactly as in
+    // the conformance test: the CI runner is ephemeral, and local reruns
+    // reclaim it through the tag sweep. The timeout case still tears down.
+    backend
+        .destroy(&handle)
+        .await
+        .expect("tearing the egress-probe sandbox down succeeds");
+    checks.expect("egress probes completed within their bound");
+}

--- a/crates/openwave-server/src/sandbox_docker.rs
+++ b/crates/openwave-server/src/sandbox_docker.rs
@@ -75,9 +75,18 @@
 //! [`address`](SandboxBackend::address) resolves the proxy's port. The per-run
 //! transport secret still gates attach.
 //!
-//! Residual: engines differ on whether the embedded DNS resolver forwards
-//! external lookups from internal networks; where an older engine does, name
-//! lookups (not payload connections) can leak. Not closed here.
+//! The sandbox never needs external DNS: CONNECT carries the destination
+//! *name* and the proxy resolves it outside the sandbox. So the sandbox
+//! container's DNS upstream is pointed at a blackhole ([`SANDBOX_DNS_SINK`])
+//! — the embedded resolver still answers the internal network's own names
+//! (the proxy alias) authoritatively, but an external lookup has nowhere to
+//! go. On engines new enough to not forward external lookups from internal
+//! networks the flag is redundant; on older engines that do forward, it turns
+//! the name-lookup side channel into a query addressed to an unroutable
+//! documentation prefix. Residual: on those older engines the query packet
+//! still *leaves* the host toward that prefix before being dropped unanswered,
+//! so an observer on the local segment could see looked-up names; payload
+//! connections stay blocked either way.
 //!
 //! # The image is not verified
 //!
@@ -134,10 +143,19 @@ const NETWORK_TAG_LIST_FORMAT: &str = "{{.Name}}\t{{.Label \"openwave.run-tag\"}
 pub const EGRESS_PROXY_ALIAS: &str = "openwave-egress";
 /// The in-proxy CONNECT listener port. Kept in sync with the agent binary's
 /// `egress-proxy` default; never published to the host.
-const EGRESS_PROXY_PORT: u16 = 3128;
+pub(crate) const EGRESS_PROXY_PORT: u16 = 3128;
 /// Environment variable carrying the compiled egress policy (JSON) into the
 /// proxy container. Kept in sync with the agent's constant of the same name.
 const EGRESS_POLICY_ENV: &str = "OPENWAVE_EGRESS_POLICY";
+/// The sandbox container's DNS upstream: an RFC 5737 documentation address
+/// (TEST-NET-1), guaranteed never assigned, so a forwarded lookup goes
+/// nowhere and gets no answer. Docker's embedded resolver keeps answering the
+/// internal network's own names ([`EGRESS_PROXY_ALIAS`] included)
+/// authoritatively regardless of the upstream; only external lookups — which
+/// the sandbox never legitimately needs, since the proxy resolves CONNECT
+/// destinations host-side — are affected. See the module docs' egress section
+/// for the residual this leaves on older engines.
+const SANDBOX_DNS_SINK: &str = "192.0.2.1";
 /// Environment variable overriding the proxy's transport-relay listener.
 const RELAY_LISTEN_ENV: &str = "OPENWAVE_RELAY_LISTEN";
 /// Environment variable naming the relay's upstream — the sandbox container's
@@ -658,8 +676,9 @@ fn proxy_name(tag: SandboxTag) -> String {
 }
 
 /// The per-run sandbox container's name: the DNS name the proxy's transport
-/// relay dials on the internal network.
-fn sandbox_name(tag: SandboxTag) -> String {
+/// relay dials on the internal network. Crate-visible so the Docker-gated
+/// e2e egress probe can `docker exec` into the sandbox by name.
+pub(crate) fn sandbox_name(tag: SandboxTag) -> String {
     format!("openwave-sbx-{tag}")
 }
 
@@ -831,6 +850,12 @@ fn run_args(
         // it could not reach the host anyway; the proxy relays the transport.
         "--network".to_owned(),
         network_name(tag),
+        // External DNS points at a blackhole: the proxy resolves CONNECT
+        // destinations host-side, so the sandbox needs only the internal
+        // network's own names, which the embedded resolver answers without
+        // consulting this upstream.
+        "--dns".to_owned(),
+        SANDBOX_DNS_SINK.to_owned(),
         "--label".to_owned(),
         format!("{RUN_TAG_LABEL}={tag}"),
         "--label".to_owned(),
@@ -1124,6 +1149,11 @@ mod tests {
         let network_at = args.iter().position(|arg| arg == "--network").unwrap();
         assert_eq!(args[network_at + 1], network_name(tag));
         assert!(!args.iter().any(|arg| arg == "--publish"));
+        // External DNS is blackholed: the embedded resolver still answers the
+        // internal network's names, and the proxy resolves CONNECT
+        // destinations, so nothing legitimate needs an external lookup.
+        let dns_at = args.iter().position(|arg| arg == "--dns").unwrap();
+        assert_eq!(args[dns_at + 1], SANDBOX_DNS_SINK);
         // Compliant tools are pointed at the proxy by every spelling.
         for var in ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"] {
             assert!(args.contains(&format!(
@@ -1189,6 +1219,9 @@ mod tests {
         // It is tagged for the sweep and deterministically named for recovery.
         assert!(args.contains(&format!("{RUN_TAG_LABEL}={tag}")));
         assert!(args.contains(&proxy_name(tag)));
+        // The proxy resolves CONNECT destinations for the sandbox, so it must
+        // keep real DNS — the blackhole belongs to the sandbox only.
+        assert!(!args.iter().any(|arg| arg == "--dns"));
 
         // A test image without the agent binary can stand in a port-holder.
         let stand_in = DockerConfig {


### PR DESCRIPTION
Closes #1346. Follow-up to #1347: the loopback tests prove the proxy's protocol; only a real container boundary can prove the topology around it. This adds that probe to the post-merge `sandbox-resident container e2e` lane, and closes most of the DNS residual #1347 disclosed.

## The e2e probe

A new Docker-gated test (`docker_egress_boundary_denies_and_allows_through_the_proxy`, picked up by the lane's existing `sandbox_container_run::tests::docker` filter and image-build serialization) provisions a sandbox under a policy that allows exactly one host (`example.com`, 443 only) and runs Python probes inside the sandbox container via `docker exec`:

1. a direct connection to a public address — ignoring `HTTP(S)_PROXY` — fails: the internal network has no route out;
2. a CONNECT to a policy-denied destination is refused with the proxy's 403;
3. a CONNECT to the allowed host is established end to end (the proxy resolves the name host-side and splices a real upstream connection — this leg needs the runner's outbound reach);
4. an external DNS lookup inside the sandbox fails, while the proxy alias keeps resolving (the CONNECT probes depend on it).

Probe scripts always exit 0 and print a marker line, so a failure shows the probe's own diagnostics rather than an opaque exit code.

## The DNS residual: mitigated, with a narrower remainder

The sandbox never legitimately needs external DNS — CONNECT carries the destination name and the proxy resolves it outside the sandbox. So the sandbox container now runs with `--dns 192.0.2.1` (RFC 5737 TEST-NET-1, never assigned): Docker's embedded resolver still answers the internal network's own names authoritatively, but an external lookup has nowhere to go. On engines that already refuse to forward external lookups from internal networks the flag is redundant; on older engines that do forward, it turns the name-lookup side channel into a query addressed to an unroutable documentation prefix. The remaining residual — on those older engines the query packet still leaves the host toward that prefix before being dropped, visible to an observer on the local segment — is documented in `sandbox_docker`'s module docs. No change to #1187's hardening: `--cap-drop ALL` stays, no `NET_ADMIN`.

The proxy container keeps real DNS (it resolves destinations for the sandbox); a unit assertion pins that the blackhole is on the sandbox argv only, and the existing argv test pins `--dns` so a silently dropped flag fails visibly.

## Verification

No reachable Docker daemon on this machine, so the new e2e test could not run locally. Verified: `cargo check -p openwave-server --locked --all-targets`, clippy clean, the `sandbox_docker` unit tests (including the new argv pins), and the generated probe scripts compile and behave as expected outside a sandbox (`python3 -m py_compile`; the direct-connect probe prints REACHED on an unconfined host). What only the post-merge lane proves: the internal network actually blocking direct egress, the 403/200 verdicts as observed from inside the boundary, and the failing external lookup on a real engine.