### PR TITLE
fix(code-execution): pin the E2B template by ID so other accounts can resolve it

### DIFF
--- a/.github/workflows/publish-e2b-template.yml
+++ b/.github/workflows/publish-e2b-template.yml
@@ -24,9 +24,13 @@ run-name: >-
 #   2. Merging that PR touches crates/openwave-sandbox-agent/e2b/, which
 #      triggers this workflow.
 #   3. This workflow builds the template under the new alias and publishes it.
-#   4. Its `pin` job opens a PR bumping `E2B_TEMPLATE` in e2b.rs to that alias.
-#      That pin moves last on purpose: pointing the client at an alias that is
-#      not published yet drops every E2B user to the fallback.
+#   4. Its `pin` job opens a PR bumping `E2B_TEMPLATE` in e2b.rs to the
+#      *template ID* the alias resolves to. The ID rather than the alias:
+#      E2B resolves a custom template's alias only inside the owning team, so
+#      an alias pin works from the OpenWave account and 404s from every other
+#      one (verified 2026-08-04). The pin moves last on purpose: pointing the
+#      client at a template that is not published yet drops every E2B user to
+#      the fallback.
 #
 # Idempotence is the whole design. The alias is version-suffixed, so a run
 # whose alias is already published is a no-op — re-runs, README edits, and
@@ -98,6 +102,9 @@ jobs:
       cpu_count: ${{ steps.definition.outputs.cpu_count }}
       memory_mb: ${{ steps.definition.outputs.memory_mb }}
       publish: ${{ steps.state.outputs.publish }}
+      # The template ID the alias already resolves to, when it does. Empty on
+      # a 404; the publish job's own verification supplies it in that case.
+      template_id: ${{ steps.state.outputs.template_id }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -188,9 +195,11 @@ jobs:
             "$E2B_API_BASE/templates/aliases/$ALIAS")"
 
           publish=false
+          template_id=""
           case "$status" in
             200)
               public="$(python3 -c 'import json,sys; print(str(json.load(open(sys.argv[1])).get("public")).lower())' "$body")"
+              template_id="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("templateID", ""))' "$body")"
               if [[ "$public" == "true" ]]; then
                 if [[ "$FORCE_REBUILD" == "true" ]]; then
                   echo "::notice::$ALIAS is already public; rebuilding because force_rebuild was requested."
@@ -222,6 +231,7 @@ jobs:
               ;;
           esac
           echo "publish=$publish" >> "$GITHUB_OUTPUT"
+          echo "template_id=$template_id" >> "$GITHUB_OUTPUT"
 
   publish:
     name: build and publish the template
@@ -236,6 +246,7 @@ jobs:
       contents: read
     outputs:
       published: ${{ steps.verify.outputs.published }}
+      template_id: ${{ steps.verify.outputs.template_id }}
     env:
       ALIAS: ${{ needs.resolve.outputs.alias }}
       E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
@@ -270,7 +281,8 @@ jobs:
             --memory-mb "$MEMORY_MB"
 
       # Makes the template public, which is the entire point: a published
-      # template is creatable by alias from any E2B account, so a user who has
+      # template is creatable from any E2B account — by its template ID; the
+      # alias only resolves inside the OpenWave team — so a user who has
       # pasted nothing but their own API key gets the documents image.
       - name: Publish the template
         working-directory: ${{ env.TEMPLATE_DIR }}
@@ -304,11 +316,14 @@ jobs:
               sys.exit(f"the alias resolves but is not public: {alias}")
           print(f"published template {alias['templateID']}")
           EOF
+          template_id="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["templateID"])' "$body")"
           echo "published=true" >> "$GITHUB_OUTPUT"
