### PR TITLE
feat(desktop): add local and Gemini voice input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
+            cmake \
             libwebkit2gtk-4.1-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev \
@@ -378,7 +379,7 @@ jobs:
       - name: Install headless system deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends mold
+          sudo apt-get install -y --no-install-recommends cmake mold
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: cargo-registry-v3-${{ hashFiles('Cargo.lock') }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ design before large changes.
 
 ## Development
 
+Desktop builds require CMake to compile the pinned whisper.cpp local voice engine (`brew install cmake` on macOS; install the `cmake` package on Linux).
+
 ```sh
 # Run the desktop app: installs the UI dependencies, then opens the window.
 # Arguments are forwarded to `cargo tauri dev`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex 1.3.0",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,7 +1005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -993,6 +1013,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
 
 [[package]]
 name = "cfb"
@@ -1060,6 +1089,26 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1634,7 +1683,7 @@ dependencies = [
  "cssparser 0.37.0",
  "foldhash",
  "html5ever 0.39.0",
- "nom",
+ "nom 8.0.0",
  "precomputed-hash",
  "selectors 0.38.0",
  "tendril",
@@ -2022,6 +2071,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -3017,6 +3072,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -3323,7 +3387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -3350,6 +3414,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3513,6 +3587,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3611,6 +3691,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -4058,11 +4148,13 @@ dependencies = [
  "openwave-core",
  "openwave-host-broker",
  "openwave-server",
+ "opus-decoder",
  "reqwest 0.12.28",
  "semver",
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "symphonia",
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",
@@ -4077,6 +4169,7 @@ dependencies = [
  "unicode-general-category",
  "url",
  "uuid",
+ "whisper-rs",
  "windows-sys 0.61.2",
  "zip 8.6.0",
 ]
@@ -4249,6 +4342,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "opus-decoder"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ae32c275dabb0cd2c863460bf349e9abc3568ba2abf0f9eb7b7d2edeeed07e"
+dependencies = [
+ "thiserror 2.0.19",
+]
 
 [[package]]
 name = "ordered-float"
@@ -5043,6 +5145,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5471,7 +5579,7 @@ dependencies = [
  "derive-where",
  "derive_more",
  "futures-util",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "mac_address",
  "ouroboros",
@@ -5531,7 +5639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4cbb7ae053b9b37c919ea944a3bc52f7830a90c223f8a765c908293bca8f22d"
 dependencies = [
  "heck 0.5.0",
- "itertools",
+ "itertools 0.14.0",
  "pluralizer",
  "proc-macro2",
  "quote",
@@ -5991,6 +6099,12 @@ dependencies = [
 
 [[package]]
 name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
@@ -6418,6 +6532,106 @@ dependencies = [
  "base64 0.21.7",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "symphonia"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1758d6c853020a7244de03cc3e0185eaea3f58715122422dd3cc7452e6d4c16a"
+dependencies = [
+ "lazy_static",
+ "symphonia-codec-aac",
+ "symphonia-codec-alac",
+ "symphonia-core",
+ "symphonia-format-isomp4",
+ "symphonia-format-mkv",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-aac"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1979c515a76371b186aad2feff5f23e21cbec775bf95de08bf1e3af92a2ad76"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-common",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-alac"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a149cbfc7fb5c405d123a273227d31de17138419552112bf1aa7b73e65827b8"
+dependencies = [
+ "log",
+ "symphonia-common",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-common"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8257891ffa7f05e02b58f4761e2abf7e5278c8744fd59e981559e050f86eef55"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ec293b5f288383b72a7bffcade6b2860b642cf66f28b3bd5967349a49938b1"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "lazy_static",
+ "log",
+ "num-complex",
+ "smallvec",
+]
+
+[[package]]
+name = "symphonia-format-isomp4"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d179a01305b3505940135a9f0180d6ef4b487912748fe97554756f120fbd05e"
+dependencies = [
+ "log",
+ "symphonia-common",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb17713e134f5ad316c2690fa3104590ccc85842cdbcf82c3cd1a845cb08aa74"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-common",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31acf5cd623398a6208e2225d18f4b20f761c55098a796a5247ad516a4a8681"
+dependencies = [
+ "lazy_static",
+ "log",
+ "regex-lite",
+ "smallvec",
+ "symphonia-core",
 ]
 
 [[package]]
@@ -7982,6 +8196,28 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "whisper-rs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
+dependencies = [
+ "whisper-rs-sys",
+]
+
+[[package]]
+name = "whisper-rs-sys"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
+dependencies = [
+ "bindgen",
+ "cfg-if",
+ "cmake",
+ "fs_extra",
+ "semver",
+]
 
 [[package]]
 name = "whoami"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,9 @@ tokio-util = { version = "=0.7.19", features = ["io-util"] }
 reqwest = { version = "=0.12.28", default-features = false, features = ["json", "multipart", "stream", "rustls-tls"] }
 ring = "=0.17.14"
 sha2 = "=0.11.0"
+symphonia = { version = "=0.6.0", default-features = false, features = ["aac", "alac", "isomp4", "mkv"] }
+opus-decoder = "=0.1.1"
+whisper-rs = "=0.16.0"
 base64 = "=0.23.0"
 libc = "=0.2.189"
 async-stream = "=0.3.6"

--- a/crates/openwave-desktop/Cargo.toml
+++ b/crates/openwave-desktop/Cargo.toml
@@ -43,6 +43,8 @@ openwave-server = { path = "../openwave-server" }
 reqwest = { workspace = true }
 semver = "=1.0.28"
 sha2 = { workspace = true }
+symphonia = { workspace = true }
+opus-decoder = { workspace = true }
 tauri = { version = "=2.11.5", features = [] }
 tauri-plugin-deep-link = "=2.4.9"
 tauri-plugin-dialog = "=2.7.2"
@@ -56,6 +58,7 @@ tokio-util = { workspace = true }
 unicode-general-category = { workspace = true }
 url = "=2.5.8"
 uuid = { workspace = true }
+whisper-rs = { workspace = true }
 tempfile.workspace = true
 zip.workspace = true
 

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -26,6 +26,7 @@ mod media_type;
 mod office_install;
 mod office_pdf;
 mod updater;
+mod voice_transcription;
 
 /// Connection details the webview needs to reach the in-process API.
 #[derive(Clone, Serialize)]
@@ -323,15 +324,19 @@ async fn boot_server(
     ));
     // The exec provider renders office outputs with the same managed/system
     // LibreOffice the preview panel converts with.
-    let office_converter = Arc::new(office_pdf::ExecOfficeConverter::new(data_dir));
+    let office_converter = Arc::new(office_pdf::ExecOfficeConverter::new(data_dir.clone()));
     // Skill-declared host tools warm and report through the managed installer.
     let host_tool_broker = Arc::new(office_install::DesktopHostToolBroker::new(app.clone()));
+    let local_voice = Arc::new(voice_transcription::DesktopLocalVoiceRunner::new(
+        data_dir.clone(),
+    ));
     let server = openwave_server::bind_configured_with_desktop_executor_and_folder_grants(
         config,
         client_executor_id,
         folder_grants,
         Some(office_converter),
         Some(host_tool_broker),
+        Some(local_voice),
     )
     .await
     .map_err(|e| e.to_string())?;

--- a/crates/openwave-desktop/src/voice_transcription.rs
+++ b/crates/openwave-desktop/src/voice_transcription.rs
@@ -1,0 +1,411 @@
+//! Trusted desktop-local voice transcription.
+//!
+//! The renderer sends only recorded bytes to the loopback API. This native
+//! runner owns the pinned model path, download verification, media decoding,
+//! resampling, and whisper.cpp inference.
+
+use std::io::{Cursor, Read as _};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use futures::StreamExt as _;
+use openwave_server::{LocalVoiceRunner, LocalVoiceState, LocalVoiceStatus};
+use sha2::{Digest, Sha256};
+use symphonia::core::codecs::audio::AudioDecoderOptions;
+use symphonia::core::codecs::CodecParameters;
+use symphonia::core::errors::Error as SymphoniaError;
+use symphonia::core::formats::probe::Hint;
+use symphonia::core::formats::{FormatOptions, TrackType};
+use symphonia::core::io::MediaSourceStream;
+use symphonia::core::meta::MetadataOptions;
+use tokio::io::AsyncWriteExt as _;
+use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
+
+const MODEL_VERSION: &str = "whisper.cpp-c521a4b02f422512d734391fdf08bb08c0862f68-tiny.en-q5_1";
+const MODEL_URL: &str = "https://huggingface.co/ggerganov/whisper.cpp/resolve/c521a4b02f422512d734391fdf08bb08c0862f68/ggml-tiny.en-q5_1.bin";
+const MODEL_SHA256: &str = "c77c5766f1cef09b6b7d47f21b546cbddd4157886b3b5d6d4f709e91e66c7c2b";
+const MODEL_BYTES: u64 = 32_166_155;
+const WHISPER_SAMPLE_RATE: u32 = 16_000;
+
+#[derive(Clone)]
+pub(crate) struct DesktopLocalVoiceRunner {
+    data_dir: PathBuf,
+    state: Arc<Mutex<RuntimeState>>,
+    install_lock: Arc<tokio::sync::Mutex<()>>,
+}
+
+#[derive(Default)]
+struct RuntimeState {
+    downloading: bool,
+    downloaded_bytes: u64,
+    total_bytes: Option<u64>,
+    error: Option<String>,
+}
+
+impl DesktopLocalVoiceRunner {
+    pub(crate) fn new(data_dir: PathBuf) -> Self {
+        Self {
+            data_dir,
+            state: Arc::default(),
+            install_lock: Arc::default(),
+        }
+    }
+
+    fn model_dir(&self) -> PathBuf {
+        self.data_dir
+            .join("models")
+            .join("voice")
+            .join(MODEL_VERSION)
+    }
+
+    fn model_path(&self) -> PathBuf {
+        self.model_dir().join("model.bin")
+    }
+
+    fn marker_path(&self) -> PathBuf {
+        self.model_dir().join("installed.json")
+    }
+
+    fn installed(&self) -> bool {
+        let Ok(marker) = std::fs::read(self.marker_path()) else {
+            return false;
+        };
+        let Ok(marker): Result<serde_json::Value, _> = serde_json::from_slice(&marker) else {
+            return false;
+        };
+        marker["version"].as_str() == Some(MODEL_VERSION)
+            && marker["sha256"].as_str() == Some(MODEL_SHA256)
+            && self.model_path().is_file()
+    }
+
+    fn status_now(&self) -> LocalVoiceStatus {
+        if self.installed() {
+            return LocalVoiceStatus {
+                state: LocalVoiceState::Ready,
+                downloaded_bytes: Some(MODEL_BYTES),
+                total_bytes: Some(MODEL_BYTES),
+                error: None,
+            };
+        }
+        let state = self.state.lock().expect("voice state lock");
+        LocalVoiceStatus {
+            state: if state.downloading {
+                LocalVoiceState::Downloading
+            } else if state.error.is_some() {
+                LocalVoiceState::Failed
+            } else {
+                LocalVoiceState::NotInstalled
+            },
+            downloaded_bytes: state.downloading.then_some(state.downloaded_bytes),
+            total_bytes: state.total_bytes,
+            error: state.error.clone(),
+        }
+    }
+
+    async fn ensure_installed(&self) -> Result<LocalVoiceStatus, String> {
+        let _guard = self.install_lock.lock().await;
+        if self.installed() {
+            return Ok(self.status_now());
+        }
+        {
+            let mut state = self.state.lock().expect("voice state lock");
+            state.downloading = true;
+            state.downloaded_bytes = 0;
+            state.total_bytes = Some(MODEL_BYTES);
+            state.error = None;
+        }
+        let outcome = self.download_model().await;
+        let mut state = self.state.lock().expect("voice state lock");
+        state.downloading = false;
+        state.error = outcome.as_ref().err().cloned();
+        drop(state);
+        outcome.map(|()| self.status_now())
+    }
+
+    async fn download_model(&self) -> Result<(), String> {
+        let directory = self.model_dir();
+        tokio::fs::create_dir_all(&directory)
+            .await
+            .map_err(|error| {
+                format!("Could not prepare the local voice model directory: {error}")
+            })?;
+        let partial = directory.join("model.bin.partial");
+        let _ = tokio::fs::remove_file(&partial).await;
+        let response = reqwest::Client::new()
+            .get(MODEL_URL)
+            .send()
+            .await
+            .map_err(|_| "Could not download the local voice model".to_owned())?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "Could not download the local voice model: server answered {}",
+                response.status()
+            ));
+        }
+        let mut file = tokio::fs::File::create(&partial)
+            .await
+            .map_err(|error| format!("Could not write the local voice model: {error}"))?;
+        let mut stream = response.bytes_stream();
+        let mut downloaded = 0_u64;
+        while let Some(chunk) = stream.next().await {
+            let chunk =
+                chunk.map_err(|_| "The local voice model download was interrupted".to_owned())?;
+            file.write_all(&chunk)
+                .await
+                .map_err(|error| format!("Could not write the local voice model: {error}"))?;
+            downloaded += chunk.len() as u64;
+            self.state
+                .lock()
+                .expect("voice state lock")
+                .downloaded_bytes = downloaded;
+        }
+        file.flush()
+            .await
+            .map_err(|error| format!("Could not write the local voice model: {error}"))?;
+        drop(file);
+        let digest = sha256_file(&partial)
+            .map_err(|error| format!("Could not verify the local voice model: {error}"))?;
+        if digest != MODEL_SHA256 {
+            let _ = tokio::fs::remove_file(&partial).await;
+            return Err("The downloaded local voice model failed its pinned SHA-256 check and was discarded".into());
+        }
+        tokio::fs::rename(&partial, self.model_path())
+            .await
+            .map_err(|error| format!("Could not install the local voice model: {error}"))?;
+        let marker = serde_json::to_vec_pretty(
+            &serde_json::json!({"version": MODEL_VERSION, "sha256": MODEL_SHA256}),
+        )
+        .map_err(|_| "Could not record the local voice model install".to_owned())?;
+        let marker_partial = directory.join("installed.json.partial");
+        tokio::fs::write(&marker_partial, marker)
+            .await
+            .map_err(|error| format!("Could not record the local voice model install: {error}"))?;
+        tokio::fs::rename(&marker_partial, self.marker_path())
+            .await
+            .map_err(|error| format!("Could not record the local voice model install: {error}"))?;
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl LocalVoiceRunner for DesktopLocalVoiceRunner {
+    async fn status(&self) -> LocalVoiceStatus {
+        self.status_now()
+    }
+
+    async fn install(&self) -> Result<LocalVoiceStatus, String> {
+        self.ensure_installed().await
+    }
+
+    async fn transcribe(&self, content_type: &str, audio: Vec<u8>) -> Result<String, String> {
+        self.ensure_installed().await?;
+        let model = self.model_path();
+        let content_type = content_type.to_owned();
+        tokio::task::spawn_blocking(move || transcribe_blocking(&model, &content_type, audio))
+            .await
+            .map_err(|_| "Local voice transcription worker stopped unexpectedly".to_owned())?
+    }
+}
+
+fn transcribe_blocking(model: &Path, content_type: &str, audio: Vec<u8>) -> Result<String, String> {
+    let samples = decode_audio(content_type, audio)?;
+    let context = WhisperContext::new_with_params(model, WhisperContextParameters::default())
+        .map_err(|_| "Could not load the local voice model".to_owned())?;
+    let mut state = context
+        .create_state()
+        .map_err(|_| "Could not initialize local voice transcription".to_owned())?;
+    let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+    params.set_language(Some("en"));
+    params.set_translate(false);
+    params.set_no_context(true);
+    params.set_print_progress(false);
+    params.set_print_realtime(false);
+    params.set_print_timestamps(false);
+    state
+        .full(params, &samples)
+        .map_err(|_| "Local voice transcription failed".to_owned())?;
+    let mut text = String::new();
+    for segment in state.as_iter() {
+        text.push_str(
+            &segment
+                .to_str_lossy()
+                .map_err(|_| "Local voice transcription returned invalid text".to_owned())?,
+        );
+    }
+    Ok(text.trim().to_owned())
+}
+
+fn decode_audio(content_type: &str, audio: Vec<u8>) -> Result<Vec<f32>, String> {
+    let mime = content_type.split(';').next().unwrap_or("");
+    if !matches!(mime, "audio/webm" | "audio/mp4") {
+        return Err("Unsupported voice recording format".into());
+    }
+    let mut hint = Hint::new();
+    hint.with_extension(if mime == "audio/mp4" { "m4a" } else { "webm" });
+    let source = MediaSourceStream::new(Box::new(Cursor::new(audio)), Default::default());
+    let mut format = symphonia::default::get_probe()
+        .probe(
+            &hint,
+            source,
+            FormatOptions::default(),
+            MetadataOptions::default(),
+        )
+        .map_err(|_| "Could not read the voice recording container".to_owned())?;
+    let track = format
+        .default_track(TrackType::Audio)
+        .ok_or_else(|| "The voice recording has no audio track".to_owned())?;
+    let track_id = track.id;
+    let CodecParameters::Audio(params) = track
+        .codec_params
+        .as_ref()
+        .ok_or_else(|| "The voice recording has no audio codec".to_owned())?
+    else {
+        return Err("The voice recording has no audio codec".into());
+    };
+    let rate = params
+        .sample_rate
+        .ok_or_else(|| "The voice recording has no sample rate".to_owned())?;
+    let channels = params
+        .channels
+        .as_ref()
+        .map(|channels| channels.count())
+        .ok_or_else(|| "The voice recording has no channel layout".to_owned())?;
+    if !(1..=2).contains(&channels) {
+        return Err("Voice recordings must be mono or stereo".into());
+    }
+    let mut interleaved = Vec::new();
+    if params.codec.to_string() == "0x1001" {
+        let mut decoder = opus_decoder::OpusDecoder::new(rate, channels)
+            .map_err(|_| "Could not initialize the Opus decoder".to_owned())?;
+        let mut pcm = vec![0_i16; decoder.max_frame_size_per_channel() * channels];
+        loop {
+            match format.next_packet() {
+                Ok(Some(packet)) if packet.track_id == track_id => {
+                    let frames = decoder
+                        .decode(&packet.data, &mut pcm, false)
+                        .map_err(|_| "Could not decode the WebM/Opus recording".to_owned())?;
+                    interleaved.extend(
+                        pcm[..frames * channels]
+                            .iter()
+                            .map(|sample| *sample as f32 / i16::MAX as f32),
+                    );
+                }
+                Ok(Some(_)) => {}
+                Ok(None) | Err(SymphoniaError::IoError(_)) => break,
+                Err(_) => return Err("Could not read the WebM/Opus recording".into()),
+            }
+        }
+    } else {
+        let mut decoder = symphonia::default::get_codecs()
+            .make_audio_decoder(params, &AudioDecoderOptions::default())
+            .map_err(|_| "Unsupported codec in voice recording".to_owned())?;
+        loop {
+            match format.next_packet() {
+                Ok(Some(packet)) if packet.track_id == track_id => match decoder.decode(&packet) {
+                    Ok(buffer) => {
+                        let start = interleaved.len();
+                        interleaved.resize(start + buffer.samples_interleaved(), 0.0);
+                        buffer.copy_to_slice_interleaved(&mut interleaved[start..]);
+                    }
+                    Err(SymphoniaError::DecodeError(_)) => {}
+                    Err(_) => return Err("Could not decode the MP4 recording".into()),
+                },
+                Ok(Some(_)) => {}
+                Ok(None) | Err(SymphoniaError::IoError(_)) => break,
+                Err(_) => return Err("Could not read the MP4 recording".into()),
+            }
+        }
+    }
+    if interleaved.is_empty() {
+        return Err("The voice recording contained no decodable audio".into());
+    }
+    let mono: Vec<f32> = if channels == 1 {
+        interleaved
+    } else {
+        interleaved
+            .chunks_exact(2)
+            .map(|pair| (pair[0] + pair[1]) * 0.5)
+            .collect()
+    };
+    Ok(resample_linear(&mono, rate, WHISPER_SAMPLE_RATE))
+}
+
+fn resample_linear(input: &[f32], source_rate: u32, target_rate: u32) -> Vec<f32> {
+    if source_rate == target_rate {
+        return input.to_vec();
+    }
+    let output_len = ((input.len() as u64 * target_rate as u64) / source_rate as u64) as usize;
+    let ratio = source_rate as f64 / target_rate as f64;
+    (0..output_len)
+        .map(|index| {
+            let position = index as f64 * ratio;
+            let left = position.floor() as usize;
+            let right = (left + 1).min(input.len() - 1);
+            let fraction = (position - left as f64) as f32;
+            input[left] + (input[right] - input[left]) * fraction
+        })
+        .collect()
+}
+
+fn sha256_file(path: &Path) -> std::io::Result<String> {
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 1024 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    Ok(hex)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resampling_preserves_endpoints_and_expected_length() {
+        let output = resample_linear(&[0.0, 1.0, 0.0, -1.0], 4, 8);
+        assert_eq!(output.len(), 8);
+        assert_eq!(output[0], 0.0);
+    }
+
+    #[test]
+    fn marker_must_match_the_exact_pinned_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner = DesktopLocalVoiceRunner::new(dir.path().to_owned());
+        std::fs::create_dir_all(runner.model_dir()).unwrap();
+        std::fs::write(runner.model_path(), b"model").unwrap();
+        std::fs::write(
+            runner.marker_path(),
+            br#"{"version":"other","sha256":"bad"}"#,
+        )
+        .unwrap();
+        assert!(!runner.installed());
+    }
+
+    #[test]
+    #[ignore = "downloads the pinned model and runs real local inference"]
+    fn transcribes_real_webm_and_mp4_fixtures() {
+        let webm = std::env::var("OPENWAVE_TEST_VOICE_WEBM").expect("webm fixture path");
+        let mp4 = std::env::var("OPENWAVE_TEST_VOICE_MP4").expect("mp4 fixture path");
+        let model = std::env::var("OPENWAVE_TEST_VOICE_MODEL").expect("model path");
+        for (mime, path) in [("audio/webm", webm), ("audio/mp4", mp4)] {
+            let text = transcribe_blocking(
+                Path::new(&model),
+                mime,
+                std::fs::read(path).expect("voice fixture"),
+            )
+            .expect("local transcription");
+            assert!(!text.is_empty());
+        }
+    }
+}

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -74,6 +74,7 @@ import { TranscriptVisibilityProvider } from "./TranscriptVisibility";
 import { useTurnLifecycle } from "./TurnLifecycleSignals";
 import { useChatFolderAttachments } from "./useChatFolderAttachments";
 import { appendTranscript, useVoiceComposer } from "./useVoiceComposer";
+import { useVoiceInputStore, voiceSelectionReady } from "./VoiceInputStore";
 
 let msgSeq = 0;
 
@@ -288,9 +289,18 @@ export function ChatRoute({ chatId }: { chatId: string }) {
     composerDraftActions.setDraft(chatId, next);
   }
 
-  const voice = useVoiceComposer((audio) => client.transcribeVoice(audio), (transcript) => {
-    setComposerDraft(appendTranscript(draftRef.current, transcript));
-  });
+  const voice = useVoiceComposer(
+    (audio) => client.transcribeVoice(audio),
+    (transcript) => setComposerDraft(appendTranscript(draftRef.current, transcript)),
+    undefined,
+    async () => {
+      const info = await useVoiceInputStore.getState().load(client);
+      if (voiceSelectionReady(info)) return true;
+      const path: string = "/settings/voice-transcription";
+      await navigate({ to: path });
+      return false;
+    },
+  );
 
   function setComposerFiles(
     update: (current: readonly ImportedDocument[]) => ImportedDocument[],

--- a/crates/openwave-desktop/ui/src/Composer.test.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.test.tsx
@@ -157,9 +157,25 @@ describe("Composer", () => {
     );
 
     expect(markup).toContain('placeholder="Transcribing…"');
-    expect(markup).toContain("Transcribing…");
+    expect(markup).toContain('placeholder="Transcribing…"');
     expect(markup).toContain('aria-label="Transcribing voice recording"');
+    expect(markup).toContain("lucide-mic");
+    expect(markup).not.toContain("lucide-loader-circle");
     expect(markup).not.toContain('<textarea disabled=""');
+  });
+
+  it("keeps the mic active while requesting and disables it only while transcribing", () => {
+    const requesting = renderToStaticMarkup(
+      <Composer activeTurnId={null} busy={false} cancelError={null} cancelPending={false} disabled={false} draft="" voice={{ available: true, state: "requesting", error: null, onStart: vi.fn(), onStop: vi.fn() }} onDraftChange={vi.fn()} onSend={noop} onSteer={noop} onStop={noop} resetKey="chat-1" steerError={null} steerPending={false} steerStatus={null} />,
+    );
+    const transcribing = renderToStaticMarkup(
+      <Composer activeTurnId={null} busy={false} cancelError={null} cancelPending={false} disabled={false} draft="" voice={{ available: true, state: "transcribing", error: null, onStart: vi.fn(), onStop: vi.fn() }} onDraftChange={vi.fn()} onSend={noop} onSteer={noop} onStop={noop} resetKey="chat-1" steerError={null} steerPending={false} steerStatus={null} />,
+    );
+    expect(requesting).toContain('aria-label="Waiting for microphone permission"');
+    expect(requesting).not.toContain('aria-label="Waiting for microphone permission" disabled=""');
+    expect(requesting).toContain("lucide-mic");
+    expect(transcribing).toContain('aria-label="Transcribing voice recording" disabled=""');
+    expect(transcribing).toContain("lucide-mic");
   });
 
   it("keeps one action slot and presents the stop control during a turn", () => {

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -453,16 +453,14 @@ export function Composer({
               label={
                 voice.state === "recording"
                   ? "Stop recording"
-                  : voice.state === "requesting"
-                    ? "Waiting for microphone…"
-                    : voice.state === "transcribing"
+                  : voice.state === "transcribing"
                       ? "Transcribing…"
-                      : "Record voice"
+                      : "Record voice input"
               }
             >
               <Button
                 type="button"
-                variant={voice.state === "recording" ? "secondary" : "ghost"}
+                variant={voice.state === "idle" ? "outline" : "default"}
                 size="icon-8"
                 aria-label={
                   voice.state === "recording"
@@ -475,21 +473,13 @@ export function Composer({
                 }
                 disabled={
                   inputDisabled ||
-                  voice.state === "requesting" ||
                   voice.state === "transcribing"
                 }
                 onClick={
                   voice.state === "recording" ? voice.onStop : voice.onStart
                 }
               >
-                {voice.state === "requesting" ||
-                voice.state === "transcribing" ? (
-                  <LoaderCircle className="animate-spin" size={15} />
-                ) : voice.state === "recording" ? (
-                  <Square size={12} fill="currentColor" strokeWidth={0} />
-                ) : (
-                  <Mic size={15} />
-                )}
+                <Mic size={15} />
               </Button>
             </WithTooltip>
           )}
@@ -548,11 +538,6 @@ export function Composer({
             ? "Agent is responding"
             : "Ready to send"}
       </span>
-      {voiceWorking && (
-        <span className="text-xs text-muted-foreground" role="status">
-          {voice?.state === "transcribing" ? "Transcribing…" : "Listening…"}
-        </span>
-      )}
       {voice?.error && (
         <span className="text-xs text-destructive" role="alert">
           {voice.error}

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -38,6 +38,7 @@ import { WelcomeState } from "./WelcomeState";
 import type { AttachedFiles } from "./attachments";
 import { MAX_IMAGE_ATTACHMENTS } from "./ImageAttachments";
 import { appendTranscript, useVoiceComposer } from "./useVoiceComposer";
+import { useVoiceInputStore, voiceSelectionReady } from "./VoiceInputStore";
 
 const chatListActions = useChatListStore.getState();
 const composerDraftActions = useComposerDrafts.getState();
@@ -56,10 +57,21 @@ export function HomeRoute() {
   const draft = useComposerDraft(HOME_DRAFT_KEY);
   const setDraft = (text: string) =>
     composerDraftActions.setDraft(HOME_DRAFT_KEY, text);
-  const voice = useVoiceComposer((audio) => client.transcribeVoice(audio), (transcript) => {
-    const current = useComposerDrafts.getState().drafts[HOME_DRAFT_KEY] ?? "";
-    setDraft(appendTranscript(current, transcript));
-  });
+  const voice = useVoiceComposer(
+    (audio) => client.transcribeVoice(audio),
+    (transcript) => {
+      const current = useComposerDrafts.getState().drafts[HOME_DRAFT_KEY] ?? "";
+      setDraft(appendTranscript(current, transcript));
+    },
+    undefined,
+    async () => {
+      const info = await useVoiceInputStore.getState().load(client);
+      if (voiceSelectionReady(info)) return true;
+      const path: string = "/settings/voice-transcription";
+      await navigate({ to: path });
+      return false;
+    },
+  );
   const [error, setError] = useState<string | null>(null);
   const newChat = useNewChatSettings();
   // What the pickers show and the created chat will get: this visit's picks

--- a/crates/openwave-desktop/ui/src/VoiceInputRequiredButton.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/VoiceInputRequiredButton.dom.test.tsx
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { renderWithRouter } from "./test/router";
+import { VoiceInputRequiredButton } from "./VoiceInputRequiredButton";
+
+describe("voice input settings routing", () => {
+  it("takes an unavailable voice model directly to voice input settings", async () => {
+    const user = userEvent.setup();
+    const { router } = await renderWithRouter(<VoiceInputRequiredButton />);
+
+    await user.click(screen.getByRole("button", { name: "Configure voice input" }));
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/settings/voice-transcription");
+    });
+  });
+});

--- a/crates/openwave-desktop/ui/src/VoiceInputRequiredButton.tsx
+++ b/crates/openwave-desktop/ui/src/VoiceInputRequiredButton.tsx
@@ -1,0 +1,12 @@
+import { useNavigate } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
+
+export function VoiceInputRequiredButton() {
+  const navigate = useNavigate();
+  const settingsPath: string = "/settings/voice-transcription";
+  return (
+    <Button type="button" onClick={() => void navigate({ to: settingsPath })}>
+      Configure voice input
+    </Button>
+  );
+}

--- a/crates/openwave-desktop/ui/src/VoiceInputStore.ts
+++ b/crates/openwave-desktop/ui/src/VoiceInputStore.ts
@@ -1,0 +1,79 @@
+import { create } from "zustand";
+import type { ApiClient, VoiceTranscriptionInfo, VoiceTranscriptionModel } from "./api";
+
+type VoiceInputStore = {
+  info: VoiceTranscriptionInfo | null;
+  loading: boolean;
+  error: string | null;
+  load: (client: ApiClient) => Promise<VoiceTranscriptionInfo | null>;
+  select: (client: ApiClient, model: VoiceTranscriptionModel) => Promise<void>;
+  install: (client: ApiClient) => Promise<void>;
+};
+
+export const useVoiceInputStore = create<VoiceInputStore>()((set) => ({
+  info: null,
+  loading: false,
+  error: null,
+  async load(client) {
+    set({ loading: true, error: null });
+    try {
+      const info = await client.getVoiceTranscription();
+      set({ info, loading: false });
+      return info;
+    } catch (caught) {
+      set({ loading: false, error: String(caught) });
+      return null;
+    }
+  },
+  async select(client, model) {
+    set({ loading: true, error: null });
+    try {
+      set({ info: await client.putVoiceTranscription(model), loading: false });
+    } catch (caught) {
+      set({ loading: false, error: String(caught) });
+    }
+  },
+  async install(client) {
+    set((state) => ({
+      loading: true,
+      error: null,
+      info: state.info
+        ? {
+            ...state.info,
+            local: {
+              ...state.info.local,
+              state: "downloading",
+              downloaded_bytes: 0,
+            },
+          }
+        : null,
+    }));
+    let stopped = false;
+    const poll = async () => {
+      while (!stopped) {
+        await new Promise((resolve) => window.setTimeout(resolve, 500));
+        if (stopped) break;
+        const info = await client.getVoiceTranscription();
+        set({ info });
+        if (info.local.state !== "downloading") break;
+      }
+    };
+    const polling = poll().catch(() => undefined);
+    try {
+      await client.installLocalVoice();
+      set({ info: await client.getVoiceTranscription(), loading: false });
+    } catch (caught) {
+      set({ loading: false, error: String(caught) });
+    } finally {
+      stopped = true;
+      await polling;
+    }
+  },
+}));
+
+export function voiceSelectionReady(info: VoiceTranscriptionInfo | null): boolean {
+  if (!info) return false;
+  if (info.model === "local") return info.local.state === "ready";
+  if (info.model === "gpt4o_transcribe") return info.openai_ready;
+  return info.gemini_ready;
+}

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -166,11 +166,18 @@ export type StickyChatDefaults = WireStickyChatDefaults;
 
 export type ProviderInfo = WireProviderInfo;
 
-export type VoiceTranscriptionModel = "local" | "gpt4o_transcribe";
+export type VoiceTranscriptionModel = "local" | "gpt4o_transcribe" | "gemini_flash";
+export type LocalVoiceInfo = {
+  state: "not_installed" | "downloading" | "ready" | "failed" | "unavailable";
+  downloaded_bytes: number | null;
+  total_bytes: number | null;
+  error: string | null;
+};
 export type VoiceTranscriptionInfo = {
   model: VoiceTranscriptionModel;
-  local_ready: boolean;
+  local: LocalVoiceInfo;
   openai_ready: boolean;
+  gemini_ready: boolean;
 };
 
 export type CustomModelConfig = WireCustomModelConfig;
@@ -792,6 +799,13 @@ export class ApiClient {
       method: "PUT",
       headers: this.headers(true),
       body: JSON.stringify({ model }),
+    });
+  }
+
+  installLocalVoice(): Promise<LocalVoiceInfo> {
+    return this.json("/voice-transcription/install", {
+      method: "POST",
+      headers: this.headers(),
     });
   }
 

--- a/crates/openwave-desktop/ui/src/settings/VoiceTranscriptionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/VoiceTranscriptionPanel.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useState } from "react";
-import type {
-  ApiClient,
-  VoiceTranscriptionInfo,
-  VoiceTranscriptionModel,
-} from "../api";
+import { useEffect } from "react";
+import { useNavigate } from "@tanstack/react-router";
+
+import type { ApiClient, VoiceTranscriptionModel } from "../api";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
 import {
   Select,
   SelectContent,
@@ -11,64 +11,129 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { SettingsError, SettingsPanel, SettingsSection } from "./primitives";
+import { useVoiceInputStore } from "@/VoiceInputStore";
+import {
+  SettingsError,
+  SettingsField,
+  SettingsPanel,
+  SettingsSection,
+  SettingsStatus,
+} from "./primitives";
 
 export function VoiceTranscriptionPanel({ client }: { client: ApiClient }) {
-  const [info, setInfo] = useState<VoiceTranscriptionInfo | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
+  const navigate = useNavigate();
+  const info = useVoiceInputStore((state) => state.info);
+  const loading = useVoiceInputStore((state) => state.loading);
+  const error = useVoiceInputStore((state) => state.error);
+  const providersPath: string = "/settings/providers";
 
   useEffect(() => {
-    void client.getVoiceTranscription().then(setInfo).catch((caught) => {
-      setError(String(caught));
-    });
+    void useVoiceInputStore.getState().load(client);
   }, [client]);
 
-  async function select(model: VoiceTranscriptionModel) {
-    setSaving(true);
-    setError(null);
-    try {
-      setInfo(await client.putVoiceTranscription(model));
-    } catch (caught) {
-      setError(String(caught));
-    } finally {
-      setSaving(false);
-    }
-  }
+  const localReady = info?.local.state === "ready";
+  const selectedReady = info
+    ? info.model === "local"
+      ? localReady
+      : info.model === "gpt4o_transcribe"
+        ? info.openai_ready
+        : info.gemini_ready
+    : false;
+  const localProgress =
+    info?.local.downloaded_bytes != null && info.local.total_bytes
+      ? (info.local.downloaded_bytes / info.local.total_bytes) * 100
+      : 0;
 
   return (
     <SettingsPanel
-      title="Voice transcription"
-      description="Choose how recordings become editable message drafts. Local transcription is recommended."
+      title="Voice input"
+      description="Choose how microphone recordings become editable message drafts. Audio stays local when the local model is selected."
+      busy={loading}
     >
-      <SettingsSection title="Model">
-        <Select
-          value={info?.model ?? "local"}
-          disabled={!info || saving}
-          onValueChange={(value) => void select(value as VoiceTranscriptionModel)}
-        >
-          <SelectTrigger aria-label="Voice transcription model">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="local">Local model · recommended</SelectItem>
-            <SelectItem value="gpt4o_transcribe" disabled={!info?.openai_ready}>
-              OpenAI · gpt-4o-transcribe
-            </SelectItem>
-          </SelectContent>
-        </Select>
-        {info?.model === "local" && !info.local_ready && (
-          <p className="text-xs text-muted-foreground">
-            The pinned local model runner is not included in this build yet.
-          </p>
-        )}
-        {info && !info.openai_ready && (
-          <p className="text-xs text-muted-foreground">
-            Enable OpenAI and save its credential in Providers to use cloud transcription.
-          </p>
-        )}
-        {error && <SettingsError>{error}</SettingsError>}
+      <SettingsSection>
+        <SettingsStatus
+          tone={selectedReady ? "ready" : "not-configured"}
+          label={selectedReady ? "Ready" : "Setup required"}
+          description={
+            selectedReady
+              ? "The selected voice input model is ready to transcribe recordings."
+              : "Install the local model or configure a supported cloud provider before recording."
+          }
+        />
       </SettingsSection>
+
+      <SettingsSection title="Transcription model">
+        <SettingsField
+          label="Model"
+          hint="Local is recommended and never sends recordings off this device."
+        >
+          <Select
+            value={info?.model ?? "local"}
+            disabled={!info || loading}
+            onValueChange={(value) =>
+              void useVoiceInputStore
+                .getState()
+                .select(client, value as VoiceTranscriptionModel)
+            }
+          >
+            <SelectTrigger aria-label="Voice input model">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="local">Local · Whisper tiny English</SelectItem>
+              {info?.openai_ready && (
+                <SelectItem value="gpt4o_transcribe">OpenAI · gpt-4o-transcribe</SelectItem>
+              )}
+              {info?.gemini_ready && (
+                <SelectItem value="gemini_flash">Google · Gemini 3.6 Flash</SelectItem>
+              )}
+            </SelectContent>
+          </Select>
+        </SettingsField>
+      </SettingsSection>
+
+      <SettingsSection title="Local model">
+        <SettingsStatus
+          tone={localReady ? "ready" : info?.local.state === "unavailable" ? "disabled" : "not-configured"}
+          label={localReady ? "Installed" : info?.local.state === "downloading" ? "Downloading" : "Not installed"}
+          description={
+            info?.local.error ??
+            (localReady
+              ? "Whisper tiny English is installed and verified."
+              : "Downloads a pinned 31 MB quantized model and verifies its SHA-256 before use.")
+          }
+        />
+        {info?.local.state === "downloading" && <Progress value={localProgress} />}
+        {!localReady && info?.local.state !== "unavailable" && (
+          <Button
+            type="button"
+            className="w-fit"
+            disabled={loading}
+            onClick={() => void useVoiceInputStore.getState().install(client)}
+          >
+            {info?.local.state === "failed" ? "Retry download" : "Download local model"}
+          </Button>
+        )}
+      </SettingsSection>
+
+      {info && !info.openai_ready && !info.gemini_ready && (
+        <SettingsSection title="Cloud models">
+          <SettingsStatus
+            tone="not-configured"
+            label="No cloud voice model configured"
+            description="OpenAI gpt-4o-transcribe and Google Gemini become available here when their provider is enabled and credentialed."
+          />
+          <Button
+            type="button"
+            variant="outline"
+            className="w-fit"
+            onClick={() => void navigate({ to: providersPath })}
+          >
+            Open Providers
+          </Button>
+        </SettingsSection>
+      )}
+      {error && <SettingsError>{error}</SettingsError>}
     </SettingsPanel>
   );
 }

--- a/crates/openwave-desktop/ui/src/test/router.tsx
+++ b/crates/openwave-desktop/ui/src/test/router.tsx
@@ -46,12 +46,17 @@ export async function renderWithRouter(
     path: "web-search",
     component: () => <>{ui}</>,
   });
+  const voiceSettingsRoute = createRoute({
+    getParentRoute: () => settingsRoute,
+    path: "voice-transcription",
+    component: () => <>{ui}</>,
+  });
 
   const router = createRouter({
     routeTree: rootRoute.addChildren([
       homeRoute,
       chatRoute,
-      settingsRoute.addChildren([webSearchSettingsRoute]),
+      settingsRoute.addChildren([webSearchSettingsRoute, voiceSettingsRoute]),
     ]),
     history: createMemoryHistory({ initialEntries: [initialUrl] }),
   });

--- a/crates/openwave-desktop/ui/src/useVoiceComposer.test.ts
+++ b/crates/openwave-desktop/ui/src/useVoiceComposer.test.ts
@@ -100,6 +100,24 @@ describe("voice composer", () => {
     expect(draft).toBe("Existing draft spoken words");
   });
 
+  it("checks selected-model readiness before requesting microphone access", async () => {
+    const getUserMedia = vi.fn();
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: { getUserMedia },
+    });
+    const beforeStart = vi.fn(async () => false);
+    const { result } = renderHook(() =>
+      useVoiceComposer(vi.fn(), vi.fn(), undefined, beforeStart),
+    );
+
+    await act(async () => result.current.start());
+
+    expect(beforeStart).toHaveBeenCalledOnce();
+    expect(getUserMedia).not.toHaveBeenCalled();
+    expect(result.current.state).toBe("idle");
+  });
+
   it("rejects an empty or too-short recording before transcription", async () => {
     FakeMediaRecorder.chunk = new Blob([]);
     Object.defineProperty(navigator, "mediaDevices", {

--- a/crates/openwave-desktop/ui/src/useVoiceComposer.ts
+++ b/crates/openwave-desktop/ui/src/useVoiceComposer.ts
@@ -51,6 +51,7 @@ export function useVoiceComposer(
   transcribe: VoiceTranscriber,
   onTranscript: (transcript: string) => void,
   now: () => number = () => performance.now(),
+  beforeStart: () => Promise<boolean> = async () => true,
 ): VoiceComposer {
   const available =
     typeof navigator !== "undefined" &&
@@ -87,6 +88,7 @@ export function useVoiceComposer(
 
   const start = useCallback(async () => {
     if (!available || recorderRef.current) return;
+    if (!(await beforeStart())) return;
     setError(null);
     setState("requesting");
     try {
@@ -151,7 +153,7 @@ export function useVoiceComposer(
       setState("idle");
       setError(voiceError(caught));
     }
-  }, [available, now, releaseStream]);
+  }, [available, beforeStart, now, releaseStream]);
 
   const stop = useCallback(() => {
     const recorder = recorderRef.current;

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -160,6 +160,52 @@ impl GeminiProvider {
             }
         }
     }
+
+    pub async fn transcribe_audio(
+        &self,
+        model: &str,
+        content_type: &str,
+        audio_base64: &str,
+    ) -> Result<String> {
+        let endpoint = self
+            .endpoint(model)?
+            .replace(":streamGenerateContent?alt=sse", ":generateContent");
+        let body = json!({
+            "contents": [{
+                "role": "user",
+                "parts": [
+                    {"text": "Transcribe this audio verbatim. Return only the transcript text."},
+                    {"inlineData": {"mimeType": content_type, "data": audio_base64}}
+                ]
+            }],
+            "generationConfig": {"temperature": 0}
+        });
+        let request = self
+            .client
+            .post(endpoint)
+            .header("content-type", "application/json")
+            .json(&body);
+        let request = match &self.auth {
+            GeminiAuth::ApiKey(api_key) => request.header("x-goog-api-key", api_key),
+            GeminiAuth::Bearer(source) => request.bearer_auth(source.bearer_token().await?),
+        };
+        let response = request.send().await.map_err(|_| {
+            AgentError::Provider("gemini audio transcription request failed".into())
+        })?;
+        if !response.status().is_success() {
+            return Err(AgentError::Provider(format!(
+                "gemini audio transcription returned {}",
+                response.status().as_u16()
+            )));
+        }
+        let body: Value = response.json().await.map_err(|_| {
+            AgentError::Provider("gemini returned an invalid audio transcription response".into())
+        })?;
+        body.pointer("/candidates/0/content/parts/0/text")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .ok_or_else(|| AgentError::Provider("gemini returned no audio transcript".into()))
+    }
 }
 
 fn requires_global_vertex(model: &str) -> bool {

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -72,6 +72,13 @@ impl VertexRoute {
             credential_fingerprint,
         }
     }
+
+    pub fn project_id(&self) -> &str {
+        &self.project_id
+    }
+    pub fn location(&self) -> &str {
+        &self.location
+    }
 }
 
 impl std::fmt::Debug for VertexRoute {

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -111,7 +111,7 @@ pub use pairing::{
     register_pending_pairing, register_replacing_pairing, PairingError, PairingHandle,
     PendingRegistration,
 };
-pub use state::AppState;
+pub use state::{AppState, LocalVoiceRunner, LocalVoiceState, LocalVoiceStatus};
 
 pub(crate) const MAX_RAW_DOCUMENT_BYTES: usize = 16 * 1024 * 1024;
 const MAX_WEB_SEARCH_CREDENTIAL_BODY_BYTES: usize = 16 * 1024;
@@ -390,6 +390,10 @@ pub fn app(state: AppState) -> Router {
                 .put(routes::put_voice_transcription)
                 .post(routes::post_voice_transcription)
                 .layer(DefaultBodyLimit::max(voice_transcription::MAX_AUDIO_BYTES)),
+        )
+        .route(
+            "/voice-transcription/install",
+            post(routes::post_voice_transcription_install),
         )
         .route(
             "/providers/{kind}",
@@ -676,6 +680,7 @@ pub async fn bind(config: Config) -> Result<Server> {
         None,
         None,
         None,
+        None,
     )
     .await
 }
@@ -686,7 +691,7 @@ pub async fn bind(config: Config) -> Result<Server> {
 /// to use [`bind`] when process-environment configuration is undesirable.
 pub async fn bind_configured(config: Config) -> Result<Server> {
     let mcp_servers = mcp_config::ConfiguredMcpServers::from_env()?;
-    bind_inner(config, None, mcp_servers, None, None, None).await
+    bind_inner(config, None, mcp_servers, None, None, None, None).await
 }
 
 /// Bind the API with a stable app-private native executor identity.
@@ -704,6 +709,7 @@ pub async fn bind_with_desktop_executor(
         config,
         Some(client_executor_id),
         mcp_config::ConfiguredMcpServers::default(),
+        None,
         None,
         None,
         None,
@@ -728,6 +734,7 @@ pub async fn bind_configured_with_desktop_executor(
         None,
         None,
         None,
+        None,
     )
     .await
 }
@@ -742,6 +749,7 @@ pub async fn bind_configured_with_desktop_executor_and_folder_grants(
     folder_grant_resolver: Arc<dyn code_execution::ExecFolderGrantResolver>,
     office_converter: Option<Arc<dyn openwave_code_execution::HostOfficeConverter>>,
     host_tool_broker: Option<Arc<dyn openwave_code_execution::HostToolBroker>>,
+    local_voice: Option<Arc<dyn LocalVoiceRunner>>,
 ) -> Result<Server> {
     if client_executor_id.is_nil() {
         return Err(AgentError::config("client executor id must not be nil"));
@@ -754,6 +762,7 @@ pub async fn bind_configured_with_desktop_executor_and_folder_grants(
         Some(folder_grant_resolver),
         office_converter,
         host_tool_broker,
+        local_voice,
     )
     .await
 }
@@ -791,6 +800,7 @@ async fn bind_inner(
     folder_grant_resolver: Option<Arc<dyn code_execution::ExecFolderGrantResolver>>,
     office_converter: Option<Arc<dyn openwave_code_execution::HostOfficeConverter>>,
     host_tool_broker: Option<Arc<dyn openwave_code_execution::HostToolBroker>>,
+    local_voice: Option<Arc<dyn LocalVoiceRunner>>,
 ) -> Result<Server> {
     // Desktop live delivery remains process-local. Turns, steering, and tool
     // approvals are durable, while one process still owns the complete data
@@ -895,6 +905,9 @@ async fn bind_inner(
     // into the gateway's reuse detection (a spurious full sign-out).
     state.gateway = gateway;
     state.os_policy = os_policy;
+    if let Some(local_voice) = local_voice {
+        state.set_local_voice_runner(local_voice);
+    }
     state.mcp.initialize(mcp_servers).await?;
     let token = state.token.clone();
     let client_executor_token = state.client_executor_token.clone();

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -324,7 +324,7 @@ impl ProviderCredential {
     }
 
     /// The raw service-account key file, if this credential carries one.
-    fn as_service_account(&self) -> Option<&str> {
+    pub(crate) fn as_service_account(&self) -> Option<&str> {
         match self {
             Self::ServiceAccount { json } => Some(json),
             Self::ApiKey { .. } | Self::Oauth {} => None,

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1110,7 +1110,7 @@ pub async fn get_voice_transcription(
     State(state): State<AppState>,
 ) -> Result<Json<VoiceTranscriptionInfo>, ServerError> {
     Ok(Json(
-        voice_transcription::info(&*state.store, &*state.secrets).await?,
+        voice_transcription::info(&*state.store, &*state.secrets, &*state.local_voice).await?,
     ))
 }
 
@@ -1119,7 +1119,8 @@ pub async fn put_voice_transcription(
     Json(body): Json<VoiceTranscriptionUpdate>,
 ) -> Result<Json<VoiceTranscriptionInfo>, ServerError> {
     Ok(Json(
-        voice_transcription::update(&*state.store, &*state.secrets, body).await?,
+        voice_transcription::update(&*state.store, &*state.secrets, &*state.local_voice, body)
+            .await?,
     ))
 }
 
@@ -1132,9 +1133,23 @@ pub async fn post_voice_transcription(
         .get(header::CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
         .ok_or_else(|| ServerError::bad_request("voice recording content type is required"))?;
-    let text = voice_transcription::transcribe(&*state.store, &*state.secrets, content_type, audio)
-        .await?;
+    let text = voice_transcription::transcribe(
+        &*state.store,
+        &*state.secrets,
+        &*state.local_voice,
+        content_type,
+        audio,
+    )
+    .await?;
     Ok(Json(serde_json::json!({ "text": text })))
+}
+
+pub async fn post_voice_transcription_install(
+    State(state): State<AppState>,
+) -> Result<Json<voice_transcription::LocalVoiceInfo>, ServerError> {
+    Ok(Json(
+        voice_transcription::install_local(&*state.local_voice).await?,
+    ))
 }
 
 /// A selectable model in the catalog.

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -20,6 +20,60 @@ use crate::mcp_config::McpRuntime;
 use crate::resolver::ProviderResolver;
 use crate::view_frames::ViewFrameTokens;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalVoiceStatus {
+    pub state: LocalVoiceState,
+    pub downloaded_bytes: Option<u64>,
+    pub total_bytes: Option<u64>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalVoiceState {
+    NotInstalled,
+    Downloading,
+    Ready,
+    Failed,
+    Unavailable,
+}
+
+#[async_trait::async_trait]
+pub trait LocalVoiceRunner: Send + Sync {
+    async fn status(&self) -> LocalVoiceStatus;
+    async fn install(&self) -> std::result::Result<LocalVoiceStatus, String>;
+    async fn transcribe(
+        &self,
+        content_type: &str,
+        audio: Vec<u8>,
+    ) -> std::result::Result<String, String>;
+}
+
+struct UnavailableLocalVoiceRunner;
+
+#[async_trait::async_trait]
+impl LocalVoiceRunner for UnavailableLocalVoiceRunner {
+    async fn status(&self) -> LocalVoiceStatus {
+        LocalVoiceStatus {
+            state: LocalVoiceState::Unavailable,
+            downloaded_bytes: None,
+            total_bytes: None,
+            error: Some("local voice input is available only in the desktop app".into()),
+        }
+    }
+
+    async fn install(&self) -> std::result::Result<LocalVoiceStatus, String> {
+        Err("local voice input is available only in the desktop app".into())
+    }
+
+    async fn transcribe(
+        &self,
+        _content_type: &str,
+        _audio: Vec<u8>,
+    ) -> std::result::Result<String, String> {
+        Err("local voice input is available only in the desktop app".into())
+    }
+}
+
 /// The state cloned into each handler: the boot config, the durable store, the
 /// agent's dependencies (provider + tools + tuning), the per-launch bearer token,
 /// and the guard that keeps a chat to one running turn at a time.
@@ -101,6 +155,7 @@ pub struct AppState {
     pub events: Arc<EventBus>,
     /// Coordinates durable Sensitive-tool decisions and low-latency wakeups.
     pub approvals: Arc<ApprovalBroker>,
+    pub(crate) local_voice: Arc<dyn LocalVoiceRunner>,
 }
 
 impl AppState {
@@ -203,7 +258,12 @@ impl AppState {
             sandbox_attempts: Arc::new(SandboxAttemptGuard::default()),
             events: Arc::new(EventBus::default()),
             approvals: Arc::new(ApprovalBroker::new(store)),
+            local_voice: Arc::new(UnavailableLocalVoiceRunner),
         })
+    }
+
+    pub fn set_local_voice_runner(&mut self, runner: Arc<dyn LocalVoiceRunner>) {
+        self.local_voice = runner;
     }
 }
 

--- a/crates/openwave-server/src/voice_transcription.rs
+++ b/crates/openwave-server/src/voice_transcription.rs
@@ -1,12 +1,15 @@
 //! Voice transcription settings and the credential-custody cloud adapter.
 
 use axum::body::Bytes;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 
 use openwave_core::{SecretProvider, Store};
 
 use crate::error::ServerError;
-use crate::providers::{self, ProviderKind};
+use crate::providers::{self, ProviderCredential, ProviderKind};
+use crate::state::{LocalVoiceRunner, LocalVoiceState};
 
 const SETTING_KEY: &str = "voice.transcription_v1";
 pub const MAX_AUDIO_BYTES: usize = 25 * 1024 * 1024;
@@ -17,6 +20,7 @@ pub enum VoiceTranscriptionModel {
     #[default]
     Local,
     Gpt4oTranscribe,
+    GeminiFlash,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -27,8 +31,17 @@ struct VoiceTranscriptionConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub struct VoiceTranscriptionInfo {
     pub model: VoiceTranscriptionModel,
-    pub local_ready: bool,
+    pub local: LocalVoiceInfo,
     pub openai_ready: bool,
+    pub gemini_ready: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
+pub struct LocalVoiceInfo {
+    pub state: String,
+    pub downloaded_bytes: Option<u64>,
+    pub total_bytes: Option<u64>,
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -47,42 +60,85 @@ async fn read_config(store: &dyn Store) -> openwave_core::Result<VoiceTranscript
 pub async fn info(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
+    local_voice: &dyn LocalVoiceRunner,
 ) -> Result<VoiceTranscriptionInfo, ServerError> {
     let config = read_config(store).await?;
     let openai = providers::read_config(store, ProviderKind::Openai).await?;
+    let gemini = providers::read_config(store, ProviderKind::Gemini).await?;
+    let local = local_voice.status().await;
     Ok(VoiceTranscriptionInfo {
         model: config.model,
-        // Deliberately false until the pinned lazy local runner lands.
-        local_ready: false,
+        local: LocalVoiceInfo {
+            state: match local.state {
+                LocalVoiceState::NotInstalled => "not_installed",
+                LocalVoiceState::Downloading => "downloading",
+                LocalVoiceState::Ready => "ready",
+                LocalVoiceState::Failed => "failed",
+                LocalVoiceState::Unavailable => "unavailable",
+            }
+            .to_owned(),
+            downloaded_bytes: local.downloaded_bytes,
+            total_bytes: local.total_bytes,
+            error: local.error,
+        },
         openai_ready: openai.enabled
             && providers::has_credential(secrets, ProviderKind::Openai).await,
+        gemini_ready: gemini.enabled
+            && providers::has_credential(secrets, ProviderKind::Gemini).await,
     })
 }
 
 pub async fn update(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
+    local_voice: &dyn LocalVoiceRunner,
     update: VoiceTranscriptionUpdate,
 ) -> Result<VoiceTranscriptionInfo, ServerError> {
-    if update.model == VoiceTranscriptionModel::Gpt4oTranscribe {
-        let current = info(store, secrets).await?;
-        if !current.openai_ready {
+    let current = info(store, secrets, local_voice).await?;
+    match update.model {
+        VoiceTranscriptionModel::Gpt4oTranscribe if !current.openai_ready => {
             return Err(ServerError::conflict(
                 "enable OpenAI and save its credential before selecting gpt-4o-transcribe",
-            ));
+            ))
         }
+        VoiceTranscriptionModel::GeminiFlash if !current.gemini_ready => {
+            return Err(ServerError::conflict(
+                "enable Gemini and save a supported credential before selecting Gemini voice input",
+            ))
+        }
+        _ => {}
     }
     let value = serde_json::to_value(VoiceTranscriptionConfig {
         model: update.model,
     })
     .map_err(|_| ServerError::internal("failed to serialize voice transcription settings"))?;
     store.set_setting(SETTING_KEY, &value).await?;
-    info(store, secrets).await
+    info(store, secrets, local_voice).await
+}
+
+pub async fn install_local(
+    local_voice: &dyn LocalVoiceRunner,
+) -> Result<LocalVoiceInfo, ServerError> {
+    let status = local_voice.install().await.map_err(ServerError::internal)?;
+    Ok(LocalVoiceInfo {
+        state: match status.state {
+            LocalVoiceState::NotInstalled => "not_installed",
+            LocalVoiceState::Downloading => "downloading",
+            LocalVoiceState::Ready => "ready",
+            LocalVoiceState::Failed => "failed",
+            LocalVoiceState::Unavailable => "unavailable",
+        }
+        .to_owned(),
+        downloaded_bytes: status.downloaded_bytes,
+        total_bytes: status.total_bytes,
+        error: status.error,
+    })
 }
 
 pub async fn transcribe(
     store: &dyn Store,
     secrets: &dyn SecretProvider,
+    local_voice: &dyn LocalVoiceRunner,
     content_type: &str,
     audio: Bytes,
 ) -> Result<String, ServerError> {
@@ -91,9 +147,13 @@ pub async fn transcribe(
     }
     let config = read_config(store).await?;
     if config.model == VoiceTranscriptionModel::Local {
-        return Err(ServerError::conflict(
-            "the recommended local transcription model is not installed in this build yet",
-        ));
+        return local_voice
+            .transcribe(content_type, audio.to_vec())
+            .await
+            .map_err(ServerError::internal);
+    }
+    if config.model == VoiceTranscriptionModel::GeminiFlash {
+        return transcribe_gemini(store, secrets, content_type, &audio).await;
     }
     let provider = providers::read_config(store, ProviderKind::Openai).await?;
     if !provider.enabled {
@@ -142,4 +202,138 @@ pub async fn transcribe(
         .await
         .map_err(|_| ServerError::internal("OpenAI returned an invalid transcription response"))?;
     Ok(transcript.text)
+}
+
+async fn transcribe_gemini(
+    store: &dyn Store,
+    secrets: &dyn SecretProvider,
+    content_type: &str,
+    audio: &[u8],
+) -> Result<String, ServerError> {
+    const MODEL: &str = "gemini-3.6-flash";
+    let config = providers::read_config(store, ProviderKind::Gemini).await?;
+    if !config.enabled {
+        return Err(ServerError::conflict("Gemini is not enabled"));
+    }
+    let credential = providers::read_credential(secrets, ProviderKind::Gemini).await?;
+    let provider = match credential {
+        Some(ProviderCredential::ApiKey { key }) if !key.is_empty() => {
+            openwave_router::GeminiProvider::new(key)
+        }
+        Some(credential) => {
+            let json = credential
+                .as_service_account()
+                .ok_or_else(|| ServerError::conflict("Gemini has no supported saved credential"))?;
+            let account = openwave_router::GoogleServiceAccount::from_json(json)
+                .map_err(|_| ServerError::conflict("Gemini service account is invalid"))?;
+            let project = account.project_id().to_owned();
+            let source = std::sync::Arc::new(
+                openwave_router::GoogleServiceAccountTokenSource::new(account),
+            );
+            openwave_router::GeminiProvider::vertex(
+                project,
+                config.vertex_location.as_deref().unwrap_or("global"),
+                source,
+            )
+            .map_err(ServerError::from)?
+        }
+        None => {
+            let key = providers::resolve_api_key(secrets, ProviderKind::Gemini)
+                .await
+                .ok_or_else(|| ServerError::conflict("Gemini has no saved credential"))?;
+            openwave_router::GeminiProvider::new(key)
+        }
+    };
+    provider
+        .transcribe_audio(MODEL, content_type, &BASE64.encode(audio))
+        .await
+        .map_err(ServerError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::{LocalVoiceState, LocalVoiceStatus};
+    use openwave_core::{DbStore, Result as CoreResult};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct TestSecrets(Mutex<HashMap<String, String>>);
+
+    #[async_trait::async_trait]
+    impl SecretProvider for TestSecrets {
+        async fn get_secret(&self, key: &str) -> CoreResult<Option<String>> {
+            Ok(self.0.lock().unwrap().get(key).cloned())
+        }
+        async fn set_secret(&self, key: &str, value: &str) -> CoreResult<()> {
+            self.0.lock().unwrap().insert(key.into(), value.into());
+            Ok(())
+        }
+        async fn delete_secret(&self, key: &str) -> CoreResult<()> {
+            self.0.lock().unwrap().remove(key);
+            Ok(())
+        }
+    }
+
+    async fn test_store() -> (tempfile::TempDir, DbStore) {
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory.path().join("voice.sqlite");
+        let store = DbStore::connect(&format!("sqlite://{}?mode=rwc", database.display()))
+            .await
+            .unwrap();
+        (directory, store)
+    }
+
+    struct ReadyLocal;
+
+    #[async_trait::async_trait]
+    impl LocalVoiceRunner for ReadyLocal {
+        async fn status(&self) -> LocalVoiceStatus {
+            LocalVoiceStatus {
+                state: LocalVoiceState::Ready,
+                downloaded_bytes: Some(10),
+                total_bytes: Some(10),
+                error: None,
+            }
+        }
+
+        async fn install(&self) -> Result<LocalVoiceStatus, String> {
+            Ok(self.status().await)
+        }
+
+        async fn transcribe(&self, content_type: &str, audio: Vec<u8>) -> Result<String, String> {
+            assert_eq!(content_type, "audio/webm");
+            assert_eq!(audio, b"local audio");
+            Ok("local transcript".into())
+        }
+    }
+
+    #[tokio::test]
+    async fn local_selection_delegates_bytes_to_the_native_runner() {
+        let (_directory, store) = test_store().await;
+        let secrets = TestSecrets::default();
+        let text = transcribe(
+            &store,
+            &secrets,
+            &ReadyLocal,
+            "audio/webm",
+            Bytes::from_static(b"local audio"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(text, "local transcript");
+    }
+
+    #[tokio::test]
+    async fn info_projects_local_lifecycle_without_paths_or_model_bytes() {
+        let (_directory, store) = test_store().await;
+        let info = info(&store, &TestSecrets::default(), &ReadyLocal)
+            .await
+            .unwrap();
+        assert_eq!(info.local.state, "ready");
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(!json.contains("model.bin"));
+        assert!(!json.contains("models/voice"));
+    }
 }


### PR DESCRIPTION
## Summary

- add a trusted native local voice runner boundary backed by `whisper-rs`/whisper.cpp and the pinned quantized `ggml-tiny.en-q5_1` model
- lazy-download the exact model artifact from the pinned whisper.cpp repository commit, reject SHA-256 mismatches, install atomically, and report not-installed/downloading/ready/failed state without exposing native paths or model bytes
- decode the composer’s negotiated WebM/Opus and MP4 AAC/ALAC recordings locally, resample to 16 kHz mono, and run inference off the async request executor
- keep the existing OpenAI `gpt-4o-transcribe` path and add Google Gemini voice input through `gemini-3.6-flash` `generateContent` with inline audio
- reuse Gemini Developer API key custody and the existing Vertex service-account OAuth/token path; no credential is projected to the renderer
- centralize voice capability state in a shared renderer store, redesign the setting as Voice input with shared settings primitives, and route an unready mic click directly to `/settings/voice-transcription` before microphone permission
- match Alpha’s composer mic states: persistent Mic icon, outline idle state, high-contrast active state, listening/transcribing placeholders, and no redundant visible status line

## Gemini API choice

The Google cloud option uses `gemini-3.6-flash`, already curated by OpenWave, through native `generateContent` rather than a compatibility endpoint:

- Developer API: `POST /v1beta/models/gemini-3.6-flash:generateContent` with `x-goog-api-key`
- Vertex AI: `POST /v1/projects/{project}/locations/global/publishers/google/models/gemini-3.6-flash:generateContent` with the existing service-account bearer-token source
- audio is supplied as a documented `inlineData` part using the recorder MIME type

## Local supply-chain contract

- engine binding: `whisper-rs = 0.16.0`
- model: `ggml-tiny.en-q5_1.bin` from whisper.cpp commit `c521a4b02f422512d734391fdf08bb08c0862f68`
- exact SHA-256: `c77c5766f1cef09b6b7d47f21b546cbddd4157886b3b5d6d4f709e91e66c7c2b`
- exact size: 32,166,155 bytes

## Verification

- `cargo check --workspace --locked`
- `cargo clippy -p openwave-server -p openwave-desktop --all-targets --locked -- -D warnings`
- `cargo fmt --all --check`
- `cargo test -p openwave-desktop voice_transcription --locked`
- `cargo test -p openwave-server voice_transcription --locked`
- `pnpm --dir crates/openwave-desktop/ui test` — 704 tests
- `pnpm --dir crates/openwave-desktop/ui build`
- `pnpm --dir crates/openwave-desktop/ui exec tsc --noEmit`
- real local inference smoke test against generated WebM/Opus and MP4/AAC recordings; both decoded and produced non-empty transcripts with the pinned model

Closes #1435
