### PR TITLE
refactor(core): retire the free-text approval summary

### DIFF
--- a/crates/openwave-core/fixtures/journal-events.json
+++ b/crates/openwave-core/fixtures/journal-events.json
@@ -42,8 +42,7 @@
         "status"
       ],
       "cwd": "."
-    },
-    "summary": "Run a command"
+    }
   },
   {
     "type": "approval_decided",

--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -3018,7 +3018,6 @@ impl Agent {
                 ApprovalClass::Sensitive => !matches!(mode, PermissionMode::Allow),
             };
         if gate_required && !bypass_by_explicit_grant {
-            let summary = format!("{} requires approval", call.name);
             let kind = durable_approval
                 .map(|approval| approval.kind)
                 .unwrap_or(kind_for_call);
@@ -3063,7 +3062,6 @@ impl Agent {
                     class: approval_class,
                     kind,
                     preview: preview.clone(),
-                    summary: summary.clone(),
                     auto_judge,
                 },
                 journal,
@@ -3089,7 +3087,6 @@ impl Agent {
                     Vec::new()
                 },
                 preview,
-                summary,
             };
             let authorized_by_standing_grant = matches!(
                 registration.publication,
@@ -10761,7 +10758,6 @@ mod tests {
                     class: ApprovalClass::Sensitive,
                     kind: ToolApprovalKind::for_tool_name(&call.name),
                     preview: None,
-                    summary: "search requires approval".into(),
                 },
                 Utc::now(),
             )
@@ -10963,7 +10959,6 @@ mod tests {
                     class: ApprovalClass::Sensitive,
                     kind: ToolApprovalKind::for_tool_name(&call.name),
                     preview: None,
-                    summary: "persisted write requires approval".into(),
                 },
                 Utc::now(),
             )

--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -67,7 +67,7 @@ pub enum ToolApprovalStatus {
 ///
 /// Each presentable variant names the egress a human is consenting to, so the
 /// renderer can describe the action without ever seeing the model-authored
-/// summary or arguments. `Unsupported` is the fail-closed default: a Sensitive
+/// arguments. `Unsupported` is the fail-closed default: a Sensitive
 /// action the server can only reject, never approve.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
@@ -835,8 +835,6 @@ pub struct ApprovalRequest {
     /// Closed projection of the arguments this call will run with, when the
     /// tool has one. Registration ignores it; it exists to be presented.
     pub preview: Option<ToolActionPreview>,
-    /// Short human-readable summary of what will happen.
-    pub summary: String,
     /// Whether the Auto-mode judge should own this call once parked. Stamped
     /// inside the park transaction so the renderer never flashes a bare human
     /// card before the judge's placeholder. Storage refuses the flag for any

--- a/crates/openwave-core/src/db/ops/approval.rs
+++ b/crates/openwave-core/src/db/ops/approval.rs
@@ -222,7 +222,6 @@ pub(in crate::db) async fn request_and_append_event(
             Vec::new()
         },
         preview: request.preview.clone(),
-        summary: request.summary.clone(),
     };
     let turn = entities::turn_run::Entity::find_by_id(request.turn_id.0)
         .one(&transaction)

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -8950,7 +8950,6 @@ async fn claimed_sensitive_call_with(
         class: ApprovalClass::Sensitive,
         kind: crate::ToolApprovalKind::for_tool_name(&call.name),
         preview: None,
-        summary: "search requires approval".into(),
     };
     (turn_id, lease_token, call, request)
 }

--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -98,8 +98,6 @@ pub enum AgentEvent {
         /// Absent on journal rows written before previews existed.
         #[serde(default)]
         preview: Option<crate::preview::ToolActionPreview>,
-        /// A short, human-readable summary of what will happen.
-        summary: String,
     },
     /// The human decided on a parked tool call.
     ApprovalDecided {
@@ -325,7 +323,6 @@ mod tests {
                     args: vec!["status".into()],
                     cwd: ".".into(),
                 }),
-                summary: "Run a command".into(),
             },
             AgentEvent::ApprovalDecided {
                 call_id: CallId(id(2)),
@@ -476,6 +473,34 @@ mod tests {
             loaded,
             journal_samples(),
             "a stored journal row no longer round-trips to the value it was written from"
+        );
+    }
+
+    /// `ApprovalRequired` rows written before the free-text `summary` field was
+    /// retired still carry it in `event.payload`; the extra key must stay
+    /// ignorable, or one such row makes a whole chat's history unreadable.
+    #[test]
+    fn approval_rows_with_the_retired_summary_field_still_load() {
+        let legacy = serde_json::json!({
+            "type": "approval_required",
+            "call_id": id(2),
+            "tool_name": "exec",
+            "class": "sensitive",
+            "kind": "exec_may_run_networked_command",
+            "summary": "exec requires approval",
+        });
+        let loaded: AgentEvent = serde_json::from_value(legacy).expect("legacy row deserializes");
+        assert_eq!(
+            loaded,
+            AgentEvent::ApprovalRequired {
+                auto_judging: false,
+                call_id: CallId(id(2)),
+                tool_name: "exec".into(),
+                class: ApprovalClass::Sensitive,
+                kind: crate::approval::ToolApprovalKind::ExecMayRunNetworkedCommand,
+                grant_scopes: Vec::new(),
+                preview: None,
+            }
         );
     }
 }

