### PR TITLE
build(desktop): move pnpm build-script approvals to pnpm-workspace.yaml

### DIFF
--- a/crates/openwave-desktop/ui/package.json
+++ b/crates/openwave-desktop/ui/package.json
@@ -3,13 +3,6 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "canvas",
-      "esbuild",
-      "protobufjs"
-    ]
-  },
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/crates/openwave-desktop/ui/pnpm-workspace.yaml
+++ b/crates/openwave-desktop/ui/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+onlyBuiltDependencies:
+  - canvas
+  - esbuild
+  - protobufjs


### PR DESCRIPTION
Follow-up to #1470: newer pnpm no longer reads the `pnpm` field in `package.json` (it warns `"pnpm.onlyBuiltDependencies" ignored`), so the approval list had no effect on current installs and `scripts/dev.sh` still failed with `ERR_PNPM_IGNORED_BUILDS`.

`pnpm-workspace.yaml` is the setting's current home and is read by both current and recent pnpm 10.x, so the list moves there and the ignored `package.json` field goes away.

Verified: `pnpm install --frozen-lockfile` completes with no ignored-builds error, no deprecation warning, and no lockfile change (checked on pnpm 10.18.3; the reporter's newer pnpm is the version that ignores the old field).