### PR TITLE
fix(desktop): stop granting the IPC to loopback origins in release builds

### DIFF
--- a/crates/openwave-desktop/capabilities-dev/dev-server.json
+++ b/crates/openwave-desktop/capabilities-dev/dev-server.json
@@ -1,0 +1,21 @@
+{
+  "identifier": "dev-server",
+  "description": "The Vite dev server's origin, which `tauri dev` loads the frontend from (`build.devUrl`). Deliberately outside `capabilities/` so the build script's `./capabilities/**/*` glob cannot compile it into a release binary: it is added at runtime under `debug_assertions` only. The port is the exact one `build.devUrl` names — a wildcard would hand the IPC to anything else listening on loopback, including HTML the embedded API server serves to sandboxed app frames.",
+  "windows": [
+    "main"
+  ],
+  "remote": {
+    "urls": [
+      "http://localhost:1420",
+      "http://127.0.0.1:1420"
+    ]
+  },
+  "permissions": [
+    "core:default",
+    "core:event:deny-emit",
+    "core:event:deny-emit-to",
+    "core:window:allow-start-dragging",
+    "core:webview:allow-set-webview-zoom",
+    "shell:allow-open"
+  ]
+}

--- a/crates/openwave-desktop/capabilities/default.json
+++ b/crates/openwave-desktop/capabilities/default.json
@@ -1,16 +1,10 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for the main window",
+  "description": "Capability for the main window. Local origins only: a packaged app serves its frontend from Tauri's own protocol, so nothing served over http://localhost — including MCP-app HTML the embedded API serves — reaches the IPC through this capability. The Vite dev server's origin is granted separately and only in debug builds; see capabilities-dev/dev-server.json.",
   "windows": [
     "main"
   ],
-  "remote": {
-    "urls": [
-      "http://localhost:*",
-      "http://127.0.0.1:*"
-    ]
-  },
   "permissions": [
     "core:default",
     "core:event:deny-emit",

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -248,6 +248,13 @@ pub fn run() {
         ])
         .on_menu_event(updater::handle_menu_event)
         .setup(move |app| {
+            // The dev server's origin is remote as far as the IPC is
+            // concerned, so `tauri dev` needs it granted explicitly. Added
+            // here rather than in `capabilities/` so a release binary cannot
+            // carry it: a packaged app serves its frontend from Tauri's own
+            // protocol and has no business trusting anything on loopback.
+            #[cfg(debug_assertions)]
+            app.add_capability(include_str!("../capabilities-dev/dev-server.json"))?;
             let handle = app.handle().clone();
             deep_link::install(&handle);
             #[cfg(target_os = "macos")]

--- a/crates/openwave-desktop/tauri.conf.json
+++ b/crates/openwave-desktop/tauri.conf.json
@@ -38,6 +38,9 @@
     }
   },
   "plugins": {
+    "shell": {
+      "open": "https?://.+"
+    },
     "deep-link": {
       "desktop": {
         "schemes": ["openwave", "openwave-dev"]

--- a/crates/openwave-desktop/ui/src/apps/AppFrame.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/apps/AppFrame.dom.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AppFrame } from "./AppFrame";
+import type { AppsApis } from "./appsApis";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AppFrame", () => {
+  /**
+   * The app bundle is untrusted markup served over http from the same
+   * loopback origin the API answers on. `allow-same-origin` would put it on
+   * that origin — able to read `server_info`, and through it the API bearer.
+   * Nothing else in the renderer restates this, so the attribute is pinned
+   * here.
+   */
+  it("runs a stored revision with an opaque origin", async () => {
+    const apis = {
+      baseUrl: "http://127.0.0.1:7777",
+      viewSession: vi
+        .fn()
+        .mockResolvedValue({ frame_path: "/apps/view-frames/token-1" }),
+      invoke: vi.fn(),
+      invokeOperation: vi.fn(),
+    } as unknown as AppsApis;
+
+    render(<AppFrame appId="app-1" name="Budget" apis={apis} />);
+
+    const frame = await screen.findByTitle("App: Budget");
+    expect(frame).toHaveAttribute(
+      "src",
+      "http://127.0.0.1:7777/apps/view-frames/token-1",
+    );
+    expect(frame).toHaveAttribute("sandbox", "allow-scripts");
+    expect(frame.getAttribute("sandbox")).not.toContain("allow-same-origin");
+    expect(frame).toHaveAttribute("referrerPolicy", "no-referrer");
+  });
+});