--- a/crates/openwave-mcp/src/server.rs
+++ b/crates/openwave-mcp/src/server.rs
@@ -88,7 +88,6 @@ impl ApprovalBridge {
             class,
             kind,
             preview: action,
-            summary: format!("{tool_name} requires approval"),
             // The MCP face has no chat permission mode; every gated call is a
             // human's to decide.
             auto_judge: false,

--- a/crates/openwave-server/src/approvals.rs
+++ b/crates/openwave-server/src/approvals.rs
@@ -458,7 +458,6 @@ mod tests {
                 class: ApprovalClass::Sensitive,
                 kind: openwave_core::ToolApprovalKind::for_tool_name(tool_name),
                 preview: None,
-                summary: "private summary".into(),
             },
         )
     }
@@ -478,7 +477,6 @@ mod tests {
             class: ApprovalClass::Sensitive,
             kind: openwave_core::ToolApprovalKind::for_tool_name(tool_name),
             preview: None,
-            summary: "private summary".into(),
         };
         assert!(matches!(
             store
@@ -1420,7 +1418,6 @@ mod tests {
             class: ApprovalClass::Sensitive,
             kind: openwave_core::ToolApprovalKind::for_tool_name("search"),
             preview: None,
-            summary: "search requires approval".into(),
         };
         assert!(matches!(
             store

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -393,7 +393,6 @@ mod tests {
                 kind: ToolApprovalKind::Unsupported,
                 grant_scopes: Vec::new(),
                 preview: None,
-                summary: "upload /Users/private/document.txt".into(),
             },
             AgentEvent::ToolCallCompleted {
                 call_id,
@@ -556,7 +555,6 @@ mod tests {
                         "cwd": "checkout",
                     }),
                 ),
-                summary: "private model-authored summary".into(),
             },
         });
         let json = serde_json::to_string(&projected).unwrap();
@@ -565,8 +563,6 @@ mod tests {
         assert!(json.contains(r#""command":"cargo""#));
         assert!(json.contains(r#""args":["test","--workspace"]"#));
         assert!(json.contains(r#""cwd":"checkout""#));
-        // The preview replaces the model-authored summary; it does not join it.
-        assert!(!json.contains("private model-authored summary"));
     }
 
     #[test]
@@ -588,7 +584,6 @@ mod tests {
                         "cwd": ".",
                     }),
                 ),
-                summary: "run an interpreter".into(),
             },
         });
 
@@ -719,12 +714,12 @@ mod tests {
                 kind: ToolApprovalKind::Unsupported,
                 grant_scopes: Vec::new(),
                 // A tool with no variant projects nothing, so the card has no
-                // action to show and the summary is all that crosses.
+                // action to show; the desktop renders its own canned ask from
+                // the approval kind.
                 preview: ToolActionPreview::build(
                     "write_file",
                     &serde_json::json!({ "path": "private/path" }),
                 ),
-                summary: "a write".into(),
             },
         });
         let json = serde_json::to_string(&projected).unwrap();
@@ -757,7 +752,6 @@ mod tests {
                     "web_search",
                     &serde_json::json!({ "query": "quarterly filings", "max_results": 5 }),
                 ),
-                summary: "a web search".into(),
             },
         });
         let json = serde_json::to_string(&projected).unwrap();
@@ -835,7 +829,6 @@ mod tests {
                 kind: ToolApprovalKind::SearchMayShareQueryAndExcerpts,
                 grant_scopes: vec![openwave_core::GrantScope::WholeTool],
                 preview: None,
-                summary: "private query and document title".into(),
             },
         });
         let json = serde_json::to_string(&projected).unwrap();
@@ -856,7 +849,6 @@ mod tests {
                 kind: ToolApprovalKind::WebSearchMayShareQuery,
                 grant_scopes: Vec::new(),
                 preview: None,
-                summary: "private query and domain filters".into(),
             },
         });
         let json = serde_json::to_string(&projected).unwrap();
@@ -878,7 +870,6 @@ mod tests {
                 kind: ToolApprovalKind::ExternalMcpMayCallServer,
                 grant_scopes: Vec::new(),
                 preview: None,
-                summary: "private model-authored arguments".into(),
             },
         });
         let json = serde_json::to_string(&projected).unwrap();


### PR DESCRIPTION
Slice 2 of the ask-vocabulary work planned on #939 (does not close it).

`ApprovalRequest.summary` and the `summary` field on `AgentEvent::ApprovalRequired` were host-authored boilerplate (`"{tool} requires approval"`) with no readers: never persisted on the approval row (`db/ops/approval.rs` rebuilds presentation from stored name+args), dropped at the renderer boundary (`event_projection.rs` projects `ApprovalRequired` without it, pinned by the leak tests), and absent from `wire.ts` — the desktop synthesizes its own ask sentence from `ToolApprovalKind`. This removes the field and every write site, so the ask vocabulary is entirely typed: class + kind + preview, with no free text left to drift from what the card renders.

Journal compatibility: `AgentEvent` is internally tagged with serde's default unknown-field tolerance (no `deny_unknown_fields`), so historical `ApprovalRequired` rows that carry `summary` in `event.payload` still deserialize — the key is ignored. The checked-in journal fixture is regenerated for the new write shape, and a new test (`approval_rows_with_the_retired_summary_field_still_load`) pins that a legacy payload containing `summary` still loads, since one unreadable row fails a whole chat's history. Receipt recovery in `exact_required_event` compares deserialized payloads, so old receipts compare equal under the new shape as well.

No wire or UI change: the renderer event never carried the field, so `ui/src/generated/wire.ts` is untouched.

Not adding `full-ci`: no Postgres-divergent path is touched — the change is a field removal on an already-tolerant serde shape. Verified locally with the full `openwave-core` lib suite (559 passed), the full `openwave-server` lib suite (529 passed), `openwave-mcp` tests, and clippy on the touched crates; heavy lanes run post-merge on main as the backstop.