### PR TITLE
fix(core): project exec's staged files into the consent preview

### DIFF
--- a/crates/openwave-core/fixtures/journal-events.json
+++ b/crates/openwave-core/fixtures/journal-events.json
@@ -41,7 +41,10 @@
       "args": [
         "status"
       ],
-      "cwd": "."
+      "cwd": ".",
+      "files": [
+        "documents/report.pdf"
+      ]
     }
   },
   {
@@ -69,7 +72,10 @@
       "args": [
         "status"
       ],
-      "cwd": "."
+      "cwd": ".",
+      "files": [
+        "documents/report.pdf"
+      ]
     },
     "result": {
       "tool": "exec",

--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -1220,6 +1220,7 @@ mod standing_grant_tests {
             command: command.into(),
             args: args.iter().map(|arg| (*arg).to_owned()).collect(),
             cwd: ".".into(),
+            files: Vec::new(),
         })
     }
 
@@ -1254,6 +1255,52 @@ mod standing_grant_tests {
         assert!(!grants.covers(chat, None, "exec", kind, &exec_args("rm", &["test"])));
         // An action the renderer could not describe was never the one granted.
         assert!(!grants.covers(chat, None, "exec", kind, &no_args()));
+    }
+
+    /// Staging is part of the action, and a grant retained from before the
+    /// projection carried it must not stretch over calls that stage files.
+    #[test]
+    fn a_grant_that_named_no_staged_files_does_not_cover_a_call_that_stages_them() {
+        let chat = ChatId::new();
+        let kind = ToolApprovalKind::for_tool_name("exec");
+        let grants = StandingGrants::new();
+        // How a grant stored before `files` existed reads back: the field is
+        // absent from the persisted scope, so it defaults rather than failing
+        // the row's load.
+        let stored = serde_json::json!({
+            "scope": "exact_action",
+            "tool": "exec",
+            "command": "cat",
+            "args": ["notes.txt"],
+            "cwd": "."
+        });
+        let scope: GrantScope = serde_json::from_value(stored).expect("a retained scope loads");
+        grants.record(
+            StandingGrant::scoped(
+                GrantLevel::Chat { chat_id: chat },
+                "exec",
+                kind,
+                scope,
+                Utc::now(),
+            )
+            .unwrap(),
+        );
+
+        // The call it was given for still runs unprompted.
+        assert!(grants.covers(chat, None, "exec", kind, &exec_args("cat", &["notes.txt"])));
+        // The same command handed a document is a different action, and the
+        // retained grant does not reach it.
+        assert!(!grants.covers(
+            chat,
+            None,
+            "exec",
+            kind,
+            &serde_json::json!({
+                "command": "cat",
+                "args": ["notes.txt"],
+                "files": ["documents/salaries.csv"]
+            })
+        ));
     }
 
     #[test]
@@ -1349,6 +1396,7 @@ mod standing_grant_tests {
                     command: "npm".into(),
                     args: vec!["install".into()],
                     cwd: "./sandbox".into(),
+                    files: Vec::new(),
                 }),
                 Utc::now(),
             )

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -9118,6 +9118,7 @@ async fn recovered_exec_approval_still_names_the_command_it_will_run() {
             command: "cargo".into(),
             args: vec!["build".into()],
             cwd: "checkout".into(),
+            files: Vec::new(),
         })
     );
 }

