### PR TITLE
feat(broker): individually revocable capability grants

### DIFF
--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -470,6 +470,48 @@ async fn capability_statement(
     })
 }
 
+/// One statement-level revocation, named exactly as the consent surface
+/// listed it: the broker's stable grant identity plus the level the statement
+/// reaches, from which the owning subject is rebuilt.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct RevokeCapabilityConsentRequest {
+    grant_id: openwave_host_broker::GrantId,
+    level: openwave_core::GrantLevel,
+}
+
+/// Withdraw one host-broker capability grant from the Permissions surface.
+///
+/// The subject is derived from the statement's level rather than looked up:
+/// a grant whose chat or project was deleted still conveys authority, and the
+/// consent surface exists precisely so such a statement can be withdrawn. A
+/// mismatched level revokes nothing and reports `false`.
+#[tauri::command]
+pub(crate) async fn revoke_capability_consent(
+    state: State<'_, HostAccess>,
+    request: RevokeCapabilityConsentRequest,
+) -> Result<bool, String> {
+    let subject = match request.level {
+        openwave_core::GrantLevel::Chat { chat_id } => GrantSubject::conversation(chat_id.0),
+        openwave_core::GrantLevel::Project { project_id } => GrantSubject::project(project_id.0),
+    }
+    .map_err(|_| "invalid consent statement".to_owned())?;
+    let result = state
+        .broker
+        .control(ControlRequest::RevokeGrant(
+            openwave_host_broker::RevokeGrantRequest {
+                subject,
+                grant_id: request.grant_id,
+            },
+        ))
+        .await
+        .map_err(|error| error.to_string())?;
+    let ControlResult::RevokeGrant(result) = result else {
+        return Err("host broker returned an unexpected response".to_owned());
+    };
+    Ok(result.revoked)
+}
+
 #[tauri::command]
 pub(crate) async fn connect_approved_folder(
     app: AppHandle,

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -226,6 +226,7 @@ pub fn run() {
             host_access::connect_approved_folder,
             host_access::list_approved_folders,
             host_access::list_capability_consents,
+            host_access::revoke_capability_consent,
             host_access::list_connected_folders,
             host_access::disconnect_folder,
             updater::desktop_update_state,

--- a/crates/openwave-desktop/ui/src/host.ts
+++ b/crates/openwave-desktop/ui/src/host.ts
@@ -54,6 +54,26 @@ export function listCapabilityConsents(): Promise<ConsentStatementSnapshot[]> {
   return invoke("list_capability_consents");
 }
 
+/**
+ * Withdraw one host-broker capability grant by the statement that names it.
+ * Returns whether anything was revoked; `false` means the grant was already
+ * gone. Resolving `false` outside the native host keeps a stray browser call
+ * from claiming a revocation nothing performed.
+ */
+export function revokeCapabilityConsent(
+  statement: ConsentStatementSnapshot,
+): Promise<boolean> {
+  if (!isTauri() || statement.handle.kind !== "capability_grant") {
+    return Promise.resolve(false);
+  }
+  return invoke("revoke_capability_consent", {
+    request: {
+      grantId: statement.handle.grant_id,
+      level: statement.level,
+    },
+  });
+}
+
 export function connectFolder(chat: Chat): Promise<ConnectedFolder | null> {
   return invoke("connect_folder", {
     request: { chatId: chat.id },

--- a/crates/openwave-desktop/ui/src/settings/PermissionsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/PermissionsPanel.dom.test.tsx
@@ -8,7 +8,10 @@ import { PermissionsPanel } from "./PermissionsPanel";
 const listCapabilityConsents = vi.hoisted(() =>
   vi.fn<() => Promise<ConsentStatementSnapshot[]>>(),
 );
-vi.mock("../host", () => ({ listCapabilityConsents }));
+const revokeCapabilityConsent = vi.hoisted(() =>
+  vi.fn<() => Promise<boolean>>(),
+);
+vi.mock("../host", () => ({ listCapabilityConsents, revokeCapabilityConsent }));
 
 const execStatement: ConsentStatementSnapshot = {
   handle: {
@@ -62,7 +65,15 @@ afterEach(() => {
 
 describe("PermissionsPanel", () => {
   it("revokes a tool grant after confirmation and drops the row", async () => {
-    const client = api();
+    const listConsentStatements = vi.fn().mockResolvedValue([execStatement]);
+    const client = api({
+      listConsentStatements,
+      revokeStandingGrant: vi.fn().mockImplementation(() => {
+        // The reload after a revocation reads back what the server now holds.
+        listConsentStatements.mockResolvedValue([]);
+        return Promise.resolve(undefined);
+      }),
+    });
     render(<PermissionsPanel client={client} />);
 
     // The statement renders under its chat, worded as the width of the consent.
@@ -85,20 +96,39 @@ describe("PermissionsPanel", () => {
     );
   });
 
-  it("renders a broker capability grant beside tool grants, without a revoke control", async () => {
+  it("revokes a broker capability grant through the host and reloads the list", async () => {
     listCapabilityConsents.mockResolvedValue([folderWriteStatement]);
+    revokeCapabilityConsent.mockImplementation(() => {
+      // The reloaded list is what the broker now holds.
+      listCapabilityConsents.mockResolvedValue([]);
+      return Promise.resolve(true);
+    });
     const client = api();
     render(<PermissionsPanel client={client} />);
 
-    // Both halves of the read model land in the same chat group: the folder
-    // by its safe display name with its capability verb and picker
-    // provenance, and only the tool grant offers revocation here.
+    // Both halves of the read model land in the same chat group, and both
+    // offer the same revocation control.
     await screen.findByText("Documents");
     screen.getByText("cargo …");
     screen.getByText("Write files");
     screen.getByText(/with the folder picker/);
-    screen.getByText("Managed with its folder");
-    expect(screen.getAllByRole("button", { name: "Revoke" })).toHaveLength(1);
+    const revokes = screen.getAllByRole("button", { name: "Revoke" });
+    expect(revokes).toHaveLength(2);
+
+    // The capability row is listed after the tool grant in its group.
+    await userEvent.click(revokes[1]);
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Revoke", hidden: false }),
+    );
+    await waitFor(() =>
+      expect(revokeCapabilityConsent).toHaveBeenCalledWith(
+        folderWriteStatement,
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("Documents")).not.toBeInTheDocument(),
+    );
+    expect(client.revokeStandingGrant).not.toHaveBeenCalled();
   });
 
   it("names a project statement as reaching past the chat that made it", async () => {

--- a/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
@@ -7,7 +7,7 @@ import type {
   RendererToolName,
 } from "../api";
 import { useConfirm } from "../components/ConfirmDialog";
-import { listCapabilityConsents } from "../host";
+import { listCapabilityConsents, revokeCapabilityConsent } from "../host";
 import { Button } from "@/components/ui/button";
 import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
 
@@ -223,17 +223,9 @@ function StatementRow({
           </p>
         )}
       </div>
-      {statement.handle.kind === "tool_grant" ? (
-        <Button variant="ghost" size="sm" disabled={busy} onClick={onRevoke}>
-          Revoke
-        </Button>
-      ) : (
-        // Capability statements are not individually revocable yet; the
-        // Folders surface disconnects the whole folder. Read model first.
-        <span className="text-muted-foreground text-xs">
-          Managed with its folder
-        </span>
-      )}
+      <Button variant="ghost" size="sm" disabled={busy} onClick={onRevoke}>
+        Revoke
+      </Button>
     </div>
   );
 }
@@ -264,31 +256,36 @@ export function PermissionsPanel({ client }: { client: ApiClient }) {
   }, [reload]);
 
   async function revoke(statement: ConsentStatementSnapshot) {
-    if (statement.handle.kind !== "tool_grant") return;
-    const callId = statement.handle.call_id;
     const confirmed = await confirm({
       title: "Revoke this approval?",
-      description: `The agent will ask again before ${verbLabel(
-        statement.verb,
-      ).toLowerCase()} covered by “${resourceLabel(
-        statement,
-      )}” in ${levelLabel(statement).toLowerCase()}.`,
+      description:
+        statement.verb.kind === "capability" &&
+        statement.verb.capability === "read_files"
+          ? `The agent loses “${verbLabel(statement.verb).toLowerCase()}” for “${resourceLabel(
+              statement,
+            )}” in ${levelLabel(
+              statement,
+            ).toLowerCase()} — and command access to it, which depends on reading.`
+          : `The agent will ask again before ${verbLabel(
+              statement.verb,
+            ).toLowerCase()} covered by “${resourceLabel(
+              statement,
+            )}” in ${levelLabel(statement).toLowerCase()}.`,
       confirmLabel: "Revoke",
       destructive: true,
     });
     if (!confirmed) return;
     setBusyId(handleKey(statement));
     try {
-      await client.revokeStandingGrant(callId);
-      setStatements(
-        (current) =>
-          current?.filter(
-            (existing) =>
-              existing.handle.kind !== "tool_grant" ||
-              existing.handle.call_id !== callId,
-          ) ?? null,
-      );
-      setError(null);
+      if (statement.handle.kind === "tool_grant") {
+        await client.revokeStandingGrant(statement.handle.call_id);
+      } else {
+        await revokeCapabilityConsent(statement);
+      }
+      // Reload rather than filter locally: revoking a folder's read access
+      // also withdraws its dependent command access, and the list should show
+      // exactly what the broker now holds.
+      await reload();
     } catch {
       setError("The approval could not be revoked. Try again.");
     } finally {

--- a/crates/openwave-host-broker/src/audit.rs
+++ b/crates/openwave-host-broker/src/audit.rs
@@ -71,6 +71,7 @@ pub enum AuditOperation {
     DetachRoot,
     LookupRootAttachmentReceipt,
     RevokeRoot,
+    RevokeGrant,
     PruneUnavailableRoot,
     ResolveExecRoots,
     ListRoots,

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -39,10 +39,10 @@ use crate::{
         OperationRequest, OperationResponseEnvelope, OperationResult, PathRequest,
         ReadFileBinaryResult, ReadFileResult, RegisterRootReceipt, RegisterRootRequest,
         RegisterRootResult, ResolveExecRootsRequest, ResolvedExecRoot, Response, ResponseEnvelope,
-        RevokeRootRequest, RevokeRootResult, RootAccess, RootAttachmentMutationKind,
-        RootAttachmentMutationReceipt, RootAttachmentMutationRequest, RootAttachmentMutationResult,
-        RootSummary, WriteFileMode, WriteFileRequest, WriteFileResult, MAX_READ_FILE_BINARY_BYTES,
-        PROTOCOL_VERSION,
+        RevokeGrantRequest, RevokeGrantResult, RevokeRootRequest, RevokeRootResult, RootAccess,
+        RootAttachmentMutationKind, RootAttachmentMutationReceipt, RootAttachmentMutationRequest,
+        RootAttachmentMutationResult, RootSummary, WriteFileMode, WriteFileRequest,
+        WriteFileResult, MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
     },
     Capability, ConsentMethod, ConsentRecord, ExecutionContext, Grant, GrantError, GrantId,
     GrantSubject, OperationId, RelativePath, RequestId, RootAttachment, RootId, RootPolicy,
@@ -331,6 +331,8 @@ struct ControlAudit {
     operation: AuditOperation,
     operation_id: Option<OperationId>,
     target: AuditTarget,
+    /// Grant this request names directly, for single-grant revocation.
+    grant_id: Option<GrantId>,
     /// This request can change consent or host state, so its record must be
     /// durable before it runs.
     mutates: bool,
@@ -364,6 +366,7 @@ impl ControlAudit {
                 // user folder-aware execution while buying no coverage.
                 mutates: false,
                 operation: AuditOperation::ResolveExecRoots,
+                grant_id: None,
                 operation_id: None,
                 target: AuditTarget::Subject,
             }),
@@ -374,6 +377,7 @@ impl ControlAudit {
                 },
                 mutates: true,
                 operation: AuditOperation::RegisterRoot,
+                grant_id: None,
                 operation_id: Some(request.operation_id),
                 target: AuditTarget::selected_folder(&request.path),
             }),
@@ -384,6 +388,7 @@ impl ControlAudit {
                 },
                 mutates: false,
                 operation: AuditOperation::LookupRegisterRootReceipt,
+                grant_id: None,
                 operation_id: Some(request.operation_id),
                 target: AuditTarget::Subject,
             }),
@@ -394,6 +399,7 @@ impl ControlAudit {
                 },
                 mutates: true,
                 operation: AuditOperation::AttachRoot,
+                grant_id: None,
                 operation_id: Some(request.operation_id),
                 target: AuditTarget::Root {
                     root_id: request.root_id,
@@ -406,6 +412,7 @@ impl ControlAudit {
                 },
                 mutates: true,
                 operation: AuditOperation::DetachRoot,
+                grant_id: None,
                 operation_id: Some(request.operation_id),
                 target: AuditTarget::Root {
                     root_id: request.root_id,
@@ -418,6 +425,7 @@ impl ControlAudit {
                 },
                 mutates: false,
                 operation: AuditOperation::LookupRootAttachmentReceipt,
+                grant_id: None,
                 operation_id: Some(request.operation_id),
                 target: AuditTarget::Root {
                     root_id: request.root_id,
@@ -430,10 +438,24 @@ impl ControlAudit {
                 },
                 mutates: true,
                 operation: AuditOperation::RevokeRoot,
+                grant_id: None,
                 operation_id: Some(request.operation_id),
                 target: AuditTarget::Root {
                     root_id: request.root_id,
                 },
+            }),
+            ControlRequest::RevokeGrant(request) => Some(Self {
+                actor: AuditActor::Control {
+                    subject: request.subject,
+                    conversation_id: None,
+                },
+                mutates: true,
+                operation: AuditOperation::RevokeGrant,
+                grant_id: Some(request.grant_id),
+                // Naturally idempotent: the grant id names the exact row, so
+                // there is no separate mutation identity to correlate.
+                operation_id: None,
+                target: AuditTarget::Subject,
             }),
         }
     }
@@ -449,7 +471,7 @@ impl ControlAudit {
             target: self.target.clone(),
             outcome: AuditOutcome::Attempted,
             capability: None,
-            grant_id: None,
+            grant_id: self.grant_id,
             error_code: None,
             item_count: None,
             bytes: None,
@@ -645,7 +667,7 @@ impl Controller {
             target: metadata.target,
             outcome: audit_outcome(error),
             capability: None,
-            grant_id: None,
+            grant_id: metadata.grant_id,
             error_code: error.map(|error| error.code),
             item_count: None,
             bytes: None,
@@ -692,6 +714,9 @@ impl Controller {
                 .map(ControlResult::LookupRootAttachmentReceipt),
             ControlRequest::RevokeRoot(request) => {
                 self.revoke_root(request).map(ControlResult::RevokeRoot)
+            }
+            ControlRequest::RevokeGrant(request) => {
+                self.revoke_grant(request).map(ControlResult::RevokeGrant)
             }
         }
     }
@@ -1036,6 +1061,31 @@ impl Controller {
         self.commit_state(&mut state, next)
             .map_err(error_response)?;
         result
+    }
+
+    /// Withdraw one capability grant, live or dormant.
+    ///
+    /// Deriving the boundary from statements means the rows `authorize()`
+    /// consults are exactly the rows the consent surface shows, so a
+    /// statement-level "revoke" is a plain removal of that row — with one
+    /// dependency kept honest: exec reach is only ever additional on top of
+    /// read, so revoking a folder's `ReadFiles` takes its `ExecuteCommands`
+    /// with it, while revoking exec alone leaves the folder readable.
+    fn revoke_grant(
+        &self,
+        request: RevokeGrantRequest,
+    ) -> Result<RevokeGrantResult, ErrorResponse> {
+        let mut state = self.lock_state().map_err(error_response)?;
+        let mut next = state.clone();
+        let revoked = remove_grant_statement(&mut next.grants, request.subject, request.grant_id)
+            || next.unavailable.iter_mut().any(|root| {
+                remove_grant_statement(&mut root.grants, request.subject, request.grant_id)
+            });
+        if revoked {
+            self.commit_state(&mut state, next)
+                .map_err(error_response)?;
+        }
+        Ok(RevokeGrantResult { revoked })
     }
 
     fn commit_state(
@@ -2072,6 +2122,48 @@ fn subject_has_root_grant(state: &State, subject: GrantSubject, root_id: RootId)
             && grant.capability() == Capability::ReadFiles
             && matches!(grant.scope(), Scope::Root { root_id: granted } if *granted == root_id)
     })
+}
+
+/// Remove one grant (and what depends on it) from a grant table.
+///
+/// `false` when no grant with this identity belongs to `subject` — a
+/// mismatched subject is indistinguishable from an absent grant, so the
+/// caller cannot probe another subject's rows. When the removed grant is a
+/// folder's `ReadFiles`, that folder's `ExecuteCommands` grants for the same
+/// subject go with it: exec reach is only ever additional on top of read.
+fn remove_grant_statement(
+    grants: &mut Vec<Grant>,
+    subject: GrantSubject,
+    grant_id: GrantId,
+) -> bool {
+    let Some(index) = grants
+        .iter()
+        .position(|grant| grant.id() == grant_id && grant.subject() == subject)
+    else {
+        return false;
+    };
+    let removed = grants.remove(index);
+    if removed.capability() == Capability::ReadFiles {
+        if let Scope::Root { root_id } | Scope::PathSubtree { root_id, .. } = *removed.scope() {
+            let still_readable = grants.iter().any(|grant| {
+                grant.subject() == subject
+                    && grant.capability() == Capability::ReadFiles
+                    && matches!(
+                        *grant.scope(),
+                        Scope::Root { root_id: granted } | Scope::PathSubtree { root_id: granted, .. }
+                            if granted == root_id
+                    )
+            });
+            if !still_readable {
+                grants.retain(|grant| {
+                    !(grant.subject() == subject
+                        && grant.capability() == Capability::ExecuteCommands
+                        && matches!(*grant.scope(), Scope::Root { root_id: granted } if granted == root_id))
+                });
+            }
+        }
+    }
+    true
 }
 
 fn ensure_subject_grants(

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -341,6 +341,119 @@ fn unwrap_response<T>(envelope: ResponseEnvelope<T>) -> Result<T, ErrorResponse>
     }
 }
 
+fn grant_statements(controller: &Controller) -> Vec<GrantStatementSummary> {
+    let result = unwrap_response(controller.handle(ControlEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: crate::RequestId::new(),
+        request: ControlRequest::ListGrantStatements,
+    }))
+    .unwrap();
+    let ControlResult::ListGrantStatements { grants } = result else {
+        panic!("unexpected control result")
+    };
+    grants
+}
+
+fn revoke_grant(controller: &Controller, subject: GrantSubject, grant_id: GrantId) -> bool {
+    let result = unwrap_response(controller.handle(ControlEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: crate::RequestId::new(),
+        request: ControlRequest::RevokeGrant(RevokeGrantRequest { subject, grant_id }),
+    }))
+    .unwrap();
+    let ControlResult::RevokeGrant(result) = result else {
+        panic!("unexpected control result")
+    };
+    result.revoked
+}
+
+/// The statement-level boundary derivation: revoking one grant removes
+/// exactly that authority — plus what depends on it — and enforcement follows
+/// because `authorize()` reads the same rows the statements project.
+#[test]
+fn revoking_read_takes_exec_with_it_and_revoking_exec_leaves_read() {
+    let (_temp, broker, path) = setup();
+    let controller = broker.controller();
+    let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    let root_id = register(&controller, subject, conversation, path, OperationId::new())
+        .root
+        .root_id;
+    let context = ExecutionContext::standalone(conversation).unwrap();
+    let find = |capability: Capability| {
+        grant_statements(&controller)
+            .into_iter()
+            .find(|grant| grant.capability == capability)
+    };
+
+    // Revoking exec alone leaves the folder readable.
+    let exec_id = find(Capability::ExecuteCommands).unwrap().grant_id;
+    // Another subject's revocation touches nothing and cannot probe.
+    assert!(!revoke_grant(
+        &controller,
+        GrantSubject::conversation(Uuid::new_v4()).unwrap(),
+        exec_id,
+    ));
+    assert!(revoke_grant(&controller, subject, exec_id));
+    assert!(!revoke_grant(&controller, subject, exec_id));
+    assert!(find(Capability::ExecuteCommands).is_none());
+    assert!(operate(
+        &broker.operator(),
+        context,
+        OperationRequest::ListDirectory(PathRequest {
+            root_id,
+            path: RelativePath::parse("reports").unwrap(),
+        }),
+    )
+    .is_ok());
+
+    // Revoking read takes nothing else — except that nothing depends on it
+    // anymore — and enforcement denies the next read outright.
+    let read_id = find(Capability::ReadFiles).unwrap().grant_id;
+    assert!(revoke_grant(&controller, subject, read_id));
+    assert!(find(Capability::ReadFiles).is_none());
+    assert!(find(Capability::WriteFiles).is_some());
+    assert_eq!(
+        operate(
+            &broker.operator(),
+            context,
+            OperationRequest::ListDirectory(PathRequest {
+                root_id,
+                path: RelativePath::parse("reports").unwrap(),
+            }),
+        )
+        .unwrap_err()
+        .code,
+        ErrorCode::Denied
+    );
+}
+
+/// Read carries exec with it when both stand: exec reach is only ever
+/// additional on top of read.
+#[test]
+fn revoking_read_cascades_to_exec() {
+    let (_temp, broker, path) = setup();
+    let controller = broker.controller();
+    let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    register(&controller, subject, conversation, path, OperationId::new());
+    let read_id = grant_statements(&controller)
+        .into_iter()
+        .find(|grant| grant.capability == Capability::ReadFiles)
+        .unwrap()
+        .grant_id;
+
+    assert!(revoke_grant(&controller, subject, read_id));
+    let remaining = grant_statements(&controller)
+        .into_iter()
+        .map(|grant| grant.capability)
+        .collect::<Vec<_>>();
+    assert!(!remaining.contains(&Capability::ReadFiles));
+    assert!(!remaining.contains(&Capability::ExecuteCommands));
+    assert!(remaining.contains(&Capability::WriteFiles));
+    assert!(remaining.contains(&Capability::ListRoots));
+}
+
 #[test]
 fn an_empty_conversation_lists_no_roots_without_needing_a_grant() {
     let (_temp, broker, _path) = setup();

--- a/crates/openwave-host-broker/src/lib.rs
+++ b/crates/openwave-host-broker/src/lib.rs
@@ -37,9 +37,9 @@ pub use protocol::{
     OperationRequest, OperationResponseEnvelope, OperationResult, PathRequest,
     ReadFileBinaryResult, ReadFileResult, RegisterRootReceipt, RegisterRootRequest,
     RegisterRootResult, ResolveExecRootsRequest, ResolvedExecRoot, Response, ResponseEnvelope,
-    RevokeRootRequest, RevokeRootResult, RootAccess, RootAttachmentMutationKind,
-    RootAttachmentMutationReceipt, RootAttachmentMutationRequest, RootAttachmentMutationResult,
-    RootSummary, WriteApproval, WriteFileMode, WriteFileRequest, WriteFileResult,
-    MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
+    RevokeGrantRequest, RevokeGrantResult, RevokeRootRequest, RevokeRootResult, RootAccess,
+    RootAttachmentMutationKind, RootAttachmentMutationReceipt, RootAttachmentMutationRequest,
+    RootAttachmentMutationResult, RootSummary, WriteApproval, WriteFileMode, WriteFileRequest,
+    WriteFileResult, MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
 };
 pub use relative_path::{RelativePath, RelativePathError};

--- a/crates/openwave-host-broker/src/protocol.rs
+++ b/crates/openwave-host-broker/src/protocol.rs
@@ -94,6 +94,13 @@ pub enum ControlRequest {
     LookupRootAttachmentReceipt(LookupRootAttachmentReceiptRequest),
     /// Disconnect a root owned by the exact subject. Idempotent.
     RevokeRoot(RevokeRootRequest),
+    /// Withdraw one capability grant by its stable identity.
+    ///
+    /// The statement-level revocation the unified consent surface offers:
+    /// "stop allowing writes here" without disconnecting the folder. No
+    /// operation id — the grant id already names the exact row, so a retry
+    /// observes `revoked: false` and nothing can be withdrawn twice.
+    RevokeGrant(RevokeGrantRequest),
 }
 
 /// Strict payload for a native-picker root registration.
@@ -173,6 +180,16 @@ pub struct RevokeRootRequest {
     /// Original registering subject allowed to forget this host approval.
     pub subject: GrantSubject,
     pub root_id: RootId,
+}
+
+/// Strict payload for an idempotent single-grant revocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RevokeGrantRequest {
+    /// Subject the grant belongs to. A mismatched subject revokes nothing,
+    /// indistinguishable from a grant that does not exist.
+    pub subject: GrantSubject,
+    pub grant_id: GrantId,
 }
 
 /// Capability-checked agent operations.
@@ -329,6 +346,7 @@ pub enum ControlResult {
     DetachRoot(RootAttachmentMutationResult),
     LookupRootAttachmentReceipt(LookupRootAttachmentReceiptResult),
     RevokeRoot(RevokeRootResult),
+    RevokeGrant(RevokeGrantResult),
 }
 
 /// One currently authorized host root for native local execution.
@@ -494,6 +512,17 @@ pub enum RootAttachmentMutationReceipt {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RevokeRootResult {
+    pub revoked: bool,
+}
+
+/// Result of an idempotent single-grant revocation.
+///
+/// `revoked` is `false` for a grant that does not exist, was already
+/// withdrawn, or belongs to another subject — deliberately one answer, so the
+/// response cannot be used to probe another subject's grants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RevokeGrantResult {
     pub revoked: bool,
 }
 


### PR DESCRIPTION
Slice 5 of #939: derive the boundary from statements. The rows `authorize()` consults and the rows the Permissions panel shows are the same rows — so a statement-level revocation is now a first-class broker operation, and the panel's read-only "Managed with its folder" placeholder from slice 3 (#1382) goes live as a real Revoke control.

- New trusted control op `RevokeGrant { subject, grant_id }`, live and dormant (set-aside roots keep their grants; those statements are revocable too). No operation-id ceremony: the grant id names the exact row, so the operation is naturally idempotent — a retry, an already-withdrawn grant, and another subject's grant all answer `revoked: false`, indistinguishable by design so the response cannot probe.
- One dependency kept honest, per the capability model's own doc: exec reach is only ever additional on top of read, so revoking a folder's `ReadFiles` takes its `ExecuteCommands` with it; revoking exec alone leaves the folder readable. Everything else is a plain removal.
- Audit: `RevokeGrant` records intent-before-effect like every mutating control op, and control audit events now carry the named `grant_id`.
- Desktop: `revoke_capability_consent` Tauri command rebuilds the owning subject from the statement's level (deliberately not a store lookup — a grant whose chat was deleted still conveys authority, and this surface exists to withdraw exactly such consent).
- Permissions panel: capability rows get the same Revoke flow as tool grants; the read-revocation confirm says command access goes with it; the list reloads from both stores after any revocation so it shows exactly what is now held.

On the plan's "split the four-grant mint": the picker mint has stored four separate grant rows (list/read/write/exec) since #1211's exec split, so no state migration was needed — the missing piece was only the revocation surface, which is this PR. The one-click picker default is untouched.

Tests: broker — revoke-exec-keeps-read and revoke-read-cascades-exec end to end through `authorize()` (a revoked folder denies the next read), wrong-subject and double-revoke report false; desktop — PermissionsPanel revokes a capability row through the host and reloads. Verified: full `openwave-host-broker` suite, `openwave-desktop` cargo check, clippy, fmt, touched vitest.

Part of #939. Depends on nothing unmerged; #1388 fixes the pre-existing renderer `tsc` break this PR would otherwise inherit in its UI lane.