### PR TITLE
feat(core): declare the approval class of the agent-orchestration tools

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -134,6 +134,7 @@ enum RegisteredTool {
     ForegroundOrchestration {
         spec: ToolSpec,
         kind: ForegroundOrchestrationKind,
+        class: ApprovalClass,
     },
 }
 
@@ -212,6 +213,19 @@ impl ToolRegistry {
     /// A claimed foreground worker must still opt in before either definition
     /// is advertised. Sandboxed workers never opt in, keeping delegation depth
     /// bounded at one.
+    ///
+    /// Both declare [`ApprovalClass::Sensitive`]. A delegated child reaches the
+    /// public web and, where the host routes children to a container, runs
+    /// commands there; none of those calls pass back through this chat's
+    /// approval gate, so the delegation itself is the boundary that carries
+    /// their weight. The pair shares one class because it is one contract: the
+    /// wait exists only to consume what a spawn produced, and advertising half
+    /// of it in a surface that forbids the other half would only invite a call
+    /// that cannot be honored.
+    ///
+    /// The class decides advertisement, not admission: a spawn writes its tool
+    /// call already completed, so there is no pending record for the approval
+    /// gate to park on. Issue #1477 holds what closing that would take.
     pub fn register_foreground_agent_orchestration(&mut self) {
         for (spec, kind) in [
             (
@@ -225,7 +239,11 @@ impl ToolRegistry {
         ] {
             self.tools.insert(
                 spec.name.clone(),
-                RegisteredTool::ForegroundOrchestration { spec, kind },
+                RegisteredTool::ForegroundOrchestration {
+                    spec,
+                    kind,
+                    class: ApprovalClass::Sensitive,
+                },
             );
         }
     }
@@ -301,9 +319,10 @@ impl ToolRegistry {
     /// narrowed to the read-only planning subset.
     ///
     /// A plan-mode turn advertises only `ReadOnly` registrations — server
-    /// tools by their declared [`Tool::approval_class`], client tools by the
-    /// class declared at registration — and never the orchestration pair:
-    /// spawned agents execute, and executing is exactly what a plan turn
+    /// tools by their declared [`Tool::approval_class`], client and
+    /// orchestration tools by the class declared at registration. The
+    /// orchestration pair is `Sensitive`, so a plan turn drops it by that same
+    /// rule: spawned agents execute, and executing is exactly what a plan turn
     /// must not do.
     #[must_use]
     pub fn specs_for_surface(
@@ -322,6 +341,7 @@ impl ToolRegistry {
                 RegisteredTool::Server(tool) => Some(tool.spec()),
                 RegisteredTool::Client { class, .. }
                 | RegisteredTool::ForegroundClient { class, .. }
+                | RegisteredTool::ForegroundOrchestration { class, .. }
                     if read_only && *class != ApprovalClass::ReadOnly =>
                 {
                     None
@@ -340,7 +360,7 @@ impl ToolRegistry {
                 }
                 RegisteredTool::ForegroundClient { .. } => None,
                 RegisteredTool::ForegroundOrchestration { spec, .. }
-                    if allow_agent_orchestration && !read_only =>
+                    if allow_agent_orchestration =>
                 {
                     Some(spec.clone())
                 }
@@ -349,18 +369,19 @@ impl ToolRegistry {
             .collect()
     }
 
-    /// The declared approval class of a registered tool, if it has one.
+    /// The declared approval class of every registered tool.
     ///
-    /// Orchestration registrations return `None`: they have no class because
-    /// no mode admits them outside the foreground coordinator's opt-in, and
-    /// plan mode treats classless as mutating.
+    /// `None` means only that nothing is registered under `name`. Every
+    /// registration declares a class, including the orchestration pair, so a
+    /// caller asking what a name costs is never answered with silence it has
+    /// to interpret.
     #[must_use]
     pub fn registered_class(&self, name: &str) -> Option<ApprovalClass> {
         match self.tools.get(name)? {
             RegisteredTool::Server(tool) => Some(tool.approval_class()),
             RegisteredTool::Client { class, .. }
-            | RegisteredTool::ForegroundClient { class, .. } => Some(*class),
-            RegisteredTool::ForegroundOrchestration { .. } => None,
+            | RegisteredTool::ForegroundClient { class, .. }
+            | RegisteredTool::ForegroundOrchestration { class, .. } => Some(*class),
         }
     }
 

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -194,6 +194,24 @@ in-process worker rather than failing. A container-located run is attached-only
 and proxies its model inference back through the host, so no model credential
 enters the container. See [Sandbox providers](sandbox-providers.md).
 
+### Delegation and consent
+
+Both orchestration tools declare the `Sensitive` approval class. A child's own
+calls never pass back through the parent chat's approval gate — the sandbox
+worker advances them under its own lease — so the delegation is the only place
+in the chat where the reader could speak about what the child does. Classing it
+below the authority it hands out would state the opposite.
+
+Declaring the class is not the same as gating on it. The gate parks a *pending
+server tool call* on a durable approval receipt, and a spawn has no such
+record: its tool call is written already completed, inside the same transaction
+that admits the child. So the class today decides advertisement — a plan turn
+never sees the pair — and not admission. The consequence worth naming: in a
+chat where a foreground `web_search` would stop and ask, the same egress
+performed by a delegated child does not. Closing that requires a durable
+pending-spawn checkpoint the reader can answer, which is its own change
+(issue #1477), not a flag.
+
 ## Bounded scheduling
 
 Concurrency control has three independent purposes: protecting the machine,


### PR DESCRIPTION
Stacked on #1471 (docs). Part of #1454.

`spawn_sandbox_agent` and `wait_for_agents` were the only registrations with no declared approval class. `registered_class` answered `None` for them, which callers had to read as "classless means mutating", and the plan-mode surface encoded that as its own match arm rather than the class rule it applies to every other registration.

**The decision: both are `Sensitive`.** A delegated child reaches the public web, and runs commands in a container wherever the host routes children there (`OPENWAVE_CONTAINER_EXECUTION_ENABLED`). None of those calls pass back through the parent chat's approval gate — the sandbox worker advances them under its own lease — so the delegation is the only point in the chat that can carry their weight. Classing it below the authority it hands out would state the opposite of what is true.

The pair shares one class rather than splitting spawn from wait. Waiting exercises no authority of its own, but it exists only to consume what a spawn produced; advertising it in a surface that forbids spawning would only invite a call that cannot be honored.

With that declared, plan-mode filtering falls out of the class instead of the special case. A plan turn sees exactly what it saw before — `plan_surface_advertises_only_read_only_tools` is the assertion that holds it — and the `!read_only` guard on the orchestration arm is gone.

**What this deliberately does not do.** Declaring the class is not gating on it. The approval gate parks a *pending server tool call* on a durable approval receipt; a spawn has no such record, because its tool call is written already completed inside the same transaction that admits the child. So the concrete gap stands: in a chat where a foreground `web_search` would stop and ask, the same egress performed by a delegated child does not. Fixing it needs a durable pending-spawn checkpoint plus a product call about whether every delegation should cost a card — filed as #1477 with the two candidate shapes, rather than chosen unilaterally here.

No new tests: the change is a class declaration plus the removal of a special case, and the existing plan-surface test is what would fail if the derivation were wrong.

Verified: `cargo check -p openwave-core -p openwave-server --locked`, `cargo test -p openwave-core --lib agent::tests` (76 passed), `cargo fmt --check`.

Supersedes #1478, which was auto-closed when its stack base merged and could not be reopened after the branch deletion. Rebased onto current main; content unchanged.