### PR TITLE
feat(core): owner attribution and principal-scoped queries for root aggregates

### DIFF
--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -46,6 +46,7 @@ pub mod document {
         pub canonical_text: String,
         pub created_at: DateTimeUtc,
         pub updated_at: DateTimeUtc,
+        pub owner: String,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -65,6 +66,7 @@ pub mod project {
         pub title: Option<String>,
         pub attachment_revision: i64,
         pub created_at: DateTimeUtc,
+        pub owner: String,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
@@ -98,6 +100,7 @@ pub mod chat {
         pub network_policy: String,
         pub attachment_revision: i64,
         pub created_at: DateTimeUtc,
+        pub owner: String,
     }
 
     #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -107,6 +107,7 @@ impl MigratorTrait for Migrator {
             Box::new(AddSandboxToolCallRetry),
             Box::new(AddConnectedApps),
             Box::new(AddSandboxProvisionAdmission),
+            Box::new(AddOwnerAttribution),
         ]
     }
 }
@@ -9115,6 +9116,7 @@ enum Project {
     Title,
     AttachmentRevision,
     CreatedAt,
+    Owner,
 }
 
 #[derive(DeriveIden)]
@@ -9140,6 +9142,7 @@ enum Document {
     CreatedAt,
     UpdatedAt,
     IndexedAt,
+    Owner,
 }
 
 #[derive(DeriveIden)]
@@ -9357,6 +9360,7 @@ enum Chat {
     CitationFormat,
     AttachmentRevision,
     CreatedAt,
+    Owner,
 }
 
 #[derive(DeriveIden)]
@@ -10903,5 +10907,54 @@ impl MigrationTrait for AddSandboxProvisionAdmission {
                     .to_owned(),
             )
             .await
