### PR TITLE
feat(server): new chats inherit the last-chosen mode, model, and network policy

### DIFF
--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1385,22 +1385,69 @@ pub struct CreateChat {
     /// Optional project to file this chat under; omitted for a loose chat.
     #[serde(default)]
     pub project_id: Option<ProjectId>,
-    /// Optional model for this chat; omitted to use the configured default.
+    /// Optional model for this chat; omitted seeds the sticky default, else
+    /// the configured default.
     #[serde(default)]
     pub model: Option<String>,
     /// Optional reasoning-effort override for this chat; honored only by models
-    /// that expose the control.
+    /// that expose the control. Omitted seeds the sticky default.
     #[serde(default)]
     pub reasoning_effort: Option<ReasoningEffort>,
-    /// Optional permission mode for this chat; omitted means `ask`.
+    /// Optional permission mode for this chat; omitted seeds the sticky
+    /// default (clamped to any managed ceiling), else `ask`.
     #[serde(default)]
     pub permission_mode: Option<PermissionMode>,
     /// Code-execution network access for this conversation workspace.
+    /// Omitted seeds the sticky default, else no network.
     #[serde(default)]
-    pub network_policy: openwave_core::NetworkPolicy,
+    pub network_policy: Option<openwave_core::NetworkPolicy>,
+}
+
+/// Settings keys holding the sticky new-chat defaults: the reader's last
+/// explicit per-chat choice at these routes, replayed into the next chat.
+///
+/// Deployment-scoped like every other setting. `model` deliberately gets its
+/// own key rather than reusing the global `model` selection: seeding is a
+/// creation-time copy into the new chat, so picking a model in one chat never
+/// retargets existing chats that ride the configured default.
+const STICKY_MODEL_KEY: &str = "chat_default.model";
+const STICKY_REASONING_EFFORT_KEY: &str = "chat_default.reasoning_effort";
+const STICKY_PERMISSION_MODE_KEY: &str = "chat_default.permission_mode";
+const STICKY_NETWORK_POLICY_KEY: &str = "chat_default.network_policy";
+
+/// Read one sticky new-chat default. A stored value this build no longer
+/// recognizes reads as unset rather than failing the create.
+async fn read_sticky_default<T: serde::de::DeserializeOwned>(
+    store: &dyn Store,
+    key: &str,
+) -> openwave_core::Result<Option<T>> {
+    Ok(store
+        .get_setting(key)
+        .await?
+        .and_then(|value| serde_json::from_value(value).ok()))
+}
+
+/// Record (or clear, with `None`) one sticky new-chat default.
+async fn write_sticky_default<T: Serialize>(
+    store: &dyn Store,
+    key: &str,
+    value: Option<&T>,
+) -> Result<(), ServerError> {
+    let value = match value {
+        Some(value) => serde_json::to_value(value)
+            .map_err(|_| ServerError::internal("could not encode a sticky chat default"))?,
+        None => serde_json::Value::Null,
+    };
+    Ok(store.set_setting(key, &value).await?)
 }
 
 /// `POST /chats` — create a chat and return it (`201 Created`).
