### PR TITLE
fix(router): use OpenAI Responses for native models

### DIFF
--- a/crates/openwave-router/Cargo.toml
+++ b/crates/openwave-router/Cargo.toml
@@ -11,10 +11,12 @@ authors.workspace = true
 workspace = true
 
 [features]
-default = ["anthropic", "openai-compat", "gemini"]
+default = ["anthropic", "openai", "openai-compat", "gemini"]
 # The Anthropic (Messages API) provider adapter.
 anthropic = ["_http"]
-# OpenAI-compatible Chat Completions adapter (OpenAI, OpenRouter, vLLM, …).
+# Native OpenAI Responses API adapter.
+openai = ["_http"]
+# OpenAI-compatible Chat Completions adapter (OpenRouter, vLLM, …).
 openai-compat = ["_http"]
 # Google Gemini Developer API adapter (native GenerateContent protocol).
 gemini = ["_http", "dep:ring", "dep:uuid"]

--- a/crates/openwave-router/src/lib.rs
+++ b/crates/openwave-router/src/lib.rs
@@ -20,6 +20,9 @@ pub mod anthropic;
 #[cfg(feature = "openai-compat")]
 pub mod openai_compat;
 
+#[cfg(feature = "openai")]
+pub mod openai;
+
 #[cfg(feature = "gemini")]
 pub mod gemini;
 
@@ -35,6 +38,8 @@ pub use google_auth::{
     valid_resource_segment as valid_google_resource_segment, valid_vertex_location,
     GoogleServiceAccount, GoogleServiceAccountTokenSource,
 };
+#[cfg(feature = "openai")]
+pub use openai::OpenAiProvider;
 #[cfg(feature = "openai-compat")]
 pub use openai_compat::OpenAiCompatProvider;
 pub use router::{BearerTokenSource, Route, RouteKind, Router, VertexRoute};

