### PR TITLE
feat(mcp): attested gateway endpoints mount and dispatch with per-chat bearers

### DIFF
--- a/crates/openwave-mcp/src/client.rs
+++ b/crates/openwave-mcp/src/client.rs
@@ -73,6 +73,22 @@ pub struct McpServerInfo {
     pub version: String,
 }
 
+/// Per-call bearer supplier for tool invocations, resolved from the chat a
+/// call belongs to.
+///
+/// The connection's own bearer is fixed at connect time and shared by every
+/// chat in the process — right for `initialize` and `tools/list`, but a
+/// gateway-attested MCP endpoint only accepts a `tools/call` whose token
+/// carries the calling chat's attestation context. A client given one of
+/// these asks it before each `tools/call`; everything else keeps the
+/// connection bearer.
+#[async_trait]
+pub trait CallBearerSource: Send + Sync {
+    /// The bearer for a call from `chat`, or `None` to keep the connection's
+    /// own bearer. Implementations must never log or echo the token.
+    async fn call_bearer(&self, chat: openwave_core::id::ChatId) -> Result<Option<String>>;
+}
+
 /// A connected external MCP server whose tools can be mounted into OpenWave.
 ///
 /// The configured `server_name` is a stable local namespace, independent of the
@@ -84,6 +100,7 @@ pub struct McpClient {
     server_info: McpServerInfo,
     tools: Vec<MountedTool>,
     session: Arc<Mutex<Session>>,
+    call_bearer: Option<Arc<dyn CallBearerSource>>,
 }
 
 impl McpClient {
@@ -267,6 +284,7 @@ impl McpClient {
             server_info: initialized.server_info,
             tools,
             session: Arc::new(Mutex::new(session)),
+            call_bearer: None,
         })
     }
 
@@ -382,9 +400,19 @@ impl McpClient {
                 server_name: self.server_name.clone(),
                 ui_resource_uri: tool.ui_resource_uri.clone(),
                 session: Arc::clone(&self.session),
+                call_bearer: self.call_bearer.clone(),
             }));
         }
         refused
+    }
+
+    /// Ask `source` for a per-chat bearer before each `tools/call` mounted
+    /// from this client. Set before [`Self::mount`]; already-mounted tools
+    /// keep the connection bearer.
+    #[must_use]
+    pub fn with_call_bearer_source(mut self, source: Arc<dyn CallBearerSource>) -> Self {
+        self.call_bearer = Some(source);
+        self
     }
 }
 
