### PR TITLE
fix(desktop): carry allow_local_mcp_servers in renderer ManagedPolicy fixtures

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -51,6 +51,7 @@ const unmanaged: import("./api").ManagedPolicy = {
   managed: false,
   source: "unmanaged",
   misconfigured: false,
+allow_local_mcp_servers: false,
 };
 const getPolicy = vi.fn(async () => unmanaged);
 const getGatewayStatus = vi.fn(async () => ({
@@ -488,6 +489,7 @@ describe("app shell", () => {
       gateway_url: "https://gateway.example/",
       source: "os",
       misconfigured: false,
+    allow_local_mcp_servers: false,
     });
     const user = userEvent.setup();
     await mountApp();

--- a/crates/openwave-desktop/ui/src/ManagedGate.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.dom.test.tsx
@@ -14,6 +14,7 @@ const managed: ManagedPolicy = {
   gateway_url: "https://gateway.example/",
   source: "os",
   misconfigured: false,
+allow_local_mcp_servers: false,
 };
 
 const signedOut: GatewayStatus = {
@@ -148,6 +149,7 @@ describe("ManagedGate", () => {
       managed: false,
       source: "unmanaged",
       misconfigured: false,
+    allow_local_mcp_servers: false,
     };
     // The profile starts open, then a deep-link pairing provisions it and the
     // session already satisfies the new policy.
@@ -184,6 +186,7 @@ describe("ManagedGate", () => {
         managed: false,
         source: "unmanaged",
         misconfigured: false,
+      allow_local_mcp_servers: false,
       } satisfies ManagedPolicy)
       .mockResolvedValue(managed);
     const client = api({
@@ -211,6 +214,7 @@ describe("ManagedGate", () => {
         managed: false,
         source: "unmanaged",
         misconfigured: false,
+        allow_local_mcp_servers: false,
         pending_gateway_url: "https://new-gw.example/",
       } satisfies ManagedPolicy),
       getGatewayStatus: vi.fn().mockResolvedValue({
@@ -254,6 +258,7 @@ describe("ManagedGate", () => {
         managed: false,
         source: "unmanaged",
         misconfigured: false,
+        allow_local_mcp_servers: false,
         pending_gateway_url: "https://new-gw.example/",
       } satisfies ManagedPolicy),
       getGatewayStatus: vi.fn().mockResolvedValue({
@@ -265,6 +270,7 @@ describe("ManagedGate", () => {
         managed: false,
         source: "unmanaged",
         misconfigured: false,
+      allow_local_mcp_servers: false,
       } satisfies ManagedPolicy),
     });
     const user = userEvent.setup();
@@ -286,6 +292,7 @@ describe("ManagedGate", () => {
       gateway_url: "https://gateway.example/",
       source: "provisioned",
       misconfigured: false,
+      allow_local_mcp_servers: false,
       pending_gateway_url: "https://new-gw.example/",
     };
     const client = api({
@@ -475,6 +482,7 @@ describe("ManagedGate", () => {
       managed: false,
       source: "unmanaged",
       misconfigured: false,
+    allow_local_mcp_servers: false,
     };
     const client = api({
       getPolicy: vi

--- a/crates/openwave-desktop/ui/src/ManagedGate.tsx
+++ b/crates/openwave-desktop/ui/src/ManagedGate.tsx
@@ -150,7 +150,12 @@ export function ManagedGate({
           // product is correct, not a dead end.
           setPolicyState({
             kind: "resolved",
-            policy: { managed: false, source: "unmanaged", misconfigured: false },
+            policy: {
+              managed: false,
+              source: "unmanaged",
+              misconfigured: false,
+              allow_local_mcp_servers: false,
+            },
           });
           return;
         }

--- a/crates/openwave-desktop/ui/src/PermissionModeMenu.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/PermissionModeMenu.dom.test.tsx
@@ -38,6 +38,7 @@ it("locks modes above a managed ceiling", async () => {
     managed: false,
     source: "unmanaged",
     misconfigured: false,
+    allow_local_mcp_servers: false,
     permission_mode_ceiling: "ask",
   };
   const onChange = vi.fn();

--- a/crates/openwave-desktop/ui/src/managedPolicy.ts
+++ b/crates/openwave-desktop/ui/src/managedPolicy.ts
@@ -9,6 +9,7 @@ const UNMANAGED: ManagedPolicy = {
   managed: false,
   source: "unmanaged",
   misconfigured: false,
+allow_local_mcp_servers: false,
 };
 
 /**


### PR DESCRIPTION
#1384 added the required `allow_local_mcp_servers` field to the `ManagedPolicy` wire type without updating the renderer's own policy literals, so `tsc` has been failing since — invisibly, because that push's UI lane did not run. This adds the field (`false`, the fail-closed default and the unmanaged neutral) to the two production fallbacks (`managedPolicy.ts`, `ManagedGate.tsx` 404 path) and the test fixtures in `AppShell`, `ManagedGate`, and `PermissionModeMenu` suites.

Verified: `tsc` clean, full `pnpm test` (100 files, 689 tests) green.