### PR TITLE
fix(desktop): the gateway sync button also reconciles MCP endpoint mounts

### DIFF
--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.dom.test.tsx
@@ -131,7 +131,7 @@ describe("GatewayPanel", () => {
     expect(screen.getByText(/2 models entitled/)).toBeInTheDocument();
     expect(screen.getByText(/Installation install-1/)).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /Refresh models/ }));
+    await user.click(screen.getByRole("button", { name: /Sync with gateway/ }));
     await waitFor(() => expect(client.syncGatewayModels).toHaveBeenCalled());
     expect(onChanged).toHaveBeenCalled();
 

--- a/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/GatewayPanel.tsx
@@ -21,7 +21,8 @@ const SIGN_IN_POLL_MS = 2_000;
  * management, never from settings — there is no URL field and no enable
  * toggle in any state. Unmanaged profiles render a signpost at that flow;
  * managed profiles get the slim identity panel: who is signed in, the
- * read-only gateway origin from policy, sign in/out, and a models refresh.
+ * read-only gateway origin from policy, sign in/out, and an explicit
+ * gateway sync (models and MCP endpoint mounts together).
  */
 export function GatewayPanel({
   client,
@@ -222,12 +223,12 @@ function ManagedGatewayPanel({
                   void run(async () => {
                     await client.syncGatewayModels();
                     onChanged();
-                    toast.success("Refreshed entitled models");
+                    toast.success("Synced models and MCP endpoints from the gateway");
                   })
                 }
               >
                 <RefreshCw size={14} />
-                Refresh models
+                Sync with gateway
               </Button>
               <Button
                 type="button"

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -280,12 +280,17 @@ pub async fn get_gateway_apps(
     Ok(Json(state.gateway.apps().await?))
 }
 
-/// `POST /gateway/models/sync` — refetch the entitled models into the
-/// provider's model set.
+/// `POST /gateway/models/sync` — the settings page's explicit "sync with the
+/// gateway": refetch the entitled models into the provider's model set and
+/// reconcile the entitled MCP endpoint mounts, the same pair the periodic
+/// sync tick performs. An explicit click reports failure honestly rather
+/// than degrading quietly the way the background tick does — the user asked
+/// for a sync and deserves to know it didn't complete.
 pub async fn post_gateway_models_sync(
     State(state): State<AppState>,
 ) -> Result<Json<crate::gateway_runtime::GatewayStatus>, ServerError> {
     state.gateway.sync_models().await?;
+    state.gateway.reconcile_endpoint_mounts(&state.mcp).await?;
     Ok(Json(state.gateway.status().await?))
 }
 


### PR DESCRIPTION
The Model Gateway settings page's button ran `sync_models()` only — a newly entitled MCP endpoint waited for the next 5-minute background tick (or a re-sign-in) to auto-mount, even when the user explicitly asked the gateway for fresh state. The route now performs the same pair the periodic tick performs: model sync + `reconcile_endpoint_mounts`. Deliberate asymmetry with the background tick: an explicit click propagates a reconcile failure to the user instead of degrading quietly — the user asked for a sync and deserves to know it didn't complete.

Copy updated to match the widened meaning: button "Refresh models" → "Sync with gateway", toast "Refreshed entitled models" → "Synced models and MCP endpoints from the gateway", panel doc comment updated. No new tests: the reconcile function's semantics (idempotence, tombstones, quiet no-op states) are covered by its own tests from #1399, and the handler is two sequential calls — a wiring assertion would not tell us anything we'd act on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)