### PR TITLE
feat(desktop): let users grant write to an already-attached folder

### DIFF
--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -512,6 +512,95 @@ pub(crate) async fn connect_approved_folder(
     .map(Some)
 }
 
+/// The capabilities the folders panel may ask to add to an attached folder.
+///
+/// Read is deliberately absent: a folder whose read consent was revoked no
+/// longer appears in the panel at all, so the recovery for that is the
+/// ordinary re-attach ceremony, not a widening of something still visible.
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum WidenedFolderCapability {
+    WriteFiles,
+    ExecuteCommands,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct GrantFolderCapabilityRequest {
+    chat_id: Uuid,
+    root_id: RootId,
+    capability: WidenedFolderCapability,
+}
+
+/// Grant one more capability to a folder this chat already has attached.
+///
+/// The same shape as attach-time consent: a native dialog names the chat, the
+/// folder, and exactly what is being allowed, and the broker records the
+/// approval as a fresh permission-dialog grant. The folder identity comes
+/// from the broker's own listing for this conversation, never from renderer
+/// strings, and the broker independently re-checks that the root is live and
+/// attached before minting anything.
+#[tauri::command]
+pub(crate) async fn grant_folder_capability(
+    app: AppHandle,
+    state: State<'_, HostAccess>,
+    request: GrantFolderCapabilityRequest,
+) -> Result<Option<bool>, String> {
+    let context = state.context(request.chat_id).await?;
+    let chat_label = conversation_label(&state, request.chat_id).await?;
+    let result = state
+        .broker
+        .operation(OperationEnvelope {
+            protocol_version: openwave_host_broker::PROTOCOL_VERSION,
+            request_id: openwave_host_broker::RequestId::new(),
+            context: context.execution,
+            request: OperationRequest::ListRoots,
+        })
+        .await
+        .map_err(|error| error.to_string())?;
+    let OperationResult::ListRoots { roots } = result else {
+        return Err("host broker returned an unexpected response".to_owned());
+    };
+    let root = roots
+        .into_iter()
+        .find(|root| root.root_id == request.root_id)
+        .ok_or_else(|| "the folder is no longer connected".to_owned())?;
+
+    let _consent = state
+        .picker
+        .try_lock()
+        .map_err(|_| "a folder permission prompt is already open".to_owned())?;
+    if !confirm_folder_widening(&app, &chat_label, &root.display_name, request.capability).await? {
+        return Ok(None);
+    }
+
+    // Resolve authority again after the user responds so a deleted or changed
+    // conversation cannot reuse the earlier context.
+    let _root_change = state.root_changes.lock().await;
+    let context = state.context(request.chat_id).await?;
+    let capability = match request.capability {
+        WidenedFolderCapability::WriteFiles => Capability::WriteFiles,
+        WidenedFolderCapability::ExecuteCommands => Capability::ExecuteCommands,
+    };
+    let result = state
+        .broker
+        .control(ControlRequest::GrantRootCapability(
+            openwave_host_broker::GrantRootCapabilityRequest {
+                subject: context.subject,
+                conversation_id: context.chat_id,
+                root_id: request.root_id,
+                capability,
+                consent_method: openwave_host_broker::ConsentMethod::PermissionDialog,
+            },
+        ))
+        .await
+        .map_err(|error| error.to_string())?;
+    let ControlResult::GrantRootCapability(result) = result else {
+        return Err("host broker returned an unexpected response".to_owned());
+    };
+    Ok(Some(result.granted))
+}
+
 #[tauri::command]
 pub(crate) async fn disconnect_folder(
     state: State<'_, HostAccess>,
@@ -599,6 +688,38 @@ async fn confirm_folder_attachment(
         .title("Connect folder")
         .buttons(MessageDialogButtons::OkCancelCustom(
             "Connect".to_owned(),
+            "Cancel".to_owned(),
+        ));
+    if let Some(window) = app.get_webview_window("main") {
+        dialog = dialog.parent(&window);
+    }
+    dialog.show(move |approved| {
+        let _ = tx.send(approved);
+    });
+    rx.await
+        .map_err(|_| "folder permission prompt closed unexpectedly".to_owned())
+}
+
+async fn confirm_folder_widening(
+    app: &AppHandle,
+    chat_label: &str,
+    display_name: &str,
+    capability: WidenedFolderCapability,
+) -> Result<bool, String> {
+    let folder_label = safe_dialog_label(display_name);
+    let allowed = match capability {
+        WidenedFolderCapability::WriteFiles => "write files in",
+        WidenedFolderCapability::ExecuteCommands => "run commands in",
+    };
+    let (tx, rx) = oneshot::channel();
+    let mut dialog = app
+        .dialog()
+        .message(format!(
+            "Allow the chat “{chat_label}” to {allowed} the connected folder “{folder_label}”?"
+        ))
+        .title("Grant folder access")
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Allow".to_owned(),
             "Cancel".to_owned(),
         ));
     if let Some(window) = app.get_webview_window("main") {

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -234,6 +234,7 @@ pub fn run() {
             host_access::list_capability_consents,
             host_access::revoke_capability_consent,
             host_access::list_connected_folders,
+            host_access::grant_folder_capability,
             host_access::disconnect_folder,
             updater::desktop_update_state,
             updater::check_for_update,

--- a/crates/openwave-desktop/ui/src/FoldersView.test.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersView.test.tsx
@@ -10,6 +10,7 @@ vi.mock("./host", () => ({
   connectApprovedFolder: vi.fn(),
   connectFolder: vi.fn(),
   disconnectFolder: vi.fn(),
+  grantFolderCapability: vi.fn(),
   listApprovedFolders: vi.fn(),
   listCapabilityConsents: vi.fn(),
   listConnectedFolders: vi.fn(),
@@ -64,6 +65,7 @@ beforeEach(() => {
   vi.mocked(host.connectApprovedFolder).mockResolvedValue(null);
   vi.mocked(host.connectFolder).mockResolvedValue(null);
   vi.mocked(host.disconnectFolder).mockResolvedValue(false);
+  vi.mocked(host.grantFolderCapability).mockResolvedValue(null);
   vi.mocked(host.revokeCapabilityConsent).mockResolvedValue(true);
 });
 
@@ -108,9 +110,10 @@ describe("FoldersView", () => {
       await screen.findByText("Read, write, and commands"),
     ).toBeInTheDocument();
     expect(screen.getByText("Read only")).toBeInTheDocument();
-    // Each statement is its own row, revocable in place.
-    expect(screen.getByText("Run commands")).toBeInTheDocument();
-    expect(screen.getByText("Write files")).toBeInTheDocument();
+    // Each held statement is its own row, revocable in place; what a folder
+    // is missing gets a grant affordance instead.
+    expect(screen.getAllByRole("button", { name: "Revoke" })).toHaveLength(4);
+    expect(screen.getAllByRole("button", { name: "Grant" })).toHaveLength(2);
   });
 
   it("revokes one statement in place and reloads what the broker holds", async () => {
@@ -136,12 +139,66 @@ describe("FoldersView", () => {
     await waitFor(() =>
       expect(host.revokeCapabilityConsent).toHaveBeenCalledWith(write),
     );
+    // The write statement is gone; what remains of it is a grant affordance.
     await waitFor(() =>
-      expect(screen.queryByText("Write files")).not.toBeInTheDocument(),
+      expect(screen.getAllByRole("button", { name: "Revoke" })).toHaveLength(1),
     );
     // The folder itself was not disconnected.
     expect(host.disconnectFolder).not.toHaveBeenCalled();
     expect(screen.getByText("Drafts")).toBeInTheDocument();
+  });
+
+  it("offers to grant what a read-only folder is missing and reloads once granted", async () => {
+    vi.mocked(host.listConnectedFolders).mockResolvedValue([
+      folder("read-only", "Archive"),
+    ]);
+    vi.mocked(host.listCapabilityConsents)
+      .mockResolvedValueOnce([statement("read-only", "read_files")])
+      .mockResolvedValue([
+        statement("read-only", "read_files"),
+        statement("read-only", "write_files"),
+      ]);
+    vi.mocked(host.grantFolderCapability).mockResolvedValue(true);
+    const user = userEvent.setup();
+    render(<FoldersView chat={chat} />);
+
+    // The missing rungs are visible before any refusal: write and commands
+    // each get a grant affordance beside the statements the folder holds.
+    await screen.findByText("Read only");
+    expect(screen.getByText("Write files")).toBeInTheDocument();
+    expect(screen.getByText("Run commands")).toBeInTheDocument();
+    const grants = screen.getAllByRole("button", { name: "Grant" });
+    expect(grants).toHaveLength(2);
+
+    await user.click(grants[0]);
+    expect(host.grantFolderCapability).toHaveBeenCalledWith(
+      chat,
+      "read-only",
+      "write_files",
+    );
+    // Consent happened natively; the panel just follows the broker's answer.
+    await waitFor(() =>
+      expect(screen.getByText("Read and write")).toBeInTheDocument(),
+    );
+    expect(screen.getAllByRole("button", { name: "Grant" })).toHaveLength(1);
+  });
+
+  it("changes nothing when native widening consent is canceled", async () => {
+    vi.mocked(host.listConnectedFolders).mockResolvedValue([
+      folder("read-only", "Archive"),
+    ]);
+    vi.mocked(host.listCapabilityConsents).mockResolvedValue([
+      statement("read-only", "read_files"),
+    ]);
+    const user = userEvent.setup();
+    render(<FoldersView chat={chat} />);
+
+    await screen.findByText("Read only");
+    await user.click(screen.getAllByRole("button", { name: "Grant" })[0]);
+
+    expect(host.grantFolderCapability).toHaveBeenCalledOnce();
+    expect(host.listConnectedFolders).toHaveBeenCalledOnce();
+    expect(screen.getByText("Read only")).toBeInTheDocument();
   });
 
   it("offers approved folders that are not already connected", async () => {

--- a/crates/openwave-desktop/ui/src/FoldersView.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersView.tsx
@@ -19,11 +19,13 @@ import {
   connectApprovedFolder,
   connectFolder,
   disconnectFolder,
+  grantFolderCapability,
   listApprovedFolders,
   listCapabilityConsents,
   listConnectedFolders,
   revokeCapabilityConsent,
   type ConnectedFolder,
+  type WidenedFolderCapability,
 } from "./host";
 import {
   PICKER_BUSY_MESSAGE,
@@ -126,6 +128,20 @@ export function FoldersView({ chat }: { chat: Chat }) {
   async function addApprovedFolder(rootId: string) {
     await withPicker(PICKER_HOLDERS.confirmApprovedFolder, () =>
       connectApprovedFolder(chat, rootId),
+    );
+  }
+
+  /**
+   * Widen one attached folder by one capability. The consent ceremony is the
+   * native host dialog — the same trust boundary attach-time approval crosses
+   * — so this only runs the request and follows the broker's answer.
+   */
+  async function widenFolder(
+    rootId: string,
+    capability: WidenedFolderCapability,
+  ) {
+    await withPicker(PICKER_HOLDERS.grantFolderCapability, () =>
+      grantFolderCapability(chat, rootId, capability),
     );
   }
 
@@ -236,11 +252,19 @@ export function FoldersView({ chat }: { chat: Chat }) {
                     folder.rootId,
                     chat,
                   );
+                  const reach = folderReach(statements);
+                  // What the folder does not yet allow is offered next to what
+                  // it does, so the recovery for a read-only folder is visible
+                  // before a refused write, not after it. Read is not offered:
+                  // a folder without read consent is not listed here at all.
+                  const missing = (
+                    ["write_files", "execute_commands"] as const
+                  ).filter((capability) => !reach.includes(capability));
                   return (
                     <FolderCard
                       key={folder.rootId}
                       name={folder.displayName}
-                      reach={folderReach(statements)}
+                      reach={reach}
                       action={
                         <Button
                           variant="outline"
@@ -273,6 +297,26 @@ export function FoldersView({ chat }: { chat: Chat }) {
                             }
                           >
                             Revoke
+                          </Button>
+                        </div>
+                      ))}
+                      {missing.map((capability) => (
+                        <div
+                          key={capability}
+                          className="flex items-center justify-between gap-3"
+                        >
+                          <span className="text-sm text-muted-foreground/60">
+                            {verbLabel({ kind: "capability", capability })}
+                          </span>
+                          <Button
+                            variant="ghost"
+                            size="xs"
+                            disabled={working}
+                            onClick={() =>
+                              void widenFolder(folder.rootId, capability)
+                            }
+                          >
+                            Grant
                           </Button>
                         </div>
                       ))}

--- a/crates/openwave-desktop/ui/src/NativePickerLatch.ts
+++ b/crates/openwave-desktop/ui/src/NativePickerLatch.ts
@@ -25,6 +25,7 @@ export type NativePickerLatchStore = {
 export const PICKER_HOLDERS = {
   connectFolder: "connect-folder",
   confirmApprovedFolder: "confirm-approved-folder",
+  grantFolderCapability: "grant-folder-capability",
   importSource: "import-source",
   exportOutput: "export-output",
   attachImage: "attach-image",

--- a/crates/openwave-desktop/ui/src/host.ts
+++ b/crates/openwave-desktop/ui/src/host.ts
@@ -86,6 +86,27 @@ export function disconnectFolder(chat: Chat, rootId: string): Promise<boolean> {
   });
 }
 
+/** The reach the folders panel can add to an already-attached folder. Read is
+ * absent on purpose: a folder whose read consent was revoked no longer
+ * appears in the panel, so its recovery is the re-attach ceremony. */
+export type WidenedFolderCapability = "write_files" | "execute_commands";
+
+/**
+ * Ask to add one capability to a folder this chat already has attached. The
+ * consent ceremony is native — a host dialog naming the chat, the folder, and
+ * exactly what is being allowed — and the approval is recorded by the broker
+ * as a fresh permission-dialog grant. Resolves `null` when the user cancels.
+ */
+export function grantFolderCapability(
+  chat: Chat,
+  rootId: string,
+  capability: WidenedFolderCapability,
+): Promise<boolean | null> {
+  return invoke("grant_folder_capability", {
+    request: { chatId: chat.id, rootId, capability },
+  });
+}
+
 export function resolveFolderAccessRequest(
   chatId: string,
   callId: string,

--- a/crates/openwave-host-broker/src/audit.rs
+++ b/crates/openwave-host-broker/src/audit.rs
@@ -72,6 +72,7 @@ pub enum AuditOperation {
     LookupRootAttachmentReceipt,
     RevokeRoot,
     RevokeGrant,
+    GrantRootCapability,
     PruneUnavailableRoot,
     ResolveExecRoots,
     ListRoots,

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -33,13 +33,14 @@ use crate::{
     path_policy::RootIdentity,
     protocol::{
         ControlEnvelope, ControlRequest, ControlResponseEnvelope, ControlResult, DirectoryEntry,
-        EntryKind, ErrorCode, ErrorResponse, GrantStatementSummary, HelloResult,
-        LookupRegisterRootReceiptRequest, LookupRegisterRootReceiptResult,
-        LookupRootAttachmentReceiptRequest, LookupRootAttachmentReceiptResult, OperationEnvelope,
-        OperationRequest, OperationResponseEnvelope, OperationResult, PathRequest,
-        ReadFileBinaryResult, ReadFileResult, RegisterRootReceipt, RegisterRootRequest,
-        RegisterRootResult, ResolveExecRootsRequest, ResolvedExecRoot, Response, ResponseEnvelope,
-        RevokeGrantRequest, RevokeGrantResult, RevokeRootRequest, RevokeRootResult, RootAccess,
+        EntryKind, ErrorCode, ErrorResponse, GrantRootCapabilityRequest, GrantRootCapabilityResult,
+        GrantStatementSummary, HelloResult, LookupRegisterRootReceiptRequest,
+        LookupRegisterRootReceiptResult, LookupRootAttachmentReceiptRequest,
+        LookupRootAttachmentReceiptResult, OperationEnvelope, OperationRequest,
+        OperationResponseEnvelope, OperationResult, PathRequest, ReadFileBinaryResult,
+        ReadFileResult, RegisterRootReceipt, RegisterRootRequest, RegisterRootResult,
+        ResolveExecRootsRequest, ResolvedExecRoot, Response, ResponseEnvelope, RevokeGrantRequest,
+        RevokeGrantResult, RevokeRootRequest, RevokeRootResult, RootAccess,
         RootAttachmentMutationKind, RootAttachmentMutationReceipt, RootAttachmentMutationRequest,
         RootAttachmentMutationResult, RootSummary, WriteFileMode, WriteFileRequest,
         WriteFileResult, MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
@@ -457,6 +458,21 @@ impl ControlAudit {
                 operation_id: None,
                 target: AuditTarget::Subject,
             }),
+            ControlRequest::GrantRootCapability(request) => Some(Self {
+                actor: AuditActor::Control {
+                    subject: request.subject,
+                    conversation_id: Some(request.conversation_id),
+                },
+                mutates: true,
+                operation: AuditOperation::GrantRootCapability,
+                grant_id: None,
+                // Naturally idempotent: an equivalent live grant makes a retry
+                // a no-op, so there is no separate mutation identity.
+                operation_id: None,
+                target: AuditTarget::Root {
+                    root_id: request.root_id,
+                },
+            }),
         }
     }
 
@@ -718,6 +734,9 @@ impl Controller {
             ControlRequest::RevokeGrant(request) => {
                 self.revoke_grant(request).map(ControlResult::RevokeGrant)
             }
+            ControlRequest::GrantRootCapability(request) => self
+                .grant_root_capability(request)
+                .map(ControlResult::GrantRootCapability),
         }
     }
 
@@ -1086,6 +1105,63 @@ impl Controller {
                 .map_err(error_response)?;
         }
         Ok(RevokeGrantResult { revoked })
+    }
+
+    /// Widen one attached root by one capability, with fresh consent.
+    ///
+    /// The mirror of [`Broker::revoke_grant`] at the same statement
+    /// granularity, for the folders panel's "allow write to this folder"
+    /// affordance. The boundary is deliberately narrow: the root must be live
+    /// (a set-aside root's directory cannot be confirmed) and already attached
+    /// to the requesting conversation, so this can deepen reach over a folder
+    /// the user is looking at but can never introduce a folder or attachment.
+    /// `Grant::from_consent` rejects capability/scope vocabulary that does not
+    /// describe an operation class, so only the per-root capabilities — read,
+    /// write, exec — can be minted here.
+    fn grant_root_capability(
+        &self,
+        request: GrantRootCapabilityRequest,
+    ) -> Result<GrantRootCapabilityResult, ErrorResponse> {
+        validate_subject_conversation(request.subject, request.conversation_id)
+            .map_err(error_response)?;
+        // A widening records a consent interaction the desktop actually held.
+        // The picker methods describe choosing a folder, not answering a
+        // capability question, and `CarriedForward` describes a migration.
+        if !matches!(request.consent_method, ConsentMethod::PermissionDialog) {
+            return Err(error_response(BrokerError::InvalidConsentMethod));
+        }
+        let mut state = self.lock_state().map_err(error_response)?;
+        let mut next = state.clone();
+        if !next.roots.contains_key(&request.root_id) {
+            return Err(error_response(BrokerError::UnknownRoot));
+        }
+        if !has_root_attachment(&next, request.conversation_id, request.root_id) {
+            return Err(error_response(BrokerError::Denied));
+        }
+        let already_granted = next.grants.iter().any(|grant| {
+            grant.subject() == request.subject
+                && grant.capability() == request.capability
+                && matches!(*grant.scope(), Scope::Root { root_id } if root_id == request.root_id)
+        });
+        if already_granted {
+            return Ok(GrantRootCapabilityResult { granted: false });
+        }
+        next.grants.push(
+            Grant::from_consent(
+                GrantId::new(),
+                request.subject,
+                request.capability,
+                Scope::Root {
+                    root_id: request.root_id,
+                },
+                ConsentRecord::new(request.consent_method, Utc::now()),
+            )
+            .map_err(BrokerError::from)
+            .map_err(error_response)?,
+        );
+        self.commit_state(&mut state, next)
+            .map_err(error_response)?;
+        Ok(GrantRootCapabilityResult { granted: true })
     }
 
     fn commit_state(

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -454,6 +454,112 @@ fn revoking_read_cascades_to_exec() {
     assert!(remaining.contains(&Capability::ListRoots));
 }
 
+/// The widening boundary: an attached read-only folder can regain write
+/// through a fresh permission-dialog consent — and only through one. The
+/// request cannot reach an unattached conversation, an unknown root, or claim
+/// a consent interaction the picker methods describe, and a retry after the
+/// grant stands is a no-op rather than a duplicate statement.
+#[test]
+fn granting_write_to_an_attached_root_requires_fresh_dialog_consent() {
+    let (_temp, broker, path) = setup();
+    let controller = broker.controller();
+    let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    let root_id = register(&controller, subject, conversation, path, OperationId::new())
+        .root
+        .root_id;
+    let context = ExecutionContext::standalone(conversation).unwrap();
+    let write_grant = |grants: Vec<GrantStatementSummary>| {
+        grants
+            .into_iter()
+            .find(|grant| grant.capability == Capability::WriteFiles)
+    };
+    let widen = |subject, conversation_id, root_id, consent_method| {
+        unwrap_response(controller.handle(ControlEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: crate::RequestId::new(),
+            request: ControlRequest::GrantRootCapability(GrantRootCapabilityRequest {
+                subject,
+                conversation_id,
+                root_id,
+                capability: Capability::WriteFiles,
+                consent_method,
+            }),
+        }))
+    };
+
+    // The pre-v3 shape: write consent was never recorded for this root.
+    let original = write_grant(grant_statements(&controller)).unwrap();
+    assert!(revoke_grant(&controller, subject, original.grant_id));
+    let listed_write = || {
+        let OperationResult::ListRoots { roots } =
+            operate(&broker.operator(), context, OperationRequest::ListRoots).unwrap()
+        else {
+            panic!("unexpected operation result")
+        };
+        roots[0].capabilities.contains(&Capability::WriteFiles)
+    };
+    assert!(!listed_write());
+
+    // Wrong consent vocabulary, wrong conversation, wrong root: all refused.
+    assert!(widen(subject, conversation, root_id, ConsentMethod::FolderPicker).is_err());
+    let stranger = Uuid::new_v4();
+    assert_eq!(
+        widen(
+            GrantSubject::conversation(stranger).unwrap(),
+            stranger,
+            root_id,
+            ConsentMethod::PermissionDialog,
+        )
+        .unwrap_err()
+        .code,
+        ErrorCode::Denied
+    );
+    assert!(widen(
+        subject,
+        conversation,
+        RootId::new(),
+        ConsentMethod::PermissionDialog
+    )
+    .is_err());
+    assert!(!listed_write());
+
+    // The real widening mints one statement with dialog provenance, and the
+    // same `authorize()` rows the listing reads now allow writing.
+    assert_eq!(
+        widen(
+            subject,
+            conversation,
+            root_id,
+            ConsentMethod::PermissionDialog
+        )
+        .unwrap(),
+        ControlResult::GrantRootCapability(GrantRootCapabilityResult { granted: true })
+    );
+    assert!(listed_write());
+    let minted = write_grant(grant_statements(&controller)).unwrap();
+    assert_eq!(minted.consent_method, ConsentMethod::PermissionDialog);
+
+    // A retry observes the standing grant instead of minting a second row.
+    assert_eq!(
+        widen(
+            subject,
+            conversation,
+            root_id,
+            ConsentMethod::PermissionDialog
+        )
+        .unwrap(),
+        ControlResult::GrantRootCapability(GrantRootCapabilityResult { granted: false })
+    );
+    assert_eq!(
+        grant_statements(&controller)
+            .into_iter()
+            .filter(|grant| grant.capability == Capability::WriteFiles)
+            .count(),
+        1
+    );
+}
+
 #[test]
 fn an_empty_conversation_lists_no_roots_without_needing_a_grant() {
     let (_temp, broker, _path) = setup();

--- a/crates/openwave-host-broker/src/lib.rs
+++ b/crates/openwave-host-broker/src/lib.rs
@@ -31,15 +31,16 @@ pub use id::{
 pub use path_policy::{RootPolicy, RootPolicyError, ValidatedRoot};
 pub use protocol::{
     ControlEnvelope, ControlRequest, ControlResponseEnvelope, ControlResult, DirectoryEntry,
-    EntryKind, ErrorCode, ErrorResponse, GrantStatementSummary, HelloResult,
-    LookupRegisterRootReceiptRequest, LookupRegisterRootReceiptResult,
-    LookupRootAttachmentReceiptRequest, LookupRootAttachmentReceiptResult, OperationEnvelope,
-    OperationRequest, OperationResponseEnvelope, OperationResult, PathRequest,
-    ReadFileBinaryResult, ReadFileResult, RegisterRootReceipt, RegisterRootRequest,
-    RegisterRootResult, ResolveExecRootsRequest, ResolvedExecRoot, Response, ResponseEnvelope,
-    RevokeGrantRequest, RevokeGrantResult, RevokeRootRequest, RevokeRootResult, RootAccess,
-    RootAttachmentMutationKind, RootAttachmentMutationReceipt, RootAttachmentMutationRequest,
-    RootAttachmentMutationResult, RootSummary, WriteApproval, WriteFileMode, WriteFileRequest,
-    WriteFileResult, MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
+    EntryKind, ErrorCode, ErrorResponse, GrantRootCapabilityRequest, GrantRootCapabilityResult,
+    GrantStatementSummary, HelloResult, LookupRegisterRootReceiptRequest,
+    LookupRegisterRootReceiptResult, LookupRootAttachmentReceiptRequest,
+    LookupRootAttachmentReceiptResult, OperationEnvelope, OperationRequest,
+    OperationResponseEnvelope, OperationResult, PathRequest, ReadFileBinaryResult, ReadFileResult,
+    RegisterRootReceipt, RegisterRootRequest, RegisterRootResult, ResolveExecRootsRequest,
+    ResolvedExecRoot, Response, ResponseEnvelope, RevokeGrantRequest, RevokeGrantResult,
+    RevokeRootRequest, RevokeRootResult, RootAccess, RootAttachmentMutationKind,
+    RootAttachmentMutationReceipt, RootAttachmentMutationRequest, RootAttachmentMutationResult,
+    RootSummary, WriteApproval, WriteFileMode, WriteFileRequest, WriteFileResult,
+    MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
 };
 pub use relative_path::{RelativePath, RelativePathError};

--- a/crates/openwave-host-broker/src/protocol.rs
+++ b/crates/openwave-host-broker/src/protocol.rs
@@ -101,6 +101,16 @@ pub enum ControlRequest {
     /// operation id — the grant id already names the exact row, so a retry
     /// observes `revoked: false` and nothing can be withdrawn twice.
     RevokeGrant(RevokeGrantRequest),
+    /// Widen what an already-connected root allows for one subject.
+    ///
+    /// The inverse of [`ControlRequest::RevokeGrant`] at the same statement
+    /// granularity: one capability over one registered root, backed by a fresh
+    /// trusted consent interaction. It cannot register a root or attach one —
+    /// the folder must already be attached to the requesting conversation, so
+    /// this only ever deepens reach the user can already see in the folders
+    /// panel. No operation id — an equivalent live grant makes a retry observe
+    /// `granted: false`, so nothing can be minted twice.
+    GrantRootCapability(GrantRootCapabilityRequest),
 }
 
 /// Strict payload for a native-picker root registration.
@@ -190,6 +200,23 @@ pub struct RevokeGrantRequest {
     /// indistinguishable from a grant that does not exist.
     pub subject: GrantSubject,
     pub grant_id: GrantId,
+}
+
+/// Strict payload for widening one attached root by one capability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GrantRootCapabilityRequest {
+    /// Trusted subject receiving the grant; must match `conversation_id` when
+    /// conversation-scoped, exactly as attachment mutations require.
+    pub subject: GrantSubject,
+    /// Conversation whose attachment authorizes the widening.
+    pub conversation_id: Uuid,
+    pub root_id: RootId,
+    pub capability: Capability,
+    /// Fresh trusted consent for the widening. Only
+    /// [`crate::ConsentMethod::PermissionDialog`] is accepted: the broker
+    /// refuses to record an interaction the desktop did not actually hold.
+    pub consent_method: ConsentMethod,
 }
 
 /// Capability-checked agent operations.
@@ -347,6 +374,7 @@ pub enum ControlResult {
     LookupRootAttachmentReceipt(LookupRootAttachmentReceiptResult),
     RevokeRoot(RevokeRootResult),
     RevokeGrant(RevokeGrantResult),
+    GrantRootCapability(GrantRootCapabilityResult),
 }
 
 /// One currently authorized host root for native local execution.
@@ -524,6 +552,17 @@ pub struct RevokeRootResult {
 #[serde(deny_unknown_fields)]
 pub struct RevokeGrantResult {
     pub revoked: bool,
+}
+
+/// Result of an idempotent single-capability widening.
+///
+/// `granted` is `false` when an equivalent live grant already covers the
+/// request — a retry after a lost response, or a capability the subject never
+/// lost. Either way the subject holds the capability afterwards.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GrantRootCapabilityResult {
+    pub granted: bool,
 }
 
 /// Portable kind of one addressable directory entry.


### PR DESCRIPTION
Closes #1114.

A folder attached before broker state v3 loads read-only — #1113 correctly stopped the migration from forging write consent — and until now the only way to widen it was detach and re-attach, discovered mid-turn by a refused write.

This adds an explicit widening path with real consent:

- The broker gains a `GrantRootCapability` control request, the inverse of `RevokeGrant` at the same statement granularity: one capability over one registered root, recorded as a fresh `PermissionDialog` grant. The boundary is narrow — the root must be live and already attached to the requesting conversation, only `PermissionDialog` consent is accepted, and `Grant::from_consent`'s vocabulary check limits it to the per-root capabilities. No operation id: an equivalent standing grant makes a retry observe `granted: false` instead of minting a duplicate statement.
- The desktop's `grant_folder_capability` command runs the same native consent ceremony as attach-time: a host dialog naming the chat, the folder (by the broker's own display name for this conversation, not renderer strings), and exactly what is being allowed. Write and commands are offered; read is deliberately not — a folder without read consent no longer appears in the panel at all, so its recovery is the ordinary re-attach ceremony.
- In the folders panel, each connected folder's card now shows the capabilities it is missing next to the statements it holds, each with a Grant affordance — so the recovery for a read-only folder is visible before the refusal, not after it.

One broker test covers the widening boundary end to end (revoked write, refused consent vocabulary / stranger conversation / unknown root, real grant with dialog provenance, idempotent retry); two renderer tests cover the affordance and the canceled-dialog path. Two existing assertions were updated because capability labels now also appear as grant rows.