+    }
+}
+
+/// Gives every root aggregate — chat, project, document — a durable owner
+/// (#853). The owner column holds the storage key of the principal the row
+/// belongs to; owner-scoped store queries filter on it so one shared database
+/// can partition cleanly by user. Everything that existed before this
+/// migration belongs to the single local-profile owner, so the column's
+/// default is both the backfill and the value unscoped (local-profile) writers
+/// keep inserting.
+struct AddOwnerAttribution;
+
+impl MigrationName for AddOwnerAttribution {
+    fn name(&self) -> &str {
+        "m20260803_000045_add_owner_attribution"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for AddOwnerAttribution {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        for (table, column) in [
+            (Chat::Table.into_iden(), Chat::Owner.into_iden()),
+            (Project::Table.into_iden(), Project::Owner.into_iden()),
+            (Document::Table.into_iden(), Document::Owner.into_iden()),
+        ] {
+            manager
+                .alter_table(
+                    Table::alter()
+                        .table(table)
+                        .add_column(ColumnDef::new(column).text().not_null().default("local"))
+                        .to_owned(),
+                )
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        for (table, column) in [
+            (Chat::Table.into_iden(), Chat::Owner.into_iden()),
+            (Project::Table.into_iden(), Project::Owner.into_iden()),
+            (Document::Table.into_iden(), Document::Owner.into_iden()),
+        ] {
+            manager
+                .alter_table(Table::alter().table(table).drop_column(column).to_owned())
+                .await?;
+        }
+        Ok(())
     }
 }

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -36,7 +36,7 @@ use crate::model::{
     AgentRunWaitSetCandidate, BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus,
     Chat, DocumentListCursor, DocumentRecord, DocumentScope, DocumentSourceBlob,
     DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, Message, MessageAttachment,
-    MessageDocumentAttachment, NetworkPolicy, PermissionMode, Project, ReasoningEffort,
+    MessageDocumentAttachment, NetworkPolicy, OwnerId, PermissionMode, Project, ReasoningEffort,
     RootAttachmentChange, RootAttachmentChangeTerminal, SandboxToolCall, SandboxToolCallReceipt,
     SandboxToolCallRequest, ToolCallRecord, ToolCallResolution, TurnAgentRunWaitStatus,
     TurnCheckpointProgress, TurnClientWaitStatus, TurnFailureRetry, TurnRun, TurnRunStatus,
@@ -116,9 +116,8 @@ impl DbStore {
     }
 }
 
-#[async_trait]
-impl Store for DbStore {
-    async fn create_project(&self, project: &Project) -> Result<()> {
+impl DbStore {
+    async fn create_project_impl(&self, project: &Project, owner: Option<&OwnerId>) -> Result<()> {
         validate_project_attachments(project)?;
         let transaction = self.conn.begin().await.map_err(store_err)?;
         entities::project::ActiveModel {
@@ -126,6 +125,12 @@ impl Store for DbStore {
             title: Set(project.title.clone()),
             attachment_revision: Set(project.attachment_revision),
             created_at: Set(project.created_at),
+            // The local owner rides the column default; only a named
+            // principal writes the column explicitly (#853).
+            owner: match owner {
+                Some(owner) if !owner.is_local() => Set(owner.as_str().to_owned()),
+                _ => sea_orm::ActiveValue::NotSet,
+            },
         }
         .insert(&transaction)
         .await
@@ -145,8 +150,16 @@ impl Store for DbStore {
         Ok(())
     }
 
-    async fn get_project(&self, id: ProjectId) -> Result<Option<Project>> {
-        let mut rows = entities::project::Entity::find_by_id(id.0)
+    async fn get_project_impl(
+        &self,
+        id: ProjectId,
+        owner: Option<&OwnerId>,
+    ) -> Result<Option<Project>> {
+        let mut query = entities::project::Entity::find_by_id(id.0);
+        if let Some(owner) = owner {
+            query = query.filter(entities::project::Column::Owner.eq(owner.as_str()));
+        }
+        let mut rows = query
             .find_with_related(entities::project_root_attachment::Entity)
             .order_by_asc(entities::project_root_attachment::Column::Position)
             .all(&self.conn)
@@ -157,8 +170,12 @@ impl Store for DbStore {
             .transpose()
     }
 
-    async fn list_projects(&self) -> Result<Vec<Project>> {
-        let mut projects = entities::project::Entity::find()
+    async fn list_projects_impl(&self, owner: Option<&OwnerId>) -> Result<Vec<Project>> {
+        let mut query = entities::project::Entity::find();
+        if let Some(owner) = owner {
+            query = query.filter(entities::project::Column::Owner.eq(owner.as_str()));
+        }
+        let mut projects = query
             .find_with_related(entities::project_root_attachment::Entity)
             .order_by_asc(entities::project_root_attachment::Column::Position)
             .all(&self.conn)
@@ -176,24 +193,48 @@ impl Store for DbStore {
         Ok(projects)
     }
 
-    async fn update_project_title(&self, id: ProjectId, title: Option<String>) -> Result<bool> {
-        let result = entities::project::Entity::update_many()
+    async fn update_project_title_impl(
+        &self,
+        id: ProjectId,
+        title: Option<String>,
+        owner: Option<&OwnerId>,
+    ) -> Result<bool> {
+        let mut update = entities::project::Entity::update_many()
             .set(entities::project::ActiveModel {
                 title: Set(title),
                 ..Default::default()
             })
-            .filter(entities::project::Column::Id.eq(id.0))
-            .exec(&self.conn)
-            .await
-            .map_err(store_err)?;
+            .filter(entities::project::Column::Id.eq(id.0));
+        if let Some(owner) = owner {
+            update = update.filter(entities::project::Column::Owner.eq(owner.as_str()));
+        }
+        let result = update.exec(&self.conn).await.map_err(store_err)?;
         Ok(result.rows_affected == 1)
     }
 
-    async fn delete_project(&self, id: ProjectId) -> Result<DeleteProjectOutcome> {
+    async fn delete_project_impl(
+        &self,
+        id: ProjectId,
+        owner: Option<&OwnerId>,
+    ) -> Result<DeleteProjectOutcome> {
         let transaction = self.conn.begin().await.map_err(store_err)?;
         if !ops::acquire_project_write_lock(&transaction, id).await? {
             transaction.rollback().await.map_err(store_err)?;
             return Ok(DeleteProjectOutcome::NotFound);
+        }
+        // Someone else's project is indistinguishable from an absent one
+        // (#853). The owner cannot change while the write lock is held.
+        if let Some(owner) = owner {
+            let owned = entities::project::Entity::find_by_id(id.0)
+                .filter(entities::project::Column::Owner.eq(owner.as_str()))
+                .one(&transaction)
+                .await
+                .map_err(store_err)?
+                .is_some();
+            if !owned {
+                transaction.rollback().await.map_err(store_err)?;
+                return Ok(DeleteProjectOutcome::NotFound);
+            }
         }
 
         let has_chats = entities::chat::Entity::find()
@@ -233,6 +274,81 @@ impl Store for DbStore {
         Ok(DeleteProjectOutcome::Deleted)
     }
 
+    async fn delete_document_impl(&self, id: DocumentId, owner: Option<&OwnerId>) -> Result<()> {
+        let transaction = self.conn.begin().await.map_err(store_err)?;
+        let document = entities::document::Entity::find_by_id(id.0)
+            .one(&transaction)
+            .await
+            .map_err(store_err)?;
+        // Someone else's document is left untouched — indistinguishable from
+        // an absent one, which is also this method's outcome for absent (#853).
+        let document = document
+            .filter(|document| !owner.is_some_and(|owner| owner.as_str() != document.owner));
+        if let Some(document) = document {
+            entities::document::Entity::delete_by_id(id.0)
+                .exec(&transaction)
+                .await
+                .map_err(store_err)?;
+            if let Some(blob_id) = document.source_blob_id {
+                ops::blob::enqueue_on(&transaction, blob_id).await?;
+            }
+        }
+        transaction.commit().await.map_err(store_err)?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Store for DbStore {
+    async fn create_project(&self, project: &Project) -> Result<()> {
+        self.create_project_impl(project, None).await
+    }
+
+    async fn create_project_scoped(&self, owner: &OwnerId, project: &Project) -> Result<()> {
+        self.create_project_impl(project, Some(owner)).await
+    }
+
+    async fn get_project(&self, id: ProjectId) -> Result<Option<Project>> {
+        self.get_project_impl(id, None).await
+    }
+
+    async fn get_project_scoped(&self, owner: &OwnerId, id: ProjectId) -> Result<Option<Project>> {
+        self.get_project_impl(id, Some(owner)).await
+    }
+
+    async fn list_projects(&self) -> Result<Vec<Project>> {
+        self.list_projects_impl(None).await
+    }
+
+    async fn list_projects_scoped(&self, owner: &OwnerId) -> Result<Vec<Project>> {
+        self.list_projects_impl(Some(owner)).await
+    }
+
+    async fn update_project_title(&self, id: ProjectId, title: Option<String>) -> Result<bool> {
+        self.update_project_title_impl(id, title, None).await
+    }
+
+    async fn update_project_title_scoped(
+        &self,
+        owner: &OwnerId,
+        id: ProjectId,
+        title: Option<String>,
+    ) -> Result<bool> {
+        self.update_project_title_impl(id, title, Some(owner)).await
+    }
+
+    async fn delete_project(&self, id: ProjectId) -> Result<DeleteProjectOutcome> {
+        self.delete_project_impl(id, None).await
+    }
+
+    async fn delete_project_scoped(
+        &self,
+        owner: &OwnerId,
+        id: ProjectId,
+    ) -> Result<DeleteProjectOutcome> {
+        self.delete_project_impl(id, Some(owner)).await
+    }
+
     async fn create_document(&self, document: &DocumentRecord) -> Result<()> {
         let source_byte_len = document
             .source_blob
@@ -242,6 +358,8 @@ impl Store for DbStore {
         let transaction = self.conn.begin().await.map_err(store_err)?;
         ops::require_document_scope_write_lock(&transaction, document.chat_id, document.project_id)
             .await?;
+        let parent_owner =
+            document_scope_owner_on(&transaction, document.chat_id, document.project_id).await?;
         entities::document::ActiveModel {
             id: Set(document.id.0),
             chat_id: Set(document.chat_id.map(|id| id.0)),
@@ -258,6 +376,13 @@ impl Store for DbStore {
             canonical_text: Set(document.canonical_text.clone()),
             created_at: Set(document.created_at),
             updated_at: Set(document.updated_at),
+            // A parented document always carries its parent's owner; a
+            // standalone one created through the unscoped surface belongs to
+            // the local owner via the column default (#853).
+            owner: match parent_owner {
+                Some(owner) if owner != OwnerId::LOCAL => Set(owner),
+                _ => sea_orm::ActiveValue::NotSet,
+            },
         }
         .insert(&transaction)
         .await
@@ -271,6 +396,20 @@ impl Store for DbStore {
 
     async fn get_document(&self, id: DocumentId) -> Result<Option<DocumentRecord>> {
         entities::document::Entity::find_by_id(id.0)
+            .one(&self.conn)
+            .await
+            .map_err(store_err)?
+            .map(document_from_model)
+            .transpose()
+    }
+
+    async fn get_document_scoped(
+        &self,
+        owner: &OwnerId,
+        id: DocumentId,
+    ) -> Result<Option<DocumentRecord>> {
+        entities::document::Entity::find_by_id(id.0)
+            .filter(entities::document::Column::Owner.eq(owner.as_str()))
             .one(&self.conn)
             .await
             .map_err(store_err)?
@@ -306,59 +445,17 @@ impl Store for DbStore {
         after: Option<DocumentListCursor>,
         limit: u64,
     ) -> Result<Vec<DocumentSummaryRecord>> {
-        let mut query = entities::document::Entity::find();
-        query = match scope {
-            DocumentScope::All => query,
-            DocumentScope::Unscoped => query
-                .filter(entities::document::Column::ChatId.is_null())
-                .filter(entities::document::Column::ProjectId.is_null()),
-            DocumentScope::Project(id) => query
-                .filter(entities::document::Column::ChatId.is_null())
-                .filter(entities::document::Column::ProjectId.eq(id.0)),
-            DocumentScope::Chat(id) => query.filter(entities::document::Column::ChatId.eq(id.0)),
-        };
-        if let Some(cursor) = after {
-            query = query.filter(
-                sea_orm::Condition::any()
-                    .add(entities::document::Column::CreatedAt.lt(cursor.created_at))
-                    .add(
-                        sea_orm::Condition::all()
-                            .add(entities::document::Column::CreatedAt.eq(cursor.created_at))
-                            .add(entities::document::Column::Id.lt(cursor.id.0)),
-                    ),
-            );
-        }
+        list_document_summaries_on(self, None, scope, after, limit).await
+    }
 
-        query
-            .select_only()
-            .columns([
-                entities::document::Column::Id,
-                entities::document::Column::ChatId,
-                entities::document::Column::ProjectId,
-                entities::document::Column::SourceUri,
-                entities::document::Column::MediaType,
-                entities::document::Column::Title,
-                entities::document::Column::SourceByteLen,
-                entities::document::Column::CreatedAt,
-                entities::document::Column::UpdatedAt,
-            ])
-            .column_as(
-                sea_orm::sea_query::ExprTrait::ne(
-                    sea_orm::sea_query::Expr::col(entities::document::Column::CanonicalText),
-                    "",
-                ),
-                "has_canonical_text",
-            )
-            .order_by_desc(entities::document::Column::CreatedAt)
-            .order_by_desc(entities::document::Column::Id)
-            .limit(limit)
-            .into_model::<DocumentSummaryRow>()
-            .all(&self.conn)
-            .await
-            .map_err(store_err)?
-            .into_iter()
-            .map(document_summary_from_row)
-            .collect()
+    async fn list_document_summaries_scoped(
+        &self,
+        owner: &OwnerId,
+        scope: DocumentScope,
+        after: Option<DocumentListCursor>,
+        limit: u64,
+    ) -> Result<Vec<DocumentSummaryRecord>> {
+        list_document_summaries_on(self, Some(owner), scope, after, limit).await
     }
 
     async fn list_document_ids(&self, scope: DocumentScope) -> Result<Vec<DocumentId>> {
@@ -484,22 +581,11 @@ impl Store for DbStore {
     }
 
     async fn delete_document(&self, id: DocumentId) -> Result<()> {
-        let transaction = self.conn.begin().await.map_err(store_err)?;
-        let document = entities::document::Entity::find_by_id(id.0)
-            .one(&transaction)
-            .await
-            .map_err(store_err)?;
-        if let Some(document) = document {
-            entities::document::Entity::delete_by_id(id.0)
-                .exec(&transaction)
-                .await
-                .map_err(store_err)?;
-            if let Some(blob_id) = document.source_blob_id {
-                ops::blob::enqueue_on(&transaction, blob_id).await?;
-            }
-        }
-        transaction.commit().await.map_err(store_err)?;
-        Ok(())
+        self.delete_document_impl(id, None).await
+    }
+
+    async fn delete_document_scoped(&self, owner: &OwnerId, id: DocumentId) -> Result<()> {
+        self.delete_document_impl(id, Some(owner)).await
     }
 
     async fn upsert_document(&self, document: &DocumentUpsert) -> Result<DocumentRecord> {
@@ -515,15 +601,35 @@ impl Store for DbStore {
         &self,
         document: &DocumentSourceUpsert,
     ) -> Result<DocumentRecord> {
-        ops::document::accept_source(self, document).await
+        ops::document::accept_source(self, document, None).await
+    }
+
+    async fn accept_document_source_scoped(
+        &self,
+        owner: &OwnerId,
+        document: &DocumentSourceUpsert,
+    ) -> Result<DocumentRecord> {
+        ops::document::accept_source(self, document, Some(owner)).await
     }
 
     async fn create_chat(&self, chat: &Chat) -> Result<()> {
-        ops::conversation::create_chat(self, chat).await
+        ops::conversation::create_chat(self, chat, None).await
+    }
+
+    async fn create_chat_scoped(&self, owner: &OwnerId, chat: &Chat) -> Result<()> {
+        ops::conversation::create_chat(self, chat, Some(owner)).await
     }
 
     async fn create_chat_with_project_defaults(&self, chat: &Chat) -> Result<Chat> {
-        ops::conversation::create_chat_with_project_defaults(self, chat).await
+        ops::conversation::create_chat_with_project_defaults(self, chat, None).await
+    }
+
+    async fn create_chat_with_project_defaults_scoped(
+        &self,
+        owner: &OwnerId,
+        chat: &Chat,
+    ) -> Result<Chat> {
+        ops::conversation::create_chat_with_project_defaults(self, chat, Some(owner)).await
     }
 
     async fn set_chat_model(&self, id: ChatId, model: Option<String>) -> Result<()> {
@@ -555,27 +661,71 @@ impl Store for DbStore {
             reasoning_effort,
             permission_mode,
             network_policy,
+            None,
+        )
+        .await
+    }
+
+    async fn update_chat_metadata_scoped(
+        &self,
+        owner: &OwnerId,
+        id: ChatId,
+        title: Option<Option<String>>,
+        model: Option<Option<String>>,
+        reasoning_effort: Option<Option<ReasoningEffort>>,
+        permission_mode: Option<Option<PermissionMode>>,
+        network_policy: Option<NetworkPolicy>,
+    ) -> Result<bool> {
+        ops::conversation::update_chat_metadata(
+            self,
+            id,
+            title,
+            model,
+            reasoning_effort,
+            permission_mode,
+            network_policy,
+            Some(owner),
         )
         .await
     }
 
     async fn get_chat(&self, id: ChatId) -> Result<Option<Chat>> {
-        ops::conversation::get_chat(self, id).await
+        ops::conversation::get_chat(self, id, None).await
+    }
+
+    async fn get_chat_scoped(&self, owner: &OwnerId, id: ChatId) -> Result<Option<Chat>> {
+        ops::conversation::get_chat(self, id, Some(owner)).await
     }
 
     async fn list_chats(&self) -> Result<Vec<Chat>> {
-        ops::conversation::list_chats(self).await
+        ops::conversation::list_chats(self, None).await
+    }
+
+    async fn list_chats_scoped(&self, owner: &OwnerId) -> Result<Vec<Chat>> {
+        ops::conversation::list_chats(self, Some(owner)).await
     }
 
     async fn delete_chat(&self, id: ChatId) -> Result<DeleteChatOutcome> {
-        ops::conversation::delete_chat(self, id).await
+        ops::conversation::delete_chat(self, id, None).await
+    }
+
+    async fn delete_chat_scoped(&self, owner: &OwnerId, id: ChatId) -> Result<DeleteChatOutcome> {
+        ops::conversation::delete_chat(self, id, Some(owner)).await
     }
 
     async fn get_chat_transcript(
         &self,
         id: ChatId,
     ) -> Result<Option<crate::storage::ChatTranscriptSnapshot>> {
-        ops::conversation::get_chat_transcript(self, id).await
+        ops::conversation::get_chat_transcript(self, id, None).await
+    }
+
+    async fn get_chat_transcript_scoped(
+        &self,
+        owner: &OwnerId,
+        id: ChatId,
+    ) -> Result<Option<crate::storage::ChatTranscriptSnapshot>> {
+        ops::conversation::get_chat_transcript(self, id, Some(owner)).await
     }
 
     async fn create_output(&self, request: &CreateOutput) -> Result<OutputRecord> {
@@ -2104,6 +2254,101 @@ impl Store for DbStore {
         ops::operation_log::len(self, run_id).await
     }
 }
+/// The owner of a document's parent scope: its chat's or project's owner, or
+/// `None` for a standalone document. Callers hold the document-scope write
+/// lock, so a present parent cannot disappear underneath this read.
+pub(in crate::db) async fn document_scope_owner_on<C>(
+    conn: &C,
+    chat_id: Option<ChatId>,
+    project_id: Option<ProjectId>,
+) -> Result<Option<String>>
+where
+    C: ConnectionTrait,
+{
+    if let Some(chat_id) = chat_id {
+        let chat = entities::chat::Entity::find_by_id(chat_id.0)
+            .one(conn)
+            .await
+            .map_err(store_err)?
+            .ok_or_else(|| AgentError::Store(format!("chat {chat_id} not found")))?;
+        return Ok(Some(chat.owner));
+    }
+    if let Some(project_id) = project_id {
+        let project = entities::project::Entity::find_by_id(project_id.0)
+            .one(conn)
+            .await
+            .map_err(store_err)?
+            .ok_or(AgentError::ProjectNotFound(project_id))?;
+        return Ok(Some(project.owner));
+    }
+    Ok(None)
+}
+
+async fn list_document_summaries_on(
+    store: &DbStore,
+    owner: Option<&OwnerId>,
+    scope: DocumentScope,
+    after: Option<DocumentListCursor>,
+    limit: u64,
+) -> Result<Vec<DocumentSummaryRecord>> {
+    let mut query = entities::document::Entity::find();
+    if let Some(owner) = owner {
+        query = query.filter(entities::document::Column::Owner.eq(owner.as_str()));
+    }
+    query = match scope {
+        DocumentScope::All => query,
+        DocumentScope::Unscoped => query
+            .filter(entities::document::Column::ChatId.is_null())
+            .filter(entities::document::Column::ProjectId.is_null()),
+        DocumentScope::Project(id) => query
+            .filter(entities::document::Column::ChatId.is_null())
+            .filter(entities::document::Column::ProjectId.eq(id.0)),
+        DocumentScope::Chat(id) => query.filter(entities::document::Column::ChatId.eq(id.0)),
+    };
+    if let Some(cursor) = after {
+        query = query.filter(
+            sea_orm::Condition::any()
+                .add(entities::document::Column::CreatedAt.lt(cursor.created_at))
+                .add(
+                    sea_orm::Condition::all()
+                        .add(entities::document::Column::CreatedAt.eq(cursor.created_at))
+                        .add(entities::document::Column::Id.lt(cursor.id.0)),
+                ),
+        );
+    }
+
+    query
+        .select_only()
+        .columns([
+            entities::document::Column::Id,
+            entities::document::Column::ChatId,
+            entities::document::Column::ProjectId,
+            entities::document::Column::SourceUri,
+            entities::document::Column::MediaType,
+            entities::document::Column::Title,
+            entities::document::Column::SourceByteLen,
+            entities::document::Column::CreatedAt,
+            entities::document::Column::UpdatedAt,
+        ])
+        .column_as(
+            sea_orm::sea_query::ExprTrait::ne(
+                sea_orm::sea_query::Expr::col(entities::document::Column::CanonicalText),
+                "",
+            ),
+            "has_canonical_text",
+        )
+        .order_by_desc(entities::document::Column::CreatedAt)
+        .order_by_desc(entities::document::Column::Id)
+        .limit(limit)
+        .into_model::<DocumentSummaryRow>()
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(document_summary_from_row)
+        .collect()
+}
+
 async fn upsert_document_on<C>(conn: &C, document: &DocumentUpsert) -> Result<DocumentRecord>
 where
     C: ConnectionTrait,
@@ -2131,6 +2376,14 @@ where
         }
     }
 
+    // The row's owner never changes on an upsert; a new row carries its
+    // parent's owner, or the local owner for a standalone document (#853).
+    let row_owner = match existing.as_ref() {
+        Some(existing) => existing.owner.clone(),
+        None => document_scope_owner_on(conn, document.chat_id, document.project_id)
+            .await?
+            .unwrap_or_else(|| OwnerId::LOCAL.to_owned()),
+    };
     let active = entities::document::ActiveModel {
         id: Set(document.id.0),
         chat_id: Set(document.chat_id.map(|id| id.0)),
@@ -2146,6 +2399,7 @@ where
             .as_ref()
             .map_or(document.updated_at, |current| current.created_at)),
         updated_at: Set(document.updated_at),
+        owner: Set(row_owner),
     };
     if existing.is_some() {
         active.update(conn).await.map_err(store_err)?;

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -12,8 +12,8 @@ use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{ChatId, HostRootId, MessageId, ProjectId, TurnId};
 use crate::model::{
     validate_chat_root_projection, validate_chat_root_projection_against_project, Chat,
-    ChatRootAttachment, Message, PermissionMode, ReasoningEffort, Role, RootAttachmentOrigin,
-    ToolCallRecord, TurnRunStatus, MAX_ROOT_ATTACHMENTS,
+    ChatRootAttachment, Message, OwnerId, PermissionMode, ReasoningEffort, Role,
+    RootAttachmentOrigin, ToolCallRecord, TurnRunStatus, MAX_ROOT_ATTACHMENTS,
 };
 use crate::storage::{
     ChatTerminalTurnSnapshot, ChatTerminalTurnStatus, ChatToolActivitySnapshot,
@@ -103,11 +103,15 @@ where
         })
 }
 
-pub(in crate::db) async fn create_chat(store: &DbStore, chat: &Chat) -> Result<()> {
+pub(in crate::db) async fn create_chat(
+    store: &DbStore,
+    chat: &Chat,
+    owner: Option<&OwnerId>,
+) -> Result<()> {
     let transaction = store.conn.begin().await.map_err(store_err)?;
-    let project_roots = load_chat_project_roots(&transaction, chat.project_id).await?;
+    let project_roots = load_chat_project_roots(&transaction, chat.project_id, owner).await?;
     validate_chat_attachments(chat, &project_roots)?;
-    insert_chat_on(&transaction, chat).await?;
+    insert_chat_on(&transaction, chat, owner).await?;
     insert_foreground_agent_run_on(&transaction, chat.id, chat.created_at).await?;
     transaction.commit().await.map_err(store_err)?;
     Ok(())
@@ -116,6 +120,7 @@ pub(in crate::db) async fn create_chat(store: &DbStore, chat: &Chat) -> Result<(
 pub(in crate::db) async fn create_chat_with_project_defaults(
     store: &DbStore,
     base: &Chat,
+    owner: Option<&OwnerId>,
 ) -> Result<Chat> {
     if base.attachment_revision != 0 || !base.root_attachments.is_empty() {
         return Err(AgentError::Store(
@@ -123,7 +128,7 @@ pub(in crate::db) async fn create_chat_with_project_defaults(
         ));
     }
     let transaction = store.conn.begin().await.map_err(store_err)?;
-    let project_roots = load_chat_project_roots(&transaction, base.project_id).await?;
+    let project_roots = load_chat_project_roots(&transaction, base.project_id, owner).await?;
     let mut chat = base.clone();
     chat.root_attachments = project_roots
         .into_iter()
@@ -136,7 +141,7 @@ pub(in crate::db) async fn create_chat_with_project_defaults(
         chat.attachment_revision = 1;
     }
     validate_chat_root_projection(&chat).map_err(|message| AgentError::Store(message.into()))?;
-    insert_chat_on(&transaction, &chat).await?;
+    insert_chat_on(&transaction, &chat, owner).await?;
     insert_foreground_agent_run_on(&transaction, chat.id, chat.created_at).await?;
     transaction.commit().await.map_err(store_err)?;
     Ok(chat)
@@ -145,6 +150,7 @@ pub(in crate::db) async fn create_chat_with_project_defaults(
 async fn load_chat_project_roots<C>(
     conn: &C,
     project_id: Option<ProjectId>,
+    owner: Option<&OwnerId>,
 ) -> Result<Vec<HostRootId>>
 where
     C: ConnectionTrait,
@@ -164,10 +170,15 @@ where
     let (model, roots) = rows
         .pop()
         .ok_or_else(|| AgentError::Store(format!("chat project {project_id} does not exist")))?;
+    // A project belonging to someone else must be indistinguishable from a
+    // missing one (#853).
+    if owner.is_some_and(|owner| owner.as_str() != model.owner) {
+        return Err(AgentError::ProjectNotFound(project_id));
+    }
     Ok(project_from_models(model, roots)?.root_attachments)
 }
 
-async fn insert_chat_on<C>(conn: &C, chat: &Chat) -> Result<()>
+async fn insert_chat_on<C>(conn: &C, chat: &Chat, owner: Option<&OwnerId>) -> Result<()>
 where
     C: ConnectionTrait,
 {
@@ -196,6 +207,13 @@ where
         },
         attachment_revision: Set(chat.attachment_revision),
         created_at: Set(chat.created_at),
+        // The local owner rides the column default (which also keeps this
+        // insert valid against a pre-owner schema in the upgrade tests); only
+        // a named principal writes the column explicitly.
+        owner: match owner {
+            Some(owner) if !owner.is_local() => Set(owner.as_str().to_owned()),
+            _ => sea_orm::ActiveValue::NotSet,
+        },
     }
     .insert(conn)
     .await
@@ -272,6 +290,7 @@ pub(in crate::db) async fn set_chat_title_if_unset(
     Ok(result.rows_affected == 1)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(in crate::db) async fn update_chat_metadata(
     store: &DbStore,
     id: ChatId,
@@ -280,6 +299,7 @@ pub(in crate::db) async fn update_chat_metadata(
     reasoning_effort: Option<Option<ReasoningEffort>>,
     permission_mode: Option<Option<PermissionMode>>,
     network_policy: Option<crate::NetworkPolicy>,
+    owner: Option<&OwnerId>,
 ) -> Result<bool> {
     if title.is_none()
         && model.is_none()
@@ -287,11 +307,11 @@ pub(in crate::db) async fn update_chat_metadata(
         && permission_mode.is_none()
         && network_policy.is_none()
     {
-        return Ok(entities::chat::Entity::find_by_id(id.0)
-            .one(&store.conn)
-            .await
-            .map_err(store_err)?
-            .is_some());
+        let mut query = entities::chat::Entity::find_by_id(id.0);
+        if let Some(owner) = owner {
+            query = query.filter(entities::chat::Column::Owner.eq(owner.as_str()));
+        }
+        return Ok(query.one(&store.conn).await.map_err(store_err)?.is_some());
     }
 
     let mut update = entities::chat::Entity::update_many();
@@ -330,16 +350,24 @@ pub(in crate::db) async fn update_chat_metadata(
             sea_orm::sea_query::Expr::value(encoded),
         );
     }
-    let result = update
-        .filter(entities::chat::Column::Id.eq(id.0))
-        .exec(&store.conn)
-        .await
-        .map_err(store_err)?;
+    let mut update = update.filter(entities::chat::Column::Id.eq(id.0));
+    if let Some(owner) = owner {
+        update = update.filter(entities::chat::Column::Owner.eq(owner.as_str()));
+    }
+    let result = update.exec(&store.conn).await.map_err(store_err)?;
     Ok(result.rows_affected == 1)
 }
 
-pub(in crate::db) async fn get_chat(store: &DbStore, id: ChatId) -> Result<Option<Chat>> {
-    let mut rows = entities::chat::Entity::find_by_id(id.0)
+pub(in crate::db) async fn get_chat(
+    store: &DbStore,
+    id: ChatId,
+    owner: Option<&OwnerId>,
+) -> Result<Option<Chat>> {
+    let mut query = entities::chat::Entity::find_by_id(id.0);
+    if let Some(owner) = owner {
+        query = query.filter(entities::chat::Column::Owner.eq(owner.as_str()));
+    }
+    let mut rows = query
         .find_with_related(entities::chat_root_attachment::Entity)
         .order_by_asc(entities::chat_root_attachment::Column::Position)
         .all(&store.conn)
@@ -350,8 +378,15 @@ pub(in crate::db) async fn get_chat(store: &DbStore, id: ChatId) -> Result<Optio
         .transpose()
 }
 
-pub(in crate::db) async fn list_chats(store: &DbStore) -> Result<Vec<Chat>> {
-    let mut chats = entities::chat::Entity::find()
+pub(in crate::db) async fn list_chats(
+    store: &DbStore,
+    owner: Option<&OwnerId>,
+) -> Result<Vec<Chat>> {
+    let mut query = entities::chat::Entity::find();
+    if let Some(owner) = owner {
+        query = query.filter(entities::chat::Column::Owner.eq(owner.as_str()));
+    }
+    let mut chats = query
         .find_with_related(entities::chat_root_attachment::Entity)
         .order_by_asc(entities::chat_root_attachment::Column::Position)
         .all(&store.conn)
@@ -379,11 +414,27 @@ pub(in crate::db) async fn list_chats(store: &DbStore) -> Result<Vec<Chat>> {
 pub(in crate::db) async fn delete_chat(
     store: &DbStore,
     chat_id: ChatId,
+    owner: Option<&OwnerId>,
 ) -> Result<DeleteChatOutcome> {
     let transaction = store.conn.begin().await.map_err(store_err)?;
     if !acquire_chat_write_lock(&transaction, chat_id).await? {
         transaction.rollback().await.map_err(store_err)?;
         return Ok(DeleteChatOutcome::NotFound);
+    }
+    // Someone else's chat is indistinguishable from an absent one (#853). The
+    // owner cannot change while the write lock above is held: no owner
+    // transfer exists.
+    if let Some(owner) = owner {
+        let owned = entities::chat::Entity::find_by_id(chat_id.0)
+            .filter(entities::chat::Column::Owner.eq(owner.as_str()))
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .is_some();
+        if !owned {
+            transaction.rollback().await.map_err(store_err)?;
+            return Ok(DeleteChatOutcome::NotFound);
+        }
     }
 
     let roots_attached = entities::chat_root_attachment::Entity::find()
@@ -686,11 +737,25 @@ pub(in crate::db) async fn delete_chat(
 pub(in crate::db) async fn get_chat_transcript(
     store: &DbStore,
     chat_id: ChatId,
+    owner: Option<&OwnerId>,
 ) -> Result<Option<ChatTranscriptSnapshot>> {
     let transaction = store.conn.begin().await.map_err(store_err)?;
     if !acquire_chat_write_lock(&transaction, chat_id).await? {
         transaction.rollback().await.map_err(store_err)?;
         return Ok(None);
+    }
+    // Someone else's transcript is indistinguishable from an absent one (#853).
+    if let Some(owner) = owner {
+        let owned = entities::chat::Entity::find_by_id(chat_id.0)
+            .filter(entities::chat::Column::Owner.eq(owner.as_str()))
+            .one(&transaction)
+            .await
+            .map_err(store_err)?
+            .is_some();
+        if !owned {
+            transaction.rollback().await.map_err(store_err)?;
+            return Ok(None);
+        }
     }
     let messages = list_messages_on(&transaction, chat_id).await?;
     let message_attachments =

--- a/crates/openwave-core/src/db/ops/document.rs
+++ b/crates/openwave-core/src/db/ops/document.rs
@@ -1,10 +1,11 @@
 use sea_orm::{ActiveModelTrait, EntityTrait, Set, TransactionTrait};
 
 use crate::error::{AgentError, Result};
-use crate::model::{DocumentRecord, DocumentSourceUpsert};
+use crate::model::{DocumentRecord, DocumentSourceUpsert, OwnerId};
 
 use super::super::{
-    document_from_model, entities, store_err, validate_document_source_blob, DbStore,
+    document_from_model, document_scope_owner_on, entities, store_err,
+    validate_document_source_blob, DbStore,
 };
 use super::blob as blob_ops;
 use super::require_document_scope_write_lock;
@@ -12,11 +13,30 @@ use super::require_document_scope_write_lock;
 pub(in crate::db) async fn accept_source(
     store: &DbStore,
     source: &DocumentSourceUpsert,
+    owner: Option<&OwnerId>,
 ) -> Result<DocumentRecord> {
     validate_source_input(source)?;
 
     let transaction = store.conn.begin().await.map_err(store_err)?;
     require_document_scope_write_lock(&transaction, source.chat_id, source.project_id).await?;
+    // A parented document carries its parent's owner; through the scoped
+    // surface the parent must belong to the requester, and a standalone
+    // document belongs to whoever accepts it (#853).
+    let parent_owner =
+        document_scope_owner_on(&transaction, source.chat_id, source.project_id).await?;
+    if let (Some(owner), Some(parent_owner)) = (owner, parent_owner.as_deref()) {
+        if owner.as_str() != parent_owner {
+            // Someone else's parent is indistinguishable from a missing one.
+            return Err(match (source.chat_id, source.project_id) {
+                (Some(chat_id), _) => AgentError::Store(format!("chat {chat_id} not found")),
+                (None, Some(project_id)) => AgentError::ProjectNotFound(project_id),
+                (None, None) => unreachable!("a parent owner implies a parent id"),
+            });
+        }
+    }
+    let row_owner = parent_owner
+        .or_else(|| owner.map(|owner| owner.as_str().to_owned()))
+        .unwrap_or_else(|| OwnerId::LOCAL.to_owned());
     let existing = entities::document::Entity::find_by_id(source.id.0)
         .one(&transaction)
         .await
@@ -24,6 +44,7 @@ pub(in crate::db) async fn accept_source(
     if let Some(current) = existing.as_ref() {
         if current.chat_id != source.chat_id.map(|id| id.0)
             || current.project_id != source.project_id.map(|id| id.0)
+            || current.owner != row_owner
         {
             return Err(AgentError::Store(format!(
                 "document {} cannot move between document corpora",
@@ -49,6 +70,7 @@ pub(in crate::db) async fn accept_source(
             .as_ref()
             .map_or(source.updated_at, |current| current.created_at)),
         updated_at: Set(source.updated_at),
+        owner: Set(row_owner),
     };
     if existing.is_some() {
         active.update(&transaction).await.map_err(store_err)?;

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -89,6 +89,7 @@ async fn create_chat_before_agent_run_split(store: &DbStore, chat: &Chat) {
         network_policy: sea_orm::ActiveValue::NotSet,
         attachment_revision: Set(chat.attachment_revision),
         created_at: Set(chat.created_at),
+        owner: sea_orm::ActiveValue::NotSet,
     })
     .exec_without_returning(&store.conn)
     .await
@@ -461,6 +462,7 @@ async fn project_membership_fk_and_attachment_insertions_are_atomic() {
         network_policy: Set(r#"{"mode":"off"}"#.into()),
         attachment_revision: Set(0),
         created_at: Set(Utc::now()),
+        owner: sea_orm::ActiveValue::NotSet,
     };
     assert!(orphan.insert(&store.conn).await.is_err());
 
@@ -485,6 +487,7 @@ async fn project_membership_fk_and_attachment_insertions_are_atomic() {
         title: Set(None),
         attachment_revision: Set(MAX_ATTACHMENT_REVISION + 1),
         created_at: Set(Utc::now()),
+        owner: sea_orm::ActiveValue::NotSet,
     };
     assert!(direct_excessive.insert(&store.conn).await.is_err());
 
@@ -582,6 +585,7 @@ async fn chats_stored_before_the_effort_scale_widened_still_load() {
             network_policy: Set(r#"{"mode":"off"}"#.into()),
             attachment_revision: Set(0),
             created_at: Set(chat.created_at),
+            owner: sea_orm::ActiveValue::NotSet,
         }
         .insert(&store.conn)
         .await
@@ -10541,4 +10545,244 @@ async fn cancellation_with_partial_output_commits_a_durable_message() {
         1,
         "a retried acknowledgement must not duplicate the output message"
     );
+}
+
+/// The #853 scoping contract: two principals' root aggregates are disjoint
+/// under the owner-scoped surface — reads, lists, mutations, and creation
+/// against another owner's parent all behave as if the other owner's rows do
+/// not exist — while the unscoped surface still sees everything and keeps
+/// attributing new rows to the local owner.
+#[tokio::test]
+async fn owner_scoped_queries_partition_root_aggregates() {
+    let (_dir, store) = temp_store().await;
+    let alice = OwnerId::new("user:alice").unwrap();
+    let bob = OwnerId::new("user:bob").unwrap();
+    let local = OwnerId::local();
+
+    let project = sample_project();
+    store.create_project_scoped(&alice, &project).await.unwrap();
+    let mut chat = sample_chat();
+    chat.project_id = Some(project.id);
+    store.create_chat_scoped(&alice, &chat).await.unwrap();
+
+    // Chats: partitioned reads, lists, and mutations.
+    assert_eq!(
+        store
+            .get_chat_scoped(&alice, chat.id)
+            .await
+            .unwrap()
+            .as_ref(),
+        Some(&chat)
+    );
+    assert_eq!(store.get_chat_scoped(&bob, chat.id).await.unwrap(), None);
+    assert_eq!(
+        store.list_chats_scoped(&alice).await.unwrap(),
+        vec![chat.clone()]
+    );
+    assert_eq!(store.list_chats_scoped(&bob).await.unwrap(), Vec::new());
+    assert_eq!(
+        store.delete_chat_scoped(&bob, chat.id).await.unwrap(),
+        DeleteChatOutcome::NotFound
+    );
+    assert!(!store
+        .update_chat_metadata_scoped(
+            &bob,
+            chat.id,
+            Some(Some("stolen".into())),
+            None,
+            None,
+            None,
+            None
+        )
+        .await
+        .unwrap());
+    assert!(store
+        .get_chat_transcript_scoped(&bob, chat.id)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(store
+        .get_chat_transcript_scoped(&alice, chat.id)
+        .await
+        .unwrap()
+        .is_some());
+    // The failed cross-owner mutation left the row untouched.
+    assert_eq!(
+        store
+            .get_chat_scoped(&alice, chat.id)
+            .await
+            .unwrap()
+            .as_ref(),
+        Some(&chat)
+    );
+
+    // Projects: partitioned, and unusable as another owner's chat parent.
+    assert_eq!(
+        store.get_project_scoped(&bob, project.id).await.unwrap(),
+        None
+    );
+    assert_eq!(store.list_projects_scoped(&bob).await.unwrap(), Vec::new());
+    assert!(!store
+        .update_project_title_scoped(&bob, project.id, Some("stolen".into()))
+        .await
+        .unwrap());
+    assert_eq!(
+        store.delete_project_scoped(&bob, project.id).await.unwrap(),
+        DeleteProjectOutcome::NotFound
+    );
+    let mut cross_owner_chat = sample_chat();
+    cross_owner_chat.project_id = Some(project.id);
+    assert!(store
+        .create_chat_scoped(&bob, &cross_owner_chat)
+        .await
+        .is_err());
+    assert!(store
+        .create_chat_with_project_defaults_scoped(&bob, &cross_owner_chat)
+        .await
+        .is_err());
+
+    // Documents: inherit the parent's owner and partition with it.
+    let source = DocumentSourceUpsert {
+        id: DocumentId::new(),
+        chat_id: Some(chat.id),
+        project_id: None,
+        source_uri: None,
+        media_type: "text/plain".into(),
+        title: None,
+        source_blob: DocumentSourceBlob::from_bytes(b"alice's notes"),
+        canonical_text: "alice's notes".into(),
+        updated_at: Utc::now(),
+    };
+    let document = store
+        .accept_document_source_scoped(&alice, &source)
+        .await
+        .unwrap();
+    assert!(store
+        .get_document_scoped(&alice, document.id)
+        .await
+        .unwrap()
+        .is_some());
+    assert_eq!(
+        store.get_document_scoped(&bob, document.id).await.unwrap(),
+        None
+    );
+    assert_eq!(
+        store
+            .list_document_summaries_scoped(&bob, DocumentScope::Chat(chat.id), None, 10)
+            .await
+            .unwrap(),
+        Vec::new()
+    );
+    assert_eq!(
+        store
+            .list_document_summaries_scoped(&alice, DocumentScope::Chat(chat.id), None, 10)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    // A cross-owner accept against alice's chat is indistinguishable from a
+    // missing parent; a cross-owner delete leaves the row in place.
+    assert!(store
+        .accept_document_source_scoped(&bob, &source)
+        .await
+        .is_err());
+    store
+        .delete_document_scoped(&bob, document.id)
+        .await
+        .unwrap();
+    assert!(store
+        .get_document_scoped(&alice, document.id)
+        .await
+        .unwrap()
+        .is_some());
+
+    // The unscoped surface still sees everything, and unscoped creation
+    // attributes to the local owner.
+    assert_eq!(store.list_chats().await.unwrap().len(), 1);
+    let loose = sample_chat();
+    store.create_chat(&loose).await.unwrap();
+    assert_eq!(
+        store
+            .get_chat_scoped(&local, loose.id)
+            .await
+            .unwrap()
+            .as_ref(),
+        Some(&loose)
+    );
+    assert_eq!(store.get_chat_scoped(&alice, loose.id).await.unwrap(), None);
+}
+
+/// The owner-attribution migration backfills every pre-existing chat,
+/// project, and document to the local owner, so a migrated desktop database
+/// behaves identically through the scoped surface.
+#[tokio::test]
+async fn owner_attribution_migration_backfills_existing_rows_to_the_local_owner() {
+    let dir = tempfile::tempdir().unwrap();
+    let url = format!(
+        "sqlite://{}?mode=rwc",
+        dir.path().join("owner-backfill.db").display()
+    );
+    let conn = Database::connect(&url).await.unwrap();
+    let before_owner_attribution = u32::try_from(
+        migration::Migrator::migrations()
+            .iter()
+            .position(|migration| migration.name() == "m20260803_000045_add_owner_attribution")
+            .expect("the owner-attribution migration is registered"),
+    )
+    .unwrap();
+    migration::Migrator::up(&conn, Some(before_owner_attribution))
+        .await
+        .unwrap();
+
+    let chat_id = ChatId::new();
+    let project_id = ProjectId::new();
+    let document_id = DocumentId::new();
+    conn.execute_unprepared(&format!(
+        "INSERT INTO chat (id, attachment_revision, created_at) \
+         VALUES (X'{}', 0, '2023-11-14 22:13:20+00:00')",
+        chat_id.0.simple()
+    ))
+    .await
+    .unwrap();
+    conn.execute_unprepared(&format!(
+        "INSERT INTO project (id, attachment_revision, created_at) \
+         VALUES (X'{}', 0, '2023-11-14 22:13:20+00:00')",
+        project_id.0.simple()
+    ))
+    .await
+    .unwrap();
+    conn.execute_unprepared(&format!(
+        "INSERT INTO document (id, media_type, canonical_text, created_at, updated_at) \
+         VALUES (X'{}', 'text/plain', 'legacy', \
+          '2023-11-14 22:13:20+00:00', '2023-11-14 22:13:20+00:00')",
+        document_id.0.simple()
+    ))
+    .await
+    .unwrap();
+
+    migration::Migrator::up(&conn, None).await.unwrap();
+    let store = DbStore { conn };
+    let local = OwnerId::local();
+    let someone_else = OwnerId::new("user:alice").unwrap();
+    assert!(store
+        .get_chat_scoped(&local, chat_id)
+        .await
+        .unwrap()
+        .is_some());
+    assert!(store
+        .get_project_scoped(&local, project_id)
+        .await
+        .unwrap()
+        .is_some());
+    assert!(store
+        .get_document_scoped(&local, document_id)
+        .await
+        .unwrap()
+        .is_some());
+    assert!(store
+        .get_chat_scoped(&someone_else, chat_id)
+        .await
+        .unwrap()
+        .is_none());
 }

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -155,7 +155,7 @@ pub use model::{
     DelegatedFileReadClaim, DocumentListCursor, DocumentRecord, DocumentScope, DocumentSourceBlob,
     DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, ExecFileChange, ExecFileRejection,
     ExecFileRejectionReason, ExecFileRejectionRecord, ExecFileSnapshot, ExecFileSnapshotRecord,
-    ExecUndoState, Message, MessageAttachment, MessageDocumentAttachment, NetworkPolicy,
+    ExecUndoState, Message, MessageAttachment, MessageDocumentAttachment, NetworkPolicy, OwnerId,
     PermissionMode, Project, ReasoningEffort, Role, RootAttachmentChange,
     RootAttachmentChangeAction, RootAttachmentChangeFailure, RootAttachmentChangePhase,
     RootAttachmentChangeTerminal, RootAttachmentOrigin, RootAttachmentSubjectKind,

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -27,6 +27,61 @@ use crate::id::{
 /// replacements predictably small.
 pub const MAX_ROOT_ATTACHMENTS: usize = 32;
 
+/// The durable owner key of a root aggregate (chat, project, document).
+///
+/// This is the storage-side identity of a principal (#853): the server maps
+/// the authenticated principal onto an `OwnerId` and every owner-scoped store
+/// query filters on it. The desktop profile has exactly one principal — the
+/// person at the machine — whose key is [`OwnerId::local`]; named users on a
+/// shared deployment map to distinct keys that can never collide with it.
+///
+/// The key is an identity label, not a secret: it lives in owner columns and
+/// is kept greppable and log-safe.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct OwnerId(std::sync::Arc<str>);
+
+impl OwnerId {
+    /// The durable key of the single local-profile owner. Existing rows from
+    /// before owner attribution are backfilled to this owner.
+    pub const LOCAL: &'static str = "local";
+
+    /// The one person at the machine on the desktop/local profile.
+    #[must_use]
+    pub fn local() -> Self {
+        Self(Self::LOCAL.into())
+    }
+
+    /// Validate and intern an owner key: 1–96 visible ASCII characters.
+    pub fn new(id: &str) -> crate::error::Result<Self> {
+        let valid = !id.is_empty() && id.len() <= 96 && id.bytes().all(|b| b.is_ascii_graphic());
+        if valid {
+            Ok(Self(id.into()))
+        } else {
+            Err(crate::error::AgentError::Store(format!(
+                "invalid owner id {id:?}: expected 1-96 visible ASCII characters"
+            )))
+        }
+    }
+
+    /// The exact durable key, as stored in owner columns.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Whether this is the local-profile owner.
+    #[must_use]
+    pub fn is_local(&self) -> bool {
+        &*self.0 == Self::LOCAL
+    }
+}
+
+impl std::fmt::Display for OwnerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 /// Largest attachment revision represented exactly by every supported client.
 ///
 /// JSON numbers become JavaScript `number` values in the desktop renderer, so

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -41,7 +41,7 @@ use crate::model::{
     DocumentListCursor, DocumentRecord, DocumentScope, DocumentSourceBlob, DocumentSourceUpsert,
     DocumentSummaryRecord, DocumentUpsert, ExecFileRejection, ExecFileRejectionRecord,
     ExecFileSnapshot, ExecFileSnapshotRecord, Message, MessageAttachment,
-    MessageDocumentAttachment, NetworkPolicy, PermissionMode, Project, ReasoningEffort,
+    MessageDocumentAttachment, NetworkPolicy, OwnerId, PermissionMode, Project, ReasoningEffort,
     RootAttachmentChange, RootAttachmentChangeTerminal, ToolCallRecord, ToolCallResolution,
     TurnAgentRunWait, TurnAgentRunWaitSet, TurnCheckpointProgress, TurnClientWait,
     TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnSteer,
@@ -1505,6 +1505,180 @@ pub trait Store: Send + Sync {
         permission_mode: Option<Option<PermissionMode>>,
         network_policy: Option<NetworkPolicy>,
     ) -> Result<bool>;
+
+    // ------------------------------------------------------------------
+    // Owner-scoped root surface (#853).
+    //
+    // Chats, projects, and documents are the ownership roots: everything
+    // else hangs off one of them by id. The scoped variants below take the
+    // requesting principal's durable [`OwnerId`] where the query is built,
+    // so a row belonging to someone else is indistinguishable from a row
+    // that does not exist. Request-facing callers (the server's routes) use
+    // this surface; system paths that act on already-authorized ids (turn
+    // workers, retirement scans) keep the unscoped methods.
+    //
+    // The defaults treat the store as single-owner — they ignore the owner
+    // and delegate to the unscoped method, which is exact for the local
+    // profile's in-process test stores. Any store that can hold rows for
+    // more than one owner must override every method in this block; the
+    // database-backed store does.
+    // ------------------------------------------------------------------
+
+    /// Persist a new chat owned by `owner`. When `chat.project_id` is set,
+    /// the project must belong to the same owner.
+    async fn create_chat_scoped(&self, owner: &OwnerId, chat: &Chat) -> Result<()> {
+        let _ = owner;
+        self.create_chat(chat).await
+    }
+
+    /// [`Store::create_chat_with_project_defaults`], attributing the chat to
+    /// `owner` and resolving defaults only from a project of the same owner.
+    async fn create_chat_with_project_defaults_scoped(
+        &self,
+        owner: &OwnerId,
+        chat: &Chat,
+    ) -> Result<Chat> {
+        let _ = owner;
+        self.create_chat_with_project_defaults(chat).await
+    }
+
+    /// Fetch `owner`'s chat by id; `None` when it does not exist **or**
+    /// belongs to someone else.
+    async fn get_chat_scoped(&self, owner: &OwnerId, id: ChatId) -> Result<Option<Chat>> {
+        let _ = owner;
+        self.get_chat(id).await
+    }
+
+    /// List `owner`'s chats, most-recently-created first.
+    async fn list_chats_scoped(&self, owner: &OwnerId) -> Result<Vec<Chat>> {
+        let _ = owner;
+        self.list_chats().await
+    }
+
+    /// [`Store::delete_chat`] restricted to `owner`'s chats; someone else's
+    /// chat reports [`DeleteChatOutcome::NotFound`].
+    async fn delete_chat_scoped(&self, owner: &OwnerId, id: ChatId) -> Result<DeleteChatOutcome> {
+        let _ = owner;
+        self.delete_chat(id).await
+    }
+
+    /// [`Store::get_chat_transcript`] restricted to `owner`'s chats.
+    async fn get_chat_transcript_scoped(
+        &self,
+        owner: &OwnerId,
+        id: ChatId,
+    ) -> Result<Option<ChatTranscriptSnapshot>> {
+        let _ = owner;
+        self.get_chat_transcript(id).await
+    }
+
+    /// [`Store::update_chat_metadata`] restricted to `owner`'s chats;
+    /// someone else's chat reports `false`.
+    #[allow(clippy::too_many_arguments)]
+    async fn update_chat_metadata_scoped(
+        &self,
+        owner: &OwnerId,
+        id: ChatId,
+        title: Option<Option<String>>,
+        model: Option<Option<String>>,
+        reasoning_effort: Option<Option<ReasoningEffort>>,
+        permission_mode: Option<Option<PermissionMode>>,
+        network_policy: Option<NetworkPolicy>,
+    ) -> Result<bool> {
+        let _ = owner;
+        self.update_chat_metadata(
+            id,
+            title,
+            model,
+            reasoning_effort,
+            permission_mode,
+            network_policy,
+        )
+        .await
+    }
+
+    /// Persist a new project owned by `owner`.
+    async fn create_project_scoped(&self, owner: &OwnerId, project: &Project) -> Result<()> {
+        let _ = owner;
+        self.create_project(project).await
+    }
+
+    /// Fetch `owner`'s project by id; `None` when it does not exist or
+    /// belongs to someone else.
+    async fn get_project_scoped(&self, owner: &OwnerId, id: ProjectId) -> Result<Option<Project>> {
+        let _ = owner;
+        self.get_project(id).await
+    }
+
+    /// List `owner`'s projects, most-recently-created first.
+    async fn list_projects_scoped(&self, owner: &OwnerId) -> Result<Vec<Project>> {
+        let _ = owner;
+        self.list_projects().await
+    }
+
+    /// [`Store::update_project_title`] restricted to `owner`'s projects.
+    async fn update_project_title_scoped(
+        &self,
+        owner: &OwnerId,
+        id: ProjectId,
+        title: Option<String>,
+    ) -> Result<bool> {
+        let _ = owner;
+        self.update_project_title(id, title).await
+    }
+
+    /// [`Store::delete_project`] restricted to `owner`'s projects; someone
+    /// else's project reports [`DeleteProjectOutcome::NotFound`].
+    async fn delete_project_scoped(
+        &self,
+        owner: &OwnerId,
+        id: ProjectId,
+    ) -> Result<DeleteProjectOutcome> {
+        let _ = owner;
+        self.delete_project(id).await
+    }
+
+    /// Fetch `owner`'s document by id; `None` when it does not exist or
+    /// belongs to someone else.
+    async fn get_document_scoped(
+        &self,
+        owner: &OwnerId,
+        id: DocumentId,
+    ) -> Result<Option<DocumentRecord>> {
+        let _ = owner;
+        self.get_document(id).await
+    }
+
+    /// [`Store::list_document_summaries`] restricted to `owner`'s documents.
+    async fn list_document_summaries_scoped(
+        &self,
+        owner: &OwnerId,
+        scope: DocumentScope,
+        after: Option<DocumentListCursor>,
+        limit: u64,
+    ) -> Result<Vec<DocumentSummaryRecord>> {
+        let _ = owner;
+        self.list_document_summaries(scope, after, limit).await
+    }
+
+    /// [`Store::delete_document`] restricted to `owner`'s documents; someone
+    /// else's document is left untouched, indistinguishable from absent.
+    async fn delete_document_scoped(&self, owner: &OwnerId, id: DocumentId) -> Result<()> {
+        let _ = owner;
+        self.delete_document(id).await
+    }
+
+    /// [`Store::accept_document_source`] attributing a new standalone
+    /// document to `owner`; a chat- or project-bound document must name a
+    /// parent that belongs to `owner`.
+    async fn accept_document_source_scoped(
+        &self,
+        owner: &OwnerId,
+        document: &DocumentSourceUpsert,
+    ) -> Result<DocumentRecord> {
+        let _ = owner;
+        self.accept_document_source(document).await
+    }
 
     /// Create a conversation output together with its first revision.
     ///

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1374,7 +1374,7 @@ end_published_at: string | null, } | { "tool": "web_extract", url: string, };
  *
  * Each presentable variant names the egress a human is consenting to, so the
  * renderer can describe the action without ever seeing the model-authored
- * summary or arguments. `Unsupported` is the fail-closed default: a Sensitive
+ * arguments. `Unsupported` is the fail-closed default: a Sensitive
  * action the server can only reject, never approve.
  */
 export type ToolApprovalKind = "search_may_share_query_and_excerpts" | "web_search_may_share_query" | "web_extract_may_fetch_url" | "exec_may_run_networked_command" | "external_mcp_may_call_server" | "workspace_may_modify_files" | "unsupported";

--- a/crates/openwave-server/src/principal.rs
+++ b/crates/openwave-server/src/principal.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 use axum::http::StatusCode;
-use openwave_core::{AgentError, Result};
+use openwave_core::{AgentError, OwnerId, Result};
 
 /// The authenticated identity a request acts as.
 ///
@@ -40,6 +40,24 @@ pub enum Principal {
     /// A named user on a shared deployment, resolved from a configured
     /// credential (today the self-host token file — see [`crate::auth`]).
     User(UserId),
+}
+
+impl Principal {
+    /// The durable storage key this principal's rows are attributed to and
+    /// scoped by (#853).
+    ///
+    /// The local owner maps to the fixed [`OwnerId::local`] key; a named user
+    /// maps to `user:<id>`. The prefix keeps the two namespaces disjoint —
+    /// [`UserId`] rejects `:`, so no operator-assigned user id can collide
+    /// with `local` or with another user's key.
+    #[must_use]
+    pub fn owner_id(&self) -> OwnerId {
+        match self {
+            Self::LocalOwner => OwnerId::local(),
+            Self::User(id) => OwnerId::new(&format!("user:{id}"))
+                .expect("a validated user id forms a valid owner key"),
+        }
+    }
 }
 
 /// The operator-assigned identifier of a named user on a shared deployment.

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -42,6 +42,7 @@ use crate::exec_write_snapshot::{
 use crate::extract::{Json, Path, Query};
 use crate::mcp_config::{McpServersConfig, McpServersInfo};
 use crate::model_roles::{self, ModelRole};
+use crate::principal::AuthContext;
 use crate::providers::{self, ProviderCredential, ProviderInfo, ProviderKind, ProviderUpdate};
 use crate::state::AppState;
 use crate::view_frames::ViewFrameSource;
@@ -692,6 +693,7 @@ pub async fn post_undo_one_file_change(
 /// paths, or a reusable document identity.
 pub async fn get_file_change_preview(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path((chat_id, turn_id, snapshot_id, revision)): Path<(
         ChatId,
         TurnId,
@@ -699,7 +701,12 @@ pub async fn get_file_change_preview(
         ExecFilePreviewRevision,
     )>,
 ) -> Result<Response, ServerError> {
-    if state.store.get_chat(chat_id).await?.is_none() {
+    if state
+        .store
+        .get_chat_scoped(&auth.principal.owner_id(), chat_id)
+        .await?
+        .is_none()
+    {
         return Err(ServerError::not_found(format!("chat {chat_id} not found")));
     }
     let _permit = state
@@ -1302,6 +1309,7 @@ fn normalize_chat_title(title: Option<String>) -> Result<Option<String>, ServerE
 /// `POST /projects` — create a project and return it (`201 Created`).
 pub async fn create_project(
     State(state): State<AppState>,
+    auth: AuthContext,
     Json(body): Json<CreateProject>,
 ) -> Result<impl IntoResponse, ServerError> {
     let project = Project {
@@ -1311,25 +1319,34 @@ pub async fn create_project(
         root_attachments: Vec::new(),
         created_at: Utc::now(),
     };
-    state.store.create_project(&project).await?;
+    state
+        .store
+        .create_project_scoped(&auth.principal.owner_id(), &project)
+        .await?;
     Ok((StatusCode::CREATED, Json(project)))
 }
 
 /// `PATCH /projects/{id}` — update bounded human-facing project metadata.
 pub async fn patch_project(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(id): Path<ProjectId>,
     Json(body): Json<ProjectUpdate>,
 ) -> Result<Json<Project>, ServerError> {
+    let owner = auth.principal.owner_id();
     let title = body.title.map(normalize_project_title).transpose()?;
     if let Some(title) = title {
-        if !state.store.update_project_title(id, title).await? {
+        if !state
+            .store
+            .update_project_title_scoped(&owner, id, title)
+            .await?
+        {
             return Err(ServerError::not_found(format!("project {id} not found")));
         }
     }
     state
         .store
-        .get_project(id)
+        .get_project_scoped(&owner, id)
         .await?
         .map(Json)
         .ok_or_else(|| ServerError::not_found(format!("project {id} not found")))
@@ -1338,18 +1355,25 @@ pub async fn patch_project(
 /// `GET /projects` — list projects, most-recently-created first.
 pub async fn list_projects(
     State(state): State<AppState>,
+    auth: AuthContext,
 ) -> Result<Json<Vec<Project>>, ServerError> {
-    Ok(Json(state.store.list_projects().await?))
+    Ok(Json(
+        state
+            .store
+            .list_projects_scoped(&auth.principal.owner_id())
+            .await?,
+    ))
 }
 
 /// `GET /projects/{id}` — fetch one project, or `404`.
 pub async fn get_project(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(id): Path<ProjectId>,
 ) -> Result<Json<Project>, ServerError> {
     state
         .store
-        .get_project(id)
+        .get_project_scoped(&auth.principal.owner_id(), id)
         .await?
         .map(Json)
         .ok_or_else(|| ServerError::not_found(format!("project {id} not found")))
@@ -1360,9 +1384,14 @@ pub async fn get_project(
 /// lifecycle APIs first; this boundary never cascades them.
 pub async fn delete_project(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(id): Path<ProjectId>,
 ) -> Result<StatusCode, ServerError> {
-    match state.store.delete_project(id).await? {
+    match state
+        .store
+        .delete_project_scoped(&auth.principal.owner_id(), id)
+        .await?
+    {
         DeleteProjectOutcome::Deleted => Ok(StatusCode::NO_CONTENT),
         DeleteProjectOutcome::NotFound => {
             Err(ServerError::not_found(format!("project {id} not found")))
@@ -1402,14 +1431,16 @@ pub struct CreateChat {
 /// `POST /chats` — create a chat and return it (`201 Created`).
 pub async fn create_chat(
     State(state): State<AppState>,
+    auth: AuthContext,
     Json(mut body): Json<CreateChat>,
 ) -> Result<impl IntoResponse, ServerError> {
+    let owner = auth.principal.owner_id();
     // Return a product-facing 400 for an unknown project. The Store and schema
     // independently enforce the same membership invariant inside insertion.
     if let Some(project_id) = body.project_id {
         state
             .store
-            .get_project(project_id)
+            .get_project_scoped(&owner, project_id)
             .await?
             .ok_or_else(|| ServerError::not_found(format!("project {project_id} not found")))?;
     }
@@ -1430,7 +1461,10 @@ pub async fn create_chat(
         root_attachments: Vec::new(),
         created_at: Utc::now(),
     };
-    let chat = state.store.create_chat_with_project_defaults(&chat).await?;
+    let chat = state
+        .store
+        .create_chat_with_project_defaults_scoped(&owner, &chat)
+        .await?;
     Ok((StatusCode::CREATED, Json(chat)))
 }
 
@@ -1461,9 +1495,11 @@ pub struct ChatUpdate {
 /// `PATCH /chats/{id}` — update the human-facing title and/or model selection.
 pub async fn patch_chat(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(id): Path<ChatId>,
     Json(mut body): Json<ChatUpdate>,
 ) -> Result<Json<Chat>, ServerError> {
+    let owner = auth.principal.owner_id();
     // Validate every supplied field before touching durable state. This keeps a
     // mixed request all-or-nothing from the user's point of view.
     if let Some(Some(model)) = body.model.as_mut() {
@@ -1480,13 +1516,14 @@ pub async fn patch_chat(
 
     let mut chat = state
         .store
-        .get_chat(id)
+        .get_chat_scoped(&owner, id)
         .await?
         .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))?;
 
     if !state
         .store
-        .update_chat_metadata(
+        .update_chat_metadata_scoped(
+            &owner,
             id,
             title.clone(),
             body.model.clone(),
@@ -1713,11 +1750,12 @@ impl ChatMessageSnapshot {
 /// an empty conversation.
 pub async fn list_chat_messages(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(id): Path<ChatId>,
 ) -> Result<Json<ChatTranscript>, ServerError> {
     let transcript = state
         .store
-        .get_chat_transcript(id)
+        .get_chat_transcript_scoped(&auth.principal.owner_id(), id)
         .await?
         .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))?;
     let mut citations_by_message = std::collections::HashMap::new();
@@ -1795,18 +1833,27 @@ pub async fn list_chat_messages(
 }
 
 /// `GET /chats` — list chats, most-recently-created first.
-pub async fn list_chats(State(state): State<AppState>) -> Result<Json<Vec<Chat>>, ServerError> {
-    Ok(Json(state.store.list_chats().await?))
+pub async fn list_chats(
+    State(state): State<AppState>,
+    auth: AuthContext,
+) -> Result<Json<Vec<Chat>>, ServerError> {
+    Ok(Json(
+        state
+            .store
+            .list_chats_scoped(&auth.principal.owner_id())
+            .await?,
+    ))
 }
 
 /// `GET /chats/{id}` — fetch one chat, or `404`.
 pub async fn get_chat(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(id): Path<ChatId>,
 ) -> Result<Json<Chat>, ServerError> {
     state
         .store
-        .get_chat(id)
+        .get_chat_scoped(&auth.principal.owner_id(), id)
         .await?
         .map(Json)
         .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))
@@ -1817,9 +1864,14 @@ pub async fn get_chat(
 /// caller must first finish cancellation and durable broker detachment.
 pub async fn delete_chat(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(id): Path<ChatId>,
 ) -> Result<StatusCode, ServerError> {
-    match state.store.delete_chat(id).await? {
+    match state
+        .store
+        .delete_chat_scoped(&auth.principal.owner_id(), id)
+        .await?
+    {
         DeleteChatOutcome::Deleted => {
             state.blob_retirement_wake.notify_one();
             let scratch_root = state.config.data_dir.join("scratch");
@@ -2126,11 +2178,12 @@ fn foreground_activity(
 /// `GET /chats/{id}/agent-runs` — list renderer-safe execution state.
 pub async fn list_agent_runs(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(id): Path<ChatId>,
 ) -> Result<Json<Vec<AgentRunSnapshot>>, ServerError> {
     state
         .store
-        .get_chat(id)
+        .get_chat_scoped(&auth.principal.owner_id(), id)
         .await?
         .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))?;
     let runs = state.store.list_agent_runs(id).await?;
@@ -2169,9 +2222,15 @@ pub async fn list_agent_runs(
 /// unrelated run identifier exists.
 pub async fn list_agent_run_activity(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path((chat_id, run_id)): Path<(ChatId, openwave_core::AgentRunId)>,
 ) -> Result<Json<Vec<AgentActivityHistoryItem>>, ServerError> {
-    if state.store.get_chat(chat_id).await?.is_none() {
+    if state
+        .store
+        .get_chat_scoped(&auth.principal.owner_id(), chat_id)
+        .await?
+        .is_none()
+    {
         return Err(ServerError::not_found(format!("chat {chat_id} not found")));
     }
     let run = state
@@ -2214,9 +2273,15 @@ pub enum AgentRunCancellationStatus {
 /// executor details.
 pub async fn post_agent_run_cancel(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path((chat_id, run_id)): Path<(ChatId, openwave_core::AgentRunId)>,
 ) -> Result<(StatusCode, Json<AgentRunCancellationSnapshot>), ServerError> {
-    if state.store.get_chat(chat_id).await?.is_none() {
+    if state
+        .store
+        .get_chat_scoped(&auth.principal.owner_id(), chat_id)
+        .await?
+        .is_none()
+    {
         return Err(ServerError::not_found(format!("chat {chat_id} not found")));
     }
     let Some(run) = state.store.get_agent_run(run_id).await? else {
@@ -2614,6 +2679,7 @@ mod image_capability_tests {
 /// with `model_image_input_unsupported`.
 pub async fn post_message(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(id): Path<ChatId>,
     Json(body): Json<PostMessage>,
 ) -> Result<StatusCode, ServerError> {
@@ -2627,7 +2693,7 @@ pub async fn post_message(
     }
     let chat = state
         .store
-        .get_chat(id)
+        .get_chat_scoped(&auth.principal.owner_id(), id)
         .await?
         .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))?;
 
@@ -2751,6 +2817,7 @@ pub struct SteerBody {
 /// unavailable turn, and `400` for malformed input.
 pub async fn post_steer(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(id): Path<ChatId>,
     Json(body): Json<SteerBody>,
 ) -> Result<StatusCode, ServerError> {
@@ -2765,7 +2832,12 @@ pub async fn post_steer(
             "steer content must be non-empty, contain no NUL characters, and fit the size limit",
         ));
     }
-    if state.store.get_chat(id).await?.is_none() {
+    if state
+        .store
+        .get_chat_scoped(&auth.principal.owner_id(), id)
+        .await?
+        .is_none()
+    {
         return Err(ServerError::not_found(format!("chat {id} not found")));
     }
     match state
@@ -2811,11 +2883,17 @@ pub struct CancelBody {
 
 pub async fn post_cancel(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(id): Path<ChatId>,
     Json(body): Json<CancelBody>,
 ) -> Result<StatusCode, ServerError> {
     // Distinguish "unknown chat" (404) from "known chat, nothing running" (409).
-    if state.store.get_chat(id).await?.is_none() {
+    if state
+        .store
+        .get_chat_scoped(&auth.principal.owner_id(), id)
+        .await?
+        .is_none()
+    {
         return Err(ServerError::not_found(format!("chat {id} not found")));
     }
     if !state
@@ -3028,6 +3106,7 @@ pub(crate) fn grant_rungs_from_scopes(
 /// `GET /chats/{id}/approvals` — recover a bounded page of pending cards.
 pub(crate) async fn list_pending_approvals(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(chat_id): Path<ChatId>,
     Query(query): Query<PendingApprovalsQuery>,
 ) -> Result<Json<Vec<PendingApprovalSnapshot>>, ServerError> {
@@ -3036,7 +3115,12 @@ pub(crate) async fn list_pending_approvals(
             "approval limit must be between 1 and 100",
         ));
     }
-    if state.store.get_chat(chat_id).await?.is_none() {
+    if state
+        .store
+        .get_chat_scoped(&auth.principal.owner_id(), chat_id)
+        .await?
+        .is_none()
+    {
         return Err(ServerError::not_found(format!("chat {chat_id} not found")));
     }
     let approvals = state
@@ -3141,11 +3225,17 @@ pub(crate) async fn delete_standing_grant(
 /// holding its slot until it finishes after the decision.
 pub async fn post_approval(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path((chat_id, call_id)): Path<(ChatId, CallId)>,
     Json(body): Json<ApprovalBody>,
 ) -> Result<StatusCode, ServerError> {
     // Confirm the chat exists so a typo'd id doesn't look like "not pending".
-    if state.store.get_chat(chat_id).await?.is_none() {
+    if state
+        .store
+        .get_chat_scoped(&auth.principal.owner_id(), chat_id)
+        .await?
+        .is_none()
+    {
         return Err(ServerError::not_found(format!("chat {chat_id} not found")));
     }
     let decision = match body.decision {
@@ -3233,12 +3323,17 @@ pub struct EventsQuery {
 /// browser accepts the handshake (RFC 6455).
 pub async fn chat_events(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(id): Path<ChatId>,
     Query(query): Query<EventsQuery>,
     headers: axum::http::HeaderMap,
     upgrade: WebSocketUpgrade,
 ) -> Result<Response, ServerError> {
-    let Some(chat) = state.store.get_chat(id).await? else {
+    let Some(chat) = state
+        .store
+        .get_chat_scoped(&auth.principal.owner_id(), id)
+        .await?
+    else {
         return Err(ServerError::not_found(format!("chat {id} not found")));
     };
     let upgrade = if offered_handshake_subprotocol(&headers) {

--- a/crates/openwave-server/src/routes/document.rs
+++ b/crates/openwave-server/src/routes/document.rs
@@ -11,12 +11,14 @@ use unicode_general_category::{get_general_category, GeneralCategory};
 
 use openwave_core::{
     AgentError, ChatId, DocumentId, DocumentListCursor, DocumentRecord, DocumentScope,
-    DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, ProjectId, SourceReadiness,
+    DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, OwnerId, ProjectId,
+    SourceReadiness,
 };
 
 use crate::document_decode::decode_document;
 use crate::error::ServerError;
 use crate::extract::{Json, Path, Query, RawBytes};
+use crate::principal::AuthContext;
 use crate::routes::SERVED_BYTES_CONTENT_POLICY;
 use crate::state::AppState;
 use crate::MAX_RAW_DOCUMENT_BYTES;
@@ -257,33 +259,39 @@ impl From<DocumentRecord> for DocumentDetail {
 /// `POST /documents` — decode and durably retain source bytes.
 pub async fn ingest_document(
     State(state): State<AppState>,
+    auth: AuthContext,
     Json(body): Json<IngestDocument>,
 ) -> Result<impl IntoResponse, ServerError> {
-    ingest_document_in_scope(&state, None, None, body).await
+    ingest_document_in_scope(&state, &auth.principal.owner_id(), None, None, body).await
 }
 
 /// `POST /projects/{project_id}/documents` — ingest a document in one project corpus.
 pub async fn ingest_project_document(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(project_id): Path<ProjectId>,
     Json(body): Json<IngestDocument>,
 ) -> Result<impl IntoResponse, ServerError> {
-    require_project(&state, project_id).await?;
-    ingest_document_in_scope(&state, None, Some(project_id), body).await
+    let owner = auth.principal.owner_id();
+    require_project(&state, &owner, project_id).await?;
+    ingest_document_in_scope(&state, &owner, None, Some(project_id), body).await
 }
 
 /// `POST /chats/{chat_id}/documents` — ingest a source owned by one conversation.
 pub async fn ingest_chat_document(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(chat_id): Path<ChatId>,
     Json(body): Json<IngestDocument>,
 ) -> Result<impl IntoResponse, ServerError> {
-    require_chat(&state, chat_id).await?;
-    ingest_document_in_scope(&state, Some(chat_id), None, body).await
+    let owner = auth.principal.owner_id();
+    require_chat(&state, &owner, chat_id).await?;
+    ingest_document_in_scope(&state, &owner, Some(chat_id), None, body).await
 }
 
 async fn ingest_document_in_scope(
     state: &AppState,
+    owner: &OwnerId,
     chat_id: Option<ChatId>,
     project_id: Option<ProjectId>,
     body: IngestDocument,
@@ -293,6 +301,7 @@ async fn ingest_document_in_scope(
     }
     publish_document_source(
         state,
+        owner,
         chat_id,
         project_id,
         body.uri,
@@ -307,25 +316,38 @@ async fn ingest_document_in_scope(
 /// `Content-Type` and decode it synchronously.
 pub async fn ingest_raw_document(
     State(state): State<AppState>,
+    auth: AuthContext,
     Query(query): Query<RawDocumentQuery>,
     headers: HeaderMap,
     RawBytes(bytes): RawBytes,
 ) -> Result<impl IntoResponse, ServerError> {
-    ingest_raw_document_in_scope(&state, None, None, query, &headers, bytes.to_vec()).await
+    ingest_raw_document_in_scope(
+        &state,
+        &auth.principal.owner_id(),
+        None,
+        None,
+        query,
+        &headers,
+        bytes.to_vec(),
+    )
+    .await
 }
 
 /// `POST /projects/{project_id}/documents/raw` — retain exact bytes in one
 /// project corpus and decode it synchronously.
 pub async fn ingest_raw_project_document(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(project_id): Path<ProjectId>,
     Query(query): Query<RawDocumentQuery>,
     headers: HeaderMap,
     RawBytes(bytes): RawBytes,
 ) -> Result<impl IntoResponse, ServerError> {
-    require_project(&state, project_id).await?;
+    let owner = auth.principal.owner_id();
+    require_project(&state, &owner, project_id).await?;
     ingest_raw_document_in_scope(
         &state,
+        &owner,
         None,
         Some(project_id),
         query,
@@ -339,13 +361,24 @@ pub async fn ingest_raw_project_document(
 /// conversation and decode it synchronously.
 pub async fn ingest_raw_chat_document(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(chat_id): Path<ChatId>,
     Query(query): Query<RawDocumentQuery>,
     headers: HeaderMap,
     RawBytes(bytes): RawBytes,
 ) -> Result<impl IntoResponse, ServerError> {
-    require_chat(&state, chat_id).await?;
-    ingest_raw_document_in_scope(&state, Some(chat_id), None, query, &headers, bytes.to_vec()).await
+    let owner = auth.principal.owner_id();
+    require_chat(&state, &owner, chat_id).await?;
+    ingest_raw_document_in_scope(
+        &state,
+        &owner,
+        Some(chat_id),
+        None,
+        query,
+        &headers,
+        bytes.to_vec(),
+    )
+    .await
 }
 
 /// `POST /chats/{chat_id}/documents/raw-stream` — stream one native-selected
@@ -353,12 +386,14 @@ pub async fn ingest_raw_chat_document(
 /// conversation-local identity.
 pub async fn ingest_streamed_raw_chat_document(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(chat_id): Path<ChatId>,
     Query(query): Query<StreamedRawDocumentQuery>,
     headers: HeaderMap,
     body: Body,
 ) -> Result<impl IntoResponse, ServerError> {
-    require_chat(&state, chat_id).await?;
+    let owner = auth.principal.owner_id();
+    require_chat(&state, &owner, chat_id).await?;
     let source_blob = streamed_source_blob(&query)?;
     let media_type = raw_document_media_type(&headers)?;
     let title = normalize_document_title(query.title.as_deref())?;
@@ -366,7 +401,7 @@ pub async fn ingest_streamed_raw_chat_document(
 
     if let Some(existing) = state
         .store
-        .get_document(document_id)
+        .get_document_scoped(&owner, document_id)
         .await?
         .filter(|document| document.chat_id == Some(chat_id) && document.project_id.is_none())
     {
@@ -398,17 +433,20 @@ pub async fn ingest_streamed_raw_chat_document(
     let canonical_text = decode_document(&media_type, &source_bytes);
     let document = state
         .store
-        .accept_document_source(&DocumentSourceUpsert {
-            id: document_id,
-            chat_id: Some(chat_id),
-            project_id: None,
-            source_uri: None,
-            media_type,
-            title,
-            source_blob,
-            canonical_text,
-            updated_at: Utc::now(),
-        })
+        .accept_document_source_scoped(
+            &owner,
+            &DocumentSourceUpsert {
+                id: document_id,
+                chat_id: Some(chat_id),
+                project_id: None,
+                source_uri: None,
+                media_type,
+                title,
+                source_blob,
+                canonical_text,
+                updated_at: Utc::now(),
+            },
+        )
         .await?;
     state.blob_retirement_wake.notify_one();
     Ok((
@@ -423,6 +461,7 @@ pub async fn ingest_streamed_raw_chat_document(
 
 async fn ingest_raw_document_in_scope(
     state: &AppState,
+    owner: &OwnerId,
     chat_id: Option<ChatId>,
     project_id: Option<ProjectId>,
     query: RawDocumentQuery,
@@ -435,6 +474,7 @@ async fn ingest_raw_document_in_scope(
     let media_type = raw_document_media_type(headers)?;
     publish_document_source(
         state,
+        owner,
         chat_id,
         project_id,
         query.uri,
@@ -445,8 +485,10 @@ async fn ingest_raw_document_in_scope(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn publish_document_source(
     state: &AppState,
+    owner: &OwnerId,
     chat_id: Option<ChatId>,
     project_id: Option<ProjectId>,
     source_uri: Option<String>,
@@ -484,17 +526,20 @@ async fn publish_document_source(
     state.blobs.put(source_blob.id, source_bytes).await?;
     let document = state
         .store
-        .accept_document_source(&DocumentSourceUpsert {
-            id: document_id,
-            chat_id,
-            project_id,
-            source_uri,
-            media_type,
-            title,
-            source_blob,
-            canonical_text,
-            updated_at: Utc::now(),
-        })
+        .accept_document_source_scoped(
+            owner,
+            &DocumentSourceUpsert {
+                id: document_id,
+                chat_id,
+                project_id,
+                source_uri,
+                media_type,
+                title,
+                source_blob,
+                canonical_text,
+                updated_at: Utc::now(),
+            },
+        )
         .await?;
     state.blob_retirement_wake.notify_one();
     Ok((
@@ -612,33 +657,45 @@ mod title_tests {
 /// corpus scoping; this endpoint never widens to every project's documents.
 pub async fn list_documents(
     State(state): State<AppState>,
+    auth: AuthContext,
     Query(query): Query<DocumentListQuery>,
 ) -> Result<Json<DocumentListPage>, ServerError> {
-    list_documents_in_scope(&state, DocumentScope::Unscoped, query).await
+    list_documents_in_scope(
+        &state,
+        &auth.principal.owner_id(),
+        DocumentScope::Unscoped,
+        query,
+    )
+    .await
 }
 
 /// `GET /projects/{project_id}/documents` — list one project's document corpus.
 pub async fn list_project_documents(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(project_id): Path<ProjectId>,
     Query(query): Query<DocumentListQuery>,
 ) -> Result<Json<DocumentListPage>, ServerError> {
-    require_project(&state, project_id).await?;
-    list_documents_in_scope(&state, DocumentScope::Project(project_id), query).await
+    let owner = auth.principal.owner_id();
+    require_project(&state, &owner, project_id).await?;
+    list_documents_in_scope(&state, &owner, DocumentScope::Project(project_id), query).await
 }
 
 /// `GET /chats/{chat_id}/documents` — list only sources owned by one conversation.
 pub async fn list_chat_documents(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(chat_id): Path<ChatId>,
     Query(query): Query<DocumentListQuery>,
 ) -> Result<Json<DocumentListPage>, ServerError> {
-    require_chat(&state, chat_id).await?;
-    list_documents_in_scope(&state, DocumentScope::Chat(chat_id), query).await
+    let owner = auth.principal.owner_id();
+    require_chat(&state, &owner, chat_id).await?;
+    list_documents_in_scope(&state, &owner, DocumentScope::Chat(chat_id), query).await
 }
 
 async fn list_documents_in_scope(
     state: &AppState,
+    owner: &OwnerId,
     scope: DocumentScope,
     query: DocumentListQuery,
 ) -> Result<Json<DocumentListPage>, ServerError> {
@@ -655,7 +712,7 @@ async fn list_documents_in_scope(
         .transpose()?;
     let mut records = state
         .store
-        .list_document_summaries(scope, cursor, limit + 1)
+        .list_document_summaries_scoped(owner, scope, cursor, limit + 1)
         .await?;
     let has_more = records.len() > limit as usize;
     records.truncate(limit as usize);
@@ -677,11 +734,12 @@ async fn list_documents_in_scope(
 /// `GET /documents/{id}` — fetch canonical source and catalog metadata, or `404`.
 pub async fn get_document(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(id): Path<DocumentId>,
 ) -> Result<Json<DocumentDetail>, ServerError> {
     state
         .store
-        .get_document(id)
+        .get_document_scoped(&auth.principal.owner_id(), id)
         .await?
         .filter(|document| document.chat_id.is_none() && document.project_id.is_none())
         .map(DocumentDetail::from)
@@ -692,12 +750,14 @@ pub async fn get_document(
 /// `GET /projects/{project_id}/documents/{document_id}` — fetch an owned document.
 pub async fn get_project_document(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path((project_id, document_id)): Path<(ProjectId, DocumentId)>,
 ) -> Result<Json<DocumentDetail>, ServerError> {
-    require_project(&state, project_id).await?;
+    let owner = auth.principal.owner_id();
+    require_project(&state, &owner, project_id).await?;
     state
         .store
-        .get_document(document_id)
+        .get_document_scoped(&owner, document_id)
         .await?
         .filter(|document| document.chat_id.is_none() && document.project_id == Some(project_id))
         .map(DocumentDetail::from)
@@ -709,12 +769,14 @@ pub async fn get_project_document(
 /// the path conversation owns it.
 pub async fn get_chat_document(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path((chat_id, document_id)): Path<(ChatId, DocumentId)>,
 ) -> Result<Json<ChatDocumentDetail>, ServerError> {
-    require_chat(&state, chat_id).await?;
+    let owner = auth.principal.owner_id();
+    require_chat(&state, &owner, chat_id).await?;
     state
         .store
-        .get_document(document_id)
+        .get_document_scoped(&owner, document_id)
         .await?
         .filter(|document| document.chat_id == Some(chat_id) && document.project_id.is_none())
         .map(ChatDocumentDetail::from)
@@ -726,24 +788,37 @@ pub async fn get_chat_document(
 /// explicitly unscoped document.
 pub async fn get_document_file_content(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(id): Path<DocumentId>,
     method: Method,
     headers: HeaderMap,
 ) -> Result<Response, ServerError> {
-    serve_document_file_content(&state, id, None, None, method, &headers).await
+    serve_document_file_content(
+        &state,
+        &auth.principal.owner_id(),
+        id,
+        None,
+        None,
+        method,
+        &headers,
+    )
+    .await
 }
 
 /// `GET /projects/{project_id}/documents/{document_id}/file-content` — serve
 /// original bytes only when the path project owns the document.
 pub async fn get_project_document_file_content(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path((project_id, document_id)): Path<(ProjectId, DocumentId)>,
     method: Method,
     headers: HeaderMap,
 ) -> Result<Response, ServerError> {
-    require_project(&state, project_id).await?;
+    let owner = auth.principal.owner_id();
+    require_project(&state, &owner, project_id).await?;
     serve_document_file_content(
         &state,
+        &owner,
         document_id,
         None,
         Some(project_id),
@@ -757,12 +832,23 @@ pub async fn get_project_document_file_content(
 /// bytes only when the path conversation owns the document.
 pub async fn get_chat_document_file_content(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path((chat_id, document_id)): Path<(ChatId, DocumentId)>,
     method: Method,
     headers: HeaderMap,
 ) -> Result<Response, ServerError> {
-    require_chat(&state, chat_id).await?;
-    serve_document_file_content(&state, document_id, Some(chat_id), None, method, &headers).await
+    let owner = auth.principal.owner_id();
+    require_chat(&state, &owner, chat_id).await?;
+    serve_document_file_content(
+        &state,
+        &owner,
+        document_id,
+        Some(chat_id),
+        None,
+        method,
+        &headers,
+    )
+    .await
 }
 
 /// How one response names and offers a document's original bytes.
@@ -872,6 +958,7 @@ impl ServedMediaType {
 
 async fn serve_document_file_content(
     state: &AppState,
+    owner: &OwnerId,
     document_id: DocumentId,
     chat_id: Option<ChatId>,
     project_id: Option<ProjectId>,
@@ -880,7 +967,7 @@ async fn serve_document_file_content(
 ) -> Result<Response, ServerError> {
     let Some(document) = state
         .store
-        .get_document(document_id)
+        .get_document_scoped(owner, document_id)
         .await?
         .filter(|document| document.chat_id == chat_id && document.project_id == project_id)
     else {
@@ -1102,17 +1189,19 @@ mod byte_range_tests {
 /// `DELETE /documents/{id}` — delete one authoritative source.
 pub async fn delete_document(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path(id): Path<DocumentId>,
 ) -> Result<StatusCode, ServerError> {
+    let owner = auth.principal.owner_id();
     if state
         .store
-        .get_document(id)
+        .get_document_scoped(&owner, id)
         .await?
         .is_some_and(|document| document.chat_id.is_some() || document.project_id.is_some())
     {
         return Err(ServerError::not_found(format!("document {id} not found")));
     }
-    state.store.delete_document(id).await?;
+    state.store.delete_document_scoped(&owner, id).await?;
     state.blob_retirement_wake.notify_one();
     Ok(StatusCode::ACCEPTED)
 }
@@ -1120,12 +1209,14 @@ pub async fn delete_document(
 /// `DELETE /projects/{project_id}/documents/{document_id}` — retire an owned document.
 pub async fn delete_project_document(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path((project_id, document_id)): Path<(ProjectId, DocumentId)>,
 ) -> Result<StatusCode, ServerError> {
-    require_project(&state, project_id).await?;
+    let owner = auth.principal.owner_id();
+    require_project(&state, &owner, project_id).await?;
     if state
         .store
-        .get_document(document_id)
+        .get_document_scoped(&owner, document_id)
         .await?
         .is_none_or(|document| {
             document.chat_id.is_some() || document.project_id != Some(project_id)
@@ -1135,7 +1226,10 @@ pub async fn delete_project_document(
             "document {document_id} not found"
         )));
     }
-    state.store.delete_document(document_id).await?;
+    state
+        .store
+        .delete_document_scoped(&owner, document_id)
+        .await?;
     state.blob_retirement_wake.notify_one();
     Ok(StatusCode::ACCEPTED)
 }
@@ -1144,12 +1238,14 @@ pub async fn delete_project_document(
 /// by a conversation without exposing another conversation's source identity.
 pub async fn delete_chat_document(
     State(state): State<AppState>,
+    auth: AuthContext,
     Path((chat_id, document_id)): Path<(ChatId, DocumentId)>,
 ) -> Result<StatusCode, ServerError> {
-    require_chat(&state, chat_id).await?;
+    let owner = auth.principal.owner_id();
+    require_chat(&state, &owner, chat_id).await?;
     if state
         .store
-        .get_document(document_id)
+        .get_document_scoped(&owner, document_id)
         .await?
         .is_none_or(|document| document.chat_id != Some(chat_id) || document.project_id.is_some())
     {
@@ -1157,13 +1253,25 @@ pub async fn delete_chat_document(
             "document {document_id} not found"
         )));
     }
-    state.store.delete_document(document_id).await?;
+    state
+        .store
+        .delete_document_scoped(&owner, document_id)
+        .await?;
     state.blob_retirement_wake.notify_one();
     Ok(StatusCode::ACCEPTED)
 }
 
-async fn require_project(state: &AppState, project_id: ProjectId) -> Result<(), ServerError> {
-    if state.store.get_project(project_id).await?.is_none() {
+async fn require_project(
+    state: &AppState,
+    owner: &OwnerId,
+    project_id: ProjectId,
+) -> Result<(), ServerError> {
+    if state
+        .store
+        .get_project_scoped(owner, project_id)
+        .await?
+        .is_none()
+    {
         return Err(ServerError::not_found(format!(
             "project {project_id} not found"
         )));
@@ -1171,8 +1279,12 @@ async fn require_project(state: &AppState, project_id: ProjectId) -> Result<(), 
     Ok(())
 }
 
-async fn require_chat(state: &AppState, chat_id: ChatId) -> Result<(), ServerError> {
-    if state.store.get_chat(chat_id).await?.is_none() {
+async fn require_chat(
+    state: &AppState,
+    owner: &OwnerId,
+    chat_id: ChatId,
+) -> Result<(), ServerError> {
+    if state.store.get_chat_scoped(owner, chat_id).await?.is_none() {
         return Err(ServerError::not_found(format!("chat {chat_id} not found")));
     }
     Ok(())


### PR DESCRIPTION
Slice 3 of #853 (does not close it): the root aggregates gain a durable owner and the `Store` trait gains a principal-scoped query surface, with the desktop backfilled to the local owner and observable behavior unchanged.

## Ownership model

- Chats, projects, and documents are the ownership roots — everything else (messages, turns, runs, outputs, attachments) hangs off one of them by id. Migration `m20260803_000045_add_owner_attribution` adds an `owner` text column to the three tables, `NOT NULL DEFAULT 'local'`, so every pre-existing row backfills to the local owner and the column stays insertable against older writers. `down` drops the columns.
- `OwnerId` (openwave-core) is the durable storage key of a principal. The server maps `Principal::LocalOwner` to `local` and `Principal::User(id)` to `user:<id>` — the prefix keeps operator-assigned user ids (which reject `:`) collision-free with the local key.
- Documents always carry their parent's owner: parented creation inherits the chat's/project's owner inside the store, standalone documents take the accepting principal's, and an upsert never changes a row's owner.

## The scoped surface

The trait grows `*_scoped` variants for the root query surface (get/list/create/delete, chat transcript + metadata update, project title update, document summaries + accept-source). Inside `DbStore` they filter or pre-check on the owner column under the same locks as the unscoped ops, so another owner's row is indistinguishable from a missing one — including a cross-owner project used as a chat parent and a cross-owner parent in document acceptance. Trait defaults delegate to the unscoped methods (documented as single-owner behavior), so the in-process test stores stay valid; the database store overrides every one.

The server's routes now call the scoped surface with the request principal from the slice-1 `AuthContext` extractor. On the desktop profile the only live principal is the local owner and all rows are local-owned, so every query resolves exactly as before. System paths that act on already-authorized ids (turn workers, blob retirement, titling) deliberately keep the unscoped surface; collapsing routes onto a store view bound to `AuthContext` — and retiring the per-route existence predicates — is slice 4.

Also regenerated `ui/src/generated/wire.ts`: a doc-comment change that landed on main left the generated bindings one comment line stale, which failed the staleness gate here.

## Tests

- `owner_scoped_queries_partition_root_aggregates` — two principals' chats, projects, and documents are disjoint under the scoped surface (reads, lists, mutations, deletes, and creation against another owner's parent), while the unscoped surface still sees everything and attributes new rows to the local owner.
- `owner_attribution_migration_backfills_existing_rows_to_the_local_owner` — rows inserted under the pre-owner schema read back as local-owned through the scoped surface after migrating.
- Rebased the connected-apps absorption test to locate its migration by name instead of assuming it is last.

Verified locally: full `openwave-core` lib suite (562 passed) and full `openwave-server` suite (534 + 5 passed), clippy `-D warnings` on both crates, rustfmt, `cargo check --workspace --locked --all-targets`. The migration and scoped filters use the shared SeaORM DSL with no Postgres-divergent path; the post-merge Postgres lane on main covers backend parity.

Part of #853.