### PR TITLE
feat(desktop): pick a local voice model from a catalog

### DIFF
--- a/crates/openwave-desktop/src/voice_transcription.rs
+++ b/crates/openwave-desktop/src/voice_transcription.rs
@@ -4,11 +4,15 @@
 //! runner owns the pinned model path, download verification, media decoding,
 //! resampling, and whisper.cpp inference.
 
+use std::collections::HashMap;
 use std::io::{Cursor, Read as _};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use futures::StreamExt as _;
+use openwave_server::voice_transcription::{
+    local_voice_model, LocalVoiceModel, LOCAL_VOICE_REPO_COMMIT,
+};
 use openwave_server::{LocalVoiceError, LocalVoiceRunner, LocalVoiceState, LocalVoiceStatus};
 use sha2::{Digest, Sha256};
 use symphonia::core::codecs::audio::AudioDecoderOptions;
@@ -21,16 +25,30 @@ use symphonia::core::meta::MetadataOptions;
 use tokio::io::AsyncWriteExt as _;
 use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
 
-const MODEL_VERSION: &str = "whisper.cpp-c521a4b02f422512d734391fdf08bb08c0862f68-tiny.en-q5_1";
-const MODEL_URL: &str = "https://huggingface.co/ggerganov/whisper.cpp/resolve/c521a4b02f422512d734391fdf08bb08c0862f68/ggml-tiny.en-q5_1.bin";
-const MODEL_SHA256: &str = "c77c5766f1cef09b6b7d47f21b546cbddd4157886b3b5d6d4f709e91e66c7c2b";
-const MODEL_BYTES: u64 = 32_166_155;
 const WHISPER_SAMPLE_RATE: u32 = 16_000;
+
+fn model_version(model: &LocalVoiceModel) -> String {
+    format!("whisper.cpp-{LOCAL_VOICE_REPO_COMMIT}-{}", model.id)
+}
+
+fn model_url(model: &LocalVoiceModel) -> String {
+    format!(
+        "https://huggingface.co/ggerganov/whisper.cpp/resolve/{LOCAL_VOICE_REPO_COMMIT}/{}",
+        model.file
+    )
+}
+
+fn catalog_model(id: &str) -> Result<&'static LocalVoiceModel, String> {
+    local_voice_model(id).ok_or_else(|| "Unknown local voice model".to_owned())
+}
 
 #[derive(Clone)]
 pub(crate) struct DesktopLocalVoiceRunner {
     data_dir: PathBuf,
-    state: Arc<Mutex<RuntimeState>>,
+    /// Download progress and the last failure, per catalog model id. Only a
+    /// model that has been downloaded in this session has an entry; an
+    /// installed model's state is read from disk.
+    state: Arc<Mutex<HashMap<&'static str, RuntimeState>>>,
     install_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
@@ -51,43 +69,51 @@ impl DesktopLocalVoiceRunner {
         }
     }
 
