### PR TITLE
feat(server): cross-principal conformance and fail-closed self-host boot

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1837,11 +1837,26 @@ impl Store for DbStore {
     }
 
     async fn list_standing_tool_grants(&self) -> Result<Vec<crate::approval::StandingGrantRecord>> {
-        ops::approval::list_standing_grants(self).await
+        ops::approval::list_standing_grants(self, None).await
+    }
+
+    async fn list_standing_tool_grants_scoped(
+        &self,
+        owner: &OwnerId,
+    ) -> Result<Vec<crate::approval::StandingGrantRecord>> {
+        ops::approval::list_standing_grants(self, Some(owner)).await
     }
 
     async fn revoke_standing_tool_grant(&self, source_call_id: CallId) -> Result<bool> {
-        ops::approval::revoke_standing_grant(self, source_call_id).await
+        ops::approval::revoke_standing_grant(self, source_call_id, None).await
+    }
+
+    async fn revoke_standing_tool_grant_scoped(
+        &self,
+        owner: &OwnerId,
+        source_call_id: CallId,
+    ) -> Result<bool> {
+        ops::approval::revoke_standing_grant(self, source_call_id, Some(owner)).await
     }
 
     async fn claim_client_tool_call(

--- a/crates/openwave-core/src/db/ops/approval.rs
+++ b/crates/openwave-core/src/db/ops/approval.rs
@@ -11,7 +11,7 @@ use crate::approval::{
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::id::{CallId, ChatId, TurnId};
-use crate::model::{ToolCallExecution, ToolCallStatus, TurnRunStatus};
+use crate::model::{OwnerId, ToolCallExecution, ToolCallStatus, TurnRunStatus};
 use crate::preview::ToolActionPreview;
 use crate::storage::{
     DecideToolApprovalOutcome, JournaledToolApprovalOutcome, RequestToolApprovalOutcome,
@@ -117,13 +117,41 @@ fn grant_level_from_row(
     }
 }
 
+/// The grants `owner` may see and withdraw: those whose level points at one
+/// of the owner's own chats or projects.
+///
+/// Ownership is derived from the level rather than stored on the grant row: a
+/// grant's chat or project carries an invariant owner, and the foreign keys
+/// delete the grant with its parent, so the derivation cannot dangle or drift.
+fn owned_grants_condition(owner: &OwnerId) -> sea_orm::Condition {
+    let owned_chats = sea_orm::sea_query::Query::select()
+        .column(entities::chat::Column::Id)
+        .from(entities::chat::Entity)
+        .and_where(entities::chat::Column::Owner.eq(owner.as_str()))
+        .to_owned();
+    let owned_projects = sea_orm::sea_query::Query::select()
+        .column(entities::project::Column::Id)
+        .from(entities::project::Entity)
+        .and_where(entities::project::Column::Owner.eq(owner.as_str()))
+        .to_owned();
+    sea_orm::Condition::any()
+        .add(entities::standing_tool_grant::Column::ChatId.in_subquery(owned_chats))
+        .add(entities::standing_tool_grant::Column::ProjectId.in_subquery(owned_projects))
+}
+
 /// Every durable standing grant, newest first, hydrated on the same terms as
 /// [`matching_standing_grant`]: a row whose kind, scope, or grantability no
-/// longer parses is skipped rather than surfaced or widened.
+/// longer parses is skipped rather than surfaced or widened. With an `owner`,
+/// only grants reachable through that owner's chats and projects are listed.
 pub(in crate::db) async fn list_standing_grants(
     store: &DbStore,
+    owner: Option<&OwnerId>,
 ) -> Result<Vec<crate::approval::StandingGrantRecord>> {
-    let rows = entities::standing_tool_grant::Entity::find()
+    let mut query = entities::standing_tool_grant::Entity::find();
+    if let Some(owner) = owner {
+        query = query.filter(owned_grants_condition(owner));
+    }
+    let rows = query
         .order_by_desc(entities::standing_tool_grant::Column::GrantedAt)
         .all(&store.conn)
         .await
@@ -145,15 +173,20 @@ pub(in crate::db) async fn list_standing_grants(
 }
 
 /// Delete one standing grant by its source approval. Idempotent: deleting a
-/// grant that is already gone reports `false` rather than erroring.
+/// grant that is already gone reports `false` rather than erroring. With an
+/// `owner`, another owner's grant is left standing and reports `false`,
+/// indistinguishable from absent.
 pub(in crate::db) async fn revoke_standing_grant(
     store: &DbStore,
     source_call_id: CallId,
+    owner: Option<&OwnerId>,
 ) -> Result<bool> {
-    let result = entities::standing_tool_grant::Entity::delete_by_id(source_call_id.0)
-        .exec(&store.conn)
-        .await
-        .map_err(store_err)?;
+    let mut delete = entities::standing_tool_grant::Entity::delete_many()
+        .filter(entities::standing_tool_grant::Column::SourceCallId.eq(source_call_id.0));
+    if let Some(owner) = owner {
+        delete = delete.filter(owned_grants_condition(owner));
+    }
+    let result = delete.exec(&store.conn).await.map_err(store_err)?;
     Ok(result.rows_affected == 1)
 }
 

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1680,6 +1680,30 @@ pub trait Store: Send + Sync {
         self.accept_document_source(document).await
     }
 
+    /// [`Store::list_standing_tool_grants`] restricted to grants whose chat
+    /// or project belongs to `owner`. A grant's owner is its level's owner:
+    /// grants are created inside an owner-scoped chat and cascade-deleted
+    /// with their chat or project, so the derivation cannot drift.
+    async fn list_standing_tool_grants_scoped(
+        &self,
+        owner: &OwnerId,
+    ) -> Result<Vec<crate::approval::StandingGrantRecord>> {
+        let _ = owner;
+        self.list_standing_tool_grants().await
+    }
+
+    /// [`Store::revoke_standing_tool_grant`] restricted to `owner`'s grants;
+    /// someone else's grant is left standing and reports `false`,
+    /// indistinguishable from a grant that never existed.
+    async fn revoke_standing_tool_grant_scoped(
+        &self,
+        owner: &OwnerId,
+        source_call_id: CallId,
+    ) -> Result<bool> {
+        let _ = owner;
+        self.revoke_standing_tool_grant(source_call_id).await
+    }
+
     /// Create a conversation output together with its first revision.
     ///
     /// The caller has already written the revision's bytes to conversation

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -10,6 +10,12 @@ authors.workspace = true
 [lints]
 workspace = true
 
+[features]
+# Compile the PostgreSQL driver in, so a self-host boot can open the store
+# `OPENWAVE_DATABASE_URL` names. Off by default: the desktop profile is
+# SQLite-only and the driver is a heavy build-time dependency.
+postgres = ["openwave-core/postgres"]
+
 [dependencies]
 openwave-shell-policy = { path = "../openwave-shell-policy" }
 openwave-code-execution = { path = "../openwave-code-execution" }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -1078,8 +1078,13 @@ fn agent_deps(
 
 /// Open the durable store the profile selects.
 ///
-/// Only the desktop profile (SQLite under `data_dir`) is wired today; the
-/// self-host Postgres store lands with that profile's slice.
+/// Desktop opens SQLite under `data_dir`. Self-host opens the database named
+/// by `OPENWAVE_DATABASE_URL` (PostgreSQL; build with the `postgres` feature
+/// to compile the driver in) — and only after the profile's principal-naming
+/// authenticator loads. A shared store must never open behind an API that
+/// cannot tell its callers apart, so a self-host config without a valid
+/// token file refuses to boot here, before the store exists, on every path
+/// that opens it (#853).
 async fn connect_store(config: &Config) -> Result<Arc<dyn Store>> {
     match config.profile {
         Profile::Desktop => {
@@ -1088,8 +1093,25 @@ async fn connect_store(config: &Config) -> Result<Arc<dyn Store>> {
             let store = desktop_schema::connect(config).await?;
             Ok(Arc::new(store))
         }
+        Profile::SelfHost => {
+            let tokens = config.auth_tokens_file.as_deref().ok_or_else(|| {
+                AgentError::config(
+                    "refusing to open a shared store without a principal-naming \
+                     authenticator: self-host requires OPENWAVE_AUTH_TOKENS_FILE \
+                     (format in the auth module docs)",
+                )
+            })?;
+            // Load and discard: boot proves the authenticator names someone
+            // before the shared store exists. State assembly re-loads the
+            // same file as the request path's credential map.
+            auth::TokenMap::load(tokens)?;
+            let store = openwave_core::DbStore::connect(&config.database_url()?).await?;
+            Ok(Arc::new(store))
+        }
+        // An unknown future profile has chosen neither a store nor an
+        // authenticator; fail closed rather than defaulting to either.
         _ => Err(AgentError::config(
-            "only the desktop profile is supported for now",
+            "no store backend is wired for this profile",
         )),
     }
 }

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -3032,13 +3032,14 @@ pub(crate) struct StandingGrantSnapshot {
     pub granted_at: chrono::DateTime<Utc>,
 }
 
-/// `GET /grants` — every standing grant, newest first, across all chats.
+/// `GET /grants` — the principal's standing grants, newest first, across all
+/// of their chats.
 ///
 /// The settings surface for "what the agent can do without asking": a grant
 /// the reader cannot find is a one-way door, and this is where it is found.
-/// Grants themselves are not owner-keyed yet (#853 slice 5); the provenance
-/// titles are resolved through the requesting principal's own chats and
-/// projects, so this route never reads another owner's titles.
+/// Grants are owner-scoped through the chat or project their level points at
+/// (#853), and the provenance titles resolve through the same principal's
+/// chats and projects.
 pub(crate) async fn list_standing_grants(
     store: ScopedStore,
 ) -> Result<Json<Vec<StandingGrantSnapshot>>, ServerError> {

--- a/crates/openwave-server/src/scoped_store.rs
+++ b/crates/openwave-server/src/scoped_store.rs
@@ -7,12 +7,14 @@
 //! simply does not exist on this type, and the inner handle never escapes it,
 //! so route code cannot express a query that crosses owners (#853).
 //!
-//! Non-root operations (turns, agent runs, events, approvals, grants) hang
-//! off a root by id and pass through unchanged; the handler authorizes the
-//! root through this view first, exactly as the store's scoping model
-//! prescribes. System paths that act on already-authorized ids — turn
-//! workers, retirement scans, post-commit signalling — are not requests and
-//! keep the separate unscoped handle on [`AppState`].
+//! Non-root operations (turns, agent runs, events, approvals) hang off a
+//! root by id and pass through unchanged; the handler authorizes the root
+//! through this view first, exactly as the store's scoping model prescribes.
+//! Standing grants, which span chats, are owner-scoped directly through the
+//! chat or project their level points at. System paths that act on
+//! already-authorized ids — turn workers, retirement scans, post-commit
+//! signalling — are not requests and keep the separate unscoped handle on
+//! [`AppState`].
 //!
 //! The extractor fails closed like [`AuthContext`] itself: on a route the
 //! auth middleware does not cover it answers `401`, never a defaulted owner.
@@ -194,9 +196,11 @@ impl ScopedStore {
 
     // ------------------------------------------------------------------
     // Non-root operations — keyed by ids that hang off a root the handler
-    // has already authorized through this view. Settings and standing
-    // grants are not per-owner yet (#853 slice 5); they pass through so the
-    // route surface still has exactly one store seam.
+    // has already authorized through this view. Standing grants are the
+    // exception: their reads and revocations are owner-scoped here, since
+    // the grant list is a cross-chat surface with no per-request root to
+    // authorize first. Settings stay deployment-scoped by design (#853) —
+    // see the self-host section of `docs/how-openwave-works.md`.
     // ------------------------------------------------------------------
 
     /// [`Store::get_turn_run`].
@@ -291,16 +295,22 @@ impl ScopedStore {
             .await
     }
 
-    /// [`Store::list_standing_tool_grants`].
+    /// The standing grants reachable through the principal's own chats and
+    /// projects, newest first.
     pub async fn list_standing_tool_grants(
         &self,
     ) -> Result<Vec<openwave_core::StandingGrantRecord>> {
-        self.store.list_standing_tool_grants().await
+        self.store
+            .list_standing_tool_grants_scoped(&self.owner)
+            .await
     }
 
-    /// [`Store::revoke_standing_tool_grant`].
+    /// Withdraw one of the principal's standing grants. Someone else's grant
+    /// is left standing and reports `false`, indistinguishable from absent.
     pub async fn revoke_standing_tool_grant(&self, source_call_id: CallId) -> Result<bool> {
-        self.store.revoke_standing_tool_grant(source_call_id).await
+        self.store
+            .revoke_standing_tool_grant_scoped(&self.owner, source_call_id)
+            .await
     }
 
     /// [`Store::list_events`].

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -39,6 +39,7 @@ mod app_invoke;
 mod app_library;
 mod chat_titling;
 mod configuration;
+mod conformance;
 mod connected_apps;
 mod conversations;
 mod documents;

--- a/crates/openwave-server/src/tests/conformance.rs
+++ b/crates/openwave-server/src/tests/conformance.rs
@@ -1,0 +1,442 @@
+//! Cross-principal conformance over the self-host route surface (#853).
+//!
+//! Two named users share one store, and everything one of them owns —
+//! chats, transcripts, projects, documents, standing grants, the WebSocket
+//! event stream — must be invisible and immutable to the other:
+//! indistinguishable from data that does not exist. The suite drives the
+//! real router with the self-host profile's named bearer tokens, so it
+//! covers the token-to-principal resolution, the `ScopedStore` seam, and
+//! the owner-scoped queries as one path.
+
+use super::*;
+
+use std::net::SocketAddr;
+
+use openwave_core::{ApprovalDecision, ApprovalGate, ApprovalRequest};
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+const ALICE_TOKEN: &str = "alice-token-0123456789abcdef";
+const BOB_TOKEN: &str = "bob-token-9876543210fedcba";
+
+/// A self-host app over one shared store, authenticating the two named
+/// principals above (and nothing else).
+async fn self_host_app() -> (Router, AppState, Arc<dyn Store>, tempfile::TempDir) {
+    let (dir, store) = temp_db_store("conformance.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let tokens_file = dir.path().join("tokens");
+    std::fs::write(
+        &tokens_file,
+        format!("alice {ALICE_TOKEN}\nbob {BOB_TOKEN}\n"),
+    )
+    .unwrap();
+    let mut config = Config::desktop(dir.path());
+    config.profile = Profile::SelfHost;
+    config.auth_tokens_file = Some(tokens_file);
+    let state = AppState::new(
+        config,
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    spawn_turn_worker(&state);
+    (app(state.clone()), state, store, dir)
+}
+
+async fn request(
+    router: &Router,
+    method: &str,
+    uri: &str,
+    bearer: &str,
+    body: Option<serde_json::Value>,
+) -> axum::response::Response {
+    let builder = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header(header::AUTHORIZATION, bearer);
+    let request = match body {
+        Some(body) => builder
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body.to_string())),
+        None => builder.body(Body::empty()),
+    }
+    .unwrap();
+    router.clone().oneshot(request).await.unwrap()
+}
+
+async fn ingest_document(router: &Router, bearer: &str, uri: &str) -> String {
+    let accepted: serde_json::Value = json_body(
+        post_raw(
+            router,
+            bearer,
+            uri,
+            Some("text/plain"),
+            b"the text".to_vec(),
+        )
+        .await,
+    )
+    .await;
+    accepted["document_id"].as_str().unwrap().to_owned()
+}
+
+/// The REST matrix: everything B can ask about A's data answers as if the
+/// data did not exist, and none of B's rejected mutations leave a mark.
+#[tokio::test]
+async fn cross_principal_rest_surface_is_disjoint() {
+    let (router, state, store, _dir) = self_host_app().await;
+    let alice = format!("Bearer {ALICE_TOKEN}");
+    let bob = format!("Bearer {BOB_TOKEN}");
+
+    // On the shared profile only the named tokens authenticate: the
+    // per-launch capability token names nobody, so it admits nobody.
+    for token in [format!("Bearer {}", state.token), "Bearer bogus".into()] {
+        let response = request(&router, "GET", "/chats", &token, None).await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{token}");
+    }
+
+    // Alice's world: a project, a chat with a finished turn, and documents
+    // at both the standalone and chat scope.
+    let project: Project = json_body(
+        request(
+            &router,
+            "POST",
+            "/projects",
+            &alice,
+            Some(serde_json::json!({"title": "Filings"})),
+        )
+        .await,
+    )
+    .await;
+    let chat = make_chat(&router, &alice).await;
+    assert_eq!(
+        send_message(&router, &alice, chat.id, "hello").await,
+        StatusCode::ACCEPTED
+    );
+    wait_for_turn(&store, chat.id).await;
+    let document_id = ingest_document(&router, &alice, "/documents/raw?title=a.txt").await;
+    let chat_document_id = ingest_document(
+        &router,
+        &alice,
+        &format!("/chats/{}/documents/raw?title=b.txt", chat.id),
+    )
+    .await;
+
+    // Positive control: the owner sees all of it.
+    let chats: Vec<Chat> = json_body(request(&router, "GET", "/chats", &alice, None).await).await;
+    assert_eq!(chats.len(), 1);
+    let transcript: serde_json::Value = json_body(
+        request(
+            &router,
+            "GET",
+            &format!("/chats/{}/messages", chat.id),
+            &alice,
+            None,
+        )
+        .await,
+    )
+    .await;
+    assert!(!transcript["messages"].as_array().unwrap().is_empty());
+
+    // Bob's lists are empty — not filtered views that leak counts, but the
+    // same responses an empty account gets.
+    for uri in ["/chats", "/projects"] {
+        let listed: Vec<serde_json::Value> =
+            json_body(request(&router, "GET", uri, &bob, None).await).await;
+        assert_eq!(listed, Vec::<serde_json::Value>::new(), "{uri}");
+    }
+    let documents: serde_json::Value =
+        json_body(request(&router, "GET", "/documents", &bob, None).await).await;
+    assert_eq!(documents["documents"].as_array().unwrap().len(), 0);
+
+    // Every direct route over Alice's ids answers 404 for Bob: reads,
+    // transcript, turn mutations, and the document surface alike.
+    let patch_body = serde_json::json!({"title": "stolen"});
+    let message_body = serde_json::json!({"turn_id": TurnId::new(), "content": "mine now"});
+    let matrix: Vec<(&str, String, Option<serde_json::Value>)> = vec![
+        ("GET", format!("/chats/{}", chat.id), None),
+        (
+            "PATCH",
+            format!("/chats/{}", chat.id),
+            Some(patch_body.clone()),
+        ),
+        ("DELETE", format!("/chats/{}", chat.id), None),
+        ("GET", format!("/chats/{}/messages", chat.id), None),
+        (
+            "POST",
+            format!("/chats/{}/messages", chat.id),
+            Some(message_body),
+        ),
+        (
+            "POST",
+            format!("/chats/{}/cancel", chat.id),
+            Some(serde_json::json!({"turn_id": TurnId::new()})),
+        ),
+        ("GET", format!("/chats/{}/approvals", chat.id), None),
+        ("GET", format!("/chats/{}/agent-runs", chat.id), None),
+        (
+            "POST",
+            format!("/chats/{}/documents/raw?title=c.txt", chat.id),
+            None,
+        ),
+        (
+            "GET",
+            format!("/chats/{}/documents/{chat_document_id}", chat.id),
+            None,
+        ),
+        ("GET", format!("/projects/{}", project.id), None),
+        (
+            "PATCH",
+            format!("/projects/{}", project.id),
+            Some(patch_body),
+        ),
+        ("DELETE", format!("/projects/{}", project.id), None),
+        ("GET", format!("/documents/{document_id}"), None),
+        (
+            "GET",
+            format!("/documents/{document_id}/file-content"),
+            None,
+        ),
+    ];
+    for (method, uri, body) in matrix {
+        let response = request(&router, method, &uri, &bob, body).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "{method} {uri} must not reveal another owner's data"
+        );
+    }
+
+    // Standalone document deletion is idempotent (deleting an absent id also
+    // answers 202), so the line to hold is subtler: Bob's delete of Alice's
+    // document must behave exactly like deleting nothing.
+    let response = request(
+        &router,
+        "DELETE",
+        &format!("/documents/{document_id}"),
+        &bob,
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    // Alice's world is untouched by any of it.
+    let response = request(&router, "GET", &format!("/chats/{}", chat.id), &alice, None).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let chat_after: Chat = json_body(response).await;
+    assert_eq!(chat_after.title, chat.title);
+    let response = request(
+        &router,
+        "GET",
+        &format!("/documents/{document_id}"),
+        &alice,
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// Standing grants belong to the owner of the chat or project they cover:
+/// invisible in the other principal's list and immune to their revocation.
+#[tokio::test]
+async fn standing_grants_are_owner_scoped_across_the_grant_surface() {
+    let (router, state, store, _dir) = self_host_app().await;
+    let alice = format!("Bearer {ALICE_TOKEN}");
+    let bob = format!("Bearer {BOB_TOKEN}");
+    let chat = make_chat(&router, &alice).await;
+
+    // Park a Sensitive call in Alice's chat and approve it with a standing
+    // grant, through the same durable approval path the route uses.
+    let call_id = CallId::new();
+    let approval = ApprovalRequest {
+        auto_judge: false,
+        call_id,
+        chat_id: chat.id,
+        turn_id: TurnId::new(),
+        tool_name: "search".into(),
+        class: ApprovalClass::Sensitive,
+        kind: openwave_core::ToolApprovalKind::for_tool_name("search"),
+        preview: None,
+    };
+    assert!(matches!(
+        store
+            .accept_tool_call(&ToolCallRecord {
+                id: call_id,
+                chat_id: chat.id,
+                turn_id: approval.turn_id,
+                provider_id: format!("provider-{call_id}"),
+                name: "search".into(),
+                arguments: serde_json::json!({ "query": "quarterly filings" }),
+                raw_arguments: None,
+                execution: ToolCallExecution::Server,
+                status: ToolCallStatus::Pending,
+                result: None,
+                result_preview: None,
+                error_code: None,
+                error_detail: None,
+                client_executor_id: None,
+                client_lease_expires_at: None,
+                created_at: chrono::Utc::now(),
+                resolved_at: None,
+            })
+            .await
+            .unwrap(),
+        openwave_core::AcceptToolCallOutcome::Accepted(_)
+    ));
+    let pending = state.approvals.register(approval, None).await;
+    drop(pending.decision);
+    assert_eq!(
+        state
+            .approvals
+            .resolve_with_grant(
+                chat.id,
+                call_id,
+                ApprovalDecision::Approve,
+                Some(crate::routes::ApprovalGrantRung::WholeTool),
+            )
+            .await
+            .unwrap(),
+        crate::approvals::ResolveApprovalOutcome::Resolved
+    );
+
+    // The owner finds the grant on both consent surfaces; Bob finds nothing.
+    let grants: Vec<serde_json::Value> =
+        json_body(request(&router, "GET", "/grants", &alice, None).await).await;
+    assert_eq!(grants.len(), 1);
+    for uri in ["/grants", "/consent/statements"] {
+        let listed: Vec<serde_json::Value> =
+            json_body(request(&router, "GET", uri, &bob, None).await).await;
+        assert_eq!(listed, Vec::<serde_json::Value>::new(), "{uri}");
+    }
+
+    // Bob cannot withdraw it — and cannot learn it exists by trying.
+    let response = request(&router, "DELETE", &format!("/grants/{call_id}"), &bob, None).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(store.list_standing_tool_grants().await.unwrap().len(), 1);
+
+    // The owner can.
+    let response = request(
+        &router,
+        "DELETE",
+        &format!("/grants/{call_id}"),
+        &alice,
+        None,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert!(store.list_standing_tool_grants().await.unwrap().is_empty());
+}
+
+/// The WebSocket event surface holds the same line: no upgrade onto another
+/// owner's chat, and no event delivery across owners on your own socket.
+#[tokio::test(flavor = "multi_thread")]
+async fn ws_event_surface_is_owner_gated() {
+    let (router, _state, store, _dir) = self_host_app().await;
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+    let addr: SocketAddr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router.clone()).await;
+    });
+
+    let client = reqwest::Client::new();
+    let alice_chat: Chat = client
+        .post(format!("http://{addr}/chats"))
+        .bearer_auth(ALICE_TOKEN)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let bob_chat: Chat = client
+        .post(format!("http://{addr}/chats"))
+        .bearer_auth(BOB_TOKEN)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    // Bob cannot upgrade onto Alice's chat: the handshake is refused before
+    // any socket exists, indistinguishable from a chat that isn't there.
+    let mut upgrade = format!("ws://{addr}/chats/{}/events", alice_chat.id)
+        .into_client_request()
+        .unwrap();
+    upgrade.headers_mut().insert(
+        "Authorization",
+        format!("Bearer {BOB_TOKEN}").parse().unwrap(),
+    );
+    match connect_async(upgrade).await {
+        Err(tokio_tungstenite::tungstenite::Error::Http(response)) => {
+            assert_eq!(response.status(), 404)
+        }
+        other => panic!("expected a refused handshake, got {other:?}"),
+    }
+
+    // Bob's socket on his own chat stays silent while Alice's turn runs.
+    let mut bob_request = format!("ws://{addr}/chats/{}/events", bob_chat.id)
+        .into_client_request()
+        .unwrap();
+    bob_request.headers_mut().insert(
+        "Authorization",
+        format!("Bearer {BOB_TOKEN}").parse().unwrap(),
+    );
+    let (mut bob_socket, _) = connect_async(bob_request).await.unwrap();
+
+    let response = client
+        .post(format!("http://{addr}/chats/{}/messages", alice_chat.id))
+        .bearer_auth(ALICE_TOKEN)
+        .json(&serde_json::json!({"turn_id": TurnId::new(), "content": "hi"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::ACCEPTED);
+    let events = wait_for_turn(&store, alice_chat.id).await;
+    assert!(!events.is_empty(), "alice's turn journaled its events");
+
+    // Alice's completed turn delivered nothing to Bob's live stream.
+    let leaked = tokio::time::timeout(Duration::from_millis(300), bob_socket.next()).await;
+    assert!(
+        leaked.is_err(),
+        "bob's socket must not observe alice's events: {leaked:?}"
+    );
+}
+
+/// The boot side of the contract: a self-host store cannot open without a
+/// principal-naming authenticator, on any path that opens the store.
+#[tokio::test]
+async fn self_host_boot_fails_closed_without_a_principal_naming_authenticator() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut config = Config::desktop(dir.path());
+    config.profile = Profile::SelfHost;
+
+    // No authenticator configured: refused before any store exists.
+    let refusal = match crate::connect_store(&config).await {
+        Err(refusal) => refusal.to_string(),
+        Ok(_) => panic!("a self-host store must not open without an authenticator"),
+    };
+    assert!(
+        refusal.contains("OPENWAVE_AUTH_TOKENS_FILE"),
+        "the refusal names the missing authenticator: {refusal}"
+    );
+
+    // An authenticator that names nobody is refused the same way.
+    let tokens_file = dir.path().join("tokens");
+    std::fs::write(&tokens_file, "# nobody\n").unwrap();
+    config.auth_tokens_file = Some(tokens_file);
+    let refusal = match crate::connect_store(&config).await {
+        Err(refusal) => refusal.to_string(),
+        Ok(_) => panic!("a self-host store must not open behind an empty authenticator"),
+    };
+    assert!(
+        refusal.contains("names no principals"),
+        "an empty authenticator must refuse boot: {refusal}"
+    );
+}

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -745,28 +745,47 @@ new session and publish its tool surface only for subsequent turns.
 ### Self-host
 
 The `Profile::SelfHost` shape and PostgreSQL database implementation exist, and
-CI exercises the durable turn state machine against PostgreSQL. The server still
-rejects the self-host profile at startup, and document/blob PostgreSQL parity is
-not comprehensively tested. Production Postgres wiring, remote secret custody,
-object storage, and multi-process ownership remain future integration work.
+CI exercises the durable turn state machine against PostgreSQL. Document/blob
+PostgreSQL parity is not comprehensively tested, and production Postgres
+wiring, remote secret custody, object storage, and multi-process ownership
+remain future integration work. Building `openwave-server` with its `postgres`
+feature compiles the driver in; the store then opens from
+`OPENWAVE_DATABASE_URL`.
 
-**Authorization is the gate on this profile, and it is not built.** The API has
-no per-user authorization at all: `auth.rs` is a per-launch bearer on a loopback
-port, which answers "is this the client this process handed a token to" — a
-capability check on a local process, not a principal. No route is owner-scoped;
-`require_chat` checks that a chat *exists* and nothing else, and the document,
-project, and settings surfaces are the same. Identity work (#578) is deliberately
-attributive only and states that no read path consults it, so it does not close
-this.
+**Authorization — the gate this profile was blocked on (#853) — is built.**
+The pieces, each enforced where it cannot silently drift:
 
-That is the right trade for a local-first desktop, where the bearer is
-per-launch, loopback-only, and belongs to the one person at the machine. It stops
-being right the moment more than one person's data shares a store: an existence
-check that passes for any authenticated caller is an authorization bug as soon as
-callers differ. Finishing this profile without resolving a principal in the
-request path and scoping queries by owner would ship a multi-user server whose
-every mode degrades to "any authenticated caller can see everything". Tracked as
-a gate in #853, which any shared-deployment work should be blocked on.
+- **The token names someone.** Self-host authenticates with static named
+  bearer tokens from an operator file (`OPENWAVE_AUTH_TOKENS_FILE`; format in
+  the server's `auth` module docs). The middleware resolves every credential
+  to a typed `Principal`; a token that names no one is rejected there, and
+  the desktop's per-launch capability token names nobody on a shared
+  deployment, so it authenticates nobody. Gateway-derived identity (#578) can
+  later replace the file behind the same credential-to-principal seam.
+- **Queries are owner-scoped where they are built.** Chats, projects, and
+  documents carry an owner column; route handlers reach storage only through
+  a `ScopedStore` view bound to the request's authenticated principal, on
+  which the unscoped root queries do not exist. Another owner's row answers
+  as absent — reads, mutations, transcripts, and the WebSocket event surface
+  alike. Standing tool grants are scoped through the chat or project they
+  cover. A conformance suite drives two named principals across the route
+  surface and asserts complete disjointness.
+- **Boot fails closed.** `connect_store` refuses to open a self-host store
+  unless the principal-naming authenticator is configured and names at least
+  one user, so a shared store can never exist behind an API that cannot tell
+  its callers apart.
+
+One deliberate exception, accepted rather than deferred: **settings are
+deployment-scoped, not per-user.** The settings table configures the
+deployment itself — enabled providers and credentials, model roles,
+web-search and code-execution configuration, managed policy — and the issue
+itself observed that a credential able to reconfigure the app is not
+containable per-user by a row filter. Every named user on a self-host
+deployment shares (and can change) that configuration, so the profile is for
+mutually trusting users of one operator's deployment — a household or a small
+team — not for adversarial tenants. Per-user preference settings can split
+out of the deployment table if that boundary is ever needed; multi-tenant
+isolation is explicitly not claimed.
 
 ## Where the code lives
 
@@ -836,10 +855,10 @@ The main next steps are:
   sandbox-safe capabilities without widening exact delegated-file or spawn
   authority;
 - add richer parsers;
-- resolve a principal in the request path and scope queries by owner (#853)
-  before finishing the self-host profile, which is otherwise a multi-user server
-  with no per-user authorization;
-- finish the self-host profile rather than only testing Postgres state logic;
+- finish the self-host profile — the request path resolves a principal and
+  queries are owner-scoped (#853), so what remains is production integration:
+  Postgres document/blob parity, remote secret custody, object storage, and
+  multi-process ownership;
 - add health-aware provider failover;
 - add output deletion, version history, richer formats, and durable export
   receipts without widening the native write boundary;


### PR DESCRIPTION
Closes #853 — the final slice of the authorization gate, after #1338 (principal context), #1352 (named tokens), #1371 (owner-scoped storage), and #1380 (the ScopedStore view).

## Fail-closed boot

`connect_store` now accepts the self-host profile — but only after the principal-naming authenticator loads and names at least one user. A self-host config with no `OPENWAVE_AUTH_TOKENS_FILE`, or one whose file names nobody, refuses to boot before the shared store exists, on every path that opens the store (including secret re-homing). The store itself opens from `OPENWAVE_DATABASE_URL`; a new optional `postgres` feature on `openwave-server` compiles the driver in, so default desktop builds are unchanged.

## Owner-scoped standing grants

Of the three deferrals slice 4 named, standing grants are implemented here: the `Store` trait grows `list_standing_tool_grants_scoped` / `revoke_standing_tool_grant_scoped`, the SeaORM store filters both through the owner column of the chat or project the grant's level points at (ownership is derived from the level — parents carry an invariant owner and cascade-delete their grants, so the derivation cannot dangle), and `ScopedStore` routes `GET /grants`, `GET /consent/statements`, and `DELETE /grants/{call_id}` through them. One principal's grants are now invisible to and irrevocable by another, with a cross-owner revocation indistinguishable from revoking nothing.

## Conformance

A new suite drives two named principals across the real router over one shared store and asserts complete disjointness:

- REST: another owner's chats, transcripts, projects, and documents answer as absent for reads, mutations, message posts, cancels, and approval listings; list endpoints return the same empty responses an empty account gets; the idempotent standalone document delete deletes nothing cross-owner.
- Standing grants: invisible in the other principal's lists and immune to their revocation, on both consent surfaces.
- WebSocket: the upgrade onto another owner's chat is refused before a socket exists, and a completed turn delivers nothing to the other principal's live stream.
- Boot: both refusal shapes of the fail-closed contract.
- The per-launch capability token authenticates nobody on the shared profile.

## Accepted, not deferred

Settings stay deployment-scoped by design. The settings table configures the deployment itself — provider credentials, model roles, web-search/code-execution config, managed policy — and a credential able to reconfigure the app is not containable per-user by a row filter. The self-host section of `docs/how-openwave-works.md` records the shipped mechanism, this trade, and its consequence: the profile is for mutually trusting users of one operator's deployment, and multi-tenant isolation is explicitly not claimed.

Verified with the full `openwave-core` and `openwave-server` suites locally, plus a `--features postgres` build of the server.