### PR TITLE
feat(server): fail-closed detached-admission gate on a durable provisioning decision

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -310,6 +310,10 @@ pub mod sandbox_provision {
         pub tag: String,
         /// `intended` | `committed` | `teardown` | `done`.
         pub state: String,
+        /// `attached_only` | `detached` — the run's durable admission
+        /// decision, recorded before the create call. Fail closed: anything
+        /// unrecognized reads as `attached_only`.
+        pub admission: String,
         /// The backend's sandbox reference, `NULL` until committed.
         pub handle: Option<String>,
         /// A well-formed result that arrived after the run was already

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -106,6 +106,7 @@ impl MigratorTrait for Migrator {
             Box::new(RetainCancelledTurnOutput),
             Box::new(AddSandboxToolCallRetry),
             Box::new(AddConnectedApps),
+            Box::new(AddSandboxProvisionAdmission),
         ]
     }
 }
@@ -9294,6 +9295,7 @@ enum SandboxProvision {
     RunId,
     Tag,
     State,
+    Admission,
     Handle,
     LateResultEvidence,
     WindowExpiresAt,
@@ -10851,6 +10853,55 @@ impl MigrationTrait for AddConnectedApps {
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
             .drop_table(Table::drop().table(ConnectedApp::Table).to_owned())
+            .await
+    }
+}
+
+/// Adds the durable admission decision to the sandbox provisioning record
+/// (issue #824): whether the run may keep working while its host is absent.
+///
+/// Fail closed by construction: the column defaults to `attached_only`, so
+/// every record written before this migration — and every future record whose
+/// caller does not decide otherwise — reads as attached-only. The value
+/// domain is enforced at the read boundary (anything unrecognized reads as
+/// `attached_only`) rather than by a CHECK, because SQLite cannot add a table
+/// constraint in place and a fail-open rebuild here would buy nothing.
+/// Purely additive, with a symmetric `down` and identical shape on SQLite and
+/// PostgreSQL.
+struct AddSandboxProvisionAdmission;
+
+impl MigrationName for AddSandboxProvisionAdmission {
+    fn name(&self) -> &str {
+        "m20260803_000044_add_sandbox_provision_admission"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddSandboxProvisionAdmission {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(SandboxProvision::Table)
+                    .add_column(
+                        ColumnDef::new(SandboxProvision::Admission)
+                            .string_len(16)
+                            .not_null()
+                            .default("attached_only"),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(SandboxProvision::Table)
+                    .drop_column(SandboxProvision::Admission)
+                    .to_owned(),
+            )
             .await
     }
 }

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -840,8 +840,9 @@ impl Store for DbStore {
         run_id: uuid::Uuid,
         tag: &str,
         window_expires_at: chrono::DateTime<Utc>,
+        admission: crate::storage::SandboxAdmissionMode,
     ) -> Result<crate::storage::BeginSandboxProvisionOutcome> {
-        ops::sandbox_provision::begin(self, run_id, tag, window_expires_at).await
+        ops::sandbox_provision::begin(self, run_id, tag, window_expires_at, admission).await
     }
 
     async fn commit_sandbox_provision_handle(

--- a/crates/openwave-core/src/db/ops/sandbox_provision.rs
+++ b/crates/openwave-core/src/db/ops/sandbox_provision.rs
@@ -17,7 +17,9 @@ use sea_orm::sea_query::Expr;
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, Set, TransactionTrait, TryInsertResult};
 
 use crate::error::Result;
-use crate::storage::{BeginSandboxProvisionOutcome, SandboxProvision, SandboxProvisionState};
+use crate::storage::{
+    BeginSandboxProvisionOutcome, SandboxAdmissionMode, SandboxProvision, SandboxProvisionState,
+};
 
 use super::super::entities::sandbox_provision;
 use super::super::{entities, store_err, DbStore};
@@ -26,6 +28,25 @@ const STATE_INTENDED: &str = "intended";
 const STATE_COMMITTED: &str = "committed";
 const STATE_TEARDOWN: &str = "teardown";
 const STATE_DONE: &str = "done";
+
+const ADMISSION_ATTACHED_ONLY: &str = "attached_only";
+const ADMISSION_DETACHED: &str = "detached";
+
+fn admission_to_str(admission: SandboxAdmissionMode) -> &'static str {
+    match admission {
+        SandboxAdmissionMode::AttachedOnly => ADMISSION_ATTACHED_ONLY,
+        SandboxAdmissionMode::Detached => ADMISSION_DETACHED,
+    }
+}
+
+fn admission_from_str(admission: &str) -> SandboxAdmissionMode {
+    match admission {
+        ADMISSION_DETACHED => SandboxAdmissionMode::Detached,
+        // Fail closed: a record written before the column existed, or any
+        // unrecognized value, is an attached-only admission.
+        _ => SandboxAdmissionMode::AttachedOnly,
+    }
+}
 
 fn state_from_str(state: &str) -> SandboxProvisionState {
     match state {
@@ -43,6 +64,7 @@ fn from_model(model: sandbox_provision::Model) -> SandboxProvision {
         run_id: model.run_id,
         tag: model.tag,
         state: state_from_str(&model.state),
+        admission: admission_from_str(&model.admission),
         handle: model.handle,
         late_result_evidence: model.late_result_evidence,
         window_expires_at: model.window_expires_at,
@@ -54,6 +76,7 @@ pub(in crate::db) async fn begin(
     run_id: uuid::Uuid,
     tag: &str,
     window_expires_at: chrono::DateTime<chrono::Utc>,
+    admission: SandboxAdmissionMode,
 ) -> Result<BeginSandboxProvisionOutcome> {
     let transaction = store.conn.begin().await.map_err(store_err)?;
     let now = Utc::now();
@@ -65,6 +88,7 @@ pub(in crate::db) async fn begin(
         run_id: Set(run_id),
         tag: Set(tag.to_owned()),
         state: Set(STATE_INTENDED.to_owned()),
+        admission: Set(admission_to_str(admission).to_owned()),
         handle: Set(None),
         late_result_evidence: Set(None),
         window_expires_at: Set(window_expires_at),

--- a/crates/openwave-core/src/db/tests/connected_app.rs
+++ b/crates/openwave-core/src/db/tests/connected_app.rs
@@ -75,7 +75,16 @@ async fn absorption_migrates_servers_rekeys_manifests_and_drops_grants() {
     let database = dir.path().join("upgrade.db");
     let url = format!("sqlite://{}?mode=rwc", database.display());
     let conn = Database::connect(&url).await.unwrap();
-    let before_absorption = u32::try_from(migration::Migrator::migrations().len() - 1).unwrap();
+    // Stop right before the absorption migration by name, not by position:
+    // migrations registered after it must not push the cut out from under
+    // this test's legacy seed data.
+    let before_absorption = u32::try_from(
+        migration::Migrator::migrations()
+            .iter()
+            .position(|migration| migration.name() == "m20260803_000043_add_connected_apps")
+            .expect("the absorption migration is registered"),
+    )
+    .unwrap();
     migration::Migrator::up(&conn, Some(before_absorption))
         .await
         .unwrap();

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -215,8 +215,9 @@ pub use storage::{
     ParkTurnForClientCallOutcome, PendingChatPrompt, RecordTurnFailureOutcome,
     RequestAgentRunCancellationOutcome, RequestToolApprovalOutcome, RequestTurnCancellationOutcome,
     ResolveSandboxToolCallOutcome, ResolveToolCallOutcome, ResumeTurnForAgentRunWaitSetOutcome,
-    RetrySandboxToolCallOutcome, SandboxProvision, SandboxProvisionState, SecretProvider, Store,
-    SubmitAgentRunResultOutcome, TurnLeaseFence, MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
+    RetrySandboxToolCallOutcome, SandboxAdmissionMode, SandboxProvision, SandboxProvisionState,
+    SecretProvider, Store, SubmitAgentRunResultOutcome, TurnLeaseFence,
+    MAX_PENDING_ROOT_ATTACHMENT_CHANGES,
 };
 pub use tool::{
     input_schema_for, strict_json_schema, ApprovalClass, OptionalProperties, Tool, ToolCtx,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1131,6 +1131,28 @@ pub enum SandboxProvisionState {
     Done,
 }
 
+/// Whether one sandbox-resident run may keep working while its host is
+/// absent — a durable decision made at admission, never revisited by a
+/// disconnect.
+///
+/// Fail closed: the default everywhere is [`AttachedOnly`], a record written
+/// before this field existed reads as [`AttachedOnly`], and `Detached` can
+/// only be recorded by an admission gate whose preconditions all held. The
+/// wire-facing `AdmissionMode` a sandbox receives in its run init is derived
+/// from this record, never from code.
+///
+/// [`AttachedOnly`]: SandboxAdmissionMode::AttachedOnly
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SandboxAdmissionMode {
+    /// The default: the run must not work while unattached; it checkpoints
+    /// and waits for its host.
+    #[default]
+    AttachedOnly,
+    /// The run was admitted to keep working through host absence, within its
+    /// bounds.
+    Detached,
+}
+
 /// One container run's durable provisioning record.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SandboxProvision {
@@ -1142,6 +1164,10 @@ pub struct SandboxProvision {
     pub tag: String,
     /// Where the record stands.
     pub state: SandboxProvisionState,
+    /// The run's durable admission decision. Reconciliation and reattachment
+    /// derive the sandbox's admission mode from this field, so a crash can
+    /// never upgrade a run to detached.
+    pub admission: SandboxAdmissionMode,
     /// The backend's own reference for the sandbox, present once committed.
     pub handle: Option<String>,
     /// A well-formed result that arrived after the run was already terminal:
@@ -1856,11 +1882,16 @@ pub trait Store: Send + Sync {
     /// backend is asked to create anything. Returns the existing record instead
     /// when one is already present, so a restarted host reconciles rather than
     /// provisioning a second sandbox for the same single-attempt run.
+    ///
+    /// `admission` is the run's durable admission decision, recorded on the
+    /// intent so it survives crashes and disconnects; every later derivation
+    /// of the sandbox's admission mode reads the record, never the caller.
     async fn begin_sandbox_provision(
         &self,
         _run_id: uuid::Uuid,
         _tag: &str,
         _window_expires_at: chrono::DateTime<chrono::Utc>,
+        _admission: SandboxAdmissionMode,
     ) -> Result<BeginSandboxProvisionOutcome> {
         agent_run_storage_unavailable()
     }

--- a/crates/openwave-sandbox-protocol/src/provisioning.rs
+++ b/crates/openwave-sandbox-protocol/src/provisioning.rs
@@ -274,6 +274,20 @@ pub trait SandboxBackend: Send + Sync {
         let _ = live_tags;
         Ok(Vec::new())
     }
+
+    /// Whether this backend enforces a sandbox lifetime cap from **outside**
+    /// the sandbox, set at provisioning through
+    /// [`ProvisionRequest::lifetime_cap_secs`] to no more than the run's
+    /// absolute deadline.
+    ///
+    /// Detached admission requires this capability: without it, nothing bounds
+    /// an orphaned sandbox whose host never returns. The default is `false`
+    /// (fail closed) — a backend that does not declare the enforcement cannot
+    /// host a detached run. A local container runtime never overrides this: no
+    /// mechanism outside the container bounds its lifetime.
+    fn enforces_external_lifetime_cap(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/crates/openwave-server/src/sandbox_admission.rs
+++ b/crates/openwave-server/src/sandbox_admission.rs
@@ -1,4 +1,5 @@
-//! Startup-time routing for newly admitted background agent runs.
+//! Startup-time routing for newly admitted background agent runs, and the
+//! fail-closed detached-admission gate (issue #824).
 //!
 //! The container runtime is a detected capability, but checking it belongs at
 //! process assembly rather than at every model-authored spawn. The resolved
@@ -7,7 +8,7 @@
 
 use std::sync::Arc;
 
-use openwave_core::{AgentRunExecutionLocation, Config};
+use openwave_core::{AgentRunExecutionLocation, Config, SandboxAdmissionMode};
 
 use crate::sandbox_docker::{DockerConfig, DockerSandboxBackend};
 
@@ -59,6 +60,120 @@ pub(crate) fn docker_config(config: &Config) -> DockerConfig {
     docker
 }
 
+/// The facts the detached-admission decision consumes, gathered by the caller
+/// at run admission.
+///
+/// Every field defaults to the unmet state, so a caller that cannot establish
+/// a precondition does not have to remember to deny it — constructing the
+/// struct with `..Default::default()` is already the closed position. The
+/// preconditions are the ones docs/sandbox-providers.md fixes for detached
+/// admission; each maps one-to-one onto a [`DetachedAdmissionDenial`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DetachedPreconditions {
+    /// A short-lived, scoped, revocable model token can be minted for this
+    /// run (a gateway session or a provider that issues them). A long-lived
+    /// provider API key never satisfies this.
+    pub(crate) scoped_model_token_available: bool,
+    /// The backend enforces a sandbox lifetime cap from outside the sandbox,
+    /// set at provisioning to no more than the run's absolute deadline.
+    pub(crate) external_lifetime_cap: bool,
+    /// The agent image is verified within the topology's trust root.
+    pub(crate) image_verified: bool,
+    /// The run's tool surface can reach a host-authority operation (work that
+    /// needs consent mid-run). Such a run is refused detached admission at
+    /// the start, not parked indefinitely in the middle.
+    pub(crate) host_authority_tool_surface: bool,
+    /// The run carries third-party credentials (connected-app or similar).
+    /// The scoped model token itself is deliberately exempt.
+    pub(crate) carries_third_party_credentials: bool,
+    /// Egress policy is enforced from outside the sandbox by a mechanism the
+    /// host knows out-of-band. Consulted only for credential-bearing runs.
+    pub(crate) external_egress_enforcement: bool,
+}
+
+impl Default for DetachedPreconditions {
+    /// The closed position: nothing established, host-authority reach and
+    /// credential carriage assumed present. Evaluating the default denies.
+    fn default() -> Self {
+        Self {
+            scoped_model_token_available: false,
+            external_lifetime_cap: false,
+            image_verified: false,
+            host_authority_tool_surface: true,
+            carries_third_party_credentials: true,
+            external_egress_enforcement: false,
+        }
+    }
+}
+
+/// One unmet detached-admission precondition, named for surfacing (the
+/// settings slice renders these per provider) and for the audit trail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DetachedAdmissionDenial {
+    /// No issuer of short-lived, scoped, revocable model tokens.
+    NoScopedModelToken,
+    /// Nothing outside the sandbox bounds its lifetime.
+    NoExternalLifetimeCap,
+    /// The agent image is not verified within the topology's trust root.
+    ImageNotVerified,
+    /// The tool surface reaches a host-authority operation.
+    HostAuthorityToolSurface,
+    /// The run carries third-party credentials without externally enforced
+    /// egress policy.
+    CredentialsWithoutExternalEgress,
+}
+
+/// The detached-admission decision: admitted only when every precondition
+/// holds, otherwise denied with every unmet precondition named.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DetachedAdmission {
+    /// Every precondition held; the run may be recorded as detached-admitted.
+    Admitted,
+    /// At least one precondition failed; the run falls back to attached-only.
+    Denied(Vec<DetachedAdmissionDenial>),
+}
+
+impl DetachedAdmission {
+    /// The durable admission mode this decision records.
+    pub(crate) fn mode(&self) -> SandboxAdmissionMode {
+        match self {
+            Self::Admitted => SandboxAdmissionMode::Detached,
+            Self::Denied(_) => SandboxAdmissionMode::AttachedOnly,
+        }
+    }
+}
+
+/// Evaluate the doc's detached-admission preconditions, failing closed.
+///
+/// The contract: `Admitted` requires **all** preconditions to hold, and a
+/// denial names every unmet one rather than the first, so the settings
+/// surface can say exactly what a provider is missing.
+pub(crate) fn evaluate_detached_admission(
+    preconditions: DetachedPreconditions,
+) -> DetachedAdmission {
+    let mut denials = Vec::new();
+    if !preconditions.scoped_model_token_available {
+        denials.push(DetachedAdmissionDenial::NoScopedModelToken);
+    }
+    if !preconditions.external_lifetime_cap {
+        denials.push(DetachedAdmissionDenial::NoExternalLifetimeCap);
+    }
+    if !preconditions.image_verified {
+        denials.push(DetachedAdmissionDenial::ImageNotVerified);
+    }
+    if preconditions.host_authority_tool_surface {
+        denials.push(DetachedAdmissionDenial::HostAuthorityToolSurface);
+    }
+    if preconditions.carries_third_party_credentials && !preconditions.external_egress_enforcement {
+        denials.push(DetachedAdmissionDenial::CredentialsWithoutExternalEgress);
+    }
+    if denials.is_empty() {
+        DetachedAdmission::Admitted
+    } else {
+        DetachedAdmission::Denied(denials)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,6 +192,92 @@ mod tests {
             execution_location(true, false),
             AgentRunExecutionLocation::InProcess
         );
+    }
+
+    /// The fail-closed contract of the detached gate: admission requires
+    /// every precondition, any single unmet one denies with its name, and the
+    /// default (nothing established) denies.
+    #[test]
+    fn detached_admission_fails_closed_on_any_unmet_precondition() {
+        let all_met = DetachedPreconditions {
+            scoped_model_token_available: true,
+            external_lifetime_cap: true,
+            image_verified: true,
+            host_authority_tool_surface: false,
+            carries_third_party_credentials: false,
+            external_egress_enforcement: false,
+        };
+        assert_eq!(
+            evaluate_detached_admission(all_met),
+            DetachedAdmission::Admitted
+        );
+        assert_eq!(
+            evaluate_detached_admission(all_met).mode(),
+            SandboxAdmissionMode::Detached
+        );
+
+        let single_failures = [
+            (
+                DetachedPreconditions {
+                    scoped_model_token_available: false,
+                    ..all_met
+                },
+                DetachedAdmissionDenial::NoScopedModelToken,
+            ),
+            (
+                DetachedPreconditions {
+                    external_lifetime_cap: false,
+                    ..all_met
+                },
+                DetachedAdmissionDenial::NoExternalLifetimeCap,
+            ),
+            (
+                DetachedPreconditions {
+                    image_verified: false,
+                    ..all_met
+                },
+                DetachedAdmissionDenial::ImageNotVerified,
+            ),
+            (
+                DetachedPreconditions {
+                    host_authority_tool_surface: true,
+                    ..all_met
+                },
+                DetachedAdmissionDenial::HostAuthorityToolSurface,
+            ),
+            (
+                DetachedPreconditions {
+                    carries_third_party_credentials: true,
+                    ..all_met
+                },
+                DetachedAdmissionDenial::CredentialsWithoutExternalEgress,
+            ),
+        ];
+        for (preconditions, expected) in single_failures {
+            let decision = evaluate_detached_admission(preconditions);
+            assert_eq!(decision, DetachedAdmission::Denied(vec![expected]));
+            assert_eq!(decision.mode(), SandboxAdmissionMode::AttachedOnly);
+        }
+
+        // Credential-bearing work with externally enforced egress is not a
+        // denial on its own.
+        assert_eq!(
+            evaluate_detached_admission(DetachedPreconditions {
+                carries_third_party_credentials: true,
+                external_egress_enforcement: true,
+                ..all_met
+            }),
+            DetachedAdmission::Admitted
+        );
+
+        // The default is the closed position, and the denial names every
+        // unmet precondition, not the first.
+        let DetachedAdmission::Denied(denials) =
+            evaluate_detached_admission(DetachedPreconditions::default())
+        else {
+            panic!("the default preconditions must deny");
+        };
+        assert_eq!(denials.len(), 5);
     }
 
     #[test]

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -43,7 +43,7 @@ use futures::StreamExt;
 use openwave_core::{
     AgentConfig, AgentError, AgentRun, AgentRunExecutionLocation, AgentRunId, AgentRunStatus,
     BeginSandboxProvisionOutcome, ChatMessage, ChatRequest, ProviderEvent, Result, Role,
-    SandboxProvisionState, Store, SubmitAgentRunResultOutcome,
+    SandboxAdmissionMode, SandboxProvisionState, Store, SubmitAgentRunResultOutcome,
 };
 use openwave_sandbox_protocol::{
     events::EventPayload,
@@ -62,6 +62,7 @@ use uuid::Uuid;
 
 use crate::durable_oplog::DurableOperationStore;
 use crate::resolver::ProviderResolver;
+use crate::sandbox_admission::{evaluate_detached_admission, DetachedPreconditions};
 
 /// The provider attribution stamped on reverse operations from a local
 /// container. Untrusted attribution rendered on consent prompts, never a claim
@@ -374,16 +375,42 @@ impl SandboxContainerRunner {
             }
         };
 
+        // The detached-admission gate (issue #824), evaluated before any
+        // durable state is written and recorded on the provisioning intent:
+        // every precondition from docs/sandbox-providers.md must hold or the
+        // run is admitted attached-only. Today every input is the unmet state
+        // for a local container — no run-scoped token issuer (slice 2), no
+        // external lifetime cap (the backend's fail-closed declaration), no
+        // image verification within a trust root (#1188) — so the decision is
+        // structurally a denial; what this establishes is that the mode is a
+        // recorded decision, never a constant.
+        let admission_decision = evaluate_detached_admission(DetachedPreconditions {
+            // No issuer of run-scoped, short-lived model tokens exists yet;
+            // the host is the model proxy and holds the only credentials.
+            scoped_model_token_available: false,
+            external_lifetime_cap: self.backend.enforces_external_lifetime_cap(),
+            image_verified: false,
+            // The container capability host grants ModelInference only; no
+            // reverse capability reaches a host-authority operation.
+            host_authority_tool_surface: false,
+            // No third-party credential is ever delivered into a container
+            // run today.
+            carries_third_party_credentials: false,
+            external_egress_enforcement: false,
+        });
+        let mut admission = admission_decision.mode();
+
         // Durable provisioning intent — carrying the host-minted correlation
-        // tag and its window — committed before the create call, so a crash on
-        // either side of the create converges through the window lapse and the
-        // tag sweep instead of leaking a container or double-provisioning.
+        // tag, its window, and the admission decision — committed before the
+        // create call, so a crash on either side of the create converges
+        // through the window lapse and the tag sweep instead of leaking a
+        // container or double-provisioning.
         let run_uuid = *run_id.as_uuid();
         let tag = SandboxTag::new();
         let window_expires_at = chrono::Utc::now() + chrono_duration(self.config.provision_window)?;
         let handle = match self
             .store
-            .begin_sandbox_provision(run_uuid, &tag.to_string(), window_expires_at)
+            .begin_sandbox_provision(run_uuid, &tag.to_string(), window_expires_at, admission)
             .await?
         {
             BeginSandboxProvisionOutcome::Started => {
@@ -432,6 +459,11 @@ impl SandboxContainerRunner {
                 }
             }
             BeginSandboxProvisionOutcome::Existing(record) => {
+                // The durable record's admission decision wins over anything
+                // this process would decide: no admission decision is
+                // revisited by a disconnect or a crash, and recovery can
+                // never upgrade a run to detached.
+                admission = record.admission;
                 match (record.state, record.handle) {
                     // A prior attempt of this same claim committed a handle and
                     // then lost its own commit: reconcile the container that
@@ -466,7 +498,15 @@ impl SandboxContainerRunner {
         // From here on a container exists, so every terminal path must drive its
         // teardown obligation.
         let outcome = self
-            .attach_and_drive(&run, lease_token, protocol_run_id, config, task, &handle)
+            .attach_and_drive(
+                &run,
+                lease_token,
+                protocol_run_id,
+                config,
+                task,
+                &handle,
+                admission,
+            )
             .await;
         self.teardown(run_uuid, &handle).await;
         outcome
@@ -513,6 +553,7 @@ impl SandboxContainerRunner {
         Ok((config, network_policy))
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn attach_and_drive(
         &self,
         run: &AgentRun,
@@ -521,6 +562,7 @@ impl SandboxContainerRunner {
         config: AgentConfig,
         task: String,
         handle: &SandboxHandle,
+        admission: SandboxAdmissionMode,
     ) -> Result<SandboxContainerRunOutcome> {
         let run_id = run.id;
         // One capability host per run, shared across every connection: it holds
@@ -562,7 +604,15 @@ impl SandboxContainerRunner {
                 .deadline_at
                 .map(|deadline| deadline.timestamp().max(0).unsigned_abs())
                 .unwrap_or_default(),
-            admission: AdmissionMode::AttachedOnly,
+            // Derived from the durable admission decision — never a constant:
+            // absent an admitting record, this is attached-only. A detached
+            // init additionally requires the scoped token a later slice
+            // delivers, and the gate refuses detached admission until one can
+            // be minted.
+            admission: match admission {
+                SandboxAdmissionMode::AttachedOnly => AdmissionMode::AttachedOnly,
+                SandboxAdmissionMode::Detached => AdmissionMode::Detached,
+            },
             policy: PolicySnapshot {
                 egress_allowlist: Vec::new(),
                 granted_capabilities: vec![Capability::ModelInference],

--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -460,6 +460,7 @@ async fn container_worker_service_cadence_completes_pending_teardown() {
                 run_id,
                 &SandboxTag::new().to_string(),
                 chrono::Utc::now() + chrono::Duration::seconds(60),
+                openwave_core::SandboxAdmissionMode::AttachedOnly,
             )
             .await
             .unwrap();
@@ -544,9 +545,74 @@ async fn drives_a_container_run_end_to_end_over_loopback() {
         // The container was provisioned once and torn down.
         assert_eq!(backend.provisions.load(Ordering::SeqCst), 1);
         assert_eq!(backend.destroys.load(Ordering::SeqCst), 1);
+
+        // The fail-closed detached gate: no precondition holds on a local
+        // container, so the durable admission decision the driver recorded is
+        // attached-only (issue #824).
+        let provision = store
+            .get_sandbox_provision(*run_id.as_uuid())
+            .await
+            .unwrap()
+            .expect("the run has a provisioning record");
+        assert_eq!(
+            provision.admission,
+            openwave_core::SandboxAdmissionMode::AttachedOnly,
+            "a local container run must be admitted attached-only"
+        );
     })
     .await
     .expect("test completed within its time bound");
+}
+
+/// The admission decision is a durable fact on the provisioning record: what
+/// was recorded is what reads back, and recovery derives the run's admission
+/// from the record rather than re-deciding — so a crash can never upgrade a
+/// run to detached, and a detached admission survives the host that made it.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_admission_decision_is_durable_on_the_provisioning_record() {
+    let (_dir, store, _chat) = store().await;
+    let run_uuid = Uuid::new_v4();
+    assert!(matches!(
+        store
+            .begin_sandbox_provision(
+                run_uuid,
+                &SandboxTag::new().to_string(),
+                chrono::Utc::now() + chrono::Duration::seconds(600),
+                openwave_core::SandboxAdmissionMode::Detached,
+            )
+            .await
+            .unwrap(),
+        openwave_core::BeginSandboxProvisionOutcome::Started
+    ));
+    let record = store
+        .get_sandbox_provision(run_uuid)
+        .await
+        .unwrap()
+        .expect("the record exists");
+    assert_eq!(
+        record.admission,
+        openwave_core::SandboxAdmissionMode::Detached
+    );
+
+    // A second begin for the same run — the crash-recovery path — observes
+    // the recorded decision, not its own argument.
+    let openwave_core::BeginSandboxProvisionOutcome::Existing(existing) = store
+        .begin_sandbox_provision(
+            run_uuid,
+            &SandboxTag::new().to_string(),
+            chrono::Utc::now() + chrono::Duration::seconds(600),
+            openwave_core::SandboxAdmissionMode::AttachedOnly,
+        )
+        .await
+        .unwrap()
+    else {
+        panic!("the second begin must observe the existing record");
+    };
+    assert_eq!(
+        existing.admission,
+        openwave_core::SandboxAdmissionMode::Detached,
+        "recovery reads the durable decision, never re-decides"
+    );
 }
 
 /// An agent loop that ends WITHOUT submitting a result — it exhausts its step
@@ -936,7 +1002,12 @@ async fn a_lapsed_intent_refuses_a_late_handle_commit() {
     let expired = chrono::Utc::now() - chrono::Duration::seconds(1);
     assert!(matches!(
         store
-            .begin_sandbox_provision(run_uuid, &tag.to_string(), expired)
+            .begin_sandbox_provision(
+                run_uuid,
+                &tag.to_string(),
+                expired,
+                openwave_core::SandboxAdmissionMode::AttachedOnly
+            )
             .await
             .unwrap(),
         openwave_core::BeginSandboxProvisionOutcome::Started
@@ -972,11 +1043,21 @@ async fn the_sweep_reclaims_a_lapsed_intent_and_preserves_live_ones() {
     let expired = chrono::Utc::now() - chrono::Duration::seconds(1);
     let open = chrono::Utc::now() + chrono::Duration::seconds(600);
     store
-        .begin_sandbox_provision(Uuid::new_v4(), &dead_tag.to_string(), expired)
+        .begin_sandbox_provision(
+            Uuid::new_v4(),
+            &dead_tag.to_string(),
+            expired,
+            openwave_core::SandboxAdmissionMode::AttachedOnly,
+        )
         .await
         .unwrap();
     store
-        .begin_sandbox_provision(Uuid::new_v4(), &live_tag.to_string(), open)
+        .begin_sandbox_provision(
+            Uuid::new_v4(),
+            &live_tag.to_string(),
+            open,
+            openwave_core::SandboxAdmissionMode::AttachedOnly,
+        )
         .await
         .unwrap();
 
@@ -1064,6 +1145,7 @@ async fn a_committed_handle_is_reconciled_not_reprovisioned() {
                 run_uuid,
                 &tag.to_string(),
                 chrono::Utc::now() + chrono::Duration::seconds(600),
+                openwave_core::SandboxAdmissionMode::AttachedOnly,
             )
             .await
             .unwrap();
@@ -1121,6 +1203,7 @@ async fn a_dead_drivers_container_run_is_recovered_to_completion() {
                 run_uuid,
                 &tag.to_string(),
                 chrono::Utc::now() + chrono::Duration::seconds(600),
+                openwave_core::SandboxAdmissionMode::AttachedOnly,
             )
             .await
             .unwrap();
@@ -1177,6 +1260,7 @@ async fn a_terminal_container_failure_enqueues_its_teardown() {
             run_uuid,
             &tag.to_string(),
             chrono::Utc::now() + chrono::Duration::seconds(600),
+            openwave_core::SandboxAdmissionMode::AttachedOnly,
         )
         .await
         .unwrap();
@@ -1272,6 +1356,7 @@ async fn a_late_result_is_retained_as_evidence_not_committed() {
             run_uuid,
             &SandboxTag::new().to_string(),
             chrono::Utc::now() + chrono::Duration::seconds(600),
+            openwave_core::SandboxAdmissionMode::AttachedOnly,
         )
         .await
         .unwrap();
@@ -1386,6 +1471,7 @@ async fn cancelling_an_unattached_container_child_enqueues_its_teardown() {
             run_uuid,
             &SandboxTag::new().to_string(),
             chrono::Utc::now() + chrono::Duration::seconds(600),
+            openwave_core::SandboxAdmissionMode::AttachedOnly,
         )
         .await
         .unwrap();


### PR DESCRIPTION
Slice 1 of #824 (see the slice plan on the issue): the fail-closed detached-admission gate. Invariant established: no run initializes detached without a durable admission record, and absent a record — or absent any precondition — admission is attached-only.

Until now the admission mode a sandbox received in its run init was a hardcoded constant (`AdmissionMode::AttachedOnly` at the construction site). Detached admission is a durable decision per docs/sandbox-providers.md, so this slice turns the constant into one:

- **Durable record.** The `sandbox_provision` record gains an `admission` column (`attached_only` | `detached`), written with the intent before the backend's create call. The migration defaults the column to `attached_only`, and the read boundary maps any unrecognized value to `attached_only`, so pre-existing rows and future vocabulary drift both fail closed.
- **The gate.** `sandbox_admission.rs` gains a typed evaluator over the doc's preconditions — scoped model token, external lifetime cap, verified image, no host-authority tool surface, external egress enforcement for credential-bearing work. `Admitted` requires all of them; a denial names every unmet precondition (the settings slice will surface these per provider), and the default-constructed preconditions deny.
- **Backend declaration.** `SandboxBackend` declares whether it enforces a sandbox lifetime cap from outside the sandbox, defaulting to `false`. The local Docker backend does not override it, so a local container is structurally denied detached admission for the reason the doc states, rather than by a constant.
- **Recovery honors the record.** The container driver evaluates the gate before writing the intent, records the decision on it, and derives `RunInit.admission` from the durable record; when a restarted driver reconciles an existing record, the record's decision wins — a crash can never upgrade a run to detached.

Today every evaluation denies (no run-scoped token issuer, no external lifetime cap, no image verification within a trust root), so observable behavior is unchanged: every container run remains attached-only. What changed is that attached-only is now a recorded, fail-closed decision with a seam the later slices (scoped gateway tokens, managed backends with capability declarations, absence reconciliation) fill in.

Tests: the gate's fail-closed contract (any single unmet precondition denies with its name; the default denies), the durability contract (the recorded decision reads back and a second `begin` observes the record, not its argument), and the end-to-end loopback run now asserts its durable admission is attached-only.

References #824 (slice 1 — the issue stays open for the remaining slices).
