### PR TITLE
fix(server): one GatewayRuntime shared by resolver, routes, and MCP dispatch

### DIFF
--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -1512,6 +1512,136 @@ mod tests {
         assert!(mcp.snapshot().get("mcp__tools__lookup").is_none());
     }
 
+    /// #1441: the assembled `AppState` must give the resolver, the /gateway
+    /// routes, and MCP dispatch ONE gateway runtime. Attestation contexts
+    /// live in a per-instance registry, so when `state.mcp` held its own
+    /// runtime a chat's inference token and its MCP call bearer minted in
+    /// two different contexts and the gateway's observation-consume refused
+    /// every attested `tools/call`. Assembled the way `bind_inner` does —
+    /// one runtime injected into the resolver and the state — and driven
+    /// across the boundary that used to be two instances: the token source
+    /// from `state.gateway`, the dispatch bearer through `state.mcp`.
+    #[tokio::test]
+    async fn assembled_state_mints_inference_and_mcp_dispatch_in_one_attestation_context() {
+        let gateway = Arc::new(FakeGateway::default());
+        let address = serve(gateway.clone()).await;
+        let base = format!("http://{address}");
+        let directory = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                directory.path().join("gateway.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let secrets: Arc<dyn SecretProvider> = Arc::new(MockSecrets::default());
+        let credentials: openwave_connectors::GatewayCredentials = serde_json::from_value(json!({
+            "base_url": base,
+            "installation_id": "install-1",
+            "user_id": "user-1",
+            "refresh_token": "mg_rt_seed",
+            "access_tokens": {}
+        }))
+        .unwrap();
+        CredentialVault::new(secrets.clone())
+            .save(&credentials)
+            .await
+            .unwrap();
+        crate::managed_policy::provision(&*store, &base)
+            .await
+            .unwrap();
+
+        let os_policy: Arc<dyn crate::managed_policy::OsPolicySource> =
+            Arc::new(crate::managed_policy::NoOsPolicy);
+        let runtime = GatewayRuntime::new(store.clone(), secrets.clone(), os_policy.clone());
+        let resolver = Arc::new(crate::resolver::ConfiguredResolver::new(
+            store.clone(),
+            secrets.clone(),
+            runtime.clone(),
+            os_policy.clone(),
+        ));
+        let state = crate::state::AppState::with_gateway_runtime(
+            openwave_core::Config::desktop(directory.path()),
+            store.clone(),
+            resolver,
+            secrets,
+            Arc::new(openwave_core::ToolRegistry::new()),
+            openwave_core::AgentConfig::default(),
+            uuid::Uuid::new_v4(),
+            runtime,
+            os_policy,
+        )
+        .unwrap();
+
+        // Identity first: dispatch resolves through the very runtime the
+        // routes and resolver hold — the cheap pin on the bug class.
+        let dispatch = state.mcp.gateway_endpoints();
+        assert!(
+            std::ptr::eq(
+                Arc::as_ptr(&dispatch) as *const (),
+                Arc::as_ptr(&state.gateway) as *const (),
+            ),
+            "MCP dispatch must share the state's gateway runtime"
+        );
+
+        // And behaviorally: mount an endpoint through the state's MCP
+        // runtime, dispatch one chat's tools/call, mint that chat's
+        // router-facing inference token — one attestation context.
+        let info = state
+            .mcp
+            .replace(crate::mcp_config::McpServersConfig {
+                servers: vec![crate::mcp_config::McpServerDefinition {
+                    name: "tools".to_string(),
+                    command: None,
+                    args: Vec::new(),
+                    env: std::collections::BTreeMap::new(),
+                    env_from: Vec::new(),
+                    cwd: None,
+                    url: None,
+                    bearer_token_env: None,
+                    gateway_endpoint: Some("tools".to_string()),
+                    request_timeout_ms: 60_000,
+                    enabled: true,
+                }],
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            info.servers[0].health,
+            crate::mcp_config::McpHealth::Healthy
+        );
+
+        let chat = openwave_core::id::ChatId::new();
+        let snapshot = state.mcp.snapshot();
+        let tool = snapshot.get("mcp__tools__lookup").unwrap();
+        let ctx = openwave_core::ToolCtx::without_private_scratch(chat, None);
+        tool.execute(&ctx, json!({})).await.unwrap();
+        let source = state
+            .gateway
+            .route_token_source()
+            .await
+            .expect("signed-in runtime offers a token source");
+        source.bearer_token_for(Some(chat)).await.unwrap();
+
+        let minted = gateway.minted.lock().unwrap();
+        let chat_mcp = minted
+            .iter()
+            .filter(|(resource, _)| resource == "mcp:tools")
+            .nth(1)
+            .map(|(_, context)| context.clone().unwrap())
+            .expect("the tool call minted a chat-scoped mcp:tools token");
+        let chat_llm = minted
+            .iter()
+            .find(|(resource, _)| resource == "llm")
+            .map(|(_, context)| context.clone().unwrap())
+            .expect("the chat's inference minted an llm token");
+        assert_eq!(
+            chat_mcp, chat_llm,
+            "inference and MCP dispatch must mint in the same attestation context"
+        );
+    }
+
     /// Mount-by-default, end to end: a reconcile against the entitled apps
     /// list mounts the endpoint enabled and connected, and a second
     /// reconcile with unchanged entitlements is a strict no-op — the

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -886,25 +886,30 @@ async fn bind_inner(
         config.data_dir.clone(),
     );
     let tools = Arc::new(tools);
-    let mut state = match client_executor_id {
-        Some(client_executor_id) => AppState::new_with_client_executor_id(
-            config,
-            store,
-            resolver,
-            secrets,
-            tools,
-            agent_config,
-            client_executor_id,
-        )?,
-        None => AppState::new(config, store, resolver, secrets, tools, agent_config),
-    };
+    // The resolver, the /gateway routes, and MCP dispatch must share ONE
+    // runtime, so it is injected at assembly rather than patched in after:
+    // attestation contexts live in a per-instance registry (a second
+    // instance splits a chat's inference tokens and MCP call bearers across
+    // two contexts, and the gateway refuses every attested tools/call —
+    // #1441), and refresh rotation is serialized per GatewayConnection
+    // instance (two instances over the same keychain entry can race a stale
+    // refresh token into the gateway's reuse detection, a spurious full
+    // sign-out).
+    let mut state = AppState::with_gateway_runtime(
+        config,
+        store,
+        resolver,
+        secrets,
+        tools,
+        agent_config,
+        client_executor_id.unwrap_or_else(Uuid::new_v4),
+        gateway,
+        os_policy,
+    )?;
+    // Without a restart-stable native executor identity, durable
+    // root-attachment mutations stay off — matching `AppState::new`.
+    state.root_attachment_routes_enabled = client_executor_id.is_some();
     state.blobs = blobs;
-    // The resolver and the /gateway routes must share ONE runtime: refresh
-    // rotation is serialized per GatewayConnection instance, and two
-    // instances over the same keychain entry can race a stale refresh token
-    // into the gateway's reuse detection (a spurious full sign-out).
-    state.gateway = gateway;
-    state.os_policy = os_policy;
     if let Some(local_voice) = local_voice {
         state.set_local_voice_runner(local_voice);
     }

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -684,6 +684,15 @@ impl McpRuntime {
         }
     }
 
+    /// The gateway resolver MCP dispatch rides on — exposed so tests can pin
+    /// that it is the same instance as `AppState::gateway` (#1441: a second
+    /// runtime splits attestation contexts and every attested `tools/call`
+    /// is refused).
+    #[cfg(test)]
+    pub(crate) fn gateway_endpoints(&self) -> Arc<dyn GatewayEndpoints> {
+        self.gateway.clone()
+    }
+
     /// How far managed policy currently locks the manual transports.
     ///
     /// Read per operation rather than cached at boot, like every other policy

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -104,14 +104,14 @@ pub struct AppState {
     /// prefetched MCP views and stored local-app revisions alike.
     pub(crate) view_frames: Arc<ViewFrameTokens>,
     /// The signed-in model-gateway session handle (sign-in, model sync,
-    /// per-request tokens). The production assembly in `bind_inner` replaces
-    /// this with the resolver's instance — refresh rotation is serialized
-    /// per instance, so routes and resolver must share one.
+    /// per-request tokens). Always the same instance `mcp` dispatches
+    /// through — see [`Self::with_gateway_runtime`] for why the process
+    /// must hold exactly one.
     pub(crate) gateway: Arc<crate::gateway_runtime::GatewayRuntime>,
-    /// The OS-managed policy reader for managed-mode resolution. Constructed
-    /// as the source that asserts nothing, so directly assembled state (tests,
-    /// custom hosts) reads nothing from the host OS; the production
-    /// assembly in `bind_inner` replaces this with the platform's reader via
+    /// The OS-managed policy reader for managed-mode resolution. Directly
+    /// assembled state (tests, custom hosts) gets the source that asserts
+    /// nothing, so it reads nothing from the host OS; the production
+    /// assembly in `bind_inner` injects the platform's reader via
     /// `managed_policy::platform_source`.
     pub(crate) os_policy: Arc<dyn crate::managed_policy::OsPolicySource>,
     /// Wakes the durable turn worker after acceptance or cancellation commits.
@@ -195,6 +195,53 @@ impl AppState {
         agent_config: AgentConfig,
         client_executor_id: Uuid,
     ) -> Result<Self> {
+        // Hermetic default wiring: the policy source that asserts nothing and
+        // one gateway runtime built over these same inputs. The sharing
+        // invariant lives in `with_gateway_runtime`; this only picks inputs.
+        let os_policy: Arc<dyn crate::managed_policy::OsPolicySource> =
+            Arc::new(crate::managed_policy::NoOsPolicy);
+        let gateway = crate::gateway_runtime::GatewayRuntime::new(
+            store.clone(),
+            secrets.clone(),
+            os_policy.clone(),
+        );
+        Self::with_gateway_runtime(
+            config,
+            store,
+            resolver,
+            secrets,
+            tools,
+            agent_config,
+            client_executor_id,
+            gateway,
+            os_policy,
+        )
+    }
+
+    /// Assemble state around the one process-wide gateway runtime and the OS
+    /// policy source it was built from.
+    ///
+    /// Every holder that reaches the gateway — the provider resolver, the
+    /// `/gateway` routes (`state.gateway`), and MCP dispatch (`state.mcp`) —
+    /// must share this single instance. Attestation contexts live in a
+    /// per-instance in-memory registry, so a second instance mints a chat's
+    /// inference tokens and its MCP call bearers in *different* attestation
+    /// contexts and the gateway refuses every attested `tools/call` (#1441).
+    /// Refresh rotation is likewise serialized per instance; two instances
+    /// over the same keychain entry can race a stale refresh token into the
+    /// gateway's reuse detection (a spurious full sign-out).
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn with_gateway_runtime(
+        config: Config,
+        store: Arc<dyn Store>,
+        resolver: Arc<dyn ProviderResolver>,
+        secrets: Arc<dyn SecretProvider>,
+        tools: Arc<ToolRegistry>,
+        agent_config: AgentConfig,
+        client_executor_id: Uuid,
+        gateway: Arc<crate::gateway_runtime::GatewayRuntime>,
+        os_policy: Arc<dyn crate::managed_policy::OsPolicySource>,
+    ) -> Result<Self> {
         if client_executor_id.is_nil() {
             return Err(AgentError::config("client executor id must not be nil"));
         }
@@ -217,13 +264,6 @@ impl AppState {
         };
         let blobs: Arc<dyn BlobStore> = Arc::new(FsBlobStore::new(config.data_dir.join("blobs")));
         let blob_writes = Arc::new(BlobWriteGuard::new(config.data_dir.join("blob-locks")));
-        let os_policy: Arc<dyn crate::managed_policy::OsPolicySource> =
-            Arc::new(crate::managed_policy::NoOsPolicy);
-        let gateway = crate::gateway_runtime::GatewayRuntime::new(
-            store.clone(),
-            secrets.clone(),
-            os_policy.clone(),
-        );
         let mcp = Arc::new(McpRuntime::new(
             tools.clone(),
             store.clone(),


### PR DESCRIPTION
Closes #1441

## What was broken, in user terms

On a gateway-managed profile with an attested MCP endpoint mounted Healthy, **every chat tool call to that endpoint failed** with "This tool call was not authorized by the model gateway or was already used" — deterministically, on every turn. The feature shipped in #1423 never worked end to end.

## Why

The process held **two** `GatewayRuntime` instances. `AppState` assembly built a private one (over `NoOsPolicy`) and handed it to `McpRuntime`; `bind_inner` then built the real shared runtime and replaced `state.gateway` after the fact — but `McpRuntime`'s captured reference is immutable, so it kept the orphan. Attestation contexts are client-minted UUIDs held in a per-instance in-memory registry, so the same chat got one context for its LLM inference tokens and a different one for its MCP dispatch bearers. The gateway's observation-consume requires context equality, so no attested `tools/call` could ever match the observation its inference recorded. (The orphan also read no OS/MDM policy — on a pure-MDM profile dispatch would have refused bearers outright.)

## The fix

One runtime per process, injected at assembly instead of patched in after:

- `bind_inner` builds the single `GatewayRuntime` (with the platform OS-policy source) and passes it — together with that policy source — into the new `AppState::with_gateway_runtime`, which wires the **same Arc** into `state.gateway` and `McpRuntime`. The post-hoc `state.gateway = …; state.os_policy = …;` rewiring is gone.
- The public `AppState::new` / `new_with_client_executor_id` keep their signatures and delegate: they build the hermetic `NoOsPolicy` runtime once and share it the same way, so directly assembled state (tests, custom hosts) stays coherent.
- The pairing handle and the model-sync loop already flowed from `state.gateway`, so every holder now shares the one instance. The only other `GatewayConnection` built separately is the deliberately ephemeral boot-time revoke in `retire_superseded_gateway_session`, which runs before the runtime exists.

## Regression coverage

One new test (`gateway_runtime.rs`) drives the production assembly shape against the existing fake gateway: it constructs `AppState` exactly the way `bind_inner` does, asserts pointer identity between `state.gateway` and the runtime `McpRuntime` dispatches through (the cheap pin on this bug class, which review caught once before), then mounts an endpoint through `state.mcp`, dispatches a chat's `tools/call`, mints the chat's router-facing inference token, and asserts both minted in the **same** attestation context.

`cargo test -p openwave-server --locked` (576 tests), scoped clippy `-D warnings`, and rustfmt all pass locally. Not verified against a live gateway: the gateway's development-fixture inference path records no observations (gateway-side gap noted in #1441), so the unit/integration suite is the verification here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)