### PR TITLE
feat(server): publish digest-pinned sandbox agent images and consume them by default

### DIFF
--- a/.github/workflows/publish-sandbox-image.yml
+++ b/.github/workflows/publish-sandbox-image.yml
@@ -1,0 +1,164 @@
+name: Publish sandbox agent images
+
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch'
+    && format('Publish sandbox images {0}', inputs.image_tag)
+    || format('Publish sandbox images {0}', github.ref_name) }}
+
+# Builds the two sandbox-agent image variants from
+# crates/openwave-sandbox-agent/Dockerfile and publishes them to GHCR:
+#
+#   ghcr.io/brightwave-inc/openwave-sandbox-agent            (slim)
+#   ghcr.io/brightwave-inc/openwave-sandbox-agent-documents  (documents, the
+#                                                             local backend's
+#                                                             default)
+#
+# Each publish is multi-arch (amd64 + arm64, built on native runners — the
+# development fleet is Apple Silicon, so an amd64-only image would run the
+# whole sandbox under emulation there). Version tags are treated as immutable:
+# a tag that already exists on GHCR fails the run rather than being repointed.
+# The final manifest-list digests land in the run summary; the local backend
+# records the documents digest as its verified pin (see `sandbox_docker` in
+# openwave-server for the recorded pin and the follow-up-PR step).
+#
+# Publishing uses the workflow's own GITHUB_TOKEN with packages:write only; no
+# repository secret is consumed. First-time note: a package created by this
+# workflow is private by default — making it publicly pullable (and linking it
+# to the repository) is a one-time manual toggle in the GHCR package settings.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: >-
+          Image tag to publish from the dispatched ref (vX.Y.Z, optionally with
+          a pre-release suffix such as v0.9.0-images.1)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: openwave-sandbox-image-${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  SLIM_REPOSITORY: ghcr.io/${{ github.repository_owner }}/openwave-sandbox-agent
+  DOCUMENTS_REPOSITORY: ghcr.io/${{ github.repository_owner }}/openwave-sandbox-agent-documents
+  IMAGE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || github.ref_name }}
+
+jobs:
+  build:
+    name: build and push · ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Reject an invalid image tag
+        run: |
+          [[ "$IMAGE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]] || {
+            echo "Image tag must look like vX.Y.Z (optional pre-release suffix): $IMAGE_TAG" >&2
+            exit 1
+          }
+
+      - name: Log in to GHCR
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+      # Version tags are immutable: refuse the whole build when the final
+      # manifest-list tag already exists, before any per-arch push mutates
+      # anything.
+      - name: Refuse to republish an existing version tag
+        run: |
+          for repository in "$SLIM_REPOSITORY" "$DOCUMENTS_REPOSITORY"; do
+            if docker manifest inspect "$repository:$IMAGE_TAG" >/dev/null 2>&1; then
+              echo "Refusing to overwrite existing image tag $repository:$IMAGE_TAG" >&2
+              exit 1
+            fi
+          done
+
+      - name: Build both image variants
+        run: |
+          docker build \
+            --file crates/openwave-sandbox-agent/Dockerfile \
+            --target slim \
+            --tag "$SLIM_REPOSITORY:$IMAGE_TAG-${{ matrix.arch }}" \
+            .
+          docker build \
+            --file crates/openwave-sandbox-agent/Dockerfile \
+            --target documents \
+            --tag "$DOCUMENTS_REPOSITORY:$IMAGE_TAG-${{ matrix.arch }}" \
+            .
+
+      - name: Smoke test the documents variant
+        run: |
+          docker run --rm --entrypoint python3 \
+            "$DOCUMENTS_REPOSITORY:$IMAGE_TAG-${{ matrix.arch }}" \
+            -c 'import fpdf, pypdf, pptx, docx, openpyxl, matplotlib, pypdfium2'
+          docker run --rm --entrypoint soffice \
+            "$DOCUMENTS_REPOSITORY:$IMAGE_TAG-${{ matrix.arch }}" \
+            --version
+
+      - name: Push per-architecture tags
+        run: |
+          docker push "$SLIM_REPOSITORY:$IMAGE_TAG-${{ matrix.arch }}"
+          docker push "$DOCUMENTS_REPOSITORY:$IMAGE_TAG-${{ matrix.arch }}"
+
+  manifest:
+    name: assemble multi-arch manifests
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Log in to GHCR
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
+      - name: Create the immutable version manifests
+        run: |
+          for repository in "$SLIM_REPOSITORY" "$DOCUMENTS_REPOSITORY"; do
+            if docker manifest inspect "$repository:$IMAGE_TAG" >/dev/null 2>&1; then
+              echo "Refusing to overwrite existing image tag $repository:$IMAGE_TAG" >&2
+              exit 1
+            fi
+            docker buildx imagetools create \
+              --tag "$repository:$IMAGE_TAG" \
+              "$repository:$IMAGE_TAG-amd64" \
+              "$repository:$IMAGE_TAG-arm64"
+          done
+
+      - name: Record published digests
+        run: |
+          {
+            echo "## Published sandbox agent images"
+            echo
+            for repository in "$SLIM_REPOSITORY" "$DOCUMENTS_REPOSITORY"; do
+              digest="$(docker buildx imagetools inspect \
+                "$repository:$IMAGE_TAG" \
+                --format '{{json .Manifest.Digest}}' | tr -d '"')"
+              echo "- \`$repository:$IMAGE_TAG\` → \`$digest\`"
+            done
+            echo
+            echo "Pin the documents digest as \`PUBLISHED_IMAGE_DIGEST\` in"
+            echo "\`crates/openwave-server/src/sandbox_docker.rs\` (one-line follow-up PR)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/crates/openwave-code-execution/src/daytona.rs
+++ b/crates/openwave-code-execution/src/daytona.rs
@@ -78,6 +78,7 @@ pub struct DaytonaExecutionProvider {
     client: Client,
     endpoints: DaytonaEndpoints,
     egress: Option<EgressPolicy>,
+    snapshot: Option<String>,
 }
 
 #[derive(Clone)]
@@ -136,7 +137,24 @@ impl DaytonaExecutionProvider {
             client,
             endpoints,
             egress: None,
+            snapshot: None,
         })
+    }
+
+    /// Create every sandbox from this account-registered Daytona snapshot
+    /// instead of Daytona's default.
+    ///
+    /// Daytona cannot pull an arbitrary OCI ref at sandbox creation: an image
+    /// must first be registered as a *snapshot* in the account (their tooling
+    /// accepts a digest-pinned ref, which is where the integrity pin lives).
+    /// Pointing Daytona at the official OpenWave documents image means
+    /// registering it as a snapshot and naming that snapshot here. Absent an
+    /// override the default snapshot keeps working — skills fall back to
+    /// in-sandbox `pip install`.
+    #[must_use]
+    pub fn with_snapshot(mut self, snapshot: impl Into<String>) -> Self {
+        self.snapshot = Some(snapshot.into());
+        self
     }
 
     /// Compile an egress policy into every sandbox this provider creates.
