### PR TITLE
feat(gateway): per-chat attestation context on gateway inference

### DIFF
--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -117,7 +117,7 @@ impl ModelProvider for AnthropicProvider {
         };
         let url = format!("{}/v1/messages", self.base_url);
         let api_key = match &self.token_source {
-            Some(source) => source.bearer_token().await?,
+            Some(source) => source.bearer_token_for(req.conversation).await?,
             None => self.api_key.clone(),
         };
 
@@ -1758,5 +1758,46 @@ mod tests {
         );
         assert!(requests[1].get(GATEWAY_CONVERSATION_HEADER).is_none());
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn the_token_source_is_asked_for_the_request_conversation() {
+        // The conversation must reach the token source, not just the header:
+        // a gateway source mints inside the chat's attestation context, and a
+        // token fetched without the conversation would record no observations
+        // for the chat's tool calls.
+        struct Recording(std::sync::Mutex<Vec<Option<openwave_core::id::ChatId>>>);
+
+        #[async_trait::async_trait]
+        impl crate::BearerTokenSource for Recording {
+            async fn bearer_token(&self) -> openwave_core::Result<String> {
+                unreachable!("the adapter must ask per conversation");
+            }
+
+            async fn bearer_token_for(
+                &self,
+                conversation: Option<openwave_core::id::ChatId>,
+            ) -> openwave_core::Result<String> {
+                self.0.lock().unwrap().push(conversation);
+                Ok("mg_at_test".into())
+            }
+        }
+
+        let source = std::sync::Arc::new(Recording(std::sync::Mutex::new(Vec::new())));
+        let provider = AnthropicProvider::new("unused")
+            .with_base_url("http://127.0.0.1:9")
+            .with_token_source(source.clone());
+        let conversation = openwave_core::id::ChatId::new();
+        // The request itself fails (nothing listens); the token exchange has
+        // already happened by then, which is all this asserts.
+        let _ = provider
+            .stream(ChatRequest {
+                model: "claude-opus-4-8".into(),
+                conversation: Some(conversation),
+                messages: vec![ChatMessage::text(Role::User, "hi")],
+                ..Default::default()
+            })
+            .await;
+        assert_eq!(source.0.lock().unwrap().as_slice(), &[Some(conversation)]);
     }
 }

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -34,6 +34,19 @@ use crate::OpenAiCompatProvider;
 pub trait BearerTokenSource: Send + Sync {
     /// A currently valid token, refreshing if the cached one is near expiry.
     async fn bearer_token(&self) -> Result<String>;
+
+    /// The token for a request that belongs to `conversation`. Sources that
+    /// scope credentials per conversation override this — the model gateway
+    /// mints inside a per-conversation attestation context, which is what
+    /// lets its attested MCP endpoints match the tool calls this inference
+    /// emits. Everything else serves the shared token.
+    async fn bearer_token_for(
+        &self,
+        conversation: Option<openwave_core::id::ChatId>,
+    ) -> Result<String> {
+        let _ = conversation;
+        self.bearer_token().await
+    }
 }
 
 /// Vertex-specific route data. The credential fingerprint is already an

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -777,6 +777,25 @@ impl BearerTokenSource for GatewayTokenSource {
     async fn bearer_token(&self) -> Result<String> {
         self.0.access_token(RESOURCE_LLM).await
     }
+
+    /// A chat's inference rides a token minted inside that chat's
+    /// attestation context, so the gateway records its tool calls as
+    /// observations and attested MCP endpoints can match them. Requests
+    /// with no conversation — titling, judging, other maintenance — keep
+    /// the shared token: there is no chat for an observation to serve.
+    async fn bearer_token_for(
+        &self,
+        conversation: Option<openwave_core::id::ChatId>,
+    ) -> Result<String> {
+        match conversation {
+            Some(chat) => {
+                self.0
+                    .attested_access_token(RESOURCE_LLM, &chat.to_string())
+                    .await
+            }
+            None => self.bearer_token().await,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1119,6 +1138,21 @@ mod tests {
         // A fresh token is cached: no second refresh inside the expiry leeway.
         assert_eq!(source.bearer_token().await.unwrap(), token);
         assert_eq!(gateway.refreshes.load(Ordering::SeqCst), 1);
+
+        // A conversation mints inside that chat's attestation context: cached
+        // per chat, distinct across chats, and never the shared token.
+        let chat = openwave_core::id::ChatId::new();
+        let attested = source.bearer_token_for(Some(chat)).await.unwrap();
+        assert_ne!(attested, token);
+        assert_eq!(source.bearer_token_for(Some(chat)).await.unwrap(), attested);
+        let other = source
+            .bearer_token_for(Some(openwave_core::id::ChatId::new()))
+            .await
+            .unwrap();
+        assert_ne!(other, attested);
+        // No conversation — titling, judging, maintenance — keeps the shared
+        // token and records nothing.
+        assert_eq!(source.bearer_token_for(None).await.unwrap(), token);
 
         // The route set includes the gateway with its synced models claimed.
         // A legacy provider row — even one pointing at a different deployment


### PR DESCRIPTION
Stacked on #1420 (retarget to `main` after it lands). Second slice of #1416.

The gateway records model-emitted tool calls as observations only when the inference request's token was minted inside an attestation context; attested MCP endpoints later match `tools/call` against those observations, per context. OpenWave's `llm` token has always been shared across chats, so gateway-served turns recorded nothing and attested endpoints had nothing to match.

## What changed

- `BearerTokenSource` gains `bearer_token_for(conversation)` with a default that serves the shared token, so the Vertex source and other implementors are untouched.
- The Anthropic adapter asks the source with `req.conversation` — the same field #1369 threads from `Agent::drive` — instead of the conversation-blind method. Direct Anthropic routes carry no token source, so nothing new crosses the wire off the gateway route.
- `GatewayTokenSource` overrides it: a chat's turn rides a token minted inside that chat's attestation context via the slice-1 connectors API (one serialized refresh on a chat's first turn, cached for the token's lifetime after). Conversationless requests — titling, the approval judge, maintenance — keep the shared token deliberately: there is no chat for an observation to serve.

## Tests

- `the_token_source_is_asked_for_the_request_conversation` (router): a recording source proves the adapter consults the per-conversation seam — the regression this guards is a token fetched without the conversation, which would silently stop observation recording.
- `the_route_token_source_mints_llm_tokens_per_rotation` (server) extended: per-chat mints are cached per chat, distinct across chats, and `None` keeps the shared token.

`cargo test -p openwave-router --locked` — 84 passed. Gateway-runtime token test passes. Crate clippy clean, workspace check clean with no lock diff.

Part of #1416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)