### PR TITLE
fix(server): classify missing model credentials

### DIFF
--- a/crates/openwave-core/src/error.rs
+++ b/crates/openwave-core/src/error.rs
@@ -65,6 +65,10 @@ pub enum AgentError {
     #[error("configuration error: {0}")]
     Config(String),
 
+    /// No credential is configured for the selected model provider.
+    #[error("provider credential missing: {0}")]
+    MissingCredential(String),
+
     /// A persistence failure from the `Store` / `BlobStore`.
     #[error("store error: {0}")]
     Store(String),
@@ -133,6 +137,7 @@ impl AgentError {
     pub fn kind(&self) -> &'static str {
         match self {
             Self::Config(_) => "config",
+            Self::MissingCredential(_) => "missing_credential",
             Self::Store(_) => "store",
             Self::ProjectNotFound(_) => "not_found",
             Self::Secret(_) => "secret",

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -218,7 +218,7 @@ impl TurnFailureCategory {
     pub(crate) fn from_kind(kind: &str) -> Self {
         match kind {
             "rate_limited" | "overloaded" => Self::RateLimited,
-            "authentication" => Self::Auth,
+            "authentication" | "missing_credential" => Self::Auth,
             "provider" | "store" | "secret" | "empty_model_response" => Self::Transient,
             _ => Self::Unknown,
         }
@@ -479,6 +479,10 @@ mod tests {
             ),
             (
                 AgentError::Authentication("invalid x-api-key sk-live".into()),
+                TurnFailureCategory::Auth,
+            ),
+            (
+                AgentError::MissingCredential("no model provider is configured".into()),
                 TurnFailureCategory::Auth,
             ),
             (

--- a/crates/openwave-server/src/provider.rs
+++ b/crates/openwave-server/src/provider.rs
@@ -20,8 +20,8 @@ impl ModelProvider for UnconfiguredProvider {
     }
 
     async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
-        Err(AgentError::config(
-            "no model provider is configured (enable a provider and set its credential)",
+        Err(AgentError::MissingCredential(
+            "no model provider is configured (enable a provider and set its credential)".into(),
         ))
     }
 }


### PR DESCRIPTION
## Summary

- add a dedicated `MissingCredential` agent error kind for an unconfigured model provider
- classify missing credentials as an auth failure while leaving unrelated configuration errors unknown
- extend the renderer projection contract test for the missing-credential case

## Verification

- `cargo fmt --all --check`
- `cargo check -p openwave-core --locked`
- `cargo check -p openwave-server --locked`
- `cargo test -p openwave-core --locked error::tests`
- `cargo test -p openwave-server --locked event_projection::tests::failure_projection_carries_a_category_and_nothing_else`
- `cargo test -p openwave-server --locked tests::workers::turn_fails_closed_with_no_provider_configured`

Closes #1171