### PR TITLE
chore(router): format the overloaded-error fixture line

### DIFF
--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -888,7 +888,9 @@ mod tests {
                 ProviderEvent::Failed {
                     error: ProviderErrorInfo {
                         kind: "overloaded".into(),
-                        message: "openai-compat returned 500 (server_error): upstream is overloaded".into(),
+                        message:
+                            "openai-compat returned 500 (server_error): upstream is overloaded"
+                                .into(),
                     },
                 },
             ]


### PR DESCRIPTION
#1492 merged green against a base predating the current rustfmt gate run,
leaving one over-long line in openai_compat.rs that fails cargo fmt --check
on main and on every PR's merge ref.
