### PR TITLE
ci: auto-bump the E2B template definition pins on sandbox image publish

### DIFF
--- a/.github/workflows/publish-sandbox-image.yml
+++ b/.github/workflows/publish-sandbox-image.yml
@@ -48,9 +48,14 @@ run-name: >-
 #
 # The final manifest-list digests land in the run summary, and the `pin` job
 # proposes the follow-up PR that records the documents digest as the local
-# backend's verified pin (see `sandbox_docker` in openwave-server) and as the
+# backend's verified pin (see `sandbox_docker` in openwave-server), as the
 # ref the Daytona provider registers as a snapshot (see `daytona` in
-# openwave-code-execution).
+# openwave-code-execution), and as the base of the E2B template definition
+# (see `crates/openwave-sandbox-agent/e2b/`, whose alias is version-suffixed
+# and so moves with the tag too). The one pin the job deliberately leaves
+# alone is `E2B_TEMPLATE` in `e2b.rs`: that alias only exists once a human has
+# published the template from the OpenWave E2B account, so it moves in that
+# manual step, not here.
 #
 # Publishing uses the workflow's own GITHUB_TOKEN; no repository secret is
 # consumed. First-time note: a package created by this workflow is private by
@@ -437,6 +442,40 @@ jobs:
                   sys.exit(f"expected exactly one match for {pattern}, found {replaced}")
           with open(path, "w") as handle:
               handle.write(source)
+
+          # E2B builds a template from this Dockerfile rather than pulling the
+          # ref, so the template definition carries its own copy of the digest
+          # and of the version-suffixed alias. Both move with the pin above.
+          # `E2B_TEMPLATE` in `crates/openwave-code-execution/src/e2b.rs`
+          # deliberately does not: that alias only exists once a human has
+          # published the template from the OpenWave E2B account, and bumping
+          # the client ahead of the publish would drop every user to the
+          # code-interpreter fallback until it happens.
+          repository = os.environ["DOCUMENTS_REPOSITORY"]
+          alias = f"openwave-documents-{os.environ['IMAGE_TAG']}".replace(".", "-")
+          template_pins = {
+              "crates/openwave-sandbox-agent/e2b/e2b.Dockerfile": {
+                  rf'(?m)^(# {re.escape(repository)}:)[^\n]*()$':
+                      f"{os.environ['IMAGE_TAG']}.",
+                  rf'(?m)^(FROM {re.escape(repository)}@)sha256:[0-9a-f]{{64}}()$':
+                      digest,
+              },
+              "crates/openwave-sandbox-agent/e2b/e2b.toml": {
+                  r'(?m)^(template_id = ")[^"]*(")$': alias,
+                  r'(?m)^(template_name = ")[^"]*(")$': alias,
+              },
+          }
+          for path, pins in template_pins.items():
+              with open(path) as handle:
+                  source = handle.read()
+              for pattern, value in pins.items():
+                  source, replaced = re.subn(
+                      pattern, lambda m: m.group(1) + value + m.group(2), source
+                  )
+                  if replaced != 1:
+                      sys.exit(f"expected exactly one match for {pattern} in {path}, found {replaced}")
+              with open(path, "w") as handle:
+                  handle.write(source)
           EOF
 
       - name: Open or update the pin PR
@@ -455,8 +494,17 @@ jobs:
           body_file="$(mktemp)"
           cat > "$body_file" <<EOF
           Automated follow-up from a sandbox image publish: records the new documents
