### PR TITLE
feat(exec): render office outputs to PDF on the host for the model's visual QA

### DIFF
--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -18,6 +18,7 @@ mod http;
 mod local;
 #[cfg(target_os = "macos")]
 mod network;
+pub mod office_render;
 mod output;
 pub mod overlay;
 pub mod package_cache;
@@ -36,6 +37,9 @@ pub use host_paths::{
     ScratchDir, ScratchEntry, ScratchEntryKind, ScratchRefusal,
 };
 pub use local::LocalExecutionProvider;
+pub use office_render::{
+    render_office_outputs, HostOfficeConverter, OfficeConvertError, OFFICE_RENDER_DIR,
+};
 pub use overlay::{
     materialize_file, materialized_file_matches, sweep_abandoned_overlays,
     MaterializationPrecondition, MaterializedChange, MaterializedChangeKind, NativeTrash,
@@ -50,8 +54,8 @@ pub use preview::{scan_preview_directory, PreviewScan};
 pub use remote::RemoteSessionPool;
 pub use skills::{
     is_valid_skill_description, is_valid_skill_name, load_skills, merged_skills,
-    parse_skill_manifest, LoadedSkill, SkillOrigin, SkillPackage, SkillParseError, SKILLS_DIR,
-    SKILL_MANIFEST_FILE,
+    parse_skill_manifest, HostDep, LoadedSkill, SkillOrigin, SkillPackage, SkillParseError,
+    SKILLS_DIR, SKILL_MANIFEST_FILE,
 };
 pub use tool::{ExecTool, EXEC_TOOL_NAME};
 pub use types::{

--- a/crates/openwave-code-execution/src/office_render.rs
+++ b/crates/openwave-code-execution/src/office_render.rs
@@ -1,0 +1,433 @@
+//! Host-side office-to-PDF rendering for the model's visual QA loop.
+//!
+//! The document skills teach a validation pass that converts a saved deck or
+//! document through LibreOffice and inspects page images. No sandbox can be
+//! relied on for that conversion: the local provider pins its `PATH` to
+//! system directories and will never see a managed `soffice`, and managed
+//! cloud sandboxes ship no LibreOffice today. The converter the host already
+//! uses for the preview panel is the one capability that exists everywhere
+//! the app runs, so rendering becomes a host service instead of a sandbox
+//! binary.
+//!
+//! The seam is the workspace itself: after an exec lands office files under
+//! `output/` in host scratch (directly for the local provider, via the
+//! result pull for remote ones), the host converts each to a PDF under
+//! [`OFFICE_RENDER_DIR`] and says so in the command's sync notes. The model
+//! finishes the loop with the bundled `render_pdf.py` helper — pure pip
+//! dependencies that install in every sandbox — which turns the staged PDF
+//! into `preview/` images the exec result attaches. Remote sandboxes need the
+//! PDF listed in the next call's `files`; the note spells that out.
+//!
+//! Everything here treats scratch as hostile the way the sync layer does: a
+//! sandbox confined to scratch can still plant symlinks in it, so sources are
+//! read and targets written only through [`ScratchDir`] handles that refuse
+//! symlinked components.
+
+use std::path::Path;
+
+use async_trait::async_trait;
+
+use crate::host_paths::{try_resolve_scratch_directory, ScratchDir, ScratchEntryKind};
+use crate::MAX_WORKSPACE_FILE_BYTES;
+
+/// Workspace-relative directory host-converted PDFs are written under,
+/// mirroring each source's path relative to `output/`. The PDF for
+/// `output/reports/deck.pptx` is `.openwave/render/reports/deck.pptx.pdf` —
+/// the full source filename stays in the name so two sources with one stem
+/// can never answer for each other.
+pub const OFFICE_RENDER_DIR: &str = ".openwave/render";
+
+/// File extensions the render pass converts: the same formats the in-sandbox
+/// `render_office.py` helper accepts.
+const OFFICE_RENDER_EXTENSIONS: &[&str] = &["docx", "pptx"];
+
+/// The most conversions one exec result will trigger. A QA loop inspects one
+/// document at a time; a command that emits a pile of decks should not stall
+/// its result behind a conversion queue.
+const MAX_RENDERS_PER_EXEC: usize = 3;
+
+/// Why a host conversion did not produce a PDF.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OfficeConvertError {
+    /// No usable LibreOffice on this host. A first-class state, not a fault:
+    /// the caller reports it and the skill's reopen checks carry the QA.
+    ConverterMissing,
+    /// A converter exists and the conversion failed.
+    Failed(String),
+}
+
+impl std::fmt::Display for OfficeConvertError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConverterMissing => write!(f, "no LibreOffice is available on this host"),
+            Self::Failed(reason) => write!(f, "{reason}"),
+        }
+    }
+}
+
+/// Converts one office document's bytes to PDF with a host-provided
+/// LibreOffice. The desktop registers its managed-install-backed converter;
+/// headless embeddings register none and the render pass degrades to an
+/// honest note.
+#[async_trait]
+pub trait HostOfficeConverter: Send + Sync {
+    /// Convert `bytes` — an office document whose format is named by
+    /// `extension` (`docx` or `pptx`) — into PDF bytes.
+    async fn convert_to_pdf(
+        &self,
+        bytes: &[u8],
+        extension: &str,
+    ) -> Result<Vec<u8>, OfficeConvertError>;
+}
+
+/// One office file found under `output/`, as workspace-relative paths.
+struct RenderCandidate {
+    /// `output/...` source path, for notes.
+    source: String,
+    /// Path relative to `output/`, mirrored under the render directory.
+    relative: String,
+    /// Extension the converter keys its import filter on.
+    extension: &'static str,
+    modified: Option<std::time::SystemTime>,
+}
+
+/// Convert the office files under `<host_dir>/output` into PDFs under
+/// [`OFFICE_RENDER_DIR`], returning sync notes describing what happened.
+///
+/// Nothing here fails the exec: the command already ran, and every outcome —
+/// a fresh conversion, an already-current PDF, a missing converter, a failed
+/// conversion — degrades into one bounded note the model can act on. A
+/// conversion is skipped when its PDF already exists and is at least as new
+/// as the source, so reruns of an unchanged deck cost nothing.
+pub async fn render_office_outputs(
+    converter: Option<&dyn HostOfficeConverter>,
+    host_dir: &Path,
+) -> Vec<String> {
+    let mut notes = Vec::new();
+    let candidates = match collect_candidates(host_dir).await {
+        Ok(candidates) => candidates,
+        Err(note) => {
+            if let Some(note) = note {
+                notes.push(note);
+            }
+            return notes;
+        }
+    };
+    if candidates.is_empty() {
+        return notes;
+    }
+    let Some(converter) = converter else {
+        notes.push(
+            "office render unavailable: this host has no office-to-PDF converter; validate \
+             office outputs by reopening them with their library"
+                .into(),
+        );
+        return notes;
+    };
+    let omitted = candidates.len().saturating_sub(MAX_RENDERS_PER_EXEC);
+    for candidate in candidates.into_iter().take(MAX_RENDERS_PER_EXEC) {
+        match render_candidate(converter, host_dir, &candidate).await {
+            Ok(()) => notes.push(format!(
+                "office render: {} -> {OFFICE_RENDER_DIR}/{}.pdf (converted on the host); \
+                 render page images with .openwave/exec-scripts/render_pdf.py — on a managed \
+                 sandbox, list the PDF in that call's 'files'",
+                candidate.source, candidate.relative
+            )),
+            Err(OfficeConvertError::ConverterMissing) => {
+                notes.push(
+                    "office render unavailable: no LibreOffice on this host; validate office \
+                     outputs by reopening them with their library"
+                        .into(),
+                );
+                break;
+            }
+            Err(OfficeConvertError::Failed(reason)) => notes.push(format!(
+                "office render failed for {}: {reason}",
+                candidate.source
+            )),
+        }
+    }
+    if omitted > 0 {
+        notes.push(format!(
+            "office render: {omitted} more office file(s) beyond the {MAX_RENDERS_PER_EXEC}-per-command conversion limit"
+        ));
+    }
+    notes
+}
+
+/// Walk `output/` for convertible office files, without following symlinks.
+///
+/// `Err(None)` means there is no output directory — nothing to do and nothing
+/// to say. `Err(Some(note))` reports a directory that exists but cannot be
+/// walked.
+async fn collect_candidates(host_dir: &Path) -> Result<Vec<RenderCandidate>, Option<String>> {
+    let output = try_resolve_scratch_directory(host_dir, "output", false)
+        .await
+        .map_err(|_| None)?;
+    let mut candidates = Vec::new();
+    let mut stack: Vec<(ScratchDir, String)> = vec![(output, String::new())];
+    while let Some((dir, prefix)) = stack.pop() {
+        let entries = dir
+            .entries()
+            .await
+            .map_err(|_| Some("office render skipped: output/ could not be listed".to_owned()))?;
+        for entry in entries {
+            let relative = if prefix.is_empty() {
+                entry.name.clone()
+            } else {
+                format!("{prefix}/{}", entry.name)
+            };
+            match entry.kind {
+                ScratchEntryKind::Directory => {
+                    if let Ok(child) = dir.open_dir(&entry.name).await {
+                        stack.push((child, relative));
+                    }
+                }
+                ScratchEntryKind::File => {
+                    let Some(extension) = office_extension(&entry.name) else {
+                        continue;
+                    };
+                    let Some(stamp) = dir.file_stamp(&entry.name).await else {
+                        continue;
+                    };
+                    if stamp.len > MAX_WORKSPACE_FILE_BYTES as u64 {
+                        continue;
+                    }
+                    candidates.push(RenderCandidate {
+                        source: format!("output/{relative}"),
+                        relative,
+                        extension,
+                        modified: stamp.modified,
+                    });
+                }
+                ScratchEntryKind::Other => {}
+            }
+        }
+    }
+    candidates.sort_by(|a, b| a.relative.cmp(&b.relative));
+    Ok(candidates)
+}
+
+fn office_extension(name: &str) -> Option<&'static str> {
+    let (_, extension) = name.rsplit_once('.')?;
+    OFFICE_RENDER_EXTENSIONS
+        .iter()
+        .find(|known| extension.eq_ignore_ascii_case(known))
+        .copied()
+}
+
+/// Convert one candidate unless its PDF is already current.
+async fn render_candidate(
+    converter: &dyn HostOfficeConverter,
+    host_dir: &Path,
+    candidate: &RenderCandidate,
+) -> Result<(), OfficeConvertError> {
+    let (source_parent_rel, source_name) = split_relative(&candidate.relative);
+    let source_parent =
+        try_resolve_scratch_directory(host_dir, &join_under("output", source_parent_rel), false)
+            .await
+            .map_err(|refusal| {
+                OfficeConvertError::Failed(format!("source unreadable: {refusal:?}"))
+            })?;
+
+    let target_name = format!("{source_name}.pdf");
+    let target_rel = join_under(OFFICE_RENDER_DIR, source_parent_rel);
+    // Peek at an existing PDF without scaffolding the render directory: a
+    // conversion that never happens (converter missing, source unreadable)
+    // should leave no trace.
+    if let Ok(existing) = try_resolve_scratch_directory(host_dir, &target_rel, false).await {
+        if let (Some(target), Some(source)) = (
+            existing
+                .file_stamp(&target_name)
+                .await
+                .and_then(|stamp| stamp.modified),
+            candidate.modified,
+        ) {
+            if target >= source && !existing.is_symlink(&target_name).await {
+                // Already converted; the note still points the model at it.
+                return Ok(());
+            }
+        }
+    }
+
+    if source_parent.is_symlink(source_name).await {
+        return Err(OfficeConvertError::Failed("source is a symlink".into()));
+    }
+    let bytes = source_parent
+        .read_file(source_name)
+        .await
+        .map_err(|error| OfficeConvertError::Failed(format!("source unreadable: {error}")))?;
+    let pdf = converter
+        .convert_to_pdf(&bytes, candidate.extension)
+        .await?;
+    let target_parent = try_resolve_scratch_directory(host_dir, &target_rel, true)
+        .await
+        .map_err(|refusal| {
+            OfficeConvertError::Failed(format!("render directory unavailable: {refusal:?}"))
+        })?;
+    if target_parent.is_symlink(&target_name).await {
+        return Err(OfficeConvertError::Failed(
+            "render target is a symlink".into(),
+        ));
+    }
+    target_parent
+        .write_file(&target_name, &pdf)
+        .await
+        .map_err(|error| OfficeConvertError::Failed(format!("PDF unwritable: {error}")))?;
+    Ok(())
+}
+
+fn split_relative(relative: &str) -> (&str, &str) {
+    relative
+        .rsplit_once('/')
+        .map_or(("", relative), |(parent, name)| (parent, name))
+}
+
+fn join_under(root: &str, relative: &str) -> String {
+    if relative.is_empty() {
+        root.to_owned()
+    } else {
+        format!("{root}/{relative}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Converts by wrapping the input, so the test can prove which bytes
+    /// travelled and that the output landed where the note says.
+    struct FakeConverter {
+        conversions: AtomicUsize,
+    }
+
+    impl FakeConverter {
+        fn new() -> Self {
+            Self {
+                conversions: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl HostOfficeConverter for FakeConverter {
+        async fn convert_to_pdf(
+            &self,
+            bytes: &[u8],
+            extension: &str,
+        ) -> Result<Vec<u8>, OfficeConvertError> {
+            self.conversions.fetch_add(1, Ordering::SeqCst);
+            let mut pdf = format!("%PDF({extension})").into_bytes();
+            pdf.extend_from_slice(bytes);
+            Ok(pdf)
+        }
+    }
+
+    /// The whole contract in one pass: office files under `output/` convert
+    /// into mirrored PDFs under the render directory with an actionable note,
+    /// non-office files are ignored, and a rerun over unchanged sources
+    /// converts nothing.
+    #[tokio::test]
+    async fn converts_new_office_outputs_once_and_notes_the_staged_path() {
+        let host = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(host.path().join("output/reports")).unwrap();
+        std::fs::write(host.path().join("output/deck.pptx"), b"deck bytes").unwrap();
+        std::fs::write(host.path().join("output/reports/brief.docx"), b"doc bytes").unwrap();
+        std::fs::write(host.path().join("output/data.csv"), b"not office").unwrap();
+        let converter = FakeConverter::new();
+
+        let notes = render_office_outputs(Some(&converter), host.path()).await;
+
+        assert_eq!(converter.conversions.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            std::fs::read(host.path().join(".openwave/render/deck.pptx.pdf")).unwrap(),
+            b"%PDF(pptx)deck bytes"
+        );
+        assert_eq!(
+            std::fs::read(host.path().join(".openwave/render/reports/brief.docx.pdf")).unwrap(),
+            b"%PDF(docx)doc bytes"
+        );
+        assert!(!host.path().join(".openwave/render/data.csv.pdf").exists());
+        assert_eq!(notes.len(), 2, "{notes:?}");
+        assert!(
+            notes[0].contains("output/deck.pptx")
+                && notes[0].contains(".openwave/render/deck.pptx.pdf")
+                && notes[0].contains("render_pdf.py")
+                && notes[0].contains("'files'"),
+            "{notes:?}"
+        );
+
+        // Unchanged sources do not reconvert; the notes still point at the
+        // existing PDFs so the model knows they are there.
+        let again = render_office_outputs(Some(&converter), host.path()).await;
+        assert_eq!(converter.conversions.load(Ordering::SeqCst), 2);
+        assert_eq!(again.len(), 2, "{again:?}");
+    }
+
+    /// Degraded states stay honest and never fail the pass: no converter and
+    /// no LibreOffice each produce one note naming the fallback, and a
+    /// workspace without office outputs says nothing at all.
+    #[tokio::test]
+    async fn degraded_states_produce_one_honest_note() {
+        let host = tempfile::tempdir().unwrap();
+        assert!(render_office_outputs(None, host.path()).await.is_empty());
+
+        std::fs::create_dir_all(host.path().join("output")).unwrap();
+        std::fs::write(host.path().join("output/deck.pptx"), b"deck").unwrap();
+        let notes = render_office_outputs(None, host.path()).await;
+        assert_eq!(notes.len(), 1);
+        assert!(notes[0].contains("office render unavailable"), "{notes:?}");
+
+        struct Missing;
+        #[async_trait]
+        impl HostOfficeConverter for Missing {
+            async fn convert_to_pdf(
+                &self,
+                _bytes: &[u8],
+                _extension: &str,
+            ) -> Result<Vec<u8>, OfficeConvertError> {
+                Err(OfficeConvertError::ConverterMissing)
+            }
+        }
+        let notes = render_office_outputs(Some(&Missing), host.path()).await;
+        assert_eq!(notes.len(), 1);
+        assert!(notes[0].contains("no LibreOffice"), "{notes:?}");
+        assert!(!host.path().join(".openwave/render").exists());
+    }
+
+    /// Local exec is confined to scratch but can plant symlinks in it; the
+    /// pass must neither read a source through one nor write a PDF through
+    /// one.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn symlinked_sources_and_targets_are_refused() {
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret.pptx"), b"host secret").unwrap();
+        let host = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(host.path().join("output")).unwrap();
+        std::os::unix::fs::symlink(
+            outside.path().join("secret.pptx"),
+            host.path().join("output/deck.pptx"),
+        )
+        .unwrap();
+        let converter = FakeConverter::new();
+        render_office_outputs(Some(&converter), host.path()).await;
+        assert_eq!(converter.conversions.load(Ordering::SeqCst), 0);
+
+        // A symlinked render directory must not receive writes either; the
+        // conversion may have run, but nothing lands outside scratch.
+        std::fs::remove_file(host.path().join("output/deck.pptx")).unwrap();
+        std::fs::write(host.path().join("output/deck.pptx"), b"real deck").unwrap();
+        std::fs::create_dir_all(host.path().join(".openwave")).unwrap();
+        std::os::unix::fs::symlink(outside.path(), host.path().join(".openwave/render")).unwrap();
+        let notes = render_office_outputs(Some(&converter), host.path()).await;
+        assert!(
+            notes
+                .iter()
+                .any(|note| note.contains("office render failed")),
+            "{notes:?}"
+        );
+        assert!(!outside.path().join("deck.pptx.pdf").exists());
+    }
+}

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -304,7 +304,7 @@ async fn boot_server(
     data_dir: PathBuf,
 ) -> Result<(), String> {
     let client_executor_id = app.state::<host_access::HostAccess>().client_executor_id();
-    let mut config = Config::desktop(data_dir);
+    let mut config = Config::desktop(data_dir.clone());
     config.exec_scripts_dir = Some(exec_scripts_dir(&app)?);
     config.exec_skills_dir = Some(exec_skills_dir(&app)?);
     // The effective identifier — including the debug-build override — keys
@@ -321,10 +321,14 @@ async fn boot_server(
     let folder_grants = Arc::new(host_access::DesktopExecFolderGrantResolver::new(
         app.clone(),
     ));
+    // The exec provider renders office outputs with the same managed/system
+    // LibreOffice the preview panel converts with.
+    let office_converter = Arc::new(office_pdf::ExecOfficeConverter::new(data_dir));
     let server = openwave_server::bind_configured_with_desktop_executor_and_folder_grants(
         config,
         client_executor_id,
         folder_grants,
+        Some(office_converter),
     )
     .await
     .map_err(|e| e.to_string())?;

--- a/crates/openwave-desktop/src/office_pdf.rs
+++ b/crates/openwave-desktop/src/office_pdf.rs
@@ -479,6 +479,68 @@ async fn prune_cache(cache_dir: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Host converter registered with the embedded server's exec provider.
+///
+/// The same LibreOffice resolution, containment, and on-disk conversion cache
+/// as the preview panel above, exposed behind the exec render seam so the
+/// model's office visual-QA loop and the preview panel can never disagree
+/// about which converter this machine has.
+pub(crate) struct ExecOfficeConverter {
+    data_dir: PathBuf,
+}
+
+impl ExecOfficeConverter {
+    pub(crate) fn new(data_dir: PathBuf) -> Self {
+        Self { data_dir }
+    }
+}
+
+#[async_trait::async_trait]
+impl openwave_code_execution::HostOfficeConverter for ExecOfficeConverter {
+    async fn convert_to_pdf(
+        &self,
+        bytes: &[u8],
+        extension: &str,
+    ) -> Result<Vec<u8>, openwave_code_execution::OfficeConvertError> {
+        use openwave_code_execution::OfficeConvertError;
+        if bytes.is_empty() || bytes.len() > MAX_BINARY_DELIVERABLE_BYTES {
+            return Err(OfficeConvertError::Failed(
+                "the document is empty or too large to convert".into(),
+            ));
+        }
+        let cache_dir = self.data_dir.join(CACHE_DIRECTORY);
+        let cache_path = cache_dir.join(format!("{}.pdf", content_key(bytes)));
+        if let Ok(cached) = tokio::fs::read(&cache_path).await {
+            if !cached.is_empty() {
+                return Ok(cached);
+            }
+        }
+        // Serialize with the preview panel's conversions: two cold
+        // LibreOffice launches race, and both callers share one cache.
+        let _serialized = conversion_lock().lock().await;
+        if let Ok(cached) = tokio::fs::read(&cache_path).await {
+            if !cached.is_empty() {
+                return Ok(cached);
+            }
+        }
+        let Some(soffice) = locate_soffice(&self.data_dir) else {
+            return Err(OfficeConvertError::ConverterMissing);
+        };
+        match run_conversion(&soffice, bytes, extension).await {
+            Ok(pdf) => {
+                // Cache best-effort, shared with the preview panel: the same
+                // deck previewed and QA-rendered converts once.
+                let _ = store_cached_pdf(&cache_dir, &cache_path, &pdf).await;
+                Ok(pdf)
+            }
+            // A resolved path that will not spawn is the same state as no
+            // LibreOffice at all.
+            Err(ConversionError::Spawn) => Err(OfficeConvertError::ConverterMissing),
+            Err(ConversionError::Failed(reason)) => Err(OfficeConvertError::Failed(reason)),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -821,6 +821,9 @@ pub struct ConfiguredCodeExecutionProvider {
     /// without a restart. `None` disables user skills entirely.
     user_skills_dir: Option<PathBuf>,
     folder_grant_resolver: Option<Arc<dyn ExecFolderGrantResolver>>,
+    /// Host-provided office-to-PDF converter feeding the model's visual QA
+    /// loop. `None` (headless embeddings) degrades to an honest sync note.
+    office_converter: Option<Arc<dyn openwave_code_execution::HostOfficeConverter>>,
     /// Cross-process exclusion for the blobs a write-back snapshot publishes.
     blob_writes: Option<Arc<BlobWriteGuard>>,
     remote_sessions: RemoteSessionPool,
@@ -982,6 +985,7 @@ impl ConfiguredCodeExecutionProvider {
             skills: Arc::new(Vec::new()),
             user_skills_dir: None,
             folder_grant_resolver: None,
+            office_converter: None,
             blob_writes: None,
             remote_sessions: RemoteSessionPool::default(),
             write_overlays: Mutex::new(HashMap::new()),
@@ -1202,6 +1206,18 @@ impl ConfiguredCodeExecutionProvider {
         resolver: Option<Arc<dyn ExecFolderGrantResolver>>,
     ) -> Self {
         self.folder_grant_resolver = resolver;
+        self
+    }
+
+    /// Install the host office-to-PDF converter that renders office outputs
+    /// for the model's visual QA loop. Non-desktop embeddings leave this
+    /// absent and the render pass degrades to an honest note.
+    #[must_use]
+    pub fn with_office_converter(
+        mut self,
+        converter: Option<Arc<dyn openwave_code_execution::HostOfficeConverter>>,
+    ) -> Self {
+        self.office_converter = converter;
         self
     }
 
@@ -1704,6 +1720,18 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
             if let Some(inspector) = inspector {
                 response.sync_notes.extend(inspector.notes().await);
             }
+            // Local exec writes output/ directly into scratch; convert any
+            // office files there so the skill's visual QA loop has a PDF to
+            // render, exactly like the remote pull path below.
+            if response.exit_code == Some(0) && !response.timed_out {
+                response.sync_notes.extend(
+                    openwave_code_execution::render_office_outputs(
+                        self.office_converter.as_deref(),
+                        &host_dir,
+                    )
+                    .await,
+                );
+            }
             return Ok(response);
         };
         // A staging that fails outright fails the execution: a listed path
@@ -1726,6 +1754,19 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
             Err(error) => notes.push(format!(
                 "output files were not copied back to private scratch: {error}"
             )),
+        }
+        // The pull just landed any office outputs in host scratch; convert
+        // them there so the model can render page images next call. The
+        // sandbox itself has no LibreOffice — the host is where the converter
+        // lives, for every provider.
+        if response.exit_code == Some(0) && !response.timed_out {
+            notes.extend(
+                openwave_code_execution::render_office_outputs(
+                    self.office_converter.as_deref(),
+                    &host_dir,
+                )
+                .await,
+            );
         }
         // A failed command plus an empty or thin staged set usually means the
         // command's inputs were never listed; one bounded line points there.

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -666,6 +666,7 @@ pub async fn bind(config: Config) -> Result<Server> {
         None,
         mcp_config::ConfiguredMcpServers::default(),
         None,
+        None,
     )
     .await
 }
@@ -676,7 +677,7 @@ pub async fn bind(config: Config) -> Result<Server> {
 /// to use [`bind`] when process-environment configuration is undesirable.
 pub async fn bind_configured(config: Config) -> Result<Server> {
     let mcp_servers = mcp_config::ConfiguredMcpServers::from_env()?;
-    bind_inner(config, None, mcp_servers, None).await
+    bind_inner(config, None, mcp_servers, None, None).await
 }
 
 /// Bind the API with a stable app-private native executor identity.
@@ -695,6 +696,7 @@ pub async fn bind_with_desktop_executor(
         Some(client_executor_id),
         mcp_config::ConfiguredMcpServers::default(),
         None,
+        None,
     )
     .await
 }
@@ -709,15 +711,18 @@ pub async fn bind_configured_with_desktop_executor(
         return Err(AgentError::config("client executor id must not be nil"));
     }
     let mcp_servers = mcp_config::ConfiguredMcpServers::from_env()?;
-    bind_inner(config, Some(client_executor_id), mcp_servers, None).await
+    bind_inner(config, Some(client_executor_id), mcp_servers, None, None).await
 }
 
-/// Desktop binding with the native bridge that resolves current connected
-/// folders into per-invocation local sandbox grants.
+/// Desktop binding with the native bridges only the product app can provide:
+/// the resolver that turns connected folders into per-invocation local
+/// sandbox grants, and the office-to-PDF converter that renders office
+/// outputs for the model's visual QA loop.
 pub async fn bind_configured_with_desktop_executor_and_folder_grants(
     config: Config,
     client_executor_id: Uuid,
     folder_grant_resolver: Arc<dyn code_execution::ExecFolderGrantResolver>,
+    office_converter: Option<Arc<dyn openwave_code_execution::HostOfficeConverter>>,
 ) -> Result<Server> {
     if client_executor_id.is_nil() {
         return Err(AgentError::config("client executor id must not be nil"));
@@ -728,6 +733,7 @@ pub async fn bind_configured_with_desktop_executor_and_folder_grants(
         Some(client_executor_id),
         mcp_servers,
         Some(folder_grant_resolver),
+        office_converter,
     )
     .await
 }
@@ -763,6 +769,7 @@ async fn bind_inner(
     client_executor_id: Option<Uuid>,
     mcp_servers: mcp_config::ConfiguredMcpServers,
     folder_grant_resolver: Option<Arc<dyn code_execution::ExecFolderGrantResolver>>,
+    office_converter: Option<Arc<dyn openwave_code_execution::HostOfficeConverter>>,
 ) -> Result<Server> {
     // Desktop live delivery remains process-local. Turns, steering, and tool
     // approvals are durable, while one process still owns the complete data
@@ -830,7 +837,8 @@ async fn bind_inner(
         .with_document_scripts(config.exec_scripts_dir.clone())
         .with_skills(config.exec_skills_dir.clone())
         .with_user_skills(Some(config.user_skills_dir()))
-        .with_folder_grant_resolver(folder_grant_resolver),
+        .with_folder_grant_resolver(folder_grant_resolver)
+        .with_office_converter(office_converter),
     );
     let foreground_web_search =
         Box::new(web_search::foreground_tool(store.clone(), secrets.clone()));

--- a/scripts/exec-documents/README.md
+++ b/scripts/exec-documents/README.md
@@ -8,7 +8,7 @@ in an exec workspace into concise stdout summaries and bounded images under
 | --- | --- | --- |
 | `render_pdf.py` | Render selected PDF pages and an overview grid | Python, Pillow, and either pypdfium2 or pdf2image + Poppler |
 | `extract_pdf_figures.py` | Extract embedded PDF raster figures and an overview | Python, Pillow, and Poppler `pdfimages` |
-| `render_office.py` | Convert DOCX/PPTX to PDF, then render selected pages | The PDF renderer above plus LibreOffice |
+| `render_office.py` | Convert DOCX/PPTX to PDF, then render selected pages | The PDF renderer above, plus LibreOffice in the sandbox or a host-converted PDF under `.openwave/render/` |
 | `analyze_xlsx.py` | Print sheet inventory, used ranges, and sample rows; thumbnail sheets | Python, openpyxl, and Pillow |
 
 The desktop copies this directory into each exec workspace at

--- a/scripts/exec-documents/render_office.py
+++ b/scripts/exec-documents/render_office.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Convert DOCX/PPTX with LibreOffice and render the resulting PDF."""
+"""Render DOCX/PPTX pages, through LibreOffice or a host-converted PDF.
+
+Conversion to PDF is tried in order: a LibreOffice inside this sandbox
+(container images that ship one), then a PDF the host converted after the
+file landed in output/ (staged at .openwave/render/<name>.pdf). When
+neither exists the error says exactly what to do next.
+"""
 
 from __future__ import annotations
 
@@ -17,6 +23,8 @@ from _openwave_preview import (
     run_cli,
 )
 from render_pdf import render_document
+
+HOST_RENDER_DIR = Path(".openwave/render")
 
 
 def parser() -> argparse.ArgumentParser:
@@ -43,6 +51,50 @@ def parser() -> argparse.ArgumentParser:
     return cli
 
 
+def host_converted_pdf(source: Path) -> Path | None:
+    """The host-side conversion of `source`, if one has been staged.
+
+    The host mirrors office files under output/ into
+    .openwave/render/<path relative to output>.pdf after each successful
+    command; on a managed sandbox that PDF must be listed in a call's
+    'files' to appear here.
+    """
+    try:
+        relative = source.resolve().relative_to((Path.cwd() / "output").resolve())
+    except ValueError:
+        return None
+    candidate = HOST_RENDER_DIR / relative.parent / f"{relative.name}.pdf"
+    return candidate if candidate.is_file() else None
+
+
+def convert_with_libreoffice(libreoffice: str, source: Path, out_dir: Path) -> Path:
+    profile = out_dir / "profile"
+    profile.mkdir()
+    environment = os.environ.copy()
+    environment["HOME"] = str(out_dir)
+    completed = subprocess.run(
+        [
+            libreoffice,
+            "--headless",
+            f"-env:UserInstallation={profile.resolve().as_uri()}",
+            "--convert-to",
+            "pdf",
+            "--outdir",
+            str(out_dir),
+            str(source.resolve()),
+        ],
+        capture_output=True,
+        text=True,
+        env=environment,
+        check=False,
+    )
+    converted = out_dir / f"{source.stem}.pdf"
+    if completed.returncode != 0 or not converted.is_file():
+        detail = (completed.stderr or completed.stdout).strip()
+        raise HelperError(f"LibreOffice conversion failed: {detail or 'no PDF produced'}")
+    return converted
+
+
 def main() -> int:
     args = parser().parse_args()
     if not 72 <= args.dpi <= 300:
@@ -50,47 +102,42 @@ def main() -> int:
     source = existing_file(args.document, [".docx", ".pptx"])
     preview = ensure_preview_dir(args.preview_dir)
     libreoffice = shutil.which("libreoffice") or shutil.which("soffice")
-    if libreoffice is None:
-        raise HelperError(
-            "Office rendering requires the LibreOffice 'libreoffice' or 'soffice' executable"
-        )
 
-    with tempfile.TemporaryDirectory(prefix="openwave-office-") as temporary:
-        temporary_path = Path(temporary)
-        profile = temporary_path / "profile"
-        profile.mkdir()
-        environment = os.environ.copy()
-        environment["HOME"] = temporary
-        completed = subprocess.run(
-            [
-                libreoffice,
-                "--headless",
-                f"-env:UserInstallation={profile.resolve().as_uri()}",
-                "--convert-to",
-                "pdf",
-                "--outdir",
-                temporary,
-                str(source.resolve()),
-            ],
-            capture_output=True,
-            text=True,
-            env=environment,
-            check=False,
-        )
-        converted = temporary_path / f"{source.stem}.pdf"
-        if completed.returncode != 0 or not converted.is_file():
-            detail = (completed.stderr or completed.stdout).strip()
-            raise HelperError(f"LibreOffice conversion failed: {detail or 'no PDF produced'}")
+    if libreoffice is not None:
+        with tempfile.TemporaryDirectory(prefix="openwave-office-") as temporary:
+            converted = convert_with_libreoffice(libreoffice, source, Path(temporary))
+            renderer, outputs, count, omitted = render_document(
+                converted,
+                preview,
+                args.pages,
+                args.dpi,
+            )
+        converted_how = "with LibreOffice"
+    else:
+        staged = host_converted_pdf(source)
+        if staged is None:
+            expected = HOST_RENDER_DIR / f"{source.name}.pdf"
+            raise HelperError(
+                "LibreOffice is not available in this sandbox, and no host-converted PDF "
+                f"was staged at {expected}. The host converts office files saved under "
+                "output/ after each successful command — check that command's workspace "
+                "sync notes for the PDF's path, and on a managed sandbox list the PDF in "
+                "this call's 'files' so it is staged here. If the notes said office "
+                "rendering is unavailable on the host, skip the visual pass: validate by "
+                "reopening the file with its library and say the visual check was not "
+                "possible."
+            )
         renderer, outputs, count, omitted = render_document(
-            converted,
+            staged,
             preview,
             args.pages,
             args.dpi,
         )
+        converted_how = "on the host"
 
     names = ", ".join(path.name for path in outputs)
     print(
-        f"Converted {source.name} with LibreOffice and rendered "
+        f"Converted {source.name} {converted_how} and rendered "
         f"{len(outputs) - 1} of {count} page(s) with {renderer}."
     )
     print(f"Preview images: {names}")

--- a/skills/presentations/SKILL.md
+++ b/skills/presentations/SKILL.md
@@ -70,13 +70,18 @@ only when the user asks for a distinct deck.
 1. Reopen the saved file — `pptx.Presentation("output/<file>.pptx")` — and
    confirm the slide count and that each slide's title and body text are
    what you intended. A file that fails to reopen is not a deliverable.
-2. When LibreOffice is available in the sandbox, render slides for a visual
-   check with the bundled helper:
+2. Render slides for a visual check with the bundled helper:
    `python3 .openwave/exec-scripts/render_office.py output/<file>.pptx`
-   (images land in `preview/`; at most 3 are returned per exec call).
-   Inspect for clipped text, overlapping shapes, and anything crossing the
-   slide edge, and fix the generator rather than accepting a flawed slide.
-   If the helper reports LibreOffice is missing, rely on the reopen check
-   and say the visual pass was not possible.
+   (images land in `preview/`; at most 3 are returned per exec call; the
+   renderer needs `pypdfium2` and `pillow`, installable with pip). The
+   helper converts through a sandbox LibreOffice when one exists; otherwise
+   it renders the PDF the host converts after every successful command that
+   saved the deck — the workspace sync notes name it (under
+   `.openwave/render/`), and on a managed sandbox you must list that PDF in
+   the helper call's `files` to stage it in. Inspect for clipped text,
+   overlapping shapes, and anything crossing the slide edge, and fix the
+   generator rather than accepting a flawed slide. Only when the sync notes
+   say office rendering is unavailable on the host, rely on the reopen
+   check and say the visual pass was not possible.
 
 Only declare the deck done after validation passes.

--- a/skills/word-documents/SKILL.md
+++ b/skills/word-documents/SKILL.md
@@ -65,11 +65,16 @@ change it only when the user asks for a distinct document.
    to write is actually there (headings present, table dimensions right,
    no empty required sections). A file that fails to reopen is not a
    deliverable.
-2. When LibreOffice is available in the sandbox, render pages for a visual
-   check with the bundled helper:
+2. Render pages for a visual check with the bundled helper:
    `python3 .openwave/exec-scripts/render_office.py output/<file>.docx`
-   (images land in `preview/`; at most 3 are returned per exec call). If the
-   helper reports LibreOffice is missing, rely on the reopen check and say
-   the visual pass was not possible.
+   (images land in `preview/`; at most 3 are returned per exec call; the
+   renderer needs `pypdfium2` and `pillow`, installable with pip). The
+   helper converts through a sandbox LibreOffice when one exists; otherwise
+   it renders the PDF the host converts after every successful command that
+   saved the document — the workspace sync notes name it (under
+   `.openwave/render/`), and on a managed sandbox you must list that PDF in
+   the helper call's `files` to stage it in. Only when the sync notes say
+   office rendering is unavailable on the host, rely on the reopen check
+   and say the visual pass was not possible.
 
 Only declare the document done after validation passes.


### PR DESCRIPTION
The office skills teach a QA loop that converts the saved deck/document through LibreOffice and inspects page images — and today it dead-ends with "requires LibreOffice" in every sandbox: the local provider's pinned PATH can never see the managed `soffice`, and the managed cloud sandboxes ship none. This makes rendering a host capability instead of a sandbox binary (option (a) of the system-skills design on #772).

**Seam.** After a successful exec lands office files under `output/` in host scratch — directly for the local provider, via the result pull for remote ones — the configured provider converts each (`docx`/`pptx`, up to 3 per command, skipped when already current) to a PDF under `.openwave/render/`, mirroring the path relative to `output/`, and reports it in the command's sync notes. The model finishes the loop with the existing `render_pdf.py` helper, whose deps (pypdfium2 + Pillow) are pure pip installs that work in every sandbox. No new tool, no new protocol: the PDF rides the same workspace vocabulary as everything else, and on a managed sandbox the model stages it into the next call with `files` exactly like any other scratch path.

**Per provider**, the QA loop becomes:
- **Local (Seatbelt):** scratch is the workspace, so the converted PDF appears in place; the next `render_office.py` call renders it with no staging.
- **E2B / Daytona:** the pull lands the deck in host scratch, the host converts, and the sync note tells the model to list `.openwave/render/<name>.pdf` in the helper call's `files`.
- **Containers that ship LibreOffice** (the coming documents image): the helper still prefers the in-sandbox `soffice` and never round-trips.

`render_office.py`'s failure message now names the exact state and next action (host PDF path, `files` staging, or reopen-checks fallback) instead of "requires LibreOffice"; the presentations and word-documents skills describe the same ladder.

The desktop registers a converter backed by the same LibreOffice resolution, containment, on-disk cache, and conversion lock as the preview panel, so the preview and the QA loop can never disagree about which converter the machine has or race two cold launches. Headless embeddings register none, and the pass degrades to one honest sync note. Sources are read and PDFs written only through `ScratchDir` handles: a sandbox-planted symlink can neither feed a host file into a conversion nor steer the write outside scratch.

Verified live on this machine with the managed LibreOffice 25.8.7 install: converted the fixture deck to PDF with the managed `soffice`, then ran `render_office.py` with no LibreOffice on PATH against a staged `.openwave/render/deck.pptx.pdf` — it rendered all 4 pages with pypdfium2 into `preview/` — and confirmed the no-PDF error message names the staging step.

Refs #772