### PR TITLE
fix(desktop): keep document viewers mounted while typing in the composer

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -17,7 +17,6 @@ import { loadChatApprovalHydration } from "./ChatApprovalHydration";
 import { useChatListStore } from "./ChatListStore";
 import {
   useComposerAttachments,
-  useComposerDraft,
   useComposerDrafts,
 } from "./ComposerDrafts";
 import { ChatSessionController } from "./ChatSessionController";
@@ -109,16 +108,18 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   const deletingChatId = useChatListStore((state) => state.deletingChatId);
   const busy = useChatSessionStore((session) => session.busy);
   const [hydrated, setHydrated] = useState(false);
-  const draft = useComposerDraft(chatId);
   const files = useComposerAttachments(chatId).files;
   const [attaching, setAttaching] = useState(false);
   const [attachError, setAttachError] = useState<string | null>(null);
   const images = useImageAttachments(client, chatId);
   const handleEventRef = useRef<(event: SequencedEvent) => void>(() => {});
   const terminalHydrationGenerationRef = useRef(0);
-  // Steering reads the draft synchronously, from outside a render.
-  const draftRef = useRef(draft);
-  draftRef.current = draft;
+  // Steering reads the draft synchronously, from outside a render. The route
+  // deliberately does not subscribe to the draft — a keystroke re-renders the
+  // chat pane (which subscribes in ChatView), not the whole panel arrangement —
+  // so the ref is seeded from the store and kept current by setComposerDraft,
+  // the only writer on this route.
+  const draftRef = useRef(useComposerDrafts.getState().drafts[chatId] ?? "");
 
   const chat = chats.find((candidate) => candidate.id === chatId) ?? null;
   const nativeHost = hasNativeHost();
