### PR TITLE
feat(sandbox): expire abandoned containers on idle

### DIFF
--- a/crates/openwave-sandbox-agent/src/main.rs
+++ b/crates/openwave-sandbox-agent/src/main.rs
@@ -21,6 +21,8 @@
 //!   `/workspace`, provisioned in the container image).
 //! - `OPENWAVE_SANDBOX_LIFETIME_CAP_SECS` — an absolute lifetime cap. When it
 //!   elapses the entrypoint exits, which stops the container.
+//! - `OPENWAVE_SANDBOX_IDLE_TIMEOUT_SECS` — an idle timeout reset by authenticated
+//!   host keepalives and run activity. When it elapses the entrypoint exits.
 //!
 //! # Why the cap is enforced here
 //!
@@ -32,10 +34,9 @@
 //! reclaims containers a *living* host has lost track of; this cap covers the
 //! host that never comes back.
 //!
-//! It is an absolute bound on existence, not an idle timeout — a long, legitimate
-//! exec is not interrupted for being slow, and a container that keeps itself
-//! nominally busy still dies. Distinguishing idle from busy would need a keepalive
-//! from the attached host, which the transport does not carry yet.
+//! The idle watchdog reclaims an abandoned container promptly, while the
+//! absolute cap remains independent and ends even a host-owned run that is
+//! genuinely wedged forever.
 
 use std::env;
 use std::time::Duration;
@@ -57,6 +58,8 @@ const DEFAULT_WORKSPACE: &str = "/workspace";
 /// match the name the backend injects (see `sandbox_docker`'s
 /// `LIFETIME_CAP_ENV`).
 const LIFETIME_CAP_ENV: &str = "OPENWAVE_SANDBOX_LIFETIME_CAP_SECS";