@@ -433,6 +461,19 @@ impl Session {
     }
 
     async fn request(&mut self, method: &str, params: Value) -> Result<Value> {
+        self.request_with_bearer(method, params, None).await
+    }
+
+    /// [`Self::request`] with a per-request bearer override on the HTTP
+    /// transport — a gateway-attested `tools/call` rides the calling chat's
+    /// token rather than the connection's. The stdio transport has no
+    /// bearer, so an override there is ignored.
+    async fn request_with_bearer(
+        &mut self,
+        method: &str,
+        params: Value,
+        bearer: Option<&str>,
+    ) -> Result<Value> {
         let id = self.next_id;
         self.next_id = self
             .next_id
@@ -464,7 +505,7 @@ impl Session {
             Wire::Http(http) => {
                 timeout(
                     request_timeout,
-                    http.request(id, &request, tools_list_changed),
+                    http.request(id, &request, tools_list_changed, bearer),
                 )
                 .await
             }
@@ -951,6 +992,7 @@ struct McpTool {
     /// host can surface the declared MCP Apps view for this tool's results.
     ui_resource_uri: Option<String>,
     session: Arc<Mutex<Session>>,
+    call_bearer: Option<Arc<dyn CallBearerSource>>,
 }
 
 #[async_trait]
@@ -963,14 +1005,27 @@ impl Tool for McpTool {
         ApprovalClass::Sensitive
     }
 
-    async fn execute(&self, _ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+    async fn execute(&self, ctx: &ToolCtx, args: Value) -> Result<ToolOutput> {
+        // Resolved before the session lock: a bearer mint may be a network
+        // round trip, and holding the shared session across it would stall
+        // every other chat's calls to this server.
+        let bearer = match &self.call_bearer {
+            Some(source) => source.call_bearer(ctx.chat_id).await.map_err(|error| {
+                mcp_message(format!(
+                    "MCP server {} could not resolve a call credential: {error}",
+                    self.server_name
+                ))
+            })?,
+            None => None,
+        };
         let result = self
             .session
             .lock()
             .await
-            .request(
+            .request_with_bearer(
                 "tools/call",
                 json!({"name": self.remote_name, "arguments": args}),
+                bearer.as_deref(),
             )
             .await
             .map_err(|error| {

--- a/crates/openwave-mcp/src/http.rs
+++ b/crates/openwave-mcp/src/http.rs
@@ -86,8 +86,9 @@ impl HttpWire {
         expected_id: u64,
         message: &Value,
         tools_list_changed: &mut bool,
+        bearer: Option<&str>,
     ) -> Result<Value> {
-        let response = self.post(message).await?;
+        let response = self.post(message, bearer).await?;
         let status = response.status();
         if status == reqwest::StatusCode::ACCEPTED {
             return Err(mcp_message(
@@ -128,12 +129,27 @@ impl HttpWire {
     /// Send one notification. Streamable HTTP servers acknowledge with an
     /// empty 202; any success status is accepted and the body is ignored.
     pub(crate) async fn notify(&mut self, message: &Value) -> Result<()> {
-        let response = self.post(message).await?;
+        let response = self.post(message, None).await?;
         check_status(response.status())?;
         self.absorb_session_id(&response)
     }
 
-    async fn post(&self, message: &Value) -> Result<reqwest::Response> {
+    /// POST one message. A `bearer` override replaces the connection's own
+    /// Authorization for this request only — a gateway-attested `tools/call`
+    /// must present the calling chat's token — and is validated exactly like
+    /// the connect-time token so it can never smuggle header syntax.
+    async fn post(&self, message: &Value, bearer: Option<&str>) -> Result<reqwest::Response> {
+        let authorization = match bearer {
+            Some(token) => {
+                if token.is_empty() || token.bytes().any(|byte| byte.is_ascii_control()) {
+                    return Err(mcp_message(
+                        "external server bearer token must be a non-empty header-safe value",
+                    ));
+                }
+                Some(format!("Bearer {token}"))
+            }
+            None => self.authorization.clone(),
+        };
         let mut request = self
             .client
             .post(self.url.clone())
@@ -143,7 +159,7 @@ impl HttpWire {
             )
             .header(PROTOCOL_VERSION_HEADER, PROTOCOL_VERSION)
             .json(message);
-        if let Some(authorization) = &self.authorization {
+        if let Some(authorization) = &authorization {
             request = request.header(reqwest::header::AUTHORIZATION, authorization);
         }
         if let Some(session_id) = &self.session_id {

--- a/crates/openwave-mcp/src/lib.rs
+++ b/crates/openwave-mcp/src/lib.rs
@@ -50,7 +50,7 @@ mod server;
 mod stdio;
 
 pub use client::{
-    McpClient, McpProbe, McpServerInfo, ResourceContent, DEFAULT_REQUEST_TIMEOUT,
+    CallBearerSource, McpClient, McpProbe, McpServerInfo, ResourceContent, DEFAULT_REQUEST_TIMEOUT,
     MAX_SERVER_NAME_BYTES,
 };
 pub use http::validate_http_url;

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -658,11 +658,19 @@ impl GatewayRuntime {
     }
 }
 
+/// Attestation-context key for connect-time MCP traffic — `initialize` and
+/// `tools/list` belong to no chat, but a gateway-attested endpoint refuses
+/// any token minted without a context, so the handshake rides a shared one.
+/// Not a UUID, so it can never collide with a chat key.
+const MCP_CONNECT_CONTEXT_KEY: &str = "mcp:connect";
+
 #[async_trait]
 impl crate::mcp_config::GatewayEndpoints for GatewayRuntime {
     /// Resolve a gateway MCP endpoint from the signed-in session: its URL
     /// under the configured base, and a fresh `mcp:<slug>` bearer minted (or
-    /// served from cache) inside the connector's rotation lock.
+    /// served from cache) inside the connector's rotation lock. The bearer
+    /// carries the shared connect context, which is what lets an attested
+    /// endpoint accept the handshake and list its tools.
     async fn endpoint(&self, slug: &str) -> Result<crate::mcp_config::GatewayEndpointAccess> {
         let connection = self
             .connection()
@@ -670,8 +678,25 @@ impl crate::mcp_config::GatewayEndpoints for GatewayRuntime {
             .ok_or_else(|| AgentError::config("no model gateway is configured"))?;
         Ok(crate::mcp_config::GatewayEndpointAccess {
             url: connection.mcp_endpoint_url(slug)?,
-            bearer_token: connection.mcp_access_token(slug).await?,
+            bearer_token: connection
+                .attested_mcp_access_token(slug, MCP_CONNECT_CONTEXT_KEY)
+                .await?,
         })
+    }
+
+    /// A `tools/call` from a chat rides a token minted inside that chat's
+    /// attestation context — the same context the chat's inference tokens
+    /// carry — so an attested endpoint can match the call against the
+    /// observation that inference recorded. Direct endpoints ignore the
+    /// context, so every gateway mount dispatches this way.
+    async fn call_bearer(&self, slug: &str, chat: openwave_core::id::ChatId) -> Result<String> {
+        let connection = self
+            .connection()
+            .await?
+            .ok_or_else(|| AgentError::config("no model gateway is configured"))?;
+        connection
+            .attested_mcp_access_token(slug, &chat.to_string())
+            .await
     }
 }
 
@@ -839,6 +864,10 @@ mod tests {
         /// When set, `/api/v1/cli/apps` answers 500 — the outage shape the
         /// endpoint-mount reconcile must degrade quietly on.
         apps_fail: std::sync::atomic::AtomicBool,
+        /// `(resource, attestation_context_id)` per refresh grant, in order.
+        minted: std::sync::Mutex<Vec<(String, Option<String>)>>,
+        /// `(method, authorization)` per MCP endpoint request, in order.
+        mcp_requests: std::sync::Mutex<Vec<(String, String)>>,
     }
 
     /// One entitled connected app aggregating the fixture's `tools` MCP
@@ -878,6 +907,10 @@ mod tests {
         );
         let sequence = gateway.refreshes.fetch_add(1, Ordering::SeqCst);
         let resource = form.get("resource").cloned().unwrap_or_default();
+        gateway.minted.lock().unwrap().push((
+            resource.clone(),
+            form.get("attestation_context_id").cloned(),
+        ));
         Json(json!({
             "access_token": format!("mg_at_{resource}_{sequence}"),
             "token_type": "Bearer",
@@ -927,15 +960,25 @@ mod tests {
 
     /// Minimal Streamable HTTP MCP endpoint that requires an `mcp:tools`
     /// session bearer, exactly as the gateway's `/mcp/{slug}` route does.
-    async fn mcp_endpoint(headers: HeaderMap, body: String) -> Response {
+    async fn mcp_endpoint(
+        State(gateway): State<Arc<FakeGateway>>,
+        headers: HeaderMap,
+        body: String,
+    ) -> Response {
         let bearer = headers
             .get("authorization")
             .and_then(|value| value.to_str().ok())
             .unwrap_or_default();
         assert!(bearer.starts_with("Bearer mg_at_mcp:tools_"), "{bearer}");
         let request: Value = serde_json::from_str(&body).unwrap();
+        let method = request["method"].as_str().unwrap_or_default().to_string();
+        gateway
+            .mcp_requests
+            .lock()
+            .unwrap()
+            .push((method.clone(), bearer.to_string()));
         let id = request.get("id").cloned().unwrap_or_default();
-        let result = match request["method"].as_str().unwrap_or_default() {
+        let result = match method.as_str() {
             "initialize" => json!({
                 "protocolVersion": openwave_mcp::PROTOCOL_VERSION,
                 "capabilities": {"tools": {}},
@@ -947,6 +990,9 @@ mod tests {
                     "description": "Look something up",
                     "inputSchema": {"type": "object"}
                 }]
+            }),
+            "tools/call" => json!({
+                "content": [{"type": "text", "text": "ok"}]
             }),
             _ => json!({}),
         };
@@ -1350,7 +1396,8 @@ mod tests {
 
     #[tokio::test]
     async fn mounts_a_gateway_endpoint_from_the_signed_in_session() {
-        let address = serve(Arc::new(FakeGateway::default())).await;
+        let gateway = Arc::new(FakeGateway::default());
+        let address = serve(gateway.clone()).await;
         let base = format!("http://{address}");
         let (runtime, store, _directory) = signed_in_runtime(&base).await;
 
@@ -1382,6 +1429,67 @@ mod tests {
             crate::mcp_config::McpHealth::Healthy
         );
         assert!(mcp.snapshot().get("mcp__tools__lookup").is_some());
+
+        // The handshake rode a context-bearing token: an attested endpoint
+        // refuses any request minted without one, so the connect mint is what
+        // makes attested mounts able to list their tools at all.
+        let connect_context = {
+            let minted = gateway.minted.lock().unwrap();
+            let (_, context) = minted
+                .iter()
+                .find(|(resource, _)| resource == "mcp:tools")
+                .expect("the mount minted an mcp:tools token")
+                .clone();
+            context.expect("the connect mint carries an attestation context")
+        };
+
+        // A tool call from a chat presents that chat's bearer, minted inside
+        // the same attestation context the chat's inference tokens carry —
+        // the invariant that lets an attested endpoint match the call against
+        // the observation the inference recorded.
+        let chat = openwave_core::id::ChatId::new();
+        let snapshot = mcp.snapshot();
+        let tool = snapshot.get("mcp__tools__lookup").unwrap();
+        let ctx = openwave_core::ToolCtx::without_private_scratch(chat, None);
+        tool.execute(&ctx, json!({})).await.unwrap();
+
+        let source = runtime
+            .route_token_source()
+            .await
+            .expect("signed-in runtime offers a token source");
+        source.bearer_token_for(Some(chat)).await.unwrap();
+        {
+            let minted = gateway.minted.lock().unwrap();
+            let chat_mcp = minted
+                .iter()
+                .filter(|(resource, _)| resource == "mcp:tools")
+                .nth(1)
+                .map(|(_, context)| context.clone().unwrap())
+                .expect("the tool call minted a second mcp:tools token");
+            let chat_llm = minted
+                .iter()
+                .find(|(resource, _)| resource == "llm")
+                .map(|(_, context)| context.clone().unwrap())
+                .expect("the chat's inference minted an llm token");
+            assert_ne!(chat_mcp, connect_context);
+            assert_eq!(chat_mcp, chat_llm);
+        }
+        {
+            let requests = gateway.mcp_requests.lock().unwrap();
+            let handshake: Vec<&str> = requests
+                .iter()
+                .filter(|(method, _)| method == "initialize" || method == "tools/list")
+                .map(|(_, bearer)| bearer.as_str())
+                .collect();
+            assert!(!handshake.is_empty());
+            let call = requests
+                .iter()
+                .find(|(method, _)| method == "tools/call")
+                .map(|(_, bearer)| bearer.as_str())
+                .expect("the tool call reached the endpoint");
+            assert!(handshake.iter().all(|bearer| *bearer == handshake[0]));
+            assert_ne!(call, handshake[0]);
+        }
 
         // Sign-out degrades the mount to a secret-free sign-in diagnostic and
         // keeps the definition; the tool leaves the registry.

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -209,6 +209,30 @@ impl std::fmt::Debug for McpServerDefinition {
 #[async_trait::async_trait]
 pub(crate) trait GatewayEndpoints: Send + Sync {
     async fn endpoint(&self, slug: &str) -> Result<GatewayEndpointAccess>;
+
+    /// The bearer for one `tools/call` from `chat`. The gateway runtime
+    /// mints inside the chat's attestation context so gateway-attested
+    /// endpoints can match the call against the observation the chat's
+    /// inference recorded; the default keeps the connect-time bearer for
+    /// implementations that don't distinguish.
+    async fn call_bearer(&self, slug: &str, chat: openwave_core::id::ChatId) -> Result<String> {
+        let _ = chat;
+        Ok(self.endpoint(slug).await?.bearer_token)
+    }
+}
+
+/// [`openwave_mcp::CallBearerSource`] over the gateway resolver for one
+/// mounted endpoint: each `tools/call` presents the calling chat's token.
+struct GatewayCallBearer {
+    gateway: Arc<dyn GatewayEndpoints>,
+    slug: String,
+}
+
+#[async_trait::async_trait]
+impl openwave_mcp::CallBearerSource for GatewayCallBearer {
+    async fn call_bearer(&self, chat: openwave_core::id::ChatId) -> Result<Option<String>> {
+        self.gateway.call_bearer(&self.slug, chat).await.map(Some)
+    }
 }
 
 /// One resolved gateway endpoint: where to connect and the bearer to present.
@@ -246,7 +270,7 @@ impl McpServerDefinition {
         Ok(command)
     }
 
-    async fn connect(&self, gateway: &dyn GatewayEndpoints) -> Result<McpClient> {
+    async fn connect(&self, gateway: &Arc<dyn GatewayEndpoints>) -> Result<McpClient> {
         if let Some(slug) = &self.gateway_endpoint {
             // Resolved per connection: a reconnect always presents a token
             // that is fresh at that moment, so expiry is survived by the
@@ -259,7 +283,15 @@ impl McpServerDefinition {
                 INITIALIZATION_TIMEOUT,
                 Duration::from_millis(self.request_timeout_ms),
             )
-            .await;
+            .await
+            .map(|client| {
+                // Dispatch rides per-chat tokens; the connect-time bearer
+                // serves only the handshake and discovery above.
+                client.with_call_bearer_source(std::sync::Arc::new(GatewayCallBearer {
+                    gateway: Arc::clone(gateway),
+                    slug: slug.clone(),
+                }))
+            });
         }
         if let Some(url) = &self.url {
             let bearer_token = self.resolve_bearer_token()?;
@@ -289,7 +321,7 @@ impl McpServerDefinition {
     /// degrades; tools are unaffected).
     async fn connect_with_views(
         &self,
-        gateway: &dyn GatewayEndpoints,
+        gateway: &Arc<dyn GatewayEndpoints>,
     ) -> Result<(McpClient, HashMap<String, UiViewDocument>)> {
         let client = self.connect(gateway).await?;
         let uris: HashSet<String> = client
@@ -1110,7 +1142,7 @@ impl McpRuntime {
                 })
                 .collect()
         };
-        let gateway = &*self.gateway;
+        let gateway = &self.gateway;
         let lockdown = self.manual_lockdown().await;
         let mut servers = HashMap::new();
         let connections = join_all(definitions.iter().map(|definition| async move {
@@ -1220,7 +1252,7 @@ impl McpRuntime {
         definitions: Vec<McpServerDefinition>,
         ids: BTreeMap<String, ConnectedAppId>,
     ) {
-        let gateway = &*self.gateway;
+        let gateway = &self.gateway;
         let lockdown = self.manual_lockdown().await;
         let mut servers = HashMap::new();
         let connections = join_all(definitions.iter().map(|definition| async move {
@@ -1430,7 +1462,7 @@ impl McpRuntime {
             server.diagnostic = None;
             (definition, server.epoch)
         };
-        match definition.connect_with_views(&*self.gateway).await {
+        match definition.connect_with_views(&self.gateway).await {
             Ok((client, ui_views)) => {
                 let mut state = self.state.lock().await;
                 // A settings replacement may have won while the process started.
@@ -2276,7 +2308,8 @@ mod tests {
             }}]}}"#
         ))
         .unwrap();
-        let error = config.0[0].connect(&NoGateway).await.err().unwrap();
+        let gateway: Arc<dyn GatewayEndpoints> = Arc::new(NoGateway);
+        let error = config.0[0].connect(&gateway).await.err().unwrap();
         assert!(error.to_string().contains(MISSING));
         assert!(error.to_string().contains("is not set"));
         assert!(!error.to_string().contains("secret-value"));
@@ -2694,7 +2727,8 @@ mod tests {
         assert!(std::env::var_os(MISSING).is_none());
         let mut definition = http_definition("gateway", "http://127.0.0.1:1/mcp");
         definition.bearer_token_env = Some(MISSING.to_string());
-        let error = definition.connect(&NoGateway).await.err().unwrap();
+        let gateway: Arc<dyn GatewayEndpoints> = Arc::new(NoGateway);
+        let error = definition.connect(&gateway).await.err().unwrap();
         assert!(error.to_string().contains(MISSING));
         assert!(error.to_string().contains("is not set"));
 

--- a/crates/openwave-server/src/routes/app_invoke.rs
+++ b/crates/openwave-server/src/routes/app_invoke.rs
@@ -456,10 +456,14 @@ async fn require_app_grant(
 /// `mcp__{server}__{tool}` shape — which no built-in server tool does — and
 /// must resolve to a server-executed registration; a client-executed contract
 /// has no executor here and refuses. The execution context is deliberately
-/// inert: no chat owns this call and no scratch is attached, so even though
-/// `McpTool::execute` ignores its context, nothing dispatched from here could
-/// reach a workspace capability. Results cross back through the MCP client's
-/// own 1 MiB call-result clamp.
+/// inert: no chat owns this call and no scratch is attached, so nothing
+/// dispatched from here could reach a workspace capability. The synthetic
+/// chat id is process-stable rather than per-call: gateway tools resolve a
+/// per-chat call credential from it, and a fresh id per invoke would mint a
+/// fresh gateway attestation context per invoke — pure token churn, since an
+/// app invoke has no model emission to attest and gateway-attested tools
+/// refuse it regardless (the recorded Direct-endpoints-only limitation).
+/// Results cross back through the MCP client's own 1 MiB call-result clamp.
 pub(crate) async fn dispatch_mounted_tool(
     state: &AppState,
     tool_name: &str,
@@ -476,7 +480,8 @@ pub(crate) async fn dispatch_mounted_tool(
     }
     let registry = state.mcp.snapshot();
     let tool = registry.get(tool_name).ok_or_else(unknown)?;
-    let ctx = ToolCtx::without_private_scratch(ChatId::new(), None);
+    static APP_INVOKE_CHAT: std::sync::LazyLock<ChatId> = std::sync::LazyLock::new(ChatId::new);
+    let ctx = ToolCtx::without_private_scratch(*APP_INVOKE_CHAT, None);
     let output = tool.execute(&ctx, arguments).await?;
     Ok(AppInvokeResult {
         content: output.content,

--- a/docs/gateway-boundary.md
+++ b/docs/gateway-boundary.md
@@ -132,6 +132,12 @@ The connector speaks a small, versioned HTTP surface on the gateway:
   the gateway settings panel. A `404` means an older gateway; the section
   hides instead of erroring.
 - `/oauth/authorize`, `/oauth/token`, `/oauth/revoke` — the flow above.
+  A refresh grant may also declare an `attestation_context_id`: a
+  client-minted random UUID naming the chat's attestation context, one per
+  chat plus one shared connect context for MCP handshakes. It correlates a
+  chat's inference tokens with its MCP tokens so gateway-attested endpoints
+  can match tool calls against model-emitted observations; it carries no
+  chat content and is meaningless outside the session it is pinned to.
 - Inference itself — invoked with `llm`-audience bearers on the gateway's
   protocol-compatible routes, through the same provider machinery as any
   direct provider. A turn's request also declares which conversation it
@@ -141,10 +147,15 @@ The connector speaks a small, versioned HTTP surface on the gateway:
   a direct provider never does, and it is a header rather than wire data, so
   no model receives it. The chat id is the only thing declared — no title, no
   content, no participant.
-- MCP — `{base}/mcp/{slug}` per mounted endpoint, each connection minting
-  its own `mcp:<slug>` bearer from the session at connect time.
-  Gateway-attested endpoints refuse sessions that arrive without the
-  gateway's attestation; that check is the gateway's, not the client's.
+- MCP — `{base}/mcp/{slug}` per mounted endpoint. The connection minting
+  its `mcp:<slug>` bearer at connect time rides the shared connect
+  attestation context, and each `tools/call` presents a bearer minted
+  inside the calling chat's context instead. Gateway-attested endpoints
+  accept the handshake on any context-bearing token but a tool call only
+  when it consumes the matching model-emitted observation; that check is
+  the gateway's, not the client's. Chats on non-gateway models and
+  local-app invokes carry no matching observation, so attested endpoints
+  refuse those calls by design.
 
 Everything here degrades independently: a gateway that is down fails model
 sync, inference, and MCP connects with visible errors, while the local


### PR DESCRIPTION
Stacked on #1421 (retarget after it lands). Third slice of #1416 — with this, chats on gateway-provided models can call gateway-attested MCP endpoints, and attested endpoints mount healthy instead of failing in settings.

## Why mounting failed

An attested endpoint 403s **every** request from a token minted without an attestation context — `initialize` included. Mounting connects eagerly to enumerate tools, so the mount died on the handshake (the settings-page failure that started #1416).

## What changed

**Mount:** `GatewayEndpoints` resolution mints the connect bearer inside a shared connect context (`mcp:connect` key — not a UUID, can't collide with chat keys). Attested endpoints accept the handshake and list tools (`tools/list` is the same roster aggregation Direct endpoints use, verified in the gateway source); Direct endpoints ignore the context entirely.

**Dispatch:** a `tools/call` must present a token whose context matches the observation recorded by the calling chat's inference. `McpClient` gains a `CallBearerSource` consulted before each `tools/call`, and the HTTP wire takes a per-request Authorization override (validated exactly like the connect-time token). The source resolves `ToolCtx.chat_id` → `GatewayEndpoints::call_bearer` → a bearer minted inside that chat's attestation context — the same context slice 2 puts on the chat's inference tokens. Resolution happens before the shared session lock, so a mint round trip never stalls other chats' calls. Stdio has no bearer and ignores the override; non-gateway HTTP servers attach no source.

**App invokes:** unchanged in behavior (attested endpoints refuse them by design — no model emission to observe), but their synthetic chat id becomes process-stable so gateway dispatch doesn't mint a throwaway context per invoke.

**Docs:** the boundary doc's exhaustive wire list gains the `attestation_context_id` refresh-grant field and the attested-MCP call semantics.

## Documented, not enforced

A gateway mount whose local server name diverges from the endpoint slug (manual rename, or auto-mount collision suffixing) emits `mcp__<name>__…` tool names the gateway's observation matcher doesn't recognize — attested calls from such a mount can't match. Hard-refusing divergent names would break collision-renamed and pre-existing configs; the mode-aware settings annotation (deferred #1416 follow-up, needs the gateway to expose `execution_mode`) is where this becomes visible instead.

## Tests

The gateway-runtime mount test now drives the whole contract end to end against the fake gateway: the handshake mints one shared connect context, a tool call presents a *different* bearer minted inside the calling chat's context, handshake bearers are uniform while the call bearer differs, and the chat's MCP context equals the context on its `llm` token — the invariant observation matching depends on.

Suites: openwave-mcp 49 passed; mcp_config 29; gateway_runtime 19; app_invoke 8. Crate clippy clean; `cargo check --workspace --locked` clean, no lock diff.

Closes #1416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)