### PR TITLE
feat(desktop): cool-neutral dark mode palette

### DIFF
--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -103,35 +103,39 @@
 
 .dark {
   /* --- OpenWave palette (oklch, dark mode) --- */
+  /* Deliberate divergence from Brightwave: cool near-neutral grays (hue ~262,
+     chroma <= 0.01) instead of the warm hue-85 ramp, which read brown at low
+     lightness. Elevation is carried by the lightness ramp alone:
+     page chrome 0.12 < popover 0.14 < card 0.16 < content surface 0.21. */
   color-scheme: dark;
 
-  --background: oklch(0.1993 0.01 85);
+  --background: oklch(0.21 0.008 262);
   --foreground: oklch(0.95 0 0);
-  --page-background: oklch(0.09 0 0);
+  --page-background: oklch(0.12 0.005 262);
 
-  --border: oklch(0.3 0.007 69);
-  --input: oklch(0.4 0.007 69);
+  --border: oklch(0.31 0.009 262);
+  --input: oklch(0.4 0.01 262);
   --ring: oklch(0.65 0.04 256.788);
 
   --primary: oklch(0.95 0 0);
-  --primary-foreground: oklch(0.09 0 0);
+  --primary-foreground: oklch(0.12 0.005 262);
 
-  --secondary: oklch(0.26 0.02 85);
+  --secondary: oklch(0.27 0.009 262);
   --secondary-foreground: oklch(0.75 0 0);
 
-  --muted: oklch(0.26 0.02 85);
-  --muted-foreground: oklch(0.65 0 0);
+  --muted: oklch(0.27 0.009 262);
+  --muted-foreground: oklch(0.68 0.006 262);
 
-  --accent: oklch(0.26 0.02 85);
+  --accent: oklch(0.27 0.009 262);
   --accent-foreground: var(--color-zinc-100);
 
-  --card: var(--color-neutral-950);
+  --card: oklch(0.16 0.006 262);
   --card-foreground: var(--color-neutral-200);
 
-  --popover: oklch(0.12 0.005 0);
-  --popover-foreground: oklch(0.9 0.03 97.54);
+  --popover: oklch(0.14 0.006 262);
+  --popover-foreground: oklch(0.92 0.003 262);
 
-  --destructive: oklch(0.68 0.22 27.325);
+  --destructive: oklch(0.55 0.21 27.325);
   --destructive-foreground: oklch(0.95 0.005 247.858);
 
   /* Semantic status — dark */


### PR DESCRIPTION
The dark theme's grays were warm — background at hue 85, borders at hue 69, popover text at hue 97, all at low lightness and chroma, which is exactly the region that reads as brown. This replaces the dark neutral ramp with cool near-neutrals (hue ~262, chroma at or below 0.01), the direction modern dark UIs take. Token names are unchanged, so every component picks the new values up for free. Light mode is untouched.

Elevation is now carried by a deliberate lightness ramp instead of hue noise: page chrome 0.12 < popover 0.14 < card 0.16 < content surface 0.21, with borders at 0.31 and inputs at 0.40 so edges stay visible but quiet.

## Key token changes

| Token | Before | After |
| --- | --- | --- |
| `--background` | `oklch(0.1993 0.01 85)` (warm) | `oklch(0.21 0.008 262)` |
| `--page-background` | `oklch(0.09 0 0)` | `oklch(0.12 0.005 262)` |
| `--border` | `oklch(0.3 0.007 69)` (warm) | `oklch(0.31 0.009 262)` |
| `--input` | `oklch(0.4 0.007 69)` (warm) | `oklch(0.4 0.01 262)` |
| `--secondary` / `--muted` / `--accent` | `oklch(0.26 0.02 85)` (warmest offender) | `oklch(0.27 0.009 262)` |
| `--muted-foreground` | `oklch(0.65 0 0)` | `oklch(0.68 0.006 262)` |
| `--card` | `neutral-950` (`0.145` pure) | `oklch(0.16 0.006 262)` |
| `--popover` | `oklch(0.12 0.005 0)` | `oklch(0.14 0.006 262)` |
| `--popover-foreground` | `oklch(0.9 0.03 97.54)` (yellow text) | `oklch(0.92 0.003 262)` |
| `--primary-foreground` | `oklch(0.09 0 0)` | `oklch(0.12 0.005 262)` |
| `--destructive` | `oklch(0.68 0.22 27.325)` | `oklch(0.55 0.21 27.325)` |

Unchanged on purpose: all status colors (success/warning/critical/info — they sit fine on cool neutrals and their fg/bg pairs already pass AA), `--ring` (already cool blue), `--code-block-*` (already hue 285), `--code-ink` (intentional warm code accent, matches light mode), `--brightwave` brand.

`--destructive` is the one semantic dark variant adjusted: white-on-red was 2.83:1 (AA fail, pre-existing); deepening to 0.55 lightness gives 4.67:1 while keeping 3.28:1 against the background.

## Computed WCAG contrast (oklch to linear sRGB to relative luminance)

| Pair | Ratio | Requirement |
| --- | --- | --- |
| foreground / background | 15.31 | 4.5 pass |
| foreground / page-background | 17.54 | 4.5 pass |
| foreground / card | 16.77 | 4.5 pass |
| muted-fg / background | 6.15 | 4.5 pass |
| muted-fg / muted | 5.23 | 4.5 pass |
| secondary-fg / secondary | 6.77 | 4.5 pass |
| accent-fg / accent | 13.69 | 4.5 pass |
| card-fg / card | 15.41 | 4.5 pass |
| popover-fg / popover | 15.71 | 4.5 pass |
| primary-fg / primary | 17.54 | 4.5 pass |
| destructive-fg / destructive | 4.67 | 4.5 pass (was 2.83 fail) |
| status fg / status bg (all four) | 8.2+ | 4.5 pass |
| status accents / background (all five) | 5.4–10.3 | 3.0 pass |
| border / background | 1.35 | non-text, visible-but-quiet |

Verified with tsc, the full vitest suite (690 tests), and pnpm build. No hardcoded dark-mode colors exist outside the token block (remaining oklch/hex literals are brand icons and document-format converters). I could not eyeball the running app — worth a visual pass on the sidebar/card boundary and popover menus, where the lightness steps changed most.