### PR TITLE
feat: surface sandbox first-run progress and degraded-fallback warnings in the app

### DIFF
--- a/crates/openwave-code-execution/src/daytona.rs
+++ b/crates/openwave-code-execution/src/daytona.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use openwave_core::SecretProvider;
+use openwave_core::{ExecDegradation, SecretProvider};
 use openwave_egress::{EgressEnforcement, EgressPolicy};
 use reqwest::{Client, Response, StatusCode, Url};
 use serde::{Deserialize, Serialize};
@@ -17,9 +19,9 @@ use crate::remote::{
 };
 use crate::{
     CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest,
-    CodeExecutionResponse, ExecutionWorkspaceId, StagedUpload, WorkspaceFileEntry,
-    WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, MAX_WORKSPACE_FILE_BYTES,
-    MAX_WORKSPACE_LIST_ENTRIES,
+    CodeExecutionResponse, ExecutionWorkspaceId, SandboxPreparation, SandboxPreparationSink,
+    StagedUpload, WorkspaceFileEntry, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing,
+    MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES,
 };
 
 const DAYTONA_API_BASE: &str = "https://app.daytona.io/api";
@@ -111,6 +113,11 @@ pub struct DaytonaExecutionProvider {
     egress: Option<EgressPolicy>,
     snapshot: Option<String>,
     documents_snapshot: tokio::sync::Mutex<DocumentsSnapshot>,
+    /// Set when the documents snapshot latches to [`DocumentsSnapshot::Fallback`],
+    /// and taken by the execution that observes it. The latch means one
+    /// provider instance degrades once, so the report goes out once too.
+    degradation_pending: AtomicBool,
+    preparation: Option<Arc<dyn SandboxPreparationSink>>,
 }
 
 /// Whether this provider instance has settled how it creates sandboxes when no
@@ -156,6 +163,44 @@ enum SnapshotError {
     Degraded(String),
 }
 
+/// A first-run image preparation, announced at most once and always closed.
+///
+/// Only the paths that actually make the caller wait announce — a snapshot
+/// already `active` costs one request and must not flash a progress state on
+/// screen. Ending it lives in `Drop` so every early return, error, and
+/// cancellation closes the report rather than leaving a wait showing forever.
+struct PreparationReport<'a> {
+    sink: Option<&'a dyn SandboxPreparationSink>,
+    workspace_id: &'a str,
+    announced: AtomicBool,
+}
+
+impl<'a> PreparationReport<'a> {
+    fn new(sink: Option<&'a dyn SandboxPreparationSink>, workspace_id: &'a str) -> Self {
+        Self {
+            sink,
+            workspace_id,
+            announced: AtomicBool::new(false),
+        }
+    }
+
+    fn announce(&self) {
+        let Some(sink) = self.sink else { return };
+        if self.announced.swap(true, Ordering::Relaxed) {
+            return;
+        }
+        sink.report(self.workspace_id, SandboxPreparation::Started);
+    }
+}
+
+impl Drop for PreparationReport<'_> {
+    fn drop(&mut self) {
+        if let (Some(sink), true) = (self.sink, self.announced.load(Ordering::Relaxed)) {
+            sink.report(self.workspace_id, SandboxPreparation::Finished);
+        }
+    }
+}
+
 impl DaytonaExecutionProvider {
     pub fn new(
         credential: DaytonaCredential,
@@ -199,7 +244,20 @@ impl DaytonaExecutionProvider {
             egress: None,
             snapshot: None,
             documents_snapshot: tokio::sync::Mutex::new(DocumentsSnapshot::default()),
+            degradation_pending: AtomicBool::new(false),
+            preparation: None,
         })
+    }
+
+    /// Report first-run image preparation to the host while it runs.
+    ///
+    /// Registering the documents snapshot pulls a multi-gigabyte image into the
+    /// caller's Daytona organization, which takes minutes and returns nothing
+    /// until it finishes. Without a sink the wait is silent, exactly as before.
+    #[must_use]
+    pub fn with_preparation_sink(mut self, sink: Arc<dyn SandboxPreparationSink>) -> Self {
+        self.preparation = Some(sink);
+        self
     }
 
     /// Create every sandbox from this account-registered Daytona snapshot
