### PR TITLE
feat(exec): verified shared package cache for local sandboxes

### DIFF
--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -20,6 +20,7 @@ mod local;
 mod network;
 mod output;
 pub mod overlay;
+pub mod package_cache;
 mod preview;
 mod receipt;
 mod remote;
@@ -41,6 +42,9 @@ pub use overlay::{
     OverlayInspector, OverlayOutcome, OverlaySlot, PreparedWriteSnapshot, PriorContents,
     RejectedChange, RejectedChangeReason, StagedChange, TrashSink, WriteOverlay, WriteSnapshotSink,
     OVERLAY_DIR,
+};
+pub use package_cache::{
+    PromotionReport, SharedPackageCache, PACKAGE_CACHE_DIR, PACKAGE_CACHE_ENV,
 };
 pub use preview::{scan_preview_directory, PreviewScan};
 pub use remote::RemoteSessionPool;

--- a/crates/openwave-code-execution/src/local.rs
+++ b/crates/openwave-code-execution/src/local.rs
@@ -57,6 +57,7 @@ pub struct LocalExecutionProvider {
     scratch_root: PathBuf,
     timeout: Duration,
     document_scripts_dir: Option<PathBuf>,
+    shared_package_cache: Option<PathBuf>,
     network_policy: NetworkPolicy,
 }
 
@@ -91,6 +92,7 @@ impl LocalExecutionProvider {
             scratch_root: scratch_root.into(),
             timeout,
             document_scripts_dir: None,
+            shared_package_cache: None,
             network_policy: NetworkPolicy::Off,
         })
     }
@@ -106,6 +108,15 @@ impl LocalExecutionProvider {
     #[must_use]
     pub fn with_document_scripts(mut self, directory: Option<PathBuf>) -> Self {
         self.document_scripts_dir = directory;
+        self
+    }
+
+    /// Expose the host-verified shared package cache's wheels directory as a
+    /// read-only subtree. The profile never lists it as writable, so no
+    /// conversation can plant an artifact another conversation would consume.
+    #[must_use]
+    pub fn with_shared_package_cache(mut self, directory: Option<PathBuf>) -> Self {
+        self.shared_package_cache = directory;
         self
     }
 
@@ -331,6 +342,15 @@ impl CodeExecutionProvider for LocalExecutionProvider {
                 })
             })
             .transpose()?;
