### PR TITLE
feat(desktop): install staged updates autonomously when the app is quiescent

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1220,6 +1220,10 @@ impl Store for DbStore {
         ops::turn::list_turn_runs(self, chat_id).await
     }
 
+    async fn count_active_work(&self) -> Result<crate::storage::ActiveWorkSnapshot> {
+        ops::active_work::count_active_work(self).await
+    }
+
     async fn accept_turn(
         &self,
         id: TurnId,

--- a/crates/openwave-core/src/db/ops/active_work.rs
+++ b/crates/openwave-core/src/db/ops/active_work.rs
@@ -1,0 +1,49 @@
+//! Global in-flight-work accounting for host quiescence decisions.
+//!
+//! The embedding host reads this before restarting itself (for example to
+//! install an update). The status sets mirror the claim-side definitions of
+//! liveness: every non-terminal turn status (the set `find_active_turn_on`
+//! guards chat admission with), and every non-terminal background-run status.
+
+use sea_orm::{ColumnTrait, EntityTrait, PaginatorTrait, QueryFilter};
+
+use crate::error::Result;
+use crate::model::{AgentRunStatus, AgentRunTier, TurnRunStatus};
+use crate::storage::ActiveWorkSnapshot;
+
+use super::super::{entities, store_err, DbStore};
+
+pub(in crate::db) async fn count_active_work(store: &DbStore) -> Result<ActiveWorkSnapshot> {
+    let active_turns = entities::turn_run::Entity::find()
+        .filter(entities::turn_run::Column::Status.is_in([
+            TurnRunStatus::Queued.as_str(),
+            TurnRunStatus::Running.as_str(),
+            TurnRunStatus::Cancelling.as_str(),
+            TurnRunStatus::WaitingForClient.as_str(),
+            TurnRunStatus::WaitingForAgentRun.as_str(),
+            TurnRunStatus::CancellingClient.as_str(),
+            TurnRunStatus::Resuming.as_str(),
+            TurnRunStatus::RetryWait.as_str(),
+        ]))
+        .count(&store.conn)
+        .await
+        .map_err(store_err)?;
+
+    let live_background_runs = entities::agent_run::Entity::find()
+        .filter(entities::agent_run::Column::Tier.eq(AgentRunTier::Background.as_str()))
+        .filter(entities::agent_run::Column::Status.is_in([
+            AgentRunStatus::Queued.as_str(),
+            AgentRunStatus::Running.as_str(),
+            AgentRunStatus::Cancelling.as_str(),
+            AgentRunStatus::Waiting.as_str(),
+            AgentRunStatus::RetryWait.as_str(),
+        ]))
+        .count(&store.conn)
+        .await
+        .map_err(store_err)?;
+
+    Ok(ActiveWorkSnapshot {
+        active_turns,
+        live_background_runs,
+    })
+}

--- a/crates/openwave-core/src/db/ops/mod.rs
+++ b/crates/openwave-core/src/db/ops/mod.rs
@@ -5,6 +5,7 @@ use crate::id::{CallId, ChatId, ProjectId, TurnId};
 
 use super::{entities, store_err};
 
+pub(in crate::db) mod active_work;
 pub(in crate::db) mod agent_run;
 pub(in crate::db) mod app;
 pub(in crate::db) mod approval;

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -2973,3 +2973,85 @@ async fn m0021_maps_existing_execution_rows_onto_tier_and_location() {
     assert_eq!(child.parent_id, Some(foreground_id));
     assert_eq!(child.input.as_deref(), Some("legacy delegated task"));
 }
+
+#[tokio::test]
+async fn active_work_counts_gate_host_quiescence() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+
+    // The always-present foreground coordinator run never blocks quiescence:
+    // a freshly created chat reports no active work.
+    assert!(store.count_active_work().await.unwrap().is_quiescent());
+
+    let turn_id = TurnId::new();
+    store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap();
+
+    let spawn_call_id = CallId::new();
+    let child_id = AgentRunId::sandbox_for_spawn_call(spawn_call_id);
+    let now = Utc::now();
+    crate::db::entities::agent_run::ActiveModel {
+        id: Set(child_id.0),
+        chat_id: Set(chat.id.0),
+        parent_id: Set(Some(AgentRunId::foreground_for_chat(chat.id).0)),
+        parent_depth: Set(Some(0)),
+        spawn_call_id: Set(Some(spawn_call_id.0)),
+        tier: Set(AgentRunTier::Background.as_str().into()),
+        execution_location: Set(crate::model::AgentRunExecutionLocation::InProcess
+            .as_str()
+            .into()),
+        depth: Set(1),
+        status: Set(AgentRunStatus::Queued.as_str().into()),
+        input: Set(Some("delegated background task".into())),
+        model: Set(None),
+        attempt_count: Set(0),
+        max_attempts: Set(AgentRun::DEFAULT_MAX_ATTEMPTS),
+        claim_count: Set(0),
+        available_at: Set(now),
+        deadline_at: Set(Some(now + AgentRun::DEFAULT_MAX_DURATION)),
+        lease_token: Set(None),
+        lease_expires_at: Set(None),
+        started_at: Set(None),
+        finished_at: Set(None),
+        last_error_code: Set(None),
+        last_error_detail: Set(None),
+        created_at: Set(now),
+        updated_at: Set(now),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+
+    let busy = store.count_active_work().await.unwrap();
+    assert_eq!(busy.active_turns, 1);
+    assert_eq!(busy.live_background_runs, 1);
+    assert!(!busy.is_quiescent());
+
+    // Settled rows drop out of both counts.
+    let mut settled_turn: crate::db::entities::turn_run::ActiveModel =
+        crate::db::entities::turn_run::Entity::find_by_id(turn_id.0)
+            .one(&store.conn)
+            .await
+            .unwrap()
+            .unwrap()
+            .into();
+    settled_turn.status = Set(TurnRunStatus::Cancelled.as_str().into());
+    settled_turn.finished_at = Set(Some(now));
+    settled_turn.update(&store.conn).await.unwrap();
+
+    let mut settled_run: crate::db::entities::agent_run::ActiveModel =
+        crate::db::entities::agent_run::Entity::find_by_id((child_id.0, chat.id.0, 1))
+            .one(&store.conn)
+            .await
+            .unwrap()
+            .unwrap()
+            .into();
+    settled_run.status = Set(AgentRunStatus::Cancelled.as_str().into());
+    settled_run.finished_at = Set(Some(now));
+    settled_run.update(&store.conn).await.unwrap();
+
+    assert!(store.count_active_work().await.unwrap().is_quiescent());
+}

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -179,6 +179,35 @@ pub enum DeleteProjectOutcome {
     NotEmpty,
 }
 
+/// Counts of in-flight work the embedding host process must stay alive to
+/// supervise.
+///
+/// A host that wants to restart itself (for example to install an update)
+/// reads this to decide whether the process is quiescent. The counts are
+/// deliberately strict: every non-terminal turn counts, including turns parked
+/// on the client, and every live background-tier run counts regardless of
+/// execution location. In-process background runs do not survive a host
+/// restart — their lease expires and the claim-scan reaper fails them — so a
+/// loose definition here would silently kill work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ActiveWorkSnapshot {
+    /// Turns in any non-terminal [`crate::TurnRunStatus`], across every chat.
+    pub active_turns: u64,
+    /// Background-tier agent runs in any non-terminal
+    /// [`crate::AgentRunStatus`], across every chat. Foreground coordinator
+    /// runs are excluded: their live work is already counted as turns.
+    pub live_background_runs: u64,
+}
+
+impl ActiveWorkSnapshot {
+    /// True when the host supervises no in-flight work and may restart
+    /// without interrupting or stranding anything.
+    #[must_use]
+    pub const fn is_quiescent(self) -> bool {
+        self.active_turns == 0 && self.live_background_runs == 0
+    }
+}
+
 /// Fixed lifecycle vocabulary exposed for a historical tool card.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
