### PR TITLE
fix(desktop): unstick the LibreOffice install UI and warm the converter ahead of the first preview

### DIFF
--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -226,6 +226,7 @@ pub fn run() {
             office_pdf::convert_presentation_to_pdf,
             office_install::install_presentation_converter,
             office_install::cancel_presentation_converter_install,
+            office_install::warm_presentation_converter,
             client_execution::resolve_folder_access_request,
             client_execution::output_writeback::resolve_output_writeback_request,
             host_access::connect_folder,

--- a/crates/openwave-desktop/src/office_install.rs
+++ b/crates/openwave-desktop/src/office_install.rs
@@ -178,7 +178,14 @@ fn install_lock() -> &'static tokio::sync::Mutex<()> {
 /// preview stops auto-retrying until the user asks again.
 #[tauri::command]
 pub(crate) async fn install_presentation_converter(app: AppHandle) -> Result<(), String> {
-    let data_dir = crate::data_dir(&app)?;
+    ensure_installed(&app).await
+}
+
+/// The one install path both entry points share: serialize on the install
+/// lock, short-circuit if a concurrent caller already finished, run the
+/// install with a registered cancel flag, and remember the outcome.
+async fn ensure_installed(app: &AppHandle) -> Result<(), String> {
+    let data_dir = crate::data_dir(app)?;
     let _serialized = install_lock().lock().await;
     if managed_soffice(&data_dir).is_some() {
         // Another caller finished the install while this one waited.
@@ -192,13 +199,53 @@ pub(crate) async fn install_presentation_converter(app: AppHandle) -> Result<(),
         state.last_failure = None;
         state.cancel = Some(cancel.clone());
     }
-    let outcome = run_install(&app, &data_dir, &cancel).await;
+    let outcome = run_install(app, &data_dir, &cancel).await;
     {
         let mut state = state().lock().expect("install state lock");
         state.cancel = None;
         state.last_failure = outcome.as_ref().err().cloned();
     }
     outcome
+}
+
+/// Start the managed install in the background, ahead of the first preview.
+///
+/// The renderer fires this when a turn produces its first presentation
+/// output: by the time the user clicks the deck, the ~300 MB download is
+/// already under way or done, instead of starting at the moment a preview
+/// panel needs it. Deliberately quiet and non-binding — it never blocks
+/// anything, runs at most once per app run, and defers to every existing
+/// rule: a verified managed install, a *working* converter the user already
+/// has, or a remembered failure each make it a no-op. A broken launcher
+/// script on `PATH` (a package manager's leftover) does not count as a
+/// working converter here, exactly as it does not at conversion time.
+///
+/// Progress still goes out on [`INSTALL_PROGRESS_EVENT`], so a preview panel
+/// opened mid-warm-up joins the install (over the same lock) and shows the
+/// real download bar rather than starting a second download.
+#[tauri::command]
+pub(crate) fn warm_presentation_converter(app: AppHandle) {
+    if !supported() {
+        return;
+    }
+    static WARM_REQUESTED: AtomicBool = AtomicBool::new(false);
+    if WARM_REQUESTED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+    tauri::async_runtime::spawn(async move {
+        let Ok(data_dir) = crate::data_dir(&app) else {
+            return;
+        };
+        if managed_soffice(&data_dir).is_some() || last_failure().is_some() {
+            return;
+        }
+        if crate::office_pdf::workable_system_soffice().await {
+            return;
+        }
+        // Failures are remembered like any install failure; the preview
+        // surfaces the reason with a Try again instead of re-downloading.
+        let _ = ensure_installed(&app).await;
+    });
 }
 
 /// Flag the in-flight install to stop. The install command itself returns

--- a/crates/openwave-desktop/src/office_pdf.rs
+++ b/crates/openwave-desktop/src/office_pdf.rs
@@ -120,6 +120,21 @@ pub(crate) async fn convert_presentation_to_pdf(
         }
     }
 
