### PR TITLE
feat(server): REST connected apps acquire specs by URL with operation selection

### DIFF
--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1557,6 +1557,32 @@ chat_defaults: StickyChatDefaults, };
 export type SignInProgress = { "state": "idle" } | { "state": "pending", authorization_url: string, } | { "state": "failed", message: string, };
 
 /**
+ * What a document declares, for the configuration form's operation picker.
+ * Renderer-safe: ids, methods, paths, and truncated summaries only.
+ */
+export type SpecPreviewInfo = { 
+/**
+ * Hex SHA-256 of the raw document — the pin the upsert must carry back
+ * with a URL source.
+ */
+document_sha256: string, operations: Array<SpecPreviewOperation>, 
+/**
+ * Operations the document declares that cannot be selected (no
+ * well-formed `operationId`, an over-bound path, or a repeated id).
+ */
+unlistable: number, 
+/**
+ * Whether the operation list was cut at the inventory bound.
+ */
+truncated: boolean, };
+
+export type SpecPreviewOperation = { operation_id: string, 
+/**
+ * Lowercase HTTP method, as a path item declares it.
+ */
+method: string, path: string, summary: string | null, };
+
+/**
  * One durable "don't ask again" the reader has made, with enough provenance
  * to recognize it later and withdraw it. Grant scopes are already closed
  * renderer-safe projections, so the snapshot carries them verbatim.

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -329,6 +329,12 @@ pub fn app(state: AppState) -> Router {
                 )),
         )
         .route(
+            "/connected-apps/rest/spec-preview",
+            post(routes::post_rest_spec_preview).layer(DefaultBodyLimit::max(
+                routes::MAX_REST_CONNECTED_APP_BODY_BYTES,
+            )),
+        )
+        .route(
             "/mcp/servers/{name}/reconnect",
             post(routes::post_mcp_server_reconnect),
         )

--- a/crates/openwave-server/src/openapi_catalog.rs
+++ b/crates/openwave-server/src/openapi_catalog.rs
@@ -23,9 +23,11 @@ use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
-/// Largest OpenAPI document accepted, in bytes. Prevents a configuration
-/// upload from ballooning the connected-app record and the ingest's memory.
-pub const MAX_OPENAPI_DOCUMENT_BYTES: usize = 1024 * 1024;
+/// Largest OpenAPI document accepted as ingest *input*, in bytes. Real vendor
+/// documents run to many megabytes; the bound only caps ingest memory and the
+/// configuration upload, because the record never stores the document — only
+/// the bounded catalog, whose own limits below are what keep it small.
+pub const MAX_OPENAPI_DOCUMENT_BYTES: usize = 16 * 1024 * 1024;
 /// Most operations one catalog may hold. Prevents a spec from minting an
 /// unbounded binding/consent surface.
 pub const MAX_CATALOG_OPERATIONS: usize = 256;
@@ -225,14 +227,228 @@ pub enum OpenApiIngestError {
     RefDepthExceeded { operation_id: String },
     #[error("malformed OpenAPI structure: {context}")]
     MalformedStructure { context: &'static str },
+    #[error(
+        "a selected operationId is empty, over {} bytes, or outside [A-Za-z0-9_.-]",
+        MAX_OPERATION_ID_BYTES
+    )]
+    InvalidSelectedOperationId,
+    #[error("selected operationId {operation_id} is not declared by the document")]
+    SelectedOperationNotFound { operation_id: String },
 }
 
 /// Ingest an OpenAPI document into a bounded [`OperationCatalog`], or refuse.
 ///
-/// JSON, OpenAPI 3.x documents only. Every declared operation must carry a
-/// well-formed `operationId`; any operation the catalog cannot represent
-/// within its bounds refuses the whole document rather than being skipped.
-pub fn ingest_openapi_document(document: &[u8]) -> Result<OperationCatalog, OpenApiIngestError> {
+/// JSON, OpenAPI 3.x documents only. With `selection: None` the whole
+/// document is the catalog: every declared operation must carry a well-formed
+/// `operationId`, and any operation the catalog cannot represent within its
+/// bounds refuses the whole document rather than being skipped.
+///
+/// With a selection, the fail-closed posture scopes to what the catalog will
+/// actually declare: only selected operations are validated and ingested,
+/// and paths declaring none of them are skipped wholesale — a vendor document
+/// is allowed to be broken in the parts the record will never execute. Every
+/// selected id must still be found, exactly once, and ingest cleanly; the
+/// selection cannot exceed [`MAX_CATALOG_OPERATIONS`].
+pub fn ingest_openapi_document(
+    document: &[u8],
+    selection: Option<&BTreeSet<String>>,
+) -> Result<OperationCatalog, OpenApiIngestError> {
+    if let Some(selection) = selection {
+        if selection.is_empty() {
+            return Err(OpenApiIngestError::NoOperations);
+        }
+        if selection.len() > MAX_CATALOG_OPERATIONS {
+            return Err(OpenApiIngestError::TooManyOperations);
+        }
+        // Selected ids are caller input: they are only ever echoed in errors
+        // after passing the same well-formedness bound declared ids do.
+        if !selection.iter().all(|id| well_formed_operation_id(id)) {
+            return Err(OpenApiIngestError::InvalidSelectedOperationId);
+        }
+    }
+    let root = parse_openapi_root(document)?;
+    let paths = declared_paths(&root)?;
+
+    let mut operations = BTreeMap::new();
+    for (path, path_item) in paths.into_iter().flatten() {
+        if let Some(selection) = selection {
+            // Peek before validating: a path contributing nothing to the
+            // selection must not be able to refuse the ingest.
+            let declares_selected = path_item.as_object().is_some_and(|item| {
+                item.iter().any(|(key, operation_value)| {
+                    HttpMethod::from_path_item_key(key).is_some()
+                        && operation_value
+                            .get("operationId")
+                            .and_then(Value::as_str)
+                            .is_some_and(|id| selection.contains(id))
+                })
+            });
+            if !declares_selected {
+                continue;
+            }
+        }
+        if path.len() > MAX_PATH_TEMPLATE_BYTES {
+            return Err(OpenApiIngestError::PathTemplateTooLong);
+        }
+        let template_parameters = parse_path_template(path)?;
+        let Value::Object(path_item) = path_item else {
+            return Err(OpenApiIngestError::MalformedStructure {
+                context: "a path item is not an object",
+            });
+        };
+        let path_level_parameters = path_item.get("parameters");
+        for (key, operation_value) in path_item {
+            let Some(method) = HttpMethod::from_path_item_key(key) else {
+                continue;
+            };
+            if let Some(selection) = selection {
+                let selected = operation_value
+                    .get("operationId")
+                    .and_then(Value::as_str)
+                    .is_some_and(|id| selection.contains(id));
+                if !selected {
+                    continue;
+                }
+            }
+            let operation = ingest_operation(
+                &root,
+                method,
+                path,
+                operation_value,
+                path_level_parameters,
+                &template_parameters,
+            )?;
+            if operations.len() == MAX_CATALOG_OPERATIONS {
+                return Err(OpenApiIngestError::TooManyOperations);
+            }
+            let operation_id = operation.operation_id.clone();
+            if operations.insert(operation_id.clone(), operation).is_some() {
+                return Err(OpenApiIngestError::DuplicateOperationId { operation_id });
+            }
+        }
+    }
+    if let Some(selection) = selection {
+        // Refusing an absent selection, rather than storing a narrower
+        // catalog, keeps the catalog honest about the selection it was built
+        // from — the same no-partial-acceptance posture as the bounds.
+        if let Some(missing) = selection.iter().find(|id| !operations.contains_key(*id)) {
+            return Err(OpenApiIngestError::SelectedOperationNotFound {
+                operation_id: missing.clone(),
+            });
+        }
+    }
+    if operations.is_empty() {
+        return Err(OpenApiIngestError::NoOperations);
+    }
+
+    Ok(OperationCatalog {
+        document_sha256: sha256_hex(document),
+        operations,
+    })
+}
+
+/// One operation surfaced by [`enumerate_openapi_operations`] for selection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct InventoryOperation {
+    /// The declared, well-formed `operationId` a selection would name.
+    pub operation_id: String,
+    pub method: HttpMethod,
+    /// Path template as declared. Bounded by [`MAX_PATH_TEMPLATE_BYTES`].
+    pub path: String,
+    /// The operation's `summary`, truncated to a display-sized prefix.
+    pub summary: Option<String>,
+}
+
+/// What a document declares, listed for the configuration surface's
+/// operation picker without judging ingestibility.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SpecInventory {
+    /// Lowercase-hex SHA-256 of the raw document bytes — the pin a
+    /// URL-sourced upsert re-verifies against.
+    pub document_sha256: String,
+    /// Every listable operation, in document order.
+    pub operations: Vec<InventoryOperation>,
+    /// Operations the inventory could not list (no well-formed `operationId`,
+    /// an over-bound path, or a repeated id). They exist in the document but
+    /// cannot be selected; a count keeps the inventory honest about them.
+    pub unlistable: usize,
+    /// Whether the operation list was cut at [`MAX_INVENTORY_OPERATIONS`].
+    pub truncated: bool,
+}
+
+/// Most operations one inventory reports. Far above any real selection need;
+/// keeps a pathological document from minting an unbounded response.
+pub const MAX_INVENTORY_OPERATIONS: usize = 4096;
+
+/// Longest `summary` prefix the inventory retains, in bytes.
+const MAX_INVENTORY_SUMMARY_BYTES: usize = 160;
+
+/// List the operations an OpenAPI document declares, tolerantly.
+///
+/// The document-level checks (size, JSON, OpenAPI 3.x) still refuse, but a
+/// malformed *operation* is counted rather than refusing the walk: the
+/// inventory exists so a selection can be made from a document that only
+/// needs to be partially ingestible, so it must survive the parts an eventual
+/// selection would skip.
+pub fn enumerate_openapi_operations(document: &[u8]) -> Result<SpecInventory, OpenApiIngestError> {
+    let root = parse_openapi_root(document)?;
+    let paths = declared_paths(&root)?;
+
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    let mut operations = Vec::new();
+    let mut unlistable = 0usize;
+    let mut truncated = false;
+    for (path, path_item) in paths.into_iter().flatten() {
+        let Value::Object(path_item) = path_item else {
+            continue;
+        };
+        for (key, operation_value) in path_item {
+            let Some(method) = HttpMethod::from_path_item_key(key) else {
+                continue;
+            };
+            let listable_id = operation_value
+                .get("operationId")
+                .and_then(Value::as_str)
+                .filter(|id| well_formed_operation_id(id));
+            let Some(operation_id) = listable_id else {
+                unlistable += 1;
+                continue;
+            };
+            // A repeated id cannot be selected (ingest would refuse the
+            // duplicate), so only its first occurrence is listable.
+            if path.len() > MAX_PATH_TEMPLATE_BYTES || !seen.insert(operation_id.to_string()) {
+                unlistable += 1;
+                continue;
+            }
+            if operations.len() == MAX_INVENTORY_OPERATIONS {
+                truncated = true;
+                unlistable += 1;
+                continue;
+            }
+            let summary = operation_value
+                .get("summary")
+                .and_then(Value::as_str)
+                .map(truncate_to_display_prefix);
+            operations.push(InventoryOperation {
+                operation_id: operation_id.to_string(),
+                method,
+                path: path.clone(),
+                summary,
+            });
+        }
+    }
+
+    Ok(SpecInventory {
+        document_sha256: sha256_hex(document),
+        operations,
+        unlistable,
+        truncated,
+    })
+}
+
+/// The document-level admission shared by ingest and enumeration: byte bound,
+/// JSON object, not Swagger 2.0, declares OpenAPI 3.x.
+fn parse_openapi_root(document: &[u8]) -> Result<Value, OpenApiIngestError> {
     if document.len() > MAX_OPENAPI_DOCUMENT_BYTES {
         return Err(OpenApiIngestError::DocumentTooLarge);
     }
@@ -261,65 +477,52 @@ pub fn ingest_openapi_document(document: &[u8]) -> Result<OperationCatalog, Open
     if !declares_openapi_3 {
         return Err(OpenApiIngestError::NotOpenApi3);
     }
+    Ok(root)
+}
 
-    let paths = match root_object.get("paths") {
-        None | Some(Value::Object(_)) => root_object.get("paths").and_then(Value::as_object),
-        Some(_) => {
-            return Err(OpenApiIngestError::MalformedStructure {
-                context: "paths is not an object",
-            })
-        }
-    };
-
-    let mut operations = BTreeMap::new();
-    for (path, path_item) in paths.into_iter().flatten() {
-        if path.len() > MAX_PATH_TEMPLATE_BYTES {
-            return Err(OpenApiIngestError::PathTemplateTooLong);
-        }
-        let template_parameters = parse_path_template(path)?;
-        let Value::Object(path_item) = path_item else {
-            return Err(OpenApiIngestError::MalformedStructure {
-                context: "a path item is not an object",
-            });
-        };
-        let path_level_parameters = path_item.get("parameters");
-        for (key, operation_value) in path_item {
-            let Some(method) = HttpMethod::from_path_item_key(key) else {
-                continue;
-            };
-            let operation = ingest_operation(
-                &root,
-                method,
-                path,
-                operation_value,
-                path_level_parameters,
-                &template_parameters,
-            )?;
-            if operations.len() == MAX_CATALOG_OPERATIONS {
-                return Err(OpenApiIngestError::TooManyOperations);
-            }
-            let operation_id = operation.operation_id.clone();
-            if operations.insert(operation_id.clone(), operation).is_some() {
-                return Err(OpenApiIngestError::DuplicateOperationId { operation_id });
-            }
-        }
+/// The document's `paths` object, or a refusal if it declares a non-object.
+fn declared_paths(root: &Value) -> Result<Option<&Map<String, Value>>, OpenApiIngestError> {
+    let root_object = root.as_object().expect("admitted root is an object");
+    match root_object.get("paths") {
+        None => Ok(None),
+        Some(Value::Object(paths)) => Ok(Some(paths)),
+        Some(_) => Err(OpenApiIngestError::MalformedStructure {
+            context: "paths is not an object",
+        }),
     }
-    if operations.is_empty() {
-        return Err(OpenApiIngestError::NoOperations);
-    }
+}
 
+/// Whether an `operationId` fits the bounds every echoing surface assumes.
+fn well_formed_operation_id(operation_id: &str) -> bool {
+    !operation_id.is_empty()
+        && operation_id.len() <= MAX_OPERATION_ID_BYTES
+        && operation_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b'-'))
+}
+
+/// Truncate free text to a UTF-8-clean display prefix of at most
+/// [`MAX_INVENTORY_SUMMARY_BYTES`].
+fn truncate_to_display_prefix(text: &str) -> String {
+    if text.len() <= MAX_INVENTORY_SUMMARY_BYTES {
+        return text.to_string();
+    }
+    let mut end = MAX_INVENTORY_SUMMARY_BYTES;
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    text[..end].to_string()
+}
+
+/// Lowercase-hex SHA-256 of the raw document bytes.
+pub(crate) fn sha256_hex(document: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(document);
-    let document_sha256 = hasher
+    hasher
         .finalize()
         .iter()
         .map(|byte| format!("{byte:02x}"))
-        .collect();
-
-    Ok(OperationCatalog {
-        document_sha256,
-        operations,
-    })
+        .collect()
 }
 
 /// Validate one path template and return its `{param}` names.
@@ -380,12 +583,7 @@ fn ingest_operation(
             })
         }
     };
-    let well_formed_id = !operation_id.is_empty()
-        && operation_id.len() <= MAX_OPERATION_ID_BYTES
-        && operation_id
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b'-'));
-    if !well_formed_id {
+    if !well_formed_operation_id(operation_id) {
         return Err(OpenApiIngestError::InvalidOperationId {
             method,
             path: path.to_string(),
@@ -627,6 +825,87 @@ mod tests {
         .unwrap()
     }
 
+    /// A vendor-shaped document: one clean operation, one path with no
+    /// `operationId`, and one operation that declares an unsupported cookie
+    /// parameter — both siblings refuse a whole-document ingest.
+    fn partially_broken_document() -> Vec<u8> {
+        document(json!({
+            "/clean": { "get": { "operationId": "clean.get", "summary": "The good one" } },
+            "/anonymous": { "get": { "summary": "no operationId" } },
+            "/cookie": {
+                "get": {
+                    "operationId": "cookie.get",
+                    "parameters": [{ "name": "sid", "in": "cookie", "required": true }]
+                }
+            }
+        }))
+    }
+
+    #[test]
+    fn a_selection_scopes_the_fail_closed_posture_to_itself() {
+        let bytes = partially_broken_document();
+
+        // Unselected, the document refuses on the first broken sibling.
+        assert!(ingest_openapi_document(&bytes, None).is_err());
+
+        // Selected, the catalog is exactly the selection: broken siblings are
+        // skipped wholesale, not judged.
+        let selection = BTreeSet::from(["clean.get".to_string()]);
+        let catalog = ingest_openapi_document(&bytes, Some(&selection)).unwrap();
+        assert_eq!(catalog.operations.keys().collect::<Vec<_>>(), ["clean.get"]);
+
+        // A selected operation must still ingest cleanly…
+        let cookie = BTreeSet::from(["cookie.get".to_string()]);
+        assert_eq!(
+            ingest_openapi_document(&bytes, Some(&cookie)).unwrap_err(),
+            OpenApiIngestError::UnsupportedParameterLocation {
+                operation_id: "cookie.get".to_string()
+            }
+        );
+        // …every selected id must exist…
+        let absent = BTreeSet::from(["clean.get".to_string(), "ghost".to_string()]);
+        assert_eq!(
+            ingest_openapi_document(&bytes, Some(&absent)).unwrap_err(),
+            OpenApiIngestError::SelectedOperationNotFound {
+                operation_id: "ghost".to_string()
+            }
+        );
+        // …and a malformed selected id is refused before it can be echoed.
+        let malformed = BTreeSet::from(["not valid!".to_string()]);
+        assert_eq!(
+            ingest_openapi_document(&bytes, Some(&malformed)).unwrap_err(),
+            OpenApiIngestError::InvalidSelectedOperationId
+        );
+    }
+
+    #[test]
+    fn enumeration_lists_tolerantly_and_pins_the_same_document_hash() {
+        let bytes = partially_broken_document();
+        let inventory = enumerate_openapi_operations(&bytes).unwrap();
+
+        // Listability is about selectability, not ingestibility: the cookie
+        // operation has a well-formed id, so it is listed (its ingest refusal
+        // comes later, precisely, if selected); the id-less one cannot be.
+        let ids: Vec<&str> = inventory
+            .operations
+            .iter()
+            .map(|operation| operation.operation_id.as_str())
+            .collect();
+        assert_eq!(ids, ["clean.get", "cookie.get"]);
+        assert_eq!(inventory.unlistable, 1);
+        assert!(!inventory.truncated);
+        assert_eq!(
+            inventory.operations[0].summary.as_deref(),
+            Some("The good one")
+        );
+
+        // The inventory's pin is the ingest's pin: what was previewed is what
+        // a hash-pinned upsert verifies against.
+        let selection = BTreeSet::from(["clean.get".to_string()]);
+        let catalog = ingest_openapi_document(&bytes, Some(&selection)).unwrap();
+        assert_eq!(inventory.document_sha256, catalog.document_sha256);
+    }
+
     #[test]
     fn realistic_spec_ingests_to_a_selfcontained_catalog_that_round_trips() {
         let bytes = serde_json::to_vec(&json!({
@@ -680,7 +959,7 @@ mod tests {
         }))
         .unwrap();
 
-        let catalog = ingest_openapi_document(&bytes).unwrap();
+        let catalog = ingest_openapi_document(&bytes, None).unwrap();
 
         let mut hasher = Sha256::new();
         hasher.update(&bytes);
@@ -951,7 +1230,7 @@ mod tests {
         ];
         for (case, bytes, expected) in cases {
             assert_eq!(
-                ingest_openapi_document(&bytes).unwrap_err(),
+                ingest_openapi_document(&bytes, None).unwrap_err(),
                 expected,
                 "{case}"
             );
@@ -983,7 +1262,7 @@ mod tests {
         };
 
         // S0 → … → S7 (terminal): eight followed refs, exactly at the cap.
-        let catalog = ingest_openapi_document(&spec_with_chain(7)).unwrap();
+        let catalog = ingest_openapi_document(&spec_with_chain(7), None).unwrap();
         assert_eq!(
             catalog.operations["op"].parameters[0].schema,
             Some(json!({ "type": "string" }))
@@ -991,7 +1270,7 @@ mod tests {
 
         // One more link exceeds the cap; a cyclic graph hits the same refusal.
         assert_eq!(
-            ingest_openapi_document(&spec_with_chain(8)).unwrap_err(),
+            ingest_openapi_document(&spec_with_chain(8), None).unwrap_err(),
             OpenApiIngestError::RefDepthExceeded {
                 operation_id: "op".to_string(),
             }
@@ -1005,7 +1284,7 @@ mod tests {
         cyclic["components"] =
             json!({ "schemas": { "Loop": { "$ref": "#/components/schemas/Loop" } } });
         assert_eq!(
-            ingest_openapi_document(&serde_json::to_vec(&cyclic).unwrap()).unwrap_err(),
+            ingest_openapi_document(&serde_json::to_vec(&cyclic).unwrap(), None).unwrap_err(),
             OpenApiIngestError::RefDepthExceeded {
                 operation_id: "op".to_string(),
             }

--- a/crates/openwave-server/src/rest_executor.rs
+++ b/crates/openwave-server/src/rest_executor.rs
@@ -562,11 +562,32 @@ fn serialize_body(
 /// and configuration that cannot mean anything should be corrected, not
 /// silently rewritten.
 pub(crate) fn admit_base_url(base_url: &str) -> Result<Url, RestExecuteError> {
-    let refuse = |reason| Err(RestExecuteError::InadmissibleBaseUrl { reason });
-    if base_url.len() > MAX_REST_BASE_URL_BYTES {
+    admit_https_url(base_url, UrlQueryPolicy::Refuse).map_err(|refusal| match refusal {
+        UrlAdmissionRefusal::Reason(reason) => RestExecuteError::InadmissibleBaseUrl { reason },
+        UrlAdmissionRefusal::DeniedAddress => RestExecuteError::DeniedAddress,
+    })
+}
+
+/// Whether an admitted URL may carry a query. A *base* URL with a query is
+/// configuration that cannot mean anything; a document URL legitimately needs
+/// one (`?format=json`, versioned exports).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum UrlQueryPolicy {
+    Refuse,
+    Allow,
+}
+
+enum UrlAdmissionRefusal {
+    Reason(&'static str),
+    DeniedAddress,
+}
+
+fn admit_https_url(url: &str, query: UrlQueryPolicy) -> Result<Url, UrlAdmissionRefusal> {
+    let refuse = |reason| Err(UrlAdmissionRefusal::Reason(reason));
+    if url.len() > MAX_REST_BASE_URL_BYTES {
         return refuse("URL exceeds the byte limit");
     }
-    let Ok(parsed) = Url::parse(base_url) else {
+    let Ok(parsed) = Url::parse(url) else {
         return refuse("URL is not valid");
     };
     if parsed.scheme() != "https" {
@@ -578,7 +599,7 @@ pub(crate) fn admit_base_url(base_url: &str) -> Result<Url, RestExecuteError> {
     if parsed.fragment().is_some() {
         return refuse("URL must not carry a fragment");
     }
-    if parsed.query().is_some() {
+    if query == UrlQueryPolicy::Refuse && parsed.query().is_some() {
         return refuse("URL must not carry a query");
     }
     match parsed.host_str() {
@@ -597,7 +618,7 @@ pub(crate) fn admit_base_url(base_url: &str) -> Result<Url, RestExecuteError> {
         match literal.parse::<IpAddr>() {
             Ok(address) => {
                 if admit_fetch_address(address).is_err() {
-                    return Err(RestExecuteError::DeniedAddress);
+                    return Err(UrlAdmissionRefusal::DeniedAddress);
                 }
             }
             Err(_) => return refuse("URL host is not a name or address"),
@@ -936,6 +957,159 @@ impl RestHostResolver for TokioRestHostResolver {
         }
         Ok(addresses)
     }
+}
+
+/// Most redirect hops a spec fetch will follow.
+pub const MAX_SPEC_FETCH_REDIRECTS: usize = 5;
+
+/// Whole-fetch wall-time budget across every redirect hop.
+pub const SPEC_FETCH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Why a config-time OpenAPI document fetch was refused or failed.
+///
+/// Closed and renderer-safe, the same posture as [`RestExecuteError`]: no
+/// variant echoes response bytes, and transport text is kept URL-free.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum SpecFetchError {
+    #[error("document URL is inadmissible: {reason}")]
+    InadmissibleUrl { reason: &'static str },
+    #[error("document URL resolves into a denied network range")]
+    DeniedAddress,
+    #[error("document URL's host did not resolve")]
+    UnresolvableHost,
+    #[error("fetch followed more than {MAX_SPEC_FETCH_REDIRECTS} redirects")]
+    TooManyRedirects,
+    #[error("a redirect carried no usable location")]
+    MalformedRedirect,
+    #[error("the server answered HTTP {status}")]
+    HttpStatus { status: u16 },
+    #[error(
+        "fetched document exceeds {} bytes",
+        crate::openapi_catalog::MAX_OPENAPI_DOCUMENT_BYTES
+    )]
+    DocumentTooLarge,
+    #[error("fetch exceeded its time budget")]
+    Timeout,
+    #[error("fetch transport failed: {0}")]
+    Transport(String),
+}
+
+/// Fetch an OpenAPI document from an operator-supplied URL, at configuration
+/// time, with the executor's egress hygiene: https-only admission, fresh
+/// per-hop resolution vetted against the denied-network list, a pinned
+/// no-proxy client, and a bounded body.
+///
+/// Unlike operation execution, redirects are followed — vendors move and
+/// version their published documents — but explicitly, one admitted hop at a
+/// time, so every `Location` gets the same vetting as the original URL and no
+/// credential is ever attached to any hop.
+pub(crate) async fn fetch_spec_document(url: &str) -> Result<Vec<u8>, SpecFetchError> {
+    let started = std::time::Instant::now();
+    let mut current = url.to_string();
+    for _ in 0..=MAX_SPEC_FETCH_REDIRECTS {
+        let admitted =
+            admit_https_url(&current, UrlQueryPolicy::Allow).map_err(|refusal| match refusal {
+                UrlAdmissionRefusal::Reason(reason) => SpecFetchError::InadmissibleUrl { reason },
+                UrlAdmissionRefusal::DeniedAddress => SpecFetchError::DeniedAddress,
+            })?;
+        let remaining = SPEC_FETCH_TIMEOUT
+            .checked_sub(started.elapsed())
+            .ok_or(SpecFetchError::Timeout)?;
+
+        // Same vetting shape as operation execution: every fresh answer for a
+        // domain host must clear the denied-network list, and the connection
+        // is pinned to exactly those answers. An IP-literal host was vetted
+        // by the admission above.
+        let addresses = match admitted.domain() {
+            Some(domain) => {
+                let resolved = TokioRestHostResolver
+                    .resolve(domain)
+                    .await
+                    .map_err(|_| SpecFetchError::UnresolvableHost)?;
+                if resolved.is_empty() {
+                    return Err(SpecFetchError::UnresolvableHost);
+                }
+                if resolved
+                    .iter()
+                    .any(|address| admit_fetch_address(*address).is_err())
+                {
+                    return Err(SpecFetchError::DeniedAddress);
+                }
+                resolved
+            }
+            None => Vec::new(),
+        };
+
+        let mut builder = reqwest::Client::builder()
+            // Load-bearing for the same reason as the operation transport: a
+            // discovered proxy would dial the proxy, not the vetted address.
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .https_only(true)
+            .user_agent(REST_EXECUTOR_USER_AGENT)
+            .connect_timeout(remaining.min(Duration::from_secs(10)))
+            .timeout(remaining);
+        if let Some(domain) = admitted.domain() {
+            let port = admitted.port_or_known_default().unwrap_or(443);
+            let pinned: Vec<std::net::SocketAddr> = addresses
+                .iter()
+                .map(|address| std::net::SocketAddr::new(*address, port))
+                .collect();
+            builder = builder.resolve_to_addrs(domain, &pinned);
+        }
+        let client = builder.build().map_err(spec_transport_failure)?;
+        let response = client
+            .get(admitted.clone())
+            .header(reqwest::header::ACCEPT, "application/json")
+            .send()
+            .await
+            .map_err(spec_transport_failure)?;
+
+        let status = response.status();
+        if status.is_redirection() {
+            let location = response
+                .headers()
+                .get(reqwest::header::LOCATION)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|location| admitted.join(location).ok())
+                .ok_or(SpecFetchError::MalformedRedirect)?;
+            current = location.to_string();
+            continue;
+        }
+        if !status.is_success() {
+            return Err(SpecFetchError::HttpStatus {
+                status: status.as_u16(),
+            });
+        }
+
+        let cap = crate::openapi_catalog::MAX_OPENAPI_DOCUMENT_BYTES;
+        if response
+            .content_length()
+            .is_some_and(|length| length > cap as u64)
+        {
+            return Err(SpecFetchError::DocumentTooLarge);
+        }
+        use futures::StreamExt;
+        let mut body = Vec::new();
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(spec_transport_failure)?;
+            if body.len().saturating_add(chunk.len()) > cap {
+                return Err(SpecFetchError::DocumentTooLarge);
+            }
+            body.extend_from_slice(&chunk);
+        }
+        return Ok(body);
+    }
+    Err(SpecFetchError::TooManyRedirects)
+}
+
+/// Map a spec-fetch transport failure, URL-stripped, timeout told apart.
+fn spec_transport_failure(error: reqwest::Error) -> SpecFetchError {
+    if error.is_timeout() {
+        return SpecFetchError::Timeout;
+    }
+    SpecFetchError::Transport(error.without_url().to_string())
 }
 
 #[cfg(test)]

--- a/crates/openwave-server/src/routes/connected_apps.rs
+++ b/crates/openwave-server/src/routes/connected_apps.rs
@@ -22,9 +22,13 @@ use crate::connected_apps::{
 use crate::error::ServerError;
 use crate::extract::{Json, Path};
 use crate::mcp_config::McpHealth;
-use crate::openapi_catalog::{ingest_openapi_document, MAX_OPENAPI_DOCUMENT_BYTES};
+use crate::openapi_catalog::{
+    enumerate_openapi_operations, ingest_openapi_document, sha256_hex, MAX_OPENAPI_DOCUMENT_BYTES,
+};
 use crate::providers::managed_profile_refusal;
-use crate::rest_executor::{admit_base_url, CredentialPlacement, RestCredential};
+use crate::rest_executor::{
+    admit_base_url, fetch_spec_document, CredentialPlacement, RestCredential,
+};
 use crate::state::AppState;
 
 /// Body bound for the `rest_api` upsert route: the OpenAPI document travels
@@ -104,15 +108,32 @@ pub enum RestCredentialStatus {
 }
 
 /// `PUT /connected-apps/rest/{id}` body: the complete configuration of one
-/// `rest_api` connected app, with the raw OpenAPI document to ingest.
+/// `rest_api` connected app, with the OpenAPI document to ingest — inline, or
+/// fetched from a URL under a hash pin. Ingested once, here; only the bounded
+/// operation catalog (with the document's hash) is stored.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RestConnectedAppUpsert {
     pub name: String,
     pub base_url: String,
-    /// The raw JSON OpenAPI document. Ingested once, here; only the bounded
-    /// operation catalog (with the document's hash) is stored.
-    pub openapi_document: String,
+    /// The raw JSON OpenAPI document, when supplied inline. Exactly one of
+    /// this and `openapi_document_url` must be present.
+    #[serde(default)]
+    pub openapi_document: Option<String>,
+    /// URL to fetch the document from at upsert time, under the executor's
+    /// egress hygiene. Requires `document_sha256`.
+    #[serde(default)]
+    pub openapi_document_url: Option<String>,
+    /// Hex SHA-256 the (fetched or inline) document must hash to — the pin
+    /// carried forward from the preview, so what was previewed is exactly
+    /// what ingests. Required with a URL source, optional inline.
+    #[serde(default)]
+    pub document_sha256: Option<String>,
+    /// When present, ingest only these `operationId`s: the catalog is the
+    /// selection, and the rest of the document is not judged. Absent means
+    /// the whole document must ingest, as before.
+    #[serde(default)]
+    pub operation_ids: Option<Vec<String>>,
     pub credential: RestCredentialUpdate,
 }
 
@@ -175,11 +196,62 @@ pub async fn put_rest_connected_app(
 
     admit_base_url(&body.base_url).map_err(|error| ServerError::bad_request(error.to_string()))?;
 
+    let document = match (&body.openapi_document, &body.openapi_document_url) {
+        (Some(_), Some(_)) => {
+            return Err(ServerError::bad_request(
+                "supply the OpenAPI document inline or by URL, not both",
+            ))
+        }
+        (None, None) => {
+            return Err(ServerError::bad_request(
+                "an OpenAPI document is required, inline or by URL",
+            ))
+        }
+        (Some(inline), None) => inline.as_bytes().to_vec(),
+        (None, Some(url)) => {
+            if body.document_sha256.is_none() {
+                return Err(ServerError::bad_request(
+                    "a URL-sourced document requires document_sha256 from the preview",
+                ));
+            }
+            fetch_spec_document(url)
+                .await
+                .map_err(|error| ServerError::bad_request_kind("spec_fetch", error.to_string()))?
+        }
+    };
+    // The pin closes the preview-to-upsert gap: if the published document
+    // changed in between, what the picker showed is not what would ingest,
+    // so nothing does.
+    if let Some(expected) = &body.document_sha256 {
+        let actual = sha256_hex(&document);
+        if !actual.eq_ignore_ascii_case(expected) {
+            return Err(ServerError::conflict(
+                "the document no longer matches the previewed hash — it changed upstream; \
+                 re-run the preview and reselect operations",
+            ));
+        }
+    }
+    let selection = match &body.operation_ids {
+        None => None,
+        Some(ids) => {
+            if ids.is_empty() {
+                return Err(ServerError::bad_request(
+                    "operation_ids must select at least one operation when present",
+                ));
+            }
+            Some(
+                ids.iter()
+                    .cloned()
+                    .collect::<std::collections::BTreeSet<_>>(),
+            )
+        }
+    };
+
     // Ingest once, at configuration time. The raw document is not stored;
     // only the bounded catalog — carrying the document's hash — is. The
     // ingest errors are bounded and renderer-safe, so they travel verbatim
     // as the form error.
-    let catalog = ingest_openapi_document(body.openapi_document.as_bytes())
+    let catalog = ingest_openapi_document(&document, selection.as_ref())
         .map_err(|error| ServerError::bad_request_kind("openapi_ingest", error.to_string()))?;
 
     let mut rest_records = rest_records(&state).await?;
@@ -304,6 +376,89 @@ pub async fn delete_rest_connected_app(
         .delete_secret(&rest_credential_secret_key(id))
         .await;
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// `POST /connected-apps/rest/spec-preview` body: where the OpenAPI document
+/// comes from. Externally tagged and closed: `{"url": …}` or
+/// `{"document": …}`.
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub enum SpecPreviewSource {
+    /// Fetch the document from this URL, with the executor's egress hygiene.
+    Url(String),
+    /// The raw JSON document, inline.
+    Document(String),
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SpecPreviewRequest {
+    pub source: SpecPreviewSource,
+}
+
+/// What a document declares, for the configuration form's operation picker.
+/// Renderer-safe: ids, methods, paths, and truncated summaries only.
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct SpecPreviewInfo {
+    /// Hex SHA-256 of the raw document — the pin the upsert must carry back
+    /// with a URL source.
+    pub document_sha256: String,
+    pub operations: Vec<SpecPreviewOperation>,
+    /// Operations the document declares that cannot be selected (no
+    /// well-formed `operationId`, an over-bound path, or a repeated id).
+    pub unlistable: usize,
+    /// Whether the operation list was cut at the inventory bound.
+    pub truncated: bool,
+}
+
+#[derive(Debug, Serialize, ts_rs::TS)]
+pub struct SpecPreviewOperation {
+    pub operation_id: String,
+    /// Lowercase HTTP method, as a path item declares it.
+    pub method: String,
+    pub path: String,
+    pub summary: Option<String>,
+}
+
+/// `POST /connected-apps/rest/spec-preview` — list what an OpenAPI document
+/// declares so the form can offer an operation selection, without judging
+/// whether the unselected remainder would ingest.
+///
+/// Refused on managed profiles like the upsert: this surface exists only to
+/// configure local REST records, and the URL source performs egress.
+pub async fn post_rest_spec_preview(
+    State(state): State<AppState>,
+    Json(body): Json<SpecPreviewRequest>,
+) -> Result<Json<SpecPreviewInfo>, ServerError> {
+    let policy = crate::managed_policy::resolve(&*state.store, &*state.os_policy).await?;
+    if policy.managed {
+        return Err(managed_profile_refusal(
+            "REST connected apps are managed by your organization's gateway",
+        ));
+    }
+    let document = match &body.source {
+        SpecPreviewSource::Document(inline) => inline.as_bytes().to_vec(),
+        SpecPreviewSource::Url(url) => fetch_spec_document(url)
+            .await
+            .map_err(|error| ServerError::bad_request_kind("spec_fetch", error.to_string()))?,
+    };
+    let inventory = enumerate_openapi_operations(&document)
+        .map_err(|error| ServerError::bad_request_kind("openapi_ingest", error.to_string()))?;
+    Ok(Json(SpecPreviewInfo {
+        document_sha256: inventory.document_sha256,
+        operations: inventory
+            .operations
+            .into_iter()
+            .map(|operation| SpecPreviewOperation {
+                operation_id: operation.operation_id,
+                method: operation.method.as_str().to_string(),
+                path: operation.path,
+                summary: operation.summary,
+            })
+            .collect(),
+        unlistable: inventory.unlistable,
+        truncated: inventory.truncated,
+    }))
 }
 
 /// Every stored `rest_api` record, in storage order.

--- a/crates/openwave-server/src/tests/app_invoke.rs
+++ b/crates/openwave-server/src/tests/app_invoke.rs
@@ -701,7 +701,7 @@ async fn seed_rest_record(store: &Arc<dyn Store>, id: ConnectedAppId, base_url: 
         }
     });
     let catalog =
-        crate::openapi_catalog::ingest_openapi_document(spec.to_string().as_bytes()).unwrap();
+        crate::openapi_catalog::ingest_openapi_document(spec.to_string().as_bytes(), None).unwrap();
     store
         .replace_connected_apps(
             ConnectedAppKind::RestApi,

--- a/crates/openwave-server/src/tests/connected_apps.rs
+++ b/crates/openwave-server/src/tests/connected_apps.rs
@@ -411,6 +411,101 @@ async fn a_refused_upsert_persists_nothing() {
     );
 }
 
+/// The spec-acquisition contract across preview and upsert: a vendor
+/// document broken outside the selection previews tolerantly and ingests
+/// exactly the selection, and the hash pin refuses a document that no longer
+/// matches what was previewed.
+#[tokio::test]
+async fn selection_and_hash_pin_govern_the_upsert() {
+    let (router, bearer, _state, _dir) = connected_apps_test_app().await;
+    let id = ConnectedAppId::new();
+
+    // `listIssues` is fine; the sibling operation has no operationId, so the
+    // whole-document ingest refuses this spec.
+    let vendor_spec = json!({
+        "openapi": "3.0.3",
+        "info": { "title": "Issues", "version": "1" },
+        "paths": {
+            "/issues": { "get": { "operationId": "listIssues" } },
+            "/broken": { "get": { "summary": "no operationId" } }
+        }
+    })
+    .to_string();
+    let pin = crate::openapi_catalog::sha256_hex(vendor_spec.as_bytes());
+
+    // Preview lists the selectable operation and stays honest about the one
+    // it cannot list.
+    let preview = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/connected-apps/rest/spec-preview")
+                .header("authorization", &bearer)
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({ "source": { "document": vendor_spec } }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(preview.status(), StatusCode::OK);
+    let preview: serde_json::Value = serde_json::from_str(&raw_body(preview).await).unwrap();
+    assert_eq!(preview["document_sha256"], json!(pin));
+    assert_eq!(
+        preview["operations"][0]["operation_id"],
+        json!("listIssues")
+    );
+    assert_eq!(preview["unlistable"], json!(1));
+
+    let body = |operation_ids: serde_json::Value, sha: &str| {
+        json!({
+            "name": "issues",
+            "base_url": "https://api.example.com",
+            "openapi_document": vendor_spec,
+            "document_sha256": sha,
+            "operation_ids": operation_ids,
+            "credential": "none",
+        })
+        .to_string()
+    };
+
+    // Whole-document ingest still refuses the broken sibling.
+    let unselected = json!({
+        "name": "issues",
+        "base_url": "https://api.example.com",
+        "openapi_document": vendor_spec,
+        "credential": "none",
+    })
+    .to_string();
+    let refused = put_rest(&router, &bearer, id, unselected).await;
+    assert_eq!(refused.status(), StatusCode::BAD_REQUEST);
+
+    // A stale pin refuses before anything ingests or persists.
+    let stale = put_rest(
+        &router,
+        &bearer,
+        id,
+        body(json!(["listIssues"]), &"0".repeat(64)),
+    )
+    .await;
+    assert_eq!(stale.status(), StatusCode::CONFLICT);
+
+    // The selection ingests to exactly itself under the correct pin.
+    let accepted = put_rest(&router, &bearer, id, body(json!(["listIssues"]), &pin)).await;
+    assert_eq!(accepted.status(), StatusCode::OK);
+    let listing: serde_json::Value = serde_json::from_str(&raw_body(accepted).await).unwrap();
+    let entry = listing["apps"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["kind"] == "rest_api")
+        .expect("the record is listed");
+    assert_eq!(entry["operation_count"], json!(1));
+    assert_eq!(entry["document_sha256"], json!(pin));
+}
+
 /// The managed posture: `rest_api` upserts are refused wholesale with the
 /// stable `managed_profile` kind — local credential entry is what the
 /// lockdown closes — while DELETE stays available, because removing a local

--- a/crates/openwave-server/src/wire_types.rs
+++ b/crates/openwave-server/src/wire_types.rs
@@ -360,6 +360,9 @@ mod tests {
         // The Connected apps settings listing: per-kind health/catalog
         // projections and credential *status* — never definitions or values.
         generate::collect_from::<crate::routes::ConnectedAppsInfo>(&cfg, &mut out);
+        // The spec-preview response: what a document declares, for the REST
+        // form's operation picker.
+        generate::collect_from::<crate::routes::SpecPreviewInfo>(&cfg, &mut out);
         // Named separately because `serde(flatten)` inlines it into
         // `McpServerInfo` rather than referencing it, so the walk never reaches
         // it — and the renderer uses it on its own as the PUT body shape.


### PR DESCRIPTION
Server slice of #1505. Real vendor OpenAPI documents don't fit the v1 paste-only ingest (PostHog's is 12 MB, ~1,250 paths), so configuring a REST connected app meant hand-authoring a trimmed JSON document. This makes the configuration surface acquire specs instead.

## What changed

- **Ingest-time operation selection.** `ingest_openapi_document` takes an optional set of `operationId`s. Selected operations must all resolve and ingest cleanly within the unchanged per-operation bounds; paths contributing nothing to the selection are skipped wholesale — the fail-closed posture scopes to what the catalog will actually declare, so a vendor document may be broken in the parts the record will never execute. Unknown, duplicate, or malformed selected ids refuse.
- **The 1 MiB document bound becomes a 16 MiB ingest *input* bound.** Only the bounded catalog ever persists, so the stored record stays small; the catalog's own limits (256 ops, schema subtrees, ref depth) are unchanged.
- **`POST /connected-apps/rest/spec-preview`** lists what a document declares (ids, methods, paths, truncated summaries) for the operation picker, tolerating malformed entries, and returns the document's SHA-256 as a pin. Managed profiles are refused, same as the upsert.
- **URL-sourced upsert with hash pinning.** The rest upsert accepts `openapi_document_url` + `document_sha256` as an alternative to the inline document. The fetch reuses the executor's egress hygiene — https-only admission, fresh per-hop resolution vetted against the denied-network list, pinned no-proxy client, bounded body — with redirects followed explicitly one admitted hop at a time (no credential is ever attached). A hash mismatch refuses with 409: what was previewed is exactly what ingests, with no server-side preview state.

Consent fingerprints are untouched: they already hash the raw document, and grants are per-app `{app, operation_ids[]}`, so widening a record's selection cannot widen any existing grant, and narrowing fail-closes at invoke.

## Tests

- `a_selection_scopes_the_fail_closed_posture_to_itself` and `enumeration_lists_tolerantly_and_pins_the_same_document_hash` pin the new ingest/enumeration contract, including that the preview's pin equals the ingest's.
- `selection_and_hash_pin_govern_the_upsert` drives preview → stale-pin 409 → selected ingest through the routes and the stored record.
- Existing ingest, executor, and connected-apps suites pass unchanged (the ingest signature gained the `None` argument at call sites).

Follow-ups tracked separately: the Settings form's URL field + operation picker (coordinating with #1490's page rework), YAML acceptance (needs a deliberate dependency choice), and refresh-with-diff per the connected-apps design discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)