### PR TITLE
fix(desktop): add the staged-files field to the exec preview fixture

### DIFF
--- a/crates/openwave-desktop/ui/src/ToolCallCard.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.dom.test.tsx
@@ -10,6 +10,7 @@ const preview = {
   command: "python3",
   args: ["render.py"],
   cwd: ".",
+  files: [],
 };
 
 afterEach(() => {


### PR DESCRIPTION
#1482 merged green against a base that predates #1480 (which made `files` a required part of the exec consent preview), so on `main` the shared fixture in `ToolCallCard.dom.test.tsx` lacks the field. That single gap breaks two lanes: `tsc` fails `before-tauri-build` (killing **Warm macOS release cache**), and vitest — which doesn't typecheck — reaches `preview.files.length` at runtime and crashes the **desktop UI** job.

Add the empty list the type requires.

Verified: `pnpm exec tsc --noEmit` clean; full UI suite passes (106 files, 716 tests).