@@ -219,6 +237,7 @@ impl DaytonaExecutionProvider {
                 // Delete once the idle stop happens. A later command creates a
                 // fresh chat workspace instead of leaving stopped resources.
                 auto_delete_interval: 0,
+                snapshot: self.snapshot.as_deref(),
             })
             .send()
             .await
@@ -712,6 +731,9 @@ struct CreateSandboxRequest<'a> {
     network: DaytonaNetworkSettings,
     auto_stop_interval: u32,
     auto_delete_interval: u32,
+    /// An account-registered snapshot name; omitted, Daytona uses its default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    snapshot: Option<&'a str>,
 }
 
 #[derive(Serialize)]

--- a/crates/openwave-code-execution/src/e2b.rs
+++ b/crates/openwave-code-execution/src/e2b.rs
@@ -85,6 +85,7 @@ pub struct E2BExecutionProvider {
     client: Client,
     endpoints: E2BEndpoints,
     egress: Option<EgressPolicy>,
+    template: String,
 }
 
 #[derive(Clone)]
@@ -143,7 +144,23 @@ impl E2BExecutionProvider {
             client,
             endpoints,
             egress: None,
+            template: E2B_TEMPLATE.into(),
         })
+    }
+
+    /// Create every sandbox from this E2B template instead of the default
+    /// public code-interpreter template.
+    ///
+    /// E2B provisions from account-registered *templates*, not arbitrary OCI
+    /// refs, so pointing E2B at the official OpenWave documents image means
+    /// registering a template built from
+    /// `crates/openwave-sandbox-agent/Dockerfile` with E2B's own tooling and
+    /// naming its id here. Absent an override the default template keeps
+    /// working — skills fall back to in-sandbox `pip install`.
+    #[must_use]
+    pub fn with_template(mut self, template: impl Into<String>) -> Self {
+        self.template = template.into();
+        self
     }
 
     /// Compile an egress policy into every sandbox this provider creates.
