### PR TITLE
fix(server): stage document skills at turn start so the prompted SKILL.md read succeeds

### DIFF
--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -135,14 +135,17 @@ fn exec_scripts_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
     Ok(directory)
 }
 
+/// The document skills every packaged build must carry; boot fails without
+/// them, and the bundle test below pins the resource map that ships them.
+const REQUIRED_SKILLS: [&str; 5] = [
+    "charts",
+    "pdf-documents",
+    "presentations",
+    "spreadsheets",
+    "word-documents",
+];
+
 fn exec_skills_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
-    const REQUIRED_SKILLS: [&str; 5] = [
-        "charts",
-        "pdf-documents",
-        "presentations",
-        "spreadsheets",
-        "word-documents",
-    ];
     let directory = app
         .path()
         .resource_dir()
@@ -360,6 +363,39 @@ async fn boot_server(
         .await;
     });
     server.serve().await.map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod bundle_tests {
+    use super::REQUIRED_SKILLS;
+
+    /// Packaged-style skill resolution, pinned at test time: the
+    /// `tauri.conf.json` resource map must stage a skills tree into the app
+    /// bundle, and that tree must yield every skill `exec_skills_dir`
+    /// requires. Dropping the resource line or breaking a manifest would
+    /// otherwise surface only as a packaged-app boot failure.
+    #[test]
+    fn bundled_resources_carry_all_required_skills() {
+        let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let conf: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(manifest_dir.join("tauri.conf.json")).unwrap(),
+        )
+        .unwrap();
+        let source = conf["bundle"]["resources"]
+            .as_object()
+            .expect("tauri.conf.json maps bundle resources")
+            .iter()
+            .find_map(|(source, target)| {
+                (target.as_str() == Some("skills/")).then(|| source.clone())
+            })
+            .expect("tauri.conf.json bundles a skills/ resource");
+        let skills = openwave_code_execution::load_builtin_skills(&manifest_dir.join(source));
+        let names: Vec<&str> = skills
+            .iter()
+            .map(|skill| skill.package.name.as_str())
+            .collect();
+        assert_eq!(names, REQUIRED_SKILLS);
+    }
 }
 
 #[cfg(test)]

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -993,6 +993,33 @@ impl ConfiguredCodeExecutionProvider {
             .collect()
     }
 
+    /// Stage the chat's workspace at turn start, before the model runs.
+    ///
+    /// The operating prompt tells the model to `read_file` a skill's
+    /// `SKILL.md` *before* producing that kind of document, so the staging
+    /// that `execute` performs on the first command comes strictly too late:
+    /// the read races ahead of any exec and finds nothing. This runs the same
+    /// idempotent preparation when the turn surface is composed. Best-effort
+    /// on purpose — prompt enrichment is not an authority boundary, and
+    /// `execute` re-prepares (with the provider-correct mirroring flag)
+    /// before any command runs.
+    pub(crate) async fn stage_turn_workspace(&self, chat_id: ChatId) {
+        if self.skills.is_empty() {
+            return;
+        }
+        let host_dir = self.scratch_root.join(chat_id.to_string());
+        if let Err(error) = prepare_execution_directories(
+            &host_dir,
+            false,
+            self.document_scripts_source.as_deref(),
+            &self.skills,
+        )
+        .await
+        {
+            tracing::warn!("turn-start workspace staging failed for chat {chat_id}: {error}");
+        }
+    }
+
     /// The shared package cache keyspace for the local sandbox interpreter.
     ///
     /// The wheel-compatibility runtime key is probed from the same interpreter
@@ -2499,10 +2526,62 @@ mod tests {
         );
     }
 
