### PR TITLE
fix(core): honor OPENWAVE_KEYCHAIN_MOCK only in debug builds

### DIFF
--- a/crates/openwave-core/src/keychain.rs
+++ b/crates/openwave-core/src/keychain.rs
@@ -34,10 +34,10 @@ impl KeychainSecretProvider {
     /// Use the default service name (`openwave`).
     ///
     /// If [`use_mock`](Self::use_mock) was called earlier in the process, all
-    /// operations go to an in-memory store instead of the OS keychain. The
-    /// `OPENWAVE_KEYCHAIN_MOCK` env var (any non-empty value) has the same
-    /// effect — useful for subprocess-based integration tests where you can't
-    /// call `use_mock` before `main`.
+    /// operations go to an in-memory store instead of the OS keychain. In
+    /// **debug builds only**, the `OPENWAVE_KEYCHAIN_MOCK` env var (any
+    /// non-empty value) has the same effect — useful for subprocess-based
+    /// integration tests where you can't call `use_mock` before `main`.
     #[must_use]
     pub fn new() -> Self {
         Self::with_service(DEFAULT_SERVICE)
@@ -47,6 +47,13 @@ impl KeychainSecretProvider {
     /// Honors [`use_mock`](Self::use_mock) and `OPENWAVE_KEYCHAIN_MOCK` the
     /// same way [`new`](Self::new) does.
     pub fn with_service(service: impl Into<String>) -> Self {
+        // Debug-only on purpose. In a shipped build this env var would let
+        // anything that can set the app's environment silently swap the OS
+        // keychain for a process-local store: secrets written during the run
+        // evaporate, and reads that should have returned a stored credential
+        // return nothing. Only debug-binary tests consume it, so a release
+        // binary has no reason to honor it and every reason not to.
+        #[cfg(debug_assertions)]
         if std::env::var("OPENWAVE_KEYCHAIN_MOCK").is_ok_and(|v| !v.is_empty()) {
             Self::use_mock();
         }


### PR DESCRIPTION
`KeychainSecretProvider::with_service` honored `OPENWAVE_KEYCHAIN_MOCK` in every build. In a shipped binary that means anything able to set the app's environment can swap the OS keychain for a process-local in-memory store: secrets written during the run evaporate on exit, and reads that should have returned a stored credential return nothing.

The env-var escape hatch now sits behind `#[cfg(debug_assertions)]`. Its only consumers are the CLI's `serve` integration tests, which spawn a debug binary — they still pass. `use_mock()` is unchanged; an in-process caller opting in explicitly is not the concern.

No test: the interesting assertion ("a release binary ignores it") can't be made from a debug test binary, and asserting the debug behavior would only restate the `cfg`.

Part of #1461