### PR TITLE
feat(desktop): folders and permissions panels share the consent statement model

### DIFF
--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -244,37 +244,6 @@ pub(crate) struct ConnectedFolder {
     pub(crate) display_name: String,
 }
 
-/// What the agent may do inside one connected folder.
-///
-/// The broker's own capability set also covers subject-wide discovery, which is
-/// not a property of a folder and so has no member here.
-#[derive(Debug, Clone, Copy, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum FolderCapability {
-    Read,
-    Write,
-}
-
-impl FolderCapability {
-    fn from_broker(capability: Capability) -> Option<Self> {
-        match capability {
-            Capability::ReadFiles => Some(Self::Read),
-            Capability::WriteFiles => Some(Self::Write),
-            _ => None,
-        }
-    }
-}
-
-/// A connected folder together with what this conversation may currently do in
-/// it, as the broker reports it rather than as the app assumes.
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct ConnectedFolderAccess {
-    pub(crate) root_id: RootId,
-    pub(crate) display_name: String,
-    pub(crate) capabilities: Vec<FolderCapability>,
-}
-
 #[tauri::command]
 pub(crate) async fn connect_folder(
     app: AppHandle,
@@ -306,7 +275,7 @@ pub(crate) async fn connect_folder(
 pub(crate) async fn list_connected_folders(
     state: State<'_, HostAccess>,
     chat_id: Uuid,
-) -> Result<Vec<ConnectedFolderAccess>, String> {
+) -> Result<Vec<ConnectedFolder>, String> {
     let context = state.context(chat_id).await?;
     let store = state
         .store()
@@ -338,17 +307,16 @@ pub(crate) async fn list_connected_folders(
         .iter()
         .map(|attachment| *attachment.root_id.as_uuid())
         .collect::<std::collections::HashSet<_>>();
+    // What each folder allows is no longer projected here: the renderer reads
+    // it from the same consent statements the Permissions surface shows
+    // (`list_capability_consents`), so both panels are groupings of one model
+    // and the desktop keeps no folder-capability vocabulary of its own.
     Ok(roots
         .into_iter()
         .filter(|root| product_roots.contains(&root.root_id.as_uuid()))
-        .map(|root| ConnectedFolderAccess {
+        .map(|root| ConnectedFolder {
             root_id: root.root_id,
             display_name: root.display_name,
-            capabilities: root
-                .capabilities
-                .into_iter()
-                .filter_map(FolderCapability::from_broker)
-                .collect(),
         })
         .collect())
 }

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -33,8 +33,8 @@ import { WithTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { documentIcon } from "@/documentIcon";
 import type { ImportedDocument } from "@/documents";
-import { folderAccessLabel } from "./FolderAccess";
-import type { ConnectedFolderAccess } from "./host";
+import { folderAccessLabel, folderReach } from "./FolderAccess";
+import type { ChatFolderAccess } from "./useChatFolderAttachments";
 
 const MIN_COMPOSER_LINES = 1;
 export const MAX_COMPOSER_LINES = 6;
@@ -126,7 +126,7 @@ export type ComposerFiles = {
 };
 
 export type ComposerFolders = {
-  items: ConnectedFolderAccess[];
+  items: ChatFolderAccess[];
   working: boolean;
   error: string | null;
   onAttach?: () => void;
@@ -278,7 +278,7 @@ export function Composer({
     if (acceptTransfer(event.clipboardData)) event.preventDefault();
   }
 
-  async function removeFolder(folder: ConnectedFolderAccess) {
+  async function removeFolder(folder: ChatFolderAccess) {
     const accepted = await confirm({
       title: `Disconnect ${folder.displayName}?`,
       description: "The agent loses access to this folder.",
@@ -535,7 +535,7 @@ function FolderAttachmentChip({
   disabled,
   onRemove,
 }: {
-  folder: ConnectedFolderAccess;
+  folder: ChatFolderAccess;
   disabled: boolean;
   onRemove: () => void;
 }) {
@@ -552,7 +552,7 @@ function FolderAttachmentChip({
           {folder.displayName}
         </strong>
         <small className="text-[0.68rem]">
-          {folderAccessLabel(folder.capabilities)}
+          {folderAccessLabel(folderReach(folder.statements))}
         </small>
       </span>
       <button

--- a/crates/openwave-desktop/ui/src/ComposerFolders.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerFolders.dom.test.tsx
@@ -24,7 +24,24 @@ it("attaches and confirms revoking a folder from the ordinary chat composer", as
           {
             rootId: "root-1",
             displayName: "Research",
-            capabilities: ["read", "write"],
+            statements: (["read_files", "write_files"] as const).map(
+              (capability, index) => ({
+                handle: {
+                  kind: "capability_grant" as const,
+                  grant_id: `grant-${index}`,
+                },
+                level: { level: "chat" as const, chat_id: "chat-1" },
+                level_title: null,
+                verb: { kind: "capability" as const, capability },
+                resource: {
+                  kind: "host_root" as const,
+                  root_id: "root-1",
+                  display_name: null,
+                },
+                method: "folder_picker" as const,
+                granted_at: "2026-07-30T12:00:00Z",
+              }),
+            ),
           },
         ],
         working: false,

--- a/crates/openwave-desktop/ui/src/FolderAccess.ts
+++ b/crates/openwave-desktop/ui/src/FolderAccess.ts
@@ -1,15 +1,74 @@
-import type { FolderCapability } from "./host";
+import type { Chat, ConsentStatementSnapshot } from "./api";
 
-export function folderAccessLabel(
-  capabilities: readonly FolderCapability[],
-): string {
-  const read = capabilities.includes("read");
-  const write = capabilities.includes("write");
-  return read
-    ? write
-      ? "Read and write"
-      : "Read only"
-    : write
-      ? "Write only"
-      : "No access";
+/**
+ * The broker's capability vocabulary as consent statements carry it. Folder
+ * access is read off the same statements the Permissions surface shows —
+ * there is deliberately no folder-capability model of the app's own left to
+ * drift from what the broker holds.
+ */
+export type FolderReach = Extract<
+  ConsentStatementSnapshot["verb"],
+  { kind: "capability" }
+>["capability"];
+
+/** Whether a statement's level covers this chat: the chat itself, or the
+ * project it is filed under. */
+export function statementReachesChat(
+  statement: ConsentStatementSnapshot,
+  chat: Chat,
+): boolean {
+  return statement.level.level === "chat"
+    ? statement.level.chat_id === chat.id
+    : statement.level.project_id === chat.project_id;
+}
+
+/** The capability statements naming one connected folder, for this chat. */
+export function folderStatements(
+  statements: readonly ConsentStatementSnapshot[],
+  rootId: string,
+  chat: Chat,
+): ConsentStatementSnapshot[] {
+  return statements.filter(
+    (statement) =>
+      statement.verb.kind === "capability" &&
+      (statement.resource.kind === "host_root" ||
+        statement.resource.kind === "host_path_subtree") &&
+      statement.resource.root_id === rootId &&
+      statementReachesChat(statement, chat),
+  );
+}
+
+/** The distinct reach a set of folder statements adds up to. */
+export function folderReach(
+  statements: readonly ConsentStatementSnapshot[],
+): FolderReach[] {
+  const reach: FolderReach[] = [];
+  for (const statement of statements) {
+    if (
+      statement.verb.kind === "capability" &&
+      !reach.includes(statement.verb.capability)
+    ) {
+      reach.push(statement.verb.capability);
+    }
+  }
+  return reach;
+}
+
+export function folderAccessLabel(reach: readonly FolderReach[]): string {
+  const parts: string[] = [];
+  if (reach.includes("read_files")) parts.push("Read");
+  if (reach.includes("write_files")) parts.push("write");
+  if (reach.includes("execute_commands")) parts.push("commands");
+  switch (parts.length) {
+    case 0:
+      return "No access";
+    case 1: {
+      const only = parts[0];
+      return `${only[0].toUpperCase()}${only.slice(1)} only`;
+    }
+    case 2:
+      return `${parts[0]} and ${parts[1]}`;
+    default:
+      return `${parts[0]}, ${parts[1]}, and ${parts[2]}`;
+  }
 }

--- a/crates/openwave-desktop/ui/src/FoldersView.test.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersView.test.tsx
@@ -2,7 +2,7 @@
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Chat } from "./api";
+import type { Chat, ConsentStatementSnapshot } from "./api";
 import { FoldersView } from "./FoldersView";
 import * as host from "./host";
 
@@ -11,7 +11,9 @@ vi.mock("./host", () => ({
   connectFolder: vi.fn(),
   disconnectFolder: vi.fn(),
   listApprovedFolders: vi.fn(),
+  listCapabilityConsents: vi.fn(),
   listConnectedFolders: vi.fn(),
+  revokeCapabilityConsent: vi.fn(),
 }));
 
 const chat = {
@@ -20,11 +22,31 @@ const chat = {
   project_id: null,
 } as unknown as Chat;
 
-function readWrite(
+function folder(rootId: string, displayName: string): host.ConnectedFolder {
+  return { rootId, displayName };
+}
+
+type FolderCapabilityVerb = Extract<
+  ConsentStatementSnapshot["verb"],
+  { kind: "capability" }
+>["capability"];
+
+let nextGrant = 0;
+
+function statement(
   rootId: string,
-  displayName: string,
-): host.ConnectedFolderAccess {
-  return { rootId, displayName, capabilities: ["read", "write"] };
+  capability: FolderCapabilityVerb,
+): ConsentStatementSnapshot {
+  nextGrant += 1;
+  return {
+    handle: { kind: "capability_grant", grant_id: `grant-${nextGrant}` },
+    level: { level: "chat", chat_id: chat.id },
+    level_title: null,
+    verb: { kind: "capability", capability },
+    resource: { kind: "host_root", root_id: rootId, display_name: null },
+    method: "folder_picker",
+    granted_at: "2026-07-30T12:00:00Z",
+  };
 }
 
 function deferred<T>() {
@@ -38,9 +60,11 @@ function deferred<T>() {
 beforeEach(() => {
   vi.mocked(host.listConnectedFolders).mockResolvedValue([]);
   vi.mocked(host.listApprovedFolders).mockResolvedValue([]);
+  vi.mocked(host.listCapabilityConsents).mockResolvedValue([]);
   vi.mocked(host.connectApprovedFolder).mockResolvedValue(null);
   vi.mocked(host.connectFolder).mockResolvedValue(null);
   vi.mocked(host.disconnectFolder).mockResolvedValue(false);
+  vi.mocked(host.revokeCapabilityConsent).mockResolvedValue(true);
 });
 
 afterEach(() => {
@@ -59,27 +83,73 @@ describe("FoldersView", () => {
     expect(host.listApprovedFolders).toHaveBeenCalledOnce();
   });
 
-  // The badge is the only place a reader learns whether the agent can change
-  // files in a folder, so it has to follow the host's answer rather than a
-  // constant the app chose.
-  it("shows each folder's access as the host reports it", async () => {
+  // Access is read off the same consent statements the Permissions surface
+  // shows, so the badge follows what the broker holds — including command
+  // reach, which the retired folder-capability model could not name.
+  it("derives each folder's access from its consent statements", async () => {
     vi.mocked(host.listConnectedFolders).mockResolvedValue([
-      readWrite("writable", "Drafts"),
-      { rootId: "read-only", displayName: "Archive", capabilities: ["read"] },
+      folder("writable", "Drafts"),
+      folder("read-only", "Archive"),
+    ]);
+    vi.mocked(host.listCapabilityConsents).mockResolvedValue([
+      statement("writable", "read_files"),
+      statement("writable", "write_files"),
+      statement("writable", "execute_commands"),
+      statement("read-only", "read_files"),
+      // Another chat's statement must not color this chat's badge.
+      {
+        ...statement("read-only", "write_files"),
+        level: { level: "chat", chat_id: "someone-else" },
+      },
     ]);
     render(<FoldersView chat={chat} />);
 
-    expect(await screen.findByText("Read and write")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Read, write, and commands"),
+    ).toBeInTheDocument();
     expect(screen.getByText("Read only")).toBeInTheDocument();
-    expect(screen.getAllByText("Read and write")).toHaveLength(1);
+    // Each statement is its own row, revocable in place.
+    expect(screen.getByText("Run commands")).toBeInTheDocument();
+    expect(screen.getByText("Write files")).toBeInTheDocument();
+  });
+
+  it("revokes one statement in place and reloads what the broker holds", async () => {
+    const write = statement("writable", "write_files");
+    vi.mocked(host.listConnectedFolders).mockResolvedValue([
+      folder("writable", "Drafts"),
+    ]);
+    vi.mocked(host.listCapabilityConsents)
+      .mockResolvedValueOnce([statement("writable", "read_files"), write])
+      .mockResolvedValue([statement("writable", "read_files")]);
+    const user = userEvent.setup();
+    render(<FoldersView chat={chat} />);
+
+    await screen.findByText("Write files");
+    const revokes = screen.getAllByRole("button", { name: "Revoke" });
+    expect(revokes).toHaveLength(2);
+    await user.click(revokes[1]);
+    // The confirmation says the folder stays connected before anything acts.
+    await user.click(
+      await screen.findByRole("button", { name: "Revoke", hidden: false }),
+    );
+
+    await waitFor(() =>
+      expect(host.revokeCapabilityConsent).toHaveBeenCalledWith(write),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("Write files")).not.toBeInTheDocument(),
+    );
+    // The folder itself was not disconnected.
+    expect(host.disconnectFolder).not.toHaveBeenCalled();
+    expect(screen.getByText("Drafts")).toBeInTheDocument();
   });
 
   it("offers approved folders that are not already connected", async () => {
     vi.mocked(host.listConnectedFolders)
-      .mockResolvedValueOnce([readWrite("connected", "Current project")])
+      .mockResolvedValueOnce([folder("connected", "Current project")])
       .mockResolvedValueOnce([
-        readWrite("connected", "Current project"),
-        readWrite("available", "Research"),
+        folder("connected", "Current project"),
+        folder("available", "Research"),
       ]);
     vi.mocked(host.listApprovedFolders).mockResolvedValue([
       { rootId: "connected", displayName: "Current project" },
@@ -123,8 +193,8 @@ describe("FoldersView", () => {
   it("ignores a late folder response after switching chats", async () => {
     const firstChat = { ...chat, id: "chat-a", title: "Chat A" };
     const secondChat = { ...chat, id: "chat-b", title: "Chat B" };
-    const firstResponse = deferred<host.ConnectedFolderAccess[]>();
-    const secondResponse = deferred<host.ConnectedFolderAccess[]>();
+    const firstResponse = deferred<host.ConnectedFolder[]>();
+    const secondResponse = deferred<host.ConnectedFolder[]>();
     vi.mocked(host.listConnectedFolders).mockImplementation((requestedChat) =>
       requestedChat.id === firstChat.id
         ? firstResponse.promise
@@ -134,10 +204,10 @@ describe("FoldersView", () => {
     const { rerender } = render(<FoldersView chat={firstChat} />);
     rerender(<FoldersView chat={secondChat} />);
 
-    secondResponse.resolve([readWrite("chat-b-root", "Chat B folder")]);
+    secondResponse.resolve([folder("chat-b-root", "Chat B folder")]);
     expect(await screen.findByText("Chat B folder")).toBeInTheDocument();
 
-    firstResponse.resolve([readWrite("chat-a-root", "Chat A folder")]);
+    firstResponse.resolve([folder("chat-a-root", "Chat A folder")]);
     await waitFor(() =>
       expect(screen.queryByText("Chat A folder")).not.toBeInTheDocument(),
     );

--- a/crates/openwave-desktop/ui/src/FoldersView.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersView.tsx
@@ -1,7 +1,7 @@
 import { FolderOpenIcon, PlusIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
-import type { Chat } from "./api";
+import type { Chat, ConsentStatementSnapshot } from "./api";
 import { PanelSecondaryHeader } from "@/components/PanelHeader";
 import { useConfirm } from "@/components/ConfirmDialog";
 import { Badge } from "@/components/ui/badge";
@@ -20,32 +20,38 @@ import {
   connectFolder,
   disconnectFolder,
   listApprovedFolders,
+  listCapabilityConsents,
   listConnectedFolders,
+  revokeCapabilityConsent,
   type ConnectedFolder,
-  type ConnectedFolderAccess,
-  type FolderCapability,
 } from "./host";
 import {
   PICKER_BUSY_MESSAGE,
   PICKER_HOLDERS,
   useNativePickerLatch,
 } from "./NativePickerLatch";
-import { folderAccessLabel } from "./FolderAccess";
+import {
+  folderAccessLabel,
+  folderReach,
+  folderStatements,
+  type FolderReach,
+} from "./FolderAccess";
+import { verbLabel } from "./settings/PermissionsPanel";
 import { useRefreshSignals } from "./RefreshSignals";
 
 /**
- * A chat's connected folders: the directories the native host may reach on this
- * conversation's behalf, each shown with the access the broker actually grants
- * it.
+ * A chat's connected folders: the directories the native host may reach on
+ * this conversation's behalf.
  *
- * Two sections rather than one. The first is what this conversation can reach.
- * The second is what this device has already approved and can be reattached
- * without going back through the picker — an affordance that only makes sense
- * for an app holding its own grants, and the reason this panel is not simply
- * a list.
+ * This panel and the Permissions panel are two groupings of the same consent
+ * statements — this one by folder, that one by what the statements reach.
+ * Each folder row lists the statements that name it, with the same revocation
+ * the Permissions panel offers, so what a folder allows can be narrowed here
+ * without disconnecting it.
  */
 export function FoldersView({ chat }: { chat: Chat }) {
-  const [folders, setFolders] = useState<ConnectedFolderAccess[]>([]);
+  const [folders, setFolders] = useState<ConnectedFolder[]>([]);
+  const [consents, setConsents] = useState<ConsentStatementSnapshot[]>([]);
   const [approvedFolders, setApprovedFolders] = useState<ConnectedFolder[]>([]);
   const [working, setWorking] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -61,13 +67,15 @@ export function FoldersView({ chat }: { chat: Chat }) {
     const generation = ++refreshGeneration.current;
     setError(null);
     try {
-      const [connected, approved] = await Promise.all([
+      const [connected, approved, statements] = await Promise.all([
         listConnectedFolders(chat),
         listApprovedFolders(),
+        listCapabilityConsents(),
       ]);
       if (generation !== refreshGeneration.current) return;
       setFolders(connected);
       setApprovedFolders(approved);
+      setConsents(statements);
     } catch (err) {
       if (generation !== refreshGeneration.current) return;
       setError(String(err));
@@ -77,6 +85,7 @@ export function FoldersView({ chat }: { chat: Chat }) {
   useEffect(() => {
     setFolders([]);
     setApprovedFolders([]);
+    setConsents([]);
     setWorking(false);
     setError(null);
     void refresh();
@@ -140,6 +149,34 @@ export function FoldersView({ chat }: { chat: Chat }) {
     }
   }
 
+  async function revokeStatement(
+    folder: ConnectedFolder,
+    statement: ConsentStatementSnapshot,
+  ) {
+    const capability =
+      statement.verb.kind === "capability" ? statement.verb.capability : null;
+    const accepted = await confirm({
+      title: `Revoke “${verbLabel(statement.verb)}” for ${folder.displayName}?`,
+      description:
+        capability === "read_files"
+          ? "The agent can no longer read this folder — and loses command access to it, which depends on reading."
+          : `The agent loses “${verbLabel(statement.verb).toLowerCase()}” for this folder. It stays connected.`,
+      confirmLabel: "Revoke",
+      destructive: true,
+    });
+    if (!accepted) return;
+    setWorking(true);
+    setError(null);
+    try {
+      await revokeCapabilityConsent(statement);
+      useRefreshSignals.getState().signal("folderAccess");
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setWorking(false);
+    }
+  }
+
   const connectButton = (
     <Button size="sm" disabled={working} onClick={() => void addFolder()}>
       <PlusIcon className="size-4" />
@@ -193,30 +230,62 @@ export function FoldersView({ chat }: { chat: Chat }) {
           <>
             {folders.length > 0 && (
               <FolderSection label="Connected">
-                {folders.map((folder) => (
-                  <FolderRow
-                    key={folder.rootId}
-                    name={folder.displayName}
-                    badge={<AccessBadge capabilities={folder.capabilities} />}
-                    action={
-                      <Button
-                        variant="outline"
-                        size="xs"
-                        disabled={working}
-                        onClick={() => void removeFolder(folder)}
-                      >
-                        Disconnect
-                      </Button>
-                    }
-                  />
-                ))}
+                {folders.map((folder) => {
+                  const statements = folderStatements(
+                    consents,
+                    folder.rootId,
+                    chat,
+                  );
+                  return (
+                    <FolderCard
+                      key={folder.rootId}
+                      name={folder.displayName}
+                      reach={folderReach(statements)}
+                      action={
+                        <Button
+                          variant="outline"
+                          size="xs"
+                          disabled={working}
+                          onClick={() => void removeFolder(folder)}
+                        >
+                          Disconnect
+                        </Button>
+                      }
+                    >
+                      {statements.map((statement) => (
+                        <div
+                          key={
+                            statement.handle.kind === "capability_grant"
+                              ? statement.handle.grant_id
+                              : statement.granted_at
+                          }
+                          className="flex items-center justify-between gap-3"
+                        >
+                          <span className="text-sm text-muted-foreground">
+                            {verbLabel(statement.verb)}
+                          </span>
+                          <Button
+                            variant="ghost"
+                            size="xs"
+                            disabled={working}
+                            onClick={() =>
+                              void revokeStatement(folder, statement)
+                            }
+                          >
+                            Revoke
+                          </Button>
+                        </div>
+                      ))}
+                    </FolderCard>
+                  );
+                })}
               </FolderSection>
             )}
 
             {availableFolders.length > 0 && (
               <FolderSection label="Available on this Mac">
                 {availableFolders.map((folder) => (
-                  <FolderRow
+                  <FolderCard
                     key={folder.rootId}
                     name={folder.displayName}
                     badge={
@@ -247,16 +316,12 @@ export function FoldersView({ chat }: { chat: Chat }) {
 }
 
 /**
- * The folder's access state, read off what the broker reports rather than
- * assumed from what the app requested.
- *
- * Connecting a folder currently grants reading and writing together, so this
- * renders "Read and write" in practice. It is derived anyway: the moment the
- * grant ladder narrows, a badge computed from a constant would keep claiming
- * access the agent no longer has, which is the failure worth designing out.
+ * The folder's access state, read off the consent statements the broker
+ * reports rather than assumed from what the app requested — the moment a
+ * statement is revoked, the badge follows.
  */
-function AccessBadge({ capabilities }: { capabilities: FolderCapability[] }) {
-  const label = folderAccessLabel(capabilities);
+function AccessBadge({ reach }: { reach: readonly FolderReach[] }) {
+  const label = folderAccessLabel(reach);
   const hasAccess = label !== "No access";
   return (
     <Badge variant={hasAccess ? "secondary" : "outline"} size="sm">
@@ -280,23 +345,30 @@ function FolderSection({
   );
 }
 
-function FolderRow({
+function FolderCard({
   name,
+  reach,
   badge,
   action,
+  children,
 }: {
   name: string;
-  badge: React.ReactNode;
+  reach?: readonly FolderReach[];
+  badge?: React.ReactNode;
   action: React.ReactNode;
+  children?: React.ReactNode;
 }) {
   return (
-    <Card className="flex flex-row items-center justify-between gap-3 px-3 py-2.5">
-      <div className="flex min-w-0 items-center gap-2">
-        <FolderOpenIcon className="size-4 shrink-0 text-muted-foreground" />
-        <span className="truncate text-sm font-medium">{name}</span>
-        {badge}
+    <Card className="flex flex-col gap-2 px-3 py-2.5">
+      <div className="flex flex-row items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <FolderOpenIcon className="size-4 shrink-0 text-muted-foreground" />
+          <span className="truncate text-sm font-medium">{name}</span>
+          {reach ? <AccessBadge reach={reach} /> : badge}
+        </div>
+        <div className="shrink-0">{action}</div>
       </div>
-      <div className="shrink-0">{action}</div>
+      {children}
     </Card>
   );
 }

--- a/crates/openwave-desktop/ui/src/host.ts
+++ b/crates/openwave-desktop/ui/src/host.ts
@@ -7,19 +7,6 @@ export type ConnectedFolder = {
   displayName: string;
 };
 
-/** What the agent may do inside one connected folder. */
-export type FolderCapability = "read" | "write";
-
-/**
- * A connected folder and the access the host broker reports for it, checked
- * against the same authorization the agent's own operations go through. The app
- * must not substitute an assumption for this — a folder's access state is what
- * the broker would allow, not what the app asked for.
- */
-export type ConnectedFolderAccess = ConnectedFolder & {
-  capabilities: FolderCapability[];
-};
-
 export type FolderAccessDecision = "allow" | "decline";
 export type OutputWritebackDecision = "allow" | "decline";
 
@@ -33,9 +20,13 @@ export async function requestUserAttention(): Promise<void> {
   await invoke("request_user_attention");
 }
 
-export function listConnectedFolders(
-  chat: Chat,
-): Promise<ConnectedFolderAccess[]> {
+/**
+ * The folders this conversation can reach, by their safe identities. What
+ * each folder *allows* is not part of this answer: access is rendered from
+ * the same consent statements the Permissions surface shows
+ * ([`listCapabilityConsents`]), so both panels are groupings of one model.
+ */
+export function listConnectedFolders(chat: Chat): Promise<ConnectedFolder[]> {
   return invoke("list_connected_folders", { chatId: chat.id });
 }
 

--- a/crates/openwave-desktop/ui/src/useChatFolderAttachments.test.tsx
+++ b/crates/openwave-desktop/ui/src/useChatFolderAttachments.test.tsx
@@ -12,6 +12,7 @@ import { useChatFolderAttachments } from "./useChatFolderAttachments";
 vi.mock("./host", () => ({
   connectFolder: vi.fn(),
   disconnectFolder: vi.fn(),
+  listCapabilityConsents: vi.fn(),
   listConnectedFolders: vi.fn(),
 }));
 
@@ -55,13 +56,13 @@ afterEach(() => {
 });
 
 it("connects and revokes a chat folder through the existing host flow", async () => {
+  vi.mocked(host.listCapabilityConsents).mockResolvedValue([]);
   vi.mocked(host.listConnectedFolders)
     .mockResolvedValueOnce([])
     .mockResolvedValueOnce([
       {
         rootId: "root-1",
         displayName: "Research",
-        capabilities: ["read", "write"],
       },
     ])
     .mockResolvedValueOnce([]);

--- a/crates/openwave-desktop/ui/src/useChatFolderAttachments.ts
+++ b/crates/openwave-desktop/ui/src/useChatFolderAttachments.ts
@@ -4,9 +4,12 @@ import type { Chat } from "./api";
 import {
   connectFolder,
   disconnectFolder,
+  listCapabilityConsents,
   listConnectedFolders,
-  type ConnectedFolderAccess,
+  type ConnectedFolder,
 } from "./host";
+import { folderStatements } from "./FolderAccess";
+import type { ConsentStatementSnapshot } from "./api";
 import {
   PICKER_BUSY_MESSAGE,
   PICKER_HOLDERS,
@@ -14,8 +17,17 @@ import {
 } from "./NativePickerLatch";
 import { useRefreshSignals } from "./RefreshSignals";
 
+/**
+ * A connected folder joined with the consent statements that say what it
+ * allows for this chat — the same rows the Permissions surface lists, so a
+ * folder's access state cannot drift from what the broker holds.
+ */
+export type ChatFolderAccess = ConnectedFolder & {
+  statements: ConsentStatementSnapshot[];
+};
+
 export type ChatFolderAttachments = {
-  items: ConnectedFolderAccess[];
+  items: ChatFolderAccess[];
   working: boolean;
   error: string | null;
   attach: () => void;
@@ -31,7 +43,7 @@ export function useChatFolderAttachments(
   chat: Chat | null,
   nativeHost: boolean,
 ): ChatFolderAttachments {
-  const [items, setItems] = useState<ConnectedFolderAccess[]>([]);
+  const [items, setItems] = useState<ChatFolderAccess[]>([]);
   const [working, setWorking] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const refreshGeneration = useRef(0);
@@ -45,9 +57,15 @@ export function useChatFolderAttachments(
       return;
     }
     setError(null);
-    void listConnectedFolders(chat).then(
-      (folders) => {
-        if (generation === refreshGeneration.current) setItems(folders);
+    void Promise.all([listConnectedFolders(chat), listCapabilityConsents()]).then(
+      ([folders, consents]) => {
+        if (generation !== refreshGeneration.current) return;
+        setItems(
+          folders.map((folder) => ({
+            ...folder,
+            statements: folderStatements(consents, folder.rootId, chat),
+          })),
+        );
       },
       (reason) => {
         if (generation === refreshGeneration.current) setError(String(reason));


### PR DESCRIPTION
Slice 6 of #939, the panel merge: `FoldersView` and the Permissions panel become two groupings of the same consent statements — by folder here, by what they reach there — with uniform revocation, and the desktop's folder-capability shadow model goes away.

- `host.ts` loses `FolderCapability`/`ConnectedFolderAccess`, and the Rust `list_connected_folders` stops projecting capabilities entirely: it answers only *which* folders this conversation reaches, by their safe identities. What each folder allows is read from `list_capability_consents` — the same rows `authorize()` consults — so a folder's access state cannot drift from what the broker holds.
- `FolderAccess.ts` becomes the statement-join helpers (`folderStatements`, `folderReach`, `statementReachesChat`) shared by the Folders panel and the composer's folder chips through `useChatFolderAttachments`.
- Each connected-folder card lists its statements with in-place Revoke (slice 5's `revoke_capability_consent`), so "stop allowing writes here" no longer requires disconnecting the folder; the read-revocation confirm says command access goes with it. Exec reach is now *visible and revocable* in the folders UI — the `FolderCapability::from_broker → None` wart #1212 calls out is gone with the model that had it. (#1212 stays open for its remaining seam: `RequestedFolderCapability` still cannot ask for exec explicitly.)
- The access badge is derived, exec-aware prose ("Read, write, and commands"), and follows revocations immediately.

Tests: FoldersView derives access from statements (other chats' statements excluded), revokes one statement in place without disconnecting, and the pre-existing connect/cancel/late-response cases carried over; composer chip and attachment-hook fixtures moved to the statement shape. Verified: `openwave-desktop` cargo check + clippy, fmt, `tsc`, full `pnpm test` (100 files, 690 tests).

Closes #939.