### PR TITLE
fix: unbreak main's rustfmt and headless test lanes

### DIFF
--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -2170,7 +2170,12 @@ async fn m0006_upgrades_an_existing_store_without_losing_records() {
         .unwrap();
     migration::Migrator::up(&conn, Some(5)).await.unwrap();
     let store = DbStore { conn: conn.clone() };
-    let chat = sample_chat();
+    // The legacy insert below predates the per-chat network policy, so the
+    // migrated row reads back Off — preserved, not today's new-chat default.
+    let chat = Chat {
+        network_policy: crate::model::NetworkPolicy::Off,
+        ..sample_chat()
+    };
     create_chat_before_agent_run_split(&store, &chat).await;
 
     migration::Migrator::up(&conn, None).await.unwrap();
@@ -2719,7 +2724,12 @@ async fn m0013_adds_outputs_to_an_existing_conversation_store() {
         .unwrap();
     migration::Migrator::up(&conn, Some(12)).await.unwrap();
     let store = DbStore { conn: conn.clone() };
-    let chat = sample_chat();
+    // The legacy insert below predates the per-chat network policy, so the
+    // migrated row reads back Off — preserved, not today's new-chat default.
+    let chat = Chat {
+        network_policy: crate::model::NetworkPolicy::Off,
+        ..sample_chat()
+    };
     create_chat_before_agent_run_split(&store, &chat).await;
 
     migration::Migrator::up(&conn, None).await.unwrap();

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -888,7 +888,9 @@ mod tests {
                 ProviderEvent::Failed {
                     error: ProviderErrorInfo {
                         kind: "overloaded".into(),
-                        message: "openai-compat returned 500 (server_error): upstream is overloaded".into(),
+                        message:
+                            "openai-compat returned 500 (server_error): upstream is overloaded"
+                                .into(),
                     },
                 },
             ]

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -1066,9 +1066,11 @@ mod tests {
             false,
         );
 
+        // Re-pinned when #1491 made Open the default network policy for new
+        // chats: the representative prompt's network guidance moved with it.
         assert_eq!(
             identity(&prompt),
-            "foreground-v2:sha256:a37f05bd14906db68575354e6118609ce6a2b5e8f908aeee4abad6ac2e1cb072"
+            "foreground-v2:sha256:28043f7e84f2ef827100574ba635f534c04ad969f9e8e9b2cf534fd91ff7d664"
         );
     }
 }


### PR DESCRIPTION
Unbreaks `main`'s full-ci lanes, red since this afternoon's merges and inherited by every open PR's merge ref (e.g. #1493). Three independent breakages, one green-main outcome:

1. **`m0006` / `m0013` legacy-migration tests** (from #1491): the tests insert their chat through the pre-split path, which predates the per-chat policy column — the migrated row correctly reads back `Off`, but the expected fixture built from `sample_chat()`'s `Default::default()` now says `Open`. Pinned `Off` explicitly in the two fixtures; the migration behavior is unchanged and right.
2. **`representative_prompt_has_an_intentional_golden_identity`** (from #1491): the golden composes with `NetworkPolicy::default()`, which #1491 deliberately moved to Open without re-pinning the prompt identity. Re-pinned to the new hash with a comment naming the cause — the deliberate acknowledgment the test exists to force.
3. **rustfmt drift in `openwave-router/src/openai_compat.rs`** (from #1492): reformatted.

Test/formatting only; `full-ci` proves the previously failing lanes before merge.

Closes #1496
