### PR TITLE
feat(desktop): name the execution backend on the command card

### DIFF
--- a/crates/openwave-core/src/event.rs
+++ b/crates/openwave-core/src/event.rs
@@ -361,6 +361,7 @@ mod tests {
                     images: Vec::new(),
                     outputs: Vec::new(),
                     degraded: None,
+                    backend: None,
                 }),
             },
             AgentEvent::TurnCompleted {

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -435,6 +435,23 @@ pub enum ExecDegradation {
     SandboxImageUnavailable,
 }
 
+/// The execution backend that ran a command, as a closed vocabulary.
+///
+/// Read through this enum rather than surfaced as a string, on the same terms
+/// as [`ExecDegradation`]: the card names the backend, and the card's words
+/// are written on this side. A backend the renderer does not know projects as
+/// nothing rather than as passthrough text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecBackend {
+    /// The host's native process sandbox.
+    Local,
+    /// A managed E2B cloud sandbox.
+    E2b,
+    /// A managed Daytona cloud sandbox.
+    Daytona,
+}
+
 /// What a call produced, in a form a human can read.
 ///
 /// A command's output is the whole reason to run it. Withholding it leaves the
@@ -466,6 +483,11 @@ pub enum ToolResultPreview {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         #[ts(optional)]
         degraded: Option<ExecDegradation>,
+        /// Which backend ran the command. Defaulted so exec rows persisted
+        /// before the field existed read back unchanged.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        backend: Option<ExecBackend>,
     },
     /// Web search is available after the reader chooses and configures a
     /// provider. Carries no model- or provider-authored text.
@@ -571,6 +593,9 @@ impl ToolResultPreview {
                     // a tool's data is not a place the card takes prose from.
                     degraded: data.get("degraded").and_then(|value| {
                         serde_json::from_value::<ExecDegradation>(value.clone()).ok()
+                    }),
+                    backend: data.get("provider").and_then(|value| {
+                        serde_json::from_value::<ExecBackend>(value.clone()).ok()
                     }),
                 })
             }
@@ -1407,6 +1432,7 @@ mod tests {
                 "output_truncated": true,
                 "stdout": "line one\nline two\n",
                 "stderr": "boom\n",
+                "provider": "e2b",
             })),
         );
         assert_eq!(
@@ -1420,6 +1446,7 @@ mod tests {
                 images: Vec::new(),
                 outputs: Vec::new(),
                 degraded: None,
+                backend: Some(ExecBackend::E2b),
             })
         );
         assert!(result.unwrap().has_output());
