### PR TITLE
fix(desktop): cfg-gate the macOS-only halves of the LibreOffice installer

### DIFF
--- a/crates/openwave-desktop/src/office_install.rs
+++ b/crates/openwave-desktop/src/office_install.rs
@@ -44,7 +44,6 @@
 //! rest of the app run and reported alongside the install hint. Nothing
 //! re-downloads on its own; the user's explicit retry clears the memory.
 
-#[cfg(target_os = "macos")]
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -53,7 +52,6 @@ use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-#[cfg(target_os = "macos")]
 use sha2::{Digest, Sha256};
 use tauri::AppHandle;
 #[cfg(target_os = "macos")]
@@ -467,7 +465,9 @@ async fn download(
 }
 
 /// SHA-256 of a file's contents, streamed, as lowercase hex.
-#[cfg(target_os = "macos")]
+// Compiled on every platform — its test is platform-neutral — but only the
+// macOS install path calls it from the lib target.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 fn sha256_hex_of_file(path: &Path) -> std::io::Result<String> {
     let mut file = std::fs::File::open(path)?;
     let mut hasher = Sha256::new();

--- a/crates/openwave-desktop/src/office_install.rs
+++ b/crates/openwave-desktop/src/office_install.rs
@@ -44,6 +44,7 @@
 //! rest of the app run and reported alongside the install hint. Nothing
 //! re-downloads on its own; the user's explicit retry clears the memory.
 
+#[cfg(target_os = "macos")]
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -52,20 +53,28 @@ use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
+#[cfg(target_os = "macos")]
 use sha2::{Digest, Sha256};
-use tauri::{AppHandle, Emitter as _};
+use tauri::AppHandle;
+#[cfg(target_os = "macos")]
+use tauri::Emitter as _;
 
 /// The exact LibreOffice version this build installs and trusts.
 pub(crate) const LIBREOFFICE_VERSION: &str = "25.8.7";
 
 /// Shown in UI copy and used for the disk-space check; the aarch64 dmg is
 /// 299,584,229 bytes and the copied bundle about 816 MB.
+#[cfg(target_os = "macos")]
 const REQUIRED_FREE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 
 /// Progress events the preview panel renders as a determinate bar.
+#[cfg(target_os = "macos")]
 pub(crate) const INSTALL_PROGRESS_EVENT: &str = "presentation-converter-install-progress";
 
 struct PinnedArtifact {
+    // Read only by the macOS install path; other platforms carry the pinned
+    // shape (`PINNED = None`) without an installer to consume the URL.
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     url: &'static str,
     sha256: &'static str,
 }
@@ -458,6 +467,7 @@ async fn download(
 }
 
 /// SHA-256 of a file's contents, streamed, as lowercase hex.
+#[cfg(target_os = "macos")]
 fn sha256_hex_of_file(path: &Path) -> std::io::Result<String> {
     let mut file = std::fs::File::open(path)?;
     let mut hasher = Sha256::new();


### PR DESCRIPTION
#1397 landed with its install path `#[cfg(target_os = "macos")]`-gated but several supporting definitions unconditional — `REQUIRED_FREE_BYTES`, `INSTALL_PROGRESS_EVENT`, `PinnedArtifact::url`, `sha256_hex_of_file`, and the `Emitter`/`Read`/`sha2` imports. Its own PR rode the fast gate (desktop-only diff skips clippy), so the dead-code errors only surface in Linux workspace clippy — post-merge on main and on every unrelated `full-ci` PR, which is how it was found (blocking #1399/#1402).

Fix: gate the definitions to match their uses; `PinnedArtifact::url` gets `cfg_attr(not(macos), allow(dead_code))` since the struct shape is shared by the cross-platform `PINNED = None` arm. No behavior change on any platform. `full-ci` applied so the Linux clippy lane proves the fix pre-merge (macOS-local clippy cannot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)