### PR TITLE
feat(desktop): list recent chats in the conversation rail

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -408,8 +408,23 @@ describe("app shell", () => {
     for (const label of conversationOnly) {
       expect(screen.getByRole("button", { name: label })).toBeEnabled();
     }
-    // And the conversation's rail is not a place to browse the others from.
-    expect(screen.queryByLabelText("Recent chats")).not.toBeInTheDocument();
+  });
+
+  it("switches to another conversation from inside one", async () => {
+    const user = userEvent.setup();
+    const { router } = await mountApp({ at: "/c/chat-1" });
+    await screen.findByTestId("transcript");
+
+    // The rail lists the recents with the open chat marked, so leaving for
+    // another conversation is one click, not a trip through home.
+    const recentList = await screen.findByLabelText("Recent chats");
+    expect(
+      within(recentList).getByRole("button", { name: "Roadmap" }),
+    ).toHaveAttribute("aria-current", "page");
+
+    await user.click(within(recentList).getByRole("button", { name: "New chat" }));
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/c/chat-2"));
   });
 
   it("remembers the collapsed rail across a restart", async () => {

--- a/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
@@ -14,7 +14,8 @@ import { listDeliverables, type DeliverablesCatalog } from "@/deliverables";
 import type { PanelType } from "@/panel/panelTypes";
 import { usePanelNav } from "@/panel/usePanelNav";
 import { useRefreshSignals } from "@/RefreshSignals";
-import { SidebarButton } from "./primitives";
+import { RecentChatsSection } from "./RecentChatsSection";
+import { SidebarButton, SidebarSectionTitle } from "./primitives";
 import { SidebarFrame } from "./SidebarFrame";
 
 // Module scope, not an inline arrow: the count effect keys on the extractor's
@@ -23,13 +24,13 @@ const countDeliverables = (catalog: DeliverablesCatalog) =>
   catalog.deliverables.length;
 
 /**
- * The rail inside one conversation, holding only what acts on that
- * conversation.
+ * The rail inside one conversation: the controls that act on it, and the way
+ * to the others.
  *
- * The chat list is deliberately absent. Every control here needs a chat to
- * mean anything, and because this rail only exists inside one, none of them
- * has a disabled state to fall back to — which was the tell that the previous
- * shared rail was in the wrong place.
+ * The recent-chats list rides along even though nothing in it is scoped to
+ * this conversation, because switching conversations is the one navigation
+ * done most, and routing it through home made the common path the longest
+ * one. The open chat is marked so the list also says where the reader is.
  */
 export function ChatSidebar({ chat }: { chat: Chat }) {
   const navigate = useNavigate();
@@ -43,9 +44,8 @@ export function ChatSidebar({ chat }: { chat: Chat }) {
       ? new Set([layout.left.type, layout.right.type])
       : new Set<PanelType>(["chat"]);
 
-  // The list is not here to carry a per-row marker, but an agent parking a turn
-  // in another conversation still has to be noticeable from this one. The way
-  // back doubles as where that is reported.
+  // The recent list carries per-row markers, but a chat past its cut can still
+  // park a turn on a question. The way back doubles as where that is reported.
   const elsewhereNeedsAttention = [...chatIdsWithPendingPrompts].some(
     (id) => id !== chat.id,
   );
@@ -83,6 +83,11 @@ export function ChatSidebar({ chat }: { chat: Chat }) {
         active={openPanelTypes.has("folders")}
         onClick={() => openPanel({ type: "folders" })}
       />
+
+      <SidebarSectionTitle className="mt-4">Chats</SidebarSectionTitle>
+      <div className="flex flex-col gap-0.5">
+        <RecentChatsSection activeChatId={chat.id} />
+      </div>
     </SidebarFrame>
   );
 }

--- a/crates/openwave-desktop/ui/src/sidebar/HomeSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/HomeSidebar.tsx
@@ -1,17 +1,12 @@
-import { useState } from "react";
 import { useNavigate, useRouterState, useSearch } from "@tanstack/react-router";
-import { History, LayoutGrid, MessagesSquare } from "lucide-react";
+import { LayoutGrid, MessagesSquare } from "lucide-react";
 
 import { useApp } from "@/AppContext";
-import { useChatAttention } from "@/ChatAttention";
 import { useChatListStore } from "@/ChatListStore";
 import { NewChatButton } from "./NewChatButton";
-import { RecentChatRow } from "./RecentChatRow";
-import { SidebarButton, SidebarSectionTitle, useSidebarWidth } from "./primitives";
+import { RecentChatsSection } from "./RecentChatsSection";
+import { SidebarButton, SidebarSectionTitle } from "./primitives";
 import { SidebarFrame } from "./SidebarFrame";
-
-/** How many conversations the rail shows before deferring to the All chats table. */
-const RECENT_CHAT_LIMIT = 8;
 
 /**
  * The rail outside any conversation: starting one, and returning to one.
@@ -26,22 +21,12 @@ const RECENT_CHAT_LIMIT = 8;
  */
 export function HomeSidebar() {
   const navigate = useNavigate();
-  const { newChat, deleteChat, startRename, commitRename, cancelRename, refreshChats } = useApp();
-  const chats = useChatListStore((state) => state.chats);
+  const { newChat, refreshChats } = useApp();
   const chatsError = useChatListStore((state) => state.chatsError);
   const creatingChat = useChatListStore((state) => state.creatingChat);
   const deletingChatId = useChatListStore((state) => state.deletingChatId);
-  const renamingChatId = useChatListStore((state) => state.renamingChatId);
-  const renameChatDraft = useChatListStore((state) => state.renameChatDraft);
-  const savingTitle = useChatListStore((state) => state.savingTitle);
-  const setRenameDraft = useChatListStore((state) => state.setRenameDraft);
-  const chatIdsWithPendingPrompts = useChatAttention(
-    (state) => state.chatIdsWithPendingPrompts,
-  );
-  const isCompact = useSidebarWidth() === "compact";
   const pathname = useRouterState({ select: (state) => state.location.pathname });
   const search = useSearch({ strict: false }) as { left?: string; right?: string };
-  const [recentCollapsed, setRecentCollapsed] = useState(false);
 
   // The Apps library lives on home; the entry is "current" when either slot
   // holds it, list or detail alike.
@@ -49,9 +34,6 @@ export function HomeSidebar() {
     segment === "apps" || segment?.startsWith("apps.") === true;
   const appsOpen =
     pathname === "/" && (holdsApps(search.left) || holdsApps(search.right));
-
-  const recentChats = chats.slice(0, RECENT_CHAT_LIMIT);
-  const showRecent = !recentCollapsed && !isCompact && recentChats.length > 0;
 
   return (
     <SidebarFrame>
@@ -63,38 +45,7 @@ export function HomeSidebar() {
 
       <SidebarSectionTitle className="mt-4">Chats</SidebarSectionTitle>
       <div className="flex flex-col gap-0.5">
-        <SidebarButton
-          aria-expanded={!recentCollapsed}
-          onClick={() => setRecentCollapsed((collapsed) => !collapsed)}
-        >
-          <History />
-          <span>Recent</span>
-        </SidebarButton>
-        {showRecent && (
-          <div
-            className="ml-4 flex flex-col gap-0.5 border-l border-border pl-2"
-            aria-label="Recent chats"
-          >
-            {recentChats.map((chat) => (
-              <RecentChatRow
-                key={chat.id}
-                chat={chat}
-                active={false}
-                needsAttention={chatIdsWithPendingPrompts.has(chat.id)}
-                renaming={renamingChatId === chat.id}
-                renameDraft={renameChatDraft}
-                savingTitle={savingTitle}
-                mutating={deletingChatId !== null || creatingChat}
-                onRenameDraftChange={setRenameDraft}
-                onOpen={() => void navigate({ to: "/c/$chatId", params: { chatId: chat.id } })}
-                onStartRename={() => startRename(chat)}
-                onCommitRename={() => commitRename(chat)}
-                onCancelRename={cancelRename}
-                onDelete={() => deleteChat(chat)}
-              />
-            ))}
-          </div>
-        )}
+        <RecentChatsSection />
         <SidebarButton
           aria-current={pathname === "/chats" ? "page" : undefined}
           data-active={pathname === "/chats" || undefined}

--- a/crates/openwave-desktop/ui/src/sidebar/RecentChatsSection.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/RecentChatsSection.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { History } from "lucide-react";
+
+import { useApp } from "@/AppContext";
+import { useChatAttention } from "@/ChatAttention";
+import { useChatListStore } from "@/ChatListStore";
+import { RecentChatRow } from "./RecentChatRow";
+import { SidebarButton, useSidebarWidth } from "./primitives";
+
+/** How many conversations the rail shows before deferring to the All chats table. */
+const RECENT_CHAT_LIMIT = 8;
+
+/**
+ * The rail's short list of recent conversations, collapsible under its own
+ * header row.
+ *
+ * Shared between the home rail and the conversation rail: switching chats is
+ * the navigation done most, so the list is reachable from inside a
+ * conversation too, with the open one marked. Anything beyond the cut goes
+ * through the full All chats table.
+ */
+export function RecentChatsSection({ activeChatId }: { activeChatId?: string }) {
+  const navigate = useNavigate();
+  const { deleteChat, startRename, commitRename, cancelRename } = useApp();
+  const chats = useChatListStore((state) => state.chats);
+  const creatingChat = useChatListStore((state) => state.creatingChat);
+  const deletingChatId = useChatListStore((state) => state.deletingChatId);
+  const renamingChatId = useChatListStore((state) => state.renamingChatId);
+  const renameChatDraft = useChatListStore((state) => state.renameChatDraft);
+  const savingTitle = useChatListStore((state) => state.savingTitle);
+  const setRenameDraft = useChatListStore((state) => state.setRenameDraft);
+  const chatIdsWithPendingPrompts = useChatAttention(
+    (state) => state.chatIdsWithPendingPrompts,
+  );
+  const isCompact = useSidebarWidth() === "compact";
+  const [recentCollapsed, setRecentCollapsed] = useState(false);
+
+  const recentChats = chats.slice(0, RECENT_CHAT_LIMIT);
+  const showRecent = !recentCollapsed && !isCompact && recentChats.length > 0;
+
+  return (
+    <>
+      <SidebarButton
+        aria-expanded={!recentCollapsed}
+        onClick={() => setRecentCollapsed((collapsed) => !collapsed)}
+      >
+        <History />
+        <span>Recent</span>
+      </SidebarButton>
+      {showRecent && (
+        <div
+          className="ml-4 flex flex-col gap-0.5 border-l border-border pl-2"
+          aria-label="Recent chats"
+        >
+          {recentChats.map((chat) => (
+            <RecentChatRow
+              key={chat.id}
+              chat={chat}
+              active={chat.id === activeChatId}
+              needsAttention={chatIdsWithPendingPrompts.has(chat.id)}
+              renaming={renamingChatId === chat.id}
+              renameDraft={renameChatDraft}
+              savingTitle={savingTitle}
+              mutating={deletingChatId !== null || creatingChat}
+              onRenameDraftChange={setRenameDraft}
+              onOpen={() => void navigate({ to: "/c/$chatId", params: { chatId: chat.id } })}
+              onStartRename={() => startRename(chat)}
+              onCommitRename={() => commitRename(chat)}
+              onCancelRename={cancelRename}
+              onDelete={() => deleteChat(chat)}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
Scoping the rail to its route (#651) took the chat list out of a conversation, so changing conversations became: back to home, then pick — the longest path for the one navigation people do most.

Brightwave's answer to this is a recent-conversations list in the sidebar that stays visible inside a conversation, so this ports that shape instead of introducing a separate switching surface. The issue floated a ⌘K palette; the rail list is what the reference app actually does, and it also gives the open chat a visible place in the navigation.

- Extracts the recent-chats section (collapsible header, rows with rename/delete actions and per-row attention markers) from `HomeSidebar` into a shared `RecentChatsSection`.
- Mounts it in `ChatSidebar` under a Chats section, with the open conversation marked `aria-current="page"`; clicking another row navigates to it directly.
- The back link keeps its elsewhere-needs-attention marker, which still covers chats beyond the list's cut.
- Replaces the shell test assertion that pinned the old separation with one that switches conversations from inside one and checks the active marker.

Verified with `tsc --noEmit` and the AppShell DOM suite (17 passing).

Closes #655