### PR TITLE
fix(connectors): require https for gateway pairing off loopback

### DIFF
--- a/crates/openwave-connectors/src/gateway.rs
+++ b/crates/openwave-connectors/src/gateway.rs
@@ -50,6 +50,26 @@ fn gateway_error(context: &str, detail: impl std::fmt::Display) -> AgentError {
     AgentError::config(format!("model-gateway {context}: {detail}"))
 }
 
+/// Whether a URL's host is the local machine.
+///
+/// Cleartext `http` is only tolerated for a gateway running beside the app —
+/// a developer deployment on `localhost`. Everything else carries an OAuth
+/// authorization code and opaque tokens, so it must be `https`; a provision
+/// link parked on a webpage would otherwise be able to point the whole
+/// exchange at an attacker-readable origin. `localhost` counts because the
+/// resolver is required to map it to a loopback address; other names do not,
+/// since what they resolve to is not knowable here.
+pub(crate) fn is_loopback_url(url: &reqwest::Url) -> bool {
+    url.host_str().is_some_and(|host| {
+        host.eq_ignore_ascii_case("localhost")
+            || host
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .parse::<std::net::IpAddr>()
+                .is_ok_and(|address| address.is_loopback())
+    })
+}
+
 /// How this client identifies itself to the gateway.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GatewayAuthConfig {
