### PR TITLE
ci: pin the release signing job's cache restore to the released source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -399,6 +399,16 @@ jobs:
 
       # This restore-only step runs before production secrets are loaded. The
       # matching cache is written by a credential-free prerequisite job.
+      #
+      # Every key below pins the source identity of what it may restore: the
+      # release commit SHA, or at minimum the Cargo.lock and toolchain hashes.
+      # An arch-only fallback would let this job restore a `main`-warmed
+      # archive that has no relation to the released tag. The path list must
+      # stay byte-identical to the writing jobs' — `actions/cache` folds it
+      # into the cache version, so trimming entries here would silently miss
+      # every key instead of restoring a subset. The next step deletes the
+      # linked products the archive carries, so only compiler intermediates
+      # survive into the signed build.
       - name: Restore unsigned Rust build cache
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -420,7 +430,22 @@ jobs:
             macos-release-prepared-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}-
             macos-release-target-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-${{ needs.validate.outputs.sha }}
             macos-release-target-v3-${{ matrix.arch }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml') }}-
-            macos-release-target-v3-${{ matrix.arch }}-
+
+      # A restore extracts the whole archive, including the linked products a
+      # cache-warming run left in it. Those are the bytes that get signed, so
+      # delete them and let the signed build relink them from the tag's
+      # sources; the compiler intermediates that make the reuse worthwhile
+      # stay. The sidecar matters most: Tauri copies it into the signed
+      # product verbatim, with no Cargo fingerprint governing it.
+      - name: Discard restored product binaries
+        env:
+          RELEASE_TARGET: ${{ matrix.target }}
+        run: |
+          rm -rf \
+            "target/$RELEASE_TARGET/release/openwave-desktop" \
+            "target/$RELEASE_TARGET/release/openwave-host-broker" \
+            "target/$RELEASE_TARGET/release/"libopenwave_desktop_lib.* \
+            "crates/openwave-desktop/binaries/openwave-host-broker-$RELEASE_TARGET"
 
       - name: Validate production signing configuration
         env:

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -134,9 +134,13 @@ automatic.
    credential-free prerequisite otherwise compiles the tag with its product
    version and saves unsigned Cargo outputs before any signing or notarization
    can fail.
-6. The production job restores those exact prepared outputs, signs the app with
-   the Developer ID identity, notarizes and staples the app and DMG, verifies
-   them with Apple tooling, and creates a signed Tauri updater archive.
+6. The production job reuses those prepared compiler outputs — every cache key
+   it can restore names the release commit or, at minimum, the `Cargo.lock` and
+   toolchain hashes, and it deletes the linked binaries the archive carries so
+   the products it signs are always linked from the tag's own sources. It then
+   signs the app with the Developer ID identity, notarizes and staples the app
+   and DMG, verifies them with Apple tooling, and creates a signed Tauri updater
+   archive.
 7. Only after the build passes does the publisher upload immutable versioned
    files, advance the public manifests, invalidate their CDN paths, and
    smoke-test the hosted release. If a prior attempt already uploaded the

--- a/scripts/workflow-security.test.mjs
+++ b/scripts/workflow-security.test.mjs
@@ -523,6 +523,19 @@ test("release caches restore only credential-free compiler products", () => {
     assert.doesNotMatch(cacheStep, /bundle|\.app|dmg|signature|keychain/i);
   }
 
+  // `actions/cache` folds the path list into the cache version, so the signing
+  // job can only reach an archive a writing job saved under the same list.
+  // Keeping them identical is what makes the key ladder below, rather than a
+  // silent total miss, the thing that governs what gets restored.
+  const cachedPaths = (step) =>
+    step.match(/path: \|\n([\s\S]*?)\n\s+key:/)?.[1];
+  assert.ok(cachedPaths(releaseBuildCache));
+  assert.equal(
+    cachedPaths(releaseBuildCache),
+    cachedPaths(releasePrepareCacheSave),
+  );
+  assert.equal(cachedPaths(releaseBuildCache), cachedPaths(warmBuildCacheSave));
+
   for (const restoreStep of [
     releasePrepareCache,
     releaseBuildCache,
@@ -539,6 +552,56 @@ test("release caches restore only credential-free compiler products", () => {
       "older cache generations bake in a stale MACOSX_DEPLOYMENT_TARGET and must not be restored",
     );
   }
+
+  // The credential-free jobs recompile from the tag or from `main`'s tip, so a
+  // fallback that names only the architecture costs them compile time at
+  // worst.
+  for (const restoreStep of [releasePrepareCache, warmBuildCache]) {
+    assert.match(
+      restoreStep,
+      /^\s*macos-release-target-v3-\$\{\{ matrix\.arch \}\}-$/m,
+      "credential-free jobs may fall back to any warmed cache for this arch",
+    );
+  }
+
+  // The signing job signs what it restores, so every key it can hit must pin
+  // the source identity of the archive: the release commit SHA, or at minimum
+  // the Cargo.lock and toolchain hashes. An arch-only fallback would restore
+  // an archive warmed from an unrelated `main` commit and sign binaries that
+  // do not correspond to the released tag.
+  const signingCacheKeys = releaseBuildCache
+    .split("\n")
+    .map((line) => line.trim().replace(/^key: /, ""))
+    .filter((line) => line.startsWith("macos-release-"));
+  assert.ok(signingCacheKeys.length >= 4);
+  for (const key of signingCacheKeys) {
+    assert.ok(
+      key.includes("hashFiles('Cargo.lock',"),
+      `restorable signing-job cache key does not pin the source: ${key}`,
+    );
+  }
+
+  // Whatever a restore extracts, the products that actually get signed are
+  // relinked from the tag's own sources.
+  const discardProducts = signedBuildJob.match(
+    /- name: Discard restored product binaries[\s\S]*?(?=\n\s+- name:)/,
+  )?.[0];
+  assert.ok(discardProducts);
+  for (const product of [
+    /release\/openwave-desktop/,
+    /release\/openwave-host-broker/,
+    /libopenwave_desktop_lib\./,
+    /binaries\/openwave-host-broker-\$RELEASE_TARGET/,
+  ]) {
+    assert.match(discardProducts, product);
+  }
+  assert.ok(
+    signedBuildJob.indexOf("Discard restored product binaries") >
+      signedBuildJob.indexOf("Restore unsigned Rust build cache") &&
+      signedBuildJob.indexOf("Discard restored product binaries") <
+        signedBuildJob.indexOf("Build, sign, and notarize the Tauri app"),
+    "restored product binaries must be discarded before the signed build",
+  );
 });
 
 test("an existing immutable release resumes without rebuilding or overwriting", () => {


### PR DESCRIPTION
The signing job's restore-keys ladder ended in `macos-release-target-v3-<arch>-`,
which matches any archive the main-tip cache warmer wrote. A release of an older
tag misses the SHA-scoped keys, falls through to that key, and restores an
archive built from an unrelated commit. The archive carries linked products —
the app binary, the host-broker binary, the desktop cdylib, and the
`externalBin` sidecar the bundler copies in without a Cargo fingerprint — so
those bytes can be signed with the Developer ID and notarized while claiming to
be the tag.

Drop the arch-only fallback from that job: every key it can now restore names
either the release commit or the Cargo.lock and toolchain hashes. The
credential-free `prepare_macos` and the cache warmer keep it; they recompile
from the tag and sign nothing.

Also delete the linked products after the restore. Narrowing the restore `path`
list would not work — `actions/cache` folds the path list into the cache
version, so a shorter list misses every key rather than restoring a subset — and
the key pin alone still admits any main commit that leaves Cargo.lock untouched.
Removing the four product paths costs a relink and guarantees the signed
artifacts are linked from the tag's sources.

The workflow test asserted the loose fallbacks were present and described the
cache as compiler-only while its path list named product binaries. It now
enforces the invariant instead: every restorable signing-job key carries the
source hash, the path lists across the reading and writing jobs stay identical,
and the discard step runs between the restore and the signed build.

Closes #1457
