### PR TITLE
fix(server): hold MCP environment values in the secret store, not the definition

### DIFF
--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -241,7 +241,11 @@ export type McpHealth = WireMcpHealth;
 /** Typed stdio process data. Values are argv entries, never shell source. */
 export type McpServerDefinition = WireMcpServerDefinition;
 
-/** Renderer-safe health projection. Resolved `env_from` values are never sent. */
+/**
+ * Renderer-safe health projection. No environment value of any kind is sent:
+ * `env` and `env_from` carry names, and the values behind them live in the
+ * host process or the OS credential store.
+ */
 export type McpServerInfo = WireMcpServerInfo;
 
 export type McpServersInfo = WireMcpServersInfo;

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1000,9 +1000,20 @@ export type McpHealth = "initializing" | "healthy" | "degraded" | "reconnecting"
  */
 export type McpServerDefinition = { name: string, command: string | null, args: Array<string>, 
 /**
- * Explicit literal values. The UI labels these as non-secret.
+ * Names of the environment variables this server is given directly. The
+ * values live in the secret store under [`env_secret_key`] and never
+ * enter this type, so they neither persist in the connected-app record
+ * nor project through the API.
  */
-env: { [key in string]: string }, 
+env: Array<string>, 
+/**
+ * Inbound-only: values for [`env`](Self::env) names being set or
+ * changed. A commit writes these into the secret store and drops them; a
+ * name present in `env` but absent here keeps the value already stored,
+ * which is what makes "leave blank to keep" work. `skip_serializing`
+ * keeps them out of both the persisted record and every projection.
+ */
+env_values?: { [key in string]: string }, 
 /**
  * Parent environment names to forward. Their values never enter this type.
  */
@@ -1030,9 +1041,20 @@ gateway_endpoint: string | null, request_timeout_ms: number, enabled: boolean, }
  */
 export type McpServerInfo = { health: McpHealth, tool_count: number, diagnostic: string | null, name: string, command: string | null, args: Array<string>, 
 /**
- * Explicit literal values. The UI labels these as non-secret.
+ * Names of the environment variables this server is given directly. The
+ * values live in the secret store under [`env_secret_key`] and never
+ * enter this type, so they neither persist in the connected-app record
+ * nor project through the API.
  */
-env: { [key in string]: string }, 
+env: Array<string>, 
+/**
+ * Inbound-only: values for [`env`](Self::env) names being set or
+ * changed. A commit writes these into the secret store and drops them; a
+ * name present in `env` but absent here keeps the value already stored,
+ * which is what makes "leave blank to keep" work. `skip_serializing`
+ * keeps them out of both the persisted record and every projection.
+ */
+env_values?: { [key in string]: string }, 
 /**
  * Parent environment names to forward. Their values never enter this type.
  */

--- a/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
@@ -12,7 +12,7 @@ const docsServer: McpServerInfo = {
   name: "docs",
   command: "/usr/local/bin/docs-mcp",
   args: [],
-  env: {},
+  env: [],
   env_from: [],
   cwd: null,
   url: null,

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
@@ -23,7 +23,7 @@ const healthy: McpServersInfo = {
       name: "private_docs",
       command: "/opt/mcp/docs",
       args: ["--stdio"],
-      env: { LOG_LEVEL: "info" },
+      env: ["LOG_LEVEL"],
       env_from: ["PRIVATE_DOCS_TOKEN"],
       cwd: "/tmp/docs",
       url: null,
@@ -56,7 +56,7 @@ function gatewayMount(
     name: slug,
     command: null,
     args: [],
-    env: {},
+    env: [],
     env_from: [],
     cwd: null,
     url: null,
@@ -165,6 +165,42 @@ describe("McpPanel", () => {
     );
   });
 
+  it("shows an existing environment value as blank and keeps it unless retyped", async () => {
+    const client = api();
+    const user = userEvent.setup();
+    render(<McpPanel client={client} />);
+
+    await screen.findByText("Healthy");
+    // The server returns names only, so the value field starts empty and is
+    // password-typed — people put credentials here whatever the label says.
+    const value = screen.getByLabelText("Environment value 1");
+    expect(value).toHaveValue("");
+    expect(value).toHaveAttribute("type", "password");
+
+    // Saving without touching it sends no value for that name, which is what
+    // tells the server to keep the stored one.
+    await user.click(screen.getByRole("button", { name: "Save and verify" }));
+    await waitFor(() =>
+      expect(client.putMcpServers).toHaveBeenCalledWith([
+        expect.objectContaining({ env: ["LOG_LEVEL"] }),
+      ]),
+    );
+    expect(
+      vi.mocked(client.putMcpServers).mock.calls[0][0][0].env_values ?? {},
+    ).toEqual({});
+
+    await user.type(value, "rotated-secret");
+    await user.click(screen.getByRole("button", { name: "Save and verify" }));
+    await waitFor(() =>
+      expect(client.putMcpServers).toHaveBeenLastCalledWith([
+        expect.objectContaining({
+          env: ["LOG_LEVEL"],
+          env_values: { LOG_LEVEL: "rotated-secret" },
+        }),
+      ]),
+    );
+  });
+
   it("reconnects by namespace and replaces the displayed health snapshot", async () => {
     const client = api();
     const user = userEvent.setup();
@@ -224,7 +260,7 @@ describe("McpPanel", () => {
         expect.objectContaining({
           command: null,
           args: [],
-          env: {},
+          env: [],
           env_from: [],
           cwd: null,
           url: "http://127.0.0.1:28081/mcp/tools",
@@ -280,7 +316,7 @@ describe("McpPanel", () => {
               name: "gateway",
               command: null,
               args: [],
-              env: {},
+              env: [],
               env_from: [],
               cwd: null,
               url: "http://127.0.0.1:28081/mcp/tools",
@@ -339,7 +375,7 @@ describe("McpPanel", () => {
           name: "tools",
           command: null,
           args: [],
-          env: {},
+          env: [],
           env_from: [],
           cwd: null,
           url: null,
@@ -651,7 +687,7 @@ describe("McpPanel", () => {
           name: "legacy_docs",
           command: "/opt/mcp/docs",
           args: ["--stdio"],
-          env: { LOG_LEVEL: "info" },
+          env: ["LOG_LEVEL"],
           env_from: ["PRIVATE_DOCS_TOKEN"],
           cwd: "/tmp/docs",
           url: null,

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
@@ -32,7 +32,7 @@ function emptyServer(index: number): McpServerInfo {
     name: `server_${index + 1}`,
     command: "",
     args: [],
-    env: {},
+    env: [],
     env_from: [],
     cwd: null,
     url: null,
@@ -60,7 +60,7 @@ function transportFields(transport: "stdio" | "http"): Partial<McpServerInfo> {
     ? {
         command: null,
         args: [],
-        env: {},
+        env: [],
         env_from: [],
         cwd: null,
         url: "",
@@ -603,9 +603,12 @@ export function McpPanel({
               {transportOf(server) === "stdio" && (
                 <>
                   <EnvironmentEditor
-                    values={server.env}
+                    names={server.env}
+                    values={server.env_values ?? {}}
                     disabled={working}
-                    onChange={(env) => update(index, { env })}
+                    onChange={(env, env_values) =>
+                      update(index, { env, env_values })
+                    }
                   />
 
                   <StringListEditor
@@ -701,10 +704,10 @@ export function McpPanel({
 
           <p className="text-sm leading-relaxed text-muted-foreground">
             MCP tools are always sensitive and keep OpenWave’s existing approval
-            boundary. Child environments start empty. Put credentials in the
-            host environment and select only their variable names above; do not
-            enter secrets in the executable, arguments, working directory,
-            literal values, or a server URL.
+            boundary. Child environments start empty. Environment values are
+            held in the OS credential store and never come back to this window;
+            do not enter secrets in the executable, arguments, working
+            directory, or a server URL, which are ordinary settings.
           </p>
         </>
       )}
@@ -783,7 +786,7 @@ function mountDefinition(slug: string, name: string): McpServerDefinition {
     name,
     command: null,
     args: [],
-    env: {},
+    env: [],
     env_from: [],
     cwd: null,
     url: null,
@@ -1028,29 +1031,48 @@ function StringListEditor({
   );
 }
 
+/**
+ * The child's own environment: names on the left, values on the right.
+ *
+ * The server returns names only — a stored value never comes back — so an
+ * existing row's value field starts blank and staying blank keeps whatever is
+ * stored. Typing replaces it. That is why the inputs are password-style
+ * despite the label: people put API keys here regardless of what the label
+ * says, so the field is built for the credential case.
+ */
 function EnvironmentEditor({
+  names,
   values,
   disabled,
   onChange,
 }: {
+  names: string[];
   values: Record<string, string>;
   disabled: boolean;
-  onChange: (values: Record<string, string>) => void;
+  onChange: (names: string[], values: Record<string, string>) => void;
 }) {
-  const rows = Object.entries(values);
-  function replaceRow(index: number, name: string, value: string) {
-    const next = rows.map(([key, item], itemIndex) =>
-      itemIndex === index ? ([name, value] as const) : ([key, item] as const),
+  function replaceRow(index: number, name: string, value: string | null) {
+    const previous = names[index];
+    const nextNames = names.map((item, itemIndex) =>
+      itemIndex === index ? name : item,
     );
-    onChange(Object.fromEntries(next));
+    const nextValues: Record<string, string> = {};
+    for (const [key, item] of Object.entries(values)) {
+      if (key !== previous) nextValues[key] = item;
+    }
+    // A renamed row cannot keep a value it never showed: the stored value
+    // belongs to the old name, and the new one starts unset.
+    const carried = value ?? (name === previous ? values[previous] : undefined);
+    if (carried !== undefined && carried !== "") nextValues[name] = carried;
+    onChange(nextNames, nextValues);
   }
   return (
     <FieldGroup
-      label="Literal non-secret environment"
-      hint="These values are displayed and stored as ordinary settings. Never put credentials here."
+      label="Environment"
+      hint="Values are held in the OS credential store, never in settings, and are never sent back to this window. Leave a value blank to keep the one already stored."
     >
       <div className="flex flex-col gap-2">
-        {rows.map(([name, value], index) => (
+        {names.map((name, index) => (
           <div className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] gap-2" key={index}>
             <Input
               aria-label={`Environment name ${index + 1}`}
@@ -1059,14 +1081,13 @@ function EnvironmentEditor({
               disabled={disabled}
               autoComplete="off"
               spellCheck={false}
-              onChange={(event) =>
-                replaceRow(index, event.target.value, value)
-              }
+              onChange={(event) => replaceRow(index, event.target.value, null)}
             />
             <Input
+              type="password"
               aria-label={`Environment value ${index + 1}`}
-              placeholder="non-secret value"
-              value={value}
+              placeholder="leave blank to keep"
+              value={values[name] ?? ""}
               disabled={disabled}
               autoComplete="off"
               spellCheck={false}
@@ -1079,13 +1100,14 @@ function EnvironmentEditor({
               variant="outline"
               aria-label={`Remove environment value ${index + 1}`}
               disabled={disabled}
-              onClick={() =>
+              onClick={() => {
+                const nextValues = { ...values };
+                delete nextValues[name];
                 onChange(
-                  Object.fromEntries(
-                    rows.filter((_, itemIndex) => itemIndex !== index),
-                  ),
-                )
-              }
+                  names.filter((_, itemIndex) => itemIndex !== index),
+                  nextValues,
+                );
+              }}
             >
               <Trash2 size={14} />
             </Button>
@@ -1096,10 +1118,10 @@ function EnvironmentEditor({
           variant="outline"
           className="self-start"
           disabled={disabled}
-          onClick={() => onChange({ ...values, "": "" })}
+          onClick={() => onChange([...names, ""], values)}
         >
           <Plus size={14} />
-          Add literal value
+          Add variable
         </Button>
       </div>
     </FieldGroup>

--- a/crates/openwave-server/src/gateway_runtime.rs
+++ b/crates/openwave-server/src/gateway_runtime.rs
@@ -1101,6 +1101,7 @@ mod tests {
         Arc::new(crate::mcp_config::McpRuntime::new(
             Arc::new(openwave_core::ToolRegistry::new()),
             store.clone(),
+            Arc::new(MockSecrets::default()),
             runtime.clone(),
             Arc::new(crate::managed_policy::NoOsPolicy),
         ))
@@ -1406,7 +1407,8 @@ mod tests {
             name: "tools".to_string(),
             command: None,
             args: Vec::new(),
-            env: std::collections::BTreeMap::new(),
+            env: std::collections::BTreeSet::new(),
+            env_values: std::collections::BTreeMap::new(),
             env_from: Vec::new(),
             cwd: None,
             url: None,
@@ -1595,7 +1597,8 @@ mod tests {
                     name: "tools".to_string(),
                     command: None,
                     args: Vec::new(),
-                    env: std::collections::BTreeMap::new(),
+                    env: std::collections::BTreeSet::new(),
+                    env_values: std::collections::BTreeMap::new(),
                     env_from: Vec::new(),
                     cwd: None,
                     url: None,

--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -2,13 +2,14 @@
 //!
 //! A definition is either a local stdio child process or a remote Streamable
 //! HTTP endpoint. Definitions are typed data, never shell fragments. Every
-//! child starts with a cleared environment and receives only literal values
-//! explicitly marked non-secret plus values selected by *name* from the parent
-//! environment; an HTTP server's bearer token is likewise selected by name.
-//! Selected values are resolved only at the connection boundary and are never
-//! stored or projected through the API.
+//! child starts with a cleared environment and receives only values named by
+//! the definition: literal values held in the secret store, plus values
+//! selected by *name* from the parent environment. An HTTP server's bearer
+//! token is likewise selected by name. **No environment value of any kind
+//! lives in a definition**: the connected-app record and every API projection
+//! carry names only, and values are resolved at the connection boundary.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -20,7 +21,7 @@ use futures::future::join_all;
 use openwave_core::connected_app::{ConnectedApp, ConnectedAppKind};
 use openwave_core::id::ConnectedAppId;
 use openwave_core::local_app::CREATE_APP_TOOL;
-use openwave_core::{AgentError, Result, Store, ToolRegistry};
+use openwave_core::{AgentError, Result, SecretProvider, Store, ToolRegistry};
 use openwave_mcp::{McpClient, McpProbe, MAX_SERVER_NAME_BYTES};
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
@@ -156,9 +157,19 @@ pub(crate) struct McpServerDefinition {
     pub(crate) command: Option<String>,
     #[serde(default)]
     pub(crate) args: Vec<String>,
-    /// Explicit literal values. The UI labels these as non-secret.
+    /// Names of the environment variables this server is given directly. The
+    /// values live in the secret store under [`env_secret_key`] and never
+    /// enter this type, so they neither persist in the connected-app record
+    /// nor project through the API.
     #[serde(default)]
-    pub(crate) env: BTreeMap<String, String>,
+    pub(crate) env: BTreeSet<String>,
+    /// Inbound-only: values for [`env`](Self::env) names being set or
+    /// changed. A commit writes these into the secret store and drops them; a
+    /// name present in `env` but absent here keeps the value already stored,
+    /// which is what makes "leave blank to keep" work. `skip_serializing`
+    /// keeps them out of both the persisted record and every projection.
+    #[serde(default, skip_serializing)]
+    pub(crate) env_values: BTreeMap<String, String>,
     /// Parent environment names to forward. Their values never enter this type.
     #[serde(default)]
     pub(crate) env_from: Vec<String>,
@@ -190,7 +201,7 @@ impl std::fmt::Debug for McpServerDefinition {
             .field("name", &self.name)
             .field("command", &self.command)
             .field("argument_count", &self.args.len())
-            .field("env_names", &self.env.keys().collect::<Vec<_>>())
+            .field("env_names", &self.env.iter().collect::<Vec<_>>())
             .field("env_from", &self.env_from)
             .field("cwd", &self.cwd)
             .field("url", &self.url)
@@ -244,7 +255,10 @@ pub(crate) struct GatewayEndpointAccess {
 }
 
 impl McpServerDefinition {
-    fn build_command(&self) -> Result<Command> {
+    /// Build the child command. `env` is the definition's literal environment
+    /// as resolved from the secret store — passed in rather than read off the
+    /// definition, because the definition never holds values.
+    fn build_command(&self, env: &BTreeMap<String, String>) -> Result<Command> {
         let Some(program) = &self.command else {
             return Err(AgentError::config(
                 "MCP server definition has no command to spawn",
@@ -263,14 +277,24 @@ impl McpServerDefinition {
             })?;
             command.env(name, value);
         }
-        command.envs(&self.env);
+        // Only names the definition still declares: a resolved map that has
+        // drifted ahead of a just-edited definition must not widen the child.
+        for (name, value) in env {
+            if self.env.contains(name) {
+                command.env(name, value);
+            }
+        }
         if let Some(cwd) = &self.cwd {
             command.current_dir(cwd);
         }
         Ok(command)
     }
 
-    async fn connect(&self, gateway: &Arc<dyn GatewayEndpoints>) -> Result<McpClient> {
+    async fn connect(
+        &self,
+        gateway: &Arc<dyn GatewayEndpoints>,
+        env: &BTreeMap<String, String>,
+    ) -> Result<McpClient> {
         if let Some(slug) = &self.gateway_endpoint {
             // Resolved per connection: a reconnect always presents a token
             // that is fresh at that moment, so expiry is survived by the
@@ -306,7 +330,7 @@ impl McpServerDefinition {
         }
         McpClient::spawn_with_timeouts(
             self.name.clone(),
-            self.build_command()?,
+            self.build_command(env)?,
             INITIALIZATION_TIMEOUT,
             Duration::from_millis(self.request_timeout_ms),
         )
@@ -322,8 +346,9 @@ impl McpServerDefinition {
     async fn connect_with_views(
         &self,
         gateway: &Arc<dyn GatewayEndpoints>,
+        env: &BTreeMap<String, String>,
     ) -> Result<(McpClient, HashMap<String, UiViewDocument>)> {
-        let client = self.connect(gateway).await?;
+        let client = self.connect(gateway, env).await?;
         let uris: HashSet<String> = client
             .tools()
             .filter_map(|spec| client.ui_resource_uri(&spec.name))
@@ -393,7 +418,10 @@ impl McpServerDefinition {
 /// `env_names` is the sorted *names* of the literal `env` entries and
 /// `env_from` the sorted selected parent-environment names — configuration
 /// values and resolved secrets never enter the canonical form, so the
-/// fingerprint can never be a value oracle. `bearer_token_env_set` records
+/// fingerprint can never be a value oracle. That is also why moving the
+/// literal values out of the definition and into the secret store did not
+/// bump `v`: the canonical form only ever saw the names, which are unchanged,
+/// so every grant issued before the move still matches after it. `bearer_token_env_set` records
 /// only whether a bearer name is selected. `cwd` is the configured path,
 /// lossily UTF-8. The `v:1` form excluded the server name because grants were
 /// keyed by it; app-keyed grants pin a record id instead, so `namespace`
@@ -427,7 +455,7 @@ pub(crate) fn definition_fingerprint(definition: &McpServerDefinition) -> [u8; 3
         gateway_endpoint: Option<&'a str>,
     }
 
-    let mut env_names: Vec<&str> = definition.env.keys().map(String::as_str).collect();
+    let mut env_names: Vec<&str> = definition.env.iter().map(String::as_str).collect();
     env_names.sort_unstable();
     let mut env_from: Vec<&str> = definition.env_from.iter().map(String::as_str).collect();
     env_from.sort_unstable();
@@ -463,6 +491,49 @@ const fn default_request_timeout_ms() -> u64 {
     DEFAULT_REQUEST_TIMEOUT_MS
 }
 
+/// Secret-store key holding one server's literal environment: a JSON object
+/// of name → value.
+///
+/// Derived from the connected-app record id, never from anything in a
+/// request, so this surface can only ever read and write its own secrets.
+/// Mirrors `rest_credential_secret_key` for the REST connected-app kind.
+fn env_secret_key(id: ConnectedAppId) -> String {
+    format!("mcp.{id}.env_v1")
+}
+
+/// Lift literal `env` values out of a connected-app record persisted before
+/// the values moved into the secret store, leaving `env` in the name-array
+/// shape the current definition uses.
+///
+/// Definitions written before that move stored `env` as a JSON object of
+/// name → value, in cleartext, in `connected_app.definition_json`. Rejecting
+/// them would take working MCP servers down at boot, so they are migrated
+/// instead: the values come out here and the loader writes them to the secret
+/// store and rewrites the record. Names are unchanged, so the definition
+/// fingerprint — and therefore every app grant pinned to it — survives the
+/// migration untouched. A record already in the new shape yields nothing and
+/// takes no write.
+fn take_legacy_env_values(definition: &mut serde_json::Value) -> BTreeMap<String, String> {
+    let Some(entries) = definition
+        .get("env")
+        .and_then(serde_json::Value::as_object)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|(name, value)| Some((name.clone(), value.as_str()?.to_string())))
+                .collect::<BTreeMap<String, String>>()
+        })
+    else {
+        return BTreeMap::new();
+    };
+    definition["env"] = serde_json::Value::Array(
+        entries
+            .keys()
+            .map(|name| serde_json::Value::String(name.clone()))
+            .collect(),
+    );
+    entries
+}
 const fn enabled_by_default() -> bool {
     true
 }
@@ -652,6 +723,9 @@ pub(crate) struct McpRuntime {
     state: Mutex<RuntimeState>,
     mutation: Mutex<()>,
     store: Arc<dyn Store>,
+    /// Holds each server's literal environment values, keyed by record id.
+    /// Definitions carry only the names.
+    secrets: Arc<dyn SecretProvider>,
     /// Resolves gateway-managed endpoints at every connection.
     gateway: Arc<dyn GatewayEndpoints>,
     /// The OS authority for managed-mode resolution. Managed policy locks the
@@ -665,6 +739,7 @@ impl McpRuntime {
     pub(crate) fn new(
         base_tools: Arc<ToolRegistry>,
         store: Arc<dyn Store>,
+        secrets: Arc<dyn SecretProvider>,
         gateway: Arc<dyn GatewayEndpoints>,
         os_policy: Arc<dyn crate::managed_policy::OsPolicySource>,
     ) -> Self {
@@ -678,10 +753,97 @@ impl McpRuntime {
             }),
             mutation: Mutex::new(()),
             store,
+            secrets,
             gateway,
             os_policy,
             next_epoch: AtomicU64::new(1),
         }
+    }
+
+    /// One server's literal environment as stored, by record id. A missing or
+    /// unreadable entry resolves empty: the child then starts without those
+    /// names and fails with the server's own diagnostic, which beats taking
+    /// an unrelated settings save down.
+    async fn stored_env(&self, id: ConnectedAppId) -> BTreeMap<String, String> {
+        match self.secrets.get_secret(&env_secret_key(id)).await {
+            Ok(Some(raw)) => serde_json::from_str(&raw).unwrap_or_default(),
+            Ok(None) => BTreeMap::new(),
+            Err(error) => {
+                tracing::warn!(%error, "could not read stored MCP environment values");
+                BTreeMap::new()
+            }
+        }
+    }
+
+    /// The environment to hand each definition's child, resolved once for a
+    /// whole replacement so the connections below can run concurrently.
+    async fn resolve_envs(
+        &self,
+        definitions: &[McpServerDefinition],
+        ids: &BTreeMap<String, ConnectedAppId>,
+    ) -> HashMap<String, BTreeMap<String, String>> {
+        let mut resolved = HashMap::with_capacity(definitions.len());
+        for definition in definitions {
+            if definition.env.is_empty() {
+                resolved.insert(definition.name.clone(), BTreeMap::new());
+                continue;
+            }
+            let Some(id) = ids.get(&definition.name).copied() else {
+                resolved.insert(definition.name.clone(), BTreeMap::new());
+                continue;
+            };
+            resolved.insert(definition.name.clone(), self.stored_env(id).await);
+        }
+        resolved
+    }
+
+    /// Commit each definition's environment values to the secret store and
+    /// return the definitions with `env_values` emptied, ready to persist.
+    ///
+    /// The stored entry becomes exactly what the definition declares: values
+    /// just set win, names dropped from `env` lose their stored value, and a
+    /// name kept without a new value keeps the one already stored. Records
+    /// that no longer exist have their entry deleted, so removing a server
+    /// takes its credentials with it.
+    async fn commit_env_values(
+        &self,
+        definitions: &mut [McpServerDefinition],
+        ids: &BTreeMap<String, ConnectedAppId>,
+    ) -> Result<()> {
+        let live: HashSet<ConnectedAppId> = ids.values().copied().collect();
+        let stale: Vec<ConnectedAppId> = {
+            let state = self.state.lock().await;
+            state
+                .ids
+                .values()
+                .copied()
+                .filter(|id| !live.contains(id))
+                .collect()
+        };
+        for id in stale {
+            // Best effort: a leftover entry is unreachable (nothing
+            // references the id) and a failure here must not fail the save.
+            let _ = self.secrets.delete_secret(&env_secret_key(id)).await;
+        }
+        for definition in definitions {
+            let Some(id) = ids.get(&definition.name).copied() else {
+                definition.env_values.clear();
+                continue;
+            };
+            let mut values = self.stored_env(id).await;
+            values.append(&mut definition.env_values);
+            values.retain(|name, _| definition.env.contains(name));
+            let key = env_secret_key(id);
+            if values.is_empty() {
+                let _ = self.secrets.delete_secret(&key).await;
+                continue;
+            }
+            let encoded = serde_json::to_string(&values).map_err(|error| {
+                AgentError::config(format!("could not encode MCP environment values: {error}"))
+            })?;
+            self.secrets.set_secret(&key, &encoded).await?;
+        }
+        Ok(())
     }
 
     /// The gateway resolver MCP dispatch rides on — exposed so tests can pin
@@ -691,6 +853,13 @@ impl McpRuntime {
     #[cfg(test)]
     pub(crate) fn gateway_endpoints(&self) -> Arc<dyn GatewayEndpoints> {
         self.gateway.clone()
+    }
+
+    /// The secret store this runtime writes environment values to — so a test
+    /// can read back exactly what landed there.
+    #[cfg(test)]
+    pub(crate) fn secrets(&self) -> Arc<dyn SecretProvider> {
+        self.secrets.clone()
     }
 
     /// How far managed policy currently locks the manual transports.
@@ -811,14 +980,24 @@ impl McpRuntime {
         if !records.is_empty() {
             let mut ids = BTreeMap::new();
             let mut definitions = Vec::with_capacity(records.len());
+            let mut migrated = Vec::new();
             for record in records {
-                let mut definition: McpServerDefinition = serde_json::from_value(record.definition)
-                    .map_err(|error| {
+                let mut stored = record.definition;
+                // Records written before literal values moved into the secret
+                // store carry them here in cleartext; lift them out before the
+                // definition is typed, so no value ever enters the type again.
+                let legacy = take_legacy_env_values(&mut stored);
+                let mut definition: McpServerDefinition =
+                    serde_json::from_value(stored).map_err(|error| {
                         AgentError::config(format!(
                             "invalid saved connected-app definition {:?}: {error}",
                             record.name
                         ))
                     })?;
+                if !legacy.is_empty() {
+                    migrated.push(record.name.clone());
+                    definition.env_values = legacy;
+                }
                 // The record's name is authoritative for the namespace; the
                 // stored definition mirrors it and is repaired if they ever
                 // disagree.
@@ -827,6 +1006,18 @@ impl McpRuntime {
                 definitions.push(definition);
             }
             validate_servers(&definitions)?;
+            if !migrated.is_empty() {
+                tracing::info!(
+                    servers = ?migrated,
+                    "moving stored MCP environment values into the secret store"
+                );
+                // Writes the values, empties `env_values`, and rewrites the
+                // records without them. A failure leaves the cleartext records
+                // untouched and retries next boot rather than starting servers
+                // whose credentials just went missing.
+                self.commit_env_values(&mut definitions, &ids).await?;
+                self.persist_definitions(&definitions, &ids).await?;
+            }
             self.replace_permissive(definitions, ids).await;
             return Ok(());
         }
@@ -1047,7 +1238,8 @@ impl McpRuntime {
                 name,
                 command: None,
                 args: Vec::new(),
-                env: BTreeMap::new(),
+                env: BTreeSet::new(),
+                env_values: BTreeMap::new(),
                 env_from: Vec::new(),
                 cwd: None,
                 url: None,
@@ -1160,7 +1352,7 @@ impl McpRuntime {
 
     async fn replace_strict(
         &self,
-        definitions: Vec<McpServerDefinition>,
+        mut definitions: Vec<McpServerDefinition>,
         persist: bool,
     ) -> Result<()> {
         validate_servers(&definitions)?;
@@ -1180,14 +1372,25 @@ impl McpRuntime {
                 })
                 .collect()
         };
+        // Before anything connects, so the children below see the environment
+        // this replacement declares rather than the previous one's. A boot
+        // file's values land in the same store under the same derived key:
+        // one resolution path, and the file stops being a second home for
+        // credentials.
+        self.commit_env_values(&mut definitions, &ids).await?;
+        let definitions = definitions;
+        let envs = self.resolve_envs(&definitions, &ids).await;
         let gateway = &self.gateway;
         let lockdown = self.manual_lockdown().await;
         let mut servers = HashMap::new();
-        let connections = join_all(definitions.iter().map(|definition| async move {
-            if connects(definition, lockdown) {
-                definition.connect_with_views(gateway).await.map(Some)
-            } else {
-                Ok(None)
+        let connections = join_all(definitions.iter().map(|definition| {
+            let env = envs.get(&definition.name).cloned().unwrap_or_default();
+            async move {
+                if connects(definition, lockdown) {
+                    definition.connect_with_views(gateway, &env).await.map(Some)
+                } else {
+                    Ok(None)
+                }
             }
         }))
         .await;
@@ -1263,26 +1466,38 @@ impl McpRuntime {
             // Before the new state publishes, while the published set is
             // still what this replacement diffs against.
             self.remember_endpoint_unmounts(&definitions).await;
-            let now = chrono::Utc::now();
-            let records: Vec<ConnectedApp> = definitions
-                .iter()
-                .map(|definition| {
-                    Ok(ConnectedApp {
-                        id: ids[&definition.name],
-                        name: definition.name.clone(),
-                        kind: ConnectedAppKind::McpServer,
-                        definition: serde_json::to_value(definition)?,
-                        created_at: now,
-                        updated_at: now,
-                    })
-                })
-                .collect::<Result<_>>()?;
-            self.store
-                .replace_connected_apps(ConnectedAppKind::McpServer, &records)
-                .await?;
+            self.persist_definitions(&definitions, &ids).await?;
         }
         self.publish(definitions, ids, servers).await;
         Ok(())
+    }
+
+    /// Write the definitions as this profile's complete `mcp_server`
+    /// connected-app set. `env_values` is `skip_serializing`, so the record
+    /// carries environment *names* and nothing more; the values are already in
+    /// the secret store by the time this runs.
+    async fn persist_definitions(
+        &self,
+        definitions: &[McpServerDefinition],
+        ids: &BTreeMap<String, ConnectedAppId>,
+    ) -> Result<()> {
+        let now = chrono::Utc::now();
+        let records: Vec<ConnectedApp> = definitions
+            .iter()
+            .map(|definition| {
+                Ok(ConnectedApp {
+                    id: ids[&definition.name],
+                    name: definition.name.clone(),
+                    kind: ConnectedAppKind::McpServer,
+                    definition: serde_json::to_value(definition)?,
+                    created_at: now,
+                    updated_at: now,
+                })
+            })
+            .collect::<Result<_>>()?;
+        self.store
+            .replace_connected_apps(ConnectedAppKind::McpServer, &records)
+            .await
     }
 
     async fn replace_permissive(
@@ -1290,14 +1505,18 @@ impl McpRuntime {
         definitions: Vec<McpServerDefinition>,
         ids: BTreeMap<String, ConnectedAppId>,
     ) {
+        let envs = self.resolve_envs(&definitions, &ids).await;
         let gateway = &self.gateway;
         let lockdown = self.manual_lockdown().await;
         let mut servers = HashMap::new();
-        let connections = join_all(definitions.iter().map(|definition| async move {
-            if connects(definition, lockdown) {
-                definition.connect_with_views(gateway).await.map(Some)
-            } else {
-                Ok(None)
+        let connections = join_all(definitions.iter().map(|definition| {
+            let env = envs.get(&definition.name).cloned().unwrap_or_default();
+            async move {
+                if connects(definition, lockdown) {
+                    definition.connect_with_views(gateway, &env).await.map(Some)
+                } else {
+                    Ok(None)
+                }
             }
         }))
         .await;
@@ -1471,7 +1690,7 @@ impl McpRuntime {
             (server.reconnect_lock.clone(), server.epoch)
         };
         let _reconnect = reconnect_lock.lock().await;
-        let (definition, start_epoch) = {
+        let (definition, app_id, start_epoch) = {
             let mut state = self.state.lock().await;
             let definition = state
                 .definitions
@@ -1488,6 +1707,7 @@ impl McpRuntime {
             if !definition.enabled {
                 return Err(AgentError::config("disabled MCP server cannot reconnect"));
             }
+            let app_id = state.ids.get(name).copied();
             let Some(server) = state.servers.get_mut(name) else {
                 return Err(AgentError::config("MCP server runtime is missing"));
             };
@@ -1498,9 +1718,16 @@ impl McpRuntime {
             }
             server.health = McpHealth::Reconnecting;
             server.diagnostic = None;
-            (definition, server.epoch)
+            (definition, app_id, server.epoch)
         };
-        match definition.connect_with_views(&self.gateway).await {
+        // Resolved fresh for this attempt, outside the state lock: a
+        // credential rotated since the last connection takes effect on the
+        // next reconnect without a settings save.
+        let env = match app_id {
+            Some(id) if !definition.env.is_empty() => self.stored_env(id).await,
+            _ => BTreeMap::new(),
+        };
+        match definition.connect_with_views(&self.gateway, &env).await {
             Ok((client, ui_views)) => {
                 let mut state = self.state.lock().await;
                 // A settings replacement may have won while the process started.
@@ -1822,9 +2049,17 @@ fn validate_servers(servers: &[McpServerDefinition]) -> Result<()> {
             ));
         }
         let mut environment_names = HashSet::new();
-        for (key, value) in &server.env {
+        for key in &server.env {
             validate_environment_name(&server.name, key)?;
             environment_names.insert(key.as_str());
+        }
+        for (key, value) in &server.env_values {
+            if !server.env.contains(key) {
+                return Err(server_error(
+                    &server.name,
+                    format!("environment value {key:?} names no configured variable"),
+                ));
+            }
             validate_process_string(&server.name, "environment value", value)?;
         }
         for key in &server.env_from {
@@ -2004,6 +2239,18 @@ mod tests {
             .collect()
     }
 
+    /// The persisted `mcp_server` records themselves, so a test can look at
+    /// the stored JSON rather than the type it parses into.
+    async fn saved_records(store: &Arc<dyn Store>) -> Vec<ConnectedApp> {
+        store
+            .list_connected_apps()
+            .await
+            .unwrap()
+            .into_iter()
+            .filter(|record| record.kind == ConnectedAppKind::McpServer)
+            .collect()
+    }
+
     /// Persist definitions as connected-app records, the way a settings save
     /// would, without connecting anything.
     async fn seed_records(store: &Arc<dyn Store>, definitions: &[McpServerDefinition]) {
@@ -2028,6 +2275,25 @@ mod tests {
     /// The signed-out stand-in: every resolution demands a session.
     struct NoGateway;
 
+    /// An in-memory secret store, so a test can assert what the runtime put
+    /// there — and what it did not.
+    #[derive(Default)]
+    struct TestSecrets(std::sync::Mutex<BTreeMap<String, String>>);
+
+    #[async_trait::async_trait]
+    impl SecretProvider for TestSecrets {
+        async fn get_secret(&self, key: &str) -> Result<Option<String>> {
+            Ok(self.0.lock().unwrap().get(key).cloned())
+        }
+        async fn set_secret(&self, key: &str, value: &str) -> Result<()> {
+            self.0.lock().unwrap().insert(key.into(), value.into());
+            Ok(())
+        }
+        async fn delete_secret(&self, key: &str) -> Result<()> {
+            self.0.lock().unwrap().remove(key);
+            Ok(())
+        }
+    }
     #[async_trait::async_trait]
     impl GatewayEndpoints for NoGateway {
         async fn endpoint(&self, _slug: &str) -> Result<GatewayEndpointAccess> {
@@ -2042,7 +2308,8 @@ mod tests {
             name: name.to_string(),
             command: Some(command.to_string()),
             args: Vec::new(),
-            env: BTreeMap::new(),
+            env: BTreeSet::new(),
+            env_values: BTreeMap::new(),
             env_from: Vec::new(),
             cwd: None,
             url: None,
@@ -2058,7 +2325,8 @@ mod tests {
             name: name.to_string(),
             command: None,
             args: Vec::new(),
-            env: BTreeMap::new(),
+            env: BTreeSet::new(),
+            env_values: BTreeMap::new(),
             env_from: Vec::new(),
             cwd: None,
             url: Some(url.to_string()),
@@ -2074,7 +2342,8 @@ mod tests {
             name: name.to_string(),
             command: None,
             args: Vec::new(),
-            env: BTreeMap::new(),
+            env: BTreeSet::new(),
+            env_values: BTreeMap::new(),
             env_from: Vec::new(),
             cwd: None,
             url: None,
@@ -2112,6 +2381,7 @@ mod tests {
             Arc::new(McpRuntime::new(
                 Arc::new(ToolRegistry::new()),
                 store.clone(),
+                Arc::new(TestSecrets::default()),
                 gateway,
                 os_policy,
             )),
@@ -2221,7 +2491,8 @@ mod tests {
                     "name": "private_docs",
                     "command": "/usr/local/bin/docs-mcp",
                     "args": ["--stdio"],
-                    "env": {"LOG_LEVEL": "info"},
+                    "env": ["LOG_LEVEL"],
+                    "env_values": {"LOG_LEVEL": "info"},
                     "env_from": ["DOCS_TOKEN"],
                     "cwd": "/srv/docs",
                     "request_timeout_ms": 2500
@@ -2233,7 +2504,8 @@ mod tests {
         assert_eq!(server.name, "private_docs");
         assert_eq!(server.command.as_deref(), Some("/usr/local/bin/docs-mcp"));
         assert_eq!(server.args, ["--stdio"]);
-        assert_eq!(server.env.get("LOG_LEVEL").unwrap(), "info");
+        assert!(server.env.contains("LOG_LEVEL"));
+        assert_eq!(server.env_values.get("LOG_LEVEL").unwrap(), "info");
         assert_eq!(server.env_from, ["DOCS_TOKEN"]);
         assert_eq!(server.cwd.as_deref(), Some(Path::new("/srv/docs")));
         assert_eq!(server.request_timeout_ms, 2500);
@@ -2248,7 +2520,7 @@ mod tests {
         assert!(server.env.is_empty());
         assert!(server.env_from.is_empty());
         assert_eq!(server.request_timeout_ms, 60_000);
-        let command = server.build_command().unwrap();
+        let command = server.build_command(&BTreeMap::new()).unwrap();
         assert!(command.as_std().get_envs().next().is_none());
     }
 
@@ -2291,13 +2563,24 @@ mod tests {
             r#"{"servers":[{
                 "name":"docs",
                 "command":"/bin/docs",
-                "env":{"DOCS_TOKEN":"literal"},
+                "env":["DOCS_TOKEN"],
                 "env_from":["DOCS_TOKEN"]
             }]}"#,
         )
         .err()
         .unwrap();
         assert!(duplicate.to_string().contains("configured more than once"));
+
+        let orphan = parse(
+            r#"{"servers":[{
+                "name":"docs",
+                "command":"/bin/docs",
+                "env_values":{"DOCS_TOKEN":"literal"}
+            }]}"#,
+        )
+        .err()
+        .unwrap();
+        assert!(orphan.to_string().contains("names no configured variable"));
 
         let invalid = parse(
             r#"{"servers":[{
@@ -2323,7 +2606,7 @@ mod tests {
             }]}"#,
         )
         .unwrap();
-        let command = config.0[0].build_command().unwrap();
+        let command = config.0[0].build_command(&BTreeMap::new()).unwrap();
         let forwarded_path = command
             .as_std()
             .get_envs()
@@ -2347,7 +2630,11 @@ mod tests {
         ))
         .unwrap();
         let gateway: Arc<dyn GatewayEndpoints> = Arc::new(NoGateway);
-        let error = config.0[0].connect(&gateway).await.err().unwrap();
+        let error = config.0[0]
+            .connect(&gateway, &BTreeMap::new())
+            .await
+            .err()
+            .unwrap();
         assert!(error.to_string().contains(MISSING));
         assert!(error.to_string().contains("is not set"));
         assert!(!error.to_string().contains("secret-value"));
@@ -2555,7 +2842,7 @@ mod tests {
 
         for (field, fragment) in [
             (r#""args":["--stdio"]"#, "args apply only"),
-            (r#""env":{"A":"b"}"#, "environment applies only"),
+            (r#""env":["A"]"#, "environment applies only"),
             (r#""env_from":["TOKEN"]"#, "environment applies only"),
             (r#""cwd":"/srv""#, "cwd applies only"),
         ] {
@@ -2766,7 +3053,11 @@ mod tests {
         let mut definition = http_definition("gateway", "http://127.0.0.1:1/mcp");
         definition.bearer_token_env = Some(MISSING.to_string());
         let gateway: Arc<dyn GatewayEndpoints> = Arc::new(NoGateway);
-        let error = definition.connect(&gateway).await.err().unwrap();
+        let error = definition
+            .connect(&gateway, &BTreeMap::new())
+            .await
+            .err()
+            .unwrap();
         assert!(error.to_string().contains(MISSING));
         assert!(error.to_string().contains("is not set"));
 
@@ -3063,7 +3354,10 @@ mod tests {
     #[test]
     fn fingerprints_derive_from_fields_cover_the_namespace_and_leak_no_values() {
         let mut definition = disabled_definition("docs", "/bin/docs");
-        definition.env.insert("TOKEN".into(), "secret-a".into());
+        definition.env.insert("TOKEN".into());
+        definition
+            .env_values
+            .insert("TOKEN".into(), "secret-a".into());
         let baseline = definition_fingerprint(&definition);
 
         let mut toggled = definition.clone();
@@ -3076,11 +3370,21 @@ mod tests {
         );
 
         let mut rotated = definition.clone();
-        rotated.env.insert("TOKEN".into(), "secret-b".into());
+        rotated.env_values.insert("TOKEN".into(), "secret-b".into());
         assert_eq!(
             definition_fingerprint(&rotated),
             baseline,
             "environment values never enter the canonical form"
+        );
+
+        let stored_only = disabled_definition("docs", "/bin/docs");
+        let mut stored_only = stored_only;
+        stored_only.env.insert("TOKEN".into());
+        assert_eq!(
+            definition_fingerprint(&stored_only),
+            baseline,
+            "moving the values into the secret store leaves every grant pinned \
+             to this definition still matching"
         );
 
         let mut renamed = definition.clone();
@@ -3097,12 +3401,175 @@ mod tests {
         assert_ne!(definition_fingerprint(&swapped), baseline);
     }
 
+    /// The whole point of the change: a value the user typed into Settings
+    /// lands in the secret store, and nothing that leaves this process — the
+    /// persisted record or the projection the renderer reads — carries it.
+    #[tokio::test]
+    async fn environment_values_reach_the_secret_store_and_nothing_else() {
+        const VALUE: &str = "sk-not-a-real-key-2f1c";
+        let (runtime, store, _directory) = test_runtime().await;
+        let mut definition = disabled_definition("docs", "/bin/docs");
+        definition.env.insert("DOCS_TOKEN".to_string());
+        definition
+            .env_values
+            .insert("DOCS_TOKEN".to_string(), VALUE.to_string());
+        runtime
+            .replace(McpServersConfig {
+                servers: vec![definition],
+            })
+            .await
+            .unwrap();
+
+        // The projection the renderer reads, serialized exactly as the route
+        // sends it.
+        let projected = serde_json::to_string(&runtime.info().await).unwrap();
+        assert!(!projected.contains(VALUE), "{projected}");
+        assert!(projected.contains("DOCS_TOKEN"), "{projected}");
+
+        // The durable record.
+        let record = &saved_records(&store).await[0];
+        let stored = serde_json::to_string(&record.definition).unwrap();
+        assert!(!stored.contains(VALUE), "{stored}");
+        assert_eq!(record.definition["env"], serde_json::json!(["DOCS_TOKEN"]));
+
+        // And where it did go.
+        let secret = runtime
+            .secrets()
+            .get_secret(&env_secret_key(record.id))
+            .await
+            .unwrap()
+            .expect("the value is in the secret store");
+        assert_eq!(secret, format!(r#"{{"DOCS_TOKEN":"{VALUE}"}}"#));
+    }
+
+    /// A save that leaves a value blank keeps the stored one; dropping the
+    /// name takes the value with it. Without this, editing any other field of
+    /// a server would silently wipe its credentials.
+    #[tokio::test]
+    async fn a_blank_value_keeps_the_stored_one_and_removing_a_name_drops_it() {
+        let (runtime, store, _directory) = test_runtime().await;
+        let mut definition = disabled_definition("docs", "/bin/docs");
+        definition.env.insert("DOCS_TOKEN".to_string());
+        definition
+            .env_values
+            .insert("DOCS_TOKEN".to_string(), "first".to_string());
+        runtime
+            .replace(McpServersConfig {
+                servers: vec![definition.clone()],
+            })
+            .await
+            .unwrap();
+        let id = saved_records(&store).await[0].id;
+
+        // The renderer round-trips the definition it was given, which carries
+        // names only — no `env_values` at all.
+        let mut retimed = definition.clone();
+        retimed.env_values.clear();
+        retimed.request_timeout_ms += 1;
+        runtime
+            .replace(McpServersConfig {
+                servers: vec![retimed],
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            runtime
+                .stored_env(id)
+                .await
+                .get("DOCS_TOKEN")
+                .map(String::as_str),
+            Some("first")
+        );
+
+        let mut cleared = definition.clone();
+        cleared.env.clear();
+        cleared.env_values.clear();
+        runtime
+            .replace(McpServersConfig {
+                servers: vec![cleared],
+            })
+            .await
+            .unwrap();
+        assert!(runtime.stored_env(id).await.is_empty());
+    }
+
+    /// Definitions persisted before the values moved out carry them in
+    /// cleartext. Boot migrates them into the secret store and rewrites the
+    /// record, and the definition fingerprint — what every app grant is
+    /// pinned to — comes out unchanged, so no grant is invalidated.
+    #[tokio::test]
+    async fn a_legacy_record_migrates_its_cleartext_values_without_moving_the_fingerprint() {
+        const VALUE: &str = "legacy-secret-9a4d";
+        let (runtime, store, _directory) = test_runtime().await;
+        let expected = {
+            let mut definition = disabled_definition("docs", "/bin/docs");
+            definition.env.insert("DOCS_TOKEN".to_string());
+            definition_fingerprint(&definition)
+        };
+        // The pre-migration shape, written straight to the store.
+        let now = chrono::Utc::now();
+        let id = ConnectedAppId::new();
+        let legacy = serde_json::json!({
+            "name": "docs",
+            "command": "/bin/docs",
+            "args": [],
+            "env": {"DOCS_TOKEN": VALUE},
+            "env_from": [],
+            "cwd": null,
+            "url": null,
+            "bearer_token_env": null,
+            "gateway_endpoint": null,
+            "request_timeout_ms": DEFAULT_REQUEST_TIMEOUT_MS,
+            "enabled": false,
+        });
+        store
+            .replace_connected_apps(
+                ConnectedAppKind::McpServer,
+                &[ConnectedApp {
+                    id,
+                    name: "docs".to_string(),
+                    kind: ConnectedAppKind::McpServer,
+                    definition: legacy,
+                    created_at: now,
+                    updated_at: now,
+                }],
+            )
+            .await
+            .unwrap();
+
+        runtime
+            .initialize(ConfiguredMcpServers::default())
+            .await
+            .unwrap();
+
+        let record = &saved_records(&store).await[0];
+        assert_eq!(record.id, id, "the record keeps its identity");
+        assert_eq!(record.definition["env"], serde_json::json!(["DOCS_TOKEN"]));
+        assert!(!serde_json::to_string(&record.definition)
+            .unwrap()
+            .contains(VALUE));
+        assert_eq!(
+            runtime
+                .stored_env(id)
+                .await
+                .get("DOCS_TOKEN")
+                .map(String::as_str),
+            Some(VALUE)
+        );
+        assert_eq!(
+            runtime.app_fingerprints().await[&id].fingerprint,
+            expected,
+            "the canonical form only ever saw the names, so grants survive"
+        );
+    }
+
     #[test]
     fn debug_projection_redacts_argument_and_literal_environment_values() {
         let mut definition = disabled_definition("docs", "/bin/docs");
         definition.args = vec!["argument-secret".to_string()];
+        definition.env.insert("TOKEN".to_string());
         definition
-            .env
+            .env_values
             .insert("TOKEN".to_string(), "literal-secret".to_string());
         let debug = format!("{definition:?}");
         assert!(!debug.contains("argument-secret"));

--- a/crates/openwave-server/src/pairing.rs
+++ b/crates/openwave-server/src/pairing.rs
@@ -355,6 +355,7 @@ mod tests {
         let mcp = Arc::new(McpRuntime::new(
             Arc::new(ToolRegistry::new()),
             store.clone(),
+            Arc::new(TestSecrets::default()),
             Arc::new(NoGateway),
             Arc::new(NoOsPolicy),
         ));
@@ -567,6 +568,7 @@ mod tests {
         let mcp = Arc::new(McpRuntime::new(
             Arc::new(ToolRegistry::new()),
             store.clone(),
+            Arc::new(TestSecrets::default()),
             Arc::new(NoGateway),
             Arc::new(OsAsserted),
         ));
@@ -838,7 +840,8 @@ mod tests {
                 name: "private_docs".to_string(),
                 command: None,
                 args: Vec::new(),
-                env: std::collections::BTreeMap::new(),
+                env: std::collections::BTreeSet::new(),
+                env_values: std::collections::BTreeMap::new(),
                 env_from: Vec::new(),
                 cwd: None,
                 url: Some(serve_manual_mcp().await),

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -294,6 +294,7 @@ impl AppState {
         let mcp = Arc::new(McpRuntime::new(
             tools.clone(),
             store.clone(),
+            secrets.clone(),
             gateway.clone(),
             os_policy.clone(),
         ));

--- a/crates/openwave-server/src/tests/app_grant.rs
+++ b/crates/openwave-server/src/tests/app_grant.rs
@@ -89,7 +89,8 @@ async fn grant_responses_carry_names_only_never_definitions_or_env_values() {
                         "name": "cmd",
                         "command": "/opt/secret-location/docs-mcp",
                         "args": ["--secret-flag"],
-                        "env": {"LITERAL_NAME": "literal-value-hunter2"},
+                        "env": ["LITERAL_NAME"],
+                        "env_values": {"LITERAL_NAME": "literal-value-hunter2"},
                         "env_from": ["PARENT_SECRET_NAME"],
                         "enabled": false
                     }]})

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -156,7 +156,8 @@ async fn mcp_settings_roundtrip_disabled_typed_definitions_without_credentials()
                 "name": "private_docs",
                 "command": "/not/started/while/disabled",
                 "args": ["--stdio"],
-                "env": {"LOG_LEVEL": "info"},
+                "env": ["LOG_LEVEL"],
+                "env_values": {"LOG_LEVEL": "value-hunter2-not-a-real-key"},
                 "env_from": ["PATH"],
                 "cwd": "/tmp",
                 "request_timeout_ms": 2500,
@@ -173,6 +174,13 @@ async fn mcp_settings_roundtrip_disabled_typed_definitions_without_credentials()
     let encoded = info.to_string();
     assert!(!encoded.contains("resolved_value"));
     assert!(!encoded.contains("inherit_env"));
+    // The name comes back; the value the request set does not, on the
+    // response or on the fetch after it.
+    assert_eq!(info["servers"][0]["env"], serde_json::json!(["LOG_LEVEL"]));
+    assert!(
+        !encoded.contains("value-hunter2"),
+        "an environment value leaked into renderer JSON"
+    );
     if let Ok(path) = std::env::var("PATH") {
         assert!(
             !encoded.contains(&path),

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -16,8 +16,9 @@ Each server has:
 - a stable namespace containing ASCII letters, numbers, `_`, or `-`;
 - exactly one transport:
   - **stdio** — an executable, zero or more individual arguments, an optional
-    working directory, optional literal **non-secret** environment values, and
-    optional `env_from` names selected from the OpenWave host environment; or
+    working directory, optional environment variable *names* (`env`) whose
+    values are held in the OS credential store, and optional `env_from` names
+    selected from the OpenWave host environment; or
   - **HTTP** — an `http`/`https` URL and an optional bearer-token variable
     name selected from the OpenWave host environment; or
   - **gateway** — the slug of a model-gateway MCP endpoint
@@ -30,18 +31,31 @@ Each server has:
 - a request timeout from 1 to 3,600,000 milliseconds; and
 - an enabled switch.
 
-The child environment starts empty. Literal values are ordinary settings and
-are visible in the Settings form. Executables, arguments, working directories,
-and URLs are also ordinary displayed settings, so do not put credentials in
-any of those fields. For a credential, set it in the environment that launches
-OpenWave and enter only its variable name — under **Forward environment names**
-for a stdio server, or **Bearer token variable** for an HTTP server. OpenWave
-resolves that value at the connection boundary; it does not store it in SQLite
-or return it to the renderer. A missing selected name produces a server-specific
-error containing the name, not a value. Child stderr is discarded so a server
-cannot copy a forwarded credential into OpenWave's host logs, and HTTP
-diagnostics are fixed strings that never echo the URL, a token, or a response
-body.
+The child environment starts empty, and **no environment value of any kind
+lives in a definition**. Executables, arguments, working directories, and URLs
+are ordinary displayed settings, so do not put credentials in any of those
+fields. The two channels that do carry a value are:
+
+- **Environment** (`env`) — the definition holds the variable names; the values
+  live in the OS credential store, keyed by the server's connected-app record.
+  Settings shows a password field per name that starts blank and keeps the
+  stored value if you leave it blank. The values are never returned to the
+  renderer and never enter SQLite. Deleting a name, or the server, deletes its
+  stored value.
+- **`env_from`** and **Bearer token variable** — a name selected from the
+  environment that launched OpenWave, resolved at the connection boundary and
+  never stored at all.
+
+A missing selected name produces a server-specific error containing the name,
+not a value. Child stderr is discarded so a server cannot copy a forwarded
+credential into OpenWave's host logs, and HTTP diagnostics are fixed strings
+that never echo the URL, a token, or a response body.
+
+Definitions saved before the values moved into the credential store held them
+in cleartext in the connected-app record. They are migrated on first load: the
+values move to the credential store and the record is rewritten with names
+only. Names are all the definition fingerprint ever covered, so existing app
+grants stay valid across the migration.
 
 All mounted names use `mcp__{namespace}__{remote_tool}`. MCP tools are sensitive:
 the existing OpenWave approval gate must approve each call before it crosses
@@ -122,7 +136,8 @@ named by `OPENWAVE_MCP_CONFIG`:
       "command": "/absolute/path/to/documents-mcp",
       "args": ["--stdio"],
       "cwd": "/absolute/path/to/workspace",
-      "env": {
+      "env": ["LOG_LEVEL"],
+      "env_values": {
         "LOG_LEVEL": "info"
       },
       "env_from": ["DOCUMENTS_TOKEN"],
@@ -141,6 +156,9 @@ named by `OPENWAVE_MCP_CONFIG`:
 ```
 
 The schema is closed, including at the API boundary. Broad process-environment
-inheritance is not supported. When there is no saved desktop configuration, a
-malformed bootstrap file, missing selected environment name, or failed enabled
-server makes startup fail rather than silently narrowing the advertised tools.
+inheritance is not supported. `env_values` is an input only — it is written to
+the credential store and never appears in a response or a saved record, and a
+bootstrap file's values land in the same place as any other. When there is no
+saved desktop configuration, a malformed bootstrap file, missing selected
+environment name, or failed enabled server makes startup fail rather than
+silently narrowing the advertised tools.


### PR DESCRIPTION
An MCP server's literal `env` map was persisted unencrypted in `connected_app.definition_json`, handed back to the renderer through the flattened definition on every settings load, and rendered in a plain `type="text"` input. The label said non-secret; users put API keys there anyway. That made a key cleartext on disk and cleartext on the wire, twice per edit.

A definition now carries environment variable **names** only. The values live in the OS credential store under `mcp.<record id>.env_v1` — a key derived from the connected-app record id, never from a request — written on commit and resolved at the connection boundary. That is the shape `env_from`, the HTTP bearer, the gateway `mcp:<slug>` bearer, and the REST connected-app credential already use; this was the one channel that didn't.

**Wire shape.** `env` becomes `string[]` in both directions. A new inbound-only `env_values` (`skip_serializing`) carries values being set; a name in `env` with no entry in `env_values` keeps whatever is stored. Removing a name drops its stored value; removing the server deletes its whole entry.

**UI.** The editor is a name column plus a password-style value column that starts blank, placeholder "leave blank to keep". The panel copy no longer tells people to route credentials through the host environment instead — this field is now the right place for them.

## Migration

**Migrate on first load, don't invalidate.** Records written before this hold `env` as a JSON object of cleartext values. Rejecting them would take working servers down at boot for a change the user didn't make. Instead `initialize` lifts the values out at the storage boundary, writes them to the credential store, and rewrites the record with the name array — keeping the record id, so nothing downstream re-keys.

**Grants survive.** The v:2 definition fingerprint hashes `env_names` and has never seen a value, so a migrated definition fingerprints identically to what it did before. No `v` bump, no grant invalidated. There is a test asserting exactly that against a hand-written pre-migration record.

A migration that fails to write leaves the cleartext record untouched and retries next boot, rather than starting servers whose credentials just vanished.

The `OPENWAVE_MCP_CONFIG` bootstrap file gains `env_values` for the same purpose; its values land in the same store under the same derived key, so there is one resolution path rather than a second home for credentials.

## Verification

`cargo test -p openwave-server` (574 passed), `pnpm tsc --noEmit`, `pnpm test` (711 passed), `cargo check --workspace --all-targets`, clippy clean on the crate.

Tests added, one per property that would actually cost us if it broke:
- `environment_values_reach_the_secret_store_and_nothing_else` — asserts on the *serialized* `McpServersInfo` and the raw stored record that the value is absent and the name present, then that the value is in the secret store. This is the regression the PR exists to prevent.
- `a_blank_value_keeps_the_stored_one_and_removing_a_name_drops_it` — without this, editing any unrelated field of a server would silently wipe its credentials.
- `a_legacy_record_migrates_its_cleartext_values_without_moving_the_fingerprint` — the compatibility claim above, driven through `initialize` from a hand-written pre-migration record.
- One UI test: the value field is password-typed and blank for a stored name, an untouched save sends no value, a typed one does.

Existing route tests `mcp_settings_roundtrip_…` and `grant_responses_carry_names_only_…` were already leak assertions; both now also pin that a value sent in a PUT never comes back.

Not verified by running the app.

Part of #1461