### PR TITLE
feat(desktop): gather the composer's setup actions into one tools menu

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -54,8 +54,7 @@ import {
 } from "./ImageAttachments";
 import { useImageAttachments } from "./useImageAttachments";
 import { modelForSelection } from "./ModelSelection";
-import { ModelMenu, ReasoningEffortMenu } from "./ModelMenu";
-import { NetworkPolicyMenu } from "./NetworkPolicyMenu";
+import { ModelMenu } from "./ModelMenu";
 import { PermissionModeMenu } from "./PermissionModeMenu";
 import {
   PICKER_BUSY_MESSAGE,
@@ -600,34 +599,32 @@ export function ChatRoute({ chatId }: { chatId: string }) {
               onRetry: images.retry,
             }}
             composerModelMenu={
-              <>
-                <ModelMenu
-                  models={models}
-                  value={chat!.model}
-                  defaultKey={defaultModelKey}
-                  disabled={deletingChatId !== null}
-                  onChange={onModelChange}
-                />
-                {efforts.length > 0 && (
-                  <ReasoningEffortMenu
-                    levels={efforts}
-                    value={chat!.reasoning_effort}
-                    disabled={deletingChatId !== null}
-                    onChange={onReasoningEffortChange}
-                  />
-                )}
-                <PermissionModeMenu
-                  value={chat!.permission_mode}
-                  disabled={deletingChatId !== null}
-                  onChange={onPermissionModeChange}
-                />
-                <NetworkPolicyMenu
-                  value={chat!.network_policy}
-                  disabled={deletingChatId !== null}
-                  onChange={onNetworkPolicyChange}
-                />
-              </>
+              <ModelMenu
+                models={models}
+                value={chat!.model}
+                defaultKey={defaultModelKey}
+                disabled={deletingChatId !== null}
+                onChange={onModelChange}
+              />
             }