+    // One conversion at a time. Duplicate requests for the same deck arrive
+    // routinely (two panels, or a fetch retried around an aborted render) and
+    // used to race two cold LibreOffice launches — flaky in exactly the
+    // hard-to-reproduce way, and their `.partial` cache staging collided.
+    // Serialized, the second request waits and is answered from the cache the
+    // first one just wrote.
+    let _serialized = conversion_lock().lock().await;
+    if let Ok(cached) = tokio::fs::read(&cache_path).await {
+        if !cached.is_empty() {
+            return Ok(PresentationPdfResult::Converted {
+                pdf_base64: BASE64.encode(cached),
+            });
+        }
+    }
+
     let Some(soffice) = locate_soffice(&data_dir) else {
         return Ok(converter_missing());
     };
@@ -212,6 +227,42 @@ fn system_soffice() -> Option<PathBuf> {
         }
     }
     None
+}
+
+/// Whether a system LibreOffice not only resolves but actually runs.
+///
+/// The install warm-up must not be talked out of downloading by a leftover
+/// launcher script on `PATH` — a Homebrew shim pointing at a removed
+/// `/Applications` bundle resolves as a file, spawns, and exits 126/127. One
+/// cheap `--version` probe (called at most once per app run) separates a
+/// converter that will work from remains that will not.
+pub(crate) async fn workable_system_soffice() -> bool {
+    let Some(candidate) = system_soffice() else {
+        return false;
+    };
+    let mut command = Command::new(&candidate);
+    command
+        .arg("--version")
+        .env_clear()
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let Ok(child) = command.spawn() else {
+        return false;
+    };
+    matches!(
+        tokio::time::timeout(Duration::from_secs(20), child.wait_with_output()).await,
+        Ok(Ok(output)) if output.status.success()
+    )
+}
+
+/// Serializes conversions; see the call site for why concurrency here is a
+/// hazard rather than a win.
+fn conversion_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+        std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+    &LOCK
 }
 
 #[cfg(target_os = "macos")]
@@ -334,12 +385,22 @@ async fn run_conversion(
         if matches!(output.status.code(), Some(126) | Some(127)) {
             return Err(ConversionError::Spawn);
         }
+        // The reason travels to the failure card, so it names what actually
+        // happened: LibreOffice's own words when it said any, its exit status
+        // when it did not.
         let detail = String::from_utf8_lossy(&output.stderr);
-        let detail = detail.trim();
+        let detail = brief(detail.trim());
         return Err(ConversionError::Failed(if detail.is_empty() {
-            "The presentation could not be converted".to_owned()
+            format!(
+                "LibreOffice produced no PDF ({})",
+                if output.status.success() {
+                    "it exited cleanly without writing one".to_owned()
+                } else {
+                    output.status.to_string()
+                }
+            )
         } else {
-            format!("The presentation could not be converted: {detail}")
+            format!("LibreOffice failed: {detail}")
         }));
     }
     if produced_len > MAX_PDF_BYTES {
@@ -350,6 +411,18 @@ async fn run_conversion(
     tokio::fs::read(&produced)
         .await
         .map_err(|error| ConversionError::Failed(format!("conversion: {error}")))
+}
+
+/// The leading slice of a tool's stderr that fits a failure card. LibreOffice
+/// can dump pages; the first lines carry the diagnosis.
+fn brief(detail: &str) -> String {
+    const MAX_CHARS: usize = 400;
+    if detail.chars().count() <= MAX_CHARS {
+        return detail.to_owned();
+    }
+    let mut cut: String = detail.chars().take(MAX_CHARS).collect();
+    cut.push('…');
+    cut
 }
 
 /// A `file:` URI for LibreOffice's `-env:UserInstallation` argument.

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -40,6 +40,7 @@ import { AppsPanel } from "./apps/AppsPanel";
 import { OutputDetailRoot } from "./outputs/OutputDetailRoot";
 import { OutputsView } from "./outputs/OutputsView";
 import { DocumentDetailRoot } from "./document-detail/DocumentDetailRoot";
+import { warmPresentationConverter } from "./document/officePdf";
 import { FoldersView } from "./FoldersView";
 import { hasNativeHost } from "./host";
 import { attachChatFiles, type AttachedFiles } from "./attachments";
@@ -243,6 +244,9 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         return;
       case "refresh_plan_approvals":
         signalRefresh("planApprovals");
+        return;
+      case "warm_presentation_converter":
+        warmPresentationConverter();
         return;
       case "turn_began":
         signalTurnLifecycle(effect.startsDifferentTurn ? "began" : "began_same_turn");

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -311,6 +311,37 @@ describe("published outputs", () => {
       },
     ]);
     expect(effects).toContainEqual({ type: "refresh_output_writebacks" });
