### PR TITLE
feat(server): AllowLocalMcpServers policy key narrows the managed MCP lockdown

### DIFF
--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -953,7 +953,14 @@ pending_gateway_url?: string,
  * Asserted per key, so it binds even when no gateway URL is deployed and
  * the profile is otherwise unmanaged.
  */
-permission_mode_ceiling?: PermissionMode, };
+permission_mode_ceiling?: PermissionMode, 
+/**
+ * True when the OS policy explicitly allows local stdio MCP servers on a
+ * managed profile. False by default — the managed lockdown covers every
+ * manual transport unless the organization opts in — and carries no
+ * meaning while unmanaged, where nothing is locked to begin with.
+ */
+allow_local_mcp_servers: boolean, };
 
 /**
  * Which authority asserted the active policy.

--- a/crates/openwave-server/src/managed_policy.rs
+++ b/crates/openwave-server/src/managed_policy.rs
@@ -34,6 +34,13 @@ const MANAGED_GATEWAY_URL_KEY: &str = "GatewayURL";
 /// below it, never above.
 const MANAGED_PERMISSION_MODE_KEY: &str = "MaximumPermissionMode";
 
+/// The key an OS artifact stores the local-MCP allowance under, shared by the
+/// Windows registry value and the macOS managed-preferences key. When true,
+/// managed policy leaves local stdio MCP servers to the user; remote manual
+/// (`url`) servers stay locked. Absent reads as false — deny is the managed
+/// default, and the organization opts in explicitly.
+const MANAGED_ALLOW_LOCAL_MCP_KEY: &str = "AllowLocalMcpServers";
+
 /// Which authority asserted the active policy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
@@ -76,6 +83,11 @@ pub(crate) struct ManagedPolicy {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub(crate) permission_mode_ceiling: Option<PermissionMode>,
+    /// True when the OS policy explicitly allows local stdio MCP servers on a
+    /// managed profile. False by default — the managed lockdown covers every
+    /// manual transport unless the organization opts in — and carries no
+    /// meaning while unmanaged, where nothing is locked to begin with.
+    pub(crate) allow_local_mcp_servers: bool,
 }
 
 impl ManagedPolicy {
@@ -89,6 +101,7 @@ impl ManagedPolicy {
             misconfigured: true,
             pending_gateway_url: None,
             permission_mode_ceiling: None,
+            allow_local_mcp_servers: false,
         }
     }
 
@@ -129,6 +142,14 @@ pub(crate) trait OsPolicySource: Send + Sync {
     /// fails that closed by clamping to the default mode rather than
     /// dropping the ceiling.
     fn permission_mode_ceiling(&self) -> Result<Option<PermissionMode>> {
+        Ok(None)
+    }
+
+    /// The OS-asserted local-MCP allowance, when the platform declares one.
+    /// Same error contract as [`Self::gateway_url`]: `Err` means an artifact
+    /// exists but its assertion cannot be honored — [`resolve`] fails that
+    /// closed to deny rather than honoring a broken opt-in.
+    fn allow_local_mcp_servers(&self) -> Result<Option<bool>> {
         Ok(None)
     }
 }
@@ -317,6 +338,10 @@ impl OsPolicySource for ManagedPreferencesSource {
     fn permission_mode_ceiling(&self) -> Result<Option<PermissionMode>> {
         self.channel_value(permission_mode_from_managed_plist)
     }
+
+    fn allow_local_mcp_servers(&self) -> Result<Option<bool>> {
+        self.channel_value(allow_local_mcp_from_managed_plist)
+    }
 }
 
 /// Read one managed-preferences channel's bytes: an absent file is `None`.
@@ -377,14 +402,7 @@ fn trusted_plist_bytes(path: &Path, trusted_owner: u32) -> Result<Option<Vec<u8>
 // Live via the reader only where the platform wires it; tested everywhere.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 fn string_from_managed_plist(bytes: &[u8], key: &str) -> Result<Option<String>> {
-    let value = plist::Value::from_reader(std::io::Cursor::new(bytes))
-        .map_err(|_| AgentError::config("managed preferences plist is unreadable"))?;
-    let Some(dictionary) = value.as_dictionary() else {
-        return Err(AgentError::config(
-            "managed preferences plist is not a dictionary",
-        ));
-    };
-    match dictionary.get(key) {
+    match value_from_managed_plist(bytes, key)? {
         None => Ok(None),
         Some(value) => match value.as_string() {
             Some(raw) => Ok(Some(raw.to_owned())),
@@ -393,6 +411,19 @@ fn string_from_managed_plist(bytes: &[u8], key: &str) -> Result<Option<String>> 
             ))),
         },
     }
+}
+
+/// Look one key up in a managed-preferences plist (binary or XML).
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn value_from_managed_plist(bytes: &[u8], key: &str) -> Result<Option<plist::Value>> {
+    let value = plist::Value::from_reader(std::io::Cursor::new(bytes))
+        .map_err(|_| AgentError::config("managed preferences plist is unreadable"))?;
+    let Some(dictionary) = value.as_dictionary() else {
+        return Err(AgentError::config(
+            "managed preferences plist is not a dictionary",
+        ));
+    };
+    Ok(dictionary.get(key).cloned())
 }
 
 /// Extract and validate `GatewayURL` from a managed-preferences plist.
@@ -410,6 +441,23 @@ fn permission_mode_from_managed_plist(bytes: &[u8]) -> Result<Option<PermissionM
     string_from_managed_plist(bytes, MANAGED_PERMISSION_MODE_KEY)?
         .map(|raw| asserted_permission_mode(&raw))
         .transpose()
+}
+
+/// Extract `AllowLocalMcpServers` from a managed-preferences plist: a native
+/// plist boolean as profile tooling authors it, or the shared string token
+/// for hand-built artifacts.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn allow_local_mcp_from_managed_plist(bytes: &[u8]) -> Result<Option<bool>> {
+    match value_from_managed_plist(bytes, MANAGED_ALLOW_LOCAL_MCP_KEY)? {
+        None => Ok(None),
+        Some(plist::Value::Boolean(flag)) => Ok(Some(flag)),
+        Some(value) => match value.as_string() {
+            Some(raw) => asserted_policy_flag(raw).map(Some),
+            None => Err(AgentError::config(format!(
+                "managed preferences {MANAGED_ALLOW_LOCAL_MCP_KEY} is not a boolean"
+            ))),
+        },
+    }
 }
 
 /// Machine policy from the Windows registry:
@@ -462,6 +510,12 @@ impl OsPolicySource for RegistryPolicySource {
             .map(|raw| asserted_permission_mode(&raw))
             .transpose()
     }
+
+    fn allow_local_mcp_servers(&self) -> Result<Option<bool>> {
+        registry_policy_value(MANAGED_ALLOW_LOCAL_MCP_KEY)?
+            .map(|raw| asserted_policy_flag(&raw))
+            .transpose()
+    }
 }
 
 /// A JSON policy file: `{"gateway_url": "https://…"}`. Linux wires this at
@@ -511,11 +565,15 @@ impl OsPolicySource for PolicyFileSource {
             .map(|raw| asserted_permission_mode(&raw))
             .transpose()
     }
+
+    fn allow_local_mcp_servers(&self) -> Result<Option<bool>> {
+        Ok(self.read()?.and_then(|file| file.allow_local_mcp_servers))
+    }
 }
 
 /// The policy-file payload: `{"gateway_url": "https://…",
-/// "maximum_permission_mode": "ask"}`, each key optional but at least one
-/// required.
+/// "maximum_permission_mode": "ask", "allow_local_mcp_servers": true}`, each
+/// key optional but at least one required.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 #[derive(Deserialize)]
 struct PolicyFilePayload {
@@ -523,6 +581,8 @@ struct PolicyFilePayload {
     gateway_url: Option<String>,
     #[serde(default)]
     maximum_permission_mode: Option<String>,
+    #[serde(default)]
+    allow_local_mcp_servers: Option<bool>,
 }
 
 /// Decode the policy-file payload. Split from the reader so the format is
@@ -535,7 +595,10 @@ struct PolicyFilePayload {
 fn decode_policy_json(bytes: &[u8]) -> Result<PolicyFilePayload> {
     let file: PolicyFilePayload = serde_json::from_slice(bytes)
         .map_err(|_| AgentError::config("managed policy file is not the expected JSON shape"))?;
-    if file.gateway_url.is_none() && file.maximum_permission_mode.is_none() {
+    if file.gateway_url.is_none()
+        && file.maximum_permission_mode.is_none()
+        && file.allow_local_mcp_servers.is_none()
+    {
         return Err(AgentError::config(
             "managed policy file names no recognized policy keys",
         ));
@@ -568,6 +631,22 @@ fn asserted_permission_mode(raw: &str) -> Result<PermissionMode> {
              expected one of plan, ask, auto, allow"
         ))
     })
+}
+
+/// The shared token check for a boolean policy value read from an OS artifact
+/// that carries strings (the registry's `REG_SZ`, a hand-authored plist):
+/// trimmed, then held to `true`/`false`. Anything else — including blank — is
+/// a misconfiguration, never silently ignored.
+// Live via the readers only where the platform wires it; tested everywhere.
+#[cfg_attr(not(any(target_os = "macos", windows)), allow(dead_code))]
+fn asserted_policy_flag(raw: &str) -> Result<bool> {
+    match raw.trim() {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        value => Err(AgentError::config(format!(
+            "managed policy asserts an unknown flag value {value:?}; expected true or false"
+        ))),
+    }
 }
 
 /// The durable provisioned state, stored as one setting.
@@ -610,6 +689,19 @@ pub(crate) async fn resolve(
             Some(PermissionMode::Ask)
         }
     };
+    // Same per-key shape for the local-MCP allowance, with the opposite
+    // failure direction: an opt-in whose artifact is broken fails closed to
+    // the deny default rather than granting the allowance.
+    policy.allow_local_mcp_servers = match os_policy.allow_local_mcp_servers() {
+        Ok(flag) => flag.unwrap_or(false),
+        Err(error) => {
+            tracing::warn!(
+                "OS-managed local-MCP allowance is present but unusable: {error}; \
+                 failing closed to deny"
+            );
+            false
+        }
+    };
     Ok(policy)
 }
 
@@ -647,6 +739,7 @@ async fn resolve_gateway(
         misconfigured: false,
         pending_gateway_url: None,
         permission_mode_ceiling: None,
+        allow_local_mcp_servers: false,
     })
 }
 
@@ -661,6 +754,7 @@ fn asserted(source: ManagedPolicySource, gateway_url: &str) -> ManagedPolicy {
             misconfigured: false,
             pending_gateway_url: None,
             permission_mode_ceiling: None,
+            allow_local_mcp_servers: false,
         },
         Err(error) => {
             tracing::warn!("{source:?}-asserted gateway URL fails the contract: {error}");
@@ -903,6 +997,16 @@ mod tests {
         let policy = resolve(&*store, &reader).await.unwrap();
         assert!(policy.managed && !policy.misconfigured);
         assert_eq!(policy.permission_mode_ceiling, Some(PermissionMode::Auto));
+        // The local-MCP allowance defaults to deny; the org asserts it as a
+        // native JSON boolean alongside whatever else the file carries.
+        assert!(!policy.allow_local_mcp_servers);
+        std::fs::write(
+            &path,
+            br#"{ "gateway_url": "https://corp.gateway", "allow_local_mcp_servers": true }"#,
+        )
+        .unwrap();
+        let policy = resolve(&*store, &reader).await.unwrap();
+        assert!(policy.managed && policy.allow_local_mcp_servers);
 
         for corrupt in [&b"not json"[..], br#"{ "gateway": "wrong shape" }"#] {
             std::fs::write(&path, corrupt).unwrap();
@@ -975,6 +1079,26 @@ mod tests {
         );
         let unknown = xml("<key>MaximumPermissionMode</key><string>yolo</string>");
         assert!(permission_mode_from_managed_plist(unknown.as_bytes()).is_err());
+
+        // The local-MCP allowance reads the native plist boolean profiles
+        // author, or the shared string token; absent is `None`, and a token
+        // outside true/false refuses.
+        let allowed = xml("<key>AllowLocalMcpServers</key><true/>");
+        assert_eq!(
+            allow_local_mcp_from_managed_plist(allowed.as_bytes()).unwrap(),
+            Some(true)
+        );
+        let token = xml("<key>AllowLocalMcpServers</key><string> true </string>");
+        assert_eq!(
+            allow_local_mcp_from_managed_plist(token.as_bytes()).unwrap(),
+            Some(true)
+        );
+        assert_eq!(
+            allow_local_mcp_from_managed_plist(unrelated.as_bytes()).unwrap(),
+            None
+        );
+        let bad_flag = xml("<key>AllowLocalMcpServers</key><string>yes</string>");
+        assert!(allow_local_mcp_from_managed_plist(bad_flag.as_bytes()).is_err());
     }
 
     /// The ceiling's failure direction: a present-but-broken assertion clamps

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -49,6 +49,33 @@ const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(30);
 pub(crate) const MANAGED_DISABLED_DIAGNOSTIC: &str =
     "Disabled by managed policy. Gateway-managed MCP endpoints remain available.";
 
+/// How far managed policy locks the manual transports right now.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ManualLockdown {
+    /// Unmanaged: nothing is locked.
+    Open,
+    /// Managed with `AllowLocalMcpServers`: local stdio servers are the
+    /// user's; remote manual (`url`) servers stay locked, because a
+    /// credentialed remote endpoint outside the gateway is exactly the
+    /// egress the entitlement list exists to answer for.
+    RemoteManual,
+    /// The managed default: every manual transport is locked.
+    AllManual,
+}
+
+impl ManualLockdown {
+    /// The lockdown a resolved policy asserts.
+    pub(crate) fn for_policy(policy: &crate::managed_policy::ManagedPolicy) -> Self {
+        if !policy.managed {
+            Self::Open
+        } else if policy.allow_local_mcp_servers {
+            Self::RemoteManual
+        } else {
+            Self::AllManual
+        }
+    }
+}
+
 /// Validated external servers selected by the legacy boot file.
 #[derive(Default)]
 pub(crate) struct ConfiguredMcpServers(Vec<McpServerDefinition>);
@@ -597,26 +624,26 @@ impl McpRuntime {
         }
     }
 
-    /// Whether managed policy currently locks the manual transports.
+    /// How far managed policy currently locks the manual transports.
     ///
     /// Read per operation rather than cached at boot, like every other policy
     /// consumer, so an MDM push or removal takes effect without a restart. An
-    /// unreadable policy fails closed to locked — the same judgment the BYOK
-    /// boot paths make.
-    async fn manual_transports_locked(&self) -> bool {
+    /// unreadable policy fails closed to the full lockdown — the same judgment
+    /// the BYOK boot paths make.
+    async fn manual_lockdown(&self) -> ManualLockdown {
         match crate::managed_policy::resolve(&*self.store, &*self.os_policy).await {
-            Ok(policy) => policy.managed,
+            Ok(policy) => ManualLockdown::for_policy(&policy),
             Err(error) => {
                 tracing::warn!(
                     "managed policy is unreadable; locking manual MCP transports: {error}"
                 );
-                true
+                ManualLockdown::AllManual
             }
         }
     }
 
-    /// The names in `candidate` that would add or change a manual (stdio or
-    /// HTTP) server relative to what is already configured.
+    /// The names in `candidate` that would add or change a manual server the
+    /// lockdown covers, relative to what is already configured.
     ///
     /// Managed lockdown refuses these rather than every manual definition in
     /// the body: a profile that carried manual servers before it was managed
@@ -627,12 +654,16 @@ impl McpRuntime {
     ///
     /// "Unchanged" is the whole definition, by equality: a flipped `enabled`,
     /// a renamed server, a widened timeout are all edits.
-    async fn manual_additions(&self, candidate: &McpServersConfig) -> Vec<String> {
+    async fn manual_additions(
+        &self,
+        candidate: &McpServersConfig,
+        lockdown: ManualLockdown,
+    ) -> Vec<String> {
         let existing = &self.state.lock().await.definitions;
         candidate
             .servers
             .iter()
-            .filter(|server| server.gateway_endpoint.is_none())
+            .filter(|server| manual_lockdown_applies(server, lockdown))
             .filter(|server| !existing.iter().any(|current| current == *server))
             .map(|server| server.name.clone())
             .collect()
@@ -649,18 +680,18 @@ impl McpRuntime {
     ///
     /// Returns whether anything was taken down.
     pub(crate) async fn enforce_manual_lockdown(&self) -> bool {
-        if !self.manual_transports_locked().await {
-            return false;
+        match self.manual_lockdown().await {
+            ManualLockdown::Open => false,
+            lockdown => self.take_down_locked_manual_servers(lockdown).await,
         }
-        self.take_down_locked_manual_servers().await
     }
 
-    async fn take_down_locked_manual_servers(&self) -> bool {
+    async fn take_down_locked_manual_servers(&self, lockdown: ManualLockdown) -> bool {
         let mut state = self.state.lock().await;
         let locked: Vec<String> = state
             .definitions
             .iter()
-            .filter(|definition| definition.gateway_endpoint.is_none())
+            .filter(|definition| manual_lockdown_applies(definition, lockdown))
             .map(|definition| definition.name.clone())
             .collect();
         let mut torn_down = false;
@@ -732,9 +763,12 @@ impl McpRuntime {
         }
         // The boot file is a host-environment artifact: on a managed
         // profile it is exactly the channel the lockdown exists to
-        // close, so it is inert rather than partially honored. The
-        // warning is the operator's diagnostic for the silence.
-        if !boot.is_empty() && self.manual_transports_locked().await {
+        // close, so it is inert rather than partially honored — unless
+        // the org's `AllowLocalMcpServers` opt-in re-opens the local
+        // channel, in which case any remote (`url`) definitions it names
+        // are still forced down per definition below. The warning is the
+        // operator's diagnostic for the silence.
+        if !boot.is_empty() && self.manual_lockdown().await == ManualLockdown::AllManual {
             tracing::warn!(
                 "{CONFIG_ENV} is ignored on a managed profile; \
                  mount MCP endpoints from the model gateway instead"
@@ -816,7 +850,10 @@ impl McpRuntime {
     /// keeps the tests that predate the policy check reading as they did.
     #[cfg(test)]
     pub(crate) async fn replace(&self, config: McpServersConfig) -> Result<McpServersInfo> {
-        match self.replace_under_policy(config, false).await? {
+        match self
+            .replace_under_policy(config, ManualLockdown::Open)
+            .await?
+        {
             McpReplaceOutcome::Replaced(info) => Ok(info),
             McpReplaceOutcome::RefusedManual(_) => {
                 unreachable!("an unmanaged replacement is never refused")
@@ -842,14 +879,12 @@ impl McpRuntime {
     pub(crate) async fn replace_under_policy(
         &self,
         config: McpServersConfig,
-        managed: bool,
+        lockdown: ManualLockdown,
     ) -> Result<McpReplaceOutcome> {
         let _mutation = self.mutation.lock().await;
-        if managed {
-            let refused = self.manual_additions(&config).await;
-            if !refused.is_empty() {
-                return Ok(McpReplaceOutcome::RefusedManual(refused));
-            }
+        let refused = self.manual_additions(&config, lockdown).await;
+        if !refused.is_empty() {
+            return Ok(McpReplaceOutcome::RefusedManual(refused));
         }
         Ok(McpReplaceOutcome::Replaced(
             self.replace_committed(config).await?,
@@ -922,10 +957,10 @@ impl McpRuntime {
                 .collect()
         };
         let gateway = &*self.gateway;
-        let locked = self.manual_transports_locked().await;
+        let lockdown = self.manual_lockdown().await;
         let mut servers = HashMap::new();
         let connections = join_all(definitions.iter().map(|definition| async move {
-            if connects(definition, locked) {
+            if connects(definition, lockdown) {
                 definition.connect_with_views(gateway).await.map(Some)
             } else {
                 Ok(None)
@@ -969,7 +1004,7 @@ impl McpRuntime {
                     ManagedServer {
                         client: None,
                         health: McpHealth::Disabled,
-                        diagnostic: managed_lockdown_diagnostic(definition, locked),
+                        diagnostic: managed_lockdown_diagnostic(definition, lockdown),
                         reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
                         epoch: self.fresh_epoch(),
                         reconnect_lock: Arc::new(Mutex::new(())),
@@ -1020,10 +1055,10 @@ impl McpRuntime {
         ids: BTreeMap<String, ConnectedAppId>,
     ) {
         let gateway = &*self.gateway;
-        let locked = self.manual_transports_locked().await;
+        let lockdown = self.manual_lockdown().await;
         let mut servers = HashMap::new();
         let connections = join_all(definitions.iter().map(|definition| async move {
-            if connects(definition, locked) {
+            if connects(definition, lockdown) {
                 definition.connect_with_views(gateway).await.map(Some)
             } else {
                 Ok(None)
@@ -1035,7 +1070,7 @@ impl McpRuntime {
                 Ok(None) => ManagedServer {
                     client: None,
                     health: McpHealth::Disabled,
-                    diagnostic: managed_lockdown_diagnostic(definition, locked),
+                    diagnostic: managed_lockdown_diagnostic(definition, lockdown),
                     reconnect_backoff: INITIAL_RECONNECT_BACKOFF,
                     epoch: self.fresh_epoch(),
                     reconnect_lock: Arc::new(Mutex::new(())),
@@ -1167,7 +1202,7 @@ impl McpRuntime {
         // blocking unrelated servers. A waiter captures the current epoch, so
         // it returns the first attempt's result instead of launching a duplicate
         // child after the lock becomes available.
-        let locked = self.manual_transports_locked().await;
+        let lockdown = self.manual_lockdown().await;
         let (reconnect_lock, requested_epoch) = {
             let state = self.state.lock().await;
             let definition = state
@@ -1175,7 +1210,7 @@ impl McpRuntime {
                 .iter()
                 .find(|definition| definition.name == name)
                 .ok_or_else(|| AgentError::config("MCP server not found"))?;
-            if manual_lockdown_applies(definition, locked) {
+            if manual_lockdown_applies(definition, lockdown) {
                 return Err(AgentError::config(MANAGED_DISABLED_DIAGNOSTIC));
             }
             if !definition.enabled {
@@ -1202,7 +1237,7 @@ impl McpRuntime {
             // Re-checked against the definition as it stands now: a
             // replacement may have swapped this name onto a manual transport
             // while this caller waited for the per-server lock.
-            if manual_lockdown_applies(&definition, locked) {
+            if manual_lockdown_applies(&definition, lockdown) {
                 return Err(AgentError::config(MANAGED_DISABLED_DIAGNOSTIC));
             }
             if !definition.enabled {
@@ -1298,19 +1333,19 @@ impl McpRuntime {
     pub(crate) async fn supervise(self: Arc<Self>) {
         loop {
             tokio::time::sleep(HEALTH_INTERVAL).await;
-            let locked = self.manual_transports_locked().await;
+            let lockdown = self.manual_lockdown().await;
             // Policy may have flipped since the last sweep. Enforce the effect
             // before probing: a server that is now locked must be taken down,
             // not merely left out of the probe set.
-            if locked {
-                self.take_down_locked_manual_servers().await;
+            if lockdown != ManualLockdown::Open {
+                self.take_down_locked_manual_servers(lockdown).await;
             }
             let probes = {
                 let state = self.state.lock().await;
                 state
                     .definitions
                     .iter()
-                    .filter(|definition| connects(definition, locked))
+                    .filter(|definition| connects(definition, lockdown))
                     .filter_map(|definition| {
                         state.servers.get(&definition.name).map(|server| {
                             (
@@ -1402,24 +1437,32 @@ impl McpRuntime {
 /// Managed policy forces every manual transport down whatever its stored flag
 /// says; the definition itself is left untouched, so lifting the policy
 /// restores exactly what the profile had.
-fn connects(definition: &McpServerDefinition, manual_locked: bool) -> bool {
-    definition.enabled && !manual_lockdown_applies(definition, manual_locked)
+fn connects(definition: &McpServerDefinition, lockdown: ManualLockdown) -> bool {
+    definition.enabled && !manual_lockdown_applies(definition, lockdown)
 }
 
-/// Whether the managed lockdown applies to this definition: manual transports
-/// only. A gateway mount is the sanctioned path and is never forced down.
-fn manual_lockdown_applies(definition: &McpServerDefinition, manual_locked: bool) -> bool {
-    manual_locked && definition.gateway_endpoint.is_none()
+/// Whether the managed lockdown applies to this definition. A gateway mount
+/// is the sanctioned path and is never forced down; under the org's
+/// `AllowLocalMcpServers` opt-in a local stdio (`command`) server is spared
+/// while a remote (`url`) one stays covered.
+fn manual_lockdown_applies(definition: &McpServerDefinition, lockdown: ManualLockdown) -> bool {
+    if definition.gateway_endpoint.is_some() {
+        return false;
+    }
+    match lockdown {
+        ManualLockdown::Open => false,
+        ManualLockdown::RemoteManual => definition.command.is_none(),
+        ManualLockdown::AllManual => true,
+    }
 }
 
 /// The diagnostic a forced-down manual server carries, so the settings list
 /// says why it is off instead of showing an unexplained disabled row.
 fn managed_lockdown_diagnostic(
     definition: &McpServerDefinition,
-    manual_locked: bool,
+    lockdown: ManualLockdown,
 ) -> Option<String> {
-    manual_lockdown_applies(definition, manual_locked)
-        .then(|| MANAGED_DISABLED_DIAGNOSTIC.to_string())
+    manual_lockdown_applies(definition, lockdown).then(|| MANAGED_DISABLED_DIAGNOSTIC.to_string())
 }
 
 fn validate_servers(servers: &[McpServerDefinition]) -> Result<()> {
@@ -1752,6 +1795,13 @@ mod tests {
     async fn test_runtime_with_gateway(
         gateway: Arc<dyn GatewayEndpoints>,
     ) -> (Arc<McpRuntime>, Arc<dyn Store>, tempfile::TempDir) {
+        test_runtime_with(gateway, Arc::new(crate::managed_policy::NoOsPolicy)).await
+    }
+
+    async fn test_runtime_with(
+        gateway: Arc<dyn GatewayEndpoints>,
+        os_policy: Arc<dyn crate::managed_policy::OsPolicySource>,
+    ) -> (Arc<McpRuntime>, Arc<dyn Store>, tempfile::TempDir) {
         let directory = tempfile::tempdir().unwrap();
         let store: Arc<dyn Store> = Arc::new(
             DbStore::connect(&format!(
@@ -1766,7 +1816,7 @@ mod tests {
                 Arc::new(ToolRegistry::new()),
                 store.clone(),
                 gateway,
-                Arc::new(crate::managed_policy::NoOsPolicy),
+                os_policy,
             )),
             store,
             directory,
@@ -2448,6 +2498,79 @@ mod tests {
         runtime.initialize(boot).await.unwrap();
         assert!(runtime.info().await.servers.is_empty());
         assert!(store.list_connected_apps().await.unwrap().is_empty());
+    }
+
+    /// The org's `AllowLocalMcpServers` opt-in narrows the managed lockdown
+    /// to remote manual servers. A local stdio definition is the user's again
+    /// — the runtime attempts its child (the fixture command doesn't exist,
+    /// so it degrades) instead of forcing it down — and its edits are
+    /// admitted, while a `url` server stays forced down with the managed
+    /// diagnostic and adding one is still refused.
+    #[tokio::test]
+    async fn allow_local_mcp_scopes_the_lockdown_to_remote_transports() {
+        struct ManagedAllowingLocal;
+
+        impl crate::managed_policy::OsPolicySource for ManagedAllowingLocal {
+            fn gateway_url(&self) -> Result<Option<String>> {
+                Ok(Some("https://corp.gateway".to_string()))
+            }
+            fn allow_local_mcp_servers(&self) -> Result<Option<bool>> {
+                Ok(Some(true))
+            }
+        }
+
+        let (runtime, store, _directory) =
+            test_runtime_with(Arc::new(NoGateway), Arc::new(ManagedAllowingLocal)).await;
+        let mut local = disabled_definition("local_docs", "/bin/docs");
+        local.enabled = true;
+        let remote = http_definition("remote", "http://127.0.0.1:9/mcp");
+        seed_records(&store, &[local.clone(), remote.clone()]).await;
+
+        runtime
+            .initialize(ConfiguredMcpServers::default())
+            .await
+            .unwrap();
+        let info = runtime.info().await;
+        assert_eq!(info.servers[0].health, McpHealth::Degraded);
+        assert_ne!(
+            info.servers[0].diagnostic.as_deref(),
+            Some(MANAGED_DISABLED_DIAGNOSTIC)
+        );
+        assert_eq!(info.servers[1].health, McpHealth::Disabled);
+        assert_eq!(
+            info.servers[1].diagnostic.as_deref(),
+            Some(MANAGED_DISABLED_DIAGNOSTIC)
+        );
+
+        // The admission check draws the same line: a body adding another
+        // remote server is refused by name, while one that only edits the
+        // stdio definition (disabling it) lands.
+        let extra_remote = http_definition("extra_remote", "http://127.0.0.1:9/mcp");
+        let outcome = runtime
+            .replace_under_policy(
+                McpServersConfig {
+                    servers: vec![local.clone(), remote.clone(), extra_remote],
+                },
+                ManualLockdown::RemoteManual,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            McpReplaceOutcome::RefusedManual(refused) if refused == ["extra_remote"]
+        ));
+
+        local.enabled = false;
+        let outcome = runtime
+            .replace_under_policy(
+                McpServersConfig {
+                    servers: vec![local, remote],
+                },
+                ManualLockdown::RemoteManual,
+            )
+            .await
+            .unwrap();
+        assert!(matches!(outcome, McpReplaceOutcome::Replaced(_)));
     }
 
     /// The v:2 canonical-form invariants that keep consent honest: derived

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -104,7 +104,9 @@ pub async fn get_mcp_servers(
 /// validated or connected — so a refused write leaves the configuration
 /// exactly as it was. Gateway-endpoint mounts remain the sanctioned path, and
 /// manual servers already on file may still ride along a save unchanged (they
-/// run forced-disabled) or be removed.
+/// run forced-disabled) or be removed. An org that deploys the
+/// `AllowLocalMcpServers` policy key narrows the lockdown to remote (`url`)
+/// servers, leaving local stdio servers to the user.
 pub async fn put_mcp_servers(
     State(state): State<AppState>,
     Json(body): Json<McpServersConfig>,
@@ -118,8 +120,8 @@ pub async fn put_mcp_servers(
     // Once validation/startup begins, finish the durable/live commit even if
     // the HTTP client disconnects and drops this handler future.
     let runtime = state.mcp.clone();
-    let managed = policy.managed;
-    let mutation = tokio::spawn(async move { runtime.replace_under_policy(body, managed).await });
+    let lockdown = crate::mcp_config::ManualLockdown::for_policy(&policy);
+    let mutation = tokio::spawn(async move { runtime.replace_under_policy(body, lockdown).await });
     let outcome = mutation
         .await
         .map_err(|_| ServerError::internal("MCP settings update task failed"))?

--- a/docs/managed-policy.md
+++ b/docs/managed-policy.md
@@ -12,6 +12,13 @@ shape, wrong type, or a URL failing that contract — never falls back to the
 open experience: the profile resolves managed-but-misconfigured with no
 usable gateway, and the server logs a warning naming what is broken.
 
+Each platform's artifact may also carry `AllowLocalMcpServers`. On a managed
+profile manual MCP configuration is locked and gateway-managed endpoint
+mounts are the only sanctioned path; this key is the org's explicit opt-out
+for local tooling. When it is `true`, local stdio (`command`) MCP servers
+are left to the user, while remote (`url`) servers remain locked. Absent
+means `false`, and a present-but-broken value fails closed to deny.
+
 ## macOS — managed preferences
 
 Deploy a configuration profile that forces a preference for the app's bundle
@@ -20,6 +27,8 @@ identifier:
 - Domain: `io.brightwave.openwave` (release builds; debug builds read
   `io.brightwave.openwave.dev`)
 - Key: `GatewayURL` (string)
+- Key: `AllowLocalMcpServers` (boolean, optional; also accepted as the
+  string `true`/`false`)
 
 OpenWave reads the forced-preferences domain that `cfprefsd` materializes
 under `/Library/Managed Preferences`, honoring the user channel before the
@@ -33,6 +42,7 @@ Deploy (GPO or Intune) a machine-scoped registry value:
 
 - Key: `HKLM\Software\Policies\Brightwave\OpenWave`
 - Value: `GatewayURL` (`REG_SZ`)
+- Value: `AllowLocalMcpServers` (`REG_SZ`, optional; `true` or `false`)
 
 The native 64-bit view of the hive is read explicitly.
 
@@ -41,14 +51,15 @@ The native 64-bit view of the hive is read explicitly.
 Install a JSON file:
 
 - Path: `/etc/openwave/managed-policy.json`
-- Schema: `{ "gateway_url": "https://gateway.example.com" }`
+- Schema: `{ "gateway_url": "https://gateway.example.com",
+  "allow_local_mcp_servers": false }` (the second key is optional)
+
+An absent file means no OS policy; an unreadable or malformed file resolves
+managed-but-misconfigured, as above.
 
 Deploy it root-owned and not world-writable, as `/etc` content should be.
 Unlike the macOS reader, the file reader does not verify ownership today —
 the permissions are deployment guidance, not an enforced guarantee.
-
-An absent file means no OS policy; an unreadable or malformed file resolves
-managed-but-misconfigured, as above.
 
 ## Developer flow — the sqlite policy toggle
 


### PR DESCRIPTION
Closes #940 with the decision it asked for: yes, managed mode gets an org-controlled escape hatch for local MCP servers, and it defaults to deny.

## Decision

`AllowLocalMcpServers` joins the OS policy artifacts (macOS managed-preferences key, Windows registry value, Linux policy-file field), following the per-key pattern `MaximumPermissionMode` established. Absent means false — the managed lockdown keeps covering every manual transport — and only the organization's own artifact can flip it, auditable in the same place that asserts the gateway. When true, the lockdown narrows to remote (`url`) manual servers: local stdio (`command`) servers are the user's again, while a credentialed remote endpoint outside the gateway — exactly the egress the entitlement list exists to answer for — stays locked, as do additions of one. A present-but-broken value fails closed to deny, the opposite direction from the mode ceiling's fail-closed clamp, because a broken opt-in must not grant anything.

## Implementation

- `ManagedPolicy.allow_local_mcp_servers` resolved per key from all three OS readers; the plist reader accepts the native boolean or the shared string token, the registry and JSON-file readers follow their existing value shapes.
- `mcp_config` replaces the boolean lockdown with a three-state `ManualLockdown` (open / remote-manual / all-manual) applied uniformly at every enforcement point: save admission, connect/force-down, live teardown, reconnect, the supervisor sweep, and the boot file (which becomes honored under the opt-in, with any `url` definitions it names still forced down per definition).
- Docs: the key documented for each platform artifact in `docs/managed-policy.md`; wire bindings regenerated.

## Tests

One behavior test per decision: the policy-file and plist extraction tests grow the new key's parse/refusal shapes, and a runtime test drives a managed-with-opt-in profile end to end — the stdio server is attempted instead of forced down and its edits are admitted, while the `url` server stays disabled with the managed diagnostic and adding another is refused by name. The existing managed-without-key tests (teardown on policy flip, boot file inert) are unchanged and still pass.