### PR TITLE
fix(ci): make the desktop UI lane propagate test and build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,5 +514,7 @@ jobs:
           cache-dependency-path: crates/openwave-desktop/ui/pnpm-lock.yaml
       - name: Install UI dependencies
         run: pnpm install --frozen-lockfile
-      - name: Test and build
-        run: pnpm test & pnpm build & wait
+      - name: Test
+        run: pnpm test
+      - name: Build
+        run: pnpm build

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -166,13 +166,18 @@ test("heavy CI is opt-in on pull requests and automatic elsewhere", () => {
   assert.doesNotMatch(desktopCargo, /document-parsers/);
 });
 
-test("UI tests and production build run as a single parallel step", () => {
+test("UI tests and production build each gate the UI lane", () => {
   const ci = workflows["ci.yml"];
   const ui = workflowJob(ci, "ui");
 
   assert.match(ui, /if:.*needs\.changes\.outputs\.ui == 'true'/);
   assert.match(ui, /run: pnpm install --frozen-lockfile/);
-  assert.match(ui, /pnpm test & pnpm build & wait/);
+  // Sequential steps, one command each: a backgrounded `a & b & wait` swallows
+  // the children's exit codes, so a failing test or build reported success
+  // (#1376). Each step's status must reach the job directly.
+  assert.match(ui, /run: pnpm test/);
+  assert.match(ui, /run: pnpm build/);
+  assert.doesNotMatch(ui, /& wait/);
   assert.doesNotMatch(ci, /matrix\.task/);
 });
 


### PR DESCRIPTION
Closes #1376

The desktop UI job's single step ran \`pnpm test & pnpm build & wait\`. Bash \`wait\` with no operands always returns 0, so the step succeeded even when the tests or the build failed — main's push run for 3c8750f1 logged TypeScript errors in \`MessageList.dom.test.tsx\` and still concluded green.

This splits the step into sequential \`Test\` and \`Build\` steps. Each command's exit code now fails the job directly, and their logs no longer interleave. The parallel overlap saved little (the suite runs in ~10s, the build in ~14s locally) against the job's 10-minute timeout, so sequential is the simpler correct shape.

The second half of #1376 — the type errors themselves in \`MessageList.dom.test.tsx\` (missing \`cwd\`, snake_case fields against the camelCase \`ToolResultDetail\`) — was already fixed on main by #1370, which carried the one-fixture correction. Verified on this branch: \`pnpm exec tsc --noEmit\` is clean, all 99 test files / 683 tests pass, and \`pnpm build\` succeeds. The workflow change itself can't be exercised outside Actions; the logic was validated by reading — two ordinary steps under the default \`bash -e\` shell have no exit-code-swallowing path.