### PR TITLE
feat(desktop): app-centric Connected apps page with per-app tool listing

### DIFF
--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -585,7 +585,26 @@ id: ConnectedAppId,
 /**
  * Display name — also the namespace the server's tools mount under.
  */
-name: string, health: McpHealth, tool_count: number, diagnostic: string | null, } | { "kind": "rest_api", 
+name: string, health: McpHealth, tool_count: number, 
+/**
+ * The bare mounted tool names (after the `mcp__{server}__` prefix),
+ * bounded by the per-server discovery cap. Names only — never
+ * remote-authored descriptions — the consent sheet's posture.
+ */
+tools: Array<string>, diagnostic: string | null, 
+/**
+ * The gateway MCP endpoint slug this record mounts, when it is
+ * gateway-backed rather than a local stdio/HTTP definition.
+ */
+gateway_endpoint: string | null, 
+/**
+ * Display names of the organization's entitled apps that ride this
+ * record's gateway endpoint. Empty for local records — and, by
+ * graceful degradation, when the gateway is unreachable or predates
+ * the apps surface: the entry then renders without org-app names
+ * rather than erroring.
+ */
+gateway_apps: Array<string>, } | { "kind": "rest_api", 
 /**
  * The record id app bindings name.
  */

--- a/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
@@ -7,7 +7,7 @@ import { ConnectedAppsPanel } from "./ConnectedAppsPanel";
 
 const SECRET = "sk-rest-value-hunter2";
 
-/** One configured manual server, so the embedded editor has a row to show. */
+/** One configured manual server, so the demoted editor has a row to show. */
 const docsServer: McpServerInfo = {
   name: "docs",
   command: "/usr/local/bin/docs-mcp",
@@ -25,15 +25,31 @@ const docsServer: McpServerInfo = {
   diagnostic: null,
 };
 
-const bothKinds: ConnectedAppsInfo = {
+/** The app-first listing: a gateway-backed record (org apps ride the
+ * `primary` endpoint), a local record, and a REST entry. */
+const listing: ConnectedAppsInfo = {
   apps: [
+    {
+      kind: "mcp_server",
+      id: "00000000-0000-4000-8000-000000000000",
+      name: "primary",
+      health: "healthy",
+      tool_count: 2,
+      tools: ["sentry__proxy_api", "linear__proxy_api"],
+      diagnostic: null,
+      gateway_endpoint: "primary",
+      gateway_apps: ["Sentry (org)", "Linear (org)"],
+    },
     {
       kind: "mcp_server",
       id: "11111111-1111-4111-8111-111111111111",
       name: "docs",
       health: "healthy",
       tool_count: 3,
+      tools: ["search", "fetch", "list_sources"],
       diagnostic: null,
+      gateway_endpoint: null,
+      gateway_apps: [],
     },
     {
       kind: "rest_api",
@@ -51,14 +67,37 @@ const bothKinds: ConnectedAppsInfo = {
 
 function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
   return {
-    listConnectedApps: vi.fn().mockResolvedValue(bothKinds),
-    putRestConnectedApp: vi.fn().mockResolvedValue(bothKinds),
+    listConnectedApps: vi.fn().mockResolvedValue(listing),
+    putRestConnectedApp: vi.fn().mockResolvedValue(listing),
     deleteRestConnectedApp: vi.fn().mockResolvedValue(undefined),
-    // The embedded MCP editor reads its own server list and gateway session.
+    // The demoted MCP editor reads its own server list and gateway session.
     listMcpServers: vi.fn().mockResolvedValue({ servers: [docsServer] }),
     getGatewayStatus: vi.fn().mockResolvedValue({ signed_in: false }),
+    getGatewayApps: vi.fn().mockResolvedValue({ supported: true, apps: [] }),
     ...overrides,
   } as unknown as ApiClient;
+}
+
+/** A signed-in gateway session whose org apps ride the `primary` endpoint,
+ * for tests that open the Advanced disclosure's endpoint toggles. */
+function signedInOverrides() {
+  return {
+    getGatewayStatus: vi
+      .fn()
+      .mockResolvedValue({ signed_in: true, model_count: 1, sign_in: { state: "idle" } }),
+    getGatewayApps: vi.fn().mockResolvedValue({
+      supported: true,
+      apps: [
+        {
+          id: "app-1",
+          name: "Sentry (org)",
+          app_kind: "mcp_server",
+          enabled: true,
+          mcp_endpoint_slugs: ["primary"],
+        },
+      ],
+    }),
+  };
 }
 
 afterEach(() => {
@@ -67,34 +106,79 @@ afterEach(() => {
 });
 
 describe("ConnectedAppsPanel", () => {
-  it("is one page with both kinds: the embedded MCP editor beside REST detail", async () => {
-    const client = api();
-    render(<ConnectedAppsPanel client={client} managed={false} />);
+  it("leads with apps: org-app names for gateway entries, record names for local ones", async () => {
+    render(<ConnectedAppsPanel client={api()} managed={false} />);
 
-    // The MCP section is the full server editor, not a read-only list with a
-    // deep link to a separate page.
-    expect(await screen.findByText("docs")).toBeInTheDocument();
+    // The gateway-backed entry leads with the organization's app names, not
+    // its endpoint slug; the local record is its own app.
     expect(
-      screen.getByRole("button", { name: /Save and verify/ }),
+      await screen.findByText("Sentry (org), Linear (org)"),
     ).toBeInTheDocument();
-    expect(screen.getByLabelText(/Namespace/)).toHaveValue("docs");
-    expect(
-      screen.queryByRole("button", { name: /Manage MCP servers/ }),
-    ).not.toBeInTheDocument();
+    expect(screen.getByText("docs")).toBeInTheDocument();
+    expect(screen.queryByText("primary")).not.toBeInTheDocument();
 
-    expect(await screen.findByText("Sentry")).toBeInTheDocument();
+    // REST entries are first-class app entries in the same list.
+    expect(screen.getByText("Sentry")).toBeInTheDocument();
     expect(
-      screen.getByText(/api\.sentry\.example\/v2 · 2 operations · Credential configured/),
+      screen.getByText(
+        /api\.sentry\.example\/v2 · 2 operations · Credential configured/,
+      ),
     ).toBeInTheDocument();
   });
 
-  it("managed: shows the read-only notice and no REST editing affordances", async () => {
-    render(<ConnectedAppsPanel client={api()} managed />);
+  it("expands a collapsed accordion to monospace tool names", async () => {
+    const user = userEvent.setup();
+    render(<ConnectedAppsPanel client={api()} managed={false} />);
+
+    await screen.findByText("docs");
+    // Collapsed by default: no tool names anywhere.
+    expect(screen.queryByText("search")).not.toBeInTheDocument();
+    expect(screen.queryByText("sentry__proxy_api")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "3 tools" }));
+    const tool = screen.getByText("search");
+    expect(tool).toHaveClass("font-mono");
+    expect(screen.getByText("list_sources")).toBeInTheDocument();
+    // Only the clicked entry expanded.
+    expect(screen.queryByText("sentry__proxy_api")).not.toBeInTheDocument();
+  });
+
+  it("keeps endpoints and the manual editor inside the Advanced disclosure", async () => {
+    const user = userEvent.setup();
+    render(
+      <ConnectedAppsPanel client={api(signedInOverrides())} managed={false} />,
+    );
+
+    await screen.findByText("docs");
+    // Before expanding: no mount toggles, no editor, no endpoint section.
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Save and verify/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Gateway endpoints")).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /Advanced: transport & endpoints/ }),
+    );
+    // Every existing capability is reachable: the mount toggle, the manual
+    // editor with its namespace field, and save.
+    expect(
+      await screen.findByRole("switch", { name: "Mount primary" }),
+    ).toBeInTheDocument();
+    expect(await screen.findByLabelText(/Namespace/)).toHaveValue("docs");
+    expect(
+      screen.getByRole("button", { name: /Save and verify/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("managed: keeps the notice and mount toggles but no edit affordances", async () => {
+    const user = userEvent.setup();
+    render(<ConnectedAppsPanel client={api(signedInOverrides())} managed />);
 
     expect(
       await screen.findByText(/Managed by your organization/),
     ).toBeInTheDocument();
-    // Entries stay visible read-only; every write affordance is gone.
+    // Entries stay visible read-only; every REST write affordance is gone.
     expect(screen.getByText("Sentry")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /Add REST API/ }),
@@ -103,7 +187,25 @@ describe("ConnectedAppsPanel", () => {
       screen.queryByRole("button", { name: /Edit/ }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /Remove/ }),
+      screen.queryByRole("button", { name: /^Remove/ }),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /Advanced: transport & endpoints/ }),
+    );
+    // The endpoint toggle — the one write managed policy admits — stays
+    // live; nothing manual is editable.
+    expect(
+      await screen.findByRole("switch", { name: "Mount primary" }),
+    ).toBeEnabled();
+    await waitFor(() =>
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole("button", { name: "Add server" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Save and verify/ }),
     ).not.toBeInTheDocument();
   });
 

--- a/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { Pencil, Plus, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Pencil, Plus, Trash2 } from "lucide-react";
 import type {
   ApiClient,
   ConnectedAppInfo,
@@ -19,6 +19,7 @@ import {
 } from "./primitives";
 
 type RestEntry = Extract<ConnectedAppInfo, { kind: "rest_api" }>;
+type McpEntry = Extract<ConnectedAppInfo, { kind: "mcp_server" }>;
 
 type CredentialMode = "none" | "bearer" | "header";
 
@@ -81,12 +82,109 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+/** The name an app entry leads with. A gateway-backed record shows the
+ * organization's entitled app names when the gateway reported them; a local
+ * record has no org-app concept — its record display name is the app. */
+function mcpTitle(entry: McpEntry): string {
+  return entry.gateway_endpoint !== null && entry.gateway_apps.length > 0
+    ? entry.gateway_apps.join(", ")
+    : entry.name;
+}
+
+/** One renderer-safe status sentence per entry; diagnostics already are one. */
+function mcpStatus(entry: McpEntry): string {
+  switch (entry.health) {
+    case "healthy":
+      return `${entry.tool_count} tool${entry.tool_count === 1 ? "" : "s"} available to new turns.`;
+    case "initializing":
+    case "reconnecting":
+      return "Connecting…";
+    case "disabled":
+      return entry.diagnostic ?? "Disabled.";
+    default:
+      return entry.diagnostic ?? "Needs attention. See Advanced below.";
+  }
+}
+
 /**
- * The Connected apps page: the one settings surface for both kinds. The MCP
- * section is the full server editor — `McpPanel`, absorbed here when the
- * standalone MCP servers page retired — and REST entries are created,
- * edited, and deleted below it. The absorption is presentation only; the
- * connected-apps record was authoritative throughout the phasing.
+ * One MCP-backed app entry: the app name first, a status line, and a
+ * collapsed accordion enumerating the mounted tool names. Names only — never
+ * remote-authored tool descriptions — the same renderer-safety posture as
+ * the consent sheet.
+ */
+function McpAppCard({ entry }: { entry: McpEntry }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="flex flex-col gap-1 rounded-md border px-3 py-2">
+      <p className="text-sm font-bold">{mcpTitle(entry)}</p>
+      <p className="text-xs text-muted-foreground">
+        {entry.gateway_endpoint !== null &&
+          "Via your organization's gateway · "}
+        {mcpStatus(entry)}
+      </p>
+      {entry.tools.length > 0 && (
+        <>
+          <button
+            type="button"
+            className="flex items-center gap-1 self-start text-xs text-muted-foreground hover:text-foreground"
+            aria-expanded={open}
+            onClick={() => setOpen((current) => !current)}
+          >
+            {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+            {entry.tools.length} tool{entry.tools.length === 1 ? "" : "s"}
+          </button>
+          {open && (
+            <ul className="flex flex-col gap-0.5 pl-4">
+              {entry.tools.map((tool) => (
+                <li key={tool} className="font-mono text-xs">
+                  {tool}
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The demoted transport machinery: gateway endpoint mounts, per-server
+ * health, and (on unmanaged profiles) the manual MCP server editor — the
+ * whole `McpPanel`, unchanged, behind a disclosure. Everything it could do
+ * it still does; it just no longer leads the page.
+ */
+function AdvancedSection({
+  client,
+  managed,
+}: {
+  client: ApiClient;
+  managed: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <section className="flex flex-col gap-6">
+      <button
+        type="button"
+        className="flex items-center gap-1 self-start text-sm font-medium text-muted-foreground hover:text-foreground"
+        aria-expanded={open}
+        onClick={() => setOpen((current) => !current)}
+      >
+        {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        Advanced: transport &amp; endpoints
+      </button>
+      {open && <McpPanel client={client} managed={managed} />}
+    </section>
+  );
+}
+
+/**
+ * The Connected apps page, app-first: the primary list is the apps this
+ * profile can reach — org-app names for gateway-backed MCP records, record
+ * names for local ones, REST entries beside them — each with a names-only
+ * tool accordion. The transport machinery (endpoint mounts, the manual MCP
+ * server editor absorbed from the retired MCP page) is demoted to an
+ * Advanced disclosure below; nothing is removed, only de-emphasized.
  */
 export function ConnectedAppsPanel({
   client,
@@ -126,10 +224,6 @@ export function ConnectedAppsPanel({
       cancelled = true;
     };
   }, [client]);
-
-  const restEntries = apps.filter(
-    (entry): entry is RestEntry => entry.kind === "rest_api",
-  );
 
   function update(change: Partial<Draft>) {
     setDraft((current) => (current === null ? null : { ...current, ...change }));
@@ -203,8 +297,11 @@ export function ConnectedAppsPanel({
     }
   }
 
-  const restRows = restEntries.map((entry) => (
-    <div key={entry.id} className="flex items-center justify-between gap-4">
+  const restRow = (entry: RestEntry) => (
+    <div
+      key={entry.id}
+      className="flex items-center justify-between gap-4 rounded-md border px-3 py-2"
+    >
       <div className="min-w-0 flex-1">
         <p className="text-sm font-bold">{entry.name}</p>
         <p className="truncate text-xs text-muted-foreground">
@@ -237,7 +334,7 @@ export function ConnectedAppsPanel({
         </div>
       )}
     </div>
-  ));
+  );
 
   const editor = draft !== null && (
     <SettingsSection
@@ -358,18 +455,16 @@ export function ConnectedAppsPanel({
   return (
     <SettingsPanel
       title="Connected apps"
-      description="Outside integrations this profile can reach: MCP servers and REST APIs, bound by local apps with your consent."
+      description="The apps this profile can reach — through your organization's gateway, local MCP servers, and REST APIs — bound by local apps with your consent."
       busy={loading || saving || deleting !== null}
     >
-      <McpPanel client={client} managed={managed} />
-
       {loading ? (
         <p className="text-sm text-muted-foreground">Loading connected apps…</p>
       ) : (
         <>
           <SettingsSection
-            title="REST APIs"
-            description="A base URL and an OpenAPI document; requests run through the governed executor."
+            title="Apps"
+            description="Each entry is one connected app. Expand it to see the tools it makes available."
           >
             {managed && (
               <SettingsStatus
@@ -378,12 +473,19 @@ export function ConnectedAppsPanel({
                 description="REST connected apps are managed by your organization's gateway; there is nothing to configure here."
               />
             )}
-            {restEntries.length === 0 ? (
+            {apps.length === 0 ? (
               <p className="text-sm text-muted-foreground">
-                No REST APIs connected.
+                No apps connected. Add a REST API here, or configure MCP
+                servers under Advanced below.
               </p>
             ) : (
-              restRows
+              apps.map((entry) =>
+                entry.kind === "mcp_server" ? (
+                  <McpAppCard key={entry.id} entry={entry} />
+                ) : (
+                  restRow(entry)
+                ),
+              )
             )}
             {!managed && draft === null && (
               <div>
@@ -405,6 +507,9 @@ export function ConnectedAppsPanel({
           {!managed && editor}
         </>
       )}
+
+      <AdvancedSection client={client} managed={managed} />
+
       {listError && <SettingsError>{listError}</SettingsError>}
     </SettingsPanel>
   );

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -905,6 +905,35 @@ impl McpRuntime {
         }
     }
 
+    /// The bare mounted tool names of every connected server, by namespace —
+    /// the name each tool carries after the `mcp__{server}__` mount prefix.
+    ///
+    /// Names only, never remote-authored descriptions or schemas: the same
+    /// renderer-safety posture as the consent sheet. Bounded by the
+    /// per-server discovery cap the client enforces at connect time.
+    pub(crate) async fn tool_names(&self) -> BTreeMap<String, Vec<String>> {
+        let state = self.state.lock().await;
+        state
+            .servers
+            .iter()
+            .map(|(name, server)| {
+                let prefix = format!("mcp__{name}__");
+                let tools = server.client.as_ref().map_or_else(Vec::new, |client| {
+                    client
+                        .tools()
+                        .map(|spec| {
+                            spec.name
+                                .strip_prefix(&prefix)
+                                .unwrap_or(&spec.name)
+                                .to_string()
+                        })
+                        .collect()
+                });
+                (name.clone(), tools)
+            })
+            .collect()
+    }
+
     /// The unmanaged shape of [`replace_under_policy`](Self::replace_under_policy),
     /// whose refusal arm is unreachable. Production has one entry point; this
     /// keeps the tests that predate the policy check reading as they did.

--- a/crates/openwave-server/src/routes/connected_apps.rs
+++ b/crates/openwave-server/src/routes/connected_apps.rs
@@ -56,7 +56,20 @@ pub enum ConnectedAppInfo {
         name: String,
         health: McpHealth,
         tool_count: usize,
+        /// The bare mounted tool names (after the `mcp__{server}__` prefix),
+        /// bounded by the per-server discovery cap. Names only — never
+        /// remote-authored descriptions — the consent sheet's posture.
+        tools: Vec<String>,
         diagnostic: Option<String>,
+        /// The gateway MCP endpoint slug this record mounts, when it is
+        /// gateway-backed rather than a local stdio/HTTP definition.
+        gateway_endpoint: Option<String>,
+        /// Display names of the organization's entitled apps that ride this
+        /// record's gateway endpoint. Empty for local records — and, by
+        /// graceful degradation, when the gateway is unreachable or predates
+        /// the apps surface: the entry then renders without org-app names
+        /// rather than erroring.
+        gateway_apps: Vec<String>,
     },
     RestApi {
         /// The record id app bindings name.
@@ -317,20 +330,51 @@ async fn connected_apps_info(state: &AppState) -> Result<ConnectedAppsInfo, Serv
         .into_iter()
         .map(|(id, fingerprint)| (fingerprint.name, id))
         .collect();
-    let mut apps: Vec<ConnectedAppInfo> = state
-        .mcp
-        .info()
-        .await
-        .servers
+    let tool_names = state.mcp.tool_names().await;
+    let servers = state.mcp.info().await.servers;
+    // Org-app display names by endpoint slug, so gateway-backed entries can
+    // lead with the apps the organization granted instead of endpoint slugs.
+    // Best-effort by design: fetched only when a gateway-backed record exists,
+    // and any failure — signed out, unreachable, a gateway predating the apps
+    // surface — degrades to entries without org-app names, never an error.
+    let mut gateway_app_names: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
+    if servers
+        .iter()
+        .any(|server| server.definition.gateway_endpoint.is_some())
+    {
+        if let Ok(gateway_apps) = state.gateway.apps().await {
+            for app in gateway_apps.apps.into_iter().filter(|app| app.enabled) {
+                for slug in &app.mcp_endpoint_slugs {
+                    gateway_app_names
+                        .entry(slug.clone())
+                        .or_default()
+                        .push(app.name.clone());
+                }
+            }
+        }
+    }
+    let mut apps: Vec<ConnectedAppInfo> = servers
         .into_iter()
         .filter_map(|server| {
             let id = *ids.get(&server.definition.name)?;
+            let gateway_endpoint = server.definition.gateway_endpoint.clone();
+            let gateway_apps = gateway_endpoint
+                .as_ref()
+                .and_then(|slug| gateway_app_names.get(slug).cloned())
+                .unwrap_or_default();
             Some(ConnectedAppInfo::McpServer {
                 id,
+                tools: tool_names
+                    .get(&server.definition.name)
+                    .cloned()
+                    .unwrap_or_default(),
                 name: server.definition.name,
                 health: server.health,
                 tool_count: server.tool_count,
                 diagnostic: server.diagnostic,
+                gateway_endpoint,
+                gateway_apps,
             })
         })
         .collect();

--- a/crates/openwave-server/src/tests/connected_apps.rs
+++ b/crates/openwave-server/src/tests/connected_apps.rs
@@ -280,6 +280,91 @@ async fn rest_credential_lifecycle_walks_set_keep_none_and_delete() {
     );
 }
 
+/// A minimal streamable-HTTP MCP fixture advertising one tool whose
+/// remote-authored description must never reach the settings listing.
+async fn serve_fake_http_mcp() -> std::net::SocketAddr {
+    use axum::routing::post;
+
+    async fn handler(body: String) -> ([(&'static str, &'static str); 1], String) {
+        let request: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let id = request.get("id").cloned().unwrap_or_default();
+        let result = match request["method"].as_str().unwrap_or_default() {
+            "initialize" => json!({
+                "protocolVersion": openwave_mcp::PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "listing-fixture", "version": "1"}
+            }),
+            "tools/list" => json!({
+                "tools": [{
+                    "name": "lookup",
+                    "description": "Remote-authored prose that stays out of settings",
+                    "inputSchema": {"type": "object"}
+                }]
+            }),
+            _ => json!({}),
+        };
+        (
+            [("content-type", "application/json")],
+            json!({"jsonrpc": "2.0", "id": id, "result": result}).to_string(),
+        )
+    }
+
+    let app = axum::Router::new().route("/mcp", post(handler));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    address
+}
+
+/// The listing enumerates a mounted server's tool names — and only names:
+/// the remote-authored tool description never crosses to this renderer
+/// surface. A local record also reads as non-gateway (`gateway_endpoint`
+/// null) with no org-app names.
+#[tokio::test]
+async fn the_listing_carries_mounted_tool_names_only() {
+    let (router, bearer, _state, _dir) = connected_apps_test_app().await;
+    let address = serve_fake_http_mcp().await;
+
+    let put = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/mcp/servers")
+                .header("authorization", &bearer)
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({"servers": [{
+                        "name": "docs",
+                        "url": format!("http://{address}/mcp")
+                    }]})
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(put.status(), StatusCode::OK);
+
+    let body = raw_body(get_listing(&router, &bearer).await).await;
+    assert!(
+        !body.contains("Remote-authored"),
+        "tool descriptions must never reach the listing: {body}"
+    );
+    let listing: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let entry = listing["apps"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["kind"] == "mcp_server" && entry["name"] == "docs")
+        .expect("the mounted server is listed");
+    assert_eq!(entry["tools"], json!(["lookup"]));
+    assert_eq!(entry["gateway_endpoint"], json!(null));
+    assert_eq!(entry["gateway_apps"], json!([]));
+}
+
 /// Configuration-time refusals persist nothing: a rejected document (or an
 /// inadmissible base URL) leaves no record and stores no credential value.
 #[tokio::test]


### PR DESCRIPTION
Closes #1439

## What changed

The Connected apps settings page led with gateway *endpoints* (infrastructure slugs like `primary`) and showed only tool counts. This inverts the page to be app-centric, matching docs/connected-apps.md's framing that users think "I connected Sentry", not "I mounted an endpoint slug":

- **Apps first.** The page's primary list is the connected apps the profile can reach. A gateway-backed MCP record leads with the organization's entitled app display names (server-side join of the record's `gateway_endpoint` slug against the gateway's entitled-apps data, enabled apps only); a local stdio/HTTP record has no org-app concept, so its entry is the record's display name. REST entries stay in the list as first-class app entries, with their existing edit/remove/create flow; the managed "nothing to configure here" notice stays.
- **Per-app tool accordion, names only.** Each MCP entry expands (collapsed by default) to its bare mounted tool names as monospace rows, bounded by the existing 128/server discovery cap. No tool descriptions: remote-authored prose stays out of settings — the same names-only renderer-safety posture as the consent sheet, and the new server test pins that the description never reaches the listing body.
- **Endpoints demoted, not removed.** The mount/unmount toggles, per-endpoint health/diagnostics, reconnect, and the manual MCP server editor — the whole `McpPanel`, unchanged — now render behind an "Advanced: transport & endpoints" disclosure at the bottom. On managed profiles the mount toggles stay live inside Advanced and the manual half stays read-only, exactly as before.

## Wire shape

The `GET /connected-apps` mcp projection gains three fields (regenerated `wire.ts`, never hand-edited):

- `tools: Array<string>` — bare mounted tool names (after the `mcp__{server}__` prefix)
- `gateway_endpoint: string | null` — the endpoint slug when gateway-backed
- `gateway_apps: Array<string>` — display names of entitled org apps riding that endpoint

Enrichment is best-effort by design: the gateway apps read happens only when a gateway-backed record exists, and any failure (signed out, unreachable, a gateway predating the apps surface) degrades to entries without org-app names rather than erroring.

## Join strategy: flat list, org-app names on the header

Tools are shown as one flat list per entry, with the org-app names on the entry header — **not** grouped per org app by `<app-slug>__proxy_api` prefix. The gateway's apps surface (`/api/v1/cli/apps`, per docs/gateway-boundary.md) carries `{id, name, app_kind, enabled, mcp_endpoint_slugs}` — display names, not the app slugs that prefix proxy tool names — and inventing a display-name→slug mapping would be guesswork. If the gateway ever exposes app slugs, prefix-grouping becomes a small follow-up.

## Tests

- Server (`tests/connected_apps.rs`): new `the_listing_carries_mounted_tool_names_only` — a real streamable-HTTP MCP fixture is mounted and the listing must carry `tools: ["lookup"]` while the remote-authored description must not appear anywhere in the response body; local records read as `gateway_endpoint: null` / `gateway_apps: []`.
- UI (`ConnectedAppsPanel.dom.test.tsx`, 6 tests): app-first rendering (org-app names for a gateway-backed entry, record name for a local one, endpoint slug absent), accordion collapsed by default and expanding to `font-mono` tool names, endpoints and manual editor reachable only inside the Advanced disclosure, managed profile keeps the notice and live mount toggles with zero edit affordances, plus the two existing REST form tests (PUT shape / credential keep) carried forward. The two prior structure tests were replaced by the app-first and Advanced-disclosure tests covering the same intent (both kinds on one page, editor reachable).
- Not covered: the server-side gateway-apps enrichment join itself — exercising it end to end needs a signed-in fake-gateway session, and the existing FakeGateway harness is private to `gateway_runtime`'s test module; the degrade path (no session → empty `gateway_apps`) is covered by the listing test.

Checks run: `cargo test -p openwave-server --locked` (570 passed), `cargo fmt --check`, scoped clippy `-D warnings`, wire regen, `tsc --noEmit`, `pnpm vitest run src/settings` (60 passed), `pnpm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)