@@ -77,6 +97,12 @@ impl GatewayAuthConfig {
             return Err(gateway_error(
                 "configuration",
                 "base URL must use http or https",
+            ));
+        }
+        if base_url.scheme() == "http" && !is_loopback_url(&base_url) {
+            return Err(gateway_error(
+                "configuration",
+                "base URL must use https unless the gateway is on loopback",
             ));
         }
         if !base_url.username().is_empty() || base_url.password().is_some() {
@@ -1160,8 +1186,26 @@ mod tests {
     #[test]
     fn config_rejects_invalid_base_urls() {
         assert!(GatewayAuthConfig::new("http://127.0.0.1:28081").is_ok());
+        assert!(GatewayAuthConfig::new("http://localhost:28081").is_ok());
+        assert!(GatewayAuthConfig::new("http://[::1]:28081").is_ok());
         assert!(GatewayAuthConfig::new("https://gateway.example").is_ok());
         for url in ["ftp://x", "not a url", "http://user:pw@host"] {
+            assert!(GatewayAuthConfig::new(url).is_err(), "{url}");
+        }
+    }
+
+    /// Cleartext to anything but this machine would put the OAuth code and the
+    /// tokens it buys on the wire in the clear, and a provision link naming
+    /// the origin is reachable by any webpage.
+    #[test]
+    fn config_requires_https_off_loopback() {
+        for url in [
+            "http://gateway.example",
+            "http://gateway.example:8080/base",
+            // Not loopback: a public address, and a name that merely looks local.
+            "http://10.0.0.5:28081",
+            "http://localhost.attacker.example",
+        ] {
             assert!(GatewayAuthConfig::new(url).is_err(), "{url}");
         }
     }

--- a/crates/openwave-desktop/src/deep_link.rs
+++ b/crates/openwave-desktop/src/deep_link.rs
@@ -128,7 +128,8 @@ pub(crate) fn focus_main_window(app: &tauri::AppHandle) {
 /// The contract is strict — scheme `openwave` (dev builds also answer
 /// `openwave-dev`), action `provision` with no userinfo, port, or extra
 /// path, exactly one query parameter named `gateway`, and a gateway value
-/// that is an http(s) URL with no userinfo, query, or fragment — so a
+/// that is an https URL (http only on loopback) with no userinfo, query, or
+/// fragment — so a
 /// malformed or hostile link is refused whole rather than partially honored.
 /// Near-miss gateway values matter: the conflict check on the write path
 /// compares normalized URL strings, so accepting a decorated variant would
@@ -174,6 +175,12 @@ fn provision_link(url: &tauri::Url) -> Result<ProvisionLink, String> {
     if !matches!(gateway.scheme(), "http" | "https") {
         return Err("the gateway URL must use http or https".into());
     }
+    // A provision link is reachable by any webpage, and pairing spends an
+    // OAuth code and stores the tokens it returns. Cleartext is only tolerated
+    // for a gateway on this machine — a developer deployment on localhost.
+    if gateway.scheme() == "http" && !gateway_host_is_loopback(&gateway) {
+        return Err("the gateway URL must use https unless it is on loopback".into());
+    }
     if !gateway.username().is_empty() || gateway.password().is_some() {
         return Err("the gateway URL must not carry credentials".into());
     }
@@ -183,6 +190,21 @@ fn provision_link(url: &tauri::Url) -> Result<ProvisionLink, String> {
     Ok(ProvisionLink {
         origin: gateway.origin().ascii_serialization(),
         gateway_url: value.into_owned(),
+    })
+}
+
+/// Whether a gateway URL's host is the local machine. `localhost` counts
+/// because the resolver is required to map it to a loopback address; other
+/// names do not, since what they resolve to is not knowable here. Mirrors the
+/// connectors-side check that holds the same line server-side.
+fn gateway_host_is_loopback(url: &tauri::Url) -> bool {
+    url.host_str().is_some_and(|host| {
+        host.eq_ignore_ascii_case("localhost")
+            || host
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .parse::<std::net::IpAddr>()
+                .is_ok_and(|address| address.is_loopback())
     })
 }
 
@@ -496,6 +518,23 @@ mod tests {
             ),
             (
                 "openwave://provision?gateway=https%3A%2F%2Fgw.example%2F%23frag",
+                None,
+            ),
+            // Cleartext is only tolerated toward this machine: any webpage can
+            // fire a provision link, and pairing spends an OAuth code and
+            // stores the tokens it buys.
+            (
+                "openwave://provision?gateway=http%3A%2F%2F127.0.0.1%3A28081",
+                Some("http://127.0.0.1:28081"),
+            ),
+            (
+                "openwave://provision?gateway=http%3A%2F%2Flocalhost%3A28081",
+                Some("http://localhost:28081"),
+            ),
+            ("openwave://provision?gateway=http://gw.example", None),
+            ("openwave://provision?gateway=http://10.0.0.5:28081", None),
+            (
+                "openwave://provision?gateway=http://localhost.attacker.example",
                 None,
             ),
         ];

--- a/crates/openwave-server/src/pairing.rs
+++ b/crates/openwave-server/src/pairing.rs
@@ -429,24 +429,24 @@ mod tests {
         let (store, _directory) = test_store().await;
         let (handle, _mcp, gateway) = test_handle_with_runtimes(&store);
 
-        let outcome = register_pending_pairing(&handle, "http://gw.invalid")
+        let outcome = register_pending_pairing(&handle, "https://gw.invalid")
             .await
             .unwrap();
         assert_eq!(outcome, PendingRegistration::Registered);
         assert!(!resolve(&*store, &NoOsPolicy).await.unwrap().managed);
         assert_eq!(
             gateway.pending_pairing_url().await.as_deref(),
-            Some("http://gw.invalid/"),
+            Some("https://gw.invalid/"),
             "the parked URL is the normalized one the commit will write"
         );
 
-        let outcome = register_pending_pairing(&handle, "http://other.invalid")
+        let outcome = register_pending_pairing(&handle, "https://other.invalid")
             .await
             .unwrap();
         assert_eq!(outcome, PendingRegistration::Registered);
         assert_eq!(
             gateway.pending_pairing_url().await.as_deref(),
-            Some("http://other.invalid/")
+            Some("https://other.invalid/")
         );
 
         gateway.dismiss_pending_pairing().await;
@@ -460,12 +460,12 @@ mod tests {
     #[tokio::test]
     async fn registration_refuses_a_gateway_other_than_the_managing_one() {
         let (store, _directory) = test_store().await;
-        managed_policy::provision(&*store, "http://managed.invalid/")
+        managed_policy::provision(&*store, "https://managed.invalid/")
             .await
             .unwrap();
         let (handle, _mcp, gateway) = test_handle_with_runtimes(&store);
 
-        let error = register_pending_pairing(&handle, "http://other.invalid")
+        let error = register_pending_pairing(&handle, "https://other.invalid")
             .await
             .err()
             .unwrap();
@@ -474,7 +474,7 @@ mod tests {
                 provisioned_url,
                 replaceable,
             } => {
-                assert_eq!(provisioned_url, "http://managed.invalid/");
+                assert_eq!(provisioned_url, "https://managed.invalid/");
                 assert!(
                     replaceable,
                     "a provisioned row is user-consented state, so the shell may offer re-pairing"
@@ -485,7 +485,7 @@ mod tests {
         assert!(error.to_string().contains("already provisioned"));
         assert_eq!(gateway.pending_pairing_url().await, None);
 
-        let outcome = register_pending_pairing(&handle, "http://managed.invalid")
+        let outcome = register_pending_pairing(&handle, "https://managed.invalid")
             .await
             .unwrap();
         assert_eq!(outcome, PendingRegistration::AlreadyManaged);
@@ -494,7 +494,7 @@ mod tests {
         let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
         assert_eq!(
             policy.gateway_url.as_deref(),
-            Some("http://managed.invalid/")
+            Some("https://managed.invalid/")
         );
     }
 
@@ -505,45 +505,48 @@ mod tests {
     #[tokio::test]
     async fn a_replacing_registration_holds_the_row_to_the_confirmed_expectation() {
         let (store, _directory) = test_store().await;
-        managed_policy::provision(&*store, "http://managed.invalid/")
+        managed_policy::provision(&*store, "https://managed.invalid/")
             .await
             .unwrap();
         let (handle, _mcp, gateway) = test_handle_with_runtimes(&store);
 
         let outcome =
-            register_replacing_pairing(&handle, "http://new.invalid", "http://managed.invalid/")
+            register_replacing_pairing(&handle, "https://new.invalid", "https://managed.invalid/")
                 .await
                 .unwrap();
         assert_eq!(outcome, PendingRegistration::Registered);
         assert_eq!(
             gateway.pending_pairing_url().await.as_deref(),
-            Some("http://new.invalid/")
+            Some("https://new.invalid/")
         );
         // Parking is process-ephemeral: the durable row has not moved.
         let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
         assert_eq!(
             policy.gateway_url.as_deref(),
-            Some("http://managed.invalid/")
+            Some("https://managed.invalid/")
         );
 
         // A confirmation that raced a row change: the expectation no longer
         // matches, so the registration is the typed conflict naming what the
         // row now holds — and the already-parked pairing is not clobbered.
-        let error =
-            register_replacing_pairing(&handle, "http://new.invalid", "http://elsewhere.invalid/")
-                .await
-                .err()
-                .unwrap();
+        let error = register_replacing_pairing(
+            &handle,
+            "https://new.invalid",
+            "https://elsewhere.invalid/",
+        )
+        .await
+        .err()
+        .unwrap();
         match &error {
             PairingError::Conflict {
                 provisioned_url,
                 replaceable: true,
-            } => assert_eq!(provisioned_url, "http://managed.invalid/"),
+            } => assert_eq!(provisioned_url, "https://managed.invalid/"),
             other => panic!("expected the replaceable conflict, got {other:?}"),
         }
         assert_eq!(
             gateway.pending_pairing_url().await.as_deref(),
-            Some("http://new.invalid/")
+            Some("https://new.invalid/")
         );
     }
 
@@ -556,7 +559,7 @@ mod tests {
 
         impl crate::managed_policy::OsPolicySource for OsAsserted {
             fn gateway_url(&self) -> Result<Option<String>> {
-                Ok(Some("http://mdm.invalid/".to_string()))
+                Ok(Some("https://mdm.invalid/".to_string()))
             }
         }
 
@@ -575,11 +578,11 @@ mod tests {
         let handle = PairingHandle::new(store.clone(), mcp, gateway.clone());
 
         for error in [
-            register_pending_pairing(&handle, "http://other.invalid")
+            register_pending_pairing(&handle, "https://other.invalid")
                 .await
                 .err()
                 .unwrap(),
-            register_replacing_pairing(&handle, "http://other.invalid", "http://mdm.invalid/")
+            register_replacing_pairing(&handle, "https://other.invalid", "https://mdm.invalid/")
                 .await
                 .err()
                 .unwrap(),
@@ -588,7 +591,7 @@ mod tests {
                 PairingError::Conflict {
                     provisioned_url,
                     replaceable: false,
-                } => assert_eq!(provisioned_url, "http://mdm.invalid/"),
+                } => assert_eq!(provisioned_url, "https://mdm.invalid/"),
                 other => panic!("expected the non-replaceable conflict, got {other:?}"),
             }
         }
@@ -605,7 +608,7 @@ mod tests {
         providers::write_gateway_snapshot(
             &*store,
             &providers::GatewayModelSnapshot {
-                gateway_url: "http://old.gateway.test/".to_string(),
+                gateway_url: "https://old.gateway.test/".to_string(),
                 models: vec![providers::CustomModelConfig {
                     id: "stale-model".into(),
                     display_name: None,
@@ -622,7 +625,7 @@ mod tests {
             &NoOsPolicy,
             test_secrets(),
             &mcp,
-            "http://gateway-a.invalid/",
+            "https://gateway-a.invalid/",
             None,
         )
         .await
@@ -632,7 +635,7 @@ mod tests {
         assert!(policy.managed);
         assert_eq!(
             policy.gateway_url.as_deref(),
-            Some("http://gateway-a.invalid/")
+            Some("https://gateway-a.invalid/")
         );
 
         // The stale snapshot carries the old deployment's stamp, so the new
@@ -648,7 +651,7 @@ mod tests {
             &NoOsPolicy,
             test_secrets(),
             &mcp,
-            "http://gateway-a.invalid/",
+            "https://gateway-a.invalid/",
             None,
         )
         .await
@@ -662,7 +665,7 @@ mod tests {
     async fn a_commit_refuses_a_profile_claimed_mid_flow() {
         let (store, _directory) = test_store().await;
         let (_handle, mcp, _gateway) = test_handle_with_runtimes(&store);
-        managed_policy::provision(&*store, "http://mdm.invalid/")
+        managed_policy::provision(&*store, "https://mdm.invalid/")
             .await
             .unwrap();
 
@@ -671,17 +674,17 @@ mod tests {
             &NoOsPolicy,
             test_secrets(),
             &mcp,
-            "http://pending.invalid/",
+            "https://pending.invalid/",
             None,
         )
         .await
         .err()
         .unwrap();
-        assert!(error.to_string().contains("http://mdm.invalid/"));
+        assert!(error.to_string().contains("https://mdm.invalid/"));
         assert!(!error.to_string().contains("pending.invalid"));
 
         let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
-        assert_eq!(policy.gateway_url.as_deref(), Some("http://mdm.invalid/"));
+        assert_eq!(policy.gateway_url.as_deref(), Some("https://mdm.invalid/"));
     }
 
     /// A minimal gateway that answers session revocation, standing in for
@@ -752,7 +755,7 @@ mod tests {
             &NoOsPolicy,
             secrets.clone(),
             &mcp,
-            "http://new-gw.invalid/",
+            "https://new-gw.invalid/",
             Some(&old_url),
         )
         .await
@@ -762,7 +765,7 @@ mod tests {
         assert!(policy.managed);
         assert_eq!(
             policy.gateway_url.as_deref(),
-            Some("http://new-gw.invalid/")
+            Some("https://new-gw.invalid/")
         );
         assert!(
             revoked
@@ -785,16 +788,16 @@ mod tests {
     #[tokio::test]
     async fn a_replacing_commit_refuses_a_row_that_moved_mid_flow() {
         let (store, _directory) = test_store().await;
-        managed_policy::provision(&*store, "http://old.invalid/")
+        managed_policy::provision(&*store, "https://old.invalid/")
             .await
             .unwrap();
         let (_handle, mcp, _gateway) = test_handle_with_runtimes(&store);
         // Another pairing path re-pointed the row after the user's
-        // confirmation named http://old.invalid/.
+        // confirmation named https://old.invalid/.
         store
             .set_setting(
                 "managed_policy_v1",
-                &json!({"gateway_url": "http://third.invalid/"}),
+                &json!({"gateway_url": "https://third.invalid/"}),
             )
             .await
             .unwrap();
@@ -804,16 +807,19 @@ mod tests {
             &NoOsPolicy,
             test_secrets(),
             &mcp,
-            "http://new-gw.invalid/",
-            Some("http://old.invalid/"),
+            "https://new-gw.invalid/",
+            Some("https://old.invalid/"),
         )
         .await
         .err()
         .unwrap();
-        assert!(error.to_string().contains("http://third.invalid/"));
+        assert!(error.to_string().contains("https://third.invalid/"));
 
         let policy = resolve(&*store, &NoOsPolicy).await.unwrap();
-        assert_eq!(policy.gateway_url.as_deref(), Some("http://third.invalid/"));
+        assert_eq!(
+            policy.gateway_url.as_deref(),
+            Some("https://third.invalid/")
+        );
     }
 
     /// The commit applies the policy it writes, not just persists it: a
@@ -852,7 +858,7 @@ mod tests {
             &NoOsPolicy,
             test_secrets(),
             &mcp,
-            "http://gateway.invalid/",
+            "https://gateway.invalid/",
             None,
         )
         .await

--- a/docs/gateway-boundary.md
+++ b/docs/gateway-boundary.md
@@ -61,7 +61,11 @@ is that **the link never writes anything**:
 
 - The shell validates the link strictly and *registers* it as a pending
   pairing: an in-memory slot on the server runtime. Nothing durable exists,
-  and the named gateway is not even probed.
+  and the named gateway is not even probed. The base URL must be `https`
+  unless its host is loopback (`localhost`, `127.0.0.1`, `::1`), which is
+  the developer-deployment exception — the pairing spends an OAuth code and
+  stores the tokens it buys, so cleartext to anywhere but this machine would
+  hand the whole exchange to whoever is on the path.
 - The sign-in gate presents the pending pairing full-window. The consent is
   the sign-in: only an OAuth flow the user completes against that gateway
   commits the provision, inside the exchange's finish, before the session is


### PR DESCRIPTION
A provision link is an unauthenticated remote trigger — any webpage can raise `openwave://provision?gateway=<url>` — and completing one spends an OAuth authorization code and stores the opaque tokens it buys. Accepting `http` to an arbitrary host put that whole exchange on the wire in the clear.

Both the shell-side link parser (`deep_link.rs`) and the connectors-side `GatewayAuthConfig` now refuse `http` unless the host is loopback — `localhost`, or an IP literal that parses as loopback. That keeps a gateway running beside the app on `localhost` usable, which is the only reason cleartext was ever accepted. `localhost.attacker.example` and a private-range address are both refused; the resolver only guarantees loopback for `localhost` itself.

Test gateway URLs in `pairing.rs` that were incidentally `http://…invalid` moved to `https` — they were never exercising the scheme.

Coverage: the rejection is asserted on both sides — `config_requires_https_off_loopback` in connectors, and new rows in the deep link's existing contract table (loopback http accepted, off-loopback http refused).

Part of #1461