### PR TITLE
feat(server): bounded profile log file for tracing events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4196,6 +4196,7 @@ dependencies = [
  "tower",
  "tower-http 0.7.0",
  "tracing",
+ "tracing-subscriber",
  "ts-rs",
  "unicode-general-category",
  "uuid",

--- a/crates/openwave-cli/src/main.rs
+++ b/crates/openwave-cli/src/main.rs
@@ -89,6 +89,9 @@ fn profile_config() -> Result<Config> {
 /// Bind the server and run its accept loop, announcing where to reach it.
 async fn serve() -> Result<()> {
     let config = profile_config()?;
+    // Tracing events land in `logs/openwave.log` under the profile data dir
+    // (plus stderr in debug builds); see `openwave_server::logging`.
+    openwave_server::logging::init_logging(&config.data_dir);
     let server = openwave_server::bind_configured(config).await?;
     // The address and token are the client's entry point: the parent process that
     // launched the daemon reads them from stdout to connect. The token is a secret,

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -250,6 +250,10 @@ pub fn run() {
             updater::install_update_menu(app)?;
             updater::spawn_update_loop(handle.clone());
             let data = data_dir(&handle)?;
+            // Before anything that can warn: the embedded server's tracing
+            // events land in `logs/openwave.log` under the profile data dir
+            // (stderr-only if that file cannot be created).
+            openwave_server::logging::init_logging(&data);
             let home = home_dir(&handle)?;
             let host_access = host_access::HostAccess::new(handle.clone(), data.clone(), home)?;
             app.manage(host_access);

--- a/crates/openwave-server/Cargo.toml
+++ b/crates/openwave-server/Cargo.toml
@@ -63,6 +63,11 @@ plist = "=1.10.0"
 # minimal misconfigured state; these warnings are the admin's field
 # diagnostic for what exactly is broken.
 tracing = "=0.1.44"
+# The shared subscriber both entry points (desktop shell, `openwave serve`)
+# install via [`logging::init_logging`]. Default features stay off: `ansi` and
+# `tracing-log` would pull crates the lockfile doesn't already resolve, and a
+# plain profile log file wants neither.
+tracing-subscriber = { version = "=0.3.23", default-features = false, features = ["fmt", "env-filter"] }
 # Bounded unified diffs for the post-turn connected-folder change summary.
 similar = "=2.7.0"
 # Private, automatically removed inputs and outputs for ephemeral document previews.

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -34,6 +34,7 @@ mod exec_write_snapshot;
 mod extract;
 mod foreground_prompt;
 mod gateway_runtime;
+pub mod logging;
 mod managed_policy;
 mod mcp_config;
 mod model_registry;

--- a/crates/openwave-server/src/logging.rs
+++ b/crates/openwave-server/src/logging.rs
@@ -1,0 +1,290 @@
+//! Process-wide tracing subscriber for the desktop shell and `openwave serve`.
+//!
+//! Events land in a bounded log file under the profile data directory —
+//! `logs/openwave.log` next to `openwave.db` — so a warning like a gateway
+//! mount failure leaves a diagnosable trace on the user's machine. When the
+//! file passes [`LOG_ROTATE_BYTES`] it is renamed to `openwave.log.1`
+//! (replacing any previous rotation) and a fresh file is started, capping the
+//! profile's log footprint at roughly two files of that size. Debug builds
+//! also mirror events to stderr for `openwave serve` / `tauri dev` terminals.
+//!
+//! The default level policy is `info` for the workspace's own `openwave*`
+//! crates and `warn` for everything else. The `OPENWAVE_LOG` environment
+//! variable overrides it with standard `tracing_subscriber::EnvFilter`
+//! directives (e.g. `OPENWAVE_LOG=debug` or
+//! `OPENWAVE_LOG=warn,openwave_server=trace`); an invalid spec falls back to
+//! the default rather than failing boot.
+//!
+//! # Redaction posture
+//!
+//! The workspace's emit sites are disciplined: reqwest errors are URL-stripped
+//! before logging, policy diagnostics name environment *variables* rather than
+//! values, and no secret or token ever appears in an error's `Display` text.
+//! This subscriber must not widen that surface: it uses the plain compact
+//! formatter (timestamp, level, target, message) and records no span-lifecycle
+//! events, so nothing beyond the literal event fields reaches disk. New log
+//! sites must uphold the same posture — log names and shapes, never values
+//! that could carry a credential, URL query, or file contents.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use tracing_subscriber::filter::EnvFilter;
+use tracing_subscriber::fmt::writer::MakeWriter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+/// Rotate `openwave.log` to `openwave.log.1` once it would pass this size.
+pub const LOG_ROTATE_BYTES: u64 = 5 * 1024 * 1024;
+
+/// Environment variable holding `EnvFilter` directives that override
+/// [`DEFAULT_DIRECTIVES`].
+const LOG_ENV_VAR: &str = "OPENWAVE_LOG";
+
+/// `info` for the workspace's own crates, `warn` for dependencies.
+const DEFAULT_DIRECTIVES: &str = "warn,openwave_cli=info,openwave_code_execution=info,\
+    openwave_connectors=info,openwave_core=info,openwave_desktop=info,openwave_egress=info,\
+    openwave_host_broker=info,openwave_mcp=info,openwave_router=info,\
+    openwave_sandbox_agent=info,openwave_sandbox_protocol=info,openwave_server=info,\
+    openwave_shell_policy=info,openwave_web_search=info";
+
+/// Install the process-global subscriber, writing to `logs/openwave.log`
+/// under `data_dir`.
+///
+/// Infallible by design: if the log directory or file cannot be created the
+/// subscriber degrades to stderr-only, and if a subscriber is already
+/// installed (tests, a second call) the call is a no-op. Logging must never
+/// block boot.
+pub fn init_logging(data_dir: &Path) {
+    let filter = env_filter();
+    match open_log_writer(data_dir) {
+        Ok(writer) => {
+            let subscriber = tracing_subscriber::registry().with(filter).with(
+                tracing_subscriber::fmt::layer()
+                    .compact()
+                    .with_ansi(false)
+                    .with_writer(writer),
+            );
+            #[cfg(debug_assertions)]
+            let subscriber = subscriber.with(
+                tracing_subscriber::fmt::layer()
+                    .compact()
+                    .with_ansi(false)
+                    .with_writer(io::stderr),
+            );
+            let _ = subscriber.try_init();
+        }
+        Err(error) => {
+            eprintln!("openwave: profile log file unavailable ({error}); logging to stderr only");
+            let subscriber = tracing_subscriber::registry().with(filter).with(
+                tracing_subscriber::fmt::layer()
+                    .compact()
+                    .with_ansi(false)
+                    .with_writer(io::stderr),
+            );
+            let _ = subscriber.try_init();
+        }
+    }
+}
+
+/// The active filter: `OPENWAVE_LOG` when set and valid, the default policy
+/// otherwise.
+fn env_filter() -> EnvFilter {
+    match std::env::var(LOG_ENV_VAR) {
+        Ok(spec) if !spec.trim().is_empty() => EnvFilter::try_new(&spec).unwrap_or_else(|error| {
+            eprintln!("openwave: invalid {LOG_ENV_VAR} ({error}); using the default filter");
+            EnvFilter::new(DEFAULT_DIRECTIVES)
+        }),
+        _ => EnvFilter::new(DEFAULT_DIRECTIVES),
+    }
+}
+
+/// Create `logs/` under the data directory and open the bounded writer.
+fn open_log_writer(data_dir: &Path) -> io::Result<RotatingFileWriter> {
+    let logs = data_dir.join("logs");
+    fs::create_dir_all(&logs)?;
+    RotatingFileWriter::new(logs.join("openwave.log"), LOG_ROTATE_BYTES)
+}
+
+/// A size-capped log file with a single rotation slot.
+///
+/// Appends to `path`; once a write would push the file past `cap` bytes, the
+/// file is renamed to `<path>.1` (replacing any previous rotation) and a
+/// fresh file is started. Best-effort throughout: a failed rotation or reopen
+/// silently drops output rather than surfacing errors into the subscriber.
+#[derive(Clone)]
+struct RotatingFileWriter {
+    inner: Arc<Mutex<RotatingFile>>,
+}
+
+struct RotatingFile {
+    path: PathBuf,
+    cap: u64,
+    /// `None` after a reopen failure; writes are then dropped.
+    file: Option<File>,
+    written: u64,
+}
+
+impl RotatingFileWriter {
+    fn new(path: PathBuf, cap: u64) -> io::Result<Self> {
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let written = file.metadata()?.len();
+        Ok(Self {
+            inner: Arc::new(Mutex::new(RotatingFile {
+                path,
+                cap,
+                file: Some(file),
+                written,
+            })),
+        })
+    }
+}
+
+impl RotatingFile {
+    /// Rename the current file to the `.1` slot and start a fresh one.
+    ///
+    /// The handle is dropped before the rename so Windows can move the file.
+    fn rotate(&mut self) {
+        if let Some(file) = self.file.take() {
+            let _ = (&file).flush();
+            drop(file);
+        }
+        let mut rotated = self.path.clone().into_os_string();
+        rotated.push(".1");
+        let rotated = PathBuf::from(rotated);
+        let _ = fs::remove_file(&rotated);
+        let _ = fs::rename(&self.path, &rotated);
+        self.file = File::create(&self.path).ok();
+        self.written = 0;
+    }
+
+    fn write_all_bytes(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if self.written > 0 && self.written.saturating_add(buf.len() as u64) > self.cap {
+            self.rotate();
+        }
+        if let Some(file) = self.file.as_mut() {
+            file.write_all(buf)?;
+            self.written += buf.len() as u64;
+        }
+        // A dead writer (reopen failure) swallows output by design; reporting
+        // an error here would only make the fmt layer spam stderr forever.
+        Ok(buf.len())
+    }
+}
+
+impl Write for RotatingFileWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self.inner.lock() {
+            Ok(mut inner) => inner.write_all_bytes(buf),
+            Err(_) => Ok(buf.len()),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if let Ok(mut inner) = self.inner.lock() {
+            if let Some(file) = inner.file.as_mut() {
+                file.flush()?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for RotatingFileWriter {
+    type Writer = RotatingFileWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Writes past the cap rotate exactly once — old bytes move to the `.1`
+    /// slot, new bytes keep landing in a fresh primary file.
+    #[test]
+    fn writes_past_the_cap_rotate_once_and_keep_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("openwave.log");
+        let mut writer = RotatingFileWriter::new(path.clone(), 64).unwrap();
+
+        let first = [b'a'; 48];
+        let second = [b'b'; 48];
+        writer.write_all(&first).unwrap();
+        // 48 + 48 > 64: this write rotates first.
+        writer.write_all(&second).unwrap();
+        // 48 + 10 <= 64: no second rotation.
+        writer.write_all(b"tail-bytes").unwrap();
+        writer.flush().unwrap();
+
+        let rotated = fs::read(dir.path().join("openwave.log.1")).unwrap();
+        assert_eq!(rotated, first);
+        let current = fs::read(&path).unwrap();
+        assert_eq!(
+            current,
+            b"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbtail-bytes"
+        );
+    }
+
+    /// A second rotation replaces the previous `.1` file instead of growing a
+    /// chain, keeping the on-disk footprint bounded.
+    #[test]
+    fn a_later_rotation_replaces_the_previous_slot() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("openwave.log");
+        let mut writer = RotatingFileWriter::new(path.clone(), 8).unwrap();
+
+        writer.write_all(b"first").unwrap();
+        writer.write_all(b"second").unwrap(); // rotates: .1 = "first"
+        writer.write_all(b"third").unwrap(); // rotates: .1 = "second"
+        writer.flush().unwrap();
+
+        let rotated = fs::read(dir.path().join("openwave.log.1")).unwrap();
+        assert_eq!(rotated, b"second");
+        assert_eq!(fs::read(&path).unwrap(), b"third");
+    }
+
+    /// The degrade trigger: an unusable log location surfaces as an error from
+    /// the writer constructor, which `init_logging` converts into stderr-only
+    /// operation. Calling `init_logging` itself here would install a
+    /// process-global stderr subscriber that spams every later test in this
+    /// binary, so only the branch point is exercised.
+    #[test]
+    fn an_uncreatable_log_directory_fails_the_writer_not_the_process() {
+        let dir = tempfile::tempdir().unwrap();
+        // A *file* where the data dir should be makes `logs/` uncreatable.
+        let occupied = dir.path().join("data");
+        fs::write(&occupied, b"not a directory").unwrap();
+        assert!(open_log_writer(&occupied).is_err());
+    }
+
+    /// Smoke: a `tracing::warn!` dispatched through the real layer stack lands
+    /// in the file. Uses a scoped dispatcher rather than `init_logging` so the
+    /// test binary's process-global subscriber slot stays free.
+    #[test]
+    fn a_warn_event_lands_in_the_log_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let writer = open_log_writer(dir.path()).unwrap();
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::new(DEFAULT_DIRECTIVES))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .compact()
+                    .with_ansi(false)
+                    .with_writer(writer),
+            );
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::warn!("gateway endpoint unreachable");
+        });
+        let contents = fs::read_to_string(dir.path().join("logs/openwave.log")).unwrap();
+        assert!(contents.contains("WARN"), "level missing: {contents:?}");
+        assert!(
+            contents.contains("gateway endpoint unreachable"),
+            "message missing: {contents:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1393

The workspace emits `tracing::warn!`/`info!` at load-bearing points (managed-policy failures, gateway MCP mount failures, MCP lockdown notices), but no crate installed a subscriber — the desktop app and `openwave serve` dropped every event. When a user hit "Could not connect to this gateway endpoint", nothing on their machine recorded the cause.

## What changed

- New `openwave_server::logging` module with `pub fn init_logging(data_dir: &Path)`, called from the desktop shell's `setup` (right after the data dir resolves, before the embedded server boots) and from `openwave serve`.
- **Sink**: `logs/openwave.log` under the profile data dir (the same root as `openwave.db`; `blobs/`, `scratch/`, `tools/` are precedent for subdirectories there — nothing enumerates that root destructively, and `desktop_schema` only touches its named files). A hand-rolled `RotatingFileWriter` (Mutex-guarded `std::io::Write`) rotates once at ~5 MiB: rename to `openwave.log.1` (replacing any previous), start fresh. Debug builds also mirror to stderr for `openwave serve` / `tauri dev`.
- **Degradation**: if `logs/` can't be created, init falls back to stderr-only and continues; a second init is a no-op (`try_init`). Logging never blocks boot.
- **Levels**: default `info` for `openwave*` crates, `warn` for everything else; `OPENWAVE_LOG` overrides with standard `EnvFilter` directives (invalid spec falls back to the default rather than failing boot).
- **Redaction posture**: plain compact formatter (timestamp/level/target/message), no span-lifecycle capture; the module doc records the posture new log sites must uphold.

## Dependency

`tracing-subscriber = =0.3.23` (the version already resolved transitively via sea-orm), `default-features = false`, features `fmt` + `env-filter` only — `env-filter`'s deps (matchers, regex-automata) are already in the lock, while default `ansi`/`tracing-log` would add nu-ansi-term and tracing-log, which are not. The `Cargo.lock` diff is the single new dependency-edge line; no resolved version changes (`cargo check --workspace --locked` passes).

## Tests

- Rotation: writes past a tiny cap rotate exactly once, old bytes in `.1`, new bytes keep landing; a later rotation replaces the `.1` slot instead of growing a chain.
- Degrade trigger: a data-dir path occupied by a file makes the writer constructor fail (the branch `init_logging` turns into stderr-only). The test does not call `init_logging` itself: that would install a process-global stderr subscriber and make every later test in the binary write uncaptured tracing output to stderr — the init-once flakiness the issue anticipated — so the fallible part is tested and the trivial fallback branch is left uncovered by design.
- Smoke: a `tracing::warn!` through the real layer stack (EnvFilter + fmt + writer) lands in `logs/openwave.log`, using a scoped dispatcher so the process-global slot stays free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)