### PR TITLE
fix(exec): replace pooled managed sandboxes when the egress policy changes

### DIFF
--- a/crates/openwave-code-execution/src/daytona.rs
+++ b/crates/openwave-code-execution/src/daytona.rs
@@ -445,11 +445,30 @@ impl RemoteSandboxAdapter for DaytonaExecutionProvider {
         self.credential.fingerprint()
     }
 
+    fn egress_fingerprint(&self) -> [u8; 32] {
+        crate::remote::egress_policy_fingerprint(self.egress.as_ref())
+    }
+
     async fn create_session(
         &self,
         workspace_id: &str,
     ) -> Result<RemoteSession, CodeExecutionError> {
         self.create_sandbox(workspace_id).await
+    }
+
+    async fn destroy_sandbox(&self, session: &RemoteSession) -> Result<(), CodeExecutionError> {
+        validate_sandbox_id(&session.sandbox_id)?;
+        let response = self
+            .client
+            .delete(self.api_url(&format!("/sandbox/{}", session.sandbox_id)))
+            .bearer_auth(self.credential.as_str())
+            .send()
+            .await
+            .map_err(|_| CodeExecutionError::Unavailable("could not reach Daytona".into()))?;
+        if response.status() == StatusCode::NOT_FOUND || response.status().is_success() {
+            return Ok(());
+        }
+        Err(provider_status_error(response.status()))
     }
 
     async fn reconnect_session(
@@ -586,21 +605,6 @@ impl RemoteWorkspaceAdapter for DaytonaExecutionProvider {
         let truncated = entries.len() > MAX_WORKSPACE_LIST_ENTRIES;
         entries.truncate(MAX_WORKSPACE_LIST_ENTRIES);
         Ok(WorkspaceListing { entries, truncated })
-    }
-
-    async fn destroy_sandbox(&self, session: &RemoteSession) -> Result<(), CodeExecutionError> {
-        validate_sandbox_id(&session.sandbox_id)?;
-        let response = self
-            .client
-            .delete(self.api_url(&format!("/sandbox/{}", session.sandbox_id)))
-            .bearer_auth(self.credential.as_str())
-            .send()
-            .await
-            .map_err(|_| CodeExecutionError::Unavailable("could not reach Daytona".into()))?;
-        if response.status() == StatusCode::NOT_FOUND || response.status().is_success() {
-            return Ok(());
-        }
-        Err(provider_status_error(response.status()))
     }
 }
 

--- a/crates/openwave-code-execution/src/e2b.rs
+++ b/crates/openwave-code-execution/src/e2b.rs
@@ -331,11 +331,35 @@ impl RemoteSandboxAdapter for E2BExecutionProvider {
         self.credential.fingerprint()
     }
 
+    fn egress_fingerprint(&self) -> [u8; 32] {
+        crate::remote::egress_policy_fingerprint(self.egress.as_ref())
+    }
+
     async fn create_session(
         &self,
         workspace_id: &str,
     ) -> Result<RemoteSession, CodeExecutionError> {
         self.create_sandbox(workspace_id).await
+    }
+
+    async fn destroy_sandbox(&self, session: &RemoteSession) -> Result<(), CodeExecutionError> {
+        validate_sandbox_id(&session.sandbox_id)?;
+        let url = format!(
+            "{}/sandboxes/{}",
+            self.endpoints.api_base.trim_end_matches('/'),
+            session.sandbox_id
+        );
+        let response = self
+            .client
+            .delete(url)
+            .header("X-API-Key", self.credential.as_str())
+            .send()
+            .await
+            .map_err(|_| CodeExecutionError::Unavailable("could not reach the E2B API".into()))?;
+        if response.status() == StatusCode::NOT_FOUND || response.status().is_success() {
+            return Ok(());
+        }
+        Err(provider_status_error(response.status()))
     }
 
     async fn reconnect_session(
@@ -484,26 +508,6 @@ impl RemoteWorkspaceAdapter for E2BExecutionProvider {
         let truncated = entries.len() > MAX_WORKSPACE_LIST_ENTRIES;
         entries.truncate(MAX_WORKSPACE_LIST_ENTRIES);
         Ok(WorkspaceListing { entries, truncated })
-    }
-
-    async fn destroy_sandbox(&self, session: &RemoteSession) -> Result<(), CodeExecutionError> {
-        validate_sandbox_id(&session.sandbox_id)?;
-        let url = format!(
-            "{}/sandboxes/{}",
-            self.endpoints.api_base.trim_end_matches('/'),
-            session.sandbox_id
-        );
-        let response = self
-            .client
-            .delete(url)
-            .header("X-API-Key", self.credential.as_str())
-            .send()
-            .await
-            .map_err(|_| CodeExecutionError::Unavailable("could not reach the E2B API".into()))?;
-        if response.status() == StatusCode::NOT_FOUND || response.status().is_success() {
-            return Ok(());
-        }
-        Err(provider_status_error(response.status()))
     }
 }
 
