### PR TITLE
ci: check dependencies against the RustSec advisory database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,27 @@ jobs:
             ghcr.io/gitleaks/gitleaks@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f \
             detect --source=/repo --redact --verbose
 
+  advisories:
+    name: supply-chain advisories (cargo-deny)
+    needs: changes
+    # cargo-deny resolves the crate graph and reads the RustSec database; it
+    # compiles nothing, so this runs on every Rust-scoped pull request instead
+    # of hiding behind `full-ci`. The weekly scheduled run re-checks an
+    # unchanged lockfile against newly published advisories.
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
+        with:
+          tool: cargo-deny@0.20.2
+      # Posture and exceptions live in deny.toml. `--all-features` covers
+      # optional dependencies that a default-feature graph would miss.
+      - name: Check RustSec advisories
+        run: cargo deny --all-features check advisories
+
   fmt:
     name: rustfmt
     needs: changes

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,28 @@
+# Supply-chain advisory policy for `cargo deny check advisories`.
+#
+# Scope is deliberately narrow: this is the RustSec advisory gate, not a
+# license or dependency-ban policy. Only the `advisories` check is wired into
+# CI (`.github/workflows/ci.yml`), so the other sections cargo-deny supports
+# are intentionally absent.
+
+[advisories]
+# Security advisories and unsound APIs always fail. These are the findings we
+# would act on the day they appear.
+version = 2
+
+# Unmaintained crates we pull in directly are ours to replace; unmaintained
+# crates that arrive through someone else's dependency tree are not actionable
+# here and would otherwise make the lane permanently red. Today those are the
+# GTK3 bindings behind Tauri's Linux backend, the `unic-*` family, and
+# `proc-macro-error*` — all transitive, none with a fix we control.
+unmaintained = "workspace"
+
+# Yanked versions are reported as a warning rather than a hard failure: a crate
+# can be yanked at any moment for reasons unrelated to us, and the fix is a
+# lockfile bump that Dependabot already drives.
+yanked = "warn"
+
+# Advisories consciously accepted, each with the reason it is safe to carry.
+# Keep this list short and dated; an entry that outlives its justification is
+# worse than no gate at all.
+ignore = []


### PR DESCRIPTION
Adds a `cargo deny check advisories` lane — the one supply-chain check with no CI coverage today.

The lane runs on the Rust change scope and is not gated behind `full-ci`: cargo-deny compiles nothing, so it costs about a minute. Scheduled and manual runs pick it up through the existing full-validation path, which is what catches an advisory published against a lockfile that hasn't changed.

`deny.toml` holds the posture and is scoped to advisories only — no license or dependency-ban policy:

- vulnerabilities and unsound APIs fail;
- unmaintained crates fail only when a workspace crate depends on them directly, since a transitive one has no fix we control;
- yanked versions warn, because a crate can be yanked at any time and Dependabot already drives the lockfile bump.

Run locally against this tree, the check passes. It surfaces the GTK3 bindings behind Tauri's Linux backend, the `unic-*` family and `proc-macro-error*` as unmaintained (all transitive) and `spin` 0.9.8 as yanked (via `flume` → `sqlx`). No exceptions were needed, so the `ignore` list is empty.

The job definition itself can only be proven by CI.

Part of #1461