### PR TITLE
feat(server): auto-mount entitled gateway MCP endpoints

### DIFF
--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -259,6 +259,48 @@ impl GatewayRuntime {
         })
     }
 
+    /// Mount newly entitled gateway MCP endpoints into the configured server
+    /// set — mount-by-default for a managed profile, where the organization
+    /// already curated the entitlements.
+    ///
+    /// The entitlement source is the same `/api/v1/cli/apps` read the
+    /// settings panel lists, so server and UI cannot disagree about what is
+    /// entitled. Endpoints the user explicitly unmounted are remembered by
+    /// the MCP runtime and never re-mounted here; a repeat reconcile with no
+    /// new entitlements changes nothing. Every state where a reconcile cannot
+    /// run — unmanaged profile, misconfigured policy, no session for the
+    /// policy's deployment, a gateway predating the apps surface — is
+    /// "nothing to do", not an error, so callers may run this on every
+    /// trigger without gating.
+    pub(crate) async fn reconcile_endpoint_mounts(
+        &self,
+        mcp: &crate::mcp_config::McpRuntime,
+    ) -> Result<()> {
+        let policy = self.policy().await?;
+        let Some(connection) = self.connection_for(&policy).await? else {
+            return Ok(());
+        };
+        if connection.stored_credentials().await?.is_none() {
+            return Ok(());
+        }
+        let Some(apps) = connection.apps().await? else {
+            return Ok(());
+        };
+        let entitled: Vec<String> = apps
+            .into_iter()
+            .flat_map(|app| app.mcp_endpoint_slugs)
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        if entitled.is_empty() {
+            return Ok(());
+        }
+        if mcp.auto_mount_gateway_endpoints(&entitled).await? {
+            tracing::info!("auto-mounted newly entitled gateway MCP endpoints");
+        }
+        Ok(())
+    }
+
     /// Start a browser sign-in and return the URL to open.
     ///
     /// A pending pairing wins the target: the sign-in runs against the
