### PR TITLE
feat(consent): unified consent read model across tool grants and folder capabilities

### DIFF
--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -360,6 +360,116 @@ pub(crate) async fn list_approved_folders(
     approved_folders(&state).await
 }
 
+/// The capability half of the unified consent read model.
+///
+/// Every host-broker grant, mapped into the same statement shape the server
+/// serves for standing tool grants, so the Permissions surface renders both
+/// stores as one list. Read-only: enforcement stays in the broker's
+/// `authorize()`, and these rows are a projection of the records it consults.
+#[tauri::command]
+pub(crate) async fn list_capability_consents(
+    state: State<'_, HostAccess>,
+) -> Result<Vec<openwave_server::consent::ConsentStatementSnapshot>, String> {
+    let result = state
+        .broker
+        .control(ControlRequest::ListGrantStatements)
+        .await
+        .map_err(|error| error.to_string())?;
+    let ControlResult::ListGrantStatements { grants } = result else {
+        return Err("host broker returned an unexpected response".to_owned());
+    };
+
+    let store = state
+        .store()
+        .ok_or_else(|| "OpenWave is still starting".to_owned())?;
+    let mut statements = Vec::with_capacity(grants.len());
+    for grant in grants {
+        let Some(statement) = capability_statement(store.as_ref(), grant).await else {
+            continue;
+        };
+        statements.push(statement);
+    }
+    Ok(statements)
+}
+
+/// One broker grant as a consent statement, or `None` for vocabulary this
+/// build does not know how to render.
+///
+/// A subject whose chat or project no longer exists keeps its row with no
+/// title: the grant still conveys authority until something revokes it, and
+/// the read model exists precisely so such consent stays visible.
+async fn capability_statement(
+    store: &dyn Store,
+    grant: openwave_host_broker::GrantStatementSummary,
+) -> Option<openwave_server::consent::ConsentStatementSnapshot> {
+    use openwave_host_broker::{ConsentMethod, Scope, SubjectKind};
+    use openwave_server::consent::{
+        ConsentHandle, ConsentMethodSnapshot, ConsentResource, ConsentStatementSnapshot,
+        ConsentVerb, HostCapability,
+    };
+
+    let capability = match grant.capability {
+        Capability::ListRoots => HostCapability::ListRoots,
+        Capability::ReadFiles => HostCapability::ReadFiles,
+        Capability::WriteFiles => HostCapability::WriteFiles,
+        Capability::ExecuteCommands => HostCapability::ExecuteCommands,
+        _ => return None,
+    };
+    let method = match grant.consent_method {
+        ConsentMethod::FolderPicker => ConsentMethodSnapshot::FolderPicker,
+        ConsentMethod::PermissionDialog => ConsentMethodSnapshot::PermissionDialog,
+        ConsentMethod::OperatorConfig => ConsentMethodSnapshot::OperatorConfig,
+        ConsentMethod::CarriedForward => ConsentMethodSnapshot::CarriedForward,
+        _ => return None,
+    };
+    let (level, level_title) = match grant.subject.kind() {
+        SubjectKind::Conversation => {
+            let chat_id = ChatId::from(grant.subject.id());
+            let title = store
+                .get_chat(chat_id)
+                .await
+                .ok()
+                .flatten()
+                .and_then(|chat| chat.title);
+            (openwave_core::GrantLevel::Chat { chat_id }, title)
+        }
+        SubjectKind::Project => {
+            let project_id = openwave_core::ProjectId::from(grant.subject.id());
+            let title = store
+                .get_project(project_id)
+                .await
+                .ok()
+                .flatten()
+                .and_then(|project| project.title);
+            (openwave_core::GrantLevel::Project { project_id }, title)
+        }
+    };
+    let resource = match &grant.scope {
+        Scope::Subject => ConsentResource::HostSubject,
+        Scope::Root { root_id } => ConsentResource::HostRoot {
+            root_id: root_id.to_string(),
+            display_name: grant.root_display_name.clone(),
+        },
+        Scope::PathSubtree { root_id, relative } => ConsentResource::HostPathSubtree {
+            root_id: root_id.to_string(),
+            display_name: grant.root_display_name.clone(),
+            relative: relative.as_str().to_owned(),
+        },
+        _ => return None,
+    };
+    Some(ConsentStatementSnapshot {
+        handle: ConsentHandle::CapabilityGrant {
+            grant_id: grant.grant_id.to_string(),
+        },
+        level,
+        level_title,
+        verb: ConsentVerb::Capability { capability },
+        resource,
+        method,
+        granted_at: grant.granted_at,
+    })
+}
+
 #[tauri::command]
 pub(crate) async fn connect_approved_folder(
     app: AppHandle,

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -223,6 +223,7 @@ pub fn run() {
             host_access::connect_folder,
             host_access::connect_approved_folder,
             host_access::list_approved_folders,
+            host_access::list_capability_consents,
             host_access::list_connected_folders,
             host_access::disconnect_folder,
             updater::desktop_update_state,

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -37,6 +37,7 @@ import {
   type GatewayStatus as WireGatewayStatus,
   type SignInProgress,
   type StandingGrantSnapshot,
+  type ConsentStatementSnapshot,
   type GrantLevel,
   type GrantScope,
   type McpServerInfo as WireMcpServerInfo,
@@ -87,6 +88,7 @@ export type {
   GrantLevel,
   GrantScope,
   StandingGrantSnapshot,
+  ConsentStatementSnapshot,
   ChatToolActivityStatus,
   TranscriptRole,
   RendererToolName,
@@ -1550,6 +1552,15 @@ export class ApiClient {
   /** Every standing "don't ask again", newest first, across all chats. */
   listStandingGrants(): Promise<StandingGrantSnapshot[]> {
     return this.json(`/grants`, { headers: this.headers() });
+  }
+
+  /**
+   * The server's rows of the unified consent read model: every standing tool
+   * grant as one consent statement. The capability half comes from the host
+   * broker over the Tauri boundary and joins these rows renderer-side.
+   */
+  listConsentStatements(): Promise<ConsentStatementSnapshot[]> {
+    return this.json(`/consent/statements`, { headers: this.headers() });
   }
 
   /** Withdraw a standing grant; later matching calls ask again. */

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -617,6 +617,63 @@ export type ConnectedAppsInfo = {
 apps: Array<ConnectedAppInfo>, };
 
 /**
+ * The durable identity a revocation names.
+ *
+ * The two stores revoke differently: a tool grant is withdrawn through
+ * `DELETE /grants/{call_id}`, while a capability grant is not individually
+ * revocable yet — today the Folders surface disconnects the whole root, and
+ * per-statement withdrawal arrives when the boundary is derived from these
+ * statements.
+ */
+export type ConsentHandle = { "kind": "tool_grant", call_id: CallId, } | { "kind": "capability_grant", grant_id: string, };
+
+/**
+ * The trusted interaction that captured a consent statement.
+ */
+export type ConsentMethodSnapshot = "approval_card" | "folder_picker" | "permission_dialog" | "operator_config" | "carried_forward";
+
+/**
+ * What a consent statement's verb is allowed to touch.
+ */
+export type ConsentResource = { "kind": "action_scope", scope: GrantScope, } | { "kind": "host_subject" } | { "kind": "host_root", root_id: string, display_name: string | null, } | { "kind": "host_path_subtree", root_id: string, display_name: string | null, relative: string, };
+
+/**
+ * One statement of consent the agent currently holds, whatever store it
+ * lives in.
+ */
+export type ConsentStatementSnapshot = { 
+/**
+ * What a revocation of this statement names, and where to send it.
+ */
+handle: ConsentHandle, 
+/**
+ * How far the statement reaches — one chat, or every chat in a project.
+ */
+level: GrantLevel, 
+/**
+ * The name of whatever the level points at, for provenance. `None` when
+ * that chat or project is untitled.
+ */
+level_title: string | null, 
+/**
+ * The class of action the user allowed.
+ */
+verb: ConsentVerb, 
+/**
+ * What the verb is allowed to touch.
+ */
+resource: ConsentResource, 
+/**
+ * The trusted interaction through which consent was captured.
+ */
+method: ConsentMethodSnapshot, granted_at: string, };
+
+/**
+ * The class of action a consent statement allows.
+ */
+export type ConsentVerb = { "kind": "tool", action: RendererToolName, approval: ToolApprovalKind, } | { "kind": "capability", capability: HostCapability, };
+
+/**
  * Where the resolved credential value is placed on the request.
  *
  * Externally tagged and closed: `"bearer"` or `{"header": "X-Api-Key"}`; an
@@ -801,6 +858,15 @@ export type GrantLevel = { "level": "chat", chat_id: ChatId, } | { "level": "pro
  * much larger thing to agree to than "don't ask me about `cargo` again".
  */
 export type GrantScope = { "scope": "exact_action" } & ToolActionPreview | { "scope": "any_args_for", command: string, } | { "scope": "command_prefix", tokens: Array<string>, } | { "scope": "whole_tool" };
+
+/**
+ * Renderer-safe mirror of the host broker's capability vocabulary.
+ *
+ * The server does not link the broker crate, so the boundary vocabulary is
+ * restated here for the wire; the desktop maps the broker's own enum into
+ * this one when it assembles capability statements.
+ */
+export type HostCapability = "list_roots" | "read_files" | "write_files" | "execute_commands";
 
 /**
  * Opaque identifier for a folder registered with a host broker.

--- a/crates/openwave-desktop/ui/src/host.ts
+++ b/crates/openwave-desktop/ui/src/host.ts
@@ -1,6 +1,6 @@
 import { invoke, isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import type { Chat } from "./api";
+import type { Chat, ConsentStatementSnapshot } from "./api";
 
 export type ConnectedFolder = {
   rootId: string;
@@ -41,6 +41,17 @@ export function listConnectedFolders(
 
 export function listApprovedFolders(): Promise<ConnectedFolder[]> {
   return invoke("list_approved_folders");
+}
+
+/**
+ * The capability half of the unified consent read model: every host-broker
+ * grant over connected folders, in the same statement shape the server serves
+ * for standing tool grants. Empty outside the native host — a browser build
+ * has no broker and therefore no capability consent to report.
+ */
+export function listCapabilityConsents(): Promise<ConsentStatementSnapshot[]> {
+  if (!isTauri()) return Promise.resolve([]);
+  return invoke("list_capability_consents");
 }
 
 export function connectFolder(chat: Chat): Promise<ConnectedFolder | null> {

--- a/crates/openwave-desktop/ui/src/settings/PermissionsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/PermissionsPanel.dom.test.tsx
@@ -1,27 +1,59 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ApiClient, StandingGrantSnapshot } from "../api";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApiClient, ConsentStatementSnapshot } from "../api";
 import { PermissionsPanel } from "./PermissionsPanel";
 
-const execGrant: StandingGrantSnapshot = {
-  source_call_id: "11111111-1111-1111-1111-111111111111",
+const listCapabilityConsents = vi.hoisted(() =>
+  vi.fn<() => Promise<ConsentStatementSnapshot[]>>(),
+);
+vi.mock("../host", () => ({ listCapabilityConsents }));
+
+const execStatement: ConsentStatementSnapshot = {
+  handle: {
+    kind: "tool_grant",
+    call_id: "11111111-1111-1111-1111-111111111111",
+  },
   level: { level: "chat", chat_id: "22222222-2222-2222-2222-222222222222" },
   level_title: "Quarterly filings",
-  action: "exec",
-  approval: "exec_may_run_networked_command",
-  scope: { scope: "any_args_for", command: "cargo" },
+  verb: { kind: "tool", action: "exec", approval: "exec_may_run_networked_command" },
+  resource: {
+    kind: "action_scope",
+    scope: { scope: "any_args_for", command: "cargo" },
+  },
+  method: "approval_card",
   granted_at: "2026-07-29T12:00:00Z",
+};
+
+const folderWriteStatement: ConsentStatementSnapshot = {
+  handle: {
+    kind: "capability_grant",
+    grant_id: "44444444-4444-4444-4444-444444444444",
+  },
+  level: { level: "chat", chat_id: "22222222-2222-2222-2222-222222222222" },
+  level_title: "Quarterly filings",
+  verb: { kind: "capability", capability: "write_files" },
+  resource: {
+    kind: "host_root",
+    root_id: "55555555-5555-5555-5555-555555555555",
+    display_name: "Documents",
+  },
+  method: "folder_picker",
+  granted_at: "2026-07-30T12:00:00Z",
 };
 
 function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
   return {
-    listStandingGrants: vi.fn().mockResolvedValue([execGrant]),
+    listConsentStatements: vi.fn().mockResolvedValue([execStatement]),
     revokeStandingGrant: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   } as unknown as ApiClient;
 }
+
+beforeEach(() => {
+  listCapabilityConsents.mockResolvedValue([]);
+});
 
 afterEach(() => {
   cleanup();
@@ -29,11 +61,11 @@ afterEach(() => {
 });
 
 describe("PermissionsPanel", () => {
-  it("revokes a grant after confirmation and drops the row", async () => {
+  it("revokes a tool grant after confirmation and drops the row", async () => {
     const client = api();
     render(<PermissionsPanel client={client} />);
 
-    // The grant renders under its chat, worded as the width of the consent.
+    // The statement renders under its chat, worded as the width of the consent.
     await screen.findByText("Quarterly filings");
     screen.getByText("cargo …");
 
@@ -45,7 +77,7 @@ describe("PermissionsPanel", () => {
 
     await waitFor(() =>
       expect(client.revokeStandingGrant).toHaveBeenCalledWith(
-        execGrant.source_call_id,
+        "11111111-1111-1111-1111-111111111111",
       ),
     );
     await waitFor(() =>
@@ -53,26 +85,47 @@ describe("PermissionsPanel", () => {
     );
   });
 
-  it("names a project grant as reaching past the chat that made it", async () => {
-    const projectGrant: StandingGrantSnapshot = {
-      ...execGrant,
-      level: { level: "project", project_id: "33333333-3333-3333-3333-333333333333" },
+  it("renders a broker capability grant beside tool grants, without a revoke control", async () => {
+    listCapabilityConsents.mockResolvedValue([folderWriteStatement]);
+    const client = api();
+    render(<PermissionsPanel client={client} />);
+
+    // Both halves of the read model land in the same chat group: the folder
+    // by its safe display name with its capability verb and picker
+    // provenance, and only the tool grant offers revocation here.
+    await screen.findByText("Documents");
+    screen.getByText("cargo …");
+    screen.getByText("Write files");
+    screen.getByText(/with the folder picker/);
+    screen.getByText("Managed with its folder");
+    expect(screen.getAllByRole("button", { name: "Revoke" })).toHaveLength(1);
+  });
+
+  it("names a project statement as reaching past the chat that made it", async () => {
+    const projectStatement: ConsentStatementSnapshot = {
+      ...execStatement,
+      level: {
+        level: "project",
+        project_id: "33333333-3333-3333-3333-333333333333",
+      },
       level_title: "Filings",
     };
     const client = api({
-      listStandingGrants: vi.fn().mockResolvedValue([projectGrant]),
+      listConsentStatements: vi.fn().mockResolvedValue([projectStatement]),
     });
     render(<PermissionsPanel client={client} />);
 
-    // Not "Filings" alone: the reader has to be able to tell a grant that
+    // Not "Filings" alone: the reader has to be able to tell a statement that
     // covers conversations they have not started yet.
     await screen.findByText("Everything in Filings");
   });
 
   it("says so when nothing is saved", async () => {
-    const client = api({ listStandingGrants: vi.fn().mockResolvedValue([]) });
+    const client = api({
+      listConsentStatements: vi.fn().mockResolvedValue([]),
+    });
     render(<PermissionsPanel client={client} />);
     await screen.findByText(/Nothing saved yet/);
-    expect(client.listStandingGrants).toHaveBeenCalled();
+    expect(client.listConsentStatements).toHaveBeenCalled();
   });
 });

--- a/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
@@ -2,18 +2,20 @@ import { useCallback, useEffect, useState } from "react";
 
 import type {
   ApiClient,
+  ConsentStatementSnapshot,
   GrantScope,
   RendererToolName,
-  StandingGrantSnapshot,
 } from "../api";
 import { useConfirm } from "../components/ConfirmDialog";
+import { listCapabilityConsents } from "../host";
 import { Button } from "@/components/ui/button";
 import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
 
-// The "what the agent can do without asking" surface: every standing grant,
-// grouped by the chat it applies to, each revocable back to being asked.
-// A grant the reader cannot find is a one-way door; this page is where it is
-// found.
+// The "what may the agent do without asking" surface, rendered from the
+// unified consent read model: standing tool grants served by the server and
+// host-broker capability grants reported over the Tauri boundary, as one list
+// of statements grouped by what they reach. A consent the reader cannot find
+// is a one-way door; this page is where it is found.
 
 const TOOL_LABELS: Partial<Record<RendererToolName, string>> = {
   exec: "Commands",
@@ -24,6 +26,26 @@ const TOOL_LABELS: Partial<Record<RendererToolName, string>> = {
 
 export function toolGrantLabel(action: RendererToolName): string {
   return TOOL_LABELS[action] ?? action;
+}
+
+const CAPABILITY_LABELS: Record<
+  Extract<
+    ConsentStatementSnapshot["verb"],
+    { kind: "capability" }
+  >["capability"],
+  string
+> = {
+  list_roots: "List folders",
+  read_files: "Read files",
+  write_files: "Write files",
+  execute_commands: "Run commands",
+};
+
+/** The verb line: the class of action this statement allows. */
+export function verbLabel(verb: ConsentStatementSnapshot["verb"]): string {
+  return verb.kind === "tool"
+    ? toolGrantLabel(verb.action)
+    : CAPABILITY_LABELS[verb.capability];
 }
 
 /**
@@ -72,78 +94,124 @@ export function grantScopeLabel(
   }
 }
 
+/**
+ * The resource line: what the statement's verb is allowed to touch. Host
+ * resources carry the same safe folder identity the folders surface shows —
+ * a display name, never an absolute path.
+ */
+export function resourceLabel(statement: ConsentStatementSnapshot): string {
+  const { resource, verb } = statement;
+  switch (resource.kind) {
+    case "action_scope":
+      return grantScopeLabel(
+        resource.scope,
+        verb.kind === "tool" ? verb.action : "other",
+      );
+    case "host_subject":
+      return "Connected folders";
+    case "host_root":
+      return resource.display_name ?? `Folder ${shortOpaqueId(resource.root_id)}`;
+    case "host_path_subtree": {
+      const folder =
+        resource.display_name ?? `Folder ${shortOpaqueId(resource.root_id)}`;
+      return `${folder}/${resource.relative}`;
+    }
+  }
+}
+
+const METHOD_PHRASES: Record<ConsentStatementSnapshot["method"], string> = {
+  approval_card: "from an approval card",
+  folder_picker: "with the folder picker",
+  permission_dialog: "in a permission dialog",
+  operator_config: "by operator configuration",
+  carried_forward: "carried forward from an earlier approval",
+};
+
 export function shortOpaqueId(id: string): string {
   return id.length <= 10 ? id : `${id.slice(0, 6)}…${id.slice(-4)}`;
 }
 
-/** The identity of whatever a grant reaches, for grouping. */
-export function levelKey(grant: StandingGrantSnapshot): string {
-  return grant.level.level === "chat"
-    ? `chat:${grant.level.chat_id}`
-    : `project:${grant.level.project_id}`;
+/** The identity of whatever a statement reaches, for grouping. */
+export function levelKey(statement: ConsentStatementSnapshot): string {
+  return statement.level.level === "chat"
+    ? `chat:${statement.level.chat_id}`
+    : `project:${statement.level.project_id}`;
 }
 
 /**
- * What a group of grants applies to, named the way the reader chose it. A
- * project grant says so out loud: it reaches conversations that have not been
- * started yet, which is the whole point and also the thing worth being able
- * to see.
+ * What a group of statements applies to, named the way the reader chose it. A
+ * project statement says so out loud: it reaches conversations that have not
+ * been started yet, which is the whole point and also the thing worth being
+ * able to see.
  */
-export function levelLabel(grant: StandingGrantSnapshot): string {
-  const title = grant.level_title?.trim();
-  if (grant.level.level === "project") {
+export function levelLabel(statement: ConsentStatementSnapshot): string {
+  const title = statement.level_title?.trim();
+  if (statement.level.level === "project") {
     return title
       ? `Everything in ${title}`
-      : `Everything in project ${shortOpaqueId(grant.level.project_id)}`;
+      : `Everything in project ${shortOpaqueId(statement.level.project_id)}`;
   }
-  return title || `Chat ${shortOpaqueId(grant.level.chat_id)}`;
+  return title || `Chat ${shortOpaqueId(statement.level.chat_id)}`;
 }
 
-function grantedAtLabel(grantedAt: string): string {
-  const when = new Date(grantedAt);
+function grantedAtLabel(statement: ConsentStatementSnapshot): string {
+  const when = new Date(statement.granted_at);
   if (Number.isNaN(when.getTime())) return "";
-  return `Added ${when.toLocaleDateString(undefined, {
+  const date = when.toLocaleDateString(undefined, {
     year: "numeric",
     month: "short",
     day: "numeric",
-  })}`;
+  });
+  return `Added ${date} ${METHOD_PHRASES[statement.method]}`;
 }
 
-/** Grants in listing order, bucketed by what they reach, order preserved. */
+/** A statement's revocation identity, unique across both stores. */
+export function handleKey(statement: ConsentStatementSnapshot): string {
+  return statement.handle.kind === "tool_grant"
+    ? `tool_grant:${statement.handle.call_id}`
+    : `capability_grant:${statement.handle.grant_id}`;
+}
+
+/** Statements in listing order, bucketed by what they reach, order preserved. */
 export function groupByLevel(
-  grants: readonly StandingGrantSnapshot[],
-): { key: string; label: string; grants: StandingGrantSnapshot[] }[] {
+  statements: readonly ConsentStatementSnapshot[],
+): { key: string; label: string; statements: ConsentStatementSnapshot[] }[] {
   const groups = new Map<
     string,
-    { key: string; label: string; grants: StandingGrantSnapshot[] }
+    { key: string; label: string; statements: ConsentStatementSnapshot[] }
   >();
-  for (const grant of grants) {
-    const key = levelKey(grant);
+  for (const statement of statements) {
+    const key = levelKey(statement);
     const group = groups.get(key);
-    if (group) group.grants.push(grant);
-    else groups.set(key, { key, label: levelLabel(grant), grants: [grant] });
+    if (group) group.statements.push(statement);
+    else
+      groups.set(key, {
+        key,
+        label: levelLabel(statement),
+        statements: [statement],
+      });
   }
   return [...groups.values()];
 }
 
-function GrantRow({
-  grant,
+function StatementRow({
+  statement,
   busy,
   onRevoke,
 }: {
-  grant: StandingGrantSnapshot;
+  statement: ConsentStatementSnapshot;
   busy: boolean;
   onRevoke: () => void;
 }) {
-  const metadata = grantedAtLabel(grant.granted_at);
+  const metadata = grantedAtLabel(statement);
   return (
     <div className="flex items-center justify-between gap-4">
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-medium">
-          {grantScopeLabel(grant.scope, grant.action)}
+          {resourceLabel(statement)}
         </p>
         <p className="text-muted-foreground mt-0.5 truncate text-sm">
-          {toolGrantLabel(grant.action)}
+          {verbLabel(statement.verb)}
         </p>
         {metadata && (
           <p className="text-muted-foreground mt-1 truncate text-xs">
@@ -151,22 +219,36 @@ function GrantRow({
           </p>
         )}
       </div>
-      <Button variant="ghost" size="sm" disabled={busy} onClick={onRevoke}>
-        Revoke
-      </Button>
+      {statement.handle.kind === "tool_grant" ? (
+        <Button variant="ghost" size="sm" disabled={busy} onClick={onRevoke}>
+          Revoke
+        </Button>
+      ) : (
+        // Capability statements are not individually revocable yet; the
+        // Folders surface disconnects the whole folder. Read model first.
+        <span className="text-muted-foreground text-xs">
+          Managed with its folder
+        </span>
+      )}
     </div>
   );
 }
 
 export function PermissionsPanel({ client }: { client: ApiClient }) {
-  const [grants, setGrants] = useState<StandingGrantSnapshot[] | null>(null);
+  const [statements, setStatements] = useState<
+    ConsentStatementSnapshot[] | null
+  >(null);
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const { confirm, dialog } = useConfirm();
 
   const reload = useCallback(async () => {
     try {
-      setGrants(await client.listStandingGrants());
+      const [tool, capability] = await Promise.all([
+        client.listConsentStatements(),
+        listCapabilityConsents(),
+      ]);
+      setStatements([...tool, ...capability]);
       setError(null);
     } catch {
       setError("Saved approvals could not be loaded.");
@@ -177,26 +259,29 @@ export function PermissionsPanel({ client }: { client: ApiClient }) {
     void reload();
   }, [reload]);
 
-  async function revoke(grant: StandingGrantSnapshot) {
+  async function revoke(statement: ConsentStatementSnapshot) {
+    if (statement.handle.kind !== "tool_grant") return;
+    const callId = statement.handle.call_id;
     const confirmed = await confirm({
       title: "Revoke this approval?",
-      description: `The agent will ask again before ${toolGrantLabel(
-        grant.action,
-      ).toLowerCase()} covered by “${grantScopeLabel(
-        grant.scope,
-        grant.action,
-      )}” in ${levelLabel(grant).toLowerCase()}.`,
+      description: `The agent will ask again before ${verbLabel(
+        statement.verb,
+      ).toLowerCase()} covered by “${resourceLabel(
+        statement,
+      )}” in ${levelLabel(statement).toLowerCase()}.`,
       confirmLabel: "Revoke",
       destructive: true,
     });
     if (!confirmed) return;
-    setBusyId(grant.source_call_id);
+    setBusyId(handleKey(statement));
     try {
-      await client.revokeStandingGrant(grant.source_call_id);
-      setGrants(
+      await client.revokeStandingGrant(callId);
+      setStatements(
         (current) =>
           current?.filter(
-            (existing) => existing.source_call_id !== grant.source_call_id,
+            (existing) =>
+              existing.handle.kind !== "tool_grant" ||
+              existing.handle.call_id !== callId,
           ) ?? null,
       );
       setError(null);
@@ -211,25 +296,25 @@ export function PermissionsPanel({ client }: { client: ApiClient }) {
     <SettingsPanel
       title="Permissions"
       description="What the agent can do without asking. Revoke anything to be asked again."
-      busy={grants === null}
+      busy={statements === null}
     >
       {error && <SettingsError>{error}</SettingsError>}
-      {grants !== null && grants.length === 0 && !error && (
+      {statements !== null && statements.length === 0 && !error && (
         <p className="text-sm text-muted-foreground">
-          Nothing saved yet. When you answer an approval with “always allow”,
-          it appears here.
+          Nothing saved yet. When you answer an approval with “always allow”
+          or connect a folder, it appears here.
         </p>
       )}
-      {grants !== null &&
-        groupByLevel(grants).map((group) => (
+      {statements !== null &&
+        groupByLevel(statements).map((group) => (
           <SettingsSection key={group.key} title={group.label}>
             <div className="flex flex-col gap-4">
-              {group.grants.map((grant) => (
-                <GrantRow
-                  key={grant.source_call_id}
-                  grant={grant}
-                  busy={busyId === grant.source_call_id}
-                  onRevoke={() => void revoke(grant)}
+              {group.statements.map((statement) => (
+                <StatementRow
+                  key={handleKey(statement)}
+                  statement={statement}
+                  busy={busyId === handleKey(statement)}
+                  onRevoke={() => void revoke(statement)}
                 />
               ))}
             </div>

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -33,15 +33,16 @@ use crate::{
     path_policy::RootIdentity,
     protocol::{
         ControlEnvelope, ControlRequest, ControlResponseEnvelope, ControlResult, DirectoryEntry,
-        EntryKind, ErrorCode, ErrorResponse, HelloResult, LookupRegisterRootReceiptRequest,
-        LookupRegisterRootReceiptResult, LookupRootAttachmentReceiptRequest,
-        LookupRootAttachmentReceiptResult, OperationEnvelope, OperationRequest,
-        OperationResponseEnvelope, OperationResult, PathRequest, ReadFileBinaryResult,
-        ReadFileResult, RegisterRootReceipt, RegisterRootRequest, RegisterRootResult,
-        ResolveExecRootsRequest, ResolvedExecRoot, Response, ResponseEnvelope, RevokeRootRequest,
-        RevokeRootResult, RootAccess, RootAttachmentMutationKind, RootAttachmentMutationReceipt,
-        RootAttachmentMutationRequest, RootAttachmentMutationResult, RootSummary, WriteFileMode,
-        WriteFileRequest, WriteFileResult, MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
+        EntryKind, ErrorCode, ErrorResponse, GrantStatementSummary, HelloResult,
+        LookupRegisterRootReceiptRequest, LookupRegisterRootReceiptResult,
+        LookupRootAttachmentReceiptRequest, LookupRootAttachmentReceiptResult, OperationEnvelope,
+        OperationRequest, OperationResponseEnvelope, OperationResult, PathRequest,
+        ReadFileBinaryResult, ReadFileResult, RegisterRootReceipt, RegisterRootRequest,
+        RegisterRootResult, ResolveExecRootsRequest, ResolvedExecRoot, Response, ResponseEnvelope,
+        RevokeRootRequest, RevokeRootResult, RootAccess, RootAttachmentMutationKind,
+        RootAttachmentMutationReceipt, RootAttachmentMutationRequest, RootAttachmentMutationResult,
+        RootSummary, WriteFileMode, WriteFileRequest, WriteFileResult, MAX_READ_FILE_BINARY_BYTES,
+        PROTOCOL_VERSION,
     },
     Capability, ConsentMethod, ConsentRecord, ExecutionContext, Grant, GrantError, GrantId,
     GrantSubject, OperationId, RelativePath, RequestId, RootAttachment, RootId, RootPolicy,
@@ -338,13 +339,16 @@ struct ControlAudit {
 impl ControlAudit {
     fn from_request(request: &ControlRequest) -> Option<Self> {
         match request {
-            // Neither reaches user data or changes anything. `Hello` is a
-            // version handshake against a constant, and `ListApprovedRoots`
-            // projects folders the trusted control surface already knows about
-            // for the management UI. Recording them would add volume to a
-            // bounded, rotating log without adding anything a reader could act
-            // on, which costs the records that matter their retention.
-            ControlRequest::Hello | ControlRequest::ListApprovedRoots => None,
+            // None of these reaches user data or changes anything. `Hello` is
+            // a version handshake against a constant, and the two listings
+            // project state the trusted control surface already knows about —
+            // approved folders and standing grants — for the management UI.
+            // Recording them would add volume to a bounded, rotating log
+            // without adding anything a reader could act on, which costs the
+            // records that matter their retention.
+            ControlRequest::Hello
+            | ControlRequest::ListApprovedRoots
+            | ControlRequest::ListGrantStatements => None,
             ControlRequest::ResolveExecRoots(request) => Some(Self {
                 actor: AuditActor::Control {
                     subject: match request.context.project_id() {
@@ -659,6 +663,11 @@ impl Controller {
             ControlRequest::ListApprovedRoots => {
                 let state = self.lock_state().map_err(error_response)?;
                 list_approved_roots(&state).map(|roots| ControlResult::ListApprovedRoots { roots })
+            }
+            ControlRequest::ListGrantStatements => {
+                let state = self.lock_state().map_err(error_response)?;
+                list_grant_statements(&state)
+                    .map(|grants| ControlResult::ListGrantStatements { grants })
             }
             ControlRequest::ResolveExecRoots(request) => {
                 let state = self.lock_state().map_err(error_response)?;
@@ -2193,6 +2202,63 @@ fn list_approved_roots(state: &State) -> Result<Vec<RootSummary>, ErrorResponse>
             .then_with(|| left.root_id.to_string().cmp(&right.root_id.to_string()))
     });
     Ok(roots)
+}
+
+/// Every grant the broker holds, live and dormant, newest consent first.
+///
+/// Unavailable roots keep their grants in the listing: the approval stands
+/// until something withdraws it, and hiding a statement because its volume is
+/// unmounted would make the consent surface understate what the user agreed
+/// to. Their display name is recovered from the approved path's basename, the
+/// same identity a live registration would carry.
+fn list_grant_statements(state: &State) -> Result<Vec<GrantStatementSummary>, ErrorResponse> {
+    // Registration mints a bounded number of grants per root, so the grant
+    // table scales with the root table; the cap exists for the same reason as
+    // the root listing's.
+    const MAX_LIST_GRANTS: usize = MAX_LIST_ROOTS * 8;
+    let scope_display_name = |scope: &Scope, dormant: Option<&UnavailableRoot>| {
+        let root_id = match scope {
+            Scope::Subject => return None,
+            Scope::Root { root_id } | Scope::PathSubtree { root_id, .. } => *root_id,
+        };
+        if let Some(root) = state.roots.get(&root_id) {
+            return Some(root.display_name.clone());
+        }
+        dormant
+            .filter(|root| root.id == root_id)
+            .and_then(|root| root.path.file_name())
+            .map(|name| name.to_string_lossy().into_owned())
+    };
+    let live = state
+        .grants
+        .iter()
+        .map(|grant| (grant, None::<&UnavailableRoot>));
+    let dormant = state
+        .unavailable
+        .iter()
+        .flat_map(|root| root.grants.iter().map(move |grant| (grant, Some(root))));
+    let mut statements = live
+        .chain(dormant)
+        .map(|(grant, dormant)| GrantStatementSummary {
+            grant_id: grant.id(),
+            subject: grant.subject(),
+            capability: grant.capability(),
+            scope: grant.scope().clone(),
+            root_display_name: scope_display_name(grant.scope(), dormant),
+            consent_method: grant.consent().method(),
+            granted_at: grant.consent().granted_at(),
+        })
+        .collect::<Vec<_>>();
+    if statements.len() > MAX_LIST_GRANTS {
+        return Err(error_response(BrokerError::RootListTooLarge));
+    }
+    statements.sort_by(|left, right| {
+        right
+            .granted_at
+            .cmp(&left.granted_at)
+            .then_with(|| left.grant_id.to_string().cmp(&right.grant_id.to_string()))
+    });
+    Ok(statements)
 }
 
 fn list_roots(

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -353,6 +353,54 @@ fn an_empty_conversation_lists_no_roots_without_needing_a_grant() {
 }
 
 #[test]
+fn grant_statements_report_every_minted_consent_with_safe_folder_identity() {
+    let (_temp, broker, path) = setup();
+    let controller = broker.controller();
+    let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    register(&controller, subject, conversation, path, OperationId::new());
+
+    let result = unwrap_response(controller.handle(ControlEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: crate::RequestId::new(),
+        request: ControlRequest::ListGrantStatements,
+    }))
+    .unwrap();
+    let ControlResult::ListGrantStatements { grants } = result else {
+        panic!("unexpected control result")
+    };
+
+    // One picker consent mints exactly the four-capability bundle, and every
+    // statement carries the provenance the consent surface renders.
+    let mut capabilities = grants
+        .iter()
+        .map(|grant| grant.capability)
+        .collect::<Vec<_>>();
+    capabilities.sort_by_key(|capability| format!("{capability:?}"));
+    assert_eq!(
+        capabilities,
+        vec![
+            Capability::ExecuteCommands,
+            Capability::ListRoots,
+            Capability::ReadFiles,
+            Capability::WriteFiles,
+        ]
+    );
+    for grant in &grants {
+        assert_eq!(grant.subject, subject);
+        assert_eq!(grant.consent_method, ConsentMethod::FolderPicker);
+        match &grant.scope {
+            Scope::Subject => assert_eq!(grant.root_display_name, None),
+            Scope::Root { .. } | Scope::PathSubtree { .. } => {
+                // The safe identity is the registered folder's basename, the
+                // same name the approved-roots listing exposes — never a path.
+                assert_eq!(grant.root_display_name.as_deref(), Some("Documents"));
+            }
+        }
+    }
+}
+
+#[test]
 fn approved_roots_can_be_explicitly_attached_to_another_standalone_conversation() {
     let (_temp, broker, path) = setup();
     let first_conversation = Uuid::new_v4();

--- a/crates/openwave-host-broker/src/lib.rs
+++ b/crates/openwave-host-broker/src/lib.rs
@@ -31,14 +31,15 @@ pub use id::{
 pub use path_policy::{RootPolicy, RootPolicyError, ValidatedRoot};
 pub use protocol::{
     ControlEnvelope, ControlRequest, ControlResponseEnvelope, ControlResult, DirectoryEntry,
-    EntryKind, ErrorCode, ErrorResponse, HelloResult, LookupRegisterRootReceiptRequest,
-    LookupRegisterRootReceiptResult, LookupRootAttachmentReceiptRequest,
-    LookupRootAttachmentReceiptResult, OperationEnvelope, OperationRequest,
-    OperationResponseEnvelope, OperationResult, PathRequest, ReadFileBinaryResult, ReadFileResult,
-    RegisterRootReceipt, RegisterRootRequest, RegisterRootResult, ResolveExecRootsRequest,
-    ResolvedExecRoot, Response, ResponseEnvelope, RevokeRootRequest, RevokeRootResult, RootAccess,
-    RootAttachmentMutationKind, RootAttachmentMutationReceipt, RootAttachmentMutationRequest,
-    RootAttachmentMutationResult, RootSummary, WriteApproval, WriteFileMode, WriteFileRequest,
-    WriteFileResult, MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
+    EntryKind, ErrorCode, ErrorResponse, GrantStatementSummary, HelloResult,
+    LookupRegisterRootReceiptRequest, LookupRegisterRootReceiptResult,
+    LookupRootAttachmentReceiptRequest, LookupRootAttachmentReceiptResult, OperationEnvelope,
+    OperationRequest, OperationResponseEnvelope, OperationResult, PathRequest,
+    ReadFileBinaryResult, ReadFileResult, RegisterRootReceipt, RegisterRootRequest,
+    RegisterRootResult, ResolveExecRootsRequest, ResolvedExecRoot, Response, ResponseEnvelope,
+    RevokeRootRequest, RevokeRootResult, RootAccess, RootAttachmentMutationKind,
+    RootAttachmentMutationReceipt, RootAttachmentMutationRequest, RootAttachmentMutationResult,
+    RootSummary, WriteApproval, WriteFileMode, WriteFileRequest, WriteFileResult,
+    MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
 };
 pub use relative_path::{RelativePath, RelativePathError};

--- a/crates/openwave-host-broker/src/protocol.rs
+++ b/crates/openwave-host-broker/src/protocol.rs
@@ -10,8 +10,8 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
-    Capability, ConsentMethod, ExecutionContext, GrantSubject, OperationId, RelativePath,
-    RequestId, RootId,
+    Capability, ConsentMethod, ExecutionContext, GrantId, GrantSubject, OperationId, RelativePath,
+    RequestId, RootId, Scope,
 };
 
 /// Current pre-v1 broker protocol. Bump this for incompatible wire changes.
@@ -66,6 +66,13 @@ pub enum ControlRequest {
     /// This is a trusted-host management operation, not an agent operation.
     /// It exposes neither absolute paths nor attachment authority.
     ListApprovedRoots,
+    /// List every capability grant with its consent provenance.
+    ///
+    /// A trusted-host management operation feeding the unified consent read
+    /// model: a grant the user cannot find is a one-way door. It exposes the
+    /// same safe folder identity as [`ControlRequest::ListApprovedRoots`] —
+    /// display names, never absolute paths — and confers no authority.
+    ListGrantStatements,
     /// Resolve exact product-attached roots for one local-exec invocation.
     ///
     /// This trusted-host operation returns absolute paths and must never be
@@ -314,6 +321,7 @@ pub type OperationResponseEnvelope = ResponseEnvelope<OperationResult>;
 pub enum ControlResult {
     Hello(HelloResult),
     ListApprovedRoots { roots: Vec<RootSummary> },
+    ListGrantStatements { grants: Vec<GrantStatementSummary> },
     ResolveExecRoots { roots: Vec<ResolvedExecRoot> },
     RegisterRoot(RegisterRootResult),
     LookupRegisterRootReceipt(LookupRegisterRootReceiptResult),
@@ -371,6 +379,27 @@ pub struct HelloResult {
 pub struct RootSummary {
     pub root_id: RootId,
     pub display_name: String,
+}
+
+/// One capability grant with its consent provenance, for the management UI.
+///
+/// The scope is reported verbatim; `root_display_name` joins in the same safe
+/// folder identity [`RootSummary`] exposes when the scope names a root, so a
+/// reader can recognize the folder without the broker revealing its absolute
+/// path. Grants whose root is currently unavailable still appear: the consent
+/// stands until something withdraws it, and a statement the user cannot see
+/// cannot be reconsidered.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GrantStatementSummary {
+    pub grant_id: GrantId,
+    pub subject: GrantSubject,
+    pub capability: Capability,
+    pub scope: Scope,
+    /// Present when the scope names a root the broker can still describe.
+    pub root_display_name: Option<String>,
+    pub consent_method: ConsentMethod,
+    pub granted_at: chrono::DateTime<chrono::Utc>,
 }
 
 /// One reachable folder together with what the broker would actually allow on

--- a/crates/openwave-server/src/consent.rs
+++ b/crates/openwave-server/src/consent.rs
@@ -1,0 +1,223 @@
+//! The unified consent read model.
+//!
+//! "What may the agent do without asking me" is answered by two stores with no
+//! shared type: standing tool grants in the journal database, and host-broker
+//! capability grants over connected folders. A [`ConsentStatementSnapshot`] is
+//! one row of the union — subject, verb, resource, consent provenance, and a
+//! revocation handle — so the settings surface can render every statement the
+//! user has made in one list. This is deliberately a read model: enforcement
+//! stays where it is (the approval gate for tools, `authorize()` in the
+//! broker), and these rows are projections of the records those consult.
+//!
+//! The server can only produce the tool-grant half; capability grants live in
+//! the desktop's host broker and reach the renderer over the Tauri boundary in
+//! this same shape, which is why the capability vocabulary here is `pub` and
+//! constructible from outside the crate.
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use openwave_core::{CallId, GrantLevel, GrantScope, RendererToolName, ToolApprovalKind};
+
+/// One statement of consent the agent currently holds, whatever store it
+/// lives in.
+#[derive(Debug, Clone, Serialize, ts_rs::TS)]
+pub struct ConsentStatementSnapshot {
+    /// What a revocation of this statement names, and where to send it.
+    pub handle: ConsentHandle,
+    /// How far the statement reaches — one chat, or every chat in a project.
+    pub level: GrantLevel,
+    /// The name of whatever the level points at, for provenance. `None` when
+    /// that chat or project is untitled.
+    pub level_title: Option<String>,
+    /// The class of action the user allowed.
+    pub verb: ConsentVerb,
+    /// What the verb is allowed to touch.
+    pub resource: ConsentResource,
+    /// The trusted interaction through which consent was captured.
+    pub method: ConsentMethodSnapshot,
+    pub granted_at: DateTime<Utc>,
+}
+
+/// The durable identity a revocation names.
+///
+/// The two stores revoke differently: a tool grant is withdrawn through
+/// `DELETE /grants/{call_id}`, while a capability grant is not individually
+/// revocable yet — today the Folders surface disconnects the whole root, and
+/// per-statement withdrawal arrives when the boundary is derived from these
+/// statements.
+#[derive(Debug, Clone, Serialize, ts_rs::TS)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ConsentHandle {
+    /// The approval decision that created a standing tool grant.
+    ToolGrant { call_id: CallId },
+    /// The host broker's stable identity for a capability grant.
+    CapabilityGrant { grant_id: String },
+}
+
+/// The class of action a consent statement allows.
+#[derive(Debug, Clone, Serialize, ts_rs::TS)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ConsentVerb {
+    /// A gated tool call the user said "always allow" to.
+    Tool {
+        action: RendererToolName,
+        approval: ToolApprovalKind,
+    },
+    /// A host action class guarded by the broker.
+    Capability { capability: HostCapability },
+}
+
+/// Renderer-safe mirror of the host broker's capability vocabulary.
+///
+/// The server does not link the broker crate, so the boundary vocabulary is
+/// restated here for the wire; the desktop maps the broker's own enum into
+/// this one when it assembles capability statements.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+pub enum HostCapability {
+    /// Discover safe summaries of connected folders.
+    ListRoots,
+    /// List directories and read file bytes within a connected folder.
+    ReadFiles,
+    /// Create or explicitly approved replacement of files in a connected
+    /// folder.
+    WriteFiles,
+    /// Expose a connected folder to model-authored commands.
+    ExecuteCommands,
+}
+
+/// What a consent statement's verb is allowed to touch.
+#[derive(Debug, Clone, Serialize, ts_rs::TS)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ConsentResource {
+    /// The action scope of a standing tool grant, verbatim.
+    ActionScope { scope: GrantScope },
+    /// A subject-wide host action that touches no particular folder.
+    HostSubject,
+    /// An entire connected folder, named by the same safe identity the
+    /// folders surface shows — never an absolute path.
+    HostRoot {
+        root_id: String,
+        display_name: Option<String>,
+    },
+    /// One subtree within a connected folder.
+    HostPathSubtree {
+        root_id: String,
+        display_name: Option<String>,
+        relative: String,
+    },
+}
+
+/// The trusted interaction that captured a consent statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+pub enum ConsentMethodSnapshot {
+    /// "Always allow" on an approval card.
+    ApprovalCard,
+    /// A folder chosen through the trusted native picker.
+    FolderPicker,
+    /// An explicit permission dialog.
+    PermissionDialog,
+    /// A local operator deliberately provisioned a headless installation.
+    OperatorConfig,
+    /// A state migration named reach an existing consent already conveyed;
+    /// the timestamp is the original consent's, not a fresh approval.
+    CarriedForward,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openwave_core::{ChatId, ProjectId};
+    use uuid::Uuid;
+
+    /// Both halves of the union serialize to the tagged JSON the renderer's
+    /// generated types describe. The desktop builds capability rows in another
+    /// process, so this shape is a cross-process contract, not an internal.
+    #[test]
+    fn both_consent_statement_flavors_serialize_to_the_shared_wire_shape() {
+        let chat_id = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+        let call_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+        let granted_at: DateTime<Utc> = "2026-07-29T12:00:00Z".parse().unwrap();
+
+        let tool = ConsentStatementSnapshot {
+            handle: ConsentHandle::ToolGrant {
+                call_id: CallId(call_id),
+            },
+            level: GrantLevel::Chat {
+                chat_id: ChatId::from(chat_id),
+            },
+            level_title: Some("Quarterly filings".into()),
+            verb: ConsentVerb::Tool {
+                action: openwave_core::RendererToolName::Exec,
+                approval: ToolApprovalKind::ExecMayRunNetworkedCommand,
+            },
+            resource: ConsentResource::ActionScope {
+                scope: GrantScope::CommandPrefix {
+                    tokens: vec!["cargo".into(), "test".into()],
+                },
+            },
+            method: ConsentMethodSnapshot::ApprovalCard,
+            granted_at,
+        };
+        assert_eq!(
+            serde_json::to_value(&tool).unwrap(),
+            serde_json::json!({
+                "handle": {"kind": "tool_grant", "call_id": call_id},
+                "level": {"level": "chat", "chat_id": chat_id},
+                "level_title": "Quarterly filings",
+                "verb": {
+                    "kind": "tool",
+                    "action": "exec",
+                    "approval": "exec_may_run_networked_command",
+                },
+                "resource": {
+                    "kind": "action_scope",
+                    "scope": {"scope": "command_prefix", "tokens": ["cargo", "test"]},
+                },
+                "method": "approval_card",
+                "granted_at": "2026-07-29T12:00:00Z",
+            })
+        );
+
+        let project_id = Uuid::parse_str("33333333-3333-3333-3333-333333333333").unwrap();
+        let capability = ConsentStatementSnapshot {
+            handle: ConsentHandle::CapabilityGrant {
+                grant_id: "44444444-4444-4444-4444-444444444444".into(),
+            },
+            level: GrantLevel::Project {
+                project_id: ProjectId::from(project_id),
+            },
+            level_title: None,
+            verb: ConsentVerb::Capability {
+                capability: HostCapability::WriteFiles,
+            },
+            resource: ConsentResource::HostRoot {
+                root_id: "55555555-5555-5555-5555-555555555555".into(),
+                display_name: Some("Documents".into()),
+            },
+            method: ConsentMethodSnapshot::FolderPicker,
+            granted_at,
+        };
+        assert_eq!(
+            serde_json::to_value(&capability).unwrap(),
+            serde_json::json!({
+                "handle": {
+                    "kind": "capability_grant",
+                    "grant_id": "44444444-4444-4444-4444-444444444444",
+                },
+                "level": {"level": "project", "project_id": project_id},
+                "level_title": null,
+                "verb": {"kind": "capability", "capability": "write_files"},
+                "resource": {
+                    "kind": "host_root",
+                    "root_id": "55555555-5555-5555-5555-555555555555",
+                    "display_name": "Documents",
+                },
+                "method": "folder_picker",
+                "granted_at": "2026-07-29T12:00:00Z",
+            })
+        );
+    }
+}

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -22,6 +22,9 @@ mod chat_titling;
 /// Host-owned code-execution provider selection and policy.
 pub mod code_execution;
 mod connected_apps;
+/// The unified consent read model: standing tool grants and host-broker
+/// capability grants as one renderer-facing statement shape.
+pub mod consent;
 mod desktop_schema;
 mod document_decode;
 mod durable_oplog;
@@ -469,6 +472,7 @@ pub fn app(state: AppState) -> Router {
             post(routes::post_approval),
         )
         .route("/grants", get(routes::list_standing_grants))
+        .route("/consent/statements", get(routes::list_consent_statements))
         .route(
             "/grants/{call_id}",
             axum::routing::delete(routes::delete_standing_grant),

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -3040,6 +3040,12 @@ pub(crate) struct StandingGrantSnapshot {
 pub(crate) async fn list_standing_grants(
     store: ScopedStore,
 ) -> Result<Json<Vec<StandingGrantSnapshot>>, ServerError> {
+    standing_grant_snapshots(&store).await.map(Json)
+}
+
+async fn standing_grant_snapshots(
+    store: &ScopedStore,
+) -> Result<Vec<StandingGrantSnapshot>, ServerError> {
     let grants = store.list_standing_tool_grants().await?;
     let chat_titles: std::collections::HashMap<ChatId, Option<String>> = store
         .list_chats()
@@ -3053,28 +3059,57 @@ pub(crate) async fn list_standing_grants(
         .into_iter()
         .map(|project| (project.id, project.title))
         .collect();
-    Ok(Json(
-        grants
-            .into_iter()
-            .map(|record| {
-                let level = record.grant.level();
-                let level_title = match level {
-                    openwave_core::GrantLevel::Chat { chat_id } => {
-                        chat_titles.get(&chat_id).cloned().flatten()
-                    }
-                    openwave_core::GrantLevel::Project { project_id } => {
-                        project_titles.get(&project_id).cloned().flatten()
-                    }
-                };
-                StandingGrantSnapshot {
-                    source_call_id: record.source_call_id,
-                    level,
-                    level_title,
-                    action: openwave_core::RendererToolName::from(record.grant.tool_name()),
-                    approval: record.grant.kind(),
-                    scope: record.grant.scope().clone(),
-                    granted_at: record.grant.granted_at(),
+    Ok(grants
+        .into_iter()
+        .map(|record| {
+            let level = record.grant.level();
+            let level_title = match level {
+                openwave_core::GrantLevel::Chat { chat_id } => {
+                    chat_titles.get(&chat_id).cloned().flatten()
                 }
+                openwave_core::GrantLevel::Project { project_id } => {
+                    project_titles.get(&project_id).cloned().flatten()
+                }
+            };
+            StandingGrantSnapshot {
+                source_call_id: record.source_call_id,
+                level,
+                level_title,
+                action: openwave_core::RendererToolName::from(record.grant.tool_name()),
+                approval: record.grant.kind(),
+                scope: record.grant.scope().clone(),
+                granted_at: record.grant.granted_at(),
+            }
+        })
+        .collect())
+}
+
+/// `GET /consent/statements` — the server's rows of the unified consent read
+/// model: every standing tool grant as one [`ConsentStatementSnapshot`].
+///
+/// The capability half of the union lives in the desktop's host broker and
+/// joins these rows renderer-side; the server serves what its own store
+/// holds, in the shared statement shape, so both halves render as one list.
+pub(crate) async fn list_consent_statements(
+    store: ScopedStore,
+) -> Result<Json<Vec<crate::consent::ConsentStatementSnapshot>>, ServerError> {
+    Ok(Json(
+        standing_grant_snapshots(&store)
+            .await?
+            .into_iter()
+            .map(|grant| crate::consent::ConsentStatementSnapshot {
+                handle: crate::consent::ConsentHandle::ToolGrant {
+                    call_id: grant.source_call_id,
+                },
+                level: grant.level,
+                level_title: grant.level_title,
+                verb: crate::consent::ConsentVerb::Tool {
+                    action: grant.action,
+                    approval: grant.approval,
+                },
+                resource: crate::consent::ConsentResource::ActionScope { scope: grant.scope },
+                method: crate::consent::ConsentMethodSnapshot::ApprovalCard,
+                granted_at: grant.granted_at,
             })
             .collect(),
     ))

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -320,6 +320,7 @@ mod tests {
         // validators narrow *from* — see the aliases in api.ts.
         generate::collect_from::<crate::routes::PendingApprovalSnapshot>(&cfg, &mut out);
         generate::collect_from::<crate::routes::StandingGrantSnapshot>(&cfg, &mut out);
+        generate::collect_from::<crate::consent::ConsentStatementSnapshot>(&cfg, &mut out);
         // The app-invoke refusal envelope. The invoke payloads themselves are
         // opaque passthrough for the sandboxed frame and stay hand-written;
         // only the refusal is generated, because the renderer branches on its


### PR DESCRIPTION
Slice 3 of #939: one read model for every consent the agent currently holds, so "what may the agent do to my files" is answerable in one place. Read-only by design — enforcement is untouched on both sides (the approval gate for tools, `authorize()` in the broker).

**The shape.** `ConsentStatementSnapshot` is one flat statement: a revocation `handle` (tagged by store: the tool grant's `call_id` for `DELETE /grants/{call_id}`, or the broker's `grant_id`), the `level` it reaches (chat or project, with title), a `verb` (a gated tool action or a host `capability`), a `resource` (the tool grant's action scope verbatim, or a connected folder / subtree named by its safe display name — never an absolute path), the consent `method` (approval card, folder picker, permission dialog, operator config, carried forward), and `granted_at`.

**The producers.**
- The host broker gains a trusted control operation, `ListGrantStatements`, reporting every capability grant with its consent provenance, joined with the same safe folder identity the approved-roots listing exposes. Grants on currently unavailable roots stay in the listing: the consent stands until something withdraws it.
- The server serves its half at `GET /consent/statements` (standing tool grants as statements; `GET /grants` and revocation are unchanged), and the statement vocabulary lives in a new public `consent` module so the desktop can emit the same shape.
- A new Tauri command, `list_capability_consents`, maps broker grants into statements, resolving chat/project titles from the store. A subject whose chat is gone keeps its row untitled — the read model exists precisely so such consent stays visible.

**The surface.** The Permissions panel now renders both halves as one list, grouped by what they reach. Tool statements keep their Revoke flow exactly as before; capability statements render read-only ("Managed with its folder") until per-statement withdrawal arrives with the boundary-derivation slice.

Tests: a broker test proving a picker registration reports its four-capability bundle with provenance and safe folder identity; a serde shape test pinning both statement flavors' wire JSON (the desktop builds capability rows in another process, so the tagging is a cross-process contract); the panel suite adapted to statements plus one rendering test covering a capability row beside a tool row. Wire types regenerated.

Part of #939 (slice 3 of the plan; does not close it).