### PR TITLE
feat(desktop): install a managed LibreOffice for presentation previews

### DIFF
--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -23,6 +23,7 @@ mod documents;
 mod host_access;
 mod image_attachments;
 mod media_type;
+mod office_install;
 mod office_pdf;
 mod updater;
 
@@ -220,6 +221,8 @@ pub fn run() {
             deliverables::restore_output_revision,
             deliverables::delete_output,
             office_pdf::convert_presentation_to_pdf,
+            office_install::install_presentation_converter,
+            office_install::cancel_presentation_converter_install,
             client_execution::resolve_folder_access_request,
             client_execution::output_writeback::resolve_output_writeback_request,
             host_access::connect_folder,

--- a/crates/openwave-desktop/src/office_install.rs
+++ b/crates/openwave-desktop/src/office_install.rs
@@ -1,0 +1,592 @@
+//! Managed LibreOffice install for the presentation preview.
+//!
+//! The preview converts decks with LibreOffice, and most machines do not have
+//! one. Rather than sending the user off to install it, the app fetches its
+//! own copy the first time a preview needs it: an exact pinned version from
+//! The Document Foundation's official download service, digest-verified
+//! before a single byte of it is unpacked, installed under the app's data
+//! directory (`tools/libreoffice/<version>/LibreOffice.app`) with no admin
+//! rights and no writes outside app-owned paths.
+//!
+//! Supply-chain posture, deliberately rigid: the URL names an exact version —
+//! never "latest" — and the artifact's SHA-256 is pinned in this file next to
+//! it. `download.documentfoundation.org` redirects to third-party mirrors
+//! (MirrorBrain); those mirrors are untrusted and do not need to be trusted,
+//! because the download is rejected unless it hashes to the pinned digest.
+//! The digests below were taken from TDF's published checksum files:
+//!
+//! - <https://download.documentfoundation.org/libreoffice/stable/25.8.7/mac/aarch64/LibreOffice_25.8.7_MacOS_aarch64.dmg.sha256>
+//! - <https://download.documentfoundation.org/libreoffice/stable/25.8.7/mac/x86_64/LibreOffice_25.8.7_MacOS_x86-64.dmg.sha256>
+//!
+//! macOS is the supported platform (TDF ships `.dmg` only, so install mounts
+//! the image read-only with `hdiutil`, copies the bundle out with `ditto`,
+//! and detaches). Other platforms keep the install-it-yourself hint.
+//!
+//! Gatekeeper: a download performed by this process carries no
+//! `com.apple.quarantine` attribute — quarantine is applied by applications
+//! that opt in via `LSFileQuarantineEnabled` (browsers), not by the kernel —
+//! and copying out of an unquarantined disk image propagates none either, so
+//! the CLI-invoked `soffice` runs without any Gatekeeper prompt. Verified
+//! end-to-end on a real download of this pinned artifact. The quarantine
+//! attribute is still stripped after the copy, deliberately: it costs one
+//! `xattr` invocation and keeps the install working if a future code path
+//! ever hands us a quarantined file.
+//!
+//! Integrity at rest: the install directory carries an `installed.json`
+//! marker recording the version and the verified dmg digest. Resolution
+//! trusts the managed install only when the marker matches the constants
+//! pinned here — a marker for a different digest (a tampered or half-written
+//! install, or a stale layout after the pin moves) makes the managed copy
+//! invisible and a fresh install replaces it. The 800 MB bundle is not
+//! re-hashed per preview; the marker plus the binary's presence is the check.
+//!
+//! Failure discipline: one failed or cancelled install is remembered for the
+//! rest of the app run and reported alongside the install hint. Nothing
+//! re-downloads on its own; the user's explicit retry clears the memory.
+
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, LazyLock, Mutex};
+#[cfg(target_os = "macos")]
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tauri::{AppHandle, Emitter as _};
+
+/// The exact LibreOffice version this build installs and trusts.
+pub(crate) const LIBREOFFICE_VERSION: &str = "25.8.7";
+
+/// Shown in UI copy and used for the disk-space check; the aarch64 dmg is
+/// 299,584,229 bytes and the copied bundle about 816 MB.
+const REQUIRED_FREE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+/// Progress events the preview panel renders as a determinate bar.
+pub(crate) const INSTALL_PROGRESS_EVENT: &str = "presentation-converter-install-progress";
+
+struct PinnedArtifact {
+    url: &'static str,
+    sha256: &'static str,
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+static PINNED: Option<PinnedArtifact> = Some(PinnedArtifact {
+    url: "https://download.documentfoundation.org/libreoffice/stable/25.8.7/mac/aarch64/LibreOffice_25.8.7_MacOS_aarch64.dmg",
+    sha256: "e7556aa61e282f89578ebaf35afdb09c94dcf9d6ee7c137004377bee81a6e900",
+});
+
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+static PINNED: Option<PinnedArtifact> = Some(PinnedArtifact {
+    url: "https://download.documentfoundation.org/libreoffice/stable/25.8.7/mac/x86_64/LibreOffice_25.8.7_MacOS_x86-64.dmg",
+    sha256: "110439f207b5e420d7c8e441180c8374431761d549a1c14b584045ac56cd71c5",
+});
+
+#[cfg(not(target_os = "macos"))]
+static PINNED: Option<PinnedArtifact> = None;
+
+/// Whether this platform can install its own converter.
+pub(crate) fn supported() -> bool {
+    PINNED.is_some()
+}
+
+/// The install failure (or cancellation) most recently hit this app run, if
+/// any. While set, the preview shows the hint instead of re-downloading;
+/// an explicit retry clears it.
+pub(crate) fn last_failure() -> Option<String> {
+    state()
+        .lock()
+        .expect("install state lock")
+        .last_failure
+        .clone()
+}
+
+fn managed_version_dir(data_dir: &Path) -> PathBuf {
+    data_dir
+        .join("tools")
+        .join("libreoffice")
+        .join(LIBREOFFICE_VERSION)
+}
+
+#[cfg(target_os = "macos")]
+fn staging_dir(data_dir: &Path) -> PathBuf {
+    data_dir.join("tools").join("libreoffice").join("staging")
+}
+
+fn marker_path(version_dir: &Path) -> PathBuf {
+    version_dir.join("installed.json")
+}
+
+fn managed_binary(version_dir: &Path) -> PathBuf {
+    version_dir.join("LibreOffice.app/Contents/MacOS/soffice")
+}
+
+/// What `installed.json` records: which artifact the directory was verified
+/// against. Written only after the digest check and the copy both succeeded.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct InstallMarker {
+    version: String,
+    dmg_sha256: String,
+}
+
+/// The managed `soffice`, if a verified install of the pinned artifact is
+/// present. This is the cheap at-rest check: marker matches the pin, binary
+/// exists.
+pub(crate) fn managed_soffice(data_dir: &Path) -> Option<PathBuf> {
+    let pinned = PINNED.as_ref()?;
+    managed_soffice_expecting(data_dir, pinned.sha256)
+}
+
+/// Seam for [`managed_soffice`]: the same resolution against an explicit
+/// expected digest, so the marker gate is testable off-macOS.
+fn managed_soffice_expecting(data_dir: &Path, expected_sha256: &str) -> Option<PathBuf> {
+    let version_dir = managed_version_dir(data_dir);
+    let marker = std::fs::read(marker_path(&version_dir)).ok()?;
+    let marker: InstallMarker = serde_json::from_slice(&marker).ok()?;
+    if marker.version != LIBREOFFICE_VERSION || marker.dmg_sha256 != expected_sha256 {
+        return None;
+    }
+    let binary = managed_binary(&version_dir);
+    binary.is_file().then_some(binary)
+}
+
+struct InstallState {
+    last_failure: Option<String>,
+    cancel: Option<Arc<AtomicBool>>,
+}
+
+fn state() -> &'static Mutex<InstallState> {
+    static STATE: LazyLock<Mutex<InstallState>> = LazyLock::new(|| {
+        Mutex::new(InstallState {
+            last_failure: None,
+            cancel: None,
+        })
+    });
+    &STATE
+}
+
+/// Serializes installs; two presentation panels hitting a cold machine at
+/// once produce one download.
+fn install_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: LazyLock<tokio::sync::Mutex<()>> = LazyLock::new(|| tokio::sync::Mutex::new(()));
+    &LOCK
+}
+
+/// Install the managed LibreOffice. Emits [`INSTALL_PROGRESS_EVENT`] while
+/// running; on failure the reason is both returned and remembered so the
+/// preview stops auto-retrying until the user asks again.
+#[tauri::command]
+pub(crate) async fn install_presentation_converter(app: AppHandle) -> Result<(), String> {
+    let data_dir = crate::data_dir(&app)?;
+    let _serialized = install_lock().lock().await;
+    if managed_soffice(&data_dir).is_some() {
+        // Another caller finished the install while this one waited.
+        state().lock().expect("install state lock").last_failure = None;
+        return Ok(());
+    }
+
+    let cancel = Arc::new(AtomicBool::new(false));
+    {
+        let mut state = state().lock().expect("install state lock");
+        state.last_failure = None;
+        state.cancel = Some(cancel.clone());
+    }
+    let outcome = run_install(&app, &data_dir, &cancel).await;
+    {
+        let mut state = state().lock().expect("install state lock");
+        state.cancel = None;
+        state.last_failure = outcome.as_ref().err().cloned();
+    }
+    outcome
+}
+
+/// Flag the in-flight install to stop. The install command itself returns
+/// the cancellation as its error.
+#[tauri::command]
+pub(crate) fn cancel_presentation_converter_install() {
+    if let Some(cancel) = &state().lock().expect("install state lock").cancel {
+        cancel.store(true, Ordering::Relaxed);
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct InstallProgress {
+    /// `downloading` is determinate; `installing` covers verify + mount +
+    /// copy and is not.
+    phase: &'static str,
+    downloaded_bytes: u64,
+    total_bytes: Option<u64>,
+}
+
+#[cfg(target_os = "macos")]
+fn emit_progress(app: &AppHandle, progress: InstallProgress) {
+    let _ = app.emit(INSTALL_PROGRESS_EVENT, progress);
+}
+
+#[cfg(target_os = "macos")]
+const CANCELLED: &str = "Download cancelled";
+
+#[cfg(target_os = "macos")]
+async fn run_install(app: &AppHandle, data_dir: &Path, cancel: &AtomicBool) -> Result<(), String> {
+    let pinned = PINNED
+        .as_ref()
+        .ok_or_else(|| "Automatic install is not supported on this platform".to_owned())?;
+
+    let staging = staging_dir(data_dir);
+    // A previous run's partial download or dead mountpoint; start clean.
+    let _ = tokio::fs::remove_dir_all(&staging).await;
+    tokio::fs::create_dir_all(&staging)
+        .await
+        .map_err(|error| format!("Could not prepare the install directory: {error}"))?;
+
+    let result = install_into(app, data_dir, &staging, pinned, cancel).await;
+
+    // The staging directory never survives: success moved the bundle out,
+    // failure leaves only partial artifacts worth reclaiming.
+    let _ = tokio::fs::remove_dir_all(&staging).await;
+    result
+}
+
+#[cfg(not(target_os = "macos"))]
+async fn run_install(
+    _app: &AppHandle,
+    _data_dir: &Path,
+    _cancel: &AtomicBool,
+) -> Result<(), String> {
+    Err("Automatic install is not supported on this platform".to_owned())
+}
+
+#[cfg(target_os = "macos")]
+async fn install_into(
+    app: &AppHandle,
+    data_dir: &Path,
+    staging: &Path,
+    pinned: &PinnedArtifact,
+    cancel: &AtomicBool,
+) -> Result<(), String> {
+    ensure_free_disk(staging, REQUIRED_FREE_BYTES).await?;
+
+    let dmg = staging.join("LibreOffice.dmg");
+    download(app, pinned.url, &dmg, cancel).await?;
+
+    emit_progress(
+        app,
+        InstallProgress {
+            phase: "installing",
+            downloaded_bytes: 0,
+            total_bytes: None,
+        },
+    );
+
+    // Verify against the pinned digest before touching the image in any way.
+    // Hashing streams from disk; the incremental work was already paid during
+    // the download's page-cache-warm write, so this is quick even at 300 MB.
+    let digest = {
+        let dmg = dmg.clone();
+        tokio::task::spawn_blocking(move || sha256_hex_of_file(&dmg))
+            .await
+            .map_err(|error| format!("Could not verify the download: {error}"))?
+            .map_err(|error| format!("Could not verify the download: {error}"))?
+    };
+    if digest != pinned.sha256 {
+        let _ = tokio::fs::remove_file(&dmg).await;
+        return Err(
+            "The downloaded LibreOffice did not match its published checksum, so it was discarded. \
+             This can mean a corrupted mirror or a tampered download — try again later."
+                .to_owned(),
+        );
+    }
+
+    // TDF ships macOS builds as .dmg only, so: mount read-only, copy the
+    // bundle out with ditto (preserves the code-signed structure), detach.
+    let mount = staging.join("mnt");
+    tokio::fs::create_dir(&mount)
+        .await
+        .map_err(|error| format!("Could not prepare the install directory: {error}"))?;
+    run_tool(
+        "/usr/bin/hdiutil",
+        &[
+            "attach".as_ref(),
+            "-nobrowse".as_ref(),
+            "-readonly".as_ref(),
+            "-mountpoint".as_ref(),
+            mount.as_os_str(),
+            dmg.as_os_str(),
+        ],
+        Duration::from_secs(120),
+    )
+    .await?;
+
+    let copied = staging.join("LibreOffice.app");
+    let copy_result = run_tool(
+        "/usr/bin/ditto",
+        &[
+            mount.join("LibreOffice.app").as_os_str(),
+            copied.as_os_str(),
+        ],
+        Duration::from_secs(600),
+    )
+    .await;
+    // Detach regardless: a mounted image outliving the install would pin the
+    // staging directory and confuse the next attempt.
+    let _ = run_tool(
+        "/usr/bin/hdiutil",
+        &["detach".as_ref(), mount.as_os_str()],
+        Duration::from_secs(120),
+    )
+    .await;
+    copy_result?;
+
+    // Deliberate quarantine strip; see the module docs for why this is a
+    // no-op today and kept anyway.
+    let _ = run_tool(
+        "/usr/bin/xattr",
+        &[
+            "-dr".as_ref(),
+            "com.apple.quarantine".as_ref(),
+            copied.as_os_str(),
+        ],
+        Duration::from_secs(120),
+    )
+    .await;
+
+    let version_dir = managed_version_dir(data_dir);
+    tokio::fs::create_dir_all(&version_dir)
+        .await
+        .map_err(|error| format!("Could not prepare the install directory: {error}"))?;
+    let installed_app = version_dir.join("LibreOffice.app");
+    // A leftover unverified bundle (no marker names it) makes the rename
+    // fail; replace it.
+    let _ = tokio::fs::remove_dir_all(&installed_app).await;
+    tokio::fs::rename(&copied, &installed_app)
+        .await
+        .map_err(|error| format!("Could not move LibreOffice into place: {error}"))?;
+
+    // The marker lands last, so a crash anywhere above leaves an install that
+    // resolution ignores and the next attempt replaces.
+    let marker = serde_json::to_vec_pretty(&InstallMarker {
+        version: LIBREOFFICE_VERSION.to_owned(),
+        dmg_sha256: pinned.sha256.to_owned(),
+    })
+    .map_err(|error| format!("Could not record the install: {error}"))?;
+    let marker_file = marker_path(&version_dir);
+    let partial = marker_file.with_extension("json.partial");
+    tokio::fs::write(&partial, marker)
+        .await
+        .map_err(|error| format!("Could not record the install: {error}"))?;
+    tokio::fs::rename(&partial, &marker_file)
+        .await
+        .map_err(|error| format!("Could not record the install: {error}"))?;
+
+    if managed_soffice(data_dir).is_none() {
+        return Err("The installed LibreOffice did not verify".to_owned());
+    }
+    Ok(())
+}
+
+/// Stream the artifact to disk with determinate progress and cooperative
+/// cancellation. Verification happens after, against the whole file.
+#[cfg(target_os = "macos")]
+async fn download(
+    app: &AppHandle,
+    url: &str,
+    destination: &Path,
+    cancel: &AtomicBool,
+) -> Result<(), String> {
+    use futures::StreamExt as _;
+    use tokio::io::AsyncWriteExt as _;
+
+    let client = reqwest::Client::builder()
+        .build()
+        .map_err(|error| format!("Could not start the download: {error}"))?;
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|error| format!("Could not download LibreOffice: {error}"))?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "Could not download LibreOffice: the server answered {}",
+            response.status()
+        ));
+    }
+    let total_bytes = response.content_length();
+    emit_progress(
+        app,
+        InstallProgress {
+            phase: "downloading",
+            downloaded_bytes: 0,
+            total_bytes,
+        },
+    );
+
+    let mut file = tokio::fs::File::create(destination)
+        .await
+        .map_err(|error| format!("Could not write the download: {error}"))?;
+    let mut stream = response.bytes_stream();
+    let mut downloaded: u64 = 0;
+    let mut last_reported: u64 = 0;
+    const REPORT_EVERY_BYTES: u64 = 4 * 1024 * 1024;
+    while let Some(chunk) = stream.next().await {
+        if cancel.load(Ordering::Relaxed) {
+            return Err(CANCELLED.to_owned());
+        }
+        let chunk = chunk.map_err(|error| format!("The download was interrupted: {error}"))?;
+        file.write_all(&chunk)
+            .await
+            .map_err(|error| format!("Could not write the download: {error}"))?;
+        downloaded += chunk.len() as u64;
+        if downloaded - last_reported >= REPORT_EVERY_BYTES {
+            last_reported = downloaded;
+            emit_progress(
+                app,
+                InstallProgress {
+                    phase: "downloading",
+                    downloaded_bytes: downloaded,
+                    total_bytes,
+                },
+            );
+        }
+    }
+    file.flush()
+        .await
+        .map_err(|error| format!("Could not write the download: {error}"))?;
+    Ok(())
+}
+
+/// SHA-256 of a file's contents, streamed, as lowercase hex.
+fn sha256_hex_of_file(path: &Path) -> std::io::Result<String> {
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0u8; 1024 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    Ok(hex)
+}
+
+/// Run one system tool to completion under a hard timeout, failing on a
+/// non-zero exit with its stderr in the reason.
+#[cfg(target_os = "macos")]
+async fn run_tool(
+    program: &str,
+    args: &[&std::ffi::OsStr],
+    timeout: Duration,
+) -> Result<(), String> {
+    let mut command = tokio::process::Command::new(program);
+    command
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+    let child = command
+        .spawn()
+        .map_err(|error| format!("Could not run {program}: {error}"))?;
+    let output = tokio::time::timeout(timeout, child.wait_with_output())
+        .await
+        .map_err(|_| format!("{program} timed out"))?
+        .map_err(|error| format!("Could not run {program}: {error}"))?;
+    if !output.status.success() {
+        let detail = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("{program} failed: {}", detail.trim()));
+    }
+    Ok(())
+}
+
+/// Refuse to start a gigabyte of work on a nearly full disk. `df` because the
+/// standard library has no free-space query and this path is macOS-only.
+#[cfg(target_os = "macos")]
+async fn ensure_free_disk(directory: &Path, required: u64) -> Result<(), String> {
+    let output = tokio::process::Command::new("/bin/df")
+        .arg("-Pk")
+        .arg(directory)
+        .output()
+        .await
+        .map_err(|error| format!("Could not check free disk space: {error}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let available_kib: u64 = stdout
+        .lines()
+        .nth(1)
+        .and_then(|line| line.split_whitespace().nth(3))
+        .and_then(|field| field.parse().ok())
+        .ok_or_else(|| "Could not check free disk space".to_owned())?;
+    if available_kib.saturating_mul(1024) < required {
+        return Err(
+            "Not enough free disk space to install LibreOffice (about 2 GB is needed)".to_owned(),
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The verification gate: a wrong digest is rejected and a right one
+    /// accepted, against real bytes on disk. This is the check standing
+    /// between a compromised mirror and an unpacked application bundle.
+    #[test]
+    fn download_digest_verification_accepts_only_the_pinned_hash() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let artifact = dir.path().join("artifact.dmg");
+        std::fs::write(&artifact, b"hello world").expect("write");
+
+        let actual = sha256_hex_of_file(&artifact).expect("hash");
+        assert_eq!(
+            actual,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+        assert_ne!(actual, "0".repeat(64));
+    }
+
+    /// At-rest integrity: the managed install only resolves behind a marker
+    /// naming the pinned version and digest — no marker, or a marker for a
+    /// different artifact, and the bundle is invisible to resolution.
+    #[test]
+    fn managed_install_resolves_only_with_a_matching_marker() {
+        let expected = "e7556aa61e282f89578ebaf35afdb09c94dcf9d6ee7c137004377bee81a6e900";
+        let data_dir = tempfile::tempdir().expect("tempdir");
+        let version_dir = managed_version_dir(data_dir.path());
+        let binary = managed_binary(&version_dir);
+        std::fs::create_dir_all(binary.parent().expect("parent")).expect("dirs");
+        std::fs::write(&binary, b"#!/bin/sh\n").expect("binary");
+
+        // Bundle present, no marker: an interrupted install, not trusted.
+        assert_eq!(managed_soffice_expecting(data_dir.path(), expected), None);
+
+        let write_marker = |digest: &str| {
+            std::fs::write(
+                marker_path(&version_dir),
+                serde_json::to_vec(&InstallMarker {
+                    version: LIBREOFFICE_VERSION.to_owned(),
+                    dmg_sha256: digest.to_owned(),
+                })
+                .expect("marker json"),
+            )
+            .expect("write marker");
+        };
+
+        write_marker(&"0".repeat(64));
+        assert_eq!(managed_soffice_expecting(data_dir.path(), expected), None);
+
+        write_marker(expected);
+        assert_eq!(
+            managed_soffice_expecting(data_dir.path(), expected),
+            Some(binary)
+        );
+    }
+}

--- a/crates/openwave-desktop/src/office_pdf.rs
+++ b/crates/openwave-desktop/src/office_pdf.rs
@@ -2,9 +2,11 @@
 //!
 //! There is no presentation engine in the renderer, so slides are shown the
 //! way most tools outside PowerPoint show them: converted to PDF and drawn by
-//! the PDF viewer. Conversion runs a LibreOffice the user already has
-//! installed — nothing is bundled or downloaded — and its absence is a
-//! first-class state the renderer turns into an install hint, not an error.
+//! the PDF viewer. Conversion prefers the app's own managed LibreOffice
+//! (downloaded and digest-verified by [`crate::office_install`] the first
+//! time a preview needs it, on macOS), then falls back to one the user
+//! installed. Its absence is a first-class state the renderer turns into a
+//! download or an install hint, not an error.
 //!
 //! The converter processes untrusted bytes, so the invocation is contained
 //! the way the rest of the app treats external processes: an empty
@@ -59,12 +61,29 @@ pub(crate) struct PresentationPdfRequest {
 }
 
 /// Outcome of a conversion request. A missing converter is a state the
-/// renderer designs for (install hint + download remains), not a failure.
+/// renderer designs for, not a failure: on macOS it triggers the managed
+/// download (unless one already failed this run), elsewhere the install hint.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase", tag = "status")]
 pub(crate) enum PresentationPdfResult {
-    Converted { pdf_base64: String },
-    ConverterMissing,
+    Converted {
+        pdf_base64: String,
+    },
+    ConverterMissing {
+        /// Whether this platform can install its own LibreOffice.
+        installable: bool,
+        /// Why the last managed install this app run failed (or was
+        /// cancelled), if it did. While present the renderer shows the hint
+        /// and waits for an explicit retry instead of re-downloading.
+        install_failure: Option<String>,
+    },
+}
+
+fn converter_missing() -> PresentationPdfResult {
+    PresentationPdfResult::ConverterMissing {
+        installable: crate::office_install::supported(),
+        install_failure: crate::office_install::last_failure(),
+    }
 }
 
 /// Convert one presentation's bytes to PDF with the user's LibreOffice.
@@ -90,7 +109,8 @@ pub(crate) async fn convert_presentation_to_pdf(
         return Err("That file is too large to preview".to_owned());
     }
 
-    let cache_dir = crate::data_dir(&app)?.join(CACHE_DIRECTORY);
+    let data_dir = crate::data_dir(&app)?;
+    let cache_dir = data_dir.join(CACHE_DIRECTORY);
     let cache_path = cache_dir.join(format!("{}.pdf", content_key(&bytes)));
     if let Ok(cached) = tokio::fs::read(&cache_path).await {
         if !cached.is_empty() {
@@ -100,8 +120,8 @@ pub(crate) async fn convert_presentation_to_pdf(
         }
     }
 
-    let Some(soffice) = locate_soffice() else {
-        return Ok(PresentationPdfResult::ConverterMissing);
+    let Some(soffice) = locate_soffice(&data_dir) else {
+        return Ok(converter_missing());
     };
 
     let pdf = match run_conversion(&soffice, &bytes, extension).await {
@@ -109,7 +129,7 @@ pub(crate) async fn convert_presentation_to_pdf(
         // The resolved path failed to spawn — a stale launcher script or a
         // half-removed install. To the user that is the same state as no
         // LibreOffice at all: the install hint is the actionable message.
-        Err(ConversionError::Spawn) => return Ok(PresentationPdfResult::ConverterMissing),
+        Err(ConversionError::Spawn) => return Ok(converter_missing()),
         Err(ConversionError::Failed(reason)) => return Err(reason),
     };
 
@@ -152,13 +172,31 @@ fn content_key(bytes: &[u8]) -> String {
     key
 }
 
-/// Find a LibreOffice the user installed, checking the platform's standard
-/// application location before `PATH`.
+/// Find a LibreOffice to convert with: the app's own verified managed
+/// install first, then one the user installed system-wide, then `PATH`.
 ///
-/// A hit here is a candidate, not a guarantee — package managers leave
-/// launcher scripts behind after the application is removed — so spawn
-/// failure downstream is folded back into the missing-converter state.
-fn locate_soffice() -> Option<PathBuf> {
+/// The managed install leads because it is the copy whose provenance this
+/// app verified; a system hit is a candidate, not a guarantee — package
+/// managers leave launcher scripts behind after the application is removed —
+/// so spawn failure downstream is folded back into the missing-converter
+/// state.
+fn locate_soffice(data_dir: &Path) -> Option<PathBuf> {
+    resolve_soffice(
+        crate::office_install::managed_soffice(data_dir),
+        system_soffice,
+    )
+}
+
+/// The resolution order, as a seam: a managed install wins outright and the
+/// system is not probed at all behind one.
+fn resolve_soffice(
+    managed: Option<PathBuf>,
+    system: impl FnOnce() -> Option<PathBuf>,
+) -> Option<PathBuf> {
+    managed.or_else(system)
+}
+
+fn system_soffice() -> Option<PathBuf> {
     for candidate in standard_install_paths() {
         if candidate.is_file() {
             return Some(candidate);
@@ -391,13 +429,29 @@ mod tests {
         assert_eq!(input_extension("application/pdf"), None);
     }
 
+    /// A verified managed install answers resolution outright; the system is
+    /// only probed when there is none. Probing order matters because the
+    /// system scan reads `PATH` and can resolve stale launcher scripts.
+    #[test]
+    fn managed_install_preempts_the_system_scan() {
+        let managed = PathBuf::from("/data/tools/libreoffice/x/soffice");
+        assert_eq!(
+            resolve_soffice(Some(managed.clone()), || {
+                panic!("system scan ran despite a managed install")
+            }),
+            Some(managed)
+        );
+        let system = PathBuf::from("/usr/bin/soffice");
+        assert_eq!(resolve_soffice(None, || Some(system.clone())), Some(system));
+    }
+
     /// End-to-end proof against a real LibreOffice, when one is installed.
     /// Skips silently otherwise — CI runners and most dev machines carry no
     /// LibreOffice, and its absence is exactly the state the feature designs
     /// for, not a test failure.
     #[tokio::test]
     async fn converts_a_real_deck_when_libreoffice_is_installed() {
-        let Some(soffice) = locate_soffice() else {
+        let Some(soffice) = system_soffice() else {
             eprintln!("skipping: no LibreOffice installed");
             return;
         };

--- a/crates/openwave-desktop/ui/src/document/PresentationViewer.tsx
+++ b/crates/openwave-desktop/ui/src/document/PresentationViewer.tsx
@@ -2,17 +2,26 @@
  * The presentation viewer: the original deck converted to PDF and drawn with
  * the PDF engine, behind a thin strip saying so.
  *
- * The conversion needs a LibreOffice the user installed. Its absence gets a
- * card with the install hint rather than an error — the deck itself is fine
- * and still exports — and a failed conversion gets its own card so a corrupt
- * file never reads as a broken app.
+ * The conversion needs LibreOffice. On macOS the app installs its own copy
+ * the first time a preview needs one — visibly and cancellably, with a
+ * determinate download bar — an exact pinned version the host verifies
+ * against a pinned digest before unpacking. A failed or cancelled install
+ * turns into the install hint with the reason and an explicit retry; nothing
+ * re-downloads on its own. Platforms without a managed install keep the
+ * install-it-yourself hint, and a failed conversion gets its own card so a
+ * corrupt file never reads as a broken app.
  */
 import { Loader2Icon, PresentationIcon } from "lucide-react";
-import { lazy, useMemo } from "react";
+import { lazy, useEffect, useMemo, useRef, useState } from "react";
 
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
 import {
+  cancelPresentationConverterInstall,
   ConverterMissingError,
+  installPresentationConverter,
   presentationPdfSource,
+  type ConverterInstallProgress,
 } from "@/document/officePdf";
 import {
   useFileDownload,
@@ -33,11 +42,16 @@ interface Props {
 }
 
 export function PresentationViewer({ source, mediaType, className }: Props) {
-  const pdfSource = useMemo(
-    () => presentationPdfSource(source, mediaType),
+  // Bumped when the managed install completes, so the conversion that found
+  // no converter is retried under a fresh cache key.
+  const [attempt, setAttempt] = useState(0);
+  const pdfSource = useMemo(() => {
+    const converted = presentationPdfSource(source, mediaType);
+    return attempt === 0
+      ? converted
+      : { ...converted, cacheKey: `${converted.cacheKey}#${attempt}` };
     // The source object is rebuilt each render; its cache key is its identity.
-    [source.cacheKey, mediaType],
-  );
+  }, [source.cacheKey, mediaType, attempt]);
   const { data, isLoading, error } = useFileDownload(pdfSource, {
     parseAs: "arrayBuffer",
   });
@@ -54,6 +68,15 @@ export function PresentationViewer({ source, mediaType, className }: Props) {
   }
 
   if (error instanceof ConverterMissingError) {
+    if (error.installable) {
+      return (
+        <ConverterInstall
+          key={attempt}
+          initialFailure={error.installFailure}
+          onReady={() => setAttempt((current) => current + 1)}
+        />
+      );
+    }
     return (
       <PresentationNotice>
         Install LibreOffice to preview presentations. The file itself is fine —
@@ -79,6 +102,116 @@ export function PresentationViewer({ source, mediaType, className }: Props) {
       <PdfViewer source={pdfSource} className={cn("min-h-0", className)} />
     </div>
   );
+}
+
+/**
+ * The managed LibreOffice install, as the preview panel sees it: starts on
+ * its own unless an earlier attempt this run already failed, shows a
+ * determinate download bar, and can be cancelled. Failure lands on the hint
+ * with the reason; only the explicit retry starts another download.
+ */
+function ConverterInstall({
+  initialFailure,
+  onReady,
+}: {
+  initialFailure: string | null;
+  onReady: () => void;
+}) {
+  const [failure, setFailure] = useState<string | null>(initialFailure);
+  const [running, setRunning] = useState(initialFailure === null);
+  const [progress, setProgress] = useState<ConverterInstallProgress | null>(
+    null,
+  );
+  const startedRef = useRef(false);
+  const onReadyRef = useRef(onReady);
+  onReadyRef.current = onReady;
+
+  useEffect(() => {
+    if (!running || startedRef.current) return;
+    startedRef.current = true;
+    let disposed = false;
+    void installPresentationConverter((next) => {
+      if (!disposed) setProgress(next);
+    })
+      .then(() => {
+        if (!disposed) onReadyRef.current();
+      })
+      .catch((error: unknown) => {
+        if (disposed) return;
+        setFailure(error instanceof Error ? error.message : String(error));
+        setRunning(false);
+        setProgress(null);
+      });
+    return () => {
+      disposed = true;
+    };
+  }, [running]);
+
+  if (!running) {
+    return (
+      <PresentationNotice>
+        <span className="block">
+          Couldn’t set up the presentation preview
+          {failure ? `: ${failure}` : "."}
+        </span>
+        <span className="mt-1 block">
+          The file itself is fine — Save as… exports it unchanged. You can also
+          install LibreOffice yourself.
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          className="mt-3"
+          onClick={() => {
+            startedRef.current = false;
+            setFailure(null);
+            setRunning(true);
+          }}
+        >
+          Try again
+        </Button>
+      </PresentationNotice>
+    );
+  }
+
+  const downloading = progress?.phase !== "installing";
+  const percent =
+    progress?.phase === "downloading" && progress.totalBytes
+      ? Math.min(100, (progress.downloadedBytes / progress.totalBytes) * 100)
+      : null;
+
+  return (
+    <div className="flex grow items-center justify-center p-6">
+      <div className="flex w-full max-w-sm flex-col items-center gap-3 text-center">
+        <PresentationIcon className="size-6 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground" role="status">
+          {downloading
+            ? "Preparing presentation preview — downloading LibreOffice (~300 MB)…"
+            : "Setting up LibreOffice…"}
+        </p>
+        <Progress value={percent ?? undefined} className="w-56" />
+        {percent !== null && progress?.totalBytes ? (
+          <p className="text-xs text-muted-foreground">
+            {formatMegabytes(progress.downloadedBytes)} of{" "}
+            {formatMegabytes(progress.totalBytes)} MB
+          </p>
+        ) : null}
+        {downloading ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => void cancelPresentationConverterInstall()}
+          >
+            Cancel
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function formatMegabytes(bytes: number): string {
+  return Math.round(bytes / (1024 * 1024)).toString();
 }
 
 function PresentationNotice({ children }: { children: React.ReactNode }) {

--- a/crates/openwave-desktop/ui/src/document/officePdf.test.ts
+++ b/crates/openwave-desktop/ui/src/document/officePdf.test.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const invokeMock = vi.hoisted(() => vi.fn());
+const listenMock = vi.hoisted(() => vi.fn());
 vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
+vi.mock("@tauri-apps/api/event", () => ({ listen: listenMock }));
 
 import {
   ConverterMissingError,
   convertPresentationToPdf,
+  installPresentationConverter,
   presentationPdfSource,
 } from "./officePdf";
 import type { FileBytesSource } from "./useFileDownload";
@@ -13,7 +16,10 @@ import type { FileBytesSource } from "./useFileDownload";
 const PPTX =
   "application/vnd.openxmlformats-officedocument.presentationml.presentation";
 
-beforeEach(() => invokeMock.mockReset());
+beforeEach(() => {
+  invokeMock.mockReset();
+  listenMock.mockReset();
+});
 
 describe("presentation-to-PDF conversion", () => {
   it("round-trips bytes through the host command as base64", async () => {
@@ -33,12 +39,52 @@ describe("presentation-to-PDF conversion", () => {
     });
   });
 
-  it("surfaces a missing converter as its own error, not a failure", async () => {
-    invokeMock.mockResolvedValue({ status: "converterMissing" });
+  it("surfaces a missing converter with its install state, not a failure", async () => {
+    invokeMock.mockResolvedValue({
+      status: "converterMissing",
+      installable: true,
+      installFailure: "Download cancelled",
+    });
 
-    await expect(
-      convertPresentationToPdf(new Uint8Array([1]), PPTX),
-    ).rejects.toBeInstanceOf(ConverterMissingError);
+    const error = await convertPresentationToPdf(
+      new Uint8Array([1]),
+      PPTX,
+    ).then(
+      () => null,
+      (thrown: unknown) => thrown,
+    );
+
+    expect(error).toBeInstanceOf(ConverterMissingError);
+    const missing = error as ConverterMissingError;
+    expect(missing.installable).toBe(true);
+    expect(missing.installFailure).toBe("Download cancelled");
+  });
+
+  it("relays install progress events and tears the listener down after", async () => {
+    let emit: ((event: { payload: unknown }) => void) | undefined;
+    const unlisten = vi.fn();
+    listenMock.mockImplementation(
+      (_name: string, handler: (event: { payload: unknown }) => void) => {
+        emit = handler;
+        return Promise.resolve(unlisten);
+      },
+    );
+    const seen: unknown[] = [];
+    invokeMock.mockImplementation(() => {
+      // The host emits progress while the install command is in flight.
+      emit?.({
+        payload: { phase: "downloading", downloadedBytes: 1, totalBytes: 2 },
+      });
+      return Promise.resolve(undefined);
+    });
+
+    await installPresentationConverter((progress) => seen.push(progress));
+
+    expect(invokeMock).toHaveBeenCalledWith("install_presentation_converter");
+    expect(seen).toEqual([
+      { phase: "downloading", downloadedBytes: 1, totalBytes: 2 },
+    ]);
+    expect(unlisten).toHaveBeenCalled();
   });
 
   it("derives the converted source from the original's immutable cache key", async () => {

--- a/crates/openwave-desktop/ui/src/document/officePdf.ts
+++ b/crates/openwave-desktop/ui/src/document/officePdf.ts
@@ -12,6 +12,7 @@
  * viewer shows an install hint while the original file stays exportable.
  */
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 
 import type { FileBytesSource } from "@/document/useFileDownload";
 
@@ -21,17 +22,33 @@ export const PRESENTATION_MEDIA_TYPES = new Set([
   "application/vnd.oasis.opendocument.presentation",
 ]);
 
-/** LibreOffice is not installed (or its remains cannot start). */
+/**
+ * LibreOffice is not installed (or its remains cannot start).
+ *
+ * On macOS the host can install its own copy: `installable` says so, and
+ * `installFailure` carries the reason the last managed install this app run
+ * failed or was cancelled. While a failure is recorded the viewer shows the
+ * hint and waits for an explicit retry rather than re-downloading.
+ */
 export class ConverterMissingError extends Error {
-  constructor() {
+  readonly installable: boolean;
+  readonly installFailure: string | null;
+
+  constructor(installable = false, installFailure: string | null = null) {
     super("No presentation converter is installed");
     this.name = "ConverterMissingError";
+    this.installable = installable;
+    this.installFailure = installFailure;
   }
 }
 
 type PresentationPdfResponse =
   | { status: "converted"; pdfBase64: string }
-  | { status: "converterMissing" };
+  | {
+      status: "converterMissing";
+      installable: boolean;
+      installFailure: string | null;
+    };
 
 /**
  * Convert one presentation's bytes to PDF on the host.
@@ -47,9 +64,48 @@ export async function convertPresentationToPdf(
     request: { contentBase64: encodeBase64(bytes), mediaType },
   })) as PresentationPdfResponse;
   if (response.status === "converterMissing") {
-    throw new ConverterMissingError();
+    throw new ConverterMissingError(
+      response.installable,
+      response.installFailure,
+    );
   }
   return decodeBase64(response.pdfBase64);
+}
+
+const INSTALL_PROGRESS_EVENT = "presentation-converter-install-progress";
+
+/** How far the managed LibreOffice install has got. */
+export type ConverterInstallProgress = {
+  /** `downloading` is determinate; `installing` (verify + unpack) is not. */
+  phase: "downloading" | "installing";
+  downloadedBytes: number;
+  totalBytes: number | null;
+};
+
+/**
+ * Install the app's own LibreOffice (macOS): an exact pinned version from
+ * TDF's official download service, digest-verified by the host before
+ * unpacking. Resolves once the converter is ready; rejects with the host's
+ * reason on failure or cancellation, which the host also remembers so the
+ * viewer stops auto-retrying until the user asks again.
+ */
+export async function installPresentationConverter(
+  onProgress: (progress: ConverterInstallProgress) => void,
+): Promise<void> {
+  const unlisten = await listen<ConverterInstallProgress>(
+    INSTALL_PROGRESS_EVENT,
+    (event) => onProgress(event.payload),
+  );
+  try {
+    await invoke("install_presentation_converter");
+  } finally {
+    unlisten();
+  }
+}
+
+/** Ask the in-flight managed install to stop; it rejects with the reason. */
+export async function cancelPresentationConverterInstall(): Promise<void> {
+  await invoke("cancel_presentation_converter_install");
 }
 
 /**


### PR DESCRIPTION
#1385 shipped the pptx→PDF preview against a LibreOffice the user already had, with an install hint when there was none. On macOS the hint is now the fallback, not the plan: the first presentation preview that needs a converter installs the app's own copy, lazily and visibly, and then converts as normal.

## Managed install

- Lives under the app data directory (`tools/libreoffice/25.8.7/LibreOffice.app`) — never `/Applications`, no admin rights. Resolution order becomes: verified managed install → system installs (#1385's paths) → `PATH`; only when all three miss does the download trigger. Other platforms keep the install-it-yourself hint unchanged.
- **Pinned artifact, verified before unpacking.** The URL names LibreOffice 25.8.7 exactly (per-arch, aarch64 and x86_64 detected at compile time) on `download.documentfoundation.org`, and its SHA-256 is pinned beside it in `office_install.rs`, taken from TDF's published `.dmg.sha256` files (paths cited in the module docs). TDF's service redirects to MirrorBrain mirrors; those stay untrusted — the download is hashed from disk and rejected on any mismatch, with the reason shown. No "latest" URLs anywhere.
- **Mechanics.** TDF ships macOS builds as `.dmg` only, so install streams the image into a staging directory (wiped on every entry and exit, so partial downloads never accumulate), verifies the digest, mounts read-only with `hdiutil attach -nobrowse`, copies the bundle out with `ditto`, detaches, and renames into place. Free disk is checked (2 GB floor: ~300 MB image + ~816 MB bundle) before a byte is fetched. Concurrent triggers (two presentation panels on a cold machine) serialize on one download.
- **Integrity at rest.** An `installed.json` marker recording the version and verified dmg digest is written last; resolution trusts the managed copy only when the marker matches the constants pinned in code, so an interrupted install or a stale layout after a pin bump is invisible and gets replaced. No 800 MB re-hash per preview — the marker plus the binary's presence is the check.

## Gatekeeper

Tested against a real download of the pinned artifact on this machine: a fetch performed by the app's own process carries no `com.apple.quarantine` (quarantine is applied by applications opting in via `LSFileQuarantineEnabled`, not by the kernel), and copying out of an unquarantined image propagates none, so the CLI-invoked `soffice` runs with no Gatekeeper prompt. The install still strips the attribute after the copy, deliberately — one `xattr` call keeps this working if a future path ever hands over a quarantined file. The conversion itself keeps #1385's containment unchanged (cleared environment, throwaway profile/HOME/TMPDIR, timeout, size caps).

## UX

Automatic on first need, but visible and cancellable: the preview panel shows "Preparing presentation preview — downloading LibreOffice (~300 MB)…" with a determinate bar and byte counter (progress events from the host), an indeterminate "Setting up…" phase for verify/mount/copy, and a Cancel control. On success the conversion retries by itself and the deck renders. Failure — offline, checksum mismatch, disk — lands on the install hint with the reason and a "Try again" button; the host remembers the failure for the app run and nothing re-downloads until that explicit retry.

## Verification

- `cargo fmt --check`, `cargo check --locked`, `cargo clippy --all-targets` on `openwave-desktop`, and its full test suite (97 tests) — clean. New tests cover the two gates worth defending: digest verification against real bytes on disk, and the managed-install marker/resolution-order rules.
- UI: `tsc`, vitest for `src/document` (38 tests incl. the new install-protocol coverage) — clean.
- **Live, on this machine (arm64):** downloaded the actual pinned 25.8.7 aarch64 dmg from TDF (299,584,229 bytes; digest matched the pin exactly), mounted, ditto-copied to a user directory, confirmed no quarantine attribute end to end, and ran the crate's own contained conversion against that copy — the real fixture deck converted to a valid PDF in ~9 s. Not exercised live: the compiled Tauri command flow itself (progress events over IPC, the cancel round-trip, and the panel UI states) — that needs the running app.

Residual: the x86_64 pin is taken from TDF's published checksum but was not exercised on hardware; and if a future release bumps the pinned version, the old versioned directory is left behind rather than reclaimed — both cheap follow-ups when they matter.
