### PR TITLE
fix(desktop): teach the picker-holder census about the capability grant surface

### DIFF
--- a/crates/openwave-desktop/ui/src/NativePickerLatch.test.ts
+++ b/crates/openwave-desktop/ui/src/NativePickerLatch.test.ts
@@ -46,13 +46,14 @@ describe("native picker latch", () => {
   });
 
   it("names every surface that opens a host picker", () => {
-    // Six Tauri commands take the host picker mutex: resolving a folder-access
+    // Seven Tauri commands take the host picker mutex: resolving a folder-access
     // decision (keyed by call id), connecting a folder, confirming a previously
-    // approved one, importing a source, exporting an output, and attaching an
-    // image to a message.
+    // approved one, granting a capability on an attached folder, importing a
+    // source, exporting an output, and attaching an image to a message.
     expect(Object.values(PICKER_HOLDERS)).toEqual([
       "connect-folder",
       "confirm-approved-folder",
+      "grant-folder-capability",
       "import-source",
       "export-output",
       "attach-image",


### PR DESCRIPTION
#1404 added the grant-folder-capability picker holder but not its row in the census test, so the UI test lane on main has been red since it merged. The test exists to make a new mutex holder a deliberate, reviewed addition — this records the one that was added.