@@ -1060,14 +1064,9 @@ mod tests {
         }
     }
 
-    async fn mock_provider(
+    async fn mock_server(
         mode: ProcessMode,
-        egress: Option<EgressPolicy>,
-    ) -> (
-        E2BExecutionProvider,
-        Arc<MockState>,
-        tokio::task::JoinHandle<()>,
-    ) {
+    ) -> (Arc<MockState>, String, tokio::task::JoinHandle<()>) {
         let state = Arc::new(MockState::new(mode));
         let app = Router::new()
             .route("/sandboxes", post(mock_create))
@@ -1084,20 +1083,40 @@ mod tests {
         let server = tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
         });
+        (state, base, server)
+    }
+
+    fn provider_at(
+        base: &str,
+        pool: RemoteSessionPool,
+        egress: Option<EgressPolicy>,
+    ) -> E2BExecutionProvider {
         let provider = E2BExecutionProvider::with_endpoints(
             E2BCredential::parse("test-e2b-key").unwrap(),
             Duration::from_secs(2),
-            RemoteSessionPool::default(),
+            pool,
             E2BEndpoints {
-                api_base: base.clone(),
-                sandbox_base: base,
+                api_base: base.to_owned(),
+                sandbox_base: base.to_owned(),
             },
         )
         .unwrap();
-        let provider = match egress {
+        match egress {
             Some(policy) => provider.with_egress_policy(policy),
             None => provider,
-        };
+        }
+    }
+
+    async fn mock_provider(
+        mode: ProcessMode,
+        egress: Option<EgressPolicy>,
+    ) -> (
+        E2BExecutionProvider,
+        Arc<MockState>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let (state, base, server) = mock_server(mode).await;
+        let provider = provider_at(&base, RemoteSessionPool::default(), egress);
         (provider, state, server)
     }
 
@@ -1483,6 +1502,54 @@ mod tests {
         let block_all = e2b_network_settings(Some(&EgressPolicy::BlockAll));
         assert!(!block_all.allow_internet_access);
         assert!(block_all.network.is_none());
+        server.abort();
+    }
+
+    /// Reproduction of a bug we hit: a chat starts with network off, the E2B
+    /// sandbox is created deny-by-default, and after the user opens the chat's
+    /// network policy every pip install still fails DNS because the pooled
+    /// sandbox — whose egress is fixed at creation — keeps being reused. A
+    /// policy change must destroy the stale sandbox and create one under the
+    /// new policy; an unchanged policy must keep reusing the live sandbox.
+    #[tokio::test]
+    async fn e2b_replaces_the_pooled_sandbox_when_the_egress_policy_changes() {
+        use openwave_egress::EgressAllowlist;
+
+        let (state, base, server) = mock_server(ProcessMode::Complete).await;
+        let pool = RemoteSessionPool::default();
+
+        // Chat network policy off: deny-all sandbox.
+        let blocked = provider_at(
+            &base,
+            pool.clone(),
+            Some(EgressPolicy::Allowlist(EgressAllowlist::default())),
+        );
+        blocked
+            .execute(request("execution-1", "workspace-policy", "first"))
+            .await
+            .unwrap();
+        assert_eq!(state.creates.load(Ordering::SeqCst), 1);
+        assert_eq!(state.deletes.load(Ordering::SeqCst), 0);
+
+        // The user opens the policy; resolve() builds a fresh provider over the
+        // same pool. The stale deny-all sandbox is destroyed and replaced by an
+        // open-internet one instead of being reused.
+        let open = provider_at(&base, pool.clone(), None);
+        open.execute(request("execution-2", "workspace-policy", "second"))
+            .await
+            .unwrap();
+        assert_eq!(state.deletes.load(Ordering::SeqCst), 1);
+        assert_eq!(state.creates.load(Ordering::SeqCst), 2);
+        let create = state.create_body.lock().unwrap().clone().unwrap();
+        assert_eq!(create["allow_internet_access"], true);
+
+        // Unchanged policy: the live sandbox is reconnected, not replaced.
+        let same = provider_at(&base, pool, None);
+        same.execute(request("execution-3", "workspace-policy", "third"))
+            .await
+            .unwrap();
+        assert_eq!(state.creates.load(Ordering::SeqCst), 2);
+        assert_eq!(state.deletes.load(Ordering::SeqCst), 1);
         server.abort();
     }
 

