### PR TITLE
feat(desktop): give set-aside folders a product surface

### DIFF
--- a/crates/openwave-desktop/src/client_execution/root_attachment_reconciliation.rs
+++ b/crates/openwave-desktop/src/client_execution/root_attachment_reconciliation.rs
@@ -866,6 +866,7 @@ fn connected_folder(root: RootSummary) -> ConnectedFolder {
     ConnectedFolder {
         root_id: root.root_id,
         display_name: root.display_name,
+        status: crate::host_access::FolderStatus::Connected,
     }
 }
 

--- a/crates/openwave-desktop/src/host_access.rs
+++ b/crates/openwave-desktop/src/host_access.rs
@@ -237,11 +237,25 @@ pub(crate) struct ConnectApprovedFolderRequest {
     root_id: RootId,
 }
 
+/// Whether the broker can currently reach a listed folder.
+///
+/// `Unavailable` is the set-aside state: the approval and attachment stand,
+/// but the directory could not be reopened — an unplugged drive, a moved
+/// folder. The distinction is the product surface for it; without this a
+/// set-aside folder is indistinguishable from one the user detached.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum FolderStatus {
+    Connected,
+    Unavailable,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ConnectedFolder {
     pub(crate) root_id: RootId,
     pub(crate) display_name: String,
+    pub(crate) status: FolderStatus,
 }
 
 #[tauri::command]
@@ -311,14 +325,38 @@ pub(crate) async fn list_connected_folders(
     // it from the same consent statements the Permissions surface shows
     // (`list_capability_consents`), so both panels are groupings of one model
     // and the desktop keeps no folder-capability vocabulary of its own.
-    Ok(roots
+    let mut folders = roots
         .into_iter()
         .filter(|root| product_roots.contains(&root.root_id.as_uuid()))
         .map(|root| ConnectedFolder {
             root_id: root.root_id,
             display_name: root.display_name,
+            status: FolderStatus::Connected,
         })
-        .collect())
+        .collect::<Vec<_>>();
+    // A set-aside root — one the broker could not reopen — used to vanish
+    // from this listing entirely, leaving an unplugged drive looking exactly
+    // like a deliberate detach. It stays visible instead, marked unavailable,
+    // so the panel can say what happened and offer to forget it.
+    let result = state
+        .broker
+        .control(ControlRequest::ListUnavailableRoots)
+        .await
+        .map_err(|error| error.to_string())?;
+    let ControlResult::ListUnavailableRoots { roots } = result else {
+        return Err("host broker returned an unexpected response".to_owned());
+    };
+    folders.extend(
+        roots
+            .into_iter()
+            .filter(|root| product_roots.contains(&root.root_id.as_uuid()))
+            .map(|root| ConnectedFolder {
+                root_id: root.root_id,
+                display_name: root.display_name,
+                status: FolderStatus::Unavailable,
+            }),
+    );
+    Ok(folders)
 }
 
 #[tauri::command]
