### PR TITLE
feat(server): surface per-provider detached-admission denials in settings

### DIFF
--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -503,7 +503,15 @@ export type CodeExecutionConfigInfo = { provider?: CodeExecutionProviderKind, ti
  * status, so the renderer can present the policy and disclose which
  * providers actually restrict egress today.
  */
-egress: CodeExecutionEgressInfo, };
+egress: CodeExecutionEgressInfo, 
+/**
+ * Per-provider detached-admission evaluation: for each execution
+ * provider, whether the fail-closed gate (issue #824) would admit a
+ * detached run it hosted, and every named precondition it fails. Derived
+ * by running the real admission evaluator over each provider's declared
+ * capabilities — the settings surface and the gate cannot disagree.
+ */
+detached_admission: Array<DetachedAdmissionProviderInfo>, };
 
 /**
  * Renderer-safe readiness for one managed provider's fixed credential slot.
@@ -583,6 +591,32 @@ context_window: number,
  * Maximum output sent to the endpoint.
  */
 max_output_tokens: number, };
+
+/**
+ * Wire mirror of the admission gate's typed denial reasons
+ * ([`crate::sandbox_admission::DetachedAdmissionDenial`]), so the renderer
+ * maps each to user-facing language instead of receiving prose the server
+ * composed.
+ */
+export type DetachedAdmissionDenialReason = "no_scoped_model_token" | "no_external_lifetime_cap" | "image_not_verified" | "host_authority_tool_surface" | "credentials_without_external_egress";
+
+/**
+ * One provider's detached-admission verdict, renderer-safe.
+ *
+ * `denials` is what the real evaluator returned for this provider's declared
+ * capabilities: empty exactly when `admitted`. The rows exist even for
+ * providers that cannot host background runs at all — every precondition is
+ * simply unestablished for them, and the fail-closed evaluation names each.
+ */
+export type DetachedAdmissionProviderInfo = { provider: CodeExecutionProviderKind, 
+/**
+ * Whether the gate would admit a detached run hosted by this provider.
+ */
+admitted: boolean, 
+/**
+ * Every unmet precondition, named — not just the first.
+ */
+denials: Array<DetachedAdmissionDenialReason>, };
 
 /**
  * Identifies an authoritative source document.

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
@@ -36,6 +36,40 @@ const OPEN_EGRESS: CodeExecutionConfigInfo["egress"] = {
   ],
 };
 
+/**
+ * Today's server position: no provider is admitted for detached runs, and the
+ * local row names the three structural gaps.
+ */
+const NO_DETACHED: CodeExecutionConfigInfo["detached_admission"] = [
+  {
+    provider: "local",
+    admitted: false,
+    denials: [
+      "no_scoped_model_token",
+      "no_external_lifetime_cap",
+      "image_not_verified",
+    ],
+  },
+  {
+    provider: "e2b",
+    admitted: false,
+    denials: [
+      "no_scoped_model_token",
+      "no_external_lifetime_cap",
+      "image_not_verified",
+    ],
+  },
+  {
+    provider: "daytona",
+    admitted: false,
+    denials: [
+      "no_scoped_model_token",
+      "no_external_lifetime_cap",
+      "image_not_verified",
+    ],
+  },
+];
+
 function clientFor(
   config: CodeExecutionConfigInfo,
   credentials: CodeExecutionCredentialReadiness[] = [
@@ -79,6 +113,7 @@ describe("CodeExecutionPanel", () => {
         available: false,
         has_credential: false,
         egress: OPEN_EGRESS,
+      detached_admission: NO_DETACHED,
       });
 
     render(<CodeExecutionPanel client={client} />);
@@ -122,6 +157,7 @@ describe("CodeExecutionPanel", () => {
         available: true,
         has_credential: true,
         egress: OPEN_EGRESS,
+      detached_admission: NO_DETACHED,
       },
       [
         { provider: "e2b", has_credential: true },
@@ -148,6 +184,7 @@ describe("CodeExecutionPanel", () => {
       available: true,
       has_credential: true,
       egress: OPEN_EGRESS,
+      detached_admission: NO_DETACHED,
     });
 
     render(<CodeExecutionPanel client={client} />);
@@ -168,6 +205,7 @@ describe("CodeExecutionPanel", () => {
       available: true,
       has_credential: true,
       egress: OPEN_EGRESS,
+      detached_admission: NO_DETACHED,
     });
 
     render(<CodeExecutionPanel client={client} />);
@@ -188,6 +226,7 @@ describe("CodeExecutionPanel", () => {
       available: true,
       has_credential: false,
       egress: OPEN_EGRESS,
+      detached_admission: NO_DETACHED,
     });
 
     render(<CodeExecutionPanel client={client} />);
@@ -199,5 +238,33 @@ describe("CodeExecutionPanel", () => {
 
     await screen.findByRole("alert");
     expect(putCodeExecutionConfig).not.toHaveBeenCalled();
+  });
+
+  it("explains per provider why detached runs are unavailable, in plain language", async () => {
+    const { client } = clientFor({
+      provider: "local",
+      timeout_ms: 20_000,
+      available: true,
+      has_credential: false,
+      egress: OPEN_EGRESS,
+      detached_admission: NO_DETACHED,
+    });
+
+    render(<CodeExecutionPanel client={client} />);
+
+    // One "Not available" badge per provider, and the typed denial reasons
+    // are rendered as honest sentences — never raw enum names.
+    expect(await screen.findAllByText("Not available")).toHaveLength(3);
+    expect(
+      screen.getAllByText(/token limited to a single run/i).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/limits how long it can live/i).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/isn't yet verified against a trusted source/i)
+        .length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText(/no_scoped_model_token/)).toBeNull();
   });
 });

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
@@ -216,6 +216,13 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
             />
           </SettingsSection>
 
+          <SettingsSection
+            title="Detached background runs"
+            description="A detached run keeps working in its sandbox even when this app is closed. It is only allowed when every safety precondition holds; until then, background runs stay attached and end with the app."
+          >
+            <DetachedAdmissionDisclosure rows={config.detached_admission} />
+          </SettingsSection>
+
           {/* One save for the whole surface: it stores every key typed above
               and the selection together, so a provider cannot go active in a
               pass that failed to save its key. */}
@@ -242,6 +249,76 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
 
 type EgressEnforcementRow =
   CodeExecutionConfigInfo["egress"]["enforcement"][number];
+
+type DetachedAdmissionRow =
+  CodeExecutionConfigInfo["detached_admission"][number];
+type DetachedAdmissionDenialReason = DetachedAdmissionRow["denials"][number];
+
+/**
+ * Each typed denial reason mapped to an honest sentence: what is missing, and
+ * what would change it. The reasons come from the server's real admission
+ * evaluator, so this list is exactly what the gate would deny a run for —
+ * the surface never composes its own judgement.
+ */
+const DETACHED_DENIAL_SENTENCES: Record<DetachedAdmissionDenialReason, string> =
+  {
+    no_scoped_model_token:
+      "The model gateway can't yet issue a token limited to a single run, so a detached run would have to carry a long-lived credential. This clears when the gateway can mint run-scoped tokens.",
+    no_external_lifetime_cap:
+      "Nothing outside the sandbox limits how long it can live, so a run this app never reconnects to would keep running unbounded. This needs a provider that enforces a time limit at creation.",
+    image_not_verified:
+      "The sandbox image isn't yet verified against a trusted source before it runs.",
+    host_authority_tool_surface:
+      "The run's tools could reach an operation that needs your approval mid-run, and a detached run has no one to ask.",
+    credentials_without_external_egress:
+      "The run would carry third-party credentials without an externally enforced network boundary keeping them from leaving.",
+  };
+
+const DETACHED_PROVIDER_LABEL: Record<
+  DetachedAdmissionRow["provider"],
+  string
+> = {
+  local: "Local native sandbox",
+  e2b: "E2B cloud sandbox",
+  daytona: "Daytona cloud sandbox",
+};
+
+/**
+ * Per-provider detached-admission disclosure: for each execution provider,
+ * whether a detached run would be allowed, and — when it wouldn't — every
+ * unmet precondition in plain language, so the user can see why detached
+ * execution is unavailable and what would change it.
+ */
+function DetachedAdmissionDisclosure({
+  rows,
+}: {
+  rows: CodeExecutionConfigInfo["detached_admission"];
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      {rows.map((row) => (
+        <div key={row.provider} className="flex flex-col gap-1 text-sm">
+          <div className="flex items-center gap-2">
+            <Badge variant={row.admitted ? "success" : "warning"} size="sm">
+              {row.admitted ? "Available" : "Not available"}
+            </Badge>
+            <span className="font-medium text-foreground">
+              {DETACHED_PROVIDER_LABEL[row.provider]}
+            </span>
+          </div>
+          {!row.admitted && (
+            <ul className="ml-5 list-disc text-muted-foreground">
+              {row.denials.map((denial) => (
+                <li key={denial}>{DETACHED_DENIAL_SENTENCES[denial]}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 
 /**
  * How each enforcement status reads: the badge never claims a boundary a

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -349,6 +349,12 @@ pub struct CodeExecutionConfigInfo {
     /// status, so the renderer can present the policy and disclose which
     /// providers actually restrict egress today.
     pub egress: CodeExecutionEgressInfo,
+    /// Per-provider detached-admission evaluation: for each execution
+    /// provider, whether the fail-closed gate (issue #824) would admit a
+    /// detached run it hosted, and every named precondition it fails. Derived
+    /// by running the real admission evaluator over each provider's declared
+    /// capabilities — the settings surface and the gate cannot disagree.
+    pub detached_admission: Vec<DetachedAdmissionProviderInfo>,
 }
 
 /// Renderer-safe egress policy plus per-provider enforcement disclosure.
@@ -412,6 +418,75 @@ pub struct CodeExecutionEgressEnforcement {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub requirement: Option<String>,
+}
+
+/// One provider's detached-admission verdict, renderer-safe.
+///
+/// `denials` is what the real evaluator returned for this provider's declared
+/// capabilities: empty exactly when `admitted`. The rows exist even for
+/// providers that cannot host background runs at all — every precondition is
+/// simply unestablished for them, and the fail-closed evaluation names each.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
+pub struct DetachedAdmissionProviderInfo {
+    pub provider: CodeExecutionProviderKind,
+    /// Whether the gate would admit a detached run hosted by this provider.
+    pub admitted: bool,
+    /// Every unmet precondition, named — not just the first.
+    pub denials: Vec<DetachedAdmissionDenialReason>,
+}
+
+/// Wire mirror of the admission gate's typed denial reasons
+/// ([`crate::sandbox_admission::DetachedAdmissionDenial`]), so the renderer
+/// maps each to user-facing language instead of receiving prose the server
+/// composed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+pub enum DetachedAdmissionDenialReason {
+    /// No issuer of short-lived, scoped, revocable model tokens.
+    NoScopedModelToken,
+    /// Nothing outside the sandbox bounds its lifetime.
+    NoExternalLifetimeCap,
+    /// The agent image is not verified within the topology's trust root.
+    ImageNotVerified,
+    /// The tool surface reaches a host-authority operation.
+    HostAuthorityToolSurface,
+    /// Third-party credentials without externally enforced egress policy.
+    CredentialsWithoutExternalEgress,
+}
+
+impl From<crate::sandbox_admission::DetachedAdmissionDenial> for DetachedAdmissionDenialReason {
+    fn from(denial: crate::sandbox_admission::DetachedAdmissionDenial) -> Self {
+        use crate::sandbox_admission::DetachedAdmissionDenial as Denial;
+        match denial {
+            Denial::NoScopedModelToken => Self::NoScopedModelToken,
+            Denial::NoExternalLifetimeCap => Self::NoExternalLifetimeCap,
+            Denial::ImageNotVerified => Self::ImageNotVerified,
+            Denial::HostAuthorityToolSurface => Self::HostAuthorityToolSurface,
+            Denial::CredentialsWithoutExternalEgress => Self::CredentialsWithoutExternalEgress,
+        }
+    }
+}
+
+/// Project the per-provider admission evaluation into the settings payload.
+fn detached_admission_info(
+    host_config: &openwave_core::Config,
+) -> Vec<DetachedAdmissionProviderInfo> {
+    use crate::sandbox_admission::DetachedAdmission;
+    crate::sandbox_admission::settings_detached_admissions(host_config)
+        .into_iter()
+        .map(|(provider, decision)| match decision {
+            DetachedAdmission::Admitted => DetachedAdmissionProviderInfo {
+                provider,
+                admitted: true,
+                denials: Vec::new(),
+            },
+            DetachedAdmission::Denied(denials) => DetachedAdmissionProviderInfo {
+                provider,
+                admitted: false,
+                denials: denials.into_iter().map(Into::into).collect(),
+            },
+        })
+        .collect()
 }
 
 /// The precondition Daytona's per-sandbox egress boundary is gated on. The
@@ -557,6 +632,7 @@ async fn write_config(store: &dyn Store, config: &CodeExecutionConfig) -> Result
 }
 
 pub async fn config_info(
+    host_config: &openwave_core::Config,
     store: &dyn Store,
     secrets: &dyn SecretProvider,
 ) -> Result<CodeExecutionConfigInfo> {
@@ -577,6 +653,7 @@ pub async fn config_info(
         available,
         has_credential,
         egress: CodeExecutionEgressInfo::from_config(config.egress),
+        detached_admission: detached_admission_info(host_config),
     })
 }
 
@@ -594,6 +671,7 @@ pub async fn credentials_info(secrets: &dyn SecretProvider) -> CodeExecutionCred
 }
 
 pub async fn update_config(
+    host_config: &openwave_core::Config,
     store: &dyn Store,
     secrets: &dyn SecretProvider,
     update: CodeExecutionConfigUpdate,
@@ -610,7 +688,9 @@ pub async fn update_config(
     }
     config.validate()?;
     write_config(store, &config).await?;
-    config_info(store, secrets).await.map_err(Into::into)
+    config_info(host_config, store, secrets)
+        .await
+        .map_err(Into::into)
 }
 
 pub async fn write_credential(
@@ -2664,8 +2744,10 @@ mod tests {
     #[tokio::test]
     async fn configuration_can_disable_and_reenable_local_execution() {
         let (store, _dir) = test_store().await;
+        let host_config = openwave_core::Config::desktop(_dir.path());
         let secrets = NoSecrets;
         let disabled = update_config(
+            &host_config,
             &store,
             &secrets,
             CodeExecutionConfigUpdate {
@@ -2683,6 +2765,7 @@ mod tests {
         assert!(!disabled.available);
 
         let local = update_config(
+            &host_config,
             &store,
             &secrets,
             CodeExecutionConfigUpdate {

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -586,7 +586,7 @@ pub async fn get_code_execution_config(
     State(state): State<AppState>,
 ) -> Result<Json<CodeExecutionConfigInfo>, ServerError> {
     Ok(Json(
-        code_execution::config_info(&*state.store, &*state.secrets).await?,
+        code_execution::config_info(&state.config, &*state.store, &*state.secrets).await?,
     ))
 }
 
@@ -596,7 +596,7 @@ pub async fn put_code_execution_config(
     Json(body): Json<CodeExecutionConfigUpdate>,
 ) -> Result<Json<CodeExecutionConfigInfo>, ServerError> {
     Ok(Json(
-        code_execution::update_config(&*state.store, &*state.secrets, body).await?,
+        code_execution::update_config(&state.config, &*state.store, &*state.secrets, body).await?,
     ))
 }
 

--- a/crates/openwave-server/src/sandbox_admission.rs
+++ b/crates/openwave-server/src/sandbox_admission.rs
@@ -8,9 +8,12 @@
 
 use std::sync::Arc;
 
+use openwave_code_execution::CodeExecutionProviderKind;
 use openwave_core::{AgentRunExecutionLocation, Config, SandboxAdmissionMode};
+use openwave_sandbox_protocol::provisioning::SandboxBackend;
 
 use crate::sandbox_docker::{DockerConfig, DockerSandboxBackend};
+use crate::scoped_model_token::{GatewayScopedTokenIssuer, ScopedModelTokenIssuer};
 
 /// Container backend and admission route resolved once during server startup.
 pub(crate) struct SandboxContainerAdmission {
@@ -172,6 +175,66 @@ pub(crate) fn evaluate_detached_admission(
     } else {
         DetachedAdmission::Denied(denials)
     }
+}
+
+/// The preconditions the current run shape establishes, given the two facts
+/// owned by other components: token issuance (the issuer's honest
+/// availability) and the backend's external lifetime cap.
+///
+/// The remaining fields are the run shape every sandbox run has today — the
+/// container capability host grants ModelInference only, so no reverse
+/// capability reaches a host-authority operation, and no third-party
+/// credential is ever delivered into a run. Image verification within a trust
+/// root does not exist yet (#1188). The runner and the settings surface both
+/// read this one function, so what settings says a provider is missing is by
+/// construction what the gate would deny it for.
+pub(crate) fn structural_preconditions(
+    scoped_model_token_available: bool,
+    external_lifetime_cap: bool,
+) -> DetachedPreconditions {
+    DetachedPreconditions {
+        scoped_model_token_available,
+        external_lifetime_cap,
+        // No image verification within a trust root yet (#1188).
+        image_verified: false,
+        // The container capability host grants ModelInference only; no
+        // reverse capability reaches a host-authority operation.
+        host_authority_tool_surface: false,
+        // No third-party credential is ever delivered into a sandbox run.
+        carries_third_party_credentials: false,
+        external_egress_enforcement: false,
+    }
+}
+
+/// Per-provider detached-admission evaluation for the settings surface: what
+/// the gate would decide for a run hosted by each execution provider, from
+/// declared capabilities only — nothing is provisioned to answer this.
+///
+/// The token-issuer fact is deployment-wide (the gateway either can mint
+/// run-scoped tokens or it cannot); the lifetime-cap fact is per backend. The
+/// local provider reads the real Docker backend's declaration. E2B and
+/// Daytona have no sandbox backend at all today — they are exec adapters, not
+/// hosts for background agent runs — so no capability is established for them
+/// and the fail-closed evaluation names everything missing.
+pub(crate) fn settings_detached_admissions(
+    config: &Config,
+) -> Vec<(CodeExecutionProviderKind, DetachedAdmission)> {
+    let scoped_token = GatewayScopedTokenIssuer.available();
+    let local_lifetime_cap =
+        DockerSandboxBackend::new(docker_config(config)).enforces_external_lifetime_cap();
+    [
+        (CodeExecutionProviderKind::Local, local_lifetime_cap),
+        (CodeExecutionProviderKind::E2b, false),
+        (CodeExecutionProviderKind::Daytona, false),
+    ]
+    .into_iter()
+    .map(|(provider, lifetime_cap)| {
+        (
+            provider,
+            evaluate_detached_admission(structural_preconditions(scoped_token, lifetime_cap)),
+        )
+    })
+    .collect()
 }
 
 #[cfg(test)]

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -304,23 +304,15 @@ impl SandboxContainerRunner {
 
     /// The detached-admission preconditions this process can establish for a
     /// local container run, each derived from the component that owns the fact
-    /// — never a constant.
+    /// — never a constant. The same shared shape backs the settings surface,
+    /// so what settings names as missing is what this gate denies for.
     fn detached_preconditions(&self) -> DetachedPreconditions {
-        DetachedPreconditions {
+        crate::sandbox_admission::structural_preconditions(
             // The real fact from the configured issuer: true only when a
             // run-scoped, short-lived, revocable token can actually be minted.
-            scoped_model_token_available: self.token_issuer.available(),
-            external_lifetime_cap: self.backend.enforces_external_lifetime_cap(),
-            // No image verification within a trust root yet (#1188).
-            image_verified: false,
-            // The container capability host grants ModelInference only; no
-            // reverse capability reaches a host-authority operation.
-            host_authority_tool_surface: false,
-            // No third-party credential is ever delivered into a container
-            // run today.
-            carries_third_party_credentials: false,
-            external_egress_enforcement: false,
-        }
+            self.token_issuer.available(),
+            self.backend.enforces_external_lifetime_cap(),
+        )
     }
 
     /// Claim and drive the container-located run `run_id` to a terminal state.

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -575,6 +575,31 @@ async fn code_execution_config_route_is_authenticated_and_preserves_explicit_dis
     assert!(initial["available"].is_boolean());
     assert_eq!(initial["has_credential"], false);
 
+    // The detached-admission wire shape: one row per execution provider, each
+    // carrying the gate's named denial reasons. No provider is admitted today,
+    // and the local row names exactly the structural gaps — the scoped-token
+    // issuer, the external lifetime cap, and image verification.
+    let admission = initial["detached_admission"]
+        .as_array()
+        .expect("detached_admission is an array");
+    assert_eq!(
+        admission
+            .iter()
+            .map(|row| row["provider"].as_str().unwrap().to_owned())
+            .collect::<Vec<_>>(),
+        ["local", "e2b", "daytona"]
+    );
+    let local = &admission[0];
+    assert_eq!(local["admitted"], false);
+    assert_eq!(
+        local["denials"],
+        serde_json::json!([
+            "no_scoped_model_token",
+            "no_external_lifetime_cap",
+            "image_not_verified"
+        ])
+    );
+
     let unauthenticated_credentials = router
         .clone()
         .oneshot(


### PR DESCRIPTION
The detached-admission gate (#824, slices 1–2 in #1358 and #1362) denies with named, typed reasons, but nothing showed a user why detached execution is unavailable for a provider. This is the settings surface from the slice plan.

The `GET /code-execution` payload gains `detached_admission`: one row per execution provider (local, E2B, Daytona), carrying whether the fail-closed gate would admit a detached run hosted by that provider and every unmet precondition, named. The rows come from running the real admission evaluator over each provider's declared capabilities — no live provisioning — and the runner's own precondition assembly now shares the same structural-preconditions function, so what settings names as missing is by construction what the gate denies for. E2B and Daytona have no sandbox backend today, so every capability is unestablished for them and the fail-closed evaluation names each gap.

The desktop code-execution panel renders a "Detached background runs" section: per provider, an availability badge and each denial as a plain sentence stating what is missing and what would change it (no scoped-token issuer, nothing bounding the sandbox lifetime from outside, unverified image), never raw enum names. Today every provider is denied, which is exactly the honest position.

Tests: the wire shape asserted on the existing code-execution route test (row order, local's exact structural denials), and one rendering test that the sentences appear and enum names never do. The evaluator's own contract is already covered by the slice-1 tests and is not re-asserted.

Verified locally: rustfmt, `cargo check -p openwave-server --locked --all-targets`, the full `openwave-server` suite, and the code-execution panel vitest. `tsc` fails on `src/MessageList.dom.test.tsx` on `main` independently of this change (introduced by #1372; the desktop UI lane masks it — issue to follow).

References #824.