### PR TITLE
feat(desktop): one Connected apps settings page — absorb the MCP servers page

### DIFF
--- a/crates/openwave-desktop/ui/src/router.tsx
+++ b/crates/openwave-desktop/ui/src/router.tsx
@@ -106,6 +106,30 @@ const settingsIndexRoute = createRoute({
   component: SettingsIndexRedirect,
 });
 
+/**
+ * The standalone MCP servers page was absorbed into Connected apps; stale
+ * deep links and history entries still name its old path, so it lands there
+ * rather than on a blank route.
+ */
+function McpSettingsRedirect() {
+  const navigate = useNavigate();
+  useEffect(() => {
+    // Settings sections are registered from a runtime table, so TanStack's
+    // generated route union contains `/settings` but not each literal child.
+    const connectedAppsPath: string = "/settings/connected-apps";
+    void navigate({ to: connectedAppsPath, replace: true });
+  }, [navigate]);
+  return (
+    <p className="text-muted-foreground p-6 text-sm">Opening settings…</p>
+  );
+}
+
+const settingsMcpRedirectRoute = createRoute({
+  getParentRoute: () => settingsRoute,
+  path: "mcp",
+  component: McpSettingsRedirect,
+});
+
 const settingsSectionRoutes = SETTINGS_SECTIONS.map((section) =>
   createRoute({
     getParentRoute: () => settingsRoute,
@@ -118,7 +142,11 @@ export const routeTree = rootRoute.addChildren([
   homeRoute,
   allChatsRoute,
   chatRoute,
-  settingsRoute.addChildren([settingsIndexRoute, ...settingsSectionRoutes]),
+  settingsRoute.addChildren([
+    settingsIndexRoute,
+    settingsMcpRedirectRoute,
+    ...settingsSectionRoutes,
+  ]),
 ]);
 
 /**

--- a/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
@@ -2,10 +2,28 @@
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ApiClient, ConnectedAppsInfo } from "../api";
+import type { ApiClient, ConnectedAppsInfo, McpServerInfo } from "../api";
 import { ConnectedAppsPanel } from "./ConnectedAppsPanel";
 
 const SECRET = "sk-rest-value-hunter2";
+
+/** One configured manual server, so the embedded editor has a row to show. */
+const docsServer: McpServerInfo = {
+  name: "docs",
+  command: "/usr/local/bin/docs-mcp",
+  args: [],
+  env: {},
+  env_from: [],
+  cwd: null,
+  url: null,
+  bearer_token_env: null,
+  gateway_endpoint: null,
+  request_timeout_ms: 60_000,
+  enabled: true,
+  health: "healthy",
+  tool_count: 3,
+  diagnostic: null,
+};
 
 const bothKinds: ConnectedAppsInfo = {
   apps: [
@@ -36,6 +54,9 @@ function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
     listConnectedApps: vi.fn().mockResolvedValue(bothKinds),
     putRestConnectedApp: vi.fn().mockResolvedValue(bothKinds),
     deleteRestConnectedApp: vi.fn().mockResolvedValue(undefined),
+    // The embedded MCP editor reads its own server list and gateway session.
+    listMcpServers: vi.fn().mockResolvedValue({ servers: [docsServer] }),
+    getGatewayStatus: vi.fn().mockResolvedValue({ signed_in: false }),
     ...overrides,
   } as unknown as ApiClient;
 }
@@ -46,37 +67,29 @@ afterEach(() => {
 });
 
 describe("ConnectedAppsPanel", () => {
-  it("lists both kinds with per-kind detail and deep-links MCP editing", async () => {
+  it("is one page with both kinds: the embedded MCP editor beside REST detail", async () => {
     const client = api();
-    const onOpenMcpSettings = vi.fn();
-    const user = userEvent.setup();
-    render(
-      <ConnectedAppsPanel
-        client={client}
-        managed={false}
-        onOpenMcpSettings={onOpenMcpSettings}
-      />,
-    );
+    render(<ConnectedAppsPanel client={client} managed={false} />);
 
+    // The MCP section is the full server editor, not a read-only list with a
+    // deep link to a separate page.
     expect(await screen.findByText("docs")).toBeInTheDocument();
-    expect(screen.getByText(/Healthy — 3 tools/)).toBeInTheDocument();
-    expect(screen.getByText("Sentry")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Save and verify/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/Namespace/)).toHaveValue("docs");
+    expect(
+      screen.queryByRole("button", { name: /Manage MCP servers/ }),
+    ).not.toBeInTheDocument();
+
+    expect(await screen.findByText("Sentry")).toBeInTheDocument();
     expect(
       screen.getByText(/api\.sentry\.example\/v2 · 2 operations · Credential configured/),
     ).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: /Manage MCP servers/ }));
-    expect(onOpenMcpSettings).toHaveBeenCalled();
   });
 
   it("managed: shows the read-only notice and no REST editing affordances", async () => {
-    render(
-      <ConnectedAppsPanel
-        client={api()}
-        managed
-        onOpenMcpSettings={() => undefined}
-      />,
-    );
+    render(<ConnectedAppsPanel client={api()} managed />);
 
     expect(
       await screen.findByText(/Managed by your organization/),
@@ -97,13 +110,7 @@ describe("ConnectedAppsPanel", () => {
   it("submits the PUT shape from the create form and never renders the value back", async () => {
     const client = api();
     const user = userEvent.setup();
-    render(
-      <ConnectedAppsPanel
-        client={client}
-        managed={false}
-        onOpenMcpSettings={() => undefined}
-      />,
-    );
+    render(<ConnectedAppsPanel client={client} managed={false} />);
 
     await user.click(
       await screen.findByRole("button", { name: /Add REST API/ }),
@@ -142,13 +149,7 @@ describe("ConnectedAppsPanel", () => {
   it("an edit with an untouched value keeps the stored credential", async () => {
     const client = api();
     const user = userEvent.setup();
-    render(
-      <ConnectedAppsPanel
-        client={client}
-        managed={false}
-        onOpenMcpSettings={() => undefined}
-      />,
-    );
+    render(<ConnectedAppsPanel client={client} managed={false} />);
 
     await user.click(await screen.findByRole("button", { name: /Edit/ }));
     await user.type(

--- a/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.tsx
@@ -9,6 +9,7 @@ import type {
 } from "../api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { McpPanel } from "./McpPanel";
 import {
   SettingsError,
   SettingsField,
@@ -18,7 +19,6 @@ import {
 } from "./primitives";
 
 type RestEntry = Extract<ConnectedAppInfo, { kind: "rest_api" }>;
-type McpEntry = Extract<ConnectedAppInfo, { kind: "mcp_server" }>;
 
 type CredentialMode = "none" | "bearer" | "header";
 
@@ -64,13 +64,6 @@ function samePlacement(
   return stored.header === chosen.header;
 }
 
-function healthLabel(entry: McpEntry): string {
-  const health = entry.health.charAt(0).toUpperCase() + entry.health.slice(1);
-  return entry.health === "healthy"
-    ? `${health} — ${entry.tool_count} tool${entry.tool_count === 1 ? "" : "s"}`
-    : health;
-}
-
 function credentialLabel(entry: RestEntry): string {
   switch (entry.credential_status) {
     case "none":
@@ -89,22 +82,22 @@ function errorMessage(err: unknown): string {
 }
 
 /**
- * The Connected apps page: one listing across both kinds. MCP entries show
- * the runtime's health and deep-link to the MCP servers page for editing —
- * the phased absorption is presentation only — while REST entries are
- * created, edited, and deleted right here.
+ * The Connected apps page: the one settings surface for both kinds. The MCP
+ * section is the full server editor — `McpPanel`, absorbed here when the
+ * standalone MCP servers page retired — and REST entries are created,
+ * edited, and deleted below it. The absorption is presentation only; the
+ * connected-apps record was authoritative throughout the phasing.
  */
 export function ConnectedAppsPanel({
   client,
   managed = false,
-  onOpenMcpSettings,
 }: {
   client: ApiClient;
   /** On a managed profile the server refuses `rest_api` writes wholesale —
    * the gateway is the sole governed REST channel — so the REST half renders
-   * a read-only notice and no editing affordances. */
+   * a read-only notice and no editing affordances. `McpPanel` reads the same
+   * flag and renders its own managed view. */
   managed?: boolean;
-  onOpenMcpSettings: () => void;
 }) {
   const [apps, setApps] = useState<ConnectedAppInfo[]>([]);
   const [loading, setLoading] = useState(true);
@@ -134,9 +127,6 @@ export function ConnectedAppsPanel({
     };
   }, [client]);
 
-  const mcpEntries = apps.filter(
-    (entry): entry is McpEntry => entry.kind === "mcp_server",
-  );
   const restEntries = apps.filter(
     (entry): entry is RestEntry => entry.kind === "rest_api",
   );
@@ -371,41 +361,12 @@ export function ConnectedAppsPanel({
       description="Outside integrations this profile can reach: MCP servers and REST APIs, bound by local apps with your consent."
       busy={loading || saving || deleting !== null}
     >
+      <McpPanel client={client} managed={managed} />
+
       {loading ? (
         <p className="text-sm text-muted-foreground">Loading connected apps…</p>
       ) : (
         <>
-          <SettingsSection
-            title="MCP servers"
-            description="Tool servers mounted into conversations. Configure them on the MCP servers page."
-          >
-            {mcpEntries.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                No MCP servers configured.
-              </p>
-            ) : (
-              mcpEntries.map((entry) => (
-                <div
-                  key={entry.id}
-                  className="flex items-center justify-between gap-4"
-                >
-                  <div className="min-w-0 flex-1">
-                    <p className="text-sm font-bold">{entry.name}</p>
-                    <p className="truncate text-xs text-muted-foreground">
-                      {healthLabel(entry)}
-                      {entry.diagnostic !== null && ` — ${entry.diagnostic}`}
-                    </p>
-                  </div>
-                </div>
-              ))
-            )}
-            <div>
-              <Button variant="outline" size="sm" onClick={onOpenMcpSettings}>
-                Manage MCP servers
-              </Button>
-            </div>
-          </SettingsSection>
-
           <SettingsSection
             title="REST APIs"
             description="A base URL and an OpenAPI document; requests run through the governed executor."

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
@@ -40,10 +40,10 @@ function managedPanel(
   client: ApiClient,
   {
     onChanged = () => undefined,
-    onOpenMcpSettings = () => undefined,
+    onOpenConnectedApps = () => undefined,
   }: {
     onChanged?: () => void;
-    onOpenMcpSettings?: () => void;
+    onOpenConnectedApps?: () => void;
   } = {},
 ) {
   return (
@@ -52,7 +52,7 @@ function managedPanel(
       managed
       gatewayUrl={GATEWAY_URL}
       onChanged={onChanged}
-      onOpenMcpSettings={onOpenMcpSettings}
+      onOpenConnectedApps={onOpenConnectedApps}
     />
   );
 }
@@ -72,7 +72,7 @@ describe("GatewayPanel", () => {
         managed={false}
         gatewayUrl={null}
         onChanged={() => undefined}
-        onOpenMcpSettings={() => undefined}
+        onOpenConnectedApps={() => undefined}
       />,
     );
 
@@ -201,11 +201,11 @@ describe("GatewayPanel", () => {
     expect(screen.queryByText("Connected apps")).not.toBeInTheDocument();
     // The route to mounting still shows: older gateways mount by slug too.
     expect(
-      screen.getByRole("button", { name: /Mount endpoints in MCP servers/ }),
+      screen.getByRole("button", { name: /Mount endpoints in Connected apps/ }),
     ).toBeInTheDocument();
   });
 
-  it("keeps connected apps informational and sends mounting to the MCP page", async () => {
+  it("keeps connected apps informational and sends mounting to Connected apps", async () => {
     const client = api({
       getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
       getGatewayApps: vi.fn().mockResolvedValue({
@@ -221,9 +221,9 @@ describe("GatewayPanel", () => {
         ],
       }),
     });
-    const openMcpSettings = vi.fn();
+    const openConnectedApps = vi.fn();
     const user = userEvent.setup();
-    render(managedPanel(client, { onOpenMcpSettings: openMcpSettings }));
+    render(managedPanel(client, { onOpenConnectedApps: openConnectedApps }));
 
     expect(await screen.findByText("Incident API")).toBeInTheDocument();
     expect(
@@ -231,9 +231,9 @@ describe("GatewayPanel", () => {
     ).not.toBeInTheDocument();
 
     await user.click(
-      screen.getByRole("button", { name: /Mount endpoints in MCP servers/ }),
+      screen.getByRole("button", { name: /Mount endpoints in Connected apps/ }),
     );
-    expect(openMcpSettings).toHaveBeenCalled();
+    expect(openConnectedApps).toHaveBeenCalled();
   });
 
   it("a policy that names no gateway cannot be connected to", async () => {
@@ -252,7 +252,7 @@ describe("GatewayPanel", () => {
         managed
         gatewayUrl={null}
         onChanged={() => undefined}
-        onOpenMcpSettings={() => undefined}
+        onOpenConnectedApps={() => undefined}
       />,
     );
 

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
@@ -28,7 +28,7 @@ export function GatewayPanel({
   managed,
   gatewayUrl,
   onChanged,
-  onOpenMcpSettings,
+  onOpenConnectedApps,
 }: {
   client: ApiClient;
   /** Whether the resolved policy manages this profile. */
@@ -36,10 +36,11 @@ export function GatewayPanel({
   /** The policy's locked gateway origin, shown read-only. */
   gatewayUrl: string | null;
   onChanged: () => void;
-  /** Navigates to the MCP servers section, where entitled endpoints are
-   * mounted. Mounting lives beside the health of what is mounted, so this
-   * panel points at it rather than carrying its own toggles. */
-  onOpenMcpSettings: () => void;
+  /** Navigates to the Connected apps page, whose MCP section is where
+   * entitled endpoints are mounted. Mounting lives beside the health of what
+   * is mounted, so this panel points at it rather than carrying its own
+   * toggles. */
+  onOpenConnectedApps: () => void;
 }) {
   if (!managed) {
     // Deep links and stale history entries still resolve here even though
@@ -64,7 +65,7 @@ export function GatewayPanel({
       client={client}
       gatewayUrl={gatewayUrl}
       onChanged={onChanged}
-      onOpenMcpSettings={onOpenMcpSettings}
+      onOpenConnectedApps={onOpenConnectedApps}
     />
   );
 }
@@ -78,12 +79,12 @@ function ManagedGatewayPanel({
   client,
   gatewayUrl,
   onChanged,
-  onOpenMcpSettings,
+  onOpenConnectedApps,
 }: {
   client: ApiClient;
   gatewayUrl: string | null;
   onChanged: () => void;
-  onOpenMcpSettings: () => void;
+  onOpenConnectedApps: () => void;
 }) {
   const [status, setStatus] = useState<GatewayStatus | null>(null);
   const [apps, setApps] = useState<GatewayApps | null>(null);
@@ -166,16 +167,17 @@ function ManagedGatewayPanel({
   // (it is what the profile is locked to) and fall back to the echo.
   const origin = gatewayUrl ?? status.base_url ?? null;
   // The one route to mounting, shown whenever signed in: a gateway without
-  // the apps surface still mounts endpoints by slug on the MCP servers page.
+  // the apps surface still mounts endpoints by slug from the Connected apps
+  // page's MCP section.
   const mountSignpost = (
     <Button
       type="button"
       variant="outline"
       className="self-start"
-      onClick={onOpenMcpSettings}
+      onClick={onOpenConnectedApps}
     >
       <PlugZap size={14} />
-      Mount endpoints in MCP servers
+      Mount endpoints in Connected apps
     </Button>
   );
 
@@ -302,7 +304,7 @@ function ManagedGatewayPanel({
         (apps?.supported ? (
           <SettingsSection
             title="Connected apps"
-            description="The apps your teams have granted this deployment. Mounting their MCP endpoints happens under MCP servers, beside the health of what is mounted."
+            description="The apps your teams have granted this deployment. Mounting their MCP endpoints happens on the Connected apps page, beside the health of what is mounted."
           >
             {apps.apps.length === 0 ? (
               <p className="text-muted-foreground text-sm">

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
@@ -13,7 +13,6 @@ import { Switch } from "@/components/ui/switch";
 import {
   SettingsError,
   SettingsField,
-  SettingsPanel,
   SettingsSection,
   SettingsStatus,
 } from "./primitives";
@@ -380,8 +379,7 @@ export function McpPanel({
 
   if (managed) {
     return (
-      <SettingsPanel
-        title="MCP servers"
+      <McpKindSection
         description="Tool servers provided by your organization's model gateway."
         busy={loading || working}
       >
@@ -393,13 +391,12 @@ export function McpPanel({
         )}
         {fallbackListError}
         {error && <SettingsError>{error}</SettingsError>}
-      </SettingsPanel>
+      </McpKindSection>
     );
   }
 
   return (
-    <SettingsPanel
-      title="MCP servers"
+    <McpKindSection
       description="Connect local stdio tool servers or remote HTTP endpoints without a shell or a desktop restart."
       busy={loading || working}
     >
@@ -713,7 +710,33 @@ export function McpPanel({
       )}
       {fallbackListError}
       {error && <SettingsError>{error}</SettingsError>}
-    </SettingsPanel>
+    </McpKindSection>
+  );
+}
+
+/**
+ * The MCP kind-section frame. This panel renders inside the Connected apps
+ * page rather than as a page of its own, so it leads with a section heading
+ * — the page title, column, and rhythm belong to the surrounding
+ * `SettingsPanel` — while `aria-busy` still scopes this kind's own work.
+ */
+function McpKindSection({
+  description,
+  busy,
+  children,
+}: {
+  description: string;
+  busy: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-10" aria-busy={busy}>
+      <div className="flex flex-col gap-1">
+        <h2 className="text-lg font-semibold">MCP servers</h2>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+      {children}
+    </section>
   );
 }
 

--- a/crates/openwave-desktop/ui/src/settings/sections.tsx
+++ b/crates/openwave-desktop/ui/src/settings/sections.tsx
@@ -6,7 +6,6 @@ import {
   Globe,
   KeyRound,
   Palette,
-  PlugZap,
   RefreshCw,
   ShieldCheck,
   SquareTerminal,
@@ -20,7 +19,6 @@ import { AppearancePanel } from "./AppearancePanel";
 import { CodeExecutionPanel } from "./CodeExecutionPanel";
 import { ConnectedAppsPanel } from "./ConnectedAppsPanel";
 import { GatewayPanel } from "./GatewayPanel";
-import { McpPanel } from "./McpPanel";
 import { PermissionsPanel } from "./PermissionsPanel";
 import { ModelsPanel } from "./ModelsPanel";
 import { ProvidersPanel } from "./ProvidersPanel";
@@ -51,14 +49,14 @@ function GatewaySection() {
   const navigate = useNavigate();
   // Settings sections are registered from a runtime table, so TanStack's
   // generated route union contains `/settings` but not each literal child.
-  const mcpPath: string = "/settings/mcp";
+  const connectedAppsPath: string = "/settings/connected-apps";
   return (
     <GatewayPanel
       client={client}
       managed={policy.managed}
       gatewayUrl={policy.gateway_url ?? null}
       onChanged={() => void refreshCatalog()}
-      onOpenMcpSettings={() => void navigate({ to: mcpPath })}
+      onOpenConnectedApps={() => void navigate({ to: connectedAppsPath })}
     />
   );
 }
@@ -86,26 +84,10 @@ function CodeExecutionSection() {
   return <CodeExecutionPanel client={client} />;
 }
 
-function McpSection() {
-  const { client } = useApp();
-  const { managed } = useManagedPolicy();
-  return <McpPanel client={client} managed={managed} />;
-}
-
 function ConnectedAppsSection() {
   const { client } = useApp();
   const { managed } = useManagedPolicy();
-  const navigate = useNavigate();
-  // Settings sections are registered from a runtime table, so TanStack's
-  // generated route union contains `/settings` but not each literal child.
-  const mcpPath: string = "/settings/mcp";
-  return (
-    <ConnectedAppsPanel
-      client={client}
-      managed={managed}
-      onOpenMcpSettings={() => void navigate({ to: mcpPath })}
-    />
-  );
+  return <ConnectedAppsPanel client={client} managed={managed} />;
 }
 
 function PermissionsSection() {
@@ -179,7 +161,6 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     icon: Blocks,
     Component: ConnectedAppsSection,
   },
-  { path: "mcp", label: "MCP servers", icon: PlugZap, Component: McpSection },
   {
     path: "permissions",
     label: "Permissions",

--- a/docs/connected-apps.md
+++ b/docs/connected-apps.md
@@ -110,7 +110,9 @@ Settings phasing: the MCP servers page remains during the epic; the
 end state is one Connected apps page listing both kinds (per-kind detail —
 health and mounting for MCP, catalog and credential status for REST). The
 phasing is presentation only; the record is authoritative from its first
-slice.
+slice. The absorption has since completed: the standalone MCP servers page
+retired into the Connected apps page (its editor unchanged, `/settings/mcp`
+redirecting there), with no change to the record.
 
 ## Consumers
 

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -3,7 +3,8 @@
 OpenWave connects to MCP servers over three transports: a local stdio child
 process, a remote Streamable HTTP endpoint, or a model-gateway MCP endpoint
 bound to the signed-in gateway session. In the desktop app, open
-**Settings → MCP servers**, add a definition, pick its transport, and choose
+**Settings → Connected apps → MCP servers**, add a definition, pick its
+transport, and choose
 **Save and verify**. For a stdio server, OpenWave starts the executable
 directly with the argument array shown in the form; it never joins the fields
 into a shell command. For an HTTP server, OpenWave sends each JSON-RPC request
@@ -23,7 +24,7 @@ Each server has:
     (`gateway_endpoint`). The endpoint URL and a short-lived `mcp:<slug>`
     bearer are resolved from the signed-in gateway session at every
     connection; nothing is copied, selected by name, or stored. Mount these
-    from **Settings → MCP servers → Gateway endpoints** with a toggle. Signed
+    from **Settings → Connected apps → Gateway endpoints** with a toggle. Signed
     out, the mount degrades to a "sign in to reconnect" diagnostic and
     recovers on the next reconnect after sign-in;
 - a request timeout from 1 to 3,600,000 milliseconds; and


### PR DESCRIPTION
Completes the settings phasing recorded in docs/connected-apps.md: "the end state is one Connected apps page listing both kinds". The split surface — a Connected apps page whose MCP half was a read-only list deep-linking to a separate MCP servers page — was confusing and duplicative; this collapses it into the one page the phasing promised. Presentation only: no wire types, no record changes, no Rust.

## What changed

- **`ConnectedAppsPanel`** now renders `McpPanel` — the full server editor, behaviorally unchanged — as its MCP servers section, replacing the read-only MCP list and its "Manage MCP servers" deep link. The page reads as one surface with two kind sections: MCP servers (editor, gateway-endpoint mounting, health) and REST APIs (inline CRUD, credential status). `McpPanel`'s draft-and-replace reconciliation (`adoptServers`, `dirtyRef`) is untouched; only its outer frame changed from a page title to a section heading.
- **`McpPanel` stops being a routed page.** The standalone "MCP servers" nav entry is removed from `sections.tsx`; `/settings/mcp` remains as a redirect route to `/settings/connected-apps` so stale deep links and history entries land correctly.
- **`GatewayPanel`**'s mount signpost now navigates to Connected apps (`onOpenConnectedApps`), with copy updated to match ("Mount endpoints in Connected apps").
- **Docs**: `docs/connected-apps.md` records the absorption as completed; `docs/mcp-servers.md` names the new settings location.

## Tests

Updated in place, no new coverage: `ConnectedAppsPanel.dom.test.tsx` asserts the embedded editor renders instead of the read-only list; `GatewayPanel.dom.test.tsx` follows the renamed callback and button copy; `McpPanel.test.tsx` passes unchanged — it is the same component. `pnpm exec tsc --noEmit`, `pnpm vitest run src/settings src/AppShell.dom.test.tsx` (75 passed), and `pnpm build` are green locally. `full-ci` so the UI lane runs pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)