### PR TITLE
fix(server): allowlist the app's origin on the API and the socket

### DIFF
--- a/crates/openwave-server/src/auth.rs
+++ b/crates/openwave-server/src/auth.rs
@@ -41,7 +41,7 @@ use std::path::Path;
 
 use axum::extract::{Request, State};
 use axum::http::{
-    header::{AUTHORIZATION, SEC_WEBSOCKET_PROTOCOL, UPGRADE},
+    header::{AUTHORIZATION, HOST, ORIGIN, SEC_WEBSOCKET_PROTOCOL, UPGRADE},
     HeaderMap, HeaderName, StatusCode,
 };
 use axum::middleware::Next;
@@ -237,6 +237,116 @@ pub async fn require_client_executor_token(
     }
 }
 
+/// Reject a request whose `Origin` names a site that is not this app, or
+/// whose `Host` is not the loopback address the desktop server binds to.
+///
+/// The bearer stays the gate; this is the second condition that makes a
+/// *leaked* bearer insufficient rather than sufficient. Two attacks it closes,
+/// neither of which CORS covers:
+///
+/// - **WebSocket upgrades.** CORS does not apply to them at all, and a browser
+///   can set `Sec-WebSocket-Protocol` freely — so a page that learned the
+///   token could open the event stream. It cannot forge `Origin`.
+/// - **DNS rebinding.** A name the attacker controls, re-resolved to
+///   `127.0.0.1`, reaches the server as a same-origin request from the
+///   attacker's page. The `Host` header still carries their name.
+///
+/// Deliberately permissive in two places, because the alternative is breaking
+/// legitimate callers to close nothing:
+///
+/// - **A request with no `Origin` passes.** Only browsers attach one; a `curl`
+///   or an SDK never does, and rejecting them would gate a header the threat
+///   model does not depend on.
+/// - **Only the desktop profile is checked.** A self-host deployment is
+///   reached from an operator-chosen origin over an operator-chosen name, and
+///   neither is knowable here. It keeps the bearer and the operator's own
+///   fronting.
+///
+/// The desktop profile is also what a bare `openwave serve` boots, so an
+/// integrator driving that daemon from a browser page of their own must run it
+/// as `OPENWAVE_PROFILE=self_host`. A parent process reading the daemon's
+/// stdout — the documented integration — sends no `Origin` and is unaffected.
+pub async fn require_app_origin(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if state.config.profile == Profile::Desktop
+        && !(origin_is_this_app(request.headers()) && host_is_loopback(request.headers()))
+    {
+        return StatusCode::FORBIDDEN.into_response();
+    }
+    next.run(request).await
+}
+
+/// Whether the request's `Origin`, if it declared one, is this app's.
+#[must_use]
+pub fn origin_is_this_app(headers: &HeaderMap) -> bool {
+    let Some(origin) = headers.get(ORIGIN) else {
+        // Not a browser request, or a same-origin navigation (an iframe
+        // loading a view frame). Nothing to check.
+        return true;
+    };
+    origin_value_is_this_app(origin)
+}
+
+/// The same judgement on a bare header value, for the CORS layer's predicate.
+#[must_use]
+pub fn origin_value_is_this_app(origin: &axum::http::HeaderValue) -> bool {
+    origin
+        .to_str()
+        .is_ok_and(|origin| APP_ORIGINS.contains(&origin) || dev_server_origin(origin))
+}
+
+/// The origins the packaged webview loads its frontend from.
+///
+/// Tauri serves `frontendDist` over its own protocol: `tauri://localhost` on
+/// macOS and Linux, `http(s)://tauri.localhost` on Windows. `null` is here
+/// because a document on a non-http scheme is reported as an opaque origin by
+/// some webviews, and refusing it would take the packaged app's own requests
+/// down; it grants nothing a page could not already reach without an `Origin`
+/// header at all.
+const APP_ORIGINS: &[&str] = &[
+    "tauri://localhost",
+    "http://tauri.localhost",
+    "https://tauri.localhost",
+    "null",
+];
+
+/// The Vite dev server, in debug builds only — `build.devUrl` in
+/// `tauri.conf.json`, and the same port a browser tab uses during UI work.
+fn dev_server_origin(origin: &str) -> bool {
+    cfg!(debug_assertions) && matches!(origin, "http://localhost:1420" | "http://127.0.0.1:1420")
+}
+
+/// Whether the request addressed the server by a loopback name.
+///
+/// The desktop server binds loopback, so a `Host` naming anything else is a
+/// request that arrived through a name resolving there — the rebinding case.
+/// An absent `Host` passes, for the same reason an absent `Origin` does: HTTP/2
+/// carries the authority in the request line instead, and every browser sends
+/// one, so the header's absence never describes the attack.
+#[must_use]
+pub fn host_is_loopback(headers: &HeaderMap) -> bool {
+    let Some(host) = headers.get(HOST) else {
+        return true;
+    };
+    let Ok(host) = host.to_str() else {
+        return false;
+    };
+    // Strip the port, keeping an IPv6 literal's brackets intact.
+    let name = match host.strip_prefix('[') {
+        Some(rest) => match rest.split_once(']') {
+            Some((inner, _)) => inner,
+            None => return false,
+        },
+        None => host.split(':').next().unwrap_or(host),
+    };
+    // `localhost` is resolved locally rather than through the DNS an attacker
+    // could answer, so it is as loopback-bound as the literals.
+    name.eq_ignore_ascii_case("localhost") || name == "127.0.0.1" || name == "::1"
+}
+
 /// Resolve the presented token: `Authorization` wins; on WebSocket upgrades,
 /// fall back to the `openwave-token.` subprotocol entry.
 pub fn extract_token(headers: &HeaderMap) -> Option<&str> {
@@ -318,6 +428,54 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 mod tests {
     use super::*;
     use axum::http::HeaderValue;
+
+    fn headers(pairs: &[(HeaderName, &str)]) -> HeaderMap {
+        let mut map = HeaderMap::new();
+        for (name, value) in pairs {
+            map.insert(name.clone(), HeaderValue::from_str(value).unwrap());
+        }
+        map
+    }
+
+    /// The point of the check: a page on the public web that has somehow
+    /// learned the bearer still cannot open the event stream, because CORS
+    /// never covered WebSocket upgrades and `Origin` is the one header its
+    /// script cannot forge.
+    #[test]
+    fn a_foreign_origin_is_refused_and_the_app_and_non_browsers_are_not() {
+        assert!(!origin_is_this_app(&headers(&[(
+            axum::http::header::ORIGIN,
+            "https://evil.example"
+        )])));
+        // A loopback port that is not the dev server is a foreign site too —
+        // the embedded API itself serves untrusted app HTML on one.
+        assert!(!origin_is_this_app(&headers(&[(
+            axum::http::header::ORIGIN,
+            "http://127.0.0.1:53219"
+        )])));
+        // The packaged webview's own origin.
+        assert!(origin_is_this_app(&headers(&[(
+            axum::http::header::ORIGIN,
+            "tauri://localhost"
+        )])));
+        // A CLI or SDK attaches no Origin at all; only browsers do.
+        assert!(origin_is_this_app(&HeaderMap::new()));
+    }
+
+    /// DNS rebinding: the request reaches loopback, but the name the browser
+    /// was pointed at travels with it.
+    #[test]
+    fn a_host_that_is_not_loopback_is_refused() {
+        assert!(!host_is_loopback(&headers(&[(
+            HOST,
+            "rebind.example:7777"
+        )])));
+        assert!(host_is_loopback(&headers(&[(HOST, "127.0.0.1:7777")])));
+        assert!(host_is_loopback(&headers(&[(HOST, "localhost:7777")])));
+        assert!(host_is_loopback(&headers(&[(HOST, "[::1]:7777")])));
+        // HTTP/2 carries the authority in the request line instead.
+        assert!(host_is_loopback(&HeaderMap::new()));
+    }
 
     #[test]
     fn token_map_parses_the_documented_format_and_resolves_exactly() {

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -497,13 +497,17 @@ pub fn app(state: AppState) -> Router {
             auth::require_token,
         ))
         .with_state(state.clone());
-    let frame_state = state;
+    let frame_state = state.clone();
 
-    // Loopback-only + bearer token is the real gate. CORS mirrors the request
-    // Origin so the Tauri webview (and a browser on `vite` during UI work) can
-    // call the API from a different localhost port.
+    // Loopback-only + bearer token is the real gate. CORS names the origins
+    // this app actually loads its frontend from rather than mirroring whatever
+    // asked, so a page on the public web cannot read a response even holding a
+    // leaked bearer. The same predicate backs the `Origin` middleware below,
+    // which covers what CORS does not: WebSocket upgrades.
     let cors = CorsLayer::new()
-        .allow_origin(AllowOrigin::mirror_request())
+        .allow_origin(AllowOrigin::predicate(|origin, _parts| {
+            auth::origin_value_is_this_app(origin)
+        }))
         .allow_methods([
             Method::GET,
             Method::POST,
@@ -534,10 +538,19 @@ pub fn app(state: AppState) -> Router {
         .with_state(frame_state);
 
     Router::new()
-        .route("/healthz", get(healthz))
         .merge(view_frames)
         .merge(api)
+        // Inside CORS, so a foreign preflight is answered by the CORS layer's
+        // own rejection rather than by a bare 403.
+        .layer(axum::middleware::from_fn_with_state(
+            state,
+            auth::require_app_origin,
+        ))
         .layer(cors)
+        // A liveness probe with no auth, added after both layers so it carries
+        // neither: nothing reads it cross-origin, and answering preflights for
+        // it only helps a page confirm the app is on a guessed port.
+        .route("/healthz", get(healthz))
 }
 
 /// Liveness probe — no auth, no state.

--- a/crates/openwave-server/src/tests.rs
+++ b/crates/openwave-server/src/tests.rs
@@ -1676,6 +1676,80 @@ async fn test_app_with_secrets() -> (Router, Arc<str>, Arc<MemSecrets>, tempfile
     (app(state), token, secrets, dir)
 }
 
+/// The bearer is the gate; this is the second condition that keeps a leaked
+/// one from being enough. CORS does not apply to WebSocket upgrades at all, so
+/// without this a page holding the token could open the event stream — and
+/// `Origin` is the header its script cannot set.
+#[tokio::test]
+async fn a_foreign_origin_is_refused_even_holding_the_bearer() {
+    let (router, token, _store, _dir) = test_app().await;
+
+    let refused = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/chats")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header(header::ORIGIN, "https://evil.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), StatusCode::FORBIDDEN);
+
+    // Same for the socket, which CORS never covered.
+    let refused_upgrade = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/chats/events")
+                .header(header::UPGRADE, "websocket")
+                .header(
+                    header::SEC_WEBSOCKET_PROTOCOL,
+                    format!("openwave-v1, openwave-token.{token}"),
+                )
+                .header(header::ORIGIN, "https://evil.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(refused_upgrade.status(), StatusCode::FORBIDDEN);
+
+    // A name that resolved to loopback still carries the name it was reached
+    // by, which is what makes rebinding visible.
+    let rebound = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/chats")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header(header::HOST, "rebind.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(rebound.status(), StatusCode::FORBIDDEN);
+
+    // The packaged webview's own origin is served as before.
+    let allowed = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/chats")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header(header::ORIGIN, "tauri://localhost")
+                .header(header::HOST, "127.0.0.1:7777")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(allowed.status(), StatusCode::OK);
+}
+
 #[tokio::test]
 async fn app_state_roots_blob_storage_under_the_data_directory() {
     let (dir, store) = temp_db_store("t.db").await;


### PR DESCRIPTION
`AllowOrigin::mirror_request()` reflected whatever asked, and CORS does not cover WebSocket upgrades at all — where the token travels in `Sec-WebSocket-Protocol`, a header browser JavaScript sets freely. So a page that had somehow learned the bearer could open the event stream, and a hostname the attacker controlled, re-resolved to `127.0.0.1`, reached the whole API as same-origin.

On the **desktop profile** a request now has to name this app:

- **`Origin`**, when present, must be the packaged webview's own — `tauri://localhost` (macOS/Linux), `http(s)://tauri.localhost` (Windows), or `null` — or, in debug builds only, the dev server's exact port (`localhost:1420` / `127.0.0.1:1420`, from `build.devUrl`). CORS uses the same predicate; the middleware covers the upgrade path CORS never did.
- **`Host`**, when present, must be a loopback name. That is the rebinding signal: the request lands on loopback either way, but the name the browser was pointed at travels with it.
- **Absent headers pass.** Only browsers attach an `Origin`; HTTP/2 carries the authority in the request line rather than a `Host` header. Rejecting their absence would gate CLI and SDK callers to close nothing. The bearer stays the primary gate throughout.
- **Self-host is untouched** — its origin and hostname are the operator's to choose, and unknowable here.

`/healthz` is added after both layers, so it carries neither. Nothing reads it cross-origin, and answering its preflight only helps a page confirm the app is listening on a guessed port.

### The production origin

`tauri.conf.json` sets `build.frontendDist: "ui/dist"`, so a packaged app is served over Tauri's custom protocol, not over http. Per `tauri` 2.11.5 (`manager::tauri_protocol_url`) that origin is `tauri://localhost` on macOS and Linux and `http://tauri.localhost` on Windows (`https://` with `useHttpsScheme`). All four are allowed, plus `null`, because some webviews report a custom-scheme document's origin as opaque — and `null` grants nothing a request with no `Origin` header could not already reach.

### Needs a run of the real app before merging

The origin the packaged webview actually puts on the wire is the one thing I could not verify without launching:

1. **A packaged build** — open a chat and confirm the transcript streams (the WebSocket upgrade is the strictest path) and that documents, images, and app frames load. A wrong guess here shows up as a blanket 403, not as a subtle degradation.
2. **`pnpm tauri dev`** — the debug-only dev-server origin. Also confirm a browser tab on `http://localhost:1420` still works against a debug `cargo run` server, if that is a flow you use.
3. **Windows**, if you have a build handy — it is the only platform on the `http://tauri.localhost` branch.

One behavior change worth naming: a bare `openwave serve` boots the desktop profile, so an integrator driving that daemon from a browser page of their own would now need `OPENWAVE_PROFILE=self_host`. A parent process reading the daemon's stdout — the documented integration — sends no `Origin` and is unaffected.

Part of #1461