@@ -283,7 +341,7 @@ impl DaytonaExecutionProvider {
         &self,
         workspace_id: &str,
     ) -> Result<RemoteSession, CodeExecutionError> {
-        let snapshot = self.resolve_snapshot().await?;
+        let snapshot = self.resolve_snapshot(workspace_id).await?;
         let response = self
             .client
             .post(self.api_url("/sandbox"))
@@ -331,7 +389,10 @@ impl DaytonaExecutionProvider {
     /// made ready once per provider instance — registered from the pinned
     /// digest if missing, reactivated if Daytona let it lapse — and `None`
     /// (Daytona's default snapshot) is the degraded answer when that fails.
-    async fn resolve_snapshot(&self) -> Result<Option<&str>, CodeExecutionError> {
+    async fn resolve_snapshot(
+        &self,
+        workspace_id: &str,
+    ) -> Result<Option<&str>, CodeExecutionError> {
         if let Some(configured) = self.snapshot.as_deref() {
             return Ok(Some(configured));
         }
@@ -341,7 +402,13 @@ impl DaytonaExecutionProvider {
             DocumentsSnapshot::Fallback => return Ok(None),
             DocumentsSnapshot::Unresolved => {}
         }
-        match self.ensure_documents_snapshot().await {
+        // Scoped so the report closes — and the host stops showing a wait —
+        // before this returns, whichever way it returns.
+        let outcome = {
+            let preparing = PreparationReport::new(self.preparation.as_deref(), workspace_id);
+            self.ensure_documents_snapshot(&preparing).await
+        };
+        match outcome {
             Ok(()) => {
                 *state = DocumentsSnapshot::Ready;
                 Ok(Some(DOCUMENTS_SNAPSHOT))
@@ -357,15 +424,19 @@ impl DaytonaExecutionProvider {
                      install their dependencies inside each sandbox instead"
                 );
                 *state = DocumentsSnapshot::Fallback;
+                self.degradation_pending.store(true, Ordering::Relaxed);
                 Ok(None)
             }
         }
     }
 
     /// Idempotently bring the documents snapshot to `active` in this account.
-    async fn ensure_documents_snapshot(&self) -> Result<(), SnapshotError> {
+    async fn ensure_documents_snapshot(
+        &self,
+        preparing: &PreparationReport<'_>,
+    ) -> Result<(), SnapshotError> {
         match self.fetch_snapshot(DOCUMENTS_SNAPSHOT).await? {
-            Some(snapshot) => self.await_snapshot_active(snapshot).await,
+            Some(snapshot) => self.await_snapshot_active(snapshot, preparing).await,
             None => {
                 tracing::info!(
                     snapshot = DOCUMENTS_SNAPSHOT,
@@ -373,6 +444,7 @@ impl DaytonaExecutionProvider {
                     "preparing the OpenWave documents sandbox image in Daytona \
                      (first run only; this pulls a multi-gigabyte image)"
                 );
+                preparing.announce();
                 let response = self
                     .client
                     .post(self.api_url("/snapshots"))
@@ -388,7 +460,7 @@ impl DaytonaExecutionProvider {
                     .await
                     .map_err(|_| SnapshotError::Degraded("could not reach Daytona".into()))?;
                 let created = decode_snapshot(response).await?;
-                self.await_snapshot_active(created).await
+                self.await_snapshot_active(created, preparing).await
             }
         }
     }
@@ -398,6 +470,7 @@ impl DaytonaExecutionProvider {
     async fn await_snapshot_active(
         &self,
         mut snapshot: DaytonaSnapshot,
+        preparing: &PreparationReport<'_>,
     ) -> Result<(), SnapshotError> {
         let deadline = Instant::now() + DAYTONA_SNAPSHOT_TIMEOUT;
         let started = Instant::now();
@@ -411,6 +484,7 @@ impl DaytonaExecutionProvider {
                         snapshot = DOCUMENTS_SNAPSHOT,
                         "reactivating the OpenWave documents snapshot in Daytona"
                     );
+                    preparing.announce();
                     let response = self
                         .client
                         .post(self.api_url(&format!("/snapshots/{DOCUMENTS_SNAPSHOT}/activate")))
@@ -422,7 +496,7 @@ impl DaytonaExecutionProvider {
                     requested_activation = true;
                     continue;
                 }
-                Some("pending" | "building" | "pulling" | "snapshotting") => {}
+                Some("pending" | "building" | "pulling" | "snapshotting") => preparing.announce(),
                 state => {
                     return Err(SnapshotError::Degraded(snapshot_failure(
                         state,
@@ -932,7 +1006,11 @@ impl CodeExecutionProvider for DaytonaExecutionProvider {
         &self,
         request: CodeExecutionRequest,
     ) -> Result<CodeExecutionResponse, CodeExecutionError> {
-        execute_remote(self, &self.pool, request).await
+        let mut response = execute_remote(self, &self.pool, request).await?;
+        if self.degradation_pending.swap(false, Ordering::Relaxed) {
+            response.degraded = Some(ExecDegradation::SandboxImageUnavailable);
+        }
+        Ok(response)
     }
 
     fn workspace_lifecycle(&self) -> Option<&dyn WorkspaceLifecycle> {
@@ -1500,6 +1578,32 @@ mod tests {
         .unwrap()
     }
 
+    fn request_in(workspace_id: &str, execution_id: &str) -> CodeExecutionRequest {
+        CodeExecutionRequest::new(
+            ExecutionId::parse(execution_id).unwrap(),
+            ExecutionWorkspaceId::parse(workspace_id).unwrap(),
+            "printf",
+            vec!["ok".into()],
+            ".",
+        )
+        .unwrap()
+    }
+
+    /// Records what a host would have shown while an image was being prepared.
+    #[derive(Default)]
+    struct RecordingPreparationSink {
+        stages: Mutex<Vec<(String, SandboxPreparation)>>,
+    }
+
+    impl SandboxPreparationSink for RecordingPreparationSink {
+        fn report(&self, workspace_id: &str, stage: SandboxPreparation) {
+            self.stages
+                .lock()
+                .unwrap()
+                .push((workspace_id.to_owned(), stage));
+        }
+    }
+
     fn timeout_request() -> CodeExecutionRequest {
         CodeExecutionRequest::new(
             ExecutionId::parse("call-timeout").unwrap(),
@@ -1807,6 +1911,41 @@ mod tests {
         server.abort();
     }
 
+    /// A first run pulls a multi-gigabyte image and returns nothing until it
+    /// finishes, so the wait has to be visible where the person is looking.
+    /// A snapshot that is already active is not a wait and must not flash one.
+    #[tokio::test]
+    async fn daytona_reports_first_run_image_preparation_but_not_a_ready_one() {
+        let (base, _state, server) = spawn_mock().await;
+        let sink = Arc::new(RecordingPreparationSink::default());
+        let provider = mock_provider(&base).with_preparation_sink(sink.clone());
+
+        provider
+            .execute(request_in("chat-first-run", "call-one"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            sink.stages.lock().unwrap().as_slice(),
+            [
+                ("chat-first-run".to_owned(), SandboxPreparation::Started),
+                ("chat-first-run".to_owned(), SandboxPreparation::Finished),
+            ]
+        );
+
+        // A fresh provider against the now-registered snapshot: one lookup,
+        // nothing to wait for, and so nothing to say.
+        let ready_sink = Arc::new(RecordingPreparationSink::default());
+        mock_provider(&base)
+            .with_preparation_sink(ready_sink.clone())
+            .execute(request_in("chat-second-run", "call-two"))
+            .await
+            .unwrap();
+
+        assert!(ready_sink.stages.lock().unwrap().is_empty());
+        server.abort();
+    }
+
     #[tokio::test]
     async fn daytona_reactivates_the_documents_snapshot_it_let_lapse() {
         let (base, state, server) = spawn_mock().await;
@@ -1838,12 +1977,12 @@ mod tests {
         *state.create_snapshot_status.lock().unwrap() = Some(StatusCode::PAYMENT_REQUIRED);
         let provider = mock_provider(&base);
 
-        provider
-            .create_workspace(&ExecutionWorkspaceId::parse("chat-one").unwrap())
+        let first = provider
+            .execute(request_in("chat-one", "call-one"))
             .await
             .unwrap();
-        provider
-            .create_workspace(&ExecutionWorkspaceId::parse("chat-two").unwrap())
+        let second = provider
+            .execute(request_in("chat-two", "call-two"))
             .await
             .unwrap();
 
@@ -1851,6 +1990,13 @@ mod tests {
         // refused registration is not retried on every creation.
         assert_eq!(created_from(&state), [None, None]);
         assert_eq!(snapshot_calls(&state), ["snapshot-get", "snapshot-create"]);
+        // The run that discovered the shortfall says so; the ones after it
+        // inherit the latched decision and have nothing new to report.
+        assert_eq!(
+            first.degraded,
+            Some(ExecDegradation::SandboxImageUnavailable)
+        );
+        assert_eq!(second.degraded, None);
         server.abort();
     }
 

--- a/crates/openwave-code-execution/src/e2b.rs
+++ b/crates/openwave-code-execution/src/e2b.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use futures::StreamExt as _;
-use openwave_core::SecretProvider;
+use openwave_core::{ExecDegradation, SecretProvider};
 use openwave_egress::{
     CidrBlock, EgressEnforcement, EgressPolicy, EnforcementException, ExceptionReach,
     ExceptionScope,
@@ -114,6 +114,10 @@ pub struct E2BExecutionProvider {
     /// remaining sandbox creations of this provider's life skip the doomed
     /// first attempt.
     template_unavailable: AtomicBool,
+    /// Set when `template_unavailable` latches, and taken by the execution that
+    /// observes it. The latch means one provider instance degrades once, so the
+    /// report goes out once too.
+    degradation_pending: AtomicBool,
 }
 
 #[derive(Clone)]
@@ -175,6 +179,7 @@ impl E2BExecutionProvider {
             template: E2B_TEMPLATE.into(),
             default_template: true,
             template_unavailable: AtomicBool::new(false),
+            degradation_pending: AtomicBool::new(false),
         })
     }
 
@@ -270,6 +275,7 @@ impl E2BExecutionProvider {
                     self.template
                 );
                 self.template_unavailable.store(true, Ordering::Relaxed);
+                self.degradation_pending.store(true, Ordering::Relaxed);
                 self.create_sandbox_from(workspace_id, E2B_FALLBACK_TEMPLATE)
                     .await
                     .map_err(|failure| failure.into_error(E2B_FALLBACK_TEMPLATE))
@@ -700,7 +706,11 @@ impl CodeExecutionProvider for E2BExecutionProvider {
         &self,
         request: CodeExecutionRequest,
     ) -> Result<CodeExecutionResponse, CodeExecutionError> {
-        execute_remote(self, &self.pool, request).await
+        let mut response = execute_remote(self, &self.pool, request).await?;
+        if self.degradation_pending.swap(false, Ordering::Relaxed) {
+            response.degraded = Some(ExecDegradation::SandboxImageUnavailable);
+        }
+        Ok(response)
     }
 
     fn workspace_lifecycle(&self) -> Option<&dyn WorkspaceLifecycle> {
@@ -1721,11 +1731,11 @@ mod tests {
         let (state, base, server) = mock_server_without_template(E2B_TEMPLATE).await;
         let provider = provider_at(&base, RemoteSessionPool::default(), None);
 
-        provider
+        let first = provider
             .execute(request("execution-1", "workspace-a", "first"))
             .await
             .unwrap();
-        provider
+        let second = provider
             .execute(request("execution-2", "workspace-b", "second"))
             .await
             .unwrap();
@@ -1734,6 +1744,13 @@ mod tests {
             state.create_templates.lock().unwrap().as_slice(),
             [E2B_TEMPLATE, E2B_FALLBACK_TEMPLATE, E2B_FALLBACK_TEMPLATE]
         );
+        // The run that discovered the missing template reports the degraded
+        // setup; the ones after it inherit the latch and report nothing.
+        assert_eq!(
+            first.degraded,
+            Some(ExecDegradation::SandboxImageUnavailable)
+        );
+        assert_eq!(second.degraded, None);
         server.abort();
     }
 

--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -63,11 +63,11 @@ pub use tool::{ExecTool, EXEC_TOOL_NAME};
 pub use types::{
     CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest,
     CodeExecutionResponse, ExecFolderAccess, ExecFolderGrant, ExecutionId, ExecutionWorkspaceId,
-    OutputArtifactEntry, OutputArtifactScan, OutputArtifactStatus, StagedUpload,
-    WorkspaceFileEntry, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, MAX_ARGUMENTS,
-    MAX_ARGUMENT_BYTES, MAX_CAPTURE_BYTES, MAX_COMMAND_BYTES, MAX_CWD_BYTES,
-    MAX_EXEC_FOLDER_GRANTS, MAX_STAGED_PATHS, MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES,
-    MAX_WORKSPACE_PATH_BYTES,
+    OutputArtifactEntry, OutputArtifactScan, OutputArtifactStatus, SandboxPreparation,
+    SandboxPreparationSink, StagedUpload, WorkspaceFileEntry, WorkspaceFilePath,
+    WorkspaceLifecycle, WorkspaceListing, MAX_ARGUMENTS, MAX_ARGUMENT_BYTES, MAX_CAPTURE_BYTES,
+    MAX_COMMAND_BYTES, MAX_CWD_BYTES, MAX_EXEC_FOLDER_GRANTS, MAX_STAGED_PATHS,
+    MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES, MAX_WORKSPACE_PATH_BYTES,
 };
 
 /// Stable workspace-relative location populated by hosts that ship the

--- a/crates/openwave-code-execution/src/output.rs
+++ b/crates/openwave-code-execution/src/output.rs
@@ -66,6 +66,7 @@ impl Capture {
             output_truncated: self.truncated,
             duration_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
             sync_notes: Vec::new(),
+            degraded: None,
         }
     }
 }

--- a/crates/openwave-code-execution/src/tool.rs
+++ b/crates/openwave-code-execution/src/tool.rs
@@ -206,6 +206,17 @@ impl Tool for ExecTool {
         if response.output_truncated {
             content.push_str("\noutput_truncated: true");
         }
+        if response.degraded.is_some() {
+            // The model is told too: a run that installs its own dependencies
+            // is slower and can fail on a network policy, and that is not a
+            // fact it should have to infer from a pip log.
+            content.push_str(
+                "\n\nsandbox: the prepared OpenWave sandbox image was unavailable, so this \
+                 command ran on the backend's stock image. Document tooling installs its \
+                 dependencies at run time here, which is slower and needs package-registry \
+                 network access.",
+            );
+        }
         if !response.sync_notes.is_empty() {
             content.push_str("\n\nworkspace sync:");
             for note in &response.sync_notes {
@@ -265,6 +276,7 @@ impl Tool for ExecTool {
                 "stdout": response.stdout,
                 "stderr": response.stderr,
                 "sync_notes": response.sync_notes,
+                "degraded": response.degraded,
                 "outputs": artifacts
                     .entries
                     .iter()
@@ -318,6 +330,7 @@ mod tests {
                 output_truncated: false,
                 duration_ms: 3,
                 sync_notes: Vec::new(),
+                degraded: None,
             })
         }
     }
@@ -393,6 +406,7 @@ mod tests {
                 output_truncated: false,
                 duration_ms: 60_012,
                 sync_notes: Vec::new(),
+                degraded: None,
             })
         }
     }
@@ -444,6 +458,7 @@ mod tests {
                 output_truncated: false,
                 duration_ms: 1,
                 sync_notes: Vec::new(),
+                degraded: None,
             })
         }
 
@@ -490,6 +505,7 @@ mod tests {
                 output_truncated: false,
                 duration_ms: 1,
                 sync_notes: Vec::new(),
+                degraded: None,
             })
         }
 

--- a/crates/openwave-code-execution/src/types.rs
+++ b/crates/openwave-code-execution/src/types.rs
@@ -1,6 +1,7 @@
 use std::path::{Component, Path, PathBuf};
 
 use async_trait::async_trait;
+use openwave_core::ExecDegradation;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -513,6 +514,38 @@ pub struct CodeExecutionResponse {
     /// provider shares the host filesystem or the mirror was complete.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub sync_notes: Vec<String>,
+    /// How this execution's backend fell short of its intended setup, when it
+    /// did. Set on the execution that discovered the shortfall; the providers
+    /// latch the degradation itself, so later executions run the same degraded
+    /// way without repeating the report.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub degraded: Option<ExecDegradation>,
+}
+
+/// A stage of the one-time sandbox image preparation a managed provider may
+/// perform before it can create its first sandbox.
+///
+/// Reported out of band rather than returned, because the whole problem it
+/// solves is that nothing is returned for minutes while it runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SandboxPreparation {
+    /// The provider is registering and pulling the OpenWave sandbox image into
+    /// the user's own account. First run only, and measured in minutes.
+    Started,
+    /// Preparation finished — ready, degraded, or failed. The distinction is
+    /// the execution's own outcome to report; this only ends the waiting.
+    Finished,
+}
+
+/// Where a provider reports out-of-band preparation progress.
+///
+/// The crate has no view of chats, sockets, or clients; the host installs a
+/// sink that knows how to show it. Implementations must not block: a provider
+/// calls this from inside the request it is trying to make progress on.
+pub trait SandboxPreparationSink: Send + Sync {
+    /// `workspace_id` is the opaque workspace identity the execution was
+    /// requested under — the same one sandbox creation is labelled with.
+    fn report(&self, workspace_id: &str, stage: SandboxPreparation);
 }
 
 /// What one file under `output/` did to the durable output record.

--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -358,6 +358,7 @@ mod tests {
                     stderr: String::new(),
                     images: Vec::new(),
                     outputs: Vec::new(),
+                    degraded: None,
                 }),
             },
             AgentEvent::TurnCompleted {

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -180,7 +180,7 @@ pub use plan_mode::{
     MAX_PLAN_FEEDBACK_CHARS, MAX_PLAN_TITLE_CHARS, MIN_PLAN_CONTENT_CHARS,
 };
 pub use preview::{
-    format_bytes, ResultEntry, ResultEntryKind, ResultFailure, ToolActionPreview,
+    format_bytes, ExecDegradation, ResultEntry, ResultEntryKind, ResultFailure, ToolActionPreview,
     ToolResultPreview, MAX_RESULT_ENTRIES, MAX_RESULT_ENTRY_CHARS,
 };
 pub use provider::{

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -393,6 +393,21 @@ pub fn format_bytes(bytes: u64) -> String {
     }
 }
 
+/// A way the execution backend ran with less than its intended setup.
+///
+/// Closed, and deliberately coarse: what a reader needs is what happened and
+/// what it costs them, not which vendor API returned which status. A provider
+/// that degrades a second way earns a second variant here rather than a free
+/// string, because the sentence the card shows is written on this side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecDegradation {
+    /// The prepared OpenWave sandbox image could not be used, so commands run
+    /// on the backend's stock image and document tooling installs its
+    /// dependencies inside the sandbox on every run.
+    SandboxImageUnavailable,
+}
+
 /// What a call produced, in a form a human can read.
 ///
 /// A command's output is the whole reason to run it. Withholding it leaves the
@@ -418,6 +433,12 @@ pub enum ToolResultPreview {
         /// existed read back unchanged.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         outputs: Vec<ResultEntry>,
+        /// How the execution backend fell short of its intended setup, when it
+        /// did. Reported on the first execution that degrades and not on the
+        /// ones after it, so a chat says this once rather than on every card.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        degraded: Option<ExecDegradation>,
     },
     /// Web search is available after the reader chooses and configures a
     /// provider. Carries no model- or provider-authored text.
@@ -519,6 +540,11 @@ impl ToolResultPreview {
                     stderr: stream(data.get("stderr")),
                     images: output.images.clone(),
                     outputs: exec_output_entries(data.get("outputs")),
+                    // Read through the closed enum rather than as a string:
+                    // a tool's data is not a place the card takes prose from.
+                    degraded: data.get("degraded").and_then(|value| {
+                        serde_json::from_value::<ExecDegradation>(value.clone()).ok()
+                    }),
                 })
             }
             // Only an external MCP proxy can carry a view declaration, and a
@@ -1362,6 +1388,7 @@ mod tests {
                 stderr: "boom\n".into(),
                 images: Vec::new(),
                 outputs: Vec::new(),
+                degraded: None,
             })
         );
         assert!(result.unwrap().has_output());
@@ -1385,6 +1412,7 @@ mod tests {
                 stderr: String::new(),
                 images: Vec::new(),
                 outputs: Vec::new(),
+                degraded: None,
             }
         );
         assert!(!result.has_output());

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -210,6 +210,13 @@ export function ChatRoute({ chatId }: { chatId: string }) {
           chatListActions.applyDerivedTitle(chatId, metadata.title);
           return;
         }
+        if (metadata.metadata === "sandbox_preparing") {
+          updateSession((session) => ({
+            ...session,
+            sandboxPreparing: metadata.preparing,
+          }));
+          return;
+        }
         const generation = ++terminalHydrationGenerationRef.current;
         void refreshTerminalTranscript(generation);
       },

--- a/crates/openwave-desktop/ui/src/ChatSessionController.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionController.ts
@@ -68,6 +68,10 @@ function metadataFrame(frame: ChatFrame): ChatMetadataFrame | null {
     const { title } = frame as { title?: unknown };
     return typeof title === "string" ? { metadata, title } : null;
   }
+  if (metadata === "sandbox_preparing") {
+    const { preparing } = frame as { preparing?: unknown };
+    return typeof preparing === "boolean" ? { metadata, preparing } : null;
+  }
   if (metadata === "file_changes_recorded") {
     const { turn_id } = frame as { turn_id?: unknown };
     return typeof turn_id === "string" ? { metadata, turn_id } : null;

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.ts
@@ -37,6 +37,14 @@ export type ChatSessionState = {
   hydratedMessageIds: ReadonlySet<string>;
   /** One truncation notice per turn, however many truncation events arrive. */
   contextTruncationNoted: boolean;
+  /**
+   * Whether code execution is preparing its sandbox image right now.
+   *
+   * Pushed outside the journal, so it is not reduced from an event and never
+   * survives a reload — which is correct: it describes a wait that is either
+   * happening or over.
+   */
+  sandboxPreparing: boolean;
 };
 
 export type ChatSessionEffect =
@@ -81,6 +89,7 @@ export function initialChatSessionState(): ChatSessionState {
     provisionalToolCallIds: new Set(),
     hydratedMessageIds: new Set(),
     contextTruncationNoted: false,
+    sandboxPreparing: false,
   };
 }
 

--- a/crates/openwave-desktop/ui/src/ToolCallCard.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.dom.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { useChatSessionStore } from "./ChatSessionStore";
+import { ToolCommandCard } from "./ToolCallCard";
+
+const preview = {
+  tool: "exec" as const,
+  command: "python3",
+  args: ["render.py"],
+  cwd: ".",
+};
+
+afterEach(() => {
+  cleanup();
+  useChatSessionStore.getState().reset();
+});
+
+describe("ToolCommandCard sandbox preparation", () => {
+  it("shows a first-run image pull on the command that is waiting for it", () => {
+    useChatSessionStore
+      .getState()
+      .update((session) => ({ ...session, sandboxPreparing: true }));
+
+    render(
+      <ToolCommandCard
+        name="exec"
+        status="running"
+        preview={preview}
+        result={null}
+      />,
+    );
+
+    expect(
+      screen.getByText(/Preparing the sandbox image \(first run only\)/),
+    ).toBeTruthy();
+    expect(screen.getByText("Preparing sandbox\u2026")).toBeTruthy();
+  });
+
+  it("keeps the notice off a command that is no longer waiting", () => {
+    useChatSessionStore
+      .getState()
+      .update((session) => ({ ...session, sandboxPreparing: true }));
+
+    render(
+      <ToolCommandCard
+        name="exec"
+        status="completed"
+        preview={preview}
+        result={null}
+      />,
+    );
+
+    expect(screen.queryByText(/Preparing the sandbox image/)).toBeNull();
+  });
+});

--- a/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.test.tsx
@@ -123,6 +123,32 @@ describe("ToolCommandCard", () => {
     }
   });
 
+  it("says a degraded run is degraded without needing the card opened", () => {
+    const markup = renderToStaticMarkup(
+      <ToolCommandCard
+        name="exec"
+        status="completed"
+        preview={preview}
+        result={{
+          tool: "exec",
+          exitCode: 0,
+          timedOut: false,
+          outputTruncated: false,
+          stdout: "",
+          stderr: "",
+          degraded: "sandbox_image_unavailable",
+        }}
+      />,
+    );
+
+    // A settled card is collapsed, so a warning inside its body would never
+    // be read. What it costs the reader has to be on the outside.
+    expect(markup).toContain('aria-expanded="false"');
+    expect(visibleText(markup)).toContain(
+      "install their dependencies at run time",
+    );
+  });
+
   it("renders exec preview images inside the output surface", () => {
     const markup = renderToStaticMarkup(
       <ToolCommandCard

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -1,6 +1,7 @@
 import { Check, Clock, Terminal, X } from "lucide-react";
 import {
   isRendererToolName,
+  type ExecDegradation,
   type ExecResultPreview,
   type RendererToolName,
   type ToolActionPreview,
@@ -15,6 +16,22 @@ import { ScrollableContainer } from "./ScrollableContainer";
 import { ToolCardShell } from "./ToolCardShell";
 import { toolPreviewPresentation } from "./ToolPreview";
 import { ChatImage } from "./TranscriptImageAttachments";
+import { useChatSessionStore } from "./ChatSessionStore";
+
+/**
+ * What a first-run sandbox image pull is doing, said where the person is
+ * already looking. Registering the image pulls several gigabytes into the
+ * account and returns nothing until it finishes, so a command card with no
+ * output is otherwise indistinguishable from a hang.
+ */
+const SANDBOX_PREPARING_NOTICE =
+  "Preparing the sandbox image (first run only). This downloads several gigabytes and can take a few minutes; the command runs as soon as it is ready.";
+
+/** One line per way execution can fall short of its intended setup. */
+const EXEC_DEGRADATION_NOTICE: Record<ExecDegradation, string> = {
+  sandbox_image_unavailable:
+    "The prepared OpenWave sandbox image was unavailable, so commands run on the backend's stock image — document tools will install their dependencies at run time, which is slower.",
+};
 
 export type ToolCallStatus =
   | "running"
@@ -244,6 +261,10 @@ export function ToolCommandCard({
   const presentation = toolCallPresentation(name, status);
   const command = toolPreviewPresentation(preview, result);
   const running = presentation.tone === "running";
+  // Live, unjournaled state: only a command that is still running can be the
+  // one waiting on the image, and a settled card must never claim it is.
+  const preparing =
+    useChatSessionStore((session) => session.sandboxPreparing) && running;
   const output = commandOutput(result);
   const images = result?.images ?? [];
   // A command that finished silently has nothing to tab between, and a
@@ -251,73 +272,97 @@ export function ToolCommandCard({
   const tabbed = running || output !== null || images.length > 0;
 
   return (
-    <ToolCardShell
-      label={`${presentation.label}: ${presentation.statusLabel}`}
-      icon={<Terminal className="size-3.5 shrink-0" aria-hidden="true" />}
-      title={command.headline}
-      titleClassName="font-mono"
-      badge={<ToolStatusBadge presentation={presentation} result={result} />}
-      defaultExpanded={running || images.length > 0}
-    >
-      {tabbed ? (
-        <Tabs defaultValue="output">
-          <TabsList className="flex w-full items-center justify-start gap-1 border-b px-1">
-            <TabsTrigger value="command" className="py-1 text-xs capitalize">
-              command
-            </TabsTrigger>
-            <TabsTrigger value="output" className="py-1 text-xs capitalize">
-              output
-            </TabsTrigger>
-          </TabsList>
-          <div className="p-1">
-            <TabsContent value="command" className="mt-0">
-              <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
-                {command.detail}
-              </ScrollableContainer>
-            </TabsContent>
-            <TabsContent value="output" className="mt-0">
-              {output === null ? (
-                <p className="text-muted-foreground flex items-center gap-1.5 p-2 text-xs">
-                  <Spinner className="size-3.5" aria-hidden="true" />
-                  Waiting for output…
-                </p>
-              ) : null}
-              {output !== null && (
+    <div className="flex max-w-prose flex-col gap-1.5">
+      <ToolCardShell
+        label={`${presentation.label}: ${presentation.statusLabel}`}
+        icon={<Terminal className="size-3.5 shrink-0" aria-hidden="true" />}
+        title={command.headline}
+        titleClassName="font-mono"
+        badge={
+          <ToolStatusBadge
+            presentation={presentation}
+            result={result}
+            preparing={preparing}
+          />
+        }
+        defaultExpanded={running || images.length > 0}
+      >
+        {tabbed ? (
+          <Tabs defaultValue="output">
+            <TabsList className="flex w-full items-center justify-start gap-1 border-b px-1">
+              <TabsTrigger value="command" className="py-1 text-xs capitalize">
+                command
+              </TabsTrigger>
+              <TabsTrigger value="output" className="py-1 text-xs capitalize">
+                output
+              </TabsTrigger>
+            </TabsList>
+            <div className="p-1">
+              <TabsContent value="command" className="mt-0">
                 <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
-                  {output}
+                  {command.detail}
                 </ScrollableContainer>
-              )}
-              {images.length > 0 && imageClient && chatId && (
-                <div
-                  className="message-image-grid mt-2"
-                  aria-label="Command preview images"
-                >
-                  {images.map((image, index) => (
-                    <ChatImage
-                      key={image.attachmentId}
-                      client={imageClient}
-                      chatId={chatId}
-                      attachmentId={image.attachmentId}
-                      mediaType={image.mediaType}
-                      width={image.width}
-                      height={image.height}
-                      label={`Command preview ${index + 1}: ${image.width} by ${image.height} pixels`}
-                      unavailableLabel="Command preview unavailable"
-                    />
-                  ))}
-                </div>
-              )}
-            </TabsContent>
+              </TabsContent>
+              <TabsContent value="output" className="mt-0">
+                {output === null ? (
+                  <p className="text-muted-foreground flex items-center gap-1.5 p-2 text-xs">
+                    <Spinner className="size-3.5" aria-hidden="true" />
+                    Waiting for output…
+                  </p>
+                ) : null}
+                {output !== null && (
+                  <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
+                    {output}
+                  </ScrollableContainer>
+                )}
+                {images.length > 0 && imageClient && chatId && (
+                  <div
+                    className="message-image-grid mt-2"
+                    aria-label="Command preview images"
+                  >
+                    {images.map((image, index) => (
+                      <ChatImage
+                        key={image.attachmentId}
+                        client={imageClient}
+                        chatId={chatId}
+                        attachmentId={image.attachmentId}
+                        mediaType={image.mediaType}
+                        width={image.width}
+                        height={image.height}
+                        label={`Command preview ${index + 1}: ${image.width} by ${image.height} pixels`}
+                        unavailableLabel="Command preview unavailable"
+                      />
+                    ))}
+                  </div>
+                )}
+              </TabsContent>
+            </div>
+          </Tabs>
+        ) : (
+          <div className="p-1">
+            <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
+              {command.detail}
+            </ScrollableContainer>
           </div>
-        </Tabs>
-      ) : (
-        <div className="p-1">
-          <ScrollableContainer className="bg-muted text-muted-foreground rounded-md p-2 text-xs whitespace-pre-wrap">
-            {command.detail}
-          </ScrollableContainer>
-        </div>
+        )}
+      </ToolCardShell>
+      {/* Outside the collapsible body on purpose: a card that reports a
+          degraded run only when someone expands it has not reported it. */}
+      {preparing && (
+        <p
+          className="text-muted-foreground flex items-start gap-1.5 text-xs"
+          role="status"
+        >
+          <Spinner className="mt-0.5 size-3 shrink-0" aria-hidden="true" />
+          {SANDBOX_PREPARING_NOTICE}
+        </p>
       )}
-    </ToolCardShell>
+      {result?.degraded && (
+        <p className="text-muted-foreground text-xs" role="status">
+          {EXEC_DEGRADATION_NOTICE[result.degraded]}
+        </p>
+      )}
+    </div>
   );
 }
 
@@ -345,15 +390,17 @@ export function commandOutput(result: ExecResultPreview | null): string | null {
 function ToolStatusBadge({
   presentation,
   result,
+  preparing = false,
 }: {
   presentation: ToolCallPresentation;
   result: ExecResultPreview | null;
+  preparing?: boolean;
 }) {
   if (presentation.tone === "running") {
     return (
       <Badge variant="outline" className="shrink-0 gap-1">
         <Spinner className="size-3" aria-hidden="true" />
-        Running…
+        {preparing ? "Preparing sandbox…" : "Running…"}
       </Badge>
     );
   }

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -68,6 +68,7 @@ import {
   type ChatTerminalTurnSnapshot,
   type ChatToolActivitySnapshot,
   type ChatToolActivityStatus,
+  type ExecDegradation,
   type ExecFileChangeSummary as WireExecFileChangeSummary,
   type RendererAgentEvent,
   type RendererChatFrame,
@@ -96,6 +97,7 @@ export type {
   ResultEntryKind,
   ToolActionPreview,
   RendererRefusal,
+  ExecDegradation,
 };
 
 /**
@@ -392,6 +394,12 @@ export type ToolResultPreview =
       }[];
       /** Durable outputs the command's output/ files created or updated. */
       outputs?: ResultEntry[];
+      /**
+       * How the execution backend fell short of its intended setup, when it
+       * did. Sent on the first command that degrades and not on the ones
+       * after it, so a conversation says this once.
+       */
+      degraded?: ExecDegradation;
     }
   | {
       /** Web search is available after the reader configures a provider. */
@@ -2392,6 +2400,7 @@ export function parseToolResultPreview(
     stderr,
     images,
     outputs,
+    degraded,
   }: UncheckedExecResult = value;
   const imageValues = images ?? [];
   const outputValues = outputs ?? [];
@@ -2443,7 +2452,14 @@ export function parseToolResultPreview(
     stderr,
     images: parsedImages,
     outputs: parsedOutputs,
+    // Unknown to this build means unshowable, not unusable: the command's
+    // output still renders, without a sentence nobody wrote copy for.
+    degraded: isExecDegradation(degraded) ? degraded : undefined,
   };
+}
+
+function isExecDegradation(value: unknown): value is ExecDegradation {
+  return value === "sandbox_image_unavailable";
 }
 
 /**

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -787,6 +787,16 @@ export type EgressConfig = { "mode": "open" } | { "mode": "allowlist", domains: 
 export type EgressEnforcementStatus = "boundary" | "conditional_boundary" | "applied_with_gaps" | "unconfirmed";
 
 /**
+ * A way the execution backend ran with less than its intended setup.
+ *
+ * Closed, and deliberately coarse: what a reader needs is what happened and
+ * what it costs them, not which vendor API returned which status. A provider
+ * that degrades a second way earns a second variant here rather than a free
+ * string, because the sentence the card shows is written on this side.
+ */
+export type ExecDegradation = "sandbox_image_unavailable";
+
+/**
  * Renderer-safe selection metadata; bytes remain behind the scoped endpoint.
  */
 export type ExecFileBinaryPreview = { format: ExecFilePreviewFormat, before: ExecFilePreviewAvailability, after: ExecFilePreviewAvailability, };
@@ -1376,7 +1386,7 @@ export type RendererChatFrame = RendererSequencedEvent | RendererChatMetadata;
 /**
  * Chat metadata pushed to an open client, outside the turn journal.
  */
-export type RendererChatMetadata = { "metadata": "titled", title: string, } | { "metadata": "file_changes_recorded", turn_id: TurnId, };
+export type RendererChatMetadata = { "metadata": "titled", title: string, } | { "metadata": "file_changes_recorded", turn_id: TurnId, } | { "metadata": "sandbox_preparing", preparing: boolean, };
 
 /**
  * Bounded refusal metadata safe to present in the desktop transcript.
@@ -1634,7 +1644,13 @@ images?: Array<ImageRef>,
  * not listed. Defaulted so exec rows persisted before the field
  * existed read back unchanged.
  */
-outputs?: Array<ResultEntry>, } | { "tool": "web_search_provider_required" } | { "tool": "mcp_app", 
+outputs?: Array<ResultEntry>, 
+/**
+ * How the execution backend fell short of its intended setup, when it
+ * did. Reported on the first execution that degrades and not on the
+ * ones after it, so a chat says this once rather than on every card.
+ */
+degraded?: ExecDegradation, } | { "tool": "web_search_provider_required" } | { "tool": "mcp_app", 
 /**
  * The configured MCP server namespace that serves the view.
  */

--- a/crates/openwave-server/src/bus.rs
+++ b/crates/openwave-server/src/bus.rs
@@ -39,6 +39,15 @@ pub enum ChatMetadataNotice {
     Titled { title: String },
     /// A terminal turn's connected-folder write report is durable and readable.
     FileChangesRecorded { turn_id: TurnId },
+    /// Whether code execution is currently preparing its sandbox image before
+    /// it can run anything.
+    ///
+    /// Deliberately live-only, like everything else here: it describes what is
+    /// happening right now, and a journaled row would still be asserting it
+    /// months later. A client that connects mid-pull learns about it on the
+    /// next report rather than from replay, which is the right trade for a
+    /// state whose whole meaning is "still waiting".
+    SandboxPreparing { preparing: bool },
 }
 
 /// Per-chat broadcast channels for live turn events and metadata notices.

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -8,7 +8,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -356,10 +356,14 @@ fn configured_daytona(
     pool: RemoteSessionPool,
     egress: &EgressConfig,
     snapshot: Option<&str>,
+    preparation: Option<Arc<dyn openwave_code_execution::SandboxPreparationSink>>,
 ) -> std::result::Result<DaytonaExecutionProvider, CodeExecutionError> {
     let mut provider = DaytonaExecutionProvider::with_session_pool(credential, timeout, pool)?;
     if let Some(snapshot) = snapshot {
         provider = provider.with_snapshot(snapshot);
+    }
+    if let Some(sink) = preparation {
+        provider = provider.with_preparation_sink(sink);
     }
     match resolve_egress_policy(egress)? {
         Some(policy) => provider.with_egress_policy(policy),
@@ -847,6 +851,39 @@ pub struct ConfiguredCodeExecutionProvider {
     /// Whether a host-side cache population pass is running or has succeeded;
     /// cleared again on failure so a later exec can retry.
     package_cache_population: Arc<std::sync::atomic::AtomicBool>,
+    /// Where live sandbox-preparation progress is announced. Installed after
+    /// the app's state is assembled, because the bus is built there; execution
+    /// works exactly as before until it is.
+    events: OnceLock<Arc<crate::bus::EventBus>>,
+    /// Chats already told that execution is running degraded.
+    ///
+    /// The providers latch the degradation per instance, and an instance is
+    /// built per execution — so without this the same warning would land on
+    /// every card that recreates a sandbox. Warning once per chat is what a
+    /// reader needs: the second card says nothing new.
+    degradation_reported: Mutex<HashSet<ChatId>>,
+}
+
+/// Publishes a provider's first-run image preparation to the chat that is
+/// waiting on it.
+struct SandboxPreparationNotices {
+    events: Arc<crate::bus::EventBus>,
+}
+
+impl openwave_code_execution::SandboxPreparationSink for SandboxPreparationNotices {
+    fn report(&self, workspace_id: &str, stage: openwave_code_execution::SandboxPreparation) {
+        // The workspace identity is the chat's; a workspace that does not name
+        // one has no window to tell, and the execution itself proceeds.
+        let Ok(chat) = workspace_id.parse::<ChatId>() else {
+            return;
+        };
+        self.events.publish_metadata(
+            chat,
+            crate::bus::ChatMetadataNotice::SandboxPreparing {
+                preparing: matches!(stage, openwave_code_execution::SandboxPreparation::Started),
+            },
+        );
+    }
 }
 
 /// One turn's staging for one chat.
@@ -1000,7 +1037,20 @@ impl ConfiguredCodeExecutionProvider {
             write_overlays: Mutex::new(HashMap::new()),
             package_cache_runtime: tokio::sync::OnceCell::new(),
             package_cache_population: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            events: OnceLock::new(),
+            degradation_reported: Mutex::new(HashSet::new()),
         }
+    }
+
+    /// Install the chat event bus this provider announces sandbox preparation
+    /// on. Called once, after the app state that owns the bus is assembled.
+    pub fn attach_event_bus(&self, events: Arc<crate::bus::EventBus>) {
+        let _ = self.events.set(events);
+    }
+
+    fn preparation_sink(&self) -> Option<Arc<dyn openwave_code_execution::SandboxPreparationSink>> {
+        let events = self.events.get()?.clone();
+        Some(Arc::new(SandboxPreparationNotices { events }))
     }
 
     /// Install the blob lifecycle lock the write-back snapshot publishes under.
@@ -1625,6 +1675,7 @@ impl ConfiguredCodeExecutionProvider {
                     self.remote_sessions.clone(),
                     &egress,
                     config.daytona_snapshot.as_deref(),
+                    self.preparation_sink(),
                 )?)
             }
             _ => {
@@ -1840,6 +1891,18 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
             notes.push(staged_set_note(&request.files));
         }
         response.sync_notes.extend(notes);
+        // Degrading is news once. The provider reports it on the execution that
+        // discovered it; a later sandbox rebuild rediscovers the same thing, and
+        // repeating it on every card would be noise rather than information.
+        if response.degraded.is_some()
+            && !self
+                .degradation_reported
+                .lock()
+                .map(|mut reported| reported.insert(chat_id))
+                .unwrap_or(false)
+        {
+            response.degraded = None;
+        }
         Ok(response)
     }
 
@@ -3150,6 +3213,7 @@ mod tests {
             pool.clone(),
             &allowlist,
             None,
+            None,
         )
         .unwrap();
         assert_eq!(daytona.egress_policy(), Some(&expected));
@@ -3170,6 +3234,7 @@ mod tests {
             timeout,
             pool,
             &EgressConfig::Open,
+            None,
             None,
         )
         .unwrap();

--- a/crates/openwave-server/src/event_projection.rs
+++ b/crates/openwave-server/src/event_projection.rs
@@ -49,6 +49,10 @@ pub(crate) enum RendererChatMetadata {
     Titled { title: String },
     /// A post-turn file-change summary is ready for transcript hydration.
     FileChangesRecorded { turn_id: TurnId },
+    /// Code execution is preparing its sandbox image, or has stopped doing so.
+    /// A first run pulls a multi-gigabyte image, which returns nothing for
+    /// minutes; this is how the running command's card says so.
+    SandboxPreparing { preparing: bool },
 }
 
 impl From<&crate::bus::ChatMetadataNotice> for RendererChatMetadata {
@@ -59,6 +63,11 @@ impl From<&crate::bus::ChatMetadataNotice> for RendererChatMetadata {
             },
             crate::bus::ChatMetadataNotice::FileChangesRecorded { turn_id } => {
                 Self::FileChangesRecorded { turn_id: *turn_id }
+            }
+            crate::bus::ChatMetadataNotice::SandboxPreparing { preparing } => {
+                Self::SandboxPreparing {
+                    preparing: *preparing,
+                }
             }
         }
     }

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -910,6 +910,10 @@ async fn bind_inner(
     // root-attachment mutations stay off — matching `AppState::new`.
     state.root_attachment_routes_enabled = client_executor_id.is_some();
     state.blobs = blobs;
+    // The bus is built with the app state, after the exec provider it belongs
+    // to; handing it over here is what lets a first-run image pull reach the
+    // chat that is waiting on it.
+    code_execution.attach_event_bus(state.events.clone());
     if let Some(local_voice) = local_voice {
         state.set_local_voice_runner(local_voice);
     }

--- a/crates/openwave-server/src/tests/image_attachment.rs
+++ b/crates/openwave-server/src/tests/image_attachment.rs
@@ -589,6 +589,7 @@ async fn a_tool_preview_is_fetchable_only_through_its_chat() {
             byte_len: bytes.len() as u64,
         }],
         outputs: Vec::new(),
+        degraded: None,
     };
     store
         .resolve_server_tool_call_with_artifacts(


### PR DESCRIPTION
Two behaviors in `openwave-code-execution` were only visible in tracing output. On a Daytona first run the provider registers the OpenWave documents image as a snapshot in the user's own organization; Daytona pulls a multi-gigabyte image, which takes minutes and returns nothing while it does. On screen that is indistinguishable from a hang. And when either provider degrades — E2B to `code-interpreter-v1` when the published template does not resolve, Daytona to its default snapshot when registration fails — document runs start installing their dependencies inside the sandbox on every call, with nothing in the app saying why.

## The seams

The two signals have different lifetimes, so they take different existing paths rather than one new channel.

**The wait is live-only.** It rides `ChatMetadataNotice` — the same non-journaled per-chat push that carries the derived title and the file-change signal — as `SandboxPreparing { preparing }`, projected to `RendererChatMetadata`. It describes something that is either happening or over; a journal row would still be asserting it months later, and replay would resurrect a wait that ended long ago. `ChatRoute` already routes metadata frames, so this is one more arm.

`openwave-code-execution` keeps no view of chats or clients, so the provider takes an optional `SandboxPreparationSink`; the server's `ConfiguredCodeExecutionProvider` implements it over the event bus (attached after `AppState` is assembled, since the bus is built there). Only the paths that actually make the caller wait announce — a snapshot already `active` costs one request and must not flash a progress state — and the report is closed in `Drop`, so an error, a deadline, or a cancellation cannot leave a wait showing forever.

**The degradation is durable**, because it belongs to the turn it happened in. `CodeExecutionResponse` carries a closed `ExecDegradation`, the exec tool puts it in its output data (and in the model-facing text, since a run that installs its own dependencies is slower and can fail on a network policy), and `ToolResultPreview::Exec` projects it into the card the same way exit code and streams already travel.

Rejected: a toast (nothing in the transcript toasts today; the pattern is settings-only), a `role: "system"` transcript notice (detaches the warning from the command it describes), and a new `AgentEvent` variant for the wait (durability is exactly the wrong property for it).

## What the user sees

- **Daytona first run**: the running command's card badge reads `Preparing sandbox…` instead of `Running…`, with a line under it explaining that the sandbox image is being prepared, that it happens on the first run only, that it downloads several gigabytes, and that the command runs as soon as it is ready. It clears when preparation ends, whichever way it ends. A snapshot that is already active shows nothing.
- **Either provider degraded**: the card that discovered it carries one line — the prepared image was unavailable, commands run on the backend's stock image, document tools will install their dependencies at run time. It sits outside the collapsible body, because a settled card is collapsed and a warning inside it would never be read.
- **Later commands in the same chat**: nothing. Providers latch the degradation per instance and an instance is built per execution, so the server latches per chat on top of that; the second card has nothing new to say.

Execution behavior is unchanged and the providers' existing tracing lines stay.

## Tests

- `daytona_reports_first_run_image_preparation_but_not_a_ready_one` — new, over the existing axum mock: a first run reports start and finish for its workspace, and a fresh provider against the now-registered snapshot reports nothing.
- `daytona_degrades_to_its_default_snapshot_when_registration_is_refused` — extended to run two executions and assert the first response carries the degradation and the second does not.
- `e2b_falls_back_to_the_public_template_when_openwave_s_is_unresolvable` — same extension; it already ran two executions across two workspaces.
- `ToolCallCard.test.tsx` — a degraded result's line is present on a collapsed card.
- `ToolCallCard.dom.test.tsx` — new file (the store's live value needs a real render, not SSR): the preparing notice appears on a running command and not on a settled one.

## Verification

`cargo test -p openwave-code-execution`, `-p openwave-core`, `-p openwave-server`, `cargo check --workspace --all-targets`, and `cargo clippy --all-targets` on the three touched crates all pass, all `--locked` with no lockfile drift. `pnpm test` (713 tests), `tsc --noEmit`, and `pnpm build` pass. Wire types regenerated with `UPDATE_WIRE_TYPES=1`; the journal fixture is unchanged, since the new preview field is `skip_serializing_if`.

Not verified: I cannot run the app, so the live Daytona first-run sequence and the on-screen layout of the two notices have not been seen against a real account. The provider-side reports and the card's rendering of them are covered by the tests above, but the end-to-end appearance is worth a look while running a first Daytona execution.