### PR TITLE
feat(desktop): add configurable voice transcription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3503,6 +3503,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5065,6 +5075,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -7549,6 +7560,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ sea-orm = { version = "=2.0.0", default-features = false, features = ["macros", 
 sea-orm-migration = { version = "=2.0.0", default-features = false, features = ["runtime-tokio-rustls"] }
 tokio = { version = "=1.53.1", features = ["rt", "macros", "fs"] }
 tokio-util = { version = "=0.7.19", features = ["io-util"] }
-reqwest = { version = "=0.12.28", default-features = false, features = ["json", "stream", "rustls-tls"] }
+reqwest = { version = "=0.12.28", default-features = false, features = ["json", "multipart", "stream", "rustls-tls"] }
 ring = "=0.17.14"
 sha2 = "=0.11.0"
 base64 = "=0.23.0"

--- a/crates/openwave-desktop/Info.plist
+++ b/crates/openwave-desktop/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>OpenWave uses the microphone only when you choose to record a message draft.</string>
+</dict>
+</plist>

--- a/crates/openwave-desktop/tauri.conf.json
+++ b/crates/openwave-desktop/tauri.conf.json
@@ -53,6 +53,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "macOS": {
+      "infoPlist": "Info.plist"
+    },
     "resources": {
       "../../scripts/exec-documents/": "exec-scripts/",
       "../../skills/": "skills/"

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -73,6 +73,7 @@ import { useRefreshSignals } from "./RefreshSignals";
 import { TranscriptVisibilityProvider } from "./TranscriptVisibility";
 import { useTurnLifecycle } from "./TurnLifecycleSignals";
 import { useChatFolderAttachments } from "./useChatFolderAttachments";
+import { appendTranscript, useVoiceComposer } from "./useVoiceComposer";
 
 let msgSeq = 0;
 
@@ -286,6 +287,10 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     draftRef.current = next;
     composerDraftActions.setDraft(chatId, next);
   }
+
+  const voice = useVoiceComposer((audio) => client.transcribeVoice(audio), (transcript) => {
+    setComposerDraft(appendTranscript(draftRef.current, transcript));
+  });
 
   function setComposerFiles(
     update: (current: readonly ImportedDocument[]) => ImportedDocument[],
@@ -550,6 +555,13 @@ export function ChatRoute({ chatId }: { chatId: string }) {
               error: folders.error,
               onAttach: nativeHost ? folders.attach : undefined,
               onRemove: folders.remove,
+            }}
+            voice={{
+              available: voice.available,
+              state: voice.state,
+              error: voice.error,
+              onStart: () => void voice.start(),
+              onStop: voice.stop,
             }}
             nativeDropTarget={
               <DocumentDropTarget

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -16,6 +16,7 @@ import {
   type ComposerFiles,
   type ComposerFolders,
   type ComposerImages,
+  type ComposerVoice,
 } from "./Composer";
 import { MessageList, type RetryableTurn } from "./MessageList";
 import { useTranscriptVisible } from "./TranscriptVisibility";
@@ -42,6 +43,7 @@ export type ChatViewProps = {
   composerImages: ComposerImages;
   files: ComposerFiles;
   folders?: ComposerFolders;
+  voice?: ComposerVoice;
   nativeDropTarget?: ReactNode;
   attachError: string | null;
   onDraftChange: (value: string) => void;
@@ -73,6 +75,7 @@ export function ChatView({
   composerImages,
   files,
   folders,
+  voice,
   nativeDropTarget,
   attachError,
   onDraftChange,
@@ -351,6 +354,7 @@ export function ChatView({
           images={composerImages}
           files={files}
           folders={folders}
+          voice={voice}
           nativeDropTarget={nativeDropTarget}
           attachError={attachError}
           // Typing retires the verdict on the last piece of guidance. Accepted

--- a/crates/openwave-desktop/ui/src/Composer.test.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.test.tsx
@@ -129,6 +129,39 @@ describe("Composer", () => {
     expect(shouldRestoreComposerFocus("chat-1", "chat-1", true)).toBe(false);
   });
 
+  it("shows voice progress in the composer and preserves the editable textarea", () => {
+    const markup = renderToStaticMarkup(
+      <Composer
+        activeTurnId={null}
+        busy={false}
+        cancelError={null}
+        cancelPending={false}
+        disabled={false}
+        draft="Existing draft"
+        voice={{
+          available: true,
+          state: "transcribing",
+          error: null,
+          onStart: vi.fn(),
+          onStop: vi.fn(),
+        }}
+        onDraftChange={vi.fn()}
+        onSend={noop}
+        onSteer={noop}
+        onStop={noop}
+        resetKey="chat-1"
+        steerError={null}
+        steerPending={false}
+        steerStatus={null}
+      />,
+    );
+
+    expect(markup).toContain('placeholder="Transcribing…"');
+    expect(markup).toContain("Transcribing…");
+    expect(markup).toContain('aria-label="Transcribing voice recording"');
+    expect(markup).not.toContain('<textarea disabled=""');
+  });
+
   it("keeps one action slot and presents the stop control during a turn", () => {
     const markup = renderToStaticMarkup(
       <Composer

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -14,6 +14,7 @@ import {
   FolderPlus,
   Image as ImageIcon,
   LoaderCircle,
+  Mic,
   Paperclip,
   Square,
   X,
@@ -133,6 +134,14 @@ export type ComposerFolders = {
   onRemove: (rootId: string) => void;
 };
 
+export type ComposerVoice = {
+  available: boolean;
+  state: "idle" | "requesting" | "recording" | "transcribing";
+  error: string | null;
+  onStart: () => void;
+  onStop: () => void;
+};
+
 /** Whether attached images stop this turn from being sent, and why. */
 export function imageSendBlocker(images: ComposerImages | undefined): string | null {
   if (!images || images.items.length === 0) return null;
@@ -157,6 +166,7 @@ export type ComposerProps = {
   images?: ComposerImages;
   files?: ComposerFiles;
   folders?: ComposerFolders;
+  voice?: ComposerVoice;
   nativeDropTarget?: ReactNode;
   attachError?: string | null;
   onDraftChange: (draft: string) => void;
@@ -180,6 +190,7 @@ export function Composer({
   images,
   files,
   folders,
+  voice,
   nativeDropTarget,
   attachError = null,
   onDraftChange,
@@ -206,6 +217,7 @@ export function Composer({
   const steerTooLong =
     active && [...draft.trim()].length > MAX_STEER_CHARACTERS;
   const imageBlocker = imageSendBlocker(images);
+  const voiceWorking = voice?.state !== undefined && voice.state !== "idle";
   const canSubmit =
     !inputDisabled &&
     !steerPending &&
@@ -372,7 +384,13 @@ export function Composer({
         className="w-full resize-none border-none bg-transparent px-1 text-base placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-0"
         value={draft}
         placeholder={
-          active ? "Guide the active response…" : "Message OpenWave…"
+          voice?.state === "requesting" || voice?.state === "recording"
+            ? "Listening…"
+            : voice?.state === "transcribing"
+              ? "Transcribing…"
+              : active
+                ? "Guide the active response…"
+                : "Message OpenWave…"
         }
         aria-label="Message"
         // A stable hook for the shell's focus-composer shortcut, which has to
@@ -430,6 +448,51 @@ export function Composer({
             </WithTooltip>
           )}
           {modelMenu}
+          {voice?.available && (
+            <WithTooltip
+              label={
+                voice.state === "recording"
+                  ? "Stop recording"
+                  : voice.state === "requesting"
+                    ? "Waiting for microphone…"
+                    : voice.state === "transcribing"
+                      ? "Transcribing…"
+                      : "Record voice"
+              }
+            >
+              <Button
+                type="button"
+                variant={voice.state === "recording" ? "secondary" : "ghost"}
+                size="icon-8"
+                aria-label={
+                  voice.state === "recording"
+                    ? "Stop voice recording"
+                    : voice.state === "transcribing"
+                      ? "Transcribing voice recording"
+                      : voice.state === "requesting"
+                        ? "Waiting for microphone permission"
+                        : "Record voice message"
+                }
+                disabled={
+                  inputDisabled ||
+                  voice.state === "requesting" ||
+                  voice.state === "transcribing"
+                }
+                onClick={
+                  voice.state === "recording" ? voice.onStop : voice.onStart
+                }
+              >
+                {voice.state === "requesting" ||
+                voice.state === "transcribing" ? (
+                  <LoaderCircle className="animate-spin" size={15} />
+                ) : voice.state === "recording" ? (
+                  <Square size={12} fill="currentColor" strokeWidth={0} />
+                ) : (
+                  <Mic size={15} />
+                )}
+              </Button>
+            </WithTooltip>
+          )}
         </div>
         <div className="flex items-center gap-2">
           {active ? (
@@ -477,8 +540,24 @@ export function Composer({
         </div>
       </div>
       <span className="sr-only" role="status">
-        {busy ? "Agent is responding" : "Ready to send"}
+        {voiceWorking
+          ? voice?.state === "transcribing"
+            ? "Transcribing voice recording"
+            : "Listening for voice input"
+          : busy
+            ? "Agent is responding"
+            : "Ready to send"}
       </span>
+      {voiceWorking && (
+        <span className="text-xs text-muted-foreground" role="status">
+          {voice?.state === "transcribing" ? "Transcribing…" : "Listening…"}
+        </span>
+      )}
+      {voice?.error && (
+        <span className="text-xs text-destructive" role="alert">
+          {voice.error}
+        </span>
+      )}
       {cancelError && (
         <span className="text-xs text-destructive" role="status">
           {"Couldn’t stop turn: "}{cancelError}

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -37,6 +37,7 @@ import { HomeSidebar } from "./sidebar/HomeSidebar";
 import { WelcomeState } from "./WelcomeState";
 import type { AttachedFiles } from "./attachments";
 import { MAX_IMAGE_ATTACHMENTS } from "./ImageAttachments";
+import { appendTranscript, useVoiceComposer } from "./useVoiceComposer";
 
 const chatListActions = useChatListStore.getState();
 const composerDraftActions = useComposerDrafts.getState();
@@ -55,6 +56,10 @@ export function HomeRoute() {
   const draft = useComposerDraft(HOME_DRAFT_KEY);
   const setDraft = (text: string) =>
     composerDraftActions.setDraft(HOME_DRAFT_KEY, text);
+  const voice = useVoiceComposer((audio) => client.transcribeVoice(audio), (transcript) => {
+    const current = useComposerDrafts.getState().drafts[HOME_DRAFT_KEY] ?? "";
+    setDraft(appendTranscript(current, transcript));
+  });
   const [error, setError] = useState<string | null>(null);
   const newChat = useNewChatSettings();
   // What the pickers show and the created chat will get: this visit's picks
@@ -289,6 +294,13 @@ export function HomeRoute() {
             disabled={creatingChat}
             draft={draft}
             images={composerImages}
+            voice={{
+              available: voice.available,
+              state: voice.state,
+              error: voice.error,
+              onStart: () => void voice.start(),
+              onStop: voice.stop,
+            }}
             files={{
               items: pendingFiles,
               attaching,

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -166,6 +166,13 @@ export type StickyChatDefaults = WireStickyChatDefaults;
 
 export type ProviderInfo = WireProviderInfo;
 
+export type VoiceTranscriptionModel = "local" | "gpt4o_transcribe";
+export type VoiceTranscriptionInfo = {
+  model: VoiceTranscriptionModel;
+  local_ready: boolean;
+  openai_ready: boolean;
+};
+
 export type CustomModelConfig = WireCustomModelConfig;
 
 /**
@@ -772,6 +779,33 @@ export class ApiClient {
       method: "DELETE",
       headers: this.headers(),
     });
+  }
+
+  getVoiceTranscription(): Promise<VoiceTranscriptionInfo> {
+    return this.json("/voice-transcription", { headers: this.headers() });
+  }
+
+  putVoiceTranscription(
+    model: VoiceTranscriptionModel,
+  ): Promise<VoiceTranscriptionInfo> {
+    return this.json("/voice-transcription", {
+      method: "PUT",
+      headers: this.headers(true),
+      body: JSON.stringify({ model }),
+    });
+  }
+
+  async transcribeVoice(audio: Blob): Promise<string> {
+    const response = await fetch(`${this.baseUrl}/voice-transcription`, {
+      method: "POST",
+      headers: {
+        ...this.headers(),
+        "Content-Type": audio.type || "audio/webm",
+      },
+      body: audio,
+    });
+    await throwIfNotOk(response);
+    return ((await response.json()) as { text: string }).text;
   }
 
   /**

--- a/crates/openwave-desktop/ui/src/settings/VoiceTranscriptionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/VoiceTranscriptionPanel.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+import type {
+  ApiClient,
+  VoiceTranscriptionInfo,
+  VoiceTranscriptionModel,
+} from "../api";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
+
+export function VoiceTranscriptionPanel({ client }: { client: ApiClient }) {
+  const [info, setInfo] = useState<VoiceTranscriptionInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    void client.getVoiceTranscription().then(setInfo).catch((caught) => {
+      setError(String(caught));
+    });
+  }, [client]);
+
+  async function select(model: VoiceTranscriptionModel) {
+    setSaving(true);
+    setError(null);
+    try {
+      setInfo(await client.putVoiceTranscription(model));
+    } catch (caught) {
+      setError(String(caught));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <SettingsPanel
+      title="Voice transcription"
+      description="Choose how recordings become editable message drafts. Local transcription is recommended."
+    >
+      <SettingsSection title="Model">
+        <Select
+          value={info?.model ?? "local"}
+          disabled={!info || saving}
+          onValueChange={(value) => void select(value as VoiceTranscriptionModel)}
+        >
+          <SelectTrigger aria-label="Voice transcription model">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="local">Local model · recommended</SelectItem>
+            <SelectItem value="gpt4o_transcribe" disabled={!info?.openai_ready}>
+              OpenAI · gpt-4o-transcribe
+            </SelectItem>
+          </SelectContent>
+        </Select>
+        {info?.model === "local" && !info.local_ready && (
+          <p className="text-xs text-muted-foreground">
+            The pinned local model runner is not included in this build yet.
+          </p>
+        )}
+        {info && !info.openai_ready && (
+          <p className="text-xs text-muted-foreground">
+            Enable OpenAI and save its credential in Providers to use cloud transcription.
+          </p>
+        )}
+        {error && <SettingsError>{error}</SettingsError>}
+      </SettingsSection>
+    </SettingsPanel>
+  );
+}

--- a/crates/openwave-desktop/ui/src/settings/sections.tsx
+++ b/crates/openwave-desktop/ui/src/settings/sections.tsx
@@ -9,6 +9,7 @@ import {
   RefreshCw,
   ShieldCheck,
   SquareTerminal,
+  Mic,
   Waypoints,
 } from "lucide-react";
 
@@ -24,6 +25,7 @@ import { ModelsPanel } from "./ModelsPanel";
 import { ProvidersPanel } from "./ProvidersPanel";
 import { UpdatesPanel } from "./UpdatesPanel";
 import { WebSearchPanel } from "./WebSearchPanel";
+import { VoiceTranscriptionPanel } from "./VoiceTranscriptionPanel";
 
 /**
  * Each section reads what it needs from the shell context rather than being
@@ -77,6 +79,11 @@ function ModelsSection() {
 function WebSearchSection() {
   const { client } = useApp();
   return <WebSearchPanel client={client} />;
+}
+
+function VoiceTranscriptionSection() {
+  const { client } = useApp();
+  return <VoiceTranscriptionPanel client={client} />;
 }
 
 function CodeExecutionSection() {
@@ -148,6 +155,12 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     unmanagedHidden: true,
   },
   { path: "models", label: "Models", icon: Cpu, Component: ModelsSection },
+  {
+    path: "voice-transcription",
+    label: "Voice input",
+    icon: Mic,
+    Component: VoiceTranscriptionSection,
+  },
   { path: "web-search", label: "Web search", icon: Globe, Component: WebSearchSection },
   {
     path: "code-execution",

--- a/crates/openwave-desktop/ui/src/useVoiceComposer.test.ts
+++ b/crates/openwave-desktop/ui/src/useVoiceComposer.test.ts
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  appendTranscript,
+  supportedVoiceMimeType,
+  useVoiceComposer,
+} from "./useVoiceComposer";
+
+class FakeMediaRecorder extends EventTarget {
+  static latest: FakeMediaRecorder | null = null;
+  state: RecordingState = "inactive";
+  mimeType = "audio/webm";
+
+  static isTypeSupported = vi.fn((type: string) => type === "audio/webm");
+  static chunk = new Blob(["voice"], { type: "audio/webm" });
+  options: MediaRecorderOptions | undefined;
+
+  constructor(_stream: MediaStream, options?: MediaRecorderOptions) {
+    super();
+    this.options = options;
+    FakeMediaRecorder.latest = this;
+  }
+
+  start() {
+    this.state = "recording";
+  }
+
+  stop() {
+    this.state = "inactive";
+    this.dispatchEvent(
+      new MessageEvent("dataavailable", {
+        data: FakeMediaRecorder.chunk,
+      }),
+    );
+    this.dispatchEvent(new Event("stop"));
+  }
+}
+
+describe("voice composer", () => {
+  beforeEach(() => {
+    FakeMediaRecorder.latest = null;
+    FakeMediaRecorder.chunk = new Blob(["voice"], { type: "audio/webm" });
+    FakeMediaRecorder.isTypeSupported.mockClear();
+    vi.stubGlobal("MediaRecorder", FakeMediaRecorder);
+  });
+
+  it("prefers opus, then webm, then mp4 when the webview supports them", () => {
+    expect(supportedVoiceMimeType()).toBe("audio/webm");
+    expect(FakeMediaRecorder.isTypeSupported).toHaveBeenNthCalledWith(
+      1,
+      "audio/webm;codecs=opus",
+    );
+    expect(FakeMediaRecorder.isTypeSupported).toHaveBeenNthCalledWith(
+      2,
+      "audio/webm",
+    );
+  });
+
+  it("records, exposes transcription state, and appends the editable result", async () => {
+    const stopTrack = vi.fn();
+    const getUserMedia = vi.fn(async () => ({
+      getTracks: () => [{ stop: stopTrack }],
+    }));
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: { getUserMedia },
+    });
+    let resolveTranscript!: (value: string) => void;
+    const transcribe = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveTranscript = resolve;
+        }),
+    );
+    let draft = "Existing draft";
+    const { result } = renderHook(() =>
+      useVoiceComposer(
+        transcribe,
+        (transcript) => {
+          draft = appendTranscript(draft, transcript);
+        },
+        vi.fn().mockReturnValueOnce(0).mockReturnValue(500),
+      ),
+    );
+
+    await act(async () => result.current.start());
+    expect(result.current.state).toBe("recording");
+    expect(FakeMediaRecorder.latest?.options).toEqual({ mimeType: "audio/webm" });
+    expect(getUserMedia).toHaveBeenCalledWith({ audio: true });
+
+    act(() => result.current.stop());
+    expect(result.current.state).toBe("transcribing");
+    expect(stopTrack).toHaveBeenCalledOnce();
+    expect(transcribe).toHaveBeenCalledWith(expect.any(Blob));
+
+    resolveTranscript(" spoken words ");
+    await waitFor(() => expect(result.current.state).toBe("idle"));
+    expect(draft).toBe("Existing draft spoken words");
+  });
+
+  it("rejects an empty or too-short recording before transcription", async () => {
+    FakeMediaRecorder.chunk = new Blob([]);
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: vi.fn(async () => ({ getTracks: () => [] })),
+      },
+    });
+    const transcribe = vi.fn(async () => "ignored");
+    const { result } = renderHook(() =>
+      useVoiceComposer(
+        transcribe,
+        vi.fn(),
+        vi.fn().mockReturnValueOnce(0).mockReturnValue(100),
+      ),
+    );
+
+    await act(async () => result.current.start());
+    act(() => result.current.stop());
+
+    expect(result.current.state).toBe("idle");
+    expect(result.current.error).toContain("too short");
+    expect(transcribe).not.toHaveBeenCalled();
+  });
+
+  it("cleans up the stream and reports a recorder failure", async () => {
+    const stopTrack = vi.fn();
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: vi.fn(async () => ({
+          getTracks: () => [{ stop: stopTrack }],
+        })),
+      },
+    });
+    const transcribe = vi.fn(async () => "ignored");
+    const { result } = renderHook(() =>
+      useVoiceComposer(transcribe, vi.fn(), () => 0),
+    );
+
+    await act(async () => result.current.start());
+    act(() => {
+      FakeMediaRecorder.latest?.dispatchEvent(
+        new ErrorEvent("error", { error: new Error("Recorder crashed") }),
+      );
+    });
+
+    expect(result.current.state).toBe("idle");
+    expect(result.current.error).toBe("Recorder crashed");
+    expect(stopTrack).toHaveBeenCalledOnce();
+    expect(transcribe).not.toHaveBeenCalled();
+  });
+
+  it("keeps provider failure visible without changing the draft", async () => {
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: vi.fn(async () => ({ getTracks: () => [] })),
+      },
+    });
+    const onTranscript = vi.fn();
+    const { result } = renderHook(() =>
+      useVoiceComposer(
+        vi.fn(async () => {
+          throw new Error("Voice transcription is not configured yet.");
+        }),
+        onTranscript,
+        vi.fn().mockReturnValueOnce(0).mockReturnValue(500),
+      ),
+    );
+
+    await act(async () => result.current.start());
+    act(() => result.current.stop());
+
+    await waitFor(() =>
+      expect(result.current.error).toBe(
+        "Voice transcription is not configured yet.",
+      ),
+    );
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+});

--- a/crates/openwave-desktop/ui/src/useVoiceComposer.ts
+++ b/crates/openwave-desktop/ui/src/useVoiceComposer.ts
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type VoiceComposerState =
+  | "idle"
+  | "requesting"
+  | "recording"
+  | "transcribing";
+
+export type VoiceTranscriber = (audio: Blob) => Promise<string>;
+
+export type VoiceComposer = {
+  available: boolean;
+  state: VoiceComposerState;
+  error: string | null;
+  start: () => Promise<void>;
+  stop: () => void;
+};
+
+const VOICE_MIME_TYPES = [
+  "audio/webm;codecs=opus",
+  "audio/webm",
+  "audio/mp4",
+] as const;
+const MIN_RECORDING_MS = 250;
+
+export function supportedVoiceMimeType(): string | undefined {
+  return VOICE_MIME_TYPES.find((type) => MediaRecorder.isTypeSupported(type));
+}
+
+export function appendTranscript(draft: string, transcript: string): string {
+  const spoken = transcript.trim();
+  if (!spoken) return draft;
+  if (!draft) return spoken;
+  return `${draft}${/\s$/.test(draft) ? "" : " "}${spoken}`;
+}
+
+function voiceError(error: unknown): string {
+  if (error instanceof DOMException && error.name === "NotAllowedError") {
+    return "Microphone access was denied. Allow it in system settings and try again.";
+  }
+  const message = String(error).replace(/^Error:\s*/, "").trim();
+  return message || "Could not record from the microphone.";
+}
+
+/**
+ * The browser-owned half of voice composition: ask for the microphone only
+ * after a click, capture one bounded recording, and hand its bytes to the
+ * product-selected transcriber. The hook never chooses or contacts a provider.
+ */
+export function useVoiceComposer(
+  transcribe: VoiceTranscriber,
+  onTranscript: (transcript: string) => void,
+  now: () => number = () => performance.now(),
+): VoiceComposer {
+  const available =
+    typeof navigator !== "undefined" &&
+    typeof MediaRecorder !== "undefined" &&
+    typeof navigator.mediaDevices?.getUserMedia === "function";
+  const [state, setState] = useState<VoiceComposerState>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const startedAtRef = useRef(0);
+  const recorderFailedRef = useRef(false);
+  const mountedRef = useRef(true);
+  const transcribeRef = useRef(transcribe);
+  const onTranscriptRef = useRef(onTranscript);
+  transcribeRef.current = transcribe;
+  onTranscriptRef.current = onTranscript;
+
+  const releaseStream = useCallback(() => {
+    for (const track of streamRef.current?.getTracks() ?? []) track.stop();
+    streamRef.current = null;
+    recorderRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      const recorder = recorderRef.current;
+      if (recorder?.state === "recording") recorder.stop();
+      releaseStream();
+    };
+  }, [releaseStream]);
+
+  const start = useCallback(async () => {
+    if (!available || recorderRef.current) return;
+    setError(null);
+    setState("requesting");
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      if (!mountedRef.current) {
+        for (const track of stream.getTracks()) track.stop();
+        return;
+      }
+      const mimeType = supportedVoiceMimeType();
+      const recorder = new MediaRecorder(
+        stream,
+        mimeType ? { mimeType } : undefined,
+      );
+      streamRef.current = stream;
+      recorderRef.current = recorder;
+      chunksRef.current = [];
+      recorderFailedRef.current = false;
+      recorder.addEventListener("dataavailable", (event) => {
+        if (event.data.size > 0) chunksRef.current.push(event.data);
+      });
+      recorder.addEventListener("stop", () => {
+        const elapsed = now() - startedAtRef.current;
+        const audio = new Blob(chunksRef.current, {
+          type: recorder.mimeType || chunksRef.current[0]?.type,
+        });
+        chunksRef.current = [];
+        releaseStream();
+        if (!mountedRef.current) return;
+        if (recorderFailedRef.current) return;
+        if (audio.size === 0 || elapsed < MIN_RECORDING_MS) {
+          setState("idle");
+          setError("That recording was too short. Hold the button a little longer and try again.");
+          return;
+        }
+        setState("transcribing");
+        void transcribeRef.current(audio)
+          .then((transcript) => {
+            if (!mountedRef.current) return;
+            if (transcript.trim()) onTranscriptRef.current(transcript);
+          })
+          .catch((caught) => {
+            if (mountedRef.current) setError(voiceError(caught));
+          })
+          .finally(() => {
+            if (mountedRef.current) setState("idle");
+          });
+      });
+      recorder.addEventListener("error", (event) => {
+        recorderFailedRef.current = true;
+        chunksRef.current = [];
+        releaseStream();
+        if (!mountedRef.current) return;
+        setState("idle");
+        setError(voiceError((event as ErrorEvent).error ?? "The recording failed."));
+      });
+      startedAtRef.current = now();
+      recorder.start();
+      setState("recording");
+    } catch (caught) {
+      releaseStream();
+      if (!mountedRef.current) return;
+      setState("idle");
+      setError(voiceError(caught));
+    }
+  }, [available, now, releaseStream]);
+
+  const stop = useCallback(() => {
+    const recorder = recorderRef.current;
+    if (recorder?.state === "recording") recorder.stop();
+  }, []);
+
+  return { available, state, error, start, stop };
+}

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -70,6 +70,7 @@ mod source_tools;
 mod state;
 mod turn_worker;
 mod view_frames;
+mod voice_transcription;
 /// Host-owned, inert web-search configuration and provider selection.
 pub mod web_search;
 mod wire_types;
@@ -383,6 +384,13 @@ pub fn app(state: AppState) -> Router {
                 .layer(DefaultBodyLimit::max(MAX_WEB_SEARCH_CREDENTIAL_BODY_BYTES)),
         )
         .route("/providers", get(routes::list_providers))
+        .route(
+            "/voice-transcription",
+            get(routes::get_voice_transcription)
+                .put(routes::put_voice_transcription)
+                .post(routes::post_voice_transcription)
+                .layer(DefaultBodyLimit::max(voice_transcription::MAX_AUDIO_BYTES)),
+        )
         .route(
             "/providers/{kind}",
             axum::routing::put(routes::put_provider),

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -5,8 +5,10 @@
 //! here.
 
 use axum::body::Body;
+use axum::body::Bytes;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
+use axum::http::HeaderMap;
 use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
 use cap_std::ambient_authority;
@@ -46,6 +48,7 @@ use crate::providers::{self, ProviderCredential, ProviderInfo, ProviderKind, Pro
 use crate::scoped_store::ScopedStore;
 use crate::state::AppState;
 use crate::view_frames::ViewFrameSource;
+use crate::voice_transcription::{self, VoiceTranscriptionInfo, VoiceTranscriptionUpdate};
 use crate::web_search::{
     self, WebSearchConfigInfo, WebSearchConfigUpdate, WebSearchCredentialReadiness,
     WebSearchCredentialsInfo,
@@ -1101,6 +1104,37 @@ pub async fn delete_provider_credential(
     refuse_credential_writes_when_managed(&state).await?;
     providers::delete_credential(&*state.secrets, kind).await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn get_voice_transcription(
+    State(state): State<AppState>,
+) -> Result<Json<VoiceTranscriptionInfo>, ServerError> {
+    Ok(Json(
+        voice_transcription::info(&*state.store, &*state.secrets).await?,
+    ))
+}
+
+pub async fn put_voice_transcription(
+    State(state): State<AppState>,
+    Json(body): Json<VoiceTranscriptionUpdate>,
+) -> Result<Json<VoiceTranscriptionInfo>, ServerError> {
+    Ok(Json(
+        voice_transcription::update(&*state.store, &*state.secrets, body).await?,
+    ))
+}
+
+pub async fn post_voice_transcription(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    audio: Bytes,
+) -> Result<Json<serde_json::Value>, ServerError> {
+    let content_type = headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .ok_or_else(|| ServerError::bad_request("voice recording content type is required"))?;
+    let text = voice_transcription::transcribe(&*state.store, &*state.secrets, content_type, audio)
+        .await?;
+    Ok(Json(serde_json::json!({ "text": text })))
 }
 
 /// A selectable model in the catalog.

--- a/crates/openwave-server/src/voice_transcription.rs
+++ b/crates/openwave-server/src/voice_transcription.rs
@@ -1,0 +1,150 @@
+//! Voice transcription settings and the credential-custody cloud adapter.
+
+use axum::body::Bytes;
+use serde::{Deserialize, Serialize};
+
+use openwave_core::{SecretProvider, Store};
+
+use crate::error::ServerError;
+use crate::providers::{self, ProviderKind};
+
+const SETTING_KEY: &str = "voice.transcription_v1";
+pub const MAX_AUDIO_BYTES: usize = 25 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+pub enum VoiceTranscriptionModel {
+    Local,
+    Gpt4oTranscribe,
+}
+
+impl Default for VoiceTranscriptionModel {
+    fn default() -> Self {
+        Self::Local
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+struct VoiceTranscriptionConfig {
+    model: VoiceTranscriptionModel,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
+pub struct VoiceTranscriptionInfo {
+    pub model: VoiceTranscriptionModel,
+    pub local_ready: bool,
+    pub openai_ready: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct VoiceTranscriptionUpdate {
+    pub model: VoiceTranscriptionModel,
+}
+
+async fn read_config(store: &dyn Store) -> openwave_core::Result<VoiceTranscriptionConfig> {
+    Ok(store
+        .get_setting(SETTING_KEY)
+        .await?
+        .and_then(|value| serde_json::from_value(value).ok())
+        .unwrap_or_default())
+}
+
+pub async fn info(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+) -> Result<VoiceTranscriptionInfo, ServerError> {
+    let config = read_config(store).await?;
+    let openai = providers::read_config(store, ProviderKind::Openai).await?;
+    Ok(VoiceTranscriptionInfo {
+        model: config.model,
+        // Deliberately false until the pinned lazy local runner lands.
+        local_ready: false,
+        openai_ready: openai.enabled
+            && providers::has_credential(secrets, ProviderKind::Openai).await,
+    })
+}
+
+pub async fn update(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+    update: VoiceTranscriptionUpdate,
+) -> Result<VoiceTranscriptionInfo, ServerError> {
+    if update.model == VoiceTranscriptionModel::Gpt4oTranscribe {
+        let current = info(store, secrets).await?;
+        if !current.openai_ready {
+            return Err(ServerError::conflict(
+                "enable OpenAI and save its credential before selecting gpt-4o-transcribe",
+            ));
+        }
+    }
+    let value = serde_json::to_value(VoiceTranscriptionConfig {
+        model: update.model,
+    })
+    .map_err(|_| ServerError::internal("failed to serialize voice transcription settings"))?;
+    store.set_setting(SETTING_KEY, &value).await?;
+    info(store, secrets).await
+}
+
+pub async fn transcribe(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+    content_type: &str,
+    audio: Bytes,
+) -> Result<String, ServerError> {
+    if audio.is_empty() {
+        return Err(ServerError::bad_request("voice recording is empty"));
+    }
+    let config = read_config(store).await?;
+    if config.model == VoiceTranscriptionModel::Local {
+        return Err(ServerError::conflict(
+            "the recommended local transcription model is not installed in this build yet",
+        ));
+    }
+    let provider = providers::read_config(store, ProviderKind::Openai).await?;
+    if !provider.enabled {
+        return Err(ServerError::conflict("OpenAI is not enabled"));
+    }
+    let key = providers::read_credential(secrets, ProviderKind::Openai)
+        .await?
+        .and_then(|credential| credential.as_api_key().map(ToOwned::to_owned))
+        .ok_or_else(|| ServerError::conflict("OpenAI has no saved credential"))?;
+    let extension = match content_type.split(';').next().unwrap_or("") {
+        "audio/mp4" => "m4a",
+        "audio/webm" => "webm",
+        _ => {
+            return Err(ServerError::bad_request(
+                "unsupported voice recording format",
+            ))
+        }
+    };
+    let part = reqwest::multipart::Part::bytes(audio.to_vec())
+        .file_name(format!("recording.{extension}"))
+        .mime_str(content_type)
+        .map_err(|_| ServerError::bad_request("invalid voice recording content type"))?;
+    let response = reqwest::Client::new()
+        .post("https://api.openai.com/v1/audio/transcriptions")
+        .bearer_auth(key)
+        .multipart(
+            reqwest::multipart::Form::new()
+                .text("model", "gpt-4o-transcribe")
+                .part("file", part),
+        )
+        .send()
+        .await
+        .map_err(|_| ServerError::internal("OpenAI transcription request failed"))?;
+    if !response.status().is_success() {
+        return Err(ServerError::internal(format!(
+            "OpenAI transcription failed with status {}",
+            response.status()
+        )));
+    }
+    #[derive(Deserialize)]
+    struct Transcript {
+        text: String,
+    }
+    let transcript: Transcript = response
+        .json()
+        .await
+        .map_err(|_| ServerError::internal("OpenAI returned an invalid transcription response"))?;
+    Ok(transcript.text)
+}


### PR DESCRIPTION
## Summary

- add microphone record/stop controls to the home and chat composers using webview media APIs
- negotiate supported recording formats (`webm/opus`, `webm`, then `mp4`), reject empty/too-short clips, and clean up recorder failures
- show listening, transcribing, permission, recording, and provider errors inside the composer
- append successful transcripts to the persisted editable draft rather than sending them
- add a provider-neutral voice transcription setting, recommending local by default
- support `gpt-4o-transcribe` only when the existing OpenAI provider is enabled and credentialed; the server resolves the existing keychain credential and the renderer never receives or duplicates it
- explicitly merge the macOS microphone usage description through `bundle.macOS.infoPlist`

## Scope

This remains an enabling slice of #754, not the complete issue.

The workspace has no local speech inference or audio-decoding stack today. Adding a maintained runner, pinned model artifact and digest, lazy download/install state, cross-platform packaging, and decoding would make this PR substantially larger. The settings contract therefore defaults to and recommends local while reporting that the local runner is not included yet. #1435 tracks that pinned lazy local implementation.

Speech-origin metadata carried to the agent also remains deferred. This PR does not add global dictation shortcuts, hold/toggle modes, a transcription catalog, or any Alpha-specific API coupling.

## Verification

- `pnpm --dir crates/openwave-desktop/ui test` — 701 tests
- `pnpm --dir crates/openwave-desktop/ui build`
- `cargo check -p openwave-server -p openwave-desktop --locked`
- `cargo test -p openwave-server voice_transcription --locked`
- `node crates/openwave-desktop/scripts/prepare-sidecar.mjs`
- `cargo tauri build --debug --bundles app --config '{"build":{"beforeBuildCommand":""}}'`
- inspected `target/debug/bundle/macos/OpenWave.app/Contents/Info.plist`; `NSMicrophoneUsageDescription` is present with the expected value