--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -322,6 +322,7 @@ mod tests {
                     command: "git".into(),
                     args: vec!["status".into()],
                     cwd: ".".into(),
+                    files: vec!["documents/report.pdf".into()],
                 }),
             },
             AgentEvent::ApprovalDecided {
@@ -349,6 +350,7 @@ mod tests {
                     command: "git".into(),
                     args: vec!["status".into()],
                     cwd: ".".into(),
+                    files: vec!["documents/report.pdf".into()],
                 }),
                 result: Some(crate::preview::ToolResultPreview::Exec {
                     exit_code: Some(0),
@@ -502,5 +504,30 @@ mod tests {
                 preview: None,
             }
         );
+    }
+
+    /// Exec previews written before the staging list joined the projection have
+    /// no `files` key. They must read back as "staged nothing" — the narrow
+    /// reading — rather than failing the row and taking a chat's history with
+    /// it.
+    #[test]
+    fn exec_previews_written_without_a_staging_list_still_load() {
+        let legacy = serde_json::json!({
+            "type": "approval_required",
+            "call_id": id(2),
+            "tool_name": "exec",
+            "class": "sensitive",
+            "kind": "exec_may_run_networked_command",
+            "preview": { "tool": "exec", "command": "git", "args": ["status"], "cwd": "." },
+        });
+        let loaded: AgentEvent = serde_json::from_value(legacy).expect("legacy row deserializes");
+        let AgentEvent::ApprovalRequired {
+            preview: Some(crate::preview::ToolActionPreview::Exec { files, .. }),
+            ..
+        } = loaded
+        else {
+            panic!("the row is an exec approval with a preview");
+        };
+        assert!(files.is_empty());
     }
 }

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -53,6 +53,22 @@ pub enum ToolActionPreview {
         /// Working directory relative to the chat's private scratch, never a
         /// host path.
         cwd: String,
+        /// Scratch-relative files and directories staged into the sandbox
+        /// before the command runs, empty when the model staged none.
+        ///
+        /// Part of the action, not incidental setup: this list is what the
+        /// command can read, so a person approving `python3 analyze.py` is
+        /// entitled to see which of their files it is being handed. Omitting
+        /// it also made two calls that stage different documents project
+        /// identically, which is what `describes_exactly` promises they do
+        /// not.
+        ///
+        /// `default` because grants and approval rows retained before the
+        /// field existed carry no staging list; they read back as staging
+        /// nothing, which is narrower than what they were given for and so
+        /// sends a call that stages anything back to the person.
+        #[serde(default)]
+        files: Vec<String>,
     },
     /// A search of this conversation's own sources. The query is the whole
     /// action, and it is what the excerpts returned will be chosen to match.
@@ -100,7 +116,13 @@ impl ToolActionPreview {
                 let command = clamp(arguments.get("command")?.as_str()?, MAX_ACTION_FIELD_CHARS)?;
                 let args = clamped_list(arguments.get("args"));
                 let cwd = clamped_field(arguments.get("cwd")).unwrap_or_else(|| ".".into());
-                Some(Self::Exec { command, args, cwd })
+                let files = clamped_list(arguments.get("files"));
+                Some(Self::Exec {
+                    command,
+                    args,
+                    cwd,
+                    files,
+                })
             }
             // Approving a search without seeing its query is not consent to
             // anything in particular, and for `web_search` that query is the
@@ -161,6 +183,11 @@ impl ToolActionPreview {
                     // preview shows.
                     && list_survives_clamp(arguments.get("args"))
                     && field_survives_clamp(arguments.get("cwd"))
+                    // The staging list is part of the action for the same
+                    // reason the argument vector is: it decides what the
+                    // command can read. A dropped or elided entry would let a
+                    // grant given for one set of documents cover another.
+                    && list_survives_clamp(arguments.get("files"))
             }
             // A search's action is its query, so a grant may name that query.
             // `k` is not part of it: it bounds how many passages come back and
@@ -943,6 +970,7 @@ mod tests {
                 command: "python3".into(),
                 args: vec!["-c".into(), "print(1)".into()],
                 cwd: ".".into(),
+                files: Vec::new(),
             })
         );
     }