@@ -206,7 +223,7 @@ impl E2BExecutionProvider {
             .post(url)
             .header("X-API-Key", self.credential.as_str())
             .json(&CreateSandboxRequest {
-                template_id: E2B_TEMPLATE,
+                template_id: &self.template,
                 timeout: E2B_SANDBOX_TTL_SECONDS,
                 secure: true,
                 allow_internet_access: network.allow_internet_access,
@@ -610,7 +627,7 @@ impl CodeExecutionProvider for E2BExecutionProvider {
 #[derive(Serialize)]
 struct CreateSandboxRequest<'a> {
     #[serde(rename = "templateID")]
-    template_id: &'static str,
+    template_id: &'a str,
     timeout: u64,
     secure: bool,
     allow_internet_access: bool,

--- a/crates/openwave-core/src/config.rs
+++ b/crates/openwave-core/src/config.rs
@@ -69,7 +69,9 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "is_false")]
     pub container_execution_enabled: bool,
     /// Optional container image override for sandbox-resident agent runs.
-    /// `None` uses the server's documented placeholder image.
+    /// `None` uses the server's default: the published documents agent image
+    /// pinned by digest, or the locally built development image while no
+    /// digest is recorded.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub container_image: Option<String>,
     /// Path to the self-host profile's static bearer-token file, mapping each
@@ -113,7 +115,7 @@ impl Config {
     /// `./.openwave` under the current directory — desktop/CLI clients should set
     /// this to the platform's app-data location),
     /// `OPENWAVE_CONTAINER_EXECUTION_ENABLED` (default `false`),
-    /// `OPENWAVE_CONTAINER_IMAGE` (defaulting to the server's placeholder
+    /// `OPENWAVE_CONTAINER_IMAGE` (defaulting to the server's default agent
     /// image), and `OPENWAVE_AUTH_TOKENS_FILE` (self-host only; required
     /// there).
     pub fn from_env() -> Result<Self> {

--- a/crates/openwave-sandbox-agent/Dockerfile
+++ b/crates/openwave-sandbox-agent/Dockerfile
@@ -1,4 +1,4 @@
-# The OpenWave sandbox agent image.
+# The OpenWave sandbox agent images.
 #
 # Packages the `openwave-sandbox-agent` binary: the sandbox-side transport
 # server plus the in-container agent loop. The container's entrypoint runs the
@@ -7,15 +7,28 @@
 # run with the `egress-proxy` argument it serves the sandbox's network boundary
 # from its own dual-homed container (see `sandbox_docker` in openwave-server).
 #
+# Two runtime variants build from this file:
+#
+#   - `slim`      — the agent binary on a minimal Debian base. The egress proxy
+#                   runs from this layer's contents; nothing else is needed.
+#   - `documents` — `slim` plus LibreOffice (headless DOCX/PPTX/XLSX rendering
+#                   for the document skills' visual QA loop), the bundled exec
+#                   helper scripts, and the document skills' pinned Python
+#                   dependencies preinstalled system-wide, so a sandbox produces
+#                   documents without any in-run package install. This is the
+#                   default build target and the ref the local backend runs.
+#
 # Build context is the WORKSPACE ROOT, so the whole Cargo workspace and the
 # committed Cargo.lock are visible to a `--locked` build:
 #
 #   docker build -f crates/openwave-sandbox-agent/Dockerfile -t openwave-sandbox-agent .
+#   docker build -f crates/openwave-sandbox-agent/Dockerfile --target slim -t openwave-sandbox-agent-slim .
 #
-# Nothing verifies this image by digest today. The host runs whatever ref it is
-# configured with (`DockerConfig::image`), which accepts a digest-pinned ref but
-# does not require or check one. Treat the image's integrity as unverified on the
-# local backend.
+# Official images are published to GHCR by .github/workflows/publish-sandbox-image.yml
+# on version tags, and the local backend pins the published documents image by
+# digest (see `sandbox_docker` in openwave-server for the recorded pin and its
+# provenance). A locally built tag is the development fallback and carries no
+# digest verification.
 #
 # The scoped post-merge sandbox-resident lane builds and drives this image on a
 # real container boundary.
@@ -37,31 +50,17 @@ COPY . .
 # tools live in this crate and are the point of the image.)
 RUN cargo build --release --locked -p openwave-sandbox-agent
 
-# ---- runtime stage ---------------------------------------------------------
-# The document helpers need Python plus native renderers. The container remains
-# the isolation boundary; packages are installed at image-build time and no
-# helper performs a network request at runtime.
-FROM debian:bookworm-slim AS runtime
+# ---- slim runtime ----------------------------------------------------------
+# The agent binary and nothing else: the egress proxy's image, and the base the
+# documents variant layers onto.
+FROM debian:bookworm-slim AS slim
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-       ca-certificates \
-       libreoffice-impress \
-       libreoffice-writer \
-       poppler-utils \
-       python3 \
-       python3-openpyxl \
-       python3-pil \
-       python3-pip \
-    && python3 -m pip install --break-system-packages --no-cache-dir pypdfium2==4.30.0 \
-    && rm -rf /var/lib/apt/lists/* /root/.cache \
-    && mkdir -p /workspace /opt/openwave/exec-scripts
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /workspace
 
 COPY --from=build /src/target/release/openwave-sandbox-agent /usr/local/bin/openwave-sandbox-agent
-COPY scripts/exec-documents/ /opt/openwave/exec-scripts/
-
-RUN python3 /opt/openwave/exec-scripts/render_pdf.py --help >/dev/null \
-    && python3 /opt/openwave/exec-scripts/analyze_xlsx.py --help >/dev/null
 
 # The agent — and therefore every command the model runs through `exec` — runs as
 # an unprivileged user, so a container escape starts from an account that owns
@@ -79,10 +78,53 @@ RUN groupadd --gid 10001 openwave \
 ENV OPENWAVE_SANDBOX_LISTEN=0.0.0.0:8080
 # The in-container workspace root the exec and filesystem tools are scoped to.
 ENV OPENWAVE_SANDBOX_WORKSPACE=/workspace
-# The helper library path shown to the model-facing exec tool.
-ENV OPENWAVE_EXEC_SCRIPTS=/opt/openwave/exec-scripts
 EXPOSE 8080
 
 USER openwave:openwave
 
 ENTRYPOINT ["/usr/local/bin/openwave-sandbox-agent"]
+
+# ---- documents runtime (default) -------------------------------------------
+# The document helpers need Python plus native renderers, and the document
+# skills (skills/*/SKILL.md) each pin one Python library. Preinstalling those
+# exact pins system-wide means a background document run needs no in-sandbox
+# `pip install` — no package-manager egress, no per-run install latency. The
+# container remains the isolation boundary; packages are installed at
+# image-build time and no helper performs a network request at runtime.
+FROM slim AS documents
+
+USER root
+
+# The pip pins mirror the `deps` manifests of the document skills; keep them in
+# lockstep when a SKILL.md bumps a version. pypdfium2 backs the bundled
+# render_pdf.py helper. openpyxl comes from pip rather than apt so the installed
+# version matches the spreadsheets skill's pin (bookworm's python3-openpyxl is
+# older).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       libreoffice-impress \
+       libreoffice-writer \
+       poppler-utils \
+       python3 \
+       python3-pil \
+       python3-pip \
+    && python3 -m pip install --break-system-packages --no-cache-dir \
+       pypdfium2==4.30.0 \
+       fpdf2==2.8.3 \
+       pypdf==5.1.0 \
+       python-pptx==1.0.2 \
+       python-docx==1.1.2 \
+       openpyxl==3.1.5 \
+       matplotlib==3.10.0 \
+    && rm -rf /var/lib/apt/lists/* /root/.cache \
+    && mkdir -p /opt/openwave/exec-scripts
+
+COPY scripts/exec-documents/ /opt/openwave/exec-scripts/
+
+RUN python3 /opt/openwave/exec-scripts/render_pdf.py --help >/dev/null \
+    && python3 /opt/openwave/exec-scripts/analyze_xlsx.py --help >/dev/null
+
+# The helper library path shown to the model-facing exec tool.
+ENV OPENWAVE_EXEC_SCRIPTS=/opt/openwave/exec-scripts
+
+USER openwave:openwave

--- a/crates/openwave-sandbox-protocol/src/provisioning.rs
+++ b/crates/openwave-sandbox-protocol/src/provisioning.rs
@@ -288,6 +288,19 @@ pub trait SandboxBackend: Send + Sync {
     fn enforces_external_lifetime_cap(&self) -> bool {
         false
     }
+
+    /// Whether the agent image this backend provisions from is verified within
+    /// the topology's trust root before anything executes in it — for a
+    /// registry-backed backend, that the resolved image's content is pinned by
+    /// digest rather than reached through a mutable tag.
+    ///
+    /// Detached admission requires this capability (issue #1188): an image a
+    /// registry or daemon can silently swap under a tag is not a trust root.
+    /// The default is `false` (fail closed) — a backend that does not declare
+    /// the verification cannot host a detached run.
+    fn verifies_image_integrity(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -254,6 +254,18 @@ pub struct CodeExecutionConfig {
     /// open-internet creation they already had.
     #[serde(default)]
     pub egress: EgressConfig,
+    /// E2B template id to create sandboxes from. `None` keeps E2B's public
+    /// code-interpreter template; set it to the id of a template registered
+    /// from the official OpenWave documents image so document runs need no
+    /// in-sandbox package install.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub e2b_template: Option<String>,
+    /// Daytona snapshot name to create sandboxes from. `None` keeps Daytona's
+    /// default snapshot; set it to a snapshot registered from the official
+    /// OpenWave documents image (Daytona cannot pull an arbitrary OCI ref at
+    /// creation — registration is where the digest pin lives).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daytona_snapshot: Option<String>,
 }
 
 impl Default for CodeExecutionConfig {
@@ -262,6 +274,8 @@ impl Default for CodeExecutionConfig {
             provider: Some(CodeExecutionProviderKind::Local),
             timeout_ms: DEFAULT_TIMEOUT_MS,
             egress: EgressConfig::Open,
+            e2b_template: None,
+            daytona_snapshot: None,
         }
     }
 }
@@ -272,6 +286,8 @@ impl CodeExecutionConfig {
             provider: None,
             timeout_ms: DEFAULT_TIMEOUT_MS,
             egress: EgressConfig::Open,
+            e2b_template: None,
+            daytona_snapshot: None,
         }
     }
 
@@ -315,8 +331,12 @@ fn configured_e2b(
     timeout: Duration,
     pool: RemoteSessionPool,
     egress: &EgressConfig,
+    template: Option<&str>,
 ) -> std::result::Result<E2BExecutionProvider, CodeExecutionError> {
-    let provider = E2BExecutionProvider::with_session_pool(credential, timeout, pool)?;
+    let mut provider = E2BExecutionProvider::with_session_pool(credential, timeout, pool)?;
+    if let Some(template) = template {
+        provider = provider.with_template(template);
+    }
     Ok(match resolve_egress_policy(egress)? {
         Some(policy) => provider.with_egress_policy(policy),
         None => provider,
@@ -331,8 +351,12 @@ fn configured_daytona(
     timeout: Duration,
     pool: RemoteSessionPool,
     egress: &EgressConfig,
+    snapshot: Option<&str>,
 ) -> std::result::Result<DaytonaExecutionProvider, CodeExecutionError> {
-    let provider = DaytonaExecutionProvider::with_session_pool(credential, timeout, pool)?;
+    let mut provider = DaytonaExecutionProvider::with_session_pool(credential, timeout, pool)?;
+    if let Some(snapshot) = snapshot {
+        provider = provider.with_snapshot(snapshot);
+    }
     match resolve_egress_policy(egress)? {
         Some(policy) => provider.with_egress_policy(policy),
         None => Ok(provider),
@@ -604,6 +628,15 @@ pub struct CodeExecutionConfigUpdate {
     /// no secret or endpoint is accepted here — only domain patterns and CIDRs.
     #[serde(default)]
     pub egress: Option<EgressConfig>,
+    /// Replace the E2B template id. An explicit null (or empty string) returns
+    /// to E2B's default template; absent leaves the current value unchanged.
+    #[serde(default, deserialize_with = "double_option")]
+    pub e2b_template: Option<Option<String>>,
+    /// Replace the Daytona snapshot name. An explicit null (or empty string)
+    /// returns to Daytona's default snapshot; absent leaves the current value
+    /// unchanged.
+    #[serde(default, deserialize_with = "double_option")]
+    pub daytona_snapshot: Option<Option<String>>,
 }
 
 fn double_option<'de, D, T>(deserializer: D) -> std::result::Result<Option<Option<T>>, D::Error>
@@ -688,6 +721,12 @@ pub async fn update_config(
     }
     if let Some(egress) = update.egress {
         config.egress = egress;
+    }
+    if let Some(template) = update.e2b_template {
+        config.e2b_template = template.filter(|value| !value.is_empty());
+    }
+    if let Some(snapshot) = update.daytona_snapshot {
+        config.daytona_snapshot = snapshot.filter(|value| !value.is_empty());
     }
     config.validate()?;
     write_config(store, &config).await?;
@@ -1488,6 +1527,7 @@ impl ConfiguredCodeExecutionProvider {
                     Duration::from_millis(config.timeout_ms),
                     self.remote_sessions.clone(),
                     &egress,
+                    config.e2b_template.as_deref(),
                 )?)
             }
             CodeExecutionProviderKind::Daytona => {
@@ -1502,6 +1542,7 @@ impl ConfiguredCodeExecutionProvider {
                     Duration::from_millis(config.timeout_ms),
                     self.remote_sessions.clone(),
                     &egress,
+                    config.daytona_snapshot.as_deref(),
                 )?)
             }
             _ => {
@@ -2711,6 +2752,8 @@ mod tests {
             provider: Some(CodeExecutionProviderKind::Local),
             timeout_ms: MIN_TIMEOUT_MS - 1,
             egress: EgressConfig::Open,
+            e2b_template: None,
+            daytona_snapshot: None,
         }
         .validate()
         .is_err());
@@ -2769,6 +2812,8 @@ mod tests {
             provider: Some(CodeExecutionProviderKind::E2b),
             timeout_ms: DEFAULT_TIMEOUT_MS,
             egress: bad,
+            e2b_template: None,
+            daytona_snapshot: None,
         }
         .validate()
         .is_err());
@@ -2882,6 +2927,7 @@ mod tests {
             timeout,
             pool.clone(),
             &allowlist,
+            None,
         )
         .unwrap();
         assert_eq!(e2b.egress_policy(), Some(&expected));
@@ -2891,6 +2937,7 @@ mod tests {
             timeout,
             pool.clone(),
             &allowlist,
+            None,
         )
         .unwrap();
         assert_eq!(daytona.egress_policy(), Some(&expected));
@@ -2902,6 +2949,7 @@ mod tests {
             timeout,
             pool.clone(),
             &EgressConfig::Open,
+            None,
         )
         .unwrap();
         assert_eq!(open_e2b.egress_policy(), None);
@@ -2910,6 +2958,7 @@ mod tests {
             timeout,
             pool,
             &EgressConfig::Open,
+            None,
         )
         .unwrap();
         assert_eq!(open_daytona.egress_policy(), None);
@@ -2928,6 +2977,8 @@ mod tests {
                 provider: Some(None),
                 timeout_ms: Some(MIN_TIMEOUT_MS),
                 egress: None,
+                e2b_template: None,
+                daytona_snapshot: None,
             },
         )
         .await;
@@ -2946,6 +2997,8 @@ mod tests {
                 provider: Some(Some(CodeExecutionProviderKind::Local)),
                 timeout_ms: Some(MAX_TIMEOUT_MS),
                 egress: None,
+                e2b_template: None,
+                daytona_snapshot: None,
             },
         )
         .await;

--- a/crates/openwave-server/src/sandbox_admission.rs
+++ b/crates/openwave-server/src/sandbox_admission.rs
@@ -30,10 +30,18 @@ impl SandboxContainerAdmission {
 
 /// Resolve the backend and fixed location for this server process.
 pub(crate) fn resolve(config: &Config) -> SandboxContainerAdmission {
-    let backend = Arc::new(DockerSandboxBackend::new(docker_config(config)));
+    let docker = docker_config(config);
+    let backend = Arc::new(DockerSandboxBackend::new(docker));
     let backend_available = config.container_execution_enabled && backend.is_available();
     let execution_location =
         execution_location(config.container_execution_enabled, backend_available);
+    if execution_location == AgentRunExecutionLocation::Container
+        && !backend.verifies_image_integrity()
+    {
+        // The development fallback (or an operator's mutable-tag override):
+        // containers still run, but nothing verifies what the ref resolves to.
+        tracing::warn!("sandbox container image is not digest-pinned; running it unverified");
+    }
     SandboxContainerAdmission {
         backend,
         execution_location,
@@ -53,8 +61,10 @@ fn execution_location(
 }
 
 /// Build the Docker configuration shared by admission detection and the
-/// container worker service. An absent override retains the adapter's
-/// documented placeholder image.
+/// container worker service. An absent override retains the adapter's default
+/// image (the published documents image by digest, or the local development
+/// build while no digest is pinned); an explicit override replaces the whole
+/// ref, digest included, so a mutable-tag override is honestly unverified.
 pub(crate) fn docker_config(config: &Config) -> DockerConfig {
     let mut docker = DockerConfig::default();
     if let Some(image) = &config.container_image {
@@ -177,26 +187,26 @@ pub(crate) fn evaluate_detached_admission(
     }
 }
 
-/// The preconditions the current run shape establishes, given the two facts
+/// The preconditions the current run shape establishes, given the three facts
 /// owned by other components: token issuance (the issuer's honest
-/// availability) and the backend's external lifetime cap.
+/// availability), the backend's external lifetime cap, and the backend's
+/// image verification.
 ///
 /// The remaining fields are the run shape every sandbox run has today — the
 /// container capability host grants ModelInference only, so no reverse
 /// capability reaches a host-authority operation, and no third-party
-/// credential is ever delivered into a run. Image verification within a trust
-/// root does not exist yet (#1188). The runner and the settings surface both
-/// read this one function, so what settings says a provider is missing is by
-/// construction what the gate would deny it for.
+/// credential is ever delivered into a run. The runner and the settings
+/// surface both read this one function, so what settings says a provider is
+/// missing is by construction what the gate would deny it for.
 pub(crate) fn structural_preconditions(
     scoped_model_token_available: bool,
     external_lifetime_cap: bool,
+    image_verified: bool,
 ) -> DetachedPreconditions {
     DetachedPreconditions {
         scoped_model_token_available,
         external_lifetime_cap,
-        // No image verification within a trust root yet (#1188).
-        image_verified: false,
+        image_verified,
         // The container capability host grants ModelInference only; no
         // reverse capability reaches a host-authority operation.
         host_authority_tool_surface: false,
@@ -220,18 +230,25 @@ pub(crate) fn settings_detached_admissions(
     config: &Config,
 ) -> Vec<(CodeExecutionProviderKind, DetachedAdmission)> {
     let scoped_token = GatewayScopedTokenIssuer.available();
-    let local_lifetime_cap =
-        DockerSandboxBackend::new(docker_config(config)).enforces_external_lifetime_cap();
+    let local = DockerSandboxBackend::new(docker_config(config));
+    let local_facts = (
+        local.enforces_external_lifetime_cap(),
+        local.verifies_image_integrity(),
+    );
     [
-        (CodeExecutionProviderKind::Local, local_lifetime_cap),
-        (CodeExecutionProviderKind::E2b, false),
-        (CodeExecutionProviderKind::Daytona, false),
+        (CodeExecutionProviderKind::Local, local_facts),
+        (CodeExecutionProviderKind::E2b, (false, false)),
+        (CodeExecutionProviderKind::Daytona, (false, false)),
     ]
     .into_iter()
-    .map(|(provider, lifetime_cap)| {
+    .map(|(provider, (lifetime_cap, image_verified))| {
         (
             provider,
-            evaluate_detached_admission(structural_preconditions(scoped_token, lifetime_cap)),
+            evaluate_detached_admission(structural_preconditions(
+                scoped_token,
+                lifetime_cap,
+                image_verified,
+            )),
         )
     })
     .collect()

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -312,6 +312,7 @@ impl SandboxContainerRunner {
             // run-scoped, short-lived, revocable token can actually be minted.
             self.token_issuer.available(),
             self.backend.enforces_external_lifetime_cap(),
+            self.backend.verifies_image_integrity(),
         )
     }
 

--- a/crates/openwave-server/src/sandbox_docker.rs
+++ b/crates/openwave-server/src/sandbox_docker.rs
@@ -88,12 +88,23 @@
 //! so an observer on the local segment could see looked-up names; payload
 //! connections stay blocked either way.
 //!
-//! # The image is not verified
+//! # Image verification
 //!
-//! [`DockerConfig::image`] is used verbatim. It accepts a digest-pinned ref, but
-//! nothing requires or checks one, so a mutable tag is resolved by the daemon at
-//! provisioning time with no host-side integrity check. The local backend's trust
-//! in the image is therefore the operator's trust in whatever ref they configured.
+//! The default image ref is the published documents-variant agent image pinned
+//! **by digest** ([`PUBLISHED_IMAGE_DIGEST`]): a `repository@sha256:…` ref is
+//! content-addressed, so the daemon resolves it to exactly those bytes or fails
+//! the provisioning — repointing the tag on the registry changes nothing, and a
+//! locally present image of another content cannot answer for it. That is the
+//! fail-closed digest check issue #1188 asked for, enforced at resolution
+//! rather than re-derived after the fact.
+//!
+//! A ref *without* a digest — the local development fallback while no pin is
+//! recorded, or an operator override that names a mutable tag — is used
+//! verbatim and stays unverified: the daemon resolves the tag at provisioning
+//! time with no host-side integrity check. The backend reports which case it is
+//! in through [`SandboxBackend::verifies_image_integrity`], so detached
+//! admission and the settings surface treat an unpinned image as the unmet
+//! precondition it is, and startup logs the unverified case.
 //!
 //! # The transport secret
 //!
@@ -164,9 +175,30 @@ const RELAY_TARGET_ENV: &str = "OPENWAVE_RELAY_TARGET";
 
 /// The default runtime binary, resolved on `PATH`.
 const DEFAULT_BINARY: &str = "docker";
-/// A documented placeholder image. The real agent image (loop plus supervisor) ships
-/// in a later slice; a container from this ref only needs to start and hold its port.
-const DEFAULT_IMAGE: &str = "ghcr.io/openwave/sandbox-agent:placeholder";
+/// The published documents-variant agent image: the agent binary plus
+/// LibreOffice and the document skills' pinned Python dependencies, built and
+/// pushed by `.github/workflows/publish-sandbox-image.yml` so background
+/// document runs need no in-sandbox package install.
+const PUBLISHED_IMAGE_REPOSITORY: &str = "ghcr.io/brightwave-inc/openwave-sandbox-agent-documents";
+/// The immutable manifest-list digest (`sha256:<64 hex>`) of the published
+/// documents image the default configuration runs.
+///
+/// PROVENANCE: recorded from the publish workflow's run summary — the digest
+/// each publish run prints next to the documents ref. Update it in a one-line
+/// PR whenever a new image version is published.
+///
+/// `None` until the first publish run exists: the digest cannot be pinned
+/// before an image is published, and the publish workflow lands together with
+/// this pin's machinery. While unset the default fails over to
+/// [`LOCAL_DEV_IMAGE`] — a ref that only exists after a local `docker build`
+/// and carries no digest verification, which
+/// [`SandboxBackend::verifies_image_integrity`] reports honestly.
+const PUBLISHED_IMAGE_DIGEST: Option<&str> = None;
+/// The locally built development image, produced by the documented
+/// `docker build -f crates/openwave-sandbox-agent/Dockerfile -t openwave-sandbox-agent .`
+/// (whose default target is the documents variant). The fallback default while
+/// no published digest is pinned; never digest-verified.
+const LOCAL_DEV_IMAGE: &str = "openwave-sandbox-agent:latest";
 /// The in-container port the sandbox supervisor listens on by default.
 const DEFAULT_LISTENER_PORT: u16 = 8080;
 /// The lifetime cap applied when a provisioning request names none: four hours.
@@ -220,7 +252,9 @@ pub struct DockerConfig {
     /// Docker-CLI-compatible path. Either a bare name resolved on `PATH` or an
     /// explicit path.
     pub binary: String,
-    /// The image ref to run. Defaults to a documented placeholder.
+    /// The image ref to run. Defaults to the published documents image pinned
+    /// by digest, or to the locally built development image while no digest is
+    /// recorded; see [`default_image`].
     pub image: String,
     /// The in-container port to publish to a loopback host port.
     pub listener_port: u16,
@@ -247,7 +281,7 @@ impl Default for DockerConfig {
     fn default() -> Self {
         Self {
             binary: DEFAULT_BINARY.to_owned(),
-            image: DEFAULT_IMAGE.to_owned(),
+            image: default_image(),
             listener_port: DEFAULT_LISTENER_PORT,
             command: Vec::new(),
             proxy_command: Vec::new(),
@@ -330,7 +364,7 @@ impl DockerSandboxBackend {
     }
 
     /// Build a backend with the default configuration (the `docker` binary and the
-    /// placeholder image).
+    /// default image; see [`default_image`]).
     #[must_use]
     pub fn with_defaults() -> Self {
         Self::new(DockerConfig::default())
@@ -483,6 +517,15 @@ impl DockerSandboxBackend {
 
 #[async_trait]
 impl SandboxBackend for DockerSandboxBackend {
+    /// Verified exactly when the configured ref is digest-pinned: a
+    /// `repository@sha256:…` ref is content-addressed, so the daemon either
+    /// resolves those bytes or fails the provisioning. A tag ref (the local
+    /// development fallback, or an operator override without a digest) is not
+    /// verified, and this reports it — fail closed, never assumed.
+    fn verifies_image_integrity(&self) -> bool {
+        image_digest_pinned(&self.config.image)
+    }
+
     async fn provision(&self, request: ProvisionRequest) -> Result<SandboxHandle, BackendError> {
         if !self.is_available() {
             return Err(BackendError::Provision(RUNTIME_UNAVAILABLE.to_owned()));
@@ -662,6 +705,30 @@ fn effective_lifetime_cap(config: &DockerConfig, request: &ProvisionRequest) -> 
         .lifetime_cap_secs
         .or(config.lifetime_cap_secs)
         .filter(|secs| *secs > 0)
+}
+
+/// The default image ref: the published documents image pinned by digest once
+/// [`PUBLISHED_IMAGE_DIGEST`] is recorded, the locally built development image
+/// until then. A digest-pinned ref is what makes the default verified — see
+/// the module docs' image-verification section.
+fn default_image() -> String {
+    match PUBLISHED_IMAGE_DIGEST {
+        Some(digest) => format!("{PUBLISHED_IMAGE_REPOSITORY}@{digest}"),
+        None => LOCAL_DEV_IMAGE.to_owned(),
+    }
+}
+
+/// Whether an image ref is pinned by a well-formed content digest
+/// (`…@sha256:<64 hex>`), making its resolution content-addressed and
+/// therefore fail-closed on any mismatch.
+pub(crate) fn image_digest_pinned(image: &str) -> bool {
+    image
+        .rsplit_once("@sha256:")
+        .is_some_and(|(repository, hex)| {
+            !repository.is_empty()
+                && hex.len() == 64
+                && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+        })
 }
 
 /// The per-run internal network's name — a pure function of the tag, so
@@ -1085,6 +1152,40 @@ mod tests {
         // for a present runtime binary so the positive branch is covered too.
         #[cfg(unix)]
         assert!(resolve_on_path("/bin/sh").is_some());
+    }
+
+    /// The default-image pin's honesty invariants, guarding the decision that
+    /// is easiest to reverse by accident: a recorded [`PUBLISHED_IMAGE_DIGEST`]
+    /// must be well-formed and make the default verified; while unset the
+    /// default must be the local development build and be *reported* as
+    /// unverified rather than assumed safe.
+    #[test]
+    fn default_image_pin_is_wellformed_and_reported_honestly() {
+        let default = DockerConfig::default().image;
+        match PUBLISHED_IMAGE_DIGEST {
+            Some(digest) => {
+                assert_eq!(default, format!("{PUBLISHED_IMAGE_REPOSITORY}@{digest}"));
+                assert!(PUBLISHED_IMAGE_REPOSITORY.starts_with("ghcr.io/brightwave-inc/"));
+                assert!(image_digest_pinned(&default));
+                assert!(DockerSandboxBackend::with_defaults().verifies_image_integrity());
+            }
+            None => {
+                assert_eq!(default, LOCAL_DEV_IMAGE);
+                assert!(!DockerSandboxBackend::with_defaults().verifies_image_integrity());
+            }
+        }
+
+        // The pin grammar itself: exactly a 64-hex sha256 suffix counts.
+        let digest_ref = format!("ghcr.io/brightwave-inc/example@sha256:{}", "a".repeat(64));
+        assert!(image_digest_pinned(&digest_ref));
+        assert!(!image_digest_pinned(
+            "ghcr.io/brightwave-inc/example:latest"
+        ));
+        assert!(!image_digest_pinned(&format!(
+            "ghcr.io/brightwave-inc/example@sha256:{}",
+            "a".repeat(63)
+        )));
+        assert!(!image_digest_pinned(&format!("@sha256:{}", "a".repeat(64))));
     }
 
     #[tokio::test]

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -252,6 +252,42 @@ test("production secrets remain isolated to the release workflow", () => {
   assert.match(release, /^permissions:\n  contents: read$/m);
 });
 
+test("sandbox image publishing is tag-driven, immutable, and secret-free", () => {
+  const publish = workflows["publish-sandbox-image.yml"];
+  assert.ok(publish);
+
+  // Only version tags and manual dispatch publish; a pull request never can.
+  assert.match(publish, /^on:\n  push:\n    tags: \["v\*"\]\n  workflow_dispatch:/m);
+  assert.doesNotMatch(publish, /^\s*pull_request(?:_target)?:/m);
+
+  // The default token with packages:write is the whole credential surface —
+  // publishing must not grow a dependency on repository secrets (that set
+  // stays isolated to release.yml by the production-secrets test above).
+  assert.match(publish, /^permissions:\n  contents: read$/m);
+  assert.match(publish, /^    permissions:\n      contents: read\n      packages: write$/m);
+  assert.doesNotMatch(publish, /secrets\./);
+
+  // Version tags are immutable: both the per-arch build job and the manifest
+  // job refuse a tag that already exists instead of repointing it.
+  const overwriteGuards = publish.match(
+    /Refusing to overwrite existing image tag/g,
+  );
+  assert.equal(overwriteGuards?.length, 2);
+  assert.match(publish, /docker manifest inspect "\$repository:\$IMAGE_TAG"/);
+
+  // Published refs stay under this owner's GHCR namespace, and the digest the
+  // local backend pins is surfaced by the run itself.
+  assert.match(
+    publish,
+    /ghcr\.io\/\$\{\{ github\.repository_owner \}\}\/openwave-sandbox-agent$/m,
+  );
+  assert.match(
+    publish,
+    /ghcr\.io\/\$\{\{ github\.repository_owner \}\}\/openwave-sandbox-agent-documents$/m,
+  );
+  assert.match(publish, /PUBLISHED_IMAGE_DIGEST/);
+});
+
 test("release builds use the trusted shared main cache scope", () => {
   const release = workflows["release.yml"];
   const dispatchJob = workflowJob(release, "dispatch");


### PR DESCRIPTION
Official sandbox agent images: agents download rather than build, with the document toolchain preinstalled. Closes #1188, and completes slice 3 of #1227 — closes #1227.

## Images

`crates/openwave-sandbox-agent/Dockerfile` now has two runtime targets:

- **`slim`** — the agent binary on minimal Debian; everything the egress proxy face needs.
- **`documents`** (default target, preserving today's single-image behavior for the local build and the post-merge sandbox-resident lane) — `slim` plus LibreOffice, poppler, and the document skills' exact pinned Python dependencies installed system-wide: fpdf2 2.8.3, pypdf 5.1.0, python-pptx 1.0.2, python-docx 1.1.2, openpyxl 3.1.5, matplotlib 3.10.0, and pypdfium2 4.30.0 for the bundled helpers. A background document run needs no in-sandbox `pip install` at all. openpyxl moves from apt to pip so the installed version matches the spreadsheets skill's pin (bookworm's apt package is older).

## Publishing

`.github/workflows/publish-sandbox-image.yml` publishes `ghcr.io/brightwave-inc/openwave-sandbox-agent` (slim) and `ghcr.io/brightwave-inc/openwave-sandbox-agent-documents` on `v*` tag pushes and manual dispatch:

- Multi-arch: amd64 + arm64 on native runners (the development fleet is Apple Silicon; an amd64-only image would run the whole sandbox under emulation there).
- Immutable tags: a tag that already exists on GHCR fails the run in both the build and manifest jobs rather than being repointed.
- No repository secrets — the workflow's own token with `packages: write` is the entire credential surface, and each per-arch documents image is smoke-tested (import of every pinned package, `soffice --version`) before anything is pushed.
- The final manifest-list digests are printed in the run summary, ready to paste into the pin.

`scripts/workflow-security.test.mjs` gains a test pinning this policy (tag/dispatch-only triggers, no secrets, overwrite guards, the GHCR namespace, and the digest surfacing).

## Digest-pinned consumption (the #1188 ask)

The local Docker backend's default image is the published documents image **by digest**: `PUBLISHED_IMAGE_REPOSITORY` + `PUBLISHED_IMAGE_DIGEST` in `crates/openwave-server/src/sandbox_docker.rs`, with a provenance comment. A `repository@sha256:…` ref is content-addressed — the daemon resolves exactly those bytes or fails the provisioning, so verification is enforced at resolution and fails closed by construction. `SandboxBackend::verifies_image_integrity` (fail-closed default `false`) reports the fact; the detached-admission gate's `image_verified` precondition now reads it instead of a hard-coded `false`, and server startup logs a warning when containers are enabled on an unpinned ref. An operator's `container_image` override replaces the whole ref — a mutable-tag override is honestly reported as unverified, while a digest-pinned override gets verification for free.

**Chicken-and-egg, stated plainly:** the digest cannot be pinned before the first image exists, and this machine cannot push to GHCR. `PUBLISHED_IMAGE_DIGEST` lands as `None`; while unset the default fails over to the locally built `openwave-sandbox-agent:latest` (unverified, logged, and reported as such to the admission gate). To complete publication:

1. Trigger the publish workflow: `gh workflow run publish-sandbox-image.yml --ref main -f image_tag=vX.Y.Z` (or push the next version tag). One-time GHCR setup: both packages are created private — flip them to public visibility and link them to the repository in the package settings, or pulls will require auth.
2. Merge the one-line pin PR, taking the documents digest from the run summary:

   ```rust
   const PUBLISHED_IMAGE_DIGEST: Option<&str> = Some("sha256:<64 hex from the run summary>");
   ```

   The guard test `default_image_pin_is_wellformed_and_reported_honestly` validates the pin's format and switches its assertions to the published default automatically.

## Remote providers

The documents image is meant to be the default everywhere containers run; neither vendor can simply pull an OCI ref, so each gets a config seam that fails over to today's behavior:

- **Daytona** creates sandboxes only from account-registered *snapshots*; its creation API takes a snapshot name, not an image ref, and exposes no post-start digest to verify against. The creation request now carries an optional `snapshot` (config `daytona_snapshot`; absent keeps Daytona's default snapshot). To adopt: register a snapshot from the digest-pinned documents ref with Daytona's tooling — the digest-pinned registration is where the integrity pin lives — then set `daytona_snapshot`.
- **E2B** provisions from account-registered *templates*. The template id is now configurable (`e2b_template`), falling back to the public `code-interpreter-v1`. To adopt: build a template from the same Dockerfile with E2B's CLI under the account credentials (E2B builds amd64 only), then set `e2b_template` to its id.
- Both fields ride the existing code-execution settings blob and its PUT surface; where they are unset, skills keep their documented in-sandbox `pip install` fallback.
- The macOS Seatbelt foreground provider is deliberately untouched — it is not a container, and its dependency story remains the shared package cache (#1365). Foreground-exec-in-containers-by-default is out of scope here.

## Verified

Locally: rustfmt; clippy (all targets) and the full test suites of openwave-server, openwave-code-execution, openwave-sandbox-protocol, and openwave-core; actionlint on the new workflow; workflow-security tests (18/18 including the new one). **Not verified locally:** the Docker daemon on this machine is unresponsive, so the restructured Dockerfile was not built here — the first publish run and the post-merge sandbox-resident lane (which builds the default target) prove the two-stage build and the in-workflow smoke test.

Residual, deliberately unfiled per the working agreement: surfacing `e2b_template` / `daytona_snapshot` in the settings UI, and running the egress proxy from the slim image (the local driver runs both container faces from the one configured ref today).
