### PR TITLE
fix(server): accept sandbox tool-call preambles

### DIFF
--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -1223,7 +1223,7 @@ async fn complete_sandbox_task(
                     ));
                 }
                 if reason == StopReason::ToolUse {
-                    if !text.is_empty() || calls.len() != 1 {
+                    if calls.len() != 1 {
                         return Err(AgentError::msg(
                             "sandbox agent emitted an ambiguous tool checkpoint",
                         ));
@@ -1396,6 +1396,9 @@ mod tests {
             };
             let events = if call_number == 1 {
                 vec![
+                    ProviderEvent::TextDelta {
+                        text: "I’ll research that now.".into(),
+                    },
                     ProviderEvent::ToolCallStarted {
                         index: 0,
                         id: "search_1".into(),
@@ -1825,7 +1828,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn checkpoints_one_web_search_and_rebuilds_its_receipt_before_finalizing() {
+    async fn checkpoints_web_search_after_a_text_preamble_and_rebuilds_its_receipt() {
         let dir = tempfile::tempdir().unwrap();
         let store: Arc<dyn Store> = Arc::new(
             DbStore::connect(&format!(


### PR DESCRIPTION
## Summary

- accept a single valid sandbox tool checkpoint when the model emits a text preamble before the call
- keep rejecting multiple, missing, malformed, and unadvertised sandbox tool calls
- cover the failing web-search shape through the worker checkpoint/resume path

## Root cause

The desktop starts the in-process sandbox worker, and the incident runs were claimed repeatedly. The sandbox completion parser rejected Anthropic's valid text-plus-tool-use response as `sandbox agent emitted an ambiguous tool checkpoint`. That deterministic parser failure was retried until the attempt budget was exhausted, delaying terminal delivery to `wait_for_agents`.

Read-only inspection of the live `.dev` database showed:

- `0fa72e29-8421-5555-a508-6257406a4744`: `failed`, `execution_location=in_process`, `attempt_count=5`, `claim_count=5`, final error `sandbox_execution_failed: sandbox agent emitted an ambiguous tool checkpoint`
- `ea8e54b4-b1fa-5a41-8354-7deaaedc4d16`: `cancelled`, `execution_location=in_process`, `attempt_count=4`, `claim_count=5`; it completed a persisted `web_search` checkpoint before cancellation
- the ordered wait parked at `2026-08-04T17:44:50.107999Z`, resumed at `2026-08-04T17:46:23.636999Z`, and the parent turn completed at `2026-08-04T17:46:35.711999Z`

## Verification

- `cargo fmt --all --check`
- `cargo check -p openwave-server --locked`
- focused sandbox worker regression and ambiguity tests
- `cargo test -p openwave-core --locked` (575 passed)
- `cargo test -p openwave-server --locked` (579 unit passed, 3 Docker-only ignored; 5 listener passed)
