### PR TITLE
feat(connectors): attestation contexts and context-scoped token minting

### DIFF
--- a/crates/openwave-connectors/src/gateway.rs
+++ b/crates/openwave-connectors/src/gateway.rs
@@ -7,7 +7,7 @@
 //! explicit installation pin so a swapped-out deployment behind the same URL
 //! is detected instead of silently trusted.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -356,11 +356,19 @@ impl GatewayAuth {
     /// Exchange the refresh token for a token bound to `resource`, rotating
     /// the refresh token. `invalid_grant` — an expired, revoked, or reused
     /// token — maps to a sign-in-required error.
+    ///
+    /// `attestation_context_id` is a client-minted UUID the gateway creates
+    /// on first use and pins to the session: an inference call with a token
+    /// minted inside a context records tool-call observations, and a
+    /// gateway-attested MCP endpoint only accepts calls whose token carries
+    /// the matching context. The gateway rejects a context pinned to another
+    /// session as `invalid_target`.
     pub async fn refresh(
         &self,
         refresh_token: &str,
         resource: &str,
         expected_installation: &str,
+        attestation_context_id: Option<&str>,
     ) -> Result<TokenSet> {
         let mut form: Vec<(&str, &str)> = vec![
             ("grant_type", "refresh_token"),
@@ -369,6 +377,9 @@ impl GatewayAuth {
         ];
         if let Some(client_name) = self.config.client_name.as_deref() {
             form.push(("client_name", client_name));
+        }
+        if let Some(context) = attestation_context_id {
+            form.push(("attestation_context_id", context));
         }
         let token = self.request_token(&form).await?;
         if token.resource != resource || token.installation_id != expected_installation {
@@ -481,6 +492,20 @@ impl GatewayAuth {
                 .is_some_and(|error| error.error == "invalid_grant")
             {
                 return Err(sign_in_required("the gateway session is no longer valid"));
+            }
+            // Kept distinguishable so an attested mint can tell a rejected
+            // context (remintable under a fresh id) from other failures.
+            if error
+                .as_ref()
+                .is_some_and(|error| error.error == "invalid_target")
+            {
+                let detail = error
+                    .and_then(|error| error.error_description)
+                    .unwrap_or_else(|| "the requested target is unavailable".to_string());
+                return Err(gateway_error(
+                    "token request",
+                    format!("invalid_target: {detail}"),
+                ));
             }
             let detail = error
                 .and_then(|error| error.error_description.or(Some(error.error)))
@@ -620,6 +645,29 @@ pub struct GatewayConnection {
     auth: GatewayAuth,
     vault: CredentialVault,
     token_motion: Mutex<()>,
+    /// Attestation contexts and the access tokens minted inside them.
+    /// Memory-only by design: context ids are pinned server-side to the
+    /// session they were first used with, so persisting them would carry
+    /// stale ids across sign-ins, and the tokens expire within minutes
+    /// anyway. Locked only while `token_motion` is held, so the two locks
+    /// have a fixed order.
+    attested: Mutex<AttestedTokens>,
+}
+
+/// The client-minted attestation context id for each caller key, plus the
+/// fresh access tokens minted inside each context, keyed by
+/// `(resource, context id)`.
+#[derive(Default)]
+struct AttestedTokens {
+    contexts: HashMap<String, String>,
+    tokens: HashMap<(String, String), CachedAccessToken>,
+}
+
+/// True when a token request failed because the gateway refused the
+/// requested target — for an attested mint, a context id pinned to a
+/// superseded session. Reminting under a fresh id recovers.
+fn is_attestation_context_rejected(error: &AgentError) -> bool {
+    matches!(error, AgentError::Config(message) if message.contains("invalid_target"))
 }
 
 impl GatewayConnection {
@@ -629,6 +677,7 @@ impl GatewayConnection {
             auth,
             vault,
             token_motion: Mutex::new(()),
+            attested: Mutex::new(AttestedTokens::default()),
         }
     }
 
@@ -647,6 +696,8 @@ impl GatewayConnection {
     /// state left to ever revoke it.
     pub async fn store_session(&self, session: &AuthorizedSession) -> Result<()> {
         let _guard = self.token_motion.lock().await;
+        // Attestation contexts are pinned to the session being replaced.
+        *self.attested.lock().await = AttestedTokens::default();
         // An unreadable stored blob is skipped, as in sign-out: it carries no
         // usable refresh token to revoke.
         if let Ok(Some(superseded)) = self.vault.load().await {
@@ -744,6 +795,7 @@ impl GatewayConnection {
                 &credentials.refresh_token,
                 resource,
                 &credentials.installation_id,
+                None,
             )
             .await?;
         credentials.refresh_token = token.refresh_token.clone();
@@ -757,6 +809,104 @@ impl GatewayConnection {
         );
         self.vault.save(&credentials).await?;
         Ok(token.access_token)
+    }
+
+    /// A fresh access token for `resource`, minted inside the attestation
+    /// context named by `context_key` — a caller-chosen stable key,
+    /// typically a chat id. Tokens for the same key share one gateway
+    /// context across resources; that shared context is what lets a
+    /// gateway-attested MCP endpoint match a tool call against the
+    /// observation recorded by the same chat's inference.
+    ///
+    /// The context id is a client-minted UUID the gateway creates on first
+    /// use and pins to the current session. The registry and the tokens
+    /// minted inside it live in memory only and reset when the stored
+    /// session changes; a context id somehow left over from a superseded
+    /// session is rejected by the gateway, and one remint under a fresh id
+    /// self-heals that without a sign-out.
+    pub async fn attested_access_token(&self, resource: &str, context_key: &str) -> Result<String> {
+        let _guard = self.token_motion.lock().await;
+        let Some(mut credentials) = self.vault.load().await? else {
+            return Err(sign_in_required("no gateway session is stored"));
+        };
+        if !self.matches_deployment(&credentials) {
+            return Err(sign_in_required(
+                "the stored gateway session belongs to a different gateway deployment",
+            ));
+        }
+        let mut attested = self.attested.lock().await;
+        attested.tokens.retain(|_, cached| cached.is_fresh());
+        let context = attested
+            .contexts
+            .entry(context_key.to_string())
+            .or_insert_with(|| uuid::Uuid::new_v4().to_string())
+            .clone();
+        if let Some(cached) = attested
+            .tokens
+            .get(&(resource.to_string(), context.clone()))
+        {
+            return Ok(cached.token.clone());
+        }
+        let (context, token) = match self
+            .mint_attested(&mut credentials, resource, &context)
+            .await
+        {
+            Ok(token) => (context, token),
+            Err(error) if is_attestation_context_rejected(&error) => {
+                let fresh = uuid::Uuid::new_v4().to_string();
+                attested.tokens.retain(|(_, held), _| held != &context);
+                attested
+                    .contexts
+                    .insert(context_key.to_string(), fresh.clone());
+                let token = self
+                    .mint_attested(&mut credentials, resource, &fresh)
+                    .await?;
+                (fresh, token)
+            }
+            Err(error) => return Err(error),
+        };
+        attested.tokens.insert(
+            (resource.to_string(), context),
+            CachedAccessToken {
+                token: token.access_token.clone(),
+                expires_at_unix: token.expires_at_unix,
+                scope: token.scope.clone(),
+            },
+        );
+        Ok(token.access_token)
+    }
+
+    /// A fresh access token bound to `mcp:<slug>` inside the attestation
+    /// context named by `context_key`; see [`Self::attested_access_token`].
+    pub async fn attested_mcp_access_token(&self, slug: &str, context_key: &str) -> Result<String> {
+        validate_mcp_endpoint_slug(slug)?;
+        self.attested_access_token(&format!("mcp:{slug}"), context_key)
+            .await
+    }
+
+    /// One rotating refresh bound to `resource` inside `context`. The
+    /// rotated refresh token is persisted; the minted access token is not —
+    /// attested tokens are per-context and expire within minutes, so
+    /// storing them would grow the keychain blob without ever serving a
+    /// future process.
+    async fn mint_attested(
+        &self,
+        credentials: &mut GatewayCredentials,
+        resource: &str,
+        context: &str,
+    ) -> Result<TokenSet> {
+        let token = self
+            .auth
+            .refresh(
+                &credentials.refresh_token,
+                resource,
+                &credentials.installation_id,
+                Some(context),
+            )
+            .await?;
+        credentials.refresh_token = token.refresh_token.clone();
+        self.vault.save(credentials).await?;
+        Ok(token)
     }
 
     /// Live identity check with a `control` token.
@@ -799,6 +949,7 @@ impl GatewayConnection {
     /// refresh-token expiry.
     pub async fn sign_out(&self) -> Result<()> {
         let _guard = self.token_motion.lock().await;
+        *self.attested.lock().await = AttestedTokens::default();
         if let Some(credentials) = self.vault.load().await? {
             self.revoke_stored(&credentials).await;
         }

--- a/crates/openwave-connectors/tests/gateway_flow.rs
+++ b/crates/openwave-connectors/tests/gateway_flow.rs
@@ -65,6 +65,11 @@ struct FakeGateway {
     corrupt_state: AtomicBool,
     /// Serve 404 for `/api/v1/cli/apps`, like a gateway that predates it.
     apps_unsupported: AtomicBool,
+    /// Attestation context ids observed on refresh grants, in order.
+    contexts_seen: Mutex<Vec<String>>,
+    /// Reject the next unseen attestation context with `invalid_target`,
+    /// like a context row pinned to a superseded session.
+    reject_next_context: AtomicBool,
 }
 
 impl FakeGateway {
@@ -171,6 +176,18 @@ async fn token(
             if form.get("client_name").map(String::as_str) != Some("openwave") {
                 return invalid_grant();
             }
+            // Context validation precedes refresh consumption, as on the real
+            // gateway: a rejected context aborts the grant without rotating.
+            if let Some(context) = form.get("attestation_context_id") {
+                if uuid::Uuid::parse_str(context).is_err() {
+                    return invalid_target();
+                }
+                let unseen = !gateway.contexts_seen.lock().unwrap().contains(context);
+                if unseen && gateway.reject_next_context.swap(false, Ordering::SeqCst) {
+                    return invalid_target();
+                }
+                gateway.contexts_seen.lock().unwrap().push(context.clone());
+            }
             let Some(refresh) = form.get("refresh_token") else {
                 return StatusCode::BAD_REQUEST.into_response();
             };
@@ -192,6 +209,17 @@ fn invalid_grant() -> Response {
     (
         StatusCode::BAD_REQUEST,
         Json(json!({"error": "invalid_grant"})),
+    )
+        .into_response()
+}
+
+fn invalid_target() -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({
+            "error": "invalid_target",
+            "error_description": "The requested attestation context is unavailable.",
+        })),
     )
         .into_response()
 }
@@ -444,6 +472,99 @@ async fn sign_out_revokes_remotely_and_clears_the_vault() {
         .await
         .expect_err("signed-out connection must fail");
     assert!(is_sign_in_required(&error), "{error}");
+}
+
+#[tokio::test]
+async fn attested_tokens_share_a_context_per_key_and_cache_per_resource() {
+    let (gateway, connection) = signed_in_connection().await;
+    let exchanges = gateway.token_requests.load(Ordering::SeqCst);
+
+    // Two resources under one key ride the same client-minted context —
+    // the property that lets an attested endpoint match the tool call
+    // against the observation the same chat's inference recorded.
+    let llm = connection
+        .attested_access_token(RESOURCE_LLM, "chat-a")
+        .await
+        .unwrap();
+    let mcp = connection
+        .attested_mcp_access_token("primary", "chat-a")
+        .await
+        .unwrap();
+    assert_ne!(llm, mcp);
+    assert_eq!(gateway.token_requests.load(Ordering::SeqCst), exchanges + 2);
+
+    // Same key + resource is served from the in-memory cache.
+    assert_eq!(
+        connection
+            .attested_access_token(RESOURCE_LLM, "chat-a")
+            .await
+            .unwrap(),
+        llm
+    );
+    assert_eq!(gateway.token_requests.load(Ordering::SeqCst), exchanges + 2);
+
+    // A different key mints a different context.
+    connection
+        .attested_access_token(RESOURCE_LLM, "chat-b")
+        .await
+        .unwrap();
+    let contexts = gateway.contexts_seen.lock().unwrap().clone();
+    assert_eq!(contexts.len(), 3);
+    assert_eq!(contexts[0], contexts[1]);
+    assert_ne!(contexts[0], contexts[2]);
+
+    // Attested mints never landed in the persisted per-resource cache: a
+    // plain llm token still needs its own refresh, and that refresh works —
+    // proof the rotated refresh token was persisted by the attested path.
+    let count = gateway.token_requests.load(Ordering::SeqCst);
+    let plain = connection.access_token(RESOURCE_LLM).await.unwrap();
+    assert_ne!(plain, llm);
+    assert_eq!(gateway.token_requests.load(Ordering::SeqCst), count + 1);
+}
+
+#[tokio::test]
+async fn a_rejected_attestation_context_remints_under_a_fresh_id() {
+    let (gateway, connection) = signed_in_connection().await;
+    gateway.reject_next_context.store(true, Ordering::SeqCst);
+
+    // The first mint's context is refused (as a context pinned to a
+    // superseded session would be); the connection remints under a fresh
+    // id without surfacing an error or consuming the refresh token.
+    connection
+        .attested_access_token(RESOURCE_LLM, "chat-a")
+        .await
+        .unwrap();
+    assert_eq!(gateway.contexts_seen.lock().unwrap().len(), 1);
+
+    // The session survived the rejected grant.
+    connection.access_token(RESOURCE_CONTROL).await.unwrap();
+}
+
+#[tokio::test]
+async fn attested_state_resets_with_the_stored_session() {
+    let (gateway, connection) = signed_in_connection().await;
+    connection
+        .attested_access_token(RESOURCE_LLM, "chat-a")
+        .await
+        .unwrap();
+
+    // Sign in again: same user, same gateway, new session. The same chat
+    // must not reuse the old context id — the gateway pins contexts to the
+    // session they were first used with.
+    let pending = connection.auth().start_sign_in().await.unwrap();
+    let url = pending.authorization_url().to_string();
+    let finish = tokio::spawn(pending.finish(Duration::from_secs(5)));
+    browser().get(&url).send().await.unwrap();
+    let session = finish.await.unwrap().unwrap();
+    connection.store_session(&session).await.unwrap();
+
+    connection
+        .attested_access_token(RESOURCE_LLM, "chat-a")
+        .await
+        .unwrap();
+    let contexts = gateway.contexts_seen.lock().unwrap().clone();
+    assert_eq!(contexts.len(), 2);
+    assert_ne!(contexts[0], contexts[1]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
The model gateway attests tool calls by observation matching: inference served with an access token minted inside an **attestation context** records each model-emitted tool call (context, session, user, endpoint, app, tool, canonical arguments hash), and a gateway-attested MCP endpoint accepts a `tools/call` only when the calling token carries the matching context and an unconsumed observation matches. OpenWave never sends a context, so attested endpoints refuse every request — including `initialize` at mount time, which is the settings-page failure that motivated #1416.

This is the connectors slice; the inference and MCP legs stack on it.

## What changed

- `GatewayAuth::refresh` gains the optional `attestation_context_id` form field. The context id is a client-minted UUID the gateway creates on first use and pins to `(session, user, client_name)`; it is correlation, not a secret.
- `GatewayConnection::attested_access_token(resource, context_key)` (and the `mcp:<slug>` wrapper) mints tokens inside the context named by a caller-chosen stable key, typically a chat id. Tokens for one key share one context across resources — the property observation matching needs, since the LLM token records the observation and the MCP token consumes it.
- Context ids and the tokens minted inside them live in memory only and reset when the stored session changes. Contexts are session-pinned server-side, so persisting them would carry stale ids across sign-ins; the tokens expire within minutes, so persisting them would only grow the keychain blob. The persisted vault shape is unchanged — no schema bump.
- `invalid_target` on the token grant is now distinguishable from other failures, and an attested mint that hits it remints once under a fresh id. That self-heals the superseded-session case without a sign-out; it is safe because a refused grant aborts before the refresh token is consumed.
- Every mint runs under the existing token-motion lock: the refresh chain is strictly serial, and a raced rotation trips the gateway's reuse detection, which revokes the whole session.

## Tests

Three additions to the `gateway_flow` fake-gateway suite, which now validates context ids and can refuse one like a stale session would: context sharing per key with per-resource caching (also proving attested mints rotate the persisted refresh token without polluting the persisted per-resource cache), fresh-id remint after `invalid_target` without consuming the refresh token, and context reset when a new session is stored.

`cargo test -p openwave-connectors --locked` — 10 passed. Crate clippy clean, `cargo check --workspace --locked` clean with no lock diff.

Part of #1416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)