### PR TITLE
feat(exec): host-tool broker warms declared skill deps and gates the office-rendering prompt line

### DIFF
--- a/crates/openwave-code-execution/src/host_tools.rs
+++ b/crates/openwave-code-execution/src/host_tools.rs
@@ -1,0 +1,47 @@
+//! The host-tool broker: one seam between skill-declared host dependencies
+//! and whatever machinery provides them.
+//!
+//! Skills declare host tools in their manifests (`deps: { host: [...] }`,
+//! the closed [`HostDep`] vocabulary). Something has to make those tools
+//! real: on the desktop that is the managed LibreOffice installer; headless
+//! embeddings have nothing. The broker is the one interface both sides meet
+//! at, so every caller — turn staging warming a declared dependency ahead of
+//! use, the operating prompt stating whether office rendering is real, an
+//! explicit user retry — reads and drives the same state instead of growing
+//! its own install path.
+//!
+//! `ensure` is deliberately fire-and-forget: provisioning can be a 300 MB
+//! download, and no caller is allowed to block a turn on it. The provider
+//! behind the broker keeps its own discipline (serialized installs, a
+//! remembered failure that only an explicit retry clears), and `status`
+//! reports the current truth those rules produce.
+
+use async_trait::async_trait;
+
+use crate::skills::HostDep;
+
+/// The current truth about one host tool.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HostToolStatus {
+    /// The tool resolves right now; a caller that needs it can have it.
+    Available,
+    /// Provisioning is under way; the tool is expected to resolve soon.
+    Installing,
+    /// The tool does not resolve and is not being provisioned, with the
+    /// reason (unsupported platform, a remembered install failure, or simply
+    /// not installed).
+    Unavailable(String),
+}
+
+/// Provides host tools on demand and reports their state.
+#[async_trait]
+pub trait HostToolBroker: Send + Sync {
+    /// Begin providing `tool` if it is absent and provisioning is possible;
+    /// returns immediately. Repeat calls are cheap: an available tool, an
+    /// install already under way, and a remembered failure are all no-ops —
+    /// nothing re-downloads without an explicit user retry.
+    fn ensure(&self, tool: HostDep);
+
+    /// The current truth about `tool`.
+    async fn status(&self, tool: HostDep) -> HostToolStatus;
+}

--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -14,6 +14,7 @@ mod credential;
 mod daytona;
 mod e2b;
 pub mod host_paths;
+pub mod host_tools;
 mod http;
 mod local;
 #[cfg(target_os = "macos")]
@@ -36,6 +37,7 @@ pub use host_paths::{
     resolve_scratch_directory, try_resolve_scratch_directory, FilePrecondition, FileStamp,
     ScratchDir, ScratchEntry, ScratchEntryKind, ScratchRefusal,
 };
