### PR TITLE
feat(core): place-scoped standing grants for workspace writes

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -3082,11 +3082,7 @@ impl Agent {
                 tool_name: call.name.clone(),
                 class: approval_class,
                 kind,
-                grant_scopes: if kind.is_standing_grantable() {
-                    GrantScope::ladder_for(&call.name, &arguments)
-                } else {
-                    Vec::new()
-                },
+                grant_scopes: GrantScope::mintable_ladder_for(kind, &call.name, &arguments),
                 preview,
             };
             let authorized_by_standing_grant = matches!(

--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -173,9 +173,6 @@ impl ToolApprovalKind {
             Self::WebExtractMayFetchUrl => "web_extract_may_fetch_url",
             Self::ExecMayRunNetworkedCommand => "exec_may_run_networked_command",
             Self::ExternalMcpMayCallServer => "external_mcp_may_call_server",
-            // Never stored: the kind is not standing-grantable (the chat's
-            // permission mode is the wider consent). Named anyway so the key
-            // vocabulary stays total.
             Self::WorkspaceMayModifyFiles => "workspace_may_modify_files",
             Self::Unsupported => "unsupported",
         }
@@ -237,17 +234,32 @@ impl ToolApprovalKind {
     ///
     /// MCP is intentionally one-shot: its configured executable can change
     /// while retaining a model-visible namespace, so reusing consent by name
-    /// would silently widen authority. Workspace edits are one-shot for the
-    /// opposite reason: their standing "yes" already exists as the chat's
-    /// `Auto` permission mode, and a second spelling of the same consent
-    /// would drift from the first.
+    /// would silently widen authority. Workspace edits are grantable, but only
+    /// about a place ([`GrantScope::PathSubtree`], enforced by
+    /// [`Self::grantable_at`]): their whole-tool "yes" already exists as the
+    /// chat's `Auto` permission mode, and a second spelling of the same
+    /// consent would drift from the first.
     #[must_use]
     pub const fn is_standing_grantable(self) -> bool {
-        self.is_approvable()
-            && !matches!(
-                self,
-                Self::ExternalMcpMayCallServer | Self::WorkspaceMayModifyFiles
-            )
+        self.is_approvable() && !matches!(self, Self::ExternalMcpMayCallServer)
+    }
+
+    /// Whether a standing grant of `scope` may exist for this kind.
+    ///
+    /// The place rung and the shape rungs answer different questions — where
+    /// a write may land versus what a command may look like — so each kind
+    /// admits only the rungs that describe its own action. A workspace edit
+    /// can be granted about a place and nothing wider; every other grantable
+    /// kind keeps the shape rungs and cannot borrow the place one.
+    #[must_use]
+    pub const fn grantable_at(self, scope: &GrantScope) -> bool {
+        if !self.is_standing_grantable() {
+            return false;
+        }
+        match self {
+            Self::WorkspaceMayModifyFiles => matches!(scope, GrantScope::PathSubtree { .. }),
+            _ => !matches!(scope, GrantScope::PathSubtree { .. }),
+        }
     }
 }
 
@@ -459,10 +471,10 @@ impl GrantLevel {
 /// without re-prompting.
 ///
 /// Deny-by-default, like the host broker's capability grants: a grant covers
-/// exactly one chat and one approvable tool. Resource-level sub-scoping (a path
-/// subtree, a single connector) is deliberately deferred until
-/// [`ApprovalRequest`] carries a structured resource — see the follow-up on the
-/// capability-model issue.
+/// exactly one chat (or project) and one approvable tool, narrowed further by
+/// its [`GrantScope`] — including [`GrantScope::PathSubtree`], the rung that
+/// names a workspace place now that [`ApprovalRequest`] carries a structured
+/// resource ([`ToolActionPreview::WriteFile`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StandingGrant {
     level: GrantLevel,
@@ -500,6 +512,17 @@ pub enum GrantScope {
     /// for `cargo test` cannot be stretched to something that merely starts
     /// with those letters or that smuggles a shell in behind them.
     CommandPrefix { tokens: Vec<String> },
+    /// Every write landing in one workspace place: the named path itself, or
+    /// anything below it.
+    ///
+    /// This is the rung that says *where* rather than *what* — "stop asking
+    /// about writes under `reports/`", not "stop asking about this document".
+    /// The prefix is a run of workspace-relative path segments, matched
+    /// segment-wise against the canonical `path` argument so `reports/` can
+    /// never be stretched over `reports-old/`, and only against a path the
+    /// preview reproduced in full
+    /// ([`ToolActionPreview::names_place_exactly`]).
+    PathSubtree { prefix: String },
     /// Every call to the tool.
     WholeTool,
 }
@@ -519,6 +542,13 @@ impl GrantScope {
     /// asking.
     #[must_use]
     pub fn covers_call(&self, tool_name: &str, arguments: &serde_json::Value) -> bool {
+        // A place is matched on the canonical path argument, not on the
+        // projection: the write's document never reaches the preview, so the
+        // whole-call fidelity gate below can never pass for it, and does not
+        // need to — consent about a place is indifferent to the document.
+        if let Self::PathSubtree { prefix } = self {
+            return covers_workspace_place(prefix, tool_name, arguments);
+        }
         if !ToolActionPreview::describes_exactly(tool_name, arguments) {
             // Nothing describable to match, so only the widest scope can
             // apply — and it applies to a call the renderer could not show,
@@ -542,6 +572,8 @@ impl GrantScope {
             Self::ExactAction(granted) => *granted == action,
             // Only a command has an executable or a token run to name.
             Self::AnyArgsFor { .. } | Self::CommandPrefix { .. } => false,
+            // Handled on canonical arguments above, before the fidelity gate.
+            Self::PathSubtree { .. } => unreachable!("place scopes return early"),
         }
     }
 
@@ -578,6 +610,8 @@ impl GrantScope {
                 openwave_shell_policy::CommandRuleKind::Exact,
                 exec_argv(command, args),
             ),
+            // A place names workspace writes, never a command.
+            Self::PathSubtree { .. } => unreachable!("place scopes return early"),
         };
         let Ok(rule) = rule else {
             return false;
@@ -600,6 +634,20 @@ impl GrantScope {
     /// alternative, which is the widest thing on the ladder.
     #[must_use]
     pub fn ladder_for(tool_name: &str, arguments: &serde_json::Value) -> Vec<Self> {
+        // A workspace write never describes itself exactly — the document is
+        // not projected — so its ladder is built from the place instead, and
+        // only when the path arrived intact. Falling through to the whole-tool
+        // default would offer the one workspace rung that must not exist: the
+        // chat's `Auto` mode already spells that consent.
+        if tool_name == "write_file" {
+            if !ToolActionPreview::names_place_exactly(tool_name, arguments) {
+                return Vec::new();
+            }
+            return match ToolActionPreview::build(tool_name, arguments) {
+                Some(action) => Self::ladder_for_action(&action),
+                None => Vec::new(),
+            };
+        }
         if !ToolActionPreview::describes_exactly(tool_name, arguments) {
             return vec![Self::WholeTool];
         }
@@ -607,6 +655,20 @@ impl GrantScope {
             return vec![Self::WholeTool];
         };
         Self::ladder_for_action(&action)
+    }
+
+    /// The rungs of [`Self::ladder_for`] a grant of `kind` may actually hold,
+    /// per [`ToolApprovalKind::grantable_at`]. This is the ladder a card may
+    /// offer: a rung appears only when granting it would mint.
+    #[must_use]
+    pub fn mintable_ladder_for(
+        kind: ToolApprovalKind,
+        tool_name: &str,
+        arguments: &serde_json::Value,
+    ) -> Vec<Self> {
+        let mut ladder = Self::ladder_for(tool_name, arguments);
+        ladder.retain(|scope| kind.grantable_at(scope));
+        ladder
     }
 
     /// The ladder for an action already projected from a parked call.
@@ -642,6 +704,12 @@ impl GrantScope {
             ladder.dedup();
             return ladder;
         }
+        // A write's ladder names places, narrowest first: exactly this path,
+        // then the directory that holds it. There is deliberately no
+        // whole-workspace rung — that consent already exists as `Auto` mode.
+        if let ToolActionPreview::WriteFile { path } = &action {
+            return place_ladder(path);
+        }
         vec![Self::ExactAction(action), Self::WholeTool]
     }
 }
@@ -652,6 +720,74 @@ fn exec_argv(command: &str, args: &[String]) -> Vec<String> {
     argv.push(command.to_owned());
     argv.extend(args.iter().cloned());
     argv
+}
+
+/// The canonical segments of a workspace-relative path, or `None` for a path
+/// no place grant should reason about.
+///
+/// Canonical means what the workspace itself would resolve: empty and `.`
+/// segments dropped, so a grant for `reports` covers `./reports/q1.md` rather
+/// than being dodged by a cosmetic respelling. Anything that could point
+/// outside the workspace — an absolute path, a `..` — yields `None`, and a
+/// call carrying one keeps asking instead of matching anything.
+fn place_segments(path: &str) -> Option<Vec<&str>> {
+    if path.starts_with('/') {
+        return None;
+    }
+    let segments: Vec<&str> = path
+        .split('/')
+        .filter(|segment| !segment.is_empty() && *segment != ".")
+        .collect();
+    if segments.is_empty() || segments.contains(&"..") {
+        return None;
+    }
+    Some(segments)
+}
+
+/// Whether a place grant's prefix covers the workspace write about to run.
+///
+/// Matched on the canonical `path` argument, segment-wise — `reports` never
+/// covers `reports-old/q1.md` — and only when the path reached the preview
+/// intact, so a grant given for the place the card showed cannot be stretched
+/// over paths that merely clamp to it.
+fn covers_workspace_place(prefix: &str, tool_name: &str, arguments: &serde_json::Value) -> bool {
+    if !ToolActionPreview::names_place_exactly(tool_name, arguments) {
+        return false;
+    }
+    let Some(path) = arguments.get("path").and_then(serde_json::Value::as_str) else {
+        return false;
+    };
+    let (Some(prefix), Some(path)) = (place_segments(prefix), place_segments(path)) else {
+        return false;
+    };
+    path.len() >= prefix.len()
+        && prefix
+            .iter()
+            .zip(path.iter())
+            .all(|(granted, requested)| granted == requested)
+}
+
+/// The place rungs for one workspace write, narrowest first.
+///
+/// Rebuilt from the (possibly clamped) preview on recovery, which cannot say
+/// whether a path exactly at the clamp bound was truncated — so a path at the
+/// bound gets no ladder, and no rung is ever offered for an approximate place.
+fn place_ladder(path: &str) -> Vec<GrantScope> {
+    if path.chars().count() >= crate::preview::MAX_ACTION_FIELD_CHARS {
+        return Vec::new();
+    }
+    let Some(segments) = place_segments(path) else {
+        return Vec::new();
+    };
+    let mut ladder = vec![GrantScope::PathSubtree {
+        prefix: segments.join("/"),
+    }];
+    if segments.len() > 1 {
+        ladder.push(GrantScope::PathSubtree {
+            prefix: segments[..segments.len() - 1].join("/"),
+        });
+    }
+    ladder
 }
 
 impl StandingGrant {
@@ -673,7 +809,9 @@ impl StandingGrant {
 
     /// Record consent limited to `scope`.
     ///
-    /// Returns `None` on the same terms as [`StandingGrant::new`].
+    /// Returns `None` on the same terms as [`StandingGrant::new`], and also
+    /// for a kind/scope pairing [`ToolApprovalKind::grantable_at`] refuses —
+    /// a workspace edit can be granted about a place and nothing wider.
     #[must_use]
     pub fn scoped(
         level: GrantLevel,
@@ -682,7 +820,7 @@ impl StandingGrant {
         scope: GrantScope,
         granted_at: DateTime<Utc>,
     ) -> Option<Self> {
-        if !kind.is_standing_grantable() {
+        if !kind.grantable_at(&scope) {
             return None;
         }
         Some(Self {
@@ -1430,5 +1568,129 @@ mod standing_grant_tests {
 
         grants.clear();
         assert!(!grants.covers(chat, None, "search", kind, &no_args()));
+    }
+
+    /// Canonical `write_file` arguments; the document rides along untouched
+    /// because a place grant is indifferent to it.
+    fn write_args(path: &str) -> serde_json::Value {
+        serde_json::json!({ "path": path, "content": "drafted text" })
+    }
+
+    fn place_grant(chat: ChatId, prefix: &str) -> StandingGrant {
+        StandingGrant::scoped(
+            GrantLevel::Chat { chat_id: chat },
+            "write_file",
+            ToolApprovalKind::WorkspaceMayModifyFiles,
+            GrantScope::PathSubtree {
+                prefix: prefix.into(),
+            },
+            Utc::now(),
+        )
+        .expect("a workspace write is grantable about a place")
+    }
+
+    #[test]
+    fn a_place_grant_covers_writes_under_it_and_nothing_else() {
+        let chat = ChatId::new();
+        let kind = ToolApprovalKind::WorkspaceMayModifyFiles;
+        let grants = StandingGrants::from_grants(vec![place_grant(chat, "reports")]);
+        let covers = |path: &str| grants.covers(chat, None, "write_file", kind, &write_args(path));
+
+        assert!(covers("reports/q1.md"));
+        assert!(covers("reports/2026/q1.md"));
+        // Matching is canonical, segment-wise: a cosmetic respelling of the
+        // same place is covered, a sibling that merely shares letters is not.
+        assert!(covers("./reports//q1.md"));
+        assert!(!covers("reports-old/q1.md"));
+        assert!(!covers("notes.md"));
+        // Anything that could point outside the workspace keeps asking.
+        assert!(!covers("reports/../secret.md"));
+        assert!(!covers("/reports/q1.md"));
+        // A path the preview could not reproduce was never the one granted.
+        let long = "x".repeat(crate::preview::MAX_ACTION_FIELD_CHARS + 1);
+        assert!(!covers(&format!("reports/{long}.md")));
+        // A place grant is scoped to the tool that writes, not borrowed by a
+        // command that mentions the same path.
+        assert!(!grants.covers(
+            chat,
+            None,
+            "exec",
+            ToolApprovalKind::ExecMayRunNetworkedCommand,
+            &exec_args("touch", &["reports/q1.md"]),
+        ));
+    }
+
+    #[test]
+    fn a_workspace_write_is_grantable_only_about_a_place() {
+        let level = GrantLevel::Chat {
+            chat_id: ChatId::new(),
+        };
+        let kind = ToolApprovalKind::WorkspaceMayModifyFiles;
+        // The whole-tool "yes" already exists as the chat's Auto mode.
+        assert!(StandingGrant::new(level, "write_file", kind, Utc::now()).is_none());
+        assert!(StandingGrant::scoped(
+            level,
+            "write_file",
+            kind,
+            GrantScope::ExactAction(ToolActionPreview::WriteFile {
+                path: "notes.md".into()
+            }),
+            Utc::now(),
+        )
+        .is_none());
+        // And the place rung belongs to workspace writes alone.
+        assert!(StandingGrant::scoped(
+            level,
+            "exec",
+            ToolApprovalKind::ExecMayRunNetworkedCommand,
+            GrantScope::PathSubtree {
+                prefix: "reports".into()
+            },
+            Utc::now(),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn the_write_ladder_names_the_file_then_its_directory() {
+        assert_eq!(
+            GrantScope::ladder_for("write_file", &write_args("reports/q1.md")),
+            vec![
+                GrantScope::PathSubtree {
+                    prefix: "reports/q1.md".into()
+                },
+                GrantScope::PathSubtree {
+                    prefix: "reports".into()
+                },
+            ]
+        );
+        // A root-level file has no directory rung, and there is deliberately
+        // no whole-workspace rung to fall back to.
+        assert_eq!(
+            GrantScope::ladder_for("write_file", &write_args("notes.md")),
+            vec![GrantScope::PathSubtree {
+                prefix: "notes.md".into()
+            }]
+        );
+        // Nothing is offered for a place the card could not show faithfully.
+        let long = "x".repeat(crate::preview::MAX_ACTION_FIELD_CHARS + 1);
+        assert_eq!(
+            GrantScope::ladder_for("write_file", &write_args(&long)),
+            Vec::<GrantScope>::new()
+        );
+        assert_eq!(
+            GrantScope::ladder_for("write_file", &write_args("reports/../q1.md")),
+            Vec::<GrantScope>::new()
+        );
+        // An unknown Workspace-class tool has no place to name, and the
+        // whole-tool default must not leak through the mintable ladder.
+        assert_eq!(
+            GrantScope::mintable_ladder_for(
+                ToolApprovalKind::WorkspaceMayModifyFiles,
+                "third_party_editor",
+                &no_args(),
+            ),
+            Vec::<GrantScope>::new()
+        );
     }
 }

--- a/crates/openwave-core/src/db/migration.rs
+++ b/crates/openwave-core/src/db/migration.rs
@@ -108,6 +108,7 @@ impl MigratorTrait for Migrator {
             Box::new(AddConnectedApps),
             Box::new(AddSandboxProvisionAdmission),
             Box::new(AddOwnerAttribution),
+            Box::new(WidenStandingGrantKinds),
         ]
     }
 }
@@ -7663,6 +7664,25 @@ impl MigrationName for WidenStandingGrantScope {
 
 const STANDING_GRANT_REBUILD: &str = "standing_tool_grant_rebuild";
 
+/// The closed `approval_kind` vocabulary a standing-grant row may carry.
+///
+/// The original list stopped at the first three grantable kinds; the wide one
+/// adds web extraction (grantable since the ladder widened past exec, but
+/// unstorable until now) and workspace writes (grantable about a place since
+/// the place rung).
+fn standing_grant_kind_keys(wide: bool) -> Vec<&'static str> {
+    let mut keys = vec![
+        crate::ToolApprovalKind::SearchMayShareQueryAndExcerpts.standing_grant_key(),
+        crate::ToolApprovalKind::WebSearchMayShareQuery.standing_grant_key(),
+        crate::ToolApprovalKind::ExecMayRunNetworkedCommand.standing_grant_key(),
+    ];
+    if wide {
+        keys.push(crate::ToolApprovalKind::WebExtractMayFetchUrl.standing_grant_key());
+        keys.push(crate::ToolApprovalKind::WorkspaceMayModifyFiles.standing_grant_key());
+    }
+    keys
+}
+
 /// Exactly one of `chat_id` / `project_id` names the level.
 fn standing_grant_level_check(widened: bool) -> SimpleExpr {
     if widened {
@@ -7677,7 +7697,7 @@ fn standing_grant_level_check(widened: bool) -> SimpleExpr {
     }
 }
 
-fn standing_grant_rebuild_table(widened: bool) -> TableCreateStatement {
+fn standing_grant_rebuild_table(widened: bool, wide_kinds: bool) -> TableCreateStatement {
     let mut table = Table::create();
     table
         .table(Alias::new(STANDING_GRANT_REBUILD))
@@ -7729,11 +7749,9 @@ fn standing_grant_rebuild_table(widened: bool) -> TableCreateStatement {
             Func::char_length(Expr::col(StandingToolGrant::ToolName))
                 .between(1, crate::model::ToolCallRecord::MAX_LABEL_LEN as i32),
         )
-        .check(Expr::col(StandingToolGrant::ApprovalKind).is_in([
-            crate::ToolApprovalKind::SearchMayShareQueryAndExcerpts.standing_grant_key(),
-            crate::ToolApprovalKind::WebSearchMayShareQuery.standing_grant_key(),
-            crate::ToolApprovalKind::ExecMayRunNetworkedCommand.standing_grant_key(),
-        ]));
+        .check(
+            Expr::col(StandingToolGrant::ApprovalKind).is_in(standing_grant_kind_keys(wide_kinds)),
+        );
     if widened {
         table
             .col(ColumnDef::new(StandingToolGrant::ProjectId).uuid())
@@ -7787,8 +7805,50 @@ async fn rebuild_standing_grant_sqlite(
         // table behind and make the next attempt fail on "already exists".
         // Cheaper to make the step idempotent than to test for the stranding.
         format!("DROP TABLE IF EXISTS {STANDING_GRANT_REBUILD}"),
-        standing_grant_rebuild_table(widened).to_string(SqliteQueryBuilder),
+        standing_grant_rebuild_table(widened, false).to_string(SqliteQueryBuilder),
         copy,
+        "DROP TABLE standing_tool_grant".to_owned(),
+        format!("ALTER TABLE {STANDING_GRANT_REBUILD} RENAME TO standing_tool_grant"),
+        standing_grant_rebuild_index().to_string(SqliteQueryBuilder),
+        "COMMIT".to_owned(),
+        "PRAGMA foreign_keys=ON".to_owned(),
+    ];
+    manager
+        .get_connection()
+        .execute_unprepared(&format!("{};", statements.join(";\n")))
+        .await?;
+    Ok(())
+}
+
+/// SQLite rebuild for the kind-vocabulary migration: the level shape stays
+/// widened on both sides; only the `approval_kind` check (and, when
+/// narrowing, the rows the narrow check refuses) changes.
+async fn rebuild_standing_grant_kinds_sqlite(
+    manager: &SchemaManager<'_>,
+    wide_kinds: bool,
+) -> Result<(), DbErr> {
+    let shared = "source_call_id, chat_id, tool_name, approval_kind, scope, granted_at, project_id";
+    // A row carrying a kind the narrow check refuses cannot be respelled
+    // without inventing a consent nobody gave, so narrowing drops it.
+    let kind_filter = if wide_kinds {
+        String::new()
+    } else {
+        let legacy = standing_grant_kind_keys(false)
+            .into_iter()
+            .map(|key| format!("'{key}'"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(" WHERE approval_kind IN ({legacy})")
+    };
+    let statements = vec![
+        "PRAGMA foreign_keys=OFF".to_owned(),
+        "BEGIN IMMEDIATE".to_owned(),
+        format!("DROP TABLE IF EXISTS {STANDING_GRANT_REBUILD}"),
+        standing_grant_rebuild_table(true, wide_kinds).to_string(SqliteQueryBuilder),
+        format!(
+            "INSERT INTO {STANDING_GRANT_REBUILD} ({shared}) \
+             SELECT {shared} FROM standing_tool_grant{kind_filter}"
+        ),
         "DROP TABLE standing_tool_grant".to_owned(),
         format!("ALTER TABLE {STANDING_GRANT_REBUILD} RENAME TO standing_tool_grant"),
         standing_grant_rebuild_index().to_string(SqliteQueryBuilder),
@@ -7848,10 +7908,104 @@ impl MigrationTrait for WidenStandingGrantScope {
     }
 }
 
+/// Widens the standing-grant `approval_kind` vocabulary (issue #939): the
+/// place rung lets a workspace write be remembered about a location, and the
+/// column's closed check has to admit its kind before such a grant can be
+/// stored. Web extraction joins in the same pass — it has been grantable
+/// since the ladder widened past exec, but this check silently predated it,
+/// so "always allow" for a web page failed at the insert.
+///
+/// The `down` deletes rows carrying the new kinds first: they have no
+/// representation in the narrow vocabulary, and respelling them would invent
+/// a consent nobody gave.
+struct WidenStandingGrantKinds;
+
+impl MigrationName for WidenStandingGrantKinds {
+    fn name(&self) -> &str {
+        "m20260803_000046_widen_standing_grant_kinds"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for WidenStandingGrantKinds {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        if manager.get_database_backend() == DatabaseBackend::Sqlite {
+            return rebuild_standing_grant_kinds_sqlite(manager, true).await;
+        }
+        let kinds = render_postgres_check(
+            Expr::col(StandingToolGrant::ApprovalKind).is_in(standing_grant_kind_keys(true)),
+        );
+        let statements = [
+            // The baseline's kind constraint is unnamed, so find it by the
+            // column it constrains. No other check on this table mentions
+            // `approval_kind`, and the named replacement is added only after
+            // this drop.
+            "DO $$
+             DECLARE name text;
+             BEGIN
+                 FOR name IN
+                     SELECT conname FROM pg_constraint
+                     WHERE conrelid = 'standing_tool_grant'::regclass
+                       AND contype = 'c'
+                       AND pg_get_constraintdef(oid) LIKE '%approval_kind%'
+                 LOOP
+                     EXECUTE format('ALTER TABLE standing_tool_grant DROP CONSTRAINT %I', name);
+                 END LOOP;
+             END $$"
+                .to_owned(),
+            format!(
+                "ALTER TABLE standing_tool_grant ADD CONSTRAINT chk_standing_tool_grant_kind \
+                 CHECK ({kinds})"
+            ),
+        ];
+        for statement in statements {
+            manager
+                .get_connection()
+                .execute_unprepared(&statement)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let legacy = standing_grant_kind_keys(false)
+            .into_iter()
+            .map(|key| format!("'{key}'"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        manager
+            .get_connection()
+            .execute_unprepared(&format!(
+                "DELETE FROM standing_tool_grant WHERE approval_kind NOT IN ({legacy})"
+            ))
+            .await?;
+        if manager.get_database_backend() == DatabaseBackend::Sqlite {
+            return rebuild_standing_grant_kinds_sqlite(manager, false).await;
+        }
+        let kinds = render_postgres_check(
+            Expr::col(StandingToolGrant::ApprovalKind).is_in(standing_grant_kind_keys(false)),
+        );
+        let statements = [
+            "ALTER TABLE standing_tool_grant DROP CONSTRAINT chk_standing_tool_grant_kind"
+                .to_owned(),
+            format!(
+                "ALTER TABLE standing_tool_grant ADD CONSTRAINT chk_standing_tool_grant_kind \
+                 CHECK ({kinds})"
+            ),
+        ];
+        for statement in statements {
+            manager
+                .get_connection()
+                .execute_unprepared(&statement)
+                .await?;
+        }
+        Ok(())
+    }
+}
+
 /// Retires the semantic index stage: a parsed document is ready the moment its
 /// canonical text is published, because there is no derived vector store left
-/// to publish into.
-///
+/// to publish into.///
 /// Index jobs are deleted rather than cancelled — they describe a stage that no
 /// longer exists. Documents whose canonical output was already published (or
 /// that never had raw bytes to parse) are promoted to `ready`, including rows

--- a/crates/openwave-core/src/db/ops/approval.rs
+++ b/crates/openwave-core/src/db/ops/approval.rs
@@ -249,11 +249,7 @@ pub(in crate::db) async fn request_and_append_event(
         tool_name: request.tool_name.clone(),
         class: request.class,
         kind: request.kind,
-        grant_scopes: if request.kind.is_standing_grantable() {
-            GrantScope::ladder_for(&call.name, &call.arguments)
-        } else {
-            Vec::new()
-        },
+        grant_scopes: GrantScope::mintable_ladder_for(request.kind, &call.name, &call.arguments),
         preview: request.preview.clone(),
     };
     let turn = entities::turn_run::Entity::find_by_id(request.turn_id.0)
@@ -923,6 +919,13 @@ fn approval_from_model(model: &entities::tool_call::Model) -> Result<ToolApprova
         }
         Some("search_may_share_query_and_excerpts") if model.name == "web_search" => {
             ToolApprovalKind::WebSearchMayShareQuery
+        }
+        // The page-fetch kind folds into the search spelling the same way; the
+        // missing recovery arm made a restarted card consent to "sharing a
+        // query" while fetching a URL, and stored any "always allow" under the
+        // search key where no later web_extract call could find it.
+        Some("search_may_share_query_and_excerpts") if model.name == "web_extract" => {
+            ToolApprovalKind::WebExtractMayFetchUrl
         }
         Some("search_may_share_query_and_excerpts") => {
             ToolApprovalKind::SearchMayShareQueryAndExcerpts

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -9073,7 +9073,12 @@ async fn workspace_approval_folds_storage_but_recovers_class_and_kind() {
         crate::ToolApprovalKind::WorkspaceMayModifyFiles
     );
     assert!(approval.kind.is_approvable());
-    assert!(!approval.kind.is_standing_grantable());
+    // Grantable about a place, and nothing wider — the whole-tool rung is the
+    // chat's Auto mode, not a standing grant.
+    assert!(approval.kind.grantable_at(&crate::GrantScope::PathSubtree {
+        prefix: "notes.md".into()
+    }));
+    assert!(!approval.kind.grantable_at(&crate::GrantScope::WholeTool));
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -195,6 +195,25 @@ impl ToolActionPreview {
             _ => false,
         }
     }
+
+    /// Whether the call's *place* — the workspace path a location-scoped grant
+    /// is built from and matched against — reaches the preview intact.
+    ///
+    /// Weaker than [`Self::describes_exactly`] on purpose: a workspace write
+    /// never describes itself exactly (the document is not projected), but a
+    /// grant about a place does not need the document. It needs the path, all
+    /// of it, so a grant keyed on a clamped path cannot be stretched over
+    /// other paths sharing its first [`MAX_ACTION_FIELD_CHARS`] characters.
+    #[must_use]
+    pub fn names_place_exactly(tool_name: &str, arguments: &Value) -> bool {
+        match tool_name {
+            "write_file" => arguments
+                .get("path")
+                .and_then(Value::as_str)
+                .is_some_and(survives_clamp),
+            _ => false,
+        }
+    }
 }
 
 /// What one row of a listed result is, which is what picks its icon.

--- a/crates/openwave-desktop/ui/src/ApprovalCard.tsx
+++ b/crates/openwave-desktop/ui/src/ApprovalCard.tsx
@@ -356,6 +356,27 @@ export function grantLadder(
           ]
         : [];
     }
+    if ("path_prefix" in grant) {
+      if (preview?.tool !== "write_file") return [];
+      // The concrete place comes from the parked call's own path; the rung
+      // only says how many segments of it were offered.
+      const segments = placeSegments(preview.path);
+      const count = grant.path_prefix.segments;
+      if (count < 1 || count > segments.length) return [];
+      const place = bounded(segments.slice(0, count).join("/"));
+      return [
+        {
+          kind: "decide",
+          key: `place-${count}`,
+          label:
+            count === segments.length
+              ? `Yes, and always allow writing \u201c${place}\u201d`
+              : `Yes, and always allow writes under \u201c${place}/\u201d`,
+          decision: "approve",
+          grant,
+        },
+      ];
+    }
     if (preview?.tool !== "exec") return [];
     const argv = [preview.command, ...preview.args];
     const tokens = grant.command_prefix.tokens;
@@ -391,7 +412,20 @@ function spokenAction(preview: ToolActionPreview): string {
         : preview.tool === "write_file"
           ? preview.path
           : preview.query;
+  return bounded(spoken);
+}
+
+function bounded(spoken: string): string {
   return spoken.length > SPOKEN_ACTION_CHARS
     ? `${spoken.slice(0, SPOKEN_ACTION_CHARS).trimEnd()}\u2026`
     : spoken;
+}
+
+/**
+ * The canonical segments of a workspace-relative path, matching how the
+ * server names a place: empty and `.` segments dropped, so the label shows
+ * the place the grant will actually cover.
+ */
+export function placeSegments(path: string): string[] {
+  return path.split("/").filter((segment) => segment !== "" && segment !== ".");
 }

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -287,7 +287,7 @@ export type ApprovalClass = "read_only" | "workspace" | "sensitive";
  * arguments the call is parked on. A grant can therefore only ever describe
  * the action that was actually under review.
  */
-export type ApprovalGrantRung = "exact_action" | { "command_prefix": { tokens: number, } } | "whole_tool";
+export type ApprovalGrantRung = "exact_action" | { "command_prefix": { tokens: number, } } | { "path_prefix": { segments: number, } } | "whole_tool";
 
 /**
  * Opaque renderer identity for one assistant-message citation.
@@ -857,7 +857,7 @@ export type GrantLevel = { "level": "chat", chat_id: ChatId, } | { "level": "pro
  * narrower variants exist because "don't ask me about commands again" is a
  * much larger thing to agree to than "don't ask me about `cargo` again".
  */
-export type GrantScope = { "scope": "exact_action" } & ToolActionPreview | { "scope": "any_args_for", command: string, } | { "scope": "command_prefix", tokens: Array<string>, } | { "scope": "whole_tool" };
+export type GrantScope = { "scope": "exact_action" } & ToolActionPreview | { "scope": "any_args_for", command: string, } | { "scope": "command_prefix", tokens: Array<string>, } | { "scope": "path_subtree", prefix: string, } | { "scope": "whole_tool" };
 
 /**
  * Renderer-safe mirror of the host broker's capability vocabulary.

--- a/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
@@ -22,6 +22,7 @@ const TOOL_LABELS: Partial<Record<RendererToolName, string>> = {
   search: "Document search",
   web_search: "Web search",
   web_extract: "Web pages",
+  write_file: "Workspace files",
 };
 
 export function toolGrantLabel(action: RendererToolName): string {
@@ -67,8 +68,9 @@ export function grantScopeLabel(
       if (scope.tool === "web_extract") {
         return scope.url;
       }
-      // Workspace writes are never standing-grantable, so no stored grant can
-      // carry this scope today; named anyway so the vocabulary stays total.
+      // Retained for old durable grants: workspace writes are granted about a
+      // place (`path_subtree`) rather than exactly, so no current mint stores
+      // this scope; named anyway so the vocabulary stays total.
       if (scope.tool === "write_file") {
         return scope.path;
       }
@@ -78,6 +80,8 @@ export function grantScopeLabel(
       return `${scope.command} …`;
     case "command_prefix":
       return `${scope.tokens.join(" ")} …`;
+    case "path_subtree":
+      return `Writes under ${scope.prefix}`;
     case "whole_tool":
       switch (action) {
         case "exec":

--- a/crates/openwave-server/src/approvals.rs
+++ b/crates/openwave-server/src/approvals.rs
@@ -205,6 +205,13 @@ fn grant_scope(
             ApprovalGrantRung::CommandPrefix { tokens },
             Some(action @ ToolActionPreview::Exec { .. }),
         ) if action_is_exact => command_prefix_scope(action, tokens)?,
+        // A place rung does not need whole-call fidelity: the write's document
+        // never reaches the preview, and consent about a place is indifferent
+        // to it. The ladder itself refuses a path that may have been clamped.
+        (
+            ApprovalGrantRung::PathPrefix { segments },
+            Some(action @ ToolActionPreview::WriteFile { .. }),
+        ) => path_prefix_scope(action, segments)?,
         _ => return None,
     };
     let available = match action {
@@ -229,6 +236,24 @@ fn command_prefix_scope(
         .into_iter()
         .find(|scope| {
             matches!(scope, GrantScope::CommandPrefix { tokens: offered } if offered.len() == tokens)
+        })
+}
+
+/// Rebuild a place rung from the parked call, on the same terms as
+/// [`command_prefix_scope`]: the renderer sends only a segment count, the
+/// concrete prefix comes from the call's own ladder, and a count the ladder
+/// never offered mints nothing.
+fn path_prefix_scope(
+    action: &openwave_core::ToolActionPreview,
+    segments: usize,
+) -> Option<GrantScope> {
+    openwave_core::GrantScope::ladder_for_action(action)
+        .into_iter()
+        .find(|scope| {
+            matches!(
+                scope,
+                GrantScope::PathSubtree { prefix } if prefix.split('/').count() == segments
+            )
         })
 }
 
@@ -1111,6 +1136,141 @@ mod tests {
             ApprovalRequiredPublication::Ordinary
         ));
         drop(pending.decision);
+    }
+
+    /// Reproduces the dead "always allow" for web pages: the recovered kind
+    /// folded to the search spelling, so the grant was stored under a key no
+    /// later `web_extract` call ever looked up — and the grant table's closed
+    /// `approval_kind` check predated the correct key, so the fixed spelling
+    /// also needs the kind-widening migration to be storable at all.
+    #[tokio::test]
+    async fn a_web_extract_grant_is_stored_under_its_own_kind_and_covers_the_page() {
+        let (store, request) =
+            setup_with_arguments("web_extract", json!({ "url": "https://example.com/a" })).await;
+        let broker = ApprovalBroker::new(store.clone());
+        let _pending = broker.register(request.clone(), None).await;
+        assert_eq!(
+            broker
+                .resolve_with_grant(
+                    request.chat_id,
+                    request.call_id,
+                    ApprovalDecision::Approve,
+                    Some(crate::routes::ApprovalGrantRung::ExactAction),
+                )
+                .await
+                .unwrap(),
+            ResolveApprovalOutcome::Resolved
+        );
+        let grants = store.list_standing_tool_grants().await.unwrap();
+        assert_eq!(grants.len(), 1);
+        assert_eq!(
+            grants[0].grant.kind(),
+            openwave_core::ToolApprovalKind::WebExtractMayFetchUrl
+        );
+
+        // The durable grant now covers the exact page it named.
+        let covered = request_for(
+            &store,
+            request.chat_id,
+            "web_extract",
+            json!({ "url": "https://example.com/a" }),
+        )
+        .await;
+        let registration = broker.register(covered, None).await;
+        assert!(matches!(
+            registration.publication,
+            ApprovalRequiredPublication::StandingGrant
+        ));
+        assert!(matches!(
+            registration.decision.await,
+            ApprovalDecision::Approve
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_workspace_write_can_be_remembered_for_its_place() {
+        let (store, mut request) = setup_with_arguments(
+            "write_file",
+            json!({ "path": "reports/q1.md", "content": "draft" }),
+        )
+        .await;
+        request.class = ApprovalClass::Workspace;
+        let broker = ApprovalBroker::new(store.clone());
+        let _pending = broker.register(request.clone(), None).await;
+
+        // The whole-tool rung must not exist for a workspace write: that
+        // consent is the chat's Auto mode, not a standing grant.
+        assert_eq!(
+            broker
+                .resolve_with_grant(
+                    request.chat_id,
+                    request.call_id,
+                    ApprovalDecision::Approve,
+                    Some(crate::routes::ApprovalGrantRung::WholeTool),
+                )
+                .await
+                .unwrap(),
+            ResolveApprovalOutcome::GrantNotAvailable
+        );
+        // A segment count the ladder never offered mints nothing.
+        assert_eq!(
+            broker
+                .resolve_with_grant(
+                    request.chat_id,
+                    request.call_id,
+                    ApprovalDecision::Approve,
+                    Some(crate::routes::ApprovalGrantRung::PathPrefix { segments: 3 }),
+                )
+                .await
+                .unwrap(),
+            ResolveApprovalOutcome::GrantNotAvailable
+        );
+        // The directory rung — one segment of `reports/q1.md`.
+        assert_eq!(
+            broker
+                .resolve_with_grant(
+                    request.chat_id,
+                    request.call_id,
+                    ApprovalDecision::Approve,
+                    Some(crate::routes::ApprovalGrantRung::PathPrefix { segments: 1 }),
+                )
+                .await
+                .unwrap(),
+            ResolveApprovalOutcome::Resolved
+        );
+
+        // The next write under the granted place runs without a card…
+        let covered = request_for(
+            &store,
+            request.chat_id,
+            "write_file",
+            json!({ "path": "reports/q2.md", "content": "another draft" }),
+        )
+        .await;
+        let registration = broker.register(covered, None).await;
+        assert!(matches!(
+            registration.publication,
+            ApprovalRequiredPublication::StandingGrant
+        ));
+        assert!(matches!(
+            registration.decision.await,
+            ApprovalDecision::Approve
+        ));
+
+        // …and a write anywhere else parks on the card as before.
+        let uncovered = request_for(
+            &store,
+            request.chat_id,
+            "write_file",
+            json!({ "path": "notes.md", "content": "elsewhere" }),
+        )
+        .await;
+        let registration = broker.register(uncovered, None).await;
+        assert!(matches!(
+            registration.publication,
+            ApprovalRequiredPublication::Ordinary
+        ));
+        drop(registration.decision);
     }
 
     #[tokio::test]

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -2876,6 +2876,12 @@ pub enum ApprovalGrantRung {
     /// call's own arguments and honors the length only if it appears there,
     /// so a client cannot invent a prefix the card never showed.
     CommandPrefix { tokens: usize },
+    /// A leading run of a workspace write's path segments — the file itself,
+    /// or the directory that holds it.
+    ///
+    /// Named by segment count on the same terms as [`Self::CommandPrefix`]:
+    /// the concrete place comes from the parked call, never from the client.
+    PathPrefix { segments: usize },
     /// Every call to this tool.
     WholeTool,
 }
@@ -2954,13 +2960,14 @@ pub(crate) fn approval_grant_rungs(
     action: Option<&openwave_core::ToolActionPreview>,
     action_is_exact: bool,
 ) -> Vec<ApprovalGrantRung> {
-    if !kind.is_standing_grantable() {
-        return Vec::new();
-    }
-    let scopes = match action {
+    let mut scopes = match action {
         Some(action) => openwave_core::GrantScope::ladder_for_action(action),
         None => vec![openwave_core::GrantScope::WholeTool],
     };
+    // A rung appears only when granting it would mint: the kind admits only
+    // the rungs that describe its own action, so a workspace edit offers its
+    // place rungs and an ungrantable kind offers nothing.
+    scopes.retain(|scope| kind.grantable_at(scope));
     grant_rungs_from_scopes(&scopes, action_is_exact)
 }
 
@@ -2978,6 +2985,11 @@ pub(crate) fn grant_rungs_from_scopes(
             openwave_core::GrantScope::CommandPrefix { tokens } => {
                 Some(ApprovalGrantRung::CommandPrefix {
                     tokens: tokens.len(),
+                })
+            }
+            openwave_core::GrantScope::PathSubtree { prefix } => {
+                Some(ApprovalGrantRung::PathPrefix {
+                    segments: prefix.split('/').count(),
                 })
             }
             openwave_core::GrantScope::WholeTool => Some(ApprovalGrantRung::WholeTool),


### PR DESCRIPTION
Slice 4 of #939: `GrantScope` gains the rung that names a place, so "don't ask again" can be said about a location, not only a command shape. This closes the deferral note in `approval.rs` — resource-level sub-scoping waited for `ApprovalRequest` to carry a structured resource, which slice 1 (#1356) provided as `ToolActionPreview::WriteFile { path }`.

What the rung means:

- `GrantScope::PathSubtree { prefix }` covers workspace writes landing at the named path or below it. Matching is on the canonical `path` argument, segment-wise (`reports` never covers `reports-old/…`), canonicalized (`./reports//q1.md` is the same place), and fail-closed: absolute paths, `..`, or a path the preview could not reproduce in full keep asking.
- A workspace write's ladder names the file, then the directory that holds it — and deliberately no whole-workspace rung, because that consent already exists as the chat's Auto mode. `ToolApprovalKind::grantable_at` enforces the pairing both ways: workspace edits grant only about a place, no other kind can borrow the place rung.
- The wire grows `ApprovalGrantRung::PathPrefix { segments }` on the same terms as the command-prefix rung: the renderer names a count, the server rebuilds the concrete place from the parked call's own arguments, and a count the ladder never offered mints nothing.
- The card offers "always allow writing `reports/q1.md`" / "writes under `reports/`", and the Permissions panel renders the stored scope.

Two adjacent latent bugs surfaced while widening the grant table's closed `approval_kind` check (migration `m20260803_000046`, both backends):

- `approval_from_model` had no recovery arm for `web_extract`, so a recovered page-fetch card consented as "may share a query", and an "always allow" was stored under the search key where no later `web_extract` call ever looked it up — the grant was dead on arrival. The arm now recovers `WebExtractMayFetchUrl`, which is also what makes the check widening load-bearing for that kind.
- Any legacy web_extract grant rows stored under the search key stay inert (they never authorized anything); they render with search provenance in the panel until revoked.

Tests: place-grant coverage/refusal matrix and the write ladder in `openwave-core`; end-to-end park → place-rung mint → covered/uncovered registration, plus the web_extract kind round-trip, in `openwave-server`. Verified: full `openwave-core` and `openwave-server` suites, clippy on both, wire types regenerated, `tsc` + touched vitest.

Part of #939.