### PR TITLE
ci: run the workflow-security policy from the trusted base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,16 +40,12 @@ jobs:
       contents: read
       pull-requests: read
     steps:
+      # The title and labels come from the event payload, so this job never
+      # needs the pull request's own code — only the trusted base-branch copy
+      # of the policy it is judged by.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 1
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          # Once this policy has landed, always execute its trusted base-branch
-          # copy. The root checkout is retained only to bootstrap this PR.
           ref: ${{ github.event.pull_request.base.sha }}
-          path: .trusted-release-policy
           fetch-depth: 1
       - name: Validate Conventional Commit title
         env:
@@ -58,44 +54,47 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          policy_dir="$GITHUB_WORKSPACE/.trusted-release-policy"
-          bootstrap=false
-          if [[ ! -f "$policy_dir/scripts/check-pr-title.mjs" ]] ||
-            [[ ! -f "$policy_dir/scripts/release-label.mjs" ]]; then
-            policy_dir="$GITHUB_WORKSPACE"
-            bootstrap=true
-            echo "Bootstrapping the release policy from this PR; future PRs use the trusted base copy."
-          fi
-
-          node "$policy_dir/scripts/check-pr-title.mjs" "$PR_TITLE"
-          # The transition PR runs this workflow from its head while loading the
-          # older trusted classifier from main. Fall back once to its single
-          # label interface; after merge, the trusted copy supports --labels.
-          if expected_labels_json="$(node "$policy_dir/scripts/release-label.mjs" --labels "$PR_TITLE" 2>/dev/null)"; then
-            expected_labels="$(jq -r 'sort | join(",")' <<<"$expected_labels_json")"
-          else
-            expected_labels="$(node "$policy_dir/scripts/release-label.mjs" --title "$PR_TITLE")"
-          fi
-          if [[ "$bootstrap" = false ]]; then
-            actual_labels=""
-            for _ in {1..10}; do
-              actual_labels="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
-                --jq '[.labels[].name | select(startswith("semver:") or startswith("release-note:"))] | sort | join(",")')"
-              [[ "$actual_labels" = "$expected_labels" ]] && break
-              sleep 2
-            done
-            test "$actual_labels" = "$expected_labels" || {
-              echo "Expected managed release labels $expected_labels; found: ${actual_labels:-none}." >&2
-              echo "The trusted Release draft workflow may still be synchronizing it." >&2
-              exit 1
-            }
-          fi
+          node scripts/check-pr-title.mjs "$PR_TITLE"
+          expected_labels="$(node scripts/release-label.mjs --labels "$PR_TITLE" |
+            jq -r 'sort | join(",")')"
+          actual_labels=""
+          for _ in {1..10}; do
+            actual_labels="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" \
+              --jq '[.labels[].name | select(startswith("semver:") or startswith("release-note:"))] | sort | join(",")')"
+            [[ "$actual_labels" = "$expected_labels" ]] && break
+            sleep 2
+          done
+          test "$actual_labels" = "$expected_labels" || {
+            echo "Expected managed release labels $expected_labels; found: ${actual_labels:-none}." >&2
+            echo "The trusted Release draft workflow may still be synchronizing it." >&2
+            exit 1
+          }
 
   release-policy:
     name: release policy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # The workflow-security tests read the checked-out workflows and configs,
+      # so they must run against this pull request's files — but from the base
+      # branch's copy of the test. Otherwise a pull request could introduce a
+      # violation and the assertion that forbids it in the same commit.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .trusted-release-policy
+          fetch-depth: 1
+      - name: Restore the trusted workflow-security test
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          trusted="$GITHUB_WORKSPACE/.trusted-release-policy/scripts/workflow-security.test.mjs"
+          if [[ ! -f "$trusted" ]]; then
+            echo "Missing the base branch's copy of scripts/workflow-security.test.mjs." >&2
+            echo "This job must not fall back to the pull request's own copy." >&2
+            exit 1
+          fi
+          cp "$trusted" "$GITHUB_WORKSPACE/scripts/workflow-security.test.mjs"
       - name: Test semantic title and tag policy
         run: node --test scripts/*.test.mjs
 


### PR DESCRIPTION
`release-policy` ran `scripts/workflow-security.test.mjs` from the pull request's own checkout, so one commit could add a workflow violation and relax the assertion that forbids it. `pr-title` already had the base-checkout pattern; this applies it to the policy tests.

The wrinkle is that the security test reads the workflows and configs it inspects relative to its own file location, so simply running the base copy in place would check the *base* branch's workflows and prove nothing about the pull request. Instead the job checks out the base SHA alongside and copies its `workflow-security.test.mjs` over the head copy: trusted assertions, this pull request's files. A missing base copy is a hard failure — there is no fallback to the head copy.

Only the location of the test changes; its contents are untouched (#1457 owns those).

The second half removes dead code in `pr-title`. That job reads the title and labels from the event payload and never needs the branch's code, so the head checkout is gone and the trusted base checkout is now the root checkout. Two transition artifacts go with it: the bootstrap bypass, which silently skipped the label assertion whenever the trusted copy was absent, and the `--labels`/`--title` fallback for a classifier interface that has been on `main` for a long time.

`node --test scripts/*.test.mjs` passes locally (83 tests), which is also the simulation that matters here — the unmodified test against the modified `ci.yml`. The checkout wiring itself can only be proven by a CI run.

Part of #1461