### PR TITLE
feat(desktop): surface published outputs as clickable transcript cards

### DIFF
--- a/crates/openwave-code-execution/src/tool.rs
+++ b/crates/openwave-code-execution/src/tool.rs
@@ -260,6 +260,7 @@ impl Tool for ExecTool {
                     .map(|entry| {
                         json!({
                             "filename": entry.filename,
+                            "output_id": entry.output_id,
                             "version": entry.ordinal,
                             "status": match entry.status {
                                 crate::OutputArtifactStatus::Created => "created",
@@ -443,11 +444,13 @@ mod tests {
                 entries: vec![
                     crate::OutputArtifactEntry {
                         filename: "report.md".into(),
+                        output_id: "output-report".into(),
                         ordinal: 2,
                         status: crate::OutputArtifactStatus::Updated,
                     },
                     crate::OutputArtifactEntry {
                         filename: "data.csv".into(),
+                        output_id: "output-data".into(),
                         ordinal: 1,
                         status: crate::OutputArtifactStatus::Unchanged,
                     },

--- a/crates/openwave-code-execution/src/types.rs
+++ b/crates/openwave-code-execution/src/types.rs
@@ -531,6 +531,11 @@ pub enum OutputArtifactStatus {
 pub struct OutputArtifactEntry {
     /// Display filename, equal to the file's name under `output/`.
     pub filename: String,
+    /// The durable output the file landed on, as its canonical id string.
+    ///
+    /// Carried so the renderer's result projection can route a click to the
+    /// output rather than dead-ending at a name.
+    pub output_id: String,
     /// The output's current version ordinal after the scan.
     pub ordinal: u32,
     /// Whether the file created, updated, or matched the output.

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -220,6 +220,14 @@ pub struct ResultEntry {
     /// projections predate the field.
     #[serde(default)]
     pub media_type: Option<String>,
+    /// The durable output this row names, when the row is one.
+    ///
+    /// Data rather than display text: the renderer routes a click through its
+    /// own panel navigation and never prints the id. Present only on
+    /// [`ResultEntryKind::Output`] rows; `default` because retained
+    /// projections predate the field.
+    #[serde(default)]
+    pub output_id: Option<String>,
 }
 
 impl ResultEntry {
@@ -232,6 +240,7 @@ impl ResultEntry {
             detail: None,
             meta: None,
             media_type: None,
+            output_id: None,
         }
     }
 
@@ -253,6 +262,13 @@ impl ResultEntry {
     #[must_use]
     pub fn with_media_type(mut self, media_type: impl Into<String>) -> Self {
         self.media_type = Some(media_type.into());
+        self
+    }
+
+    /// Name the durable output this row is.
+    #[must_use]
+    pub fn with_output_id(mut self, output_id: impl Into<String>) -> Self {
+        self.output_id = Some(output_id.into());
         self
     }
 }
@@ -589,10 +605,18 @@ fn exec_output_entries(value: Option<&Value>) -> Vec<ResultEntry> {
             }
             let label = clamp(row.get("filename")?.as_str()?, MAX_RESULT_ENTRY_CHARS)?;
             let version = row.get("version")?.as_u64()?;
-            Some(
-                ResultEntry::new(ResultEntryKind::Output, label)
-                    .with_meta(format!("v{version} · {status}")),
-            )
+            // The media type is derived from the filename by the same rules
+            // output creation uses, so the transcript card and the outputs
+            // panel show one file with one icon.
+            let media_type = crate::deliverable::deliverable_media_type(&label)
+                .unwrap_or_else(|| crate::deliverable::binary_media_type_for_extension(&label));
+            let mut entry = ResultEntry::new(ResultEntryKind::Output, label)
+                .with_meta(format!("v{version} · {status}"))
+                .with_media_type(media_type);
+            if let Some(output_id) = row.get("output_id").and_then(Value::as_str) {
+                entry = entry.with_output_id(output_id);
+            }
+            Some(entry)
         })
         .take(MAX_RESULT_ENTRIES)
         .collect()
@@ -605,6 +629,7 @@ fn result_entry(value: &Value) -> Option<ResultEntry> {
         detail: entry_field(value.get("detail")),
         meta: entry_field(value.get("meta")),
         media_type: entry_field(value.get("media_type")),
+        output_id: entry_field(value.get("output_id")),
     })
 }
 
@@ -890,7 +915,7 @@ mod tests {
         let output = output_with_data(serde_json::json!({
             "exit_code": 0,
             "outputs": [
-                { "filename": "report.md", "version": 3, "status": "updated" },
+                { "filename": "report.md", "output_id": "output-report", "version": 3, "status": "updated" },
                 { "filename": "chart.png", "version": 1, "status": "created" },
                 { "filename": "data.csv", "version": 2, "status": "unchanged" },
                 { "filename": 7, "version": "x", "status": "created" },
@@ -914,6 +939,14 @@ mod tests {
         assert!(outputs
             .iter()
             .all(|entry| entry.kind == ResultEntryKind::Output));
+        // The routable id crosses when the scan recorded one — that is what
+        // makes the transcript card clickable — and the icon's media type is
+        // derived from the filename by the output-creation rules. A row
+        // without an id (older journal data) still renders, unrouted.
+        assert_eq!(outputs[0].output_id.as_deref(), Some("output-report"));
+        assert_eq!(outputs[0].media_type.as_deref(), Some("text/markdown"));
+        assert_eq!(outputs[1].output_id, None);
+        assert_eq!(outputs[1].media_type.as_deref(), Some("image/png"));
 
         // A pre-outputs journal row deserializes with the field defaulted.
         let stored: ToolResultPreview = serde_json::from_value(serde_json::json!({

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -296,6 +296,7 @@ describe("published outputs", () => {
           detail: null,
           meta: "v2 · updated",
           media_type: null,
+          output_id: null,
         },
       ],
     };

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -684,8 +684,8 @@ describe("mcp app views", () => {
               tool: "entries",
               elided: 3,
               entries: [
-                { kind: "file", label: "notes.md", detail: null, meta: "1.2 KB", mediaType: null },
-                { kind: "folder", label: "reports", detail: null, meta: null, mediaType: null },
+                { kind: "file", label: "notes.md", detail: null, meta: "1.2 KB", mediaType: null, outputId: null },
+                { kind: "folder", label: "reports", detail: null, meta: null, mediaType: null, outputId: null },
               ],
               failures: [],
             },
@@ -741,6 +741,7 @@ describe("mcp app views", () => {
                   detail: "Pages 3, 7",
                   meta: "2 matches",
                   mediaType: "application/pdf",
+                  outputId: null,
                 },
               ],
               failures: [],
@@ -787,7 +788,7 @@ describe("mcp app views", () => {
               tool: "entries",
               elided: 0,
               entries: [
-                { kind: "file", label: "q3.md", detail: null, meta: null, mediaType: null },
+                { kind: "file", label: "q3.md", detail: null, meta: null, mediaType: null, outputId: null },
               ],
               failures: [
                 { label: "q4.md", error: "file is not valid UTF-8" },
@@ -824,6 +825,63 @@ describe("mcp app views", () => {
 });
 
 describe("actionable tool results", () => {
+  it("opens a published output in the content panel from its card", async () => {
+    const user = userEvent.setup();
+    const { router } = await renderWithRouter(
+      <MessageList
+        messages={[
+          {
+            id: "exec-1",
+            role: "tool",
+            callId: "call-1",
+            name: "exec",
+            status: "completed",
+            preview: { tool: "exec", command: "python3", args: ["build_deck.py"] },
+            result: {
+              tool: "exec",
+              exit_code: 0,
+              timed_out: false,
+              output_truncated: false,
+              stdout: "",
+              stderr: "",
+              outputs: [
+                {
+                  kind: "output",
+                  label: "deck.pptx",
+                  detail: null,
+                  meta: "v1 · created",
+                  mediaType:
+                    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                  outputId: "output-1",
+                },
+              ],
+            },
+          },
+        ]}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open output deck.pptx" }));
+    await waitFor(() => {
+      expect(router.state.location.search).toMatchObject({
+        right: "outputs.output-1",
+      });
+    });
+  });
+
   it("takes an unconfigured web search directly to its settings section", async () => {
     const user = userEvent.setup();
     const { router } = await renderWithRouter(

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -30,6 +30,7 @@ import { ThinkingAccordion } from "./ThinkingAccordion";
 import { stripCitationDirectives } from "./citationDirectives";
 import { MessageCitationsProvider } from "./InlineCitation";
 import { McpAppCard } from "./McpAppCard";
+import { OutputCardList } from "./OutputCard";
 import { ToolCommandCard, type ToolCallStatus } from "./ToolCallCard";
 import { ErrorBoundary } from "./ErrorBoundary";
 import {
@@ -762,8 +763,10 @@ function surfacedCards(
   // than as two piles sorted by what kind of card they are.
   phase.forEach((entry, entryIndex) => {
     let card: ReactNode = null;
+    let outputCards: ReactNode = null;
     try {
       card = surfacedCard(entry, context);
+      outputCards = surfacedOutputCards(entry);
     } catch (error) {
       console.error("tool result card could not be built", error);
       // The entry's own id may be the unreadable part, so the placeholder is
@@ -771,8 +774,28 @@ function surfacedCards(
       card = <ToolActivityUnavailable key={`card-${entryIndex}`} />;
     }
     if (card !== null) cards.push(card);
+    if (outputCards !== null) cards.push(outputCards);
   });
   return cards;
+}
+
+/**
+ * The output cards an exec call earns, or `null` when it published nothing.
+ *
+ * Separate from {@link surfacedCard} because they are additive: the command
+ * card says what ran, and these say what it produced — one clickable card per
+ * created or updated output, the way Brightwave surfaces deliverables at the
+ * end of a turn.
+ */
+function surfacedOutputCards(entry: ChatMessage): ReactNode {
+  if (entry.role !== "tool" || entry.result?.tool !== "exec") return null;
+  const outputs = entry.result.outputs ?? [];
+  if (outputs.length === 0) return null;
+  return isolatedCard(
+    `${entry.id}-outputs`,
+    outputs.map((output) => output.outputId ?? output.label).join(" "),
+    <OutputCardList outputs={outputs} />,
+  );
 }
 
 /** The card one entry earns, or `null` when it earns none. */

--- a/crates/openwave-desktop/ui/src/OutputCard.tsx
+++ b/crates/openwave-desktop/ui/src/OutputCard.tsx
@@ -1,0 +1,64 @@
+import type { ResultEntry } from "@/api";
+import { DocumentIcon } from "@/components/document-table/DocumentIcon";
+import { usePanelNav } from "@/panel/usePanelNav";
+
+/**
+ * The cards a phase hangs under itself for the outputs it published.
+ *
+ * Mirrors Brightwave's deliverable cards at the end of a turn: one bordered
+ * card per created or updated output — type icon in a tinted chip, filename,
+ * version line — and a click opens the output in the content panel, where the
+ * document viewers (Univer for spreadsheets and docs, pdf.js for PDFs) take
+ * over. The exec card's collapsed rail still names the command; these cards
+ * carry the thing the reader actually came for.
+ */
+export function OutputCardList({ outputs }: { outputs: ResultEntry[] }) {
+  if (outputs.length === 0) return null;
+  return (
+    <div className="flex flex-col items-start gap-2" aria-label="Created outputs">
+      {outputs.map((entry) => (
+        <OutputCard key={`${entry.outputId ?? entry.label}`} entry={entry} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * One published output. Clickable only when the projection carries the durable
+ * output id; rows rehydrated from journals written before the id crossed still
+ * render, as the same card without a destination.
+ */
+function OutputCard({ entry }: { entry: ResultEntry }) {
+  const { openPanel } = usePanelNav();
+  const outputId = entry.outputId;
+  const body = (
+    <>
+      <span className="bg-muted rounded-md p-2" aria-hidden="true">
+        <DocumentIcon mediaType={entry.mediaType} className="size-5" />
+      </span>
+      <span className="flex min-w-0 flex-col">
+        <span className="truncate text-sm font-semibold">{entry.label}</span>
+        {entry.meta && (
+          <span className="text-muted-foreground text-xs tabular-nums">
+            {entry.meta}
+          </span>
+        )}
+      </span>
+    </>
+  );
+  const frame =
+    "bg-background inline-flex max-w-full min-w-0 items-center gap-3 rounded-lg border px-4 py-3 text-left shadow-sm";
+  if (outputId === null) {
+    return <div className={frame}>{body}</div>;
+  }
+  return (
+    <button
+      type="button"
+      className={`${frame} hover:bg-muted/40 cursor-pointer transition-colors`}
+      onClick={() => openPanel({ type: "outputs", outputId })}
+      aria-label={`Open output ${entry.label}`}
+    >
+      {body}
+    </button>
+  );
+}

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -1,4 +1,4 @@
-import { Check, Clock, FileOutput, Terminal, X } from "lucide-react";
+import { Check, Clock, Terminal, X } from "lucide-react";
 import {
   isRendererToolName,
   type ExecResultPreview,
@@ -246,7 +246,6 @@ export function ToolCommandCard({
   const running = presentation.tone === "running";
   const output = commandOutput(result);
   const images = result?.images ?? [];
-  const outputs = result?.outputs ?? [];
   // A command that finished silently has nothing to tab between, and a
   // "Command / Output → no output" pair reads as confusing noise.
   const tabbed = running || output !== null || images.length > 0;
@@ -258,7 +257,7 @@ export function ToolCommandCard({
       title={command.headline}
       titleClassName="font-mono"
       badge={<ToolStatusBadge presentation={presentation} result={result} />}
-      defaultExpanded={running || images.length > 0 || outputs.length > 0}
+      defaultExpanded={running || images.length > 0}
     >
       {tabbed ? (
         <Tabs defaultValue="output">
@@ -317,22 +316,6 @@ export function ToolCommandCard({
             {command.detail}
           </ScrollableContainer>
         </div>
-      )}
-      {outputs.length > 0 && (
-        <ul className="flex flex-col gap-0.5 px-2 pb-1.5" aria-label="Published outputs">
-          {outputs.map((entry) => (
-            <li
-              key={`${entry.label} ${entry.meta ?? ""}`}
-              className="text-muted-foreground flex items-center gap-1.5 text-xs"
-            >
-              <FileOutput className="size-3.5 shrink-0" aria-hidden="true" />
-              <span className="truncate">{entry.label}</span>
-              {entry.meta && (
-                <span className="text-2xs shrink-0 tabular-nums">{entry.meta}</span>
-              )}
-            </li>
-          ))}
-        </ul>
       )}
     </ToolCardShell>
   );

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -948,8 +948,16 @@ describe("parseToolResultPreview closed results", () => {
           detail: "scratch",
           meta: "1.2 KB",
           mediaType: "text/markdown",
+          outputId: null,
         },
-        { kind: "folder", label: "reports", detail: null, meta: null, mediaType: null },
+        {
+          kind: "folder",
+          label: "reports",
+          detail: null,
+          meta: null,
+          mediaType: null,
+          outputId: null,
+        },
       ],
       failures: [{ label: "q4.md", error: "unreadable" }],
     });

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -381,6 +381,8 @@ export type ResultEntry = {
   meta: string | null;
   /** The document's media type, when the row is a document with one. */
   mediaType: string | null;
+  /** The durable output this row names, when the row is one. */
+  outputId: string | null;
 };
 
 /** One thing a listed call could not do. */
@@ -2140,17 +2142,19 @@ function parseResultEntry(value: unknown): ResultEntry | null {
   const detail = value.detail ?? null;
   const meta = value.meta ?? null;
   const mediaType = value.media_type ?? null;
+  const outputId = value.output_id ?? null;
   if (
     typeof label !== "string" ||
     label.length === 0 ||
     !(RESULT_ENTRY_KINDS as readonly unknown[]).includes(kind) ||
     !isOptionalString(detail) ||
     !isOptionalString(meta) ||
-    !isOptionalString(mediaType)
+    !isOptionalString(mediaType) ||
+    !isOptionalString(outputId)
   ) {
     return null;
   }
-  return { kind: kind as ResultEntryKind, label, detail, meta, mediaType };
+  return { kind: kind as ResultEntryKind, label, detail, meta, mediaType, outputId };
 }
 
 /**

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1240,7 +1240,16 @@ meta: string | null,
  * own closed mapping with a generic fallback. `default` because retained
  * projections predate the field.
  */
-media_type: string | null, };
+media_type: string | null, 
+/**
+ * The durable output this row names, when the row is one.
+ *
+ * Data rather than display text: the renderer routes a click through its
+ * own panel navigation and never prints the id. Present only on
+ * [`ResultEntryKind::Output`] rows; `default` because retained
+ * projections predate the field.
+ */
+output_id: string | null, };
 
 /**
  * What one row of a listed result is, which is what picks its icon.
@@ -1374,7 +1383,7 @@ end_published_at: string | null, } | { "tool": "web_extract", url: string, };
  *
  * Each presentable variant names the egress a human is consenting to, so the
  * renderer can describe the action without ever seeing the model-authored
- * summary or arguments. `Unsupported` is the fail-closed default: a Sensitive
+ * arguments. `Unsupported` is the fail-closed default: a Sensitive
  * action the server can only reject, never approve.
  */
 export type ToolApprovalKind = "search_may_share_query_and_excerpts" | "web_search_may_share_query" | "web_extract_may_fetch_url" | "exec_may_run_networked_command" | "external_mcp_may_call_server" | "workspace_may_modify_files" | "unsupported";

--- a/crates/openwave-desktop/ui/src/panel/panelTypes.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelTypes.ts
@@ -48,10 +48,13 @@ export function areSamePanelType(a: PanelContent, b: PanelContent): boolean {
 export function isContentPanel(panel: PanelContent): boolean {
   switch (panel.type) {
     case "chat":
-    case "outputs":
     case "folders":
     case "apps":
       return false;
+    case "outputs":
+      // The outputs list is navigation; a single opened output is the thing
+      // you picked, and reads on the content side like a document does.
+      return panel.outputId !== undefined;
     case "document":
       return true;
   }

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -1602,6 +1602,7 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
                 .into_iter()
                 .map(|entry| OutputArtifactEntry {
                     filename: entry.filename,
+                    output_id: entry.output_id.to_string(),
                     ordinal: entry.ordinal,
                     status: match entry.status {
                         openwave_core::OutputSyncStatus::Created => OutputArtifactStatus::Created,


### PR DESCRIPTION
## Problem

When a turn's exec publishes files under `output/`, the transcript only shows a small text list inside the collapsed command card — no per-type icon, no click target. The reader has to open the Outputs panel and hunt for the file. (#702)

## Change

Brightwave-style deliverable cards, driven by data that already existed one hop away:

- The output scan records each file's durable `OutputId`, but `collect_output_artifacts` dropped it. It now rides `OutputArtifactEntry` → the exec tool result data → the result projection: `ResultEntry` gains an optional `output_id`, and output rows also carry a `media_type` derived from the filename by the same rules output creation uses, so the transcript icon and the outputs panel agree.
- New `OutputCardList`/`OutputCard`: one bordered card per created/updated output under the command card — type icon chip (`DocumentIcon`: Excel/Word/PowerPoint/PDF brand marks), filename, version line. Click opens `{type: "outputs", outputId}`. Rows rehydrated from journals written before the id crossed still render as cards without a destination.
- The plain-text outputs list inside `ToolCommandCard` is replaced by the cards.
- Panel routing: a single opened output is now a content panel (right side, like a document); the outputs list stays navigation (left). This is what puts the already-integrated Univer spreadsheet/doc viewers and pdf.js one click from the transcript.

## Tests

- `preview.rs`: extended the exec outputs projection test — id crosses when recorded, media type derived, id-less rows read back unrouted.
- `MessageList.dom.test.tsx`: clicking a published output's card navigates to `right=outputs.<id>`.
- Full runs locally: openwave-core lib (561), openwave-code-execution (68), server code_execution module, UI vitest (677) and `tsc`. Wire bindings regenerated with `UPDATE_WIRE_TYPES=1`.

Closes #702