### PR TITLE
feat(desktop): once-only facts and app-first hierarchy on the Connected apps page

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -825,6 +825,10 @@ impl Store for DbStore {
         ops::app::delete_app_grant(self, app_id).await
     }
 
+    async fn list_live_app_grants(&self) -> Result<Vec<AppGrant>> {
+        ops::app::list_live_app_grants(self).await
+    }
+
     async fn list_connected_apps(&self) -> Result<Vec<ConnectedApp>> {
         ops::connected_app::list_connected_apps(self).await
     }

--- a/crates/openwave-core/src/db/ops/app.rs
+++ b/crates/openwave-core/src/db/ops/app.rs
@@ -10,7 +10,7 @@
 
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder,
-    QuerySelect, Set, TransactionTrait,
+    QuerySelect, RelationTrait, Set, TransactionTrait,
 };
 
 use crate::error::{AgentError, Result};
@@ -291,6 +291,21 @@ pub(in crate::db) async fn delete_app_grant(store: &DbStore, app_id: AppId) -> R
         .await
         .map_err(store_err)?;
     Ok(deleted.rows_affected > 0)
+}
+
+pub(in crate::db) async fn list_live_app_grants(store: &DbStore) -> Result<Vec<AppGrant>> {
+    entities::app_grant::Entity::find()
+        .join(
+            sea_orm::JoinType::InnerJoin,
+            entities::app_grant::Relation::App.def(),
+        )
+        .filter(entities::app::Column::DeletedAt.is_null())
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(grant_from_model)
+        .collect()
 }
 
 fn grant_from_model(model: entities::app_grant::Model) -> Result<AppGrant> {

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1878,6 +1878,18 @@ pub trait Store: Send + Sync {
         app_storage_unavailable()
     }
 
+    /// Every app grant whose owning app is still in the library (not
+    /// soft-deleted), in no particular order.
+    ///
+    /// Serves aggregate views over consent — e.g. how many apps currently
+    /// bind one connected app — where fetching grants one app at a time
+    /// would mean walking the whole library. A grant of a deleted app is
+    /// excluded: it can no longer be exercised, so surfaces built on this
+    /// must not count it.
+    async fn list_live_app_grants(&self) -> Result<Vec<AppGrant>> {
+        app_storage_unavailable()
+    }
+
     /// List every connected app the profile holds, oldest first.
     ///
     /// Kind-specific definitions come back as the bounded JSON the owning

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -604,7 +604,13 @@ gateway_endpoint: string | null,
  * the apps surface: the entry then renders without org-app names
  * rather than erroring.
  */
-gateway_apps: Array<string>, } | { "kind": "rest_api", 
+gateway_apps: Array<string>, 
+/**
+ * How many local mini-apps hold a live grant binding this record —
+ * a count only, never app names or ids, the renderer-safety posture
+ * of this surface. Grants of library-deleted apps do not count.
+ */
+used_by_app_count: number, } | { "kind": "rest_api", 
 /**
  * The record id app bindings name.
  */
@@ -623,7 +629,13 @@ document_sha256: string, credential_status: RestCredentialStatus,
  * one is referenced. The placement (and a custom header *name*) is
  * configuration; the value never appears on this surface.
  */
-placement: CredentialPlacement | null, updated_at: string, };
+placement: CredentialPlacement | null, updated_at: string, 
+/**
+ * How many local mini-apps hold a live grant binding this record —
+ * a count only, never app names or ids, the renderer-safety posture
+ * of this surface. Grants of library-deleted apps do not count.
+ */
+used_by_app_count: number, };
 
 /**
  * The renderer's listing of every configured connected app, across kinds.

--- a/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.dom.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ApiClient, ConnectedAppsInfo, McpServerInfo } from "../api";
@@ -7,7 +13,7 @@ import { ConnectedAppsPanel } from "./ConnectedAppsPanel";
 
 const SECRET = "sk-rest-value-hunter2";
 
-/** One configured manual server, so the demoted editor has a row to show. */
+/** One configured manual server, so the editing surface has a row to show. */
 const docsServer: McpServerInfo = {
   name: "docs",
   command: "/usr/local/bin/docs-mcp",
@@ -26,7 +32,8 @@ const docsServer: McpServerInfo = {
 };
 
 /** The app-first listing: a gateway-backed record (org apps ride the
- * `primary` endpoint), a local record, and a REST entry. */
+ * `primary` endpoint), a local record two mini-apps bind, and a REST entry
+ * one mini-app binds. */
 const listing: ConnectedAppsInfo = {
   apps: [
     {
@@ -39,6 +46,7 @@ const listing: ConnectedAppsInfo = {
       diagnostic: null,
       gateway_endpoint: "primary",
       gateway_apps: ["Sentry (org)", "Linear (org)"],
+      used_by_app_count: 0,
     },
     {
       kind: "mcp_server",
@@ -50,6 +58,7 @@ const listing: ConnectedAppsInfo = {
       diagnostic: null,
       gateway_endpoint: null,
       gateway_apps: [],
+      used_by_app_count: 2,
     },
     {
       kind: "rest_api",
@@ -61,6 +70,7 @@ const listing: ConnectedAppsInfo = {
       credential_status: "configured",
       placement: "bearer",
       updated_at: "2026-08-03T00:00:00Z",
+      used_by_app_count: 1,
     },
   ],
 };
@@ -70,7 +80,8 @@ function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
     listConnectedApps: vi.fn().mockResolvedValue(listing),
     putRestConnectedApp: vi.fn().mockResolvedValue(listing),
     deleteRestConnectedApp: vi.fn().mockResolvedValue(undefined),
-    // The demoted MCP editor reads its own server list and gateway session.
+    reconnectMcpServer: vi.fn().mockResolvedValue({ servers: [docsServer] }),
+    // The embedded MCP surface reads its own server list and gateway session.
     listMcpServers: vi.fn().mockResolvedValue({ servers: [docsServer] }),
     getGatewayStatus: vi.fn().mockResolvedValue({ signed_in: false }),
     getGatewayApps: vi.fn().mockResolvedValue({ supported: true, apps: [] }),
@@ -79,7 +90,7 @@ function api(overrides: Partial<Record<keyof ApiClient, unknown>> = {}) {
 }
 
 /** A signed-in gateway session whose org apps ride the `primary` endpoint,
- * for tests that open the Advanced disclosure's endpoint toggles. */
+ * for tests that exercise the endpoint rows. */
 function signedInOverrides() {
   return {
     getGatewayStatus: vi
@@ -100,37 +111,48 @@ function signedInOverrides() {
   };
 }
 
+/** The one list container the app entries live in. */
+async function appsList(): Promise<HTMLElement> {
+  return await screen.findByRole("list", { name: "Connected apps" });
+}
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
 });
 
 describe("ConnectedAppsPanel", () => {
-  it("leads with apps: org-app names for gateway entries, record names for local ones", async () => {
+  it("leads with apps: org-app names, health chips, and bound-app counts", async () => {
     render(<ConnectedAppsPanel client={api()} managed={false} />);
 
     // The gateway-backed entry leads with the organization's app names, not
     // its endpoint slug; the local record is its own app.
+    const list = await appsList();
     expect(
-      await screen.findByText("Sentry (org), Linear (org)"),
+      within(list).getByText("Sentry (org), Linear (org)"),
     ).toBeInTheDocument();
-    expect(screen.getByText("docs")).toBeInTheDocument();
-    expect(screen.queryByText("primary")).not.toBeInTheDocument();
+    expect(within(list).getByText("docs")).toBeInTheDocument();
+    expect(within(list).queryByText("primary")).not.toBeInTheDocument();
 
     // REST entries are first-class app entries in the same list.
-    expect(screen.getByText("Sentry")).toBeInTheDocument();
+    expect(within(list).getByText("Sentry")).toBeInTheDocument();
     expect(
-      screen.getByText(
+      within(list).getByText(
         /api\.sentry\.example\/v2 · 2 operations · Credential configured/,
       ),
     ).toBeInTheDocument();
+
+    // Bound-app counts render per entry — and only when non-zero.
+    expect(within(list).getByText("Used by 2 local apps")).toBeInTheDocument();
+    expect(within(list).getByText("Used by 1 local app")).toBeInTheDocument();
+    expect(screen.queryByText(/Used by 0/)).not.toBeInTheDocument();
   });
 
   it("expands a collapsed accordion to monospace tool names", async () => {
     const user = userEvent.setup();
     render(<ConnectedAppsPanel client={api()} managed={false} />);
 
-    await screen.findByText("docs");
+    await appsList();
     // Collapsed by default: no tool names anywhere.
     expect(screen.queryByText("search")).not.toBeInTheDocument();
     expect(screen.queryByText("sentry__proxy_api")).not.toBeInTheDocument();
@@ -143,43 +165,56 @@ describe("ConnectedAppsPanel", () => {
     expect(screen.queryByText("sentry__proxy_api")).not.toBeInTheDocument();
   });
 
-  it("keeps endpoints and the manual editor inside the Advanced disclosure", async () => {
-    const user = userEvent.setup();
+  it("unmanaged: no Advanced section; the editor follows the apps list", async () => {
     render(
       <ConnectedAppsPanel client={api(signedInOverrides())} managed={false} />,
     );
 
-    await screen.findByText("docs");
-    // Before expanding: no mount toggles, no editor, no endpoint section.
-    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
+    const list = await appsList();
+    // No gateway indirection to hide: there is no Advanced disclosure, and
+    // the endpoint toggles and the manual editor are directly reachable.
     expect(
-      screen.queryByRole("button", { name: /Save and verify/ }),
+      screen.queryByRole("button", { name: /Advanced: transport/ }),
     ).not.toBeInTheDocument();
-    expect(screen.queryByText("Gateway endpoints")).not.toBeInTheDocument();
-
-    await user.click(
-      screen.getByRole("button", { name: /Advanced: transport & endpoints/ }),
-    );
-    // Every existing capability is reachable: the mount toggle, the manual
-    // editor with its namespace field, and save.
     expect(
       await screen.findByRole("switch", { name: "Mount primary" }),
     ).toBeInTheDocument();
     expect(await screen.findByLabelText(/Namespace/)).toHaveValue("docs");
+    const save = screen.getByRole("button", { name: /Save and verify/ });
+    // The editing surface no longer leads: the apps list comes first.
     expect(
-      screen.getByRole("button", { name: /Save and verify/ }),
-    ).toBeInTheDocument();
+      list.compareDocumentPosition(save) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    // The reconnect action rides the entries themselves.
+    expect(
+      within(list).getAllByRole("button", { name: /Reconnect/ }).length,
+    ).toBeGreaterThan(0);
+
+    // The approval boundary is stated once, as the page footer.
+    expect(
+      screen.getAllByText(/existing approval boundary/),
+    ).toHaveLength(1);
   });
 
-  it("managed: keeps the notice and mount toggles but no edit affordances", async () => {
+  it("managed: prose notice, once-only facts, and a collapsed Advanced", async () => {
     const user = userEvent.setup();
     render(<ConnectedAppsPanel client={api(signedInOverrides())} managed />);
 
-    expect(
-      await screen.findByText(/Managed by your organization/),
-    ).toBeInTheDocument();
-    // Entries stay visible read-only; every REST write affordance is gone.
-    expect(screen.getByText("Sentry")).toBeInTheDocument();
+    // The managed notice is one line of muted prose under the Apps heading —
+    // not a card, and not an entry inside the list.
+    const notice = await screen.findByText(
+      /REST connected apps are managed by your organization's gateway/,
+    );
+    expect(notice.tagName).toBe("P");
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    const list = await appsList();
+    expect(list.contains(notice)).toBe(false);
+
+    // Entries stay visible read-only; every REST write affordance is gone,
+    // and no entry carries a reconnect action — that lives on the endpoint
+    // row under Advanced.
+    expect(within(list).getByText("Sentry")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /Add REST API/ }),
     ).not.toBeInTheDocument();
@@ -189,15 +224,23 @@ describe("ConnectedAppsPanel", () => {
     expect(
       screen.queryByRole("button", { name: /^Remove/ }),
     ).not.toBeInTheDocument();
+    expect(
+      within(list).queryByRole("button", { name: /Reconnect/ }),
+    ).not.toBeInTheDocument();
+
+    // Advanced is collapsed by default: no endpoint machinery on screen.
+    expect(screen.queryByRole("switch")).not.toBeInTheDocument();
 
     await user.click(
       screen.getByRole("button", { name: /Advanced: transport & endpoints/ }),
     );
-    // The endpoint toggle — the one write managed policy admits — stays
-    // live; nothing manual is editable.
+    // Compact rows: the mount toggle (the one write managed policy admits)
+    // and the serves-list, with no inner headings and nothing editable.
     expect(
       await screen.findByRole("switch", { name: "Mount primary" }),
     ).toBeEnabled();
+    expect(screen.getByText(/serves: Sentry \(org\)/)).toBeInTheDocument();
+    expect(screen.queryByText("Gateway endpoints")).not.toBeInTheDocument();
     await waitFor(() =>
       expect(screen.queryByRole("textbox")).not.toBeInTheDocument(),
     );
@@ -207,6 +250,16 @@ describe("ConnectedAppsPanel", () => {
     expect(
       screen.queryByRole("button", { name: /Save and verify/ }),
     ).not.toBeInTheDocument();
+
+    // Every fact once: with Advanced open, the tool count still renders only
+    // on the app entry, and the old status sentence is gone everywhere.
+    expect(screen.getAllByText("2 tools")).toHaveLength(1);
+    expect(
+      screen.queryByText(/available to new turns/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getAllByText(/existing approval boundary/),
+    ).toHaveLength(1);
   });
 
   it("submits the PUT shape from the create form and never renders the value back", async () => {

--- a/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import { ChevronDown, ChevronRight, Pencil, Plus, Trash2 } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronRight,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Trash2,
+} from "lucide-react";
 import type {
   ApiClient,
   ConnectedAppInfo,
@@ -8,14 +15,14 @@ import type {
   RestCredentialUpdate,
 } from "../api";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { McpPanel } from "./McpPanel";
+import { McpHealthChip, McpPanel } from "./McpPanel";
 import {
   SettingsError,
   SettingsField,
   SettingsPanel,
   SettingsSection,
-  SettingsStatus,
 } from "./primitives";
 
 type RestEntry = Extract<ConnectedAppInfo, { kind: "rest_api" }>;
@@ -91,37 +98,56 @@ function mcpTitle(entry: McpEntry): string {
     : entry.name;
 }
 
-/** One renderer-safe status sentence per entry; diagnostics already are one. */
-function mcpStatus(entry: McpEntry): string {
-  switch (entry.health) {
-    case "healthy":
-      return `${entry.tool_count} tool${entry.tool_count === 1 ? "" : "s"} available to new turns.`;
-    case "initializing":
-    case "reconnecting":
-      return "Connecting…";
-    case "disabled":
-      return entry.diagnostic ?? "Disabled.";
-    default:
-      return entry.diagnostic ?? "Needs attention. See Advanced below.";
-  }
+/** The one line naming how many local mini-apps bind an entry. */
+function usedByLabel(count: number): string {
+  return `Used by ${count} local app${count === 1 ? "" : "s"}`;
 }
 
 /**
- * One MCP-backed app entry: the app name first, a status line, and a
- * collapsed accordion enumerating the mounted tool names. Names only — never
- * remote-authored tool descriptions — the same renderer-safety posture as
- * the consent sheet.
+ * One MCP-backed app entry: the app name and its health chip on one line, a
+ * collapsed accordion enumerating the mounted tool names, and the count of
+ * local apps bound to it. Names only — never remote-authored tool
+ * descriptions — the same renderer-safety posture as the consent sheet.
+ *
+ * Tool availability lives here and nowhere else on the page; connection
+ * state is the chip, detailed (for gateway endpoints on a managed profile)
+ * on the endpoint's Advanced row. A record with no such row — any entry on
+ * an unmanaged profile, or a pre-managed manual server — carries its own
+ * diagnostic inline instead.
  */
-function McpAppCard({ entry }: { entry: McpEntry }) {
+function McpAppEntry({
+  entry,
+  managed,
+  busy,
+  reconnecting,
+  onReconnect,
+}: {
+  entry: McpEntry;
+  managed: boolean;
+  busy: boolean;
+  reconnecting: string | null;
+  onReconnect: (name: string) => void;
+}) {
   const [open, setOpen] = useState(false);
+  const detailInAdvanced = managed && entry.gateway_endpoint !== null;
+  const unhealthy =
+    entry.health !== "healthy" &&
+    entry.health !== "initializing" &&
+    entry.health !== "reconnecting";
   return (
-    <div className="flex flex-col gap-1 rounded-md border px-3 py-2">
-      <p className="text-sm font-bold">{mcpTitle(entry)}</p>
-      <p className="text-xs text-muted-foreground">
-        {entry.gateway_endpoint !== null &&
-          "Via your organization's gateway · "}
-        {mcpStatus(entry)}
-      </p>
+    <li className="flex flex-col gap-1 rounded-md border px-3 py-2">
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+        <p className="text-sm font-bold">{mcpTitle(entry)}</p>
+        <McpHealthChip health={entry.health} />
+        {entry.gateway_endpoint !== null && (
+          <span className="text-xs text-muted-foreground">
+            · via your organization's gateway
+          </span>
+        )}
+      </div>
+      {!detailInAdvanced && unhealthy && entry.diagnostic !== null && (
+        <p className="text-xs text-muted-foreground">{entry.diagnostic}</p>
+      )}
       {entry.tools.length > 0 && (
         <>
           <button
@@ -144,23 +170,39 @@ function McpAppCard({ entry }: { entry: McpEntry }) {
           )}
         </>
       )}
-    </div>
+      {entry.used_by_app_count > 0 && (
+        <p className="text-xs text-muted-foreground">
+          {usedByLabel(entry.used_by_app_count)}
+        </p>
+      )}
+      {/* No endpoint indirection on an unmanaged profile, so the reconnect
+          action rides the entry itself. */}
+      {!managed &&
+        entry.health !== "initializing" &&
+        entry.health !== "disabled" && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="self-start"
+            disabled={busy}
+            onClick={() => onReconnect(entry.name)}
+          >
+            <RefreshCw size={14} />
+            {reconnecting === entry.name ? "Reconnecting…" : "Reconnect"}
+          </Button>
+        )}
+    </li>
   );
 }
 
 /**
- * The demoted transport machinery: gateway endpoint mounts, per-server
- * health, and (on unmanaged profiles) the manual MCP server editor — the
- * whole `McpPanel`, unchanged, behind a disclosure. Everything it could do
- * it still does; it just no longer leads the page.
+ * The transport machinery, managed profiles only: `McpPanel`'s compact
+ * endpoint rows behind a disclosure, collapsed by default. Unmanaged
+ * profiles have no gateway indirection, so they get no Advanced section —
+ * the editor below the apps list is the whole transport surface.
  */
-function AdvancedSection({
-  client,
-  managed,
-}: {
-  client: ApiClient;
-  managed: boolean;
-}) {
+function AdvancedSection({ client }: { client: ApiClient }) {
   const [open, setOpen] = useState(false);
   return (
     <section className="flex flex-col gap-6">
@@ -173,18 +215,19 @@ function AdvancedSection({
         {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
         Advanced: transport &amp; endpoints
       </button>
-      {open && <McpPanel client={client} managed={managed} />}
+      {open && <McpPanel client={client} managed />}
     </section>
   );
 }
 
 /**
- * The Connected apps page, app-first: the primary list is the apps this
- * profile can reach — org-app names for gateway-backed MCP records, record
- * names for local ones, REST entries beside them — each with a names-only
- * tool accordion. The transport machinery (endpoint mounts, the manual MCP
- * server editor absorbed from the retired MCP page) is demoted to an
- * Advanced disclosure below; nothing is removed, only de-emphasized.
+ * The Connected apps page, app-first and once-only: every fact renders
+ * exactly once, at the altitude of the thing it describes. The Apps list
+ * owns identity, health chip, tool names, and the bound-app count; on a
+ * managed profile the endpoint transport collapses to compact rows behind
+ * an Advanced disclosure, while an unmanaged profile has no Advanced at
+ * all — the manual MCP editor below the list is its whole transport
+ * surface. The approval boundary is stated once, as the page footer.
  */
 export function ConnectedAppsPanel({
   client,
@@ -204,6 +247,7 @@ export function ConnectedAppsPanel({
   const [formError, setFormError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
+  const [reconnecting, setReconnecting] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -284,6 +328,26 @@ export function ConnectedAppsPanel({
     }
   }
 
+  /** Reconnect one local server from its app entry, then re-read the
+   * listing so the entry's chip reflects the outcome. */
+  async function reconnectEntry(name: string) {
+    setReconnecting(name);
+    setListError(null);
+    try {
+      await client.reconnectMcpServer(name);
+    } catch (err) {
+      setListError(errorMessage(err));
+    }
+    try {
+      const info = await client.listConnectedApps();
+      setApps(info.apps);
+    } catch {
+      // Keep the last-known entries; the reconnect error (if any) stands.
+    } finally {
+      setReconnecting(null);
+    }
+  }
+
   async function remove(entry: RestEntry) {
     setDeleting(entry.id);
     try {
@@ -298,7 +362,7 @@ export function ConnectedAppsPanel({
   }
 
   const restRow = (entry: RestEntry) => (
-    <div
+    <li
       key={entry.id}
       className="flex items-center justify-between gap-4 rounded-md border px-3 py-2"
     >
@@ -308,6 +372,11 @@ export function ConnectedAppsPanel({
           {entry.base_url} · {entry.operation_count} operation
           {entry.operation_count === 1 ? "" : "s"} · {credentialLabel(entry)}
         </p>
+        {entry.used_by_app_count > 0 && (
+          <p className="text-xs text-muted-foreground">
+            {usedByLabel(entry.used_by_app_count)}
+          </p>
+        )}
       </div>
       {!managed && (
         <div className="flex gap-2">
@@ -333,7 +402,7 @@ export function ConnectedAppsPanel({
           </Button>
         </div>
       )}
-    </div>
+    </li>
   );
 
   const editor = draft !== null && (
@@ -452,65 +521,94 @@ export function ConnectedAppsPanel({
     </SettingsSection>
   );
 
+  const busy = saving || deleting !== null || reconnecting !== null;
+
   return (
     <SettingsPanel
       title="Connected apps"
       description="The apps this profile can reach — through your organization's gateway, local MCP servers, and REST APIs — bound by local apps with your consent."
-      busy={loading || saving || deleting !== null}
+      busy={loading || busy}
     >
       {loading ? (
         <p className="text-sm text-muted-foreground">Loading connected apps…</p>
       ) : (
         <>
-          <SettingsSection
-            title="Apps"
-            description="Each entry is one connected app. Expand it to see the tools it makes available."
-          >
-            {managed && (
-              <SettingsStatus
-                tone="disabled"
-                label="Managed by your organization"
-                description="REST connected apps are managed by your organization's gateway; there is nothing to configure here."
-              />
-            )}
-            {apps.length === 0 ? (
+          <section className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <h2 className="text-lg font-semibold">Apps</h2>
               <p className="text-sm text-muted-foreground">
-                No apps connected. Add a REST API here, or configure MCP
-                servers under Advanced below.
+                Each entry is one connected app. Expand it to see the tools it
+                makes available.
               </p>
-            ) : (
-              apps.map((entry) =>
-                entry.kind === "mcp_server" ? (
-                  <McpAppCard key={entry.id} entry={entry} />
-                ) : (
-                  restRow(entry)
-                ),
-              )
-            )}
-            {!managed && draft === null && (
-              <div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={deleting !== null}
-                  onClick={() => {
-                    setFormError(null);
-                    setDraft(draftFor(null));
-                  }}
+              {managed && (
+                <p className="text-sm text-muted-foreground">
+                  REST connected apps are managed by your organization's
+                  gateway; there is nothing to configure here.
+                </p>
+              )}
+            </div>
+            <Card className="gap-4 border bg-transparent p-4">
+              {apps.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  {managed
+                    ? "No apps connected."
+                    : "No apps connected. Add a REST API here, or configure MCP servers in the editor below."}
+                </p>
+              ) : (
+                <ul
+                  aria-label="Connected apps"
+                  className="flex flex-col gap-2"
                 >
-                  <Plus size={14} /> Add REST API
-                </Button>
-              </div>
-            )}
-          </SettingsSection>
+                  {apps.map((entry) =>
+                    entry.kind === "mcp_server" ? (
+                      <McpAppEntry
+                        key={entry.id}
+                        entry={entry}
+                        managed={managed}
+                        busy={busy}
+                        reconnecting={reconnecting}
+                        onReconnect={(name) => void reconnectEntry(name)}
+                      />
+                    ) : (
+                      restRow(entry)
+                    ),
+                  )}
+                </ul>
+              )}
+              {!managed && draft === null && (
+                <div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={busy}
+                    onClick={() => {
+                      setFormError(null);
+                      setDraft(draftFor(null));
+                    }}
+                  >
+                    <Plus size={14} /> Add REST API
+                  </Button>
+                </div>
+              )}
+            </Card>
+          </section>
 
           {!managed && editor}
         </>
       )}
 
-      <AdvancedSection client={client} managed={managed} />
+      {managed ? (
+        <AdvancedSection client={client} />
+      ) : (
+        <McpPanel client={client} managed={false} />
+      )}
 
       {listError && <SettingsError>{listError}</SettingsError>}
+
+      <p className="text-sm text-muted-foreground">
+        MCP tools are always sensitive and keep OpenWave's existing approval
+        boundary.
+      </p>
     </SettingsPanel>
   );
 }

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.test.tsx
@@ -360,46 +360,48 @@ describe("McpPanel", () => {
     expect(screen.getByText(/DOCS_TOKEN/)).toBeInTheDocument();
   });
 
-  it("is read-only on a managed profile, keeping mounts and their reasons visible", async () => {
-    const client = api({
-      servers: [
-        {
-          ...healthy.servers[0],
-          name: "legacy_docs",
-          health: "disabled",
-          tool_count: 0,
-          diagnostic:
-            "Disabled by managed policy. Gateway-managed MCP endpoints remain available.",
-        },
-        {
-          name: "tools",
-          command: null,
-          args: [],
-          env: [],
-          env_from: [],
-          cwd: null,
-          url: null,
-          bearer_token_env: null,
-          gateway_endpoint: "tools",
-          request_timeout_ms: 60_000,
-          enabled: true,
-          health: "healthy",
-          tool_count: 3,
-          diagnostic: null,
-        },
-      ],
-    });
+  it("managed: compact endpoint rows only — no editor, headings, or tool counts", async () => {
+    const client = api(
+      {
+        servers: [
+          {
+            ...healthy.servers[0],
+            name: "legacy_docs",
+            health: "disabled",
+            tool_count: 0,
+            diagnostic:
+              "Disabled by managed policy. Gateway-managed MCP endpoints remain available.",
+          },
+          gatewayMount("example-security-tools"),
+        ],
+      },
+      {
+        getGatewayStatus: vi.fn().mockResolvedValue(signedIn),
+        getGatewayApps: vi.fn().mockResolvedValue(incidentApps),
+      },
+    );
     render(<McpPanel client={client} managed />);
 
-    // The gateway mount and its health stay visible; the locked manual server
-    // stays listed with the server's own reason rather than disappearing.
-    expect(await screen.findByText("Healthy")).toBeInTheDocument();
+    // One row per endpoint: mount toggle, health chip, the apps it serves,
+    // and a reconnect action — the whole transport story in one line.
+    await screen.findByRole("switch", { name: "Mount example-security-tools" });
+    const row = mountRow("example-security-tools");
+    expect(within(row).getByText("Healthy")).toBeInTheDocument();
     expect(
-      screen.getAllByText("3 tools available to new turns.").length,
-    ).toBeGreaterThan(0);
-    expect(screen.getByText(/Disabled by managed policy/)).toBeInTheDocument();
+      within(row).getByText(/serves: Incident API/),
+    ).toBeInTheDocument();
+    expect(
+      within(row).getByRole("button", { name: /Reconnect/ }),
+    ).toBeInTheDocument();
 
-    // Nothing manual is editable: no fields, and no way to add or save one.
+    // Tool availability and the locked manual server belong to the app
+    // entries on the Connected apps page, not this view — and nothing here
+    // is a heading, a per-endpoint card, or an editor.
+    expect(
+      screen.queryByText(/available to new turns/),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+    expect(screen.queryByText("legacy_docs")).not.toBeInTheDocument();
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Add server" }),

--- a/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/McpPanel.tsx
@@ -4,6 +4,7 @@ import { Plus, RefreshCw, Trash2 } from "lucide-react";
 import type {
   ApiClient,
   GatewayApps,
+  McpHealth,
   McpServerDefinition,
   McpServerInfo,
 } from "../api";
@@ -47,6 +48,43 @@ function emptyServer(index: number): McpServerInfo {
 }
 
 type Transport = "stdio" | "http" | "gateway";
+
+/**
+ * The one place connection state is spelled: a coloured dot and a short
+ * verdict. App entries and endpoint rows share it, so "healthy" can never
+ * read two different ways on the same page.
+ */
+export function McpHealthChip({ health }: { health: McpHealth }) {
+  const dot =
+    health === "healthy"
+      ? "text-emerald-600 dark:text-emerald-400"
+      : health === "degraded"
+        ? "text-destructive"
+        : "text-muted-foreground";
+  return (
+    <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+      <span aria-hidden className={dot}>
+        ●
+      </span>
+      {chipLabel(health)}
+    </span>
+  );
+}
+
+function chipLabel(health: McpHealth): string {
+  switch (health) {
+    case "healthy":
+      return "Healthy";
+    case "degraded":
+      return "Needs attention";
+    case "reconnecting":
+      return "Reconnecting";
+    case "disabled":
+      return "Disabled";
+    case "initializing":
+      return "Connecting…";
+  }
+}
 
 function transportOf(server: McpServerInfo): Transport {
   if (server.gateway_endpoint !== null) return "gateway";
@@ -378,20 +416,135 @@ export function McpPanel({
   );
 
   if (managed) {
+    // The compact transport view behind the Advanced disclosure: one row per
+    // gateway endpoint — mount toggle, health chip, the apps it serves, a
+    // reconnect action, and the diagnostic inline when unhealthy. No inner
+    // headings, no per-endpoint cards, and no tool counts: tools belong to
+    // the app entries above. Manual servers a profile carried in from before
+    // it was managed are app entries too (never started, with the policy
+    // diagnostic), so this view is endpoints only.
     return (
-      <McpKindSection
-        description="Tool servers provided by your organization's model gateway."
-        busy={loading || working}
-      >
-        {endpointsSection}
-        {loading ? (
-          <p className="text-sm text-muted-foreground">Loading MCP servers…</p>
-        ) : (
-          <ManagedServerList servers={servers} />
+      <div className="flex flex-col gap-3" aria-busy={loading || working}>
+        {!signedIn && (
+          <p className="text-muted-foreground text-xs">
+            Sign in to the Model Gateway to mount or unmount endpoints. The
+            configured mounts stay listed meanwhile.
+          </p>
         )}
-        {fallbackListError}
+        {appsFailed && (
+          <p className="text-muted-foreground text-xs">
+            Couldn't read your entitlements from the gateway; these are the
+            configured mounts.
+          </p>
+        )}
+        {listError !== null && (
+          <div className="flex items-center justify-between gap-4">
+            <SettingsError>
+              Couldn't read the MCP server list: {listError}
+            </SettingsError>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={working}
+              onClick={() => {
+                setError(null);
+                setRefreshNonce((nonce) => nonce + 1);
+              }}
+            >
+              <RefreshCw size={14} />
+              Retry
+            </Button>
+          </div>
+        )}
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Loading endpoints…</p>
+        ) : endpointSlugs.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No gateway endpoints are granted to your teams.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {endpointSlugs.map((slug) => {
+              const mounted = servers.find(
+                (server) => server.gateway_endpoint === slug,
+              );
+              const serves =
+                apps?.apps
+                  .filter(
+                    (app) =>
+                      app.enabled && app.mcp_endpoint_slugs.includes(slug),
+                  )
+                  .map((app) => app.name) ?? [];
+              const revoked =
+                apps?.supported === true &&
+                !entitledSlugs.has(slug) &&
+                mounted !== undefined;
+              return (
+                <li
+                  key={slug}
+                  className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md border px-3 py-2 text-sm"
+                >
+                  <code className="font-medium">{slug}</code>
+                  <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    mounted
+                    <Switch
+                      aria-label={`Mount ${slug}`}
+                      checked={mounted !== undefined}
+                      disabled={!signedIn || working || !serversKnown}
+                      onCheckedChange={(checked) =>
+                        void setMounted(slug, checked)
+                      }
+                    />
+                  </span>
+                  {mounted && <McpHealthChip health={mounted.health} />}
+                  {serves.length > 0 && (
+                    <span className="text-xs text-muted-foreground">
+                      serves: {serves.join(", ")}
+                    </span>
+                  )}
+                  {mounted &&
+                    mounted.health !== "initializing" &&
+                    mounted.health !== "disabled" && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={working}
+                        onClick={() => void reconnect(mounted.name)}
+                      >
+                        <RefreshCw size={14} />
+                        {reconnecting === mounted.name
+                          ? "Reconnecting…"
+                          : "Reconnect"}
+                      </Button>
+                    )}
+                  {!serversKnown && (
+                    <span className="text-xs text-muted-foreground">
+                      Mount state unknown.
+                    </span>
+                  )}
+                  {revoked && (
+                    <span className="text-xs text-muted-foreground">
+                      No longer granted to your teams. Switch off to unmount
+                      it.
+                    </span>
+                  )}
+                  {mounted &&
+                    mounted.health !== "healthy" &&
+                    mounted.health !== "initializing" &&
+                    mounted.health !== "reconnecting" &&
+                    mounted.diagnostic !== null && (
+                      <span className="text-xs text-destructive">
+                        {mounted.diagnostic}
+                      </span>
+                    )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
         {error && <SettingsError>{error}</SettingsError>}
-      </McpKindSection>
+      </div>
     );
   }
 
@@ -703,11 +856,10 @@ export function McpPanel({
           )}
 
           <p className="text-sm leading-relaxed text-muted-foreground">
-            MCP tools are always sensitive and keep OpenWave’s existing approval
-            boundary. Child environments start empty. Environment values are
-            held in the OS credential store and never come back to this window;
-            do not enter secrets in the executable, arguments, working
-            directory, or a server URL, which are ordinary settings.
+            Child environments start empty. Environment values are held in the
+            OS credential store and never come back to this window; do not
+            enter secrets in the executable, arguments, working directory, or
+            a server URL, which are ordinary settings.
           </p>
         </>
       )}
@@ -909,63 +1061,6 @@ function GatewayEndpoints({
         </ul>
       )}
     </SettingsSection>
-  );
-}
-
-/**
- * The managed read-only view: what is mounted and whether it is working.
- *
- * Manual servers a profile carried in from before it was managed stay listed
- * with the server's own diagnostic explaining that policy turned them off —
- * a row that vanished would look like data loss, and one that looked editable
- * would be a write the server refuses.
- */
-function ManagedServerList({ servers }: { servers: McpServerInfo[] }) {
-  return (
-    <>
-      {servers.length === 0 && (
-        <SettingsSection>
-          <p className="text-sm text-muted-foreground">
-            No MCP servers are mounted. Any endpoints your teams are granted
-            appear under Gateway endpoints above.
-          </p>
-        </SettingsSection>
-      )}
-      {/* Keyed by name, unlike the editable list: nothing renames a server
-          here, and the identity is what the reader sees. */}
-      {servers.map((server, index) => (
-        <SettingsSection
-          key={server.name || index}
-          title={server.name || `Server ${index + 1}`}
-        >
-          <SettingsStatus
-            tone={healthTone(server.health)}
-            label={healthLabel(server.health)}
-            description={
-              server.health === "healthy"
-                ? `${server.tool_count} tool${server.tool_count === 1 ? "" : "s"} available to new turns.`
-                : server.diagnostic ?? "This server is not connected."
-            }
-          />
-          {transportOf(server) === "gateway" ? (
-            <p className="text-sm text-muted-foreground">
-              Managed by the Model Gateway (endpoint{" "}
-              <code>{server.gateway_endpoint}</code>). Mount or unmount it under
-              Gateway endpoints above.
-            </p>
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              Configured before this device was managed. It is kept on file but
-              never started, and cannot be edited here.
-            </p>
-          )}
-        </SettingsSection>
-      ))}
-      <p className="text-sm leading-relaxed text-muted-foreground">
-        MCP tools are always sensitive and keep OpenWave&rsquo;s existing
-        approval boundary.
-      </p>
-    </>
   );
 }
 

--- a/crates/openwave-server/src/routes/connected_apps.rs
+++ b/crates/openwave-server/src/routes/connected_apps.rs
@@ -70,6 +70,10 @@ pub enum ConnectedAppInfo {
         /// the apps surface: the entry then renders without org-app names
         /// rather than erroring.
         gateway_apps: Vec<String>,
+        /// How many local mini-apps hold a live grant binding this record —
+        /// a count only, never app names or ids, the renderer-safety posture
+        /// of this surface. Grants of library-deleted apps do not count.
+        used_by_app_count: usize,
     },
     RestApi {
         /// The record id app bindings name.
@@ -87,6 +91,10 @@ pub enum ConnectedAppInfo {
         /// configuration; the value never appears on this surface.
         placement: Option<CredentialPlacement>,
         updated_at: DateTime<Utc>,
+        /// How many local mini-apps hold a live grant binding this record —
+        /// a count only, never app names or ids, the renderer-safety posture
+        /// of this surface. Grants of library-deleted apps do not count.
+        used_by_app_count: usize,
     },
 }
 
@@ -332,6 +340,16 @@ async fn connected_apps_info(state: &AppState) -> Result<ConnectedAppsInfo, Serv
         .collect();
     let tool_names = state.mcp.tool_names().await;
     let servers = state.mcp.info().await.servers;
+    // How many local mini-apps currently bind each record: distinct live
+    // grants naming the id. The binding grammar forbids a grant naming one
+    // connected app twice, so grants and apps count one-to-one.
+    let mut used_by: std::collections::BTreeMap<ConnectedAppId, usize> =
+        std::collections::BTreeMap::new();
+    for grant in state.store.list_live_app_grants().await? {
+        for binding in &grant.bindings {
+            *used_by.entry(binding.app()).or_default() += 1;
+        }
+    }
     // Org-app display names by endpoint slug, so gateway-backed entries can
     // lead with the apps the organization granted instead of endpoint slugs.
     // Best-effort by design: fetched only when a gateway-backed record exists,
@@ -375,6 +393,7 @@ async fn connected_apps_info(state: &AppState) -> Result<ConnectedAppsInfo, Serv
                 diagnostic: server.diagnostic,
                 gateway_endpoint,
                 gateway_apps,
+                used_by_app_count: used_by.get(&id).copied().unwrap_or(0),
             })
         })
         .collect();
@@ -404,6 +423,7 @@ async fn connected_apps_info(state: &AppState) -> Result<ConnectedAppsInfo, Serv
             credential_status,
             placement: definition.credential.map(|credential| credential.placement),
             updated_at: record.updated_at,
+            used_by_app_count: used_by.get(&record.id).copied().unwrap_or(0),
         });
     }
     Ok(ConnectedAppsInfo { apps })

--- a/crates/openwave-server/src/tests/connected_apps.rs
+++ b/crates/openwave-server/src/tests/connected_apps.rs
@@ -454,6 +454,96 @@ async fn managed_profiles_refuse_rest_upserts_but_allow_delete() {
     assert!(state.store.list_connected_apps().await.unwrap().is_empty());
 }
 
+/// A local app with one `rest_api` binding, created straight through the
+/// store so grant tests don't route through the authoring surface.
+fn bound_app(name: &str, connected: ConnectedAppId) -> CreateApp {
+    CreateApp {
+        id: AppId::new(),
+        revision: NewAppRevision {
+            id: AppRevisionId::new(),
+            manifest: AppManifest {
+                name: name.into(),
+                bindings: vec![AppBinding::Operations(AppOperationsBinding {
+                    app: connected,
+                    operation_ids: vec!["listIssues".into()],
+                })],
+            },
+            byte_len: 1,
+            sha256: [0; 32],
+            turn_id: None,
+            producing_run_id: None,
+            chat_id: None,
+            created_at: chrono::Utc::now(),
+        },
+    }
+}
+
+async fn consent(router: &Router, bearer: &str, app_id: AppId) {
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/apps/{app_id}/grant"))
+                .header("authorization", bearer)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// The listing counts the local apps whose live grant binds each record —
+/// 0 before any consent, the granted count after, minus apps deleted from
+/// the library — and projects the count only: no local-app name or id ever
+/// reaches this surface.
+#[tokio::test]
+async fn the_listing_counts_local_apps_bound_to_each_record() {
+    let (router, bearer, state, _dir) = connected_apps_test_app().await;
+    let connected = ConnectedAppId::new();
+    let put = put_rest(
+        &router,
+        &bearer,
+        connected,
+        upsert_body("https://api.example.com/v2", json!("none")),
+    )
+    .await;
+    assert_eq!(put.status(), StatusCode::OK);
+
+    // No grants yet: the count is zero, not absent.
+    let listing: serde_json::Value =
+        serde_json::from_str(&raw_body(get_listing(&router, &bearer).await).await).unwrap();
+    assert_eq!(rest_entry(&listing)["used_by_app_count"], json!(0));
+
+    let first = bound_app("Issues board fixture", connected);
+    let second = bound_app("Issues digest fixture", connected);
+    let (first_id, second_id) = (first.id, second.id);
+    state.store.create_app(&first).await.unwrap();
+    state.store.create_app(&second).await.unwrap();
+    consent(&router, &bearer, first_id).await;
+    consent(&router, &bearer, second_id).await;
+
+    let body = raw_body(get_listing(&router, &bearer).await).await;
+    assert!(
+        !body.contains("fixture") && !body.contains(&first_id.to_string()),
+        "the listing must carry a count only, never local-app names or ids: {body}"
+    );
+    let listing: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(rest_entry(&listing)["used_by_app_count"], json!(2));
+
+    // A grant of a library-deleted app can no longer be exercised, so it
+    // stops counting without an explicit revocation.
+    assert!(state
+        .store
+        .delete_app(second_id, chrono::Utc::now())
+        .await
+        .unwrap());
+    let listing: serde_json::Value =
+        serde_json::from_str(&raw_body(get_listing(&router, &bearer).await).await).unwrap();
+    assert_eq!(rest_entry(&listing)["used_by_app_count"], json!(1));
+}
+
 /// Editing a record's base URL through the settings route moves its
 /// fingerprint, so an app grant pinned to the old definition reads ungranted
 /// on the very next check — the same invalidation the invoke gate applies.


### PR DESCRIPTION
Refines the Connected apps page shipped in #1440 per owner review of the result. The Advanced disclosure there swallowed the old MCP page wholesale, so the same facts rendered at three altitudes; this PR makes every fact render exactly once, at the altitude of the thing it describes.

## Page structure

- **Apps list owns identity and capability.** Each entry: name (org-app names for gateway-backed records), a health chip, the names-only tools accordion, and — new — "Used by N local apps" when N > 0. The "N tools available to new turns" sentence no longer renders on the entry, the endpoint row, *and* a health card.
- **The managed-profile REST notice is prose, not a card**: one line of muted text under the Apps heading, no longer the first card inside the list masquerading as an app.
- **Managed profiles:** Advanced (collapsed by default) holds one compact row per gateway endpoint — mount toggle, health chip, `serves:` list reverse-joined from the entitled apps, reconnect, diagnostic inline when unhealthy. The inner "MCP servers" / "Gateway endpoints" h2s, per-endpoint heading + health card, and repeated tool counts are gone; `ManagedServerList` is deleted (a pre-managed manual server reads as an app entry with its policy diagnostic).
- **Unmanaged profiles:** no Advanced section at all. Entries carry the reconnect action themselves; REST entries keep inline edit/delete; the manual MCP editor (draft-and-replace reconciliation untouched) moves below the apps list as the editing surface.
- **The approval-boundary sentence appears once, as the page footer.** No execution-mode display anywhere.

## Server

- `GET /connected-apps` entries (both kinds) gain `used_by_app_count`: distinct local apps holding a live grant that binds the record, via a new `Store::list_live_app_grants` (grants inner-joined to non-soft-deleted apps). Renderer-safe: a count only, never local-app names or ids. `wire.ts` regenerated.
- The endpoint serves-list needed no new projection: it reverse-joins the already-carried gateway apps (`mcp_endpoint_slugs`) client-side.

## Tests

- Server: one test walks the count through 0 → 2 → 1 (grant consent, then library-delete an app) and asserts no local-app name or id reaches the listing body.
- UI: managed layout (notice is prose outside the list container and no `role=status` card; Advanced collapsed by default; endpoint row shows the serves-list; tool count renders exactly once with Advanced open; approval sentence exactly once) and unmanaged layout (no Advanced; editor below the list; reconnect on entries; credential status renders). Existing ConnectedAppsPanel/McpPanel tests were updated to the new structure, keeping their intent (PUT shape, credential keep, mount round-trip, revoked-entitlement row).

Closes #1490

🤖 Generated with [Claude Code](https://claude.com/claude-code)