### PR TITLE
fix(desktop): stop the transcript rendering blank after a settings round-trip

### DIFF
--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -126,7 +126,13 @@ export function ChatView({
   const scrollObserverRef = useRef<ResizeObserver | null>(null);
   const contentObserverRef = useRef<ResizeObserver | null>(null);
   const [scrolledAway, setScrolledAway] = useState(false);
-  const [maskClass, setMaskClass] = useState<string | null>(null);
+  const [fadeClass, setFadeClass] = useState<string | null>(null);
+  // False until the transcript has been scrolled to its resting place once.
+  // The first follow *places* the reader at the latest message, so it must not
+  // animate: WKWebView occasionally fails to repaint the freshly created
+  // scroll layer when a long smooth scroll runs during mount, leaving a
+  // laid-out transcript blank until the next scroll input.
+  const placedRef = useRef(false);
   // True once the reader has sent in this mounted session. Gates the turn pin so
   // a freshly loaded history reads normally, then the just-sent turn is held tall
   // enough to land near the top of the viewport.
@@ -140,7 +146,7 @@ export function ChatView({
     const fromTop = scroll.scrollTop > 0;
     const fromBottom =
       scroll.scrollHeight - scroll.scrollTop - scroll.clientHeight > 1;
-    setMaskClass(
+    setFadeClass(
       fromTop && fromBottom
         ? "is-faded-both"
         : fromTop
@@ -231,8 +237,10 @@ export function ChatView({
     // Scrolling a transcript that has been expanded away does nothing, so this
     // also runs on the way back to put a following reader at the latest message.
     if (!transcriptVisible) return;
+    const placing = !placedRef.current;
+    if (messages.length > 0) placedRef.current = true;
     if (followsLatestRef.current) {
-      scrollToBottom(followScrollBehavior(busy));
+      scrollToBottom(placing ? "auto" : followScrollBehavior(busy));
     }
     updateEdges();
   }, [messages, busy, transcriptVisible, scrollToBottom, updateEdges]);
@@ -272,7 +280,7 @@ export function ChatView({
 
   return (
     <section className="chat-pane">
-      <div className="message-view">
+      <div className={cn("message-view", fadeClass)}>
         <MessageList
           messages={messages}
           chatId={chat.id}
@@ -307,7 +315,6 @@ export function ChatView({
           streamStalled={streamStalled}
           scrollRef={attachScrollRef}
           contentRef={attachContentRef}
-          maskClass={maskClass}
           pinLastTurn={pinLastTurn}
           onScroll={handleScroll}
           onApproval={approvals.decide}

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -199,8 +199,6 @@ type MessageListProps = {
   scrollRef: Ref<HTMLDivElement>;
   /** Attached to the transcript content column so growth can drive auto-follow. */
   contentRef?: RefCallback<HTMLDivElement>;
-  /** Extra classes for the scroll container — used for the scroll-edge fades. */
-  maskClass?: string | null;
   /** Lift the trailing exchange into a pinned wrapper so a just-sent message
    *  lands near the top with room below for its streaming reply. */
   pinLastTurn?: boolean;
@@ -269,7 +267,6 @@ export function MessageList({
   streamStalled = false,
   scrollRef,
   contentRef,
-  maskClass,
   pinLastTurn = false,
   onScroll,
   onApproval,
@@ -345,11 +342,7 @@ export function MessageList({
   // history lands.
   if (!hydrated && messages.length === 0) {
     return (
-      <div
-        className={`messages${maskClass ? ` ${maskClass}` : ""}`}
-        ref={scrollRef}
-        onScroll={onScroll}
-      >
+      <div className="messages" ref={scrollRef} onScroll={onScroll}>
         <div className="messages-column">
           <TranscriptSkeleton />
         </div>
@@ -442,11 +435,7 @@ export function MessageList({
   const pin = pinLastTurn && lastTurnStart >= 0;
 
   return (
-    <div
-      className={`messages${maskClass ? ` ${maskClass}` : ""}`}
-      ref={scrollRef}
-      onScroll={onScroll}
-    >
+    <div className="messages" ref={scrollRef} onScroll={onScroll}>
       <div className="messages-column" ref={contentRef}>
         {pin ? (
           <>

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -484,28 +484,39 @@ body {
 }
 
 /* Scroll-edge fades: soften whichever edges have more content beyond them, so
-   the transcript reads as continuing past the frame rather than clipped. */
-.messages.is-faded-top {
-  mask-image: linear-gradient(180deg, transparent, #000 2rem, #000);
+   the transcript reads as continuing past the frame rather than clipped.
+   Painted as overlays on the wrapper rather than a mask-image on `.messages`:
+   masking the composited scroll layer is what WKWebView occasionally failed
+   to repaint after the mount-time catch-up scroll, leaving a fully laid-out
+   transcript blank until the next scroll input. The card behind the
+   transcript is a solid `--background`, so fading to that color is
+   indistinguishable from fading to transparent. */
+.message-view::before,
+.message-view::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2rem;
+  pointer-events: none;
+  opacity: 0;
 }
 
-.messages.is-faded-bottom {
-  mask-image: linear-gradient(
-    180deg,
-    #000,
-    #000 calc(100% - 2rem),
-    transparent
-  );
+.message-view::before {
+  top: 0;
+  background: linear-gradient(180deg, var(--background), transparent);
 }
 
-.messages.is-faded-both {
-  mask-image: linear-gradient(
-    180deg,
-    transparent,
-    #000 2rem,
-    #000 calc(100% - 2rem),
-    transparent
-  );
+.message-view::after {
+  bottom: 0;
+  background: linear-gradient(0deg, var(--background), transparent);
+}
+
+.message-view.is-faded-top::before,
+.message-view.is-faded-both::before,
+.message-view.is-faded-bottom::after,
+.message-view.is-faded-both::after {
+  opacity: 1;
 }
 
 .message {


### PR DESCRIPTION
## Symptom

Navigating chat → settings → "Back to app" occasionally showed a blank transcript: layout and scrollbar correct, nothing painted, fixed by the slightest scroll input.

## Mechanism

"Back to app" fully remounts the chat route. On remount three things collide within the first frames: the whole transcript lays out at once at `scrollTop 0`; the mount effect runs a **smooth** catch-up scroll to the bottom (`followScrollBehavior` with `busy: false`); and `updateEdges` swaps `mask-image` classes on the `.messages` scroll container several times while that animation is in flight. Masking a composited scroll layer and animating it programmatically during layer creation is a known recipe for stale, never-painted tiles in WKWebView's tiled compositor — timing-dependent, hence intermittent.

## Fix (removes both triggers)

- **Edge fades become overlays.** The scroll-edge fades are now `::before`/`::after` gradient overlays on the `.message-view` wrapper (pointer-events: none), toggled by the same `is-faded-*` state, instead of `mask-image` on the scroller. The composited scroll layer is never masked. The card behind the transcript is a solid `--background`, so fading to that color renders identically to fading to transparent. The `maskClass` prop on `MessageList` goes away; the class now sits on the wrapper, which covers the skeleton branch uniformly.
- **The first follow after mount jumps instantly.** It *places* the reader at the latest message rather than following new content, so it shouldn't animate — and it no longer drives a long smooth scroll over a freshly created layer. Every subsequent follow keeps the existing smooth/auto selection.

## Verification

- UI suite: 713 tests passing; `tsc` and `vite build` clean.
- A Playwright WebKit rig drove repeated settings round-trips over a 54k-px seeded transcript with pixel-level classification of the transcript area: resting scroll position and fade visuals (top/both/bottom states) are identical before and after the change; the scroll-to-latest button still stacks above the bottom fade.
- Honest limit: the WKWebView paint failure does not reproduce under Playwright's WebKit embedder (55/55 pre-fix round-trips rendered deterministically), so the fix is validated by removing the trigger conditions rather than by a captured repro. If the blank transcript recurs in the real app after this, the fallback is a one-time forced repaint after the initial jump.

`ScrollableContainer` (the small `<pre>` output scroller) still uses an inline mask for its bottom fade; it is height-capped and not on the remount path, so it is left out of this change deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)