### PR TITLE
fix(desktop): confine the LibreOffice conversion under Seatbelt

### DIFF
--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -26,6 +26,7 @@ pub mod package_cache;
 mod preview;
 mod receipt;
 mod remote;
+pub mod sbpl;
 pub mod skills;
 pub mod sync;
 mod tool;

--- a/crates/openwave-code-execution/src/local.rs
+++ b/crates/openwave-code-execution/src/local.rs
@@ -26,6 +26,7 @@ use crate::network::LocalEgressBroker;
 #[cfg(target_os = "macos")]
 use crate::output::{Capture, StreamKind};
 use crate::receipt::{request_fingerprint, BeginExecution, ExecutionReceipt};
+use crate::sbpl::SANDBOX_EXEC;
 #[cfg(target_os = "macos")]
 use crate::CodeExecutionProviderKind;
 use crate::{
@@ -36,7 +37,6 @@ use crate::{
 #[cfg(target_os = "macos")]
 use crate::{ExecFolderAccess, ExecFolderGrant};
 
-const SANDBOX_EXEC: &str = "/usr/bin/sandbox-exec";
 const RECEIPT_DIR: &str = ".code-execution-receipts";
 const ENV_HOME_DIR: &str = ".code-execution-env-homes";
 const MAX_RECEIPT_BYTES: u64 = 96 * 1_024;
@@ -1203,43 +1203,22 @@ fn macos_developer_dir() -> Option<PathBuf> {
 
 #[cfg(target_os = "macos")]
 fn sbpl_literal(path: &str) -> String {
-    format!("(literal \"{}\")", escape_sbpl(path))
+    crate::sbpl::literal_str(path)
 }
 
 #[cfg(target_os = "macos")]
 fn sbpl_subpath(path: &str) -> String {
-    format!("(subpath \"{}\")", escape_sbpl(path))
+    crate::sbpl::subpath_str(path)
 }
 
 #[cfg(target_os = "macos")]
 fn sandbox_subpath(path: &Path) -> Result<String, CodeExecutionError> {
-    let path = path
-        .to_str()
-        .ok_or_else(|| CodeExecutionError::Sandbox("sandbox paths must be valid UTF-8".into()))?;
-    if path.chars().any(char::is_control) {
-        return Err(CodeExecutionError::Sandbox(
-            "sandbox paths cannot contain control characters".into(),
-        ));
-    }
-    Ok(sbpl_subpath(path))
+    crate::sbpl::subpath(path).map_err(|error| CodeExecutionError::Sandbox(error.to_string()))
 }
 
 #[cfg(target_os = "macos")]
 fn sandbox_literal(path: &Path) -> Result<String, CodeExecutionError> {
-    let path = path
-        .to_str()
-        .ok_or_else(|| CodeExecutionError::Sandbox("sandbox paths must be valid UTF-8".into()))?;
-    if path.chars().any(char::is_control) {
-        return Err(CodeExecutionError::Sandbox(
-            "sandbox paths cannot contain control characters".into(),
-        ));
-    }
-    Ok(sbpl_literal(path))
-}
-
-#[cfg(target_os = "macos")]
-fn escape_sbpl(value: &str) -> String {
-    value.replace('\\', "\\\\").replace('"', "\\\"")
+    crate::sbpl::literal(path).map_err(|error| CodeExecutionError::Sandbox(error.to_string()))
 }
 
 #[cfg(test)]

--- a/crates/openwave-code-execution/src/office_render.rs
+++ b/crates/openwave-code-execution/src/office_render.rs
@@ -9,6 +9,11 @@
 //! the app runs, so rendering becomes a host service instead of a sandbox
 //! binary.
 //!
+//! Running a converter on the host does not mean running it unconfined: the
+//! bytes it parses were written by the sandbox, so the desktop's converter
+//! puts `soffice` under its own Seatbelt profile (see the desktop crate's
+//! `office_sandbox`), built with the shared helpers in [`crate::sbpl`].
+//!
 //! The seam is the workspace itself: after an exec lands office files under
 //! `output/` in host scratch (directly for the local provider, via the
 //! result pull for remote ones), the host converts each to a PDF under

--- a/crates/openwave-code-execution/src/sbpl.rs
+++ b/crates/openwave-code-execution/src/sbpl.rs
@@ -1,0 +1,71 @@
+//! Shared pieces for building macOS Seatbelt (`sandbox-exec`) profiles.
+//!
+//! Two very different processes are confined with the same machinery: the
+//! model's own commands ([`crate::local`]) and the host-side LibreOffice that
+//! renders office outputs to PDF (in the desktop crate). The profiles differ —
+//! one is a workspace the model writes in, the other a converter that reads a
+//! bundle and writes one temp directory — but the path-escaping rules and the
+//! sandbox binary are the same, and getting the escaping wrong is a sandbox
+//! escape in either. Hence one module, not two conventions.
+
+use std::path::Path;
+
+/// The system sandbox launcher. Present on every supported macOS host; its
+/// absence is reported rather than silently skipped, so an unconfined process
+/// never runs by accident.
+pub const SANDBOX_EXEC: &str = "/usr/bin/sandbox-exec";
+
+/// A path that cannot be represented safely inside a profile. Callers turn
+/// this into their own sandbox-failure state; it is never a reason to run
+/// without the sandbox.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnsafeSandboxPath {
+    NotUtf8,
+    ControlCharacters,
+}
+
+impl std::fmt::Display for UnsafeSandboxPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotUtf8 => write!(f, "sandbox paths must be valid UTF-8"),
+            Self::ControlCharacters => write!(f, "sandbox paths cannot contain control characters"),
+        }
+    }
+}
+
+impl std::error::Error for UnsafeSandboxPath {}
+
+/// `(literal "…")` for a known-good static path.
+pub fn literal_str(path: &str) -> String {
+    format!("(literal \"{}\")", escape(path))
+}
+
+/// `(subpath "…")` for a known-good static path.
+pub fn subpath_str(path: &str) -> String {
+    format!("(subpath \"{}\")", escape(path))
+}
+
+/// `(literal "…")` for a host-resolved path, rejecting anything that cannot be
+/// escaped into a profile faithfully.
+pub fn literal(path: &Path) -> Result<String, UnsafeSandboxPath> {
+    Ok(literal_str(checked(path)?))
+}
+
+/// `(subpath "…")` for a host-resolved path, with the same rejection.
+pub fn subpath(path: &Path) -> Result<String, UnsafeSandboxPath> {
+    Ok(subpath_str(checked(path)?))
+}
+
+fn checked(path: &Path) -> Result<&str, UnsafeSandboxPath> {
+    let path = path.to_str().ok_or(UnsafeSandboxPath::NotUtf8)?;
+    if path.chars().any(char::is_control) {
+        return Err(UnsafeSandboxPath::ControlCharacters);
+    }
+    Ok(path)
+}
+
+/// Escaping for an SBPL string literal: backslash first, then the quote that
+/// would otherwise end the literal and let a crafted path append clauses.
+pub fn escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}

