### PR TITLE
feat(gateway): attribute inference to the conversation it belongs to

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1356,6 +1356,7 @@ impl Agent {
                 let fitted_tokens = context::estimate_transcript_tokens(&fitted);
                 let request = ChatRequest {
                     provider: self.config.provider.clone(),
+                    conversation: Some(chat.id),
                     model: self.config.model.clone(),
                     reasoning_model: self.config.reasoning_model,
                     system: self.config.system_prompt.clone(),

--- a/crates/openwave-core/src/provider.rs
+++ b/crates/openwave-core/src/provider.rs
@@ -178,6 +178,14 @@ pub struct ChatRequest {
     /// provider. Direct adapters may ignore it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<ProviderId>,
+    /// The conversation this request belongs to, for gateway-side attribution.
+    ///
+    /// Only a gateway route declares it, and only as a header: no provider
+    /// receives it as wire data, and a direct provider never sees it at all.
+    /// Absent, the gateway records the inference without a conversation, which
+    /// is what every request did before this existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub conversation: Option<crate::id::ChatId>,
     /// Provider-specific model identifier (e.g. `claude-opus-4-8`).
     pub model: String,
     /// Whether the resolved model uses a reasoning-model request shape.

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -29,6 +29,11 @@ const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
 const DEFAULT_MAX_TOKENS: u32 = 4096;
 
+/// Header a model-gateway deployment reads to group inference into one
+/// conversation. The gateway digests the value per user and harness; it is
+/// never forwarded upstream.
+const GATEWAY_CONVERSATION_HEADER: &str = "x-model-gateway-conversation-id";
+
 /// Description for the synthetic tool that carries a constrained response.
 ///
 /// The model is told what the call is for, because a forced tool with an opaque
@@ -47,6 +52,10 @@ pub struct AnthropicProvider {
     /// Per-request credential supplier for gateways that mint short-lived
     /// tokens. Takes precedence over `api_key` when present.
     token_source: Option<std::sync::Arc<dyn crate::BearerTokenSource>>,
+    /// Whether to declare the request's conversation to a model gateway.
+    /// Off for direct Anthropic, whose API has no such header and no business
+    /// learning how the host groups its chats.
+    conversation_attribution: bool,
 }
 
 impl AnthropicProvider {
@@ -57,6 +66,7 @@ impl AnthropicProvider {
             api_key: api_key.into(),
             base_url: DEFAULT_BASE_URL.to_string(),
             token_source: None,
+            conversation_attribution: false,
         }
     }
 
@@ -76,6 +86,18 @@ impl AnthropicProvider {
         source: std::sync::Arc<dyn crate::BearerTokenSource>,
     ) -> Self {
         self.token_source = Some(source);
+        self
+    }
+
+    /// Declare each request's conversation to the gateway this provider points
+    /// at, so its usage views can group inference the way the app does.
+    ///
+    /// Only for a model-gateway base URL. Anthropic's own API is not a party to
+    /// how the host organizes conversations, and the header would be sent to
+    /// whatever `base_url` names.
+    #[must_use]
+    pub fn with_conversation_attribution(mut self) -> Self {
+        self.conversation_attribution = true;
         self
     }
 }
@@ -102,12 +124,19 @@ impl ModelProvider for AnthropicProvider {
         // Setup failures (connection, auth, 4xx/5xx) surface here as `Err` so the
         // router can classify and fail over; the returned stream only yields
         // normalized events.
-        let response = self
+        let mut request = self
             .client
             .post(url)
             .header("x-api-key", &api_key)
             .header("anthropic-version", ANTHROPIC_VERSION)
-            .header("content-type", "application/json")
+            .header("content-type", "application/json");
+        // A conversation is declared only where one is configured to be read.
+        // The id is a UUID, so it satisfies the gateway's bound on the value
+        // (1-256 ASCII graphic bytes) by construction.
+        if let (true, Some(conversation)) = (self.conversation_attribution, req.conversation) {
+            request = request.header(GATEWAY_CONVERSATION_HEADER, conversation.to_string());
+        }
+        let response = request
             .json(&body)
             .send()
             .await
@@ -1668,5 +1697,66 @@ mod tests {
         ];
         let shaped = anthropic_content(&blocks, &ImageAttachments::new()).unwrap();
         assert_eq!(shaped, serde_json::to_value(&blocks).unwrap());
+    }
+
+    #[tokio::test]
+    async fn a_conversation_is_declared_to_a_gateway_and_withheld_from_anthropic() {
+        use axum::extract::State;
+        use axum::http::{header, HeaderMap};
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use axum::Router;
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Clone, Default)]
+        struct Capture(Arc<Mutex<Vec<HeaderMap>>>);
+
+        async fn capture(State(capture): State<Capture>, headers: HeaderMap) -> impl IntoResponse {
+            capture.0.lock().unwrap().push(headers);
+            (
+                [(header::CONTENT_TYPE, "text/event-stream")],
+                "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\n",
+            )
+        }
+
+        let capture_state = Capture::default();
+        let app = Router::new()
+            .fallback(post(capture))
+            .with_state(capture_state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let base_url = format!("http://{address}");
+
+        let conversation = openwave_core::id::ChatId::new();
+        let request = || ChatRequest {
+            model: "claude-opus-4-8".into(),
+            conversation: Some(conversation),
+            messages: vec![ChatMessage::text(Role::User, "hi")],
+            ..Default::default()
+        };
+
+        let gateway = AnthropicProvider::new("token")
+            .with_base_url(&base_url)
+            .with_conversation_attribution();
+        let mut stream = gateway.stream(request()).await.unwrap();
+        while stream.next().await.is_some() {}
+
+        // Same request, same conversation, an adapter that was not configured
+        // for a gateway: how the host groups its chats is not Anthropic's.
+        let direct = AnthropicProvider::new("key").with_base_url(&base_url);
+        let mut stream = direct.stream(request()).await.unwrap();
+        while stream.next().await.is_some() {}
+
+        let requests = capture_state.0.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(
+            requests[0].get(GATEWAY_CONVERSATION_HEADER).unwrap(),
+            conversation.to_string().as_str()
+        );
+        assert!(requests[1].get(GATEWAY_CONVERSATION_HEADER).is_none());
+        server.abort();
     }
 }

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -300,7 +300,8 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
             Some(Arc::new(
                 AnthropicProvider::new(String::new())
                     .with_base_url(base.to_string())
-                    .with_token_source(source),
+                    .with_token_source(source)
+                    .with_conversation_attribution(),
             ))
         }
         #[cfg(not(feature = "anthropic"))]

