### PR TITLE
ci: roll macOS release build caches to v3 to shed poisoned CMake state

### DIFF
--- a/.github/workflows/cache-macos.yml
+++ b/.github/workflows/cache-macos.yml
@@ -88,12 +88,10 @@ jobs:
             target/${{ matrix.target }}/release/openwave-host-broker
             target/${{ matrix.target }}/release/libopenwave_desktop_lib.*
             crates/openwave-desktop/binaries/openwave-host-broker-${{ matrix.target }}
-          key: macos-release-target-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ github.sha }}
+          key: macos-release-target-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ github.sha }}
           restore-keys: |
-            macos-release-target-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
-            macos-release-target-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
-            macos-release-target-v2-${{ matrix.arch }}-
-            macos-release-target-v1-${{ matrix.arch }}-
+            macos-release-target-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            macos-release-target-v3-${{ matrix.arch }}-
 
       - name: Set up compiler cache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,16 +290,12 @@ jobs:
             target/${{ matrix.target }}/release/openwave-host-broker
             target/${{ matrix.target }}/release/libopenwave_desktop_lib.*
             crates/openwave-desktop/binaries/openwave-host-broker-${{ matrix.target }}
-          key: macos-release-prepared-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+          key: macos-release-prepared-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
           restore-keys: |
-            macos-release-prepared-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
-            macos-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
-            macos-release-target-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
-            macos-release-target-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
-            macos-release-target-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
-            macos-release-target-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
-            macos-release-target-v2-${{ matrix.arch }}-
-            macos-release-target-v1-${{ matrix.arch }}-
+            macos-release-prepared-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
+            macos-release-target-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
+            macos-release-target-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            macos-release-target-v3-${{ matrix.arch }}-
 
       - name: Set up compiler cache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
@@ -419,16 +415,12 @@ jobs:
             target/${{ matrix.target }}/release/openwave-host-broker
             target/${{ matrix.target }}/release/libopenwave_desktop_lib.*
             crates/openwave-desktop/binaries/openwave-host-broker-${{ matrix.target }}
-          key: macos-release-prepared-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
+          key: macos-release-prepared-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-${{ needs.validate.outputs.version }}
           restore-keys: |
-            macos-release-prepared-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
-            macos-release-prepared-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
-            macos-release-target-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
-            macos-release-target-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
-            macos-release-target-v2-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
-            macos-release-target-v1-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
-            macos-release-target-v2-${{ matrix.arch }}-
-            macos-release-target-v1-${{ matrix.arch }}-
+            macos-release-prepared-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
+            macos-release-target-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
+            macos-release-target-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
+            macos-release-target-v3-${{ matrix.arch }}-
 
       - name: Validate production signing configuration
         env:

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -530,13 +530,13 @@ test("release caches restore only credential-free compiler products", () => {
   ]) {
     assert.match(
       restoreStep,
-      /macos-release-target-v2-\$\{\{ matrix\.arch \}\}-/,
+      /macos-release-target-v3-\$\{\{ matrix\.arch \}\}-/,
       "unsigned product caches should be preferred when available",
     );
-    assert.match(
+    assert.doesNotMatch(
       restoreStep,
-      /macos-release-target-v1-\$\{\{ matrix\.arch \}\}-/,
-      "unsigned compiler-only caches should remain a migration fallback",
+      /macos-release-(?:target|prepared)-v[12]-/,
+      "older cache generations bake in a stale MACOSX_DEPLOYMENT_TARGET and must not be restored",
     );
   }
 });


### PR DESCRIPTION
The v0.29.0 publish run failed with the identical whisper.cpp availability errors that #1448 fixed — and the compile log shows why: both flags are present, `-mmacosx-version-min=10.15` (from the fixed config, via `CMAKE_C_FLAGS`) followed by `-mmacosx-version-min=10.13`, and the last one wins.

The stale 10.13 comes from the restored unsigned Rust build cache: it contains whisper-rs-sys's cmake build directory, whose `CMakeCache.txt` pinned `CMAKE_OSX_DEPLOYMENT_TARGET=10.13` when it was first configured before #1448 merged (restored key suffix `ac47b8d`, pre-fix main). CMake ignores the environment on reconfigure once the value is cached. The warming workflow saves its cache even when the compile fails (`if: !cancelled()`) and restores its own previous entry, so the poisoned state regenerates on every warming run rather than aging out.

This bumps `macos-release-prepared`/`macos-release-target` keys to `v3` and drops the v1/v2 restore fallbacks, so no lane can restore pre-fix state; old entries fall to normal cache eviction. Direct cache deletion would fix only today's entries — the key bump also stops the warming lane from re-saving over the poison.

Caveat for the future: cmake build dirs bake the deployment target in, so if `minimumSystemVersion` changes again these keys need another bump.

After merge, re-dispatch the v0.29.0 publish; no new tag is needed — the tag's tree is correct, only the runner-side cache was stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)