### PR TITLE
fix(desktop): move the composer mic next to send

### DIFF
--- a/crates/openwave-desktop/ui/src/Composer.test.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.test.tsx
@@ -138,6 +138,12 @@ describe("Composer", () => {
         cancelPending={false}
         disabled={false}
         draft="Existing draft"
+        files={{
+          items: [],
+          attaching: false,
+          onAttach: vi.fn(),
+          onRemove: vi.fn(),
+        }}
         voice={{
           available: true,
           state: "transcribing",
@@ -157,11 +163,17 @@ describe("Composer", () => {
     );
 
     expect(markup).toContain('placeholder="Transcribing…"');
-    expect(markup).toContain('placeholder="Transcribing…"');
     expect(markup).toContain('aria-label="Transcribing voice recording"');
     expect(markup).toContain("lucide-mic");
     expect(markup).not.toContain("lucide-loader-circle");
     expect(markup).not.toContain('<textarea disabled=""');
+    // The mic belongs with send, not with the attachment controls.
+    expect(markup.indexOf("lucide-mic")).toBeLessThan(
+      markup.indexOf('aria-label="Send message"'),
+    );
+    expect(markup.indexOf("lucide-paperclip")).toBeLessThan(
+      markup.indexOf("lucide-mic"),
+    );
   });
 
   it("keeps the mic active while requesting and disables it only while transcribing", () => {

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -381,7 +381,10 @@ export function Composer({
       )}
       <textarea
         ref={textareaRef}
-        className="w-full resize-none border-none bg-transparent px-1 text-base placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-0"
+        className={cn(
+          "w-full resize-none border-none bg-transparent px-1 text-base placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-0",
+          voiceWorking && "placeholder:italic",
+        )}
         value={draft}
         placeholder={
           voice?.state === "requesting" || voice?.state === "recording"
@@ -448,6 +451,11 @@ export function Composer({
             </WithTooltip>
           )}
           {modelMenu}
+        </div>
+        <div className="flex items-center gap-2">
+          {/* The mic sits immediately before send: both act on the draft, so
+              they belong in the same cluster, apart from the attachment and
+              model controls that only set the turn up. */}
           {voice?.available && (
             <WithTooltip
               label={
@@ -462,6 +470,11 @@ export function Composer({
                 type="button"
                 variant={voice.state === "idle" ? "outline" : "default"}
                 size="icon-8"
+                className={cn(
+                  "shrink-0",
+                  voice.state !== "idle" &&
+                    "bg-foreground text-background hover:bg-foreground/90",
+                )}
                 aria-label={
                   voice.state === "recording"
                     ? "Stop voice recording"
@@ -483,8 +496,6 @@ export function Composer({
               </Button>
             </WithTooltip>
           )}
-        </div>
-        <div className="flex items-center gap-2">
           {active ? (
             <>
               {(hasDraft || steerPending) && (


### PR DESCRIPTION
The mic landed in the composer's left cluster, beside the attachment and model
controls, which reads as another setup control rather than something that acts
on the draft you are about to send. Brightwave puts it in the right-hand action
cluster, immediately before the send button; this matches that arrangement.

- move the voice button into the right-hand action group, directly ahead of the
  send/stop control, keeping the same `icon-8` sizing and `gap-2` spacing as its
  neighbours
- carry the active state Brightwave uses (`bg-foreground text-background`) so
  recording reads as high contrast against an outline idle state, and add
  `shrink-0` so a long attachment row cannot squeeze it
- italicize the placeholder while listening or transcribing, so the transient
  prompt is distinguishable from a real draft hint

The composer test now asserts the ordering (attachments, then mic, then send)
rather than only that a mic exists.

Verified with `pnpm exec tsc --noEmit` and the composer test file. Not visually
checked in the running app.