-          image digest as the local backend's verified pin, and as the ref the Daytona
-          provider registers as a snapshot.
+          image digest as the local backend's verified pin, as the ref the Daytona
+          provider registers as a snapshot, and as the base of the E2B template
+          definition under \`crates/openwave-sandbox-agent/e2b/\` (Dockerfile digest
+          plus the version-suffixed alias in \`e2b.toml\`).
+
+          \`E2B_TEMPLATE\` in \`crates/openwave-code-execution/src/e2b.rs\` is
+          deliberately left alone. That alias exists only once someone publishes the
+          template from the OpenWave E2B account; moving the client pin before that
+          happens points every E2B user at a template that cannot be resolved and drops
+          them to the \`code-interpreter-v1\` fallback. Bump it by hand as part of the
+          publish — see \`crates/openwave-sandbox-agent/e2b/README.md\`.
 
           - Image: \`$DOCUMENTS_REPOSITORY:$IMAGE_TAG\`
           - Digest: \`$DOCUMENTS_DIGEST\`

--- a/crates/openwave-sandbox-agent/e2b/README.md
+++ b/crates/openwave-sandbox-agent/e2b/README.md
@@ -62,16 +62,23 @@ document skills install their Python dependencies at run time.
 ## Bumping the version
 
 The image tag, the digest in `e2b.Dockerfile`, the alias in `e2b.toml`, and
-`E2B_TEMPLATE` in `e2b.rs` move together:
+`E2B_TEMPLATE` in `e2b.rs` move together — but not all at the same moment. The
+two files in this directory are the template *definition*, so the publish
+workflow's `pin` job rewrites them automatically. `E2B_TEMPLATE` is the client
+pin, and it moves by hand in step 3 below, because until the template is
+actually published from the OpenWave account the new alias does not resolve for
+anyone and every E2B user falls back to `code-interpreter-v1`.
 
 1. Publish the new sandbox image (`.github/workflows/publish-sandbox-image.yml`
-   runs on version tags) and take the `documents` manifest-list digest.
-2. Update `e2b.Dockerfile`'s digest and the comment recording its tag.
-3. Rename the alias in `e2b.toml` and `E2B_TEMPLATE` to match the new version,
-   e.g. `openwave-documents-v0-27-0`.
-4. Build and publish the new alias as above. Leave the previous alias published
+   runs on version tags). Its `pin` job opens a PR that updates
+   `e2b.Dockerfile`'s digest and tag comment and renames the alias in
+   `e2b.toml` to match the new version, e.g. `openwave-documents-v0-27-0`.
+   Merge it.
+2. Build and publish the new alias as above. Leave the previous alias published
    until clients pinned to it are out of circulation — unpublishing it drops
    those users to the degraded fallback.
+3. Only once the new alias is live, update `E2B_TEMPLATE` in `e2b.rs` to it and
+   ship that.
 
 ## Notes on the template
 


### PR DESCRIPTION
The publish workflow's `pin` job already rewrites `PUBLISHED_IMAGE_DIGEST` and the
Daytona snapshot pins after every image publish. The E2B template definition added in
#1445 carries the same two facts — the documents image digest, in `e2b.Dockerfile`'s
`FROM`, and the version-suffixed alias, in `e2b.toml` — and nothing was moving them, so
they would go stale on the first publish after that PR landed.

The pin job now rewrites them too:

- `e2b.Dockerfile`: the `FROM …@sha256:…` digest and the tag recorded in the comment
  directly above it.
- `e2b.toml`: `template_id` and `template_name`, derived from the image tag the way
  #1445 derived them — dots to dashes, so `v0.27.0` becomes
  `openwave-documents-v0-27-0`.

`E2B_TEMPLATE` in `crates/openwave-code-execution/src/e2b.rs` is deliberately left
alone. It is the client pin, and the alias it names only starts resolving once someone
publishes the template from the OpenWave E2B account. Auto-bumping it at image-publish
time would point every E2B user at a template that does not exist yet and degrade them
all to the `code-interpreter-v1` fallback for however long the manual publish takes. So
the definition files move automatically and the client pin moves by hand, in the publish
step. The split is stated in the workflow's header comment, in the automated PR's body,
and in the e2b README, whose "Bumping the version" steps are reordered to match: the pin
PR lands first, then the human publishes, then `E2B_TEMPLATE` moves.

### Verification

I extracted the pin job's Python block and ran it against copies of the real
`sandbox_docker.rs`, `daytona.rs`, `e2b.Dockerfile`, and `e2b.toml` for a release tag
(`v0.27.0`), a `main` rebuild tag, and a pre-release tag (`v0.9.0-images.1`), checking
the rewritten output each time and re-running on the rewritten tree to confirm it is
idempotent. Negative cases: commenting out the `FROM` line and duplicating
`template_id` each fail the job with the expected one-match assertion, and an added
comment line naming the *slim* repository (a prefix of the documents repository) does
not get mistaken for the pinned one. `actionlint` and a YAML parse are clean.

Not verified: an actual publish run. The regexes are exercised against the current file
contents, so a future hand-edit that reflows those lines would fail the job loudly
rather than silently skipping a pin.
