### PR TITLE
fix(desktop): loading spinners and toasts for REST spec fetch and save

### DIFF
--- a/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/ConnectedAppsPanel.tsx
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 import {
   ChevronDown,
   ChevronRight,
+  Loader2,
   Pencil,
   Plus,
   RefreshCw,
@@ -444,8 +445,12 @@ export function ConnectedAppsPanel({
     try {
       const preview = await client.previewRestSpec(source);
       update({ preview, selected: defaultSelection(preview) });
+      toast.success(
+        `Found ${preview.operations.length} operation${preview.operations.length === 1 ? "" : "s"}`,
+      );
     } catch (err) {
       setFormError(errorMessage(err));
+      toast.error(errorMessage(err));
     } finally {
       setPreviewing(false);
     }
@@ -546,6 +551,7 @@ export function ConnectedAppsPanel({
       toast.success(`Saved ${name}`);
     } catch (err) {
       setFormError(errorMessage(err));
+      toast.error(errorMessage(err));
     } finally {
       setSaving(false);
     }
@@ -716,6 +722,7 @@ export function ConnectedAppsPanel({
               disabled={saving || previewing}
               onClick={() => void loadOperations()}
             >
+              {previewing && <Loader2 size={14} className="animate-spin" />}
               {previewing ? "Fetching…" : "Fetch operations"}
             </Button>
           </div>
@@ -744,6 +751,7 @@ export function ConnectedAppsPanel({
             disabled={saving || previewing}
             onClick={() => void loadOperations()}
           >
+            {previewing && <Loader2 size={14} className="animate-spin" />}
             {previewing ? "Loading…" : "Select operations…"}
           </Button>
         </div>
@@ -813,7 +821,8 @@ export function ConnectedAppsPanel({
       {formError && <SettingsError>{formError}</SettingsError>}
       <div className="flex gap-2">
         <Button disabled={saving} onClick={() => void save()}>
-          Save
+          {saving && <Loader2 size={14} className="animate-spin" />}
+          {saving ? "Saving…" : "Save"}
         </Button>
         <Button
           variant="outline"


### PR DESCRIPTION
## The UX gap

The REST connected-app form has two genuinely slow paths: **Fetch operations** calls the spec-preview route, where the server fetches what is often a multi-MB OpenAPI document, and **Save** with a URL source makes the server re-fetch that document. Both can take several seconds, but the buttons only swapped their text ("Fetching…"; Save merely disabled) — a user reported this reads as a hang.

## The fix

- The busy buttons now render a spinning `Loader2` icon (lucide-react, already a dependency) next to their in-flight text, matching the existing `RefreshCw` icon-in-button pattern in the same file: "Fetch operations" and the paste-mode "Select operations…" while previewing, and Save, which now also reads "Saving…" while in flight.
- A successful preview toasts the operation count ("Found N operations"); a failed preview or save toasts the error in addition to the existing inline form error, so the outcome is visible even if the form scrolled.

No new tests, per the repo's test philosophy — spinner presence is cosmetic. All 7 existing `ConnectedAppsPanel.dom.test.tsx` tests, the full UI suite (720 tests), `tsc --noEmit`, and `pnpm build` pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)