+    // A markdown report is not a deck; no converter warm-up.
+    expect(effects).not.toContainEqual({ type: "warm_presentation_converter" });
+
+    // A published presentation starts the converter warm-up so the first
+    // preview click finds LibreOffice ready instead of a 300 MB download.
+    const deck = play([
+      TURN,
+      { type: "tool_call_started", call_id: "exec-3", name: "exec" },
+      {
+        type: "tool_call_completed",
+        call_id: "exec-3",
+        status: "completed",
+        result: {
+          ...execResult,
+          outputs: [
+            {
+              kind: "output" as const,
+              label: "deck.pptx",
+              detail: null,
+              meta: "v1 · created",
+              media_type:
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+              output_id: null,
+            },
+          ],
+        },
+      },
+    ]);
+    expect(deck.effects).toContainEqual({
+      type: "warm_presentation_converter",
+    });
 
     // A command that published nothing moves nothing.
     const quiet = play([

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -6,6 +6,7 @@ import { TURN_CANCELLED_NOTICE } from "./MessageList";
 import type { ToolCallStatus } from "./ToolCallCard";
 import { toolApprovalPresentation } from "./ToolCallCard";
 import { upsertPendingApprovalCard } from "./ApprovalHistory";
+import { PRESENTATION_MEDIA_TYPES } from "./document/officePdf";
 
 /**
  * The pure state machine for one chat session's live event stream.
@@ -50,7 +51,13 @@ export type ChatSessionEffect =
   /** Replace the optimistic transcript with the authoritative one. */
   | { type: "hydrate_terminal_transcript" }
   /** A terminal boundary passed without hydration; stale loads must not land. */
-  | { type: "invalidate_terminal_hydration" };
+  | { type: "invalidate_terminal_hydration" }
+  /**
+   * A turn just produced its first presentation output; start the managed
+   * LibreOffice download now so the first preview click finds it ready (or at
+   * least under way) instead of starting a 300 MB fetch on demand.
+   */
+  | { type: "warm_presentation_converter" };
 
 export type ChatSessionTransition = {
   state: ChatSessionState;
@@ -292,6 +299,16 @@ export function reduceChatSessionEvent(
         (completedResult.outputs?.length ?? 0) > 0
       ) {
         effects.push({ type: "refresh_output_writebacks" });
+        // A deck exists now; the preview will want a converter shortly.
+        if (
+          completedResult.outputs?.some(
+            (output) =>
+              output.mediaType !== null &&
+              PRESENTATION_MEDIA_TYPES.has(output.mediaType),
+          )
+        ) {
+          effects.push({ type: "warm_presentation_converter" });
+        }
       }
       return {
         state: {

--- a/crates/openwave-desktop/ui/src/document/PresentationViewer.tsx
+++ b/crates/openwave-desktop/ui/src/document/PresentationViewer.tsx
@@ -88,8 +88,13 @@ export function PresentationViewer({ source, mediaType, className }: Props) {
   if (error !== null || data === null) {
     return (
       <PresentationNotice>
-        This presentation could not be converted for preview. Save as… exports
-        the original file.
+        <span className="block">
+          This presentation could not be converted for preview.
+        </span>
+        {error?.message ? (
+          <span className="mt-1 block">{error.message}</span>
+        ) : null}
+        <span className="mt-1 block">Save as… exports the original file.</span>
       </PresentationNotice>
     );
   }
@@ -122,13 +127,16 @@ function ConverterInstall({
   const [progress, setProgress] = useState<ConverterInstallProgress | null>(
     null,
   );
-  const startedRef = useRef(false);
   const onReadyRef = useRef(onReady);
   onReadyRef.current = onReady;
 
   useEffect(() => {
-    if (!running || startedRef.current) return;
-    startedRef.current = true;
+    if (!running) return;
+    // The install itself is a shared module-level operation, so effect
+    // re-runs (StrictMode mounts every effect twice) simply join the one
+    // in-flight install; `disposed` only keeps a dead mount's state setters
+    // quiet. The surviving run receives progress and completion regardless of
+    // which run started the install.
     let disposed = false;
     void installPresentationConverter((next) => {
       if (!disposed) setProgress(next);
@@ -163,7 +171,6 @@ function ConverterInstall({
           size="sm"
           className="mt-3"
           onClick={() => {
-            startedRef.current = false;
             setFailure(null);
             setRunning(true);
           }}

--- a/crates/openwave-desktop/ui/src/document/officePdf.test.ts
+++ b/crates/openwave-desktop/ui/src/document/officePdf.test.ts
@@ -10,6 +10,8 @@ import {
   convertPresentationToPdf,
   installPresentationConverter,
   presentationPdfSource,
+  resetConverterInstallStateForTest,
+  warmPresentationConverter,
 } from "./officePdf";
 import type { FileBytesSource } from "./useFileDownload";
 
@@ -19,6 +21,7 @@ const PPTX =
 beforeEach(() => {
   invokeMock.mockReset();
   listenMock.mockReset();
+  resetConverterInstallStateForTest();
 });
 
 describe("presentation-to-PDF conversion", () => {
@@ -85,6 +88,63 @@ describe("presentation-to-PDF conversion", () => {
       { phase: "downloading", downloadedBytes: 1, totalBytes: 2 },
     ]);
     expect(unlisten).toHaveBeenCalled();
+  });
+
+  it("joins an in-flight install: one command, progress and completion to every caller", async () => {
+    // The regression this guards: StrictMode disposes the effect run that
+    // started the install, and the surviving run must still see progress and
+    // resolution rather than a bar frozen at zero.
+    let emit: ((event: { payload: unknown }) => void) | undefined;
+    listenMock.mockImplementation(
+      (_name: string, handler: (event: { payload: unknown }) => void) => {
+        emit = handler;
+        return Promise.resolve(vi.fn());
+      },
+    );
+    let settle: (() => void) | undefined;
+    invokeMock.mockImplementation(
+      () => new Promise<void>((resolve) => (settle = resolve)),
+    );
+
+    const first: unknown[] = [];
+    const second: unknown[] = [];
+    const install1 = installPresentationConverter((p) => first.push(p));
+    await Promise.resolve();
+    emit?.({
+      payload: { phase: "downloading", downloadedBytes: 8, totalBytes: 16 },
+    });
+    // A later mount joins mid-download and is caught up immediately.
+    const install2 = installPresentationConverter((p) => second.push(p));
+    emit?.({
+      payload: { phase: "installing", downloadedBytes: 0, totalBytes: null },
+    });
+    settle?.();
+    await Promise.all([install1, install2]);
+
+    expect(
+      invokeMock.mock.calls.filter(
+        ([name]) => name === "install_presentation_converter",
+      ),
+    ).toHaveLength(1);
+    expect(first).toEqual([
+      { phase: "downloading", downloadedBytes: 8, totalBytes: 16 },
+      { phase: "installing", downloadedBytes: 0, totalBytes: null },
+    ]);
+    expect(second).toEqual([
+      { phase: "downloading", downloadedBytes: 8, totalBytes: 16 },
+      { phase: "installing", downloadedBytes: 0, totalBytes: null },
+    ]);
+  });
+
+  it("requests the background warm-up once per app run", () => {
+    invokeMock.mockResolvedValue(undefined);
+    warmPresentationConverter();
+    warmPresentationConverter();
+    expect(
+      invokeMock.mock.calls.filter(
+        ([name]) => name === "warm_presentation_converter",
+      ),
+    ).toHaveLength(1);
   });
 
   it("derives the converted source from the original's immutable cache key", async () => {

--- a/crates/openwave-desktop/ui/src/document/officePdf.ts
+++ b/crates/openwave-desktop/ui/src/document/officePdf.ts
@@ -82,30 +82,84 @@ export type ConverterInstallProgress = {
   totalBytes: number | null;
 };
 
+// One install flows through one shared operation, however many components ask
+// for it. This matters beyond tidiness: React StrictMode mounts effects twice,
+// and a per-call listener owned by the first (immediately-disposed) effect run
+// used to swallow every progress event and the completion itself — the panel
+// sat on an indeterminate bar while the host downloaded and installed to the
+// end. Joining an in-flight install replays the latest progress and resolves
+// every caller when the one underlying command settles.
+let installInFlight: Promise<void> | null = null;
+let lastInstallProgress: ConverterInstallProgress | null = null;
+const installSubscribers = new Set<(p: ConverterInstallProgress) => void>();
+
 /**
  * Install the app's own LibreOffice (macOS): an exact pinned version from
  * TDF's official download service, digest-verified by the host before
- * unpacking. Resolves once the converter is ready; rejects with the host's
- * reason on failure or cancellation, which the host also remembers so the
- * viewer stops auto-retrying until the user asks again.
+ * unpacking. Joins the in-flight install if one is running. Resolves once the
+ * converter is ready; rejects with the host's reason on failure or
+ * cancellation, which the host also remembers so the viewer stops
+ * auto-retrying until the user asks again.
  */
 export async function installPresentationConverter(
   onProgress: (progress: ConverterInstallProgress) => void,
 ): Promise<void> {
-  const unlisten = await listen<ConverterInstallProgress>(
-    INSTALL_PROGRESS_EVENT,
-    (event) => onProgress(event.payload),
-  );
+  installSubscribers.add(onProgress);
+  if (lastInstallProgress !== null) onProgress(lastInstallProgress);
+  installInFlight ??= (async () => {
+    const unlisten = await listen<ConverterInstallProgress>(
+      INSTALL_PROGRESS_EVENT,
+      (event) => {
+        lastInstallProgress = event.payload;
+        for (const subscriber of [...installSubscribers]) {
+          subscriber(event.payload);
+        }
+      },
+    );
+    try {
+      await invoke("install_presentation_converter");
+    } finally {
+      unlisten();
+      installInFlight = null;
+      lastInstallProgress = null;
+    }
+  })();
   try {
-    await invoke("install_presentation_converter");
+    await installInFlight;
   } finally {
-    unlisten();
+    installSubscribers.delete(onProgress);
   }
 }
 
 /** Ask the in-flight managed install to stop; it rejects with the reason. */
 export async function cancelPresentationConverterInstall(): Promise<void> {
   await invoke("cancel_presentation_converter_install");
+}
+
+let warmRequested = false;
+
+/**
+ * Start the managed LibreOffice install in the background, ahead of the first
+ * preview — fired when a turn produces its first presentation output, so the
+ * download is under way (or done) before anyone clicks the deck. Once per app
+ * run here and again host-side; the host quietly refuses when a converter
+ * already resolves or an earlier install failed, so this can never re-download
+ * or block anything.
+ */
+export function warmPresentationConverter(): void {
+  if (warmRequested) return;
+  warmRequested = true;
+  void invoke("warm_presentation_converter").catch(() => {
+    // Best-effort by design; the preview path handles every converter state.
+  });
+}
+
+/** Test seam: drop the shared install/warm state between cases. */
+export function resetConverterInstallStateForTest(): void {
+  installInFlight = null;
+  lastInstallProgress = null;
+  installSubscribers.clear();
+  warmRequested = false;
 }
 
 /**


### PR DESCRIPTION
The managed LibreOffice install (#1397) had its first real end-to-end run and failed its UX twice over: the preview panel sat on the downloading state with the determinate bar frozen at zero, and the run ended on the generic "This presentation could not be converted for preview" card. This change fixes what that run actually exposed, diagnosed against the machine it happened on, and adds the planned warm-up so the first preview stops paying for the download at all.

## What the live machine showed

- The install itself succeeded: `tools/libreoffice/25.8.7/` was fully populated under the dev app-data dir with a valid `installed.json` marker, no staging leftovers, and the managed `soffice` converts every deck involved (including the exact decks from the failing session) in ~9 s using the crate's own contained invocation. The download, verification, and unpack pipeline is not the problem.
- The frozen progress bar is a renderer defect. The install effect guarded itself with a ref and a `disposed` flag; under StrictMode's double effect run, the first (immediately disposed) run owned the only progress listener and the completion handler, and the ref stopped the surviving run from subscribing at all. Every progress event and the completion itself were swallowed — the panel could never leave the indeterminate downloading state, and the automatic post-install retry never fired.
- The conversion failure is consistent with duplicate concurrent conversions. An aborted fetch still drives its host conversion to the end, so the same deck routinely converts twice concurrently — on this run, two cold launches of the freshly installed binary, with the on-disk evidence of a converted PDF cached at install time that no panel ever displayed while the surfaced attempt reported failure. The two `.partial` cache stagings also collide on the same path. The exact stderr is unrecoverable, because the failure card threw the reason away — the third defect.

## The fixes

- The install is now one shared renderer-side operation: any caller joins the in-flight install, gets the latest progress replayed on entry, and is resolved when the one underlying command settles. Effect re-runs, StrictMode, and a second panel all converge on the same download and the same determinate bar.
- Conversions serialize on the host, and a waiter re-checks the disk cache after acquiring the lock — the duplicate request is answered from the cache the first one wrote instead of racing a second cold LibreOffice launch and colliding in the cache staging.
- Failure reasons survive to the card. The conversion error now names what happened ("LibreOffice failed: <first 400 chars of stderr>", or the exit status when it said nothing), and the preview's failure card renders that reason instead of the fixed generic line. Download and checksum failures already carried reasons; now conversion failures do too.

## Warming the converter before the first preview

When a turn's exec call publishes its first presentation output, the renderer now fires a background warm-up command: the host starts the managed install immediately, so the download runs while the agent is still finishing the turn and the user is reading — instead of starting when the preview panel opens. Trigger choice, deliberately: the renderer already parses exec result previews (media types included) on the event stream in every open chat, so this is the earliest signal available without building a new server-to-shell notification path for skill staging; that alternative buys about a minute of extra head start at the cost of a cross-crate channel, and can be layered on later if this proves too late in practice.

The warm-up is bounded on both sides: once per app run in the renderer and again in the host, never blocking anything, and refusing outright when a managed install already resolves, when an earlier install failed this run (the explicit retry stays the only re-download path), or when the user already has a working LibreOffice. "Working" is probed, not assumed — a leftover Homebrew shim on `PATH` that spawns and exits 127 (exactly what this machine has at `/opt/homebrew/bin/soffice`) must not talk the warm-up out of downloading, so the check runs `--version` once rather than trusting file existence. If a preview opens mid-warm-up it joins the same install over the same lock and shows the real progress bar. Progress, cancellation, digest pinning, and the failure-memory discipline are all unchanged.

## Verification

- `cargo fmt --check`, `cargo check --locked`, `cargo clippy --all-targets` on `openwave-desktop`, and its test suite (98 tests) — clean.
- UI: `tsc` and vitest for `src/document` plus the reducer suite — clean, including new coverage for the join semantics (one command, progress and completion to every caller including a late joiner), the once-per-run warm guard, and the reducer emitting the warm effect for a published deck but not for a markdown report.
- Live on this machine: the crate's real conversion path (`run_conversion`, contained invocation) executed against the managed 25.8.7 install and converted the fixture deck to a valid PDF in 9.2 s; the same shape also converted all three decks from the failing session by hand. Not exercised live: the compiled Tauri IPC flow and panel states, which need the running app.

Residuals: the StrictMode-frozen panel from an already-running app session will heal on its next preview open (state is per-run, nothing persisted); and if warming ever proves too late relative to deck production, the server-side staging trigger described above is the follow-up shape.
