### PR TITLE
feat(server): default new chats to open network

### DIFF
--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -199,12 +199,14 @@ where
             Some(mode) => Set(Some(mode.as_str().to_owned())),
             None => sea_orm::ActiveValue::NotSet,
         },
-        network_policy: match &chat.network_policy {
-            crate::NetworkPolicy::Off => sea_orm::ActiveValue::NotSet,
-            policy => Set(serde_json::to_string(policy).map_err(|error| {
+        // Always persist the creation-time choice explicitly. The column's
+        // historical off default remains untouched so existing databases and
+        // rows are not migrated when the product default changes.
+        network_policy: Set(
+            serde_json::to_string(&chat.network_policy).map_err(|error| {
                 AgentError::Store(format!("could not encode chat network policy: {error}"))
-            })?),
-        },
+            })?,
+        ),
         attachment_revision: Set(chat.attachment_revision),
         created_at: Set(chat.created_at),
         // The local owner rides the column default (which also keeps this

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1150,15 +1150,14 @@ impl PermissionMode {
 
 /// Network access granted to commands in one conversation workspace.
 ///
-/// The policy is provider-neutral and deny-by-default. Providers compile it to
-/// their strongest available enforcement mechanism; the local native adapter
-/// exposes only one loopback broker port and applies the destination decision
-/// outside the sandbox.
+/// The policy is provider-neutral. Providers compile it to their strongest
+/// available enforcement mechanism; the local native adapter exposes only one
+/// loopback broker port and applies the destination decision outside the
+/// sandbox. Open access still excludes local, private, and link-local targets.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, ts_rs::TS)]
 #[serde(tag = "mode", rename_all = "snake_case")]
 pub enum NetworkPolicy {
     /// Deny every outbound connection.
-    #[default]
     Off,
     /// Permit only the fixed package-registry destination class.
     PackageManagers,
@@ -1171,6 +1170,7 @@ pub enum NetworkPolicy {
     },
     /// Permit public-internet destinations. Local, private, and link-local
     /// addresses remain unreachable through the local broker.
+    #[default]
     Open,
 }
 

--- a/crates/openwave-desktop/ui/src/ComposerToolsMenu.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ComposerToolsMenu.dom.test.tsx
@@ -35,7 +35,7 @@ it("gathers the turn's setup actions behind one button", async () => {
     "Attach files",
     "Attach folder",
     "ReasoningHigh",
-    "NetworkNetwork off",
+    "NetworkOffline",
   ]);
 
   await userEvent.setup().click(

--- a/crates/openwave-desktop/ui/src/NetworkPolicyDialog.tsx
+++ b/crates/openwave-desktop/ui/src/NetworkPolicyDialog.tsx
@@ -22,8 +22,8 @@ import { Textarea } from "@/components/ui/textarea";
 const OPTIONS = [
   {
     mode: "off",
-    label: "Network off",
-    description: "Commands cannot make outbound connections.",
+    label: "Offline",
+    description: "Opt in to blocking outbound network access for this chat.",
     icon: ShieldOff,
   },
   {
@@ -40,7 +40,7 @@ const OPTIONS = [
   },
   {
     mode: "open",
-    label: "Open internet",
+    label: "Internet access",
     description: "Reach public internet destinations; local networks stay blocked.",
     icon: Globe2,
   },

--- a/crates/openwave-desktop/ui/src/NewChatSettings.ts
+++ b/crates/openwave-desktop/ui/src/NewChatSettings.ts
@@ -68,7 +68,7 @@ export const useNewChatSettings = create<NewChatSettings>((set) => ({
 /**
  * What the pickers display and the next chat will get: this visit's explicit
  * pick, else the server's sticky default, else the hard default the server
- * would fall back to (`ask`, no network, the configured model).
+ * would fall back to (`ask`, open network, the configured model).
  *
  * The model stays a `ModelSelectionKey` cast because the server reports the
  * raw sticky selection; one whose provider was since removed reads as
@@ -88,6 +88,6 @@ export function effectiveNewChatSettings(state: NewChatSettings): {
     permissionMode:
       state.permissionMode ?? state.defaults?.permission_mode ?? null,
     networkPolicy:
-      state.networkPolicy ?? state.defaults?.network_policy ?? { mode: "off" },
+      state.networkPolicy ?? state.defaults?.network_policy ?? { mode: "open" },
   };
 }

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1188,10 +1188,10 @@ resolved_key: string | null, };
 /**
  * Network access granted to commands in one conversation workspace.
  *
- * The policy is provider-neutral and deny-by-default. Providers compile it to
- * their strongest available enforcement mechanism; the local native adapter
- * exposes only one loopback broker port and applies the destination decision
- * outside the sandbox.
+ * The policy is provider-neutral. Providers compile it to their strongest
+ * available enforcement mechanism; the local native adapter exposes only one
+ * loopback broker port and applies the destination decision outside the
+ * sandbox. Open access still excludes local, private, and link-local targets.
  */
 export type NetworkPolicy = { "mode": "off" } | { "mode": "package_managers" } | { "mode": "allowed_hosts", allowed_hosts: Array<string>, package_managers: boolean, } | { "mode": "open" };
 
@@ -1580,7 +1580,7 @@ level_title: string | null, action: RendererToolName, approval: ToolApprovalKind
 /**
  * The reader's last explicit per-chat choices — what an unspecified field of
  * `POST /chats` seeds. A `None` field has no recorded choice and keeps the
- * hard default (configured model, `ask`, no network).
+ * hard default (configured model, `ask`, open network).
  *
  * The permission mode is reported clamped to any managed ceiling, so what a
  * picker displays is what creation will actually seed.

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -885,12 +885,8 @@ async fn bind_inner(
         .with_office_converter(office_converter)
         .with_host_tool_broker(host_tool_broker),
     );
-    let foreground_web_search =
-        Box::new(web_search::foreground_tool(store.clone(), secrets.clone()));
-    let web_extract = Box::new(web_search::foreground_extract_tool(
-        store.clone(),
-        secrets.clone(),
-    ));
+    let foreground_web_search = web_search::foreground_tool(store.clone(), secrets.clone());
+    let web_extract = web_search::foreground_extract_tool(store.clone(), secrets.clone());
     let (tools, agent_config) = agent_deps(
         code_execution.clone(),
         foreground_web_search,

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -533,7 +533,7 @@ pub struct Settings {
 
 /// The reader's last explicit per-chat choices — what an unspecified field of
 /// `POST /chats` seeds. A `None` field has no recorded choice and keeps the
-/// hard default (configured model, `ask`, no network).
+/// hard default (configured model, `ask`, open network).
 ///
 /// The permission mode is reported clamped to any managed ceiling, so what a
 /// picker displays is what creation will actually seed.
@@ -1489,7 +1489,7 @@ pub struct CreateChat {
     #[serde(default)]
     pub permission_mode: Option<PermissionMode>,
     /// Code-execution network access for this conversation workspace.
-    /// Omitted seeds the sticky default, else no network.
+    /// Omitted seeds the sticky default, else open public-internet access.
     #[serde(default)]
     pub network_policy: Option<openwave_core::NetworkPolicy>,
 }
@@ -1561,7 +1561,7 @@ async fn read_sticky_chat_defaults(state: &AppState) -> Result<StickyChatDefault
 /// reader's last explicit choice at these same routes — so a new chat starts
 /// the way the reader configured the previous one instead of resetting to the
 /// hard defaults. A brand-new install has no sticky state and keeps today's
-/// defaults (`ask`, network off, configured model).
+/// defaults (`ask`, open network, configured model).
 pub async fn create_chat(
     State(state): State<AppState>,
     store: ScopedStore,
@@ -1628,7 +1628,8 @@ pub async fn create_chat(
                 .await?
                 .unwrap_or_default();
             // Stored values were normalized at write; a stale one that no
-            // longer passes falls back to no network rather than failing.
+            // longer passes falls back to the product default rather than
+            // failing the create.
             if crate::code_execution::normalize_network_policy(&mut sticky).is_err() {
                 sticky = openwave_core::NetworkPolicy::default();
             }

--- a/crates/openwave-server/src/tests/conversations.rs
+++ b/crates/openwave-server/src/tests/conversations.rs
@@ -630,11 +630,11 @@ async fn chat_settings_stick_to_the_next_chat() {
 }
 
 #[tokio::test]
-async fn chat_network_policy_defaults_off_and_persists_normalized_exact_hosts() {
+async fn chat_network_policy_defaults_open_and_persists_normalized_exact_hosts() {
     let (router, token, _store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");
     let chat = make_chat(&router, &bearer).await;
-    assert_eq!(chat.network_policy, openwave_core::NetworkPolicy::Off);
+    assert_eq!(chat.network_policy, openwave_core::NetworkPolicy::Open);
 
     let updated = patch_chat(
         &router,

--- a/crates/openwave-server/src/tests/documents.rs
+++ b/crates/openwave-server/src/tests/documents.rs
@@ -1570,14 +1570,8 @@ async fn agent_deps_registers_server_tools_and_closed_foreground_capabilities() 
     let extract_store = store.clone();
     let (mut tools, config) = agent_deps(
         Arc::new(UnavailableCodeExecution),
-        Box::new(web_search::foreground_tool(
-            store.clone(),
-            Arc::new(MemSecrets::default()),
-        )),
-        Box::new(web_search::foreground_extract_tool(
-            extract_store,
-            Arc::new(MemSecrets::default()),
-        )),
+        web_search::foreground_tool(store.clone(), Arc::new(MemSecrets::default())),
+        web_search::foreground_extract_tool(extract_store, Arc::new(MemSecrets::default())),
         store,
         dir.path().join("profile-data"),
     );

--- a/crates/openwave-server/src/web_search.rs
+++ b/crates/openwave-server/src/web_search.rs
@@ -10,7 +10,10 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use openwave_core::{ChatId, DocumentId, DocumentUpsert, Result, SecretProvider, Store};
+use openwave_core::{
+    ApprovalClass, ChatId, DocumentId, DocumentUpsert, NetworkPolicy, Result, SecretProvider,
+    Store, Tool, ToolCtx, ToolOutput, ToolSpec,
+};
 use openwave_web_search::{
     BraveProvider, ExaProvider, ExtractedPageSink, ExtractedPageSinkError, NativeExtractor,
     OutboundOrigin, PageExtractor, ReqwestHttpClient, ReqwestPageFetcher, SearxngBaseUrl,
@@ -22,6 +25,50 @@ use openwave_web_search::{
 use serde::{Deserialize, Serialize};
 
 use crate::error::ServerError;
+
+const NETWORK_OFF_ERROR_CODE: &str = "chat_network_off";
+const NETWORK_OFF_MESSAGE: &str =
+    "Network is off for this chat. Turn it on from the composer's + menu under Network.";
+
+/// Enforce the per-chat network choice before a network-capable tool runs.
+///
+/// Destination admission remains inside each transport; this gate exists so
+/// an intentional offline choice is reported clearly instead of collapsing
+/// into an empty search or an opaque fetch failure.
+struct ChatNetworkPolicyTool {
+    store: Arc<dyn Store>,
+    inner: Box<dyn Tool>,
+}
+
+impl ChatNetworkPolicyTool {
+    fn new(store: Arc<dyn Store>, inner: Box<dyn Tool>) -> Self {
+        Self { store, inner }
+    }
+
+    fn denied_output() -> ToolOutput {
+        ToolOutput::error(NETWORK_OFF_MESSAGE)
+            .with_data(serde_json::json!({ "error_code": NETWORK_OFF_ERROR_CODE }))
+    }
+}
+
+#[async_trait]
+impl Tool for ChatNetworkPolicyTool {
+    fn spec(&self) -> ToolSpec {
+        self.inner.spec()
+    }
+
+    fn approval_class(&self) -> ApprovalClass {
+        self.inner.approval_class()
+    }
+
+    async fn execute(&self, ctx: &ToolCtx, args: serde_json::Value) -> Result<ToolOutput> {
+        let chat = self.store.get_chat(ctx.chat_id).await?;
+        if chat.is_some_and(|chat| chat.network_policy == NetworkPolicy::Off) {
+            return Ok(Self::denied_output());
+        }
+        self.inner.execute(ctx, args).await
+    }
+}
 
 /// Store key for the non-secret web-search configuration.
 const WEB_SEARCH_SETTING: &str = "web_search";
@@ -445,8 +492,14 @@ impl WebSearchResolver for HostWebSearchResolver {
 pub(crate) fn foreground_tool(
     store: Arc<dyn Store>,
     secrets: Arc<dyn SecretProvider>,
-) -> WebSearchTool {
-    WebSearchTool::new(Arc::new(HostWebSearchResolver { store, secrets }))
+) -> Box<dyn Tool> {
+    Box::new(ChatNetworkPolicyTool::new(
+        store.clone(),
+        Box::new(WebSearchTool::new(Arc::new(HostWebSearchResolver {
+            store,
+            secrets,
+        }))),
+    ))
 }
 
 /// Native page extraction under live host policy.
@@ -553,8 +606,8 @@ impl ExtractedPageSink for HostExtractedPageSink {
 pub(crate) fn foreground_extract_tool(
     store: Arc<dyn Store>,
     secrets: Arc<dyn SecretProvider>,
-) -> WebExtractTool {
-    WebExtractTool::new(
+) -> Box<dyn Tool> {
+    let tool = WebExtractTool::new(
         Arc::new(HostWebSearchResolver {
             store: store.clone(),
             secrets,
@@ -563,7 +616,10 @@ pub(crate) fn foreground_extract_tool(
             store: store.clone(),
         })),
     )
-    .with_page_sink(Arc::new(HostExtractedPageSink { store }))
+    .with_page_sink(Arc::new(HostExtractedPageSink {
+        store: store.clone(),
+    }));
+    Box::new(ChatNetworkPolicyTool::new(store, Box::new(tool)))
 }
 
 #[cfg(test)]
@@ -572,7 +628,8 @@ mod tests {
     use std::sync::Mutex;
 
     use async_trait::async_trait;
-    use openwave_core::{AgentError, DbStore};
+    use chrono::Utc;
+    use openwave_core::{AgentError, Chat, DbStore, ToolCtx};
 
     use super::*;
 
@@ -608,6 +665,53 @@ mod tests {
         .await
         .unwrap();
         (store, dir)
+    }
+
+    struct UnexpectedNetworkTool;
+
+    #[async_trait]
+    impl Tool for UnexpectedNetworkTool {
+        fn spec(&self) -> ToolSpec {
+            openwave_core::web_search_tool_spec()
+        }
+
+        fn approval_class(&self) -> ApprovalClass {
+            ApprovalClass::Sensitive
+        }
+
+        async fn execute(&self, _ctx: &ToolCtx, _args: serde_json::Value) -> Result<ToolOutput> {
+            panic!("offline policy must stop the network tool before execution")
+        }
+    }
+
+    #[tokio::test]
+    async fn offline_chat_network_denial_is_actionable_and_structured() {
+        let (store, _dir) = test_store().await;
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            reasoning_effort: None,
+            permission_mode: None,
+            network_policy: NetworkPolicy::Off,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let tool = ChatNetworkPolicyTool::new(Arc::new(store), Box::new(UnexpectedNetworkTool));
+
+        let output = tool
+            .execute(
+                &ToolCtx::without_private_scratch(chat.id, None),
+                serde_json::json!({"query": "anything"}),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(output.content, NETWORK_OFF_MESSAGE);
+        assert_eq!(output.data.unwrap()["error_code"], NETWORK_OFF_ERROR_CODE);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- default newly created chats to open public-internet network access while preserving existing stored policies
- make offline web search and page extraction failures explain that network is off for the chat and point to the composer's + menu
- include the structured tool error code `chat_network_off` for a future inline enable action
- present Offline as an explicit per-chat hardening choice in the existing network menu

## Safety verification

Open mode does not bypass destination guards:

- native code execution remains confined to the loopback CONNECT broker, which resolves destinations outside the sandbox, rejects private/loopback/link-local answers, and connects only to the vetted address set
- Docker code execution remains on an internal-only bridge and can egress only through the external proxy, which applies the same destination validation and restricted-address checks
- native page extraction re-admits every redirect URL, freshly resolves and vets every hop, disables ambient proxies, and pins reqwest to the vetted addresses

The historical database column default remains `off`; new chats now persist their resolved policy explicitly, so existing chats are not migrated.

## Verification

- `cargo check -p openwave-core --locked`
- `cargo check -p openwave-server --locked`
- `cargo test -p openwave-server --locked chat_network_policy_defaults_open_and_persists_normalized_exact_hosts`
- `cargo test -p openwave-server --locked offline_chat_network_denial_is_actionable_and_structured`
- `cargo test -p openwave-web-search --locked admission_rejects_unsafe_urls_and_denied_hosts_in_every_encoding`
- `cargo test -p openwave-web-search --locked redirect_hops_toward_denied_space_are_refused_before_any_fetch --features extract-native`
- `cargo test -p openwave-code-execution --locked broker_rejects_loopback_immediately_even_under_open_policy`
- `UPDATE_WIRE_TYPES=1 cargo test -p openwave-server --locked wire_types::tests::the_generated_bindings_are_current`
- `cargo fmt --all -- --check`
- `git diff --check`

UI typecheck and Vitest were not run because this worktree has no installed pnpm dependencies (`tsc` and `vitest` are unavailable).