### PR TITLE
fix(core): prune stale empty-scan receipts from agent_run_claim

### DIFF
--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -1443,6 +1443,15 @@ pub(in crate::db) async fn reclaim_container_agent_run(
     Ok(Some(reclaimed))
 }
 
+/// How long a no-work claim receipt is kept around for.
+///
+/// The receipt exists so an exact retry of the same lease token (e.g. after a
+/// lost response) recovers the same "no work" answer instead of racing a
+/// later scan that might find real work. No caller retries with the same
+/// token beyond process restart timescales, so a generous but bounded window
+/// is enough; past it the row only exists to be swept.
+const EMPTY_CLAIM_SCAN_RETENTION: chrono::Duration = chrono::Duration::hours(1);
+
 async fn record_empty_claim_scan_on<C>(
     conn: &C,
     lease_token: uuid::Uuid,
@@ -1451,6 +1460,17 @@ async fn record_empty_claim_scan_on<C>(
 where
     C: sea_orm::ConnectionTrait,
 {
+    // An idle worker polls every few seconds and would otherwise accrete one
+    // NULL-run receipt per empty scan forever (#1455). Prune expired ones
+    // before inserting the new one so the table stays bounded by the
+    // retention window instead of growing without bound.
+    entities::agent_run_claim::Entity::delete_many()
+        .filter(entities::agent_run_claim::Column::AgentRunId.is_null())
+        .filter(entities::agent_run_claim::Column::ClaimedAt.lt(now - EMPTY_CLAIM_SCAN_RETENTION))
+        .exec(conn)
+        .await
+        .map_err(store_err)?;
+
     entities::agent_run_claim::ActiveModel {
         token: Set(lease_token),
         agent_run_id: Set(None),

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -1398,6 +1398,44 @@ async fn sandbox_claims_are_exact_reclaimable_and_heartbeatable() {
 }
 
 #[tokio::test]
+async fn idle_polling_does_not_accrete_empty_claim_scan_rows() {
+    let (_dir, store) = temp_store().await;
+
+    // Stand in for a receipt an idle worker's earlier empty poll would have
+    // left behind, well outside the retention window (#1455).
+    let stale_token = uuid::Uuid::new_v4();
+    let stale_claimed_at = Utc::now() - Duration::hours(2);
+    crate::db::entities::agent_run_claim::ActiveModel {
+        token: Set(stale_token),
+        agent_run_id: Set(None),
+        attempt_count: Set(None),
+        claim_count: Set(None),
+        claimed_at: Set(stale_claimed_at),
+        lease_expires_at: Set(None),
+    }
+    .insert(&store.conn)
+    .await
+    .unwrap();
+
+    // An idle worker poll with nothing to claim.
+    assert!(store
+        .claim_agent_run(uuid::Uuid::new_v4(), Duration::minutes(1), 4, 2)
+        .await
+        .unwrap()
+        .is_none());
+
+    let remaining = crate::db::entities::agent_run_claim::Entity::find()
+        .filter(crate::db::entities::agent_run_claim::Column::AgentRunId.is_null())
+        .all(&store.conn)
+        .await
+        .unwrap();
+    // The stale receipt was swept; only the poll's own fresh receipt remains,
+    // so an idle worker no longer accretes rows without bound.
+    assert_eq!(remaining.len(), 1);
+    assert_ne!(remaining[0].token, stale_token);
+}
+
+#[tokio::test]
 async fn sandbox_result_submission_is_fenced_and_idempotent() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();


### PR DESCRIPTION
## Summary

An idle sandbox worker polls the scheduler every few seconds, and every empty poll (`record_empty_claim_scan_on`) inserted a claim receipt with `agent_run_id = NULL`. The only deletion path in `conversation.rs` filters `AgentRunId IN (subquery)`, which never matches NULL, so an idle worker accreted roughly one row per poll indefinitely.

The receipt isn't purely observability: `claim_agent_run` looks up the receipt by lease token first, and if it finds one with a NULL `agent_run_id` it returns "no work" immediately rather than re-scanning. That's load-bearing — an existing test (`scheduler_never_claims_a_sandbox_row_without_an_admission_receipt`, and the exhausted-attempt test around it) retries the exact same token after new work becomes admitted and expects it to still see no work, so a retried token can't be reused to claim different work than what it originally found nothing for.

So dropping persistence outright isn't safe here. Instead, this prunes NULL-run receipts older than a generous retention window (1 hour) as part of recording each new empty scan, in the same transaction. Retries of the same token only matter on process-restart timescales, well inside that window, so the invariant above still holds while the table stays bounded instead of growing forever.

## Test plan

- [x] `cargo check -p openwave-core --locked`
- [x] `cargo test -p openwave-core --locked db::tests::agent_run` (43 passed), including a new regression test (`idle_polling_does_not_accrete_empty_claim_scan_rows`) that seeds a stale NULL-run receipt outside the retention window, performs an idle poll, and asserts the stale row is swept and only the poll's own fresh receipt remains
- [x] `cargo fmt -p openwave-core -- --check`

Closes #1455