### PR TITLE
fix(router): send current provider request shapes

### DIFF
--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -1231,7 +1231,7 @@ mod tests {
                 ProviderEvent::Failed {
                     error: ProviderErrorInfo {
                         kind: "overloaded".into(),
-                        message: "anthropic returned 500 (overloaded_error)".into(),
+                        message: "anthropic returned 500 (overloaded_error): Overloaded".into(),
                     },
                 },
             ]

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -616,7 +616,7 @@ fn gemini_contents(
                     }
                     parts.push(json!({
                         "functionResponse": {
-                            "id": tool_use_id,
+                            "call_id": tool_use_id,
                             "name": name,
                             "response": response,
                         },
@@ -962,6 +962,12 @@ mod tests {
         );
         assert_eq!(body["toolConfig"]["functionCallingConfig"]["mode"], "AUTO");
         assert!(body.get("temperature").is_none());
+        for unsupported in ["temperature", "topP", "topK", "candidateCount"] {
+            assert!(body["generationConfig"].get(unsupported).is_none());
+        }
+        assert!(body["generationConfig"]["thinkingConfig"]
+            .get("thinkingBudget")
+            .is_none());
         assert!(body["generationConfig"].get("max_tokens").is_none());
     }
 
@@ -1059,9 +1065,10 @@ mod tests {
         assert!(contents[0]["parts"][1].get("thoughtSignature").is_none());
         let responses = contents[1]["parts"].as_array().unwrap();
         assert_eq!(responses.len(), 2);
-        assert_eq!(responses[0]["functionResponse"]["id"], "call_one");
+        assert_eq!(responses[0]["functionResponse"]["call_id"], "call_one");
         assert_eq!(responses[0]["functionResponse"]["name"], "read_file");
-        assert_eq!(responses[1]["functionResponse"]["id"], "call_two");
+        assert_eq!(responses[1]["functionResponse"]["call_id"], "call_two");
+        assert!(responses[0]["functionResponse"].get("id").is_none());
     }
 
     // ── Image blocks ───────────────────────────────────────────────

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -888,7 +888,7 @@ mod tests {
                 ProviderEvent::Failed {
                     error: ProviderErrorInfo {
                         kind: "overloaded".into(),
-                        message: "openai-compat returned 500 (server_error)".into(),
+                        message: "openai-compat returned 500 (server_error): upstream is overloaded".into(),
                     },
                 },
             ]

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -195,7 +195,10 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         body["max_completion_tokens"] = json!(max_tokens);
         // Only reasoning models understand `reasoning_effort`; forwarding it to a
         // plain chat model would be rejected. Absent, the provider's default holds.
-        if let Some(effort) = req.reasoning_effort {
+        if let Some(effort) = req
+            .reasoning_effort
+            .filter(|effort| *effort != openwave_core::ReasoningEffort::None)
+        {
             body["reasoning_effort"] = json!(effort.as_str());
         }
     } else {
@@ -735,7 +738,7 @@ mod tests {
     fn reasoning_models_use_max_completion_tokens() {
         let req = ChatRequest {
             provider: Some(ProviderId::new("openai")),
-            model: "o3".into(),
+            model: "gpt-5.6-sol".into(),
             reasoning_model: true,
             system: None,
             messages: vec![ChatMessage::text(Role::User, "hi")],
@@ -757,7 +760,7 @@ mod tests {
     fn reasoning_models_forward_reasoning_effort() {
         let req = ChatRequest {
             provider: Some(ProviderId::new("openai")),
-            model: "o3".into(),
+            model: "gpt-5.6-sol".into(),
             reasoning_model: true,
             system: None,
             messages: vec![ChatMessage::text(Role::User, "hi")],
@@ -770,6 +773,26 @@ mod tests {
         };
         let body = build_request_json(&req).unwrap();
         assert_eq!(body["reasoning_effort"], "low");
+    }
+
+    #[test]
+    fn gpt_5_6_none_uses_the_provider_default() {
+        let req = ChatRequest {
+            provider: Some(ProviderId::new("openai")),
+            model: "gpt-5.6-sol".into(),
+            reasoning_model: true,
+            messages: vec![ChatMessage::text(Role::User, "hi")],
+            max_tokens: Some(1024),
+            reasoning_effort: Some(ReasoningEffort::None),
+            ..Default::default()
+        };
+        let body = build_request_json(&req).unwrap();
+        assert!(body.get("reasoning_effort").is_none());
+        assert_eq!(
+            body["messages"],
+            json!([{ "role": "user", "content": "hi" }])
+        );
+        assert!(body.get("tools").is_none());
     }
 
     #[test]

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -101,24 +101,40 @@ pub fn frame_data(frame: &str) -> Option<serde_json::Value> {
     frame_data_raw(frame).and_then(|data| serde_json::from_str(&data).ok())
 }
 
-/// Build a client-safe provider error: status + optional stable `error.type` /
-/// `error.code` from the JSON body. Never include the raw body (it can echo
-/// secrets, and `AgentError` strings reach the client via `TurnFailed`).
+/// Build a client-safe provider error from structured JSON fields.
+///
+/// A compact stable `error.type` / `error.code` is included when present. The
+/// provider's message is useful for field-level request failures, but can echo
+/// credentials or request fragments, so only a short single-line excerpt that
+/// passes conservative secret redaction reaches `TurnFailed`.
 pub fn safe_http_error(provider: &str, status: u16, body: &str) -> String {
-    let detail = serde_json::from_str::<serde_json::Value>(body)
-        .ok()
-        .and_then(|v| {
-            let err = v.get("error").unwrap_or(&v);
-            err.get("type")
-                .or_else(|| err.get("code"))
+    let parsed = serde_json::from_str::<serde_json::Value>(body).ok();
+    let error = parsed
+        .as_ref()
+        .map(|value| value.get("error").unwrap_or(value));
+    let raw_code = error
+        .and_then(|error| error.get("type").or_else(|| error.get("code")))
+        .and_then(serde_json::Value::as_str);
+    let code = raw_code.filter(|code| safe_error_code(code));
+    let message = raw_code
+        .is_none_or(safe_error_code)
+        .then(|| {
+            error
+                .and_then(|error| error.get("message"))
                 .and_then(serde_json::Value::as_str)
-                .filter(|code| safe_error_code(code))
-                .map(str::to_owned)
-        });
-    match detail {
-        Some(code) => format!("{provider} returned {status} ({code})"),
-        None => format!("{provider} returned {status}"),
+                .and_then(safe_error_message)
+        })
+        .flatten();
+
+    let mut result = format!("{provider} returned {status}");
+    if let Some(code) = code {
+        result.push_str(&format!(" ({code})"));
     }
+    if let Some(message) = message {
+        result.push_str(": ");
+        result.push_str(&message);
+    }
+    result
 }
 
 /// Classify an error delivered *inside* a 200 stream — the in-band counterpart
@@ -157,6 +173,37 @@ fn safe_error_code(code: &str) -> bool {
         && bytes
             .iter()
             .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || *byte == b'_')
+}
+
+fn safe_error_message(message: &str) -> Option<String> {
+    const MAX_ERROR_MESSAGE_CHARS: usize = 240;
+    let collapsed = message.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.is_empty() || contains_secret_marker(&collapsed) {
+        return None;
+    }
+    let mut excerpt: String = collapsed.chars().take(MAX_ERROR_MESSAGE_CHARS).collect();
+    if collapsed.chars().count() > MAX_ERROR_MESSAGE_CHARS {
+        excerpt.push('…');
+    }
+    Some(excerpt)
+}
+
+fn contains_secret_marker(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    [
+        "sk-",
+        "aiza",
+        "bearer ",
+        "api_key",
+        "api-key",
+        "apikey",
+        "authorization:",
+        "x-goog-api-key",
+        "private_key",
+        "private key",
+    ]
+    .iter()
+    .any(|marker| lower.contains(marker))
 }
 
 /// Longest provider-requested wait taken at face value.
@@ -410,6 +457,28 @@ mod tests {
         assert_eq!(
             safe_http_error("anthropic", 429, r#"{"error":{"type":"rate_limit_error"}}"#),
             "anthropic returned 429 (rate_limit_error)"
+        );
+    }
+
+    #[test]
+    fn safe_http_error_surfaces_a_bounded_structured_message() {
+        let body = serde_json::json!({
+            "error": {
+                "type": "invalid_request_error",
+                "message": format!("Unknown model: {}", "x".repeat(300))
+            }
+        })
+        .to_string();
+        let error = safe_http_error("openai-compat", 400, &body);
+        assert!(error
+            .starts_with("openai-compat returned 400 (invalid_request_error): Unknown model: "));
+        assert!(error.ends_with('…'));
+        assert!(error.chars().count() < 320);
+
+        let secret = r#"{"error":{"message":"invalid x-goog-api-key abc123"}}"#;
+        assert_eq!(
+            safe_http_error("gemini", 400, secret),
+            "gemini returned 400"
         );
     }
 }


### PR DESCRIPTION
## Summary

- send Gemini 3.x tool results with the required `call_id` and `name`
- omit OpenWave's explicit `none` reasoning choice for GPT-5.6 so the provider default applies
- include a bounded, single-line provider 400 message excerpt after conservative secret filtering

## Root cause

The curated model ids are correct and remain unchanged. `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` are exact OpenAI API ids, while `gemini-3.6-flash` is a GA Gemini API id served through `generateContent` and `streamGenerateContent`.

The failures were request-generation incompatibilities:

- Gemini 3.x migration rules require requests to omit `temperature`, `top_p`, `top_k`, and `candidate_count`; use string `thinkingLevel` instead of legacy `thinkingBudget`; never send both thinking controls; and include `call_id` plus `name` on FunctionResponse objects. The adapter already omitted the sampling controls and used only `thinkingLevel`, but serialized tool responses as `id` instead of `call_id`. The wire test now pins all of these Gemini 3.6 rules.
- The OpenAI adapter treated OpenWave's explicit `none` effort as a provider wire value and emitted `reasoning_effort: "none"`. “Provider default” was already represented correctly as an absent Rust value and omitted. The adapter now also omits the explicit `none` choice for GPT-5.6-style reasoning requests, leaving the provider default in force. The minimal GPT-5.6 wire test pins the absence of `reasoning_effort`, tools, and other empty optional fields.

The original debug bundles only retained `openai-compat returned 400 (invalid_request_error)` and `gemini returned 400`, because provider messages were discarded. Future failures now retain a bounded structured excerpt while suppressing messages containing credential markers.

## Verification

- `cargo check -p openwave-router --locked`
- all Gemini adapter unit tests
- focused GPT-5.6 request-shape and reasoning-effort tests
- focused provider-error excerpt and secret-filtering tests
- `cargo fmt --all -- --check`
- `git diff --check`

Live provider verification is pending because no OpenAI or Gemini API keys were available in this worktree.
