### PR TITLE
feat(server): 60s default exec timeout with an honest prompt and timeout receipt

### DIFF
--- a/crates/openwave-code-execution/src/tool.rs
+++ b/crates/openwave-code-execution/src/tool.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -190,7 +191,17 @@ impl Tool for ExecTool {
             response.provider, response.duration_ms
         );
         if response.timed_out {
-            content.push_str("\ntimed_out: true");
+            // A timeout is not an ordinary failure: the command was killed by
+            // the host's time limit, so its output can be empty or partial.
+            // Say so plainly, or an empty stderr reads as an inexplicable
+            // crash and invites blind retries.
+            let _ = write!(
+                content,
+                "\ntimed_out: true (the host killed this command at its execution time limit \
+                 after {} ms; stdout/stderr may be empty or incomplete — split the work into \
+                 smaller commands rather than rerunning this one unchanged)",
+                response.duration_ms
+            );
         }
         if response.output_truncated {
             content.push_str("\noutput_truncated: true");
@@ -363,6 +374,54 @@ mod tests {
         assert!(spec.description.contains(".openwave/exec-scripts"));
         assert!(spec.description.contains("render_pdf.py"));
         assert!(spec.description.contains("analyze_xlsx.py"));
+    }
+
+    struct TimedOutProvider;
+
+    #[async_trait]
+    impl CodeExecutionProvider for TimedOutProvider {
+        async fn execute(
+            &self,
+            _request: CodeExecutionRequest,
+        ) -> std::result::Result<CodeExecutionResponse, CodeExecutionError> {
+            Ok(CodeExecutionResponse {
+                provider: CodeExecutionProviderKind::Local,
+                exit_code: None,
+                stdout: String::new(),
+                stderr: String::new(),
+                timed_out: true,
+                output_truncated: false,
+                duration_ms: 60_012,
+                sync_notes: Vec::new(),
+            })
+        }
+    }
+
+    /// A timeout must read as the host's time limit, not as an inexplicable
+    /// failure with empty stderr — the E2B incident showed the model retrying
+    /// killed installs because the receipt said nothing.
+    #[tokio::test]
+    async fn timed_out_receipt_names_the_time_limit() {
+        let tool = ExecTool::new(Arc::new(TimedOutProvider));
+        let output = tool
+            .execute(
+                &ToolCtx::new_legacy_workspace(ChatId::new(), None, PathBuf::from("/tmp/unused"))
+                    .with_call_id(CallId::new()),
+                json!({"command": "pip", "args": ["install", "python-pptx"]}),
+            )
+            .await
+            .unwrap();
+
+        assert!(output.is_error);
+        assert!(
+            output
+                .content
+                .contains("killed this command at its execution time limit"),
+            "{}",
+            output.content
+        );
+        assert!(output.content.contains("60012 ms"), "{}", output.content);
+        assert_eq!(output.data.as_ref().unwrap()["timed_out"], true);
     }
 
     struct PreviewProvider {

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -39,7 +39,10 @@ use crate::exec_write_snapshot::TurnSnapshotSink;
 use crate::state::BlobWriteGuard;
 
 const CODE_EXECUTION_SETTING: &str = "code_execution";
-pub const DEFAULT_TIMEOUT_MS: u64 = 20_000;
+/// Generous enough for a cold `pip install` that pulls compiled wheels
+/// (lxml, Pillow); 20s proved too tight and cut installs off mid-retry with
+/// empty stderr. Still host-owned: the model cannot request a longer limit.
+pub const DEFAULT_TIMEOUT_MS: u64 = 60_000;
 pub const MIN_TIMEOUT_MS: u64 = 1_000;
 pub const MAX_TIMEOUT_MS: u64 = 120_000;
 const MAX_NETWORK_ALLOWED_HOSTS: usize = 64;
@@ -942,6 +945,17 @@ impl ConfiguredCodeExecutionProvider {
         match self.shared_package_cache().await {
             Some(cache) => cache.is_ready(),
             None => false,
+        }
+    }
+
+    /// The host-configured per-command time limit, for truthful
+    /// operating-prompt steering. Execution re-reads the setting per
+    /// invocation; this is the same value rendered ahead of time so the model
+    /// can plan long-running commands around it.
+    pub(crate) async fn current_timeout_ms(&self) -> u64 {
+        match read_config(&*self.store).await {
+            Ok(config) => config.timeout_ms,
+            Err(_) => DEFAULT_TIMEOUT_MS,
         }
     }
 

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -57,7 +57,15 @@ const MCP_HEADING: &str = "## External MCP tools";
 #[must_use]
 #[cfg(test)]
 pub(crate) fn compose(specs: &[ToolSpec]) -> String {
-    compose_for_surface(specs, &[], &[], &NetworkPolicy::default(), false, false)
+    compose_for_surface(
+        specs,
+        &[],
+        &[],
+        &NetworkPolicy::default(),
+        crate::code_execution::DEFAULT_TIMEOUT_MS,
+        false,
+        false,
+    )
 }
 
 /// Render a host path as a quoted JSON string, so a path carrying a quote or a
@@ -73,6 +81,16 @@ fn quoted_host(host: &str) -> String {
     serde_json::to_string(host).expect("serializing a host string cannot fail")
 }
 
+/// Render the host-configured exec time limit in the most readable exact
+/// unit; the value is validated host state, so it composes without quoting.
+fn render_timeout(timeout_ms: u64) -> String {
+    if timeout_ms % 1000 == 0 {
+        format!("{} seconds", timeout_ms / 1000)
+    } else {
+        format!("{timeout_ms} milliseconds")
+    }
+}
+
 /// Compose the prompt for one exact tool surface, with a bounded snapshot of
 /// host-resolved local-exec folders, in the chat's current permission
 /// posture. The sandbox profile resolves the folders again per invocation.
@@ -86,6 +104,7 @@ pub(crate) fn compose_for_surface(
     exec_folders: &[ResolvedExecFolderGrant],
     skills: &[SkillPackage],
     network_policy: &NetworkPolicy,
+    exec_timeout_ms: u64,
     offline_package_cache: bool,
     plan_mode: bool,
 ) -> String {
@@ -291,6 +310,13 @@ pub(crate) fn compose_for_surface(
             "- Use `exec` for bounded computation or validation when it improves the result. Keep generated intermediates in private scratch."
                 .to_owned(),
         ];
+        // The time limit is host state rendered the way the network policy
+        // is below: the model can plan around the current value but cannot
+        // change it, and execution re-reads the setting per invocation.
+        lines.push(format!(
+            "- Each command is killed by the host after {}; no argument extends this, and only the user can change it. Cold package installs and builds can exceed the limit — split long-running work into smaller commands, and when a result reports timed_out, report that instead of rerunning the same command unchanged.",
+            render_timeout(exec_timeout_ms)
+        ));
         // The chat's live policy composes into the prompt the way folder
         // grants do below: the host renders the current value, and stored
         // host names are JSON-quoted so they cannot forge a prompt line.
@@ -524,6 +550,7 @@ fn push_section<S: AsRef<str>>(prompt: &mut String, heading: &str, lines: &[S]) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::code_execution::DEFAULT_TIMEOUT_MS as TIMEOUT;
     use serde_json::json;
     use uuid::Uuid;
 
@@ -633,8 +660,24 @@ mod tests {
     #[test]
     fn plan_mode_adds_the_planning_contract_and_nothing_else() {
         let specs = [spec("read_file"), spec("list_sources")];
-        let plan = compose_for_surface(&specs, &[], &[], &NetworkPolicy::default(), false, true);
-        let normal = compose_for_surface(&specs, &[], &[], &NetworkPolicy::default(), false, false);
+        let plan = compose_for_surface(
+            &specs,
+            &[],
+            &[],
+            &NetworkPolicy::default(),
+            TIMEOUT,
+            false,
+            true,
+        );
+        let normal = compose_for_surface(
+            &specs,
+            &[],
+            &[],
+            &NetworkPolicy::default(),
+            TIMEOUT,
+            false,
+            false,
+        );
 
         assert!(plan.contains(PLAN_MODE_HEADING));
         assert!(plan.contains("do not carry it out"));
@@ -681,6 +724,7 @@ mod tests {
             &folders,
             &[],
             &NetworkPolicy::default(),
+            TIMEOUT,
             false,
             false,
         );
@@ -703,7 +747,7 @@ mod tests {
     #[test]
     fn network_policy_renders_truthfully_per_value() {
         let compose_with = |policy: &NetworkPolicy| {
-            compose_for_surface(&[spec("exec")], &[], &[], policy, false, false)
+            compose_for_surface(&[spec("exec")], &[], &[], policy, TIMEOUT, false, false)
         };
         let pip_line = "python3 -m pip install --user";
 
@@ -716,8 +760,15 @@ mod tests {
         // With verified shared wheels mounted, an off policy still supports
         // offline installs from the read-only cache — and says so instead of
         // claiming installs are unavailable.
-        let off_with_cache =
-            compose_for_surface(&[spec("exec")], &[], &[], &NetworkPolicy::Off, true, false);
+        let off_with_cache = compose_for_surface(
+            &[spec("exec")],
+            &[],
+            &[],
+            &NetworkPolicy::Off,
+            TIMEOUT,
+            true,
+            false,
+        );
         assert!(off_with_cache.contains("no outbound network access"));
         assert!(off_with_cache.contains("--no-index --find-links \"$OPENWAVE_PACKAGE_CACHE\""));
         assert!(!off_with_cache.contains("package installs are unavailable"));
@@ -754,10 +805,25 @@ mod tests {
         assert!(hosts_with_registries.contains("plus package-manager registries"));
         assert!(hosts_with_registries.contains(pip_line));
 
-        // Every posture keeps the shared contract lines.
+        // Every posture keeps the shared contract lines, including the
+        // rendered host time limit the model plans long commands around.
         for prompt in [&off, &packages, &open, &hosts] {
             assert!(prompt.contains("Only the user can change the network policy"));
+            assert!(prompt.contains("killed by the host after 60 seconds"));
         }
+
+        // A non-integral-second setting renders exactly, never rounded into
+        // a claim the host does not enforce.
+        let odd = compose_for_surface(
+            &[spec("exec")],
+            &[],
+            &[],
+            &NetworkPolicy::Open,
+            1_500,
+            false,
+            false,
+        );
+        assert!(odd.contains("killed by the host after 1500 milliseconds"));
     }
 
     #[test]
@@ -786,6 +852,7 @@ mod tests {
             &[],
             &skills,
             &NetworkPolicy::default(),
+            TIMEOUT,
             false,
             false,
         );
@@ -803,6 +870,7 @@ mod tests {
             &[],
             &skills,
             &NetworkPolicy::default(),
+            TIMEOUT,
             false,
             false,
         );
@@ -813,6 +881,7 @@ mod tests {
             &[],
             &skills[1..],
             &NetworkPolicy::default(),
+            TIMEOUT,
             false,
             false,
         );
@@ -895,13 +964,14 @@ mod tests {
             &[],
             &skills,
             &NetworkPolicy::default(),
+            TIMEOUT,
             false,
             false,
         );
 
         assert_eq!(
             identity(&prompt),
-            "foreground-v2:sha256:32d5254bcdf0481d32c5da177458ab3e40fd157d4d99b2fa66c571c4dcc4ecec"
+            "foreground-v2:sha256:a37f05bd14906db68575354e6118609ce6a2b5e8f908aeee4abad6ac2e1cb072"
         );
     }
 }

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -147,6 +147,7 @@ pub(crate) fn freeze_foreground_turn_surface(
         &[],
         &[],
         &openwave_core::NetworkPolicy::default(),
+        crate::code_execution::DEFAULT_TIMEOUT_MS,
         false,
         false,
     )
@@ -159,6 +160,7 @@ fn freeze_foreground_turn_surface_with_folders(
     exec_folders: &[crate::code_execution::ResolvedExecFolderGrant],
     skills: &[openwave_code_execution::SkillPackage],
     network_policy: &openwave_core::NetworkPolicy,
+    exec_timeout_ms: u64,
     offline_package_cache: bool,
     plan_mode: bool,
 ) -> ForegroundTurnSurface {
@@ -168,6 +170,7 @@ fn freeze_foreground_turn_surface_with_folders(
         exec_folders,
         skills,
         network_policy,
+        exec_timeout_ms,
         offline_package_cache,
         plan_mode,
     ));
@@ -590,12 +593,17 @@ impl TurnWorker {
             Some(provider) => provider.offline_package_cache_ready().await,
             None => false,
         };
+        let exec_timeout_ms = match self.exec_folder_context.as_ref() {
+            Some(provider) => provider.current_timeout_ms().await,
+            None => crate::code_execution::DEFAULT_TIMEOUT_MS,
+        };
         let surface = freeze_foreground_turn_surface_with_folders(
             tools,
             &self.agent_config,
             &exec_folders,
             &skills,
             &chat.network_policy,
+            exec_timeout_ms,
             offline_package_cache,
             matches!(
                 chat.permission_mode,

--- a/docs/code-execution.md
+++ b/docs/code-execution.md
@@ -26,7 +26,7 @@ The initial state is:
 ```json
 {
   "provider": "local",
-  "timeout_ms": 20000,
+  "timeout_ms": 60000,
   "available": true,
   "has_credential": false
 }
@@ -35,7 +35,7 @@ The initial state is:
 `available` reports whether the selected native confinement primitive exists on
 the current host. The example above is the supported macOS state; it is false
 when execution is disabled or unsupported.
-Timeouts must be between 1 and 120 seconds. Sending `{"provider": null}`
+Timeouts must be between 1 and 120 seconds; the default is 60 seconds, enough headroom for a cold package install that pulls compiled wheels. Sending `{"provider": null}`
 disables execution; sending `{"provider": "local"}` enables the local adapter.
 `e2b` and `daytona` select the managed adapters, which become available once
 their fixed credential slot is populated. No executable, endpoint, environment


### PR DESCRIPTION
The 20-second default command timeout was too tight for real work: a cold `pip install python-pptx` pulling lxml and Pillow wheels legitimately exceeds it, and when it fired the model saw an exit with empty stderr and a bare `timed_out` flag — which read as an inexplicable failure and invited blind retries (this is exactly what masked the E2B diagnosis behind #1366).

Three changes, all keeping the principle that the model cannot set or extend timeouts:

- **Default raised to 60 seconds** (`DEFAULT_TIMEOUT_MS`), matching what manual tuning settled on. The 1s floor and 120s cap are unchanged, and the timeout remains host-settings-only.
- **The operating prompt now states the limit.** The Code execution section renders the host-configured value the same way it renders the network policy: the exact limit, that no argument extends it and only the user can change it, and that long installs should be split into smaller commands with timeouts reported rather than rerun unchanged. Composition threads the live setting through `compose_for_surface`, with the value re-read per turn.
- **The timeout receipt is honest.** Instead of `timed_out: true` alone, the exec result now says the host killed the command at its execution time limit after N ms and that stdout/stderr may be empty or partial, so a timeout is distinguishable from a command failure.

No classifier: rather than guessing which commands are installs, the prompt gives the model the real number to plan around — the simplest mechanism that stays truthful for any host-configured value.

Verified with `cargo check --locked --all-targets` and the full local test suites of both touched crates; the prompt golden identity was updated for the one new section line, and a new test pins the timed-out receipt wording. Docs updated to the new default.