+///
+/// Fields the request leaves unspecified seed from the sticky defaults — the
+/// reader's last explicit choice at these same routes — so a new chat starts
+/// the way the reader configured the previous one instead of resetting to the
+/// hard defaults. A brand-new install has no sticky state and keeps today's
+/// defaults (`ask`, network off, configured model).
 pub async fn create_chat(
     State(state): State<AppState>,
     store: ScopedStore,
@@ -1415,15 +1462,57 @@ pub async fn create_chat(
         *model = validate_model_selection(&state, model, false).await?;
     }
     refuse_permission_mode_over_ceiling(&state, body.permission_mode).await?;
-    crate::code_execution::normalize_network_policy(&mut body.network_policy)?;
+    if let Some(policy) = body.network_policy.as_mut() {
+        crate::code_execution::normalize_network_policy(policy)?;
+    }
+    let model = match body.model {
+        Some(model) => Some(model),
+        // A sticky selection that no longer validates — deregistered model,
+        // disabled or uncredentialed provider — falls back to the configured
+        // default instead of failing the create or pinning a dead model.
+        None => match read_sticky_default::<String>(&*state.store, STICKY_MODEL_KEY).await? {
+            Some(sticky) => validate_model_selection(&state, &sticky, false).await.ok(),
+            None => None,
+        },
+    };
+    let reasoning_effort = match body.reasoning_effort {
+        Some(effort) => Some(effort),
+        None => read_sticky_default(&*state.store, STICKY_REASONING_EFFORT_KEY).await?,
+    };
+    let permission_mode = match body.permission_mode {
+        Some(mode) => Some(mode),
+        // The managed ceiling clamps a sticky mode recorded before the policy
+        // arrived: a remembered `allow` under an `ask` ceiling seeds `ask`,
+        // mirroring how the turn gate treats stored over-ceiling modes.
+        None => match read_sticky_default(&*state.store, STICKY_PERMISSION_MODE_KEY).await? {
+            Some(sticky) => crate::managed_policy::resolve(&*state.store, &*state.os_policy)
+                .await?
+                .clamp_permission_mode(Some(sticky)),
+            None => None,
+        },
+    };
+    let network_policy = match body.network_policy {
+        Some(policy) => policy,
+        None => {
+            let mut sticky = read_sticky_default(&*state.store, STICKY_NETWORK_POLICY_KEY)
+                .await?
+                .unwrap_or_default();
+            // Stored values were normalized at write; a stale one that no
+            // longer passes falls back to no network rather than failing.
+            if crate::code_execution::normalize_network_policy(&mut sticky).is_err() {
+                sticky = openwave_core::NetworkPolicy::default();
+            }
+            sticky
+        }
+    };
     let chat = Chat {
         id: ChatId::new(),
         project_id: body.project_id,
         title: normalize_chat_title(body.title)?,
-        model: body.model,
-        reasoning_effort: body.reasoning_effort,
-        permission_mode: body.permission_mode,
-        network_policy: body.network_policy,
+        model,
+        reasoning_effort,
+        permission_mode,
+        network_policy,
         attachment_revision: 0,
         root_attachments: Vec::new(),
         created_at: Utc::now(),
@@ -1491,6 +1580,21 @@ pub async fn patch_chat(
         .await?
     {
         return Err(ServerError::not_found(format!("chat {id} not found")));
+    }
+    // Each explicit choice here becomes the sticky default a new chat seeds
+    // from; an explicit clear (`null`) clears the sticky default the same way,
+    // back to the hard default. Recorded server-side so every client benefits.
+    if let Some(model) = &body.model {
+        write_sticky_default(&*state.store, STICKY_MODEL_KEY, model.as_ref()).await?;
+    }
+    if let Some(effort) = &body.reasoning_effort {
+        write_sticky_default(&*state.store, STICKY_REASONING_EFFORT_KEY, effort.as_ref()).await?;
+    }
+    if let Some(mode) = &body.permission_mode {
+        write_sticky_default(&*state.store, STICKY_PERMISSION_MODE_KEY, mode.as_ref()).await?;
+    }
+    if let Some(policy) = &body.network_policy {
+        write_sticky_default(&*state.store, STICKY_NETWORK_POLICY_KEY, Some(policy)).await?;
     }
     if let Some(title) = title {
         chat.title = title;

--- a/crates/openwave-server/src/tests/conversations.rs
+++ b/crates/openwave-server/src/tests/conversations.rs
@@ -508,6 +508,89 @@ async fn patch_chat_sets_and_clears_the_model() {
     assert_eq!(json_body::<Chat>(cleared).await.model, None);
 }
 
+/// A per-chat choice of model, effort, mode, or network policy becomes the
+/// default the next chat seeds from; an explicit value in the create request
+/// still wins, and clearing a choice clears its sticky default too.
+#[tokio::test]
+async fn chat_settings_stick_to_the_next_chat() {
+    let (router, token, _store, _dir) = test_app().await;
+    let bearer = format!("Bearer {token}");
+    let first = make_chat(&router, &bearer).await;
+
+    let patched = patch_chat(
+        &router,
+        &bearer,
+        first.id,
+        serde_json::json!({
+            "model": "m-sticky",
+            "reasoning_effort": "high",
+            "permission_mode": "allow",
+            "network_policy": {"mode": "package_managers"},
+        }),
+    )
+    .await;
+    assert_eq!(patched.status(), StatusCode::OK);
+
+    let second = make_chat(&router, &bearer).await;
+    assert_eq!(second.model.as_deref(), Some("m-sticky"));
+    assert_eq!(
+        second.reasoning_effort,
+        Some(openwave_core::ReasoningEffort::High)
+    );
+    assert_eq!(
+        second.permission_mode,
+        Some(openwave_core::PermissionMode::Allow)
+    );
+    assert_eq!(
+        second.network_policy,
+        openwave_core::NetworkPolicy::PackageManagers
+    );
+
+    // An explicit value in the create request beats the sticky default.
+    let explicit: Chat = json_body(
+        router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/chats")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "permission_mode": "plan",
+                            "network_policy": {"mode": "off"},
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(
+        explicit.permission_mode,
+        Some(openwave_core::PermissionMode::Plan)
+    );
+    assert_eq!(explicit.network_policy, openwave_core::NetworkPolicy::Off);
+    // Untouched fields still seed from the sticky defaults.
+    assert_eq!(explicit.model.as_deref(), Some("m-sticky"));
+
+    // Clearing the per-chat choice clears the sticky default with it.
+    let cleared = patch_chat(
+        &router,
+        &bearer,
+        first.id,
+        serde_json::json!({"model": null, "permission_mode": null}),
+    )
+    .await;
+    assert_eq!(cleared.status(), StatusCode::OK);
+    let third = make_chat(&router, &bearer).await;
+    assert_eq!(third.model, None);
+    assert_eq!(third.permission_mode, None);
+}
+
 #[tokio::test]
 async fn chat_network_policy_defaults_off_and_persists_normalized_exact_hosts() {
     let (router, token, _store, _dir) = test_app().await;
@@ -1387,7 +1470,7 @@ async fn a_managed_ceiling_locks_over_ceiling_permission_modes() {
     let store: Arc<dyn Store> = Arc::new(store);
     let mut state = AppState::new(
         Config::desktop(dir.path()),
-        store,
+        store.clone(),
         Arc::new(FixedResolver(Arc::new(FakeProvider))),
         Arc::new(MemSecrets::default()),
         Arc::new(ToolRegistry::new()),
@@ -1435,4 +1518,16 @@ async fn a_managed_ceiling_locks_over_ceiling_permission_modes() {
         .await
         .unwrap();
     assert_eq!(over_ceiling_creation.status(), StatusCode::CONFLICT);
+
+    // A sticky `allow` recorded before the policy arrived seeds clamped to
+    // the ceiling, exactly like the turn gate treats stored modes.
+    store
+        .set_setting("chat_default.permission_mode", &serde_json::json!("allow"))
+        .await
+        .unwrap();
+    let seeded = make_chat(&router, &bearer).await;
+    assert_eq!(
+        seeded.permission_mode,
+        Some(openwave_core::PermissionMode::Ask)
+    );
 }


### PR DESCRIPTION
Chat settings were sticky only in the desktop's localStorage-backed home pickers; a choice made inside a chat evaporated, and every new chat reset to the hard defaults. This makes stickiness server-side so every client benefits and no new UI is needed.

- `PATCH /chats/{id}` now records each explicit choice — model, reasoning effort, permission mode, network policy — as a sticky default under `chat_default.*` settings keys (deployment-scoped, like every other setting). An explicit `null` clears the sticky default along with the per-chat value.
- `POST /chats` seeds any field the request leaves unspecified from those defaults. Explicit values in the create body still win, and a brand-new install has no sticky state, so the ask / network-off / configured-model defaults are unchanged until the reader's first explicit pick.
- `CreateChat.network_policy` becomes `Option<NetworkPolicy>` so an omitted policy can seed; an absent field previously meant `off`, which remains the terminal fallback.
- A sticky permission mode above a managed ceiling seeds clamped to the ceiling, mirroring the turn gate's treatment of stored over-ceiling modes; selecting over the ceiling stays refused.
- A sticky model that no longer validates (deregistered, or its provider disabled or uncredentialed) falls back to the configured default rather than pinning a dead model or failing the create. The model deliberately gets its own `chat_default.model` key instead of reusing the global `model` selection, so a per-chat pick never retargets existing chats riding the configured default.
- Reasoning effort sticks alongside the rest: it is picked at the same surface for the same reasons, and a reader who always runs at high shouldn't re-select it every chat.

Tests: one route-level test drives a patch of all four fields and asserts the next created chat seeds them, that explicit create values win, and that clearing a choice clears its default; the existing managed-ceiling test grows the sticky-clamp case.

Verified with `cargo fmt`, `cargo clippy -p openwave-server --all-targets --locked`, and the full `cargo test -p openwave-server --locked` suite (560 passing). No UI changes.