### PR TITLE
feat(protocol): acknowledge reverse operation retention

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -2268,6 +2268,10 @@ impl Store for DbStore {
     async fn operation_log_len(&self, run_id: uuid::Uuid) -> Result<usize> {
         ops::operation_log::len(self, run_id).await
     }
+
+    async fn retained_operation_body_count(&self, run_id: uuid::Uuid) -> Result<usize> {
+        ops::operation_log::retained_body_count(self, run_id).await
+    }
 }
 /// The owner of a document's parent scope: its chat's or project's owner, or
 /// `None` for a standalone document. Callers hold the document-scope write

--- a/crates/openwave-core/src/db/ops/operation_log.rs
+++ b/crates/openwave-core/src/db/ops/operation_log.rs
@@ -270,3 +270,19 @@ pub(in crate::db) async fn len(store: &DbStore, run_id: uuid::Uuid) -> Result<us
         .map_err(store_err)?;
     Ok(count as usize)
 }
+
+/// How many terminal bodies remain retained for replay. Commit markers and
+/// in-flight claims are excluded.
+pub(in crate::db) async fn retained_body_count(
+    store: &DbStore,
+    run_id: uuid::Uuid,
+) -> Result<usize> {
+    let count = entities::operation_log::Entity::find()
+        .filter(operation_log::Column::RunId.eq(run_id))
+        .filter(operation_log::Column::Retained.eq(true))
+        .filter(operation_log::Column::State.ne(STATE_CLAIMED))
+        .count(&store.conn)
+        .await
+        .map_err(store_err)?;
+    Ok(count as usize)
+}

