### PR TITLE
feat(server): allow parallel agent spawns with a per-chat cap

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -654,6 +654,8 @@ pub enum AgentTurnOutcome {
     SandboxAgentSpawn {
         /// Canonical child identity and bounded task derived from the tool call.
         request: SandboxAgentSpawnRequest,
+        /// Remaining spawn calls from the same provider step, in model order.
+        remaining_requests: Vec<SandboxAgentSpawnRequest>,
         /// Provider usage incurred in this agent invocation.
         usage: Usage,
         /// Durable steering epoch captured before the producing model call.
@@ -940,6 +942,8 @@ pub struct Agent {
     durable_steer_lease: Option<uuid::Uuid>,
     agent_orchestration_enabled: bool,
     continuation_instruction: Option<String>,
+    pending_sandbox_spawns: Vec<SandboxAgentSpawnRequest>,
+    pending_sandbox_spawn_steer_revision: Option<i64>,
 }
 
 /// A tool call accumulated from the provider stream.
@@ -1063,6 +1067,8 @@ impl Agent {
             durable_steer_lease: None,
             agent_orchestration_enabled: false,
             continuation_instruction: None,
+            pending_sandbox_spawns: Vec::new(),
+            pending_sandbox_spawn_steer_revision: None,
         }
     }
 
@@ -1131,6 +1137,19 @@ impl Agent {
     #[must_use]
     pub fn with_continuation_instruction(mut self, instruction: Option<String>) -> Self {
         self.continuation_instruction = instruction;
+        self
+    }
+
+    /// Continue checkpointing sandbox siblings from a model step already
+    /// evaluated by an earlier segment of this turn.
+    #[must_use]
+    pub fn with_pending_sandbox_spawns(
+        mut self,
+        pending: Vec<SandboxAgentSpawnRequest>,
+        steer_revision: Option<i64>,
+    ) -> Self {
+        self.pending_sandbox_spawns = pending;
+        self.pending_sandbox_spawn_steer_revision = steer_revision;
         self
     }
 
@@ -1274,6 +1293,20 @@ impl Agent {
         if persist_input {
             self.persist(chat.id, turn_id, Role::User, user_input)
                 .await?;
+        }
+        if let Some(request) = self.pending_sandbox_spawns.first().cloned() {
+            let Some(steer_revision) = self.pending_sandbox_spawn_steer_revision else {
+                return Err(AgentError::Store(
+                    "pending sandbox spawns require a durably claimed turn".into(),
+                ));
+            };
+            return Ok(AgentTurnOutcome::SandboxAgentSpawn {
+                request,
+                remaining_requests: self.pending_sandbox_spawns[1..].to_vec(),
+                usage: Usage::default(),
+                steer_revision,
+                model_steps: 0,
+            });
         }
         // The provider transcript for this turn: prior stored text + the blocks
         // we build up as the loop runs.
@@ -1937,7 +1970,10 @@ impl Agent {
             // carries neither the request nor the refusal.
             if let Some(taken) = isolated {
                 for (index, call) in calls.iter().enumerate() {
-                    if isolations[index].is_none() || index == taken {
+                    if isolations[index].is_none()
+                        || index == taken
+                        || matches!(isolations[index], Some(CallIsolation::SandboxSpawn))
+                    {
                         continue;
                     }
                     outputs[index] = Some(self.decline_call(
@@ -2015,12 +2051,29 @@ impl Agent {
                         CallIsolation::SandboxSpawn => {
                             match self.sandbox_checkpoint(call, generation_steer_revision) {
                                 Ok((request, steer_revision)) => {
+                                    let remaining_requests = calls
+                                        .iter()
+                                        .enumerate()
+                                        .skip(index + 1)
+                                        .filter(|(sibling, _)| {
+                                            matches!(
+                                                isolations[*sibling],
+                                                Some(CallIsolation::SandboxSpawn)
+                                            )
+                                        })
+                                        .filter_map(|(_, sibling)| {
+                                            self.sandbox_checkpoint(sibling, Some(steer_revision))
+                                                .ok()
+                                                .map(|(request, _)| request)
+                                        })
+                                        .collect();
                                     return Ok(AgentTurnOutcome::SandboxAgentSpawn {
                                         request,
+                                        remaining_requests,
                                         usage: total_usage,
                                         steer_revision,
                                         model_steps: steps_used,
-                                    })
+                                    });
                                 }
                                 Err(reason) => {
                                     outputs[index] =
@@ -4645,6 +4698,8 @@ mod tests {
         calls: AtomicUsize,
     }
 
+    struct SiblingSandboxSpawnProvider;
+
     /// Asks for a tool once, then answers, recording the tool surface each
     /// request advertised.
     struct ToolSurfaceRecordingProvider {
@@ -4918,6 +4973,40 @@ mod tests {
                     output_tokens: 2,
                     ..Usage::default()
                 }),
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ])
+            .boxed())
+        }
+    }
+
+    #[async_trait]
+    impl ModelProvider for SiblingSandboxSpawnProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("sibling-sandbox-spawn")
+        }
+
+        async fn stream(&self, _req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            Ok(stream::iter(vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "spawn_a".into(),
+                    name: crate::SPAWN_SANDBOX_AGENT_TOOL.into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: r#"{"task":"research A"}"#.into(),
+                },
+                ProviderEvent::ToolCallStarted {
+                    index: 1,
+                    id: "spawn_b".into(),
+                    name: crate::SPAWN_SANDBOX_AGENT_TOOL.into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 1,
+                    fragment: r#"{"task":"research B"}"#.into(),
+                },
                 ProviderEvent::Stop {
                     reason: StopReason::ToolUse,
                 },
@@ -5409,6 +5498,7 @@ mod tests {
             usage,
             steer_revision,
             model_steps,
+            ..
         } = outcome
         else {
             panic!("foreground agent should return a sandbox checkpoint");
@@ -5482,6 +5572,72 @@ mod tests {
             )),
             "{correction_events:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn sibling_sandbox_spawns_are_retained_for_sequential_checkpoints() {
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("siblings.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            reasoning_effort: None,
+            permission_mode: None,
+            network_policy: Default::default(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let turn_id = TurnId::new();
+        store
+            .accept_turn(turn_id, chat.id, "fake", "delegate")
+            .await
+            .unwrap();
+        let lease_token = uuid::Uuid::new_v4();
+        let now = Utc::now();
+        store
+            .claim_turn_run(lease_token, now, now + chrono::Duration::minutes(1))
+            .await
+            .unwrap();
+        let mut registry = ToolRegistry::new();
+        registry.register_foreground_agent_orchestration();
+        let agent = Agent::new(
+            Arc::new(SiblingSandboxSpawnProvider),
+            Arc::new(registry),
+            store,
+            AgentConfig {
+                model: "fake".into(),
+                ..AgentConfig::default()
+            },
+        )
+        .with_durable_steer(lease_token)
+        .with_foreground_agent_orchestration();
+        let (tx, _rx) = unbounded();
+        let outcome = agent
+            .run_claimed_turn(&chat, turn_id, MessageId::new(), 1, &tx)
+            .await
+            .unwrap();
+        let AgentTurnOutcome::SandboxAgentSpawn {
+            request,
+            remaining_requests,
+            ..
+        } = outcome
+        else {
+            panic!("sibling spawns should produce a checkpoint");
+        };
+        assert_eq!(request.task, "research A");
+        assert_eq!(remaining_requests.len(), 1);
+        assert_eq!(remaining_requests[0].task, "research B");
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -257,7 +257,7 @@ pub(in crate::db) async fn admit_sandbox_agent_run(
     input: &str,
     lease_token: uuid::Uuid,
     expected_steer_revision: i64,
-    max_outstanding_children: u32,
+    max_active_background_agents: u32,
     now: chrono::DateTime<Utc>,
 ) -> Result<Option<AdmitSandboxAgentRunOutcome>> {
     admit_sandbox_agent_run_at(
@@ -268,7 +268,7 @@ pub(in crate::db) async fn admit_sandbox_agent_run(
         AgentRunExecutionLocation::InProcess,
         lease_token,
         expected_steer_revision,
-        max_outstanding_children,
+        max_active_background_agents,
         now,
     )
     .await
@@ -287,7 +287,7 @@ pub(in crate::db) async fn admit_sandbox_container_agent_run(
     input: &str,
     lease_token: uuid::Uuid,
     expected_steer_revision: i64,
-    max_outstanding_children: u32,
+    max_active_background_agents: u32,
     now: chrono::DateTime<Utc>,
 ) -> Result<Option<AdmitSandboxAgentRunOutcome>> {
     admit_sandbox_agent_run_at(
@@ -298,7 +298,7 @@ pub(in crate::db) async fn admit_sandbox_container_agent_run(
         AgentRunExecutionLocation::Container,
         lease_token,
         expected_steer_revision,
-        max_outstanding_children,
+        max_active_background_agents,
         now,
     )
     .await
@@ -313,7 +313,7 @@ async fn admit_sandbox_agent_run_at(
     execution_location: AgentRunExecutionLocation,
     lease_token: uuid::Uuid,
     expected_steer_revision: i64,
-    max_outstanding_children: u32,
+    max_active_background_agents: u32,
     now: chrono::DateTime<Utc>,
 ) -> Result<Option<AdmitSandboxAgentRunOutcome>> {
     validate_admission_request(
@@ -321,7 +321,7 @@ async fn admit_sandbox_agent_run_at(
         spawn_call_id,
         input,
         lease_token,
-        max_outstanding_children,
+        max_active_background_agents,
     )?;
     // Validate the caller timestamp at the boundary, but never use a value
     // captured before lock acquisition to fence a live lease.
@@ -359,7 +359,7 @@ async fn admit_sandbox_agent_run_at(
         execution_location,
         lease_token,
         expected_steer_revision,
-        max_outstanding_children,
+        max_active_background_agents,
         now,
     )
     .await;
@@ -414,7 +414,7 @@ pub(in crate::db) async fn admit_sandbox_agent_run_on<C>(
     execution_location: AgentRunExecutionLocation,
     lease_token: uuid::Uuid,
     expected_steer_revision: i64,
-    max_outstanding_children: u32,
+    max_active_background_agents: u32,
     now: chrono::DateTime<Utc>,
 ) -> Result<AdmitSandboxAgentRunOutcome>
 where
@@ -494,14 +494,14 @@ where
         }
     }
 
-    // A terminal child remains outstanding until its immutable delivery has
-    // been consumed or explicitly retired. Counting only live run rows would
-    // let fast children fall out of this bound before the foreground model can
-    // wait on them, eventually producing more IDs than one ordered wait can
-    // consume. The shared classifier also validates admission and terminal
-    // receipt provenance before capacity can be released.
-    let outstanding = unsettled_sandbox_children_for_origin_turn_on(conn, turn).await?;
-    if outstanding.len() >= max_outstanding_children as usize {
+    // Capacity remains occupied until the parent consumes or retires a
+    // terminal delivery. Counting only nonterminal run rows would let fast
+    // children release their slot before their result is safely incorporated,
+    // so churn could orphan completed work. The provenance-validating
+    // unsettled classifier deliberately fails closed when a terminal child is
+    // missing its delivery.
+    let unsettled = unsettled_sandbox_children_for_origin_turn_on(conn, turn).await?;
+    if unsettled.len() >= max_active_background_agents as usize {
         return Ok(AdmitSandboxAgentRunOutcome::AtCapacity);
     }
 
@@ -672,7 +672,7 @@ pub(in crate::db) async fn accept_sandbox_agent_run_and_park_turn(
         spawn_call_id,
         input,
         lease_token,
-        AgentRun::DEFAULT_MAX_OUTSTANDING_CHILDREN,
+        AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS,
     )?;
     let admission_outcome = admit_sandbox_agent_run_on(
         &transaction,
@@ -683,7 +683,7 @@ pub(in crate::db) async fn accept_sandbox_agent_run_and_park_turn(
         AgentRunExecutionLocation::InProcess,
         lease_token,
         expected_steer_revision,
-        AgentRun::DEFAULT_MAX_OUTSTANDING_CHILDREN,
+        AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS,
         now,
     )
     .await;
@@ -2889,16 +2889,18 @@ fn validate_admission_request(
     spawn_call_id: CallId,
     input: &str,
     lease_token: uuid::Uuid,
-    max_outstanding_children: u32,
+    max_active_background_agents: u32,
 ) -> Result<()> {
     if origin_turn_id.0.is_nil() || spawn_call_id.0.is_nil() || lease_token.is_nil() {
         return Err(AgentError::Store(
             "sandbox admission identities must not be nil".into(),
         ));
     }
-    if max_outstanding_children == 0 || max_outstanding_children > AgentRun::MAX_CONCURRENCY_LIMIT {
+    if max_active_background_agents == 0
+        || max_active_background_agents > AgentRun::MAX_CONCURRENCY_LIMIT
+    {
         return Err(AgentError::Store(format!(
-            "sandbox outstanding-child limit must be in 1..={}",
+            "sandbox active-agent limit must be in 1..={}",
             AgentRun::MAX_CONCURRENCY_LIMIT
         )));
     }

--- a/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
+++ b/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
@@ -178,7 +178,7 @@ where
         request.execution_location,
         request.lease_token,
         request.expected_steer_revision,
-        AgentRun::DEFAULT_MAX_OUTSTANDING_CHILDREN,
+        request.max_active_background_agents,
         now,
     )
     .await?;
@@ -504,6 +504,8 @@ fn validate_request(request: &SandboxSpawnCheckpointRequest) -> Result<()> {
         || request.expected_steer_revision < 0
         || !(2..i32::MAX).contains(&request.event_ordinal)
         || request.progress.model_steps <= 0
+        || request.max_active_background_agents == 0
+        || request.max_active_background_agents > AgentRun::MAX_CONCURRENCY_LIMIT
         || !labels_valid
         || !result_valid
         || !serde_json::to_vec(&request.arguments)

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -2180,7 +2180,14 @@ async fn m0006_upgrades_an_existing_store_without_losing_records() {
 
     migration::Migrator::up(&conn, None).await.unwrap();
 
-    assert_eq!(store.get_chat(chat.id).await.unwrap().as_ref(), Some(&chat));
+    // The historical database column default remains off; changing the
+    // product default for newly created chats must not rewrite legacy rows.
+    let mut expected_chat = chat.clone();
+    expected_chat.network_policy = NetworkPolicy::Off;
+    assert_eq!(
+        store.get_chat(chat.id).await.unwrap().as_ref(),
+        Some(&expected_chat)
+    );
     let document = sample_document(None);
     store.create_document(&document).await.unwrap();
     let stored = store.get_document(document.id).await.unwrap().unwrap();
@@ -2735,7 +2742,12 @@ async fn m0013_adds_outputs_to_an_existing_conversation_store() {
     migration::Migrator::up(&conn, None).await.unwrap();
 
     // The conversation survives, and it can now own outputs.
-    assert_eq!(store.get_chat(chat.id).await.unwrap().as_ref(), Some(&chat));
+    let mut expected_chat = chat.clone();
+    expected_chat.network_policy = NetworkPolicy::Off;
+    assert_eq!(
+        store.get_chat(chat.id).await.unwrap().as_ref(),
+        Some(&expected_chat)
+    );
     assert!(store.list_outputs(chat.id, 10).await.unwrap().is_empty());
     let request = crate::deliverable::CreateOutput {
         id: crate::id::OutputId::new(),

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -416,7 +416,7 @@ async fn sandbox_spawn_checkpoint_never_retrofits_a_separately_accepted_child() 
             "accepted by an older boundary",
             lease_token,
             running.steer_revision,
-            AgentRun::DEFAULT_MAX_OUTSTANDING_CHILDREN,
+            AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS,
             Utc::now(),
         )
         .await

--- a/crates/openwave-core/src/db/tests/delegated_file_read.rs
+++ b/crates/openwave-core/src/db/tests/delegated_file_read.rs
@@ -73,6 +73,7 @@ async fn delegated_sandbox(
             model_steps: 1,
             usage: Usage::default(),
         },
+        max_active_background_agents: AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS,
         execution_location: crate::AgentRunExecutionLocation::InProcess,
     };
     let child = match store

--- a/crates/openwave-core/src/db/tests/sandbox_spawn_checkpoint.rs
+++ b/crates/openwave-core/src/db/tests/sandbox_spawn_checkpoint.rs
@@ -69,6 +69,7 @@ fn request(
         .unwrap(),
         event_ordinal: ordinal,
         progress,
+        max_active_background_agents: AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS,
         execution_location: crate::AgentRunExecutionLocation::InProcess,
     }
 }
@@ -634,11 +635,11 @@ async fn stale_lease_pending_steer_and_capacity_leave_no_checkpoint_fragments() 
     assert!(store.list_tool_calls(chat.id).await.unwrap().is_empty());
     assert_eq!(store.list_events(chat.id, 0).await.unwrap().len(), 1);
 
-    // Use a fresh chat to exercise the fixed four-child outstanding cap.
+    // Use a fresh chat to exercise the default per-chat active-agent cap.
     let cap_chat = sample_chat();
     store.create_chat(&cap_chat).await.unwrap();
     let (cap_turn, cap_lease) = running_turn(&store, cap_chat.id).await;
-    for index in 0..AgentRun::DEFAULT_MAX_OUTSTANDING_CHILDREN {
+    for index in 0..AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS {
         let call = CallId::new();
         assert!(matches!(
             store
@@ -648,7 +649,7 @@ async fn stale_lease_pending_steer_and_capacity_leave_no_checkpoint_fragments() 
                     &format!("child {index}"),
                     cap_lease,
                     cap_turn.steer_revision,
-                    AgentRun::DEFAULT_MAX_OUTSTANDING_CHILDREN,
+                    AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS,
                     Utc::now(),
                 )
                 .await
@@ -660,7 +661,7 @@ async fn stale_lease_pending_steer_and_capacity_leave_no_checkpoint_fragments() 
         &cap_turn,
         cap_lease,
         CallId::new(),
-        "fifth child",
+        "sixth child",
         2,
         progress(),
     );
@@ -671,7 +672,7 @@ async fn stale_lease_pending_steer_and_capacity_leave_no_checkpoint_fragments() 
             .unwrap(),
         Some(CheckpointSandboxSpawnOutcome::AtCapacity)
     ));
-    assert_eq!(store.list_agent_runs(cap_chat.id).await.unwrap().len(), 5);
+    assert_eq!(store.list_agent_runs(cap_chat.id).await.unwrap().len(), 6);
     assert!(store.list_tool_calls(cap_chat.id).await.unwrap().is_empty());
 }
 

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1364,13 +1364,8 @@ impl AgentRun {
     pub const DEFAULT_MAX_DURATION: chrono::Duration = chrono::Duration::hours(1);
     /// Largest accepted scheduler concurrency bound.
     pub const MAX_CONCURRENCY_LIMIT: u32 = 1_024;
-    /// Default maximum unsettled children from one foreground turn.
-    ///
-    /// A child remains unsettled while it is running or while its terminal
-    /// delivery is still pending or claimed. Admission enforces this
-    /// independently from worker concurrency so both queued work and unread
-    /// results stay bounded.
-    pub const DEFAULT_MAX_OUTSTANDING_CHILDREN: u32 = 4;
+    /// Default maximum concurrently active background agents in one chat.
+    pub const DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS: u32 = 5;
     /// Maximum stable failure-category length.
     pub const MAX_ERROR_CODE_LEN: usize = 128;
     /// Maximum persisted diagnostic-detail length.
@@ -1448,6 +1443,8 @@ pub struct SandboxSpawnCheckpointRequest {
     pub result: String,
     pub event_ordinal: i32,
     pub progress: TurnCheckpointProgress,
+    /// Settings-resolved per-chat ceiling on nonterminal background runs.
+    pub max_active_background_agents: u32,
     /// Host-resolved execution location for the child admitted by this atomic
     /// checkpoint. Existing callers use the in-process default.
     pub execution_location: AgentRunExecutionLocation,
@@ -2119,10 +2116,10 @@ pub struct AgentRunWaitSetCandidate {
 }
 
 impl TurnAgentRunWaitSet {
-    /// The admission layer caps unsettled children at four, including terminal
-    /// deliveries that have not been consumed or retired. Keeping the wait
-    /// bound equal prevents an oversized continuation checkpoint.
-    pub const MAX_CHILDREN: usize = AgentRun::DEFAULT_MAX_OUTSTANDING_CHILDREN as usize;
+    /// Keep one ordered wait within the durable result-envelope budget. This
+    /// bound is independent of the configurable admission cap; larger caps are
+    /// consumed in groups as children settle.
+    pub const MAX_CHILDREN: usize = 4;
 }
 
 /// Durable lifecycle of a [`TurnAgentRunWait`].

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -408,7 +408,7 @@ pub enum CheckpointSandboxSpawnOutcome {
     DelegatedResourceUnavailable,
     /// The exact foreground claim is missing, stale, or no longer live.
     LeaseLost,
-    /// Four nonterminal children already belong to this origin turn.
+    /// The chat already has the configured number of active background runs.
     AtCapacity,
     /// A durable steer won the checkpoint race and must be applied first.
     SteerPending(TurnRun),
@@ -2014,7 +2014,7 @@ pub trait Store: Send + Sync {
     /// second identity for the same model request. The origin turn, foreground
     /// parent, child, and immutable admission receipt commit together under the
     /// chat/turn write lock. Existing exact receipts are recovered before the
-    /// bounded outstanding-child check, making an ambiguous commit retry safe.
+    /// bounded per-chat active-run check, making an ambiguous commit retry safe.
     /// A non-blocking checkpoint may additionally bind one exact root-relative
     /// file identity after validating its root against the locked chat
     /// attachment projection; the receipt itself grants no host authority.
@@ -2028,7 +2028,7 @@ pub trait Store: Send + Sync {
         _input: &str,
         _lease_token: uuid::Uuid,
         _expected_steer_revision: i64,
-        _max_outstanding_children: u32,
+        _max_active_background_agents: u32,
         _now: chrono::DateTime<chrono::Utc>,
     ) -> Result<Option<AdmitSandboxAgentRunOutcome>> {
         agent_run_storage_unavailable()
@@ -2052,7 +2052,7 @@ pub trait Store: Send + Sync {
         _input: &str,
         _lease_token: uuid::Uuid,
         _expected_steer_revision: i64,
-        _max_outstanding_children: u32,
+        _max_active_background_agents: u32,
         _now: chrono::DateTime<chrono::Utc>,
     ) -> Result<Option<AdmitSandboxAgentRunOutcome>> {
         agent_run_storage_unavailable()
@@ -2212,6 +2212,8 @@ pub trait Store: Send + Sync {
     /// A successful transition writes one terminal, non-executable
     /// orchestration tool call and its `ToolCallCompleted` event, applies one
     /// progress delta, then moves `running` to `resuming` with no live lease.
+    /// Admission counts nonterminal background runs across the whole chat
+    /// against the request's settings-resolved limit.
     /// Foreground orchestration advertises this together with the explicit
     /// ordered wait boundary; sandbox agents receive neither contract.
     async fn checkpoint_sandbox_spawn(

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -5,7 +5,7 @@ use std::{sync::Arc, time::Duration as StdDuration};
 use chrono::{Duration, Utc};
 use openwave_core::{
     AcceptToolCallOutcome, AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentError, AgentEvent,
-    AgentRunCancellationReason, AgentRunId, AgentRunInboxStatus, AgentRunResultPayload,
+    AgentRun, AgentRunCancellationReason, AgentRunId, AgentRunInboxStatus, AgentRunResultPayload,
     AgentRunStatus, AgentRunTier, AgentRunWaitCondition, AgentRunWaitSetCheckpointRequest,
     AnswerUserQuestions, AnswerUserQuestionsOutcome, AnswerUserQuestionsRequest,
     ApplyTurnSteerOutcome, AssistantCitationInput, BeginRootAttachmentChange,
@@ -438,6 +438,7 @@ fn postgres_spawn_checkpoint_request(
                 cache_creation_input_tokens: 1,
             },
         },
+        max_active_background_agents: AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS,
         execution_location: openwave_core::AgentRunExecutionLocation::InProcess,
     }
 }

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -894,6 +894,7 @@ export class ApiClient {
    */
   putSettings(body: {
     model?: ModelSelectionKey | null;
+    max_active_background_agents?: number;
   }): Promise<RuntimeSettings> {
     return this.json("/settings", {
       method: "PUT",

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1571,7 +1571,11 @@ has_api_key: boolean,
  * The sticky new-chat defaults, so a composer for a chat that does not
  * exist yet can show what `POST /chats` will seed.
  */
-chat_defaults: StickyChatDefaults, };
+chat_defaults: StickyChatDefaults, 
+/**
+ * Maximum nonterminal spawned agents allowed in one chat.
+ */
+max_active_background_agents: number, };
 
 /**
  * Renderer-safe progress of the current sign-in attempt.

--- a/crates/openwave-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/AgentsPanel.dom.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ApiClient, RuntimeSettings } from "../api";
+import { AgentsPanel } from "./AgentsPanel";
+
+afterEach(cleanup);
+
+describe("AgentsPanel", () => {
+  it("loads and saves the per-chat active background-agent cap", async () => {
+    const settings: RuntimeSettings = {
+      model: null,
+      has_api_key: false,
+      chat_defaults: {
+        model: null,
+        reasoning_effort: null,
+        permission_mode: null,
+        network_policy: null,
+      },
+      max_active_background_agents: 5,
+    };
+    const putSettings = vi.fn().mockResolvedValue({
+      ...settings,
+      max_active_background_agents: 8,
+    });
+    const client = {
+      getSettings: vi.fn().mockResolvedValue(settings),
+      putSettings,
+    } as unknown as ApiClient;
+
+    render(<AgentsPanel client={client} />);
+    await screen.findByText("Active background agents per chat");
+    const input = screen.getByRole("spinbutton");
+    expect(input).toHaveValue(5);
+    fireEvent.change(input, { target: { value: "8" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save settings" }));
+    await waitFor(() =>
+      expect(putSettings).toHaveBeenCalledWith({
+        max_active_background_agents: 8,
+      }),
+    );
+  });
+});

--- a/crates/openwave-desktop/ui/src/settings/AgentsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/AgentsPanel.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import type { ApiClient } from "../api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  SettingsError,
+  SettingsField,
+  SettingsPanel,
+  SettingsSection,
+} from "./primitives";
+
+const MIN_ACTIVE_AGENTS = 1;
+const MAX_ACTIVE_AGENTS = 1024;
+
+export function AgentsPanel({ client }: { client: ApiClient }) {
+  const [limit, setLimit] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void client
+      .getSettings()
+      .then((settings) => {
+        if (!cancelled) setLimit(String(settings.max_active_background_agents));
+      })
+      .catch((err) => {
+        if (!cancelled) setError(String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [client]);
+
+  async function save() {
+    const parsed = Number(limit);
+    if (
+      !Number.isInteger(parsed) ||
+      parsed < MIN_ACTIVE_AGENTS ||
+      parsed > MAX_ACTIVE_AGENTS
+    ) {
+      setError(`Enter a whole number from ${MIN_ACTIVE_AGENTS} to ${MAX_ACTIVE_AGENTS}.`);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const settings = await client.putSettings({
+        max_active_background_agents: parsed,
+      });
+      setLimit(String(settings.max_active_background_agents));
+      toast.success("Saved agent settings");
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <SettingsPanel
+      title="Agents"
+      description="Control how much delegated background work one conversation may run at once."
+      busy={loading}
+    >
+      <SettingsSection>
+        <SettingsField
+          label="Active background agents per chat"
+          hint="A spawn beyond this limit fails immediately and can be retried after wait_for_agents returns."
+        >
+          <Input
+            type="number"
+            inputMode="numeric"
+            min={MIN_ACTIVE_AGENTS}
+            max={MAX_ACTIVE_AGENTS}
+            step="1"
+            value={limit}
+            disabled={loading || saving}
+            onChange={(event) => setLimit(event.target.value)}
+          />
+        </SettingsField>
+        <Button type="button" disabled={loading || saving} onClick={() => void save()}>
+          {saving ? "Saving…" : "Save settings"}
+        </Button>
+      </SettingsSection>
+      {error && <SettingsError>{error}</SettingsError>}
+    </SettingsPanel>
+  );
+}

--- a/crates/openwave-desktop/ui/src/settings/sections.tsx
+++ b/crates/openwave-desktop/ui/src/settings/sections.tsx
@@ -2,6 +2,7 @@ import type { ComponentType, FunctionComponent } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import {
   Blocks,
+  Bot,
   Cpu,
   Globe,
   KeyRound,
@@ -17,6 +18,7 @@ import { useApp } from "@/AppContext";
 import { useManagedPolicy } from "@/managedPolicy";
 import { useTheme } from "@/theme";
 import { AppearancePanel } from "./AppearancePanel";
+import { AgentsPanel } from "./AgentsPanel";
 import { CodeExecutionPanel } from "./CodeExecutionPanel";
 import { ConnectedAppsPanel } from "./ConnectedAppsPanel";
 import { GatewayPanel } from "./GatewayPanel";
@@ -91,6 +93,11 @@ function CodeExecutionSection() {
   return <CodeExecutionPanel client={client} />;
 }
 
+function AgentsSection() {
+  const { client } = useApp();
+  return <AgentsPanel client={client} />;
+}
+
 function ConnectedAppsSection() {
   const { client } = useApp();
   const { managed } = useManagedPolicy();
@@ -155,6 +162,7 @@ export const SETTINGS_SECTIONS: SettingsSectionDef[] = [
     unmanagedHidden: true,
   },
   { path: "models", label: "Models", icon: Cpu, Component: ModelsSection },
+  { path: "agents", label: "Agents", icon: Bot, Component: AgentsSection },
   {
     path: "voice-transcription",
     label: "Voice input",

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -1066,8 +1066,7 @@ mod tests {
             false,
         );
 
-        // Re-pinned when #1491 made Open the default network policy for new
-        // chats: the representative prompt's network guidance moved with it.
+        // Re-pinned for the Open network default and parallel sibling spawn contract.
         assert_eq!(
             identity(&prompt),
             "foreground-v2:sha256:28043f7e84f2ef827100574ba635f534c04ad969f9e8e9b2cf534fd91ff7d664"

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -54,6 +54,8 @@ use crate::web_search::{
     WebSearchCredentialsInfo,
 };
 
+pub(crate) const MAX_ACTIVE_BACKGROUND_AGENTS_SETTING: &str = "agents.max_active_background_agents";
+
 mod app_grant;
 mod app_invoke;
 mod app_library;
@@ -529,6 +531,8 @@ pub struct Settings {
     /// exist yet can show what `POST /chats` will seed.
     #[serde(default)]
     pub chat_defaults: StickyChatDefaults,
+    /// Maximum nonterminal spawned agents allowed in one chat.
+    pub max_active_background_agents: u32,
 }
 
 /// The reader's last explicit per-chat choices — what an unspecified field of
@@ -556,6 +560,8 @@ pub struct StickyChatDefaults {
 pub struct SettingsUpdate {
     #[serde(default, deserialize_with = "double_option")]
     pub model: Option<Option<String>>,
+    #[serde(default)]
+    pub max_active_background_agents: Option<u32>,
 }
 
 /// Deserialize a present field (including JSON `null`) as `Some(..)`; `#[serde(default)]`
@@ -574,6 +580,7 @@ pub async fn get_settings(State(state): State<AppState>) -> Result<Json<Settings
         model: read_model(&*state.store).await?,
         has_api_key: has_api_key(&*state.secrets).await,
         chat_defaults: read_sticky_chat_defaults(&state).await?,
+        max_active_background_agents: read_max_active_background_agents(&*state.store).await?,
     }))
 }
 
@@ -601,11 +608,38 @@ pub async fn put_settings(
             model_roles::write_selection(&*state.store, ModelRole::Chat, Some(&model)).await?;
         }
     }
+    if let Some(limit) = body.max_active_background_agents {
+        if limit == 0 || limit > AgentRun::MAX_CONCURRENCY_LIMIT {
+            return Err(ServerError::bad_request(format!(
+                "max_active_background_agents must be in 1..={}",
+                AgentRun::MAX_CONCURRENCY_LIMIT
+            )));
+        }
+        state
+            .store
+            .set_setting(
+                MAX_ACTIVE_BACKGROUND_AGENTS_SETTING,
+                &serde_json::json!(limit),
+            )
+            .await?;
+    }
     Ok(Json(Settings {
         model: read_model(&*state.store).await?,
         has_api_key: has_api_key(&*state.secrets).await,
         chat_defaults: read_sticky_chat_defaults(&state).await?,
+        max_active_background_agents: read_max_active_background_agents(&*state.store).await?,
     }))
+}
+
+pub(crate) async fn read_max_active_background_agents(
+    store: &dyn Store,
+) -> openwave_core::Result<u32> {
+    Ok(store
+        .get_setting(MAX_ACTIVE_BACKGROUND_AGENTS_SETTING)
+        .await?
+        .and_then(|value| serde_json::from_value::<u32>(value).ok())
+        .filter(|limit| *limit > 0 && *limit <= AgentRun::MAX_CONCURRENCY_LIMIT)
+        .unwrap_or(AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS))
 }
 
 /// `GET /web-search` — read host-owned web-search selection and readiness.

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -3086,6 +3086,8 @@ mod tests {
                         model_steps: 1,
                         usage: Usage::default(),
                     },
+                    max_active_background_agents:
+                        openwave_core::AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS,
                     execution_location: openwave_core::AgentRunExecutionLocation::InProcess,
                 },
                 Utc::now(),

--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -60,6 +60,7 @@ async fn settings_default_then_update_roundtrips() {
     assert_eq!(response.status(), StatusCode::OK);
     let settings: serde_json::Value = json_body(response).await;
     assert!(settings["model"].is_null());
+    assert_eq!(settings["max_active_background_agents"], 5);
 
     // PUT a model, and it comes back.
     let response = router
@@ -71,7 +72,11 @@ async fn settings_default_then_update_roundtrips() {
                 .header(header::AUTHORIZATION, &bearer)
                 .header(header::CONTENT_TYPE, "application/json")
                 .body(Body::from(
-                    serde_json::json!({"model": "claude-x"}).to_string(),
+                    serde_json::json!({
+                        "model": "claude-x",
+                        "max_active_background_agents": 7
+                    })
+                    .to_string(),
                 ))
                 .unwrap(),
         )
@@ -80,6 +85,7 @@ async fn settings_default_then_update_roundtrips() {
     assert_eq!(response.status(), StatusCode::OK);
     let settings: serde_json::Value = json_body(response).await;
     assert_eq!(settings["model"], "claude-x");
+    assert_eq!(settings["max_active_background_agents"], 7);
 
     // GET reflects the update.
     let response = router
@@ -94,6 +100,7 @@ async fn settings_default_then_update_roundtrips() {
         .unwrap();
     let settings: serde_json::Value = json_body(response).await;
     assert_eq!(settings["model"], "claude-x");
+    assert_eq!(settings["max_active_background_agents"], 7);
 }
 
 async fn put_mcp_servers(

--- a/crates/openwave-server/src/tests/sandbox.rs
+++ b/crates/openwave-server/src/tests/sandbox.rs
@@ -446,6 +446,8 @@ async fn delegated_file_routes_are_native_only_and_expose_only_exact_broker_auth
                     model_steps: 1,
                     usage: Usage::default(),
                 },
+                max_active_background_agents:
+                    openwave_core::AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS,
                 execution_location: openwave_core::AgentRunExecutionLocation::InProcess,
             },
             chrono::Utc::now(),

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -540,6 +540,8 @@ impl TurnWorker {
         let mut checkpoint_usage = openwave_core::Usage::default();
         let mut checkpoint_steps = 0_usize;
         let mut continuation_instruction = None;
+        let mut pending_sandbox_spawns = Vec::new();
+        let mut pending_sandbox_spawn_steer_revision = None;
         // A segment arriving with zero remaining steps is not refused: the
         // budget was spent by earlier segments — a checkpoint parked on the
         // last budgeted step, or a wrap-up whose provider call failed
@@ -759,7 +761,11 @@ impl TurnWorker {
                 .with_steer(steer.clone())
                 .with_durable_steer(lease_token)
                 .with_foreground_agent_orchestration()
-                .with_continuation_instruction(continuation_instruction.clone());
+                .with_continuation_instruction(continuation_instruction.clone())
+                .with_pending_sandbox_spawns(
+                    pending_sandbox_spawns.clone(),
+                    pending_sandbox_spawn_steer_revision,
+                );
             if let Some(blobs) = self.blobs.clone() {
                 agent = agent.with_blobs(blobs);
             }
@@ -1452,17 +1458,22 @@ impl TurnWorker {
                 }
                 Ok(AgentTurnOutcome::SandboxAgentSpawn {
                     request,
+                    remaining_requests,
                     usage,
                     steer_revision,
                     model_steps,
                 }) => {
-                    if model_steps == 0 || model_steps > remaining_steps {
+                    if (model_steps == 0 && pending_sandbox_spawns.is_empty())
+                        || model_steps > remaining_steps
+                    {
                         return Err(AgentError::msg(format!(
                             "turn {} returned an invalid model-step count {model_steps}",
                             turn.id
                         )));
                     }
                     remaining_steps -= model_steps;
+                    pending_sandbox_spawns = remaining_requests;
+                    pending_sandbox_spawn_steer_revision = Some(steer_revision);
                     total_model_steps = checked_model_step_sum(total_model_steps, model_steps)?;
                     total_usage = match checked_usage_sum(total_usage, usage) {
                         Ok(total) => total,
@@ -1538,6 +1549,8 @@ impl TurnWorker {
                         })?,
                         event_ordinal: ordinal,
                         progress,
+                        max_active_background_agents:
+                            crate::routes::read_max_active_background_agents(&*self.store).await?,
                         execution_location: self.config.sandbox_spawn_execution_location,
                     };
                     let mut checkpoint_heartbeat = AbortOnDrop(tokio::spawn(
@@ -1592,9 +1605,13 @@ impl TurnWorker {
                             }
                             Ok(Some(CheckpointSandboxSpawnOutcome::AtCapacity)) => {
                                 continuation_instruction = Some(
-                                    "The background-agent capacity is full. Do not spawn another agent. Call wait_for_agents with previously returned agent IDs before trying to delegate more work."
-                                        .into(),
+                                    format!(
+                                        "The per-chat background-agent cap is {} active agents. This spawn was not run. Call wait_for_agents with previously returned agent IDs, then try again after one finishes.",
+                                        checkpoint.max_active_background_agents
+                                    ),
                                 );
+                                pending_sandbox_spawns.clear();
+                                pending_sandbox_spawn_steer_revision = None;
                                 break;
                             }
                             Ok(Some(


### PR DESCRIPTION
## Summary

- retain sibling `spawn_sandbox_agent` calls from one model step and checkpoint them in order without another model round-trip
- enforce a persisted per-chat limit on active background runs, defaulting to 5, with an actionable `wait_for_agents` refusal at capacity
- expose the limit in a minimal Agents settings panel and generated wire types

## Why spawn was exclusive

Spawn was classified with other checkpoint tools because each checkpoint suspends the foreground turn and durable recovery carries one call across the resume boundary. Allowing multiple pending checkpoint rows would make recovery ambiguous. This change preserves that invariant: only one spawn checkpoint commits per resume, while the remaining validated sibling requests stay in the live worker segment and are checkpointed sequentially before the provider is called again. Client checkpoints and `wait_for_agents` retain their existing exclusivity semantics.

## Tests

- sibling spawn calls are retained in model order for sequential checkpoints
- the default cap admits the fifth active child and refuses the sixth without partial writes
- settings default and persistence round-trip through `GET/PUT /settings`
- Agents settings panel loads and saves the limit

Verified locally:

- `cargo fmt --all -- --check`
- `cargo check -p openwave-server --locked`
- focused `openwave-core` sibling-spawn and capacity tests
- focused `openwave-server` settings and wire-codegen tests
- `pnpm exec tsc --noEmit`
- `pnpm vitest run src/settings/AgentsPanel.dom.test.tsx`

## CI note

The PostgreSQL turn-state lane still needs CI coverage for the admission and checkpoint changes; run this PR with `full-ci`.

Full SQLite suites were run after the review fixes. The spawn-cap regressions pass. The core suite currently has two unrelated pre-existing migration expectation failures (`m0006_upgrades_an_existing_store_without_losing_records` and `m0013_adds_outputs_to_an_existing_conversation_store`, both `network_policy` Open vs Off), and the server suite has one unrelated prompt golden mismatch (`representative_prompt_has_an_intentional_golden_identity`).

