### PR TITLE
fix(server): run the wrap-up when a lease segment resumes with zero step budget

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -1270,16 +1270,14 @@ impl Agent {
         // turn boundary or a crash-recovery resume.
         let mut repeat_streak: Option<((String, String), usize)> = None;
 
-        // A turn with no budget at all has nothing to wrap up: there is no work
-        // in flight and no prose to preserve, so it stays the hard failure the
-        // worker's accounting expects.
-        if self.config.max_steps == 0 {
-            return Err(AgentError::msg("max steps per turn exceeded"));
-        }
-
         // One iteration past the budget is the wrap-up: the model is told the
         // turn is over and asked for a closing answer with no tools advertised,
         // so exhausting the budget ends in a real message rather than an error.
+        // A zero budget is the degenerate case of the same contract: a lease
+        // segment resuming after the budget was spent — a parked checkpoint on
+        // the last budgeted step, or a retried wrap-up failure — goes straight
+        // to the wrap-up call, which is safe to admit because it consumes no
+        // budget and cannot ask for another round (#1181).
         for step in 0..=self.config.max_steps {
             let wrap_up = step >= self.config.max_steps;
             // The wrap-up call is outside the budget. Counting it would let a
@@ -6211,15 +6209,15 @@ mod tests {
             store.clone(),
             AgentConfig {
                 model: "fake".into(),
-                max_steps: 0,
                 ..Default::default()
             },
         );
         let (failure_tx, failure_rx) = unbounded();
+        // An invalid first event ordinal fails execution before any event.
         let error = failing_agent
-            .run_claimed_turn(&chat, failed_turn_id, MessageId::new(), 1, &failure_tx)
+            .run_claimed_turn(&chat, failed_turn_id, MessageId::new(), 0, &failure_tx)
             .await
-            .expect_err("the zero-step guard fails execution");
+            .expect_err("the identity guard fails execution");
         drop(failure_tx);
         let failure_events = emitted_events(failure_rx.collect().await);
         assert!(failure_events.iter().all(|event| !matches!(

--- a/crates/openwave-server/src/tests/lifecycle.rs
+++ b/crates/openwave-server/src/tests/lifecycle.rs
@@ -2089,11 +2089,28 @@ async fn resumed_worker_preserves_checkpoint_usage_and_step_budget() {
     resolve_parked_client_call(&*store, exhausted_chat.id, &exhausted_call).await;
     state.turn_job_wake.notify_one();
     let exhausted_events = wait_for_turn(&store, exhausted_chat.id).await;
+    // The checkpoint spent the whole step budget, so the resuming segment has
+    // zero steps left. It still owes the user a closing answer: the resume
+    // runs the tool-free wrap-up call instead of failing (#1181), and the
+    // wrap-up stays outside the budget in the durable accounting.
     assert!(matches!(
         exhausted_events.last().map(|event| &event.event),
-        Some(AgentEvent::TurnFailed { error }) if error.kind == "max_steps_exceeded"
+        Some(AgentEvent::TurnCompleted { usage, .. })
+            if *usage == Usage {
+                input_tokens: exhausted_progress.usage.input_tokens + 2,
+                output_tokens: exhausted_progress.usage.output_tokens + 1,
+                cache_read_input_tokens: exhausted_progress.usage.cache_read_input_tokens,
+                cache_creation_input_tokens: exhausted_progress.usage.cache_creation_input_tokens,
+            }
     ));
-    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    let exhausted_turn = store
+        .list_turn_runs(exhausted_chat.id)
+        .await
+        .unwrap()
+        .pop()
+        .unwrap();
+    assert_eq!(exhausted_turn.model_steps, 2);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -2283,11 +2300,12 @@ async fn worker_checkpoints_a_client_tool_and_resumes_after_its_result() {
         },
         openwave_core::ApprovalClass::ReadOnly,
     );
+    let exhausted_requests = Arc::new(std::sync::Mutex::new(Vec::new()));
     let exhausted_state = AppState::new(
         Config::desktop(exhausted_dir.path()),
         exhausted_store.clone(),
         Arc::new(FixedResolver(Arc::new(ClientThenFinishProvider {
-            requests: Arc::new(std::sync::Mutex::new(Vec::new())),
+            requests: exhausted_requests.clone(),
         }))),
         Arc::new(MemSecrets::default()),
         Arc::new(exhausted_tools),
@@ -2299,7 +2317,7 @@ async fn worker_checkpoints_a_client_tool_and_resumes_after_its_result() {
     );
     let exhausted_token = exhausted_state.token.clone();
     spawn_turn_worker(&exhausted_state);
-    let exhausted_router = app(exhausted_state);
+    let exhausted_router = app(exhausted_state.clone());
     let exhausted_bearer = format!("Bearer {exhausted_token}");
     let exhausted_chat = make_chat(&exhausted_router, &exhausted_bearer).await;
     let exhausted_turn_id = TurnId::new();
@@ -2314,19 +2332,63 @@ async fn worker_checkpoints_a_client_tool_and_resumes_after_its_result() {
         .await,
         StatusCode::ACCEPTED
     );
+    // The client tool call landed on the last budgeted step. The turn still
+    // parks — refusing here would throw the call away — and the resuming
+    // zero-budget segment closes with the tool-free wrap-up call (#1181).
+    let exhausted_pending = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let pending = exhausted_store
+                .list_pending_client_tool_calls(exhausted_chat.id)
+                .await
+                .unwrap();
+            if let Some(call) = pending.into_iter().next() {
+                break call;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("the last budgeted step still parks its client tool");
+    let exhausted_parked = exhausted_store
+        .get_turn_run(exhausted_turn_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(exhausted_parked.status, TurnRunStatus::WaitingForClient);
+    assert_eq!(exhausted_parked.model_steps, 1);
+    resolve_parked_client_call(
+        &*exhausted_store,
+        exhausted_chat.id,
+        &ClientToolCallRequest {
+            id: exhausted_pending.id,
+            chat_id: exhausted_pending.chat_id,
+            turn_id: exhausted_pending.turn_id,
+            provider_id: exhausted_pending.provider_id.clone(),
+            name: exhausted_pending.name.clone(),
+            arguments: exhausted_pending.arguments.clone(),
+        },
+    )
+    .await;
+    exhausted_state.turn_job_wake.notify_one();
     let exhausted_events = wait_for_turn(&exhausted_store, exhausted_chat.id).await;
     assert!(matches!(
         exhausted_events.last().map(|event| &event.event),
-        Some(AgentEvent::TurnFailed { error }) if error.kind == "max_steps_exceeded"
+        Some(AgentEvent::TurnCompleted { .. })
     ));
+    {
+        // The resumed segment had no steps left, so its one model call is the
+        // wrap-up: no tools advertised, tool result in the transcript.
+        let exhausted_requests = exhausted_requests.lock().unwrap();
+        assert_eq!(exhausted_requests.len(), 2);
+        assert!(exhausted_requests[1].tools.is_empty());
+    }
     let exhausted_turn = exhausted_store
         .get_turn_run(exhausted_turn_id)
         .await
         .unwrap()
         .unwrap();
+    // The wrap-up is outside the budget: only the tool step is counted.
     assert_eq!(exhausted_turn.model_steps, 1);
-    assert_eq!(exhausted_turn.usage.input_tokens, 5);
-    assert_eq!(exhausted_turn.usage.output_tokens, 2);
     assert!(exhausted_store
         .list_pending_client_tool_calls(exhausted_chat.id)
         .await

--- a/crates/openwave-server/src/tests/workers.rs
+++ b/crates/openwave-server/src/tests/workers.rs
@@ -757,6 +757,110 @@ async fn worker_retries_a_transient_provider_failure_without_a_terminal_event() 
     assert_eq!(turn.status, TurnRunStatus::Completed);
 }
 
+/// A retryable provider failure during the wrap-up call resumes into the
+/// wrap-up, not a `max_steps_exceeded` failure (#1181). The retrying lease
+/// segment arrives with zero remaining step budget — the budget was spent
+/// before the wrap-up, which is deliberately outside it — and must still be
+/// allowed to make the one tool-free closing call.
+#[tokio::test(flavor = "multi_thread")]
+async fn zero_budget_resume_runs_the_wrap_up_instead_of_failing() {
+    struct WrapUpFailOnce {
+        calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for WrapUpFailOnce {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("wrap-up-fail-once")
+        }
+
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            match self.calls.fetch_add(1, Ordering::SeqCst) {
+                // The only budgeted step: spend it on a tool call.
+                0 => Ok(stream::iter(vec![
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: "call_1".into(),
+                        name: "read_file".into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: "{}".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ])
+                .boxed()),
+                // The wrap-up call fails retryably; the retry claims the turn
+                // with its whole step budget already consumed.
+                1 => Err(AgentError::Provider("injected wrap-up failure".into())),
+                _ => Ok(stream::iter(vec![
+                    ProviderEvent::TextDelta {
+                        text: "wrapped up after resume".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ])
+                .boxed()),
+            }
+        }
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let store: Arc<dyn Store> = Arc::new(
+        DbStore::connect(&format!(
+            "sqlite://{}?mode=rwc",
+            dir.path().join("t.db").display()
+        ))
+        .await
+        .unwrap(),
+    );
+    let calls = Arc::new(AtomicUsize::new(0));
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store.clone(),
+        Arc::new(FixedResolver(Arc::new(WrapUpFailOnce {
+            calls: calls.clone(),
+        }))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(ToolRegistry::new()),
+        AgentConfig {
+            model: "fake".into(),
+            max_steps: 1,
+            ..AgentConfig::default()
+        },
+    );
+    let token = state.token.clone();
+    spawn_turn_worker(&state);
+    let router = app(state);
+    let bearer = format!("Bearer {token}");
+    let chat = make_chat(&router, &bearer).await;
+    assert_eq!(
+        send_message(&router, &bearer, chat.id, "go").await,
+        StatusCode::ACCEPTED
+    );
+
+    let events = wait_for_turn(&store, chat.id).await;
+    assert_eq!(calls.load(Ordering::SeqCst), 3);
+    assert!(matches!(
+        events.last().map(|event| &event.event),
+        Some(AgentEvent::TurnCompleted { .. })
+    ));
+    let turn = store.list_turn_runs(chat.id).await.unwrap().pop().unwrap();
+    assert_eq!(turn.status, TurnRunStatus::Completed);
+    assert_eq!(turn.attempt_count, 2);
+    // The wrap-up is outside the budget: only the tool step is counted.
+    assert_eq!(turn.model_steps, 1);
+    assert!(store
+        .list_messages(chat.id)
+        .await
+        .unwrap()
+        .iter()
+        .any(|message| message.content == "wrapped up after resume"));
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn scanner_won_failure_does_not_wedge_the_only_worker_lane() {
     struct FailOnceProvider {

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -537,7 +537,15 @@ impl TurnWorker {
         let mut checkpoint_usage = openwave_core::Usage::default();
         let mut checkpoint_steps = 0_usize;
         let mut continuation_instruction = None;
-        if remaining_steps == 0 {
+        // A segment arriving with zero remaining steps is not refused: the
+        // budget was spent by earlier segments — a checkpoint parked on the
+        // last budgeted step, or a wrap-up whose provider call failed
+        // retryably — and the agent runs the wrap-up-only attempt those
+        // segments still owe the user (#1181). The wrap-up is outside the
+        // budget by design, so `max_steps = 0` admits exactly one tool-free
+        // model call and nothing else. Only a turn that never had a budget in
+        // the first place stays a hard failure: there is no work to wrap up.
+        if remaining_steps == 0 && consumed_steps == 0 {
             return self
                 .record_failure(
                     &turn,
@@ -545,7 +553,7 @@ impl TurnWorker {
                     total_model_steps,
                     turn.usage,
                     "max_steps_exceeded",
-                    "max steps per turn were consumed before this lease segment",
+                    "the turn was configured with no step budget",
                 )
                 .await;
         }
@@ -930,7 +938,9 @@ impl TurnWorker {
                     steer_revision,
                     model_steps,
                 }) => {
-                    if model_steps == 0 || model_steps > remaining_steps {
+                    // A wrap-up-only attempt — dispatched with a zero budget —
+                    // is the one shape that legitimately reports zero steps.
+                    if model_steps > remaining_steps || (model_steps == 0 && remaining_steps != 0) {
                         return Err(AgentError::msg(format!(
                             "turn {} returned an invalid model-step count {model_steps}",
                             turn.id
@@ -1250,19 +1260,9 @@ impl TurnWorker {
                                 .await;
                         }
                     };
-                    if remaining_steps == 0 {
-                        drop(active);
-                        return self
-                            .record_failure(
-                                &turn,
-                                lease_token,
-                                total_model_steps,
-                                total_usage,
-                                "max_steps_exceeded",
-                                "max steps per turn exceeded before client tool execution",
-                            )
-                            .await;
-                    }
+                    // Parking on the last budgeted step is fine: the resuming
+                    // segment arrives with zero steps and runs the wrap-up,
+                    // which reads the client tool's result (#1181).
                     if !client_checkpoint_is_valid(
                         surface.tools.as_ref(),
                         turn.chat_id,
@@ -1471,19 +1471,9 @@ impl TurnWorker {
                                 .await;
                         }
                     };
-                    if remaining_steps == 0 {
-                        drop(active);
-                        return self
-                            .record_failure(
-                                &turn,
-                                lease_token,
-                                total_model_steps,
-                                total_usage,
-                                "max_steps_exceeded",
-                                "max steps per turn exceeded before sandbox delegation",
-                            )
-                            .await;
-                    }
+                    // Parking on the last budgeted step is fine: the resuming
+                    // segment arrives with zero steps and runs the wrap-up,
+                    // which reads the delegation's result (#1181).
                     if !sandbox_spawn_checkpoint_is_valid(surface.tools.as_ref(), &request) {
                         drop(active);
                         return self
@@ -1738,19 +1728,9 @@ impl TurnWorker {
                                 .await;
                         }
                     };
-                    if remaining_steps == 0 {
-                        drop(active);
-                        return self
-                            .record_failure(
-                                &turn,
-                                lease_token,
-                                total_model_steps,
-                                total_usage,
-                                "max_steps_exceeded",
-                                "max steps per turn exceeded before waiting for background agents",
-                            )
-                            .await;
-                    }
+                    // Parking on the last budgeted step is fine: the resuming
+                    // segment arrives with zero steps and runs the wrap-up,
+                    // which reads the children's results (#1181).
                     if !agent_wait_checkpoint_is_valid(surface.tools.as_ref(), &request) {
                         drop(active);
                         return self
@@ -1939,7 +1919,9 @@ impl TurnWorker {
                     usage,
                     model_steps,
                 }) => {
-                    if model_steps == 0 || model_steps > remaining_steps {
+                    // A wrap-up-only attempt reports zero steps when it fails,
+                    // exactly as it does when it completes.
+                    if model_steps > remaining_steps || (model_steps == 0 && remaining_steps != 0) {
                         return Err(AgentError::msg(format!(
                             "turn {} returned an invalid failed model-step count {model_steps}",
                             turn.id


### PR DESCRIPTION
`turn_worker.rs` refused a lease segment with zero remaining steps before the agent ran, so two paths still ended in the `max_steps_exceeded` failure that #1178's graceful wrap-up was meant to eliminate: a turn that consumed its full budget and then parked on a client-tool or sandbox checkpoint, and a retryable provider failure during the wrap-up call itself. In both cases the user lost the turn's closing prose to an error.

The wrap-up is deliberately outside the step budget, which is what makes a zero-budget attempt safe: it advertises no tools, makes one model call, and is terminal by construction.

- The agent loop treats `max_steps = 0` as a wrap-up-only attempt instead of a hard error; the existing `0..=max_steps` loop already runs exactly the wrap-up iteration for it, reporting zero consumed steps.
- The worker admits a zero-budget segment when earlier segments consumed the budget, and its step-count validation accepts the zero steps a wrap-up-only attempt reports (completed or failed). A turn that never had a budget at all remains a hard failure.
- The pre-park refusals for checkpoints landing on the last budgeted step (client tool, sandbox delegation, background-agent wait) are removed: the park proceeds and the resuming segment closes with the wrap-up, reading the parked work's result instead of throwing it away.

Reproduction test first: `zero_budget_resume_runs_the_wrap_up_instead_of_failing` drives a real turn whose only budgeted step is a tool call and whose wrap-up call fails retryably — on main the retrying segment dies with `max_steps_exceeded` after two provider calls; with the fix it completes with the wrap-up prose on the third. The two lifecycle tests that pinned the old refusals now assert the new behavior: a fully-spent checkpoint resumes into a tool-free wrap-up call whose steps stay outside the durable budget, and a client tool called on the last budgeted step parks, resolves, and completes.

Closes #1181