@@ -616,6 +654,57 @@ pub(crate) async fn disconnect_folder(
     .await
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct ForgetFolderRequest {
+    root_id: RootId,
+}
+
+/// Withdraw the host approval for a folder the broker can no longer reach.
+///
+/// The remove half of the set-aside surface: a folder that is gone for good
+/// would otherwise keep its grants and attachments indefinitely, since the
+/// broker only ever deletes a registration on an explicit revocation and
+/// nothing sent one. Deliberately restricted to set-aside roots — a live
+/// folder's exit is the ordinary per-chat disconnect — and addressed at the
+/// registering subject the broker reports, which `RevokeRoot` requires.
+#[tauri::command]
+pub(crate) async fn forget_folder(
+    state: State<'_, HostAccess>,
+    request: ForgetFolderRequest,
+) -> Result<bool, String> {
+    let _root_change = state.root_changes.lock().await;
+    let result = state
+        .broker
+        .control(ControlRequest::ListUnavailableRoots)
+        .await
+        .map_err(|error| error.to_string())?;
+    let ControlResult::ListUnavailableRoots { roots } = result else {
+        return Err("host broker returned an unexpected response".to_owned());
+    };
+    let root = roots
+        .into_iter()
+        .find(|root| root.root_id == request.root_id)
+        .ok_or_else(|| {
+            "the folder is not unavailable — disconnect it from its chats instead".to_owned()
+        })?;
+    let result = state
+        .broker
+        .control(ControlRequest::RevokeRoot(
+            openwave_host_broker::RevokeRootRequest {
+                operation_id: openwave_host_broker::OperationId::new(),
+                subject: root.owner,
+                root_id: request.root_id,
+            },
+        ))
+        .await
+        .map_err(|error| error.to_string())?;
+    let ControlResult::RevokeRoot(result) = result else {
+        return Err("host broker returned an unexpected response".to_owned());
+    };
+    Ok(result.revoked)
+}
+
 async fn approved_folders(state: &HostAccess) -> Result<Vec<ConnectedFolder>, String> {
     Ok(approved_roots(state)
         .await?
@@ -623,6 +712,7 @@ async fn approved_folders(state: &HostAccess) -> Result<Vec<ConnectedFolder>, St
         .map(|root| ConnectedFolder {
             root_id: root.root_id,
             display_name: root.display_name,
+            status: FolderStatus::Connected,
         })
         .collect())
 }

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -237,6 +237,7 @@ pub fn run() {
             host_access::list_connected_folders,
             host_access::grant_folder_capability,
             host_access::disconnect_folder,
+            host_access::forget_folder,
             updater::desktop_update_state,
             updater::check_for_update,
             updater::restart_for_update

--- a/crates/openwave-desktop/ui/src/ComposerFolders.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerFolders.dom.test.tsx
@@ -24,6 +24,7 @@ it("attaches and confirms revoking a folder from the ordinary chat composer", as
           {
             rootId: "root-1",
             displayName: "Research",
+            status: "connected",
             statements: (["read_files", "write_files"] as const).map(
               (capability, index) => ({
                 handle: {

--- a/crates/openwave-desktop/ui/src/FoldersView.test.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersView.test.tsx
@@ -10,6 +10,7 @@ vi.mock("./host", () => ({
   connectApprovedFolder: vi.fn(),
   connectFolder: vi.fn(),
   disconnectFolder: vi.fn(),
+  forgetFolder: vi.fn(),
   grantFolderCapability: vi.fn(),
   listApprovedFolders: vi.fn(),
   listCapabilityConsents: vi.fn(),
@@ -23,8 +24,12 @@ const chat = {
   project_id: null,
 } as unknown as Chat;
 
-function folder(rootId: string, displayName: string): host.ConnectedFolder {
-  return { rootId, displayName };
+function folder(
+  rootId: string,
+  displayName: string,
+  status: host.FolderStatus = "connected",
+): host.ConnectedFolder {
+  return { rootId, displayName, status };
 }
 
 type FolderCapabilityVerb = Extract<
@@ -65,6 +70,7 @@ beforeEach(() => {
   vi.mocked(host.connectApprovedFolder).mockResolvedValue(null);
   vi.mocked(host.connectFolder).mockResolvedValue(null);
   vi.mocked(host.disconnectFolder).mockResolvedValue(false);
+  vi.mocked(host.forgetFolder).mockResolvedValue(true);
   vi.mocked(host.grantFolderCapability).mockResolvedValue(null);
   vi.mocked(host.revokeCapabilityConsent).mockResolvedValue(true);
 });
@@ -183,6 +189,39 @@ describe("FoldersView", () => {
     expect(screen.getAllByRole("button", { name: "Grant" })).toHaveLength(1);
   });
 
+  it("distinguishes an unavailable folder and lets it be forgotten for good", async () => {
+    vi.mocked(host.listConnectedFolders)
+      .mockResolvedValueOnce([
+        folder("live", "Drafts"),
+        folder("unplugged", "External archive", "unavailable"),
+      ])
+      .mockResolvedValue([folder("live", "Drafts")]);
+    vi.mocked(host.listCapabilityConsents).mockResolvedValue([
+      statement("live", "read_files"),
+    ]);
+    const user = userEvent.setup();
+    render(<FoldersView chat={chat} />);
+
+    // A set-aside folder no longer vanishes: it is its own group, marked and
+    // explained, distinct from both connected and previously approved.
+    expect(await screen.findByText("External archive")).toBeInTheDocument();
+    expect(screen.getByText("Unavailable")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Available on this Mac"),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Forget" }));
+    // Forgetting is destructive across every chat, so it confirms first.
+    await user.click(await screen.findByRole("button", { name: "Forget" }));
+    await waitFor(() =>
+      expect(host.forgetFolder).toHaveBeenCalledWith("unplugged"),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("External archive")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText("Drafts")).toBeInTheDocument();
+  });
+
   it("changes nothing when native widening consent is canceled", async () => {
     vi.mocked(host.listConnectedFolders).mockResolvedValue([
       folder("read-only", "Archive"),
@@ -209,12 +248,13 @@ describe("FoldersView", () => {
         folder("available", "Research"),
       ]);
     vi.mocked(host.listApprovedFolders).mockResolvedValue([
-      { rootId: "connected", displayName: "Current project" },
-      { rootId: "available", displayName: "Research" },
+      { rootId: "connected", displayName: "Current project", status: "connected" },
+      { rootId: "available", displayName: "Research", status: "connected" },
     ]);
     vi.mocked(host.connectApprovedFolder).mockResolvedValue({
       rootId: "available",
       displayName: "Research",
+      status: "connected",
     });
     const user = userEvent.setup();
     render(<FoldersView chat={chat} />);
@@ -235,7 +275,7 @@ describe("FoldersView", () => {
 
   it("leaves an approved folder unattached when native consent is canceled", async () => {
     vi.mocked(host.listApprovedFolders).mockResolvedValue([
-      { rootId: "available", displayName: "Research" },
+      { rootId: "available", displayName: "Research", status: "connected" },
     ]);
     const user = userEvent.setup();
     render(<FoldersView chat={chat} />);

--- a/crates/openwave-desktop/ui/src/FoldersView.tsx
+++ b/crates/openwave-desktop/ui/src/FoldersView.tsx
@@ -19,6 +19,7 @@ import {
   connectApprovedFolder,
   connectFolder,
   disconnectFolder,
+  forgetFolder,
   grantFolderCapability,
   listApprovedFolders,
   listCapabilityConsents,
@@ -60,6 +61,12 @@ export function FoldersView({ chat }: { chat: Chat }) {
   const refreshGeneration = useRef(0);
   const folderAccess = useRefreshSignals((state) => state.folderAccess);
   const { confirm, dialog: confirmDialog } = useConfirm();
+  const connectedFolders = folders.filter(
+    (folder) => folder.status === "connected",
+  );
+  const unavailableFolders = folders.filter(
+    (folder) => folder.status === "unavailable",
+  );
   const connectedIds = new Set(folders.map((folder) => folder.rootId));
   const availableFolders = approvedFolders.filter(
     (folder) => !connectedIds.has(folder.rootId),
@@ -165,6 +172,32 @@ export function FoldersView({ chat }: { chat: Chat }) {
     }
   }
 
+  /**
+   * Withdraw an unreachable folder's approval everywhere. The restore path
+   * is deliberately not a button: the attachment and grants are riding out
+   * the outage, so the folder comes back on its own when its directory does.
+   */
+  async function forgetUnavailableFolder(folder: ConnectedFolder) {
+    const accepted = await confirm({
+      title: `Forget ${folder.displayName}?`,
+      description:
+        "Withdraws OpenWave's approval for this folder everywhere, for every chat. If the folder comes back, connect it again from scratch.",
+      confirmLabel: "Forget",
+      destructive: true,
+    });
+    if (!accepted) return;
+    setWorking(true);
+    setError(null);
+    try {
+      await forgetFolder(folder.rootId);
+      useRefreshSignals.getState().signal("folderAccess");
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setWorking(false);
+    }
+  }
+
   async function revokeStatement(
     folder: ConnectedFolder,
     statement: ConsentStatementSnapshot,
@@ -244,9 +277,9 @@ export function FoldersView({ chat }: { chat: Chat }) {
           </Empty>
         ) : (
           <>
-            {folders.length > 0 && (
+            {connectedFolders.length > 0 && (
               <FolderSection label="Connected">
-                {folders.map((folder) => {
+                {connectedFolders.map((folder) => {
                   const statements = folderStatements(
                     consents,
                     folder.rootId,
@@ -323,6 +356,43 @@ export function FoldersView({ chat }: { chat: Chat }) {
                     </FolderCard>
                   );
                 })}
+              </FolderSection>
+            )}
+
+            {unavailableFolders.length > 0 && (
+              <FolderSection label="Unavailable">
+                {unavailableFolders.map((folder) => (
+                  <FolderCard
+                    key={folder.rootId}
+                    name={folder.displayName}
+                    action={
+                      <div className="flex shrink-0 gap-1">
+                        <Button
+                          variant="outline"
+                          size="xs"
+                          disabled={working}
+                          onClick={() => void removeFolder(folder)}
+                        >
+                          Disconnect
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="xs"
+                          disabled={working}
+                          onClick={() => void forgetUnavailableFolder(folder)}
+                        >
+                          Forget
+                        </Button>
+                      </div>
+                    }
+                  >
+                    <p className="text-sm text-muted-foreground">
+                      OpenWave can’t reach this folder right now. It stays
+                      connected and returns on its own once the folder is back
+                      — or forget it to withdraw its access everywhere.
+                    </p>
+                  </FolderCard>
+                ))}
               </FolderSection>
             )}
 

--- a/crates/openwave-desktop/ui/src/host.ts
+++ b/crates/openwave-desktop/ui/src/host.ts
@@ -2,9 +2,15 @@ import { invoke, isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import type { Chat, ConsentStatementSnapshot } from "./api";
 
+/** Whether the broker can currently reach a listed folder. "unavailable" is
+ * the set-aside state: the approval and attachment stand, but the directory
+ * could not be reopened — an unplugged drive, a moved folder. */
+export type FolderStatus = "connected" | "unavailable";
+
 export type ConnectedFolder = {
   rootId: string;
   displayName: string;
+  status: FolderStatus;
 };
 
 export type FolderAccessDecision = "allow" | "decline";
@@ -83,6 +89,18 @@ export function connectApprovedFolder(
 export function disconnectFolder(chat: Chat, rootId: string): Promise<boolean> {
   return invoke("disconnect_folder", {
     request: { chatId: chat.id, rootId },
+  });
+}
+
+/**
+ * Withdraw the host approval for a folder the broker can no longer reach —
+ * the remove half of the set-aside surface, for a folder that is gone for
+ * good. Refused for live folders, whose exit is the per-chat disconnect.
+ * Returns whether anything was revoked.
+ */
+export function forgetFolder(rootId: string): Promise<boolean> {
+  return invoke("forget_folder", {
+    request: { rootId },
   });
 }
 

--- a/crates/openwave-desktop/ui/src/useChatFolderAttachments.test.tsx
+++ b/crates/openwave-desktop/ui/src/useChatFolderAttachments.test.tsx
@@ -63,12 +63,14 @@ it("connects and revokes a chat folder through the existing host flow", async ()
       {
         rootId: "root-1",
         displayName: "Research",
+        status: "connected",
       },
     ])
     .mockResolvedValueOnce([]);
   vi.mocked(host.connectFolder).mockResolvedValue({
     rootId: "root-1",
     displayName: "Research",
+    status: "connected",
   });
   vi.mocked(host.disconnectFolder).mockResolvedValue(true);
   const user = userEvent.setup();

--- a/crates/openwave-desktop/ui/src/useChatFolderAttachments.ts
+++ b/crates/openwave-desktop/ui/src/useChatFolderAttachments.ts
@@ -61,10 +61,15 @@ export function useChatFolderAttachments(
       ([folders, consents]) => {
         if (generation !== refreshGeneration.current) return;
         setItems(
-          folders.map((folder) => ({
-            ...folder,
-            statements: folderStatements(consents, folder.rootId, chat),
-          })),
+          folders
+            // The composer chips are working controls for the current turn;
+            // an unavailable folder cannot serve it. The full Folders panel
+            // is where the set-aside state is shown and acted on.
+            .filter((folder) => folder.status === "connected")
+            .map((folder) => ({
+              ...folder,
+              statements: folderStatements(consents, folder.rootId, chat),
+            })),
         );
       },
       (reason) => {

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -42,8 +42,9 @@ use crate::{
         ResolveExecRootsRequest, ResolvedExecRoot, Response, ResponseEnvelope, RevokeGrantRequest,
         RevokeGrantResult, RevokeRootRequest, RevokeRootResult, RootAccess,
         RootAttachmentMutationKind, RootAttachmentMutationReceipt, RootAttachmentMutationRequest,
-        RootAttachmentMutationResult, RootSummary, WriteFileMode, WriteFileRequest,
-        WriteFileResult, MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
+        RootAttachmentMutationResult, RootSummary, UnavailableRootReason, UnavailableRootSummary,
+        WriteFileMode, WriteFileRequest, WriteFileResult, MAX_READ_FILE_BINARY_BYTES,
+        PROTOCOL_VERSION,
     },
     Capability, ConsentMethod, ConsentRecord, ExecutionContext, Grant, GrantError, GrantId,
     GrantSubject, OperationId, RelativePath, RequestId, RootAttachment, RootId, RootPolicy,
@@ -199,47 +200,26 @@ struct UnavailableRoot {
     attachments: Vec<RootAttachment>,
 }
 
-/// Why a persisted root could not be reopened.
-///
-/// The causes are recorded rather than acted on: an unmounted volume reports
-/// itself as missing on some hosts and as an I/O failure on others, so no cause
-/// here is reliable enough to justify destroying an approval on its own.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum UnavailableRootReason {
-    /// Nothing exists at the approved path.
-    Missing,
-    /// The path exists but the broker may no longer open it.
-    PermissionDenied,
-    /// Host I/O failed for some other reason, including a device that is
-    /// present but not ready.
-    HostIo,
-    /// The path resolves to a directory the current policy would not approve.
-    Rejected,
-    /// A different directory now occupies the approved path. Consent named the
-    /// original directory, and rebinding it to whatever replaced it would hand
-    /// out authority the user never gave.
-    Replaced,
+/// The transport reason vocabulary, derived here where the policy error is
+/// observed. The causes are recorded rather than acted on — see the enum's
+/// own docs in [`crate::protocol`].
+fn unavailable_reason(error: &RootPolicyError) -> UnavailableRootReason {
+    match error {
+        RootPolicyError::Io(error) => match error.kind() {
+            io::ErrorKind::NotFound => UnavailableRootReason::Missing,
+            io::ErrorKind::PermissionDenied => UnavailableRootReason::PermissionDenied,
+            _ => UnavailableRootReason::HostIo,
+        },
+        _ => UnavailableRootReason::Rejected,
+    }
 }
 
-impl UnavailableRootReason {
-    fn from_policy_error(error: &RootPolicyError) -> Self {
-        match error {
-            RootPolicyError::Io(error) => match error.kind() {
-                io::ErrorKind::NotFound => Self::Missing,
-                io::ErrorKind::PermissionDenied => Self::PermissionDenied,
-                _ => Self::HostIo,
-            },
-            _ => Self::Rejected,
-        }
-    }
-
-    const fn error_code(self) -> ErrorCode {
-        match self {
-            Self::Missing => ErrorCode::NotFound,
-            Self::PermissionDenied => ErrorCode::Denied,
-            Self::HostIo => ErrorCode::HostIo,
-            Self::Rejected | Self::Replaced => ErrorCode::InvalidRoot,
-        }
+const fn unavailable_error_code(reason: UnavailableRootReason) -> ErrorCode {
+    match reason {
+        UnavailableRootReason::Missing => ErrorCode::NotFound,
+        UnavailableRootReason::PermissionDenied => ErrorCode::Denied,
+        UnavailableRootReason::HostIo => ErrorCode::HostIo,
+        UnavailableRootReason::Rejected | UnavailableRootReason::Replaced => ErrorCode::InvalidRoot,
     }
 }
 
@@ -351,7 +331,8 @@ impl ControlAudit {
             // records that matter their retention.
             ControlRequest::Hello
             | ControlRequest::ListApprovedRoots
-            | ControlRequest::ListGrantStatements => None,
+            | ControlRequest::ListGrantStatements
+            | ControlRequest::ListUnavailableRoots => None,
             ControlRequest::ResolveExecRoots(request) => Some(Self {
                 actor: AuditActor::Control {
                     subject: match request.context.project_id() {
@@ -706,6 +687,11 @@ impl Controller {
                 let state = self.lock_state().map_err(error_response)?;
                 list_grant_statements(&state)
                     .map(|grants| ControlResult::ListGrantStatements { grants })
+            }
+            ControlRequest::ListUnavailableRoots => {
+                let state = self.lock_state().map_err(error_response)?;
+                list_unavailable_roots(&state)
+                    .map(|roots| ControlResult::ListUnavailableRoots { roots })
             }
             ControlRequest::ResolveExecRoots(request) => {
                 let state = self.lock_state().map_err(error_response)?;
@@ -2326,7 +2312,7 @@ fn unavailable_root_event(root: &UnavailableRoot) -> AuditEvent {
         outcome: AuditOutcome::Failed,
         capability: None,
         grant_id: None,
-        error_code: Some(root.reason.error_code()),
+        error_code: Some(unavailable_error_code(root.reason)),
         item_count: None,
         bytes: None,
     }
@@ -2427,6 +2413,41 @@ fn list_grant_statements(state: &State) -> Result<Vec<GrantStatementSummary>, Er
             .then_with(|| left.grant_id.to_string().cmp(&right.grant_id.to_string()))
     });
     Ok(statements)
+}
+
+/// Every set-aside root, by its safe identity.
+///
+/// The management-surface companion to [`list_approved_roots`], which omits
+/// these roots because they cannot be attached. Display names are recovered
+/// from the approved path's basename — the same identity a live registration
+/// would carry — and the owner and riding attachments are included so the
+/// trusted desktop can tell an outage from a detach and address a deliberate
+/// [`ControlRequest::RevokeRoot`] at the registering subject.
+fn list_unavailable_roots(state: &State) -> Result<Vec<UnavailableRootSummary>, ErrorResponse> {
+    if state.unavailable.len() > MAX_LIST_ROOTS {
+        return Err(error_response(BrokerError::RootListTooLarge));
+    }
+    let mut roots = state
+        .unavailable
+        .iter()
+        .map(|root| UnavailableRootSummary {
+            root_id: root.id,
+            display_name: root_display_name(&root.path),
+            reason: root.reason,
+            owner: root.owner,
+            attached_conversations: root
+                .attachments
+                .iter()
+                .map(|attachment| attachment.conversation_id())
+                .collect(),
+        })
+        .collect::<Vec<_>>();
+    roots.sort_by(|left, right| {
+        left.display_name
+            .cmp(&right.display_name)
+            .then_with(|| left.root_id.to_string().cmp(&right.root_id.to_string()))
+    });
+    Ok(roots)
 }
 
 fn list_roots(

--- a/crates/openwave-host-broker/src/broker/state_file.rs
+++ b/crates/openwave-host-broker/src/broker/state_file.rs
@@ -14,12 +14,12 @@ use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    has_physical_root_alias, root_display_name, scope_targets_root, BrokerError, MutationRecord,
-    RegisteredRoot, State, UnavailableRoot, UnavailableRootReason,
+    has_physical_root_alias, root_display_name, scope_targets_root, unavailable_reason,
+    BrokerError, MutationRecord, RegisteredRoot, State, UnavailableRoot,
 };
 use crate::{
     path_policy::RootIdentity, Capability, ConsentMethod, ConsentRecord, Grant, GrantId,
-    GrantSubject, OperationId, RootAttachment, RootId, RootPolicy, Scope,
+    GrantSubject, OperationId, RootAttachment, RootId, RootPolicy, Scope, UnavailableRootReason,
 };
 
 const STATE_VERSION: u32 = 4;
@@ -145,10 +145,7 @@ impl StateFile {
                     );
                 }
                 Ok(_) => unavailable.push(set_aside(item, UnavailableRootReason::Replaced)),
-                Err(error) => unavailable.push(set_aside(
-                    item,
-                    UnavailableRootReason::from_policy_error(&error),
-                )),
+                Err(error) => unavailable.push(set_aside(item, unavailable_reason(&error))),
             }
         }
 

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -222,6 +222,19 @@ fn list_approved(controller: &Controller) -> Vec<RootSummary> {
     roots
 }
 
+fn list_unavailable(controller: &Controller) -> Vec<UnavailableRootSummary> {
+    let result = unwrap_response(controller.handle(ControlEnvelope {
+        protocol_version: PROTOCOL_VERSION,
+        request_id: crate::RequestId::new(),
+        request: ControlRequest::ListUnavailableRoots,
+    }))
+    .unwrap();
+    let ControlResult::ListUnavailableRoots { roots } = result else {
+        panic!("unexpected control result")
+    };
+    roots
+}
+
 fn resolve_exec(
     controller: &Controller,
     context: ExecutionContext,
@@ -2648,6 +2661,65 @@ fn an_unreachable_root_is_set_aside_rather_than_blocking_the_others() {
     assert!(roots
         .iter()
         .any(|root| root.root_id == offline.root.root_id));
+}
+
+/// The set-aside product surface: while a root's directory is gone the
+/// listing names it safely — reason, owner, and the attachments riding out
+/// the outage — where the approved-roots listing deliberately omits it, and a
+/// deliberate revocation by the owner forgets it for good rather than letting
+/// the approval linger forever.
+#[test]
+fn set_aside_roots_are_listed_for_the_product_and_forgettable() {
+    let (temp, broker, path, state_dir) = durable_setup();
+    let conversation = Uuid::new_v4();
+    let subject = GrantSubject::conversation(conversation).unwrap();
+    let root_id = register(
+        &broker.controller(),
+        subject,
+        conversation,
+        path.clone(),
+        OperationId::new(),
+    )
+    .root
+    .root_id;
+    drop(broker);
+    let stashed = path.with_file_name("Documents-offline");
+    std::fs::rename(&path, &stashed).unwrap();
+
+    let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+    let controller = broker.controller();
+    assert!(list_approved(&controller).is_empty());
+    assert_eq!(
+        list_unavailable(&controller),
+        vec![UnavailableRootSummary {
+            root_id,
+            display_name: "Documents".to_owned(),
+            reason: UnavailableRootReason::Missing,
+            owner: subject,
+            attached_conversations: vec![conversation],
+        }]
+    );
+
+    // Forgetting is the owner's deliberate instruction, and it reaches the
+    // set-aside registration: grants, attachment, and listing all go.
+    assert_eq!(
+        revoke(&controller, OperationId::new(), subject, root_id),
+        RevokeRootResult { revoked: true }
+    );
+    assert!(list_unavailable(&controller).is_empty());
+    // The subject-wide ListRoots grant is not the root's; everything scoped to
+    // the forgotten root is gone.
+    assert!(grant_statements(&controller)
+        .iter()
+        .all(|grant| matches!(grant.scope, Scope::Subject)));
+    drop(controller);
+    drop(broker);
+
+    // The directory coming back does not resurrect the forgotten approval.
+    std::fs::rename(&stashed, &path).unwrap();
+    let broker = Broker::open(test_policy(&temp), &state_dir).unwrap();
+    assert!(list_approved(&broker.controller()).is_empty());
+    assert!(list_unavailable(&broker.controller()).is_empty());
 }
 
 #[test]

--- a/crates/openwave-host-broker/src/lib.rs
+++ b/crates/openwave-host-broker/src/lib.rs
@@ -40,7 +40,7 @@ pub use protocol::{
     ResolvedExecRoot, Response, ResponseEnvelope, RevokeGrantRequest, RevokeGrantResult,
     RevokeRootRequest, RevokeRootResult, RootAccess, RootAttachmentMutationKind,
     RootAttachmentMutationReceipt, RootAttachmentMutationRequest, RootAttachmentMutationResult,
-    RootSummary, WriteApproval, WriteFileMode, WriteFileRequest, WriteFileResult,
-    MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
+    RootSummary, UnavailableRootReason, UnavailableRootSummary, WriteApproval, WriteFileMode,
+    WriteFileRequest, WriteFileResult, MAX_READ_FILE_BINARY_BYTES, PROTOCOL_VERSION,
 };
 pub use relative_path::{RelativePath, RelativePathError};

--- a/crates/openwave-host-broker/src/protocol.rs
+++ b/crates/openwave-host-broker/src/protocol.rs
@@ -73,6 +73,17 @@ pub enum ControlRequest {
     /// same safe folder identity as [`ControlRequest::ListApprovedRoots`] —
     /// display names, never absolute paths — and confers no authority.
     ListGrantStatements,
+    /// List safe summaries of set-aside roots: approvals whose directory the
+    /// broker could not reopen when it loaded.
+    ///
+    /// A trusted-host management operation like
+    /// [`ControlRequest::ListApprovedRoots`], which deliberately omits these
+    /// roots because nothing can be attached to them. Without this listing a
+    /// set-aside root simply vanishes from every product surface — the user
+    /// cannot tell an unplugged drive from a deliberate detach, and a folder
+    /// deleted for good keeps its approval with nothing to withdraw it. Safe
+    /// identities only: display names and reasons, never absolute paths.
+    ListUnavailableRoots,
     /// Resolve exact product-attached roots for one local-exec invocation.
     ///
     /// This trusted-host operation returns absolute paths and must never be
@@ -366,6 +377,7 @@ pub enum ControlResult {
     Hello(HelloResult),
     ListApprovedRoots { roots: Vec<RootSummary> },
     ListGrantStatements { grants: Vec<GrantStatementSummary> },
+    ListUnavailableRoots { roots: Vec<UnavailableRootSummary> },
     ResolveExecRoots { roots: Vec<ResolvedExecRoot> },
     RegisterRoot(RegisterRootResult),
     LookupRegisterRootReceipt(LookupRegisterRootReceiptResult),
@@ -446,6 +458,49 @@ pub struct GrantStatementSummary {
     pub root_display_name: Option<String>,
     pub consent_method: ConsentMethod,
     pub granted_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Why a persisted root could not be reopened.
+///
+/// The causes are recorded rather than acted on: an unmounted volume reports
+/// itself as missing on some hosts and as an I/O failure on others, so no
+/// cause here is reliable enough to justify destroying an approval on its
+/// own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum UnavailableRootReason {
+    /// Nothing exists at the approved path.
+    Missing,
+    /// The path exists but the broker may no longer open it.
+    PermissionDenied,
+    /// Host I/O failed for some other reason, including a device that is
+    /// present but not ready.
+    HostIo,
+    /// The path resolves to a directory the current policy would not approve.
+    Rejected,
+    /// A different directory now occupies the approved path. Consent named the
+    /// original directory, and rebinding it to whatever replaced it would hand
+    /// out authority the user never gave.
+    Replaced,
+}
+
+/// One set-aside root, by its safe identity.
+///
+/// `owner` is the subject that originally established the approval — the one
+/// [`ControlRequest::RevokeRoot`] requires — exposed so the trusted desktop
+/// can offer to forget a folder that is gone for good. Attachments travel in
+/// conversation IDs the product already holds; the absolute path never
+/// crosses the transport.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UnavailableRootSummary {
+    pub root_id: RootId,
+    pub display_name: String,
+    pub reason: UnavailableRootReason,
+    pub owner: GrantSubject,
+    /// Conversations whose attachment is riding out the outage with the root.
+    pub attached_conversations: Vec<Uuid>,
 }
 
 /// One reachable folder together with what the broker would actually allow on


### PR DESCRIPTION
Closes #1164.

Since #1162, a root whose directory cannot be reopened is set aside — grants and attachments ride out the outage and return when the folder does. The broker side was complete, but the product could not see it: `list_connected_folders` intersects the chat's attachments with the broker's live `ListRoots`, so a set-aside root simply vanished. An unplugged drive looked exactly like a deliberate detach, and a folder deleted for good kept its approval forever because nothing ever sent `RevokeRoot`.

- The broker gains a `ListUnavailableRoots` control listing: the management-surface companion to `ListApprovedRoots`, which deliberately omits these roots because nothing can attach to them. Each summary carries the safe identity (basename display name, never the path), the set-aside reason, the registering owner — the subject `RevokeRoot` requires — and the conversations riding out the outage. The internal reason enum moves to the protocol as the transport vocabulary.
- `list_connected_folders` now merges those summaries in, and `ConnectedFolder` carries a `status` (`connected` / `unavailable`). The composer's folder chips filter to connected — they are working controls for the current turn — while the folders panel shows set-aside folders in their own "Unavailable" group, consistent with #1390's grouping, explaining that the folder returns on its own when reachable.
- Each unavailable row offers Disconnect (the existing per-chat detach, which already reaches set-aside attachments) and a new Forget: a confirmed, destructive withdrawal of the approval everywhere, wired through the previously-uncalled `RevokeRoot` via a new `forget_folder` command. The desktop restricts Forget to set-aside roots; a live folder's exit stays the ordinary disconnect.

One broker test covers the surface end to end: while the directory is gone the listing names the root with reason, owner, and riding attachment while the approved listing omits it; the owner's revocation forgets it — root-scoped grants and attachment included — and the directory coming back does not resurrect the forgotten approval. A renderer test covers the distinguishable group and the confirm-then-forget flow. Existing UI fixtures gained the new `status` field.