@@ -290,7 +291,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
   }
 
   async function onSend() {
-    await sendMessage(draft.trim());
+    await sendMessage(draftRef.current.trim());
   }
 
   /**
@@ -527,7 +528,6 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             hydrated={hydrated}
             nativeHost={nativeHost}
             deletingChat={deletingChatId !== null}
-            draft={draft}
             draftRef={draftRef}
             attachError={attachError}
             files={{

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { useRef, useState } from "react";
+import { useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient, Chat } from "./api";
 import { ChatView, type ChatViewProps } from "./ChatView";
 import type { ComposerImages } from "./Composer";
 import { useChatSessionStore } from "./ChatSessionStore";
+import { useComposerDrafts } from "./ComposerDrafts";
 import { usePendingPrompts } from "./PendingPrompts";
 
 vi.mock("./host", () => ({
@@ -49,11 +50,11 @@ function noFiles() {
 }
 
 /**
- * The pane with the draft wired up the way the root wires it: state for
- * rendering, a ref for reading it at the moment guidance is sent.
+ * The pane with the draft wired up the way the root wires it: the store slice
+ * the pane subscribes to, and a ref for reading it at the moment guidance is
+ * sent.
  */
 function DraftingChatView(overrides: Partial<ChatViewProps> = {}) {
-  const [draft, setDraft] = useState("");
   const draftRef = useRef("");
   return (
     <ChatView
@@ -62,7 +63,6 @@ function DraftingChatView(overrides: Partial<ChatViewProps> = {}) {
       hydrated
       nativeHost={false}
       deletingChat={false}
-      draft={draft}
       draftRef={draftRef}
       composerModelMenu={null}
       composerImages={noImages()}
@@ -70,7 +70,7 @@ function DraftingChatView(overrides: Partial<ChatViewProps> = {}) {
       attachError={null}
       onDraftChange={(value) => {
         draftRef.current = value;
-        setDraft(value);
+        useComposerDrafts.getState().setDraft(chat.id, value);
       }}
       onSelectPrompt={vi.fn()}
       onSend={vi.fn(async () => {})}
@@ -86,7 +86,6 @@ function renderChatView(overrides: Partial<ChatViewProps> = {}) {
     hydrated: true,
     nativeHost: false,
     deletingChat: false,
-    draft: "",
     draftRef: { current: "" },
     composerModelMenu: null,
     composerImages: noImages(),
@@ -103,6 +102,7 @@ function renderChatView(overrides: Partial<ChatViewProps> = {}) {
 
 beforeEach(() => {
   useChatSessionStore.getState().reset();
+  useComposerDrafts.getState().clearDraft(chat.id);
   usePendingPrompts.setState({ chatId: null, userQuestions: [], folderAccess: [] });
 });
 afterEach(cleanup);

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -10,6 +10,7 @@ import {
 import type { ApiClient, Chat } from "./api";
 import { followScrollBehavior, isNearBottom, scrollToLatest } from "./ChatScroll";
 import { useChatSessionStore } from "./ChatSessionStore";
+import { useComposerDraft } from "./ComposerDrafts";
 import {
   Composer,
   type ComposerFiles,
@@ -35,8 +36,7 @@ export type ChatViewProps = {
   hydrated: boolean;
   nativeHost: boolean;
   deletingChat: boolean;
-  draft: string;
-  /** The same draft, readable synchronously — see [useTurnControls]. */
+  /** The composer draft, readable synchronously — see [useTurnControls]. */
   draftRef: RefObject<string>;
   composerModelMenu: ReactNode;
   composerImages: ComposerImages;
@@ -66,7 +66,6 @@ export function ChatView({
   hydrated,
   nativeHost,
   deletingChat,
-  draft,
   draftRef,
   composerModelMenu,
   composerImages,
@@ -81,6 +80,11 @@ export function ChatView({
   onViewOutput,
 }: ChatViewProps) {
   const transcriptVisible = useTranscriptVisible();
+  // Subscribed here rather than in the route above: a keystroke should
+  // re-render the chat pane alone, never the panels beside it — a document
+  // viewer that re-renders per keystroke is one unstable dependency away from
+  // reloading its engine mid-typing.
+  const draft = useComposerDraft(chat.id);
   const folderAccess = useFolderAccessRequests(client, chat.id);
   const outputWritebacks = useOutputWritebackRequests(client, chat.id);
   const userQuestions = useUserQuestions(client, chat.id);

--- a/crates/openwave-desktop/ui/src/document/UniverSpreadsheetViewer.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/document/UniverSpreadsheetViewer.dom.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+//
+// Reproduction of a live defect: typing in the chat composer re-rendered the
+// panel tree, and every re-render tore Univer down and remounted it, because
+// the viewer's init effect depended on the object `useUniverWorker` rebuilds
+// each render. Univer itself cannot run in jsdom, so its engine is mocked at
+// the module boundary and the assertion is on the init path: `createUniver`
+// must fire exactly once while a parent re-renders per keystroke and hands the
+// viewer a fresh `source` object each time, the way the panels really do.
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import { clearFileDownloadCache, type FileBytesSource } from "./useFileDownload";
+
+const univerMocks = vi.hoisted(() => {
+  const univer = { dispose: vi.fn() };
+  const univerAPI = {
+    toggleDarkMode: vi.fn(),
+    createWorkbook: vi.fn(),
+    addEvent: vi.fn(),
+    Event: { BeforeCommandExecute: "BeforeCommandExecute" },
+    getActiveWorkbook: () => null,
+    dispose: vi.fn(),
+  };
+  return {
+    univer,
+    univerAPI,
+    createUniver: vi.fn(() => ({ univer, univerAPI })),
+  };
+});
+
+vi.mock("@univerjs/presets", () => ({
+  createUniver: univerMocks.createUniver,
+  LocaleType: { EN_US: "enUS" },
+}));
+
+vi.mock("@univerjs/preset-sheets-core", () => ({
+  UniverSheetsCorePreset: vi.fn(() => ({})),
+  CalculationMode: { WHEN_EMPTY: 0 },
+  sequenceNodeType: { REFERENCE: 3 },
+}));
+
+vi.mock("@univerjs/preset-sheets-core/locales/en-US", () => ({ default: {} }));
+vi.mock("@univerjs/preset-sheets-core/lib/index.css", () => ({}));
+vi.mock("@univerjs/core", () => ({ ICommandService: class {} }));
+
+vi.mock("@/workers/univer-formula.worker?worker&inline", () => ({
+  default: class {},
+}));
+
+// A parser worker that answers every parse with an empty workbook, so the real
+// `useUniverWorker` hook — the code under test — runs against it unchanged.
+vi.mock("@/workers/univer-parser.worker?worker&inline", () => ({
+  default: class FakeParserWorker {
+    private listeners = new Set<(event: MessageEvent) => void>();
+
+    addEventListener(type: string, listener: (event: MessageEvent) => void) {
+      if (type === "message") this.listeners.add(listener);
+    }
+
+    removeEventListener(_type: string, listener: (event: MessageEvent) => void) {
+      this.listeners.delete(listener);
+    }
+
+    postMessage(message: { type: string; opId?: string }) {
+      if (message.type !== "parse") return;
+      queueMicrotask(() => {
+        const event = {
+          data: {
+            type: "result",
+            opId: message.opId,
+            workbookData: { id: "wb", sheetOrder: [], sheets: {} },
+          },
+        } as MessageEvent;
+        for (const listener of this.listeners) listener(event);
+      });
+    }
+  },
+}));
+
+import UniverSpreadsheetViewer from "./UniverSpreadsheetViewer";
+
+const bytes = new TextEncoder().encode("a,b\n1,2\n");
+
+/** A fresh source object per call, the way `OutputContent` builds one per render. */
+function freshSource(): FileBytesSource {
+  return {
+    id: "out-1/rev-1",
+    cacheKey: "output/chat-1/out-1/rev-1",
+    fetch: async () => ({ bytes, contentType: "text/csv" }),
+  };
+}
+
+/**
+ * The shape of the real panel arrangement: composer state and the viewer under
+ * one parent, so each keystroke re-renders the viewer with all-new props.
+ */
+function PaneWithViewer() {
+  const [draft, setDraft] = useState("");
+  return (
+    <div>
+      <textarea
+        aria-label="Message"
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+      />
+      <UniverSpreadsheetViewer source={freshSource()} isCsv />
+    </div>
+  );
+}
+
+beforeEach(() => {
+  clearFileDownloadCache();
+  univerMocks.createUniver.mockClear();
+  univerMocks.univer.dispose.mockClear();
+  univerMocks.univerAPI.dispose.mockClear();
+});
+afterEach(cleanup);
+
+it("keeps one Univer instance while the composer beside it is typed into", async () => {
+  render(<PaneWithViewer />);
+  await waitFor(() => expect(univerMocks.createUniver).toHaveBeenCalledTimes(1));
+
+  const message = screen.getByLabelText("Message");
+  await userEvent.type(message, "summarize the sheet");
+  expect(message).toHaveValue("summarize the sheet");
+
+  // Still the first instance: no keystroke disposed it or built another.
+  expect(univerMocks.createUniver).toHaveBeenCalledTimes(1);
+  expect(univerMocks.univer.dispose).not.toHaveBeenCalled();
+});

--- a/crates/openwave-desktop/ui/src/document/UniverSpreadsheetViewer.tsx
+++ b/crates/openwave-desktop/ui/src/document/UniverSpreadsheetViewer.tsx
@@ -65,7 +65,11 @@ export default function UniverSpreadsheetViewer({
   const highlightRangeRef = useRef(highlightRange);
   highlightRangeRef.current = highlightRange;
   const [errorType, setErrorType] = useState<"parse" | "load" | null>(null);
-  const univerWorker = useUniverWorker();
+  // Destructured because the hook returns a fresh object every render; the
+  // callbacks inside are stable, and only those may feed the init effect below
+  // — depending on the object itself would tear Univer down and remount it on
+  // every parent re-render (every composer keystroke, in practice).
+  const { parseWorkbook, isProcessing } = useUniverWorker();
   const { resolved: resolvedTheme } = useTheme();
   const resolvedThemeRef = useRef(resolvedTheme);
   resolvedThemeRef.current = resolvedTheme;
@@ -206,8 +210,7 @@ export default function UniverSpreadsheetViewer({
     setErrorType(null);
     let disposed = false;
 
-    univerWorker
-      .parseWorkbook(fileDownload.data, fileId, { isCsv })
+    parseWorkbook(fileDownload.data, fileId, { isCsv })
       .then(({ workbookData }) => {
         if (disposed || !containerRef.current) return;
 
@@ -310,7 +313,7 @@ export default function UniverSpreadsheetViewer({
         univerInstanceRef.current = null;
       }
     };
-  }, [fileDownload.data, fileId, isCsv, univerWorker]);
+  }, [fileDownload.data, fileId, isCsv, parseWorkbook]);
 
   // Apply a highlight that arrives after the canvas is up; one that arrives
   // before it is applied by the canvas poll above.
@@ -382,7 +385,7 @@ export default function UniverSpreadsheetViewer({
 
   return (
     <div className={cn("relative flex flex-col", className)} {...restProps}>
-      {univerWorker.isProcessing && (
+      {isProcessing && (
         <div className="bg-background/80 absolute inset-0 z-10 flex items-center justify-center">
           <ViewerMessage spinner>Reading spreadsheet…</ViewerMessage>
         </div>


### PR DESCRIPTION
Every keystroke in the chat composer reloaded any spreadsheet open in the content panel: the whole Univer engine was disposed and rebuilt per character.

Two things lined up to cause it:

- `ChatRoute` subscribed to the composer draft store, so each keystroke re-rendered the entire panel arrangement, including the document/output panels beside the conversation.
- `UniverSpreadsheetViewer`'s init effect listed the object returned by `useUniverWorker()` in its dependency array. That hook returns a fresh object every render (its callbacks are stable, the wrapper is not), so any parent re-render re-ran the init effect — dispose Univer, re-parse, re-create.

Both levels are fixed:

- The draft subscription moves from `ChatRoute` into `ChatView`, which already renders the composer. Typing now re-renders the chat pane alone; the panels beside it (and the closures feeding `PanelLayout`) don't re-render at all. The route keeps its synchronous `draftRef`, seeded from the store and maintained by the one writer on the route.
- The viewer destructures `parseWorkbook` / `isProcessing` and depends on the stable callback, not the per-render wrapper object, so the engine survives parent re-renders from any source (theme flips, citation highlights, worker progress state). The docx and pdf.js viewers already keyed their init effects on `fileDownload.data` / `fileId` and were not affected.

Regression test: Univer cannot run in jsdom, so the engine is mocked at the module boundary and the real `useUniverWorker` runs against a fake parser worker. The test renders the viewer beside a textarea under one re-rendering parent that rebuilds the `source` object every render — the shape `OutputContent` produces — types into it, and asserts `createUniver` fired exactly once and nothing was disposed. Against the previous code it fails with 20 instances for 19 keystrokes.

The pre-existing `NativePickerLatch` test failure on `main` (from #1404) is unrelated and fixed separately.