@@ -272,10 +314,13 @@ impl GatewayRuntime {
     /// unmanaged one keeps the legible refusal.
     ///
     /// The exchange completes in a background task: on success the session is
-    /// stored (after any pairing commit) and the entitled models synced; on
-    /// failure the status surface carries the bounded error until the next
-    /// attempt.
-    pub(crate) async fn begin_sign_in(self: &Arc<Self>) -> Result<String> {
+    /// stored (after any pairing commit), the entitled models synced, and the
+    /// entitled MCP endpoints auto-mounted into `mcp`; on failure the status
+    /// surface carries the bounded error until the next attempt.
+    pub(crate) async fn begin_sign_in(
+        self: &Arc<Self>,
+        mcp: Arc<crate::mcp_config::McpRuntime>,
+    ) -> Result<String> {
         let policy = self.policy().await?;
         let pairing = self.pending_pairing.lock().await.clone();
         let connection = match &pairing {
@@ -336,6 +381,14 @@ impl GatewayRuntime {
                             // explicit refresh affordance, not a failed
                             // sign-in.
                             let _ = runtime.sync_models().await;
+                            // Likewise: mount-by-default must never fail a
+                            // sign-in, and the background sync retries it.
+                            if let Err(error) = runtime.reconcile_endpoint_mounts(&mcp).await {
+                                tracing::warn!(
+                                    "gateway endpoint auto-mount after sign-in failed \
+                                     (the background sync will retry): {error}"
+                                );
+                            }
                             SignInProgress::Idle
                         }
                         Err(error) => SignInProgress::Failed {
@@ -536,10 +589,21 @@ impl GatewayRuntime {
     /// deployment — is "nothing to do", not an error: the loop waits for the
     /// state to change rather than exiting, because sign-in, pairing, and MDM
     /// pushes can all happen at any time.
-    pub(crate) async fn sync_models_periodically(self: Arc<Self>) {
+    ///
+    /// The same tick reconciles the entitled MCP endpoint mounts into `mcp`:
+    /// the boot-with-stored-session case lands on the immediate first tick,
+    /// and an admin's new entitlement reaches the tool surface within the
+    /// sync interval. Each half fails independently — a failed entitlement
+    /// fetch degrades to "no reconcile this tick", never touching the
+    /// configuration.
+    pub(crate) async fn sync_models_periodically(
+        self: Arc<Self>,
+        mcp: Arc<crate::mcp_config::McpRuntime>,
+    ) {
         // One warning per outage, not one per retry: the failure state can
         // legitimately persist for hours on an offline laptop.
         let mut warned = false;
+        let mut mount_warned = false;
         loop {
             let delay = match self.sync_models_if_connected().await {
                 Ok(synced) => {
@@ -562,6 +626,16 @@ impl GatewayRuntime {
                     MODEL_SYNC_RETRY
                 }
             };
+            match self.reconcile_endpoint_mounts(&mcp).await {
+                Ok(()) => mount_warned = false,
+                Err(error) if mount_warned => {
+                    tracing::debug!("gateway endpoint auto-mount still failing: {error}");
+                }
+                Err(error) => {
+                    tracing::warn!("gateway endpoint auto-mount failed (will retry): {error}");
+                    mount_warned = true;
+                }
+            }
             tokio::time::sleep(delay).await;
         }
     }
@@ -743,6 +817,36 @@ mod tests {
         refreshes: AtomicUsize,
         /// Every refresh token posted to `/oauth/revoke`, in order.
         revoked: std::sync::Mutex<Vec<String>>,
+        /// When set, `/api/v1/cli/apps` answers 500 — the outage shape the
+        /// endpoint-mount reconcile must degrade quietly on.
+        apps_fail: std::sync::atomic::AtomicBool,
+    }
+
+    /// One entitled connected app aggregating the fixture's `tools` MCP
+    /// endpoint, the shape `/api/v1/cli/apps` serves.
+    async fn apps(State(gateway): State<Arc<FakeGateway>>, headers: HeaderMap) -> Response {
+        if gateway.apps_fail.load(Ordering::SeqCst) {
+            return (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "apps are down",
+            )
+                .into_response();
+        }
+        let bearer = headers
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+        assert!(bearer.starts_with("Bearer mg_at_control_"), "{bearer}");
+        Json(json!({
+            "apps": [{
+                "id": "app-1",
+                "name": "Tools",
+                "app_kind": "mcp_endpoint",
+                "enabled": true,
+                "mcp_endpoint_slugs": ["tools"]
+            }]
+        }))
+        .into_response()
     }
 
     async fn token(
@@ -859,6 +963,7 @@ mod tests {
             .route("/oauth/token", post(token))
             .route("/oauth/revoke", post(revoke))
             .route("/api/v1/cli/models", get(models))
+            .route("/api/v1/cli/apps", get(apps))
             .route("/mcp/{slug}", post(mcp_endpoint))
             .with_state(gateway);
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -922,6 +1027,20 @@ mod tests {
         signed_in_runtime_at(base_url, base_url).await
     }
 
+    /// An MCP runtime resolving gateway endpoints through `runtime`, the way
+    /// the server wires the two together.
+    fn mcp_for(
+        runtime: &Arc<GatewayRuntime>,
+        store: &Arc<dyn Store>,
+    ) -> Arc<crate::mcp_config::McpRuntime> {
+        Arc::new(crate::mcp_config::McpRuntime::new(
+            Arc::new(openwave_core::ToolRegistry::new()),
+            store.clone(),
+            runtime.clone(),
+            Arc::new(crate::managed_policy::NoOsPolicy),
+        ))
+    }
+
     #[tokio::test]
     async fn syncs_entitled_models_into_the_snapshot() {
         let address = serve(Arc::new(FakeGateway::default())).await;
@@ -964,7 +1083,11 @@ mod tests {
         let base = format!("http://{address}");
         let (runtime, store, _directory) = signed_in_runtime(&base).await;
 
-        let task = tokio::spawn(runtime.clone().sync_models_periodically());
+        let task = tokio::spawn(
+            runtime
+                .clone()
+                .sync_models_periodically(mcp_for(&runtime, &store)),
+        );
         let synced = async {
             loop {
                 if let Some(snapshot) = providers::read_gateway_snapshot(&*store).await.unwrap() {
@@ -1197,12 +1320,7 @@ mod tests {
         let base = format!("http://{address}");
         let (runtime, store, _directory) = signed_in_runtime(&base).await;
 
-        let mcp = Arc::new(crate::mcp_config::McpRuntime::new(
-            Arc::new(openwave_core::ToolRegistry::new()),
-            store.clone(),
-            runtime.clone(),
-            Arc::new(crate::managed_policy::NoOsPolicy),
-        ));
+        let mcp = mcp_for(&runtime, &store);
         let definition = crate::mcp_config::McpServerDefinition {
             name: "tools".to_string(),
             command: None,
@@ -1252,6 +1370,58 @@ mod tests {
         assert!(mcp.snapshot().get("mcp__tools__lookup").is_none());
     }
 
+    /// Mount-by-default, end to end: a reconcile against the entitled apps
+    /// list mounts the endpoint enabled and connected, and a second
+    /// reconcile with unchanged entitlements is a strict no-op — the
+    /// persisted records are untouched, not rewritten to the same shape.
+    #[tokio::test]
+    async fn reconcile_auto_mounts_a_newly_entitled_endpoint_exactly_once() {
+        let address = serve(Arc::new(FakeGateway::default())).await;
+        let base = format!("http://{address}");
+        let (runtime, store, _directory) = signed_in_runtime(&base).await;
+        let mcp = mcp_for(&runtime, &store);
+
+        runtime.reconcile_endpoint_mounts(&mcp).await.unwrap();
+        let info = mcp.info().await;
+        assert_eq!(info.servers.len(), 1);
+        assert_eq!(info.servers[0].definition.name, "tools");
+        assert_eq!(
+            info.servers[0].definition.gateway_endpoint.as_deref(),
+            Some("tools")
+        );
+        assert!(info.servers[0].definition.enabled);
+        assert_eq!(
+            info.servers[0].health,
+            crate::mcp_config::McpHealth::Healthy
+        );
+        assert!(mcp.snapshot().get("mcp__tools__lookup").is_some());
+
+        let records = store.list_connected_apps().await.unwrap();
+        runtime.reconcile_endpoint_mounts(&mcp).await.unwrap();
+        assert_eq!(
+            store.list_connected_apps().await.unwrap(),
+            records,
+            "a reconcile with no new entitlements must not rewrite the records"
+        );
+    }
+
+    /// A failing entitlements fetch degrades to "no reconcile this tick":
+    /// the error surfaces to the caller (which logs and retries) and the
+    /// configuration is untouched.
+    #[tokio::test]
+    async fn a_failing_entitlements_fetch_leaves_the_configuration_untouched() {
+        let gateway = Arc::new(FakeGateway::default());
+        gateway.apps_fail.store(true, Ordering::SeqCst);
+        let address = serve(gateway).await;
+        let base = format!("http://{address}");
+        let (runtime, store, _directory) = signed_in_runtime(&base).await;
+        let mcp = mcp_for(&runtime, &store);
+
+        assert!(runtime.reconcile_endpoint_mounts(&mcp).await.is_err());
+        assert!(mcp.info().await.servers.is_empty());
+        assert!(store.list_connected_apps().await.unwrap().is_empty());
+    }
+
     /// The sign-in surface on an unmanaged profile exists exactly while a
     /// pending pairing is parked: it targets the pairing's gateway, commits
     /// nothing by merely starting, and a dismissal restores the refusal —
@@ -1274,20 +1444,15 @@ mod tests {
             Arc::new(MockSecrets::default()),
             Arc::new(crate::managed_policy::NoOsPolicy),
         );
-        let mcp = Arc::new(crate::mcp_config::McpRuntime::new(
-            Arc::new(openwave_core::ToolRegistry::new()),
-            store.clone(),
-            runtime.clone(),
-            Arc::new(crate::managed_policy::NoOsPolicy),
-        ));
+        let mcp = mcp_for(&runtime, &store);
 
         // Unmanaged with nothing pending: the legible refusal.
-        assert!(runtime.begin_sign_in().await.is_err());
+        assert!(runtime.begin_sign_in(mcp.clone()).await.is_err());
 
         runtime
             .register_pending_pairing(base.clone(), mcp.clone(), None)
             .await;
-        let url = runtime.begin_sign_in().await.unwrap();
+        let url = runtime.begin_sign_in(mcp.clone()).await.unwrap();
         assert!(
             url.starts_with(&format!("{base}oauth/authorize")),
             "sign-in must target the pending gateway: {url}"
@@ -1304,7 +1469,7 @@ mod tests {
             runtime.status().await.unwrap().sign_in,
             SignInProgress::Idle
         );
-        assert!(runtime.begin_sign_in().await.is_err());
+        assert!(runtime.begin_sign_in(mcp).await.is_err());
     }
 
     #[tokio::test]
@@ -1533,7 +1698,11 @@ mod tests {
 
         // The sign-in surface is managed-only, and the refusal names the
         // remedy.
-        let error = runtime.begin_sign_in().await.err().unwrap();
+        let error = runtime
+            .begin_sign_in(mcp_for(&runtime, &store))
+            .await
+            .err()
+            .unwrap();
         assert!(
             error.to_string().contains("pair via your gateway"),
             "{error}"

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -963,7 +963,11 @@ async fn bind_inner(
     let blob_orphan_auditor = tokio::spawn(blob_orphan_auditor.run());
     let approval_judge_worker = tokio::spawn(approval_judge_worker.run());
     let mcp_supervisor = tokio::spawn(mcp_runtime.clone().supervise());
-    let gateway_model_sync = tokio::spawn(gateway_runtime.clone().sync_models_periodically());
+    let gateway_model_sync = tokio::spawn(
+        gateway_runtime
+            .clone()
+            .sync_models_periodically(mcp_runtime.clone()),
+    );
 
     Ok(Server {
         local_addr,

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -49,6 +49,20 @@ const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(30);
 pub(crate) const MANAGED_DISABLED_DIAGNOSTIC: &str =
     "Disabled by managed policy. Gateway-managed MCP endpoints remain available.";
 
+/// Persisted memory of the gateway endpoints the user explicitly unmounted:
+/// the setting's value is a JSON array of endpoint slugs, nothing more —
+/// the shape is closed and versioned by the key. A slug is recorded when a
+/// committed settings replacement removes its mount, cleared when one
+/// configures it again, and never touched by auto-mount, so "the user turned
+/// this off" survives restarts without a second copy of the configuration.
+pub(crate) const GATEWAY_ENDPOINT_UNMOUNTS_KEY: &str = "gateway.endpoint_unmounts_v1";
+
+/// Upper bound on remembered unmounts. Entitled slugs are already bounded by
+/// the gateway and configured mounts by [`MAX_SERVERS`]; this only caps what
+/// years of shifting entitlements could accumulate. Oldest entries fall off
+/// first — an ancient unmount degrading to a re-mount the user can undo.
+const MAX_REMEMBERED_UNMOUNTS: usize = 256;
+
 /// How far managed policy locks the manual transports right now.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ManualLockdown {
@@ -911,6 +925,132 @@ impl McpRuntime {
         Ok(self.info().await)
     }
 
+    /// Mount every entitled gateway endpoint that is neither configured nor
+    /// remembered as explicitly unmounted, appending a fresh enabled
+    /// `gateway_endpoint` definition for each through the same
+    /// mutation-locked commit a settings save uses — so an auto-mount can
+    /// never interleave with a concurrent PUT. Returns whether anything was
+    /// mounted; with nothing to add there is no store write and no registry
+    /// churn, so repeat reconciles are free.
+    ///
+    /// Gateway mounts are the sanctioned transport under managed policy (the
+    /// admission check refuses only manual additions), so no lockdown branch
+    /// is needed here. An unreadable unmount memory fails closed — no
+    /// mounting — rather than resurrecting an endpoint the user turned off.
+    pub(crate) async fn auto_mount_gateway_endpoints(&self, entitled: &[String]) -> Result<bool> {
+        let _mutation = self.mutation.lock().await;
+        let mut servers = self.state.lock().await.definitions.clone();
+        let unmounts = read_endpoint_unmounts(&*self.store).await?;
+        let mut configured: HashSet<String> = servers
+            .iter()
+            .filter_map(|definition| definition.gateway_endpoint.clone())
+            .collect();
+        let mut taken: HashSet<String> = servers
+            .iter()
+            .map(|definition| definition.name.clone())
+            .collect();
+        let before = servers.len();
+        for slug in entitled {
+            if configured.contains(slug) || unmounts.iter().any(|unmounted| unmounted == slug) {
+                continue;
+            }
+            // The gateway is trusted for entitlements, not for shapes: a slug
+            // outside the endpoint contract is skipped, never persisted.
+            if openwave_connectors::validate_mcp_endpoint_slug(slug).is_err() {
+                tracing::warn!(
+                    slug = %slug,
+                    "entitled gateway MCP endpoint slug is invalid; not auto-mounting"
+                );
+                continue;
+            }
+            if servers.len() >= MAX_SERVERS {
+                tracing::warn!(
+                    slug = %slug,
+                    "MCP server list is full; not auto-mounting this gateway endpoint"
+                );
+                continue;
+            }
+            let name = gateway_mount_name(slug, &taken);
+            taken.insert(name.clone());
+            configured.insert(slug.clone());
+            servers.push(McpServerDefinition {
+                name,
+                command: None,
+                args: Vec::new(),
+                env: BTreeMap::new(),
+                env_from: Vec::new(),
+                cwd: None,
+                url: None,
+                bearer_token_env: None,
+                gateway_endpoint: Some(slug.clone()),
+                request_timeout_ms: DEFAULT_REQUEST_TIMEOUT_MS,
+                enabled: true,
+            });
+        }
+        if servers.len() == before {
+            return Ok(false);
+        }
+        self.replace_committed(McpServersConfig { servers }).await?;
+        Ok(true)
+    }
+
+    /// Record the gateway-endpoint intent a committed settings replacement
+    /// expressed, against the set published just before it: a mount removed
+    /// is an explicit unmount (auto-mount only ever adds, so a removal seen
+    /// here is always deliberate), and a slug configured again clears its
+    /// memory so a manual remount stays remounted. Best-effort by design:
+    /// the replacement itself has already committed, so a failed memory
+    /// write degrades to a possible future auto-remount, never a failed
+    /// save. Callers hold the mutation lock and have not yet published the
+    /// new state.
+    async fn remember_endpoint_unmounts(&self, new_definitions: &[McpServerDefinition]) {
+        let new_slugs: HashSet<&str> = new_definitions
+            .iter()
+            .filter_map(|definition| definition.gateway_endpoint.as_deref())
+            .collect();
+        let removed: Vec<String> = {
+            let state = self.state.lock().await;
+            state
+                .definitions
+                .iter()
+                .filter_map(|definition| definition.gateway_endpoint.as_deref())
+                .filter(|slug| !new_slugs.contains(slug))
+                .map(str::to_string)
+                .collect()
+        };
+        let mut memory = match read_endpoint_unmounts(&*self.store).await {
+            Ok(memory) => memory,
+            // The write below repairs the malformed value; losing it degrades
+            // to auto-remounts the user can undo, unlike failing every save.
+            Err(error) => {
+                tracing::warn!("gateway unmount memory is unreadable; rebuilding it: {error}");
+                Vec::new()
+            }
+        };
+        let before = memory.clone();
+        memory.retain(|slug| !new_slugs.contains(slug.as_str()));
+        for slug in removed {
+            if !memory.contains(&slug) {
+                memory.push(slug);
+            }
+        }
+        if memory.len() > MAX_REMEMBERED_UNMOUNTS {
+            let excess = memory.len() - MAX_REMEMBERED_UNMOUNTS;
+            memory.drain(..excess);
+        }
+        if memory == before {
+            return;
+        }
+        let value = serde_json::to_value(&memory).expect("a list of strings serializes infallibly");
+        if let Err(error) = self
+            .store
+            .set_setting(GATEWAY_ENDPOINT_UNMOUNTS_KEY, &value)
+            .await
+        {
+            tracing::warn!("could not persist the gateway unmount memory: {error}");
+        }
+    }
+
     #[cfg(test)]
     async fn replace_with_commit_pause(
         &self,
@@ -1050,6 +1190,9 @@ impl McpRuntime {
             );
         }
         if persist {
+            // Before the new state publishes, while the published set is
+            // still what this replacement diffs against.
+            self.remember_endpoint_unmounts(&definitions).await;
             let now = chrono::Utc::now();
             let records: Vec<ConnectedApp> = definitions
                 .iter()
@@ -1492,6 +1635,41 @@ fn manual_lockdown_applies(definition: &McpServerDefinition, lockdown: ManualLoc
     }
 }
 
+/// The remembered explicit unmounts, an empty list when nothing was ever
+/// recorded. A malformed value is an error: the auto-mount caller must fail
+/// closed on it instead of treating "unreadable" as "nothing unmounted".
+async fn read_endpoint_unmounts(store: &dyn Store) -> Result<Vec<String>> {
+    let Some(value) = store.get_setting(GATEWAY_ENDPOINT_UNMOUNTS_KEY).await? else {
+        return Ok(Vec::new());
+    };
+    serde_json::from_value(value).map_err(|error| {
+        AgentError::config(format!(
+            "invalid {GATEWAY_ENDPOINT_UNMOUNTS_KEY} setting: {error}"
+        ))
+    })
+}
+
+/// A valid, unused namespace for an auto-mounted endpoint: the slug,
+/// truncated to the name limit and de-duplicated against every configured
+/// server — the same derivation the desktop's mount toggle uses
+/// (`mountName` in `McpPanel.tsx`), so a mount gets the same name whichever
+/// side creates it. Slugs are ASCII by contract, so byte slicing is safe.
+fn gateway_mount_name(slug: &str, taken: &HashSet<String>) -> String {
+    let base = &slug[..slug.len().min(MAX_SERVER_NAME_BYTES)];
+    if !taken.contains(base) {
+        return base.to_string();
+    }
+    for n in 2u64.. {
+        let suffix = format!("_{n}");
+        let keep = base.len().min(MAX_SERVER_NAME_BYTES - suffix.len());
+        let candidate = format!("{}{suffix}", &base[..keep]);
+        if !taken.contains(&candidate) {
+            return candidate;
+        }
+    }
+    unreachable!("some numeric suffix is always free")
+}
+
 /// The diagnostic a forced-down manual server carries, so the settings list
 /// says why it is off instead of showing an unexplained disabled row.
 fn managed_lockdown_diagnostic(
@@ -1870,6 +2048,99 @@ mod tests {
             store,
             directory,
         )
+    }
+
+    /// The explicit-unmount memory end to end: a settings save that removes
+    /// a gateway mount records the slug, auto-mount never resurrects it, and
+    /// a manual remount clears the record so it stays remounted. (Signed
+    /// out, the mount persists degraded — exactly what lets this run without
+    /// a live gateway.)
+    #[tokio::test]
+    async fn an_explicit_unmount_is_remembered_and_never_auto_remounted() {
+        let (runtime, store, _directory) = test_runtime().await;
+        assert!(runtime
+            .auto_mount_gateway_endpoints(&["docs".to_string()])
+            .await
+            .unwrap());
+        let saved = saved_definitions(&store).await;
+        assert_eq!(saved.len(), 1);
+        assert_eq!(saved[0].name, "docs");
+        assert_eq!(saved[0].gateway_endpoint.as_deref(), Some("docs"));
+        assert!(saved[0].enabled);
+
+        // The user unmounts: a complete settings save without the mount.
+        runtime
+            .replace(McpServersConfig {
+                servers: Vec::new(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .get_setting(GATEWAY_ENDPOINT_UNMOUNTS_KEY)
+                .await
+                .unwrap()
+                .unwrap(),
+            serde_json::json!(["docs"])
+        );
+
+        // Auto-mount refuses to fight the recorded intent.
+        assert!(!runtime
+            .auto_mount_gateway_endpoints(&["docs".to_string()])
+            .await
+            .unwrap());
+        assert!(runtime.info().await.servers.is_empty());
+
+        // A manual remount clears the memory.
+        runtime
+            .replace(McpServersConfig {
+                servers: vec![gateway_definition("docs", "docs")],
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .get_setting(GATEWAY_ENDPOINT_UNMOUNTS_KEY)
+                .await
+                .unwrap()
+                .unwrap(),
+            serde_json::json!([])
+        );
+        // Already mounted: nothing to add, nothing rewritten.
+        assert!(!runtime
+            .auto_mount_gateway_endpoints(&["docs".to_string()])
+            .await
+            .unwrap());
+    }
+
+    /// An entitled slug colliding with a configured server name derives the
+    /// same suffixed namespace the desktop's mount toggle would, instead of
+    /// failing validation on the duplicate.
+    #[tokio::test]
+    async fn auto_mount_suffixes_a_name_a_manual_server_already_took() {
+        let (runtime, _store, _directory) = test_runtime().await;
+        runtime
+            .replace(McpServersConfig {
+                servers: vec![disabled_definition("docs", "/usr/local/bin/docs-mcp")],
+            })
+            .await
+            .unwrap();
+
+        assert!(runtime
+            .auto_mount_gateway_endpoints(&["docs".to_string()])
+            .await
+            .unwrap());
+        let info = runtime.info().await;
+        let names: Vec<&str> = info
+            .servers
+            .iter()
+            .map(|server| server.definition.name.as_str())
+            .collect();
+        assert_eq!(names, ["docs", "docs_2"]);
+        assert_eq!(
+            info.servers[1].definition.gateway_endpoint.as_deref(),
+            Some("docs")
+        );
     }
 
     #[test]

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -238,7 +238,7 @@ pub async fn get_gateway_status(
 pub async fn post_gateway_sign_in(
     State(state): State<AppState>,
 ) -> Result<Json<GatewaySignInStarted>, ServerError> {
-    let authorization_url = state.gateway.begin_sign_in().await?;
+    let authorization_url = state.gateway.begin_sign_in(state.mcp.clone()).await?;
     Ok(Json(GatewaySignInStarted { authorization_url }))
 }
 


### PR DESCRIPTION
Closes #1396

On a managed profile the organization already curated which gateway MCP endpoints the user is entitled to, so a newly entitled endpoint now mounts by default instead of waiting unmounted in Settings until the user finds the toggle.

## What changed

- **Reconcile** (`GatewayRuntime::reconcile_endpoint_mounts`): reads the same `/api/v1/cli/apps` entitlement list the settings panel shows and asks the MCP runtime to mount every slug that is neither configured nor remembered as explicitly unmounted. Every cannot-run state (unmanaged profile, no session, gateway predating the apps surface) is "nothing to do", not an error.
- **Triggers**: after a completed sign-in (best-effort, never fails the sign-in), and on every background gateway sync tick — whose immediate first tick covers boot with a stored session. Failures degrade to "no reconcile this tick" with a once-per-outage warn.
- **Mounting** (`McpRuntime::auto_mount_gateway_endpoints`): appends enabled `gateway_endpoint` definitions through the same mutation-locked replace commit a settings save uses, so it cannot interleave with a concurrent PUT. Gateway mounts are the sanctioned transport under managed policy, so the managed admission check is untouched. Name derivation mirrors the desktop toggle's `mountName` (slug truncated to the name limit, `_2`/`_3`… suffix on collision), so a mount gets the same namespace whichever side creates it. A repeat reconcile with no new entitlements performs no store write and no registry churn.
- **Unmount memory**: the `gateway.endpoint_unmounts_v1` setting holds a bounded JSON array of slugs. The server-side replace path — where both the published and candidate lists are visible — records a removed gateway mount and clears a slug configured again. Auto-mount only ever adds, so a removal seen there is always the user's. An unreadable memory fails closed for auto-mount (nothing resurrected) and is repaired best-effort by the next settings save.

## Tests

- Reconcile mounts a newly entitled endpoint end to end (fixture gateway serving `/api/v1/cli/apps` + `/mcp/{slug}`), and a second reconcile leaves the persisted records byte-identical.
- A failing entitlements fetch surfaces the error and leaves the configuration untouched.
- Explicit unmount is recorded by the replace diff, respected by auto-mount, and cleared by a manual remount.
- An entitled slug colliding with a manual server named `docs` derives `docs_2`, matching the desktop derivation.

No wire types changed; the memory is server-internal and never projected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)