+    /// Turn-start staging pins the contract the prompt catalog relies on:
+    /// every advertised skill's `SKILL.md` is readable in the chat's private
+    /// scratch — the directory the `read_file` surface resolves against —
+    /// before any exec has run.
+    #[tokio::test]
+    async fn turn_start_staging_makes_skills_readable_before_any_exec() {
+        let (store, _database) = test_store().await;
+        let store = Arc::new(store);
+        let scratch_root = tempfile::tempdir().unwrap();
+        let source = tempfile::tempdir().unwrap();
+        let manifest = "---\n\
+            name: presentations\n\
+            description: Create PowerPoint decks.\n\
+            ---\n\
+            Body.\n";
+        let skill_dir = source.path().join("presentations");
+        std::fs::create_dir(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join(openwave_code_execution::SKILL_MANIFEST_FILE),
+            manifest,
+        )
+        .unwrap();
+
+        let provider = ConfiguredCodeExecutionProvider::new(
+            store.clone(),
+            Arc::new(NoSecrets),
+            scratch_root.path(),
+        )
+        .with_skills(Some(source.path().to_owned()));
+        let chat_id = ChatId::new();
+
+        provider.stage_turn_workspace(chat_id).await;
+
+        let staged = scratch_root
+            .path()
+            .join(chat_id.to_string())
+            .join(openwave_code_execution::SKILLS_DIR)
+            .join("presentations")
+            .join(openwave_code_execution::SKILL_MANIFEST_FILE);
+        assert_eq!(std::fs::read_to_string(&staged).unwrap(), manifest);
+
+        // Idempotent: the first exec re-prepares the same tree.
+        provider.stage_turn_workspace(chat_id).await;
+        assert_eq!(std::fs::read_to_string(&staged).unwrap(), manifest);
+
+        // A skill-less configuration (headless embeddings) stages nothing.
+        let bare =
+            ConfiguredCodeExecutionProvider::new(store, Arc::new(NoSecrets), scratch_root.path());
+        let bare_chat = ChatId::new();
+        bare.stage_turn_workspace(bare_chat).await;
+        assert!(!scratch_root.path().join(bare_chat.to_string()).exists());
+    }
+
     /// Local exec is confined to the scratch directory but can create entries
     /// in it, including a symlink aimed at the host. Both preparation writes
-    /// run on that directory before the next command, unsandboxed.
-    #[cfg(unix)]
+    /// run on that directory before the next command, unsandboxed.    #[cfg(unix)]
     #[tokio::test]
     async fn preparation_does_not_write_through_a_planted_symlink() {
         let outside = tempfile::tempdir().unwrap();

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -584,11 +584,17 @@ impl TurnWorker {
             },
             None => Vec::new(),
         };
-        let skills = self
-            .exec_folder_context
-            .as_ref()
-            .map(|provider| provider.skill_catalog())
-            .unwrap_or_default();
+        let skills = match self.exec_folder_context.as_ref() {
+            Some(provider) => {
+                // The prompt's skill catalog directs the model to read each
+                // staged SKILL.md before its first exec, so the workspace has
+                // to be staged now — waiting for the first exec to stage it
+                // loses that race and the read fails with not-found.
+                provider.stage_turn_workspace(chat.id).await;
+                provider.skill_catalog()
+            }
+            None => Vec::new(),
+        };
         let offline_package_cache = match self.exec_folder_context.as_ref() {
             Some(provider) => provider.offline_package_cache_ready().await,
             None => false,


### PR DESCRIPTION
The operating prompt's document-skills catalog instructs the model to read `.openwave/skills/<name>/SKILL.md` with `read_file` before producing that kind of document. Staging of those files into the chat workspace, however, only happened inside `execute()` — on the first exec invocation. The prompted read therefore always ran before any staging existed and failed with not-found.

A live journal from today's "Sample PowerPoint presentation" chat shows exactly this: the model's very first action was the prompted `read_file .openwave/skills/presentations/SKILL.md`, which returned "No such file or directory"; after a confirming `list_dir` it concluded no skill files were available and built the deck without the skill's guidance. The catalog line and the bundling were both fine — the packaged app ships the skills tree as a Tauri resource and boot fails loudly without it — the staging trigger was simply too late.

The turn worker now stages the chat workspace when it composes the turn surface, via a new idempotent, best-effort `stage_turn_workspace` on the configured exec provider. It runs the same preparation the first exec runs (skills, document helpers, conventional directories), so the prompted read finds every advertised skill before the model takes its first step; `execute()` still re-prepares with the provider-correct mirroring flag, and a skill-less configuration (headless embeddings) stages nothing.

Tests: a provider test pins that every advertised skill's manifest is readable in the chat's private scratch before any exec has run; a desktop test pins that the `tauri.conf.json` resource map bundles a skills tree yielding every skill `exec_skills_dir` requires at boot, so dropping the resource line fails at test time instead of only as a packaged-app boot failure. The five required skill names are hoisted to one module const shared by the boot check and the test.

Residual: the skill-miss failure mode remains silent to the user if it ever recurs (the model just proceeds unguided); surfacing a staging failure in the exec result notes could make it observable.