### PR TITLE
feat(server): pin the published documents sandbox image digest

### DIFF
--- a/crates/openwave-server/src/sandbox_docker.rs
+++ b/crates/openwave-server/src/sandbox_docker.rs
@@ -193,7 +193,11 @@ const PUBLISHED_IMAGE_REPOSITORY: &str = "ghcr.io/brightwave-inc/openwave-sandbo
 /// [`LOCAL_DEV_IMAGE`] — a ref that only exists after a local `docker build`
 /// and carries no digest verification, which
 /// [`SandboxBackend::verifies_image_integrity`] reports honestly.
-const PUBLISHED_IMAGE_DIGEST: Option<&str> = None;
+// Manifest-list digest of ghcr.io/brightwave-inc/openwave-sandbox-agent-documents:v0.26.0,
+// published by workflow run 30861671881 (tag push v0.26.0, 2026-08-03); the run's
+// step summary records the same value from a post-push `imagetools inspect`.
+const PUBLISHED_IMAGE_DIGEST: Option<&str> =
+    Some("sha256:dd22da7a3c5b1f315e888da902e7a46ae034585e2ab5c09c0ae4588a69f158a2");
 /// The locally built development image, produced by the documented
 /// `docker build -f crates/openwave-sandbox-agent/Dockerfile -t openwave-sandbox-agent .`
 /// (whose default target is the documents variant). The fallback default while

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -591,13 +591,11 @@ async fn code_execution_config_route_is_authenticated_and_preserves_explicit_dis
     );
     let local = &admission[0];
     assert_eq!(local["admitted"], false);
+    // With the published digest pinned, the local backend's image precondition
+    // is satisfied, so its denial list carries only the two remaining gates.
     assert_eq!(
         local["denials"],
-        serde_json::json!([
-            "no_scoped_model_token",
-            "no_external_lifetime_cap",
-            "image_not_verified"
-        ])
+        serde_json::json!(["no_scoped_model_token", "no_external_lifetime_cap"])
     );
 
     let unauthenticated_credentials = router


### PR DESCRIPTION
Sets `PUBLISHED_IMAGE_DIGEST` to the manifest-list digest of `ghcr.io/brightwave-inc/openwave-sandbox-agent-documents:v0.26.0`, published by the tag-push run of `publish-sandbox-image.yml` (run 30861671881). The digest matches both buildx's manifest-creation record in the job log and the run summary's post-push `imagetools inspect`.

With the pin set, the local Docker backend defaults to the published documents image by content-addressed digest — pulled if absent, refused on mismatch — and `verifies_image_integrity` reports true, so the detached-admission settings surface drops `image_not_verified` from the local provider's denial list; the settings test's expectation updates to the two remaining gates, which is the pin doing exactly what it exists to do.

The packages may still be private on GHCR; until they're flipped public, unauthenticated pulls fail and provisioning falls back to the locally built image as designed. The pin is correct either way — visibility only changes availability.