--- a/crates/openwave-desktop/src/lib.rs
+++ b/crates/openwave-desktop/src/lib.rs
@@ -25,6 +25,8 @@ mod image_attachments;
 mod media_type;
 mod office_install;
 mod office_pdf;
+#[cfg(target_os = "macos")]
+mod office_sandbox;
 mod updater;
 mod voice_transcription;
 

--- a/crates/openwave-desktop/src/office_pdf.rs
+++ b/crates/openwave-desktop/src/office_pdf.rs
@@ -9,12 +9,12 @@
 //! download or an install hint, not an error.
 //!
 //! The converter processes untrusted bytes, so the invocation is contained
-//! the way the rest of the app treats external processes: an empty
-//! environment, a throwaway working directory that also holds the LibreOffice
-//! profile, piped stdio, a hard timeout with `kill_on_drop`, and size caps on
-//! both input and output. It is not yet wrapped in the exec sandbox profile —
-//! that profile denies the application directories LibreOffice lives in and
-//! widening it is real design work, recorded as a known gap.
+//! the way the rest of the app treats external processes: on macOS it runs
+//! under `sandbox-exec` with the profile in [`crate::office_sandbox`] — no IP
+//! network, no writes outside the throwaway directory, the user's files
+//! unreadable — plus an empty environment, a throwaway working directory that
+//! also holds the LibreOffice profile, piped stdio, a hard timeout with
+//! `kill_on_drop`, and size caps on both input and output.
 //!
 //! Converted PDFs are cached on disk under `derived/office-pdf/`, keyed by the
 //! SHA-256 of the source bytes. The directory sits deliberately outside
