### PR TITLE
fix(desktop): raise macOS minimumSystemVersion to 10.15 for whisper.cpp

### DIFF
--- a/crates/openwave-desktop/tauri.conf.json
+++ b/crates/openwave-desktop/tauri.conf.json
@@ -54,7 +54,8 @@
     "active": true,
     "targets": "all",
     "macOS": {
-      "infoPlist": "Info.plist"
+      "infoPlist": "Info.plist",
+      "minimumSystemVersion": "10.15"
     },
     "resources": {
       "../../scripts/exec-documents/": "exec-scripts/",


### PR DESCRIPTION
The v0.28.0 macOS publish run failed twice in `prepare unsigned macOS · aarch64`: the `whisper-rs-sys` build script compiles whisper.cpp, whose ggml backend registry uses `std::filesystem` — APIs Apple marks available only on macOS 10.15+. Tauri's CLI exports `MACOSX_DEPLOYMENT_TARGET` from `bundle.macOS.minimumSystemVersion` before invoking cargo, defaulting to **10.13** when unset (verified in tauri-cli 2.11.5, `src/build.rs`), so clang rejected every `std::filesystem` use with `'path' is unavailable: introduced in macOS 10.15`.

v0.27.0 shipped fine because whisper-rs only entered the tree with #1437 — v0.28.0 is the first tag that compiles whisper.cpp.

This sets `minimumSystemVersion` to 10.15, the lowest version whisper.cpp accepts. It also becomes `LSMinimumSystemVersion` in the bundle, dropping Intel Macs on 10.13/10.14; Apple Silicon already requires 11.0.

After merge, the fix needs a new release tag to reach the publish workflow — re-dispatching v0.28.0 would keep building the broken tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)