+          echo "template_id=$template_id" >> "$GITHUB_OUTPUT"
           {
             echo "## Published E2B template"
             echo
             echo "- Alias: \`$ALIAS\`"
+            echo "- Template ID: \`$template_id\`"
             echo "- Public: yes"
             echo
             echo "Cross-account resolution is not proven here — see"
@@ -338,6 +353,9 @@ jobs:
       pull-requests: write
     env:
       ALIAS: ${{ needs.resolve.outputs.alias }}
+      # From whichever job actually resolved the alias: `publish` when this
+      # run built the template, `resolve` when it was already public.
+      TEMPLATE_ID: ${{ needs.publish.outputs.template_id || needs.resolve.outputs.template_id }}
       PIN_BRANCH: automation/e2b-template-pin
       GH_TOKEN: ${{ github.token }}
     steps:
@@ -345,8 +363,12 @@ jobs:
         with:
           ref: main
 
-      - name: Point the client at the published alias
+      - name: Point the client at the published template
         run: |
+          if [[ -z "$TEMPLATE_ID" ]]; then
+            echo "No template ID reached the pin job; refusing to guess." >&2
+            exit 1
+          fi
           python3 - <<'EOF'
           import os
           import re
@@ -354,6 +376,7 @@ jobs:
 
           directory = os.environ["TEMPLATE_DIR"]
           alias = os.environ["ALIAS"]
+          template_id = os.environ["TEMPLATE_ID"]
 
           # The client's doc comment names the exact image the alias was built
           # from. That ref lives in the template Dockerfile, which the image
@@ -381,7 +404,12 @@ jobs:
           pins = {
               rf'(?m)^(/// `{re.escape(repository)}:)[^`\n]*(`)$': tag,
               r'(?m)^(/// \(`)sha256:[0-9a-f]{64}(`\),)$': digest,
-              r'(?m)^(const E2B_TEMPLATE: &str = ")[^"\n]*(";)$': alias,
+              # The alias sits alone on its doc-comment line exactly so this
+              # rewrite has one unambiguous target.
+              r'(?m)^(/// `)[a-z0-9][a-z0-9._-]*(`)$': alias,
+              # The constant carries the template ID — the only form E2B
+              # resolves from outside the OpenWave team.
+              r'(?m)^(const E2B_TEMPLATE: &str = ")[^"\n]*(";)$': template_id,
           }
           for pattern, value in pins.items():
               source, replaced = re.subn(
@@ -412,14 +440,17 @@ jobs:
           cat > "$body_file" <<EOF
           Automated follow-up from an E2B template publish: \`$ALIAS\` is now built and
           public on E2B, so \`E2B_TEMPLATE\` in
-          \`crates/openwave-code-execution/src/e2b.rs\` can point at it. Until this
-          lands, E2B sandboxes still resolve the previous alias.
+          \`crates/openwave-code-execution/src/e2b.rs\` can point at it — by its
+          template ID \`$TEMPLATE_ID\`, because E2B resolves a custom template's
+          alias only inside the owning team. Until this lands, E2B sandboxes still
+          resolve the previous pin.
 
           The doc comment above the constant is refreshed from
           \`crates/openwave-sandbox-agent/e2b/e2b.Dockerfile\`, so the image tag and
           digest it names stay the ones the template was actually built from.
 
           - Alias: \`$ALIAS\`
+          - Template ID: \`$TEMPLATE_ID\`
           - Publish run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
 
           This PR was opened with the workflow's own GITHUB_TOKEN, and GitHub does not

--- a/crates/openwave-code-execution/src/e2b.rs
+++ b/crates/openwave-code-execution/src/e2b.rs
@@ -33,19 +33,25 @@ const E2B_SANDBOX_BASE: &str = "https://sandbox.e2b.app";
 /// The published OpenWave documents template every sandbox is created from.
 ///
 /// E2B provisions from account-registered *templates*, not arbitrary OCI refs,
-/// so the image reaches E2B as a template published from the OpenWave account —
-/// public, and therefore usable by any E2B account by alias, exactly like E2B's
-/// own `code-interpreter-v1`. A user who pastes an API key gets the documents
-/// image with no template setup of their own.
+/// so the image reaches E2B as a template published from the OpenWave account.
+/// Publishing makes it creatable from any E2B account — but only by this
+/// opaque template *ID*. E2B resolves a custom template's human alias inside
+/// the owning team alone; only E2B's own base templates, like
+/// `code-interpreter-v1`, resolve by alias from any account (verified against
+/// api.e2b.app, 2026-08-04). Pinning the alias here is what silently dropped
+/// every account but OpenWave's own to the fallback image.
 ///
-/// The alias carries the image version so the pin is visible in one place. It
-/// is currently built from
+/// The ID is what the published, version-suffixed alias — kept on its own
+/// line so the publish workflow can rewrite both together —
+/// `openwave-documents-v0-26-0`
+/// resolves to. It is currently built from
 /// `ghcr.io/brightwave-inc/openwave-sandbox-agent-documents:v0.26.0`
 /// (`sha256:dd22da7a3c5b1f315e888da902e7a46ae034585e2ab5c09c0ae4588a69f158a2`),
 /// the same ref recorded in `crates/openwave-sandbox-agent/e2b/e2b.Dockerfile`.
-/// Publishing a new image version means publishing a new alias and moving this
-/// constant with it — that directory's README has the procedure.
-const E2B_TEMPLATE: &str = "openwave-documents-v0-26-0";
+/// Publishing a new image version publishes a new alias with a new ID, and the
+/// publish workflow's pin PR moves this constant with it — that directory's
+/// README has the procedure.
+const E2B_TEMPLATE: &str = "yarxjy39quzg6wm78u1a";
 
 /// E2B's own public code-interpreter template, used only when the OpenWave
 /// template cannot be resolved. Degraded but working: document skills fall back
@@ -1538,8 +1544,9 @@ mod tests {
         let create = state.create_body.lock().unwrap().clone().unwrap();
         // Spelled out rather than compared to the constant: reverting the
         // default to E2B's public template silently costs every document run
-        // an in-sandbox dependency install.
-        assert_eq!(create["templateID"], "openwave-documents-v0-26-0");
+        // an in-sandbox dependency install, and moving it back to the human
+        // alias breaks every account but the one that published the template.
+        assert_eq!(create["templateID"], "yarxjy39quzg6wm78u1a");
         assert_eq!(create["metadata"]["openwave_workspace_id"], "workspace-1");
         assert_eq!(create["secure"], true);
         assert_eq!(create["allow_internet_access"], true);

--- a/crates/openwave-sandbox-agent/e2b/README.md
+++ b/crates/openwave-sandbox-agent/e2b/README.md
@@ -2,17 +2,20 @@
 
 E2B provisions sandboxes from templates registered with an E2B account, not
 from arbitrary OCI references. Publishing a template makes it public: any E2B
-account can create sandboxes from it by alias, the same way E2B's own
-`code-interpreter-v1` works. That is how a user who has pasted nothing but an
+account can create sandboxes from it — by its opaque *template ID*. The human
+alias is not portable: E2B resolves a custom template's alias only inside the
+team that owns it, and only E2B's own base templates (`code-interpreter-v1`)
+resolve by alias from anywhere (verified against `api.e2b.app`, 2026-08-04).
+That is how a user who has pasted nothing but an
 E2B API key still gets OpenWave's official documents image — LibreOffice, the
 `exec` helper scripts, and the document skills' Python dependencies already
 installed, so a document run needs no in-sandbox `pip install`.
 
-The alias is version-suffixed — `openwave-documents-v0-26-0` — so the client
-pins the exact sandbox contents it was built against, and publishing a new
-image version cannot change what an older client gets. `E2B_TEMPLATE` in
+The alias is version-suffixed — `openwave-documents-v0-26-0` — so publishing a
+new image version cannot change what an older client gets. `E2B_TEMPLATE` in
 [`crates/openwave-code-execution/src/e2b.rs`](../../openwave-code-execution/src/e2b.rs)
-is the client side of that pin.
+pins the template ID that alias resolves to, with the alias kept alongside in
+its doc comment for legibility.
 
 ## What is here
 
@@ -32,7 +35,7 @@ the alias and sizing out of `e2b.toml`, and:
 2. otherwise builds the template from `e2b.Dockerfile` on E2B's own
    infrastructure and publishes it, making it creatable by any E2B account;
 3. verifies the alias now resolves as public, then opens a PR bumping
-   `E2B_TEMPLATE` in `e2b.rs` to it.
+   `E2B_TEMPLATE` in `e2b.rs` to the template ID it resolves to.
 
 Because the alias is version-suffixed, the pin PR from a sandbox image publish
 is what puts a new alias in `e2b.toml`, and merging that PR is what sets this
@@ -58,11 +61,13 @@ Two things the workflow deliberately does not do:
   dispatch the workflow manually with `force_rebuild` set.
 - It cannot prove *cross-account* resolution, which is the whole point of
   publishing and the one thing a publish from inside the account does not
-  demonstrate. Check it once, by hand, with a throwaway account's API key:
+  demonstrate. Check it once, by hand, with a throwaway account's API key and
+  the template ID from the run's summary (the alias would 404 from another
+  account even when everything is right):
 
   ```sh
   E2B_API_KEY=<other-account-key> \
-    e2b sandbox create openwave-documents-v0-26-0
+    e2b sandbox create <template-id>
   ```
 
 ### Doing it by hand
@@ -105,14 +110,14 @@ step is a PR someone merges:
    `e2b.toml` to match the new version, e.g. `openwave-documents-v0-27-0`.
    Merge it.
 2. That merge touches this directory, so `publish-e2b-template.yml` builds and
-   publishes the new alias, then opens the PR moving `E2B_TEMPLATE` onto it.
-   Merge that one too.
+   publishes the new alias, then opens the PR moving `E2B_TEMPLATE` onto the
+   new template's ID. Merge that one too.
 
 `E2B_TEMPLATE` moves last on purpose: until the template is actually published,
-the new alias resolves for nobody and every E2B user drops to
-`code-interpreter-v1`. Leave the previous alias published until clients pinned
-to it are out of circulation — unpublishing it drops those users to the same
-degraded fallback.
+the new template resolves for nobody and every E2B user drops to
+`code-interpreter-v1`. Leave the previous template published until clients
+pinned to it are out of circulation — unpublishing it drops those users to the
+same degraded fallback.
 
 ## Notes on the template
 


### PR DESCRIPTION
E2B resolves a custom template's human alias only inside the team that owns
it; publishing makes the template creatable cross-account by its opaque
template ID alone (only E2B's own base templates resolve by alias from any
account). The client pinned the alias, so every account except the one that
published the template got a 404 and silently fell back to
code-interpreter-v1's stock image.

Pin the template ID instead, keep the alias in the doc comment for
legibility, and teach the publish workflow's pin job to write the ID (from
whichever job resolved the alias) while refreshing the alias line alongside
the existing tag and digest lines.