+            composerPermissionMenu={
+              <PermissionModeMenu
+                value={chat!.permission_mode}
+                disabled={deletingChatId !== null}
+                onChange={onPermissionModeChange}
+              />
+            }
+            composerReasoning={{
+              levels: efforts,
+              value: chat!.reasoning_effort,
+              disabled: deletingChatId !== null,
+              onChange: onReasoningEffortChange,
+            }}
+            composerNetwork={{
+              value: chat!.network_policy,
+              disabled: deletingChatId !== null,
+              onChange: onNetworkPolicyChange,
+            }}
             onDraftChange={setComposerDraft}
             onSelectPrompt={setComposerDraft}
             onSend={onSend}

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -65,6 +65,7 @@ function DraftingChatView(overrides: Partial<ChatViewProps> = {}) {
       deletingChat={false}
       draftRef={draftRef}
       composerModelMenu={null}
+      composerPermissionMenu={null}
       composerImages={noImages()}
       files={noFiles()}
       attachError={null}
@@ -88,6 +89,7 @@ function renderChatView(overrides: Partial<ChatViewProps> = {}) {
     deletingChat: false,
     draftRef: { current: "" },
     composerModelMenu: null,
+    composerPermissionMenu: null,
     composerImages: noImages(),
     files: noFiles(),
     attachError: null,

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -18,6 +18,10 @@ import {
   type ComposerImages,
   type ComposerVoice,
 } from "./Composer";
+import type {
+  ComposerNetwork,
+  ComposerReasoning,
+} from "./ComposerToolsMenu";
 import { MessageList, type RetryableTurn } from "./MessageList";
 import { useTranscriptVisible } from "./TranscriptVisibility";
 import { useFolderAccessRequests } from "./useFolderAccessRequests";
@@ -40,6 +44,9 @@ export type ChatViewProps = {
   /** The composer draft, readable synchronously — see [useTurnControls]. */
   draftRef: RefObject<string>;
   composerModelMenu: ReactNode;
+  composerPermissionMenu: ReactNode;
+  composerNetwork?: ComposerNetwork;
+  composerReasoning?: ComposerReasoning;
   composerImages: ComposerImages;
   files: ComposerFiles;
   folders?: ComposerFolders;
@@ -72,6 +79,9 @@ export function ChatView({
   deletingChat,
   draftRef,
   composerModelMenu,
+  composerPermissionMenu,
+  composerNetwork,
+  composerReasoning,
   composerImages,
   files,
   folders,
@@ -351,6 +361,9 @@ export function ChatView({
           disabled={deletingChat}
           draft={draft}
           modelMenu={composerModelMenu}
+          permissionMenu={composerPermissionMenu}
+          network={composerNetwork}
+          reasoning={composerReasoning}
           images={composerImages}
           files={files}
           folders={folders}

--- a/crates/openwave-desktop/ui/src/Composer.test.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.test.tsx
@@ -167,11 +167,11 @@ describe("Composer", () => {
     expect(markup).toContain("lucide-mic");
     expect(markup).not.toContain("lucide-loader-circle");
     expect(markup).not.toContain('<textarea disabled=""');
-    // The mic belongs with send, not with the attachment controls.
+    // The mic belongs with send, not with the tools menu.
     expect(markup.indexOf("lucide-mic")).toBeLessThan(
       markup.indexOf('aria-label="Send message"'),
     );
-    expect(markup.indexOf("lucide-paperclip")).toBeLessThan(
+    expect(markup.indexOf("lucide-plus")).toBeLessThan(
       markup.indexOf("lucide-mic"),
     );
   });

--- a/crates/openwave-desktop/ui/src/Composer.tsx
+++ b/crates/openwave-desktop/ui/src/Composer.tsx
@@ -11,15 +11,17 @@ import {
 import {
   ArrowUpRight,
   FolderOpen,
-  FolderPlus,
   Image as ImageIcon,
-  LoaderCircle,
   Mic,
-  Paperclip,
   Square,
   X,
 } from "lucide-react";
 import { MAX_STEER_CHARACTERS } from "./ActiveTurnSteer";
+import {
+  ComposerToolsMenu,
+  type ComposerNetwork,
+  type ComposerReasoning,
+} from "./ComposerToolsMenu";
 import {
   describeImageAttachment,
   imageFilesFrom,
@@ -163,6 +165,9 @@ export type ComposerProps = {
   disabled: boolean;
   draft: string;
   modelMenu?: ReactNode;
+  permissionMenu?: ReactNode;
+  network?: ComposerNetwork;
+  reasoning?: ComposerReasoning;
   images?: ComposerImages;
   files?: ComposerFiles;
   folders?: ComposerFolders;
@@ -187,6 +192,9 @@ export function Composer({
   disabled,
   draft,
   modelMenu,
+  permissionMenu,
+  network,
+  reasoning,
   images,
   files,
   folders,
@@ -410,51 +418,29 @@ export function Composer({
       />
       <div className="flex items-center justify-between gap-2">
         <div className="flex grow items-center gap-2">
-          {files?.onAttach && (
-            <WithTooltip label={files.attaching ? "Attaching…" : "Attach files"}>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-8"
-                aria-label={files.attaching ? "Attaching files" : "Attach files"}
-                disabled={inputDisabled || files.attaching}
-                onClick={files.onAttach}
-              >
-                {files.attaching ? (
-                  <LoaderCircle className="animate-spin" size={15} />
-                ) : (
-                  <Paperclip size={15} />
-                )}
-              </Button>
-            </WithTooltip>
-          )}
-          {folders?.onAttach && (
-            <WithTooltip
-              label={folders.working ? "Updating folders…" : "Attach folder"}
-            >
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-8"
-                aria-label={
-                  folders.working ? "Updating attached folders" : "Attach folder"
-                }
-                disabled={inputDisabled || folders.working}
-                onClick={folders.onAttach}
-              >
-                {folders.working ? (
-                  <LoaderCircle className="animate-spin" size={15} />
-                ) : (
-                  <FolderPlus size={15} />
-                )}
-              </Button>
-            </WithTooltip>
-          )}
+          <ComposerToolsMenu
+            disabled={inputDisabled}
+            attachFiles={
+              files?.onAttach
+                ? { attaching: files.attaching, onAttach: files.onAttach }
+                : undefined
+            }
+            attachFolder={
+              folders?.onAttach
+                ? { working: folders.working, onAttach: folders.onAttach }
+                : undefined
+            }
+            network={network}
+            reasoning={reasoning}
+          />
           {modelMenu}
         </div>
         <div className="flex items-center gap-2">
+          {/* The permission mode sits with the send cluster: it is what the
+              next turn will be allowed to do, not another way to prepare it. */}
+          {permissionMenu}
           {/* The mic sits immediately before send: both act on the draft, so
-              they belong in the same cluster, apart from the attachment and
+              they belong in the same cluster, apart from the tools and
               model controls that only set the turn up. */}
           {voice?.available && (
             <WithTooltip

--- a/crates/openwave-desktop/ui/src/ComposerFolders.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerFolders.dom.test.tsx
@@ -61,7 +61,8 @@ it("attaches and confirms revoking a folder from the ordinary chat composer", as
     />,
   );
 
-  await user.click(screen.getByRole("button", { name: "Attach folder" }));
+  await user.click(screen.getByRole("button", { name: "Tools" }));
+  await user.click(screen.getByRole("menuitem", { name: "Attach folder" }));
   expect(onAttach).toHaveBeenCalledOnce();
   expect(screen.getByText("Read and write")).toBeInTheDocument();
 

--- a/crates/openwave-desktop/ui/src/ComposerToolsMenu.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerToolsMenu.dom.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, it, vi } from "vitest";
+
+import { ComposerToolsMenu } from "./ComposerToolsMenu";
+
+afterEach(cleanup);
+
+const LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
+
+function open() {
+  return userEvent.setup().click(screen.getByRole("button", { name: "Tools" }));
+}
+
+it("gathers the turn's setup actions behind one button", async () => {
+  const attachFiles = vi.fn();
+  const attachFolder = vi.fn();
+  render(
+    <ComposerToolsMenu
+      disabled={false}
+      attachFiles={{ attaching: false, onAttach: attachFiles }}
+      attachFolder={{ working: false, onAttach: attachFolder }}
+      reasoning={{ levels: LEVELS, value: "high", onChange: vi.fn() }}
+      network={{ value: { mode: "off" }, onChange: vi.fn() }}
+    />,
+  );
+
+  await open();
+  // The order the menu presents: attach first, then the settings a turn runs
+  // under. Both settings name their current value on the row.
+  expect(
+    screen.getAllByRole("menuitem").map((item) => item.textContent),
+  ).toEqual([
+    "Attach files",
+    "Attach folder",
+    "ReasoningHigh",
+    "NetworkNetwork off",
+  ]);
+
+  await userEvent.setup().click(
+    screen.getByRole("menuitem", { name: "Attach files" }),
+  );
+  expect(attachFiles).toHaveBeenCalledOnce();
+});
+
+it("still names an effort level the current model no longer accepts", async () => {
+  render(
+    <ComposerToolsMenu
+      disabled={false}
+      reasoning={{
+        levels: ["none", "low", "medium", "high", "xhigh"],
+        value: "max",
+        onChange: vi.fn(),
+      }}
+    />,
+  );
+
+  await open();
+  expect(screen.getByRole("menuitem", { name: /Reasoning/ })).toHaveTextContent(
+    "Max",
+  );
+});
+
+it("opens the network policy in a dialog the menu does not clip", async () => {
+  const user = userEvent.setup();
+  render(
+    <ComposerToolsMenu
+      disabled={false}
+      network={{ value: { mode: "open" }, onChange: vi.fn() }}
+    />,
+  );
+
+  await user.click(screen.getByRole("button", { name: "Tools" }));
+  await user.click(screen.getByRole("menuitem", { name: /Network/ }));
+  await waitFor(() =>
+    expect(
+      screen.getByRole("dialog", { name: "Code execution network" }),
+    ).toBeInTheDocument(),
+  );
+});
+
+it("renders nothing when the surface offers none of its actions", () => {
+  const { container } = render(<ComposerToolsMenu disabled={false} />);
+  expect(container).toBeEmptyDOMElement();
+});

--- a/crates/openwave-desktop/ui/src/ComposerToolsMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerToolsMenu.tsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+import { FolderPlus, LoaderCircle, Paperclip, Plus } from "lucide-react";
+
+import type { NetworkPolicy, ReasoningEffort } from "./api";
+import { ReasoningEffortSubMenu } from "./ModelMenu";
+import {
+  NetworkPolicyDialog,
+  networkPolicyIcon,
+  networkPolicyLabel,
+} from "./NetworkPolicyDialog";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { WithTooltip } from "@/components/ui/tooltip";
+
+export type ComposerNetwork = {
+  value: NetworkPolicy;
+  disabled?: boolean;
+  onChange: (policy: NetworkPolicy) => void | Promise<void>;
+};
+
+export type ComposerReasoning = {
+  levels: readonly ReasoningEffort[];
+  value: ReasoningEffort | null;
+  disabled?: boolean;
+  onChange: (effort: ReasoningEffort | null) => void | Promise<void>;
+};
+
+export type ComposerToolsMenuProps = {
+  disabled: boolean;
+  attachFiles?: { attaching: boolean; onAttach: () => void };
+  attachFolder?: { working: boolean; onAttach: () => void };
+  network?: ComposerNetwork;
+  reasoning?: ComposerReasoning;
+};
+
+/**
+ * Everything that sets a turn up, behind one button.
+ *
+ * The message bar used to carry a separate control per action — two attachment
+ * buttons, the effort picker, the network picker — which read as a toolbar
+ * rather than a place to write. These actions are all things you reach for
+ * occasionally and then forget about, so they collapse into one menu and leave
+ * the bar to the model, the permission mode, and sending.
+ */
+export function ComposerToolsMenu({
+  disabled,
+  attachFiles,
+  attachFolder,
+  network,
+  reasoning,
+}: ComposerToolsMenuProps) {
+  // The dialog is a sibling of the menu, not a child: selecting the row closes
+  // the menu, and a dialog rendered inside the menu's content would be torn
+  // down with it before it could open.
+  const [networkOpen, setNetworkOpen] = useState(false);
+
+  const hasAttachments = Boolean(attachFiles || attachFolder);
+  const hasSettings = Boolean(network || reasoning);
+  if (!hasAttachments && !hasSettings) return null;
+
+  const NetworkIcon = network ? networkPolicyIcon(network.value) : null;
+
+  return (
+    <>
+      <DropdownMenu>
+        <WithTooltip label="Tools">
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-8"
+              aria-label="Tools"
+              disabled={disabled}
+            >
+              <Plus size={16} />
+            </Button>
+          </DropdownMenuTrigger>
+        </WithTooltip>
+        <DropdownMenuContent align="start" side="top" className="w-60">
+          {attachFiles && (
+            <DropdownMenuItem
+              disabled={disabled || attachFiles.attaching}
+              onSelect={attachFiles.onAttach}
+            >
+              {attachFiles.attaching ? (
+                <LoaderCircle className="size-4 animate-spin" />
+              ) : (
+                <Paperclip className="size-4" />
+              )}
+              {attachFiles.attaching ? "Attaching files…" : "Attach files"}
+            </DropdownMenuItem>
+          )}
+          {attachFolder && (
+            <DropdownMenuItem
+              disabled={disabled || attachFolder.working}
+              onSelect={attachFolder.onAttach}
+            >
+              {attachFolder.working ? (
+                <LoaderCircle className="size-4 animate-spin" />
+              ) : (
+                <FolderPlus className="size-4" />
+              )}
+              {attachFolder.working ? "Updating folders…" : "Attach folder"}
+            </DropdownMenuItem>
+          )}
+
+          {hasAttachments && hasSettings && <DropdownMenuSeparator />}
+
+          {reasoning && reasoning.levels.length > 0 && (
+            <ReasoningEffortSubMenu
+              levels={reasoning.levels}
+              value={reasoning.value}
+              disabled={disabled || reasoning.disabled}
+              onChange={reasoning.onChange}
+            />
+          )}
+          {network && NetworkIcon && (
+            <DropdownMenuItem
+              disabled={disabled || network.disabled}
+              onSelect={() => {
+                // Opened once the menu has actually gone. Raising the dialog in
+                // the same commit leaves two overlays each claiming focus and
+                // hiding the other from assistive tech.
+                window.requestAnimationFrame(() => setNetworkOpen(true));
+              }}
+            >
+              <NetworkIcon className="size-4 text-muted-foreground" />
+              <span>Network</span>
+              <span className="text-muted-foreground flex-1 text-right text-xs">
+                {networkPolicyLabel(network.value)}
+              </span>
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      {network && (
+        <NetworkPolicyDialog
+          open={networkOpen}
+          onOpenChange={setNetworkOpen}
+          value={network.value}
+          disabled={network.disabled}
+          onChange={network.onChange}
+        />
+      )}
+    </>
+  );
+}

--- a/crates/openwave-desktop/ui/src/HomeRoute.tsx
+++ b/crates/openwave-desktop/ui/src/HomeRoute.tsx
@@ -23,14 +23,13 @@ import {
   type ImageAttachment,
   type PickedImage,
 } from "./ImageAttachments";
-import { ModelMenu, ReasoningEffortMenu } from "./ModelMenu";
+import { ModelMenu } from "./ModelMenu";
 import { modelForSelection } from "./ModelSelection";
 import { effectiveNewChatSettings, useNewChatSettings } from "./NewChatSettings";
 import { AppsPanel } from "./apps/AppsPanel";
 import { PanelLayout } from "./panel/PanelLayout";
 import type { LayoutState, PanelContent } from "./panel/panelTypes";
 import { useLayoutState } from "./panel/usePanelNav";
-import { NetworkPolicyMenu } from "./NetworkPolicyMenu";
 import { PermissionModeMenu } from "./PermissionModeMenu";
 import { RouteFrame } from "./RouteFrame";
 import { HomeSidebar } from "./sidebar/HomeSidebar";
@@ -342,34 +341,32 @@ export function HomeRoute() {
             steerPending={false}
             steerStatus={null}
             modelMenu={
-              <>
-                <ModelMenu
-                  models={models}
-                  value={effective.model}
-                  defaultKey={defaultModelKey}
-                  disabled={creatingChat}
-                  onChange={newChat.setModel}
-                />
-                {efforts.length > 0 && (
-                  <ReasoningEffortMenu
-                    levels={efforts}
-                    value={effective.reasoningEffort}
-                    disabled={creatingChat}
-                    onChange={newChat.setReasoningEffort}
-                  />
-                )}
-                <PermissionModeMenu
-                  value={effective.permissionMode}
-                  disabled={creatingChat}
-                  onChange={newChat.setPermissionMode}
-                />
-                <NetworkPolicyMenu
-                  value={effective.networkPolicy}
-                  disabled={creatingChat}
-                  onChange={newChat.setNetworkPolicy}
-                />
-              </>
+              <ModelMenu
+                models={models}
+                value={effective.model}
+                defaultKey={defaultModelKey}
+                disabled={creatingChat}
+                onChange={newChat.setModel}
+              />
             }
+            permissionMenu={
+              <PermissionModeMenu
+                value={effective.permissionMode}
+                disabled={creatingChat}
+                onChange={newChat.setPermissionMode}
+              />
+            }
+            reasoning={{
+              levels: efforts,
+              value: effective.reasoningEffort,
+              disabled: creatingChat,
+              onChange: newChat.setReasoningEffort,
+            }}
+            network={{
+              value: effective.networkPolicy,
+              disabled: creatingChat,
+              onChange: newChat.setNetworkPolicy,
+            }}
             onDraftChange={setDraft}
             onSend={startChat}
             onSteer={async () => {}}

--- a/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.test.tsx
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
   firstAvailableModel,
   ModelMenu,
-  ReasoningEffortMenu,
   reasoningEffortOptions,
   visibleModelGroups,
 } from "./ModelMenu";
@@ -180,50 +179,5 @@ describe("reasoningEffortOptions", () => {
 
   it("labels the off level as Off, distinct from the menu's Default entry", () => {
     expect(reasoningEffortOptions(["none"])[0].label).toBe("Off");
-  });
-});
-
-describe("ReasoningEffortMenu", () => {
-  const LEVELS = ["low", "medium", "high", "xhigh", "max"] as const;
-
-  it("labels the trigger 'Default' when no effort is set", () => {
-    const markup = renderToStaticMarkup(
-      <ReasoningEffortMenu levels={LEVELS} value={null} onChange={() => {}} />,
-    );
-    expect(markup).toContain('aria-label="Reasoning effort: Default"');
-    expect(markup).toContain(">Default<");
-  });
-
-  it("labels the trigger with the selected effort level", () => {
-    const markup = renderToStaticMarkup(
-      <ReasoningEffortMenu levels={LEVELS} value="high" onChange={() => {}} />,
-    );
-    expect(markup).toContain('aria-label="Reasoning effort: High"');
-    expect(markup).toContain(">High<");
-  });
-
-  it("labels a level above high without falling back to its wire token", () => {
-    const markup = renderToStaticMarkup(
-      <ReasoningEffortMenu levels={LEVELS} value="xhigh" onChange={() => {}} />,
-    );
-    expect(markup).toContain('aria-label="Reasoning effort: X-high"');
-  });
-
-  it("still labels a stored level the current model no longer accepts", () => {
-    const markup = renderToStaticMarkup(
-      <ReasoningEffortMenu
-        levels={["none", "low", "medium", "high", "xhigh"]}
-        value="max"
-        onChange={() => {}}
-      />,
-    );
-    expect(markup).toContain('aria-label="Reasoning effort: Max"');
-  });
-
-  it("disables the trigger when asked", () => {
-    const markup = renderToStaticMarkup(
-      <ReasoningEffortMenu levels={LEVELS} value={null} disabled onChange={() => {}} />,
-    );
-    expect(markup).toContain("disabled");
   });
 });

--- a/crates/openwave-desktop/ui/src/ModelMenu.tsx
+++ b/crates/openwave-desktop/ui/src/ModelMenu.tsx
@@ -14,6 +14,9 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Switch } from "@/components/ui/switch";
@@ -330,17 +333,17 @@ export function reasoningEffortOptions(
 }
 
 /**
- * Per-chat reasoning-effort selector, shown next to the model picker. `null`
+ * Per-chat reasoning effort, as a submenu of the composer's tools menu. `null`
  * means "use the provider default".
  *
  * `levels` is the selected model's accepted range, and the menu offers exactly
- * those, since no model takes the whole scale. The caller hides the control
+ * those, since no model takes the whole scale. The caller omits the submenu
  * entirely when that range is empty. A level already stored on the chat still
- * labels the trigger even when the current model does not accept it — the chat
+ * labels the row even when the current model does not accept it — the chat
  * keeps its choice, and the server degrades it to the closest level the model
  * does take rather than sending one the model would reject.
  */
-export function ReasoningEffortMenu({
+export function ReasoningEffortSubMenu({
   levels,
   value,
   disabled,
@@ -354,74 +357,47 @@ export function ReasoningEffortMenu({
   const options = reasoningEffortOptions(levels);
   const isDefault = value === null;
   const label = isDefault ? "Default" : REASONING_EFFORT_LABELS[value];
-  const [open, setOpen] = useState(false);
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          className="h-8 gap-1.5"
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger disabled={disabled}>
+        <Gauge className="size-4 text-muted-foreground" />
+        <span>Reasoning</span>
+        <span className="text-muted-foreground flex-1 text-right text-xs">
+          {label}
+        </span>
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent className="w-48">
+        <DropdownMenuItem
           disabled={disabled}
-          aria-label={`Reasoning effort: ${label}`}
+          onSelect={() => {
+            if (isDefault) return;
+            void onChange(null);
+          }}
+          className="flex items-center gap-2"
         >
-          <Gauge className="size-4 text-muted-foreground" />
-          <span className="truncate">{label}</span>
-          <ChevronDown className="size-4 opacity-50" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="start"
-        side="top"
-        className="model-menu-content w-80 overflow-y-auto p-0"
-      >
-        <div className="flex flex-col gap-1 p-1">
-          <DefaultRow
-            isDefault={isDefault}
-            tooltip={
-              isDefault
-                ? "The provider decides how hard the model thinks."
-                : "Override active. Toggle Default to let the provider decide."
-            }
-            disabled={Boolean(disabled)}
-            onToggle={(useDefault) => {
-              if (useDefault) {
-                void onChange(null);
-                setOpen(false);
-                return;
-              }
-              const first = options[0];
-              if (first) {
-                void onChange(first.value);
-                setOpen(false);
-              }
-            }}
-          />
-
-          <DropdownMenuSeparator />
-
-          {options.map((option) => {
-            const selected = !isDefault && value === option.value;
-            return (
-              <DropdownMenuItem
-                key={option.value}
-                disabled={disabled}
-                onSelect={() => {
-                  if (selected) return;
-                  void onChange(option.value);
-                }}
-                className={cn(
-                  "flex items-center gap-2",
-                  isDefault && "opacity-60",
-                )}
-              >
-                <span className="text-sm">{option.label}</span>
-                {selected && <Check className="ml-auto size-4" />}
-              </DropdownMenuItem>
-            );
-          })}
-        </div>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          <span className="text-sm">Default</span>
+          {isDefault && <Check className="ml-auto size-4" />}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {options.map((option) => {
+          const selected = !isDefault && value === option.value;
+          return (
+            <DropdownMenuItem
+              key={option.value}
+              disabled={disabled}
+              onSelect={() => {
+                if (selected) return;
+                void onChange(option.value);
+              }}
+              className="flex items-center gap-2"
+            >
+              <span className="text-sm">{option.label}</span>
+              {selected && <Check className="ml-auto size-4" />}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
   );
 }
 

--- a/crates/openwave-desktop/ui/src/NetworkPolicyDialog.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/NetworkPolicyDialog.dom.test.tsx
@@ -3,18 +3,22 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { NetworkPolicyMenu } from "./NetworkPolicyMenu";
+import { NetworkPolicyDialog } from "./NetworkPolicyDialog";
 
 afterEach(cleanup);
 
-describe("NetworkPolicyMenu", () => {
+describe("NetworkPolicyDialog", () => {
   it("offers the package-registry class as one per-chat choice", () => {
     const onChange = vi.fn();
     render(
-      <NetworkPolicyMenu value={{ mode: "off" }} onChange={onChange} />,
+      <NetworkPolicyDialog
+        open
+        onOpenChange={vi.fn()}
+        value={{ mode: "off" }}
+        onChange={onChange}
+      />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Network: Network off" }));
     fireEvent.click(
       screen
         .getByText(/Only curated package registries are reachable/i)
@@ -27,10 +31,14 @@ describe("NetworkPolicyMenu", () => {
   it("builds a deduplicated custom-host policy with optional registries", () => {
     const onChange = vi.fn();
     render(
-      <NetworkPolicyMenu value={{ mode: "off" }} onChange={onChange} />,
+      <NetworkPolicyDialog
+        open
+        onOpenChange={vi.fn()}
+        value={{ mode: "off" }}
+        onChange={onChange}
+      />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Network: Network off" }));
     fireEvent.change(screen.getByLabelText("Allowed network hosts"), {
       target: { value: "api.example.com, api.example.com\nfiles.example.com" },
     });

--- a/crates/openwave-desktop/ui/src/NetworkPolicyDialog.tsx
+++ b/crates/openwave-desktop/ui/src/NetworkPolicyDialog.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import {
   Check,
-  ChevronDown,
   Globe2,
   Package,
   ShieldOff,
@@ -12,10 +11,12 @@ import type { NetworkPolicy } from "./api";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
 
 const OPTIONS = [
@@ -49,32 +50,50 @@ function optionFor(policy: NetworkPolicy) {
   return OPTIONS.find((option) => option.mode === policy.mode) ?? OPTIONS[0];
 }
 
-export function NetworkPolicyMenu({
+/** The policy's short name, for the menu row that opens this. */
+export function networkPolicyLabel(policy: NetworkPolicy): string {
+  return optionFor(policy).label;
+}
+
+export function networkPolicyIcon(policy: NetworkPolicy) {
+  return optionFor(policy).icon;
+}
+
+/**
+ * The per-chat network policy, in a dialog rather than a control of its own on
+ * the message bar. It is set once for a workspace and then left alone, so it
+ * lives behind the composer's tools menu with the other setup actions; the
+ * dialog also gives the custom-host list room a popover never had.
+ */
+export function NetworkPolicyDialog({
+  open,
+  onOpenChange,
   value,
   disabled,
   onChange,
 }: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   value: NetworkPolicy;
   disabled?: boolean;
   onChange: (policy: NetworkPolicy) => void | Promise<void>;
 }) {
-  const [open, setOpen] = useState(false);
+  // Seeded from the stored policy each time the dialog opens, so an abandoned
+  // edit does not survive into the next visit.
   const [hosts, setHosts] = useState("");
   const [includePackages, setIncludePackages] = useState(false);
-  const current = optionFor(value);
-  const CurrentIcon = current.icon;
 
-  function setOpenAndHydrate(next: boolean) {
+  function openAndHydrate(next: boolean) {
     if (next && value.mode === "allowed_hosts") {
       setHosts(value.allowed_hosts.join("\n"));
       setIncludePackages(value.package_managers);
     }
-    setOpen(next);
+    onOpenChange(next);
   }
 
   function select(policy: NetworkPolicy) {
     void onChange(policy);
-    setOpen(false);
+    onOpenChange(false);
   }
 
   function saveCustom() {
@@ -94,26 +113,14 @@ export function NetworkPolicyMenu({
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpenAndHydrate}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="ghost"
-          className="h-8 gap-1.5"
-          disabled={disabled}
-          aria-label={`Network: ${current.label}`}
-        >
-          <CurrentIcon className="size-4 text-muted-foreground" />
-          {current.label}
-          <ChevronDown className="size-4 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent align="end" side="top" className="w-80 space-y-3">
-        <div>
-          <p className="font-medium">Code execution network</p>
-          <p className="text-xs text-muted-foreground">
+    <Dialog open={open} onOpenChange={openAndHydrate}>
+      <DialogContent className="max-w-md space-y-3">
+        <DialogHeader>
+          <DialogTitle>Code execution network</DialogTitle>
+          <DialogDescription>
             This applies only to this conversation workspace.
-          </p>
-        </div>
+          </DialogDescription>
+        </DialogHeader>
 
         <div className="space-y-1">
           {OPTIONS.filter((option) => option.mode !== "allowed_hosts").map(
@@ -176,7 +183,7 @@ export function NetworkPolicyMenu({
             Use custom policy
           </Button>
         </div>
-      </PopoverContent>
-    </Popover>
+      </DialogContent>
+    </Dialog>
   );
 }


### PR DESCRIPTION
The message bar had grown six controls to the left of the text — attach files, attach folder, model, reasoning effort, permission mode, network policy. Read together they looked like a toolbar rather than a place to write, and most of them are settings you set once and then forget.

## What moves

The two attachment buttons, the reasoning picker, and the network picker collapse into a single `+` tools menu, so the composer follows the reference layout:

- **Attach files** / **Attach folder** — the same actions, now menu rows that keep their in-flight state ("Attaching files…", "Updating folders…").
- **Reasoning** — a submenu naming the current level on its row. A level the chat stored but the current model no longer accepts still shows, as before.
- **Network** — a row naming the current policy, opening a dialog. The dialog also gives the custom-host list more room than the popover it replaced, and it is raised after the menu closes so the two overlays never fight over focus.

## What stays in front

What you consult while writing:

- the **model** picker, left of the text — it is a readout as much as a control, and there is no pill elsewhere that says what will run;
- the **permission mode**, moved to the right cluster beside the mic and send, since it governs what the turn you are about to send is allowed to do.

Voice and send are untouched.

## Tests

- New `ComposerToolsMenu.dom.test.tsx` pins the row order, each row's current-value readout, the dialog handoff, and that the menu renders nothing when a surface offers none of its actions.
- The reasoning picker's five trigger-label tests are replaced by one covering a level the current model no longer accepts — the only one of the five making a behavioral claim; the rest re-asserted the same label formatting through different values.
- `ComposerFolders` and the composer's ordering assertion follow the new structure.

`pnpm exec tsc --noEmit`, `pnpm test` (105 files, 709 tests), and `pnpm exec vite build` all pass. No Rust touched.

## Needs a look

Layout is the point here, so it wants eyes rather than a green check:

- the balance of the bottom row now that the left side is `+` and the model, and permission mode sits by the mic;
- the tools menu opening upward over a tall composer, and the reasoning submenu's placement at the screen edge;
- the network dialog vs. the popover it replaced.