-    fn model_dir(&self) -> PathBuf {
+    fn model_dir(&self, model: &LocalVoiceModel) -> PathBuf {
         self.data_dir
             .join("models")
             .join("voice")
-            .join(MODEL_VERSION)
+            .join(model_version(model))
     }
 
-    fn model_path(&self) -> PathBuf {
-        self.model_dir().join("model.bin")
+    fn model_path(&self, model: &LocalVoiceModel) -> PathBuf {
+        self.model_dir(model).join("model.bin")
     }
 
-    fn marker_path(&self) -> PathBuf {
-        self.model_dir().join("installed.json")
+    fn marker_path(&self, model: &LocalVoiceModel) -> PathBuf {
+        self.model_dir(model).join("installed.json")
     }
 
-    fn installed(&self) -> bool {
-        let Ok(marker) = std::fs::read(self.marker_path()) else {
+    fn installed(&self, model: &LocalVoiceModel) -> bool {
+        let Ok(marker) = std::fs::read(self.marker_path(model)) else {
             return false;
         };
         let Ok(marker): Result<serde_json::Value, _> = serde_json::from_slice(&marker) else {
             return false;
         };
-        marker["version"].as_str() == Some(MODEL_VERSION)
-            && marker["sha256"].as_str() == Some(MODEL_SHA256)
-            && self.model_path().is_file()
+        marker["version"].as_str() == Some(model_version(model).as_str())
+            && marker["sha256"].as_str() == Some(model.sha256)
+            && self.model_path(model).is_file()
     }
 
-    fn status_now(&self) -> LocalVoiceStatus {
-        if self.installed() {
+    fn status_now(&self, model: &LocalVoiceModel) -> LocalVoiceStatus {
+        if self.installed(model) {
             return LocalVoiceStatus {
                 state: LocalVoiceState::Ready,
-                downloaded_bytes: Some(MODEL_BYTES),
-                total_bytes: Some(MODEL_BYTES),
+                downloaded_bytes: Some(model.bytes),
+                total_bytes: Some(model.bytes),
                 error: None,
             };
         }
-        let state = self.state.lock().expect("voice state lock");
+        let states = self.state.lock().expect("voice state lock");
+        let Some(state) = states.get(model.id) else {
+            return LocalVoiceStatus {
+                state: LocalVoiceState::NotInstalled,
+                downloaded_bytes: None,
+                total_bytes: Some(model.bytes),
+                error: None,
+            };
+        };
         LocalVoiceStatus {
             state: if state.downloading {
                 LocalVoiceState::Downloading
@@ -97,33 +123,38 @@ impl DesktopLocalVoiceRunner {
                 LocalVoiceState::NotInstalled
             },
             downloaded_bytes: state.downloading.then_some(state.downloaded_bytes),
-            total_bytes: state.total_bytes,
+            total_bytes: state.total_bytes.or(Some(model.bytes)),
             error: state.error.clone(),
         }
     }
 
-    async fn ensure_installed(&self) -> Result<LocalVoiceStatus, String> {
+    async fn ensure_installed(&self, model: &LocalVoiceModel) -> Result<LocalVoiceStatus, String> {
+        // One download at a time across the catalog: two multi-hundred-megabyte
+        // fetches racing each other help nobody, and the picker starts one.
         let _guard = self.install_lock.lock().await;
-        if self.installed() {
-            return Ok(self.status_now());
+        if self.installed(model) {
+            return Ok(self.status_now(model));
         }
         {
-            let mut state = self.state.lock().expect("voice state lock");
+            let mut states = self.state.lock().expect("voice state lock");
+            let state = states.entry(model.id).or_default();
             state.downloading = true;
             state.downloaded_bytes = 0;
-            state.total_bytes = Some(MODEL_BYTES);
+            state.total_bytes = Some(model.bytes);
             state.error = None;
         }
-        let outcome = self.download_model().await;
-        let mut state = self.state.lock().expect("voice state lock");
-        state.downloading = false;
-        state.error = outcome.as_ref().err().cloned();
-        drop(state);
-        outcome.map(|()| self.status_now())
+        let outcome = self.download_model(model).await;
+        {
+            let mut states = self.state.lock().expect("voice state lock");
+            let state = states.entry(model.id).or_default();
+            state.downloading = false;
+            state.error = outcome.as_ref().err().cloned();
+        }
+        outcome.map(|()| self.status_now(model))
     }
 
-    async fn download_model(&self) -> Result<(), String> {
-        let directory = self.model_dir();
+    async fn download_model(&self, model: &LocalVoiceModel) -> Result<(), String> {
+        let directory = self.model_dir(model);
         tokio::fs::create_dir_all(&directory)
             .await
             .map_err(|error| {
@@ -132,7 +163,7 @@ impl DesktopLocalVoiceRunner {
         let partial = directory.join("model.bin.partial");
         let _ = tokio::fs::remove_file(&partial).await;
         let response = reqwest::Client::new()
-            .get(MODEL_URL)
+            .get(model_url(model))
             .send()
             .await
             .map_err(|_| "Could not download the local voice model".to_owned())?;
@@ -157,6 +188,8 @@ impl DesktopLocalVoiceRunner {
             self.state
                 .lock()
                 .expect("voice state lock")
+                .entry(model.id)
+                .or_default()
                 .downloaded_bytes = downloaded;
         }
         file.flush()
@@ -165,22 +198,22 @@ impl DesktopLocalVoiceRunner {
         drop(file);
         let digest = sha256_file(&partial)
             .map_err(|error| format!("Could not verify the local voice model: {error}"))?;
-        if digest != MODEL_SHA256 {
+        if digest != model.sha256 {
             let _ = tokio::fs::remove_file(&partial).await;
             return Err("The downloaded local voice model failed its pinned SHA-256 check and was discarded".into());
         }
-        tokio::fs::rename(&partial, self.model_path())
+        tokio::fs::rename(&partial, self.model_path(model))
             .await
             .map_err(|error| format!("Could not install the local voice model: {error}"))?;
         let marker = serde_json::to_vec_pretty(
-            &serde_json::json!({"version": MODEL_VERSION, "sha256": MODEL_SHA256}),
+            &serde_json::json!({"version": model_version(model), "sha256": model.sha256}),
         )
         .map_err(|_| "Could not record the local voice model install".to_owned())?;
         let marker_partial = directory.join("installed.json.partial");
         tokio::fs::write(&marker_partial, marker)
             .await
             .map_err(|error| format!("Could not record the local voice model install: {error}"))?;
-        tokio::fs::rename(&marker_partial, self.marker_path())
+        tokio::fs::rename(&marker_partial, self.marker_path(model))
             .await
             .map_err(|error| format!("Could not record the local voice model install: {error}"))?;
         Ok(())
@@ -189,36 +222,50 @@ impl DesktopLocalVoiceRunner {
 
 #[async_trait::async_trait]
 impl LocalVoiceRunner for DesktopLocalVoiceRunner {
-    async fn status(&self) -> LocalVoiceStatus {
-        self.status_now()
+    async fn status(&self, model: &str) -> LocalVoiceStatus {
+        match catalog_model(model) {
+            Ok(model) => self.status_now(model),
+            Err(error) => LocalVoiceStatus {
+                state: LocalVoiceState::Unavailable,
+                downloaded_bytes: None,
+                total_bytes: None,
+                error: Some(error),
+            },
+        }
     }
 
-    async fn install(&self) -> Result<LocalVoiceStatus, String> {
-        self.ensure_installed().await
+    async fn install(&self, model: &str) -> Result<LocalVoiceStatus, String> {
+        self.ensure_installed(catalog_model(model)?).await
     }
 
     async fn transcribe(
         &self,
+        model: &str,
         content_type: &str,
         audio: Vec<u8>,
     ) -> Result<String, LocalVoiceError> {
-        self.ensure_installed()
+        let model = catalog_model(model).map_err(LocalVoiceError::Runner)?;
+        self.ensure_installed(model)
             .await
             .map_err(LocalVoiceError::Runner)?;
-        let model = self.model_path();
+        let path = self.model_path(model);
+        let language = if model.english_only { "en" } else { "auto" };
         let content_type = content_type.to_owned();
-        tokio::task::spawn_blocking(move || transcribe_blocking(&model, &content_type, audio))
-            .await
-            .map_err(|_| {
-                LocalVoiceError::Runner(
-                    "Local voice transcription worker stopped unexpectedly".to_owned(),
-                )
-            })?
+        tokio::task::spawn_blocking(move || {
+            transcribe_blocking(&path, language, &content_type, audio)
+        })
+        .await
+        .map_err(|_| {
+            LocalVoiceError::Runner(
+                "Local voice transcription worker stopped unexpectedly".to_owned(),
+            )
+        })?
     }
 }
 
 fn transcribe_blocking(
     model: &Path,
+    language: &str,
     content_type: &str,
     audio: Vec<u8>,
 ) -> Result<String, LocalVoiceError> {
@@ -229,7 +276,9 @@ fn transcribe_blocking(
         LocalVoiceError::Runner("Could not initialize local voice transcription".to_owned())
     })?;
     let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
-    params.set_language(Some("en"));
+    // "auto" asks whisper to detect the language; the English-only models
+    // reject anything else, so the catalog decides which is passed.
+    params.set_language(Some(language));
     params.set_translate(false);
     params.set_no_context(true);
     params.set_print_progress(false);
@@ -402,14 +451,31 @@ mod tests {
     fn marker_must_match_the_exact_pinned_model() {
         let dir = tempfile::tempdir().unwrap();
         let runner = DesktopLocalVoiceRunner::new(dir.path().to_owned());
-        std::fs::create_dir_all(runner.model_dir()).unwrap();
-        std::fs::write(runner.model_path(), b"model").unwrap();
+        let model = catalog_model("tiny.en-q5_1").unwrap();
+        std::fs::create_dir_all(runner.model_dir(model)).unwrap();
+        std::fs::write(runner.model_path(model), b"model").unwrap();
         std::fs::write(
-            runner.marker_path(),
+            runner.marker_path(model),
             br#"{"version":"other","sha256":"bad"}"#,
         )
         .unwrap();
-        assert!(!runner.installed());
+        assert!(!runner.installed(model));
+    }
+
+    /// Two catalog entries must never share an install directory, or one
+    /// download would silently satisfy the other's verified marker.
+    #[test]
+    fn every_catalog_model_installs_to_its_own_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner = DesktopLocalVoiceRunner::new(dir.path().to_owned());
+        let mut paths: Vec<PathBuf> = openwave_server::voice_transcription::LOCAL_VOICE_MODELS
+            .iter()
+            .map(|model| runner.model_path(model))
+            .collect();
+        let count = paths.len();
+        paths.sort();
+        paths.dedup();
+        assert_eq!(paths.len(), count);
     }
 
     #[test]
@@ -430,6 +496,58 @@ mod tests {
         assert!(seconds > 1.4, "decoded only {seconds}s of the recording");
     }
 
+    /// Drives a second catalog entry through the real install path: download,
+    /// SHA-256 verification, marker, and inference on a recording. Ignored
+    /// because it fetches 57 MB; run it when the catalog or the runner's
+    /// per-model layout changes.
+    ///
+    /// `cargo test -p openwave-desktop installs_and_transcribes -- --ignored`
+    #[tokio::test]
+    #[ignore = "downloads a catalog model over the network"]
+    async fn installs_and_transcribes_with_a_second_catalog_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner = DesktopLocalVoiceRunner::new(dir.path().to_owned());
+        let id = "base.en-q5_1";
+        let model = catalog_model(id).unwrap();
+
+        assert_eq!(runner.status(id).await.state, LocalVoiceState::NotInstalled);
+        let installed = runner.install(id).await.expect("install");
+        assert_eq!(installed.state, LocalVoiceState::Ready);
+        // Verification is the install's contract: the file on disk is exactly
+        // the pinned artifact, not merely something the server answered with.
+        assert_eq!(
+            sha256_file(&runner.model_path(model)).unwrap(),
+            model.sha256
+        );
+        assert_eq!(
+            std::fs::metadata(runner.model_path(model)).unwrap().len(),
+            model.bytes
+        );
+        assert_eq!(runner.status(id).await.state, LocalVoiceState::Ready);
+        // A second install is a no-op rather than a second download.
+        assert_eq!(
+            runner.install(id).await.expect("reinstall").state,
+            LocalVoiceState::Ready
+        );
+
+        // The fixture is a tone, not speech, so the transcript is expected to
+        // be empty. What this proves is the plumbing: the id selected a model,
+        // its verified bytes loaded, and inference ran to completion on a
+        // recording decoded by the same path the app uses.
+        runner
+            .transcribe(
+                id,
+                "audio/webm;codecs=opus",
+                include_bytes!("../tests/fixtures/mediarecorder-opus.webm").to_vec(),
+            )
+            .await
+            .expect("runs inference with the selected model");
+
+        // The id names the model: an entry that is not in the catalog cannot
+        // silently fall back to one that is.
+        assert!(runner.install("whisper-imaginary").await.is_err());
+    }
+
     #[test]
     #[ignore = "downloads the pinned model and runs real local inference"]
     fn transcribes_real_webm_and_mp4_fixtures() {
@@ -439,6 +557,7 @@ mod tests {
         for (mime, path) in [("audio/webm", webm), ("audio/mp4", mp4)] {
             let text = transcribe_blocking(
                 Path::new(&model),
+                "en",
                 mime,
                 std::fs::read(path).expect("voice fixture"),
             )

--- a/crates/openwave-desktop/ui/src/VoiceInputStore.test.ts
+++ b/crates/openwave-desktop/ui/src/VoiceInputStore.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import type { LocalVoiceModelInfo, VoiceTranscriptionInfo } from "./api";
+import { voiceSelectionReady } from "./VoiceInputStore";
+import { voiceSelectionValue } from "./settings/VoiceTranscriptionPanel";
+
+function model(
+  id: string,
+  state: LocalVoiceModelInfo["state"],
+): LocalVoiceModelInfo {
+  return {
+    id,
+    label: id,
+    description: "",
+    total_bytes: 1_000,
+    english_only: true,
+    recommended: false,
+    state,
+    downloaded_bytes: null,
+    error: null,
+  };
+}
+
+function info(overrides: Partial<VoiceTranscriptionInfo> = {}): VoiceTranscriptionInfo {
+  return {
+    model: "local",
+    local_model: "tiny.en-q5_1",
+    local_models: [model("tiny.en-q5_1", "ready"), model("small.en-q5_1", "not_installed")],
+    openai_ready: false,
+    gemini_ready: false,
+    ...overrides,
+  };
+}
+
+describe("voice input selection", () => {
+  it("is ready only when the selected local model is the installed one", () => {
+    expect(voiceSelectionReady(info())).toBe(true);
+    // Selecting a catalog entry that has not been downloaded must still send
+    // the mic to settings rather than start a recording nothing can transcribe.
+    expect(voiceSelectionReady(info({ local_model: "small.en-q5_1" }))).toBe(false);
+    expect(voiceSelectionReady(info({ local_model: "removed-from-catalog" }))).toBe(
+      false,
+    );
+  });
+
+  it("keeps the local model out of the provider choice", () => {
+    expect(voiceSelectionValue(info({ local_model: "small.en-q5_1" }))).toBe(
+      "local:small.en-q5_1",
+    );
+    expect(voiceSelectionValue(info({ model: "gemini_flash" }))).toBe("gemini_flash");
+  });
+});

--- a/crates/openwave-desktop/ui/src/VoiceInputStore.ts
+++ b/crates/openwave-desktop/ui/src/VoiceInputStore.ts
@@ -1,18 +1,30 @@
 import { create } from "zustand";
-import type { ApiClient, VoiceTranscriptionInfo, VoiceTranscriptionModel } from "./api";
+import type {
+  ApiClient,
+  LocalVoiceModelInfo,
+  VoiceTranscriptionInfo,
+  VoiceTranscriptionModel,
+} from "./api";
 
 type VoiceInputStore = {
   info: VoiceTranscriptionInfo | null;
   loading: boolean;
+  /** The model id currently downloading, so the picker can show its progress. */
+  installing: string | null;
   error: string | null;
   load: (client: ApiClient) => Promise<VoiceTranscriptionInfo | null>;
-  select: (client: ApiClient, model: VoiceTranscriptionModel) => Promise<void>;
-  install: (client: ApiClient) => Promise<void>;
+  select: (
+    client: ApiClient,
+    model: VoiceTranscriptionModel,
+    localModel?: string,
+  ) => Promise<void>;
+  install: (client: ApiClient, model: string) => Promise<void>;
 };
 
-export const useVoiceInputStore = create<VoiceInputStore>()((set) => ({
+export const useVoiceInputStore = create<VoiceInputStore>()((set, get) => ({
   info: null,
   loading: false,
+  installing: null,
   error: null,
   async load(client) {
     set({ loading: true, error: null });
@@ -25,29 +37,25 @@ export const useVoiceInputStore = create<VoiceInputStore>()((set) => ({
       return null;
     }
   },
-  async select(client, model) {
+  async select(client, model, localModel) {
     set({ loading: true, error: null });
     try {
-      set({ info: await client.putVoiceTranscription(model), loading: false });
+      set({
+        info: await client.putVoiceTranscription(model, localModel),
+        loading: false,
+      });
     } catch (caught) {
       set({ loading: false, error: String(caught) });
     }
   },
-  async install(client) {
-    set((state) => ({
-      loading: true,
-      error: null,
-      info: state.info
-        ? {
-            ...state.info,
-            local: {
-              ...state.info.local,
-              state: "downloading",
-              downloaded_bytes: 0,
-            },
-          }
-        : null,
-    }));
+  /**
+   * Download one catalog model, then select it.
+   *
+   * Progress is only known on the server side of the download, so the bar is
+   * fed by polling the info endpoint while the install request is in flight.
+   */
+  async install(client, model) {
+    set({ loading: true, installing: model, error: null });
     let stopped = false;
     const poll = async () => {
       while (!stopped) {
@@ -55,15 +63,20 @@ export const useVoiceInputStore = create<VoiceInputStore>()((set) => ({
         if (stopped) break;
         const info = await client.getVoiceTranscription();
         set({ info });
-        if (info.local.state !== "downloading") break;
+        if (localVoiceModel(info, model)?.state !== "downloading") break;
       }
     };
     const polling = poll().catch(() => undefined);
     try {
-      await client.installLocalVoice();
-      set({ info: await client.getVoiceTranscription(), loading: false });
+      await client.installLocalVoice(model);
+      stopped = true;
+      await polling;
+      set({ installing: null });
+      await get().select(client, "local", model);
     } catch (caught) {
-      set({ loading: false, error: String(caught) });
+      set({ loading: false, installing: null, error: String(caught) });
+      const info = await client.getVoiceTranscription().catch(() => null);
+      if (info) set({ info });
     } finally {
       stopped = true;
       await polling;
@@ -71,9 +84,35 @@ export const useVoiceInputStore = create<VoiceInputStore>()((set) => ({
   },
 }));
 
+export function localVoiceModel(
+  info: VoiceTranscriptionInfo | null,
+  id: string,
+): LocalVoiceModelInfo | undefined {
+  return info?.local_models.find((model) => model.id === id);
+}
+
+export function selectedLocalVoiceModel(
+  info: VoiceTranscriptionInfo | null,
+): LocalVoiceModelInfo | undefined {
+  return info ? localVoiceModel(info, info.local_model) : undefined;
+}
+
 export function voiceSelectionReady(info: VoiceTranscriptionInfo | null): boolean {
   if (!info) return false;
-  if (info.model === "local") return info.local.state === "ready";
+  if (info.model === "local") {
+    return selectedLocalVoiceModel(info)?.state === "ready";
+  }
   if (info.model === "gpt4o_transcribe") return info.openai_ready;
   return info.gemini_ready;
+}
+
+/** A model's size, for the confirmation dialog and the picker rows. */
+export function formatModelSize(bytes: number): string {
+  if (bytes >= 1_000_000_000) return `${(bytes / 1_000_000_000).toFixed(1)} GB`;
+  return `${Math.round(bytes / 1_000_000)} MB`;
+}
+
+export function localVoiceProgress(model: LocalVoiceModelInfo): number {
+  if (!model.total_bytes) return 0;
+  return Math.min(100, ((model.downloaded_bytes ?? 0) / model.total_bytes) * 100);
 }

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -167,15 +167,34 @@ export type StickyChatDefaults = WireStickyChatDefaults;
 export type ProviderInfo = WireProviderInfo;
 
 export type VoiceTranscriptionModel = "local" | "gpt4o_transcribe" | "gemini_flash";
+export type LocalVoiceState =
+  | "not_installed"
+  | "downloading"
+  | "ready"
+  | "failed"
+  | "unavailable";
 export type LocalVoiceInfo = {
-  state: "not_installed" | "downloading" | "ready" | "failed" | "unavailable";
+  state: LocalVoiceState;
   downloaded_bytes: number | null;
   total_bytes: number | null;
   error: string | null;
 };
+/** One entry of the local speech catalog, with its install state on this device. */
+export type LocalVoiceModelInfo = {
+  id: string;
+  label: string;
+  description: string;
+  total_bytes: number;
+  english_only: boolean;
+  recommended: boolean;
+  state: LocalVoiceState;
+  downloaded_bytes: number | null;
+  error: string | null;
+};
 export type VoiceTranscriptionInfo = {
   model: VoiceTranscriptionModel;
-  local: LocalVoiceInfo;
+  local_model: string;
+  local_models: LocalVoiceModelInfo[];
   openai_ready: boolean;
   gemini_ready: boolean;
 };
@@ -794,18 +813,20 @@ export class ApiClient {
 
   putVoiceTranscription(
     model: VoiceTranscriptionModel,
+    localModel?: string,
   ): Promise<VoiceTranscriptionInfo> {
     return this.json("/voice-transcription", {
       method: "PUT",
       headers: this.headers(true),
-      body: JSON.stringify({ model }),
+      body: JSON.stringify({ model, local_model: localModel ?? null }),
     });
   }
 
-  installLocalVoice(): Promise<LocalVoiceInfo> {
+  installLocalVoice(model: string): Promise<LocalVoiceInfo> {
     return this.json("/voice-transcription/install", {
       method: "POST",
-      headers: this.headers(),
+      headers: this.headers(true),
+      body: JSON.stringify({ model }),
     });
   }
 

--- a/crates/openwave-desktop/ui/src/settings/VoiceTranscriptionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/VoiceTranscriptionPanel.tsx
@@ -1,17 +1,27 @@
 import { useEffect } from "react";
 import { useNavigate } from "@tanstack/react-router";
 
-import type { ApiClient, VoiceTranscriptionModel } from "../api";
+import type { ApiClient, LocalVoiceModelInfo, VoiceTranscriptionInfo } from "../api";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useVoiceInputStore } from "@/VoiceInputStore";
+import { useConfirm } from "@/components/ConfirmDialog";
+import { cn } from "@/lib/utils";
+import {
+  formatModelSize,
+  localVoiceProgress,
+  selectedLocalVoiceModel,
+  useVoiceInputStore,
+  voiceSelectionReady,
+} from "@/VoiceInputStore";
 import {
   SettingsError,
   SettingsField,
@@ -20,99 +30,184 @@ import {
   SettingsStatus,
 } from "./primitives";
 
+const LOCAL_VALUE_PREFIX = "local:";
+
+/** What the closed picker says once a choice is made. */
+export function voiceSelectionLabel(info: VoiceTranscriptionInfo | null): string {
+  if (!info) return "Loading…";
+  if (info.model === "gpt4o_transcribe") return "OpenAI · gpt-4o-transcribe";
+  if (info.model === "gemini_flash") return "Google · Gemini 3.6 Flash";
+  const local = selectedLocalVoiceModel(info);
+  return local ? `On this device · ${local.label}` : "On this device";
+}
+
+export function voiceSelectionValue(info: VoiceTranscriptionInfo | null): string {
+  if (!info) return "";
+  return info.model === "local"
+    ? `${LOCAL_VALUE_PREFIX}${info.local_model}`
+    : info.model;
+}
+
 export function VoiceTranscriptionPanel({ client }: { client: ApiClient }) {
   const navigate = useNavigate();
   const info = useVoiceInputStore((state) => state.info);
   const loading = useVoiceInputStore((state) => state.loading);
+  const installing = useVoiceInputStore((state) => state.installing);
   const error = useVoiceInputStore((state) => state.error);
+  const { confirm, dialog: confirmDialog } = useConfirm();
   const providersPath: string = "/settings/providers";
 
   useEffect(() => {
     void useVoiceInputStore.getState().load(client);
   }, [client]);
 
-  const localReady = info?.local.state === "ready";
-  const selectedReady = info
-    ? info.model === "local"
-      ? localReady
-      : info.model === "gpt4o_transcribe"
-        ? info.openai_ready
-        : info.gemini_ready
-    : false;
-  const localProgress =
-    info?.local.downloaded_bytes != null && info.local.total_bytes
-      ? (info.local.downloaded_bytes / info.local.total_bytes) * 100
-      : 0;
+  const ready = voiceSelectionReady(info);
+  const selectedLocal = selectedLocalVoiceModel(info);
+  const downloading = info?.local_models.find(
+    (model) => model.state === "downloading" || model.id === installing,
+  );
+
+  /**
+   * A model the reader has not downloaded is still offered: choosing it is how
+   * you ask for it. The confirmation says what will be fetched and what it
+   * costs on disk before anything is written.
+   */
+  async function choose(value: string) {
+    if (!value.startsWith(LOCAL_VALUE_PREFIX)) {
+      await useVoiceInputStore
+        .getState()
+        .select(client, value as "gpt4o_transcribe" | "gemini_flash");
+      return;
+    }
+    const id = value.slice(LOCAL_VALUE_PREFIX.length);
+    const model = info?.local_models.find((entry) => entry.id === id);
+    if (!model) return;
+    if (model.state === "ready") {
+      await useVoiceInputStore.getState().select(client, "local", id);
+      return;
+    }
+    const accepted = await confirm({
+      title: `Download ${model.label}?`,
+      description: `${model.description} The download is about ${formatModelSize(
+        model.total_bytes,
+      )} and uses the same amount of disk once installed. Recordings transcribed with it never leave this device.`,
+      confirmLabel: "Download",
+    });
+    if (accepted) await useVoiceInputStore.getState().install(client, id);
+  }
 
   return (
     <SettingsPanel
       title="Voice input"
-      description="Choose how microphone recordings become editable message drafts. Audio stays local when the local model is selected."
+      description="Choose how microphone recordings become editable message drafts. Audio stays on this device unless you pick a cloud model."
       busy={loading}
     >
       <SettingsSection>
         <SettingsStatus
-          tone={selectedReady ? "ready" : "not-configured"}
-          label={selectedReady ? "Ready" : "Setup required"}
+          tone={ready ? "ready" : "not-configured"}
+          label={ready ? "Ready" : "Setup required"}
           description={
-            selectedReady
+            ready
               ? "The selected voice input model is ready to transcribe recordings."
-              : "Install the local model or configure a supported cloud provider before recording."
+              : "Download a model that runs on this device, or configure a supported cloud provider."
           }
         />
       </SettingsSection>
 
-      <SettingsSection title="Transcription model">
+      <SettingsSection
+        title="Transcription model"
+        description="Models that run on this device come first. One that has not been downloaded yet is still selectable — choosing it starts the download."
+      >
         <SettingsField
           label="Model"
-          hint="Local is recommended and never sends recordings off this device."
+          hint="A larger model transcribes more accurately and takes longer per recording."
         >
           <Select
-            value={info?.model ?? "local"}
+            value={voiceSelectionValue(info)}
             disabled={!info || loading}
-            onValueChange={(value) =>
-              void useVoiceInputStore
-                .getState()
-                .select(client, value as VoiceTranscriptionModel)
-            }
+            onValueChange={(value) => void choose(value)}
           >
             <SelectTrigger aria-label="Voice input model">
-              <SelectValue />
+              <SelectValue placeholder="Loading…">
+                {voiceSelectionLabel(info)}
+              </SelectValue>
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="local">Local · Whisper tiny English</SelectItem>
-              {info?.openai_ready && (
-                <SelectItem value="gpt4o_transcribe">OpenAI · gpt-4o-transcribe</SelectItem>
-              )}
-              {info?.gemini_ready && (
-                <SelectItem value="gemini_flash">Google · Gemini 3.6 Flash</SelectItem>
+              <SelectGroup>
+                <SelectLabel>On this device</SelectLabel>
+                {(info?.local_models ?? []).map((model) => (
+                  <LocalModelItem key={model.id} model={model} />
+                ))}
+              </SelectGroup>
+              {(info?.openai_ready || info?.gemini_ready) && (
+                <SelectGroup>
+                  <SelectLabel>Cloud</SelectLabel>
+                  {info?.openai_ready && (
+                    <SelectItem value="gpt4o_transcribe">
+                      OpenAI · gpt-4o-transcribe
+                    </SelectItem>
+                  )}
+                  {info?.gemini_ready && (
+                    <SelectItem value="gemini_flash">
+                      Google · Gemini 3.6 Flash
+                    </SelectItem>
+                  )}
+                </SelectGroup>
               )}
             </SelectContent>
           </Select>
         </SettingsField>
-      </SettingsSection>
 
-      <SettingsSection title="Local model">
-        <SettingsStatus
-          tone={localReady ? "ready" : info?.local.state === "unavailable" ? "disabled" : "not-configured"}
-          label={localReady ? "Installed" : info?.local.state === "downloading" ? "Downloading" : "Not installed"}
-          description={
-            info?.local.error ??
-            (localReady
-              ? "Whisper tiny English is installed and verified."
-              : "Downloads a pinned 31 MB quantized model and verifies its SHA-256 before use.")
-          }
-        />
-        {info?.local.state === "downloading" && <Progress value={localProgress} />}
-        {!localReady && info?.local.state !== "unavailable" && (
+        {downloading?.state === "downloading" && (
+          <div className="flex flex-col gap-1.5" role="status">
+            <span className="text-sm text-muted-foreground">
+              {`Downloading ${downloading.label} — ${formatModelSize(
+                downloading.downloaded_bytes ?? 0,
+              )} of ${formatModelSize(downloading.total_bytes)}`}
+            </span>
+            <Progress value={localVoiceProgress(downloading)} />
+          </div>
+        )}
+
+        {selectedLocal?.state === "failed" && (
+          <div className="flex flex-col items-start gap-2">
+            <SettingsError>
+              {selectedLocal.error ?? `${selectedLocal.label} did not download.`}
+            </SettingsError>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={loading}
+              onClick={() =>
+                void useVoiceInputStore
+                  .getState()
+                  .install(client, selectedLocal.id)
+              }
+            >
+              Retry download
+            </Button>
+          </div>
+        )}
+
+        {selectedLocal?.state === "not_installed" && (
           <Button
             type="button"
             className="w-fit"
             disabled={loading}
-            onClick={() => void useVoiceInputStore.getState().install(client)}
+            onClick={() =>
+              void useVoiceInputStore.getState().install(client, selectedLocal.id)
+            }
           >
-            {info?.local.state === "failed" ? "Retry download" : "Download local model"}
+            {`Download ${selectedLocal.label}`}
           </Button>
+        )}
+
+        {selectedLocal?.state === "unavailable" && (
+          <SettingsStatus
+            tone="disabled"
+            label="Not available here"
+            description="Models that run on this device are only available in the desktop app."
+          />
         )}
       </SettingsSection>
 
@@ -121,7 +216,7 @@ export function VoiceTranscriptionPanel({ client }: { client: ApiClient }) {
           <SettingsStatus
             tone="not-configured"
             label="No cloud voice model configured"
-            description="OpenAI gpt-4o-transcribe and Google Gemini become available here when their provider is enabled and credentialed."
+            description="OpenAI gpt-4o-transcribe and Google Gemini appear in the picker once their provider is enabled and credentialed."
           />
           <Button
             type="button"
@@ -134,6 +229,41 @@ export function VoiceTranscriptionPanel({ client }: { client: ApiClient }) {
         </SettingsSection>
       )}
       {error && <SettingsError>{error}</SettingsError>}
+      {confirmDialog}
     </SettingsPanel>
+  );
+}
+
+/**
+ * A catalog row. A model that is not on disk is ghosted rather than disabled:
+ * it is a real choice, it just costs a download first.
+ */
+function LocalModelItem({ model }: { model: LocalVoiceModelInfo }) {
+  const installed = model.state === "ready";
+  return (
+    <SelectItem
+      value={`${LOCAL_VALUE_PREFIX}${model.id}`}
+      className={cn("items-start py-2", !installed && "opacity-60")}
+    >
+      <span className="flex flex-col gap-0.5">
+        <span className="flex flex-wrap items-center gap-2">
+          <span className="font-medium">{model.label}</span>
+          <span className="text-xs text-muted-foreground">
+            {formatModelSize(model.total_bytes)}
+          </span>
+          {model.recommended && (
+            <span className="rounded-full border px-1.5 text-[0.68rem] text-muted-foreground">
+              Recommended
+            </span>
+          )}
+          {!installed && (
+            <span className="text-xs text-muted-foreground">
+              {model.state === "downloading" ? "Downloading…" : "Not downloaded"}
+            </span>
+          )}
+        </span>
+        <span className="text-xs text-muted-foreground">{model.description}</span>
+      </span>
+    </SelectItem>
   );
 }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -70,7 +70,7 @@ mod source_tools;
 mod state;
 mod turn_worker;
 mod view_frames;
-mod voice_transcription;
+pub mod voice_transcription;
 /// Host-owned, inert web-search configuration and provider selection.
 pub mod web_search;
 mod wire_types;

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -1151,9 +1151,10 @@ pub async fn post_voice_transcription(
 
 pub async fn post_voice_transcription_install(
     State(state): State<AppState>,
+    Json(request): Json<voice_transcription::LocalVoiceInstall>,
 ) -> Result<Json<voice_transcription::LocalVoiceInfo>, ServerError> {
     Ok(Json(
-        voice_transcription::install_local(&*state.local_voice).await?,
+        voice_transcription::install_local(&*state.store, &*state.local_voice, request).await?,
     ))
 }
 

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -62,12 +62,15 @@ impl LocalVoiceError {
     }
 }
 
+/// The trusted half of local voice input. Every call names a catalog model by
+/// id; the runner owns where its bytes live and how they are verified.
 #[async_trait::async_trait]
 pub trait LocalVoiceRunner: Send + Sync {
-    async fn status(&self) -> LocalVoiceStatus;
-    async fn install(&self) -> std::result::Result<LocalVoiceStatus, String>;
+    async fn status(&self, model: &str) -> LocalVoiceStatus;
+    async fn install(&self, model: &str) -> std::result::Result<LocalVoiceStatus, String>;
     async fn transcribe(
         &self,
+        model: &str,
         content_type: &str,
         audio: Vec<u8>,
     ) -> std::result::Result<String, LocalVoiceError>;
@@ -77,7 +80,7 @@ struct UnavailableLocalVoiceRunner;
 
 #[async_trait::async_trait]
 impl LocalVoiceRunner for UnavailableLocalVoiceRunner {
-    async fn status(&self) -> LocalVoiceStatus {
+    async fn status(&self, _model: &str) -> LocalVoiceStatus {
         LocalVoiceStatus {
             state: LocalVoiceState::Unavailable,
             downloaded_bytes: None,
@@ -86,12 +89,13 @@ impl LocalVoiceRunner for UnavailableLocalVoiceRunner {
         }
     }
 
-    async fn install(&self) -> std::result::Result<LocalVoiceStatus, String> {
+    async fn install(&self, _model: &str) -> std::result::Result<LocalVoiceStatus, String> {
         Err("local voice input is available only in the desktop app".into())
     }
 
     async fn transcribe(
         &self,
+        _model: &str,
         _content_type: &str,
         _audio: Vec<u8>,
     ) -> std::result::Result<String, LocalVoiceError> {

--- a/crates/openwave-server/src/voice_transcription.rs
+++ b/crates/openwave-server/src/voice_transcription.rs
@@ -14,6 +14,91 @@ use crate::state::{LocalVoiceError, LocalVoiceRunner, LocalVoiceState};
 const SETTING_KEY: &str = "voice.transcription_v1";
 pub const MAX_AUDIO_BYTES: usize = 25 * 1024 * 1024;
 
+/// The whisper.cpp model repository revision every local artifact is pinned to.
+///
+/// One revision for the whole catalog: the artifacts are content-addressed by
+/// the SHA-256 below, so the revision only decides which files exist.
+pub const LOCAL_VOICE_REPO_COMMIT: &str = "5359861c739e955e79d9a303bcbc70fb988958b1";
+
+/// One installable local speech model.
+///
+/// The catalog is a plain list because that is all it needs to be: adding a
+/// model is one entry with its artifact name, exact size, and exact digest.
+/// `file`/`sha256` never reach the renderer — the desktop runner uses them to
+/// fetch and verify, and the wire projection carries only what the picker shows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LocalVoiceModel {
+    pub id: &'static str,
+    pub label: &'static str,
+    /// One line on the quality/speed trade-off, shown under the label.
+    pub description: &'static str,
+    pub bytes: u64,
+    /// English-only models transcribe faster and refuse other languages.
+    pub english_only: bool,
+    pub recommended: bool,
+    pub file: &'static str,
+    pub sha256: &'static str,
+}
+
+pub const DEFAULT_LOCAL_VOICE_MODEL: &str = "tiny.en-q5_1";
+
+pub const LOCAL_VOICE_MODELS: &[LocalVoiceModel] = &[
+    LocalVoiceModel {
+        id: "tiny.en-q5_1",
+        label: "Whisper tiny (English)",
+        description: "Fastest and smallest. Accurate enough for short dictation.",
+        bytes: 32_166_155,
+        english_only: true,
+        recommended: true,
+        file: "ggml-tiny.en-q5_1.bin",
+        sha256: "c77c5766f1cef09b6b7d47f21b546cbddd4157886b3b5d6d4f709e91e66c7c2b",
+    },
+    LocalVoiceModel {
+        id: "base.en-q5_1",
+        label: "Whisper base (English)",
+        description: "Clearly more accurate than tiny on names and long sentences, still fast.",
+        bytes: 59_721_011,
+        english_only: true,
+        recommended: false,
+        file: "ggml-base.en-q5_1.bin",
+        sha256: "4baf70dd0d7c4247ba2b81fafd9c01005ac77c2f9ef064e00dcf195d0e2fdd2f",
+    },
+    LocalVoiceModel {
+        id: "small.en-q5_1",
+        label: "Whisper small (English)",
+        description: "Best English accuracy that still runs comfortably on a laptop CPU.",
+        bytes: 190_098_681,
+        english_only: true,
+        recommended: false,
+        file: "ggml-small.en-q5_1.bin",
+        sha256: "bfdff4894dcb76bbf647d56263ea2a96645423f1669176f4844a1bf8e478ad30",
+    },
+    LocalVoiceModel {
+        id: "small-q5_1",
+        label: "Whisper small (multilingual)",
+        description: "Same size as small English, and transcribes other languages.",
+        bytes: 190_085_487,
+        english_only: false,
+        recommended: false,
+        file: "ggml-small-q5_1.bin",
+        sha256: "ae85e4a935d7a567bd102fe55afc16bb595bdb618e11b2fc7591bc08120411bb",
+    },
+    LocalVoiceModel {
+        id: "large-v3-turbo-q5_0",
+        label: "Whisper large v3 turbo (multilingual)",
+        description: "Highest accuracy. Wants a fast machine and over half a gigabyte of disk.",
+        bytes: 574_041_195,
+        english_only: false,
+        recommended: false,
+        file: "ggml-large-v3-turbo-q5_0.bin",
+        sha256: "394221709cd5ad1f40c46e6031ca61bce88931e6e088c188294c6d5a55ffa7e2",
+    },
+];
+
+pub fn local_voice_model(id: &str) -> Option<&'static LocalVoiceModel> {
+    LOCAL_VOICE_MODELS.iter().find(|model| model.id == id)
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum VoiceTranscriptionModel {
@@ -23,17 +108,51 @@ pub enum VoiceTranscriptionModel {
     GeminiFlash,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct VoiceTranscriptionConfig {
     model: VoiceTranscriptionModel,
+    /// Which catalog entry the local option means. Kept beside the provider
+    /// choice rather than folded into it so switching to the cloud and back
+    /// does not forget the model already downloaded.
+    #[serde(default = "default_local_model")]
+    local_model: String,
+}
+
+fn default_local_model() -> String {
+    DEFAULT_LOCAL_VOICE_MODEL.to_owned()
+}
+
+impl Default for VoiceTranscriptionConfig {
+    fn default() -> Self {
+        Self {
+            model: VoiceTranscriptionModel::default(),
+            local_model: default_local_model(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
 pub struct VoiceTranscriptionInfo {
     pub model: VoiceTranscriptionModel,
-    pub local: LocalVoiceInfo,
+    /// The selected catalog entry's id, whether or not local is the active
+    /// provider.
+    pub local_model: String,
+    pub local_models: Vec<LocalVoiceModelInfo>,
     pub openai_ready: bool,
     pub gemini_ready: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
+pub struct LocalVoiceModelInfo {
+    pub id: String,
+    pub label: String,
+    pub description: String,
+    pub total_bytes: u64,
+    pub english_only: bool,
+    pub recommended: bool,
+    pub state: String,
+    pub downloaded_bytes: Option<u64>,
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ts_rs::TS)]
@@ -47,14 +166,39 @@ pub struct LocalVoiceInfo {
 #[derive(Debug, Deserialize)]
 pub struct VoiceTranscriptionUpdate {
     pub model: VoiceTranscriptionModel,
+    #[serde(default)]
+    pub local_model: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct LocalVoiceInstall {
+    /// Which model to install. Absent means the one currently selected.
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 async fn read_config(store: &dyn Store) -> openwave_core::Result<VoiceTranscriptionConfig> {
-    Ok(store
+    let mut config: VoiceTranscriptionConfig = store
         .get_setting(SETTING_KEY)
         .await?
         .and_then(|value| serde_json::from_value(value).ok())
-        .unwrap_or_default())
+        .unwrap_or_default();
+    // A model can leave the catalog; a stale selection must not strand voice
+    // input on an artifact nothing can install.
+    if local_voice_model(&config.local_model).is_none() {
+        config.local_model = default_local_model();
+    }
+    Ok(config)
+}
+
+fn state_name(state: LocalVoiceState) -> &'static str {
+    match state {
+        LocalVoiceState::NotInstalled => "not_installed",
+        LocalVoiceState::Downloading => "downloading",
+        LocalVoiceState::Ready => "ready",
+        LocalVoiceState::Failed => "failed",
+        LocalVoiceState::Unavailable => "unavailable",
+    }
 }
 
 pub async fn info(
@@ -65,22 +209,25 @@ pub async fn info(
     let config = read_config(store).await?;
     let openai = providers::read_config(store, ProviderKind::Openai).await?;
     let gemini = providers::read_config(store, ProviderKind::Gemini).await?;
-    let local = local_voice.status().await;
+    let mut local_models = Vec::with_capacity(LOCAL_VOICE_MODELS.len());
+    for model in LOCAL_VOICE_MODELS {
+        let status = local_voice.status(model.id).await;
+        local_models.push(LocalVoiceModelInfo {
+            id: model.id.to_owned(),
+            label: model.label.to_owned(),
+            description: model.description.to_owned(),
+            total_bytes: model.bytes,
+            english_only: model.english_only,
+            recommended: model.recommended,
+            state: state_name(status.state).to_owned(),
+            downloaded_bytes: status.downloaded_bytes,
+            error: status.error,
+        });
+    }
     Ok(VoiceTranscriptionInfo {
         model: config.model,
-        local: LocalVoiceInfo {
-            state: match local.state {
-                LocalVoiceState::NotInstalled => "not_installed",
-                LocalVoiceState::Downloading => "downloading",
-                LocalVoiceState::Ready => "ready",
-                LocalVoiceState::Failed => "failed",
-                LocalVoiceState::Unavailable => "unavailable",
-            }
-            .to_owned(),
-            downloaded_bytes: local.downloaded_bytes,
-            total_bytes: local.total_bytes,
-            error: local.error,
-        },
+        local_model: config.local_model,
+        local_models,
         openai_ready: openai.enabled
             && providers::has_credential(secrets, ProviderKind::Openai).await,
         gemini_ready: gemini.enabled
@@ -108,8 +255,16 @@ pub async fn update(
         }
         _ => {}
     }
+    let local_model = match update.local_model {
+        Some(id) if local_voice_model(&id).is_none() => {
+            return Err(ServerError::bad_request("unknown local voice model"))
+        }
+        Some(id) => id,
+        None => current.local_model,
+    };
     let value = serde_json::to_value(VoiceTranscriptionConfig {
         model: update.model,
+        local_model,
     })
     .map_err(|_| ServerError::internal("failed to serialize voice transcription settings"))?;
     store.set_setting(SETTING_KEY, &value).await?;
@@ -117,18 +272,25 @@ pub async fn update(
 }
 
 pub async fn install_local(
+    store: &dyn Store,
     local_voice: &dyn LocalVoiceRunner,
+    request: LocalVoiceInstall,
 ) -> Result<LocalVoiceInfo, ServerError> {
-    let status = local_voice.install().await.map_err(ServerError::internal)?;
-    Ok(LocalVoiceInfo {
-        state: match status.state {
-            LocalVoiceState::NotInstalled => "not_installed",
-            LocalVoiceState::Downloading => "downloading",
-            LocalVoiceState::Ready => "ready",
-            LocalVoiceState::Failed => "failed",
-            LocalVoiceState::Unavailable => "unavailable",
+    let id = match request.model {
+        Some(id) => {
+            if local_voice_model(&id).is_none() {
+                return Err(ServerError::bad_request("unknown local voice model"));
+            }
+            id
         }
-        .to_owned(),
+        None => read_config(store).await?.local_model,
+    };
+    let status = local_voice
+        .install(&id)
+        .await
+        .map_err(ServerError::internal)?;
+    Ok(LocalVoiceInfo {
+        state: state_name(status.state).to_owned(),
         downloaded_bytes: status.downloaded_bytes,
         total_bytes: status.total_bytes,
         error: status.error,
@@ -148,7 +310,7 @@ pub async fn transcribe(
     let config = read_config(store).await?;
     if config.model == VoiceTranscriptionModel::Local {
         return local_voice
-            .transcribe(content_type, audio.to_vec())
+            .transcribe(&config.local_model, content_type, audio.to_vec())
             .await
             .map_err(|error| match error {
                 LocalVoiceError::UnsupportedMedia(message) => {
@@ -297,7 +459,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl LocalVoiceRunner for ReadyLocal {
-        async fn status(&self) -> LocalVoiceStatus {
+        async fn status(&self, _model: &str) -> LocalVoiceStatus {
             LocalVoiceStatus {
                 state: LocalVoiceState::Ready,
                 downloaded_bytes: Some(10),
@@ -306,15 +468,17 @@ mod tests {
             }
         }
 
-        async fn install(&self) -> Result<LocalVoiceStatus, String> {
-            Ok(self.status().await)
+        async fn install(&self, model: &str) -> Result<LocalVoiceStatus, String> {
+            Ok(self.status(model).await)
         }
 
         async fn transcribe(
             &self,
+            model: &str,
             content_type: &str,
             audio: Vec<u8>,
         ) -> Result<String, LocalVoiceError> {
+            assert_eq!(model, DEFAULT_LOCAL_VOICE_MODEL);
             assert_eq!(content_type, "audio/webm");
             assert_eq!(audio, b"local audio");
             Ok("local transcript".into())
@@ -343,9 +507,69 @@ mod tests {
         let info = info(&store, &TestSecrets::default(), &ReadyLocal)
             .await
             .unwrap();
-        assert_eq!(info.local.state, "ready");
+        assert_eq!(info.local_model, DEFAULT_LOCAL_VOICE_MODEL);
+        assert_eq!(info.local_models.len(), LOCAL_VOICE_MODELS.len());
+        assert_eq!(info.local_models[0].state, "ready");
         let json = serde_json::to_string(&info).unwrap();
         assert!(!json.contains("model.bin"));
         assert!(!json.contains("models/voice"));
+        // The artifact identity is the runner's business, not the renderer's.
+        assert!(!json.contains(LOCAL_VOICE_MODELS[0].sha256));
+        assert!(!json.contains(LOCAL_VOICE_MODELS[0].file));
+    }
+
+    /// Every id must be unique and installable: the picker, the stored
+    /// selection, and the runner's on-disk layout are all keyed by it.
+    #[test]
+    fn the_catalog_has_unique_ids_and_a_recommended_default() {
+        let mut ids: Vec<&str> = LOCAL_VOICE_MODELS.iter().map(|model| model.id).collect();
+        ids.sort_unstable();
+        let count = ids.len();
+        ids.dedup();
+        assert_eq!(ids.len(), count, "duplicate local voice model id");
+        let default = local_voice_model(DEFAULT_LOCAL_VOICE_MODEL).expect("default is in catalog");
+        assert!(default.recommended);
+        assert_eq!(
+            LOCAL_VOICE_MODELS
+                .iter()
+                .filter(|model| model.recommended)
+                .count(),
+            1,
+        );
+        for model in LOCAL_VOICE_MODELS {
+            assert_eq!(model.sha256.len(), 64, "{} digest", model.id);
+            assert!(model.bytes > 0, "{} size", model.id);
+        }
+    }
+
+    #[tokio::test]
+    async fn an_unknown_local_model_is_refused_rather_than_stored() {
+        let (_directory, store) = test_store().await;
+        let secrets = TestSecrets::default();
+        let error = update(
+            &store,
+            &secrets,
+            &ReadyLocal,
+            VoiceTranscriptionUpdate {
+                model: VoiceTranscriptionModel::Local,
+                local_model: Some("whisper-imaginary".into()),
+            },
+        )
+        .await
+        .expect_err("unknown model");
+        assert!(format!("{error:?}").contains("unknown local voice model"));
+
+        let stored = update(
+            &store,
+            &secrets,
+            &ReadyLocal,
+            VoiceTranscriptionUpdate {
+                model: VoiceTranscriptionModel::Local,
+                local_model: Some("base.en-q5_1".into()),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(stored.local_model, "base.en-q5_1");
     }
 }


### PR DESCRIPTION
Local voice input shipped with exactly one model, and the setting showed it as a
single fixed row plus a separate "Local model" section with its own download
button. Anything better than whisper tiny meant editing Rust. This turns the
local half into a small catalog the picker can grow into.

## The catalog

`openwave-server::voice_transcription::LOCAL_VOICE_MODELS` is a flat list; an
entry is its id, label, one-line trade-off, exact size, exact SHA-256, artifact
name, and whether it is English-only. Adding a model is one entry. The digest
and artifact name never reach the renderer — the desktop runner uses them to
fetch and verify, and the wire projection carries only what the picker displays.

Five entries, all quantized whisper.cpp weights pinned to one repository
revision:

| model | size | trade-off |
| --- | --- | --- |
| tiny.en-q5_1 | 31 MB | fastest, English only — the default |
| base.en-q5_1 | 57 MB | clearly better on names and long sentences, still fast |
| small.en-q5_1 | 181 MB | best English accuracy that stays comfortable on a laptop CPU |
| small-q5_1 | 181 MB | same size, transcribes languages other than English |
| large-v3-turbo-q5_0 | 547 MB | highest accuracy, wants a fast machine |

The default stays tiny.en, and it is the one flagged `recommended`: it is the
cheapest thing that works, and the picker exists for readers who want more.
English-only models are run with `language=en` as before; the multilingual ones
are run with `auto` so whisper detects the language.

Every entry is pinned to whisper.cpp revision `5359861c…`, which is the first
that carries large-v3-turbo. That is a different revision from the one #1437
pinned, so the tiny.en artifact — byte-identical between the two — installs
under a new directory and is fetched once more for anyone who already had it.

## The picker

The setting is now one select. Models that are not on disk are listed as
ghosted rows rather than hidden or disabled: choosing one is how you ask for it.
That opens the shared confirmation dialog naming the model, the download size,
and the disk it will use, and only then does the download start, with progress
below the field. When it lands the model becomes the active selection. The
separate "Local model" section is gone; a failed download surfaces its error and
a retry where the picker is.

Remote options are unchanged: OpenAI and Gemini still appear once their provider
is enabled and credentialed.

## Shape changes

- `LocalVoiceRunner` takes a model id on `status`, `install`, and `transcribe`;
  the desktop runner keys its install directory, marker, and download progress
  by that id, and still serializes downloads.
- `VoiceTranscriptionInfo` replaces the single `local` status with
  `local_model` (the selection) and `local_models` (the catalog with per-entry
  install state). The stored setting gains `local_model`, so switching to a
  cloud model and back does not forget which local model was downloaded.
- `POST /voice-transcription/install` takes `{ "model": id }`; an unknown id is
  refused rather than stored or fetched.

Nothing in the audio decode or transcode path is touched. Rebased onto #1452,
whose typed `LocalVoiceError` the runner now returns from `transcribe`, an
unknown model id being a `Runner` fault. The renderer surfaces whatever message
the server sends for any non-ok status, so the new 415/422 answers need nothing
from it.

## Tests

Added: the catalog's ids are unique with one recommended default that is in the
catalog; each entry installs to its own directory (two sharing one would let a
verified marker satisfy the wrong model); an unknown id is refused by `update`;
and, on the renderer, that voice input is only ready when the *selected* local
model is the installed one — the check that keeps the mic from starting a
recording nothing can transcribe.

`installs_and_transcribes_with_a_second_catalog_model` drives base.en-q5_1
through the real install path — download, SHA-256 and length verification,
marker, a second install that is a no-op, then inference. It is `#[ignore]`d
because it fetches 57 MB. Run with
`cargo test -p openwave-desktop installs_and_transcribes -- --ignored`.

## Verification

Ran end to end locally on macOS: base.en-q5_1 downloaded through the runner's
own install path, matched its pinned digest and byte length, and transcribed
speech to "The quick brown fox jumps over the lazy dog." — so the model id
plumbing carries past tiny.en. (The committed test asserts only that inference
completes: the checked-in recording is a tone, not speech, and correctly
produces an empty transcript.)

Also `cargo clippy -p openwave-server -p openwave-desktop --all-targets`,
`cargo fmt --all --check`, `cargo test -p openwave-{server,desktop}
voice_transcription`, `cargo test -p openwave-server wire_types`,
`pnpm exec tsc --noEmit`, and the full `vitest` suite (712 passing) — all after
the rebase.

Left for a look in the running app: the picker's multi-line rows inside the
select trigger and content, the ghosted styling and Recommended pill against
both themes, and the download dialog and progress bar.