--- a/crates/openwave-desktop/ui/src/host.ts
+++ b/crates/openwave-desktop/ui/src/host.ts
@@ -159,9 +159,10 @@ export function hasMacOverlayTitlebar(): boolean {
  *
  * The webview swallows `window.open` and `target="_blank"` (no new-window
  * handler by design), so anything that must leave the app — the gateway
- * sign-in page — goes through the shell plugin, whose `open` permission
- * validates the URL scheme. Returns false outside the native host so callers
- * can fall back to `window.open` in a plain browser.
+ * sign-in page — goes through the shell plugin, whose `open` scope
+ * (`plugins.shell.open` in `tauri.conf.json`) admits only `http(s)` URLs.
+ * Returns false outside the native host so callers can fall back to
+ * `window.open` in a plain browser.
  */
 export async function openExternal(url: string): Promise<boolean> {
   if (!isTauri()) return false;

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -361,6 +361,17 @@ pub async fn get_mcp_view_frame(
 /// whatever its source: the document's own strict Content-Security-Policy
 /// (inline script and style may run; every network direction is shut) plus
 /// the no-sniff/no-referrer/no-store envelope.
+///
+/// The policy asserts `sandbox allow-scripts` itself rather than relying on
+/// the embedder's `sandbox` attribute. Both embedders set that attribute, and
+/// a test pins that they do — but the attribute is one edit away from being
+/// dropped, and the whole isolation of a served app document rests on it: with
+/// `allow-same-origin`, the document shares the API server's origin and can
+/// read `server_info` (which carries the API bearer). Stating it in the
+/// response makes the opaque origin a property of the document, not of
+/// whoever embeds it. `allow-scripts` and nothing else: the document's own
+/// inline script is the point, and forms, popups, top-level navigation, and
+/// downloads are not.
 fn view_frame_response(body: impl Into<axum::body::Body>) -> Response {
     (
         [
@@ -368,6 +379,7 @@ fn view_frame_response(body: impl Into<axum::body::Body>) -> Response {
             (
                 "content-security-policy",
                 concat!(
+                    "sandbox allow-scripts; ",
                     "default-src 'none'; script-src 'unsafe-inline'; ",
                     "style-src 'unsafe-inline'; img-src data:; font-src data:; ",
                     "connect-src 'none'; form-action 'none'; base-uri 'none'"

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -2074,6 +2074,11 @@ async fn mcp_view_frames_are_single_use_capabilities_with_their_own_csp() {
     assert!(csp.contains("default-src 'none'"));
     assert!(csp.contains("script-src 'unsafe-inline'"));
     assert!(csp.contains("connect-src 'none'"));
+    // The opaque origin is asserted by the response, not left to whoever
+    // embeds it: without this an embedder that forgot `sandbox` would give the
+    // document the API server's own origin, and with it the bearer.
+    assert!(csp.contains("sandbox allow-scripts"));
+    assert!(!csp.contains("allow-same-origin"));
     assert_eq!(
         frame
             .headers()
@@ -2194,6 +2199,11 @@ async fn app_view_frames_serve_stored_revisions_under_the_same_contract() {
     assert!(csp.contains("default-src 'none'"));
     assert!(csp.contains("script-src 'unsafe-inline'"));
     assert!(csp.contains("connect-src 'none'"));
+    // The opaque origin is asserted by the response, not left to whoever
+    // embeds it: without this an embedder that forgot `sandbox` would give the
+    // document the API server's own origin, and with it the bearer.
+    assert!(csp.contains("sandbox allow-scripts"));
+    assert!(!csp.contains("allow-same-origin"));
     assert_eq!(
         frame
             .headers()


### PR DESCRIPTION
`capabilities/default.json` granted `core:default` + `shell:allow-open` to `http://localhost:*` and `http://127.0.0.1:*` in every build. It exists for `build.devUrl` (`http://localhost:1420`), but a packaged app serves its frontend from Tauri's own protocol and never needs it. What the grant did cover is the embedded API server's own origin — which also serves MCP-app and local-app HTML — leaving the iframe `sandbox` attribute as the only thing between that markup and `server_info`, which returns the API bearer.

- **Default capability is local-only.** The dev server's origin moves to `capabilities-dev/dev-server.json`, added at runtime in `setup` under `#[cfg(debug_assertions)]`. It lives outside `capabilities/` because `tauri-build`'s default glob is `./capabilities/**/*`, so anything under that directory would be compiled into the release binary regardless. The port is now exact (`:1420`) rather than a wildcard.
- **Frame CSP asserts its own isolation.** `view_frame_response` adds `sandbox allow-scripts`, so an embedder that forgot the attribute cannot hand a served document the API server's origin. `allow-scripts` and nothing else — the inline script is the point; forms, popups, and top-level navigation are not.
- **Iframe attributes pinned.** `McpAppCard` already had a test; `AppFrame` now has one.
- **`shell > open` gets an explicit scope.** `plugins.shell.open` is set to `https?://.+` rather than relying on the plugin's default regex (which also admits `mailto:` and `tel:`, neither of which the app opens). The comment in `host.ts` now names what actually enforces this.

### Needs a run of the real app before merging

I verified this by compilation and tests only — nothing here can be proven without launching:

1. **`pnpm tauri dev`** — the frontend loads from `http://localhost:1420`, which is now granted only by the runtime-added capability. Confirm the window comes up and IPC works: the chat list loads (`server_info`), window dragging works on the macOS overlay title bar, and the gateway sign-in link opens a browser (`shell:allow-open`). If `add_capability` rejects the file the setup hook returns an error and the app will not start, so a failure here is loud rather than subtle.
2. **A release/packaged build** — confirm the app still boots with no remote grant at all, and that an MCP App card or a local app still renders inside its frame (the new CSP `sandbox` directive applies to the served document).
3. **Opening an external link** under the tightened `shell > open` scope — the gateway sign-in page, and an https link inside the PDF viewer.

Part of #1461