@@ -145,6 +145,9 @@ pub(crate) async fn convert_presentation_to_pdf(
         // half-removed install. To the user that is the same state as no
         // LibreOffice at all: the install hint is the actionable message.
         Err(ConversionError::Spawn) => return Ok(converter_missing()),
+        Err(ConversionError::Sandbox(reason)) => {
+            return Err(format!("Could not sandbox LibreOffice: {reason}"))
+        }
         Err(ConversionError::Failed(reason)) => return Err(reason),
     };
 
@@ -300,8 +303,35 @@ const PATH_BINARY_NAMES: &[&str] = &["soffice", "libreoffice"];
 enum ConversionError {
     /// The binary would not start; indistinguishable from not installed.
     Spawn,
+    /// The confinement itself could not be established. Deliberately its own
+    /// state: it says nothing about the document and everything about this
+    /// host, and it must never be answered by running LibreOffice unconfined.
+    Sandbox(String),
     /// LibreOffice ran and did not produce a usable PDF.
     Failed(String),
+}
+
+/// The command that runs one conversion: on macOS, `sandbox-exec` wrapping
+/// `soffice` with the profile from [`crate::office_sandbox`].
+///
+/// Elsewhere the converter is invoked directly, unchanged. Nothing but the
+/// desktop app converts today and its office rendering is macOS-only in
+/// practice, so no second confinement mechanism is invented here; a Windows
+/// or Linux converter needs its own and this is where it would go.
+#[cfg(target_os = "macos")]
+fn converter_command(soffice: &Path, workdir: &Path) -> Result<Command, ConversionError> {
+    // A converter that vanished between resolution and here is the
+    // missing-converter state, not a sandbox fault; the profile builder would
+    // otherwise report its failure to resolve the path.
+    if !soffice.exists() {
+        return Err(ConversionError::Spawn);
+    }
+    crate::office_sandbox::confined_command(soffice, workdir).map_err(ConversionError::Sandbox)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn converter_command(soffice: &Path, _workdir: &Path) -> Result<Command, ConversionError> {
+    Ok(Command::new(soffice))
 }
 
 /// Run one headless conversion in a throwaway directory.
@@ -332,7 +362,7 @@ async fn run_conversion(
         .await
         .map_err(|error| ConversionError::Failed(format!("workspace: {error}")))?;
 
-    let mut command = Command::new(soffice);
+    let mut command = converter_command(soffice, workdir.path())?;
     command
         .arg("--headless")
         .arg("--nologo")
@@ -381,6 +411,15 @@ async fn run_conversion(
     let metadata = tokio::fs::metadata(&produced).await;
     let produced_len = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
     if !output.status.success() || produced_len == 0 {
+        let detail = String::from_utf8_lossy(&output.stderr);
+        let detail = brief(detail.trim());
+        // `sandbox-exec` announces its own failures — an unusable profile, a
+        // converter it could not launch under one — before LibreOffice writes
+        // anything. Keeping that distinct matters: it is a host problem to
+        // report, not a document that failed to convert.
+        if detail.starts_with("sandbox-exec:") {
+            return Err(ConversionError::Sandbox(detail));
+        }
         // Package managers leave launcher scripts behind after the
         // application is removed; those spawn fine and then exit with the
         // shell's not-found / not-executable codes. Same state as no install.
@@ -390,8 +429,6 @@ async fn run_conversion(
         // The reason travels to the failure card, so it names what actually
         // happened: LibreOffice's own words when it said any, its exit status
         // when it did not.
-        let detail = String::from_utf8_lossy(&output.stderr);
-        let detail = brief(detail.trim());
         return Err(ConversionError::Failed(if detail.is_empty() {
             format!(
                 "LibreOffice produced no PDF ({})",
@@ -537,6 +574,11 @@ impl openwave_code_execution::HostOfficeConverter for ExecOfficeConverter {
             // A resolved path that will not spawn is the same state as no
             // LibreOffice at all.
             Err(ConversionError::Spawn) => Err(OfficeConvertError::ConverterMissing),
+            // A confinement failure is reported as itself, not folded into a
+            // conversion failure: the document is fine and the host is not.
+            Err(ConversionError::Sandbox(reason)) => Err(OfficeConvertError::Failed(format!(
+                "could not sandbox LibreOffice: {reason}"
+            ))),
             Err(ConversionError::Failed(reason)) => Err(OfficeConvertError::Failed(reason)),
         }
     }
@@ -595,10 +637,12 @@ mod tests {
         assert!(uri.contains("OpenWave%20Preview/profile%20%231"), "{uri}");
     }
 
-    /// End-to-end proof against a real LibreOffice, when one is installed.
-    /// Skips silently otherwise — CI runners and most dev machines carry no
-    /// LibreOffice, and its absence is exactly the state the feature designs
-    /// for, not a test failure.
+    /// End-to-end proof against a real LibreOffice, when one is installed —
+    /// and, on macOS, proof that it converts *under the Seatbelt profile*,
+    /// which is the only way that profile is ever checked against a real
+    /// `soffice`. Skips silently otherwise — CI runners and most dev machines
+    /// carry no LibreOffice, and its absence is exactly the state the feature
+    /// designs for, not a test failure.
     #[tokio::test]
     async fn converts_a_real_deck_when_libreoffice_is_installed() {
         let Some(soffice) = system_soffice() else {
@@ -615,6 +659,9 @@ mod tests {
             // spawn; that is the missing-converter state, not a defect.
             Err(ConversionError::Spawn) => {
                 eprintln!("skipping: resolved LibreOffice cannot spawn");
+            }
+            Err(ConversionError::Sandbox(reason)) => {
+                panic!("the converter could not be sandboxed: {reason}")
             }
             Err(ConversionError::Failed(reason)) => {
                 panic!("conversion failed with LibreOffice present: {reason}")

--- a/crates/openwave-desktop/src/office_sandbox.rs
+++ b/crates/openwave-desktop/src/office_sandbox.rs
@@ -1,0 +1,253 @@
+//! Seatbelt confinement for the host-side LibreOffice conversion.
+//!
+//! Rendering an office file to PDF hands attacker-influenceable bytes to a
+//! large C++ codebase, with no tool call and no approval in front of it: after
+//! any successful exec, every `.docx`/`.pptx`/`.xlsx` the agent wrote under
+//! `output/` is converted automatically. The converter therefore runs the way
+//! the agent's own commands do — under `sandbox-exec`, on a profile built here
+//! — so a LibreOffice memory-safety bug buys the document neither the user's
+//! files nor the network.
+//!
+//! The profile is empirical: it was iterated against a real conversion of a
+//! deck, a Writer document, and a spreadsheet with the pinned LibreOffice
+//! 25.8.7, widened only where a run actually failed. What the conversion turned
+//! out to need, and why each allowance is here rather than absent:
+//!
+//! - **A UNIX-domain socket.** LibreOffice always sets up its single-instance
+//!   IPC pipe, even headless; denying `network*` outright makes `soffice` exit
+//!   zero having written nothing. Only `local`/`remote unix` is allowed, so
+//!   nothing reaches an IP address — the property that matters.
+//! - **A writable `/tmp` entry for that pipe.** The socket path is compiled
+//!   into LibreOffice as `/tmp/OSL_PIPE_…` and does not follow `TMPDIR`; it
+//!   probes `/tmp` for writability first. The allowance is the directory entry
+//!   plus a regex pinned to that filename prefix, not the directory's contents.
+//! - **`mach-lookup`.** CoreText and friends fail in unpredictable ways without
+//!   it. A curated `global-name` list did convert, but logged XPC failures and
+//!   would be a per-macOS-version liability; the broad allowance is a deliberate
+//!   trade of secondary hardening for a converter that works on every host.
+//!
+//! Reads are allow-by-default with the user's data denied, matching the exec
+//! profile's shape (`openwave-code-execution`'s `macos_profile`): a converter
+//! that cannot read `/Users` cannot exfiltrate documents, and enumerating
+//! everything LibreOffice reads out of `/System` is not a bet worth taking.
+//! Writes are the reverse — deny by default, with the throwaway workdir the
+//! only place bytes can land.
+
+use std::path::{Path, PathBuf};
+
+use openwave_code_execution::sbpl;
+use tokio::process::Command;
+
+/// Reads that are denied outright. The user's own files, the login/keychain
+/// stores, and installed applications: everything the conversion has no
+/// business reading, whatever a crafted document talks it into.
+const DENIED_READS: &[&str] = &[
+    "/Applications",
+    "/Library/Keychains",
+    "/Library/Preferences",
+    "/Network",
+    "/System/Volumes/Data/Library/Keychains",
+    "/System/Volumes/Data/Users",
+    "/System/Volumes/Data/Volumes",
+    "/Users",
+    "/Volumes",
+    "/opt",
+    "/private/var/db/dslocal",
+    "/private/var/root",
+];
+
+/// The per-user cache directory, denied by pattern rather than by prefix.
+///
+/// `/private/var/folders/<x>/<y>/` holds both `C` (that user's application
+/// caches — worth denying) and `T` (the temp root, where the conversion's own
+/// throwaway directory lives, and which LibreOffice must be able to read).
+/// Denying the whole tree hangs the conversion, so only the cache half goes.
+const DENIED_USER_CACHE: &str = r#"(regex #"^/private/var/folders/[^/]+/[^/]+/C(/|$)")"#;
+
+/// LibreOffice installs whose bundle is readable even though the deny list
+/// covers the directory it sits in. A user-installed copy lives under
+/// `/Applications` or the home directory, and the managed install lives under
+/// the app's data directory in `~/Library`; a launcher script on `PATH` execs
+/// one of these rather than itself being the binary.
+fn known_bundle_roots() -> Vec<PathBuf> {
+    let mut roots = vec![PathBuf::from("/Applications/LibreOffice.app")];
+    if let Some(home) = std::env::var_os("HOME") {
+        roots.push(PathBuf::from(home).join("Applications/LibreOffice.app"));
+    }
+    roots
+}
+
+/// The confined converter invocation: `sandbox-exec` carrying the profile for
+/// this conversion, with the converter resolved to the path the kernel will
+/// see. The caller adds the LibreOffice arguments.
+///
+/// Executing the resolved path rather than the name it was found under is part
+/// of the confinement, not tidiness: a launcher on `PATH` is usually a symlink
+/// into a directory the profile denies, and the profile is written in terms of
+/// what paths resolve to.
+pub(crate) fn confined_command(soffice: &Path, workdir: &Path) -> Result<Command, String> {
+    if !Path::new(sbpl::SANDBOX_EXEC).is_file() {
+        return Err(
+            "the macOS sandbox (sandbox-exec) is missing, so the converter cannot be confined"
+                .to_owned(),
+        );
+    }
+    let converter = canonical(soffice)?;
+    let profile = profile(&converter, workdir)?;
+    let mut command = Command::new(sbpl::SANDBOX_EXEC);
+    command.arg("-p").arg(profile).arg("--").arg(&converter);
+    Ok(command)
+}
+
+/// The Seatbelt profile for one conversion.
+///
+/// `converter` is the resolved converter path and `workdir` the throwaway
+/// directory that is simultaneously the working directory, `HOME`, `TMPDIR`,
+/// the LibreOffice profile, the input, and the output. Both are host-resolved;
+/// no model-authored string reaches this function.
+fn profile(converter: &Path, workdir: &Path) -> Result<String, String> {
+    // Seatbelt matches resolved paths, so the workdir is canonicalized too: a
+    // temp root reached through `/var` -> `/private/var` would otherwise be
+    // allowed under a name the kernel never sees.
+    let workdir = canonical(workdir)?;
+    let mut read_roots = vec![bundle_root(converter)];
+    read_roots.extend(
+        known_bundle_roots()
+            .into_iter()
+            .filter(|root| root.is_dir())
+            .filter_map(|root| std::fs::canonicalize(root).ok()),
+    );
+    read_roots.sort();
+    read_roots.dedup();
+
+    let denied = DENIED_READS
+        .iter()
+        .map(|path| sbpl::subpath_str(path))
+        .chain(std::iter::once(DENIED_USER_CACHE.to_owned()))
+        .collect::<Vec<_>>()
+        .join("\n  ");
+    let converter_reads = read_roots
+        .iter()
+        .map(|path| sbpl::subpath(path))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| error.to_string())?
+        .join("\n  ");
+    // A bundle under a denied root is reached by path, and LibreOffice stats
+    // its way up from the binary; metadata on the ancestors keeps that working
+    // without opening the denied trees for reading.
+    let mut ancestors = read_roots
+        .iter()
+        .flat_map(|root| root.ancestors().skip(1))
+        .collect::<Vec<_>>();
+    ancestors.sort_unstable();
+    ancestors.dedup();
+    let converter_metadata = ancestors
+        .into_iter()
+        .map(sbpl::literal)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| error.to_string())?
+        .join("\n  ");
+    let workdir = sbpl::subpath(&workdir).map_err(|error| error.to_string())?;
+
+    Ok(format!(
+        "(version 1)\n\
+         (deny default)\n\
+         (allow process-exec)\n\
+         (allow process-fork)\n\
+         (allow signal (target self))\n\
+         (allow sysctl-read)\n\
+         (allow ipc-posix-shm)\n\
+         (allow mach-lookup)\n\
+         (allow network-bind (local unix))\n\
+         (allow network-outbound (local unix) (remote unix))\n\
+         (allow file-read*)\n\
+         (deny file-read*\n  {denied})\n\
+         (allow file-read-metadata\n  {converter_metadata})\n\
+         (allow file-read*\n  {converter_reads}\n  {workdir})\n\
+         (allow file-write*\n  {workdir}\n  \
+         (literal \"/private/tmp\")\n  \
+         (regex #\"^/private/tmp/OSL_PIPE_[^/]*$\")\n  \
+         (literal \"/dev/null\"))\n"
+    ))
+}
+
+/// The application bundle a converter binary belongs to, or its own directory
+/// when the binary is not bundled. Allowing the bundle rather than the binary
+/// is required: `soffice` is a launcher that loads the rest of the install.
+fn bundle_root(converter: &Path) -> PathBuf {
+    converter
+        .ancestors()
+        .find(|ancestor| ancestor.extension().is_some_and(|ext| ext == "app"))
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| {
+            converter
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| converter.to_path_buf())
+        })
+}
+
+fn canonical(path: &Path) -> Result<PathBuf, String> {
+    std::fs::canonicalize(path).map_err(|error| {
+        format!(
+            "could not resolve {} for the sandbox: {error}",
+            path.display()
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The properties the profile exists for: no IP network, no writes outside
+    /// the throwaway workdir, and the user's files unreadable.
+    #[test]
+    fn profile_confines_reads_writes_and_network() {
+        let workdir = tempfile::tempdir().expect("workdir");
+        let install = tempfile::tempdir().expect("install");
+        let bundle = install.path().join("LibreOffice.app/Contents/MacOS");
+        std::fs::create_dir_all(&bundle).expect("bundle");
+        let soffice = bundle.join("soffice");
+        std::fs::write(&soffice, b"#!/bin/sh\n").expect("soffice");
+        let converter = std::fs::canonicalize(&soffice).expect("canonical converter");
+
+        let profile = profile(&converter, workdir.path()).expect("profile");
+
+        assert!(profile.contains("(deny default)"));
+        // The only network allowances are UNIX-domain; nothing reaches an IP.
+        assert!(!profile.contains("(remote ip"), "{profile}");
+        assert!(!profile.contains("network-outbound (local ip"), "{profile}");
+        assert!(profile.contains("(allow network-outbound (local unix) (remote unix))"));
+        // Reads: the user's home is denied and is not silently re-allowed.
+        assert!(profile.contains("(deny file-read*"));
+        assert!(profile.contains("(subpath \"/Users\")"));
+        // Writes: the workdir, and nothing of the user's or the converter's.
+        let write_rule = profile
+            .split("(allow file-write*")
+            .nth(1)
+            .expect("profile has a write rule");
+        let canonical_workdir = std::fs::canonicalize(workdir.path()).expect("canonical workdir");
+        assert!(write_rule.contains(&sbpl::subpath(&canonical_workdir).unwrap()));
+        assert!(!write_rule.contains("/Users"), "{write_rule}");
+        assert!(!write_rule.contains("LibreOffice.app"), "{write_rule}");
+        // The converter bundle is readable as a whole, not just its launcher.
+        let canonical_bundle = std::fs::canonicalize(install.path())
+            .expect("canonical install")
+            .join("LibreOffice.app");
+        assert!(
+            profile.contains(&sbpl::subpath(&canonical_bundle).unwrap()),
+            "{profile}"
+        );
+    }
+
+    /// An install that is not an application bundle still gets a read root:
+    /// the launcher's own directory, never the whole filesystem.
+    #[test]
+    fn unbundled_converter_falls_back_to_its_own_directory() {
+        let dir = tempfile::tempdir().expect("dir");
+        let soffice = dir.path().join("soffice");
+        std::fs::write(&soffice, b"#!/bin/sh\n").expect("soffice");
+        assert_eq!(bundle_root(&soffice), dir.path());
+    }
+}


### PR DESCRIPTION
After every successful exec, the office render pass hands each `.docx`/`.pptx`/`.xlsx` the agent wrote under `output/` to `soffice` on the host, with no tool call, no approval, and no confinement. A prompt-injected agent could author a malformed document and have a large, historically CVE-prone C++ codebase parse it with the user's full privileges.

`soffice` now runs under `sandbox-exec`, on a profile built for this one job.

## The profile

- **Writes: deny by default.** The only writable location is the throwaway workdir that is simultaneously the working directory, `HOME`, `TMPDIR`, the LibreOffice user profile, the input and the output — plus `/dev/null`, and one narrow `/tmp` allowance explained below.
- **Reads: allow by default, with the user's data denied** — `/Users`, `/Volumes`, `/Network`, the keychain stores, `dslocal`, `/Applications`, `/opt`, and the per-user cache directory. The converter's own bundle is re-allowed after the denies, since both a user install and the managed install sit under denied roots. This mirrors the exec profile's shape: enumerating everything LibreOffice reads out of `/System` is not a bet worth taking, and a converter that cannot read `/Users` cannot exfiltrate documents.
- **No IP network.** Nothing in the profile allows one.

Three allowances exist only because a real run demanded them, and each was narrowed until it was the smallest thing that worked:

- **UNIX-domain sockets.** LibreOffice sets up its single-instance IPC pipe even in `--headless --convert-to` mode. Denying `network*` outright makes `soffice` exit zero having written nothing — a silent failure. Only `local`/`remote unix` is allowed.
- **A writable `/tmp` entry for that pipe.** The socket path is compiled into LibreOffice as `/tmp/OSL_PIPE_…` and does not follow `TMPDIR`; it probes `/tmp` for writability first, so the allowance is the directory entry plus a regex pinned to that filename prefix. Nothing else under `/tmp` is writable.
- **`mach-lookup`.** A curated `global-name` list did convert, but logged XPC failures and would be a per-macOS-version liability. Broad `mach-lookup` is a deliberate trade of secondary hardening for a converter that works on every host.

One deny is a pattern rather than a prefix: `/private/var/folders/<x>/<y>/C` (the per-user cache) is denied, while `…/T` — the temp root the conversion's own workdir lives in — is not. Denying the whole `/private/var/folders` tree hangs the conversion until the timeout kills it.

## Shared machinery

SBPL escaping and the `sandbox-exec` path move to `openwave_code_execution::sbpl`, used by both the exec profile and this one. The rule that matters — a quote or backslash in a path must never be able to close the string literal and append clauses — now has one implementation instead of two.

The converter is also executed by its resolved path rather than the name it was found under: a launcher on `PATH` is typically a symlink into a directory the profile denies, and Seatbelt matches what paths resolve to.

## Failure modes

A confinement failure (`sandbox-exec` missing, a path that cannot be escaped, `sandbox-exec` refusing the profile) is its own error state, distinct from a conversion failure and from a missing converter, in both the preview command and the exec render seam. It is never answered by running LibreOffice unconfined.

Non-macOS hosts are unchanged: office conversion is macOS-only in practice, and inventing a second confinement mechanism for a path nothing exercises would be speculative.

## Verification

Verified against a real LibreOffice — the exact pinned artifact the app installs (25.8.7 aarch64, digest matching `office_install`'s pin), since no LibreOffice was installed on this machine:

- `office_pdf::tests::converts_a_real_deck_when_libreoffice_is_installed` converts the fixture deck end to end **through the sandbox**, both with the bundle on a system path and with it inside `~/Library` (the managed-install shape, where the bundle sits under a denied read root). That test was already the profile's only real check; it now fails loudly on a confinement error instead of treating it as a conversion failure.
- Outside the test, the same profile shape was driven against a Writer document and a spreadsheet as well as the deck, and each candidate tightening was re-run until the narrowest working set was found. The failures that shaped it (silent zero-exit without `/tmp` or UNIX sockets, a hang with the whole per-user temp tree denied) are recorded in the module docs so the next person does not rediscover them.
- `cargo clippy -p openwave-desktop -p openwave-code-execution --all-targets`, and both crates' test suites, are clean.

Closes #1458
