### PR TITLE
fix(mcp): classify transport failures separately

### DIFF
--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -388,6 +388,9 @@ pub enum ToolErrorCategory {
     InvalidArguments,
     /// The capability is available after the reader configures it.
     ConfigurationRequired,
+    /// The channel to an external tool failed before the tool could report an
+    /// outcome of its own.
+    TransportFailed,
     /// The tool ran and reported a failure of its own.
     ToolFailed,
 }
@@ -402,6 +405,7 @@ impl ToolErrorCategory {
             Self::NotFound => "not_found",
             Self::InvalidArguments => "invalid_arguments",
             Self::ConfigurationRequired => "configuration_required",
+            Self::TransportFailed => "transport_failed",
             Self::ToolFailed => "tool_failed",
         }
     }
@@ -416,7 +420,7 @@ impl ToolErrorCategory {
             | Self::NotFound
             | Self::ConfigurationRequired
             | Self::InvalidArguments => false,
-            Self::ToolFailed => true,
+            Self::TransportFailed | Self::ToolFailed => true,
         }
     }
 }
@@ -866,6 +870,7 @@ mod tests {
         ] {
             assert!(!category.is_product_failure(), "{}", category.as_str());
         }
+        assert!(ToolErrorCategory::TransportFailed.is_product_failure());
         assert!(ToolErrorCategory::ToolFailed.is_product_failure());
 
         // Every category has a distinct durable spelling.
@@ -874,6 +879,7 @@ mod tests {
             ToolErrorCategory::UserDeclined,
             ToolErrorCategory::NotFound,
             ToolErrorCategory::ConfigurationRequired,
+            ToolErrorCategory::TransportFailed,
             ToolErrorCategory::ToolFailed,
         ]
         .map(ToolErrorCategory::as_str);

--- a/crates/openwave-mcp/src/client.rs
+++ b/crates/openwave-mcp/src/client.rs
@@ -1027,14 +1027,20 @@ impl Tool for McpTool {
                 json!({"name": self.remote_name, "arguments": args}),
                 bearer.as_deref(),
             )
-            .await
-            .map_err(|error| {
-                mcp_message(format!(
-                    "MCP server {} failed to call {}: {error}",
-                    self.server_name, self.remote_name
-                ))
-            })?;
-        let result: CallToolResponse = decode_result("tools/call", result)?;
+            .await;
+        let result: CallToolResponse =
+            match result.and_then(|result| decode_result("tools/call", result)) {
+                Ok(result) => result,
+                Err(error) => {
+                    return Ok(ToolOutput::failed(
+                        openwave_core::ToolErrorCategory::TransportFailed,
+                        format!(
+                        "MCP server {} could not complete {} because its channel failed: {error}",
+                        self.server_name, self.remote_name
+                    ),
+                    ));
+                }
+            };
         let split = split_call_content(&result.content);
         let (content, data) = clamp_call_result(split.text, result.structured_content);
         Ok(ToolOutput {
@@ -1869,6 +1875,82 @@ mod tests {
         // Text siblings keep their order, and the degraded image items keep
         // the stringified form the model saw before images were surfaced.
         assert_eq!(split.text, format!("before\n{garbage}\n{oversized}\nafter"));
+    }
+
+    #[tokio::test]
+    async fn mounted_tool_distinguishes_channel_failure_from_remote_tool_failure() {
+        async fn execute_response(result: Value) -> ToolOutput {
+            let (client_stream, server_stream) = duplex(16 * 1024);
+            let (reader, writer) = tokio::io::split(client_stream);
+            tokio::spawn(async move {
+                let (server_reader, mut server_writer) = split(server_stream);
+                let mut lines = BufReader::new(server_reader).lines();
+                while let Some(line) = lines.next_line().await.unwrap() {
+                    let request: Value = serde_json::from_str(&line).unwrap();
+                    let Some(id) = request.get("id").cloned() else {
+                        continue;
+                    };
+                    let response_result = match request["method"].as_str().unwrap() {
+                        "initialize" => json!({
+                            "protocolVersion": PROTOCOL_VERSION,
+                            "capabilities": {"tools": {}},
+                            "serverInfo": {"name": "fixture", "version": "1"}
+                        }),
+                        "tools/list" => json!({
+                            "tools": [{
+                                "name": "fail",
+                                "description": "Fail in one of two ways",
+                                "inputSchema": {"type": "object"}
+                            }]
+                        }),
+                        "tools/call" => result.clone(),
+                        method => panic!("unexpected method: {method}"),
+                    };
+                    let mut response = serde_json::to_vec(&json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": response_result
+                    }))
+                    .unwrap();
+                    response.push(b'\n');
+                    server_writer.write_all(&response).await.unwrap();
+                    server_writer.flush().await.unwrap();
+                }
+            });
+            let client = McpClient::connect("fixture", reader, writer).await.unwrap();
+            let mut registry = ToolRegistry::new();
+            client.mount(&mut registry);
+            registry
+                .get("mcp__fixture__fail")
+                .unwrap()
+                .execute(
+                    &ToolCtx::new_legacy_workspace(
+                        ChatId::new(),
+                        None,
+                        PathBuf::from("unused-by-mcp"),
+                    ),
+                    json!({}),
+                )
+                .await
+                .unwrap()
+        }
+
+        let remote = execute_response(json!({
+            "content": [{"type": "text", "text": "tool rejected the input"}],
+            "isError": true
+        }))
+        .await;
+        assert_eq!(
+            remote.error_category,
+            Some(openwave_core::ToolErrorCategory::ToolFailed)
+        );
+
+        let channel = execute_response(json!({"content": "not an MCP content array"})).await;
+        assert_eq!(
+            channel.error_category,
+            Some(openwave_core::ToolErrorCategory::TransportFailed)
+        );
+        assert!(channel.content.contains("channel failed"));
     }
 
     mod http_transport {


### PR DESCRIPTION
An MCP tool result can fail at two different boundaries: the remote tool can answer with `isError`, or the channel can fail before a valid tool result arrives. Both previously reached the turn journal as `tool_failed`, which tells the model and clients that the remote operation itself failed even when the server was unreachable, timed out, returned an oversized frame, or sent a malformed response.

This adds the closed `transport_failed` tool error category and has mounted MCP tools return it for request and response-channel failures. A remote server's explicit `isError` remains `tool_failed`, so the two cases are now durable and distinguishable without parsing prose.

The issue's HTTP-bound question is already covered on current `main`: `HttpWire` applies the shared 2 MiB `MAX_JSON_RPC_FRAME_BYTES` ceiling to both JSON response bodies and SSE frames, including chunked responses. This PR leaves that existing implementation intact and verifies its regression test.

Tests:
- `cargo test -p openwave-core tool::tests::a_reader_choice_is_not_recorded_as_a_product_failure --locked`
- `cargo test -p openwave-mcp mounted_tool_distinguishes_channel_failure_from_remote_tool_failure --locked`
- `cargo test -p openwave-mcp sse_parser_enforces_the_frame_bound --locked`
- `cargo check -p openwave-mcp --locked`
- `cargo fmt --all -- --check`

Closes #1192
