### PR TITLE
fix(ui): bump transitive undici to 7.29.0 for open security advisories

### DIFF
--- a/crates/openwave-desktop/ui/pnpm-lock.yaml
+++ b/crates/openwave-desktop/ui/pnpm-lock.yaml
@@ -3486,8 +3486,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicode-regex@4.2.0:
@@ -6988,7 +6988,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -8048,7 +8048,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicode-regex@4.2.0:
     dependencies:


### PR DESCRIPTION
Lockfile-only bump of undici 7.28.0 -> 7.29.0 in the desktop UI (`pnpm update undici`; no package.json change — undici is a transitive dev dependency of jsdom 29.1.1, used only by the vitest test environment).

Clears the 5 open npm Dependabot alerts, all on undici and all fixed in 7.29.0:

- high: GHSA-4cwx-7wf7-3272 — cross-user information disclosure / parse-time crash via degenerate private cache directives
- moderate: GHSA-m8rv-5g2x-5cg5 (CRLF injection via blob body type), GHSA-jr45-8vmc-qm54 (cache-control whitespace disclosure), GHSA-v3r7-h72x-cjcm (cookie attribute injection), GHSA-8xcm-r25x-g524 (response desync via retry interceptor)

Verified: `pnpm install`, `tsc --noEmit`, `pnpm test` (695 tests, 101 files), `pnpm build` — all pass.