### PR TITLE
feat(code-execution): default E2B sandboxes to the published OpenWave documents template

### DIFF
--- a/crates/openwave-code-execution/src/e2b.rs
+++ b/crates/openwave-code-execution/src/e2b.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::{Component, Path};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -29,7 +30,27 @@ use crate::{
 
 const E2B_API_BASE: &str = "https://api.e2b.app";
 const E2B_SANDBOX_BASE: &str = "https://sandbox.e2b.app";
-const E2B_TEMPLATE: &str = "code-interpreter-v1";
+/// The published OpenWave documents template every sandbox is created from.
+///
+/// E2B provisions from account-registered *templates*, not arbitrary OCI refs,
+/// so the image reaches E2B as a template published from the OpenWave account —
+/// public, and therefore usable by any E2B account by alias, exactly like E2B's
+/// own `code-interpreter-v1`. A user who pastes an API key gets the documents
+/// image with no template setup of their own.
+///
+/// The alias carries the image version so the pin is visible in one place. It
+/// is currently built from
+/// `ghcr.io/brightwave-inc/openwave-sandbox-agent-documents:v0.26.0`
+/// (`sha256:dd22da7a3c5b1f315e888da902e7a46ae034585e2ab5c09c0ae4588a69f158a2`),
+/// the same ref recorded in `crates/openwave-sandbox-agent/e2b/e2b.Dockerfile`.
+/// Publishing a new image version means publishing a new alias and moving this
+/// constant with it — that directory's README has the procedure.
+const E2B_TEMPLATE: &str = "openwave-documents-v0-26-0";
+
+/// E2B's own public code-interpreter template, used only when the OpenWave
+/// template cannot be resolved. Degraded but working: document skills fall back
+/// to installing their Python dependencies inside the sandbox at run time.
+const E2B_FALLBACK_TEMPLATE: &str = "code-interpreter-v1";
 const E2B_WORKSPACE_ROOT: &str = "/home/user";
 const E2B_USER: &str = "user";
 const E2B_ENVD_PORT: &str = "49983";
@@ -86,6 +107,13 @@ pub struct E2BExecutionProvider {
     endpoints: E2BEndpoints,
     egress: Option<EgressPolicy>,
     template: String,
+    /// Whether `template` is the built-in default rather than a caller's
+    /// override. Only the default may fall back.
+    default_template: bool,
+    /// Latched once E2B reports the default template unresolvable, so the
+    /// remaining sandbox creations of this provider's life skip the doomed
+    /// first attempt.
+    template_unavailable: AtomicBool,
 }
 
 #[derive(Clone)]
@@ -145,21 +173,22 @@ impl E2BExecutionProvider {
             endpoints,
             egress: None,
             template: E2B_TEMPLATE.into(),
+            default_template: true,
+            template_unavailable: AtomicBool::new(false),
         })
     }
 
-    /// Create every sandbox from this E2B template instead of the default
-    /// public code-interpreter template.
+    /// Create every sandbox from this E2B template instead of the published
+    /// OpenWave documents template.
     ///
-    /// E2B provisions from account-registered *templates*, not arbitrary OCI
-    /// refs, so pointing E2B at the official OpenWave documents image means
-    /// registering a template built from
-    /// `crates/openwave-sandbox-agent/Dockerfile` with E2B's own tooling and
-    /// naming its id here. Absent an override the default template keeps
-    /// working — skills fall back to in-sandbox `pip install`.
+    /// This is an escape hatch for an account that maintains its own template.
+    /// Unlike the default it never falls back: a template the caller named and
+    /// E2B cannot resolve is an error they need to see, not something to paper
+    /// over with different sandbox contents.
     #[must_use]
     pub fn with_template(mut self, template: impl Into<String>) -> Self {
         self.template = template.into();
+        self.default_template = false;
         self
     }
 