--- a/crates/openwave-core/src/db/ops/operation_log.rs
+++ b/crates/openwave-core/src/db/ops/operation_log.rs
@@ -236,10 +236,9 @@ pub(in crate::db) async fn state(
 /// This deliberately does *not* delete the row: a bare delete is the unsafe
 /// variant, because a re-issue of a deleted identity finds nothing, claims
 /// fresh, and re-executes an effect that already ran. Keeping the marker is what
-/// the schema (`body` nullable, `retained` flag) is shaped for. #859 owns the
-/// retention *policy* — when an entry may be evicted (an acknowledgement/cursor
-/// once the sandbox can no longer re-issue it), and whether very old markers are
-/// ever hard-deleted — layered over this safe primitive. A `Claimed` (still
+/// the schema (`body` nullable, `retained` flag) is shaped for. The
+/// reverse-channel acknowledgement invokes this once the sandbox consumes
+/// the response and can no longer re-issue the identity. A `Claimed` (still
 /// in-flight) entry is left untouched.
 pub(in crate::db) async fn evict(
     store: &DbStore,

--- a/crates/openwave-core/src/db/tests/operation_log.rs
+++ b/crates/openwave-core/src/db/tests/operation_log.rs
@@ -209,6 +209,7 @@ async fn eviction_leaves_a_marker_that_never_re_executes() {
         .await
         .unwrap();
     store.record_operation(run, op, b"body").await.unwrap();
+    assert_eq!(store.retained_operation_body_count(run).await.unwrap(), 1);
 
     // Eviction keeps the row as a commit marker: state stays terminal, but the
     // body is gone and `retained` is cleared. The row survives — a bare delete
@@ -219,6 +220,7 @@ async fn eviction_leaves_a_marker_that_never_re_executes() {
     assert!(!entry.retained);
     assert!(entry.body.is_none());
     assert_eq!(store.operation_log_len(run).await.unwrap(), 1);
+    assert_eq!(store.retained_operation_body_count(run).await.unwrap(), 0);
 
     // A re-issue of an evicted op is answered "done, do not re-execute" — never
     // a fresh claim, and never a decode-of-empty that would look ambiguous.

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -3618,9 +3618,9 @@ pub trait Store: Send + Sync {
         operation_log_storage_unavailable()
     }
 
-    /// Drop an entry once the sandbox can no longer re-issue it. This slice
-    /// removes the row; #859 owns *when* eviction is safe and may instead null
-    /// the body and clear `retained` to leave a commit marker.
+    /// Drop a terminal entry's replay body once the sandbox acknowledges
+    /// consuming its response. The durable row remains as a commit marker so
+    /// the operation identity can never execute again.
     async fn evict_operation(&self, _run_id: uuid::Uuid, _operation_id: uuid::Uuid) -> Result<()> {
         operation_log_storage_unavailable()
     }

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -3630,6 +3630,13 @@ pub trait Store: Send + Sync {
     async fn operation_log_len(&self, _run_id: uuid::Uuid) -> Result<usize> {
         operation_log_storage_unavailable()
     }
+
+    /// How many terminal operation-log bodies remain available for replay.
+    /// Commit markers are excluded so this measures replay retention rather
+    /// than audit/identity cardinality.
+    async fn retained_operation_body_count(&self, _run_id: uuid::Uuid) -> Result<usize> {
+        operation_log_storage_unavailable()
+    }
 }
 
 /// Credential custody: secrets keyed by a stable reference string (e.g.

--- a/crates/openwave-sandbox-protocol/src/conformance.rs
+++ b/crates/openwave-sandbox-protocol/src/conformance.rs
@@ -35,7 +35,7 @@ use tokio::sync::Semaphore;
 
 use crate::{
     ids::{EventCursor, OperationId, RunId, Sequence},
-    oplog::{InMemoryOperationStore, OperationStore},
+    oplog::{InMemoryOperationStore, OperationState, OperationStore},
     protocol::{
         AttachRequest, ErrorCode, Response, MAX_BUFFERED_EVENTS, MAX_EVENT_PAYLOAD_BYTES,
         MAX_MODEL_PROMPT_BYTES, PROTOCOL_VERSION,
@@ -440,7 +440,10 @@ pub async fn reverse_rpc_disconnect_fails_inflight_then_reissue_replays() {
         1,
         "the effect ran exactly once"
     );
-    assert_eq!(store.len(), 1);
+    assert!(matches!(
+        store.state(operation),
+        Some(OperationState::Evicted)
+    ));
 }
 
 /// Re-issuing an operation identity with a different request is refused.

--- a/crates/openwave-sandbox-protocol/src/host.rs
+++ b/crates/openwave-sandbox-protocol/src/host.rs
@@ -188,6 +188,13 @@ impl CapabilityHost {
         }
     }
 
+    /// Acknowledge that the sandbox consumed a terminal response and will never
+    /// re-issue its operation identity. Retention may now discard the replay
+    /// body while the durable store keeps a commit marker.
+    pub fn acknowledge(&self, operation_id: OperationId) {
+        self.shared.store.evict(operation_id);
+    }
+
     /// The capabilities this run may request, for the attach advertisement.
     #[must_use]
     pub fn granted_capabilities(&self) -> Vec<Capability> {

--- a/crates/openwave-sandbox-protocol/src/host.rs
+++ b/crates/openwave-sandbox-protocol/src/host.rs
@@ -334,6 +334,9 @@ mod tests {
         fn len(&self) -> usize {
             0
         }
+        fn retained_body_count(&self) -> usize {
+            0
+        }
     }
 
     struct CountingResponder {

--- a/crates/openwave-sandbox-protocol/src/lib.rs
+++ b/crates/openwave-sandbox-protocol/src/lib.rs
@@ -28,13 +28,11 @@
 //!
 //! # What this slice ships, and what it defers
 //!
-//! This slice ships the protocol contract, the reference backend, and the
-//! conformance suite. It backs the reverse-RPC operation log with an
-//! **in-memory** [`OperationStore`](oplog::OperationStore); the crash-safe
-//! durable operation log (#858) and its retention/eviction policy (#859) are
-//! correctness-critical designs that get their own focused review and are
-//! tracked as follow-ups (see [`oplog`]). The
-//! [`OperationStore`](oplog::OperationStore) trait is the seam they plug into.
+//! This crate ships the protocol contract, reference backend, and conformance
+//! suite. The reference backend uses an in-memory [`OperationStore`], while the
+//! server supplies the crash-safe durable implementation. Reverse responses are
+//! retained for replay until the sandbox acknowledges consuming them; the host
+//! then reduces durable entries to commit markers (see [`oplog`]).
 //!
 //! # Scope of this crate: the types, not the byte transport
 //!

--- a/crates/openwave-sandbox-protocol/src/oplog.rs
+++ b/crates/openwave-sandbox-protocol/src/oplog.rs
@@ -138,9 +138,17 @@ pub trait OperationStore: Send + Sync {
     /// reference store represents it as [`OperationState::Evicted`].
     fn evict(&self, id: OperationId);
 
-    /// How many operations the log currently retains. Chiefly for tests and,
-    /// later, retention accounting.
+    /// How many operation identities the log knows, including body-evicted
+    /// commit markers. This is audit/identity cardinality, not replay-body
+    /// retention.
     fn len(&self) -> usize;
+
+    /// How many terminal response/error bodies remain available for replay.
+    ///
+    /// The protocol bounds this count by [`MAX_INFLIGHT_REQUESTS`](crate::protocol::MAX_INFLIGHT_REQUESTS):
+    /// a sandbox cannot have consumed-and-unacknowledged responses beyond the
+    /// request lane's in-flight window. Commit markers do not count here.
+    fn retained_body_count(&self) -> usize;
 
     /// Whether the log is empty.
     fn is_empty(&self) -> bool {
@@ -228,6 +236,20 @@ impl OperationStore for InMemoryOperationStore {
 
     fn len(&self) -> usize {
         self.entries.lock().expect("operation log lock").len()
+    }
+
+    fn retained_body_count(&self) -> usize {
+        self.entries
+            .lock()
+            .expect("operation log lock")
+            .values()
+            .filter(|entry| {
+                matches!(
+                    entry.state,
+                    OperationState::Recorded(_) | OperationState::Failed(_)
+                )
+            })
+            .count()
     }
 }
 
@@ -321,8 +343,10 @@ mod tests {
         let id = OperationId::new();
         store.claim(id, &request("q"));
         store.record(id, result("a")).unwrap();
+        assert_eq!(store.retained_body_count(), 1);
         store.evict(id);
         assert_eq!(store.len(), 1);
+        assert_eq!(store.retained_body_count(), 0);
         assert!(matches!(store.state(id), Some(OperationState::Evicted)));
         assert!(matches!(
             store.claim(id, &request("q")),

--- a/crates/openwave-sandbox-protocol/src/oplog.rs
+++ b/crates/openwave-sandbox-protocol/src/oplog.rs
@@ -14,14 +14,12 @@
 //! [`OperationStore`] trait is the seam a durable, crash-safe implementation
 //! plugs into; this module ships only an [`InMemoryOperationStore`].
 //!
-//! # TODO: durable, crash-safe operation log (follow-ups #858 and #859)
+//! # Storage and retention
 //!
-//! This in-memory store is **not** crash-safe and has **no retention**, and
-//! those are deliberately out of scope for this protocol slice (see the crate
-//! docs) so the durable correctness work gets its own focused review. Two
-//! follow-ups own them:
+//! This crate's in-memory store is **not** crash-safe; production uses the
+//! durable adapter in `openwave-server`. The shared contract is:
 //!
-//! 1. **Commit ordering (#858).** A durable store persists the
+//! 1. A durable store persists the
 //!    `Claimed -> Recorded / Failed` transition on the run, committed
 //!    transactionally, and answers a re-issue from `Recorded`. Critically, a
 //!    re-issue that finds a `Claimed` entry *with no live in-flight execution* —
@@ -31,11 +29,12 @@
 //!    rather than re-execute a call that may already have spent. The
 //!    [`ClaimOutcome::ClaimedElsewhere`] arm is where that predicate belongs;
 //!    in memory it is unreachable, and [`InMemoryOperationStore`] documents why.
-//! 2. **Retention / eviction (#859).** A sandbox-resident loop issues a reverse
-//!    request per step, so the log is a high-cardinality, per-step structure,
-//!    not the bounded receipt it resembles. [`OperationStore::evict`] is the
-//!    eviction seam; a durable store keys retention to un-acknowledged
-//!    operations and may keep only a commit marker past acknowledgement.
+//! 2. A sandbox-resident loop issues a reverse request per step, so full replay
+//!    bodies are retained only until the sandbox acknowledges consuming the
+//!    terminal response. [`OperationStore::evict`] then reduces the durable
+//!    entry to a commit marker. This bounds retained response bodies by the
+//!    request lane's in-flight window; markers remain for audit and to prevent
+//!    an acknowledged identity from ever executing again.
 
 use std::{
     collections::HashMap,
@@ -131,11 +130,12 @@ pub trait OperationStore: Send + Sync {
     /// The current state of `id`, if the log knows it.
     fn state(&self, id: OperationId) -> Option<OperationState>;
 
-    /// Drop a terminal entry once the sandbox can no longer re-issue `id`.
+    /// Drop a terminal entry's replay body once the sandbox acknowledges it has
+    /// consumed the response and can no longer re-issue `id`.
     ///
-    /// The retention follow-up (see the module TODO) defines *when* this is
-    /// safe — keyed to an acknowledgement/cursor on the reverse channel. This
-    /// slice exposes the seam without a policy.
+    /// Stores keep a commit marker so a stale or invalid re-issue can never
+    /// execute again. Durable stores persist that marker; the in-memory
+    /// reference store represents it as [`OperationState::Evicted`].
     fn evict(&self, id: OperationId);
 
     /// How many operations the log currently retains. Chiefly for tests and,
@@ -218,7 +218,12 @@ impl OperationStore for InMemoryOperationStore {
     }
 
     fn evict(&self, id: OperationId) {
-        self.entries.lock().expect("operation log lock").remove(&id);
+        let mut entries = self.entries.lock().expect("operation log lock");
+        if let Some(entry) = entries.get_mut(&id) {
+            if !matches!(entry.state, OperationState::Claimed) {
+                entry.state = OperationState::Evicted;
+            }
+        }
     }
 
     fn len(&self) -> usize {
@@ -311,13 +316,17 @@ mod tests {
     }
 
     #[test]
-    fn eviction_removes_the_entry() {
+    fn eviction_leaves_a_commit_marker() {
         let store = InMemoryOperationStore::new();
         let id = OperationId::new();
         store.claim(id, &request("q"));
         store.record(id, result("a")).unwrap();
         store.evict(id);
-        assert!(store.is_empty());
-        assert!(store.state(id).is_none());
+        assert_eq!(store.len(), 1);
+        assert!(matches!(store.state(id), Some(OperationState::Evicted)));
+        assert!(matches!(
+            store.claim(id, &request("q")),
+            ClaimOutcome::Replay(OperationState::Evicted)
+        ));
     }
 }

--- a/crates/openwave-sandbox-protocol/src/protocol.rs
+++ b/crates/openwave-sandbox-protocol/src/protocol.rs
@@ -19,9 +19,10 @@ use crate::provisioning::TransportSecret;
 /// protocol is [UNSTABLE](crate) until a named release and offers no
 /// negotiation window across versions.
 ///
-/// Version 2 added the authenticated attach: [`AttachRequest`] carries a per-run
-/// [`TransportSecret`] the sandbox verifies before it installs the connection.
-pub const PROTOCOL_VERSION: u32 = 3;
+/// Version 2 added authenticated attach, version 3 added run initialization,
+/// and version 4 adds sandbox acknowledgement of consumed reverse responses so
+/// the host can evict replay bodies safely.
+pub const PROTOCOL_VERSION: u32 = 4;
 
 /// Largest single reverse-RPC or event frame a conforming transport accepts,
 /// so a peer cannot force unbounded buffering with one enormous frame.

--- a/crates/openwave-sandbox-protocol/src/reference.rs
+++ b/crates/openwave-sandbox-protocol/src/reference.rs
@@ -267,7 +267,10 @@ impl SandboxControl {
         };
         let waiter = host.dispatch(envelope);
         tokio::select! {
-            response = waiter.wait() => ReverseCallOutcome::Settled(response),
+            response = waiter.wait() => {
+                host.acknowledge(operation_id);
+                ReverseCallOutcome::Settled(response)
+            },
             () = wait_disconnected(&mut disconnect) => ReverseCallOutcome::Disconnected,
         }
     }

--- a/crates/openwave-sandbox-protocol/src/reverse.rs
+++ b/crates/openwave-sandbox-protocol/src/reverse.rs
@@ -10,9 +10,9 @@
 //! Two lanes multiplex over one connection. The **request lane**
 //! ([`RequestFrame`]) carries reverse requests and their responses and is
 //! subject to backpressure. The **control lane** ([`ControlFrame`]) carries
-//! cancellation and liveness and is deliberately *separate*, so a cancel or a
-//! heartbeat is never stuck behind the request backlog it is trying to relieve
-//! — the gap the reverse-RPC spike flagged for this step to close.
+//! cancellation, response acknowledgement, and liveness and is deliberately
+//! *separate*, so none is stuck behind the request backlog it is trying to
+//! relieve — the gap the reverse-RPC spike flagged for this step to close.
 
 use std::collections::BTreeSet;
 
@@ -132,10 +132,10 @@ pub enum RequestFrame {
 /// A unit of the **reserved control lane**, distinct from the request lane so
 /// it is never subject to request backpressure.
 ///
-/// Cancellation flows sandbox -> host; liveness flows in both directions, and
-/// the host's keepalive proves that an attached run is still owned. A
-/// conforming transport MUST carry this lane independently of [`RequestFrame`]
-/// (a separate stream, queue, or priority), so a [`ControlFrame::Cancel`] can
+/// Cancellation and acknowledgement flow sandbox -> host; liveness flows in
+/// both directions, and the host's keepalive proves that an attached run is
+/// still owned. A conforming transport MUST carry this lane independently of
+/// [`RequestFrame`] (a separate stream, queue, or priority), so control work can
 /// preempt a saturated request backlog.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(
@@ -148,6 +148,9 @@ pub enum RequestFrame {
 pub enum ControlFrame {
     /// Cancel an in-flight reverse operation by its durable identity.
     Cancel { operation_id: OperationId },
+    /// The sandbox consumed the terminal response and will never re-issue this
+    /// operation identity. The host may evict the replay body to a commit marker.
+    Acknowledge { operation_id: OperationId },
     /// Liveness probe.
     Ping { nonce: u64 },
     /// Liveness response.

--- a/crates/openwave-sandbox-protocol/src/wire/host.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/host.rs
@@ -315,6 +315,9 @@ async fn read_loop<R>(
                 });
             }
             WireFrame::Control(ControlFrame::Cancel { operation_id }) => host.cancel(operation_id),
+            WireFrame::Control(ControlFrame::Acknowledge { operation_id }) => {
+                host.acknowledge(operation_id);
+            }
             WireFrame::Control(ControlFrame::Ping { nonce }) => {
                 let _ = outbound
                     .control

--- a/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
+++ b/crates/openwave-sandbox-protocol/src/wire/sandbox.rs
@@ -317,7 +317,15 @@ impl SandboxRun {
         self.mark_activity();
 
         match rx.await {
-            Ok(response) => ReverseOutcome::Settled(response),
+            Ok(response) => {
+                let _ = conn
+                    .control
+                    .send(WireFrame::Control(ControlFrame::Acknowledge {
+                        operation_id,
+                    }))
+                    .await;
+                ReverseOutcome::Settled(response)
+            }
             Err(_) => ReverseOutcome::Disconnected,
         }
     }
@@ -551,7 +559,11 @@ where
             }
             // The sandbox originates cancels and requests; it never receives
             // them. Pong is liveness only. Ignore rather than trust peer input.
-            WireFrame::Control(ControlFrame::Pong { .. } | ControlFrame::Cancel { .. })
+            WireFrame::Control(
+                ControlFrame::Pong { .. }
+                | ControlFrame::Cancel { .. }
+                | ControlFrame::Acknowledge { .. },
+            )
             | WireFrame::Request(RequestFrame::Request(_))
             | WireFrame::Attach(_)
             | WireFrame::Handshake(_)

--- a/crates/openwave-sandbox-protocol/tests/wire_conformance.rs
+++ b/crates/openwave-sandbox-protocol/tests/wire_conformance.rs
@@ -18,8 +18,8 @@
 //!   ([`wrong_or_absent_secret_is_refused_and_serves_nothing`]), and a refused
 //!   second connection cannot hijack the live one
 //!   ([`a_refused_second_connection_cannot_hijack_the_live_one`]);
-//! - a model-inference reverse call round-trip (with exactly-once replay) —
-//!   [`model_inference_round_trips_and_replays_exactly_once`];
+//! - a model-inference reverse call round-trip with response acknowledgement —
+//!   [`model_inference_round_trips_then_acknowledges_retention`];
 //! - event-stream delivery and resume-by-sequence — [`event_stream_delivers_then_resumes_by_sequence`];
 //! - control-lane cancel preempting a saturated request lane —
 //!   [`control_lane_cancel_preempts_a_saturated_request_lane`].
@@ -46,7 +46,7 @@ use tokio::{
 
 use openwave_sandbox_protocol::{
     ids::{EventCursor, OperationId, RunId, Sequence},
-    oplog::{InMemoryOperationStore, OperationStore},
+    oplog::{InMemoryOperationStore, OperationState, OperationStore},
     protocol::{AttachRequest, ErrorCode, Response, PROTOCOL_VERSION},
     reverse::{
         Capability, CapabilityResponder, GrantSet, ModelInferenceParams, ModelInferenceResult,
@@ -340,10 +340,10 @@ async fn a_refused_second_connection_cannot_hijack_the_live_one() {
     .await;
 }
 
-/// A model-inference reverse call round-trips over the socket, and re-issuing the
-/// same operation identity replays the recorded answer without re-executing.
+/// A model-inference reverse call round-trips over the socket, then the
+/// sandbox's acknowledgement releases its replay body from the operation log.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn model_inference_round_trips_and_replays_exactly_once() {
+async fn model_inference_round_trips_then_acknowledges_retention() {
     bounded(async {
         let run = SandboxRun::new([Capability::ModelInference], expected_secret());
         let addr = spawn_sandbox(run.clone()).await;
@@ -364,20 +364,24 @@ async fn model_inference_round_trips_and_replays_exactly_once() {
         }
         assert_eq!(executions.load(Ordering::SeqCst), 1);
 
-        // Re-issue the same operation identity: the host replays the recorded
-        // outcome from its operation log and does not execute the model again.
-        match run.call(operation, infer("forecast")).await {
-            ReverseOutcome::Settled(Response::Ok(result)) => {
-                assert_eq!(completion(&result), "echo:forecast");
+        // The acknowledgement rides behind the response on the reserved control
+        // lane. Wait for it to be processed, then prove the full replay body was
+        // reduced to an in-memory commit marker.
+        for _ in 0..100 {
+            if matches!(store.state(operation), Some(OperationState::Evicted)) {
+                break;
             }
-            other => panic!("expected a recorded replay, got {other:?}"),
+            tokio::time::sleep(Duration::from_millis(5)).await;
         }
         assert_eq!(
             executions.load(Ordering::SeqCst),
             1,
-            "a replay must not execute the model again"
+            "acknowledgement must not execute the model again"
         );
-        assert_eq!(store.len(), 1, "one distinct operation was recorded");
+        assert!(
+            matches!(store.state(operation), Some(OperationState::Evicted)),
+            "the acknowledged replay body was reduced to a commit marker"
+        );
     })
     .await;
 }

--- a/crates/openwave-sandbox-protocol/tests/wire_conformance.rs
+++ b/crates/openwave-sandbox-protocol/tests/wire_conformance.rs
@@ -382,6 +382,12 @@ async fn model_inference_round_trips_then_acknowledges_retention() {
             matches!(store.state(operation), Some(OperationState::Evicted)),
             "the acknowledged replay body was reduced to a commit marker"
         );
+        assert_eq!(store.len(), 1, "the audit/identity marker remains");
+        assert_eq!(
+            store.retained_body_count(),
+            0,
+            "acknowledgement releases the replay body"
+        );
     })
     .await;
 }

--- a/crates/openwave-sandbox-protocol/tests/wire_format.rs
+++ b/crates/openwave-sandbox-protocol/tests/wire_format.rs
@@ -226,6 +226,17 @@ fn control_lane_frames_wire_shapes() {
     roundtrip(&cancel);
     golden(&cancel, &[("/control", json!("cancel"))]);
 
+    let operation_id = OperationId::new();
+    let acknowledge = ControlFrame::Acknowledge { operation_id };
+    roundtrip(&acknowledge);
+    golden(
+        &acknowledge,
+        &[
+            ("/control", json!("acknowledge")),
+            ("/body/operation_id", json!(operation_id.to_string())),
+        ],
+    );
+
     let ping = ControlFrame::Ping { nonce: 9 };
     roundtrip(&ping);
     golden(

--- a/crates/openwave-server/src/durable_oplog.rs
+++ b/crates/openwave-server/src/durable_oplog.rs
@@ -191,6 +191,15 @@ impl DurableOperationStore {
             .await
             .map_err(backend)
     }
+
+    /// How many terminal bodies remain available for replay. Commit markers do
+    /// not count, keeping replay retention distinct from audit cardinality.
+    pub async fn retained_body_count_op(&self) -> Result<usize, StoreError> {
+        self.store
+            .retained_operation_body_count(self.run_id.as_uuid())
+            .await
+            .map_err(backend)
+    }
 }
 
 /// The synchronous [`OperationStore`] seam the capability host calls, bridged to
@@ -244,6 +253,16 @@ impl OperationStore for DurableOperationStore {
             Ok(len) => len,
             Err(error) => {
                 eprintln!("openwave: durable operation-log length read failed: {error}");
+                0
+            }
+        }
+    }
+
+    fn retained_body_count(&self) -> usize {
+        match block_on(self.retained_body_count_op()) {
+            Ok(count) => count,
+            Err(error) => {
+                eprintln!("openwave: durable retained operation-body count failed: {error}");
                 0
             }
         }
@@ -364,8 +383,11 @@ mod tests {
 
         log.claim_op(op, &request("q")).await.unwrap();
         log.record_op(op, result("done")).await.unwrap();
+        assert_eq!(log.retained_body_count_op().await.unwrap(), 1);
         // Retention (#859) evicts the completed body down to a commit marker.
         log.evict_op(op).await.unwrap();
+        assert_eq!(log.len_op().await.unwrap(), 1);
+        assert_eq!(log.retained_body_count_op().await.unwrap(), 0);
 
         // A re-issue is answered "already recorded, do not re-execute" — an
         // `Evicted` replay, distinctly NOT the after-crash `ClaimedElsewhere`

--- a/crates/openwave-server/src/durable_oplog.rs
+++ b/crates/openwave-server/src/durable_oplog.rs
@@ -174,9 +174,9 @@ impl DurableOperationStore {
         Ok(Some(state))
     }
 
-    /// Evict a terminal entry's body down to a commit marker once it can no
-    /// longer be re-issued; a later re-issue then replays as `Evicted`, never
-    /// re-executing. #859 owns the retention policy over this safe primitive.
+    /// Evict a terminal entry's body down to a commit marker after the sandbox
+    /// acknowledges consuming its response; a later invalid re-issue then
+    /// resolves as `Evicted`, never re-executing.
     pub async fn evict_op(&self, id: OperationId) -> Result<(), StoreError> {
         self.store
             .evict_operation(self.run_id.as_uuid(), id.as_uuid())


### PR DESCRIPTION
## Summary

- add a versioned reverse-channel acknowledgement after the sandbox consumes a terminal response
- retain replay bodies only until acknowledgement, then reduce entries to non-reexecuting commit markers
- expose retained-body accounting separately from operation-marker cardinality
- carry acknowledgement over the reserved control lane and cover its wire shape and end-to-end retention boundary

## Retention decisions

- replay retention and audit retention are distinct: full response/error bodies are counted separately from durable operation markers
- full bodies are bounded by unacknowledged reverse operations, which are bounded by the request lane in-flight window
- acknowledgement is idempotent and keyed by `OperationId`; duplicate acknowledgements leave the same marker state
- the existing event cursor remains the event-stream commit watermark; model responses are not ordered in that event sequence, so coupling response eviction to it could evict an unconsumed response
- durable entries keep the operation fingerprint and terminal state as an audit/idempotency marker; only replay bodies are discarded

## Verification

- `cargo fmt --all --check`
- `cargo check -p openwave-sandbox-protocol --locked`
- `cargo check -p openwave-core --locked`
- `cargo check -p openwave-server --locked`
- `cargo test -p openwave-sandbox-protocol --locked`
- `cargo test -p openwave-server durable_oplog --locked`
- `cargo test -p openwave-core operation_log --locked`

Closes #859