--- a/crates/openwave-code-execution/src/remote.rs
+++ b/crates/openwave-code-execution/src/remote.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use openwave_egress::EgressPolicy;
 use sha2::{Digest as _, Sha256};
 use tokio::sync::Mutex;
 
@@ -19,7 +20,7 @@ pub struct RemoteSessionPool {
 
 #[derive(Default)]
 struct PoolState {
-    sessions: HashMap<SessionKey, Arc<Mutex<Option<RemoteSession>>>>,
+    sessions: HashMap<SessionKey, Arc<Mutex<Option<PooledSession>>>>,
     receipts: HashMap<ReceiptKey, ExecutionReceipt>,
     /// Content digests of files already staged into each workspace's live
     /// sandbox, bound to the exact sandbox instance they were uploaded to. A
@@ -52,6 +53,39 @@ pub(crate) struct RemoteSession {
     pub(crate) access_token: Option<String>,
 }
 
+/// A pooled session bound to the egress policy its sandbox was created under.
+///
+/// Managed sandboxes compile egress into creation-time network controls, so a
+/// live sandbox does not follow later policy edits. Recording the creation
+/// policy's fingerprint here lets the pool notice the mismatch and replace the
+/// sandbox instead of silently reusing one with stale egress.
+struct PooledSession {
+    session: RemoteSession,
+    egress: [u8; 32],
+}
+
+/// Stable identity of the egress policy a provider compiles into sandbox
+/// creation. `None` is today's open-internet creation.
+pub(crate) fn egress_policy_fingerprint(policy: Option<&EgressPolicy>) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    match policy {
+        None => hasher.update(b"open"),
+        Some(EgressPolicy::BlockAll) => hasher.update(b"block-all"),
+        Some(EgressPolicy::Allowlist(allowlist)) => {
+            hasher.update(b"allowlist");
+            for domain in allowlist.domains() {
+                hasher.update(b"\nd:");
+                hasher.update(domain.to_string().as_bytes());
+            }
+            for cidr in allowlist.cidrs() {
+                hasher.update(b"\nc:");
+                hasher.update(cidr.to_string().as_bytes());
+            }
+        }
+    }
+    hasher.finalize().into()
+}
+
 pub(crate) enum RemoteSessionError {
     Missing,
     Provider(CodeExecutionError),
@@ -68,8 +102,17 @@ pub(crate) trait RemoteSandboxAdapter: Send + Sync {
     fn kind(&self) -> CodeExecutionProviderKind;
     fn credential_fingerprint(&self) -> [u8; 32];
 
+    /// Fingerprint of the egress policy this adapter compiles into sandbox
+    /// creation. A pooled sandbox created under a different fingerprint is
+    /// stale — its network controls no longer reflect the effective policy —
+    /// and must be replaced rather than reused.
+    fn egress_fingerprint(&self) -> [u8; 32];
+
     async fn create_session(&self, workspace_id: &str)
         -> Result<RemoteSession, CodeExecutionError>;
+
+    /// Destroy the remote sandbox. A sandbox that is already gone is success.
+    async fn destroy_sandbox(&self, session: &RemoteSession) -> Result<(), CodeExecutionError>;
 
     async fn reconnect_session(
         &self,
@@ -104,9 +147,6 @@ pub(crate) trait RemoteWorkspaceAdapter: RemoteSandboxAdapter {
         session: &RemoteSession,
         path: Option<&WorkspaceFilePath>,
     ) -> Result<WorkspaceListing, RemoteSessionError>;
-
-    /// Destroy the remote sandbox. A sandbox that is already gone is success.
-    async fn destroy_sandbox(&self, session: &RemoteSession) -> Result<(), CodeExecutionError>;
 }
 
 impl RemoteSessionPool {
@@ -152,7 +192,7 @@ impl RemoteSessionPool {
         provider: CodeExecutionProviderKind,
         credential: [u8; 32],
         workspace_id: &str,
-    ) -> Arc<Mutex<Option<RemoteSession>>> {
+    ) -> Arc<Mutex<Option<PooledSession>>> {
         let key = SessionKey {
             provider,
             credential,
@@ -319,20 +359,35 @@ where
 
 async fn connected_session<A>(
     adapter: &A,
-    slot: &mut Option<RemoteSession>,
+    slot: &mut Option<PooledSession>,
     workspace_id: &str,
 ) -> Result<RemoteSession, CodeExecutionError>
 where
     A: RemoteSandboxAdapter + ?Sized,
 {
+    let egress = adapter.egress_fingerprint();
+    // A sandbox compiled under a different egress policy is stale: reusing it
+    // would keep enforcing the old policy (a chat whose network was off keeps
+    // failing DNS after the user opens it, and the reverse silently widens
+    // egress). Replace it. The destroy is best-effort — a sandbox the destroy
+    // could not reach expires on its own TTL.
+    if let Some(pooled) = slot.as_ref() {
+        if pooled.egress != egress {
+            let _ = adapter.destroy_sandbox(&pooled.session).await;
+            *slot = None;
+        }
+    }
     let active = match slot.as_ref() {
-        Some(existing) => match adapter.reconnect_session(existing).await? {
+        Some(pooled) => match adapter.reconnect_session(&pooled.session).await? {
             Some(connected) => connected,
             None => adapter.create_session(workspace_id).await?,
         },
         None => adapter.create_session(workspace_id).await?,
     };
-    *slot = Some(active.clone());
+    *slot = Some(PooledSession {
+        session: active.clone(),
+        egress,
+    });
     Ok(active)
 }
 
@@ -380,9 +435,16 @@ where
     let Some(existing) = slot.as_ref() else {
         return Ok(false);
     };
-    match adapter.reconnect_session(existing).await? {
+    let egress = existing.egress;
+    match adapter.reconnect_session(&existing.session).await? {
         Some(connected) => {
-            *slot = Some(connected);
+            // Reconnecting does not change the sandbox's creation-time egress,
+            // so the recorded fingerprint carries over; a mismatch with the
+            // effective policy is resolved by the next operation.
+            *slot = Some(PooledSession {
+                session: connected,
+                egress,
+            });
             Ok(true)
         }
         None => {
@@ -416,16 +478,16 @@ where
         )
         .await;
     let mut slot = slot.lock().await;
-    let Some(session) = slot.take() else {
+    let Some(pooled) = slot.take() else {
         return Ok(());
     };
-    match adapter.destroy_sandbox(&session).await {
+    match adapter.destroy_sandbox(&pooled.session).await {
         Ok(()) => {
             pool.clear_staged(&key).await;
             Ok(())
         }
         Err(error) => {
-            *slot = Some(session);
+            *slot = Some(pooled);
             Err(error)
         }
     }


### PR DESCRIPTION
## Problem

In a chat using the E2B provider, `pip install python-pptx` kept timing out even after the user opened the chat's network policy. The event journal shows the sequence: the chat started under the default network-off policy, so the first exec created the E2B sandbox deny-by-default. The user then set the policy to Open (and raised the exec timeout), but every subsequent pip attempt still failed with `NameResolutionError: Failed to resolve 'pypi.org'` inside the sandbox.

The cause: managed sandboxes compile egress into creation-time network controls (`allow_internet_access` / `allowOut` for E2B, block-all/allowlists for Daytona), but the remote session pool keyed sessions only by provider, credential, and workspace. The exec path builds a fresh provider carrying the chat's current policy on every call, yet the pool handed back the sandbox created under the old policy — and each exec refreshed its TTL, so it effectively never expired while the user kept retrying. The same staleness works in the opposite, worse direction: tightening a policy would keep an open-egress sandbox alive.

## Fix

Pooled sessions now record a fingerprint of the egress policy their sandbox was created under. On the next operation, a fingerprint mismatch destroys the stale sandbox (best-effort — the vendor TTL reaps one the destroy cannot reach) and creates a fresh sandbox under the current policy. An unchanged policy reuses the live sandbox exactly as before. `destroy_sandbox` moves from the workspace adapter trait to the base sandbox adapter trait so replacement works on the command path, not only through the workspace lifecycle.

The staged-file digest ledger was already bound to the sandbox instance id, so a replacement sandbox restages content correctly with no further changes.

## Tests

- New: `e2b_replaces_the_pooled_sandbox_when_the_egress_policy_changes` — reproduction of the bug above: deny-all sandbox created, policy change destroys and recreates it (asserting the new creation request is open-internet), unchanged policy reuses it.
- `cargo test -p openwave-code-execution --locked` (68 tests), clippy `--all-targets`, fmt, and `cargo check -p openwave-server --locked` all pass locally. Not verified against a live E2B account: after this merges, re-try a pip install in a chat whose network policy is Package managers or Open.