### PR TITLE
fix(core): report a lost failure-resolution race instead of erroring on a passed retry time

### DIFF
--- a/crates/openwave-core/src/db/ops/turn/resolution.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution.rs
@@ -529,12 +529,6 @@ async fn record_turn_run_failure_inner(
             terminal_event: sequenced_event,
         }));
     }
-    if requested_retry_at.is_some_and(|retry_at| retry_at <= requested_at) {
-        return Err(AgentError::Store(
-            "turn retry time must be after failure resolution time".into(),
-        ));
-    }
-
     let journal_chat_id = journal_chat_id(store, id, true).await?;
     if journal_chat_id.is_none() {
         return Ok(None);
@@ -558,11 +552,6 @@ async fn record_turn_run_failure_inner(
         requested_at,
         super::super::agent_run::database_now(&transaction).await?,
     );
-    if requested_retry_at.is_some_and(|retry_at| retry_at <= now) {
-        return Err(AgentError::Store(
-            "turn retry time must be after failure resolution time".into(),
-        ));
-    }
     if let Some(existing) = exact_turn_failure_on(
         &transaction,
         id,
@@ -617,6 +606,17 @@ async fn record_turn_run_failure_inner(
     {
         transaction.commit().await.map_err(store_err)?;
         return Ok(None);
+    }
+    // Enforce the future-retry invariant only for a caller that still holds
+    // the live lease. A worker retrying its exact failure request after losing
+    // the resolution race to the lease scanner arrives here with a retry time
+    // the wall clock may have passed; erroring before the stale-lease checks
+    // above would wedge that worker in a permanent retry loop instead of
+    // telling it the turn is no longer its to resolve.
+    if requested_retry_at.is_some_and(|retry_at| retry_at <= now) {
+        return Err(AgentError::Store(
+            "turn retry time must be after failure resolution time".into(),
+        ));
     }
     if model_steps < turn.model_steps {
         return Err(AgentError::Store(

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -6066,6 +6066,81 @@ async fn turn_failure_receipt_recovers_exact_retries_after_the_turn_advances() {
     );
 }
 
+/// CI-observed wedge: a worker that loses the failure-resolution race to the
+/// lease scanner retries its exact request after the wall clock has passed its
+/// requested retry time. That caller must learn the lease is no longer its to
+/// resolve (`Ok(None)`), not receive the future-retry invariant error forever.
+#[tokio::test]
+async fn stale_lease_failure_with_passed_retry_time_reports_the_lost_race() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let turn_id = TurnId::new();
+    let accepted = match store
+        .accept_turn(turn_id, chat.id, "gpt-5", "hello")
+        .await
+        .unwrap()
+    {
+        AcceptTurnOutcome::Accepted(turn) => turn,
+        outcome => panic!("unexpected acceptance outcome: {outcome:?}"),
+    };
+    set_turn_max_attempts(&store, turn_id, 2).await;
+    let claimed_at = accepted.available_at + chrono::Duration::seconds(1);
+    let worker_token = uuid::Uuid::new_v4();
+    let lease_expires_at = claimed_at + chrono::Duration::minutes(2);
+    store
+        .claim_turn_run(worker_token, claimed_at, lease_expires_at)
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+
+    // The scanner claims past the worker's lease, which retries the turn on a
+    // scan lease, then expires that lease too, terminalizing the turn out from
+    // under the worker.
+    let scan_at = lease_expires_at + chrono::Duration::microseconds(1);
+    let retried = store
+        .claim_turn_run(
+            uuid::Uuid::new_v4(),
+            scan_at,
+            scan_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap()
+        .turn
+        .unwrap();
+    let second_scan_at =
+        retried.lease_expires_at.unwrap() + chrono::Duration::microseconds(1);
+    let scanned = store
+        .claim_turn_run(
+            uuid::Uuid::new_v4(),
+            second_scan_at,
+            second_scan_at + chrono::Duration::minutes(1),
+        )
+        .await
+        .unwrap();
+    assert!(scanned.terminal_event.is_some());
+
+    // The worker retries its exact failure request; its retry time is now in
+    // the past relative to both the request and the database clock.
+    assert_eq!(
+        store
+            .record_turn_run_failure(
+                turn_id,
+                worker_token,
+                second_scan_at + chrono::Duration::seconds(1),
+                TurnFailureRetry::RetryAt(claimed_at + chrono::Duration::seconds(2)),
+                0,
+                Usage::default(),
+                "provider_unavailable",
+                Some("temporary outage"),
+            )
+            .await
+            .unwrap(),
+        None
+    );
+}
+
 #[tokio::test]
 async fn turn_failure_exhaustion_retains_retry_intent_and_rolls_back_atomically() {
     let (_dir, store) = temp_store().await;

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -6109,8 +6109,7 @@ async fn stale_lease_failure_with_passed_retry_time_reports_the_lost_race() {
         .unwrap()
         .turn
         .unwrap();
-    let second_scan_at =
-        retried.lease_expires_at.unwrap() + chrono::Duration::microseconds(1);
+    let second_scan_at = retried.lease_expires_at.unwrap() + chrono::Duration::microseconds(1);
     let scanned = store
         .claim_turn_run(
             uuid::Uuid::new_v4(),


### PR DESCRIPTION
Main's post-merge `test` lane failed twice today. One failure was the wire-types staleness check, which #1356's merge already fixed by landing the regenerated bindings; the other was `scanner_won_failure_does_not_wedge_the_only_worker_lane` wedging until its timeout in run 30833538967, and it is a real latent bug on slow runners.

When a turn worker loses the failure-resolution race to the lease scanner, it retries its exact failure request, deliberately reusing the same `requested_retry_at`. On a slow runner the database clock can pass that retry time before the retry lands. `record_turn_run_failure_inner` checked the future-retry invariant before the claim and lease validation, so instead of learning the lease was no longer its to resolve (`Ok(None)`), the worker received `turn retry time must be after failure resolution time` — a deterministic store error — on every subsequent attempt, and the retry loop wedged the lane forever.

The fix moves the invariant check after the stale-lease checks inside the transaction and drops the pre-transaction duplicate, so the invariant only applies to a caller that still holds the live lease. The database-level constraint on `turn_failure.requested_retry_at` is unchanged and still backstops the insert.

Adds a store-level regression test that reproduces the CI failure exactly: scanner expires the worker's lease, retries, then terminalizes the turn; the worker's exact retry with a now-past retry time must report the lost race, not error. It fails with the observed CI error message without the fix.

Verified locally: full `cargo test -p openwave-core --locked` (567 passed) and `cargo test -p openwave-server --locked` (544 passed, including the scanner race tests and the wire-types staleness check) on this branch rebased onto current main.