@@ -1324,7 +1352,9 @@ mod tests {
     fn exec_action_bounds_the_card_a_model_can_paint() {
         let long = "a".repeat(MAX_ACTION_FIELD_CHARS * 2);
         let many: Vec<_> = (0..MAX_ACTION_ARGS * 2).map(|i| i.to_string()).collect();
-        let Some(ToolActionPreview::Exec { command, args, cwd }) = ToolActionPreview::build(
+        let Some(ToolActionPreview::Exec {
+            command, args, cwd, ..
+        }) = ToolActionPreview::build(
             "exec",
             &serde_json::json!({
                 "command": long,
@@ -1332,7 +1362,8 @@ mod tests {
                 // Control characters could otherwise forge card structure.
                 "cwd": "scratch\n\u{1b}[31mapproved",
             }),
-        ) else {
+        )
+        else {
             panic!("exec projects an action");
         };
         assert_eq!(command.chars().count(), MAX_ACTION_FIELD_CHARS);

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -159,6 +159,7 @@ describe("approval card interactions", () => {
           command: "python3",
           args: ["-c", "import pptx"],
           cwd: ".",
+          files: [],
         },
         canRemember: false,
         grantRungs: [],
@@ -181,6 +182,7 @@ describe("approval card interactions", () => {
           command: "cargo",
           args: ["test"],
           cwd: ".",
+          files: [],
         },
         grantRungs: [
           "exact_action",
@@ -234,7 +236,7 @@ describe("approval card interactions", () => {
     render(
       card({
         onDecide,
-        preview: { tool: "exec", command: "cargo", args: ["test"], cwd: "." },
+        preview: { tool: "exec", command: "cargo", args: ["test"], cwd: ".", files: [] },
       }),
     );
 
@@ -331,6 +333,7 @@ describe("approval card interactions", () => {
           command: "cargo",
           args: ["test", "--workspace"],
           cwd: "checkout",
+          files: [],
         },
       }),
     );
@@ -358,6 +361,7 @@ describe("activity phases", () => {
     command: "cargo",
     args: ["build"],
     cwd: ".",
+    files: [],
   };
 
   function list(messages: ChatMessage[]) {
@@ -510,6 +514,7 @@ describe("card order", () => {
       command: "cargo",
       args: ["build"],
       cwd: ".",
+      files: [],
     };
     const { container } = render(
       <MessageList
@@ -558,6 +563,7 @@ describe("command output", () => {
     command: "cargo",
     args: ["build"],
     cwd: ".",
+    files: [],
   };
   const ran = {
     tool: "exec" as const,
@@ -841,6 +847,7 @@ describe("actionable tool results", () => {
               command: "python3",
               args: ["build_deck.py"],
               cwd: ".",
+              files: [],
             },
             result: {
               tool: "exec",

--- a/crates/openwave-desktop/ui/src/MessageList.isolation.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.isolation.dom.test.tsx
@@ -75,14 +75,14 @@ describe("a tool result that cannot render", () => {
         callId: "c2",
         name: "exec",
         status: "waiting_approval",
-        preview: { tool: "exec", command: "cargo", args: ["build"], cwd: "." },
+        preview: { tool: "exec", command: "cargo", args: ["build"], cwd: ".", files: [] },
       },
       {
         id: "a1",
         role: "approval",
         callId: "c2",
         summary: "Allow OpenWave to run a command?",
-        preview: { tool: "exec", command: "cargo", args: ["build"], cwd: "." },
+        preview: { tool: "exec", command: "cargo", args: ["build"], cwd: ".", files: [] },
         canApprove: true,
         canRemember: true,
       },
@@ -153,7 +153,7 @@ describe("an entry that cannot be read while the cards are assembled", () => {
       role: "approval",
       callId: "c1",
       summary: "Allow OpenWave to run a command?",
-      preview: { tool: "exec", command: "cargo", args: ["build"], cwd: "." },
+      preview: { tool: "exec", command: "cargo", args: ["build"], cwd: ".", files: [] },
       canRemember: true,
       get canApprove(): never {
         throw new Error("unreadable approval projection");
@@ -168,7 +168,7 @@ describe("an entry that cannot be read while the cards are assembled", () => {
         callId: "c2",
         name: "exec",
         status: "completed",
-        preview: { tool: "exec", command: "cargo", args: ["test"], cwd: "." },
+        preview: { tool: "exec", command: "cargo", args: ["test"], cwd: ".", files: [] },
       },
     ]);
 

--- a/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
@@ -21,6 +21,7 @@ const preview = {
   command: "cargo",
   args: ["test", "--workspace"],
   cwd: "checkout",
+  files: [],
 };
 
 describe("toolCallPresentation", () => {

--- a/crates/openwave-desktop/ui/src/ToolPreview.test.ts
+++ b/crates/openwave-desktop/ui/src/ToolPreview.test.ts
@@ -9,6 +9,7 @@ describe("toolPreviewPresentation", () => {
         command: "cargo",
         args: ["test", "--workspace"],
         cwd: ".",
+        files: [],
       }),
     ).toMatchObject({
       headline: "cargo test --workspace",
@@ -23,8 +24,23 @@ describe("toolPreviewPresentation", () => {
         command: "ls",
         args: [],
         cwd: "checkout/crates",
+        files: [],
       }).detail,
     ).toBe("ls\n# working directory: checkout/crates");
+  });
+
+  it("names the files the command is being handed", () => {
+    // Which documents a command can read is part of the action under review:
+    // the same script over an expense sheet is not the same consent.
+    expect(
+      toolPreviewPresentation({
+        tool: "exec",
+        command: "python3",
+        args: ["analyze.py"],
+        cwd: ".",
+        files: ["documents/salaries.csv", "documents/q3.xlsx"],
+      }).detail,
+    ).toBe("python3 analyze.py\n# staged files: documents/salaries.csv, documents/q3.xlsx");
   });
 
   it("quotes an argument whose boundaries would otherwise be invisible", () => {
@@ -37,6 +53,7 @@ describe("toolPreviewPresentation", () => {
         command: "python3",
         args: ["-c", "print('two words')", "", "a;rm -rf /"],
         cwd: ".",
+        files: [],
       }).headline,
     ).toBe(`python3 -c 'print('\\''two words'\\'')' '' 'a;rm -rf /'`);
   });

--- a/crates/openwave-desktop/ui/src/ToolPreview.tsx
+++ b/crates/openwave-desktop/ui/src/ToolPreview.tsx
@@ -67,6 +67,9 @@ export function toolPreviewPresentation(
   const detail = [
     headline,
     preview.cwd !== "." && `# working directory: ${preview.cwd}`,
+    // What the command is handed is part of what it will do, so the card that
+    // asks for consent says which files it can read.
+    preview.files.length > 0 && `# staged files: ${preview.files.join(", ")}`,
     result?.timedOut && "# stopped at the time limit",
     result && !result.timedOut && result.exitCode === null && "# killed by a signal",
     result?.exitCode !== null &&

--- a/crates/openwave-desktop/ui/src/WireFixtures.test.ts
+++ b/crates/openwave-desktop/ui/src/WireFixtures.test.ts
@@ -37,7 +37,13 @@ describe("validators against real server output", () => {
       action: "exec",
       approval: "exec_may_run_networked_command",
       class: "sensitive",
-      preview: { tool: "exec", command: "git", args: ["status"], cwd: "." },
+      preview: {
+        tool: "exec",
+        command: "git",
+        args: ["status"],
+        cwd: ".",
+        files: ["documents/report.pdf"],
+      },
       canApprove: true,
       canRemember: true,
       grantRungs: [

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -310,6 +310,7 @@ describe("pending approval recovery", () => {
           command: "cargo",
           args: ["test", "--workspace"],
           cwd: "checkout",
+          files: [],
         },
       })?.preview,
     ).toEqual({
@@ -317,6 +318,7 @@ describe("pending approval recovery", () => {
       command: "cargo",
       args: ["test", "--workspace"],
       cwd: "checkout",
+      files: [],
     });
   });
 
@@ -327,10 +329,10 @@ describe("pending approval recovery", () => {
       approval: "exec_may_run_networked_command",
     };
     for (const preview of [
-      { tool: "shell", command: "rm", args: [], cwd: "." },
-      { tool: "exec", command: "", args: [], cwd: "." },
-      { tool: "exec", command: "cargo", args: "test", cwd: "." },
-      { tool: "exec", command: "cargo", args: [{ hidden: true }], cwd: "." },
+      { tool: "shell", command: "rm", args: [], cwd: ".", files: [] },
+      { tool: "exec", command: "", args: [], cwd: ".", files: [] },
+      { tool: "exec", command: "cargo", args: "test", cwd: ".", files: [] },
+      { tool: "exec", command: "cargo", args: [{ hidden: true }], cwd: ".", files: [] },
       { tool: "exec", command: "cargo", args: [] },
       "cargo test",
     ]) {

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -2238,18 +2238,23 @@ export function parseToolActionPreview(
     return { tool: "web_extract", url };
   }
   if (value.tool !== "exec") return null;
-  const { command, args, cwd } = value;
+  const { command, args, cwd, files } = value;
+  // `files` joined the projection after previews were already being stored, so
+  // an absent list reads as staging nothing rather than dropping the card.
+  const staged = files === undefined ? [] : files;
   if (
     typeof command !== "string" ||
     command.length === 0 ||
     !Array.isArray(args) ||
     !args.every((arg): arg is string => typeof arg === "string") ||
     typeof cwd !== "string" ||
-    cwd.length === 0
+    cwd.length === 0 ||
+    !Array.isArray(staged) ||
+    !staged.every((file): file is string => typeof file === "string")
   ) {
     return null;
   }
-  return { tool: "exec", command, args, cwd };
+  return { tool: "exec", command, args, cwd, files: staged };
 }
 
 /**

--- a/crates/openwave-desktop/ui/src/generated/fixtures.ts
+++ b/crates/openwave-desktop/ui/src/generated/fixtures.ts
@@ -30,6 +30,9 @@ export const PENDING_APPROVAL = {
     ],
     "command": "git",
     "cwd": ".",
+    "files": [
+      "documents/report.pdf"
+    ],
     "tool": "exec"
   },
   "turn_id": "00000000-0000-0000-0000-000000000002"

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1575,7 +1575,24 @@ args: Array<string>,
  * Working directory relative to the chat's private scratch, never a
  * host path.
  */
-cwd: string, } | { "tool": "search", query: string, } | { "tool": "web_search", query: string, 
+cwd: string, 
+/**
+ * Scratch-relative files and directories staged into the sandbox
+ * before the command runs, empty when the model staged none.
+ *
+ * Part of the action, not incidental setup: this list is what the
+ * command can read, so a person approving `python3 analyze.py` is
+ * entitled to see which of their files it is being handed. Omitting
+ * it also made two calls that stage different documents project
+ * identically, which is what `describes_exactly` promises they do
+ * not.
+ *
+ * `default` because grants and approval rows retained before the
+ * field existed carry no staging list; they read back as staging
+ * nothing, which is narrower than what they were given for and so
+ * sends a call that stages anything back to the person.
+ */
+files: Array<string>, } | { "tool": "search", query: string, } | { "tool": "web_search", query: string, 
 /**
  * Sites the search is confined to, empty when the model named none.
  */

--- a/crates/openwave-server/src/approval_judge.rs
+++ b/crates/openwave-server/src/approval_judge.rs
@@ -167,9 +167,20 @@ fn action_description(preview: &ToolActionPreview) -> Option<String> {
             }
             Some(description)
         }
-        ToolActionPreview::Exec { command, args, cwd } => {
+        ToolActionPreview::Exec {
+            command,
+            args,
+            cwd,
+            files,
+        } => {
             let mut description = format!("Run: {}", exec_line(command, args));
             description.push_str(&format!("\nWorking directory: {cwd}"));
+            // What the command is handed is part of what it does. A judge that
+            // sees only the argv would rule the same way on a script run over
+            // nothing and the same script run over the user's documents.
+            if !files.is_empty() {
+                description.push_str(&format!("\nFiles staged for it: {}", files.join(", ")));
+            }
             Some(description)
         }
         // Anything else has no business in front of the judge.
@@ -457,6 +468,7 @@ mod tests {
             command: "cargo".into(),
             args: vec!["test".into()],
             cwd: ".".into(),
+            files: Vec::new(),
         };
         assert!(command_clears_the_floor(&routine));
         assert!(action_description(&routine).is_some());
@@ -467,11 +479,13 @@ mod tests {
                 command: "bash".into(),
                 args: vec!["-c".into(), "id".into()],
                 cwd: ".".into(),
+                files: Vec::new(),
             },
             ToolActionPreview::Exec {
                 command: "rm".into(),
                 args: vec!["-rf".into(), "/".into()],
                 cwd: ".".into(),
+                files: Vec::new(),
             },
         ] {
             assert!(

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -569,6 +569,7 @@ mod tests {
                 command: "git".into(),
                 args: vec!["status".into()],
                 cwd: ".".into(),
+                files: vec!["documents/report.pdf".into()],
             }),
             can_approve: true,
             can_remember: true,


### PR DESCRIPTION
`ToolActionPreview::Exec` carried `command`, `args`, and `cwd` but not `files`, so two exec calls staging different documents projected to the same action. That is precisely what `describes_exactly` promises they do not:

- an "always allow exactly this action" grant given for `python3 analyze.py` over one file covered the same script handed anything else in the workspace;
- the Auto judge was shown a command line without knowing which of the user's documents it had been handed.

Changes:
- `ToolActionPreview::Exec` gains `files`, projected through the same clamp as `args`.
- `describes_exactly` requires the staging list to survive that clamp, so a grant can only be minted from — and matched against — a call whose staging list arrived intact.
- The approval card shows `# staged files: …` beside the working directory, and the judge prompt states what the command is being handed.

**Retained data.** Grant scopes and journal previews written before the field exists have no `files` key. It deserializes with `#[serde(default)]` to the empty list — the narrow reading — so an old grant still covers the call it was given for and a call that stages anything goes back to the person. That is a re-ask, not a load failure that would take a chat's history (or the grants list) with it. Two tests pin it: one that a retained exact-action grant does not stretch over a call that stages files, one that a journal row without the key still loads.

Regenerated `ui/src/generated` and updated the UI validator, which now carries the list instead of dropping it.

Verified: `cargo test -p openwave-core -p openwave-server -p openwave-code-execution --lib`, `cargo check --workspace --all-targets`, UI `tsc` + `vitest` (104 files, 711 tests).

Part of #1461