--- a/docs/gateway-boundary.md
+++ b/docs/gateway-boundary.md
@@ -134,7 +134,13 @@ The connector speaks a small, versioned HTTP surface on the gateway:
 - `/oauth/authorize`, `/oauth/token`, `/oauth/revoke` — the flow above.
 - Inference itself — invoked with `llm`-audience bearers on the gateway's
   protocol-compatible routes, through the same provider machinery as any
-  direct provider.
+  direct provider. A turn's request also declares which conversation it
+  belongs to, as an `x-model-gateway-conversation-id` header carrying the
+  chat's id, so the gateway's usage views group inference the way the app
+  does. The header is a per-route opt-in: only the gateway adapter sends it,
+  a direct provider never does, and it is a header rather than wire data, so
+  no model receives it. The chat id is the only thing declared — no title, no
+  content, no participant.
 - MCP — `{base}/mcp/{slug}` per mounted endpoint, each connection minting
   its own `mcp:<slug>` bearer from the session at connect time.
   Gateway-attested endpoints refuse sessions that arrive without the


### PR DESCRIPTION
A model gateway groups inference into conversations from a header the client sends. OpenWave never sent one, so every turn arrived unattributed: the gateway's conversation and session views could show that an OpenWave user spent tokens, but not which chat spent them, and "what did this conversation cost" was unanswerable.

## What changed

The chat id is already the right identifier and is already in scope where the request is built — `Agent::drive` has `chat: &Chat` in the same function body as the `ChatRequest` literal. `ChatRequest` gains a `conversation: Option<ChatId>` field and the foreground turn loop sets it from `chat.id`, which is the primary key of the durable `chat` table and therefore stable across every turn of the chat and across app restarts. Because `ChatRequest` is deliberately not `#[non_exhaustive]` and every construction site spreads `..Default::default()`, no other caller needed an edit.

Declaring it is a **per-route opt-in** rather than a property of the request. `AnthropicProvider` serves both direct Anthropic and the gateway's Anthropic-compatible surface, so a field on the request alone would send the header to `api.anthropic.com` too. `with_conversation_attribution()` is set only where `build_adapter` constructs the `ModelGateway` route; a direct provider never sends it even when the request carries a conversation. It travels as a header, so no model receives it as wire data, and the value is a UUID, which satisfies the gateway's bound on it (1-256 ASCII graphic bytes, single occurrence) by construction.

The other two pieces of this contract were already in place and needed no change: sign-in is the registered `openwave` client id with PKCE, and `client_name=openwave` already rides every refresh grant (`gateway.rs`), which is what keeps minted `llm` tokens from being attributed `generic`.

`docs/gateway-boundary.md` gains the header to its "What crosses the wire" list, which is meant to be exhaustive.

## Deliberately not in this PR

Only the foreground turn is attributed. Chat titling, the approval judge, context checkpointing, and the two sandbox run paths also reach the model, and each has the chat id exactly one frame above its `ChatRequest`. They are left alone because whether background maintenance calls belong *to* the user's conversation or beside it is a product question — the codebase already accounts for checkpoint usage separately from the foreground turn — and it deserves its own change rather than being decided silently here.

Run, agent, and parent-agent attribution are also available to us later: `AgentRunId::foreground_for_chat` / `sandbox_for_spawn_call` already give a stable, derived agent hierarchy with a real parent link, which is the shape the gateway's optional agent headers expect.

## Tests

- New: `a_conversation_is_declared_to_a_gateway_and_withheld_from_anthropic` in `crates/openwave-router/src/anthropic.rs` — drives the same request through a gateway-configured adapter and a direct one against a capturing fake, asserting the header carries the chat id on the first and is absent on the second. The negative half is the point: it is what would fail if the opt-in were ever dropped and OpenWave started telling Anthropic how it groups chats.
- `cargo test -p openwave-router --locked` — 28 passed.
- `cargo clippy -p openwave-core -p openwave-router --all-targets --locked` — clean.
- `cargo fmt --all --check` — clean.
- `cargo check --workspace --locked` — clean, no `Cargo.lock` diff.

Not verified by driving the app against a live gateway; the header contract is covered by the adapter test above, and the end-to-end confirmation is a signed-in run against a real deployment.

Note for whoever runs this locally: the workspace now needs rustc >= 1.94 (sea-orm 2.0.0), so a stale `stable` toolchain fails to build anything depending on `openwave-core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)