### PR TITLE
ci: scope run cancellation to pull-request refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,18 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  # Only the newest commit on a branch matters. sccache publishes compiler
-  # objects as they are produced, so superseded main runs do not need to finish.
-  cancel-in-progress: true
+  # On a PR ref only the newest commit matters, so supersede in-progress runs.
+  # Every other event gets a unique group (keyed by run id) so nothing cancels
+  # it and it cancels nothing: post-merge runs are the full validation for the
+  # exact commits they cover — a later merge whose narrower change scope skips
+  # a lane (notably the sandbox-container e2e) must not cancel the earlier run
+  # that was responsible for it, and a manual workflow_dispatch is the
+  # deliberate backstop for those lanes, so an unrelated push must never kill
+  # it. During a merge train this runs main pushes in parallel instead of
+  # superseding them; that costs runner time, but sccache shares compiler
+  # objects across the runs and correctness of the scoped lanes wins.
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || format('{0}-run-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   pr-title:


### PR DESCRIPTION
The CI workflow used one concurrency group per ref with `cancel-in-progress: true`. On a busy merge day this starves the `sandbox-resident container e2e` lane: each merge to main cancels the in-progress run for the previous merge, and the superseding run then *skips* the lane because its own change scope does not touch sandbox files. Manual `workflow_dispatch` runs — the lane's designated backstop — were being cancelled by unrelated pushes the same way. On 2026-08-03 the lane failed to complete across three attempts (one merge run, two dispatches).

This change keeps cancellation only where it is correct and removes it everywhere else:

- `pull_request` events keep the per-ref group with `cancel-in-progress: true` — on a PR ref only the newest commit matters, unchanged.
- Every other event (`push` to main, `workflow_dispatch`, `schedule`) gets a unique group keyed by `run_id`, so it can neither cancel nor be cancelled. Each post-merge run now completes as the full validation for exactly the commits it covers, and a dispatch can no longer be killed by an unrelated merge.

Reasoning through the event matrix:

- **PR push train**: same group `CI-refs/pull/N/merge`, newest supersedes — identical to today.
- **Main merge train**: previously run A (sandbox-scoped) was cancelled by run B (out of scope), which skipped the lane; the lane went unexecuted. Now A, B, C each get distinct groups and all run to completion in parallel. Per-push change scoping is unaffected: each push event still diffs its own `before..after`, so no run inherits or drops another's scope. The cost is parallel runners during a train instead of cancellations; sccache still shares compiler objects across runs, and post-merge lanes are exactly the runs we cannot afford to discard.
- **workflow_dispatch**: unique group; runs full validation and cannot be cancelled by any push. This restores the dispatch as a reliable backstop.
- **schedule**: unique group; the weekly full run likewise cannot be cancelled.

A job-level concurrency group for the sandbox lane alone would not have worked: workflow-level cancellation kills all jobs regardless of job-level groups, so the fix has to live in the workflow `concurrency` block.

I deliberately did not take the issue's alternative (making the push scope accumulate since the last completed run): it adds statefulness to the change detector and still leaves a cancelled run's other lanes unexecuted, whereas not cancelling non-PR runs removes the whole class of gap.

Verified with `actionlint` (clean). The `cancel-in-progress` expression evaluates to a real boolean per GitHub's expression rules; the group expression always yields a non-empty string for both branches.

Closes #1377