### PR TITLE
feat(desktop): background agent activity panel

### DIFF
--- a/crates/openwave-desktop/ui/src/AgentActivityTimeline.tsx
+++ b/crates/openwave-desktop/ui/src/AgentActivityTimeline.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+
+import type { AgentActivityHistoryEntry } from "./api";
+import {
+  agentActivityHistoryLabel,
+  getAgentActivityOutcomeDotClass,
+} from "./AgentRunDisplay";
+import { cn } from "@/lib/utils";
+
+export type AgentActivityState = {
+  loading: boolean;
+  error: boolean;
+  loaded: boolean;
+  items: AgentActivityHistoryEntry[];
+};
+
+/**
+ * A background run's ordered activity history, re-read whenever the observed
+ * run advances (`updatedAt` changes) so a live run's steps settle in place
+ * without a manual refresh. `enabled` gates the fetch entirely — a collapsed
+ * row or an absent run reads nothing.
+ */
+export function useAgentRunActivity(
+  runId: string | null,
+  updatedAt: string | undefined,
+  enabled: boolean,
+  loadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>,
+): AgentActivityState {
+  const [activity, setActivity] = useState<AgentActivityState>({
+    loading: false,
+    error: false,
+    loaded: false,
+    items: [],
+  });
+
+  useEffect(() => {
+    if (!enabled || runId === null) return;
+    let cancelled = false;
+    setActivity((state) => ({ ...state, loading: !state.loaded, error: false }));
+    loadActivity(runId)
+      .then((items) => {
+        if (!cancelled) {
+          setActivity({ loading: false, error: false, loaded: true, items });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setActivity((state) => ({ ...state, loading: false, error: true }));
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, runId, updatedAt, loadActivity]);
+
+  return activity;
+}
+
+/** The ordered timeline itself: one dot, phrase, and time per recorded step. */
+export function AgentActivityTimeline({ state }: { state: AgentActivityState }) {
+  if (state.error) {
+    return (
+      <p className="text-xs text-muted-foreground" role="status">
+        Activity history is unavailable.
+      </p>
+    );
+  }
+  if (state.items.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground" role="status">
+        {state.loading && !state.loaded
+          ? "Loading activity…"
+          : "No recorded activity yet."}
+      </p>
+    );
+  }
+  return (
+    <ol className="flex flex-col gap-2 border-l-2 border-border py-0.5 pl-3" role="list">
+      {state.items.map((entry, index) => (
+        <li key={`${entry.at}:${index}`} className="flex items-center gap-2 text-xs">
+          <span
+            className={cn(
+              "size-1.5 shrink-0 rounded-full",
+              getAgentActivityOutcomeDotClass(entry.outcome),
+            )}
+            aria-hidden="true"
+          />
+          <span className="min-w-0 flex-1 truncate text-foreground">
+            {agentActivityHistoryLabel(entry)}
+          </span>
+          <time className="shrink-0 text-muted-foreground" dateTime={entry.at}>
+            {formatActivityTime(entry.at)}
+          </time>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function formatActivityTime(at: string): string {
+  const parsed = new Date(at);
+  if (Number.isNaN(parsed.getTime())) return "";
+  return parsed.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
@@ -2,11 +2,10 @@ import { useEffect, useState } from "react";
 import { Bot, ChevronDown, ChevronRight, FileOutput, Square } from "lucide-react";
 
 import type { AgentActivityHistoryEntry, AgentRun } from "./api";
+import { AgentActivityTimeline, useAgentRunActivity } from "./AgentActivityTimeline";
 import {
   AGENT_RUN_STATUS_GROUPS,
-  agentActivityHistoryLabel,
   agentRunStatusDetail,
-  getAgentActivityOutcomeDotClass,
   getAgentRunDotClass,
   RUNNING_AGENT_STATUSES,
 } from "./AgentRunDisplay";
@@ -33,6 +32,8 @@ type BackgroundAgentListProps = {
   onLoadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
   /** Open the outputs surface, when a completed run produced a result. */
   onViewOutput?: () => void;
+  /** Open one run's dedicated panel beside the conversation. */
+  onOpen?: (runId: string) => void;
 };
 
 /**
@@ -49,6 +50,7 @@ export function BackgroundAgentList({
   onCancel,
   onLoadActivity,
   onViewOutput,
+  onOpen,
 }: BackgroundAgentListProps) {
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const sandboxRuns = runs.filter((run) => run.tier === "background");
@@ -141,6 +143,7 @@ export function BackgroundAgentList({
                         onCancel={onCancel}
                         onLoadActivity={onLoadActivity}
                         onViewOutput={onViewOutput}
+                        onOpen={onOpen}
                       />
                     ))}
                   </div>
@@ -163,17 +166,12 @@ export function BackgroundAgentList({
   );
 }
 
-type ActivityState = {
-  loading: boolean;
-  error: boolean;
-  loaded: boolean;
-  items: AgentActivityHistoryEntry[];
-};
-
 /**
  * One background run: its live status on a line, expandable into the ordered
  * timeline of what it has done, with a Stop control while it is cancellable and
- * a link to its output once it finishes with one.
+ * a link to its output once it finishes with one. When the panel navigation is
+ * wired, the row itself opens the run's dedicated panel; the chevron keeps the
+ * inline timeline for a quick glance without leaving the transcript.
  */
 function BackgroundAgentRow({
   run,
@@ -181,21 +179,23 @@ function BackgroundAgentRow({
   onCancel,
   onLoadActivity,
   onViewOutput,
+  onOpen,
 }: {
   run: AgentRun;
   label: string;
   onCancel: (runId: string) => Promise<void>;
   onLoadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
   onViewOutput?: () => void;
+  onOpen?: (runId: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [stopping, setStopping] = useState(false);
-  const [activity, setActivity] = useState<ActivityState>({
-    loading: false,
-    error: false,
-    loaded: false,
-    items: [],
-  });
+  const activity = useAgentRunActivity(
+    run.id,
+    run.updated_at,
+    expanded,
+    onLoadActivity,
+  );
 
   // The Stop control is offered only while a fresh cancel would still change
   // anything. A run that is already `cancelling` shows a settled "Stopping".
@@ -210,28 +210,6 @@ function BackgroundAgentRow({
   useEffect(() => {
     if (!stoppable) setStopping(false);
   }, [stoppable]);
-
-  // Re-read the timeline whenever the row is open and the run advances, so a
-  // live run's steps settle in place without a manual refresh.
-  useEffect(() => {
-    if (!expanded) return;
-    let cancelled = false;
-    setActivity((state) => ({ ...state, loading: !state.loaded, error: false }));
-    onLoadActivity(run.id)
-      .then((items) => {
-        if (!cancelled) {
-          setActivity({ loading: false, error: false, loaded: true, items });
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setActivity((state) => ({ ...state, loading: false, error: true }));
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [expanded, run.id, run.updated_at, onLoadActivity]);
 
   const handleStop = async () => {
     setStopping(true);
@@ -251,10 +229,11 @@ function BackgroundAgentRow({
       <div className="flex min-w-0 items-center gap-2">
         <button
           type="button"
-          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+          className="shrink-0"
           onClick={() => setExpanded((open) => !open)}
           aria-expanded={expanded}
           aria-controls={contentId}
+          aria-label={expanded ? "Hide activity" : "Show activity"}
         >
           <ChevronDown
             className={cn(
@@ -263,6 +242,14 @@ function BackgroundAgentRow({
             )}
             aria-hidden="true"
           />
+        </button>
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+          onClick={() =>
+            onOpen ? onOpen(run.id) : setExpanded((open) => !open)
+          }
+        >
           <span
             className={cn("size-2 shrink-0 rounded-full", getAgentRunDotClass(run.status))}
             aria-hidden="true"
@@ -307,50 +294,4 @@ function BackgroundAgentRow({
       )}
     </div>
   );
-}
-
-function AgentActivityTimeline({ state }: { state: ActivityState }) {
-  if (state.error) {
-    return (
-      <p className="text-xs text-muted-foreground" role="status">
-        Activity history is unavailable.
-      </p>
-    );
-  }
-  if (state.items.length === 0) {
-    return (
-      <p className="text-xs text-muted-foreground" role="status">
-        {state.loading && !state.loaded
-          ? "Loading activity…"
-          : "No recorded activity yet."}
-      </p>
-    );
-  }
-  return (
-    <ol className="flex flex-col gap-2 border-l-2 border-border py-0.5 pl-3" role="list">
-      {state.items.map((entry, index) => (
-        <li key={`${entry.at}:${index}`} className="flex items-center gap-2 text-xs">
-          <span
-            className={cn(
-              "size-1.5 shrink-0 rounded-full",
-              getAgentActivityOutcomeDotClass(entry.outcome),
-            )}
-            aria-hidden="true"
-          />
-          <span className="min-w-0 flex-1 truncate text-foreground">
-            {agentActivityHistoryLabel(entry)}
-          </span>
-          <time className="shrink-0 text-muted-foreground" dateTime={entry.at}>
-            {formatActivityTime(entry.at)}
-          </time>
-        </li>
-      ))}
-    </ol>
-  );
-}
-
-function formatActivityTime(at: string): string {
-  const parsed = new Date(at);
-  if (Number.isNaN(parsed.getTime())) return "";
-  return parsed.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }

--- a/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useState } from "react";
+import { Bot, FileOutput, Square } from "lucide-react";
+
+import { useApp } from "./AppContext";
+import { AgentActivityTimeline, useAgentRunActivity } from "./AgentActivityTimeline";
+import { agentRunStatusDetail, RUNNING_AGENT_STATUSES } from "./AgentRunDisplay";
+import type { AgentRun } from "./api";
+import { useAgentRuns } from "./useAgentRuns";
+import { PanelBreadcrumb } from "@/components/PanelHeader";
+import { PanelFrame } from "@/panel/PanelFrame";
+import type { PanelPosition } from "@/panel/panelTypes";
+import { usePanelNav } from "@/panel/usePanelNav";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * One background run, opened beside the conversation from its row in the
+ * transcript's agent list.
+ *
+ * The panel reads the same durable, renderer-safe snapshot the inline list
+ * polls — status, elapsed time, and the ordered activity history — and its one
+ * command is the same durable cancellation request. It keeps observing while
+ * the run is live, so the header and timeline settle on their own as the run
+ * finishes, fails, or stops.
+ */
+export function BackgroundAgentPanel({
+  chatId,
+  runId,
+  position,
+}: {
+  chatId: string;
+  runId: string;
+  position: PanelPosition;
+}) {
+  const { client } = useApp();
+  const { openPanel } = usePanelNav();
+  const agentRuns = useAgentRuns(client, chatId, [runId]);
+  const run =
+    agentRuns.runs.find(
+      (candidate) => candidate.id === runId && candidate.tier === "background",
+    ) ?? null;
+
+  const stoppable =
+    run !== null &&
+    RUNNING_AGENT_STATUSES.has(run.status) &&
+    run.status !== "cancelling";
+  const [stopping, setStopping] = useState(false);
+  useEffect(() => {
+    if (!stoppable) setStopping(false);
+  }, [stoppable]);
+
+  const activity = useAgentRunActivity(
+    runId,
+    run?.updated_at,
+    run !== null,
+    agentRuns.loadActivity,
+  );
+
+  const stopButton = stoppable ? (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="h-7 gap-1 px-2 text-xs"
+      disabled={stopping}
+      onClick={() => {
+        setStopping(true);
+        agentRuns.cancel(runId).catch(() => setStopping(false));
+      }}
+    >
+      <Square className="size-3 fill-current" aria-hidden="true" />
+      {stopping ? "Stopping" : "Stop"}
+    </Button>
+  ) : undefined;
+
+  return (
+    <PanelFrame
+      position={position}
+      breadcrumb={<PanelBreadcrumb firstPart="Agent" />}
+      headerRightSlot={stopButton}
+      showBorder
+    >
+      {run ? (
+        <BackgroundAgentDetail
+          run={run}
+          activity={activity}
+          onViewOutput={
+            run.produced_output ? () => openPanel({ type: "outputs" }) : undefined
+          }
+        />
+      ) : agentRuns.error ? (
+        <div className="flex items-center justify-between gap-3 p-4 text-sm" role="status">
+          <span>Background agent status is unavailable.</span>
+          <button
+            type="button"
+            className="shrink-0 font-medium text-primary hover:underline"
+            onClick={agentRuns.refresh}
+          >
+            Retry
+          </button>
+        </div>
+      ) : agentRuns.loading ? (
+        <div className="flex flex-col gap-3 p-4" role="status" aria-label="Loading agent">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-4 w-64" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      ) : (
+        <p className="p-4 text-sm text-muted-foreground" role="status">
+          This agent run is not part of this chat.
+        </p>
+      )}
+    </PanelFrame>
+  );
+}
+
+function BackgroundAgentDetail({
+  run,
+  activity,
+  onViewOutput,
+}: {
+  run: AgentRun;
+  activity: ReturnType<typeof useAgentRunActivity>;
+  onViewOutput?: () => void;
+}) {
+  const live = RUNNING_AGENT_STATUSES.has(run.status);
+  const now = useNowWhile(live);
+  const elapsed = elapsedLabel(run, now);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      <div className="shrink-0 px-4 pt-4">
+        <div className="flex items-center gap-2">
+          <Bot className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+          <h2 className="min-w-0 flex-1 truncate text-base font-medium">
+            Background agent
+          </h2>
+          <AgentRunStatusBadge status={run.status} />
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {agentRunStatusDetail(run)}
+          {elapsed && <> · {elapsed}</>}
+        </p>
+        {run.status === "failed" && run.last_error_code && (
+          <p className="mt-1 font-mono text-xs text-critical">
+            {run.last_error_code}
+          </p>
+        )}
+      </div>
+      <div className="mt-3 flex shrink-0 flex-col gap-2 border-b px-4 pb-3 empty:hidden">
+        {onViewOutput && (
+          <div className="flex items-center justify-between gap-2 rounded-md border px-3 py-2">
+            <span className="text-sm text-foreground">
+              This agent produced output.
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 shrink-0 gap-1 px-2 text-xs"
+              onClick={onViewOutput}
+            >
+              <FileOutput className="size-3.5" aria-hidden="true" />
+              View output
+            </Button>
+          </div>
+        )}
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto p-4" aria-live="polite">
+        <AgentActivityTimeline state={activity} />
+      </div>
+    </div>
+  );
+}
+
+function AgentRunStatusBadge({ status }: { status: AgentRun["status"] }) {
+  switch (status) {
+    case "completed":
+      return <Badge variant="success" size="sm">Complete</Badge>;
+    case "failed":
+      return <Badge variant="critical" size="sm">Failed</Badge>;
+    case "cancelled":
+      return <Badge variant="critical" size="sm">Stopped</Badge>;
+    case "cancelling":
+      return <Badge variant="outline" size="sm">Stopping</Badge>;
+    case "waiting":
+    case "retry_wait":
+      return <Badge variant="warning" size="sm">Waiting</Badge>;
+    case "active":
+    case "queued":
+    case "running":
+      return <Badge variant="info" size="sm">Running</Badge>;
+  }
+}
+
+/** The current second, ticking only while something on screen depends on it. */
+function useNowWhile(active: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    setNow(Date.now());
+    const interval = window.setInterval(() => setNow(Date.now()), 1_000);
+    return () => window.clearInterval(interval);
+  }, [active]);
+  return now;
+}
+
+/**
+ * How long the run has been (or was) working, from its durable start to its
+ * durable finish — or to now, while it is still live. A run that has not
+ * started yet has nothing to count.
+ */
+function elapsedLabel(run: AgentRun, now: number): string | null {
+  if (!run.started_at) return null;
+  const started = new Date(run.started_at).getTime();
+  if (Number.isNaN(started)) return null;
+  const finished = run.finished_at ? new Date(run.finished_at).getTime() : now;
+  const seconds = Math.max(0, Math.floor((finished - started) / 1_000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+}

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -36,6 +36,7 @@ import type { RetryableTurn } from "./MessageList";
 import type { TranscriptFileAttachment } from "./TranscriptFileAttachments";
 import type { TranscriptImageAttachment } from "./ImageAttachments";
 import { AppsPanel } from "./apps/AppsPanel";
+import { BackgroundAgentPanel } from "./BackgroundAgentPanel";
 import { OutputDetailRoot } from "./outputs/OutputDetailRoot";
 import { OutputsView } from "./outputs/OutputsView";
 import { DocumentDetailRoot } from "./document-detail/DocumentDetailRoot";
@@ -610,6 +611,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             onSend={onSend}
             onRetryTurn={retryTurn}
             onViewOutput={() => openPanel({ type: "outputs" })}
+            onOpenAgentPanel={(runId) => openPanel({ type: "agent", runId })}
           />
         </TranscriptVisibilityProvider>
       );
@@ -650,6 +652,14 @@ export function ChatRoute({ chatId }: { chatId: string }) {
         );
       case "apps":
         return <AppsPanel panel={panel} position={side} />;
+      case "agent":
+        return (
+          <BackgroundAgentPanel
+            chatId={chatId}
+            runId={panel.runId}
+            position={side}
+          />
+        );
     }
   }
 

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -51,6 +51,8 @@ export type ChatViewProps = {
   onRetryTurn?: (turn: RetryableTurn) => void;
   /** Open the outputs surface, offered on a completed background run's row. */
   onViewOutput?: () => void;
+  /** Open one background run's panel beside the conversation. */
+  onOpenAgentPanel?: (runId: string) => void;
 };
 
 /**
@@ -78,6 +80,7 @@ export function ChatView({
   onSend,
   onRetryTurn,
   onViewOutput,
+  onOpenAgentPanel,
 }: ChatViewProps) {
   const transcriptVisible = useTranscriptVisible();
   // Subscribed here rather than in the route above: a keystroke should
@@ -296,6 +299,7 @@ export function ChatView({
           onCancelBackgroundAgentRun={agentRuns.cancel}
           onLoadBackgroundAgentActivity={agentRuns.loadActivity}
           onViewBackgroundAgentOutput={onViewOutput}
+          onOpenBackgroundAgent={onOpenAgentPanel}
           busy={busy}
           streamStalled={streamStalled}
           scrollRef={attachScrollRef}

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -192,6 +192,7 @@ type MessageListProps = {
     runId: string,
   ) => Promise<AgentActivityHistoryEntry[]>;
   onViewBackgroundAgentOutput?: () => void;
+  onOpenBackgroundAgent?: (runId: string) => void;
   busy: boolean;
   /** The live turn's stream has gone quiet — see [useStreamStalled]. */
   streamStalled?: boolean;
@@ -263,6 +264,7 @@ export function MessageList({
   onCancelBackgroundAgentRun = async () => undefined,
   onLoadBackgroundAgentActivity = async () => [],
   onViewBackgroundAgentOutput,
+  onOpenBackgroundAgent,
   busy,
   streamStalled = false,
   scrollRef,
@@ -315,6 +317,7 @@ export function MessageList({
       cancel: onCancelBackgroundAgentRun,
       loadActivity: onLoadBackgroundAgentActivity,
       viewOutput: onViewBackgroundAgentOutput,
+      open: onOpenBackgroundAgent,
     },
     retry,
   );
@@ -536,6 +539,7 @@ export function groupMessageItems(
     cancel: (runId: string) => Promise<void>;
     loadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
     viewOutput?: () => void;
+    open?: (runId: string) => void;
   } = {
     runs: [],
     loading: false,
@@ -650,6 +654,7 @@ export function groupMessageItems(
             onCancel={backgroundAgents.cancel}
             onLoadActivity={backgroundAgents.loadActivity}
             onViewOutput={backgroundAgents.viewOutput}
+            onOpen={backgroundAgents.open}
           />,
         ),
       );

--- a/crates/openwave-desktop/ui/src/panel/panelTypes.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelTypes.ts
@@ -15,7 +15,13 @@ export type PanelContent =
   | { type: "outputs"; outputId?: string }
   | { type: "folders" }
   /** The Apps library; an app id turns the list into that app's detail. */
-  | { type: "apps"; appId?: string };
+  | { type: "apps"; appId?: string }
+  /**
+   * One background agent run, opened from its row in the transcript's agent
+   * list. There is no bare agent catalog — the transcript is the list — so the
+   * run id is always present.
+   */
+  | { type: "agent"; runId: string };
 
 export type PanelType = PanelContent["type"];
 
@@ -56,6 +62,7 @@ export function isContentPanel(panel: PanelContent): boolean {
       // you picked, and reads on the content side like a document does.
       return panel.outputId !== undefined;
     case "document":
+    case "agent":
       return true;
   }
 }

--- a/crates/openwave-desktop/ui/src/panel/panelUrl.test.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelUrl.test.ts
@@ -15,6 +15,8 @@ describe("panel URLs", () => {
     expect(parsePanelSegment("folders")).toEqual({ type: "folders" });
     expect(parsePanelSegment("apps")).toEqual({ type: "apps" });
     expect(parsePanelSegment("apps.app-1")).toEqual({ type: "apps", appId: "app-1" });
+    expect(parsePanelSegment("agent.run-1")).toEqual({ type: "agent", runId: "run-1" });
+    expect(parsePanelSegment("agent")).toBeNull();
     expect(parsePanelSegment("document.doc-1")).toEqual({
       type: "document",
       documentId: "doc-1",
@@ -50,6 +52,7 @@ describe("panel URLs", () => {
       { type: "outputs" },
       { type: "outputs", outputId: "output-1" },
       { type: "folders" },
+      { type: "agent", runId: "run-1" },
     ] as const) {
       expect(parsePanelSegment(encodePanelSegment(panel))).toEqual(panel);
     }

--- a/crates/openwave-desktop/ui/src/panel/panelUrl.ts
+++ b/crates/openwave-desktop/ui/src/panel/panelUrl.ts
@@ -21,6 +21,7 @@ import {
  *   folders
  *   apps
  *   apps.{appId}
+ *   agent.{runId}
  *
  * Only the first separator picks the panel type; what follows is read by that
  * panel and nothing else. Output navigation carries the durable opaque output
@@ -47,6 +48,9 @@ export function parsePanelSegment(segment: string): PanelContent | null {
       return id ? { type: "outputs", outputId: id } : { type: "outputs" };
     case "apps":
       return id ? { type: "apps", appId: id } : { type: "apps" };
+    case "agent":
+      // A run id is the whole address; there is no bare agent panel.
+      return id ? { type: "agent", runId: id } : null;
     default:
       return null;
   }
@@ -79,6 +83,8 @@ export function encodePanelSegment(panel: PanelContent): string {
       return panel.outputId ? `outputs.${panel.outputId}` : "outputs";
     case "apps":
       return panel.appId ? `apps.${panel.appId}` : "apps";
+    case "agent":
+      return `agent.${panel.runId}`;
   }
 }
 


### PR DESCRIPTION
Clicking a background agent's row in the transcript's agent list now opens a dedicated panel beside the conversation, the same way a document or output does. The panel is addressed in the URL (`agent.{runId}`), so a layout with an open agent panel restores and links like any other.

What the panel shows:

- A status header: run state badge, the same closed-vocabulary status detail the inline list uses, elapsed time (ticking while the run is live), and the failure code when a run could not finish.
- A View output affordance once the run has produced a result, opening the outputs panel on the other side.
- The run's ordered activity timeline, full height, kept current by the same polled durable snapshot the inline list observes — the timeline re-reads whenever the run advances.
- Stop in the panel header while the run is still cancellable, with the same optimistic "Stopping" bridge as the inline row.

Multiple runs switch the one panel rather than tiling: each row click re-addresses the panel to that run.

The inline row keeps its chevron for a quick glance at the timeline without leaving the transcript; the timeline component and its refresh hook move to a shared module (`AgentActivityTimeline.tsx`) so both surfaces render one history. On the home route an `agent` panel URL collapses to home alone, like every other chat-scoped panel.

Residual (deliberately out of scope here):

- The run snapshot carries no model identity, so the header cannot name the model the agent runs on; exposing that would be a small server/wire slice.
- Live delivery is still the existing 5s poll — there are no agent-run events on the chat socket yet. A push-driven refresh signal would be the clean upgrade.
- The spawn tool call's task description is not surfaced as a panel title; the header says "Background agent".

Verified locally: `tsc --noEmit`, full `pnpm test` (101 files / 696 tests), `pnpm build`. UI-only change.