### PR TITLE
fix(desktop): release bundles register only the openwave:// scheme

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -552,7 +552,14 @@ jobs:
               bundle: {
                 targets: ["app", "dmg"],
                 macOS: { signingIdentity: process.env.APPLE_SIGNING_IDENTITY }
-              }
+              },
+              // Release bundles register only the real scheme. The dev scheme
+              // stays in tauri.conf.json for debug bundles, but a release
+              // binary refuses openwave-dev:// links by design — if its
+              // Info.plist also claimed the scheme, Launch Services would
+              // route dev pairing links to the installed app, which then
+              // drops them, shadowing whatever debug bundle should answer.
+              plugins: { "deep-link": { desktop: { schemes: ["openwave"] } } }
             }));
           '
 


### PR DESCRIPTION
The deep-link plugin config registers both `openwave` and `openwave-dev`, so release bundles' generated Info.plist claimed the dev scheme with Launch Services — while the release binary *refuses* `openwave-dev://` links by design (`provision_link` accepts the dev scheme only under `debug_assertions`). On macOS, where the bundle's Info.plist is the only registration path, that combination means every `openwave-dev://provision` link from a local gateway routes to the installed production app, which drops it — shadowing the debug bundle that should answer, with no way for a dev build to win the routing.

Fix: the release workflow's existing `--config` overlay now pins `plugins.deep-link.desktop.schemes` to `["openwave"]` (Tauri config merge replaces arrays wholesale). `tauri.conf.json` keeps both schemes, so debug bundles still register `openwave-dev://`, and the in-code scheme guard is unchanged.

Takes effect from the next tagged release; existing installs stop claiming the dev scheme once they update (Launch Services re-reads the bundle registration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)