### PR TITLE
feat(server): bind route storage access to the request principal through a scoped store view

### DIFF
--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -59,6 +59,7 @@ mod sandbox_container_run_worker;
 pub mod sandbox_docker;
 mod sandbox_web_search_worker;
 mod scoped_model_token;
+mod scoped_store;
 /// Rewriting stored credentials so the running binary owns their keychain items.
 pub mod secret_rehome;
 mod source_tools;

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -42,8 +42,8 @@ use crate::exec_write_snapshot::{
 use crate::extract::{Json, Path, Query};
 use crate::mcp_config::{McpServersConfig, McpServersInfo};
 use crate::model_roles::{self, ModelRole};
-use crate::principal::AuthContext;
 use crate::providers::{self, ProviderCredential, ProviderInfo, ProviderKind, ProviderUpdate};
+use crate::scoped_store::ScopedStore;
 use crate::state::AppState;
 use crate::view_frames::ViewFrameSource;
 use crate::web_search::{
@@ -141,10 +141,11 @@ pub async fn put_mcp_servers(
 /// and the payload is handed to the renderer as an opaque envelope for the
 /// sandboxed frame — the transcript presentation itself never reads it.
 pub async fn get_mcp_app_payload(
-    State(state): State<AppState>,
+    store: ScopedStore,
     Path((chat_id, call_id)): Path<(ChatId, CallId)>,
 ) -> Result<Json<McpAppPayload>, ServerError> {
-    let events = state.store.list_events(chat_id, 0).await?;
+    store.require_chat(chat_id).await?;
+    let events = store.list_events(chat_id, 0).await?;
     mcp_app_payload_from_events(&events, call_id)
         .map(Json)
         .ok_or_else(|| ServerError::not_found("no MCP App payload for this call"))
@@ -665,8 +666,10 @@ pub async fn delete_code_execution_credential(
 /// prior bytes journaled for one turn without clobbering later edits.
 pub async fn post_undo_turn_file_changes(
     State(state): State<AppState>,
+    store: ScopedStore,
     Path((chat_id, turn_id)): Path<(ChatId, TurnId)>,
 ) -> Result<Json<ExecTurnUndoOutcome>, ServerError> {
+    store.require_chat(chat_id).await?;
     let outcome = undo_turn_file_changes(&*state.store, &*state.blobs, chat_id, turn_id).await?;
     if outcome.files.is_empty() {
         return Err(ServerError::not_found(format!(
@@ -680,8 +683,10 @@ pub async fn post_undo_turn_file_changes(
 /// restore one file from the turn without touching its siblings.
 pub async fn post_undo_one_file_change(
     State(state): State<AppState>,
+    store: ScopedStore,
     Path((chat_id, turn_id, snapshot_id)): Path<(ChatId, TurnId, uuid::Uuid)>,
 ) -> Result<Json<ExecFileUndoOutcome>, ServerError> {
+    store.require_chat(chat_id).await?;
     undo_one_file_change(&*state.store, &*state.blobs, chat_id, turn_id, snapshot_id)
         .await?
         .map(Json)
@@ -693,7 +698,7 @@ pub async fn post_undo_one_file_change(
 /// paths, or a reusable document identity.
 pub async fn get_file_change_preview(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path((chat_id, turn_id, snapshot_id, revision)): Path<(
         ChatId,
         TurnId,
@@ -701,14 +706,7 @@ pub async fn get_file_change_preview(
         ExecFilePreviewRevision,
     )>,
 ) -> Result<Response, ServerError> {
-    if state
-        .store
-        .get_chat_scoped(&auth.principal.owner_id(), chat_id)
-        .await?
-        .is_none()
-    {
-        return Err(ServerError::not_found(format!("chat {chat_id} not found")));
-    }
+    store.require_chat(chat_id).await?;
     let _permit = state
         .file_preview_permits
         .clone()
@@ -1308,8 +1306,7 @@ fn normalize_chat_title(title: Option<String>) -> Result<Option<String>, ServerE
 
 /// `POST /projects` — create a project and return it (`201 Created`).
 pub async fn create_project(
-    State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Json(body): Json<CreateProject>,
 ) -> Result<impl IntoResponse, ServerError> {
     let project = Project {
@@ -1319,79 +1316,50 @@ pub async fn create_project(
         root_attachments: Vec::new(),
         created_at: Utc::now(),
     };
-    state
-        .store
-        .create_project_scoped(&auth.principal.owner_id(), &project)
-        .await?;
+    store.create_project(&project).await?;
     Ok((StatusCode::CREATED, Json(project)))
 }
 
 /// `PATCH /projects/{id}` — update bounded human-facing project metadata.
 pub async fn patch_project(
-    State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(id): Path<ProjectId>,
     Json(body): Json<ProjectUpdate>,
 ) -> Result<Json<Project>, ServerError> {
-    let owner = auth.principal.owner_id();
     let title = body.title.map(normalize_project_title).transpose()?;
     if let Some(title) = title {
-        if !state
-            .store
-            .update_project_title_scoped(&owner, id, title)
-            .await?
-        {
+        if !store.update_project_title(id, title).await? {
             return Err(ServerError::not_found(format!("project {id} not found")));
         }
     }
-    state
-        .store
-        .get_project_scoped(&owner, id)
+    store
+        .get_project(id)
         .await?
         .map(Json)
         .ok_or_else(|| ServerError::not_found(format!("project {id} not found")))
 }
 
 /// `GET /projects` — list projects, most-recently-created first.
-pub async fn list_projects(
-    State(state): State<AppState>,
-    auth: AuthContext,
-) -> Result<Json<Vec<Project>>, ServerError> {
-    Ok(Json(
-        state
-            .store
-            .list_projects_scoped(&auth.principal.owner_id())
-            .await?,
-    ))
+pub async fn list_projects(store: ScopedStore) -> Result<Json<Vec<Project>>, ServerError> {
+    Ok(Json(store.list_projects().await?))
 }
 
 /// `GET /projects/{id}` — fetch one project, or `404`.
 pub async fn get_project(
-    State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(id): Path<ProjectId>,
 ) -> Result<Json<Project>, ServerError> {
-    state
-        .store
-        .get_project_scoped(&auth.principal.owner_id(), id)
-        .await?
-        .map(Json)
-        .ok_or_else(|| ServerError::not_found(format!("project {id} not found")))
+    Ok(Json(store.require_project(id).await?))
 }
 
 /// `DELETE /projects/{id}` — remove an empty project. Owned conversations,
 /// documents, and root defaults must be removed through their explicit
 /// lifecycle APIs first; this boundary never cascades them.
 pub async fn delete_project(
-    State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(id): Path<ProjectId>,
 ) -> Result<StatusCode, ServerError> {
-    match state
-        .store
-        .delete_project_scoped(&auth.principal.owner_id(), id)
-        .await?
-    {
+    match store.delete_project(id).await? {
         DeleteProjectOutcome::Deleted => Ok(StatusCode::NO_CONTENT),
         DeleteProjectOutcome::NotFound => {
             Err(ServerError::not_found(format!("project {id} not found")))
@@ -1431,18 +1399,13 @@ pub struct CreateChat {
 /// `POST /chats` — create a chat and return it (`201 Created`).
 pub async fn create_chat(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Json(mut body): Json<CreateChat>,
 ) -> Result<impl IntoResponse, ServerError> {
-    let owner = auth.principal.owner_id();
     // Return a product-facing 400 for an unknown project. The Store and schema
     // independently enforce the same membership invariant inside insertion.
     if let Some(project_id) = body.project_id {
-        state
-            .store
-            .get_project_scoped(&owner, project_id)
-            .await?
-            .ok_or_else(|| ServerError::not_found(format!("project {project_id} not found")))?;
+        store.require_project(project_id).await?;
     }
     if let Some(model) = body.model.as_mut() {
         *model = validate_model_selection(&state, model, false).await?;
@@ -1461,10 +1424,7 @@ pub async fn create_chat(
         root_attachments: Vec::new(),
         created_at: Utc::now(),
     };
-    let chat = state
-        .store
-        .create_chat_with_project_defaults_scoped(&owner, &chat)
-        .await?;
+    let chat = store.create_chat_with_project_defaults(&chat).await?;
     Ok((StatusCode::CREATED, Json(chat)))
 }
 
@@ -1495,11 +1455,10 @@ pub struct ChatUpdate {
 /// `PATCH /chats/{id}` — update the human-facing title and/or model selection.
 pub async fn patch_chat(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(id): Path<ChatId>,
     Json(mut body): Json<ChatUpdate>,
 ) -> Result<Json<Chat>, ServerError> {
-    let owner = auth.principal.owner_id();
     // Validate every supplied field before touching durable state. This keeps a
     // mixed request all-or-nothing from the user's point of view.
     if let Some(Some(model)) = body.model.as_mut() {
@@ -1514,16 +1473,10 @@ pub async fn patch_chat(
     refuse_permission_mode_over_ceiling(&state, body.permission_mode.flatten()).await?;
     let title = body.title.map(normalize_chat_title).transpose()?;
 
-    let mut chat = state
-        .store
-        .get_chat_scoped(&owner, id)
-        .await?
-        .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))?;
+    let mut chat = store.require_chat(id).await?;
 
-    if !state
-        .store
-        .update_chat_metadata_scoped(
-            &owner,
+    if !store
+        .update_chat_metadata(
             id,
             title.clone(),
             body.model.clone(),
@@ -1750,12 +1703,11 @@ impl ChatMessageSnapshot {
 /// an empty conversation.
 pub async fn list_chat_messages(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(id): Path<ChatId>,
 ) -> Result<Json<ChatTranscript>, ServerError> {
-    let transcript = state
-        .store
-        .get_chat_transcript_scoped(&auth.principal.owner_id(), id)
+    let transcript = store
+        .get_chat_transcript(id)
         .await?
         .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))?;
     let mut citations_by_message = std::collections::HashMap::new();
@@ -1833,30 +1785,16 @@ pub async fn list_chat_messages(
 }
 
 /// `GET /chats` — list chats, most-recently-created first.
-pub async fn list_chats(
-    State(state): State<AppState>,
-    auth: AuthContext,
-) -> Result<Json<Vec<Chat>>, ServerError> {
-    Ok(Json(
-        state
-            .store
-            .list_chats_scoped(&auth.principal.owner_id())
-            .await?,
-    ))
+pub async fn list_chats(store: ScopedStore) -> Result<Json<Vec<Chat>>, ServerError> {
+    Ok(Json(store.list_chats().await?))
 }
 
 /// `GET /chats/{id}` — fetch one chat, or `404`.
 pub async fn get_chat(
-    State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(id): Path<ChatId>,
 ) -> Result<Json<Chat>, ServerError> {
-    state
-        .store
-        .get_chat_scoped(&auth.principal.owner_id(), id)
-        .await?
-        .map(Json)
-        .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))
+    Ok(Json(store.require_chat(id).await?))
 }
 
 /// `DELETE /chats/{id}` — remove a quiesced conversation and its product
@@ -1864,14 +1802,10 @@ pub async fn get_chat(
 /// caller must first finish cancellation and durable broker detachment.
 pub async fn delete_chat(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(id): Path<ChatId>,
 ) -> Result<StatusCode, ServerError> {
-    match state
-        .store
-        .delete_chat_scoped(&auth.principal.owner_id(), id)
-        .await?
-    {
+    match store.delete_chat(id).await? {
         DeleteChatOutcome::Deleted => {
             state.blob_retirement_wake.notify_one();
             let scratch_root = state.config.data_dir.join("scratch");
@@ -2177,28 +2111,20 @@ fn foreground_activity(
 
 /// `GET /chats/{id}/agent-runs` — list renderer-safe execution state.
 pub async fn list_agent_runs(
-    State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(id): Path<ChatId>,
 ) -> Result<Json<Vec<AgentRunSnapshot>>, ServerError> {
-    state
-        .store
-        .get_chat_scoped(&auth.principal.owner_id(), id)
-        .await?
-        .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))?;
-    let runs = state.store.list_agent_runs(id).await?;
+    store.require_chat(id).await?;
+    let runs = store.list_agent_runs(id).await?;
     // This read model needs only live client checkpoints. Loading the complete
     // tool-call transcript here would needlessly deserialize historical model
     // arguments, results, and local diagnostics just to render current work.
-    let client_calls = state.store.list_pending_client_tool_calls(id).await?;
+    let client_calls = store.list_pending_client_tool_calls(id).await?;
     let now = Utc::now();
     let mut snapshots = Vec::with_capacity(runs.len());
     for run in runs {
         let activity = if run.tier == AgentRunTier::Background {
-            let calls = state
-                .store
-                .list_sandbox_tool_calls_for_agent_run(run.id)
-                .await?;
+            let calls = store.list_sandbox_tool_calls_for_agent_run(run.id).await?;
             sandbox_activity(&calls)
         } else if run.tier == AgentRunTier::Foreground {
             foreground_activity(&client_calls, now)
@@ -2221,20 +2147,11 @@ pub async fn list_agent_runs(
 /// wrong-chat, or foreground run returns `404` rather than revealing whether an
 /// unrelated run identifier exists.
 pub async fn list_agent_run_activity(
-    State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path((chat_id, run_id)): Path<(ChatId, openwave_core::AgentRunId)>,
 ) -> Result<Json<Vec<AgentActivityHistoryItem>>, ServerError> {
-    if state
-        .store
-        .get_chat_scoped(&auth.principal.owner_id(), chat_id)
-        .await?
-        .is_none()
-    {
-        return Err(ServerError::not_found(format!("chat {chat_id} not found")));
-    }
-    let run = state
-        .store
+    store.require_chat(chat_id).await?;
+    let run = store
         .get_agent_run(run_id)
         .await?
         .filter(|run| run.chat_id == chat_id && run.tier == AgentRunTier::Background);
@@ -2243,10 +2160,7 @@ pub async fn list_agent_run_activity(
             "agent run {run_id} not found"
         )));
     };
-    let calls = state
-        .store
-        .list_sandbox_tool_calls_for_agent_run(run.id)
-        .await?;
+    let calls = store.list_sandbox_tool_calls_for_agent_run(run.id).await?;
     Ok(Json(sandbox_activity_history(&calls)))
 }
 
@@ -2273,18 +2187,11 @@ pub enum AgentRunCancellationStatus {
 /// executor details.
 pub async fn post_agent_run_cancel(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path((chat_id, run_id)): Path<(ChatId, openwave_core::AgentRunId)>,
 ) -> Result<(StatusCode, Json<AgentRunCancellationSnapshot>), ServerError> {
-    if state
-        .store
-        .get_chat_scoped(&auth.principal.owner_id(), chat_id)
-        .await?
-        .is_none()
-    {
-        return Err(ServerError::not_found(format!("chat {chat_id} not found")));
-    }
-    let Some(run) = state.store.get_agent_run(run_id).await? else {
+    store.require_chat(chat_id).await?;
+    let Some(run) = store.get_agent_run(run_id).await? else {
         return Err(ServerError::conflict("sandbox run is not cancellable"));
     };
     if run.chat_id != chat_id || run.tier != AgentRunTier::Background {
@@ -2293,11 +2200,11 @@ pub async fn post_agent_run_cancel(
 
     let mut outcome = None;
     for _ in 0..8 {
-        if let Some(resolved) = state.store.request_agent_run_cancellation(run_id).await? {
+        if let Some(resolved) = store.request_agent_run_cancellation(run_id).await? {
             outcome = Some(resolved);
             break;
         }
-        let Some(current) = state.store.get_agent_run(run_id).await? else {
+        let Some(current) = store.get_agent_run(run_id).await? else {
             return Err(ServerError::conflict("sandbox run is not cancellable"));
         };
         if current.chat_id != chat_id || current.tier != AgentRunTier::Background {
@@ -2545,7 +2452,7 @@ async fn resolve_message_attachments(
 }
 
 async fn resolve_file_attachments(
-    state: &AppState,
+    store: &ScopedStore,
     chat_id: ChatId,
     ids: &[DocumentId],
 ) -> Result<Vec<DocumentId>, ServerError> {
@@ -2569,7 +2476,7 @@ async fn resolve_file_attachments(
                 format!("file attachment {id} was submitted more than once"),
             ));
         }
-        let document = state.store.get_document(id).await?.ok_or_else(|| {
+        let document = store.get_document(id).await?.ok_or_else(|| {
             ServerError::bad_request_kind(
                 "file_attachment_not_found",
                 format!("file attachment {id} has not been imported"),
@@ -2679,7 +2586,7 @@ mod image_capability_tests {
 /// with `model_image_input_unsupported`.
 pub async fn post_message(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(id): Path<ChatId>,
     Json(body): Json<PostMessage>,
 ) -> Result<StatusCode, ServerError> {
@@ -2691,16 +2598,12 @@ pub async fn post_message(
             "message content must be non-empty and contain no NUL characters",
         ));
     }
-    let chat = state
-        .store
-        .get_chat_scoped(&auth.principal.owner_id(), id)
-        .await?
-        .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))?;
+    let chat = store.require_chat(id).await?;
 
     // An ambiguous HTTP retry names only its turn and content, not the resolved
     // model snapshot. Reuse the first acceptance's immutable model so a settings
     // change between attempts cannot turn the same request into a conflict.
-    let model = if let Some(existing) = state.store.get_turn_run(body.turn_id).await? {
+    let model = if let Some(existing) = store.get_turn_run(body.turn_id).await? {
         if existing.chat_id != id {
             return Err(ServerError::conflict(format!(
                 "turn {} was already accepted by another chat",
@@ -2729,7 +2632,7 @@ pub async fn post_message(
         validate_model_selection(&state, &selected, true).await?
     };
     let images = resolve_message_attachments(&state, &body.attachments).await?;
-    let documents = resolve_file_attachments(&state, id, &body.file_attachments).await?;
+    let documents = resolve_file_attachments(&store, id, &body.file_attachments).await?;
     if images.len().saturating_add(documents.len()) > openwave_core::MAX_MESSAGE_ATTACHMENTS {
         return Err(ServerError::bad_request_kind(
             "too_many_attachments",
@@ -2742,8 +2645,7 @@ pub async fn post_message(
     if !images.is_empty() {
         require_image_capable_model(&state, &model).await?;
     }
-    match state
-        .store
+    match store
         .accept_turn_with_attachments(body.turn_id, id, &model, &body.content, &images, &documents)
         .await?
     {
@@ -2755,7 +2657,7 @@ pub async fn post_message(
             // Concurrent identical requests can resolve different mutable model
             // defaults before either commits. Retry against the winner's immutable
             // model so the wire identity remains `(chat, turn_id, content)`.
-            let Some(existing) = state.store.get_turn_run(body.turn_id).await? else {
+            let Some(existing) = store.get_turn_run(body.turn_id).await? else {
                 return Err(ServerError::conflict(format!(
                     "turn {} was accepted with conflicting request data",
                     body.turn_id
@@ -2763,8 +2665,7 @@ pub async fn post_message(
             };
             if existing.chat_id == id
                 && matches!(
-                    state
-                        .store
+                    store
                         .accept_turn_with_attachments(
                             body.turn_id,
                             id,
@@ -2817,7 +2718,7 @@ pub struct SteerBody {
 /// unavailable turn, and `400` for malformed input.
 pub async fn post_steer(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(id): Path<ChatId>,
     Json(body): Json<SteerBody>,
 ) -> Result<StatusCode, ServerError> {
@@ -2832,16 +2733,8 @@ pub async fn post_steer(
             "steer content must be non-empty, contain no NUL characters, and fit the size limit",
         ));
     }
-    if state
-        .store
-        .get_chat_scoped(&auth.principal.owner_id(), id)
-        .await?
-        .is_none()
-    {
-        return Err(ServerError::not_found(format!("chat {id} not found")));
-    }
-    match state
-        .store
+    store.require_chat(id).await?;
+    match store
         .accept_turn_steer(
             body.steer_id,
             body.turn_id,
@@ -2883,21 +2776,13 @@ pub struct CancelBody {
 
 pub async fn post_cancel(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(id): Path<ChatId>,
     Json(body): Json<CancelBody>,
 ) -> Result<StatusCode, ServerError> {
     // Distinguish "unknown chat" (404) from "known chat, nothing running" (409).
-    if state
-        .store
-        .get_chat_scoped(&auth.principal.owner_id(), id)
-        .await?
-        .is_none()
-    {
-        return Err(ServerError::not_found(format!("chat {id} not found")));
-    }
-    if !state
-        .store
+    store.require_chat(id).await?;
+    if !store
         .get_turn_run(body.turn_id)
         .await?
         .is_some_and(|turn| turn.chat_id == id)
@@ -2908,8 +2793,7 @@ pub async fn post_cancel(
         )));
     }
     let resolution = loop {
-        if let Some(resolution) = state
-            .store
+        if let Some(resolution) = store
             .request_turn_cancellation_and_append_event(body.turn_id, Utc::now())
             .await?
         {
@@ -2918,8 +2802,7 @@ pub async fn post_cancel(
         // A heartbeat can advance `updated_at` after this request captures its
         // operational timestamp. Retry the same empty command with fresh time;
         // the store serializes it against the heartbeat and terminal decisions.
-        if !state
-            .store
+        if !store
             .get_turn_run(body.turn_id)
             .await?
             .is_some_and(|turn| turn.chat_id == id)
@@ -3105,8 +2988,7 @@ pub(crate) fn grant_rungs_from_scopes(
 
 /// `GET /chats/{id}/approvals` — recover a bounded page of pending cards.
 pub(crate) async fn list_pending_approvals(
-    State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(chat_id): Path<ChatId>,
     Query(query): Query<PendingApprovalsQuery>,
 ) -> Result<Json<Vec<PendingApprovalSnapshot>>, ServerError> {
@@ -3115,16 +2997,8 @@ pub(crate) async fn list_pending_approvals(
             "approval limit must be between 1 and 100",
         ));
     }
-    if state
-        .store
-        .get_chat_scoped(&auth.principal.owner_id(), chat_id)
-        .await?
-        .is_none()
-    {
-        return Err(ServerError::not_found(format!("chat {chat_id} not found")));
-    }
-    let approvals = state
-        .store
+    store.require_chat(chat_id).await?;
+    let approvals = store
         .list_pending_tool_call_approvals(chat_id, query.limit)
         .await?;
     Ok(Json(
@@ -3158,19 +3032,20 @@ pub(crate) struct StandingGrantSnapshot {
 ///
 /// The settings surface for "what the agent can do without asking": a grant
 /// the reader cannot find is a one-way door, and this is where it is found.
+/// Grants themselves are not owner-keyed yet (#853 slice 5); the provenance
+/// titles are resolved through the requesting principal's own chats and
+/// projects, so this route never reads another owner's titles.
 pub(crate) async fn list_standing_grants(
-    State(state): State<AppState>,
+    store: ScopedStore,
 ) -> Result<Json<Vec<StandingGrantSnapshot>>, ServerError> {
-    let grants = state.store.list_standing_tool_grants().await?;
-    let chat_titles: std::collections::HashMap<ChatId, Option<String>> = state
-        .store
+    let grants = store.list_standing_tool_grants().await?;
+    let chat_titles: std::collections::HashMap<ChatId, Option<String>> = store
         .list_chats()
         .await?
         .into_iter()
         .map(|chat| (chat.id, chat.title))
         .collect();
-    let project_titles: std::collections::HashMap<ProjectId, Option<String>> = state
-        .store
+    let project_titles: std::collections::HashMap<ProjectId, Option<String>> = store
         .list_projects()
         .await?
         .into_iter()
@@ -3207,10 +3082,10 @@ pub(crate) async fn list_standing_grants(
 /// calls park on the approval card again. `204` on success, `404` when the
 /// grant does not exist (already revoked, or never granted).
 pub(crate) async fn delete_standing_grant(
-    State(state): State<AppState>,
+    store: ScopedStore,
     Path(call_id): Path<CallId>,
 ) -> Result<StatusCode, ServerError> {
-    if state.store.revoke_standing_tool_grant(call_id).await? {
+    if store.revoke_standing_tool_grant(call_id).await? {
         Ok(StatusCode::NO_CONTENT)
     } else {
         Err(ServerError::not_found(format!(
@@ -3225,19 +3100,12 @@ pub(crate) async fn delete_standing_grant(
 /// holding its slot until it finishes after the decision.
 pub async fn post_approval(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path((chat_id, call_id)): Path<(ChatId, CallId)>,
     Json(body): Json<ApprovalBody>,
 ) -> Result<StatusCode, ServerError> {
     // Confirm the chat exists so a typo'd id doesn't look like "not pending".
-    if state
-        .store
-        .get_chat_scoped(&auth.principal.owner_id(), chat_id)
-        .await?
-        .is_none()
-    {
-        return Err(ServerError::not_found(format!("chat {chat_id} not found")));
-    }
+    store.require_chat(chat_id).await?;
     let decision = match body.decision {
         ApprovalChoice::Approve => {
             if body.reason.is_some() {
@@ -3323,19 +3191,13 @@ pub struct EventsQuery {
 /// browser accepts the handshake (RFC 6455).
 pub async fn chat_events(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(id): Path<ChatId>,
     Query(query): Query<EventsQuery>,
     headers: axum::http::HeaderMap,
     upgrade: WebSocketUpgrade,
 ) -> Result<Response, ServerError> {
-    let Some(chat) = state
-        .store
-        .get_chat_scoped(&auth.principal.owner_id(), id)
-        .await?
-    else {
-        return Err(ServerError::not_found(format!("chat {id} not found")));
-    };
+    let chat = store.require_chat(id).await?;
     let upgrade = if offered_handshake_subprotocol(&headers) {
         upgrade.protocols([WS_HANDSHAKE_SUBPROTOCOL])
     } else {

--- a/crates/openwave-server/src/routes/document.rs
+++ b/crates/openwave-server/src/routes/document.rs
@@ -11,15 +11,14 @@ use unicode_general_category::{get_general_category, GeneralCategory};
 
 use openwave_core::{
     AgentError, ChatId, DocumentId, DocumentListCursor, DocumentRecord, DocumentScope,
-    DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, OwnerId, ProjectId,
-    SourceReadiness,
+    DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, ProjectId, SourceReadiness,
 };
 
 use crate::document_decode::decode_document;
 use crate::error::ServerError;
 use crate::extract::{Json, Path, Query, RawBytes};
-use crate::principal::AuthContext;
 use crate::routes::SERVED_BYTES_CONTENT_POLICY;
+use crate::scoped_store::ScopedStore;
 use crate::state::AppState;
 use crate::MAX_RAW_DOCUMENT_BYTES;
 
@@ -259,39 +258,37 @@ impl From<DocumentRecord> for DocumentDetail {
 /// `POST /documents` — decode and durably retain source bytes.
 pub async fn ingest_document(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Json(body): Json<IngestDocument>,
 ) -> Result<impl IntoResponse, ServerError> {
-    ingest_document_in_scope(&state, &auth.principal.owner_id(), None, None, body).await
+    ingest_document_in_scope(&state, &store, None, None, body).await
 }
 
 /// `POST /projects/{project_id}/documents` — ingest a document in one project corpus.
 pub async fn ingest_project_document(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(project_id): Path<ProjectId>,
     Json(body): Json<IngestDocument>,
 ) -> Result<impl IntoResponse, ServerError> {
-    let owner = auth.principal.owner_id();
-    require_project(&state, &owner, project_id).await?;
-    ingest_document_in_scope(&state, &owner, None, Some(project_id), body).await
+    store.require_project(project_id).await?;
+    ingest_document_in_scope(&state, &store, None, Some(project_id), body).await
 }
 
 /// `POST /chats/{chat_id}/documents` — ingest a source owned by one conversation.
 pub async fn ingest_chat_document(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(chat_id): Path<ChatId>,
     Json(body): Json<IngestDocument>,
 ) -> Result<impl IntoResponse, ServerError> {
-    let owner = auth.principal.owner_id();
-    require_chat(&state, &owner, chat_id).await?;
-    ingest_document_in_scope(&state, &owner, Some(chat_id), None, body).await
+    store.require_chat(chat_id).await?;
+    ingest_document_in_scope(&state, &store, Some(chat_id), None, body).await
 }
 
 async fn ingest_document_in_scope(
     state: &AppState,
-    owner: &OwnerId,
+    store: &ScopedStore,
     chat_id: Option<ChatId>,
     project_id: Option<ProjectId>,
     body: IngestDocument,
@@ -301,7 +298,7 @@ async fn ingest_document_in_scope(
     }
     publish_document_source(
         state,
-        owner,
+        store,
         chat_id,
         project_id,
         body.uri,
@@ -316,38 +313,28 @@ async fn ingest_document_in_scope(
 /// `Content-Type` and decode it synchronously.
 pub async fn ingest_raw_document(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Query(query): Query<RawDocumentQuery>,
     headers: HeaderMap,
     RawBytes(bytes): RawBytes,
 ) -> Result<impl IntoResponse, ServerError> {
-    ingest_raw_document_in_scope(
-        &state,
-        &auth.principal.owner_id(),
-        None,
-        None,
-        query,
-        &headers,
-        bytes.to_vec(),
-    )
-    .await
+    ingest_raw_document_in_scope(&state, &store, None, None, query, &headers, bytes.to_vec()).await
 }
 
 /// `POST /projects/{project_id}/documents/raw` — retain exact bytes in one
 /// project corpus and decode it synchronously.
 pub async fn ingest_raw_project_document(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(project_id): Path<ProjectId>,
     Query(query): Query<RawDocumentQuery>,
     headers: HeaderMap,
     RawBytes(bytes): RawBytes,
 ) -> Result<impl IntoResponse, ServerError> {
-    let owner = auth.principal.owner_id();
-    require_project(&state, &owner, project_id).await?;
+    store.require_project(project_id).await?;
     ingest_raw_document_in_scope(
         &state,
-        &owner,
+        &store,
         None,
         Some(project_id),
         query,
@@ -361,17 +348,16 @@ pub async fn ingest_raw_project_document(
 /// conversation and decode it synchronously.
 pub async fn ingest_raw_chat_document(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(chat_id): Path<ChatId>,
     Query(query): Query<RawDocumentQuery>,
     headers: HeaderMap,
     RawBytes(bytes): RawBytes,
 ) -> Result<impl IntoResponse, ServerError> {
-    let owner = auth.principal.owner_id();
-    require_chat(&state, &owner, chat_id).await?;
+    store.require_chat(chat_id).await?;
     ingest_raw_document_in_scope(
         &state,
-        &owner,
+        &store,
         Some(chat_id),
         None,
         query,
@@ -386,22 +372,20 @@ pub async fn ingest_raw_chat_document(
 /// conversation-local identity.
 pub async fn ingest_streamed_raw_chat_document(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(chat_id): Path<ChatId>,
     Query(query): Query<StreamedRawDocumentQuery>,
     headers: HeaderMap,
     body: Body,
 ) -> Result<impl IntoResponse, ServerError> {
-    let owner = auth.principal.owner_id();
-    require_chat(&state, &owner, chat_id).await?;
+    store.require_chat(chat_id).await?;
     let source_blob = streamed_source_blob(&query)?;
     let media_type = raw_document_media_type(&headers)?;
     let title = normalize_document_title(query.title.as_deref())?;
     let document_id = DocumentId::derive_for_chat_content(chat_id, source_blob.sha256);
 
-    if let Some(existing) = state
-        .store
-        .get_document_scoped(&owner, document_id)
+    if let Some(existing) = store
+        .get_document(document_id)
         .await?
         .filter(|document| document.chat_id == Some(chat_id) && document.project_id.is_none())
     {
@@ -431,22 +415,18 @@ pub async fn ingest_streamed_raw_chat_document(
         ServerError::internal("streamed document disappeared before synchronous decoding")
     })?;
     let canonical_text = decode_document(&media_type, &source_bytes);
-    let document = state
-        .store
-        .accept_document_source_scoped(
-            &owner,
-            &DocumentSourceUpsert {
-                id: document_id,
-                chat_id: Some(chat_id),
-                project_id: None,
-                source_uri: None,
-                media_type,
-                title,
-                source_blob,
-                canonical_text,
-                updated_at: Utc::now(),
-            },
-        )
+    let document = store
+        .accept_document_source(&DocumentSourceUpsert {
+            id: document_id,
+            chat_id: Some(chat_id),
+            project_id: None,
+            source_uri: None,
+            media_type,
+            title,
+            source_blob,
+            canonical_text,
+            updated_at: Utc::now(),
+        })
         .await?;
     state.blob_retirement_wake.notify_one();
     Ok((
@@ -461,7 +441,7 @@ pub async fn ingest_streamed_raw_chat_document(
 
 async fn ingest_raw_document_in_scope(
     state: &AppState,
-    owner: &OwnerId,
+    store: &ScopedStore,
     chat_id: Option<ChatId>,
     project_id: Option<ProjectId>,
     query: RawDocumentQuery,
@@ -474,7 +454,7 @@ async fn ingest_raw_document_in_scope(
     let media_type = raw_document_media_type(headers)?;
     publish_document_source(
         state,
-        owner,
+        store,
         chat_id,
         project_id,
         query.uri,
@@ -488,7 +468,7 @@ async fn ingest_raw_document_in_scope(
 #[allow(clippy::too_many_arguments)]
 async fn publish_document_source(
     state: &AppState,
-    owner: &OwnerId,
+    store: &ScopedStore,
     chat_id: Option<ChatId>,
     project_id: Option<ProjectId>,
     source_uri: Option<String>,
@@ -524,22 +504,18 @@ async fn publish_document_source(
     // document may already share the same blob id.
     let _blob_write = state.blob_writes.acquire(source_blob.id).await?;
     state.blobs.put(source_blob.id, source_bytes).await?;
-    let document = state
-        .store
-        .accept_document_source_scoped(
-            owner,
-            &DocumentSourceUpsert {
-                id: document_id,
-                chat_id,
-                project_id,
-                source_uri,
-                media_type,
-                title,
-                source_blob,
-                canonical_text,
-                updated_at: Utc::now(),
-            },
-        )
+    let document = store
+        .accept_document_source(&DocumentSourceUpsert {
+            id: document_id,
+            chat_id,
+            project_id,
+            source_uri,
+            media_type,
+            title,
+            source_blob,
+            canonical_text,
+            updated_at: Utc::now(),
+        })
         .await?;
     state.blob_retirement_wake.notify_one();
     Ok((
@@ -656,46 +632,34 @@ mod title_tests {
 /// document's potentially large canonical text. Project-scoped listing lands with
 /// corpus scoping; this endpoint never widens to every project's documents.
 pub async fn list_documents(
-    State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Query(query): Query<DocumentListQuery>,
 ) -> Result<Json<DocumentListPage>, ServerError> {
-    list_documents_in_scope(
-        &state,
-        &auth.principal.owner_id(),
-        DocumentScope::Unscoped,
-        query,
-    )
-    .await
+    list_documents_in_scope(&store, DocumentScope::Unscoped, query).await
 }
 
 /// `GET /projects/{project_id}/documents` — list one project's document corpus.
 pub async fn list_project_documents(
-    State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(project_id): Path<ProjectId>,
     Query(query): Query<DocumentListQuery>,
 ) -> Result<Json<DocumentListPage>, ServerError> {
-    let owner = auth.principal.owner_id();
-    require_project(&state, &owner, project_id).await?;
-    list_documents_in_scope(&state, &owner, DocumentScope::Project(project_id), query).await
+    store.require_project(project_id).await?;
+    list_documents_in_scope(&store, DocumentScope::Project(project_id), query).await
 }
 
 /// `GET /chats/{chat_id}/documents` — list only sources owned by one conversation.
 pub async fn list_chat_documents(
-    State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(chat_id): Path<ChatId>,
     Query(query): Query<DocumentListQuery>,
 ) -> Result<Json<DocumentListPage>, ServerError> {
-    let owner = auth.principal.owner_id();
-    require_chat(&state, &owner, chat_id).await?;
-    list_documents_in_scope(&state, &owner, DocumentScope::Chat(chat_id), query).await
+    store.require_chat(chat_id).await?;
+    list_documents_in_scope(&store, DocumentScope::Chat(chat_id), query).await
 }
 
 async fn list_documents_in_scope(
-    state: &AppState,
-    owner: &OwnerId,
+    store: &ScopedStore,
     scope: DocumentScope,
     query: DocumentListQuery,
 ) -> Result<Json<DocumentListPage>, ServerError> {
@@ -710,9 +674,8 @@ async fn list_documents_in_scope(
         .as_deref()
         .map(decode_document_cursor)
         .transpose()?;
-    let mut records = state
-        .store
-        .list_document_summaries_scoped(owner, scope, cursor, limit + 1)
+    let mut records = store
+        .list_document_summaries(scope, cursor, limit + 1)
         .await?;
     let has_more = records.len() > limit as usize;
     records.truncate(limit as usize);
@@ -733,13 +696,11 @@ async fn list_documents_in_scope(
 
 /// `GET /documents/{id}` — fetch canonical source and catalog metadata, or `404`.
 pub async fn get_document(
-    State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(id): Path<DocumentId>,
 ) -> Result<Json<DocumentDetail>, ServerError> {
-    state
-        .store
-        .get_document_scoped(&auth.principal.owner_id(), id)
+    store
+        .get_document(id)
         .await?
         .filter(|document| document.chat_id.is_none() && document.project_id.is_none())
         .map(DocumentDetail::from)
@@ -748,16 +709,16 @@ pub async fn get_document(
 }
 
 /// `GET /projects/{project_id}/documents/{document_id}` — fetch an owned document.
+///
+/// The path filter is the whole authorization: an owner-scoped document that
+/// names this project as its parent proves the project is the requester's,
+/// because a document always carries its parent's owner.
 pub async fn get_project_document(
-    State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path((project_id, document_id)): Path<(ProjectId, DocumentId)>,
 ) -> Result<Json<DocumentDetail>, ServerError> {
-    let owner = auth.principal.owner_id();
-    require_project(&state, &owner, project_id).await?;
-    state
-        .store
-        .get_document_scoped(&owner, document_id)
+    store
+        .get_document(document_id)
         .await?
         .filter(|document| document.chat_id.is_none() && document.project_id == Some(project_id))
         .map(DocumentDetail::from)
@@ -768,15 +729,11 @@ pub async fn get_project_document(
 /// `GET /chats/{chat_id}/documents/{document_id}` — fetch a source only when
 /// the path conversation owns it.
 pub async fn get_chat_document(
-    State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path((chat_id, document_id)): Path<(ChatId, DocumentId)>,
 ) -> Result<Json<ChatDocumentDetail>, ServerError> {
-    let owner = auth.principal.owner_id();
-    require_chat(&state, &owner, chat_id).await?;
-    state
-        .store
-        .get_document_scoped(&owner, document_id)
+    store
+        .get_document(document_id)
         .await?
         .filter(|document| document.chat_id == Some(chat_id) && document.project_id.is_none())
         .map(ChatDocumentDetail::from)
@@ -788,37 +745,26 @@ pub async fn get_chat_document(
 /// explicitly unscoped document.
 pub async fn get_document_file_content(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(id): Path<DocumentId>,
     method: Method,
     headers: HeaderMap,
 ) -> Result<Response, ServerError> {
-    serve_document_file_content(
-        &state,
-        &auth.principal.owner_id(),
-        id,
-        None,
-        None,
-        method,
-        &headers,
-    )
-    .await
+    serve_document_file_content(&state, &store, id, None, None, method, &headers).await
 }
 
 /// `GET /projects/{project_id}/documents/{document_id}/file-content` — serve
 /// original bytes only when the path project owns the document.
 pub async fn get_project_document_file_content(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path((project_id, document_id)): Path<(ProjectId, DocumentId)>,
     method: Method,
     headers: HeaderMap,
 ) -> Result<Response, ServerError> {
-    let owner = auth.principal.owner_id();
-    require_project(&state, &owner, project_id).await?;
     serve_document_file_content(
         &state,
-        &owner,
+        &store,
         document_id,
         None,
         Some(project_id),
@@ -832,16 +778,14 @@ pub async fn get_project_document_file_content(
 /// bytes only when the path conversation owns the document.
 pub async fn get_chat_document_file_content(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path((chat_id, document_id)): Path<(ChatId, DocumentId)>,
     method: Method,
     headers: HeaderMap,
 ) -> Result<Response, ServerError> {
-    let owner = auth.principal.owner_id();
-    require_chat(&state, &owner, chat_id).await?;
     serve_document_file_content(
         &state,
-        &owner,
+        &store,
         document_id,
         Some(chat_id),
         None,
@@ -958,16 +902,15 @@ impl ServedMediaType {
 
 async fn serve_document_file_content(
     state: &AppState,
-    owner: &OwnerId,
+    store: &ScopedStore,
     document_id: DocumentId,
     chat_id: Option<ChatId>,
     project_id: Option<ProjectId>,
     method: Method,
     headers: &HeaderMap,
 ) -> Result<Response, ServerError> {
-    let Some(document) = state
-        .store
-        .get_document_scoped(owner, document_id)
+    let Some(document) = store
+        .get_document(document_id)
         .await?
         .filter(|document| document.chat_id == chat_id && document.project_id == project_id)
     else {
@@ -1189,19 +1132,17 @@ mod byte_range_tests {
 /// `DELETE /documents/{id}` — delete one authoritative source.
 pub async fn delete_document(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path(id): Path<DocumentId>,
 ) -> Result<StatusCode, ServerError> {
-    let owner = auth.principal.owner_id();
-    if state
-        .store
-        .get_document_scoped(&owner, id)
+    if store
+        .get_document(id)
         .await?
         .is_some_and(|document| document.chat_id.is_some() || document.project_id.is_some())
     {
         return Err(ServerError::not_found(format!("document {id} not found")));
     }
-    state.store.delete_document_scoped(&owner, id).await?;
+    store.delete_document(id).await?;
     state.blob_retirement_wake.notify_one();
     Ok(StatusCode::ACCEPTED)
 }
@@ -1209,14 +1150,11 @@ pub async fn delete_document(
 /// `DELETE /projects/{project_id}/documents/{document_id}` — retire an owned document.
 pub async fn delete_project_document(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path((project_id, document_id)): Path<(ProjectId, DocumentId)>,
 ) -> Result<StatusCode, ServerError> {
-    let owner = auth.principal.owner_id();
-    require_project(&state, &owner, project_id).await?;
-    if state
-        .store
-        .get_document_scoped(&owner, document_id)
+    if store
+        .get_document(document_id)
         .await?
         .is_none_or(|document| {
             document.chat_id.is_some() || document.project_id != Some(project_id)
@@ -1226,10 +1164,7 @@ pub async fn delete_project_document(
             "document {document_id} not found"
         )));
     }
-    state
-        .store
-        .delete_document_scoped(&owner, document_id)
-        .await?;
+    store.delete_document(document_id).await?;
     state.blob_retirement_wake.notify_one();
     Ok(StatusCode::ACCEPTED)
 }
@@ -1238,14 +1173,11 @@ pub async fn delete_project_document(
 /// by a conversation without exposing another conversation's source identity.
 pub async fn delete_chat_document(
     State(state): State<AppState>,
-    auth: AuthContext,
+    store: ScopedStore,
     Path((chat_id, document_id)): Path<(ChatId, DocumentId)>,
 ) -> Result<StatusCode, ServerError> {
-    let owner = auth.principal.owner_id();
-    require_chat(&state, &owner, chat_id).await?;
-    if state
-        .store
-        .get_document_scoped(&owner, document_id)
+    if store
+        .get_document(document_id)
         .await?
         .is_none_or(|document| document.chat_id != Some(chat_id) || document.project_id.is_some())
     {
@@ -1253,39 +1185,7 @@ pub async fn delete_chat_document(
             "document {document_id} not found"
         )));
     }
-    state
-        .store
-        .delete_document_scoped(&owner, document_id)
-        .await?;
+    store.delete_document(document_id).await?;
     state.blob_retirement_wake.notify_one();
     Ok(StatusCode::ACCEPTED)
-}
-
-async fn require_project(
-    state: &AppState,
-    owner: &OwnerId,
-    project_id: ProjectId,
-) -> Result<(), ServerError> {
-    if state
-        .store
-        .get_project_scoped(owner, project_id)
-        .await?
-        .is_none()
-    {
-        return Err(ServerError::not_found(format!(
-            "project {project_id} not found"
-        )));
-    }
-    Ok(())
-}
-
-async fn require_chat(
-    state: &AppState,
-    owner: &OwnerId,
-    chat_id: ChatId,
-) -> Result<(), ServerError> {
-    if state.store.get_chat_scoped(owner, chat_id).await?.is_none() {
-        return Err(ServerError::not_found(format!("chat {chat_id} not found")));
-    }
-    Ok(())
 }

--- a/crates/openwave-server/src/scoped_store.rs
+++ b/crates/openwave-server/src/scoped_store.rs
@@ -1,0 +1,324 @@
+//! The request-facing store view, bound to one authenticated principal.
+//!
+//! Route handlers do not touch [`Store`] directly. They extract a
+//! [`ScopedStore`] — the durable store bound to the requesting principal's
+//! [`OwnerId`] — and every root-aggregate query on it (chats, projects,
+//! documents) is the trait's owner-scoped variant. The unscoped root surface
+//! simply does not exist on this type, and the inner handle never escapes it,
+//! so route code cannot express a query that crosses owners (#853).
+//!
+//! Non-root operations (turns, agent runs, events, approvals, grants) hang
+//! off a root by id and pass through unchanged; the handler authorizes the
+//! root through this view first, exactly as the store's scoping model
+//! prescribes. System paths that act on already-authorized ids — turn
+//! workers, retirement scans, post-commit signalling — are not requests and
+//! keep the separate unscoped handle on [`AppState`].
+//!
+//! The extractor fails closed like [`AuthContext`] itself: on a route the
+//! auth middleware does not cover it answers `401`, never a defaulted owner.
+
+use std::sync::Arc;
+
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use axum::http::StatusCode;
+
+use openwave_core::{
+    AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentRun, AgentRunId, CallId, Chat, ChatId,
+    ChatTranscriptSnapshot, DeleteChatOutcome, DeleteProjectOutcome, DocumentId,
+    DocumentListCursor, DocumentRecord, DocumentScope, DocumentSourceUpsert, DocumentSummaryRecord,
+    ImageRef, JournaledTurnOutcome, NetworkPolicy, OwnerId, PermissionMode, Project, ProjectId,
+    ReasoningEffort, RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome, Result,
+    SandboxToolCall, SequencedEvent, Store, ToolApproval, ToolCallRecord, TurnId, TurnRun,
+    TurnSteerId,
+};
+
+use crate::error::ServerError;
+use crate::principal::AuthContext;
+use crate::state::AppState;
+
+/// The durable store as one authenticated principal may see it.
+///
+/// Constructed only from server state plus a verified [`AuthContext`], so the
+/// owner inside is always the one the auth middleware resolved. Fields stay
+/// private and no method returns the inner handle.
+#[derive(Clone)]
+pub struct ScopedStore {
+    store: Arc<dyn Store>,
+    owner: OwnerId,
+}
+
+impl ScopedStore {
+    /// Bind the state's store to the request's authenticated principal.
+    pub(crate) fn new(state: &AppState, auth: &AuthContext) -> Self {
+        Self {
+            store: state.store.clone(),
+            owner: auth.principal.owner_id(),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Root aggregates — always owner-scoped. Another owner's row is
+    // indistinguishable from a missing one.
+    // ------------------------------------------------------------------
+
+    /// Fetch the principal's chat by id.
+    pub async fn get_chat(&self, id: ChatId) -> Result<Option<Chat>> {
+        self.store.get_chat_scoped(&self.owner, id).await
+    }
+
+    /// The recurring route gate: the principal's chat, or a `404` that does
+    /// not reveal whether someone else's chat exists under that id.
+    pub async fn require_chat(&self, id: ChatId) -> std::result::Result<Chat, ServerError> {
+        self.get_chat(id)
+            .await?
+            .ok_or_else(|| ServerError::not_found(format!("chat {id} not found")))
+    }
+
+    /// List the principal's chats, most-recently-created first.
+    pub async fn list_chats(&self) -> Result<Vec<Chat>> {
+        self.store.list_chats_scoped(&self.owner).await
+    }
+
+    /// Create a chat owned by the principal, resolving project defaults only
+    /// from the principal's own projects.
+    pub async fn create_chat_with_project_defaults(&self, chat: &Chat) -> Result<Chat> {
+        self.store
+            .create_chat_with_project_defaults_scoped(&self.owner, chat)
+            .await
+    }
+
+    /// Delete the principal's chat.
+    pub async fn delete_chat(&self, id: ChatId) -> Result<DeleteChatOutcome> {
+        self.store.delete_chat_scoped(&self.owner, id).await
+    }
+
+    /// The principal's chat transcript snapshot.
+    pub async fn get_chat_transcript(&self, id: ChatId) -> Result<Option<ChatTranscriptSnapshot>> {
+        self.store.get_chat_transcript_scoped(&self.owner, id).await
+    }
+
+    /// Update user-editable metadata on the principal's chat.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_chat_metadata(
+        &self,
+        id: ChatId,
+        title: Option<Option<String>>,
+        model: Option<Option<String>>,
+        reasoning_effort: Option<Option<ReasoningEffort>>,
+        permission_mode: Option<Option<PermissionMode>>,
+        network_policy: Option<NetworkPolicy>,
+    ) -> Result<bool> {
+        self.store
+            .update_chat_metadata_scoped(
+                &self.owner,
+                id,
+                title,
+                model,
+                reasoning_effort,
+                permission_mode,
+                network_policy,
+            )
+            .await
+    }
+
+    /// Create a project owned by the principal.
+    pub async fn create_project(&self, project: &Project) -> Result<()> {
+        self.store.create_project_scoped(&self.owner, project).await
+    }
+
+    /// Fetch the principal's project by id.
+    pub async fn get_project(&self, id: ProjectId) -> Result<Option<Project>> {
+        self.store.get_project_scoped(&self.owner, id).await
+    }
+
+    /// The project counterpart of [`ScopedStore::require_chat`].
+    pub async fn require_project(
+        &self,
+        id: ProjectId,
+    ) -> std::result::Result<Project, ServerError> {
+        self.get_project(id)
+            .await?
+            .ok_or_else(|| ServerError::not_found(format!("project {id} not found")))
+    }
+
+    /// List the principal's projects, most-recently-created first.
+    pub async fn list_projects(&self) -> Result<Vec<Project>> {
+        self.store.list_projects_scoped(&self.owner).await
+    }
+
+    /// Update the title of the principal's project.
+    pub async fn update_project_title(&self, id: ProjectId, title: Option<String>) -> Result<bool> {
+        self.store
+            .update_project_title_scoped(&self.owner, id, title)
+            .await
+    }
+
+    /// Delete the principal's project.
+    pub async fn delete_project(&self, id: ProjectId) -> Result<DeleteProjectOutcome> {
+        self.store.delete_project_scoped(&self.owner, id).await
+    }
+
+    /// Fetch the principal's document by id.
+    pub async fn get_document(&self, id: DocumentId) -> Result<Option<DocumentRecord>> {
+        self.store.get_document_scoped(&self.owner, id).await
+    }
+
+    /// List the principal's document summaries in one corpus scope.
+    pub async fn list_document_summaries(
+        &self,
+        scope: DocumentScope,
+        after: Option<DocumentListCursor>,
+        limit: u64,
+    ) -> Result<Vec<DocumentSummaryRecord>> {
+        self.store
+            .list_document_summaries_scoped(&self.owner, scope, after, limit)
+            .await
+    }
+
+    /// Delete the principal's document.
+    pub async fn delete_document(&self, id: DocumentId) -> Result<()> {
+        self.store.delete_document_scoped(&self.owner, id).await
+    }
+
+    /// Accept a document source attributed to the principal; a parented
+    /// document must name a parent the principal owns.
+    pub async fn accept_document_source(
+        &self,
+        document: &DocumentSourceUpsert,
+    ) -> Result<DocumentRecord> {
+        self.store
+            .accept_document_source_scoped(&self.owner, document)
+            .await
+    }
+
+    // ------------------------------------------------------------------
+    // Non-root operations — keyed by ids that hang off a root the handler
+    // has already authorized through this view. Settings and standing
+    // grants are not per-owner yet (#853 slice 5); they pass through so the
+    // route surface still has exactly one store seam.
+    // ------------------------------------------------------------------
+
+    /// [`Store::get_turn_run`].
+    pub async fn get_turn_run(&self, id: TurnId) -> Result<Option<TurnRun>> {
+        self.store.get_turn_run(id).await
+    }
+
+    /// [`Store::accept_turn_with_attachments`].
+    pub async fn accept_turn_with_attachments(
+        &self,
+        id: TurnId,
+        chat_id: ChatId,
+        model: &str,
+        content: &str,
+        images: &[ImageRef],
+        documents: &[DocumentId],
+    ) -> Result<AcceptTurnOutcome> {
+        self.store
+            .accept_turn_with_attachments(id, chat_id, model, content, images, documents)
+            .await
+    }
+
+    /// [`Store::accept_turn_steer`].
+    pub async fn accept_turn_steer(
+        &self,
+        id: TurnSteerId,
+        turn_id: TurnId,
+        chat_id: ChatId,
+        content: &str,
+        interrupt: bool,
+    ) -> Result<AcceptTurnSteerOutcome> {
+        self.store
+            .accept_turn_steer(id, turn_id, chat_id, content, interrupt)
+            .await
+    }
+
+    /// [`Store::request_turn_cancellation_and_append_event`].
+    pub async fn request_turn_cancellation_and_append_event(
+        &self,
+        id: TurnId,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Option<JournaledTurnOutcome<RequestTurnCancellationOutcome>>> {
+        self.store
+            .request_turn_cancellation_and_append_event(id, now)
+            .await
+    }
+
+    /// [`Store::list_agent_runs`].
+    pub async fn list_agent_runs(&self, chat_id: ChatId) -> Result<Vec<AgentRun>> {
+        self.store.list_agent_runs(chat_id).await
+    }
+
+    /// [`Store::get_agent_run`].
+    pub async fn get_agent_run(&self, id: AgentRunId) -> Result<Option<AgentRun>> {
+        self.store.get_agent_run(id).await
+    }
+
+    /// [`Store::request_agent_run_cancellation`].
+    pub async fn request_agent_run_cancellation(
+        &self,
+        id: AgentRunId,
+    ) -> Result<Option<RequestAgentRunCancellationOutcome>> {
+        self.store.request_agent_run_cancellation(id).await
+    }
+
+    /// [`Store::list_sandbox_tool_calls_for_agent_run`].
+    pub async fn list_sandbox_tool_calls_for_agent_run(
+        &self,
+        agent_run_id: AgentRunId,
+    ) -> Result<Vec<SandboxToolCall>> {
+        self.store
+            .list_sandbox_tool_calls_for_agent_run(agent_run_id)
+            .await
+    }
+
+    /// [`Store::list_pending_client_tool_calls`].
+    pub async fn list_pending_client_tool_calls(
+        &self,
+        chat_id: ChatId,
+    ) -> Result<Vec<ToolCallRecord>> {
+        self.store.list_pending_client_tool_calls(chat_id).await
+    }
+
+    /// [`Store::list_pending_tool_call_approvals`].
+    pub async fn list_pending_tool_call_approvals(
+        &self,
+        chat_id: ChatId,
+        limit: u64,
+    ) -> Result<Vec<ToolApproval>> {
+        self.store
+            .list_pending_tool_call_approvals(chat_id, limit)
+            .await
+    }
+
+    /// [`Store::list_standing_tool_grants`].
+    pub async fn list_standing_tool_grants(
+        &self,
+    ) -> Result<Vec<openwave_core::StandingGrantRecord>> {
+        self.store.list_standing_tool_grants().await
+    }
+
+    /// [`Store::revoke_standing_tool_grant`].
+    pub async fn revoke_standing_tool_grant(&self, source_call_id: CallId) -> Result<bool> {
+        self.store.revoke_standing_tool_grant(source_call_id).await
+    }
+
+    /// [`Store::list_events`].
+    pub async fn list_events(&self, chat_id: ChatId, after: i64) -> Result<Vec<SequencedEvent>> {
+        self.store.list_events(chat_id, after).await
+    }
+}
+
+impl FromRequestParts<AppState> for ScopedStore {
+    /// Absence of an [`AuthContext`] means the auth middleware never ran for
+    /// this route; no context, no store.
+    type Rejection = StatusCode;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> std::result::Result<Self, Self::Rejection> {
+        let auth = AuthContext::from_request_parts(parts, state).await?;
+        Ok(Self::new(state, &auth))
+    }
+}

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -2658,3 +2658,114 @@ async fn self_host_tokens_resolve_named_principals() {
         "the per-launch bearer names nobody on a shared profile"
     );
 }
+
+/// The slice-4 boundary, exercised through real routes: handlers reach the
+/// store only through the `ScopedStore` bound to the requesting principal, so
+/// one user's root aggregates are invisible to another — reads, listings, and
+/// mutations all answer as if the row does not exist. This is the route-level
+/// face of the store partition test in `openwave-core`'s db suite.
+#[tokio::test]
+async fn routes_scope_root_aggregates_to_the_requesting_principal() {
+    let (dir, store) = temp_db_store("self-host-scoping.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let tokens_file = dir.path().join("tokens");
+    std::fs::write(
+        &tokens_file,
+        "alice aaaaaaaaaaaaaaaa\nbob bbbbbbbbbbbbbbbb\n",
+    )
+    .unwrap();
+    let mut config = Config::desktop(dir.path());
+    config.profile = openwave_core::Profile::SelfHost;
+    config.auth_tokens_file = Some(tokens_file);
+    let state = AppState::new(
+        config,
+        store,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let router = app(state);
+    let alice = "Bearer aaaaaaaaaaaaaaaa";
+    let bob = "Bearer bbbbbbbbbbbbbbbb";
+
+    let chat = make_chat(&router, alice).await;
+
+    // Alice sees her chat; Bob's view holds no trace of it.
+    let get = |bearer: &'static str, uri: String| {
+        let router = router.clone();
+        async move {
+            router
+                .oneshot(
+                    Request::builder()
+                        .uri(uri)
+                        .header(header::AUTHORIZATION, bearer)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+        }
+    };
+    assert_eq!(
+        get(alice, format!("/chats/{}", chat.id)).await.status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        get(bob, format!("/chats/{}", chat.id)).await.status(),
+        StatusCode::NOT_FOUND,
+        "another owner's chat must be indistinguishable from a missing one"
+    );
+    assert_eq!(
+        get(bob, format!("/chats/{}/messages", chat.id))
+            .await
+            .status(),
+        StatusCode::NOT_FOUND,
+        "the transcript behind the chat is equally invisible"
+    );
+    let listed: Vec<Chat> = json_body(get(bob, "/chats".to_owned()).await).await;
+    assert!(
+        listed.is_empty(),
+        "a listing never carries another owner's rows"
+    );
+
+    // Mutations answer the same way: nothing to patch, nothing to delete.
+    let patch = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(format!("/chats/{}", chat.id))
+                .header(header::AUTHORIZATION, bob)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    serde_json::json!({"title": "taken over"}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(patch.status(), StatusCode::NOT_FOUND);
+    let delete = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/chats/{}", chat.id))
+                .header(header::AUTHORIZATION, bob)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(delete.status(), StatusCode::NOT_FOUND);
+
+    // The chat survives the failed takeover, untouched.
+    let survived = get(alice, format!("/chats/{}", chat.id)).await;
+    assert_eq!(survived.status(), StatusCode::OK);
+    let survived: Chat = json_body(survived).await;
+    assert_eq!(survived.title, None, "a cross-owner patch changed nothing");
+}


### PR DESCRIPTION
Slice 4 of #853 (does not close it): enforcement converges at one seam. Route handlers no longer touch `Store` directly — they extract a `ScopedStore`, the durable store bound to the request's `AuthContext`, and the per-handler owner plumbing comes out.

## The view

`scoped_store.rs` holds the store handle and the resolved `OwnerId` in private fields. Every root-aggregate method on it (chats, projects, documents — get/list/create/delete, transcript, metadata, document acceptance) is the trait's owner-scoped variant with the suffix dropped, so `store.get_chat(id)` in a handler *is* the scoped query. The unscoped root surface does not exist on the type and the inner handle never escapes it: a handler simply cannot write a cross-owner root query, by construction rather than by review. `require_chat`/`require_project` fold the recurring existence-gate-plus-404 into the view.

Non-root operations handlers need (turns, agent runs, events, pending approvals/calls, standing grants) pass through unchanged — they act on ids the handler has already authorized through a root. Settings and standing grants are not owner-keyed yet; they ride the same seam so slice 5 changes one place. The extractor fails closed like `AuthContext`: no auth middleware, no store, `401`.

Workers, the titling/retirement/admission paths, post-commit cancellation signalling, WebSocket replay internals, and the exec file-change helpers keep the system-facing unscoped handle on `AppState` — they act on already-authorized ids and have no requesting principal.

## Holes this closed

Three chat-child routes had no ownership gate at all and now require the principal's chat first:

- `GET /chats/{id}/calls/{call_id}/mcp-app-payload` read another chat's journaled tool results,
- `POST .../file-changes/undo` and `POST .../file-changes/{snapshot}/undo` restored file bytes for any chat id.

The grants listing's title decoration now reads the principal's own chats/projects (the last route-side unscoped root read from slice 3's report).

## Retired existence checks

The document get/serve/delete pre-checks (`require_chat`/`require_project` before `get_document_scoped`) came out of six handlers: an owner-scoped document that names the path parent proves the parent is the requester's, because a document invariantly carries its parent's owner. Ingest and listing keep their parent gates — there the 404-vs-empty/error shape is load-bearing and blob writes should not start for a foreign parent.

## Tests

One route-level behavior test over a two-user self-host app (adapting slice 3's store partition test rather than duplicating its matrix): B's reads, listing, patch, and delete of A's chat all answer as if it does not exist, and A's chat survives untouched. The compile-time face of the boundary needs no test — the methods aren't there.

Verified: `cargo check -p openwave-core -p openwave-server --locked --all-targets`, clippy clean, full local test suites of both crates (566 + 545 passing).