+/// Environment variable carrying the idle timeout, in seconds.
+const IDLE_TIMEOUT_ENV: &str = "OPENWAVE_SANDBOX_IDLE_TIMEOUT_SECS";
 
 #[tokio::main]
 async fn main() {
@@ -105,9 +108,10 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // waits for the host to attach and deliver the run init — the task never
     // rides the environment, so a sandbox reclaimed before its handle committed
     // never executed anything — then runs to a submitted result.
+    let agent_run = run.clone();
     tokio::spawn(async move {
-        let init = run.init().await;
-        match run_agent(run, init.task, workspace).await {
+        let init = agent_run.init().await;
+        match run_agent(agent_run, init.task, workspace).await {
             Ok(answer) => eprintln!("openwave-sandbox-agent: submitted result: {answer}"),
             Err(error) => eprintln!("openwave-sandbox-agent: run failed: {error}"),
         }
@@ -116,12 +120,18 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // Keep serving so the host can drain the event stream and drive teardown —
     // but no longer than the lifetime cap, whose whole purpose is to end a run
     // whose host will never drive that teardown.
-    let cap = lifetime_cap(env::var(LIFETIME_CAP_ENV).ok().as_deref());
+    let cap = positive_duration(env::var(LIFETIME_CAP_ENV).ok().as_deref());
+    let idle = positive_duration(env::var(IDLE_TIMEOUT_ENV).ok().as_deref());
+    let activity = run.activity();
     tokio::select! {
         () = supervisor.serve() => {}
         () = lifetime_elapsed(cap) => {
             let secs = cap.unwrap_or_default().as_secs();
             eprintln!("openwave-sandbox-agent: lifetime cap of {secs}s reached; exiting");
+        }
+        () = idle_elapsed(idle, activity) => {
+            let secs = idle.unwrap_or_default().as_secs();
+            eprintln!("openwave-sandbox-agent: idle timeout of {secs}s reached; exiting");
         }
     }
     Ok(())
@@ -142,7 +152,7 @@ async fn run_egress_proxy() -> Result<(), Box<dyn std::error::Error>> {
             None => "off".to_owned(),
         }
     );
-    let cap = lifetime_cap(env::var(LIFETIME_CAP_ENV).ok().as_deref());
+    let cap = positive_duration(env::var(LIFETIME_CAP_ENV).ok().as_deref());
     tokio::select! {
         () = proxy.serve() => {}
         () = lifetime_elapsed(cap) => {
@@ -158,13 +168,32 @@ async fn run_egress_proxy() -> Result<(), Box<dyn std::error::Error>> {
 /// Absent, unparseable, and zero all mean "no cap": a container must not die on
 /// arrival because a cap was mistyped, and a run with no cap configured is no
 /// worse off than before one existed.
-fn lifetime_cap(configured: Option<&str>) -> Option<Duration> {
+fn positive_duration(configured: Option<&str>) -> Option<Duration> {
     configured?
         .trim()
         .parse::<u64>()
         .ok()
         .filter(|secs| *secs > 0)
         .map(Duration::from_secs)
+}
+
+/// Completes after one uninterrupted idle period. Every activity generation
+/// resets the deadline; with no timeout it never completes.
+async fn idle_elapsed(timeout: Option<Duration>, mut activity: tokio::sync::watch::Receiver<u64>) {
+    let Some(timeout) = timeout else {
+        std::future::pending::<()>().await;
+        return;
+    };
+    loop {
+        tokio::select! {
+            () = tokio::time::sleep(timeout) => return,
+            changed = activity.changed() => {
+                if changed.is_err() {
+                    return;
+                }
+            }
+        }
+    }
 }
 
 /// Completes when the cap elapses. With no cap it never completes, so the
@@ -182,13 +211,16 @@ mod tests {
 
     #[test]
     fn a_malformed_or_zero_cap_leaves_the_sandbox_uncapped() {
-        assert_eq!(lifetime_cap(Some(" 900 ")), Some(Duration::from_secs(900)));
-        assert_eq!(lifetime_cap(None), None);
-        assert_eq!(lifetime_cap(Some("")), None);
-        assert_eq!(lifetime_cap(Some("soon")), None);
-        assert_eq!(lifetime_cap(Some("-1")), None);
+        assert_eq!(
+            positive_duration(Some(" 900 ")),
+            Some(Duration::from_secs(900))
+        );
+        assert_eq!(positive_duration(None), None);
+        assert_eq!(positive_duration(Some("")), None);
+        assert_eq!(positive_duration(Some("soon")), None);
+        assert_eq!(positive_duration(Some("-1")), None);
         // The dangerous misreading: zero must not mean "expire immediately".
-        assert_eq!(lifetime_cap(Some("0")), None);
+        assert_eq!(positive_duration(Some("0")), None);
     }
 
     /// The cap must fire on its own, and only when configured. A paused clock
@@ -204,5 +236,30 @@ mod tests {
             () = &mut uncapped => panic!("an uncapped sandbox must never self-terminate"),
             () = tokio::time::sleep(Duration::from_secs(365 * 24 * 60 * 60)) => {}
         }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn activity_resets_idle_but_not_the_absolute_cap() {
+        let (activity, receiver) = tokio::sync::watch::channel(0u64);
+        let idle = idle_elapsed(Some(Duration::from_secs(10)), receiver);
+        tokio::pin!(idle);
+        let absolute = tokio::time::sleep(Duration::from_secs(25));
+        tokio::pin!(absolute);
+
+        tokio::time::advance(Duration::from_secs(9)).await;
+        activity.send_modify(|generation| *generation += 1);
+        tokio::time::advance(Duration::from_secs(9)).await;
+        assert!(tokio::time::timeout(Duration::ZERO, &mut idle)
+            .await
+            .is_err());
+
+        tokio::time::advance(Duration::from_secs(7)).await;
+        absolute.await;
+        assert!(tokio::time::timeout(Duration::ZERO, &mut idle)
+            .await
+            .is_err());
+
+        tokio::time::advance(Duration::from_secs(3)).await;
+        idle.await;
     }
 }

--- a/crates/openwave-sandbox-protocol/src/reverse.rs
+++ b/crates/openwave-sandbox-protocol/src/reverse.rs
@@ -132,7 +132,8 @@ pub enum RequestFrame {
 /// A unit of the **reserved control lane**, distinct from the request lane so
 /// it is never subject to request backpressure.
 ///
-/// Cancellation flows sandbox -> host; liveness flows in both directions. A
+/// Cancellation flows sandbox -> host; liveness flows in both directions, and
+/// the host's keepalive proves that an attached run is still owned. A
 /// conforming transport MUST carry this lane independently of [`RequestFrame`]
 /// (a separate stream, queue, or priority), so a [`ControlFrame::Cancel`] can
 /// preempt a saturated request backlog.
@@ -151,6 +152,8 @@ pub enum ControlFrame {
     Ping { nonce: u64 },
     /// Liveness response.
     Pong { nonce: u64 },
+    /// Host -> sandbox: reset the sandbox's idle watchdog.
+    Keepalive,
 }
 
 /// Provenance carried on every reverse operation for audit.

--- a/crates/openwave-sandbox-protocol/src/wire/host.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/host.rs
@@ -16,6 +16,8 @@
 //! there), hand it the [`AttachRequest`] and the run's `CapabilityHost`, and
 //! drive the returned [`HostConnection`].
 
+use std::time::Duration;
+
 use tokio::{
     io::{split, AsyncRead, AsyncWrite, BufReader},
     sync::mpsc,
@@ -237,6 +239,31 @@ impl HostConnection {
             .send(WireFrame::Control(ControlFrame::Ping { nonce }))
             .await;
     }
+
+    /// Start sending host-ownership keepalives over the reserved control lane.
+    ///
+    /// The first keepalive is immediate, then one is sent every `interval` until
+    /// this connection closes. A zero interval is ignored rather than spinning.
+    pub fn start_keepalives(&mut self, interval: Duration) {
+        if interval.is_zero() {
+            return;
+        }
+        let control = self.outbound.control.clone();
+        self.tasks.push(tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                if control
+                    .send(WireFrame::Control(ControlFrame::Keepalive))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        }));
+    }
 }
 
 impl Drop for HostConnection {
@@ -294,7 +321,7 @@ async fn read_loop<R>(
                     .send(WireFrame::Control(ControlFrame::Pong { nonce }))
                     .await;
             }
-            WireFrame::Control(ControlFrame::Pong { .. }) => {}
+            WireFrame::Control(ControlFrame::Pong { .. } | ControlFrame::Keepalive) => {}
             WireFrame::Event(event) => {
                 // An inbound event is untrusted input. `read_frame` bounds a frame
                 // at MAX_FRAME_BYTES; re-enforce the smaller per-event payload cap
@@ -336,6 +363,7 @@ mod tests {
         oplog::InMemoryOperationStore,
         protocol::{Response, MAX_EVENT_PAYLOAD_BYTES, PROTOCOL_VERSION},
         reverse::{CapabilityResponder, GrantSet, ReverseRequest, ReverseResult, RunProvenance},
+        SandboxRun, TransportSecret,
     };
 
     /// A responder that is never invoked: these tests drive only the event lane.
@@ -357,6 +385,42 @@ mod tests {
             Arc::new(NoopResponder),
             Arc::new(InMemoryOperationStore::new()),
         )
+    }
+
+    /// The public host keepalive API must cross the real framed transport and
+    /// become sandbox activity; otherwise the image watchdog would expire a
+    /// healthy attached run despite the host still owning it.
+    #[tokio::test(start_paused = true)]
+    async fn host_keepalives_reach_the_sandbox_activity_watchdog() {
+        let secret = TransportSecret::new("keepalive-boundary");
+        let run = SandboxRun::new([], Some(secret.clone()));
+        let mut activity = run.activity();
+        let (host_side, sandbox_side) = tokio::io::duplex(64 * 1024);
+        let server = tokio::spawn(crate::serve_connection(sandbox_side, run));
+        let attach = AttachRequest {
+            protocol_version: PROTOCOL_VERSION,
+            run_id: RunId::new(),
+            resume_from: EventCursor::START,
+            transport_secret: secret,
+        };
+        let mut connection = WireClient::connect(host_side, attach, events_only_host())
+            .await
+            .expect("attach succeeds");
+
+        activity.changed().await.expect("attach marks activity");
+        connection.start_keepalives(Duration::from_secs(30));
+        activity
+            .changed()
+            .await
+            .expect("first keepalive marks activity");
+        tokio::time::advance(Duration::from_secs(30)).await;
+        activity
+            .changed()
+            .await
+            .expect("periodic keepalive marks activity");
+
+        drop(connection);
+        server.abort();
     }
 
     fn attach() -> AttachRequest {

--- a/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
@@ -97,6 +97,8 @@ struct RunInner {
     /// The run init the host delivers after attach. First delivery wins; a
     /// redelivery on reattach is ignored.
     init: watch::Sender<Option<crate::init::RunInit>>,
+    /// Monotonic activity generation observed by the sandbox idle watchdog.
+    activity: watch::Sender<u64>,
 }
 
 /// One run-scoped, cloneable sandbox. Every clone shares one event buffer and one
@@ -140,6 +142,7 @@ impl SandboxRun {
     ) -> Self {
         let (conn, _) = watch::channel(None);
         let (init, _) = watch::channel(None);
+        let (activity, _) = watch::channel(0);
         Self {
             inner: Arc::new(RunInner {
                 protocol_version,
@@ -155,8 +158,21 @@ impl SandboxRun {
                 }),
                 conn,
                 init,
+                activity,
             }),
         }
+    }
+
+    /// Subscribe to authenticated host traffic and sandbox run activity.
+    #[must_use]
+    pub fn activity(&self) -> watch::Receiver<u64> {
+        self.inner.activity.subscribe()
+    }
+
+    fn mark_activity(&self) {
+        self.inner
+            .activity
+            .send_modify(|generation| *generation = generation.wrapping_add(1));
     }
 
     /// Wait for the host to deliver the run init — the task, policy snapshot,
@@ -227,6 +243,7 @@ impl SandboxRun {
 
     async fn emit(&self, payload: EventPayload) -> Result<Sequence, EmitError> {
         let event = self.buffer_event(payload)?;
+        self.mark_activity();
         let sequence = event.sequence;
         if let Some(conn) = self.current_conn() {
             // Live delivery on the current connection. A send failure only means
@@ -297,6 +314,7 @@ impl SandboxRun {
                 .remove(&request_id);
             return ReverseOutcome::Disconnected;
         }
+        self.mark_activity();
 
         match rx.await {
             Ok(response) => ReverseOutcome::Settled(response),
@@ -475,6 +493,7 @@ where
     // for want of one and leave the slot empty — `send_replace` updates the value
     // unconditionally, and a `call` that subscribes afterward still sees it.
     run.inner.conn.send_replace(Some(conn.clone()));
+    run.mark_activity();
     // The resume cursor is this host's own committed position, so take it as an
     // acknowledgement. It is what makes ignoring a superseded peer's acks below
     // lossless: the incoming host restates its commitment on attach rather than
@@ -495,6 +514,7 @@ where
         };
         match frame {
             WireFrame::Request(RequestFrame::Response(envelope)) => {
+                run.mark_activity();
                 if let Some(tx) = pending
                     .lock()
                     .expect("pending lock")
@@ -504,11 +524,13 @@ where
                 }
             }
             WireFrame::Control(ControlFrame::Ping { nonce }) => {
+                run.mark_activity();
                 let _ = conn
                     .control
                     .send(WireFrame::Control(ControlFrame::Pong { nonce }))
                     .await;
             }
+            WireFrame::Control(ControlFrame::Keepalive) => run.mark_activity(),
             // An acknowledgement is run-scoped state, so only the connection that
             // is currently installed may advance it. A superseded peer still
             // draining its socket after a reconnect speaks for a delivery the
@@ -516,13 +538,17 @@ where
             // already taken from its resume cursor at attach.
             WireFrame::EventAck { cursor } => {
                 if run.is_live(&closed) {
+                    run.mark_activity();
                     run.acknowledge(cursor);
                 }
             }
             // The run init: task, policy, and token, delivered only over an
             // authenticated connection (an unauthenticated dial never reaches
             // this loop). First delivery wins.
-            WireFrame::Init(init) => run.deliver_init(init),
+            WireFrame::Init(init) => {
+                run.mark_activity();
+                run.deliver_init(init);
+            }
             // The sandbox originates cancels and requests; it never receives
             // them. Pong is liveness only. Ignore rather than trust peer input.
             WireFrame::Control(ControlFrame::Pong { .. } | ControlFrame::Cancel { .. })

--- a/crates/openwave-sandbox-protocol/tests/wire_format.rs
+++ b/crates/openwave-sandbox-protocol/tests/wire_format.rs
@@ -236,6 +236,10 @@ fn control_lane_frames_wire_shapes() {
     let pong = ControlFrame::Pong { nonce: 9 };
     roundtrip(&pong);
     golden(&pong, &[("/control", json!("pong"))]);
+
+    let keepalive = ControlFrame::Keepalive;
+    roundtrip(&keepalive);
+    golden(&keepalive, &[("/control", json!("keepalive"))]);
 }
 
 #[test]

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -63,12 +63,22 @@ use uuid::Uuid;
 use crate::durable_oplog::DurableOperationStore;
 use crate::resolver::ProviderResolver;
 use crate::sandbox_admission::{evaluate_detached_admission, DetachedPreconditions};
+use crate::sandbox_docker::DEFAULT_IDLE_TIMEOUT_SECS;
 use crate::scoped_model_token::{GatewayScopedTokenIssuer, ScopedModelTokenIssuer};
 
 /// The provider attribution stamped on reverse operations from a local
 /// container. Untrusted attribution rendered on consent prompts, never a claim
 /// the container makes about itself.
 const CONTAINER_PROVENANCE_PROVIDER: &str = "local-container";
+/// The image's configured idle timeout and the host cadence that must remain
+/// comfortably below it. Kept together so the safety margin is reviewable and
+/// testable instead of existing only in matching comments across crates.
+const SANDBOX_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30);
+
+const _: () = assert!(
+    SANDBOX_KEEPALIVE_INTERVAL.as_secs() * 2 < DEFAULT_IDLE_TIMEOUT_SECS,
+    "two missed keepalive intervals must still leave time before idle expiry"
+);
 
 /// Tunables for driving one sandbox-resident container run.
 #[derive(Debug, Clone, Copy)]
@@ -891,6 +901,7 @@ impl SandboxContainerRunner {
                 };
             }
         };
+        conn.start_keepalives(SANDBOX_KEEPALIVE_INTERVAL);
         // Deliver the run init on every attach; the sandbox keeps the first
         // and ignores redeliveries, so a reattach is idempotent.
         conn.send_init(init.clone()).await;

--- a/crates/openwave-server/src/sandbox_docker.rs
+++ b/crates/openwave-server/src/sandbox_docker.rs
@@ -142,6 +142,8 @@ const TRANSPORT_SECRET_ENV: &str = "OPENWAVE_TRANSPORT_SECRET";
 /// container. The sandbox agent's entrypoint reads it and exits when it elapses.
 /// Kept in sync with the agent's own constant of the same name.
 pub const LIFETIME_CAP_ENV: &str = "OPENWAVE_SANDBOX_LIFETIME_CAP_SECS";
+/// Idle watchdog configured in the sandbox agent image.
+pub const IDLE_TIMEOUT_ENV: &str = "OPENWAVE_SANDBOX_IDLE_TIMEOUT_SECS";
 /// Go-template that lists a tagged container's id and correlation tag, tab-separated.
 /// Kept in sync with [`RUN_TAG_LABEL`] by a unit test.
 const TAG_LIST_FORMAT: &str = "{{.ID}}\t{{.Label \"openwave.run-tag\"}}";
@@ -212,6 +214,8 @@ const DEFAULT_LISTENER_PORT: u16 = 8080;
 /// legitimate run, short enough that a container stranded by a dead host does not
 /// outlive the day.
 const DEFAULT_LIFETIME_CAP_SECS: u64 = 4 * 60 * 60;
+/// Reclaim a container whose host no longer proves ownership within two minutes.
+pub(crate) const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 2 * 60;
 
 /// The unprivileged `uid:gid` the container runs as. Kept in sync with the
 /// `USER` directive and the workspace ownership in the sandbox-agent image's
@@ -845,6 +849,8 @@ fn proxy_run_args(
         args.push("--env".to_owned());
         args.push(format!("{LIFETIME_CAP_ENV}={secs}"));
     }
+    args.push("--env".to_owned());
+    args.push(format!("{IDLE_TIMEOUT_ENV}={DEFAULT_IDLE_TIMEOUT_SECS}"));
     args.extend(proxy_hardening_args(&config.hardening));
     args.extend([
         "--publish".to_owned(),
@@ -953,6 +959,8 @@ fn run_args(
         args.push("--env".to_owned());
         args.push(format!("{LIFETIME_CAP_ENV}={secs}"));
     }
+    args.push("--env".to_owned());
+    args.push(format!("{IDLE_TIMEOUT_ENV}={DEFAULT_IDLE_TIMEOUT_SECS}"));
     args.push(config.image.clone());
     args.extend(config.command.iter().cloned());
     args
@@ -1283,6 +1291,7 @@ mod tests {
         // The cap reaches the container as a value, since the agent inside is what
         // enforces it.
         assert!(args.contains(&format!("{LIFETIME_CAP_ENV}=900")));
+        assert!(args.contains(&format!("{IDLE_TIMEOUT_ENV}={DEFAULT_IDLE_TIMEOUT_SECS}")));
 
         // An uncapped provisioning names no cap at all rather than passing a zero
         // the container would read as "expire now".
@@ -1318,6 +1327,7 @@ mod tests {
         assert!(args.contains(&format!("{RELAY_LISTEN_ENV}=0.0.0.0:9000")));
         assert!(args.contains(&format!("{RELAY_TARGET_ENV}={}:9000", sandbox_name(tag))));
         assert!(args.contains(&format!("{LIFETIME_CAP_ENV}=900")));
+        assert!(args.contains(&format!("{IDLE_TIMEOUT_ENV}={DEFAULT_IDLE_TIMEOUT_SECS}")));
         // The default command is the agent image's second face.
         assert_eq!(args.last().unwrap(), "egress-proxy");
         // The proxy keeps the non-root, no-capability, read-only profile.


### PR DESCRIPTION
## Summary

- add a host-to-sandbox keepalive control frame on the reserved transport lane
- send keepalives from the local container driver and reset the sandbox watchdog on authenticated host traffic and run activity
- configure a two-minute idle timeout while retaining the independent four-hour absolute lifetime cap as the wedged-run backstop

## Tests

- `cargo check -p openwave-sandbox-protocol --locked`
- `cargo check -p openwave-sandbox-agent --locked`
- `cargo check -p openwave-server --locked`
- `cargo test -p openwave-sandbox-protocol --locked --test wire_format`
- `cargo test -p openwave-sandbox-protocol --locked host_keepalives_reach_the_sandbox_activity_watchdog`
- `cargo test -p openwave-sandbox-agent --locked --bin openwave-sandbox-agent`
- `cargo test -p openwave-server --locked sandbox_docker::tests::run_args`
- `cargo test -p openwave-server --locked proxy_and_network_args_compose_the_egress_topology`

The existing `openwave-core` unused-code warnings and `proc-macro-error2` future-incompatibility notice remain unchanged.

Closes #1161
