### PR TITLE
build(desktop): declare pnpm approved build scripts

### DIFF
--- a/crates/openwave-desktop/ui/package.json
+++ b/crates/openwave-desktop/ui/package.json
@@ -3,6 +3,13 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "canvas",
+      "esbuild",
+      "protobufjs"
+    ]
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",


### PR DESCRIPTION
pnpm 10 ignores dependency install scripts unless approved, and newer versions turn the ignored-builds warning into a hard install failure — which breaks `scripts/dev.sh` before it launches the app.

Declare the three packages that legitimately need their build steps (`canvas` compiles native code, `esbuild` installs its platform binary, `protobufjs` runs codegen) in `pnpm.onlyBuiltDependencies`, so the approval is explicit, reviewed, and shared rather than each contributor running `pnpm approve-builds` locally.

Verified: `pnpm install --frozen-lockfile` completes with no `ERR_PNPM_IGNORED_BUILDS` and no lockfile change.