@@ -1444,6 +1471,7 @@ mod tests {
                 images: Vec::new(),
                 outputs: Vec::new(),
                 degraded: None,
+                backend: None,
             }
         );
         assert!(!result.has_output());

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -1,6 +1,7 @@
 import { Check, Clock, Terminal, X } from "lucide-react";
 import {
   isRendererToolName,
+  type ExecBackend,
   type ExecDegradation,
   type ExecResultPreview,
   type RendererToolName,
@@ -31,6 +32,17 @@ const SANDBOX_PREPARING_NOTICE =
 const EXEC_DEGRADATION_NOTICE: Record<ExecDegradation, string> = {
   sandbox_image_unavailable:
     "The prepared OpenWave sandbox image was unavailable, so commands run on the backend's stock image — document tools will install their dependencies at run time, which is slower.",
+};
+
+/**
+ * Where the command ran, named on the card. A closed vocabulary like the
+ * degradation notices: the server reports the backend as an enum, and the
+ * words shown for each are written here.
+ */
+const EXEC_BACKEND_LABEL: Record<ExecBackend, string> = {
+  local: "Local",
+  e2b: "E2B",
+  daytona: "Daytona",
 };
 
 export type ToolCallStatus =
@@ -279,11 +291,22 @@ export function ToolCommandCard({
         title={command.headline}
         titleClassName="font-mono"
         badge={
-          <ToolStatusBadge
-            presentation={presentation}
-            result={result}
-            preparing={preparing}
-          />
+          <>
+            {result?.backend && (
+              <Badge
+                variant="outline"
+                className="text-muted-foreground shrink-0"
+                title={`Ran on the ${EXEC_BACKEND_LABEL[result.backend]} execution backend`}
+              >
+                {EXEC_BACKEND_LABEL[result.backend]}
+              </Badge>
+            )}
+            <ToolStatusBadge
+              presentation={presentation}
+              result={result}
+              preparing={preparing}
+            />
+          </>
         }
         defaultExpanded={running || images.length > 0}
       >

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -68,6 +68,7 @@ import {
   type ChatTerminalTurnSnapshot,
   type ChatToolActivitySnapshot,
   type ChatToolActivityStatus,
+  type ExecBackend,
   type ExecDegradation,
   type ExecFileChangeSummary as WireExecFileChangeSummary,
   type RendererAgentEvent,
@@ -97,6 +98,7 @@ export type {
   ResultEntryKind,
   ToolActionPreview,
   RendererRefusal,
+  ExecBackend,
   ExecDegradation,
 };
 
@@ -423,6 +425,8 @@ export type ToolResultPreview =
        * after it, so a conversation says this once.
        */
       degraded?: ExecDegradation;
+      /** Which backend ran the command, when the server said. */
+      backend?: ExecBackend;
     }
   | {
       /** Web search is available after the reader configures a provider. */
@@ -2431,6 +2435,7 @@ export function parseToolResultPreview(
     images,
     outputs,
     degraded,
+    backend,
   }: UncheckedExecResult = value;
   const imageValues = images ?? [];
   const outputValues = outputs ?? [];
@@ -2485,11 +2490,16 @@ export function parseToolResultPreview(
     // Unknown to this build means unshowable, not unusable: the command's
     // output still renders, without a sentence nobody wrote copy for.
     degraded: isExecDegradation(degraded) ? degraded : undefined,
+    backend: isExecBackend(backend) ? backend : undefined,
   };
 }
 
 function isExecDegradation(value: unknown): value is ExecDegradation {
   return value === "sandbox_image_unavailable";
+}
+
+function isExecBackend(value: unknown): value is ExecBackend {
+  return value === "local" || value === "e2b" || value === "daytona";
 }
 
 /**

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -787,6 +787,16 @@ export type EgressConfig = { "mode": "open" } | { "mode": "allowlist", domains: 
 export type EgressEnforcementStatus = "boundary" | "conditional_boundary" | "applied_with_gaps" | "unconfirmed";
 
 /**
+ * The execution backend that ran a command, as a closed vocabulary.
+ *
+ * Read through this enum rather than surfaced as a string, on the same terms
+ * as [`ExecDegradation`]: the card names the backend, and the card's words
+ * are written on this side. A backend the renderer does not know projects as
+ * nothing rather than as passthrough text.
+ */
+export type ExecBackend = "local" | "e2b" | "daytona";
+
+/**
  * A way the execution backend ran with less than its intended setup.
  *
  * Closed, and deliberately coarse: what a reader needs is what happened and
@@ -1689,7 +1699,12 @@ outputs?: Array<ResultEntry>,
  * did. Reported on the first execution that degrades and not on the
  * ones after it, so a chat says this once rather than on every card.
  */
-degraded?: ExecDegradation, } | { "tool": "web_search_provider_required" } | { "tool": "mcp_app", 
+degraded?: ExecDegradation, 
+/**
+ * Which backend ran the command. Defaulted so exec rows persisted
+ * before the field existed read back unchanged.
+ */
+backend?: ExecBackend, } | { "tool": "web_search_provider_required" } | { "tool": "mcp_app", 
 /**
  * The configured MCP server namespace that serves the view.
  */

--- a/crates/openwave-server/src/tests/image_attachment.rs
+++ b/crates/openwave-server/src/tests/image_attachment.rs
@@ -590,6 +590,7 @@ async fn a_tool_preview_is_fetchable_only_through_its_chat() {
         }],
         outputs: Vec::new(),
         degraded: None,
+        backend: None,
     };
     store
         .resolve_server_tool_call_with_artifacts(


### PR DESCRIPTION
The exec tool already reports which backend ran a command (local, E2B, or
Daytona) in its output data, but the transcript card never said — a command
that fell back from one managed provider to another, or ran locally, looked
identical. Project the backend through the result preview as a closed enum,
mirroring how degradation notices cross the renderer boundary, and show it
as a badge beside the command card's status.
