### PR TITLE
fix(desktop): pass the menu-event handler as a function reference

### DIFF
--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -229,7 +229,7 @@ pub fn run() {
             updater::check_for_update,
             updater::restart_for_update
         ])
-        .on_menu_event(|app, event| updater::handle_menu_event(app, event))
+        .on_menu_event(updater::handle_menu_event)
         .setup(move |app| {
             let handle = app.handle().clone();
             deep_link::install(&handle);


### PR DESCRIPTION
Rust 1.97's clippy flags the `on_menu_event` wrapping closure as `redundant_closure`, failing the workspace clippy lane (`-D warnings`) on main and on every full-ci pull request (first seen on #1358). Pass `updater::handle_menu_event` directly.

Verified with `cargo check -p openwave-desktop --locked` locally (no Linux clippy 1.97 toolchain here; the CI lane is the authoritative check).