+pub use host_tools::{HostToolBroker, HostToolStatus};
 pub use local::LocalExecutionProvider;
 pub use office_render::{
     render_office_outputs, HostOfficeConverter, OfficeConvertError, OFFICE_RENDER_DIR,

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -324,11 +324,14 @@ async fn boot_server(
     // The exec provider renders office outputs with the same managed/system
     // LibreOffice the preview panel converts with.
     let office_converter = Arc::new(office_pdf::ExecOfficeConverter::new(data_dir));
+    // Skill-declared host tools warm and report through the managed installer.
+    let host_tool_broker = Arc::new(office_install::DesktopHostToolBroker::new(app.clone()));
     let server = openwave_server::bind_configured_with_desktop_executor_and_folder_grants(
         config,
         client_executor_id,
         folder_grants,
         Some(office_converter),
+        Some(host_tool_broker),
     )
     .await
     .map_err(|e| e.to_string())?;

--- a/crates/openwave-desktop/src/office_install.rs
+++ b/crates/openwave-desktop/src/office_install.rs
@@ -264,6 +264,73 @@ pub(crate) fn cancel_presentation_converter_install() {
     }
 }
 
+/// The desktop's host-tool broker: skill-declared host dependencies resolve
+/// through the same managed installer, warm-up guard, and failure memory the
+/// preview panel uses, so there is exactly one install path however the need
+/// arrives — turn staging, the preview, or an explicit retry.
+pub(crate) struct DesktopHostToolBroker {
+    app: AppHandle,
+}
+
+impl DesktopHostToolBroker {
+    pub(crate) fn new(app: AppHandle) -> Self {
+        Self { app }
+    }
+}
+
+#[async_trait::async_trait]
+impl openwave_code_execution::HostToolBroker for DesktopHostToolBroker {
+    fn ensure(&self, tool: openwave_code_execution::HostDep) {
+        match tool {
+            // The warm-up already embodies the discipline `ensure` promises:
+            // returns immediately, at most one download per app run, no-op
+            // when a working converter exists or a failure is remembered.
+            openwave_code_execution::HostDep::LibreOffice => {
+                warm_presentation_converter(self.app.clone());
+            }
+        }
+    }
+
+    async fn status(
+        &self,
+        tool: openwave_code_execution::HostDep,
+    ) -> openwave_code_execution::HostToolStatus {
+        match tool {
+            openwave_code_execution::HostDep::LibreOffice => libreoffice_status(&self.app).await,
+        }
+    }
+}
+
+/// The current truth about LibreOffice on this machine, in the same
+/// resolution order conversion uses: the verified managed install, then a
+/// working system one. "Working" is probed, not assumed, exactly as the
+/// warm-up does — a leftover launcher script must not report Available.
+async fn libreoffice_status(app: &AppHandle) -> openwave_code_execution::HostToolStatus {
+    use openwave_code_execution::HostToolStatus;
+    let Ok(data_dir) = crate::data_dir(app) else {
+        return HostToolStatus::Unavailable("the app data directory is unavailable".into());
+    };
+    if managed_soffice(&data_dir).is_some() {
+        return HostToolStatus::Available;
+    }
+    if crate::office_pdf::workable_system_soffice().await {
+        return HostToolStatus::Available;
+    }
+    if state().lock().expect("install state lock").cancel.is_some() {
+        return HostToolStatus::Installing;
+    }
+    if let Some(reason) = last_failure() {
+        return HostToolStatus::Unavailable(reason);
+    }
+    if supported() {
+        HostToolStatus::Unavailable("LibreOffice is not installed yet".into())
+    } else {
+        HostToolStatus::Unavailable(
+            "automatic LibreOffice install is not supported on this platform".into(),
+        )
+    }
+}
+
 #[cfg(target_os = "macos")]
 #[derive(Serialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -824,6 +824,10 @@ pub struct ConfiguredCodeExecutionProvider {
     /// Host-provided office-to-PDF converter feeding the model's visual QA
     /// loop. `None` (headless embeddings) degrades to an honest sync note.
     office_converter: Option<Arc<dyn openwave_code_execution::HostOfficeConverter>>,
+    /// Broker that provides skill-declared host tools (the managed
+    /// LibreOffice install, on the desktop). `None` reports every tool
+    /// unavailable and warms nothing.
+    host_tool_broker: Option<Arc<dyn openwave_code_execution::HostToolBroker>>,
     /// Cross-process exclusion for the blobs a write-back snapshot publishes.
     blob_writes: Option<Arc<BlobWriteGuard>>,
     remote_sessions: RemoteSessionPool,
@@ -986,6 +990,7 @@ impl ConfiguredCodeExecutionProvider {
             user_skills_dir: None,
             folder_grant_resolver: None,
             office_converter: None,
+            host_tool_broker: None,
             blob_writes: None,
             remote_sessions: RemoteSessionPool::default(),
             write_overlays: Mutex::new(HashMap::new()),
@@ -1088,6 +1093,22 @@ impl ConfiguredCodeExecutionProvider {
         if skills.is_empty() {
             return;
         }
+        // Warm the staged skills' declared host tools while the turn runs:
+        // `ensure` is fire-and-forget with the broker's own discipline
+        // (serialized installs, remembered failures), so a declaration in a
+        // staged manifest is all it takes to start the managed install long
+        // before the QA loop needs it.
+        if let Some(broker) = self.host_tool_broker.as_deref() {
+            let mut warmed: Vec<openwave_code_execution::HostDep> = Vec::new();
+            for skill in &skills {
+                for dep in &skill.package.host_deps {
+                    if !warmed.contains(dep) {
+                        warmed.push(*dep);
+                        broker.ensure(*dep);
+                    }
+                }
+            }
+        }
         let host_dir = self.scratch_root.join(chat_id.to_string());
         if let Err(error) = prepare_execution_directories(
             &host_dir,
@@ -1099,6 +1120,34 @@ impl ConfiguredCodeExecutionProvider {
         {
             tracing::warn!("turn-start workspace staging failed for chat {chat_id}: {error}");
         }
+    }
+
+    /// Whether host-side office rendering is real for this turn, for the
+    /// operating prompt's capability line.
+    ///
+    /// `None` when no staged skill declares a LibreOffice dependency — the
+    /// line would steer nothing and is omitted. Otherwise the broker's status
+    /// is the truth: only a tool that resolves right now counts, so a prompt
+    /// never promises a converter that is mid-download or failed to install.
+    pub(crate) async fn office_rendering_available(&self) -> Option<bool> {
+        let declared = self.current_skills().iter().any(|skill| {
+            skill
+                .package
+                .host_deps
+                .contains(&openwave_code_execution::HostDep::LibreOffice)
+        });
+        if !declared {
+            return None;
+        }
+        let Some(broker) = self.host_tool_broker.as_deref() else {
+            return Some(false);
+        };
+        Some(matches!(
+            broker
+                .status(openwave_code_execution::HostDep::LibreOffice)
+                .await,
+            openwave_code_execution::HostToolStatus::Available
+        ))
     }
 
     /// The shared package cache keyspace for the local sandbox interpreter.
@@ -1218,6 +1267,19 @@ impl ConfiguredCodeExecutionProvider {
         converter: Option<Arc<dyn openwave_code_execution::HostOfficeConverter>>,
     ) -> Self {
         self.office_converter = converter;
+        self
+    }
+
+    /// Install the broker that provides skill-declared host tools. Turn
+    /// staging warms declared dependencies through it, and the operating
+    /// prompt's office-rendering capability line reads its status. Non-desktop
+    /// embeddings leave this absent.
+    #[must_use]
+    pub fn with_host_tool_broker(
+        mut self,
+        broker: Option<Arc<dyn openwave_code_execution::HostToolBroker>>,
+    ) -> Self {
+        self.host_tool_broker = broker;
         self
     }
 
@@ -2740,6 +2802,109 @@ mod tests {
         let bare_chat = ChatId::new();
         bare.stage_turn_workspace(bare_chat).await;
         assert!(!scratch_root.path().join(bare_chat.to_string()).exists());
+    }
+
+    /// The declaration-driven host-tool contract: staging a skill that
+    /// declares `host: ["libreoffice"]` warms the broker exactly once per
+    /// staging, and the prompt capability flag is the broker's status — never
+    /// a promise — omitted entirely when nothing declares the dependency.
+    #[tokio::test]
+    async fn declared_host_deps_warm_the_broker_and_gate_the_capability_flag() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct RecordingBroker {
+            ensures: AtomicUsize,
+            available: bool,
+        }
+
+        #[async_trait]
+        impl openwave_code_execution::HostToolBroker for RecordingBroker {
+            fn ensure(&self, tool: openwave_code_execution::HostDep) {
+                assert_eq!(tool, openwave_code_execution::HostDep::LibreOffice);
+                self.ensures.fetch_add(1, Ordering::SeqCst);
+            }
+
+            async fn status(
+                &self,
+                _tool: openwave_code_execution::HostDep,
+            ) -> openwave_code_execution::HostToolStatus {
+                if self.available {
+                    openwave_code_execution::HostToolStatus::Available
+                } else {
+                    openwave_code_execution::HostToolStatus::Unavailable("not installed".into())
+                }
+            }
+        }
+
+        let (store, _database) = test_store().await;
+        let store = Arc::new(store);
+        let scratch_root = tempfile::tempdir().unwrap();
+        let source = tempfile::tempdir().unwrap();
+        let skill_dir = source.path().join("presentations");
+        std::fs::create_dir(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join(openwave_code_execution::SKILL_MANIFEST_FILE),
+            "---\n\
+             name: presentations\n\
+             description: Decks.\n\
+             deps: { python: [\"python-pptx==1.0.2\"], host: [\"libreoffice\"] }\n\
+             ---\n\
+             Body.\n",
+        )
+        .unwrap();
+
+        let broker = Arc::new(RecordingBroker {
+            ensures: AtomicUsize::new(0),
+            available: true,
+        });
+        let provider = ConfiguredCodeExecutionProvider::new(
+            store.clone(),
+            Arc::new(NoSecrets),
+            scratch_root.path(),
+        )
+        .with_skills(Some(source.path().to_owned()))
+        .with_host_tool_broker(Some(broker.clone()));
+
+        provider.stage_turn_workspace(ChatId::new()).await;
+        assert_eq!(broker.ensures.load(Ordering::SeqCst), 1);
+        assert_eq!(provider.office_rendering_available().await, Some(true));
+
+        // An unavailable tool reports false — the prompt says so instead of
+        // teaching a QA loop the host cannot run.
+        let unavailable = Arc::new(RecordingBroker {
+            ensures: AtomicUsize::new(0),
+            available: false,
+        });
+        let provider = ConfiguredCodeExecutionProvider::new(
+            store.clone(),
+            Arc::new(NoSecrets),
+            scratch_root.path(),
+        )
+        .with_skills(Some(source.path().to_owned()))
+        .with_host_tool_broker(Some(unavailable));
+        assert_eq!(provider.office_rendering_available().await, Some(false));
+
+        // No declaration, no line; no broker, no promise.
+        let no_deps = tempfile::tempdir().unwrap();
+        let plain = no_deps.path().join("charts");
+        std::fs::create_dir(&plain).unwrap();
+        std::fs::write(
+            plain.join(openwave_code_execution::SKILL_MANIFEST_FILE),
+            "---\nname: charts\ndescription: Plots.\n---\nBody.\n",
+        )
+        .unwrap();
+        let provider = ConfiguredCodeExecutionProvider::new(
+            store.clone(),
+            Arc::new(NoSecrets),
+            scratch_root.path(),
+        )
+        .with_skills(Some(no_deps.path().to_owned()));
+        assert_eq!(provider.office_rendering_available().await, None);
+
+        let brokerless =
+            ConfiguredCodeExecutionProvider::new(store, Arc::new(NoSecrets), scratch_root.path())
+                .with_skills(Some(source.path().to_owned()));
+        assert_eq!(brokerless.office_rendering_available().await, Some(false));
     }
 
     /// Local exec is confined to the scratch directory but can create entries

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -64,6 +64,7 @@ pub(crate) fn compose(specs: &[ToolSpec]) -> String {
         &NetworkPolicy::default(),
         crate::code_execution::DEFAULT_TIMEOUT_MS,
         false,
+        None,
         false,
     )
 }
@@ -99,6 +100,7 @@ fn render_timeout(timeout_ms: u64) -> String {
 /// reaches composition, so the section logic below stays truthful without
 /// consulting the flag; the flag only adds the planning contract itself.
 #[must_use]
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn compose_for_surface(
     specs: &[ToolSpec],
     exec_folders: &[ResolvedExecFolderGrant],
@@ -106,6 +108,7 @@ pub(crate) fn compose_for_surface(
     network_policy: &NetworkPolicy,
     exec_timeout_ms: u64,
     offline_package_cache: bool,
+    office_rendering: Option<bool>,
     plan_mode: bool,
 ) -> String {
     let names = specs
@@ -483,6 +486,21 @@ pub(crate) fn compose_for_surface(
                 "- Before producing a kind of document listed above, read `.openwave/skills/<name>/SKILL.md` with `read_file` and follow its instructions."
                     .to_owned(),
             );
+            // Host-derived truth, like the offline package cache line above:
+            // the QA loop a skill teaches must not promise a converter the
+            // host cannot produce. Omitted entirely when no staged skill
+            // declares the dependency.
+            match office_rendering {
+                Some(true) => lines.push(
+                    "- Office rendering is available: PPTX/DOCX files saved in output/ are converted to PDF under .openwave/render/ on the host after each successful command, for visual QA per the skill instructions."
+                        .to_owned(),
+                ),
+                Some(false) => lines.push(
+                    "- Office rendering is unavailable on this host: no PDF conversion of PPTX/DOCX outputs is possible unless the sandbox itself has LibreOffice. Validate office outputs by reopening them with their library and say the visual pass was not possible."
+                        .to_owned(),
+                ),
+                None => {}
+            }
             push_section(&mut prompt, DOCUMENT_SKILLS_HEADING, &lines);
         }
     }
@@ -676,6 +694,7 @@ mod tests {
             &NetworkPolicy::default(),
             TIMEOUT,
             false,
+            None,
             true,
         );
         let normal = compose_for_surface(
@@ -685,6 +704,7 @@ mod tests {
             &NetworkPolicy::default(),
             TIMEOUT,
             false,
+            None,
             false,
         );
 
@@ -735,6 +755,7 @@ mod tests {
             &NetworkPolicy::default(),
             TIMEOUT,
             false,
+            None,
             false,
         );
 
@@ -756,7 +777,16 @@ mod tests {
     #[test]
     fn network_policy_renders_truthfully_per_value() {
         let compose_with = |policy: &NetworkPolicy| {
-            compose_for_surface(&[spec("exec")], &[], &[], policy, TIMEOUT, false, false)
+            compose_for_surface(
+                &[spec("exec")],
+                &[],
+                &[],
+                policy,
+                TIMEOUT,
+                false,
+                None,
+                false,
+            )
         };
         let pip_line = "python3 -m pip install --user";
 
@@ -776,6 +806,7 @@ mod tests {
             &NetworkPolicy::Off,
             TIMEOUT,
             true,
+            None,
             false,
         );
         assert!(off_with_cache.contains("no outbound network access"));
@@ -830,6 +861,7 @@ mod tests {
             &NetworkPolicy::Open,
             1_500,
             false,
+            None,
             false,
         );
         assert!(odd.contains("killed by the host after 1500 milliseconds"));
@@ -877,6 +909,7 @@ mod tests {
             &NetworkPolicy::default(),
             TIMEOUT,
             false,
+            None,
             false,
         );
         assert!(prompt.contains(DOCUMENT_SKILLS_HEADING));
@@ -897,6 +930,7 @@ mod tests {
             &NetworkPolicy::default(),
             TIMEOUT,
             false,
+            None,
             false,
         );
         assert!(!without_exec.contains(DOCUMENT_SKILLS_HEADING));
@@ -908,9 +942,44 @@ mod tests {
             &NetworkPolicy::default(),
             TIMEOUT,
             false,
+            None,
             false,
         );
         assert!(!forged_only.contains(DOCUMENT_SKILLS_HEADING));
+    }
+
+    /// The office-rendering line is host truth like the offline-cache line:
+    /// present in exactly the state the broker reports, absent when nothing
+    /// declares the dependency.
+    #[test]
+    fn office_rendering_line_matches_the_host_state() {
+        let skills = vec![SkillPackage {
+            name: "presentations".into(),
+            description: "Decks.".into(),
+            python_deps: Vec::new(),
+            host_deps: vec![openwave_code_execution::HostDep::LibreOffice],
+            origin: SkillOrigin::Builtin,
+        }];
+        let for_state = |office_rendering| {
+            compose_for_surface(
+                &[spec("exec")],
+                &[],
+                &skills,
+                &NetworkPolicy::default(),
+                TIMEOUT,
+                false,
+                office_rendering,
+                false,
+            )
+        };
+        let available = for_state(Some(true));
+        assert!(available.contains("Office rendering is available"));
+        assert!(available.contains(".openwave/render/"));
+        let unavailable = for_state(Some(false));
+        assert!(unavailable.contains("Office rendering is unavailable"));
+        assert!(unavailable.contains("visual pass was not possible"));
+        let undeclared = for_state(None);
+        assert!(!undeclared.contains("Office rendering"));
     }
 
     #[test]
@@ -993,6 +1062,7 @@ mod tests {
             &NetworkPolicy::default(),
             TIMEOUT,
             false,
+            None,
             false,
         );
 

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -667,6 +667,7 @@ pub async fn bind(config: Config) -> Result<Server> {
         mcp_config::ConfiguredMcpServers::default(),
         None,
         None,
+        None,
     )
     .await
 }
@@ -677,7 +678,7 @@ pub async fn bind(config: Config) -> Result<Server> {
 /// to use [`bind`] when process-environment configuration is undesirable.
 pub async fn bind_configured(config: Config) -> Result<Server> {
     let mcp_servers = mcp_config::ConfiguredMcpServers::from_env()?;
-    bind_inner(config, None, mcp_servers, None, None).await
+    bind_inner(config, None, mcp_servers, None, None, None).await
 }
 
 /// Bind the API with a stable app-private native executor identity.
@@ -697,6 +698,7 @@ pub async fn bind_with_desktop_executor(
         mcp_config::ConfiguredMcpServers::default(),
         None,
         None,
+        None,
     )
     .await
 }
@@ -711,7 +713,15 @@ pub async fn bind_configured_with_desktop_executor(
         return Err(AgentError::config("client executor id must not be nil"));
     }
     let mcp_servers = mcp_config::ConfiguredMcpServers::from_env()?;
-    bind_inner(config, Some(client_executor_id), mcp_servers, None, None).await
+    bind_inner(
+        config,
+        Some(client_executor_id),
+        mcp_servers,
+        None,
+        None,
+        None,
+    )
+    .await
 }
 
 /// Desktop binding with the native bridges only the product app can provide:
@@ -723,6 +733,7 @@ pub async fn bind_configured_with_desktop_executor_and_folder_grants(
     client_executor_id: Uuid,
     folder_grant_resolver: Arc<dyn code_execution::ExecFolderGrantResolver>,
     office_converter: Option<Arc<dyn openwave_code_execution::HostOfficeConverter>>,
+    host_tool_broker: Option<Arc<dyn openwave_code_execution::HostToolBroker>>,
 ) -> Result<Server> {
     if client_executor_id.is_nil() {
         return Err(AgentError::config("client executor id must not be nil"));
@@ -734,6 +745,7 @@ pub async fn bind_configured_with_desktop_executor_and_folder_grants(
         mcp_servers,
         Some(folder_grant_resolver),
         office_converter,
+        host_tool_broker,
     )
     .await
 }
@@ -770,6 +782,7 @@ async fn bind_inner(
     mcp_servers: mcp_config::ConfiguredMcpServers,
     folder_grant_resolver: Option<Arc<dyn code_execution::ExecFolderGrantResolver>>,
     office_converter: Option<Arc<dyn openwave_code_execution::HostOfficeConverter>>,
+    host_tool_broker: Option<Arc<dyn openwave_code_execution::HostToolBroker>>,
 ) -> Result<Server> {
     // Desktop live delivery remains process-local. Turns, steering, and tool
     // approvals are durable, while one process still owns the complete data
@@ -838,7 +851,8 @@ async fn bind_inner(
         .with_skills(config.exec_skills_dir.clone())
         .with_user_skills(Some(config.user_skills_dir()))
         .with_folder_grant_resolver(folder_grant_resolver)
-        .with_office_converter(office_converter),
+        .with_office_converter(office_converter)
+        .with_host_tool_broker(host_tool_broker),
     );
     let foreground_web_search =
         Box::new(web_search::foreground_tool(store.clone(), secrets.clone()));

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -149,6 +149,7 @@ pub(crate) fn freeze_foreground_turn_surface(
         &openwave_core::NetworkPolicy::default(),
         crate::code_execution::DEFAULT_TIMEOUT_MS,
         false,
+        None,
         false,
     )
 }
@@ -162,6 +163,7 @@ fn freeze_foreground_turn_surface_with_folders(
     network_policy: &openwave_core::NetworkPolicy,
     exec_timeout_ms: u64,
     offline_package_cache: bool,
+    office_rendering: Option<bool>,
     plan_mode: bool,
 ) -> ForegroundTurnSurface {
     let mut agent_config = base_agent_config.clone();
@@ -172,6 +174,7 @@ fn freeze_foreground_turn_surface_with_folders(
         network_policy,
         exec_timeout_ms,
         offline_package_cache,
+        office_rendering,
         plan_mode,
     ));
     ForegroundTurnSurface {
@@ -607,6 +610,10 @@ impl TurnWorker {
             Some(provider) => provider.offline_package_cache_ready().await,
             None => false,
         };
+        let office_rendering = match self.exec_folder_context.as_ref() {
+            Some(provider) => provider.office_rendering_available().await,
+            None => None,
+        };
         let exec_timeout_ms = match self.exec_folder_context.as_ref() {
             Some(provider) => provider.current_timeout_ms().await,
             None => crate::code_execution::DEFAULT_TIMEOUT_MS,
@@ -619,6 +626,7 @@ impl TurnWorker {
             &chat.network_policy,
             exec_timeout_ms,
             offline_package_cache,
+            office_rendering,
             matches!(
                 chat.permission_mode,
                 Some(openwave_core::PermissionMode::Plan)


### PR DESCRIPTION
Slices 3–5 of the system-skills design on #772: the declaration from #1412 gets its behavior.

**The seam.** `HostToolBroker` in `openwave-code-execution` — `ensure(tool)` (fire-and-forget, provider-disciplined) and `status(tool) -> Available | Installing | Unavailable(reason)` — over the closed `HostDep` vocabulary. The desktop registers `DesktopHostToolBroker` over the managed LibreOffice installer: `ensure` reuses #1407's warm-up (once per app run, no-op behind a verified managed install, a probed working system `soffice`, or a remembered failure), and `status` answers in the same resolution order conversion uses, so the broker, the preview panel, and the exec render path (#1418) can never disagree. Headless embeddings register nothing and every tool reports unavailable.

**Warm trigger, declaration-driven.** Turn staging calls `ensure()` for each host dep the staged skills declare. Where #1407's renderer-side trigger fires when a produced deck is *observed*, this fires when a turn *stages a skill that could produce one* — the server-side follow-up shape that PR anticipated — so the ~300 MB download typically starts a turn earlier. The renderer trigger stays as a harmless second caller into the same guarded path.

**Truthful capability line.** The operating prompt's Document skills section now states office rendering availability from broker status, modeled on `offline_package_cache_ready`: "available" only when the tool resolves right now (mid-install and failed both read as unavailable), and the line is omitted entirely when no staged skill declares the dependency — so the prompt never teaches a QA loop the environment cannot run, and never wastes a line when it is irrelevant.

The design's "preview panel switches to the broker" refactor turned out to be moot: #1407 already funneled every install through one shared path, and the broker is implemented over exactly that state — there is no second install path left to converge.

Tests: the declaration-to-broker contract (staging warms once; the capability flag follows broker status; no declaration means no line; no broker means no promise) and the prompt line in all three states.

Refs #772