+        let shared_package_cache = self
+            .shared_package_cache
+            .as_ref()
+            .map(|path| {
+                fs::canonicalize(path).map_err(|_| {
+                    CodeExecutionError::Sandbox("shared package cache is unavailable".into())
+                })
+            })
+            .transpose()?;
         let result = run_native(
             &request,
             &workspace,
@@ -338,6 +358,7 @@ impl CodeExecutionProvider for LocalExecutionProvider {
             &env_home,
             self.timeout,
             document_scripts_dir.as_deref(),
+            shared_package_cache.as_deref(),
             &folder_grants,
             &self.network_policy,
         )
@@ -740,6 +761,7 @@ async fn run_native(
     env_home: &Path,
     timeout: Duration,
     document_scripts_dir: Option<&Path>,
+    shared_package_cache: Option<&Path>,
     folder_grants: &[CanonicalExecFolderGrant],
     network_policy: &NetworkPolicy,
 ) -> Result<CodeExecutionResponse, CodeExecutionError> {
@@ -754,6 +776,7 @@ async fn run_native(
         env_home,
         developer_dir.as_deref(),
         document_scripts_dir,
+        shared_package_cache,
         folder_grants,
         broker.as_ref().map(LocalEgressBroker::port),
     )?;
@@ -794,6 +817,15 @@ async fn run_native(
     }
     if let Some(directory) = document_scripts_dir {
         command.env("OPENWAVE_EXEC_SCRIPTS", directory);
+    }
+    if let Some(directory) = shared_package_cache {
+        // `PIP_FIND_LINKS` makes every pip invocation consider the verified
+        // local wheels alongside (or, with `--no-index`, instead of) the
+        // registry; the OpenWave-named variable is what the operating prompt
+        // steers offline installs with.
+        command
+            .env(crate::package_cache::PACKAGE_CACHE_ENV, directory)
+            .env("PIP_FIND_LINKS", directory);
     }
     configure_unix_limits(&mut command, timeout);
 
@@ -863,6 +895,7 @@ async fn run_native(
     _env_home: &Path,
     _timeout: Duration,
     _document_scripts_dir: Option<&Path>,
+    _shared_package_cache: Option<&Path>,
     _folder_grants: &[()],
     _network_policy: &NetworkPolicy,
 ) -> Result<CodeExecutionResponse, CodeExecutionError> {
@@ -944,6 +977,7 @@ fn macos_profile(
     env_home: &Path,
     developer_dir: Option<&Path>,
     document_scripts_dir: Option<&Path>,
+    shared_package_cache: Option<&Path>,
     folder_grants: &[CanonicalExecFolderGrant],
     broker_port: Option<u16>,
 ) -> Result<String, CodeExecutionError> {
@@ -1038,6 +1072,13 @@ fn macos_profile(
         .map(sandbox_subpath)
         .transpose()?
         .unwrap_or_default();
+    // The shared package cache joins the read-only allowances and is
+    // deliberately absent from every write clause below: sandboxes consume
+    // verified artifacts, only the host's trusted acquisition writes them.
+    let package_cache = shared_package_cache
+        .map(sandbox_subpath)
+        .transpose()?
+        .unwrap_or_default();
     // `folder_grants` is the canonical, host-resolved list prepared above.
     // Command, arguments, cwd, and every other model-authored field are
     // deliberately absent from these profile clauses.
@@ -1088,7 +1129,7 @@ fn macos_profile(
          (allow file-read*)\n\
          (deny file-read*\n  {denied})\n\
          (allow file-read-metadata\n  {runtime_metadata}\n  {grant_metadata})\n\
-         (allow file-read*\n  {literals}\n  {runtimes}\n  {selected_runtime}\n  {document_scripts}\n  {granted_reads}\n  {workspace}\n  {env_home})\n\
+         (allow file-read*\n  {literals}\n  {runtimes}\n  {selected_runtime}\n  {document_scripts}\n  {package_cache}\n  {granted_reads}\n  {workspace}\n  {env_home})\n\
          (allow file-write*\n  {granted_writes}\n  {workspace}\n  {env_home}\n  (literal \"/dev/null\"))\n"
     ))
 }
@@ -1619,6 +1660,9 @@ mod tests {
             Some(Path::new(
                 "/Applications/OpenWave.app/Contents/Resources/exec-scripts",
             )),
+            Some(Path::new(
+                "/Users/test/.code-execution-package-cache/cp39-darwin-arm64/wheels",
+            )),
             &[],
             None,
         )
@@ -1631,14 +1675,19 @@ mod tests {
         assert!(profile.contains("(allow process-fork)"));
         assert!(profile.contains("we\\\"ird\\\\workspace"));
         assert!(profile.contains("Resources/exec-scripts"));
+        // The shared package cache is readable and never writable: verified
+        // artifacts flow from the host in, never from a sandbox out.
+        assert!(profile.contains(".code-execution-package-cache/cp39-darwin-arm64/wheels"));
         let write_rule = profile
             .split("(allow file-write*")
             .nth(1)
             .expect("profile has a write rule");
         assert!(!write_rule.contains("Resources/exec-scripts"));
+        assert!(!write_rule.contains(".code-execution-package-cache"));
         assert!(macos_profile(
             Path::new("/Users/test/control\nworkspace"),
             Path::new("/Users/test/env-home"),
+            None,
             None,
             None,
             &[],
@@ -1649,6 +1698,7 @@ mod tests {
         let proxied = macos_profile(
             Path::new("/Users/test/workspace"),
             Path::new("/Users/test/env-home"),
+            None,
             None,
             None,
             &[],
@@ -1675,6 +1725,7 @@ mod tests {
         let profile = macos_profile(
             Path::new("/Users/test/workspace"),
             Path::new("/Users/test/env-home"),
+            None,
             None,
             None,
             &grants,
@@ -1755,6 +1806,50 @@ mod tests {
         let response = provider.execute(request).await.unwrap();
         assert_eq!(response.exit_code, Some(0), "stderr: {}", response.stderr);
         assert_eq!(response.stdout, "visibleungranted-blocked");
+    }
+
+    /// The cross-conversation containment the shared cache rests on: a
+    /// sandbox can consume verified artifacts but can neither modify them nor
+    /// plant new ones, so no conversation can poison what another installs.
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn shared_package_cache_is_readable_and_never_writable_in_the_sandbox() {
+        let scratch = tempfile::tempdir().unwrap();
+        let workspace = "chat-cache";
+        fs::create_dir(scratch.path().join(workspace)).unwrap();
+        let cache = crate::package_cache::SharedPackageCache::open(
+            &scratch.path().join(crate::package_cache::PACKAGE_CACHE_DIR),
+            "cp39-darwin-arm64",
+        )
+        .unwrap();
+        let staging = scratch.path().join("staging");
+        fs::create_dir(&staging).unwrap();
+        fs::write(staging.join("fpdf2-2.8.3-py3-none-any.whl"), b"wheel-bytes").unwrap();
+        cache.verify_and_promote(&staging).unwrap();
+        let wheels = fs::canonicalize(cache.wheels_dir()).unwrap();
+
+        let provider = LocalExecutionProvider::new(scratch.path(), Duration::from_secs(3))
+            .unwrap()
+            .with_shared_package_cache(Some(wheels.clone()));
+        let script = format!(
+            "cat \"$OPENWAVE_PACKAGE_CACHE/fpdf2-2.8.3-py3-none-any.whl\"; \
+             if printf poison > '{planted}' 2>/dev/null; then printf ' cache-writable'; else printf ' cache-readonly'; fi; \
+             if printf poison > '{tampered}' 2>/dev/null; then printf ' wheel-writable'; else printf ' wheel-readonly'; fi",
+            planted = wheels.join("planted-1.0-py3-none-any.whl").display(),
+            tampered = wheels.join("fpdf2-2.8.3-py3-none-any.whl").display(),
+        );
+        let response = provider
+            .execute(request(workspace, "call-cache", &script))
+            .await
+            .unwrap();
+
+        assert_eq!(response.exit_code, Some(0), "stderr: {}", response.stderr);
+        assert_eq!(response.stdout, "wheel-bytes cache-readonly wheel-readonly");
+        assert!(!wheels.join("planted-1.0-py3-none-any.whl").exists());
+        assert_eq!(
+            fs::read(wheels.join("fpdf2-2.8.3-py3-none-any.whl")).unwrap(),
+            b"wheel-bytes"
+        );
     }
 
     /// The invariant staging rests on: a staged grant is writable only at the

--- a/crates/openwave-code-execution/src/package_cache.rs
+++ b/crates/openwave-code-execution/src/package_cache.rs
@@ -1,0 +1,568 @@
+//! Verified shared package cache for local sandboxes.
+//!
+//! Per-chat HOME already persists `pip install --user` state within one
+//! conversation. This module adds the cross-conversation substrate: a
+//! host-owned wheel cache that a second conversation can install pinned
+//! packages from with no network at all.
+//!
+//! The trust story is deliberately one-directional:
+//!
+//! - **Population is host-side only.** The host runs its own `pip download`
+//!   (wheels only, so no package code executes) against the real registry over
+//!   host TLS; pip authenticates every artifact against the index's published
+//!   hashes. Nothing a sandbox wrote is ever promoted: the CONNECT broker
+//!   keeps TLS end to end, so sandbox-side downloads cannot be validated by
+//!   the host and are never trusted.
+//! - **Promotion re-hashes every artifact** into a host-owned manifest. A
+//!   file whose bytes later disagree with the manifest — or a file the
+//!   manifest never recorded — is deleted, not served. Wheel filenames are
+//!   immutable upstream, so a staged file colliding with a recorded entry
+//!   under different bytes is refused outright.
+//! - **Sandboxes see the cache read-only.** The Seatbelt profile allows reads
+//!   of the wheels directory and never lists it as writable, so one
+//!   conversation cannot craft an entry another conversation would consume.
+//!
+//! Wheel compatibility is part of the cache key: artifacts live under a
+//! runtime key derived from the same interpreter the sandbox runs
+//! (`cp<maj><min>-<platform>-<machine>`), so an OS or interpreter upgrade
+//! starts a fresh keyspace instead of serving stale incompatible wheels.
+//! Lifecycle is bounded: a total-size cap evicts the oldest promotions first.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Read;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::CodeExecutionError;
+
+/// Dotted sibling of the per-chat workspaces at the scratch root, like the
+/// receipt and env-home directories: file tools and provider sync never see it.
+pub const PACKAGE_CACHE_DIR: &str = ".code-execution-package-cache";
+
+/// Environment variable the local sandbox exports at the read-only wheels
+/// directory when the cache is mounted.
+pub const PACKAGE_CACHE_ENV: &str = "OPENWAVE_PACKAGE_CACHE";
+
+const MANIFEST_FILE: &str = "manifest.json";
+const WHEELS_DIR: &str = "wheels";
+const MAX_ARTIFACT_BYTES: u64 = 256 * 1_024 * 1_024;
+const MAX_TOTAL_BYTES: u64 = 1_024 * 1_024 * 1_024;
+const MAX_MANIFEST_BYTES: u64 = 4 * 1_024 * 1_024;
+const MAX_RUNTIME_KEY_BYTES: usize = 64;
+const RUNTIME_KEY_TIMEOUT: Duration = Duration::from_secs(10);
+const PIP_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
+const MAX_REPORTED_STDERR_BYTES: usize = 2_048;
+
+/// One runtime keyspace of the host-owned shared package cache.
+pub struct SharedPackageCache {
+    runtime_dir: PathBuf,
+}
+
+/// What one verification-and-promotion pass did.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct PromotionReport {
+    /// Staged artifacts verified and promoted into the cache.
+    pub promoted: usize,
+    /// Staged artifacts refused (name/type/size, or hash disagreement with an
+    /// already-recorded entry).
+    pub refused: usize,
+    /// Cached artifacts removed because their bytes no longer match the
+    /// manifest, or because no manifest entry records them.
+    pub invalidated: usize,
+    /// Cached artifacts evicted to keep the cache under its size bound.
+    pub evicted: usize,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct Manifest {
+    entries: BTreeMap<String, ManifestEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ManifestEntry {
+    sha256: String,
+    bytes: u64,
+    promoted_at: u64,
+}
+
+fn cache_error(message: impl Into<String>) -> CodeExecutionError {
+    CodeExecutionError::Sandbox(message.into())
+}
+
+/// Whether `key` is a well-formed runtime key: bounded, lowercase
+/// alphanumerics plus `._-`, and not dotted at the front (so it can never
+/// collide with the cache's own control files or hide from listings).
+fn is_valid_runtime_key(key: &str) -> bool {
+    !key.is_empty()
+        && key.len() <= MAX_RUNTIME_KEY_BYTES
+        && !key.starts_with('.')
+        && key.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_' | b'-')
+        })
+}
+
+/// Whether `name` is a plausible wheel filename safe to record and serve:
+/// bounded ASCII, no separators or leading dot, ending in `.whl`.
+fn is_valid_artifact_name(name: &str) -> bool {
+    name.len() <= 255
+        && name.ends_with(".whl")
+        && !name.starts_with('.')
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-' | b'+'))
+}
+
+fn secure_dir(path: &Path) -> Result<(), CodeExecutionError> {
+    fs::create_dir_all(path)
+        .map_err(|_| cache_error("could not create the shared package cache"))?;
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|_| cache_error("could not inspect the shared package cache"))?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(cache_error(
+            "shared package cache is not a regular directory",
+        ));
+    }
+    #[cfg(unix)]
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+        .map_err(|_| cache_error("could not secure the shared package cache"))?;
+    Ok(())
+}
+
+fn sha256_file(path: &Path) -> Option<(String, u64)> {
+    let mut file = fs::File::open(path).ok()?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1_024];
+    let mut total = 0_u64;
+    loop {
+        let read = file.read(&mut buffer).ok()?;
+        if read == 0 {
+            break;
+        }
+        total += read as u64;
+        hasher.update(&buffer[..read]);
+    }
+    let hex = hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    Some((hex, total))
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or_default()
+}
+
+impl SharedPackageCache {
+    /// Open (creating if needed) the cache keyspace for one runtime key under
+    /// `cache_root`. The root and keyspace are host-owned `0o700` directories.
+    pub fn open(cache_root: &Path, runtime_key: &str) -> Result<Self, CodeExecutionError> {
+        if !is_valid_runtime_key(runtime_key) {
+            return Err(cache_error("shared package cache runtime key is invalid"));
+        }
+        secure_dir(cache_root)?;
+        let runtime_dir = cache_root.join(runtime_key);
+        secure_dir(&runtime_dir)?;
+        secure_dir(&runtime_dir.join(WHEELS_DIR))?;
+        Ok(Self { runtime_dir })
+    }
+
+    /// The directory of verified wheels, the only path a sandbox is shown.
+    #[must_use]
+    pub fn wheels_dir(&self) -> PathBuf {
+        self.runtime_dir.join(WHEELS_DIR)
+    }
+
+    /// Whether the cache holds at least one verified artifact worth mounting.
+    #[must_use]
+    pub fn is_ready(&self) -> bool {
+        self.load_manifest()
+            .is_some_and(|manifest| !manifest.entries.is_empty())
+    }
+
+    /// An unreadable or unparseable manifest is `None`: integrity is unknown,
+    /// so nothing is served until verification rebuilds from an empty record.
+    fn load_manifest(&self) -> Option<Manifest> {
+        let path = self.runtime_dir.join(MANIFEST_FILE);
+        let file = fs::File::open(&path).ok()?;
+        if file.metadata().ok()?.len() > MAX_MANIFEST_BYTES {
+            return None;
+        }
+        let mut bytes = Vec::new();
+        file.take(MAX_MANIFEST_BYTES + 1)
+            .read_to_end(&mut bytes)
+            .ok()?;
+        serde_json::from_slice(&bytes).ok()
+    }
+
+    fn store_manifest(&self, manifest: &Manifest) -> Result<(), CodeExecutionError> {
+        let bytes = serde_json::to_vec_pretty(manifest)
+            .map_err(|_| cache_error("could not encode the package cache manifest"))?;
+        let temporary = self.runtime_dir.join(format!(".{MANIFEST_FILE}.tmp"));
+        fs::write(&temporary, bytes)
+            .and_then(|()| fs::rename(&temporary, self.runtime_dir.join(MANIFEST_FILE)))
+            .map_err(|_| cache_error("could not persist the package cache manifest"))
+    }
+
+    /// Verify the cached artifacts against the manifest and promote staged
+    /// ones, then evict down to the size bound. See [`promote_with_limits`].
+    pub fn verify_and_promote(
+        &self,
+        staging: &Path,
+    ) -> Result<PromotionReport, CodeExecutionError> {
+        self.promote_with_limits(Some(staging), MAX_ARTIFACT_BYTES, MAX_TOTAL_BYTES)
+    }
+
+    /// Re-verify every cached artifact without promoting anything.
+    pub fn verify(&self) -> Result<PromotionReport, CodeExecutionError> {
+        self.promote_with_limits(None, MAX_ARTIFACT_BYTES, MAX_TOTAL_BYTES)
+    }
+
+    fn promote_with_limits(
+        &self,
+        staging: Option<&Path>,
+        max_artifact_bytes: u64,
+        max_total_bytes: u64,
+    ) -> Result<PromotionReport, CodeExecutionError> {
+        let wheels = self.wheels_dir();
+        let mut report = PromotionReport::default();
+        // Integrity-unknown manifests rebuild from empty: every unrecorded
+        // file below is then invalidated rather than adopted.
+        let mut manifest = self.load_manifest().unwrap_or_default();
+
+        // Verification pass: the manifest is the record of what the trusted
+        // acquisition produced. Bytes that disagree with it — and files it
+        // never recorded — are removed, never served or re-adopted.
+        let mut verified = BTreeMap::new();
+        let entries = fs::read_dir(&wheels)
+            .map_err(|_| cache_error("shared package cache wheels are unavailable"))?;
+        for entry in entries.flatten() {
+            let Ok(name) = entry.file_name().into_string() else {
+                let _ = fs::remove_file(entry.path());
+                report.invalidated += 1;
+                continue;
+            };
+            let regular = entry
+                .path()
+                .symlink_metadata()
+                .is_ok_and(|metadata| metadata.is_file() && !metadata.file_type().is_symlink());
+            let recorded = manifest.entries.get(&name);
+            let intact = regular
+                && recorded.is_some_and(|entry_record| {
+                    sha256_file(&entry.path()).is_some_and(|(sha256, bytes)| {
+                        sha256 == entry_record.sha256 && bytes == entry_record.bytes
+                    })
+                });
+            if intact {
+                verified.insert(name.clone(), recorded.expect("checked above").clone());
+            } else {
+                let path = entry.path();
+                if path.is_dir() {
+                    let _ = fs::remove_dir_all(&path);
+                } else {
+                    let _ = fs::remove_file(&path);
+                }
+                report.invalidated += 1;
+            }
+        }
+        manifest.entries = verified;
+
+        // Promotion pass: staged files come from the host-side acquisition,
+        // but are still re-hashed into the manifest here so later tampering is
+        // detectable, and a name collision with different bytes is refused —
+        // wheel filenames are immutable upstream, so disagreement is never
+        // legitimate.
+        if let Some(staging) = staging {
+            let staged = fs::read_dir(staging)
+                .map_err(|_| cache_error("package cache staging directory is unavailable"))?;
+            for entry in staged.flatten() {
+                let Ok(name) = entry.file_name().into_string() else {
+                    report.refused += 1;
+                    continue;
+                };
+                let regular = entry
+                    .path()
+                    .symlink_metadata()
+                    .is_ok_and(|metadata| metadata.is_file() && !metadata.file_type().is_symlink());
+                if !regular || !is_valid_artifact_name(&name) {
+                    report.refused += 1;
+                    continue;
+                }
+                let Some((sha256, bytes)) = sha256_file(&entry.path()) else {
+                    report.refused += 1;
+                    continue;
+                };
+                if bytes > max_artifact_bytes {
+                    report.refused += 1;
+                    continue;
+                }
+                if let Some(existing) = manifest.entries.get(&name) {
+                    if existing.sha256 != sha256 {
+                        report.refused += 1;
+                    }
+                    // Identical bytes are already cached; nothing to do.
+                    continue;
+                }
+                if fs::rename(entry.path(), wheels.join(&name)).is_err() {
+                    report.refused += 1;
+                    continue;
+                }
+                manifest.entries.insert(
+                    name,
+                    ManifestEntry {
+                        sha256,
+                        bytes,
+                        promoted_at: unix_now(),
+                    },
+                );
+                report.promoted += 1;
+            }
+        }
+
+        // Bounded lifecycle: oldest promotions leave first.
+        let mut total: u64 = manifest.entries.values().map(|entry| entry.bytes).sum();
+        while total > max_total_bytes {
+            let Some(oldest) = manifest
+                .entries
+                .iter()
+                .min_by_key(|(name, entry)| (entry.promoted_at, (*name).clone()))
+                .map(|(name, _)| name.clone())
+            else {
+                break;
+            };
+            let removed = manifest.entries.remove(&oldest).expect("key came from map");
+            let _ = fs::remove_file(wheels.join(&oldest));
+            total = total.saturating_sub(removed.bytes);
+            report.evicted += 1;
+        }
+
+        self.store_manifest(&manifest)?;
+        Ok(report)
+    }
+
+    /// Derive the wheel-compatibility cache key from the interpreter the local
+    /// sandbox actually runs. `None` disables the cache on hosts where the
+    /// interpreter is unusable.
+    pub async fn runtime_key(python: &Path) -> Option<String> {
+        let probe = tokio::process::Command::new(python)
+            .args([
+                "-c",
+                "import platform, sys; \
+                 print(f'cp{sys.version_info[0]}{sys.version_info[1]}-{sys.platform}-{platform.machine().lower()}')",
+            ])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true)
+            .output();
+        let output = tokio::time::timeout(RUNTIME_KEY_TIMEOUT, probe)
+            .await
+            .ok()?
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let key = String::from_utf8(output.stdout).ok()?.trim().to_owned();
+        is_valid_runtime_key(&key).then_some(key)
+    }
+
+    /// Host-side acquisition: download the exactly pinned requirements (and
+    /// their transitive closure) as wheels with the host's own pip, then
+    /// verify and promote them.
+    ///
+    /// `--only-binary=:all:` keeps acquisition metadata-only — no sdist build
+    /// step ever executes package code on the host — and pip authenticates
+    /// each downloaded file against the index's published hashes over host
+    /// TLS. The sandbox contributes nothing to this path: the pins come from
+    /// repo-authored skill manifests, already validated as exact
+    /// `package==version` requirements.
+    pub async fn populate_with_pip(
+        &self,
+        python: &Path,
+        pins: &[String],
+    ) -> Result<PromotionReport, CodeExecutionError> {
+        if pins.is_empty() {
+            return Ok(PromotionReport::default());
+        }
+        if !pins
+            .iter()
+            .all(|pin| crate::skills::is_pinned_python_dep(pin))
+        {
+            return Err(cache_error(
+                "package cache pins must be exact package==version requirements",
+            ));
+        }
+        let staging = self
+            .runtime_dir
+            .join(format!(".staging-{}", uuid::Uuid::new_v4()));
+        secure_dir(&staging)?;
+        let result = self.download_into(python, pins, &staging).await;
+        let promoted = match result {
+            Ok(()) => self.verify_and_promote(&staging),
+            Err(error) => Err(error),
+        };
+        let _ = fs::remove_dir_all(&staging);
+        promoted
+    }
+
+    async fn download_into(
+        &self,
+        python: &Path,
+        pins: &[String],
+        staging: &Path,
+    ) -> Result<(), CodeExecutionError> {
+        let download = tokio::process::Command::new(python)
+            .args([
+                "-m",
+                "pip",
+                "download",
+                "--only-binary=:all:",
+                "--disable-pip-version-check",
+                "--no-input",
+                "--quiet",
+                "--dest",
+            ])
+            .arg(staging)
+            .args(pins)
+            .current_dir(&self.runtime_dir)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true)
+            .output();
+        let output = tokio::time::timeout(PIP_DOWNLOAD_TIMEOUT, download)
+            .await
+            .map_err(|_| cache_error("package cache acquisition timed out"))?
+            .map_err(|_| cache_error("could not run the host package acquisition"))?;
+        if !output.status.success() {
+            let mut stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+            stderr.truncate(
+                (0..=MAX_REPORTED_STDERR_BYTES.min(stderr.len()))
+                    .rev()
+                    .find(|&end| stderr.is_char_boundary(end))
+                    .unwrap_or(0),
+            );
+            return Err(cache_error(format!(
+                "package cache acquisition failed: {}",
+                stderr.trim()
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stage(dir: &Path, name: &str, bytes: &[u8]) {
+        fs::write(dir.join(name), bytes).unwrap();
+    }
+
+    #[test]
+    fn promotion_records_hashes_and_verification_refuses_tampering() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = SharedPackageCache::open(root.path(), "cp39-darwin-arm64").unwrap();
+        assert!(!cache.is_ready());
+        assert!(SharedPackageCache::open(root.path(), "../escape").is_err());
+        assert!(SharedPackageCache::open(root.path(), ".hidden").is_err());
+
+        let staging = root.path().join("staging");
+        fs::create_dir(&staging).unwrap();
+        stage(&staging, "fpdf2-2.8.3-py3-none-any.whl", b"fpdf-bytes");
+        stage(&staging, "pypdf-5.1.0-py3-none-any.whl", b"pypdf-bytes");
+        stage(&staging, "notes.txt", b"not a wheel");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(
+            root.path().join("outside"),
+            staging.join("linked-1.0-py3-none-any.whl"),
+        )
+        .unwrap();
+
+        let report = cache.verify_and_promote(&staging).unwrap();
+        assert_eq!(report.promoted, 2);
+        assert!(report.refused >= 1, "non-wheel entries must be refused");
+        assert!(cache.is_ready());
+        let wheels = cache.wheels_dir();
+        assert!(wheels.join("fpdf2-2.8.3-py3-none-any.whl").is_file());
+        assert!(!wheels.join("notes.txt").exists());
+        assert!(!wheels.join("linked-1.0-py3-none-any.whl").exists());
+
+        // A re-staged filename with different bytes is refused: the recorded
+        // artifact stays authoritative.
+        let restage = root.path().join("restage");
+        fs::create_dir(&restage).unwrap();
+        stage(&restage, "fpdf2-2.8.3-py3-none-any.whl", b"poisoned");
+        let conflicted = cache.verify_and_promote(&restage).unwrap();
+        assert_eq!(conflicted.promoted, 0);
+        assert_eq!(conflicted.refused, 1);
+        assert_eq!(
+            fs::read(wheels.join("fpdf2-2.8.3-py3-none-any.whl")).unwrap(),
+            b"fpdf-bytes"
+        );
+
+        // Bytes tampered after promotion — and files the manifest never
+        // recorded — are removed on the next verification, never served.
+        fs::write(wheels.join("fpdf2-2.8.3-py3-none-any.whl"), b"tampered").unwrap();
+        fs::write(wheels.join("planted-1.0-py3-none-any.whl"), b"planted").unwrap();
+        let verified = cache.verify().unwrap();
+        assert_eq!(verified.invalidated, 2);
+        assert!(!wheels.join("fpdf2-2.8.3-py3-none-any.whl").exists());
+        assert!(!wheels.join("planted-1.0-py3-none-any.whl").exists());
+        assert!(wheels.join("pypdf-5.1.0-py3-none-any.whl").is_file());
+        assert!(cache.is_ready());
+
+        // A corrupt manifest means integrity is unknown: everything on disk is
+        // invalidated instead of adopted.
+        fs::write(
+            root.path().join("cp39-darwin-arm64/manifest.json"),
+            b"{ not json",
+        )
+        .unwrap();
+        assert!(!cache.is_ready());
+        let rebuilt = cache.verify().unwrap();
+        assert_eq!(rebuilt.invalidated, 1);
+        assert!(!wheels.join("pypdf-5.1.0-py3-none-any.whl").exists());
+    }
+
+    #[test]
+    fn eviction_bounds_the_cache_and_drops_the_oldest_promotions_first() {
+        let root = tempfile::tempdir().unwrap();
+        let cache = SharedPackageCache::open(root.path(), "cp39-darwin-arm64").unwrap();
+        let staging = root.path().join("staging");
+        fs::create_dir(&staging).unwrap();
+        stage(&staging, "first-1.0-py3-none-any.whl", &[b'a'; 40]);
+        cache
+            .promote_with_limits(Some(&staging), 1_024, 100)
+            .unwrap();
+        // A later promotion pushes the total over the bound; the older entry
+        // leaves and the newer survives.
+        stage(&staging, "second-1.0-py3-none-any.whl", &[b'b'; 80]);
+        let report = cache
+            .promote_with_limits(Some(&staging), 1_024, 100)
+            .unwrap();
+        assert_eq!(report.promoted, 1);
+        assert_eq!(report.evicted, 1);
+        let wheels = cache.wheels_dir();
+        assert!(!wheels.join("first-1.0-py3-none-any.whl").exists());
+        assert!(wheels.join("second-1.0-py3-none-any.whl").is_file());
+
+        // An artifact over the per-file bound is refused outright.
+        stage(&staging, "huge-1.0-py3-none-any.whl", &[b'c'; 200]);
+        let oversized = cache
+            .promote_with_limits(Some(&staging), 150, 1_000)
+            .unwrap();
+        assert_eq!(oversized.promoted, 0);
+        assert_eq!(oversized.refused, 1);
+        assert!(!wheels.join("huge-1.0-py3-none-any.whl").exists());
+    }
+}

--- a/crates/openwave-code-execution/src/skills.rs
+++ b/crates/openwave-code-execution/src/skills.rs
@@ -84,7 +84,7 @@ pub fn is_valid_skill_description(description: &str) -> bool {
         && !description.chars().any(char::is_control)
 }
 
-fn is_pinned_python_dep(dep: &str) -> bool {
+pub(crate) fn is_pinned_python_dep(dep: &str) -> bool {
     if dep.is_empty() || dep.len() > MAX_DEP_BYTES {
         return false;
     }

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -19,10 +19,10 @@ use openwave_code_execution::{
     DaytonaExecutionProvider, E2BCredential, E2BExecutionProvider, ExecFolderAccess,
     ExecFolderGrant, ExecutionId, ExecutionWorkspaceId, LocalExecutionProvider,
     MaterializationPrecondition, MaterializedChangeKind, OutputArtifactEntry, OutputArtifactScan,
-    OutputArtifactStatus, PreviewScan, RejectedChangeReason, RemoteSessionPool, StagedUpload,
-    WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, WriteOverlay, WriteSnapshotSink,
-    DAYTONA_CREDENTIAL_KEY, DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES, E2B_CREDENTIAL_KEY,
-    PACKAGE_MANAGER_DOMAINS,
+    OutputArtifactStatus, PreviewScan, RejectedChangeReason, RemoteSessionPool, SharedPackageCache,
+    StagedUpload, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, WriteOverlay,
+    WriteSnapshotSink, DAYTONA_CREDENTIAL_KEY, DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES,
+    E2B_CREDENTIAL_KEY, PACKAGE_CACHE_DIR, PACKAGE_MANAGER_DOMAINS,
 };
 use openwave_core::{
     exec_attachment_file_name, BlobStore, CallId, Chat, ChatId, ExecFileRejectionReason,
@@ -43,6 +43,23 @@ pub const DEFAULT_TIMEOUT_MS: u64 = 20_000;
 pub const MIN_TIMEOUT_MS: u64 = 1_000;
 pub const MAX_TIMEOUT_MS: u64 = 120_000;
 const MAX_NETWORK_ALLOWED_HOSTS: usize = 64;
+
+/// The interpreter the local sandbox resolves from its fixed PATH; host-side
+/// cache acquisition runs the same one, so cached wheels are compatible with
+/// the sandbox runtime by construction.
+const SANDBOX_PYTHON: &str = "/usr/bin/python3";
+
+/// Whether a per-chat policy admits package-registry downloads, mirroring the
+/// operating prompt's truth table.
+fn permits_package_installs(policy: &NetworkPolicy) -> bool {
+    match policy {
+        NetworkPolicy::Off => false,
+        NetworkPolicy::PackageManagers | NetworkPolicy::Open => true,
+        NetworkPolicy::AllowedHosts {
+            package_managers, ..
+        } => *package_managers,
+    }
+}
 
 /// Validate and canonicalize one user-authored per-chat network policy.
 ///
@@ -687,6 +704,12 @@ pub struct ConfiguredCodeExecutionProvider {
     /// when the turn ends; every `exec` in between finds it here and points the
     /// sandbox at the staged copy instead of the user's folder.
     write_overlays: Mutex<HashMap<ChatId, StagedTurn>>,
+    /// The shared package cache's runtime key, probed from the sandbox
+    /// interpreter once per process. `None` disables the cache.
+    package_cache_runtime: tokio::sync::OnceCell<Option<String>>,
+    /// Whether a host-side cache population pass is running or has succeeded;
+    /// cleared again on failure so a later exec can retry.
+    package_cache_population: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// One turn's staging for one chat.
@@ -835,6 +858,8 @@ impl ConfiguredCodeExecutionProvider {
             blob_writes: None,
             remote_sessions: RemoteSessionPool::default(),
             write_overlays: Mutex::new(HashMap::new()),
+            package_cache_runtime: tokio::sync::OnceCell::new(),
+            package_cache_population: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 
@@ -883,6 +908,89 @@ impl ConfiguredCodeExecutionProvider {
             .iter()
             .map(|skill| skill.package.clone())
             .collect()
+    }
+
+    /// The shared package cache keyspace for the local sandbox interpreter.
+    ///
+    /// The wheel-compatibility runtime key is probed from the same interpreter
+    /// the sandbox runs, once per process; `None` (an unusable interpreter, a
+    /// non-macOS host, or an unopenable cache directory) disables the cache
+    /// without affecting execution.
+    async fn shared_package_cache(&self) -> Option<SharedPackageCache> {
+        if !cfg!(target_os = "macos") {
+            return None;
+        }
+        let key = self
+            .package_cache_runtime
+            .get_or_init(|| async {
+                SharedPackageCache::runtime_key(std::path::Path::new(SANDBOX_PYTHON)).await
+            })
+            .await
+            .clone()?;
+        SharedPackageCache::open(&self.scratch_root.join(PACKAGE_CACHE_DIR), &key).ok()
+    }
+
+    /// Whether verified offline package installs are currently possible on the
+    /// selected provider, for truthful operating-prompt steering.
+    pub(crate) async fn offline_package_cache_ready(&self) -> bool {
+        let Ok(config) = read_config(&*self.store).await else {
+            return false;
+        };
+        if config.provider != Some(CodeExecutionProviderKind::Local) {
+            return false;
+        }
+        match self.shared_package_cache().await {
+            Some(cache) => cache.is_ready(),
+            None => false,
+        }
+    }
+
+    /// Best-effort host-side acquisition of the built-in skills' pinned
+    /// dependencies, spawned once per process when a networked local exec
+    /// shows the cache could be used. Failure clears the latch so a later
+    /// exec retries; conversations keep their network install path either way.
+    fn spawn_package_cache_population(&self, cache: SharedPackageCache) {
+        use std::sync::atomic::Ordering;
+        let pin_sets = self
+            .skills
+            .iter()
+            .map(|skill| skill.package.python_deps.clone())
+            .filter(|pins| !pins.is_empty())
+            .collect::<Vec<_>>();
+        if pin_sets.is_empty() {
+            return;
+        }
+        if self.package_cache_population.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let latch = self.package_cache_population.clone();
+        tokio::spawn(async move {
+            let mut failed = false;
+            // Per-skill acquisition: each skill's pins resolve as one
+            // consistent closure, and one unresolvable skill cannot sink the
+            // others' artifacts.
+            for pins in pin_sets {
+                match cache
+                    .populate_with_pip(std::path::Path::new(SANDBOX_PYTHON), &pins)
+                    .await
+                {
+                    Ok(report) => tracing::info!(
+                        promoted = report.promoted,
+                        refused = report.refused,
+                        invalidated = report.invalidated,
+                        evicted = report.evicted,
+                        "shared package cache population pass finished"
+                    ),
+                    Err(error) => {
+                        failed = true;
+                        tracing::warn!(%error, "shared package cache population failed");
+                    }
+                }
+            }
+            if failed {
+                latch.store(false, Ordering::SeqCst);
+            }
+        });
     }
 
     /// Install the native bridge that resolves product root IDs through the
@@ -1189,14 +1297,23 @@ impl ConfiguredCodeExecutionProvider {
             return Err(CodeExecutionError::NotConfigured);
         };
         let resolved: Box<dyn CodeExecutionProvider> = match provider {
-            CodeExecutionProviderKind::Local => Box::new(
-                LocalExecutionProvider::new(
-                    &self.scratch_root,
-                    Duration::from_millis(config.timeout_ms),
-                )?
-                .with_network_policy(network_policy.cloned().unwrap_or_default())
-                .with_document_scripts(self.document_scripts_source.clone()),
-            ),
+            CodeExecutionProviderKind::Local => {
+                // Mounted only once verified artifacts exist; an empty or
+                // unusable cache leaves execution exactly as it was.
+                let package_cache = match self.shared_package_cache().await {
+                    Some(cache) if cache.is_ready() => Some(cache.wheels_dir()),
+                    _ => None,
+                };
+                Box::new(
+                    LocalExecutionProvider::new(
+                        &self.scratch_root,
+                        Duration::from_millis(config.timeout_ms),
+                    )?
+                    .with_network_policy(network_policy.cloned().unwrap_or_default())
+                    .with_document_scripts(self.document_scripts_source.clone())
+                    .with_shared_package_cache(package_cache),
+                )
+            }
             CodeExecutionProviderKind::E2b => {
                 let credential = E2BCredential::load(&*self.secrets)
                     .await?
@@ -1313,6 +1430,17 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
                 CodeExecutionError::InvalidRequest("execution conversation does not exist".into())
             })?;
         let (kind, provider) = self.resolve(Some(&chat.network_policy)).await?;
+        if kind == CodeExecutionProviderKind::Local
+            && permits_package_installs(&chat.network_policy)
+        {
+            // A networked local exec is the signal that installs are wanted:
+            // the same pins a conversation installs under its per-chat HOME
+            // are acquired host-side into the shared cache, so a later
+            // conversation can install them with the network off.
+            if let Some(cache) = self.shared_package_cache().await {
+                self.spawn_package_cache_population(cache);
+            }
+        }
         if kind == CodeExecutionProviderKind::Local && cfg!(target_os = "macos") {
             // Authority is resolved again here rather than reused from the
             // turn's prompt snapshot, so a revocation mid-turn fails closed.

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -57,7 +57,7 @@ const MCP_HEADING: &str = "## External MCP tools";
 #[must_use]
 #[cfg(test)]
 pub(crate) fn compose(specs: &[ToolSpec]) -> String {
-    compose_for_surface(specs, &[], &[], &NetworkPolicy::default(), false)
+    compose_for_surface(specs, &[], &[], &NetworkPolicy::default(), false, false)
 }
 
 /// Render a host path as a quoted JSON string, so a path carrying a quote or a
@@ -86,6 +86,7 @@ pub(crate) fn compose_for_surface(
     exec_folders: &[ResolvedExecFolderGrant],
     skills: &[SkillPackage],
     network_policy: &NetworkPolicy,
+    offline_package_cache: bool,
     plan_mode: bool,
 ) -> String {
     let names = specs
@@ -297,10 +298,20 @@ pub(crate) fn compose_for_surface(
         // enforces it again per invocation.
         let package_installs_reachable = match network_policy {
             NetworkPolicy::Off => {
-                lines.push(
-                    "- This chat's network policy is off: commands have no outbound network access, and package installs are unavailable."
-                        .to_owned(),
-                );
+                // The cache flag is host-derived state, like the policy: with
+                // verified wheels mounted read-only, "installs are
+                // unavailable" would be false.
+                if offline_package_cache {
+                    lines.push(
+                        "- This chat's network policy is off: commands have no outbound network access. Previously verified packages can still be installed offline with `python3 -m pip install --user --no-index --find-links \"$OPENWAVE_PACKAGE_CACHE\" <package>==<version>`; packages not in that read-only cache are unavailable."
+                            .to_owned(),
+                    );
+                } else {
+                    lines.push(
+                        "- This chat's network policy is off: commands have no outbound network access, and package installs are unavailable."
+                            .to_owned(),
+                    );
+                }
                 false
             }
             NetworkPolicy::PackageManagers => {
@@ -622,8 +633,8 @@ mod tests {
     #[test]
     fn plan_mode_adds_the_planning_contract_and_nothing_else() {
         let specs = [spec("read_file"), spec("list_sources")];
-        let plan = compose_for_surface(&specs, &[], &[], &NetworkPolicy::default(), true);
-        let normal = compose_for_surface(&specs, &[], &[], &NetworkPolicy::default(), false);
+        let plan = compose_for_surface(&specs, &[], &[], &NetworkPolicy::default(), false, true);
+        let normal = compose_for_surface(&specs, &[], &[], &NetworkPolicy::default(), false, false);
 
         assert!(plan.contains(PLAN_MODE_HEADING));
         assert!(plan.contains("do not carry it out"));
@@ -671,6 +682,7 @@ mod tests {
             &[],
             &NetworkPolicy::default(),
             false,
+            false,
         );
 
         assert!(prompt.contains(
@@ -690,13 +702,25 @@ mod tests {
 
     #[test]
     fn network_policy_renders_truthfully_per_value() {
-        let compose_with =
-            |policy: &NetworkPolicy| compose_for_surface(&[spec("exec")], &[], &[], policy, false);
+        let compose_with = |policy: &NetworkPolicy| {
+            compose_for_surface(&[spec("exec")], &[], &[], policy, false, false)
+        };
         let pip_line = "python3 -m pip install --user";
 
         let off = compose_with(&NetworkPolicy::Off);
         assert!(off.contains("network policy is off"));
         assert!(!off.contains(pip_line));
+        assert!(off.contains("package installs are unavailable"));
+        assert!(!off.contains("OPENWAVE_PACKAGE_CACHE"));
+
+        // With verified shared wheels mounted, an off policy still supports
+        // offline installs from the read-only cache — and says so instead of
+        // claiming installs are unavailable.
+        let off_with_cache =
+            compose_for_surface(&[spec("exec")], &[], &[], &NetworkPolicy::Off, true, false);
+        assert!(off_with_cache.contains("no outbound network access"));
+        assert!(off_with_cache.contains("--no-index --find-links \"$OPENWAVE_PACKAGE_CACHE\""));
+        assert!(!off_with_cache.contains("package installs are unavailable"));
 
         let packages = compose_with(&NetworkPolicy::PackageManagers);
         assert!(packages.contains("package-manager registries only"));
@@ -763,6 +787,7 @@ mod tests {
             &skills,
             &NetworkPolicy::default(),
             false,
+            false,
         );
         assert!(prompt.contains(DOCUMENT_SKILLS_HEADING));
         assert!(prompt.contains("- pdf-documents: Generate and manipulate PDF documents."));
@@ -779,6 +804,7 @@ mod tests {
             &skills,
             &NetworkPolicy::default(),
             false,
+            false,
         );
         assert!(!without_exec.contains(DOCUMENT_SKILLS_HEADING));
         // Nothing but forged entries composes no section at all.
@@ -787,6 +813,7 @@ mod tests {
             &[],
             &skills[1..],
             &NetworkPolicy::default(),
+            false,
             false,
         );
         assert!(!forged_only.contains(DOCUMENT_SKILLS_HEADING));
@@ -863,7 +890,14 @@ mod tests {
             spec("wait_for_agents"),
             spec("mcp__example__tool"),
         ];
-        let prompt = compose_for_surface(&specs, &[], &skills, &NetworkPolicy::default(), false);
+        let prompt = compose_for_surface(
+            &specs,
+            &[],
+            &skills,
+            &NetworkPolicy::default(),
+            false,
+            false,
+        );
 
         assert_eq!(
             identity(&prompt),

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -148,15 +148,18 @@ pub(crate) fn freeze_foreground_turn_surface(
         &[],
         &openwave_core::NetworkPolicy::default(),
         false,
+        false,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn freeze_foreground_turn_surface_with_folders(
     tools: Arc<ToolRegistry>,
     base_agent_config: &AgentConfig,
     exec_folders: &[crate::code_execution::ResolvedExecFolderGrant],
     skills: &[openwave_code_execution::SkillPackage],
     network_policy: &openwave_core::NetworkPolicy,
+    offline_package_cache: bool,
     plan_mode: bool,
 ) -> ForegroundTurnSurface {
     let mut agent_config = base_agent_config.clone();
@@ -165,6 +168,7 @@ fn freeze_foreground_turn_surface_with_folders(
         exec_folders,
         skills,
         network_policy,
+        offline_package_cache,
         plan_mode,
     ));
     ForegroundTurnSurface {
@@ -582,12 +586,17 @@ impl TurnWorker {
             .as_ref()
             .map(|provider| provider.skill_catalog())
             .unwrap_or_default();
+        let offline_package_cache = match self.exec_folder_context.as_ref() {
+            Some(provider) => provider.offline_package_cache_ready().await,
+            None => false,
+        };
         let surface = freeze_foreground_turn_surface_with_folders(
             tools,
             &self.agent_config,
             &exec_folders,
             &skills,
             &chat.network_policy,
+            offline_package_cache,
             matches!(
                 chat.permission_mode,
                 Some(openwave_core::PermissionMode::Plan)


### PR DESCRIPTION
Closes #1289.

Local package installs already work per conversation (CONNECT broker + per-chat HOME), but nothing is reusable across conversations. This adds the offline dependency substrate the document-skills epic (#1310) depends on: a host-owned, verified wheel cache that a second conversation can install pinned packages from with the network off.

## Design

**Population is host-side only.** When a networked local exec runs under a policy that admits package registries, the host spawns a one-per-process background pass that acquires each built-in skill's pinned dependencies itself: `pip download --only-binary=:all:` (wheels only, so no package code ever executes during acquisition) against the real index over host TLS, where pip authenticates every file against the index's published hashes. The pins come from the repo-authored `SKILL.md` manifests, already validated as exact `package==version` requirements — no sandbox-controlled name or byte enters this path. The broker keeps TLS end to end by design, so sandbox-side downloads cannot be validated and are never promoted.

**Verification.** Promotion re-hashes every artifact into a host-owned manifest. On every later pass, bytes that disagree with the manifest — and files the manifest never recorded — are deleted, not served; a staged filename colliding with a recorded entry under different bytes is refused outright (wheel filenames are immutable upstream, so disagreement is never legitimate). A corrupt manifest invalidates everything instead of adopting what is on disk.

**Cache key.** Artifacts live under a runtime key probed from the same interpreter the sandbox resolves (`cp<maj><min>-<platform>-<machine>`, from `/usr/bin/python3`), and acquisition runs that same interpreter, so cached wheels are compatible with the sandbox runtime by construction; an OS or interpreter upgrade starts a fresh keyspace.

**Read-only inside every sandbox.** The Seatbelt profile adds the wheels directory to the read allowances and never to any write clause, and exports `OPENWAVE_PACKAGE_CACHE` plus `PIP_FIND_LINKS` so pip prefers verified local wheels. The cache is a dotted sibling of the workspaces at the scratch root (like receipts and env homes), so file tools, provider sync, and the output scan never see it.

**Lifecycle.** Host-owned `0o700` directories, a per-artifact size bound, and a total-size cap that evicts the oldest promotions first.

**Prompt truthfulness.** With the chat's network policy off and verified wheels present, the operating prompt stops claiming installs are unavailable and steers `python3 -m pip install --user --no-index --find-links "$OPENWAVE_PACKAGE_CACHE" <package>==<version>` instead.

## Tests

- Promotion/verification: recorded hashes, refusal of non-wheel/symlink/oversized staged entries, refusal of a name collision with different bytes, deletion of tampered and unrecorded artifacts, corrupt-manifest reset.
- Eviction: total-size bound drops the oldest promotion first; per-artifact bound refuses outright.
- Real-sandbox enforcement: a Seatbelt-confined command reads a cached wheel but cannot tamper with it or plant a new one, and the profile string never lists the cache in a write clause.
- Prompt: the offline steering line appears only with the cache flag, and the off-policy wording stays truthful in both states.

Verified locally: `cargo test -p openwave-code-execution --locked` (69 tests) and `cargo test -p openwave-server --locked` (534 tests) pass, `cargo clippy --all-targets -D warnings` clean for both crates, `cargo check --workspace --locked` clean with no lockfile drift. Post-merge CI on `main` covers the heavy lanes.

Residuals (follow-up issue to come): no automated end-to-end proof of the offline second-conversation `pip install` itself (it needs real registry wheels; the mount, steering, and enforcement legs are each tested), npm artifacts are out of scope (the skills epic needs Python only), and managed/container providers keep their per-session behavior.