@@ -2322,6 +2351,14 @@ pub trait Store: Send + Sync {
 
     /// List a chat's durable turn history in deterministic creation-time order.
     async fn list_turn_runs(&self, _chat_id: ChatId) -> Result<Vec<TurnRun>> {
+        turn_storage_unavailable()
+    }
+
+    /// Count in-flight work across every chat: non-terminal turns plus live
+    /// background-tier agent runs. See [`ActiveWorkSnapshot`] for what counts
+    /// and why the definition is strict. Callers gating a host restart must
+    /// treat an error as "not quiescent".
+    async fn count_active_work(&self) -> Result<ActiveWorkSnapshot> {
         turn_storage_unavailable()
     }
 

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -229,9 +229,12 @@ pub fn run() {
             updater::check_for_update,
             updater::restart_for_update
         ])
+        .on_menu_event(|app, event| updater::handle_menu_event(app, event))
         .setup(move |app| {
             let handle = app.handle().clone();
             deep_link::install(&handle);
+            #[cfg(target_os = "macos")]
+            updater::install_update_menu(app)?;
             updater::spawn_update_loop(handle.clone());
             let data = data_dir(&handle)?;
             let home = home_dir(&handle)?;

--- a/crates/openwave-desktop/src/updater.rs
+++ b/crates/openwave-desktop/src/updater.rs
@@ -11,6 +11,14 @@
 //! artifact when the feed has moved on, and the restart path re-resolves once
 //! more at click time so the app never installs an older artifact than the
 //! newest published release it can reach.
+//!
+//! A staged update is also installed autonomously, but only when doing so
+//! cannot interrupt work: the app must be quiescent (the embedded server
+//! reports no non-terminal turns and no live background runs — in-process
+//! background runs do not survive a restart) and unfocused (no window has
+//! focus, so nobody is typing into it), sustained across consecutive samples.
+//! While the app stays busy or in use, the update waits for the explicit
+//! restart button exactly as before.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
@@ -23,12 +31,22 @@ use tauri_plugin_updater::{Update, UpdaterExt};
 use crate::host_access::HostAccess;
 
 const UPDATE_STATE_EVENT: &str = "desktop-update-state";
+/// Raised to the renderer when the native "Check for Updates…" menu item is
+/// chosen; the UI opens the Updates settings panel and runs an explicit check
+/// there so the outcome (up to date, or an update staged) is visible.
+const UPDATE_CHECK_REQUESTED_EVENT: &str = "desktop-update-check-requested";
+const MENU_CHECK_FOR_UPDATES_ID: &str = "check-for-updates";
 const UPDATE_CHECK_STARTUP_DELAY: Duration = Duration::from_secs(15);
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const UPDATE_CHECK_ERROR: &str = "Could not check for updates. Try again later.";
 const UPDATE_PREPARE_ERROR: &str = "Could not prepare the update. Try again later.";
 const UPDATE_WITHDRAWN_ERROR: &str =
     "The downloaded update is no longer published. OpenWave will keep checking.";
+const AUTO_RESTART_POLL_INTERVAL: Duration = Duration::from_secs(60);
+/// Consecutive clean samples required before an autonomous restart, so a
+/// restart never fires on the instant between a user's send and the turn row
+/// becoming visible, or right as focus is returning.
+const AUTO_RESTART_REQUIRED_STREAK: u32 = 2;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
@@ -279,17 +297,120 @@ async fn run_update_check(app: AppHandle) -> DesktopUpdateState {
     current_update_state(&app)
 }
 
+/// Install the app's native menu with a "Check for Updates…" item in the
+/// standard macOS placement: the application submenu, directly under "About".
+/// The rest of the default menu is kept intact. Other platforms keep the
+/// stock menu untouched.
+#[cfg(target_os = "macos")]
+pub(crate) fn install_update_menu(app: &tauri::App) -> tauri::Result<()> {
+    use tauri::menu::{Menu, MenuItem};
+
+    let handle = app.handle();
+    let menu = Menu::default(handle)?;
+    if let Some(app_submenu) = menu
+        .items()?
+        .first()
+        .and_then(|item| item.as_submenu().cloned())
+    {
+        let check = MenuItem::with_id(
+            handle,
+            MENU_CHECK_FOR_UPDATES_ID,
+            "Check for Updates…",
+            true,
+            None::<&str>,
+        )?;
+        app_submenu.insert(&check, 1)?;
+    }
+    app.set_menu(menu)?;
+    Ok(())
+}
+
+pub(crate) fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
+    if event.id().as_ref() == MENU_CHECK_FOR_UPDATES_ID {
+        if let Err(error) = app.emit(UPDATE_CHECK_REQUESTED_EVENT, ()) {
+            eprintln!("openwave-desktop: could not raise the update-check request: {error}");
+        }
+    }
+}
+
 pub(crate) fn spawn_update_loop(app: AppHandle) {
     if !updates_enabled() {
         return;
     }
-    tauri::async_runtime::spawn(async move {
-        tokio::time::sleep(UPDATE_CHECK_STARTUP_DELAY).await;
-        loop {
-            run_update_check(app.clone()).await;
-            tokio::time::sleep(UPDATE_CHECK_INTERVAL).await;
+    tauri::async_runtime::spawn({
+        let app = app.clone();
+        async move {
+            tokio::time::sleep(UPDATE_CHECK_STARTUP_DELAY).await;
+            loop {
+                run_update_check(app.clone()).await;
+                tokio::time::sleep(UPDATE_CHECK_INTERVAL).await;
+            }
         }
     });
+    tauri::async_runtime::spawn(async move {
+        let mut streak = 0u32;
+        loop {
+            tokio::time::sleep(AUTO_RESTART_POLL_INTERVAL).await;
+            let (next, fire) = advance_auto_restart_streak(streak, auto_restart_gate(&app).await);
+            streak = next;
+            if fire {
+                // On success this call never returns: the process relaunches.
+                if let Err(error) = take_staged_and_restart(app.clone()).await {
+                    eprintln!("openwave-desktop: autonomous update restart deferred: {error}");
+                    streak = 0;
+                }
+            }
+        }
+    });
+}
+
+/// One autonomous-restart sample: an installable update is staged, the
+/// embedded server supervises no in-flight work, and no window has focus.
+/// Every failure to know is treated as "in use".
+async fn auto_restart_gate(app: &AppHandle) -> bool {
+    {
+        let manager = app.state::<UpdateManager>();
+        let state = manager
+            .state
+            .lock()
+            .expect("update state mutex poisoned")
+            .clone();
+        let has_staged = manager
+            .staged
+            .lock()
+            .expect("staged update mutex poisoned")
+            .is_some();
+        if !can_restart(&state, has_staged) {
+            return false;
+        }
+    }
+
+    if app
+        .webview_windows()
+        .values()
+        .any(|window| window.is_focused().unwrap_or(true))
+    {
+        return false;
+    }
+
+    match app.state::<HostAccess>().store() {
+        Some(store) => store
+            .count_active_work()
+            .await
+            .map(|snapshot| snapshot.is_quiescent())
+            .unwrap_or(false),
+        None => false,
+    }
+}
+
+/// Advance the consecutive-clean-sample counter; fire only once the streak
+/// reaches [`AUTO_RESTART_REQUIRED_STREAK`]. Any dirty sample resets it.
+fn advance_auto_restart_streak(streak: u32, sample_ok: bool) -> (u32, bool) {
+    if !sample_ok {
+        return (0, false);
+    }
+    let next = streak.saturating_add(1);
+    (next, next >= AUTO_RESTART_REQUIRED_STREAK)
 }
 
 #[tauri::command]
@@ -355,6 +476,13 @@ async fn resolve_latest_for_install(
 
 #[tauri::command]
 pub(crate) async fn restart_for_update(app: AppHandle) -> Result<(), String> {
+    take_staged_and_restart(app).await
+}
+
+/// Take the staged update, converge it on the newest published release, and
+/// restart into it. Shared by the explicit restart button and the autonomous
+/// quiescent-restart path. On success this never returns.
+async fn take_staged_and_restart(app: AppHandle) -> Result<(), String> {
     let staged = {
         let manager = app.state::<UpdateManager>();
         let state = manager
@@ -446,6 +574,15 @@ mod tests {
         state.status = DesktopUpdateStatus::Ready;
         state.enabled = false;
         assert!(!can_restart(&state, true));
+    }
+
+    #[test]
+    fn autonomous_restart_requires_a_sustained_clean_window() {
+        assert_eq!(advance_auto_restart_streak(0, false), (0, false));
+        assert_eq!(advance_auto_restart_streak(0, true), (1, false));
+        assert_eq!(advance_auto_restart_streak(1, true), (2, true));
+        // Any dirty sample resets the streak entirely.
+        assert_eq!(advance_auto_restart_streak(1, false), (0, false));
     }
 
     #[test]

--- a/crates/openwave-desktop/ui/src/AppContext.tsx
+++ b/crates/openwave-desktop/ui/src/AppContext.tsx
@@ -39,6 +39,8 @@ export type AppContextValue = {
   commitRename: (chat: Chat) => void;
   cancelRename: () => void;
   updateState: DesktopUpdateState;
+  /** The most recent explicit update check confirmed the app is current. */
+  updateUpToDate: boolean;
   checkForUpdate: () => Promise<DesktopUpdateState>;
   restartForUpdate: () => Promise<void>;
 };

--- a/crates/openwave-desktop/ui/src/AppShell.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Outlet, useNavigate } from "@tanstack/react-router";
+import { isTauri } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
 import {
   ApiClient,
@@ -30,7 +32,7 @@ import { useChatPromptWatcher } from "./useChatPromptWatcher";
 import { useShellShortcuts, type ShellShortcutHandlers } from "./ShellShortcuts";
 import { ShortcutsDialog } from "./ShortcutsDialog";
 import { useUiStore } from "./UiStore";
-import { useDesktopUpdates } from "./updates";
+import { UPDATE_CHECK_REQUESTED_EVENT, useDesktopUpdates } from "./updates";
 
 /** Move focus to whichever composer the current route has on screen. */
 function focusComposer(): void {
@@ -98,6 +100,29 @@ export function AppShell() {
   const { confirm, dialog: confirmDialog } = useConfirm();
   const desktopUpdates = useDesktopUpdates();
   const zoom = useInterfaceZoom();
+
+  // The native "Check for Updates…" menu item lands the reader on the
+  // Updates settings panel and runs the same explicit check the panel's
+  // button does, so the result (up to date, or an update staged) is visible.
+  const checkForUpdateRef = useRef(desktopUpdates.check);
+  checkForUpdateRef.current = desktopUpdates.check;
+  useEffect(() => {
+    if (!isTauri()) return;
+    let cancelled = false;
+    let unlisten: UnlistenFn | undefined;
+    void listen(UPDATE_CHECK_REQUESTED_EVENT, () => {
+      const updatesPath: string = "/settings/updates";
+      void navigate({ to: updatesPath });
+      void checkForUpdateRef.current();
+    }).then((stop) => {
+      if (cancelled) stop();
+      else unlisten = stop;
+    });
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [navigate]);
 
   // Shell shortcuts are defined here because these actions outlive any one
   // route: toggling the frame, starting a chat, reaching the composer, and
@@ -362,6 +387,7 @@ export function AppShell() {
           commitRename: (target) => void commitChatRename(target),
           cancelRename: cancelChatRename,
           updateState: desktopUpdates.state,
+          updateUpToDate: desktopUpdates.upToDate,
           checkForUpdate: desktopUpdates.check,
           restartForUpdate: onRestartForUpdate,
         }}

--- a/crates/openwave-desktop/ui/src/settings/UpdatesPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/UpdatesPanel.tsx
@@ -29,14 +29,16 @@ export function updateStateSummary(state: DesktopUpdateState): string {
 
 export function UpdatesPanel({
   state,
+  upToDate = false,
   onCheck,
   onRestart,
 }: {
   state: DesktopUpdateState;
+  /** The most recent explicit check confirmed the app is current. */
+  upToDate?: boolean;
   onCheck: () => Promise<DesktopUpdateState>;
   onRestart: () => Promise<void>;
 }) {
-  const [manualResult, setManualResult] = useState<string | null>(null);
   const [version, setVersion] = useState<string | null>(null);
   const busy = state.status === "checking" || state.status === "downloading";
 
@@ -55,33 +57,20 @@ export function UpdatesPanel({
     };
   }, []);
 
-  useEffect(() => {
-    if (busy || state.status === "ready" || state.error) {
-      setManualResult(null);
-    }
-  }, [busy, state.error, state.status]);
-
-  async function check() {
-    setManualResult(null);
-    const next = await onCheck();
-    if (next.enabled && next.status === "idle" && !next.error) {
-      setManualResult("OpenWave is up to date.");
-    }
-  }
 
   return (
     <SettingsPanel
       title="Updates"
-      description="OpenWave checks shortly after launch and every five minutes. Updates are downloaded in the background, but OpenWave only restarts when you choose."
+      description="OpenWave checks shortly after launch and every five minutes, and downloads updates in the background. A downloaded update installs on its own once nothing is running and the app is in the background; while agent work is in flight or the app is in use, it waits for you to restart."
       busy={busy}
     >
       <SettingsSection title="Automatic updates">
         <p className="text-sm text-muted-foreground" aria-live="polite">
           {updateStateSummary(state)}
         </p>
-        {manualResult && (
+        {upToDate && (
           <p className="text-sm text-muted-foreground" role="status">
-            {manualResult}
+            OpenWave is up to date.
           </p>
         )}
         {state.error && <SettingsError>{state.error}</SettingsError>}
@@ -96,7 +85,7 @@ export function UpdatesPanel({
               type="button"
               variant="outline"
               disabled={!state.enabled || busy}
-              onClick={() => void check()}
+              onClick={() => void onCheck()}
             >
               <RefreshCw className={busy ? "animate-spin" : undefined} />
               {state.status === "checking"

--- a/crates/openwave-desktop/ui/src/settings/sections.tsx
+++ b/crates/openwave-desktop/ui/src/settings/sections.tsx
@@ -101,10 +101,12 @@ function AppearanceSection() {
 }
 
 function UpdatesSection() {
-  const { updateState, checkForUpdate, restartForUpdate } = useApp();
+  const { updateState, updateUpToDate, checkForUpdate, restartForUpdate } =
+    useApp();
   return (
     <UpdatesPanel
       state={updateState}
+      upToDate={updateUpToDate}
       onCheck={checkForUpdate}
       onRestart={restartForUpdate}
     />

--- a/crates/openwave-desktop/ui/src/updates.ts
+++ b/crates/openwave-desktop/ui/src/updates.ts
@@ -3,6 +3,8 @@ import { invoke, isTauri } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
 const UPDATE_STATE_EVENT = "desktop-update-state";
+/** Raised by the native "Check for Updates…" menu item. */
+export const UPDATE_CHECK_REQUESTED_EVENT = "desktop-update-check-requested";
 const UPDATE_CONTROL_ERROR = "Update controls are temporarily unavailable.";
 const UPDATE_RESTART_ERROR = "Could not restart OpenWave. Try again.";
 
@@ -17,6 +19,8 @@ export type DesktopUpdatesController = {
   state: DesktopUpdateState;
   check: () => Promise<DesktopUpdateState>;
   restart: () => Promise<void>;
+  /** The most recent explicit check confirmed the app is current. */
+  upToDate: boolean;
 };
 
 export const INITIAL_UPDATE_STATE: DesktopUpdateState = {
@@ -59,6 +63,14 @@ async function restartForDesktopUpdate(): Promise<void> {
 
 export function useDesktopUpdates(): DesktopUpdatesController {
   const [state, setState] = useState<DesktopUpdateState>(INITIAL_UPDATE_STATE);
+  const [upToDate, setUpToDate] = useState(false);
+
+  // "Up to date" is a claim about the last explicit check, not a standing
+  // state; anything that contradicts it (a staged update, an error, a new
+  // check in flight) clears it.
+  useEffect(() => {
+    if (state.status !== "idle" || state.error) setUpToDate(false);
+  }, [state.error, state.status]);
 
   useEffect(() => {
     if (!isTauri()) return;
@@ -89,6 +101,7 @@ export function useDesktopUpdates(): DesktopUpdatesController {
   }, []);
 
   const check = useCallback(async () => {
+    setUpToDate(false);
     setState((current) =>
       current.enabled
         ? { ...current, status: "checking", error: null }
@@ -96,6 +109,7 @@ export function useDesktopUpdates(): DesktopUpdatesController {
     );
     const next = await checkForDesktopUpdate();
     setState(next);
+    setUpToDate(next.enabled && next.status === "idle" && !next.error);
     return next;
   }, []);
 
@@ -110,5 +124,5 @@ export function useDesktopUpdates(): DesktopUpdatesController {
     }
   }, []);
 
-  return { state, check, restart };
+  return { state, check, restart, upToDate };
 }


### PR DESCRIPTION
Builds on #1355 (merged), which made the updater converge on the newest published release. This slice installs a staged update without waiting for a click — but only when doing so cannot interrupt anything — and adds the native "Check for Updates…" menu item.

## Autonomous restart, gated on quiescence

The desktop host embeds the server, so a restart kills every worker with it. What that costs, from the durable turn-state machinery:

- A foreground turn survives a restart — it is lease-based (60s lease) and the claim scan re-drives an expired `running` turn from its durable checkpoint — but at a price: a ≥60s stall and one attempt from the budget, or a `lease_expired` failure on the final attempt. Survivable is not free.
- An in-process background run does **not** survive: the claim-scan reaper terminalizes it as `Failed`/`lease_expired` after restart. There is no resume path.
- A container run is reclaimable (`SandboxContainerRunner::recover`), but the host process is the container's only model path, so a restart severs it mid-run until recovery.

Because the cheapest of those outcomes still burns user-visible time and the worst kills work, quiescence is defined strictly rather than loosely:

- **New `Store::count_active_work()`** (`crates/openwave-core`): non-terminal turns across every chat (the same eight-status set the chat-admission predicate uses) plus background-tier agent runs in any live status, any execution location. The always-present per-chat foreground coordinator row (`active`) is excluded — its live work is already counted as turns — and the new db test pins exactly that: coordinator ignored, queued turn and queued background run block, settled rows release.
- **The gate in the desktop shell** samples every 60 seconds while an update is staged: installable update ready, **no window focused** (nobody is typing into the app), and the server reports quiescence. Every failure to know — store not yet initialized, query error, focus query error — counts as "in use". Two consecutive clean samples are required before firing, so a restart cannot land in the instant between a user's send and the turn row becoming visible. Any dirty sample resets the streak (unit-tested).
- Firing reuses the exact restart path the button uses, including #1355's install-time re-resolution against the feed. While the app stays busy or in use, nothing changes: the update waits for the explicit restart.

## "Check for Updates…" in the native menu

macOS gets the standard placement: the application submenu, directly under About, with the rest of the default menu kept intact (other platforms keep the stock menu). The item raises an event; the UI opens the Updates settings panel and runs the same explicit check the panel button does, so the outcome is visible where update state already lives — up-to-date confirmation, or checking/downloading/ready. The "OpenWave is up to date." confirmation moved from panel-local state into the shared updates controller so a menu-initiated check surfaces it too.

## Not feasible, and why

- **True zero-downtime swap of the running process is out.** The server, its workers, and the container reverse channel live in the app process; replacing the bundle under a live process without a restart is not something Tauri's updater (or macOS app replacement generally) supports.
- **Install-on-quit is redundant here**: the explicit restart path already installs before relaunch, and quit-time installation would add a second install path to keep converged with the feed for no new capability.
- **Restarting through in-flight work and leaning on recovery** was considered and rejected as the default: recovery is real but costs a ≥60s lease-expiry stall per turn and hard-fails in-process background runs. The strict gate makes those costs impossible instead of merely rare.

## Verification

`cargo fmt` / `cargo check -p openwave-desktop --locked`, updater unit tests, the new `active_work_counts_gate_host_quiescence` db test, `tsc --noEmit`, and the touched vitest files. What only a live release cycle can prove: the end-to-end autonomous relaunch on a packaged, signed macOS build (updates are disabled in dev builds), and the menu item against the real feed.