### PR TITLE
fix(desktop): make the UI dependency install work under pnpm 11

### DIFF
--- a/crates/openwave-desktop/ui/pnpm-lock.yaml
+++ b/crates/openwave-desktop/ui/pnpm-lock.yaml
@@ -3684,7 +3684,7 @@ packages:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
-    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
+    resolution: {integrity: sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==, tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
     version: 0.20.3
     engines: {node: '>=0.8'}
     hasBin: true

--- a/crates/openwave-desktop/ui/pnpm-workspace.yaml
+++ b/crates/openwave-desktop/ui/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
+# Build-script approvals in both formats: `allowBuilds` for pnpm >= 11,
+# `onlyBuiltDependencies` for pnpm 10 (what CI pins). Keep the lists in sync.
+allowBuilds:
+  canvas: true
+  esbuild: true
+  protobufjs: true
 onlyBuiltDependencies:
   - canvas
   - esbuild


### PR DESCRIPTION
pnpm 11 rejects lockfile tarball entries that carry no integrity hash, which broke `scripts/dev.sh` for anyone with pnpm 11 on their PATH: the SheetJS `xlsx` tarball entry predates pnpm recording integrity for URL tarballs. pnpm 11 also moved build-script approvals from `onlyBuiltDependencies` to a new `allowBuilds` map, so the approvals added in #1473 were ignored and installs failed with `ERR_PNPM_IGNORED_BUILDS`.

- Record the tarball's sha512 in `pnpm-lock.yaml` (hash computed from the CDN tarball; pnpm 11 verified it on install).
- Declare the build approvals in both formats, with a comment to keep the lists in sync. pnpm 10 ignores the new key; pnpm 11 ignores the old one.

Verified locally with pnpm 10.18.3 (CI's pinned major) and 11.20.0: `pnpm install --frozen-lockfile` succeeds under both with no prompts and no lockfile rewrites.