### PR TITLE
feat(desktop): frame-bridge verb for REST operation calls

### DIFF
--- a/crates/openwave-core/src/tools/definitions.rs
+++ b/crates/openwave-core/src/tools/definitions.rs
@@ -44,7 +44,12 @@ pub(super) fn create_app() -> ToolSpec {
          declared OpenAPI operationIds (`operation_ids`, for rest_api apps) under \
          it; the configured connected apps and their ids are listed at the end of \
          this description. The app renders in a sandboxed frame with no network \
-         access; pinned capabilities run only after the user grants them. Pass \
+         access; pinned capabilities run only after the user grants them. From \
+         inside the frame the bundle calls them by posting JSON-RPC 2.0 to its \
+         parent window: `tools/call` with `{name, arguments}` for pinned tools, \
+         or `operations/call` with `{operation_id, parameters?, body?}` for \
+         pinned REST operations, whose result carries the raw response as \
+         `{status, content_type, body_base64}`. Pass \
          the app_id from an earlier create_app result to publish a new revision \
          of that app — revisions append, never overwrite.",
     )

--- a/crates/openwave-desktop/ui/src/McpAppBridge.ts
+++ b/crates/openwave-desktop/ui/src/McpAppBridge.ts
@@ -18,7 +18,12 @@
 
 export const MCP_APPS_PROTOCOL_VERSION = "2026-01-26";
 
-import { AppInvokeRefusalError, type AppInvokeResult, type McpAppPayload } from "./api";
+import {
+  AppInvokeRefusalError,
+  type AppInvokeResult,
+  type AppRestInvokeResult,
+  type McpAppPayload,
+} from "./api";
 
 export type { McpAppPayload };
 
@@ -31,6 +36,19 @@ export type { McpAppPayload };
  * host-authored, so surfacing it is not interpretation).
  */
 export type AppToolInvoker = (tool: string, args: unknown) => Promise<AppInvokeResult>;
+
+/**
+ * Executes one granted REST operation on the embedded view's behalf — the
+ * `operations/call` sibling of [`AppToolInvoker`], wired to the same invoke
+ * route. Parameters, body, and the `{status, content_type, body_base64}`
+ * result are opaque passthrough in both directions; rejections map to
+ * JSON-RPC errors exactly as tool-call rejections do.
+ */
+export type AppOperationInvoker = (
+  operationId: string,
+  parameters: unknown,
+  body: unknown,
+) => Promise<AppRestInvokeResult>;
 
 const MIN_FRAME_HEIGHT = 160;
 const MAX_FRAME_HEIGHT = 800;
@@ -58,6 +76,13 @@ export function createMcpAppBridge(options: {
    * host deliberately declared.
    */
   invokeTool?: AppToolInvoker;
+  /**
+   * When present, the view may call `operations/call` and the bridge
+   * forwards it here — the REST sibling of `invokeTool`, under the same
+   * rule: absent, the method refuses with method-not-found, so a view only
+   * gets the methods its host deliberately declared.
+   */
+  invokeOperation?: AppOperationInvoker;
 }): McpAppBridge {
   let viewInitialized = false;
   let payload: McpAppPayload | null = null;
@@ -160,6 +185,51 @@ export function createMcpAppBridge(options: {
                   isError: result.is_error,
                 },
               }),
