### PR TITLE
fix(core): keep script executors out of the Auto-mode judge

### DIFF
--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -313,12 +313,18 @@ impl AutoJudgeStatus {
 /// and a command must additionally have cleared the deterministic analyzer
 /// under the broadest possible rule.
 ///
-/// That last condition is what makes judging a command defensible. The
-/// analyzer has already refused interpreters, destructive operations, writes
-/// to sensitive paths, and anything reaching outside the workspace — so what
-/// reaches the model is the structurally benign residue, and a model that
-/// answers badly can only fail towards asking. It cannot widen what the
-/// floor already refused.
+/// That last condition is what makes judging a command defensible, and it is
+/// worth stating exactly what it buys. Under the blanket `All` rule the
+/// analyzer refuses interpreters, destructive operations, sensitive reads and
+/// writes, anything reaching outside the folder — and, because a blanket rule
+/// names no program, every script executor and package installer:
+/// `python script.py`, `node server.js`, `pip install x` never reach the
+/// model, whatever their arguments look like. So what is judged is a call to
+/// a named program with ordinary operands, and a model that answers badly can
+/// only fail towards asking. It cannot widen what the floor already refused.
+///
+/// A rule the person actually wrote — "always allow `python`" — still covers
+/// those commands. The refusal here is about a rule nobody wrote.
 #[must_use]
 pub fn is_auto_judge_candidate(
     kind: ToolApprovalKind,
@@ -1412,6 +1418,74 @@ mod standing_grant_tests {
         // An action with nothing to read is still covered: that is what
         // granting the whole tool agreed to.
         assert!(grants.covers(chat, None, "exec", kind, &no_args()));
+    }
+
+    /// The judge never decides about code the agent could have written.
+    ///
+    /// A candidate has to clear the analyzer under a blanket rule, and a
+    /// script executor used to clear it whenever its operands were
+    /// workspace-relative. In Auto mode that closed a loop: `write_file`
+    /// authors `script.py`, `exec python3 script.py` goes to a model, and no
+    /// human sees either. It escalates now, while a grant naming the program
+    /// still runs it without asking.
+    #[test]
+    fn a_script_execution_is_never_handed_to_the_judge() {
+        let kind = ToolApprovalKind::for_tool_name("exec");
+        assert!(!is_auto_judge_candidate(
+            kind,
+            "exec",
+            &exec_args("python3", &["script.py"])
+        ));
+        assert!(!is_auto_judge_candidate(
+            kind,
+            "exec",
+            &exec_args("pip", &["install", "requests"])
+        ));
+        // An ordinary command with nothing to run is still judgeable.
+        assert!(is_auto_judge_candidate(
+            kind,
+            "exec",
+            &exec_args("cargo", &["test"])
+        ));
+
+        let chat = ChatId::new();
+        let grants = StandingGrants::new();
+        grants.record(
+            StandingGrant::scoped(
+                GrantLevel::Chat { chat_id: chat },
+                "exec",
+                kind,
+                GrantScope::AnyArgsFor {
+                    command: "python3".into(),
+                },
+                Utc::now(),
+            )
+            .unwrap(),
+        );
+        grants.record(
+            StandingGrant::scoped(
+                GrantLevel::Chat { chat_id: chat },
+                "exec",
+                kind,
+                exact_command("pip", &["install", "requests"]),
+                Utc::now(),
+            )
+            .unwrap(),
+        );
+        assert!(grants.covers(
+            chat,
+            None,
+            "exec",
+            kind,
+            &exec_args("python3", &["script.py"])
+        ));
+        assert!(grants.covers(
+            chat,
+            None,
+            "exec",
+            kind,
+            &exec_args("pip", &["install", "requests"])
+        ));
     }
 
     #[test]

--- a/crates/openwave-shell-policy/src/lib.rs
+++ b/crates/openwave-shell-policy/src/lib.rs
@@ -35,7 +35,10 @@
 //!   paths, and explicit deny rules win over any allow rule, including the `All` ("act without
 //!   asking in this folder") rule.
 //! * **Specificity is the safety dial.** Restricted programs (wrappers, escalators, editors/pagers,
-//!   remote/exfil tools) may only be covered by an `Exact` rule, never by `Prefix`/`All`.
+//!   remote/exfil tools) may only be covered by an `Exact` rule, never by `Prefix`/`All`. Script
+//!   executors (`python`, `node`, ...) and package installers (`pip`, `npm`, ...) run code someone
+//!   else supplied, so they need a rule that names the program: `Exact` or `Prefix` covers them,
+//!   a blanket `All` does not.
 
 use std::sync::OnceLock;
 
@@ -330,14 +333,10 @@ fn evaluate(acc: &Collected, ruleset: &ShellRuleSet) -> ShellAnalysis {
 
     // (3) Conjunctive allow — every sub-command must be independently covered.
     for sc in &acc.simples {
-        let permitted_prefix_all = !is_exact_only(&sc.program);
-        let covered = ruleset.allow.iter().any(|rule| {
-            let kind_ok = match rule.kind {
-                CommandRuleKind::Exact => true,
-                CommandRuleKind::Prefix | CommandRuleKind::All => permitted_prefix_all,
-            };
-            kind_ok && rule.matches(&sc.argv)
-        });
+        let covered = ruleset
+            .allow
+            .iter()
+            .any(|rule| rule_may_cover(rule.kind, &sc.program) && rule.matches(&sc.argv));
         if !covered {
             return ShellAnalysis::with_offender(
                 ShellVerdict::Ask,
@@ -1876,6 +1875,77 @@ fn is_exact_only(program: &str) -> bool {
         || b.starts_with("qemu-")
         || b == "ld.so"
         || b == "ld-elf.so.1"
+}
+
+/// Package managers that run code the package author wrote — `setup.py`,
+/// `postinstall`, a formula — as an ordinary part of installing.
+///
+/// Build tools that run code the *project* declares (`cargo`, `make`,
+/// `cmake`, `mvn`) are deliberately not here; that is a wider question than
+/// the one this list answers.
+const PACKAGE_INSTALLER_PROGRAMS: &[&str] = &[
+    "pip",
+    "pip3",
+    "pipenv",
+    "poetry",
+    "pdm",
+    "hatch",
+    "rye",
+    "uv",
+    "conda",
+    "mamba",
+    "micromamba",
+    "npm",
+    "pnpm",
+    "yarn",
+    "gem",
+    "bundle",
+    "bundler",
+    "composer",
+    "cabal",
+    "stack",
+    "brew",
+    "port",
+    "apt",
+    "apt-get",
+    "aptitude",
+    "dnf",
+    "yum",
+    "zypper",
+    "pacman",
+    "apk",
+];
+
+/// Whether running `program` means running code chosen by its arguments or
+/// fetched from a registry, rather than by the program itself.
+///
+/// `python script.py` and `pip install x` are only as safe as whatever wrote
+/// the script or published the package. Naming such a program in a rule is a
+/// real decision about it; a blanket "allow every command" is not.
+fn runs_supplied_code(program: &str) -> bool {
+    let b = basename(program);
+    let normalized = normalize_runtime(b);
+    SCRIPT_EXECUTOR_PROGRAMS.contains(&normalized.as_str())
+        || SCRIPT_EXECUTOR_PROGRAMS.contains(&b)
+        || PACKAGE_INSTALLER_PROGRAMS.contains(&normalized.as_str())
+        || PACKAGE_INSTALLER_PROGRAMS.contains(&b)
+}
+
+/// Whether a rule of this breadth may cover `program` at all.
+///
+/// Breadth is not one axis. A wrapper (`is_exact_only`) has to be named token
+/// for token, because its arguments are a different command and a prefix
+/// grant for `timeout` would carry every program it can launch. A script
+/// executor or package installer may be named by the program — writing
+/// `python` in an allowlist says something about `python` — but is never
+/// reached by a blanket `all`, which names nothing and so cannot have meant
+/// "run whatever the agent just wrote".
+fn rule_may_cover(kind: CommandRuleKind, program: &str) -> bool {
+    match kind {
+        CommandRuleKind::Exact => true,
+        CommandRuleKind::Prefix => !is_exact_only(program),
+        CommandRuleKind::All => !is_exact_only(program) && !runs_supplied_code(program),
+    }
 }
 
 /// Every leaf command's `argv`, or `None` when the command cannot be read

--- a/crates/openwave-shell-policy/src/tests.rs
+++ b/crates/openwave-shell-policy/src/tests.rs
@@ -461,7 +461,7 @@ fn covered_commands_auto_approve() {
             allow(vec![exact(&["pytest", "-q", "tests/"])]),
         ),
         ("ls -la", allow_all()),
-        ("npm run build", allow_all()),
+        ("npm run build", allow(vec![prefix(&["npm", "run"])])),
         ("./scripts/test.sh", allow_all()),
         ("cat <<EOF\nrm -rf /\nEOF", allow(vec![prefix(&["cat"])])),
         (
@@ -526,29 +526,35 @@ fn covered_commands_auto_approve() {
         ("LDFLAGS=-L/usr/lib make", allow_all()),
         (
             "NODE_OPTIONS=--max-old-space-size=4096 npm run build",
-            allow_all(),
+            allow(vec![prefix(&["npm", "run"])]),
         ),
         ("JAVA_TOOL_OPTIONS=-Xmx2g mvn package", allow_all()),
-        ("deno run app.ts", allow_all()),
-        ("node server.js", allow_all()),
-        ("go run .", allow_all()),
-        ("go build ./...", allow_all()),
+        ("deno run app.ts", allow(vec![prefix(&["deno"])])),
+        ("node server.js", allow(vec![prefix(&["node"])])),
+        ("go run .", allow(vec![prefix(&["go", "run"])])),
+        ("go build ./...", allow(vec![prefix(&["go", "build"])])),
         ("cargo run --bin app", allow_all()),
-        ("tsx src/index.ts", allow_all()),
+        ("tsx src/index.ts", allow(vec![prefix(&["tsx"])])),
         ("cat .env.example", allow_all()),
         ("grep DATABASE .env.template", allow_all()),
         ("git restore --staged src/main.py", allow_all()),
         ("git checkout main", allow_all()),
         ("git reset --keep HEAD~1", allow_all()),
-        ("python -E script.py", allow_all()),
-        ("python -B app.py", allow_all()),
-        ("python3.12 manage.py migrate", allow_all()),
-        ("node18 server.js", allow_all()),
-        ("lua -E app.lua", allow_all()),
-        ("R CMD build .", allow_all()),
+        ("python -E script.py", allow(vec![prefix(&["python"])])),
+        ("python -B app.py", allow(vec![prefix(&["python"])])),
+        (
+            "python3.12 manage.py migrate",
+            allow(vec![prefix(&["python3.12"])]),
+        ),
+        ("node18 server.js", allow(vec![prefix(&["node18"])])),
+        ("lua -E app.lua", allow(vec![prefix(&["lua"])])),
+        ("R CMD build .", allow(vec![prefix(&["R", "CMD", "build"])])),
         ("git config diff.tool vimdiff", allow_all()),
         ("git config merge.tool meld", allow_all()),
-        ("GOFLAGS=-mod=vendor go build ./...", allow_all()),
+        (
+            "GOFLAGS=-mod=vendor go build ./...",
+            allow(vec![prefix(&["go", "build"])]),
+        ),
     ];
     for (command, ruleset) in &cases {
         assert_eq!(
@@ -586,6 +592,45 @@ fn uncovered_or_restricted_commands_ask() {
             "should ask: {command:?}"
         );
     }
+}
+
+/// A blanket `All` rule used to auto-run agent-authored code.
+///
+/// `python3 -c …` was caught and `python3 script.py` was not, so in Auto mode
+/// a model could write a script and then run it without a human ever seeing
+/// the call — the analyzer's "act without asking here" rule was standing in
+/// for consent about a program nobody had named. `All` no longer covers a
+/// script executor or a package installer; a rule that names the program
+/// still does.
+#[test]
+fn a_blanket_rule_does_not_cover_code_someone_else_supplied() {
+    for command in [
+        "python3 script.py",
+        "pip install requests",
+        "node server.js",
+    ] {
+        assert_eq!(
+            verdict(command, &allow_all()),
+            ShellVerdict::Ask,
+            "blanket allow must not cover: {command:?}"
+        );
+    }
+
+    // What the person actually wrote about the program still holds.
+    assert_eq!(
+        verdict(
+            "python3 script.py",
+            &allow(vec![exact(&["python3", "script.py"])])
+        ),
+        ShellVerdict::Allow
+    );
+    assert_eq!(
+        verdict(
+            "pip install requests",
+            &allow(vec![prefix(&["pip", "install"])])
+        ),
+        ShellVerdict::Allow
+    );
 }
 
 // --- deny floor returns the strong `Deny` signal ---------------------------
@@ -687,13 +732,13 @@ fn rule_validation() {
 /// can be matched safely.
 #[test]
 fn the_ladder_offers_the_rungs_between_one_invocation_and_everything() {
-    let rungs = suggested_rungs("npm run test --silent");
+    let rungs = suggested_rungs("cargo test --quiet");
     assert_eq!(
         rungs,
         vec![
-            exact(&["npm", "run", "test", "--silent"]),
-            prefix(&["npm", "run", "test"]),
-            prefix(&["npm"]),
+            exact(&["cargo", "test", "--quiet"]),
+            prefix(&["cargo", "test"]),
+            prefix(&["cargo"]),
             all_rule(),
         ]
     );


### PR DESCRIPTION
The Auto-mode judge only hands a command to a model after the deterministic analyzer clears it under a blanket `all` rule, and the comment explaining why said the analyzer had "already refused interpreters". It had not: `INTERPRETERS` is shells only, and script executors (`python`, `node`, `deno`, `go`, ...) were escalated just when an operand was absolute, `~`-prefixed, or climbed out of the folder. `python3 -c 'x'` was caught; `python3 script.py` was not. `pip install x` was escalated only for three legacy build flags.

In Auto mode that closes a loop with no human in it: `write_file` authors a script and is auto-approved as a workspace write, then `exec python3 script.py` clears the floor and a model approves it. Seatbelt and the network-off default still contain the process, but the approval layer was contributing nothing.

Of the two options on the issue I took (a), scoped to the blanket rule rather than adding these programs to `EXACT_ONLY_PROGRAMS`. Exact-only would also have killed prefix rules, and the shell-policy suite already pins those as legitimate user configuration (`python manage.py migrate` under `prefix(["python", "manage.py"])`, `perl Makefile.PL` under `prefix(["perl"])`). The distinction holds up in code: rule breadth is checked per kind in the coverage tier, so `Exact` and `Prefix` — rules where a person wrote the program name — keep working, while `All`, which names nothing, no longer reaches a program whose job is running code somebody else supplied.

## Behavior change

Auto mode now prompts for script executions and package installs. `python3 script.py`, `node server.js`, `go run .`, `tsx src/index.ts`, `pip install requests`, `npm run build` ask instead of running, unless a rule or standing grant names the program. The same applies to a whole-tool exec grant, which is the same blanket rule internally — the approval card stops offering that rung for such a call, since rungs are verified against the analyzer, so the ladder stays honest about what it would actually honor.

Build tools that run project-declared code (`cargo`, `make`, `cmake`, `mvn`) are deliberately left alone. `cargo build` running a fetched crate's `build.rs` is a related hazard, but a wider question than this one, and flipping it would change nearly every Auto-mode session.

## Tests

Two, both reproductions of the gap: the analyzer-level one asserts `python3 script.py` / `pip install requests` / `node server.js` ask under `allow_all()` while an exact rule and a `pip install` prefix rule still allow them, and the core-level one asserts the same two commands are no longer auto-judge candidates while a `python3` executable grant and an exact `pip install requests` grant still cover them.

Existing cases in `covered_commands_auto_approve` that asserted these commands auto-run under `allow_all()` now carry a program-naming prefix ruleset instead — same commands, same expected `Allow`, via the rule a user would actually have written. The ladder test moved from `npm run test --silent` to `cargo test --quiet`, since npm no longer has an `all` rung to assert.

Verified: `cargo check --workspace --locked --all-targets`, clippy on both crates, `openwave-shell-policy`, `openwave-core --lib` (572), `openwave-server --lib approval` (36).

Closes #1456