### PR TITLE
feat(desktop): home composer shows and defers to the sticky chat defaults

### DIFF
--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -25,7 +25,7 @@ import {
 } from "./ImageAttachments";
 import { ModelMenu, ReasoningEffortMenu } from "./ModelMenu";
 import { modelForSelection } from "./ModelSelection";
-import { useNewChatSettings } from "./NewChatSettings";
+import { effectiveNewChatSettings, useNewChatSettings } from "./NewChatSettings";
 import { AppsPanel } from "./apps/AppsPanel";
 import { PanelLayout } from "./panel/PanelLayout";
 import type { LayoutState, PanelContent } from "./panel/panelTypes";
@@ -57,7 +57,18 @@ export function HomeRoute() {
     composerDraftActions.setDraft(HOME_DRAFT_KEY, text);
   const [error, setError] = useState<string | null>(null);
   const newChat = useNewChatSettings();
-  const efforts = modelForSelection(models, newChat.model)?.reasoning_efforts ?? [];
+  // What the pickers show and the created chat will get: this visit's picks
+  // over the server's sticky defaults. Only the explicit picks are sent; the
+  // server seeds the rest from the same defaults being displayed.
+  const effective = effectiveNewChatSettings(newChat);
+  const efforts = modelForSelection(models, effective.model)?.reasoning_efforts ?? [];
+
+  // A choice made inside a chat is recorded server-side as the sticky
+  // default; re-read it whenever the reader lands back here so the pickers
+  // show what the next chat will actually start with.
+  useEffect(() => {
+    void useNewChatSettings.getState().loadDefaults(client);
+  }, [client]);
 
   // A chat created silently when the user attaches files before typing. The
   // chat exists on the server so files can upload, but the user stays on the
@@ -107,7 +118,7 @@ export function HomeRoute() {
     const created = await client.createChat(newChat.model ?? undefined, null, {
       reasoningEffort: newChat.reasoningEffort,
       permissionMode: newChat.permissionMode,
-      networkPolicy: newChat.networkPolicy,
+      networkPolicy: newChat.networkPolicy ?? undefined,
     });
     chatListActions.prependChat(created);
     chatListActions.setChatsError(null);
@@ -201,7 +212,7 @@ export function HomeRoute() {
           {
             reasoningEffort: newChat.reasoningEffort,
             permissionMode: newChat.permissionMode,
-            networkPolicy: newChat.networkPolicy,
+            networkPolicy: newChat.networkPolicy ?? undefined,
           },
         );
         chatListActions.prependChat(created);
@@ -310,7 +321,7 @@ export function HomeRoute() {
               <>
                 <ModelMenu
                   models={models}
-                  value={newChat.model}
+                  value={effective.model}
                   defaultKey={defaultModelKey}
                   disabled={creatingChat}
                   onChange={newChat.setModel}
@@ -318,18 +329,18 @@ export function HomeRoute() {
                 {efforts.length > 0 && (
                   <ReasoningEffortMenu
                     levels={efforts}
-                    value={newChat.reasoningEffort}
+                    value={effective.reasoningEffort}
                     disabled={creatingChat}
                     onChange={newChat.setReasoningEffort}
                   />
                 )}
                 <PermissionModeMenu
-                  value={newChat.permissionMode}
+                  value={effective.permissionMode}
                   disabled={creatingChat}
                   onChange={newChat.setPermissionMode}
                 />
                 <NetworkPolicyMenu
-                  value={newChat.networkPolicy}
+                  value={effective.networkPolicy}
                   disabled={creatingChat}
                   onChange={newChat.setNetworkPolicy}
                 />

--- a/crates/openwave-desktop/ui/src/NewChatSettings.test.ts
+++ b/crates/openwave-desktop/ui/src/NewChatSettings.test.ts
@@ -1,56 +1,55 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
+
+import type { ApiClient } from "./api";
+import {
+  effectiveNewChatSettings,
+  useNewChatSettings,
+} from "./NewChatSettings";
 
 /**
- * The pre-chat choices are read back from storage a session later, so what is
- * stored there is untrusted input: a value this build no longer knows must
- * read as "unset" rather than reach chat creation, where it would be refused
- * by the server or — worse for a permission mode — mean something other than
- * what the reader chose.
+ * Persistence of the pre-chat choices lives on the server (the sticky
+ * `chat_default.*` settings), not in this store. What must hold here is the
+ * precedence the pickers and `POST /chats` both rely on: an explicit pick
+ * this visit beats the server default, an unpicked field follows it, and a
+ * failed defaults read degrades to the hard defaults instead of blocking.
  */
 describe("new chat settings", () => {
-  beforeEach(() => {
-    vi.resetModules();
-    window.localStorage.clear();
-  });
+  it("prefers this visit's pick, then the server default, then the hard default", async () => {
+    const client = {
+      getSettings: () =>
+        Promise.resolve({
+          model: null,
+          has_api_key: true,
+          chat_defaults: {
+            model: "anthropic::m-sticky",
+            reasoning_effort: "high",
+            permission_mode: "allow",
+            network_policy: { mode: "package_managers" },
+          },
+        }),
+    } as unknown as ApiClient;
 
-  it("recovers stored choices and drops ones it no longer recognizes", async () => {
-    window.localStorage.setItem("openwave.new-chat-permission-mode", "auto");
-    window.localStorage.setItem("openwave.new-chat-reasoning-effort", "sideways");
+    await useNewChatSettings.getState().loadDefaults(client);
+    let effective = effectiveNewChatSettings(useNewChatSettings.getState());
+    expect(effective.model).toBe("anthropic::m-sticky");
+    expect(effective.permissionMode).toBe("allow");
+    expect(effective.networkPolicy).toEqual({ mode: "package_managers" });
 
-    const { useNewChatSettings } = await import("./NewChatSettings");
-    const state = useNewChatSettings.getState();
+    useNewChatSettings.getState().setPermissionMode("plan");
+    effective = effectiveNewChatSettings(useNewChatSettings.getState());
+    expect(effective.permissionMode).toBe("plan");
+    // The explicit pick is what the create request will carry; the rest stay
+    // unsent and seed server-side.
+    expect(useNewChatSettings.getState().permissionMode).toBe("plan");
+    expect(useNewChatSettings.getState().networkPolicy).toBeNull();
 
-    expect(state.permissionMode).toBe("auto");
-    expect(state.reasoningEffort).toBeNull();
-    expect(state.networkPolicy).toEqual({ mode: "off" });
-  });
-
-  it("persists a choice so it outlives the visit that made it", async () => {
-    const { useNewChatSettings } = await import("./NewChatSettings");
-
-    useNewChatSettings.getState().setPermissionMode("allow");
-
-    expect(useNewChatSettings.getState().permissionMode).toBe("allow");
-    expect(window.localStorage.getItem("openwave.new-chat-permission-mode")).toBe(
-      "allow",
-    );
-  });
-
-  it("persists and validates the next chat's network policy", async () => {
-    const { useNewChatSettings } = await import("./NewChatSettings");
-
-    useNewChatSettings.getState().setNetworkPolicy({
-      mode: "package_managers",
-    });
-
-    expect(useNewChatSettings.getState().networkPolicy).toEqual({
-      mode: "package_managers",
-    });
-    expect(
-      JSON.parse(
-        window.localStorage.getItem("openwave.new-chat-network-policy")!,
-      ),
-    ).toEqual({ mode: "package_managers" });
+    // A failed refresh keeps the last known defaults on display.
+    const failing = {
+      getSettings: () => Promise.reject(new Error("offline")),
+    } as unknown as ApiClient;
+    await useNewChatSettings.getState().loadDefaults(failing);
+    effective = effectiveNewChatSettings(useNewChatSettings.getState());
+    expect(effective.networkPolicy).toEqual({ mode: "package_managers" });
   });
 });

--- a/crates/openwave-desktop/ui/src/NewChatSettings.ts
+++ b/crates/openwave-desktop/ui/src/NewChatSettings.ts
@@ -1,102 +1,13 @@
 import { create } from "zustand";
 
 import type {
+  ApiClient,
   ModelSelectionKey,
   NetworkPolicy,
   PermissionMode,
   ReasoningEffort,
+  StickyChatDefaults,
 } from "./api";
-
-const MODEL_KEY = "openwave.new-chat-model";
-const REASONING_EFFORT_KEY = "openwave.new-chat-reasoning-effort";
-const PERMISSION_MODE_KEY = "openwave.new-chat-permission-mode";
-const NETWORK_POLICY_KEY = "openwave.new-chat-network-policy";
-
-const REASONING_EFFORTS: readonly ReasoningEffort[] = [
-  "none",
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-  "max",
-];
-
-const PERMISSION_MODES: readonly PermissionMode[] = [
-  "plan",
-  "ask",
-  "auto",
-  "allow",
-];
-
-
-function read(key: string): string | null {
-  try {
-    return window.localStorage.getItem(key);
-  } catch {
-    return null;
-  }
-}
-
-function write(key: string, value: string | null): void {
-  try {
-    if (value === null) window.localStorage.removeItem(key);
-    else window.localStorage.setItem(key, value);
-  } catch {
-    // Persisting a pre-chat choice is best-effort; the session still holds it.
-  }
-}
-
-/**
- * A stored value is only honored when this build still recognizes it. A model
- * key is checked against the live catalog at the point of use rather than
- * here — the catalog is not loaded yet when this store initializes, and a
- * selection whose provider was since removed should read as "unavailable"
- * exactly the way it does inside a chat.
- */
-function readEnum<T extends string>(
-  key: string,
-  allowed: readonly T[],
-): T | null {
-  const stored = read(key);
-  return allowed.find((value) => value === stored) ?? null;
-}
-
-type NewChatSettings = {
-  model: ModelSelectionKey | null;
-  reasoningEffort: ReasoningEffort | null;
-  permissionMode: PermissionMode | null;
-  networkPolicy: NetworkPolicy;
-  setModel: (model: ModelSelectionKey | null) => void;
-  setReasoningEffort: (effort: ReasoningEffort | null) => void;
-  setPermissionMode: (mode: PermissionMode) => void;
-  setNetworkPolicy: (policy: NetworkPolicy) => void;
-};
-
-function readNetworkPolicy(): NetworkPolicy {
-  const stored = read(NETWORK_POLICY_KEY);
-  if (!stored) return { mode: "off" };
-  try {
-    const value = JSON.parse(stored) as NetworkPolicy;
-    if (
-      value.mode === "off" ||
-      value.mode === "package_managers" ||
-      value.mode === "open"
-    ) {
-      return value;
-    }
-    if (
-      value.mode === "allowed_hosts" &&
-      Array.isArray(value.allowed_hosts) &&
-      value.allowed_hosts.every((host) => typeof host === "string") &&
-      typeof value.package_managers === "boolean"
-    ) {
-      return value;
-    }
-  } catch {
-    // Fall through to the deny-by-default policy.
-  }
-  return { mode: "off" };
-}
 
 /**
  * What the next chat will be created with, chosen before it exists.
@@ -108,30 +19,75 @@ function readNetworkPolicy(): NetworkPolicy {
  * this avoids — it races the first turn, which reads the chat as it was
  * created.
  *
- * The choices persist, because "I work in Auto" is a standing preference, not
- * a per-visit one. They are deliberately not a global default applied to
- * chats created anywhere else: this is the state of one composer, and a chat
- * created from a project or a deep link has its own.
+ * Persistence lives on the server, not here. Every explicit choice — at these
+ * pickers or inside a chat — is recorded by the server as a sticky default,
+ * and an unspecified `POST /chats` field seeds from it. So this store holds
+ * only this visit's explicit picks (`null` follows the default) plus the
+ * server-reported defaults for display, refreshed on each home mount so a
+ * choice made inside a chat shows up when the reader comes back.
  */
+type NewChatSettings = {
+  /** Server-recorded sticky defaults; `null` until the first load lands. */
+  defaults: StickyChatDefaults | null;
+  model: ModelSelectionKey | null;
+  reasoningEffort: ReasoningEffort | null;
+  permissionMode: PermissionMode | null;
+  networkPolicy: NetworkPolicy | null;
+  setModel: (model: ModelSelectionKey | null) => void;
+  setReasoningEffort: (effort: ReasoningEffort | null) => void;
+  setPermissionMode: (mode: PermissionMode) => void;
+  setNetworkPolicy: (policy: NetworkPolicy) => void;
+  /**
+   * Refresh the server-side defaults. Best-effort: a failed read leaves the
+   * previous defaults standing — the server still seeds the create correctly,
+   * the pickers just display the hard defaults until a read lands.
+   */
+  loadDefaults: (client: ApiClient) => Promise<void>;
+};
+
 export const useNewChatSettings = create<NewChatSettings>((set) => ({
-  model: (read(MODEL_KEY) as ModelSelectionKey | null) ?? null,
-  reasoningEffort: readEnum(REASONING_EFFORT_KEY, REASONING_EFFORTS),
-  permissionMode: readEnum(PERMISSION_MODE_KEY, PERMISSION_MODES),
-  networkPolicy: readNetworkPolicy(),
-  setModel: (model) => {
-    write(MODEL_KEY, model);
-    set({ model });
-  },
-  setReasoningEffort: (reasoningEffort) => {
-    write(REASONING_EFFORT_KEY, reasoningEffort);
-    set({ reasoningEffort });
-  },
-  setPermissionMode: (permissionMode) => {
-    write(PERMISSION_MODE_KEY, permissionMode);
-    set({ permissionMode });
-  },
-  setNetworkPolicy: (networkPolicy) => {
-    write(NETWORK_POLICY_KEY, JSON.stringify(networkPolicy));
-    set({ networkPolicy });
+  defaults: null,
+  model: null,
+  reasoningEffort: null,
+  permissionMode: null,
+  networkPolicy: null,
+  setModel: (model) => set({ model }),
+  setReasoningEffort: (reasoningEffort) => set({ reasoningEffort }),
+  setPermissionMode: (permissionMode) => set({ permissionMode }),
+  setNetworkPolicy: (networkPolicy) => set({ networkPolicy }),
+  loadDefaults: async (client) => {
+    try {
+      const settings = await client.getSettings();
+      set({ defaults: settings.chat_defaults });
+    } catch {
+      // Keep whatever was displayed; creation seeds server-side regardless.
+    }
   },
 }));
+
+/**
+ * What the pickers display and the next chat will get: this visit's explicit
+ * pick, else the server's sticky default, else the hard default the server
+ * would fall back to (`ask`, no network, the configured model).
+ *
+ * The model stays a `ModelSelectionKey` cast because the server reports the
+ * raw sticky selection; one whose provider was since removed reads as
+ * "unavailable" in the picker, exactly the way it does inside a chat.
+ */
+export function effectiveNewChatSettings(state: NewChatSettings): {
+  model: ModelSelectionKey | null;
+  reasoningEffort: ReasoningEffort | null;
+  permissionMode: PermissionMode | null;
+  networkPolicy: NetworkPolicy;
+} {
+  return {
+    model:
+      state.model ?? (state.defaults?.model as ModelSelectionKey | null) ?? null,
+    reasoningEffort:
+      state.reasoningEffort ?? state.defaults?.reasoning_effort ?? null,
+    permissionMode:
+      state.permissionMode ?? state.defaults?.permission_mode ?? null,
+    networkPolicy:
+      state.networkPolicy ?? state.defaults?.network_policy ?? { mode: "off" },
+  };
+}

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -54,6 +54,7 @@ import {
   type NetworkPolicy as WireNetworkPolicy,
   type ReasoningEffort as WireReasoningEffort,
   type Settings,
+  type StickyChatDefaults as WireStickyChatDefaults,
   type WebSearchConfigInfo as WireWebSearchConfigInfo,
   type WebSearchCredentialReadiness as WireWebSearchCredentialReadiness,
   type WebSearchProviderKind as WireWebSearchProviderKind,
@@ -159,6 +160,9 @@ export type PermissionMode = WirePermissionMode;
 
 /** Network access granted to code execution in one conversation workspace. */
 export type NetworkPolicy = WireNetworkPolicy;
+
+/** The sticky new-chat defaults an unspecified `POST /chats` field seeds. */
+export type StickyChatDefaults = WireStickyChatDefaults;
 
 export type ProviderInfo = WireProviderInfo;
 

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1493,7 +1493,12 @@ model: string | null,
 /**
  * Whether a model API key is configured (never the key itself).
  */
-has_api_key: boolean, };
+has_api_key: boolean, 
+/**
+ * The sticky new-chat defaults, so a composer for a chat that does not
+ * exist yet can show what `POST /chats` will seed.
+ */
+chat_defaults: StickyChatDefaults, };
 
 /**
  * Renderer-safe progress of the current sign-in attempt.
@@ -1520,6 +1525,16 @@ level: GrantLevel,
  * that chat or project is untitled.
  */
 level_title: string | null, action: RendererToolName, approval: ToolApprovalKind, scope: GrantScope, granted_at: string, };
+
+/**
+ * The reader's last explicit per-chat choices — what an unspecified field of
+ * `POST /chats` seeds. A `None` field has no recorded choice and keeps the
+ * hard default (configured model, `ask`, no network).
+ *
+ * The permission mode is reported clamped to any managed ceiling, so what a
+ * picker displays is what creation will actually seed.
+ */
+export type StickyChatDefaults = { model: string | null, reasoning_effort: ReasoningEffort | null, permission_mode: PermissionMode | null, network_policy: NetworkPolicy | null, };
 
 /**
  * The action a call will take, in a form a human can inspect.

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -505,6 +505,28 @@ pub struct Settings {
     pub model: Option<String>,
     /// Whether a model API key is configured (never the key itself).
     pub has_api_key: bool,
+    /// The sticky new-chat defaults, so a composer for a chat that does not
+    /// exist yet can show what `POST /chats` will seed.
+    #[serde(default)]
+    pub chat_defaults: StickyChatDefaults,
+}
+
+/// The reader's last explicit per-chat choices — what an unspecified field of
+/// `POST /chats` seeds. A `None` field has no recorded choice and keeps the
+/// hard default (configured model, `ask`, no network).
+///
+/// The permission mode is reported clamped to any managed ceiling, so what a
+/// picker displays is what creation will actually seed.
+#[derive(Debug, Default, Serialize, Deserialize, ts_rs::TS)]
+pub struct StickyChatDefaults {
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub reasoning_effort: Option<ReasoningEffort>,
+    #[serde(default)]
+    pub permission_mode: Option<PermissionMode>,
+    #[serde(default)]
+    pub network_policy: Option<openwave_core::NetworkPolicy>,
 }
 
 /// Body of `PUT /settings`. Each field is a *double* option so an absent key is
@@ -531,6 +553,7 @@ pub async fn get_settings(State(state): State<AppState>) -> Result<Json<Settings
     Ok(Json(Settings {
         model: read_model(&*state.store).await?,
         has_api_key: has_api_key(&*state.secrets).await,
+        chat_defaults: read_sticky_chat_defaults(&state).await?,
     }))
 }
 
@@ -561,6 +584,7 @@ pub async fn put_settings(
     Ok(Json(Settings {
         model: read_model(&*state.store).await?,
         has_api_key: has_api_key(&*state.secrets).await,
+        chat_defaults: read_sticky_chat_defaults(&state).await?,
     }))
 }
 
@@ -1441,6 +1465,29 @@ async fn write_sticky_default<T: Serialize>(
     Ok(store.set_setting(key, &value).await?)
 }
 
+/// Read every sticky new-chat default, the permission mode clamped to any
+/// managed ceiling — what `POST /chats` will seed, and therefore what a
+/// composer should display before the chat exists.
+async fn read_sticky_chat_defaults(state: &AppState) -> Result<StickyChatDefaults, ServerError> {
+    let store = &*state.store;
+    let permission_mode = match read_sticky_default(store, STICKY_PERMISSION_MODE_KEY).await? {
+        // The managed ceiling clamps a sticky mode recorded before the
+        // policy arrived: a remembered `allow` under an `ask` ceiling seeds
+        // (and reads back) `ask`, mirroring the turn gate's treatment of
+        // stored over-ceiling modes.
+        Some(mode) => crate::managed_policy::resolve(store, &*state.os_policy)
+            .await?
+            .clamp_permission_mode(Some(mode)),
+        None => None,
+    };
+    Ok(StickyChatDefaults {
+        model: read_sticky_default(store, STICKY_MODEL_KEY).await?,
+        reasoning_effort: read_sticky_default(store, STICKY_REASONING_EFFORT_KEY).await?,
+        permission_mode,
+        network_policy: read_sticky_default(store, STICKY_NETWORK_POLICY_KEY).await?,
+    })
+}
+
 /// `POST /chats` — create a chat and return it (`201 Created`).
 ///
 /// Fields the request leaves unspecified seed from the sticky defaults — the
@@ -1464,6 +1511,22 @@ pub async fn create_chat(
     refuse_permission_mode_over_ceiling(&state, body.permission_mode).await?;
     if let Some(policy) = body.network_policy.as_mut() {
         crate::code_execution::normalize_network_policy(policy)?;
+    }
+    // An explicit choice at creation is as much "the last-chosen mode" as one
+    // made mid-chat — the home composer's pickers land here, never at PATCH —
+    // so record it the same way. Absent fields never clear a sticky default;
+    // only an explicit PATCH `null` does.
+    if let Some(model) = &body.model {
+        write_sticky_default(&*state.store, STICKY_MODEL_KEY, Some(model)).await?;
+    }
+    if let Some(effort) = &body.reasoning_effort {
+        write_sticky_default(&*state.store, STICKY_REASONING_EFFORT_KEY, Some(effort)).await?;
+    }
+    if let Some(mode) = &body.permission_mode {
+        write_sticky_default(&*state.store, STICKY_PERMISSION_MODE_KEY, Some(mode)).await?;
+    }
+    if let Some(policy) = &body.network_policy {
+        write_sticky_default(&*state.store, STICKY_NETWORK_POLICY_KEY, Some(policy)).await?;
     }
     let model = match body.model {
         Some(model) => Some(model),

--- a/crates/openwave-server/src/tests/conversations.rs
+++ b/crates/openwave-server/src/tests/conversations.rs
@@ -577,6 +577,44 @@ async fn chat_settings_stick_to_the_next_chat() {
     // Untouched fields still seed from the sticky defaults.
     assert_eq!(explicit.model.as_deref(), Some("m-sticky"));
 
+    // An explicit creation choice is recorded like a mid-chat one: the home
+    // composer's pickers only ever reach `POST /chats`.
+    let after_explicit = make_chat(&router, &bearer).await;
+    assert_eq!(
+        after_explicit.permission_mode,
+        Some(openwave_core::PermissionMode::Plan)
+    );
+    assert_eq!(
+        after_explicit.network_policy,
+        openwave_core::NetworkPolicy::Off
+    );
+
+    // `GET /settings` exposes the same defaults, so a composer can display
+    // what an unspecified create will seed.
+    let settings: serde_json::Value = json_body(
+        router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/settings")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(
+        settings["chat_defaults"],
+        serde_json::json!({
+            "model": "m-sticky",
+            "reasoning_effort": "high",
+            "permission_mode": "plan",
+            "network_policy": {"mode": "off"},
+        })
+    );
+
     // Clearing the per-chat choice clears the sticky default with it.
     let cleared = patch_chat(
         &router,
@@ -1530,4 +1568,22 @@ async fn a_managed_ceiling_locks_over_ceiling_permission_modes() {
         seeded.permission_mode,
         Some(openwave_core::PermissionMode::Ask)
     );
+
+    // The settings surface reports the same clamped mode, so a composer never
+    // displays an autonomy the ceiling forbids.
+    let settings: serde_json::Value = json_body(
+        router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/settings")
+                    .header(header::AUTHORIZATION, &bearer)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(settings["chat_defaults"]["permission_mode"], "ask");
 }


### PR DESCRIPTION
Follow-up to #1413. The home composer kept its own localStorage copy of the next chat's settings and always sent an explicit network policy on create, so the server-side sticky defaults never reached a desktop-created chat — a connectivity choice made inside a chat did not carry to the next one, which was the point of the feature.

- `NewChatSettings` drops localStorage entirely: it holds only this visit's explicit picks (`null` = follow the default) plus the server-reported defaults for display. The pickers show the effective value — explicit pick, else sticky default, else hard default — so what the reader sees is what the created chat gets.
- The create request carries only fields the reader actively chose; the server seeds the rest from the same defaults being displayed. The home picker stays an explicit per-chat override.
- Two small server additions the slice genuinely needs: `GET /settings` gains a `chat_defaults` object (the permission mode reported clamped to any managed ceiling, so a composer never displays an autonomy the ceiling forbids), and `POST /chats` records explicitly supplied fields as sticky defaults — the home pickers land at create, never at PATCH, and without this a choice made there would not stick. Absent create fields still never clear a default; only an explicit PATCH `null` does.
- The home route re-reads the defaults on each mount, so a choice made inside a chat shows up when the reader lands back home. A failed read keeps the last known defaults; creation still seeds server-side regardless.
- Wire types regenerated for the new `StickyChatDefaults`.

Tests: the route-level sticky test grows the create-records-sticky and `GET /settings` exposure cases, and the managed-ceiling test asserts the reported default is clamped. Replaced the `NewChatSettings` localStorage tests (persistence and stored-token validation of a mechanism that no longer exists) with one covering the precedence rule the pickers and create path share.

Verified: `cargo fmt`, `cargo clippy -p openwave-server --all-targets --locked`, full `cargo test -p openwave-server --locked` (562 passing), `tsc --noEmit`, `pnpm test` (695 passing), `pnpm build`.