@@ -213,6 +242,47 @@ impl E2BExecutionProvider {
         &self,
         workspace_id: &str,
     ) -> Result<RemoteSession, CodeExecutionError> {
+        if !self.default_template || self.template_unavailable.load(Ordering::Relaxed) {
+            let template = if self.default_template {
+                E2B_FALLBACK_TEMPLATE
+            } else {
+                self.template.as_str()
+            };
+            return self
+                .create_sandbox_from(workspace_id, template)
+                .await
+                .map_err(|failure| failure.into_error(template));
+        }
+
+        match self.create_sandbox_from(workspace_id, &self.template).await {
+            Ok(session) => Ok(session),
+            Err(CreateSandboxFailure::TemplateMissing) => {
+                // The OpenWave template is published from one account and used
+                // by all of them, so it can be absent here for reasons the user
+                // cannot fix: the publish has not happened yet on a build that
+                // shipped ahead of it, or it was withdrawn. Rather than leave
+                // code execution dead, run the same skills on E2B's public
+                // template and pay the in-sandbox install.
+                tracing::warn!(
+                    "E2B could not resolve the OpenWave template '{}'; falling back to '{E2B_FALLBACK_TEMPLATE}' \
+                     for the rest of this session. Document skills will install their Python \
+                     dependencies inside the sandbox at run time.",
+                    self.template
+                );
+                self.template_unavailable.store(true, Ordering::Relaxed);
+                self.create_sandbox_from(workspace_id, E2B_FALLBACK_TEMPLATE)
+                    .await
+                    .map_err(|failure| failure.into_error(E2B_FALLBACK_TEMPLATE))
+            }
+            Err(failure) => Err(failure.into_error(&self.template)),
+        }
+    }
+
+    async fn create_sandbox_from(
+        &self,
+        workspace_id: &str,
+        template: &str,
+    ) -> Result<RemoteSession, CreateSandboxFailure> {
         let url = format!(
             "{}/sandboxes",
             self.endpoints.api_base.trim_end_matches('/')
@@ -223,7 +293,7 @@ impl E2BExecutionProvider {
             .post(url)
             .header("X-API-Key", self.credential.as_str())
             .json(&CreateSandboxRequest {
-                template_id: &self.template,
+                template_id: template,
                 timeout: E2B_SANDBOX_TTL_SECONDS,
                 secure: true,
                 allow_internet_access: network.allow_internet_access,
@@ -232,8 +302,22 @@ impl E2BExecutionProvider {
             })
             .send()
             .await
-            .map_err(|_| CodeExecutionError::Unavailable("could not reach the E2B API".into()))?;
-        decode_session(response).await
+            .map_err(|_| {
+                CreateSandboxFailure::Other(CodeExecutionError::Unavailable(
+                    "could not reach the E2B API".into(),
+                ))
+            })?;
+        // Template resolution is the only thing creation looks up by name, and
+        // E2B answers an unresolvable one — unknown alias, or a template the
+        // key's team cannot see — with 404 and a `template '<id>' not found`
+        // body. Every other failure (401/403 credential, 429 quota, 5xx) keeps
+        // its own meaning.
+        if response.status() == StatusCode::NOT_FOUND {
+            return Err(CreateSandboxFailure::TemplateMissing);
+        }
+        decode_session(response)
+            .await
+            .map_err(CreateSandboxFailure::Other)
     }
 
     async fn connect_sandbox(
@@ -621,6 +705,25 @@ impl CodeExecutionProvider for E2BExecutionProvider {
 
     fn workspace_lifecycle(&self) -> Option<&dyn WorkspaceLifecycle> {
         Some(self)
+    }
+}
+
+/// Why a single sandbox-creation attempt failed. Split out from
+/// [`CodeExecutionError`] because only one shape — E2B failing to resolve the
+/// template — may be retried against a different template.
+enum CreateSandboxFailure {
+    TemplateMissing,
+    Other(CodeExecutionError),
+}
+
+impl CreateSandboxFailure {
+    fn into_error(self, template: &str) -> CodeExecutionError {
+        match self {
+            Self::TemplateMissing => CodeExecutionError::Unavailable(format!(
+                "E2B could not find the sandbox template '{template}'"
+            )),
+            Self::Other(error) => error,
+        }
     }
 }
 
@@ -1051,12 +1154,16 @@ mod tests {
 
     struct MockState {
         mode: ProcessMode,
+        /// Template id the mock refuses to resolve, answering the 404 E2B
+        /// returns for an alias its team cannot see.
+        missing_template: Option<String>,
         creates: AtomicUsize,
         connects: AtomicUsize,
         starts: AtomicUsize,
         deletes: AtomicUsize,
         uploads: AtomicUsize,
         create_body: StdMutex<Option<Value>>,
+        create_templates: StdMutex<Vec<String>>,
         start_bodies: StdMutex<Vec<Vec<u8>>>,
         api_keys: StdMutex<Vec<String>>,
         access_tokens: StdMutex<Vec<String>>,
@@ -1067,12 +1174,14 @@ mod tests {
         fn new(mode: ProcessMode) -> Self {
             Self {
                 mode,
+                missing_template: None,
                 creates: AtomicUsize::new(0),
                 connects: AtomicUsize::new(0),
                 starts: AtomicUsize::new(0),
                 deletes: AtomicUsize::new(0),
                 uploads: AtomicUsize::new(0),
                 create_body: StdMutex::new(None),
+                create_templates: StdMutex::new(Vec::new()),
                 start_bodies: StdMutex::new(Vec::new()),
                 api_keys: StdMutex::new(Vec::new()),
                 access_tokens: StdMutex::new(Vec::new()),
@@ -1084,7 +1193,21 @@ mod tests {
     async fn mock_server(
         mode: ProcessMode,
     ) -> (Arc<MockState>, String, tokio::task::JoinHandle<()>) {
-        let state = Arc::new(MockState::new(mode));
+        serve(MockState::new(mode)).await
+    }
+
+    /// A mock whose account cannot resolve `missing_template` — E2B's answer
+    /// when the alias is unknown or not published to this team.
+    async fn mock_server_without_template(
+        missing_template: &str,
+    ) -> (Arc<MockState>, String, tokio::task::JoinHandle<()>) {
+        let mut state = MockState::new(ProcessMode::Complete);
+        state.missing_template = Some(missing_template.to_owned());
+        serve(state).await
+    }
+
+    async fn serve(state: MockState) -> (Arc<MockState>, String, tokio::task::JoinHandle<()>) {
+        let state = Arc::new(state);
         let app = Router::new()
             .route("/sandboxes", post(mock_create))
             .route("/sandboxes/{sandbox_id}", delete(mock_delete))
@@ -1141,19 +1264,35 @@ mod tests {
         State(state): State<Arc<MockState>>,
         headers: HeaderMap,
         Json(body): Json<Value>,
-    ) -> Json<Value> {
+    ) -> Result<Json<Value>, (axum::http::StatusCode, Json<Value>)> {
         state.creates.fetch_add(1, Ordering::SeqCst);
         state
             .api_keys
             .lock()
             .unwrap()
             .push(header_value(&headers, "x-api-key"));
+        let template = body["templateID"].as_str().unwrap().to_owned();
+        state
+            .create_templates
+            .lock()
+            .unwrap()
+            .push(template.clone());
+        if state.missing_template.as_deref() == Some(template.as_str()) {
+            // The body E2B's API returns for an unresolvable template.
+            return Err((
+                axum::http::StatusCode::NOT_FOUND,
+                Json(json!({
+                    "code": 404,
+                    "message": format!("template '{template}' not found"),
+                })),
+            ));
+        }
         *state.create_body.lock().unwrap() = Some(body);
-        Json(json!({
+        Ok(Json(json!({
             "sandboxID": "sandbox-123",
             "envdVersion": "0.3.0",
             "envdAccessToken": "access-123"
-        }))
+        })))
     }
 
     async fn mock_connect(
@@ -1387,7 +1526,10 @@ mod tests {
         );
 
         let create = state.create_body.lock().unwrap().clone().unwrap();
-        assert_eq!(create["templateID"], E2B_TEMPLATE);
+        // Spelled out rather than compared to the constant: reverting the
+        // default to E2B's public template silently costs every document run
+        // an in-sandbox dependency install.
+        assert_eq!(create["templateID"], "openwave-documents-v0-26-0");
         assert_eq!(create["metadata"]["openwave_workspace_id"], "workspace-1");
         assert_eq!(create["secure"], true);
         assert_eq!(create["allow_internet_access"], true);
@@ -1567,6 +1709,54 @@ mod tests {
             .unwrap();
         assert_eq!(state.creates.load(Ordering::SeqCst), 2);
         assert_eq!(state.deletes.load(Ordering::SeqCst), 1);
+        server.abort();
+    }
+
+    /// The OpenWave template is published from one account and consumed by
+    /// every account, so a client can outrun the publish or see it withdrawn.
+    /// Creation then falls back to E2B's public template — once, with the
+    /// decision latched so later sandboxes skip the doomed first attempt.
+    #[tokio::test]
+    async fn e2b_falls_back_to_the_public_template_when_openwave_s_is_unresolvable() {
+        let (state, base, server) = mock_server_without_template(E2B_TEMPLATE).await;
+        let provider = provider_at(&base, RemoteSessionPool::default(), None);
+
+        provider
+            .execute(request("execution-1", "workspace-a", "first"))
+            .await
+            .unwrap();
+        provider
+            .execute(request("execution-2", "workspace-b", "second"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            state.create_templates.lock().unwrap().as_slice(),
+            [E2B_TEMPLATE, E2B_FALLBACK_TEMPLATE, E2B_FALLBACK_TEMPLATE]
+        );
+        server.abort();
+    }
+
+    /// A template the caller named is theirs to fix: creation surfaces the
+    /// failure instead of quietly running on different sandbox contents.
+    #[tokio::test]
+    async fn e2b_does_not_fall_back_from_an_explicit_template_override() {
+        let (state, base, server) = mock_server_without_template("acme-custom").await;
+        let provider =
+            provider_at(&base, RemoteSessionPool::default(), None).with_template("acme-custom");
+
+        let error = provider
+            .execute(request("execution-1", "workspace-a", "first"))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(&error, CodeExecutionError::Unavailable(message) if message.contains("acme-custom")),
+            "unexpected error: {error:?}"
+        );
+        assert_eq!(
+            state.create_templates.lock().unwrap().as_slice(),
+            ["acme-custom"]
+        );
         server.abort();
     }
 

--- a/crates/openwave-sandbox-agent/e2b/README.md
+++ b/crates/openwave-sandbox-agent/e2b/README.md
@@ -1,0 +1,86 @@
+# The OpenWave documents template on E2B
+
+E2B provisions sandboxes from templates registered with an E2B account, not
+from arbitrary OCI references. Publishing a template makes it public: any E2B
+account can create sandboxes from it by alias, the same way E2B's own
+`code-interpreter-v1` works. That is how a user who has pasted nothing but an
+E2B API key still gets OpenWave's official documents image — LibreOffice, the
+`exec` helper scripts, and the document skills' Python dependencies already
+installed, so a document run needs no in-sandbox `pip install`.
+
+The alias is version-suffixed — `openwave-documents-v0-26-0` — so the client
+pins the exact sandbox contents it was built against, and publishing a new
+image version cannot change what an older client gets. `E2B_TEMPLATE` in
+[`crates/openwave-code-execution/src/e2b.rs`](../../openwave-code-execution/src/e2b.rs)
+is the client side of that pin.
+
+## What is here
+
+- `e2b.Dockerfile` — the template's build definition: the published documents
+  image by digest, plus E2B's expected `user` account.
+- `e2b.toml` — the template's identity and sizing, for CLI commands that read
+  it rather than taking arguments.
+
+## Publishing (one-time, per version)
+
+Run from this directory, on a machine authenticated against the OpenWave E2B
+account. `e2b auth login` uses a browser; `E2B_ACCESS_TOKEN` (Account Settings
+in the E2B dashboard, not the API key) works headless.
+
+```sh
+npm install -g @e2b/cli    # or: brew install e2b
+e2b auth login
+
+# Build System 2.0 (current CLI). The name is the public alias; it takes no
+# config file, so the sizing recorded in e2b.toml is passed explicitly.
+e2b template create openwave-documents-v0-26-0 \
+  --dockerfile e2b.Dockerfile --cpu-count 2 --memory-mb 2048
+
+# Make it public. Without the argument the CLI would read e2b.toml's
+# template_id, which is this same alias.
+e2b template publish openwave-documents-v0-26-0
+```
+
+On an older CLI the build step is `e2b template build --name
+openwave-documents-v0-26-0` instead; it rewrites `e2b.toml` with the generated
+template id, which should be committed if it does.
+
+Verify with a throwaway account's API key that creation by alias works from
+outside the OpenWave team — that cross-account visibility is the whole point,
+and it is the one thing a publish from inside the account does not prove:
+
+```sh
+E2B_API_KEY=<other-account-key> \
+  e2b sandbox create openwave-documents-v0-26-0
+```
+
+`e2b template unpublish openwave-documents-v0-26-0` reverses the publish. The
+client tolerates that: sandbox creation falls back to `code-interpreter-v1`
+when E2B cannot resolve the OpenWave template, in a degraded mode where the
+document skills install their Python dependencies at run time.
+
+## Bumping the version
+
+The image tag, the digest in `e2b.Dockerfile`, the alias in `e2b.toml`, and
+`E2B_TEMPLATE` in `e2b.rs` move together:
+
+1. Publish the new sandbox image (`.github/workflows/publish-sandbox-image.yml`
+   runs on version tags) and take the `documents` manifest-list digest.
+2. Update `e2b.Dockerfile`'s digest and the comment recording its tag.
+3. Rename the alias in `e2b.toml` and `E2B_TEMPLATE` to match the new version,
+   e.g. `openwave-documents-v0-27-0`.
+4. Build and publish the new alias as above. Leave the previous alias published
+   until clients pinned to it are out of circulation — unpublishing it drops
+   those users to the degraded fallback.
+
+## Notes on the template
+
+- E2B runs `envd` as PID 1 and ignores the image's `ENTRYPOINT`, so the sandbox
+  agent binary the image carries is dormant on E2B. OpenWave's E2B provider
+  talks to `envd` directly; the image is here for its contents.
+- The template needs no start command: everything the document skills use is
+  installed at image-build time and nothing has to be running.
+- E2B's default sandbox user is `user` with `/home/user` as its home, which is
+  also the workspace root the provider's file APIs address. The OpenWave image
+  runs as `openwave` out of a different home, so the Dockerfile creates `user`
+  explicitly rather than depending on E2B's builder to add it.

--- a/crates/openwave-sandbox-agent/e2b/e2b.Dockerfile
+++ b/crates/openwave-sandbox-agent/e2b/e2b.Dockerfile
@@ -1,0 +1,29 @@
+# The E2B template built from the published OpenWave documents image.
+#
+# E2B provisions sandboxes from account-registered templates, not arbitrary OCI
+# refs, so the image reaches E2B by being built into a template and published
+# (made public) from the OpenWave account. A published template is usable by
+# every E2B account by alias, which is why a user who pastes only an API key
+# still gets this image. See README.md for the publish and version-bump flow.
+#
+# Digest-pinned so the template's contents are exactly the image we tested:
+# ghcr.io/brightwave-inc/openwave-sandbox-agent-documents:v0.26.0.
+FROM ghcr.io/brightwave-inc/openwave-sandbox-agent-documents@sha256:dd22da7a3c5b1f315e888da902e7a46ae034585e2ab5c09c0ae4588a69f158a2
+
+# E2B replaces the image's entrypoint with envd as PID 1 and runs commands as
+# the `user` account out of /home/user — the root the E2B provider's file and
+# command APIs address. The OpenWave image's own unprivileged account is
+# `openwave` with a different home, so make E2B's expected identity exist
+# rather than relying on the builder to add it. The `id` guard keeps this a
+# no-op if a future base already ships the account.
+USER root
+RUN (id -u user >/dev/null 2>&1 \
+      || useradd --create-home --home-dir /home/user --shell /bin/bash user) \
+    && mkdir -p /home/user \
+    && chown -R user:user /home/user
+
+# The document helpers are installed system-wide in the base image (LibreOffice,
+# poppler, and the hash-pinned Python dependency closure), so nothing else is
+# layered here: no start command, and no in-sandbox package install at run time.
+# The sandbox agent binary the image also carries is unused on E2B — envd is the
+# transport there, and OpenWave's E2B provider speaks to envd directly.

--- a/crates/openwave-sandbox-agent/e2b/e2b.toml
+++ b/crates/openwave-sandbox-agent/e2b/e2b.toml
@@ -1,0 +1,7 @@
+template_id = "openwave-documents-v0-26-0"
+template_name = "openwave-documents-v0-26-0"
+dockerfile = "e2b.Dockerfile"
+cpu_count = 2
+# LibreOffice's headless renderers are the memory floor here; E2B's defaults
+# (512 MB on the v1 CLI, 1024 MB on v2) are not enough to convert a deck.
+memory_mb = 2048

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -254,10 +254,12 @@ pub struct CodeExecutionConfig {
     /// open-internet creation they already had.
     #[serde(default)]
     pub egress: EgressConfig,
-    /// E2B template id to create sandboxes from. `None` keeps E2B's public
-    /// code-interpreter template; set it to the id of a template registered
-    /// from the official OpenWave documents image so document runs need no
-    /// in-sandbox package install.
+    /// E2B template id to create sandboxes from. `None` — the normal case —
+    /// uses the OpenWave documents template E2B publishes publicly, so an
+    /// account that has only pasted an API key still gets the official image
+    /// with no template setup of its own. Set this only to override that with
+    /// an account's own template; the override is used verbatim and, unlike the
+    /// default, never falls back to E2B's public code-interpreter template.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub e2b_template: Option<String>,
     /// Daytona snapshot name to create sandboxes from. `None` keeps Daytona's


### PR DESCRIPTION
E2B sandboxes are created from E2B's public `code-interpreter-v1` template, so every document run on E2B pays an in-sandbox `pip install` for the document skills' Python dependencies — unless the user registers a template from our image themselves and points `code_execution.e2b_template` at it. That is not a setup step anyone completes.

E2B templates can be *published*, which makes them creatable by any E2B account by alias — the same mechanism behind `code-interpreter-v1`. This defaults sandbox creation to a published OpenWave template built from `ghcr.io/brightwave-inc/openwave-sandbox-agent-documents:v0.26.0`, so pasting an API key is the entire setup and the sandbox arrives with LibreOffice, the exec helper scripts, and the pinned dependency closure already installed.

## What changed

- `E2B_TEMPLATE` is now `openwave-documents-v0-26-0`. The alias carries the image version deliberately: a client pins the sandbox contents it was built against, and publishing a newer image cannot change what an older client gets underneath it.
- `crates/openwave-sandbox-agent/e2b/` holds the template definition we publish from — `e2b.Dockerfile` (the documents image by manifest-list digest, plus E2B's expected `user` account, which our image does not have since it runs as `openwave`), `e2b.toml`, and a README covering the publish flow, cross-account verification, and the version-bump procedure.
- `CodeExecutionConfig::e2b_template`'s doc comment now describes the field as an override of the OpenWave default rather than the only way to get our image.

## Fallback semantics

The publish is an operational step outside this repo, and a published template can also be withdrawn, so creation cannot assume the alias resolves.

- Trigger: `POST /sandboxes` answering **404**. Template resolution is the only name lookup creation performs; E2B's API maps both an unknown alias and a template the key's team cannot see to 404 with a `template '<id>' not found` body. Verified against the API implementation in `e2b-dev/infra` (`packages/api/internal/handlers/sandbox_create.go` → `packages/api/internal/cache/templates/errors.go`), where template-not-found and invisible-template access-denied are the 404 cases and everything else keeps its own status.
- On that 404 the provider logs a warning and retries once against `code-interpreter-v1` — degraded but working, with the skills installing their dependencies at run time. The decision is latched on the provider instance, so subsequent sandbox creations go straight to the fallback instead of paying a doomed first attempt each time.
- 401/403 (credential), 429 (quota), and transport failures are untouched and surface as they do today.
- An explicit `with_template()` override never falls back. A template the caller named and E2B cannot resolve is an error they need to see, not something to paper over by running different sandbox contents.

## Follow-up: the publish itself

Publishing `openwave-documents-v0-26-0` from the OpenWave E2B account is a manual step that needs a human's E2B access token; the README documents it. **This is safe to merge before that happens** — until the template exists, E2B answers 404 and every sandbox lands on `code-interpreter-v1`, which is exactly today's behavior. The one thing the publish must confirm is cross-account visibility: create a sandbox from the alias with an unrelated account's API key, since a publish from inside the owning account does not prove it.

## Tests

Three E2B tests against the crate's existing axum mock, which now models a 404 for a template the account cannot resolve:

- the default-template assertion in the existing sandbox-reuse test is spelled out as the literal alias instead of comparing to the constant, so reverting the default to E2B's public template fails rather than passing tautologically;
- `e2b_falls_back_to_the_public_template_when_openwave_s_is_unresolvable` — two workspaces produce creation attempts `[openwave, code-interpreter-v1, code-interpreter-v1]`, covering both the retry and the latch;
- `e2b_does_not_fall_back_from_an_explicit_template_override` — a 404 on a `with_template()` template errors after a single attempt.

`cargo fmt`, `cargo clippy -p openwave-code-execution --all-targets`, `cargo test -p openwave-code-execution` (79 passed), and `cargo check -p openwave-server` are clean. No Daytona code touched.