### PR TITLE
fix(server): republish the create_app roster when a REST record is saved

### DIFF
--- a/crates/openwave-server/src/mcp_config.rs
+++ b/crates/openwave-server/src/mcp_config.rs
@@ -1582,6 +1582,24 @@ impl McpRuntime {
             .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(registry);
     }
 
+    /// Republish the tool registry from the current state so the
+    /// `create_app` roster reflects the stored `rest_api` records right now.
+    ///
+    /// The registry is otherwise rebuilt only when MCP configuration or
+    /// connections change, so without this a REST record saved from Settings
+    /// stays invisible to `create_app` — the description keeps claiming no
+    /// connected apps exist — until something unrelated republishes. The
+    /// connected-apps CRUD surface calls this after every store write; MCP
+    /// connections are untouched.
+    pub(crate) async fn refresh_connected_app_roster(&self) {
+        let state = self.state.lock().await;
+        let registry = self.registry_for(&state).await;
+        *self
+            .tools
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Arc::new(registry);
+    }
+
     /// Every stored `rest_api` connected app's roster inputs, read from the
     /// store when a registry is (re)built. The roster is authoring
     /// legibility, never the gate, so an unreadable store or an unparseable

--- a/crates/openwave-server/src/routes/connected_apps.rs
+++ b/crates/openwave-server/src/routes/connected_apps.rs
@@ -335,6 +335,9 @@ pub async fn put_rest_connected_app(
         .store
         .replace_connected_apps(ConnectedAppKind::RestApi, &rest_records)
         .await?;
+    // Republish the tool registry so `create_app`'s roster sees the record
+    // now — not after the next unrelated MCP reconfiguration.
+    state.mcp.refresh_connected_app_roster().await;
 
     if clear_stored_value {
         // Best-effort, and only ever the derived key: a leftover value is
@@ -376,6 +379,8 @@ pub async fn delete_rest_connected_app(
         .store
         .replace_connected_apps(ConnectedAppKind::RestApi, &remaining)
         .await?;
+    // The removed record must leave the `create_app` roster with the store.
+    state.mcp.refresh_connected_app_roster().await;
     // Best-effort, after the record is gone: a failed secret delete must not
     // strand the record, and the derived key — never a name read out of the
     // definition — is the only secret this surface may touch.

--- a/crates/openwave-server/src/tests/connected_apps.rs
+++ b/crates/openwave-server/src/tests/connected_apps.rs
@@ -411,6 +411,83 @@ async fn a_refused_upsert_persists_nothing() {
     );
 }
 
+/// A saved `rest_api` record must reach `create_app`'s roster immediately:
+/// the registry republishes on the CRUD surface, not on the next unrelated
+/// MCP reconfiguration. Reproduces a freshly configured REST app leaving
+/// chat claiming no connected apps existed until a restart; the delete leg
+/// pins the symmetric removal.
+#[tokio::test]
+async fn a_saved_rest_record_reaches_the_create_app_roster_immediately() {
+    struct StubCreateApp;
+
+    #[async_trait]
+    impl Tool for StubCreateApp {
+        fn spec(&self) -> ToolSpec {
+            ToolSpec {
+                name: openwave_core::local_app::CREATE_APP_TOOL.into(),
+                description: "create an app.".into(),
+                input_schema: json!({"type": "object"}),
+            }
+        }
+        fn approval_class(&self) -> ApprovalClass {
+            ApprovalClass::ReadOnly
+        }
+        async fn execute(
+            &self,
+            _ctx: &ToolCtx,
+            _args: serde_json::Value,
+        ) -> openwave_core::Result<ToolOutput> {
+            panic!("the roster test never executes create_app");
+        }
+    }
+
+    let (dir, store) = temp_db_store("connected-apps-roster.db").await;
+    let store: Arc<dyn Store> = Arc::new(store);
+    let mut base = ToolRegistry::new();
+    base.register(Box::new(StubCreateApp));
+    let state = AppState::new(
+        Config::desktop(dir.path()),
+        store,
+        Arc::new(FixedResolver(Arc::new(FakeProvider))),
+        Arc::new(MemSecrets::default()),
+        Arc::new(base),
+        AgentConfig {
+            model: "fake".into(),
+            ..AgentConfig::default()
+        },
+    );
+    let bearer = format!("Bearer {}", state.token);
+    let router = app(state.clone());
+
+    let roster = || {
+        state
+            .mcp
+            .snapshot()
+            .server_tool(openwave_core::local_app::CREATE_APP_TOOL)
+            .expect("create_app stays registered")
+            .spec()
+            .description
+    };
+
+    let id = ConnectedAppId::new();
+    let put = put_rest(
+        &router,
+        &bearer,
+        id,
+        upsert_body("https://api.example.com", json!("none")),
+    )
+    .await;
+    assert_eq!(put.status(), StatusCode::OK);
+    let description = roster();
+    assert!(description.contains(&id.to_string()), "{description}");
+    assert!(description.contains("listIssues"), "{description}");
+
+    let deleted = delete_rest(&router, &bearer, id).await;
+    assert_eq!(deleted.status(), StatusCode::NO_CONTENT);
+    let description = roster();
+    assert!(!description.contains(&id.to_string()), "{description}");
+}
+
 /// The spec-acquisition contract across preview and upsert: a vendor
 /// document broken outside the selection previews tolerantly and ingests
 /// exactly the selection, and the hash pin refuses a document that no longer


### PR DESCRIPTION
Found while smoke-testing #1506/#1514: configure a PostHog `rest_api` connected app in Settings, then ask chat to build an app against it — chat refuses with *"no connected apps are configured in this conversation"* even though the Settings page shows the record as configured.

## Cause

The tool registry — and the connected-app roster appended to `create_app`'s description, which is where the model learns bindable record ids — is rebuilt only on MCP configuration/connection changes (`publish`, reconnect, startup). The REST CRUD routes write the record to the store but never republish, so `create_app` keeps the stale "No connected apps are configured, so only manifests with an empty bindings list can be created" description until something unrelated rebuilds the registry or the app restarts.

## Fix

`McpRuntime::refresh_connected_app_roster()` republishes the registry from current state (fresh `rest_roster()` read; MCP connections untouched), and the rest upsert and delete routes call it after every store write.

## Test

`a_saved_rest_record_reaches_the_create_app_roster_immediately` drives PUT and DELETE through the routes with a stub `create_app` in the base registry and reads the roster off the live registry's spec. Verified it fails without the refresh calls (reproduces the report) and passes with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)