+            (error: unknown) =>
+              post({
+                jsonrpc: "2.0",
+                id,
+                error:
+                  error instanceof AppInvokeRefusalError
+                    ? {
+                        code: -32000,
+                        message: error.message,
+                        data: { kind: error.kind },
+                      }
+                    : { code: -32000, message: String(error) },
+              }),
+          );
+          break;
+        }
+        case "operations/call": {
+          const invoke = options.invokeOperation;
+          if (!invoke) {
+            post({
+              jsonrpc: "2.0",
+              id,
+              error: { code: -32601, message: "Method not found" },
+            });
+            break;
+          }
+          const params = isRecord(message.params) ? message.params : {};
+          const operationId =
+            typeof params.operation_id === "string" ? params.operation_id : null;
+          if (!operationId) {
+            post({
+              jsonrpc: "2.0",
+              id,
+              error: {
+                code: -32602,
+                message: "operations/call needs a string operation_id",
+              },
+            });
+            break;
+          }
+          // Parameters, body, and the REST result are opaque passthrough the
+          // bridge never interprets; the result object crosses back verbatim.
+          // The reply is asynchronous; `post` already refuses after dispose.
+          void invoke(operationId, params.parameters, params.body).then(
+            (result) => post({ jsonrpc: "2.0", id, result }),
             (error: unknown) =>
               post({
                 jsonrpc: "2.0",

--- a/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppDetailView.dom.test.tsx
@@ -2,7 +2,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { AppDetail, AppGrantState } from "@/api";
+import { AppInvokeRefusalError, type AppDetail, type AppGrantState } from "@/api";
 import { AppDetailView } from "./AppDetailView";
 import type { AppsApis } from "./appsApis";
 
@@ -135,6 +135,107 @@ describe("AppDetailView", () => {
       },
       "*",
     );
+  });
+
+  it("drives one REST operation round trip through the bridge", async () => {
+    const apis = apisWith(GRANTED);
+    render(<AppDetailView appId="app-1" apis={apis} onBack={() => {}} />);
+
+    const frame = (await screen.findByTitle(
+      "App: Fixture app",
+    )) as HTMLIFrameElement;
+    const contentWindow = frame.contentWindow!;
+    const posted = vi.spyOn(contentWindow, "postMessage");
+
+    // The frame asks for a REST operation; the parent forwards it to the
+    // same invoke route and posts the REST result back verbatim.
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: {
+          jsonrpc: "2.0",
+          id: 4,
+          method: "operations/call",
+          params: {
+            operation_id: "listIssues",
+            parameters: { state: "open" },
+            body: { page: 2 },
+          },
+        },
+        source: contentWindow,
+      }),
+    );
+    await waitFor(() => expect(posted).toHaveBeenCalled());
+    expect(apis.invokeOperation).toHaveBeenCalledWith(
+      "app-1",
+      "listIssues",
+      { state: "open" },
+      { page: 2 },
+    );
+    expect(posted).toHaveBeenCalledWith(
+      {
+        jsonrpc: "2.0",
+        id: 4,
+        result: {
+          status: 200,
+          content_type: "application/json",
+          body_base64: "e30=",
+          is_error: false,
+        },
+      },
+      "*",
+    );
+  });
+
+  it("re-gates behind the sheet when an operation call refuses with consent_required", async () => {
+    const apis = apisWith(GRANTED);
+    apis.grantState = vi
+      .fn()
+      .mockResolvedValueOnce(GRANTED)
+      .mockResolvedValue(STALE);
+    apis.invokeOperation = vi
+      .fn()
+      .mockRejectedValue(
+        new AppInvokeRefusalError("consent_required", "Consent required"),
+      );
+    render(<AppDetailView appId="app-1" apis={apis} onBack={() => {}} />);
+
+    const frame = (await screen.findByTitle(
+      "App: Fixture app",
+    )) as HTMLIFrameElement;
+    const contentWindow = frame.contentWindow!;
+    const posted = vi.spyOn(contentWindow, "postMessage");
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: {
+          jsonrpc: "2.0",
+          id: 5,
+          method: "operations/call",
+          params: { operation_id: "listIssues" },
+        },
+        source: contentWindow,
+      }),
+    );
+
+    // The frame sees a typed JSON-RPC error; the host refetches the grant
+    // and drops the frame back behind the consent sheet.
+    await waitFor(() =>
+      expect(posted).toHaveBeenCalledWith(
+        {
+          jsonrpc: "2.0",
+          id: 5,
+          error: {
+            code: -32000,
+            message: "Consent required",
+            data: { kind: "consent_required" },
+          },
+        },
+        "*",
+      ),
+    );
+    expect(
+      await screen.findByRole("button", { name: "Allow access" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByTitle(/^App:/)).not.toBeInTheDocument();
   });
 
   it("gates an ungranted app behind the sheet, marks staleness, and consents body-less", async () => {

--- a/crates/openwave-desktop/ui/src/apps/AppFrame.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppFrame.tsx
@@ -9,9 +9,10 @@ import type { AppsApis } from "./appsApis";
  * The running app: one stored revision in the same sandbox the MCP App card
  * uses — `sandbox="allow-scripts"` without `allow-same-origin`, so the bundle
  * runs with an opaque origin and no reach into OpenWave's DOM, storage, or
- * bearer — plus the host bridge with the tool-call leg wired in. The frame
- * posts `tools/call`; the bridge forwards it to the bearer-authenticated
- * invoke route and posts the result back, both directions opaque passthrough.
+ * bearer — plus the host bridge with both invoke legs wired in. The frame
+ * posts `tools/call` or `operations/call`; the bridge forwards either to the
+ * bearer-authenticated invoke route and posts the result back, both
+ * directions opaque passthrough.
  *
  * A `consent_required` refusal mid-session (revoked, or a server reconfigured
  * while the app was open) is reported upward so the host can re-present the
@@ -57,6 +58,19 @@ export function AppFrame({
       invokeTool: async (tool, args) => {
         try {
           return await apis.invoke(appId, tool, args);
+        } catch (error) {
+          if (
+            error instanceof AppInvokeRefusalError &&
+            error.kind === "consent_required"
+          ) {
+            onConsentRequiredRef.current?.();
+          }
+          throw error;
+        }
+      },
+      invokeOperation: async (operationId, parameters, body) => {
+        try {
+          return await apis.invokeOperation(appId, operationId, parameters, body);
         } catch (error) {
           if (
             error instanceof AppInvokeRefusalError &&

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -84,7 +84,7 @@ fn quoted_host(host: &str) -> String {
 /// Render the host-configured exec time limit in the most readable exact
 /// unit; the value is validated host state, so it composes without quoting.
 fn render_timeout(timeout_ms: u64) -> String {
-    if timeout_ms % 1000 == 0 {
+    if timeout_ms.is_multiple_of(1000) {
         format!("{} seconds", timeout_ms / 1000)
     } else {
         format!("{timeout_ms} milliseconds")


### PR DESCRIPTION
The connected-apps REST-bindings epic (#1344) covered pins, grants, consent, the invoke route, and the renderer client — but the sandboxed app frame's bridge (`McpAppBridge.ts`) spoke MCP JSON-RPC `tools/call` only, so a bundle in its frame could not reach its granted REST operations.

This adds the parallel bridge verb, renderer-only:

- **`operations/call`** JSON-RPC method on the bridge: params `{operation_id, parameters?, body?}`, forwarded through a new optional `invokeOperation` seam with the same opaque-passthrough posture as `invokeTool` — the bridge never interprets parameters, body, or result. The `AppRestInvokeResult` (`{status, content_type, body_base64, is_error, error?}`) is posted back verbatim as the JSON-RPC result. Rejections map exactly as `tools/call` rejections do: a typed `AppInvokeRefusalError` becomes `{code: -32000, message, data: {kind}}`; anything else `{code: -32000, message}`. Absent the seam (the MCP App transcript card), the method refuses with method-not-found.
- **`AppFrame`** wires the seam to `apis.invokeOperation(appId, …)` with the same `consent_required` → `onConsentRequired` re-gating as the tool leg, so a mid-session refusal drops the frame back behind the consent sheet.
- **Model-facing docs**: nothing documented `tools/call` to the model before, so the `create_app` tool description (`openwave-core/src/tools/definitions.rs`) now carries one sentence covering both verbs rather than a new documentation surface.
- **Tests**: two additions to `AppDetailView.dom.test.tsx` — one REST round trip through the frame (postMessage → `apis.invokeOperation` with the right args → result posted back verbatim) and one `consent_required` refusal that re-gates behind the sheet.

No server route changes.

Closes #1364

🤖 Generated with [Claude Code](https://claude.com/claude-code)