### PR TITLE
feat(server): {app, operation_ids[]} REST bindings with grant, consent, and governed invoke

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,6 +4164,7 @@ version = "0.0.0"
 dependencies = [
  "async-trait",
  "axum",
+ "base64 0.23.0",
  "cap-std",
  "chrono",
  "futures",

--- a/crates/openwave-core/src/db/tests/app.rs
+++ b/crates/openwave-core/src/db/tests/app.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::id::{AgentRunId, AppId, AppRevisionId, ConnectedAppId};
 use crate::local_app::{
-    AppBinding, AppManifest, CreateApp, NewAppRevision, MAX_APP_BUNDLE_BYTES, MAX_APP_REVISIONS,
+    AppBinding, AppManifest, AppToolsBinding, CreateApp, NewAppRevision, MAX_APP_BUNDLE_BYTES,
+    MAX_APP_REVISIONS,
 };
 
 fn at(second: i64) -> DateTime<Utc> {
@@ -15,10 +16,10 @@ fn digest(seed: u8) -> [u8; 32] {
 fn manifest(name: &str) -> AppManifest {
     AppManifest {
         name: name.to_owned(),
-        bindings: vec![AppBinding {
+        bindings: vec![AppBinding::Tools(AppToolsBinding {
             app: ConnectedAppId(uuid::Uuid::from_u128(1)),
             tools: vec!["mcp__sentry__list_issues".into()],
-        }],
+        })],
     }
 }
 
@@ -180,7 +181,10 @@ async fn malformed_manifests_and_out_of_bounds_bundles_are_refused() {
     // A pinned name that is not shaped like a mounted tool can never match
     // one, so the store refuses it at the door.
     let mut bare_tool = create_request(1);
-    bare_tool.revision.manifest.bindings[0].tools = vec!["list_issues".into()];
+    bare_tool.revision.manifest.bindings[0] = AppBinding::Tools(AppToolsBinding {
+        app: ConnectedAppId(uuid::Uuid::from_u128(1)),
+        tools: vec!["list_issues".into()],
+    });
     assert!(store.create_app(&bare_tool).await.is_err());
 
     let mut empty_bundle = create_request(1);
@@ -194,9 +198,11 @@ async fn malformed_manifests_and_out_of_bounds_bundles_are_refused() {
     // A manifest over the 64 KiB bound is refused however well-formed it is.
     let mut oversized_manifest = create_request(1);
     oversized_manifest.revision.manifest.bindings = (0..2_000)
-        .map(|index| AppBinding {
-            app: ConnectedAppId::new(),
-            tools: vec![format!("mcp__server_{index:04}__tool_padding_padding")],
+        .map(|index| {
+            AppBinding::Tools(AppToolsBinding {
+                app: ConnectedAppId::new(),
+                tools: vec![format!("mcp__server_{index:04}__tool_padding_padding")],
+            })
         })
         .collect();
     assert!(store.create_app(&oversized_manifest).await.is_err());

--- a/crates/openwave-core/src/db/tests/connected_app.rs
+++ b/crates/openwave-core/src/db/tests/connected_app.rs
@@ -175,11 +175,11 @@ async fn absorption_migrates_servers_rekeys_manifests_and_drops_grants() {
         .unwrap()
         .expect("the revision row survives the cut");
     assert_eq!(revision.manifest.bindings.len(), 1);
-    assert_eq!(revision.manifest.bindings[0].app, apps[0].id);
-    assert_eq!(
-        revision.manifest.bindings[0].tools,
-        ["mcp__sentry__list_issues"]
-    );
+    let crate::local_app::AppBinding::Tools(binding) = &revision.manifest.bindings[0] else {
+        panic!("the surviving binding keeps the tools vocabulary");
+    };
+    assert_eq!(binding.app, apps[0].id);
+    assert_eq!(binding.tools, ["mcp__sentry__list_issues"]);
 
     assert!(
         store

--- a/crates/openwave-core/src/local_app.rs
+++ b/crates/openwave-core/src/local_app.rs
@@ -46,6 +46,15 @@ pub const MAX_APP_NAME_CHARS: usize = 120;
 /// Provider-safe bound every mounted tool name already obeys, reused verbatim
 /// for manifest bindings so a pinned name can always match a mounted one.
 pub const MAX_MOUNTED_TOOL_NAME_BYTES: usize = 64;
+/// Largest `operationId` a `rest_api` binding may pin, in bytes.
+///
+/// A deliberate mirror of the OpenAPI ingest module's bound
+/// (`openwave_server::openapi_catalog::MAX_OPERATION_ID_BYTES`): the catalog
+/// enforces the same length and `[A-Za-z0-9_.-]` charset on every ingested
+/// operation, so a pinned id within this grammar can always match an ingested
+/// one. Duplicated here rather than imported because the manifest contract
+/// must not depend on server code.
+pub const MAX_OPERATION_ID_BYTES: usize = 128;
 
 /// Profile-data location of one immutable revision's bundle bytes.
 ///
@@ -189,7 +198,8 @@ pub struct CreateApp {
     pub revision: NewAppRevision,
 }
 
-/// The durable consent object for one app: the granted `(app, tools[])` set,
+/// The durable consent object for one app: the granted binding set —
+/// `(app, tools[])` or `(app, operation_ids[])` per bound connected app —
 /// with each bound connected app pinned to a fingerprint of its definition as
 /// it was configured at consent time.
 ///
@@ -210,11 +220,45 @@ pub struct AppGrant {
     pub created_at: DateTime<Utc>,
 }
 
-/// One granted binding: the tools the user consented to under one connected
-/// app, pinned to the definition that record carried at consent.
+/// One granted binding: the capabilities the user consented to under one
+/// connected app, pinned to the definition that record carried at consent.
+///
+/// Untagged, mirroring [`AppBinding`]: the variants differ in exactly one
+/// field name, and unknown fields refuse both shapes, so a persisted grant
+/// binding deserializes to exactly the vocabulary it was granted under.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum AppGrantBinding {
+    /// `{ app, tools[], fingerprint }` — granted mounted MCP tools.
+    Tools(AppToolsGrantBinding),
+    /// `{ app, operation_ids[], fingerprint }` — granted REST operations.
+    Operations(AppOperationsGrantBinding),
+}
+
+impl AppGrantBinding {
+    /// The connected app the grant binding names.
+    #[must_use]
+    pub fn app(&self) -> ConnectedAppId {
+        match self {
+            Self::Tools(binding) => binding.app,
+            Self::Operations(binding) => binding.app,
+        }
+    }
+
+    /// The definition fingerprint pinned at consent time.
+    #[must_use]
+    pub fn fingerprint(&self) -> [u8; 32] {
+        match self {
+            Self::Tools(binding) => binding.fingerprint,
+            Self::Operations(binding) => binding.fingerprint,
+        }
+    }
+}
+
+/// The granted mounted tools under one `mcp_server` connected app.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct AppGrantBinding {
+pub struct AppToolsGrantBinding {
     /// Connected app the consent names, matching the manifest binding it
     /// covers.
     pub app: ConnectedAppId,
@@ -224,6 +268,23 @@ pub struct AppGrantBinding {
     /// consent time, computed by the host over a canonical serialization that
     /// carries configuration *names and structure* only — never environment
     /// or token values. Persisted as lowercase hex.
+    #[serde(with = "hex_fingerprint")]
+    pub fingerprint: [u8; 32],
+}
+
+/// The granted declared operations under one `rest_api` connected app.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AppOperationsGrantBinding {
+    /// Connected app the consent names, matching the manifest binding it
+    /// covers.
+    pub app: ConnectedAppId,
+    /// Catalog `operationId`s the grant covers.
+    pub operation_ids: Vec<String>,
+    /// SHA-256 fingerprint of the connected app's definition as configured at
+    /// consent time — for a `rest_api` record, over the base URL, document
+    /// hash, and credential *reference* and placement, never a credential
+    /// value. Persisted as lowercase hex.
     #[serde(with = "hex_fingerprint")]
     pub fingerprint: [u8; 32],
 }
@@ -264,12 +325,15 @@ mod hex_fingerprint {
 /// storage door so no other write path can persist a binding the manifest
 /// validator would have refused.
 pub fn validate_app_grant(grant: &AppGrant) -> Result<serde_json::Value, String> {
-    validate_binding_set(
-        grant
-            .bindings
-            .iter()
-            .map(|binding| (binding.app, binding.tools.as_slice())),
-    )?;
+    validate_binding_set(grant.bindings.iter().map(|binding| match binding {
+        AppGrantBinding::Tools(binding) => {
+            (binding.app, BindingCapabilities::Tools(&binding.tools))
+        }
+        AppGrantBinding::Operations(binding) => (
+            binding.app,
+            BindingCapabilities::Operations(&binding.operation_ids),
+        ),
+    }))?;
     serde_json::to_value(&grant.bindings).map_err(|error| format!("unencodable app grant: {error}"))
 }
 
@@ -291,13 +355,42 @@ pub struct AppManifest {
     pub bindings: Vec<AppBinding>,
 }
 
-/// The mounted tools one connected app contributes to a local app.
+/// The capabilities one connected app contributes to a local app: mounted MCP
+/// tools for an `mcp_server` record, declared REST operations for a
+/// `rest_api` record.
+///
+/// Untagged and closed: the two shapes are distinguished by their one
+/// differing field (`tools` vs `operation_ids`), each variant refuses unknown
+/// fields, and a body carrying both fields matches neither.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(untagged)]
+pub enum AppBinding {
+    /// `{ app, tools[] }` — mounted MCP tools of an `mcp_server` record.
+    Tools(AppToolsBinding),
+    /// `{ app, operation_ids[] }` — declared operations of a `rest_api`
+    /// record.
+    Operations(AppOperationsBinding),
+}
+
+impl AppBinding {
+    /// The connected app the binding names.
+    #[must_use]
+    pub fn app(&self) -> ConnectedAppId {
+        match self {
+            Self::Tools(binding) => binding.app,
+            Self::Operations(binding) => binding.app,
+        }
+    }
+}
+
+/// The mounted tools one `mcp_server` connected app contributes to a local
+/// app.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub struct AppBinding {
+pub struct AppToolsBinding {
     /// Id of the connected app the tools belong to. The available ids are
     /// listed in the `create_app` tool description.
-    #[schemars(description = "Id of the connected app these tools belong to.")]
+    #[schemars(description = "Id of the mcp_server connected app these tools belong to.")]
     pub app: ConnectedAppId,
     /// Full mounted tool names, each `mcp__{namespace}__{tool}` under the
     /// bound connected app's namespace.
@@ -306,6 +399,22 @@ pub struct AppBinding {
                        under the bound connected app's namespace."
     )]
     pub tools: Vec<String>,
+}
+
+/// The declared operations one `rest_api` connected app contributes to a
+/// local app.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AppOperationsBinding {
+    /// Id of the connected app the operations belong to. The available ids
+    /// are listed in the `create_app` tool description.
+    #[schemars(description = "Id of the rest_api connected app these operations belong to.")]
+    pub app: ConnectedAppId,
+    /// Catalog `operationId`s of the bound connected app's ingested OpenAPI
+    /// document.
+    #[schemars(description = "OpenAPI operationIds declared by the bound rest_api \
+                       connected app's catalog.")]
+    pub operation_ids: Vec<String>,
 }
 
 /// Validate an app manifest structurally and return the JSON to store.
@@ -317,12 +426,13 @@ pub struct AppBinding {
 /// that could never match a mounted tool is refused at the door.
 pub fn validate_app_manifest(manifest: &AppManifest) -> Result<serde_json::Value, String> {
     validate_app_name(&manifest.name)?;
-    validate_binding_set(
-        manifest
-            .bindings
-            .iter()
-            .map(|binding| (binding.app, binding.tools.as_slice())),
-    )?;
+    validate_binding_set(manifest.bindings.iter().map(|binding| match binding {
+        AppBinding::Tools(binding) => (binding.app, BindingCapabilities::Tools(&binding.tools)),
+        AppBinding::Operations(binding) => (
+            binding.app,
+            BindingCapabilities::Operations(&binding.operation_ids),
+        ),
+    }))?;
     let json =
         serde_json::to_value(manifest).map_err(|error| format!("unencodable manifest: {error}"))?;
     let encoded_len = json.to_string().len();
@@ -334,37 +444,67 @@ pub fn validate_app_manifest(manifest: &AppManifest) -> Result<serde_json::Value
     Ok(json)
 }
 
+/// One binding's capability list, by vocabulary, for the shared grammar check.
+enum BindingCapabilities<'a> {
+    Tools(&'a [String]),
+    Operations(&'a [String]),
+}
+
 /// The binding grammar shared by manifests and grants: no duplicate connected
-/// apps, and every tool shaped like a full mounted name.
+/// apps (one binding per record, whichever vocabulary), every tool shaped
+/// like a full mounted name, and every operation id within the ingest
+/// module's `operationId` grammar.
 ///
 /// A namespace may itself contain `_`, so a mounted name cannot be split
 /// unambiguously without knowing the namespace — and the bound record lives
 /// behind the store. The grammar here is therefore structural only; the exact
 /// `mcp__{namespace}__` cross-check against the bound connected app's
-/// configuration belongs to the host layers that resolve ids (the
-/// `create_app` door, grant computation, the invoke gate).
+/// configuration — and the catalog membership check for operation ids —
+/// belongs to the host layers that resolve ids (the `create_app` door, grant
+/// computation, the invoke gate).
 fn validate_binding_set<'a>(
-    bindings: impl Iterator<Item = (ConnectedAppId, &'a [String])>,
+    bindings: impl Iterator<Item = (ConnectedAppId, BindingCapabilities<'a>)>,
 ) -> Result<(), String> {
     let mut apps = std::collections::HashSet::new();
-    for (app, binding_tools) in bindings {
+    for (app, capabilities) in bindings {
         if !apps.insert(app) {
             return Err(format!("duplicate binding for connected app {app}"));
         }
-        let mut tools = std::collections::HashSet::new();
-        for tool in binding_tools {
-            if tool.len() > MAX_MOUNTED_TOOL_NAME_BYTES || !is_mounted_name_charset(tool) {
-                return Err(format!(
-                    "tool {tool:?} must be at most {MAX_MOUNTED_TOOL_NAME_BYTES} bytes of [A-Za-z0-9_-]"
-                ));
+        match capabilities {
+            BindingCapabilities::Tools(binding_tools) => {
+                let mut tools = std::collections::HashSet::new();
+                for tool in binding_tools {
+                    if tool.len() > MAX_MOUNTED_TOOL_NAME_BYTES || !is_mounted_name_charset(tool) {
+                        return Err(format!(
+                            "tool {tool:?} must be at most {MAX_MOUNTED_TOOL_NAME_BYTES} bytes of [A-Za-z0-9_-]"
+                        ));
+                    }
+                    if !is_mounted_name_shape(tool) {
+                        return Err(format!(
+                            "tool {tool:?} is not a mounted `mcp__{{namespace}}__{{tool}}` name"
+                        ));
+                    }
+                    if !tools.insert(tool.as_str()) {
+                        return Err(format!("duplicate tool {tool:?}"));
+                    }
+                }
             }
-            if !is_mounted_name_shape(tool) {
-                return Err(format!(
-                    "tool {tool:?} is not a mounted `mcp__{{namespace}}__{{tool}}` name"
-                ));
-            }
-            if !tools.insert(tool.as_str()) {
-                return Err(format!("duplicate tool {tool:?}"));
+            BindingCapabilities::Operations(binding_operations) => {
+                let mut operations = std::collections::HashSet::new();
+                for operation_id in binding_operations {
+                    if operation_id.is_empty()
+                        || operation_id.len() > MAX_OPERATION_ID_BYTES
+                        || !is_operation_id_charset(operation_id)
+                    {
+                        return Err(format!(
+                            "operation id {operation_id:?} must be 1 to \
+                             {MAX_OPERATION_ID_BYTES} bytes of [A-Za-z0-9_.-]"
+                        ));
+                    }
+                    if !operations.insert(operation_id.as_str()) {
+                        return Err(format!("duplicate operation id {operation_id:?}"));
+                    }
+                }
             }
         }
     }
@@ -416,6 +556,14 @@ fn is_mounted_name_charset(name: &str) -> bool {
         .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
 }
 
+/// The ingest module's `operationId` charset, mirrored (see
+/// [`MAX_OPERATION_ID_BYTES`]).
+fn is_operation_id_charset(operation_id: &str) -> bool {
+    operation_id
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b'-'))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -452,10 +600,10 @@ mod tests {
         let app = ConnectedAppId::new();
         let manifest = |tools: &[&str]| AppManifest {
             name: "Sentry triage".into(),
-            bindings: vec![AppBinding {
+            bindings: vec![AppBinding::Tools(AppToolsBinding {
                 app,
                 tools: tools.iter().map(|tool| (*tool).to_owned()).collect(),
-            }],
+            })],
         };
 
         assert!(validate_app_manifest(&manifest(&[
@@ -491,14 +639,14 @@ mod tests {
             validate_app_manifest(&AppManifest {
                 name: "Twice".into(),
                 bindings: vec![
-                    AppBinding {
+                    AppBinding::Tools(AppToolsBinding {
                         app,
                         tools: Vec::new()
-                    },
-                    AppBinding {
+                    }),
+                    AppBinding::Tools(AppToolsBinding {
                         app,
                         tools: Vec::new()
-                    },
+                    }),
                 ],
             })
             .is_err(),
@@ -515,6 +663,92 @@ mod tests {
                 "{name:?}"
             );
         }
+    }
+
+    #[test]
+    fn manifests_enforce_the_operation_id_grammar() {
+        let app = ConnectedAppId::new();
+        let manifest = |operation_ids: &[&str]| AppManifest {
+            name: "Issue browser".into(),
+            bindings: vec![AppBinding::Operations(AppOperationsBinding {
+                app,
+                operation_ids: operation_ids.iter().map(|id| (*id).to_owned()).collect(),
+            })],
+        };
+
+        assert!(validate_app_manifest(&manifest(&["listIssues", "get.issue-v2_1"])).is_ok());
+        for operation_id in [
+            "",            // empty
+            "bad id",      // charset (space)
+            "issues/list", // charset (slash)
+            &"x".repeat(MAX_OPERATION_ID_BYTES + 1),
+        ] {
+            assert!(
+                validate_app_manifest(&manifest(&[operation_id])).is_err(),
+                "{operation_id:?}"
+            );
+        }
+        assert!(
+            validate_app_manifest(&manifest(&["listIssues", "listIssues"])).is_err(),
+            "duplicate pins are refused"
+        );
+        // One binding per connected app holds across vocabularies: the same
+        // record cannot be bound once for tools and once for operations.
+        assert!(
+            validate_app_manifest(&AppManifest {
+                name: "Twice".into(),
+                bindings: vec![
+                    AppBinding::Tools(AppToolsBinding {
+                        app,
+                        tools: Vec::new()
+                    }),
+                    AppBinding::Operations(AppOperationsBinding {
+                        app,
+                        operation_ids: Vec::new()
+                    }),
+                ],
+            })
+            .is_err(),
+            "duplicate connected-app bindings are refused across binding kinds"
+        );
+    }
+
+    #[test]
+    fn bindings_deserialize_untagged_and_closed() {
+        use serde_json::json;
+
+        let app = ConnectedAppId::new();
+        let tools: AppBinding =
+            serde_json::from_value(json!({ "app": app, "tools": ["mcp__srv__viewer"] })).unwrap();
+        assert!(matches!(tools, AppBinding::Tools(_)));
+        let operations: AppBinding =
+            serde_json::from_value(json!({ "app": app, "operation_ids": ["listIssues"] })).unwrap();
+        assert!(matches!(operations, AppBinding::Operations(_)));
+        // Both vocabularies in one binding, or any unknown field, match
+        // neither closed variant.
+        for body in [
+            json!({ "app": app, "tools": [], "operation_ids": [] }),
+            json!({ "app": app, "tools": [], "extra": true }),
+            json!({ "app": app }),
+        ] {
+            assert!(
+                serde_json::from_value::<AppBinding>(body.clone()).is_err(),
+                "{body}"
+            );
+        }
+
+        // The grant vocabulary round-trips the same way, fingerprint included.
+        let fingerprint = "ab".repeat(32);
+        let granted: AppGrantBinding = serde_json::from_value(
+            json!({ "app": app, "operation_ids": ["listIssues"], "fingerprint": fingerprint }),
+        )
+        .unwrap();
+        assert!(matches!(granted, AppGrantBinding::Operations(_)));
+        assert_eq!(granted.fingerprint(), [0xab; 32]);
+        assert!(serde_json::from_value::<AppGrantBinding>(
+            json!({ "app": app, "tools": [], "operation_ids": [], "fingerprint": fingerprint })
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/openwave-core/src/tools/create_app.rs
+++ b/crates/openwave-core/src/tools/create_app.rs
@@ -23,8 +23,8 @@ use crate::connected_app::ConnectedAppKind;
 use crate::error::Result;
 use crate::id::{AppId, AppRevisionId, TurnId};
 use crate::local_app::{
-    mounted_tool_under, publish_app_bundle, validate_app_manifest, AppManifest, AppRecord,
-    CreateApp, NewAppRevision, MAX_APP_BUNDLE_BYTES,
+    mounted_tool_under, publish_app_bundle, validate_app_manifest, AppBinding, AppManifest,
+    AppRecord, CreateApp, NewAppRevision, MAX_APP_BUNDLE_BYTES,
 };
 use crate::preview::{ResultEntry, ResultEntryKind};
 use crate::storage::Store;
@@ -47,12 +47,13 @@ pub(super) struct Arguments {
                        It runs in a sandboxed frame with no network access."
     )]
     bundle_html: String,
-    #[schemars(
-        description = "The app's manifest: its display name and the exact mounted \
-                       MCP tools it may call, grouped by connected app. Each binding \
-                       names a connected app by id (the tool description lists the \
-                       configured ids) and the full mounted tool names under it."
-    )]
+    #[schemars(description = "The app's manifest: its display name and the exact \
+                       capabilities it may call, grouped by connected app. Each \
+                       binding names a connected app by id (the tool description \
+                       lists the configured ids) and either the full mounted MCP \
+                       tool names under it (`tools`, for mcp_server apps) or the \
+                       declared OpenAPI operationIds (`operation_ids`, for \
+                       rest_api apps).")]
     manifest: AppManifest,
     #[serde(default)]
     #[schemars(
@@ -98,9 +99,11 @@ impl CreateAppTool {
             .ok_or_else(|| ToolOutput::error("this call is not recorded in this conversation"))
     }
 
-    /// Check that every manifest binding names a configured `mcp_server`
-    /// connected app and that each pinned tool is a mounted name under that
-    /// app's namespace.
+    /// Check that every manifest binding names a configured connected app of
+    /// the kind its vocabulary requires: tools bindings resolve to an
+    /// `mcp_server` record with each pinned name mounted under its namespace;
+    /// operation bindings resolve to a `rest_api` record with each pinned
+    /// `operationId` declared by its ingested catalog.
     async fn check_bindings(&self, manifest: &AppManifest) -> std::result::Result<(), String> {
         if manifest.bindings.is_empty() {
             return Ok(());
@@ -111,40 +114,80 @@ impl CreateAppTool {
             .await
             .map_err(|_| "could not read the configured connected apps".to_owned())?;
         for binding in &manifest.bindings {
-            let Some(app) = connected.iter().find(|app| app.id == binding.app) else {
+            let Some(app) = connected.iter().find(|app| app.id == binding.app()) else {
                 let configured: Vec<String> = connected
                     .iter()
-                    .filter(|app| app.kind == ConnectedAppKind::McpServer)
-                    .map(|app| format!("{} ({})", app.id, app.name))
+                    .map(|app| format!("{} ({}, {})", app.id, app.name, app.kind))
                     .collect();
                 return Err(if configured.is_empty() {
                     format!(
                         "connected app {} is not configured, and no connected apps \
                          are; only an empty bindings list is valid",
-                        binding.app
+                        binding.app()
                     )
                 } else {
                     format!(
                         "connected app {} is not configured; bind one of: {}",
-                        binding.app,
+                        binding.app(),
                         configured.join(", ")
                     )
                 });
             };
-            if app.kind != ConnectedAppKind::McpServer {
-                return Err(format!(
-                    "connected app {} ({}) is a {} app; only mcp_server apps \
-                     contribute mounted tools",
-                    app.id, app.name, app.kind
-                ));
-            }
-            for tool in &binding.tools {
-                if mounted_tool_under(&app.name, tool).is_none() {
-                    return Err(format!(
-                        "tool {tool:?} is not mounted under connected app {} — its \
-                         tools are named `mcp__{}__{{tool}}`",
-                        app.id, app.name
-                    ));
+            match binding {
+                AppBinding::Tools(binding) => {
+                    if app.kind != ConnectedAppKind::McpServer {
+                        return Err(format!(
+                            "connected app {} ({}) is a {} app; only mcp_server apps \
+                             contribute mounted tools — bind its operations with \
+                             `operation_ids` instead",
+                            app.id, app.name, app.kind
+                        ));
+                    }
+                    for tool in &binding.tools {
+                        if mounted_tool_under(&app.name, tool).is_none() {
+                            return Err(format!(
+                                "tool {tool:?} is not mounted under connected app {} — its \
+                                 tools are named `mcp__{}__{{tool}}`",
+                                app.id, app.name
+                            ));
+                        }
+                    }
+                }
+                AppBinding::Operations(binding) => {
+                    if app.kind != ConnectedAppKind::RestApi {
+                        return Err(format!(
+                            "connected app {} ({}) is a {} app; only rest_api apps \
+                             contribute operations — bind its mounted tools with \
+                             `tools` instead",
+                            app.id, app.name, app.kind
+                        ));
+                    }
+                    // A lenient read of the definition's catalog: the typed
+                    // shape and its validation live server-side, and an
+                    // authoring cross-check only needs the declared ids. A
+                    // definition without a readable catalog fails the binding
+                    // closed rather than admitting an uncheckable pin.
+                    let Some(operations) = app
+                        .definition
+                        .get("catalog")
+                        .and_then(|catalog| catalog.get("operations"))
+                        .and_then(serde_json::Value::as_object)
+                    else {
+                        return Err(format!(
+                            "connected app {} ({}) has no readable operation catalog, \
+                             so its operations cannot be bound",
+                            app.id, app.name
+                        ));
+                    };
+                    for operation_id in &binding.operation_ids {
+                        if !operations.contains_key(operation_id) {
+                            return Err(format!(
+                                "operation {operation_id:?} is not declared by connected \
+                                 app {} ({})",
+                                app.id, app.name
+                            ));
+                        }
+                    }
                 }
             }
         }
@@ -339,6 +382,7 @@ mod tests {
         turn_id: TurnId,
         profile_dir: PathBuf,
         sentry: ConnectedAppId,
+        issues: ConnectedAppId,
     }
 
     async fn fixture() -> Fixture {
@@ -361,6 +405,29 @@ mod tests {
                     name: "sentry".into(),
                     kind: ConnectedAppKind::McpServer,
                     definition: json!({ "name": "sentry", "command": "sentry-mcp" }),
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                }],
+            )
+            .await
+            .unwrap();
+        // And one rest_api record, so operation bindings resolve too. The
+        // door reads the catalog leniently, so a minimal definition works.
+        let issues = ConnectedAppId::new();
+        store
+            .replace_connected_apps(
+                ConnectedAppKind::RestApi,
+                &[crate::connected_app::ConnectedApp {
+                    id: issues,
+                    name: "issues".into(),
+                    kind: ConnectedAppKind::RestApi,
+                    definition: json!({
+                        "base_url": "https://api.example.com",
+                        "catalog": {
+                            "document_sha256": "abc",
+                            "operations": { "listIssues": {} },
+                        },
+                    }),
                     created_at: Utc::now(),
                     updated_at: Utc::now(),
                 }],
@@ -395,6 +462,7 @@ mod tests {
             turn_id,
             profile_dir,
             sentry,
+            issues,
         }
     }
 
@@ -559,6 +627,73 @@ mod tests {
         assert!(refused.is_error);
         assert!(refused.content.contains("not recorded"));
         assert_eq!(fixture.store.list_apps(10).await.unwrap().len(), 0);
+    }
+
+    /// The authoring door resolves each binding's vocabulary against the
+    /// record's kind and, for operations, against the record's declared
+    /// catalog — so a wrong kind or an undeclared operation fails here with a
+    /// teachable error rather than at the user's first open.
+    #[tokio::test]
+    async fn operation_bindings_resolve_kind_and_catalog_at_the_door() {
+        let fixture = fixture().await;
+        let operations_manifest = |app: ConnectedAppId, operation_ids: &[&str]| {
+            json!({
+                "bundle_html": "<!doctype html><h1>Issues</h1>",
+                "manifest": {
+                    "name": "Issue browser",
+                    "bindings": [{ "app": app, "operation_ids": operation_ids }],
+                },
+            })
+        };
+
+        // A declared operation on a rest_api record publishes.
+        let (_, ctx) = fixture.recorded_call().await;
+        let created = fixture
+            .tool
+            .execute(&ctx, operations_manifest(fixture.issues, &["listIssues"]))
+            .await
+            .unwrap();
+        assert!(!created.is_error, "{}", created.content);
+
+        // An operation binding against an mcp_server record is refused.
+        let (_, ctx) = fixture.recorded_call().await;
+        let refused = fixture
+            .tool
+            .execute(&ctx, operations_manifest(fixture.sentry, &["listIssues"]))
+            .await
+            .unwrap();
+        assert!(refused.is_error);
+        assert!(
+            refused.content.contains("only rest_api apps"),
+            "{}",
+            refused.content
+        );
+
+        // An operation the catalog does not declare is refused.
+        let (_, ctx) = fixture.recorded_call().await;
+        let refused = fixture
+            .tool
+            .execute(&ctx, operations_manifest(fixture.issues, &["ghostOp"]))
+            .await
+            .unwrap();
+        assert!(refused.is_error);
+        assert!(
+            refused.content.contains("not declared"),
+            "{}",
+            refused.content
+        );
+
+        // And the mirror image: a tools binding against the rest_api record.
+        let (_, ctx) = fixture.recorded_call().await;
+        let mut tools_on_rest = arguments_bound_to(fixture.issues, None);
+        tools_on_rest["manifest"]["bindings"][0]["tools"] = json!(["mcp__issues__list"]);
+        let refused = fixture.tool.execute(&ctx, tools_on_rest).await.unwrap();
+        assert!(refused.is_error);
+        assert!(
+            refused.content.contains("only mcp_server apps"),
+            "{}",
+            refused.content
+        );
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/tools/definitions.rs
+++ b/crates/openwave-core/src/tools/definitions.rs
@@ -38,13 +38,14 @@ pub(super) fn create_app() -> ToolSpec {
         crate::local_app::CREATE_APP_TOOL,
         "Publish a local mini-app the user can reopen from their Apps library: a \
          complete self-contained HTML document plus a manifest naming the app and \
-         pinning the exact mounted MCP tools it may call through the host. Each \
-         manifest binding names a connected app by its id and lists full mounted \
-         tool names (`mcp__{namespace}__{tool}`) under it; the configured \
-         connected apps and their ids are listed at the end of this description. \
-         The app renders in a sandboxed frame with no network access; pinned \
-         tools run only after the user grants them. Pass the app_id from an \
-         earlier create_app result to publish a new revision of that app — \
-         revisions append, never overwrite.",
+         pinning the exact capabilities it may call through the host. Each \
+         manifest binding names a connected app by its id and lists either full \
+         mounted tool names (`mcp__{namespace}__{tool}`, for mcp_server apps) or \
+         declared OpenAPI operationIds (`operation_ids`, for rest_api apps) under \
+         it; the configured connected apps and their ids are listed at the end of \
+         this description. The app renders in a sandboxed frame with no network \
+         access; pinned capabilities run only after the user grants them. Pass \
+         the app_id from an earlier create_app result to publish a new revision \
+         of that app — revisions append, never overwrite.",
     )
 }

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -453,6 +453,24 @@ export type AppInvokeResult = {
   is_error: boolean;
 };
 
+/**
+ * Result of a granted REST-operation invoke — {@link AppInvokeResult}'s
+ * sibling for `rest_api` bindings, hand-written for the same reason.
+ *
+ * An executed operation is opaque passthrough: whatever HTTP status the API
+ * answered (4xx/5xx included) with `is_error: false` and the raw response
+ * body base64-encoded in `body_base64` so binary responses survive JSON. A
+ * refused or failed execution is `is_error: true` with the server's closed
+ * refusal text in `error` and no response fields.
+ */
+export type AppRestInvokeResult = {
+  status?: number;
+  content_type?: string;
+  body_base64?: string;
+  is_error: boolean;
+  error?: string;
+};
+
 export type { AppInvokeRefusalKind };
 
 const APP_INVOKE_REFUSAL_KINDS: readonly AppInvokeRefusalKind[] = [
@@ -996,12 +1014,38 @@ export class ApiClient {
     tool: string,
     args: unknown,
   ): Promise<AppInvokeResult> {
+    return (await this.postAppInvoke(appId, {
+      tool,
+      arguments: args,
+    })) as AppInvokeResult;
+  }
+
+  /**
+   * Execute one of an app's pinned REST operations outside any turn — the
+   * `operation_id` sibling of {@link invokeApp}, with the same opaque
+   * passthrough and refusal contract. The response body crosses base64-
+   * encoded in `body_base64` (see {@link AppRestInvokeResult}).
+   */
+  async invokeAppOperation(
+    appId: string,
+    operationId: string,
+    parameters?: unknown,
+    body?: unknown,
+  ): Promise<AppRestInvokeResult> {
+    const request: Record<string, unknown> = { operation_id: operationId };
+    if (parameters !== undefined) request.parameters = parameters;
+    if (body !== undefined) request.body = body;
+    return (await this.postAppInvoke(appId, request)) as AppRestInvokeResult;
+  }
+
+  /** The shared invoke POST: one route, typed refusals surfaced as errors. */
+  private async postAppInvoke(appId: string, request: unknown): Promise<unknown> {
     const response = await fetch(
       `${this.baseUrl}/apps/${encodeURIComponent(appId)}/invoke`,
       {
         method: "POST",
         headers: this.headers(true),
-        body: JSON.stringify({ tool, arguments: args }),
+        body: JSON.stringify(request),
       },
     );
     if (!response.ok) {
@@ -1025,7 +1069,7 @@ export class ApiClient {
       }
       await throwIfNotOk(response);
     }
-    return (await response.json()) as AppInvokeResult;
+    return await response.json();
   }
 
   createProject(title: string): Promise<Project> {

--- a/crates/openwave-desktop/ui/src/apps/AppConsentSheet.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppConsentSheet.tsx
@@ -1,4 +1,4 @@
-import { ShieldAlert, ShieldCheck, TriangleAlert, Wrench } from "lucide-react";
+import { Globe, ShieldAlert, ShieldCheck, TriangleAlert, Wrench } from "lucide-react";
 
 import type { AppGrantState } from "@/api";
 import { Button } from "@/components/ui/button";
@@ -59,7 +59,7 @@ export function AppConsentSheet({
                 )}
               </div>
               <ul className="flex flex-col gap-0.5">
-                {binding.tools.map((tool) => (
+                {(binding.tools ?? []).map((tool) => (
                   <li
                     key={tool}
                     className="text-muted-foreground flex items-center gap-1.5 pl-1 text-xs"
@@ -68,14 +68,23 @@ export function AppConsentSheet({
                     <span className="truncate font-mono">{tool}</span>
                   </li>
                 ))}
+                {(binding.operation_ids ?? []).map((operationId) => (
+                  <li
+                    key={operationId}
+                    className="text-muted-foreground flex items-center gap-1.5 pl-1 text-xs"
+                  >
+                    <Globe className="size-3 shrink-0" aria-hidden="true" />
+                    <span className="truncate font-mono">{operationId}</span>
+                  </li>
+                ))}
               </ul>
             </li>
           ))}
         </ul>
       )}
       <p className="text-muted-foreground text-xs">
-        The app can call only these tools, only while you have it open. You can
-        revoke this at any time from the app&rsquo;s page.
+        The app can call only these tools and operations, only while you have
+        it open. You can revoke this at any time from the app&rsquo;s page.
       </p>
       {error && (
         <p className="text-critical text-sm" role="alert">

--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
@@ -25,6 +25,7 @@ const GRANTED: AppGrantState = {
       app: "11111111-1111-4111-8111-111111111111",
       name: "cmd",
       tools: ["mcp__cmd__doit"],
+      operation_ids: null,
       granted: true,
       definition_changed: false,
     },
@@ -38,8 +39,17 @@ const STALE: AppGrantState = {
       app: "11111111-1111-4111-8111-111111111111",
       name: "cmd",
       tools: ["mcp__cmd__doit"],
+      operation_ids: null,
       granted: false,
       definition_changed: true,
+    },
+    {
+      app: "22222222-2222-4222-8222-222222222222",
+      name: "issues",
+      tools: null,
+      operation_ids: ["listIssues"],
+      granted: false,
+      definition_changed: false,
     },
   ],
 };
@@ -63,6 +73,12 @@ function apisWith(grant: AppGrantState): AppsApis {
         structured_content: { ok: true },
         is_error: false,
       }),
+    invokeOperation: vi.fn().mockResolvedValue({
+      status: 200,
+      content_type: "application/json",
+      body_base64: "e30=",
+      is_error: false,
+    }),
   };
 }
 
@@ -129,6 +145,8 @@ describe("AppDetailView", () => {
     // name and tools, and the marker for a
     // definition that changed since the previous consent.
     expect(await screen.findByText("mcp__cmd__doit")).toBeInTheDocument();
+    // A rest_api binding renders its operation ids in the same list.
+    expect(screen.getByText("listIssues")).toBeInTheDocument();
     expect(
       screen.getByText("Reconfigured since you agreed"),
     ).toBeInTheDocument();

--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.tsx
@@ -157,7 +157,10 @@ export function AppDetailView({
                   <span>
                     Allowed to call{" "}
                     {grant.bindings
-                      .flatMap((binding) => binding.tools)
+                      .flatMap((binding) => [
+                        ...(binding.tools ?? []),
+                        ...(binding.operation_ids ?? []),
+                      ])
                       .join(", ") || "no tools"}
                   </span>
                 </div>

--- a/crates/openwave-desktop/ui/src/apps/appsApis.ts
+++ b/crates/openwave-desktop/ui/src/apps/appsApis.ts
@@ -4,6 +4,7 @@ import type {
   AppGrantState,
   AppInvokeResult,
   AppLibrary,
+  AppRestInvokeResult,
   AppViewSessionInfo,
 } from "@/api";
 
@@ -24,6 +25,12 @@ export type AppsApis = {
   revoke(appId: string): Promise<void>;
   viewSession(appId: string): Promise<AppViewSessionInfo>;
   invoke(appId: string, tool: string, args: unknown): Promise<AppInvokeResult>;
+  invokeOperation(
+    appId: string,
+    operationId: string,
+    parameters?: unknown,
+    body?: unknown,
+  ): Promise<AppRestInvokeResult>;
 };
 
 export function appsApisFromClient(client: ApiClient): AppsApis {
@@ -37,5 +44,7 @@ export function appsApisFromClient(client: ApiClient): AppsApis {
     revoke: (appId) => client.revokeAppGrant(appId),
     viewSession: (appId) => client.createAppViewFrame(appId),
     invoke: (appId, tool, args) => client.invokeApp(appId, tool, args),
+    invokeOperation: (appId, operationId, parameters, body) =>
+      client.invokeAppOperation(appId, operationId, parameters, body),
   };
 }

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -138,6 +138,10 @@ revisions: Array<AppRevisionSummary>, };
 
 /**
  * One current-manifest binding, projected for the consent sheet.
+ *
+ * Exactly one of `tools` and `operation_ids` is present, matching the
+ * binding's vocabulary: mounted MCP tools for an `mcp_server` binding,
+ * declared operations for a `rest_api` binding.
  */
 export type AppGrantBindingState = { 
 /**
@@ -150,13 +154,19 @@ app: ConnectedAppId,
  */
 name: string | null, 
 /**
- * Full mounted tool names the current manifest pins under this app.
+ * Full mounted tool names the current manifest pins under this app, for
+ * an `mcp_server` binding.
  */
-tools: Array<string>, 
+tools: Array<string> | null, 
 /**
- * Whether the live grant covers every listed tool under this connected
- * app and the app's current definition still matches the granted
- * fingerprint.
+ * Catalog `operationId`s the current manifest pins under this app, for a
+ * `rest_api` binding.
+ */
+operation_ids: Array<string> | null, 
+/**
+ * Whether the live grant covers every listed capability under this
+ * connected app and the app's current definition still matches the
+ * granted fingerprint.
  */
 granted: boolean, 
 /**
@@ -172,14 +182,15 @@ definition_changed: boolean, };
  *
  * `bindings` follows the app's **current** revision's manifest — ids and
  * names only. The definitions behind the connected apps, and any environment
- * or token values they select, are deliberately absent from this projection.
+ * or credential values they select, are deliberately absent from this
+ * projection.
  */
 export type AppGrantState = { 
 /**
  * Whether a live grant fully covers the current manifest with every
  * bound definition unchanged since consent — the "no sheet needed"
  * verdict. When `false`, (re-)consent is required before every pinned
- * tool is invokable.
+ * capability is invokable.
  */
 granted: boolean, 
 /**
@@ -1374,7 +1385,7 @@ end_published_at: string | null, } | { "tool": "web_extract", url: string, };
  *
  * Each presentable variant names the egress a human is consenting to, so the
  * renderer can describe the action without ever seeing the model-authored
- * summary or arguments. `Unsupported` is the fail-closed default: a Sensitive
+ * arguments. `Unsupported` is the fail-closed default: a Sensitive
  * action the server can only reject, never approve.
  */
 export type ToolApprovalKind = "search_may_share_query_and_excerpts" | "web_search_may_share_query" | "web_extract_may_fetch_url" | "exec_may_run_networked_command" | "external_mcp_may_call_server" | "workspace_may_modify_files" | "unsupported";

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -40,6 +40,8 @@ uuid = { workspace = true }
 unicode-general-category = { workspace = true }
 chrono = { workspace = true }
 ts-rs = { workspace = true }
+# REST invoke responses cross to the renderer with the raw body base64-encoded.
+base64 = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 cap-std = { workspace = true }

--- a/crates/openwave-server/src/connected_apps.rs
+++ b/crates/openwave-server/src/connected_apps.rs
@@ -1,0 +1,374 @@
+//! The `rest_api` connected-app definition and the combined per-request
+//! fingerprint lookup grant enforcement runs against.
+//!
+//! An `mcp_server` record's typed definition, validation, and fingerprint
+//! live with the MCP runtime ([`crate::mcp_config`]); this module is the
+//! same layer for the `rest_api` kind, plus the one lookup that spans both:
+//! [`current_app_fingerprints`], the map the grant, invoke, and library
+//! surfaces compare pinned fingerprints against. Everything reads live per
+//! request — never cached across one — so enforcement always judges the
+//! definition an id resolves to *now*.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use openwave_core::connected_app::ConnectedAppKind;
+use openwave_core::id::ConnectedAppId;
+use openwave_core::SecretProvider;
+
+use crate::openapi_catalog::OperationCatalog;
+use crate::rest_executor::{
+    CredentialPlacement, ReqwestRestTransport, RestApiTarget, RestCredential, RestExecuteError,
+    RestExecutor, RestHostResolver, RestOperationRequest, RestOperationResponse, RestTransport,
+    TokioRestHostResolver,
+};
+use crate::state::AppState;
+
+/// The typed definition a `rest_api` connected-app record carries: where
+/// operations execute, what the ingested catalog declares, and which stored
+/// credential (if any) authenticates them.
+///
+/// Closed on both ends: unknown fields refuse to parse, so a record written
+/// by a future shape is treated as not-configured rather than partially
+/// honored.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RestApiDefinition {
+    /// Base URL the operation path templates append to.
+    pub base_url: String,
+    /// The bounded operation catalog ingested from the app's OpenAPI
+    /// document.
+    pub catalog: OperationCatalog,
+    /// Stored credential reference and placement, when the API needs one.
+    /// The referenced value never appears in the definition.
+    pub credential: Option<RestCredential>,
+}
+
+impl RestApiDefinition {
+    /// The executor target this definition describes.
+    pub(crate) fn target(&self) -> RestApiTarget {
+        RestApiTarget {
+            base_url: self.base_url.clone(),
+            credential: self.credential.clone(),
+        }
+    }
+}
+
+/// Parse a `rest_api` record's definition JSON, failing closed per record.
+pub(crate) fn parse_rest_api_definition(
+    definition: &serde_json::Value,
+) -> Result<RestApiDefinition, String> {
+    serde_json::from_value(definition.clone())
+        .map_err(|error| format!("invalid rest_api definition: {error}"))
+}
+
+/// SHA-256 fingerprint of a `rest_api` definition as configured, the value an
+/// app grant pins the bound connected app to.
+///
+/// The digest is taken over the UTF-8 bytes of a compact JSON object with
+/// **exactly these keys, in exactly this order** (serde serializes struct
+/// fields in declaration order, and every key is always present):
+///
+/// ```json
+/// {"v":2,
+///  "kind":"rest_api",
+///  "base_url":string,
+///  "document_sha256":string,
+///  "credential_reference":string|null,
+///  "placement":"bearer"|{"header":name}|null}
+/// ```
+///
+/// `document_sha256` is the catalog's hash of the raw OpenAPI document bytes,
+/// so the ingested operations enter the form only through the document they
+/// came from — a re-serialization of the catalog cannot move the fingerprint.
+/// `credential_reference` is the secret-store *name*: rotating the credential
+/// value behind the same reference never changes what the user consented to,
+/// while repointing the reference does. The value itself never enters the
+/// form, so the fingerprint can never be a value oracle. `kind` roots the
+/// form in the connected-app vocabulary so no two kinds can collide on a
+/// canonical serialization, and `v:2` aligns with the `mcp_server` form's
+/// current version.
+///
+/// **This canonical form is a compatibility surface.** Persisted grants store
+/// the digest; changing the form (or the meaning of any field in it)
+/// invalidates every existing grant and must bump `v`.
+pub(crate) fn rest_api_fingerprint(definition: &RestApiDefinition) -> [u8; 32] {
+    use sha2::Digest as _;
+
+    #[derive(Serialize)]
+    struct CanonicalDefinition<'a> {
+        v: u32,
+        kind: &'static str,
+        base_url: &'a str,
+        document_sha256: &'a str,
+        credential_reference: Option<&'a str>,
+        placement: Option<&'a CredentialPlacement>,
+    }
+
+    let canonical = CanonicalDefinition {
+        v: 2,
+        kind: "rest_api",
+        base_url: &definition.base_url,
+        document_sha256: &definition.catalog.document_sha256,
+        credential_reference: definition
+            .credential
+            .as_ref()
+            .map(|credential| credential.secret_name.as_str()),
+        placement: definition
+            .credential
+            .as_ref()
+            .map(|credential| &credential.placement),
+    };
+    let bytes = serde_json::to_vec(&canonical)
+        .expect("a canonical definition serializes infallibly to JSON");
+    sha2::Sha256::digest(&bytes).into()
+}
+
+/// One configured connected app's display name, kind, and current definition
+/// fingerprint — the tuple grant enforcement compares per record id. For an
+/// `mcp_server` app the name is also the namespace its tools mount under.
+pub(crate) struct AppFingerprint {
+    pub(crate) name: String,
+    pub(crate) kind: ConnectedAppKind,
+    pub(crate) fingerprint: [u8; 32],
+}
+
+/// The current fingerprint of every configured connected app, across kinds.
+///
+/// `mcp_server` entries come from the live MCP runtime; `rest_api` entries
+/// are computed from the stored records. A `rest_api` record whose definition
+/// does not parse is skipped — it reads as not-configured, so every grant
+/// naming it fails closed to re-consent rather than matching anything.
+pub(crate) async fn current_app_fingerprints(
+    state: &AppState,
+) -> openwave_core::Result<BTreeMap<ConnectedAppId, AppFingerprint>> {
+    let mut current: BTreeMap<ConnectedAppId, AppFingerprint> = state
+        .mcp
+        .app_fingerprints()
+        .await
+        .into_iter()
+        .map(|(id, app)| {
+            (
+                id,
+                AppFingerprint {
+                    name: app.name,
+                    kind: ConnectedAppKind::McpServer,
+                    fingerprint: app.fingerprint,
+                },
+            )
+        })
+        .collect();
+    for (id, record_name, definition) in current_rest_definitions(state).await? {
+        current.insert(
+            id,
+            AppFingerprint {
+                name: record_name,
+                kind: ConnectedAppKind::RestApi,
+                fingerprint: rest_api_fingerprint(&definition),
+            },
+        );
+    }
+    Ok(current)
+}
+
+/// Every stored `rest_api` record whose definition parses, read live.
+///
+/// The consent computation needs the catalogs behind the fingerprints (to
+/// check pinned operation ids) and invoke dispatch needs the whole
+/// definition; both read through here so "configured" always means "parses
+/// closed".
+pub(crate) async fn current_rest_definitions(
+    state: &AppState,
+) -> openwave_core::Result<Vec<(ConnectedAppId, String, RestApiDefinition)>> {
+    Ok(state
+        .store
+        .list_connected_apps()
+        .await?
+        .into_iter()
+        .filter(|record| record.kind == ConnectedAppKind::RestApi)
+        .filter_map(|record| {
+            parse_rest_api_definition(&record.definition)
+                .ok()
+                .map(|definition| (record.id, record.name, definition))
+        })
+        .collect())
+}
+
+/// Dispatch seam for one governed REST operation, so the invoke route can be
+/// driven against a fake transport in tests while production always executes
+/// through the real [`RestExecutor`] stack.
+#[async_trait]
+pub(crate) trait RestOperationDispatcher: Send + Sync {
+    async fn dispatch(
+        &self,
+        target: &RestApiTarget,
+        catalog: &OperationCatalog,
+        request: &RestOperationRequest,
+    ) -> Result<RestOperationResponse, RestExecuteError>;
+}
+
+#[async_trait]
+impl<T: RestTransport, R: RestHostResolver> RestOperationDispatcher for RestExecutor<T, R> {
+    async fn dispatch(
+        &self,
+        target: &RestApiTarget,
+        catalog: &OperationCatalog,
+        request: &RestOperationRequest,
+    ) -> Result<RestOperationResponse, RestExecuteError> {
+        self.execute(target, catalog, request, None).await
+    }
+}
+
+/// The production dispatcher: the governed executor over the real transport
+/// and resolver, resolving credentials from the given secret store.
+pub(crate) fn governed_rest_dispatcher(
+    secrets: Arc<dyn SecretProvider>,
+) -> Arc<dyn RestOperationDispatcher> {
+    Arc::new(RestExecutor::new(
+        ReqwestRestTransport,
+        TokioRestHostResolver,
+        secrets,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn definition(
+        base_url: &str,
+        document_sha256: &str,
+        credential: Option<RestCredential>,
+    ) -> RestApiDefinition {
+        RestApiDefinition {
+            base_url: base_url.into(),
+            catalog: OperationCatalog {
+                document_sha256: document_sha256.into(),
+                operations: BTreeMap::new(),
+            },
+            credential,
+        }
+    }
+
+    /// The invariants the canonical form exists for: the fingerprint follows
+    /// the credential *reference* (never the value, which is not even
+    /// representable in the definition), it follows repointing that
+    /// reference, and it derives from exactly base URL + document hash +
+    /// reference + placement — catalog operations beyond the document hash
+    /// do not enter the form.
+    #[test]
+    fn rest_fingerprints_pin_references_and_derive_from_declared_fields_only() {
+        let credential = |secret_name: &str, placement: CredentialPlacement| RestCredential {
+            secret_name: secret_name.into(),
+            placement,
+        };
+        let baseline = rest_api_fingerprint(&definition(
+            "https://api.example.com/v2",
+            "doc-hash-a",
+            Some(credential("sentry-token", CredentialPlacement::Bearer)),
+        ));
+
+        // Rotating the credential VALUE behind the same reference is not a
+        // definition change at all: the value never appears in the
+        // definition, so the same definition always fingerprints the same.
+        assert_eq!(
+            rest_api_fingerprint(&definition(
+                "https://api.example.com/v2",
+                "doc-hash-a",
+                Some(credential("sentry-token", CredentialPlacement::Bearer)),
+            )),
+            baseline
+        );
+
+        // Repointing the reference, moving the placement, dropping the
+        // credential, changing the base URL, or swapping the document all
+        // change what the user consented to.
+        for changed in [
+            definition(
+                "https://api.example.com/v2",
+                "doc-hash-a",
+                Some(credential("other-token", CredentialPlacement::Bearer)),
+            ),
+            definition(
+                "https://api.example.com/v2",
+                "doc-hash-a",
+                Some(credential(
+                    "sentry-token",
+                    CredentialPlacement::Header("X-Api-Key".into()),
+                )),
+            ),
+            definition("https://api.example.com/v2", "doc-hash-a", None),
+            definition(
+                "https://api.example.com/v3",
+                "doc-hash-a",
+                Some(credential("sentry-token", CredentialPlacement::Bearer)),
+            ),
+            definition(
+                "https://api.example.com/v2",
+                "doc-hash-b",
+                Some(credential("sentry-token", CredentialPlacement::Bearer)),
+            ),
+        ] {
+            assert_ne!(rest_api_fingerprint(&changed), baseline, "{changed:?}");
+        }
+
+        // Catalog operations enter the form only through the document hash: a
+        // catalog carrying extra parsed operations under the same document
+        // hash fingerprints identically.
+        let mut with_operations = definition(
+            "https://api.example.com/v2",
+            "doc-hash-a",
+            Some(credential("sentry-token", CredentialPlacement::Bearer)),
+        );
+        with_operations.catalog.operations.insert(
+            "listIssues".into(),
+            crate::openapi_catalog::CatalogOperation {
+                operation_id: "listIssues".into(),
+                method: crate::openapi_catalog::HttpMethod::Get,
+                path_template: "/issues".into(),
+                parameters: Vec::new(),
+                request_body: None,
+            },
+        );
+        assert_eq!(rest_api_fingerprint(&with_operations), baseline);
+    }
+
+    /// The definition fails closed: unknown fields, missing fields, and a
+    /// non-object all refuse, and the executor's credential shapes are reused
+    /// verbatim.
+    #[test]
+    fn definitions_parse_closed() {
+        let parsed = parse_rest_api_definition(&json!({
+            "base_url": "https://api.example.com",
+            "catalog": { "document_sha256": "abc", "operations": {} },
+            "credential": { "secret_name": "token", "placement": "bearer" },
+        }))
+        .unwrap();
+        assert_eq!(
+            parsed.credential,
+            Some(RestCredential {
+                secret_name: "token".into(),
+                placement: CredentialPlacement::Bearer,
+            })
+        );
+        for malformed in [
+            json!({ "base_url": "https://api.example.com" }),
+            json!({
+                "base_url": "https://api.example.com",
+                "catalog": { "document_sha256": "abc", "operations": {} },
+                "extra": true,
+            }),
+            json!([]),
+        ] {
+            assert!(
+                parse_rest_api_definition(&malformed).is_err(),
+                "{malformed}"
+            );
+        }
+    }
+}

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -21,6 +21,7 @@ mod bus;
 mod chat_titling;
 /// Host-owned code-execution provider selection and policy.
 pub mod code_execution;
+mod connected_apps;
 mod desktop_schema;
 mod document_decode;
 mod durable_oplog;

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -467,14 +467,29 @@ impl openwave_core::Tool for CreateAppWithRoster {
     }
 }
 
+/// How many of a `rest_api` record's operation ids the roster lists before
+/// eliding the rest — enough to author against without letting a 256-entry
+/// catalog balloon the tool description.
+const ROSTER_OPERATION_IDS: usize = 20;
+
+/// One configured `rest_api` connected app's roster inputs: the record id a
+/// binding names and the operation ids its catalog declares.
+pub(crate) struct RestRosterApp {
+    pub(crate) id: ConnectedAppId,
+    pub(crate) name: String,
+    pub(crate) operation_ids: Vec<String>,
+}
+
 /// The roster text appended to `create_app`'s description: every configured
-/// `mcp_server` connected app with the id a manifest binding names and the
-/// namespace its mounted tools carry.
+/// connected app with the id a manifest binding names — the namespace an
+/// `mcp_server`'s mounted tools carry, or a bounded sample of a `rest_api`
+/// record's operation ids.
 fn connected_app_roster(
     definitions: &[McpServerDefinition],
     ids: &BTreeMap<String, ConnectedAppId>,
+    rest: &[RestRosterApp],
 ) -> String {
-    if definitions.is_empty() {
+    if definitions.is_empty() && rest.is_empty() {
         return "\n\nNo connected apps are configured, so only manifests with an \
                 empty bindings list can be created."
             .to_owned();
@@ -488,6 +503,23 @@ fn connected_app_roster(
         roster.push_str(&format!(
             "\n- {id} — {name}: tools are named `mcp__{name}__{{tool}}`",
             name = definition.name
+        ));
+    }
+    for app in rest {
+        let mut listed: Vec<&str> = app
+            .operation_ids
+            .iter()
+            .take(ROSTER_OPERATION_IDS)
+            .map(String::as_str)
+            .collect();
+        if app.operation_ids.len() > ROSTER_OPERATION_IDS {
+            listed.push("…");
+        }
+        roster.push_str(&format!(
+            "\n- {id} — {name} (rest_api): bind with `operation_ids` from: {operations}",
+            id = app.id,
+            name = app.name,
+            operations = listed.join(", ")
         ));
     }
     roster
@@ -653,7 +685,7 @@ impl McpRuntime {
             torn_down = true;
         }
         if torn_down {
-            let registry = self.registry_for(&state);
+            let registry = self.registry_for(&state).await;
             *self
                 .tools
                 .write()
@@ -1039,7 +1071,8 @@ impl McpRuntime {
         ids: BTreeMap<String, ConnectedAppId>,
         servers: HashMap<String, ManagedServer>,
     ) {
-        let registry = self.registry_with(&definitions, &ids, &servers);
+        let rest = self.rest_roster().await;
+        let registry = self.registry_with(&definitions, &ids, &servers, &rest);
         let mut state = self.state.lock().await;
         state.definitions = definitions;
         state.ids = ids;
@@ -1050,11 +1083,43 @@ impl McpRuntime {
             .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(registry);
     }
 
+    /// Every stored `rest_api` connected app's roster inputs, read from the
+    /// store when a registry is (re)built. The roster is authoring
+    /// legibility, never the gate, so an unreadable store or an unparseable
+    /// definition degrades to an absent roster line rather than failing the
+    /// registry rebuild.
+    async fn rest_roster(&self) -> Vec<RestRosterApp> {
+        let records = match self.store.list_connected_apps().await {
+            Ok(records) => records,
+            Err(error) => {
+                tracing::warn!("could not read connected apps for the create_app roster: {error}");
+                return Vec::new();
+            }
+        };
+        records
+            .into_iter()
+            .filter(|record| record.kind == ConnectedAppKind::RestApi)
+            .filter_map(|record| {
+                let operations = record
+                    .definition
+                    .get("catalog")?
+                    .get("operations")?
+                    .as_object()?;
+                Some(RestRosterApp {
+                    id: record.id,
+                    name: record.name,
+                    operation_ids: operations.keys().cloned().collect(),
+                })
+            })
+            .collect()
+    }
+
     /// [`registry_with`](Self::registry_with) over the already-published
     /// state, for the paths that refresh connections without changing the
     /// configuration.
-    fn registry_for(&self, state: &RuntimeState) -> ToolRegistry {
-        self.registry_with(&state.definitions, &state.ids, &state.servers)
+    async fn registry_for(&self, state: &RuntimeState) -> ToolRegistry {
+        let rest = self.rest_roster().await;
+        self.registry_with(&state.definitions, &state.ids, &state.servers, &rest)
     }
 
     fn registry_with(
@@ -1062,6 +1127,7 @@ impl McpRuntime {
         definitions: &[McpServerDefinition],
         ids: &BTreeMap<String, ConnectedAppId>,
         servers: &HashMap<String, ManagedServer>,
+        rest: &[RestRosterApp],
     ) -> ToolRegistry {
         let mut registry = self.base_tools.clone();
         for (name, server) in servers {
@@ -1081,7 +1147,7 @@ impl McpRuntime {
         if let Some(inner) = registry.server_tool(CREATE_APP_TOOL) {
             registry.register(Box::new(CreateAppWithRoster {
                 inner,
-                roster: connected_app_roster(definitions, ids),
+                roster: connected_app_roster(definitions, ids, rest),
             }));
         }
         registry
@@ -1188,7 +1254,7 @@ impl McpRuntime {
                 server.ui_views = ui_views;
                 server.reconnect_backoff = INITIAL_RECONNECT_BACKOFF;
                 server.epoch = self.fresh_epoch();
-                let registry = self.registry_for(&state);
+                let registry = self.registry_for(&state).await;
                 *self
                     .tools
                     .write()
@@ -1215,7 +1281,7 @@ impl McpRuntime {
                 } else {
                     return Ok(self.info_locked(&state));
                 }
-                let registry = self.registry_for(&state);
+                let registry = self.registry_for(&state).await;
                 *self
                     .tools
                     .write()
@@ -1299,7 +1365,7 @@ impl McpRuntime {
             server.ui_views = HashMap::new();
             server.reconnect_backoff = backoff;
         }
-        let registry = self.registry_for(&state);
+        let registry = self.registry_for(&state).await;
         *self
             .tools
             .write()

--- a/crates/openwave-server/src/routes/app_grant.rs
+++ b/crates/openwave-server/src/routes/app_grant.rs
@@ -3,44 +3,54 @@
 //!
 //! The renderer never supplies grant content. Consent (`POST`) is a bare
 //! affirmative — the server computes the grant from the app's *current*
-//! manifest and the server definitions *current* at that moment, so a stale
-//! sheet can never grant tools the manifest no longer pins or pin a
-//! definition that has since changed. State (`GET`) is renderer-safe
-//! metadata: server and tool *names* with coverage/staleness booleans, never
-//! definitions and never environment values.
+//! manifest and the connected-app definitions *current* at that moment, so a
+//! stale sheet can never grant capabilities the manifest no longer pins or
+//! pin a definition that has since changed. State (`GET`) is renderer-safe
+//! metadata: connected-app, tool, and operation *names* with
+//! coverage/staleness booleans, never definitions and never environment or
+//! credential values.
+
+use std::collections::BTreeMap;
 
 use axum::extract::State;
 use axum::http::StatusCode;
 use chrono::Utc;
 use serde::Serialize;
 
+use openwave_core::connected_app::ConnectedAppKind;
 use openwave_core::id::{AppId, ConnectedAppId};
 use openwave_core::local_app::{
-    mounted_tool_under, AppGrant, AppGrantBinding, AppManifest, AppRecord, AppRevision,
+    mounted_tool_under, AppBinding, AppGrant, AppGrantBinding, AppManifest,
+    AppOperationsGrantBinding, AppRecord, AppRevision, AppToolsGrantBinding,
 };
 
+use crate::connected_apps::{current_app_fingerprints, current_rest_definitions, AppFingerprint};
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
-use crate::mcp_config::McpAppFingerprint;
 use crate::state::AppState;
 
 /// Renderer-safe grant state for one app: the consent sheet's whole input.
 ///
 /// `bindings` follows the app's **current** revision's manifest — ids and
 /// names only. The definitions behind the connected apps, and any environment
-/// or token values they select, are deliberately absent from this projection.
+/// or credential values they select, are deliberately absent from this
+/// projection.
 #[derive(Debug, Serialize, ts_rs::TS)]
 pub struct AppGrantState {
     /// Whether a live grant fully covers the current manifest with every
     /// bound definition unchanged since consent — the "no sheet needed"
     /// verdict. When `false`, (re-)consent is required before every pinned
-    /// tool is invokable.
+    /// capability is invokable.
     pub granted: bool,
     /// The current manifest's bindings, one entry per bound connected app.
     pub bindings: Vec<AppGrantBindingState>,
 }
 
 /// One current-manifest binding, projected for the consent sheet.
+///
+/// Exactly one of `tools` and `operation_ids` is present, matching the
+/// binding's vocabulary: mounted MCP tools for an `mcp_server` binding,
+/// declared operations for a `rest_api` binding.
 #[derive(Debug, Serialize, ts_rs::TS)]
 pub struct AppGrantBindingState {
     /// Connected app the manifest binds, by record id.
@@ -48,11 +58,15 @@ pub struct AppGrantBindingState {
     /// The connected app's display name, absent when no record with that id
     /// is configured — the sheet says so instead of showing a raw id alone.
     pub name: Option<String>,
-    /// Full mounted tool names the current manifest pins under this app.
-    pub tools: Vec<String>,
-    /// Whether the live grant covers every listed tool under this connected
-    /// app and the app's current definition still matches the granted
-    /// fingerprint.
+    /// Full mounted tool names the current manifest pins under this app, for
+    /// an `mcp_server` binding.
+    pub tools: Option<Vec<String>>,
+    /// Catalog `operationId`s the current manifest pins under this app, for a
+    /// `rest_api` binding.
+    pub operation_ids: Option<Vec<String>>,
+    /// Whether the live grant covers every listed capability under this
+    /// connected app and the app's current definition still matches the
+    /// granted fingerprint.
     pub granted: bool,
     /// Whether a grant names this connected app but its definition changed
     /// (or the record disappeared) since consent — the "reconfigured since
@@ -68,7 +82,7 @@ pub async fn get_app_grant_state(
 ) -> Result<Json<AppGrantState>, ServerError> {
     let (app, revision) = current_live_app(&state, app_id).await?;
     let grant = state.store.get_app_grant(app.id).await?;
-    let current = state.mcp.app_fingerprints().await;
+    let current = current_app_fingerprints(&state).await?;
     Ok(Json(grant_state(
         &revision.manifest,
         grant.as_ref(),
@@ -87,36 +101,82 @@ pub async fn post_app_grant(
     Path(app_id): Path<AppId>,
 ) -> Result<Json<AppGrantState>, ServerError> {
     let (app, revision) = current_live_app(&state, app_id).await?;
-    let current = state.mcp.app_fingerprints().await;
+    let current = current_app_fingerprints(&state).await?;
+    let rest_definitions = current_rest_definitions(&state).await?;
     let mut bindings = Vec::with_capacity(revision.manifest.bindings.len());
     for binding in &revision.manifest.bindings {
         // A binding whose connected app is not configured cannot be pinned to
-        // a definition, so there is nothing coherent to consent to.
-        let Some(app_fingerprint) = current.get(&binding.app) else {
+        // a definition, so there is nothing coherent to consent to. An
+        // unparseable rest_api definition reads the same way, by design.
+        let Some(app_fingerprint) = current.get(&binding.app()) else {
             return Err(ServerError::conflict(format!(
                 "connected app {} is not configured, so this app cannot be granted",
-                binding.app
+                binding.app()
             )));
         };
-        // Nor is there anything coherent when a pinned name is not under the
-        // app's current namespace (the record was renamed after authoring):
-        // the grant would name tools that cannot exist under this app.
-        if let Some(tool) = binding
-            .tools
-            .iter()
-            .find(|tool| mounted_tool_under(&app_fingerprint.name, tool).is_none())
-        {
-            return Err(ServerError::conflict(format!(
-                "tool {tool:?} is not mounted under connected app {:?}, so this \
-                 app cannot be granted",
-                app_fingerprint.name
-            )));
+        match binding {
+            AppBinding::Tools(binding) => {
+                if app_fingerprint.kind != ConnectedAppKind::McpServer {
+                    return Err(ServerError::conflict(format!(
+                        "connected app {:?} is a {} app, so its tools binding cannot \
+                         be granted",
+                        app_fingerprint.name, app_fingerprint.kind
+                    )));
+                }
+                // Nor is there anything coherent when a pinned name is not
+                // under the app's current namespace (the record was renamed
+                // after authoring): the grant would name tools that cannot
+                // exist under this app.
+                if let Some(tool) = binding
+                    .tools
+                    .iter()
+                    .find(|tool| mounted_tool_under(&app_fingerprint.name, tool).is_none())
+                {
+                    return Err(ServerError::conflict(format!(
+                        "tool {tool:?} is not mounted under connected app {:?}, so this \
+                         app cannot be granted",
+                        app_fingerprint.name
+                    )));
+                }
+                bindings.push(AppGrantBinding::Tools(AppToolsGrantBinding {
+                    app: binding.app,
+                    tools: binding.tools.clone(),
+                    fingerprint: app_fingerprint.fingerprint,
+                }));
+            }
+            AppBinding::Operations(binding) => {
+                // Every pinned operation must exist in the record's current
+                // catalog — a pin the catalog no longer declares leaves
+                // nothing coherent to consent to.
+                let declared = rest_definitions
+                    .iter()
+                    .find(|(id, _, _)| *id == binding.app)
+                    .map(|(_, _, definition)| &definition.catalog.operations);
+                let Some(declared) = declared else {
+                    return Err(ServerError::conflict(format!(
+                        "connected app {:?} is a {} app, so its operations binding \
+                         cannot be granted",
+                        app_fingerprint.name, app_fingerprint.kind
+                    )));
+                };
+                if let Some(operation_id) = binding
+                    .operation_ids
+                    .iter()
+                    .find(|operation_id| !declared.contains_key(*operation_id))
+                {
+                    return Err(ServerError::conflict(format!(
+                        "operation {operation_id:?} is not declared by connected app \
+                         {:?}, so this app cannot be granted",
+                        app_fingerprint.name
+                    )));
+                }
+                bindings.push(AppGrantBinding::Operations(AppOperationsGrantBinding {
+                    app: binding.app,
+                    operation_ids: binding.operation_ids.clone(),
+                    fingerprint: app_fingerprint.fingerprint,
+                }));
+            }
         }
-        bindings.push(AppGrantBinding {
-            app: binding.app,
-            tools: binding.tools.clone(),
-            fingerprint: app_fingerprint.fingerprint,
-        });
     }
     let grant = AppGrant {
         app_id: app.id,
@@ -135,11 +195,11 @@ pub async fn post_app_grant(
 /// carries right now. A missing record is a mismatch, never a match.
 fn fingerprint_current(
     binding: &AppGrantBinding,
-    current: &std::collections::BTreeMap<ConnectedAppId, McpAppFingerprint>,
+    current: &BTreeMap<ConnectedAppId, AppFingerprint>,
 ) -> bool {
     current
-        .get(&binding.app)
-        .is_some_and(|app| app.fingerprint == binding.fingerprint)
+        .get(&binding.app())
+        .is_some_and(|app| app.fingerprint == binding.fingerprint())
 }
 
 /// `DELETE /apps/{id}/grant` — revoke consent.
@@ -179,16 +239,34 @@ async fn current_live_app(
     Ok((app, revision))
 }
 
+/// Whether a granted binding covers everything a current-manifest binding
+/// pins, in the same vocabulary. A grant kept under the other vocabulary
+/// covers nothing: consent named tools or operations, never "whatever the
+/// record now speaks".
+fn binding_covered(pinned: &AppBinding, granted: &AppGrantBinding) -> bool {
+    match (pinned, granted) {
+        (AppBinding::Tools(pinned), AppGrantBinding::Tools(granted)) => pinned
+            .tools
+            .iter()
+            .all(|tool| granted.tools.iter().any(|held| held == tool)),
+        (AppBinding::Operations(pinned), AppGrantBinding::Operations(granted)) => pinned
+            .operation_ids
+            .iter()
+            .all(|operation| granted.operation_ids.iter().any(|held| held == operation)),
+        _ => false,
+    }
+}
+
 /// Project grant state against the current manifest and current definitions.
 ///
 /// The same three checks the invoke gate applies, evaluated for the whole
-/// manifest: `granted` is true exactly when every pinned tool would pass the
-/// gate right now. Shared with the library listing so its granted badge is
-/// this verdict rather than a reimplementation of it.
+/// manifest: `granted` is true exactly when every pinned capability would
+/// pass the gate right now. Shared with the library listing so its granted
+/// badge is this verdict rather than a reimplementation of it.
 pub(crate) fn grant_state(
     manifest: &AppManifest,
     grant: Option<&AppGrant>,
-    current: &std::collections::BTreeMap<ConnectedAppId, McpAppFingerprint>,
+    current: &BTreeMap<ConnectedAppId, AppFingerprint>,
 ) -> AppGrantState {
     let bindings: Vec<AppGrantBindingState> = manifest
         .bindings
@@ -198,20 +276,20 @@ pub(crate) fn grant_state(
                 grant
                     .bindings
                     .iter()
-                    .find(|candidate| candidate.app == binding.app)
+                    .find(|candidate| candidate.app() == binding.app())
             });
-            let covered = granted_binding.is_some_and(|granted| {
-                binding
-                    .tools
-                    .iter()
-                    .all(|tool| granted.tools.iter().any(|held| held == tool))
-            });
+            let covered = granted_binding.is_some_and(|granted| binding_covered(binding, granted));
             let definition_changed =
                 granted_binding.is_some_and(|granted| !fingerprint_current(granted, current));
+            let (tools, operation_ids) = match binding {
+                AppBinding::Tools(binding) => (Some(binding.tools.clone()), None),
+                AppBinding::Operations(binding) => (None, Some(binding.operation_ids.clone())),
+            };
             AppGrantBindingState {
-                app: binding.app,
-                name: current.get(&binding.app).map(|app| app.name.clone()),
-                tools: binding.tools.clone(),
+                app: binding.app(),
+                name: current.get(&binding.app()).map(|app| app.name.clone()),
+                tools,
+                operation_ids,
                 granted: covered
                     && granted_binding.is_some_and(|granted| fingerprint_current(granted, current)),
                 definition_changed,

--- a/crates/openwave-server/src/routes/app_invoke.rs
+++ b/crates/openwave-server/src/routes/app_invoke.rs
@@ -1,15 +1,16 @@
 //! `POST /apps/{id}/invoke` — out-of-turn invocation of a local app's pinned
-//! MCP tools.
+//! capabilities: mounted MCP tools and declared REST operations.
 //!
 //! The first tool execution outside a model turn: the sandboxed app frame
 //! posts a call to the trusted renderer, the renderer forwards it here on its
 //! bearer, and the server performs the same dispatch a turn would — registry
-//! snapshot, `Tool::execute` — minus the turn. Enforcement is entirely
-//! server-side and fails closed, in a fixed order: the app must exist with a
-//! current revision, the requested tool must be pinned in that revision's
-//! manifest bindings, and a live app grant must cover the call — including
-//! that every granted server's current definition still matches the
-//! fingerprint recorded at consent.
+//! snapshot and `Tool::execute` for a mounted MCP tool, the governed REST
+//! executor for a declared operation — minus the turn. Enforcement is
+//! entirely server-side and fails closed, in a fixed order: the app must
+//! exist with a current revision, the requested capability must be pinned in
+//! that revision's manifest bindings, and a live app grant must cover the
+//! call — including that every granted connected app's current definition
+//! still matches the fingerprint recorded at consent.
 //!
 //! Chat approval gates, permission modes, and plan mode deliberately do not
 //! apply: there is no chat. The app grant is the whole policy.
@@ -17,39 +18,51 @@
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 
 use openwave_core::id::AppId;
-use openwave_core::local_app::{AppRecord, AppRevision};
+use openwave_core::local_app::{AppBinding, AppGrantBinding, AppRecord, AppRevision};
 use openwave_core::{AgentError, ChatId, ToolCtx};
 
+use crate::connected_apps::{current_app_fingerprints, current_rest_definitions};
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
+use crate::rest_executor::{RestExecuteError, RestOperationRequest};
 use crate::state::AppState;
 
-/// Body bound for an invoke request: a mounted tool name plus its opaque
+/// Body bound for an invoke request: a capability name plus its opaque
 /// arguments. Generous for a tool call, far below the MCP client's own 2 MiB
-/// JSON-RPC frame bound so an admitted request can always be forwarded.
+/// JSON-RPC frame bound so an admitted request can always be forwarded, and
+/// exactly the governed REST executor's request-body cap.
 pub(crate) const MAX_APP_INVOKE_BODY_BYTES: usize = 256 * 1024;
 
-/// Body of `POST /apps/{id}/invoke`.
+/// Body of `POST /apps/{id}/invoke` — one of the two invocable surfaces.
 ///
-/// `arguments` is opaque passthrough JSON authored inside the sandboxed app
-/// frame. The server hands it to the mounted tool verbatim and the renderer
-/// never interprets it, so — like [`super::McpAppPayload`] — this request has
-/// a hand-written TS twin rather than a generated wire type: the generator's
-/// precision guard rightly refuses `any`-shaped fields.
+/// Either `tool` (with optional `arguments`) for a mounted MCP tool, or
+/// `operation_id` (with optional `parameters`/`body`) for a declared REST
+/// operation — never both, never neither. The passthrough halves
+/// (`arguments`, `parameters`, `body`) are opaque JSON authored inside the
+/// sandboxed app frame; the server hands them to the executor verbatim and
+/// the renderer never interprets them, so — like [`super::McpAppPayload`] —
+/// this request has a hand-written TS twin rather than a generated wire type:
+/// the generator's precision guard rightly refuses `any`-shaped fields.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AppInvokeRequest {
     /// Full mounted name (`mcp__{server}__{tool}`) of the pinned tool to run.
-    pub tool: String,
+    pub tool: Option<String>,
     /// Opaque arguments for the tool, passed through untouched.
-    #[serde(default)]
-    pub arguments: serde_json::Value,
+    pub arguments: Option<serde_json::Value>,
+    /// Catalog `operationId` of the pinned REST operation to execute.
+    pub operation_id: Option<String>,
+    /// Declared parameter values for the operation, name → JSON scalar.
+    pub parameters: Option<serde_json::Value>,
+    /// JSON request body, only when the operation declares one.
+    pub body: Option<serde_json::Value>,
 }
 
-/// Result of a granted invoke, packaged for the sandboxed app frame.
+/// Result of a granted MCP-tool invoke, packaged for the sandboxed app frame.
 ///
 /// Deliberately not a generated wire type, for the same reason as the
 /// request: `structured_content` is opaque passthrough the renderer forwards
@@ -67,6 +80,37 @@ pub struct AppInvokeResult {
     pub is_error: bool,
 }
 
+/// Result of a granted REST-operation invoke, packaged for the sandboxed app
+/// frame — [`AppInvokeResult`]'s sibling for the `rest_api` surface, and a
+/// hand-written TS twin for the same reason.
+///
+/// An executed operation crosses as opaque passthrough: whatever status the
+/// API answered (including 4xx/5xx and unfollowed redirects) with
+/// `is_error: false`, the raw body base64-encoded so binary responses
+/// survive JSON. A refused or failed execution (validation, egress, or
+/// transport) is `is_error: true` with the executor's closed, host-authored
+/// refusal text — never a 500 and never internals.
+#[derive(Debug, PartialEq, Eq, Serialize)]
+pub struct AppRestInvokeResult {
+    /// HTTP status the operation answered with; absent when execution failed
+    /// before a response existed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<u16>,
+    /// Raw `Content-Type` header value, when the response carried one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
+    /// Base64 of the raw response body (at most the executor's 4 MiB cap);
+    /// absent when execution failed before a response existed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub body_base64: Option<String>,
+    /// Whether execution failed before an HTTP response existed.
+    pub is_error: bool,
+    /// The executor's refusal text when `is_error` — closed vocabulary, no
+    /// resolved addresses, no credential material.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 /// The stable machine-readable refusals of `POST /apps/{id}/invoke`.
 ///
 /// Unlike the passthrough payloads, the refusal envelope is host-authored and
@@ -78,11 +122,13 @@ pub struct AppInvokeResult {
 pub enum AppInvokeRefusalKind {
     /// No live app with this id.
     AppNotFound,
-    /// The requested tool is not pinned in the current revision's manifest.
+    /// The requested capability is not pinned in the current revision's
+    /// manifest.
     NotPinned,
-    /// The pinned tool is not covered by a live app grant.
+    /// The pinned capability is not covered by a live app grant.
     ConsentRequired,
-    /// The pinned name does not resolve to a mounted MCP tool right now.
+    /// The pinned name does not resolve to a mounted MCP tool or a declared
+    /// catalog operation right now.
     UnknownTool,
 }
 
@@ -101,8 +147,8 @@ impl AppInvokeRefusal {
             AppInvokeRefusalKind::NotPinned | AppInvokeRefusalKind::ConsentRequired => {
                 StatusCode::FORBIDDEN
             }
-            // The manifest pin exists but nothing mounted answers to it — a
-            // conflict with current MCP state, not a bad request.
+            // The manifest pin exists but nothing configured answers to it —
+            // a conflict with current state, not a bad request.
             AppInvokeRefusalKind::UnknownTool => StatusCode::CONFLICT,
         }
     }
@@ -139,8 +185,59 @@ impl IntoResponse for AppInvokeError {
     }
 }
 
-/// `POST /apps/{id}/invoke` — execute one of the app's pinned mounted MCP
-/// tools outside any model turn.
+/// Which surface one admitted request names.
+enum InvokeSurface {
+    Tool {
+        tool: String,
+        arguments: serde_json::Value,
+    },
+    Operation(RestOperationRequest),
+}
+
+/// Read the request's surface, refusing a body that names both or neither.
+fn requested_surface(request: AppInvokeRequest) -> Result<InvokeSurface, AppInvokeError> {
+    let invalid = |message: &str| {
+        AppInvokeError::Failed(ServerError::unprocessable_kind(
+            "invalid_invoke_request",
+            message,
+        ))
+    };
+    match (request.tool, request.operation_id) {
+        (Some(tool), None) => {
+            if request.parameters.is_some() || request.body.is_some() {
+                return Err(invalid(
+                    "parameters and body belong to operation_id invokes; a tool \
+                     invoke takes arguments",
+                ));
+            }
+            Ok(InvokeSurface::Tool {
+                tool,
+                arguments: request.arguments.unwrap_or_default(),
+            })
+        }
+        (None, Some(operation_id)) => {
+            if request.arguments.is_some() {
+                return Err(invalid(
+                    "arguments belong to tool invokes; an operation_id invoke \
+                     takes parameters and body",
+                ));
+            }
+            Ok(InvokeSurface::Operation(RestOperationRequest {
+                operation_id,
+                parameters: request
+                    .parameters
+                    .unwrap_or(serde_json::Value::Object(serde_json::Map::new())),
+                body: request.body,
+            }))
+        }
+        (Some(_), Some(_)) | (None, None) => Err(invalid(
+            "exactly one of tool or operation_id must be provided",
+        )),
+    }
+}
+
+/// `POST /apps/{id}/invoke` — execute one of the app's pinned capabilities
+/// outside any model turn.
 ///
 /// Enforcement order is fixed and fails closed: the app record first, then
 /// the manifest pin, then the grant gate, and only then dispatch. Every check
@@ -150,13 +247,31 @@ pub async fn post_app_invoke(
     State(state): State<AppState>,
     Path(app_id): Path<AppId>,
     Json(request): Json<AppInvokeRequest>,
-) -> Result<Json<AppInvokeResult>, AppInvokeError> {
+) -> Result<Response, AppInvokeError> {
+    let surface = requested_surface(request)?;
     let (app, revision) = current_app_revision(&state, app_id).await?;
-    require_pinned(&revision, &request.tool)?;
-    require_app_grant(&state, &app, &revision, &request.tool).await?;
-    dispatch_mounted_tool(&state, &request.tool, request.arguments)
-        .await
-        .map(Json)
+    match surface {
+        InvokeSurface::Tool { tool, arguments } => {
+            require_pinned_tool(&revision, &tool)?;
+            require_app_grant(&state, &app, &revision, &Pinned::Tool(&tool)).await?;
+            dispatch_mounted_tool(&state, &tool, arguments)
+                .await
+                .map(|result| Json(result).into_response())
+        }
+        InvokeSurface::Operation(request) => {
+            require_pinned_operation(&revision, &request.operation_id)?;
+            require_app_grant(
+                &state,
+                &app,
+                &revision,
+                &Pinned::Operation(&request.operation_id),
+            )
+            .await?;
+            dispatch_rest_operation(&state, &revision, &request)
+                .await
+                .map(|result| Json(result).into_response())
+        }
+    }
 }
 
 /// Resolve a live app and its current revision, or refuse as absent.
@@ -188,12 +303,15 @@ async fn current_app_revision(
 }
 
 /// Refuse any tool the current revision's manifest does not pin.
-fn require_pinned(revision: &AppRevision, tool: &str) -> Result<(), AppInvokeError> {
+fn require_pinned_tool(revision: &AppRevision, tool: &str) -> Result<(), AppInvokeError> {
     let pinned = revision
         .manifest
         .bindings
         .iter()
-        .any(|binding| binding.tools.iter().any(|pinned| pinned == tool));
+        .any(|binding| match binding {
+            AppBinding::Tools(binding) => binding.tools.iter().any(|pinned| pinned == tool),
+            AppBinding::Operations(_) => false,
+        });
     if pinned {
         return Ok(());
     }
@@ -203,61 +321,129 @@ fn require_pinned(revision: &AppRevision, tool: &str) -> Result<(), AppInvokeErr
     ))
 }
 
+/// Refuse any operation the current revision's manifest does not pin.
+fn require_pinned_operation(
+    revision: &AppRevision,
+    operation_id: &str,
+) -> Result<(), AppInvokeError> {
+    let pinned = revision
+        .manifest
+        .bindings
+        .iter()
+        .any(|binding| match binding {
+            AppBinding::Operations(binding) => binding
+                .operation_ids
+                .iter()
+                .any(|pinned| pinned == operation_id),
+            AppBinding::Tools(_) => false,
+        });
+    if pinned {
+        return Ok(());
+    }
+    Err(AppInvokeError::refused(
+        AppInvokeRefusalKind::NotPinned,
+        format!("operation {operation_id:?} is not pinned in this app's current manifest"),
+    ))
+}
+
+/// The invoked capability, for the grant gate.
+enum Pinned<'a> {
+    Tool(&'a str),
+    Operation(&'a str),
+}
+
+impl Pinned<'_> {
+    fn description(&self) -> String {
+        match self {
+            Self::Tool(tool) => format!("{tool:?}"),
+            Self::Operation(operation_id) => format!("operation {operation_id:?}"),
+        }
+    }
+}
+
 /// The consent gate, evaluated after the pin check and before dispatch.
 ///
 /// Three checks, all live and all fail-closed to `consent_required` — a
 /// missing or stale grant is a re-prompt, never an error:
 ///
 /// 1. A grant exists for the app.
-/// 2. It covers the invoked `(connected app, tool)` pair as the *current*
-///    revision's manifest binds it — so a revision that widens the manifest
-///    exceeds the grant by construction, with no special-casing.
+/// 2. It covers the invoked `(connected app, capability)` pair as the
+///    *current* revision's manifest binds it, in the same vocabulary — so a
+///    revision that widens the manifest exceeds the grant by construction,
+///    with no special-casing.
 /// 3. Every granted connected app's current definition fingerprint equals the
 ///    granted one. A reconfigured or deleted record invalidates the whole
 ///    grant: consent named a definition, not a name, and must never outlive
-///    it. The fingerprint covers the namespace too, so a renamed record can
-///    never keep a grant that now describes different mounted names.
+///    it. The `mcp_server` fingerprint covers the namespace and the
+///    `rest_api` fingerprint the base URL, document hash, and credential
+///    reference, so a repointed record can never keep a grant that now
+///    describes different capabilities.
 async fn require_app_grant(
     state: &AppState,
     app: &AppRecord,
     revision: &AppRevision,
-    tool: &str,
+    pinned: &Pinned<'_>,
 ) -> Result<(), AppInvokeError> {
     let consent_required =
         |message: String| AppInvokeError::refused(AppInvokeRefusalKind::ConsentRequired, message);
     let Some(grant) = state.store.get_app_grant(app.id).await? else {
         return Err(consent_required(format!(
-            "no live app grant covers {tool:?}"
+            "no live app grant covers {}",
+            pinned.description()
         )));
     };
     // The pin check has already passed, so exactly one current-manifest
-    // binding names this tool; its connected app is the record the grant must
-    // cover the tool under.
+    // binding names this capability; its connected app is the record the
+    // grant must cover the capability under.
     let connected_app = revision
         .manifest
         .bindings
         .iter()
-        .find(|binding| binding.tools.iter().any(|pinned| pinned == tool))
-        .map(|binding| binding.app);
-    let covered = connected_app.is_some_and(|connected_app| {
-        grant.bindings.iter().any(|binding| {
-            binding.app == connected_app && binding.tools.iter().any(|granted| granted == tool)
+        .find(|binding| match (binding, pinned) {
+            (AppBinding::Tools(binding), Pinned::Tool(tool)) => {
+                binding.tools.iter().any(|held| held == tool)
+            }
+            (AppBinding::Operations(binding), Pinned::Operation(operation_id)) => binding
+                .operation_ids
+                .iter()
+                .any(|held| held == operation_id),
+            _ => false,
         })
+        .map(AppBinding::app);
+    let covered = connected_app.is_some_and(|connected_app| {
+        grant
+            .bindings
+            .iter()
+            .any(|binding| match (binding, pinned) {
+                (AppGrantBinding::Tools(binding), Pinned::Tool(tool)) => {
+                    binding.app == connected_app
+                        && binding.tools.iter().any(|granted| granted == tool)
+                }
+                (AppGrantBinding::Operations(binding), Pinned::Operation(operation_id)) => {
+                    binding.app == connected_app
+                        && binding
+                            .operation_ids
+                            .iter()
+                            .any(|granted| granted == operation_id)
+                }
+                _ => false,
+            })
     });
     if !covered {
         return Err(consent_required(format!(
-            "the app grant does not cover {tool:?}"
+            "the app grant does not cover {}",
+            pinned.description()
         )));
     }
-    let current = state.mcp.app_fingerprints().await;
+    let current = current_app_fingerprints(state).await?;
     for binding in &grant.bindings {
         let matches = current
-            .get(&binding.app)
-            .is_some_and(|app| app.fingerprint == binding.fingerprint);
+            .get(&binding.app())
+            .is_some_and(|app| app.fingerprint == binding.fingerprint());
         if !matches {
             return Err(consent_required(format!(
                 "connected app {} was reconfigured after consent; the grant is stale",
-                binding.app
+                binding.app()
             )));
         }
     }
@@ -266,7 +452,7 @@ async fn require_app_grant(
 
 /// Resolve a pinned name against the current MCP snapshot and execute it.
 ///
-/// This route invokes mounted MCP tools only. The name must carry the mounted
+/// This path invokes mounted MCP tools only. The name must carry the mounted
 /// `mcp__{server}__{tool}` shape — which no built-in server tool does — and
 /// must resolve to a server-executed registration; a client-executed contract
 /// has no executor here and refuses. The execution context is deliberately
@@ -297,6 +483,72 @@ pub(crate) async fn dispatch_mounted_tool(
         structured_content: output.data,
         is_error: output.is_error,
     })
+}
+
+/// Resolve the pinned operation's `rest_api` record and run the governed
+/// executor against it.
+///
+/// The grant gate has already matched the record's live fingerprint, so a
+/// missing or unparseable record here is a stale read raced with an edit —
+/// refused as `consent_required`, the same verdict the sweep would reach. An
+/// operation the current catalog no longer declares refuses as
+/// `unknown_tool` (the fingerprint sweep makes this unreachable in practice:
+/// a changed document moves the fingerprint first). Every other executor
+/// refusal — validation, egress vetting, secret resolution, transport — comes
+/// back as an `is_error` result, never a 500: those failures are the app's to
+/// present, and their closed messages carry no internals.
+async fn dispatch_rest_operation(
+    state: &AppState,
+    revision: &AppRevision,
+    request: &RestOperationRequest,
+) -> Result<AppRestInvokeResult, AppInvokeError> {
+    let bound = revision
+        .manifest
+        .bindings
+        .iter()
+        .find_map(|binding| match binding {
+            AppBinding::Operations(binding)
+                if binding
+                    .operation_ids
+                    .iter()
+                    .any(|pinned| pinned == &request.operation_id) =>
+            {
+                Some(binding.app)
+            }
+            _ => None,
+        })
+        .expect("the pin check admitted this operation");
+    let definitions = current_rest_definitions(state).await?;
+    let Some((_, _, definition)) = definitions.into_iter().find(|(id, _, _)| *id == bound) else {
+        return Err(AppInvokeError::refused(
+            AppInvokeRefusalKind::ConsentRequired,
+            format!("connected app {bound} was reconfigured after consent; the grant is stale"),
+        ));
+    };
+    match state
+        .rest_dispatch
+        .dispatch(&definition.target(), &definition.catalog, request)
+        .await
+    {
+        Ok(response) => Ok(AppRestInvokeResult {
+            status: Some(response.status),
+            content_type: response.content_type,
+            body_base64: Some(base64::engine::general_purpose::STANDARD.encode(&response.body)),
+            is_error: false,
+            error: None,
+        }),
+        Err(RestExecuteError::UnknownOperation { operation_id }) => Err(AppInvokeError::refused(
+            AppInvokeRefusalKind::UnknownTool,
+            format!("operation {operation_id:?} is not declared by the connected app"),
+        )),
+        Err(error) => Ok(AppRestInvokeResult {
+            status: None,
+            content_type: None,
+            body_base64: None,
+            is_error: true,
+            error: Some(error.to_string()),
+        }),
+    }
 }
 
 /// Whether a name has the mounted `mcp__{server}__{tool}` shape.

--- a/crates/openwave-server/src/routes/app_library.rs
+++ b/crates/openwave-server/src/routes/app_library.rs
@@ -74,7 +74,7 @@ pub async fn get_app_library(
     State(state): State<AppState>,
 ) -> Result<Json<AppLibrary>, ServerError> {
     let records = state.store.list_apps(MAX_LISTED_APPS).await?;
-    let current = state.mcp.app_fingerprints().await;
+    let current = crate::connected_apps::current_app_fingerprints(&state).await?;
     let mut apps = Vec::with_capacity(records.len());
     for record in records {
         // The same computation the grant surface performs, so the badge is

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -41,6 +41,11 @@ pub struct AppState {
     pub tools: Arc<ToolRegistry>,
     /// Runtime-managed MCP connections and immutable per-turn tool snapshots.
     pub(crate) mcp: Arc<McpRuntime>,
+    /// Executes one governed REST operation for the app-invoke route. The
+    /// production assembly is the real executor over the real transport and
+    /// resolver ([`crate::connected_apps::governed_rest_dispatcher`]); tests
+    /// substitute a fake transport behind the same governed validation.
+    pub(crate) rest_dispatch: Arc<dyn crate::connected_apps::RestOperationDispatcher>,
     /// Outstanding single-use tokens redeemed by the sandboxed view frames —
     /// prefetched MCP views and stored local-app revisions alike.
     pub(crate) view_frames: Arc<ViewFrameTokens>,
@@ -170,6 +175,7 @@ impl AppState {
             gateway.clone(),
             os_policy.clone(),
         ));
+        let rest_dispatch = crate::connected_apps::governed_rest_dispatcher(secrets.clone());
         Ok(Self {
             config: Arc::new(config),
             store: store.clone(),
@@ -178,6 +184,7 @@ impl AppState {
             secrets,
             tools,
             mcp,
+            rest_dispatch,
             view_frames: Arc::default(),
             gateway,
             os_policy,

--- a/crates/openwave-server/src/tests/app_grant.rs
+++ b/crates/openwave-server/src/tests/app_grant.rs
@@ -8,7 +8,9 @@
 use super::*;
 
 use openwave_core::id::{AppId, AppRevisionId};
-use openwave_core::local_app::{AppBinding, AppManifest, CreateApp, NewAppRevision};
+use openwave_core::local_app::{
+    AppBinding, AppManifest, AppToolsBinding, CreateApp, NewAppRevision,
+};
 use serde_json::json;
 
 async fn grant_request(
@@ -44,10 +46,10 @@ async fn create_app_bound_to(
                 id: AppRevisionId::new(),
                 manifest: AppManifest {
                     name: "Grant fixture".into(),
-                    bindings: vec![AppBinding {
+                    bindings: vec![AppBinding::Tools(AppToolsBinding {
                         app,
                         tools: tools.iter().map(|tool| (*tool).to_owned()).collect(),
-                    }],
+                    })],
                 },
                 byte_len: 1,
                 sha256: [0; 32],

--- a/crates/openwave-server/src/tests/app_invoke.rs
+++ b/crates/openwave-server/src/tests/app_invoke.rs
@@ -3,7 +3,9 @@
 use super::*;
 
 use openwave_core::id::{AppId, AppRevisionId};
-use openwave_core::local_app::{AppBinding, AppManifest, CreateApp, NewAppRevision};
+use openwave_core::local_app::{
+    AppBinding, AppManifest, AppToolsBinding, CreateApp, NewAppRevision,
+};
 use serde_json::json;
 
 /// The MCP client's call-result bound and the marker its clamp leaves.
@@ -104,10 +106,10 @@ async fn create_pinned_app(store: &Arc<dyn Store>, tools: &[&str]) -> AppId {
                 id: AppRevisionId::new(),
                 manifest: AppManifest {
                     name: "Invoke fixture".into(),
-                    bindings: vec![AppBinding {
+                    bindings: vec![AppBinding::Tools(AppToolsBinding {
                         app: connected_app_id(store, "srv").await,
                         tools: tools.iter().map(|tool| (*tool).to_owned()).collect(),
-                    }],
+                    })],
                 },
                 byte_len: 1,
                 sha256: [0; 32],
@@ -393,10 +395,10 @@ async fn a_widened_manifest_requires_fresh_consent_for_the_new_tools() {
                 id: AppRevisionId::new(),
                 manifest: AppManifest {
                     name: "Invoke fixture".into(),
-                    bindings: vec![AppBinding {
+                    bindings: vec![AppBinding::Tools(AppToolsBinding {
                         app: connected_app_id(&store, "srv").await,
                         tools: vec!["mcp__srv__viewer".into(), "mcp__srv__unpinned".into()],
-                    }],
+                    })],
                 },
                 byte_len: 1,
                 sha256: [0; 32],
@@ -579,4 +581,340 @@ async fn gate_opened_dispatch_refuses_every_non_mcp_surface() {
         }
     }
     assert_eq!(log.calls.load(Ordering::SeqCst), 0);
+}
+
+// --- REST operation bindings ---
+
+use std::net::IpAddr;
+
+use base64::Engine as _;
+use openwave_core::connected_app::{ConnectedApp, ConnectedAppKind};
+use openwave_core::id::ConnectedAppId;
+use openwave_core::local_app::AppOperationsBinding;
+
+use crate::rest_executor::{
+    RestExecuteError, RestExecutor, RestHostResolver, RestOperationResponse, RestTransport,
+    RestTransportRequest,
+};
+
+/// What the fake REST transport observed and how it should answer next.
+#[derive(Default)]
+struct RestCallLog {
+    calls: AtomicUsize,
+    last_url: Mutex<Option<String>>,
+    last_headers: Mutex<Vec<(String, String)>>,
+    fail_next: AtomicBool,
+}
+
+/// A transport seam standing in for the network: the real [`RestExecutor`]
+/// still validates against the catalog, admits the base URL, vets the
+/// resolved addresses, and injects the credential — only the wire is fake.
+struct FakeRestTransport(Arc<RestCallLog>);
+
+#[async_trait]
+impl RestTransport for FakeRestTransport {
+    async fn execute(
+        &self,
+        request: &RestTransportRequest,
+    ) -> std::result::Result<RestOperationResponse, RestExecuteError> {
+        self.0.calls.fetch_add(1, Ordering::SeqCst);
+        *self.0.last_url.lock().unwrap() = Some(request.url.to_string());
+        *self.0.last_headers.lock().unwrap() = request.headers.clone();
+        if self.0.fail_next.swap(false, Ordering::SeqCst) {
+            return Err(RestExecuteError::Timeout);
+        }
+        Ok(RestOperationResponse {
+            status: 200,
+            content_type: Some("application/json".into()),
+            body: br#"{"issues":[]}"#.to_vec(),
+        })
+    }
+}
+
+/// Resolves every host to a public address so admission always vets cleanly.
+struct PublicResolver;
+
+#[async_trait]
+impl RestHostResolver for PublicResolver {
+    async fn resolve(&self, _host: &str) -> std::result::Result<Vec<IpAddr>, RestExecuteError> {
+        Ok(vec![IpAddr::V4(std::net::Ipv4Addr::new(93, 184, 216, 34))])
+    }
+}
+
+/// An authenticated API whose REST dispatch runs the real governed executor
+/// over the fake transport, with the credential value seeded in the secret
+/// store.
+async fn rest_test_app(
+    log: Arc<RestCallLog>,
+) -> (Router, String, Arc<dyn Store>, tempfile::TempDir) {
+    let (dir, store) = temp_db_store("rest-invoke.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let mut state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    state
+        .secrets
+        .set_secret("issues-token", "sk-test-rest")
+        .await
+        .unwrap();
+    state.rest_dispatch = Arc::new(RestExecutor::new(
+        FakeRestTransport(log),
+        PublicResolver,
+        state.secrets.clone(),
+    ));
+    let bearer = format!("Bearer {}", state.token);
+    (app(state), bearer, store, dir)
+}
+
+/// Replace the profile's `rest_api` records with one record for `id`,
+/// pointing at `base_url` with a catalog ingested from an inline spec.
+async fn seed_rest_record(store: &Arc<dyn Store>, id: ConnectedAppId, base_url: &str) {
+    let spec = json!({
+        "openapi": "3.0.3",
+        "info": { "title": "Issues", "version": "1" },
+        "paths": {
+            "/issues": {
+                "get": {
+                    "operationId": "listIssues",
+                    "parameters": [
+                        { "name": "q", "in": "query", "schema": { "type": "string" } }
+                    ]
+                }
+            },
+            "/issues/{id}": {
+                "get": {
+                    "operationId": "getIssue",
+                    "parameters": [
+                        { "name": "id", "in": "path", "required": true,
+                          "schema": { "type": "string" } }
+                    ]
+                }
+            }
+        }
+    });
+    let catalog =
+        crate::openapi_catalog::ingest_openapi_document(spec.to_string().as_bytes()).unwrap();
+    store
+        .replace_connected_apps(
+            ConnectedAppKind::RestApi,
+            &[ConnectedApp {
+                id,
+                name: "issues".into(),
+                kind: ConnectedAppKind::RestApi,
+                definition: json!({
+                    "base_url": base_url,
+                    "catalog": catalog,
+                    "credential": {
+                        "secret_name": "issues-token",
+                        "placement": "bearer"
+                    },
+                }),
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+            }],
+        )
+        .await
+        .unwrap();
+}
+
+/// Create an app whose current manifest pins exactly `operation_ids` under
+/// the given `rest_api` connected app.
+async fn create_operation_app(
+    store: &Arc<dyn Store>,
+    connected: ConnectedAppId,
+    operation_ids: &[&str],
+) -> AppId {
+    let app_id = AppId::new();
+    store
+        .create_app(&CreateApp {
+            id: app_id,
+            revision: NewAppRevision {
+                id: AppRevisionId::new(),
+                manifest: AppManifest {
+                    name: "REST fixture".into(),
+                    bindings: vec![AppBinding::Operations(AppOperationsBinding {
+                        app: connected,
+                        operation_ids: operation_ids.iter().map(|id| (*id).to_owned()).collect(),
+                    })],
+                },
+                byte_len: 1,
+                sha256: [0; 32],
+                turn_id: None,
+                producing_run_id: None,
+                chat_id: None,
+                created_at: chrono::Utc::now(),
+            },
+        })
+        .await
+        .unwrap();
+    app_id
+}
+
+/// The whole `rest_api` ladder over the API: an ungranted or malformed invoke
+/// never reaches the transport; consent projects the operation vocabulary and
+/// opens the gate; a granted invoke runs the real governed executor — catalog
+/// validation, URL assembly, credential injection — over the fake wire and
+/// crosses back as opaque base64 passthrough; an executor failure is an
+/// `is_error` result, not a 500; and editing the record's definition
+/// invalidates the grant on the very next invoke.
+#[tokio::test]
+async fn rest_invokes_walk_the_ladder_and_round_trip_through_the_governed_executor() {
+    let log = Arc::new(RestCallLog::default());
+    let (router, bearer, store, _dir) = rest_test_app(log.clone()).await;
+    let connected = ConnectedAppId::new();
+    seed_rest_record(&store, connected, "https://api.example.com/v2").await;
+    let app_id = create_operation_app(&store, connected, &["listIssues"]).await;
+
+    // Fail-closed before consent, and on every malformed or unpinned shape.
+    let refusals = [
+        (
+            json!({"operation_id": "listIssues"}),
+            StatusCode::FORBIDDEN,
+            "consent_required",
+        ),
+        (
+            json!({"operation_id": "getIssue"}),
+            StatusCode::FORBIDDEN,
+            "not_pinned",
+        ),
+        (
+            json!({"operation_id": "listIssues", "tool": "mcp__srv__viewer"}),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "invalid_invoke_request",
+        ),
+        (
+            json!({}),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "invalid_invoke_request",
+        ),
+        (
+            json!({"operation_id": "listIssues", "arguments": {"q": "open"}}),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "invalid_invoke_request",
+        ),
+    ];
+    for (body, status, kind) in refusals {
+        let response = invoke(&router, &bearer, app_id, body.clone()).await;
+        assert_eq!(response.status(), status, "{body}");
+        let info: AgentErrorInfo = json_body(response).await;
+        assert_eq!(info.kind, kind, "{body}");
+    }
+    assert_eq!(log.calls.load(Ordering::SeqCst), 0);
+
+    // Consent projects the operation vocabulary under the app's display name.
+    let response = grant_request(&router, &bearer, "POST", app_id).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let state: serde_json::Value = json_body(response).await;
+    assert_eq!(state["granted"], json!(true));
+    assert_eq!(state["bindings"][0]["name"], json!("issues"));
+    assert_eq!(state["bindings"][0]["operation_ids"], json!(["listIssues"]));
+    assert_eq!(state["bindings"][0]["tools"], json!(null));
+
+    // A granted invoke round-trips: the executor assembled the declared URL,
+    // injected the referenced credential, and the response crosses as opaque
+    // base64 passthrough.
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"operation_id": "listIssues", "parameters": {"q": "open"}}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let result: serde_json::Value = json_body(response).await;
+    assert_eq!(result["status"], json!(200));
+    assert_eq!(result["content_type"], json!("application/json"));
+    assert_eq!(result["is_error"], json!(false));
+    let body = base64::engine::general_purpose::STANDARD
+        .decode(result["body_base64"].as_str().unwrap())
+        .unwrap();
+    assert_eq!(body, br#"{"issues":[]}"#);
+    assert_eq!(log.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        log.last_url.lock().unwrap().as_deref(),
+        Some("https://api.example.com/v2/issues?q=open")
+    );
+    assert!(log
+        .last_headers
+        .lock()
+        .unwrap()
+        .iter()
+        .any(|(name, value)| name == "authorization" && value == "Bearer sk-test-rest"));
+
+    // An executor failure past the gate is the app's to present: an is_error
+    // result with the closed refusal text, never a 500.
+    log.fail_next.store(true, Ordering::SeqCst);
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"operation_id": "listIssues"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let result: serde_json::Value = json_body(response).await;
+    assert_eq!(result["is_error"], json!(true));
+    assert_eq!(result["error"], json!("request exceeded its time budget"));
+    assert_eq!(result.get("status"), None);
+
+    // Editing the record's definition (a moved base URL) invalidates the
+    // grant on the next invoke, and the projection says why.
+    seed_rest_record(&store, connected, "https://api.elsewhere.example/v2").await;
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"operation_id": "listIssues"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    let info: AgentErrorInfo = json_body(response).await;
+    assert_eq!(info.kind, "consent_required");
+    let response = grant_request(&router, &bearer, "GET", app_id).await;
+    let state: serde_json::Value = json_body(response).await;
+    assert_eq!(state["granted"], json!(false));
+    assert_eq!(state["bindings"][0]["definition_changed"], json!(true));
+
+    // Fresh consent re-pins to the moved definition and reopens the gate.
+    consent(&router, &bearer, app_id).await;
+    let response = invoke(
+        &router,
+        &bearer,
+        app_id,
+        json!({"operation_id": "listIssues"}),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(log
+        .last_url
+        .lock()
+        .unwrap()
+        .as_deref()
+        .unwrap()
+        .starts_with("https://api.elsewhere.example/v2/issues"));
+}
+
+/// Consent has nothing coherent to record when a pinned operation is not in
+/// the record's current catalog: the sheet conflicts instead of granting a
+/// pin that could never execute.
+#[tokio::test]
+async fn consent_conflicts_when_a_pinned_operation_left_the_catalog() {
+    let log = Arc::new(RestCallLog::default());
+    let (router, bearer, store, _dir) = rest_test_app(log.clone()).await;
+    let connected = ConnectedAppId::new();
+    seed_rest_record(&store, connected, "https://api.example.com/v2").await;
+    let app_id = create_operation_app(&store, connected, &["retiredOp"]).await;
+
+    let response = grant_request(&router, &bearer, "POST", app_id).await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let info: AgentErrorInfo = json_body(response).await;
+    assert!(info.message.contains("retiredOp"), "{}", info.message);
 }

--- a/crates/openwave-server/src/tests/app_library.rs
+++ b/crates/openwave-server/src/tests/app_library.rs
@@ -3,7 +3,9 @@
 use super::*;
 
 use openwave_core::id::{AppId, AppRevisionId};
-use openwave_core::local_app::{AppBinding, AppManifest, CreateApp, NewAppRevision};
+use openwave_core::local_app::{
+    AppBinding, AppManifest, AppToolsBinding, CreateApp, NewAppRevision,
+};
 use serde_json::json;
 
 /// The library lifecycle in one pass: the listing carries renderer-safe rows
@@ -47,10 +49,10 @@ async fn library_lists_grant_verdicts_and_deletion_removes_the_row() {
                 id: AppRevisionId::new(),
                 manifest: AppManifest {
                     name: "Library fixture".into(),
-                    bindings: vec![AppBinding {
+                    bindings: vec![AppBinding::Tools(AppToolsBinding {
                         app: connected_app_id(&store, "cmd").await,
                         tools: vec!["mcp__cmd__doit".into()],
-                    }],
+                    })],
                 },
                 byte_len: 1,
                 sha256: [0; 32],


### PR DESCRIPTION
Closes #1344

Slice 4 of the connected-apps REST-bindings epic (#1330): local-app manifests can now bind a `rest_api` connected app's declared operations, with the grant, consent-sheet, and invoke machinery carried over from the MCP vocabulary unchanged in semantics.

## What's here

- **Binding vocabulary** (`openwave-core::local_app`): `AppBinding` and `AppGrantBinding` become closed untagged pairs — `{app, tools[]}` | `{app, operation_ids[]}` (grants add `fingerprint`) — with `deny_unknown_fields` on both variants, so a body carrying both fields matches neither. The shared `validate_binding_set` enforces the ingest module's operationId grammar (≤128 bytes of `[A-Za-z0-9_.-]`, mirrored as `MAX_OPERATION_ID_BYTES` with a comment naming the mirror), no duplicate ids within a binding, and one binding per connected app across vocabularies.
- **`rest_api` definition + fingerprint** (`openwave-server::connected_apps`, new module): typed `RestApiDefinition { base_url, catalog, credential }` parsed closed per record; `rest_api_fingerprint` digests the compact canonical form `{"v":2,"kind":"rest_api","base_url":…,"document_sha256":…,"credential_reference":string|null,"placement":"bearer"|{"header":name}|null}` — rotating the credential value behind the same reference cannot move it, repointing the reference does, and catalog operations enter only through the document hash.
- **Combined fingerprint lookup**: `current_app_fingerprints` merges live MCP runtime entries with `rest_api` records read from the store per request (unparseable definitions skipped, reading as not-configured, so grants naming them fail closed to re-consent). The grant, invoke, and library surfaces all migrated onto it.
- **Consent**: `post_app_grant` handles both kinds — a rest binding conflicts unless every pinned operation is in the record's current catalog; grant bindings pin the kind-appropriate fingerprint. `AppGrantBindingState` gains mutually exclusive nullable `tools` / `operation_ids` arrays (wire.ts regenerated).
- **Invoke**: `POST /apps/{id}/invoke` accepts `{tool, arguments}` or `{operation_id, parameters?, body?}` (both/neither → 422 `invalid_invoke_request`). The fixed refusal ladder is unchanged: record → pin → grant coverage in the same vocabulary → fingerprint sweep over all grant bindings → dispatch. REST dispatch resolves the record live and runs the governed `RestExecutor`; the response crosses to the renderer as opaque passthrough `{status, content_type, body_base64}` (body base64-encoded, at most the executor's 4 MiB cap, not re-clamped). Executor failures past the gate come back as an `is_error` result with the closed refusal text, never a 500; an undeclared operation maps to the `unknown_tool` refusal. REST catalogs are not projected to the model as tools anywhere.
- **Authoring**: the `create_app` door cross-checks operation bindings against the record kind and its catalog (lenient catalog read, failing the binding closed on an unreadable definition); the roster appended to the tool description now lists `rest_api` records with up to 20 operation ids then `…`.
- **UI**: consent sheet renders operation rows (Globe icon, same monospace treatment), app detail's "Allowed to call" line includes operation ids, `api.ts` gains `AppRestInvokeResult` and `invokeAppOperation` (shared refusal narrowing with `invokeApp`), `appsApis.ts` exposes `invokeOperation`, dom tests updated.

## Test seam

`AppState` gains a `rest_dispatch: Arc<dyn RestOperationDispatcher>` defaulting to the real executor over `ReqwestRestTransport`/`TokioRestHostResolver` with the state's secret provider. The end-to-end test substitutes only the transport and resolver — catalog validation, URL admission, address vetting, and credential injection still run in the real executor.

## Tests

- `rest_api` fingerprint invariants (reference-not-value, repoint-changes, field-derivation) and closed definition parsing.
- Binding grammar: both vocabularies validate; mixed/unknown-field bodies refuse at serde; operationId bounds; duplicate app across kinds refused.
- Router-level REST ladder: no grant → `consent_required`; malformed/mixed bodies → 422; consent projects `operation_ids`; granted invoke round-trips through the fake transport with the assembled URL and injected credential asserted; executor failure → `is_error` result; base-URL edit → `consent_required` with `definition_changed: true`; pinned-but-undeclared operation at consent → 409.
- `create_app` door: operation binding against an `mcp_server` record refused, undeclared operation refused, tools binding against a `rest_api` record refused.

No existing coverage deleted. `Cargo.lock` gains only the `base64` edge for `openwave-server` (already a workspace pin; no version changes).

## Deferred

Frame-side REST invocation (`McpAppBridge`) is left for a follow-up: the bridge speaks MCP JSON-RPC (`tools/call`), and a REST verb is a protocol extension worth its own slice. The API client method and the consent/grant surfaces land here, so the follow-up is renderer-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
