### PR TITLE
feat(server): run-scoped model token seam with a fail-closed gateway issuer

### DIFF
--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -57,6 +57,7 @@ mod sandbox_container_run_worker;
 /// correlation-tag orphan sweep.
 pub mod sandbox_docker;
 mod sandbox_web_search_worker;
+mod scoped_model_token;
 /// Rewriting stored credentials so the running binary owns their keychain items.
 pub mod secret_rehome;
 mod source_tools;

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -48,7 +48,7 @@ use openwave_core::{
 use openwave_sandbox_protocol::{
     events::EventPayload,
     ids::{EventCursor, RunId},
-    init::{AdmissionMode, PolicySnapshot, RunInit},
+    init::{AdmissionMode, PolicySnapshot, RunInit, ScopedModelToken},
     protocol::{ErrorCode, ErrorResponse, Response, PROTOCOL_VERSION},
     reverse::{
         Capability, CapabilityResponder, GrantSet, ModelInferenceResult, ReverseRequest,
@@ -63,6 +63,7 @@ use uuid::Uuid;
 use crate::durable_oplog::DurableOperationStore;
 use crate::resolver::ProviderResolver;
 use crate::sandbox_admission::{evaluate_detached_admission, DetachedPreconditions};
+use crate::scoped_model_token::{GatewayScopedTokenIssuer, ScopedModelTokenIssuer};
 
 /// The provider attribution stamped on reverse operations from a local
 /// container. Untrusted attribution rendered on consent prompts, never a claim
@@ -264,6 +265,11 @@ pub struct SandboxContainerRunner {
     backend: Arc<dyn SandboxBackend>,
     resolver: Arc<dyn ProviderResolver>,
     config: SandboxContainerRunConfig,
+    /// The issuer of run-scoped model tokens for detached-admitted runs, and
+    /// the truthful source of the admission gate's
+    /// `scoped_model_token_available` input. Defaults to the gateway position
+    /// — unavailable, fail-closed — until the gateway can mint for real.
+    token_issuer: Arc<dyn ScopedModelTokenIssuer>,
 }
 
 impl SandboxContainerRunner {
@@ -281,6 +287,39 @@ impl SandboxContainerRunner {
             backend,
             resolver,
             config,
+            token_issuer: Arc::new(GatewayScopedTokenIssuer),
+        }
+    }
+
+    /// Replace the scoped-token issuer — the seam tests and future
+    /// mint-capable deployments plug into. The default is fail-closed.
+    // Production assembly keeps the default until a real issuer exists; the
+    // seam is exercised by the tests meanwhile.
+    #[cfg_attr(not(test), allow(dead_code))]
+    #[must_use]
+    pub(crate) fn with_token_issuer(mut self, issuer: Arc<dyn ScopedModelTokenIssuer>) -> Self {
+        self.token_issuer = issuer;
+        self
+    }
+
+    /// The detached-admission preconditions this process can establish for a
+    /// local container run, each derived from the component that owns the fact
+    /// — never a constant.
+    fn detached_preconditions(&self) -> DetachedPreconditions {
+        DetachedPreconditions {
+            // The real fact from the configured issuer: true only when a
+            // run-scoped, short-lived, revocable token can actually be minted.
+            scoped_model_token_available: self.token_issuer.available(),
+            external_lifetime_cap: self.backend.enforces_external_lifetime_cap(),
+            // No image verification within a trust root yet (#1188).
+            image_verified: false,
+            // The container capability host grants ModelInference only; no
+            // reverse capability reaches a host-authority operation.
+            host_authority_tool_surface: false,
+            // No third-party credential is ever delivered into a container
+            // run today.
+            carries_third_party_credentials: false,
+            external_egress_enforcement: false,
         }
     }
 
@@ -378,26 +417,12 @@ impl SandboxContainerRunner {
         // The detached-admission gate (issue #824), evaluated before any
         // durable state is written and recorded on the provisioning intent:
         // every precondition from docs/sandbox-providers.md must hold or the
-        // run is admitted attached-only. Today every input is the unmet state
-        // for a local container — no run-scoped token issuer (slice 2), no
-        // external lifetime cap (the backend's fail-closed declaration), no
-        // image verification within a trust root (#1188) — so the decision is
-        // structurally a denial; what this establishes is that the mode is a
-        // recorded decision, never a constant.
-        let admission_decision = evaluate_detached_admission(DetachedPreconditions {
-            // No issuer of run-scoped, short-lived model tokens exists yet;
-            // the host is the model proxy and holds the only credentials.
-            scoped_model_token_available: false,
-            external_lifetime_cap: self.backend.enforces_external_lifetime_cap(),
-            image_verified: false,
-            // The container capability host grants ModelInference only; no
-            // reverse capability reaches a host-authority operation.
-            host_authority_tool_surface: false,
-            // No third-party credential is ever delivered into a container
-            // run today.
-            carries_third_party_credentials: false,
-            external_egress_enforcement: false,
-        });
+        // run is admitted attached-only. Every input is derived from the
+        // component that owns the fact — the token issuer, the backend's
+        // lifetime-cap declaration, the (still absent, #1188) image
+        // verification — so for a local container today the decision is
+        // structurally a denial, and it opens only when the real facts change.
+        let admission_decision = evaluate_detached_admission(self.detached_preconditions());
         let mut admission = admission_decision.mode();
 
         // Durable provisioning intent — carrying the host-minted correlation
@@ -590,9 +615,34 @@ impl SandboxContainerRunner {
         // The run init the host delivers after each attach: the task and the
         // policy snapshot, only ever over the authenticated connection — the
         // task no longer rides the container's environment, so a sandbox
-        // reclaimed before its handle committed never executed anything. An
-        // attached-only run carries no scoped token; the host is the model
-        // proxy.
+        // reclaimed before its handle committed never executed anything.
+        let deadline_unix_secs = run
+            .deadline_at
+            .map(|deadline| deadline.timestamp().max(0).unsigned_abs())
+            .unwrap_or_default();
+        // A detached-admitted run receives exactly one model credential: a
+        // token minted for this run, expiring no later than its deadline. An
+        // attached-only run carries none — the host is its model proxy. A
+        // detached admission whose token cannot be minted (or whose issuer
+        // overruns the cap) fails the run closed rather than delivering a
+        // detached init without one; the run is never silently downgraded
+        // against its durable admission record.
+        let scoped_token = match self
+            .scoped_token_for(*run_id.as_uuid(), admission, deadline_unix_secs)
+            .await
+        {
+            Ok(token) => token,
+            Err(error) => {
+                return self
+                    .fail(
+                        run_id,
+                        lease_token,
+                        "scoped_token_unavailable",
+                        &error.to_string(),
+                    )
+                    .await;
+            }
+        };
         let init = RunInit {
             run_id: protocol_run_id,
             provenance: RunProvenance {
@@ -600,15 +650,9 @@ impl SandboxContainerRunner {
                 provider: CONTAINER_PROVENANCE_PROVIDER.to_owned(),
             },
             task,
-            deadline_unix_secs: run
-                .deadline_at
-                .map(|deadline| deadline.timestamp().max(0).unsigned_abs())
-                .unwrap_or_default(),
+            deadline_unix_secs,
             // Derived from the durable admission decision — never a constant:
-            // absent an admitting record, this is attached-only. A detached
-            // init additionally requires the scoped token a later slice
-            // delivers, and the gate refuses detached admission until one can
-            // be minted.
+            // absent an admitting record, this is attached-only.
             admission: match admission {
                 SandboxAdmissionMode::AttachedOnly => AdmissionMode::AttachedOnly,
                 SandboxAdmissionMode::Detached => AdmissionMode::Detached,
@@ -617,7 +661,7 @@ impl SandboxContainerRunner {
                 egress_allowlist: Vec::new(),
                 granted_capabilities: vec![Capability::ModelInference],
             },
-            scoped_token: None,
+            scoped_token,
         };
 
         // Drive the container while holding the lease live. A container run
@@ -705,6 +749,52 @@ impl SandboxContainerRunner {
                 }
                 Ok(SandboxContainerRunOutcome::LeaseLost(run_id))
             }
+        }
+    }
+
+    /// The scoped model token a run's admission entitles it to: `None` for an
+    /// attached-only run, a freshly minted run-scoped token for a detached
+    /// one — verified against the run's absolute deadline before delivery.
+    ///
+    /// # Errors
+    /// Fails closed for a detached run when the issuer cannot mint, when the
+    /// run carries no absolute deadline to cap the token by, or when the
+    /// minted token would outlive that deadline (in which case whatever was
+    /// minted is revoked before refusing).
+    async fn scoped_token_for(
+        &self,
+        run_uuid: Uuid,
+        admission: SandboxAdmissionMode,
+        deadline_unix_secs: u64,
+    ) -> Result<Option<ScopedModelToken>> {
+        if admission != SandboxAdmissionMode::Detached {
+            return Ok(None);
+        }
+        if deadline_unix_secs == 0 {
+            return Err(AgentError::config(
+                "a detached run requires an absolute deadline to cap its scoped token",
+            ));
+        }
+        let minted = self.token_issuer.mint(run_uuid, deadline_unix_secs).await?;
+        if minted.expires_at_unix_secs > deadline_unix_secs {
+            // The issuer's claim is verified, not trusted: a token that would
+            // outlive the run must never enter the container.
+            self.revoke_scoped_token(run_uuid).await;
+            return Err(AgentError::config(
+                "the issuer minted a scoped token outliving the run deadline",
+            ));
+        }
+        Ok(Some(minted.token))
+    }
+
+    /// Revoke the run's scoped token, best-effort. Idempotent, and a safe
+    /// no-op for runs that never minted one; the mint-time lifetime cap still
+    /// bounds the credential when the issuer cannot be reached.
+    async fn revoke_scoped_token(&self, run_uuid: Uuid) {
+        if let Err(error) = self.token_issuer.revoke(run_uuid).await {
+            eprintln!(
+                "openwave: could not revoke the scoped model token for run {run_uuid}: {error}"
+            );
         }
     }
 
@@ -919,6 +1009,10 @@ impl SandboxContainerRunner {
     /// confirmed destroy, so an unconfirmed teardown survives this process and
     /// is re-driven by [`sweep`](Self::sweep) rather than abandoned.
     async fn teardown(&self, run_uuid: Uuid, handle: &SandboxHandle) {
+        // Every terminal path drives teardown, so this is where a detached
+        // run's scoped token dies with the run — before the container is even
+        // destroyed, and idempotently for runs that never minted one.
+        self.revoke_scoped_token(run_uuid).await;
         if let Err(error) = self.store.enqueue_sandbox_teardown(run_uuid).await {
             eprintln!("openwave: could not persist a container teardown obligation: {error}");
         }
@@ -1013,11 +1107,16 @@ impl SandboxContainerRunner {
                 "openwave: sandbox provisioning intent for run {} lapsed; its tag is reclaimable",
                 record.run_id
             );
+            self.revoke_scoped_token(record.run_id).await;
         }
 
         // Directed destroys first: obligations with a committed handle name
-        // their container exactly.
+        // their container exactly. Each obligation is a run some terminal
+        // path (this driver's, the reaper's, or an unattached cancellation's)
+        // wrote off, so its scoped token is revoked here too — the reaper
+        // path's revocation, for runs whose own driver never got to it.
         for record in self.store.list_sandbox_teardowns().await? {
+            self.revoke_scoped_token(record.run_id).await;
             let Some(reference) = record.handle.clone() else {
                 continue;
             };

--- a/crates/openwave-server/src/sandbox_container_run/tests.rs
+++ b/crates/openwave-server/src/sandbox_container_run/tests.rs
@@ -46,9 +46,13 @@ use super::{
 };
 use crate::durable_oplog::DurableOperationStore;
 use crate::resolver::ProviderResolver;
+use crate::sandbox_admission::{
+    evaluate_detached_admission, DetachedAdmission, DetachedAdmissionDenial,
+};
 use crate::sandbox_container_run_worker::{
     SandboxContainerRunWorker, SandboxContainerRunWorkerConfig,
 };
+use crate::scoped_model_token::{MintedScopedToken, ScopedModelTokenIssuer};
 
 // --- Mock host model (the resolver the driver proxies inference through) ------
 
@@ -357,6 +361,67 @@ async fn spawn_sandbox_agent() -> String {
     base_url
 }
 
+/// A scoped-token issuer that records every mint and revoke, minting tokens
+/// bounded by the deadline it is handed — or deliberately overrunning it, for
+/// the driver's verification path.
+struct RecordingTokenIssuer {
+    /// `(run, deadline cap, minted expiry)` per mint, in order.
+    minted: Mutex<Vec<(Uuid, u64, u64)>>,
+    revoked: Mutex<Vec<Uuid>>,
+    /// When true, the mint ignores the cap — the misbehaving issuer the
+    /// driver must refuse rather than trust.
+    overrun: bool,
+}
+
+impl RecordingTokenIssuer {
+    fn honest() -> Arc<Self> {
+        Arc::new(Self {
+            minted: Mutex::new(Vec::new()),
+            revoked: Mutex::new(Vec::new()),
+            overrun: false,
+        })
+    }
+
+    fn overrunning() -> Arc<Self> {
+        Arc::new(Self {
+            minted: Mutex::new(Vec::new()),
+            revoked: Mutex::new(Vec::new()),
+            overrun: true,
+        })
+    }
+}
+
+#[async_trait]
+impl ScopedModelTokenIssuer for RecordingTokenIssuer {
+    fn available(&self) -> bool {
+        true
+    }
+
+    async fn mint(&self, run_id: Uuid, deadline_unix_secs: u64) -> Result<MintedScopedToken> {
+        let now = chrono::Utc::now().timestamp().max(0).unsigned_abs();
+        let expires_at_unix_secs = if self.overrun {
+            deadline_unix_secs + 300
+        } else {
+            now.saturating_add(60).min(deadline_unix_secs)
+        };
+        self.minted
+            .lock()
+            .unwrap()
+            .push((run_id, deadline_unix_secs, expires_at_unix_secs));
+        Ok(MintedScopedToken {
+            token: openwave_sandbox_protocol::init::ScopedModelToken::new(format!(
+                "scoped-{run_id}"
+            )),
+            expires_at_unix_secs,
+        })
+    }
+
+    async fn revoke(&self, run_id: Uuid) -> Result<()> {
+        self.revoked.lock().unwrap().push(run_id);
+        Ok(())
+    }
+}
+
 fn fast_config() -> SandboxContainerRunConfig {
     SandboxContainerRunConfig {
         lease: Duration::from_secs(30),
@@ -612,6 +677,176 @@ async fn the_admission_decision_is_durable_on_the_provisioning_record() {
         existing.admission,
         openwave_core::SandboxAdmissionMode::Detached,
         "recovery reads the durable decision, never re-decides"
+    );
+}
+
+/// The scoped-token contract of #824 slice 2, at the driver's mint seam: an
+/// attached-only run mints nothing; a detached run's token is capped by the
+/// run deadline, with an issuer that overruns the cap refused and revoked;
+/// and every path that cannot produce a valid token fails closed — including
+/// the default (gateway) issuer, which cannot mint today.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_detached_scoped_token_is_capped_by_the_run_deadline_and_fails_closed() {
+    let (_dir, store, _chat) = store().await;
+    let backend = MockBackend::spawning();
+    let resolver = Arc::new(FixedResolver(Arc::new(ScriptedProvider::new(vec![]))));
+    let deadline = chrono::Utc::now().timestamp().max(0).unsigned_abs() + 600;
+
+    let issuer = RecordingTokenIssuer::honest();
+    let runner = SandboxContainerRunner::new(
+        store.clone(),
+        backend.clone(),
+        resolver.clone(),
+        fast_config(),
+    )
+    .with_token_issuer(issuer.clone());
+
+    // An attached-only run never mints: the host is its model proxy.
+    assert!(runner
+        .scoped_token_for(
+            Uuid::new_v4(),
+            openwave_core::SandboxAdmissionMode::AttachedOnly,
+            deadline,
+        )
+        .await
+        .unwrap()
+        .is_none());
+    assert!(issuer.minted.lock().unwrap().is_empty());
+
+    // A detached run's token expires no later than the run deadline.
+    let run = Uuid::new_v4();
+    runner
+        .scoped_token_for(run, openwave_core::SandboxAdmissionMode::Detached, deadline)
+        .await
+        .unwrap()
+        .expect("a detached run receives a token");
+    let minted = issuer.minted.lock().unwrap().clone();
+    assert_eq!(minted.len(), 1);
+    assert!(
+        minted[0].2 <= deadline,
+        "token lifetime must be capped by the run deadline"
+    );
+
+    // An issuer whose token would outlive the run is refused, and whatever it
+    // minted is revoked before the refusal.
+    let overrunning = RecordingTokenIssuer::overrunning();
+    let refusing = SandboxContainerRunner::new(
+        store.clone(),
+        backend.clone(),
+        resolver.clone(),
+        fast_config(),
+    )
+    .with_token_issuer(overrunning.clone());
+    let run = Uuid::new_v4();
+    assert!(refusing
+        .scoped_token_for(run, openwave_core::SandboxAdmissionMode::Detached, deadline)
+        .await
+        .is_err());
+    assert_eq!(overrunning.revoked.lock().unwrap().as_slice(), &[run]);
+
+    // No absolute deadline to cap by refuses rather than minting unbounded.
+    assert!(runner
+        .scoped_token_for(
+            Uuid::new_v4(),
+            openwave_core::SandboxAdmissionMode::Detached,
+            0
+        )
+        .await
+        .is_err());
+
+    // The default issuer — the gateway, which has no run-scoped mint API —
+    // fails closed rather than delivering any credential.
+    let default_runner =
+        SandboxContainerRunner::new(store.clone(), backend, resolver, fast_config());
+    assert!(default_runner
+        .scoped_token_for(
+            Uuid::new_v4(),
+            openwave_core::SandboxAdmissionMode::Detached,
+            deadline
+        )
+        .await
+        .is_err());
+}
+
+/// The admission gate's `scoped_model_token_available` input is the issuer's
+/// real availability, not a constant: the default (gateway) issuer reads
+/// unavailable and the evaluated denial names the missing token, while an
+/// issuer that can mint flips exactly that input.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_gate_input_reflects_the_issuers_availability() {
+    let (_dir, store, _chat) = store().await;
+    let backend = MockBackend::spawning();
+    let resolver = Arc::new(FixedResolver(Arc::new(ScriptedProvider::new(vec![]))));
+
+    let default_runner = SandboxContainerRunner::new(
+        store.clone(),
+        backend.clone(),
+        resolver.clone(),
+        fast_config(),
+    );
+    let preconditions = default_runner.detached_preconditions();
+    assert!(!preconditions.scoped_model_token_available);
+    let DetachedAdmission::Denied(denials) = evaluate_detached_admission(preconditions) else {
+        panic!("a local container run must be denied detached admission");
+    };
+    assert!(denials.contains(&DetachedAdmissionDenial::NoScopedModelToken));
+
+    let minting = SandboxContainerRunner::new(store.clone(), backend, resolver, fast_config())
+        .with_token_issuer(RecordingTokenIssuer::honest());
+    assert!(
+        minting
+            .detached_preconditions()
+            .scoped_model_token_available,
+        "an issuer that can mint must read as available, truthfully"
+    );
+}
+
+/// The reaper-shaped revocation path: a run whose own driver never revoked —
+/// a lapsed provisioning intent, or a teardown obligation left by a reaped or
+/// unattached-cancelled run — has its scoped token revoked by the sweep.
+#[tokio::test(flavor = "multi_thread")]
+async fn the_sweep_revokes_tokens_for_lapsed_and_reaped_runs() {
+    let (_dir, store, _chat) = store().await;
+    let lapsed_run = Uuid::new_v4();
+    let reaped_run = Uuid::new_v4();
+    store
+        .begin_sandbox_provision(
+            lapsed_run,
+            &SandboxTag::new().to_string(),
+            chrono::Utc::now() - chrono::Duration::seconds(1),
+            openwave_core::SandboxAdmissionMode::AttachedOnly,
+        )
+        .await
+        .unwrap();
+    store
+        .begin_sandbox_provision(
+            reaped_run,
+            &SandboxTag::new().to_string(),
+            chrono::Utc::now() + chrono::Duration::seconds(600),
+            openwave_core::SandboxAdmissionMode::AttachedOnly,
+        )
+        .await
+        .unwrap();
+    store.enqueue_sandbox_teardown(reaped_run).await.unwrap();
+
+    let issuer = RecordingTokenIssuer::honest();
+    let runner = SandboxContainerRunner::new(
+        store.clone(),
+        MockBackend::spawning(),
+        Arc::new(FixedResolver(Arc::new(ScriptedProvider::new(vec![])))),
+        fast_config(),
+    )
+    .with_token_issuer(issuer.clone());
+    runner.sweep().await.expect("the sweep succeeds");
+
+    let revoked = issuer.revoked.lock().unwrap().clone();
+    assert!(
+        revoked.contains(&lapsed_run),
+        "a lapsed intent's token is revoked by the sweep"
+    );
+    assert!(
+        revoked.contains(&reaped_run),
+        "a reaped run's teardown obligation carries its revocation"
     );
 }
 
@@ -919,8 +1154,10 @@ async fn fails_terminally_and_tears_down_when_the_container_is_unreachable() {
         let backend = MockBackend::unreachable(format!("http://{dead_addr}"));
         let resolver = Arc::new(FixedResolver(Arc::new(ScriptedProvider::new(vec![]))));
 
+        let issuer = RecordingTokenIssuer::honest();
         let runner =
-            SandboxContainerRunner::new(store.clone(), backend.clone(), resolver, fast_config());
+            SandboxContainerRunner::new(store.clone(), backend.clone(), resolver, fast_config())
+                .with_token_issuer(issuer.clone());
         let outcome = runner
             .drive(run_id)
             .await
@@ -932,6 +1169,11 @@ async fn fails_terminally_and_tears_down_when_the_container_is_unreachable() {
         assert_eq!(failed.status, AgentRunStatus::Failed);
         // The teardown obligation was driven even though the run failed.
         assert_eq!(backend.destroys.load(Ordering::SeqCst), 1);
+        // Terminalization revoked the run's scoped token along the same path.
+        assert_eq!(
+            issuer.revoked.lock().unwrap().as_slice(),
+            &[*run_id.as_uuid()]
+        );
     })
     .await
     .expect("test completed within its time bound");

--- a/crates/openwave-server/src/scoped_model_token.rs
+++ b/crates/openwave-server/src/scoped_model_token.rs
@@ -1,0 +1,90 @@
+//! Run-scoped model tokens for detached-admitted sandbox runs (issue #824,
+//! slice 2).
+//!
+//! The invariant this seam carries: **no detached run ever holds a long-lived
+//! credential.** A detached-admitted run receives exactly one model credential
+//! — a token minted for that run, expiring no later than the run's absolute
+//! deadline, and revoked when the run terminalizes. Everything else in the
+//! container path proxies inference through the host and carries none.
+//!
+//! The trait is the host-side seam; who mints is a per-deployment fact. The
+//! model gateway's OAuth surface today mints only session-level, resource-bound
+//! access tokens through refresh-token rotation and can revoke only the whole
+//! session's refresh token — it has no API to mint a token scoped to one run
+//! with a caller-capped lifetime, nor to revoke one issued token without
+//! killing the session. Until it grows one, [`GatewayScopedTokenIssuer`]
+//! reports honestly unavailable and refuses to mint, and the detached-admission
+//! gate reads that refusal as its `scoped_model_token_available` input — so the
+//! gate stays closed for exactly the reason the doc names.
+
+use async_trait::async_trait;
+use openwave_core::{AgentError, Result};
+use openwave_sandbox_protocol::init::ScopedModelToken;
+use uuid::Uuid;
+
+/// A minted run-scoped token with the absolute expiry the issuer bound it to.
+///
+/// The expiry is a claim the caller verifies against the run deadline before
+/// delivering the token — an issuer that overruns the cap is refused, not
+/// trusted.
+pub(crate) struct MintedScopedToken {
+    pub(crate) token: ScopedModelToken,
+    /// When the token stops working, in Unix seconds. Must not exceed the
+    /// deadline the mint was capped by.
+    pub(crate) expires_at_unix_secs: u64,
+}
+
+/// An issuer of run-scoped, short-lived, revocable model tokens.
+///
+/// A long-lived provider API key never satisfies this trait: `mint` must
+/// return a credential that dies with the run whether or not `revoke` is ever
+/// reached.
+#[async_trait]
+pub(crate) trait ScopedModelTokenIssuer: Send + Sync {
+    /// Whether this issuer can mint at all. This is the truthful input to the
+    /// detached-admission gate's `scoped_model_token_available` precondition —
+    /// it must never report `true` unless [`mint`](Self::mint) can succeed.
+    fn available(&self) -> bool;
+
+    /// Mint a token for `run_id` expiring no later than `deadline_unix_secs`.
+    ///
+    /// # Errors
+    /// Fails when no token can be minted; the caller fails the run closed
+    /// rather than delivering a detached init without one.
+    async fn mint(&self, run_id: Uuid, deadline_unix_secs: u64) -> Result<MintedScopedToken>;
+
+    /// Revoke whatever tokens were minted for `run_id`. Idempotent and safe to
+    /// call on every terminal path, including for runs that never minted.
+    ///
+    /// # Errors
+    /// Best-effort at the issuer: a failure is logged by callers, and the
+    /// lifetime cap from [`mint`](Self::mint) still bounds the credential.
+    async fn revoke(&self, run_id: Uuid) -> Result<()>;
+}
+
+/// The gateway-backed issuer position today: unavailable, fail-closed.
+///
+/// The gateway cannot yet mint run-scoped tokens (see the module doc), so this
+/// issuer refuses to mint and reports unavailable — which keeps the
+/// detached-admission gate closed on the `NoScopedModelToken` denial rather
+/// than smuggling a session-level bearer into a container. When the gateway
+/// grows a run-scoped mint/revoke surface, this type is where it plugs in.
+pub(crate) struct GatewayScopedTokenIssuer;
+
+#[async_trait]
+impl ScopedModelTokenIssuer for GatewayScopedTokenIssuer {
+    fn available(&self) -> bool {
+        false
+    }
+
+    async fn mint(&self, _run_id: Uuid, _deadline_unix_secs: u64) -> Result<MintedScopedToken> {
+        Err(AgentError::config(
+            "the model gateway cannot mint run-scoped tokens; detached admission is unavailable",
+        ))
+    }
+
+    async fn revoke(&self, _run_id: Uuid) -> Result<()> {
+        // Nothing was ever minted; revocation is a no-op.
+        Ok(())
+    }
+}


### PR DESCRIPTION
Slice 2 of #824 (stacked on #1358; will retarget to main once it merges): the invariant that model tokens are scoped and expire with the run.

## What this does

- Adds a `ScopedModelTokenIssuer` seam in `openwave-server`: `mint(run, deadline)` returns a token with a claimed expiry, `revoke(run)` is idempotent per run, and `available()` is the truthful fact the detached-admission gate consumes.
- Flips the gate's `scoped_model_token_available` input from the hardcoded `false` to the configured issuer's real availability.
- Delivers a detached-admitted run's token via `RunInit.scoped_token` (the slot slice 1 left). The driver verifies the minted expiry against the run's absolute deadline before delivery; an issuer that overruns the cap is refused and its token revoked, a mint failure fails the run closed (`scoped_token_unavailable`) rather than silently downgrading against the durable admission record, and a run with no absolute deadline is refused a token outright.
- Revokes on every terminal path: the driver's teardown (completed, failed, cancelled, deadline-exceeded, lease-lost), and the maintenance sweep for lapsed provisioning intents and teardown obligations left by reaped or unattached-cancelled runs.

## The gateway cannot mint run-scoped tokens today

The gateway's OAuth surface (`openwave-connectors`) mints only session-level, resource-bound access tokens through refresh-token rotation, and can revoke only the whole session's refresh token — there is no API to mint a token scoped to one run with a caller-capped lifetime, nor to revoke one issued token without killing the session. So the gateway implementation here is `GatewayScopedTokenIssuer`, stubbed unavailable-fails-closed: it reports unavailable (keeping the gate's `NoScopedModelToken` denial in force) and refuses to mint. The invariant holds either way: no detached run ever holds a long-lived credential, because no detached init can be built without a deadline-capped token.

## Tests

- Token lifetime ≤ run deadline, over-cap issuers refused and revoked, attached-only mints nothing, the default issuer fails closed, and a missing deadline refuses (`a_detached_scoped_token_is_capped_by_the_run_deadline_and_fails_closed`).
- The gate input mirrors issuer availability, and the default denial names the missing token (`the_gate_input_reflects_the_issuers_availability`).
- Terminalization revokes along the teardown path (extended `fails_terminally_and_tears_down_when_the_container_is_unreachable`).
- The sweep revokes for lapsed intents and reaper-/cancellation-left teardown obligations (`the_sweep_revokes_tokens_for_lapsed_and_reaped_runs`).

Verified locally: `cargo fmt`, `cargo clippy -p openwave-server --locked --all-targets -D warnings`, and the full `cargo test -p openwave-server --locked` suite (539 passing). No Postgres-divergent path — the new state lives in the issuer seam and existing SQLite-covered provisioning records — so post-merge CI on main is the heavy backstop.

Part of #824 (slice 2; does not close it).