--- a/crates/openwave-router/src/openai.rs
+++ b/crates/openwave-router/src/openai.rs
@@ -1,0 +1,845 @@
+//! Native OpenAI Responses API provider.
+
+use std::collections::{BTreeMap, HashSet};
+
+use async_trait::async_trait;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+use futures::stream::{BoxStream, StreamExt};
+use serde_json::{json, Value};
+
+use openwave_core::error::{AgentError, ProviderErrorInfo, Result};
+use openwave_core::provider::{
+    ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId, RefusalDetails,
+    ResponseFormat, StopReason, ToolChoice, Usage,
+};
+use openwave_core::tool::{strict_json_schema, OptionalProperties};
+use openwave_core::{ImageAttachments, Role};
+
+use crate::sse::{
+    classify_in_band_error, classify_provider_error, drain_frames, frame_data,
+    read_bounded_error_body,
+};
+
+const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
+const DEFAULT_MAX_TOKENS: u32 = 4096;
+
+/// A [`ModelProvider`] for OpenAI's native Responses API.
+#[derive(Clone)]
+pub struct OpenAiProvider {
+    client: reqwest::Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl OpenAiProvider {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            client: crate::http::streaming_client(),
+            api_key: api_key.into(),
+            base_url: DEFAULT_BASE_URL.to_string(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+}
+
+#[async_trait]
+impl ModelProvider for OpenAiProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::new("openai")
+    }
+
+    async fn stream(&self, req: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+        let body = build_request_json(&req)?;
+        let url = format!("{}/responses", self.base_url.trim_end_matches('/'));
+        let response = self
+            .client
+            .post(url)
+            .bearer_auth(&self.api_key)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|_| AgentError::Provider("openai request failed".into()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let retry_after = crate::sse::retry_after_hint(response.headers());
+            let body = read_bounded_error_body(response.bytes_stream()).await;
+            return Err(classify_provider_error(
+                "openai",
+                status.as_u16(),
+                &body,
+                retry_after,
+            ));
+        }
+
+        let ceiling = crate::http::timeouts().total_stream;
+        let stream = async_stream::stream! {
+            let bytes = crate::http::with_stream_deadline(response.bytes_stream(), ceiling);
+            futures::pin_mut!(bytes);
+            let mut buffer = Vec::new();
+            let mut state = StreamState::default();
+            while let Some(chunk) = bytes.next().await {
+                let chunk = match chunk {
+                    Ok(chunk) => chunk,
+                    Err(error) => {
+                        yield ProviderEvent::Failed {
+                            error: ProviderErrorInfo::provider(error.client_message("openai")),
+                        };
+                        return;
+                    }
+                };
+                buffer.extend_from_slice(&chunk);
+                for frame in drain_frames(&mut buffer) {
+                    if let Some(data) = frame_data(&frame) {
+                        for event in normalize(&data, &mut state) {
+                            yield event;
+                        }
+                    }
+                }
+            }
+            if !buffer.is_empty() {
+                let frame = String::from_utf8_lossy(&buffer).into_owned();
+                if let Some(data) = frame_data(&frame) {
+                    for event in normalize(&data, &mut state) {
+                        yield event;
+                    }
+                }
+            }
+            if !state.terminal {
+                yield ProviderEvent::Failed {
+                    error: ProviderErrorInfo::provider("openai stream ended before completion"),
+                };
+            }
+        };
+        Ok(Box::pin(stream))
+    }
+}
+
+fn build_request_json(req: &ChatRequest) -> Result<Value> {
+    let input = build_input(req)?;
+    let mut body = json!({
+        "model": req.model,
+        "input": input,
+        "stream": true,
+        "store": false,
+        "max_output_tokens": req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
+    });
+
+    if req.reasoning_model {
+        if let Some(effort) = req.reasoning_effort {
+            body["reasoning"] = json!({ "effort": effort.as_str(), "summary": "auto" });
+        }
+    } else if let Some(temperature) = req.temperature {
+        body["temperature"] = json!(temperature);
+    }
+
+    if !req.tools.is_empty() {
+        body["tools"] = Value::Array(req.tools.iter().map(openai_tool).collect());
+    }
+    if let Some(choice) = &req.tool_choice {
+        body["tool_choice"] = openai_tool_choice(choice)?;
+    }
+    match &req.response_format {
+        Some(ResponseFormat::JsonSchema { name, schema }) => {
+            let schema =
+                strict_json_schema(schema, OptionalProperties::AcceptNull).ok_or_else(|| {
+                    AgentError::Provider(format!(
+                        "response format {name} has no strict JSON Schema form"
+                    ))
+                })?;
+            body["text"] = json!({
+                "format": {
+                    "type": "json_schema",
+                    "name": name,
+                    "strict": true,
+                    "schema": schema,
+                }
+            });
+        }
+        None => {}
+        Some(other) => {
+            return Err(AgentError::Provider(format!(
+                "openai cannot enforce response format {other:?}"
+            )))
+        }
+    }
+    Ok(body)
+}
+
+fn build_input(req: &ChatRequest) -> Result<Vec<Value>> {
+    let mut out = Vec::new();
+    if let Some(system) = &req.system {
+        out.push(json!({
+            "role": "system",
+            "content": [{ "type": "input_text", "text": system }]
+        }));
+    }
+    for message in &req.messages {
+        extend_input(&mut out, message, &req.images)?;
+    }
+    Ok(sanitize_tool_pairs(out))
+}
+
+fn extend_input(
+    out: &mut Vec<Value>,
+    message: &openwave_core::ChatMessage,
+    images: &ImageAttachments,
+) -> Result<()> {
+    let mut message_parts = Vec::new();
+    for block in &message.content {
+        match block {
+            ContentBlock::Text { text } => {
+                message_parts.push(json!({ "type": "input_text", "text": text }));
+            }
+            ContentBlock::Image { image } => {
+                let data = images.get(image.blob_id).ok_or_else(|| {
+                    AgentError::Provider(format!(
+                        "image attachment {} has no hydrated bytes",
+                        image.blob_id
+                    ))
+                })?;
+                message_parts.push(json!({
+                    "type": "input_image",
+                    "image_url": format!(
+                        "data:{};base64,{}",
+                        data.media_type().as_str(),
+                        BASE64.encode(data.bytes())
+                    )
+                }));
+            }
+            ContentBlock::ToolUse { id, name, input } => {
+                out.push(json!({
+                    "type": "function_call",
+                    "call_id": id,
+                    "name": name,
+                    "arguments": serde_json::to_string(input).unwrap_or_else(|_| "{}".into()),
+                }));
+            }
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => {
+                let output = if *is_error {
+                    format!("Error: the tool call failed.\n{content}")
+                } else {
+                    content.clone()
+                };
+                out.push(json!({
+                    "type": "function_call_output",
+                    "call_id": tool_use_id,
+                    "output": output,
+                }));
+            }
+            other => {
+                return Err(AgentError::Provider(format!(
+                    "openai cannot express content block {other:?}"
+                )))
+            }
+        }
+    }
+    if !message_parts.is_empty() {
+        let role = match message.role {
+            Role::Assistant => "assistant",
+            Role::User | Role::System | Role::Tool => "user",
+        };
+        out.push(json!({ "role": role, "content": message_parts }));
+    }
+    Ok(())
+}
+
+fn sanitize_tool_pairs(items: Vec<Value>) -> Vec<Value> {
+    let calls: HashSet<String> = items
+        .iter()
+        .filter(|item| item["type"] == "function_call")
+        .filter_map(|item| item["call_id"].as_str().map(str::to_owned))
+        .collect();
+    let outputs: HashSet<String> = items
+        .iter()
+        .filter(|item| item["type"] == "function_call_output")
+        .filter_map(|item| item["call_id"].as_str().map(str::to_owned))
+        .collect();
+    items
+        .into_iter()
+        .filter(|item| match item["type"].as_str() {
+            Some("function_call") | Some("function_call_output") => item["call_id"]
+                .as_str()
+                .is_some_and(|id| calls.contains(id) && outputs.contains(id)),
+            _ => true,
+        })
+        .collect()
+}
+
+fn openai_tool(tool: &openwave_core::tool::ToolSpec) -> Value {
+    let schema = strict_json_schema(&tool.input_schema, OptionalProperties::Reject)
+        .unwrap_or_else(|| tool.input_schema.clone());
+    json!({
+        "type": "function",
+        "name": tool.name,
+        "description": tool.description,
+        "parameters": schema,
+        "strict": strict_json_schema(&tool.input_schema, OptionalProperties::Reject).is_some(),
+    })
+}
+
+fn openai_tool_choice(choice: &ToolChoice) -> Result<Value> {
+    Ok(match choice {
+        ToolChoice::Auto => json!("auto"),
+        ToolChoice::Required => json!("required"),
+        ToolChoice::None => json!("none"),
+        ToolChoice::Tool { name } => json!({ "type": "function", "name": name }),
+        other => {
+            return Err(AgentError::Provider(format!(
+                "openai cannot express tool choice {other:?}"
+            )))
+        }
+    })
+}
+
+#[derive(Default)]
+struct StreamState {
+    calls: BTreeMap<String, CallState>,
+    next_index: u32,
+    terminal: bool,
+    refused: bool,
+}
+
+#[derive(Default)]
+struct CallState {
+    index: u32,
+    name: String,
+    started: bool,
+    saw_argument_delta: bool,
+}
+
+fn normalize(data: &Value, state: &mut StreamState) -> Vec<ProviderEvent> {
+    if state.terminal {
+        return Vec::new();
+    }
+    let event_type = data["type"].as_str().unwrap_or_default();
+    match event_type {
+        "error" => {
+            state.terminal = true;
+            vec![ProviderEvent::Failed {
+                error: ProviderErrorInfo::from_error(&classify_in_band_error(
+                    "openai",
+                    data.get("error").unwrap_or(data),
+                )),
+            }]
+        }
+        "response.output_text.delta" => data["delta"]
+            .as_str()
+            .map(|text| vec![ProviderEvent::TextDelta { text: text.into() }])
+            .unwrap_or_default(),
+        "response.reasoning_summary_text.delta" | "response.reasoning_text.delta" => data["delta"]
+            .as_str()
+            .map(|text| vec![ProviderEvent::ReasoningDelta { text: text.into() }])
+            .unwrap_or_default(),
+        "response.refusal.delta" => data["delta"]
+            .as_str()
+            .map(|text| vec![ProviderEvent::TextDelta { text: text.into() }])
+            .unwrap_or_default(),
+        "response.refusal.done" => {
+            state.refused = true;
+            Vec::new()
+        }
+        "response.output_item.added" => start_call(data, state, false),
+        "response.function_call_arguments.delta" => {
+            let call_id = data["call_id"].as_str().unwrap_or_default();
+            let mut events = ensure_call(call_id, None, state);
+            if let (Some(call), Some(fragment)) =
+                (state.calls.get_mut(call_id), data["delta"].as_str())
+            {
+                call.saw_argument_delta = true;
+                events.push(ProviderEvent::ToolCallArgsDelta {
+                    index: call.index,
+                    fragment: fragment.into(),
+                });
+            }
+            events
+        }
+        "response.output_item.done" => start_call(data, state, true),
+        "response.completed" => {
+            state.terminal = true;
+            let response = &data["response"];
+            let mut events = usage_event(response).into_iter().collect::<Vec<_>>();
+            if state.refused {
+                events.push(ProviderEvent::Refusal {
+                    details: RefusalDetails::from_category(None),
+                });
+            } else {
+                let has_calls = !state.calls.is_empty();
+                events.push(ProviderEvent::Stop {
+                    reason: if has_calls {
+                        StopReason::ToolUse
+                    } else {
+                        StopReason::EndTurn
+                    },
+                });
+            }
+            events
+        }
+        "response.incomplete" => {
+            state.terminal = true;
+            let response = &data["response"];
+            let mut events = usage_event(response).into_iter().collect::<Vec<_>>();
+            match response["incomplete_details"]["reason"].as_str() {
+                Some("max_output_tokens") => events.push(ProviderEvent::Stop {
+                    reason: StopReason::MaxTokens,
+                }),
+                Some("content_filter") => events.push(ProviderEvent::Refusal {
+                    details: RefusalDetails::from_category(Some("content_filter")),
+                }),
+                _ => events.push(ProviderEvent::Failed {
+                    error: ProviderErrorInfo::provider(
+                        "openai response ended incomplete without a supported reason",
+                    ),
+                }),
+            }
+            events
+        }
+        "response.failed" => {
+            state.terminal = true;
+            let error = data["response"].get("error").unwrap_or(&data["response"]);
+            vec![ProviderEvent::Failed {
+                error: ProviderErrorInfo::from_error(&classify_in_band_error("openai", error)),
+            }]
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn start_call(
+    data: &Value,
+    state: &mut StreamState,
+    emit_complete_args: bool,
+) -> Vec<ProviderEvent> {
+    let item = &data["item"];
+    if item["type"] != "function_call" {
+        return Vec::new();
+    }
+    let call_id = item["call_id"].as_str().unwrap_or_default();
+    let name = item["name"].as_str();
+    let mut events = ensure_call(call_id, name, state);
+    if emit_complete_args {
+        let saw_deltas = state
+            .calls
+            .get(call_id)
+            .is_some_and(|call| call.saw_argument_delta);
+        if !saw_deltas {
+            if let (Some(call), Some(arguments)) =
+                (state.calls.get(call_id), item["arguments"].as_str())
+            {
+                if !arguments.is_empty() {
+                    events.push(ProviderEvent::ToolCallArgsDelta {
+                        index: call.index,
+                        fragment: arguments.to_owned(),
+                    });
+                }
+            }
+        }
+    }
+    events
+}
+
+fn ensure_call(call_id: &str, name: Option<&str>, state: &mut StreamState) -> Vec<ProviderEvent> {
+    if call_id.is_empty() {
+        return Vec::new();
+    }
+    let call = state.calls.entry(call_id.to_owned()).or_insert_with(|| {
+        let index = state.next_index;
+        state.next_index = state.next_index.saturating_add(1);
+        CallState {
+            index,
+            name: String::new(),
+            started: false,
+            saw_argument_delta: false,
+        }
+    });
+    if let Some(name) = name.filter(|name| !name.is_empty()) {
+        call.name = name.to_owned();
+    }
+    if !call.started && !call.name.is_empty() {
+        call.started = true;
+        return vec![ProviderEvent::ToolCallStarted {
+            index: call.index,
+            id: call_id.to_owned(),
+            name: call.name.clone(),
+        }];
+    }
+    Vec::new()
+}
+
+fn usage_event(response: &Value) -> Option<ProviderEvent> {
+    let usage = response.get("usage")?;
+    let total = usage["input_tokens"].as_u64().unwrap_or(0);
+    let cached = usage["input_tokens_details"]["cached_tokens"]
+        .as_u64()
+        .unwrap_or(0);
+    Some(ProviderEvent::Usage(Usage {
+        input_tokens: u32::try_from(total.saturating_sub(cached)).unwrap_or(u32::MAX),
+        output_tokens: u32::try_from(usage["output_tokens"].as_u64().unwrap_or(0))
+            .unwrap_or(u32::MAX),
+        cache_read_input_tokens: u32::try_from(cached).unwrap_or(u32::MAX),
+        cache_creation_input_tokens: 0,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openwave_core::provider::ChatMessage;
+    use openwave_core::tool::ToolSpec;
+    use openwave_core::{ImageData, ImageMediaType, ImageRef, ReasoningEffort};
+
+    fn tool() -> ToolSpec {
+        ToolSpec {
+            name: "exec".into(),
+            description: "run a command".into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": { "command": { "type": "string" } },
+                "required": ["command"]
+            }),
+        }
+    }
+
+    #[test]
+    fn tools_and_reasoning_use_responses_shape_together() {
+        let req = ChatRequest {
+            model: "gpt-5.6-sol".into(),
+            reasoning_model: true,
+            messages: vec![ChatMessage::text(Role::User, "call a tool")],
+            tools: vec![tool()],
+            reasoning_effort: Some(ReasoningEffort::High),
+            max_tokens: Some(1024),
+            ..Default::default()
+        };
+        let body = build_request_json(&req).unwrap();
+        assert_eq!(body["reasoning"]["effort"], "high");
+        assert_eq!(body["reasoning"]["summary"], "auto");
+        assert_eq!(body["tools"][0]["type"], "function");
+        assert_eq!(body["tools"][0]["name"], "exec");
+        assert_eq!(body["max_output_tokens"], 1024);
+        assert!(body.get("messages").is_none());
+    }
+
+    #[test]
+    fn tool_history_uses_function_items_and_drops_orphans() {
+        let paired = openwave_core::ChatMessage {
+            role: Role::Assistant,
+            content: vec![ContentBlock::ToolUse {
+                id: "call_1".into(),
+                name: "exec".into(),
+                input: json!({"command":"pwd"}),
+            }],
+            reasoning: Vec::new(),
+        };
+        let result = openwave_core::ChatMessage {
+            role: Role::User,
+            content: vec![ContentBlock::ToolResult {
+                tool_use_id: "call_1".into(),
+                content: "ok".into(),
+                is_error: false,
+            }],
+            reasoning: Vec::new(),
+        };
+        let orphan = openwave_core::ChatMessage {
+            role: Role::User,
+            content: vec![ContentBlock::ToolResult {
+                tool_use_id: "missing".into(),
+                content: "bad".into(),
+                is_error: true,
+            }],
+            reasoning: Vec::new(),
+        };
+        let req = ChatRequest {
+            model: "gpt-5.6-sol".into(),
+            messages: vec![paired, result, orphan],
+            ..Default::default()
+        };
+        let input = build_input(&req).unwrap();
+        assert_eq!(input.len(), 2);
+        assert_eq!(input[0]["type"], "function_call");
+        assert_eq!(input[1]["type"], "function_call_output");
+    }
+
+    #[test]
+    fn strict_output_and_named_tool_choice_are_native() {
+        let req = ChatRequest {
+            model: "gpt-5.6-sol".into(),
+            messages: vec![ChatMessage::text(Role::User, "run")],
+            tools: vec![tool()],
+            tool_choice: Some(ToolChoice::Tool {
+                name: "exec".into(),
+            }),
+            response_format: Some(ResponseFormat::JsonSchema {
+                name: "answer".into(),
+                schema: json!({
+                    "type":"object",
+                    "properties":{"answer":{"type":"string"}},
+                    "required":["answer"]
+                }),
+            }),
+            ..Default::default()
+        };
+        let body = build_request_json(&req).unwrap();
+        assert_eq!(
+            body["tool_choice"],
+            json!({"type":"function","name":"exec"})
+        );
+        assert_eq!(body["text"]["format"]["type"], "json_schema");
+        assert_eq!(body["text"]["format"]["strict"], true);
+    }
+
+    #[test]
+    fn image_input_is_hydrated_as_a_data_url() {
+        let image = ImageRef {
+            blob_id: uuid::Uuid::from_u128(1),
+            media_type: ImageMediaType::Png,
+            width: 1,
+            height: 1,
+            byte_len: 3,
+        };
+        let mut images = ImageAttachments::new();
+        images.insert(
+            image.blob_id,
+            ImageData::new(ImageMediaType::Png, vec![1, 2, 3]),
+        );
+        let req = ChatRequest {
+            model: "gpt-5.6-sol".into(),
+            messages: vec![openwave_core::ChatMessage {
+                role: Role::User,
+                content: vec![ContentBlock::Image { image }],
+                reasoning: Vec::new(),
+            }],
+            images,
+            ..Default::default()
+        };
+        let body = build_request_json(&req).unwrap();
+        assert!(body["input"][0]["content"][0]["image_url"]
+            .as_str()
+            .unwrap()
+            .starts_with("data:image/png;base64,"));
+    }
+
+    #[test]
+    fn normalizes_text_reasoning_tool_usage_and_stop() {
+        let mut state = StreamState::default();
+        let events: Vec<_> = [
+            json!({"type":"response.reasoning_summary_text.delta","delta":"think"}),
+            json!({"type":"response.output_text.delta","delta":"hello"}),
+            json!({"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_1","name":"exec"}}),
+            json!({"type":"response.function_call_arguments.delta","call_id":"call_1","delta":"{\"command\":\"pwd\"}"}),
+            json!({"type":"response.completed","response":{"usage":{"input_tokens":10,"input_tokens_details":{"cached_tokens":4},"output_tokens":3}}}),
+        ]
+        .iter()
+        .flat_map(|event| normalize(event, &mut state))
+        .collect();
+        assert_eq!(
+            events,
+            vec![
+                ProviderEvent::ReasoningDelta {
+                    text: "think".into()
+                },
+                ProviderEvent::TextDelta {
+                    text: "hello".into()
+                },
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "call_1".into(),
+                    name: "exec".into()
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: "{\"command\":\"pwd\"}".into()
+                },
+                ProviderEvent::Usage(Usage {
+                    input_tokens: 6,
+                    output_tokens: 3,
+                    cache_read_input_tokens: 4,
+                    cache_creation_input_tokens: 0
+                }),
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn completed_function_item_supplies_arguments_when_no_deltas_arrived() {
+        let mut state = StreamState::default();
+        let events = normalize(
+            &json!({
+                "type":"response.output_item.done",
+                "item":{
+                    "type":"function_call",
+                    "call_id":"call_1",
+                    "name":"exec",
+                    "arguments":"{\"command\":\"pwd\"}"
+                }
+            }),
+            &mut state,
+        );
+        assert_eq!(
+            events,
+            vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "call_1".into(),
+                    name: "exec".into()
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: "{\"command\":\"pwd\"}".into()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn completed_function_item_does_not_duplicate_streamed_arguments() {
+        let mut state = StreamState::default();
+        let _ = normalize(
+            &json!({"type":"response.output_item.added","item":{"type":"function_call","call_id":"call_1","name":"exec"}}),
+            &mut state,
+        );
+        let _ = normalize(
+            &json!({"type":"response.function_call_arguments.delta","call_id":"call_1","delta":"{}"}),
+            &mut state,
+        );
+        assert!(normalize(
+            &json!({"type":"response.output_item.done","item":{"type":"function_call","call_id":"call_1","name":"exec","arguments":"{}"}}),
+            &mut state,
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn incomplete_and_failed_responses_are_terminal() {
+        let mut state = StreamState::default();
+        assert_eq!(
+            normalize(
+                &json!({"type":"response.incomplete","response":{"incomplete_details":{"reason":"max_output_tokens"}}}),
+                &mut state
+            ),
+            vec![ProviderEvent::Stop {
+                reason: StopReason::MaxTokens
+            }]
+        );
+        let mut state = StreamState::default();
+        let events = normalize(
+            &json!({"type":"response.failed","response":{"error":{"type":"server_error","message":"upstream failed"}}}),
+            &mut state,
+        );
+        assert!(matches!(events.as_slice(), [ProviderEvent::Failed { .. }]));
+
+        let mut state = StreamState::default();
+        assert_eq!(
+            normalize(
+                &json!({"type":"response.incomplete","response":{"incomplete_details":{"reason":"content_filter"}}}),
+                &mut state,
+            ),
+            vec![ProviderEvent::Refusal {
+                details: RefusalDetails::from_category(Some("content_filter"))
+            }]
+        );
+    }
+
+    #[test]
+    fn refusal_text_streams_and_terminal_refusal_is_normalized() {
+        let mut state = StreamState::default();
+        assert_eq!(
+            normalize(
+                &json!({"type":"response.refusal.delta","delta":"cannot"}),
+                &mut state
+            ),
+            vec![ProviderEvent::TextDelta {
+                text: "cannot".into()
+            }]
+        );
+        assert!(normalize(
+            &json!({"type":"response.refusal.done","refusal":"cannot"}),
+            &mut state
+        )
+        .is_empty());
+        assert_eq!(
+            normalize(
+                &json!({"type":"response.completed","response":{}}),
+                &mut state
+            ),
+            vec![ProviderEvent::Refusal {
+                details: RefusalDetails::from_category(None)
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn native_provider_posts_to_responses_and_streams_completion() {
+        use axum::extract::{Request, State};
+        use axum::http::StatusCode;
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use axum::Router;
+        use tokio::sync::oneshot;
+
+        async fn capture(
+            State(tx): State<std::sync::Arc<std::sync::Mutex<Option<oneshot::Sender<String>>>>>,
+            request: Request,
+        ) -> impl IntoResponse {
+            if let Some(tx) = tx.lock().unwrap().take() {
+                let _ = tx.send(request.uri().path().to_owned());
+            }
+            (
+                StatusCode::OK,
+                [("content-type", "text/event-stream")],
+                concat!(
+                    "data: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n",
+                    "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+                ),
+            )
+        }
+
+        let (tx, rx) = oneshot::channel();
+        let state = std::sync::Arc::new(std::sync::Mutex::new(Some(tx)));
+        let app = Router::new().fallback(post(capture)).with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let provider = OpenAiProvider::new("key").with_base_url(format!("http://{address}/v1"));
+        let stream = provider
+            .stream(ChatRequest {
+                model: "gpt-5.6-sol".into(),
+                messages: vec![ChatMessage::text(Role::User, "hi")],
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let events: Vec<_> = stream.collect().await;
+        assert_eq!(rx.await.unwrap(), "/v1/responses");
+        assert_eq!(
+            events,
+            vec![
+                ProviderEvent::TextDelta { text: "ok".into() },
+                ProviderEvent::Usage(Usage {
+                    input_tokens: 1,
+                    output_tokens: 1,
+                    cache_read_input_tokens: 0,
+                    cache_creation_input_tokens: 0,
+                }),
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn
+                },
+            ]
+        );
+    }
+}

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -1,11 +1,11 @@
 //! OpenAI-compatible Chat Completions provider.
 //!
 //! Speaks the widely-supported `/v1/chat/completions` streaming protocol so the
-//! same adapter covers OpenAI itself, OpenRouter, Fireworks, vLLM, LM Studio,
-//! and other OpenAI-compatible gateways. Point `base_url` at the gateway's
+//! same adapter covers OpenRouter, Fireworks, vLLM, LM Studio, and other
+//! OpenAI-compatible gateways. Point `base_url` at the gateway's
 //! `/v1` root (default: `https://api.openai.com/v1`).
 //!
-//! Native OpenAI's Responses API is a separate concern; this adapter deliberately
+//! Native OpenAI uses the separate Responses API adapter; this one deliberately
 //! targets the Chat Completions shape that local and third-party runtimes share.
 
 use async_trait::async_trait;
@@ -42,7 +42,10 @@ pub struct OpenAiCompatProvider {
 }
 
 impl OpenAiCompatProvider {
-    /// Build a provider hitting OpenAI's Chat Completions API.
+    /// Build a Chat Completions provider with OpenAI's default API root.
+    ///
+    /// Native OpenAI routing uses [`crate::OpenAiProvider`]; this constructor
+    /// remains for direct embedders that already depend on the adapter.
     pub fn new(api_key: impl Into<String>) -> Self {
         Self {
             client: crate::http::streaming_client(),
@@ -195,12 +198,7 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         body["max_completion_tokens"] = json!(max_tokens);
         // Only reasoning models understand `reasoning_effort`; forwarding it to a
         // plain chat model would be rejected. Absent, the provider's default holds.
-        // Chat Completions rejects function tools with an active reasoning
-        // effort. Keep tools usable by explicitly disabling effort for that
-        // request; without tools, preserve the chat's selected level.
-        if !req.tools.is_empty() {
-            body["reasoning_effort"] = json!(openwave_core::ReasoningEffort::None.as_str());
-        } else if let Some(effort) = req
+        if let Some(effort) = req
             .reasoning_effort
             .filter(|effort| *effort != openwave_core::ReasoningEffort::None)
         {
@@ -781,29 +779,6 @@ mod tests {
     }
 
     #[test]
-    fn reasoning_models_disable_effort_when_tools_are_advertised() {
-        for effort in [None, Some(ReasoningEffort::Low)] {
-            let req = ChatRequest {
-                provider: Some(ProviderId::new("openai")),
-                model: "gpt-5.6-sol".into(),
-                reasoning_model: true,
-                messages: vec![ChatMessage::text(Role::User, "call a tool")],
-                tools: vec![ToolSpec {
-                    name: "exec".into(),
-                    description: "run a command".into(),
-                    input_schema: json!({"type": "object"}),
-                }],
-                max_tokens: Some(1024),
-                reasoning_effort: effort,
-                ..Default::default()
-            };
-            let body = build_request_json(&req).unwrap();
-            assert_eq!(body["reasoning_effort"], "none");
-            assert_eq!(body["tools"][0]["function"]["name"], "exec");
-        }
-    }
-
-    #[test]
     fn gpt_5_6_none_uses_the_provider_default() {
         let req = ChatRequest {
             provider: Some(ProviderId::new("openai")),
@@ -1226,5 +1201,60 @@ mod tests {
         let mut out = Vec::new();
         extend_openai_messages(&mut out, &msg, &ImageAttachments::new()).unwrap();
         assert_eq!(out[0]["content"], "hi");
+    }
+
+    #[tokio::test]
+    async fn compatible_provider_keeps_the_chat_completions_endpoint() {
+        use axum::extract::{Request, State};
+        use axum::http::StatusCode;
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use axum::Router;
+        use tokio::sync::oneshot;
+
+        async fn capture(
+            State(tx): State<std::sync::Arc<std::sync::Mutex<Option<oneshot::Sender<String>>>>>,
+            request: Request,
+        ) -> impl IntoResponse {
+            if let Some(tx) = tx.lock().unwrap().take() {
+                let _ = tx.send(request.uri().path().to_owned());
+            }
+            (
+                StatusCode::OK,
+                [("content-type", "text/event-stream")],
+                concat!(
+                    "data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n",
+                    "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"
+                ),
+            )
+        }
+
+        let (tx, rx) = oneshot::channel();
+        let state = std::sync::Arc::new(std::sync::Mutex::new(Some(tx)));
+        let app = Router::new().fallback(post(capture)).with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let provider = OpenAiCompatProvider::compatible("key", format!("http://{address}/v1"));
+        let stream = provider
+            .stream(ChatRequest {
+                model: "local-model".into(),
+                messages: vec![ChatMessage::text(Role::User, "hi")],
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let events: Vec<_> = stream.collect().await;
+        assert_eq!(rx.await.unwrap(), "/v1/chat/completions");
+        assert_eq!(
+            events,
+            vec![
+                ProviderEvent::TextDelta { text: "ok".into() },
+                ProviderEvent::Stop {
+                    reason: StopReason::EndTurn
+                },
+            ]
+        );
     }
 }

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -195,7 +195,12 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         body["max_completion_tokens"] = json!(max_tokens);
         // Only reasoning models understand `reasoning_effort`; forwarding it to a
         // plain chat model would be rejected. Absent, the provider's default holds.
-        if let Some(effort) = req
+        // Chat Completions rejects function tools with an active reasoning
+        // effort. Keep tools usable by explicitly disabling effort for that
+        // request; without tools, preserve the chat's selected level.
+        if !req.tools.is_empty() {
+            body["reasoning_effort"] = json!(openwave_core::ReasoningEffort::None.as_str());
+        } else if let Some(effort) = req
             .reasoning_effort
             .filter(|effort| *effort != openwave_core::ReasoningEffort::None)
         {
@@ -776,6 +781,29 @@ mod tests {
     }
 
     #[test]
+    fn reasoning_models_disable_effort_when_tools_are_advertised() {
+        for effort in [None, Some(ReasoningEffort::Low)] {
+            let req = ChatRequest {
+                provider: Some(ProviderId::new("openai")),
+                model: "gpt-5.6-sol".into(),
+                reasoning_model: true,
+                messages: vec![ChatMessage::text(Role::User, "call a tool")],
+                tools: vec![ToolSpec {
+                    name: "exec".into(),
+                    description: "run a command".into(),
+                    input_schema: json!({"type": "object"}),
+                }],
+                max_tokens: Some(1024),
+                reasoning_effort: effort,
+                ..Default::default()
+            };
+            let body = build_request_json(&req).unwrap();
+            assert_eq!(body["reasoning_effort"], "none");
+            assert_eq!(body["tools"][0]["function"]["name"], "exec");
+        }
+    }
+
+    #[test]
     fn gpt_5_6_none_uses_the_provider_default() {
         let req = ChatRequest {
             provider: Some(ProviderId::new("openai")),
@@ -888,7 +916,9 @@ mod tests {
                 ProviderEvent::Failed {
                     error: ProviderErrorInfo {
                         kind: "overloaded".into(),
-                        message: "openai-compat returned 500 (server_error): upstream is overloaded".into(),
+                        message:
+                            "openai-compat returned 500 (server_error): upstream is overloaded"
+                                .into(),
                     },
                 },
             ]

--- a/crates/openwave-router/src/router.rs
+++ b/crates/openwave-router/src/router.rs
@@ -23,6 +23,8 @@ use crate::AnthropicProvider;
 use crate::GeminiProvider;
 #[cfg(feature = "openai-compat")]
 use crate::OpenAiCompatProvider;
+#[cfg(feature = "openai")]
+use crate::OpenAiProvider;
 
 /// A per-request credential supplier for routes whose token is short-lived.
 ///
@@ -97,7 +99,7 @@ impl std::fmt::Debug for VertexRoute {
 pub enum RouteKind {
     /// Anthropic Messages API.
     Anthropic,
-    /// OpenAI Chat Completions (api.openai.com).
+    /// Native OpenAI Responses API (api.openai.com).
     Openai,
     /// Any OpenAI-compatible Chat Completions gateway.
     OpenaiCompatible,
@@ -327,9 +329,9 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
         #[cfg(not(feature = "anthropic"))]
         RouteKind::ModelGateway => None,
 
-        #[cfg(feature = "openai-compat")]
+        #[cfg(feature = "openai")]
         RouteKind::Openai => {
-            let mut p = OpenAiCompatProvider::new(route.api_key.clone());
+            let mut p = OpenAiProvider::new(route.api_key.clone());
             if let Some(base) = &route.base_url {
                 p = p.with_base_url(base.clone());
             }
@@ -371,8 +373,10 @@ fn build_adapter(route: &Route) -> Option<Arc<dyn ModelProvider>> {
         }
         #[cfg(not(feature = "gemini"))]
         RouteKind::Gemini => None,
+        #[cfg(not(feature = "openai"))]
+        RouteKind::Openai => None,
         #[cfg(not(feature = "openai-compat"))]
-        RouteKind::Openai | RouteKind::OpenaiCompatible => None,
+        RouteKind::OpenaiCompatible => None,
     }
 }
 

--- a/crates/openwave-router/src/sse.rs
+++ b/crates/openwave-router/src/sse.rs
@@ -217,7 +217,12 @@ const MAX_RETRY_AFTER: Duration = Duration::from_secs(3600);
 ///
 /// Returns `None` when the header is absent, unparseable, or not a form we
 /// understand; a missing hint just leaves the caller on its own backoff.
-#[cfg(any(feature = "anthropic", feature = "openai-compat", feature = "gemini"))]
+#[cfg(any(
+    feature = "anthropic",
+    feature = "openai",
+    feature = "openai-compat",
+    feature = "gemini"
+))]
 pub fn retry_after_hint(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
     parse_retry_after(headers.get(reqwest::header::RETRY_AFTER)?.to_str().ok()?)
 }

--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -210,7 +210,7 @@ async fn clear_legacy_gateway_row(store: &dyn Store) -> Result<()> {
 pub enum ProviderKind {
     /// Anthropic Messages API.
     Anthropic,
-    /// OpenAI Chat Completions (api.openai.com).
+    /// Native OpenAI Responses API (api.openai.com).
     Openai,
     /// Google Gemini Developer API (generativelanguage.googleapis.com).
     Gemini,

--- a/crates/openwave-server/src/tests/chat_titling.rs
+++ b/crates/openwave-server/src/tests/chat_titling.rs
@@ -14,7 +14,7 @@ const UTILITY_MODEL: &str = "gpt-5.4-nano";
 /// The model the conversation itself runs on, so the two are never confused.
 const CHAT_MODEL: &str = "gpt-5.6-sol";
 
-/// A stub OpenAI-compatible endpoint recording everything asked of it.
+/// A stub OpenAI Responses endpoint recording everything asked of it.
 ///
 /// One endpoint serves both calls a titled conversation makes, because that is
 /// how the real thing works: the turn and the titling call reach the same
@@ -31,7 +31,7 @@ impl TitlingStub {
             .lock()
             .unwrap()
             .iter()
-            .filter(|request| request.get("response_format").is_some())
+            .filter(|request| request.get("text").is_some())
             .cloned()
             .collect()
     }
@@ -41,7 +41,7 @@ async fn answer_as_stub(
     axum::extract::State(stub): axum::extract::State<Arc<TitlingStub>>,
     axum::Json(request): axum::Json<serde_json::Value>,
 ) -> impl axum::response::IntoResponse {
-    let text = if request.get("response_format").is_some() {
+    let text = if request.get("text").is_some() {
         stub.title_answer.clone()
     } else {
         ASSISTANT_ANSWER.to_owned()
@@ -49,8 +49,8 @@ async fn answer_as_stub(
     stub.requests.lock().unwrap().push(request);
     let body = format!(
         "data: {}\n\ndata: {}\n\ndata: [DONE]\n\n",
-        serde_json::json!({"choices": [{"delta": {"content": text}, "finish_reason": null}]}),
-        serde_json::json!({"choices": [{"delta": {}, "finish_reason": "stop"}]}),
+        serde_json::json!({"type": "response.output_text.delta", "delta": text}),
+        serde_json::json!({"type": "response.completed", "response": {}}),
     );
     (
         [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
@@ -78,7 +78,7 @@ async fn titling_app(
         title_answer: title_answer.to_owned(),
     });
     let endpoint = axum::Router::new()
-        .route("/v1/chat/completions", axum::routing::post(answer_as_stub))
+        .route("/v1/responses", axum::routing::post(answer_as_stub))
         .with_state(stub.clone());
     let listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
         .await
@@ -205,10 +205,10 @@ async fn a_turn_names_the_chat_it_runs_in() {
         "titling advertises no tools; the model has nothing to do but answer",
     );
     assert_eq!(
-        request["response_format"]["json_schema"]["name"], "chat_title",
+        request["text"]["format"]["name"], "chat_title",
         "a provider that enforces the schema is what makes \"no title\" answerable",
     );
-    let material = request["messages"].to_string();
+    let material = request["input"].to_string();
     assert!(material.contains("Reconcile Q3 revenue for me"));
     assert!(
         !material.contains(ASSISTANT_ANSWER),

--- a/crates/openwave-server/src/tests/image_attachment.rs
+++ b/crates/openwave-server/src/tests/image_attachment.rs
@@ -105,7 +105,7 @@ async fn capture_openai_image_request(
     // also gets a background titling call, on a different model, which can
     // arrive first. It is identifiable by its output constraint — the turn has
     // none — and it is not what this test is capturing.
-    if request.get("response_format").is_none() {
+    if request.get("text").is_none() {
         if let Some(sender) = capture.lock().unwrap().take() {
             let _ = sender.send(request);
         }
@@ -113,8 +113,8 @@ async fn capture_openai_image_request(
     (
         [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
         concat!(
-            "data: {\"choices\":[{\"delta\":{\"content\":\"The images arrived.\"},\"finish_reason\":null}]}\n\n",
-            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"The images arrived.\"}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{}}\n\n",
             "data: [DONE]\n\n"
         ),
     )
@@ -733,7 +733,7 @@ async fn a_curated_openai_model_answers_after_receiving_png_and_jpeg_attachments
     let capture: OpenAiRequestCapture = Arc::new(std::sync::Mutex::new(Some(sender)));
     let provider = axum::Router::new()
         .route(
-            "/v1/chat/completions",
+            "/v1/responses",
             axum::routing::post(capture_openai_image_request),
         )
         .with_state(capture);
@@ -833,28 +833,30 @@ async fn a_curated_openai_model_answers_after_receiving_png_and_jpeg_attachments
         .expect("configured provider did not receive the image request")
         .expect("configured provider request capture was dropped");
     assert_eq!(request["model"], "gpt-5.6-sol");
-    let content = request["messages"]
+    let content = request["input"]
         .as_array()
         .unwrap()
         .iter()
         .find(|message| message["role"] == "user" && message["content"].is_array())
         .and_then(|message| message["content"].as_array())
         .expect("the provider request has the user message parts");
-    assert_eq!(content[0]["type"], "text");
-    let text = content[0]["text"].as_str().unwrap();
+    assert_eq!(content[0]["type"], "input_image");
+    assert_eq!(content[1]["type"], "input_image");
+    let text = content[2]["text"].as_str().unwrap();
     assert!(text.starts_with("Describe these attachments.\n\n<attachments>"));
     assert!(text.contains(&format!("image_1: id={png};")));
     assert!(text.contains(&format!("image_2: id={jpeg};")));
     assert!(text.ends_with("</attachments>"));
-    for (part, media_type) in content[1..].iter().zip(["image/png", "image/jpeg"]) {
-        assert_eq!(part["type"], "image_url");
+    for (part, media_type) in content[..2].iter().zip(["image/png", "image/jpeg"]) {
+        assert_eq!(part["type"], "input_image");
         assert!(
-            part["image_url"]["url"]
+            part["image_url"]
                 .as_str()
                 .unwrap()
                 .starts_with(&format!("data:{media_type};base64,")),
             "expected {media_type} data URL, got {part}"
         );
     }
+    assert_eq!(content[2]["type"], "input_text");
     assert_eq!(content.len(), 3);
 }


### PR DESCRIPTION
## Summary

- add a native OpenAI Responses API adapter for the curated `openai` provider
- preserve reasoning effort alongside function tools instead of disabling reasoning to satisfy Chat Completions
- keep `openai_compatible` on the widely-supported `/v1/chat/completions` protocol
- normalize Responses text, reasoning summaries, tool calls, usage, incomplete responses, refusals, and failures into OpenWave provider events
- carry strict JSON Schema output, explicit tool choice, image inputs, and tool-result history over the Responses wire
- discard orphaned historical function-call pairs before request submission

## Root cause

Native OpenAI models were routed through the shared Chat Completions adapter. GPT-5.6 rejects a Chat Completions request that combines function tools with an active `reasoning_effort`, so switching a tool-enabled chat from Anthropic to OpenAI failed before streaming.

The earlier version of this PR worked around that by sending `reasoning_effort: "none"` whenever tools were advertised. That removed the 400 but also silently removed the user-selected reasoning capability from ordinary agent turns.

Alpha already handles native OpenAI through `/v1/responses`, where reasoning and function tools are supported together. This change adopts the same provider-boundary architecture in OpenWave: native OpenAI gets a Responses adapter, while third-party OpenAI-compatible endpoints retain Chat Completions.

## Provider contract coverage

- native `/v1/responses` endpoint selection
- compatible `/v1/chat/completions` endpoint preservation
- reasoning effort plus `summary: auto`
- streamed text and reasoning summaries
- streamed and completed function-call arguments without duplication
- function call/output history and orphan sanitization
- strict tools, tool choice, and JSON Schema output
- hydrated image inputs
- fresh/cached/output token normalization
- max-output termination, content-filter refusal, provider failure, and premature stream failure

## Verification

- `cargo test -p openwave-router --locked` (97 passed)
- `cargo check -p openwave-router --no-default-features --features openai --locked`
- `cargo check -p openwave-router --no-default-features --features openai-compat --locked`
- `cargo check -p openwave-server --locked`
- `cargo fmt --all -- --check`
- `git diff --check`

`cargo clippy -p openwave-router --all-targets --locked -- -D warnings` is currently blocked by unrelated `openwave-core` warnings already present on `main` (unused variables and dead code).

Live provider verification was not run because this worktree has no OpenAI API key.