### PR TITLE
ci: add a Windows-target cargo check lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,6 +374,42 @@ jobs:
       - name: desktop tests
         run: cargo test -p openwave-desktop --locked
 
+  windows-check:
+    name: Windows cargo check
+    needs: changes
+    # A native runner keeps the Windows SDK and MSVC available for native
+    # dependencies such as ring and SQLite. Keep the default PR gate fast; add
+    # `full-ci` for pre-merge validation, while main and scheduled/manual runs
+    # always check every crate that currently contains Windows-gated code.
+    if: ${{ needs.changes.outputs.rust == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')) }}
+    runs-on: windows-latest
+    timeout-minutes: 20
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_PROFILE_DEV_DEBUG: 0
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install toolchain (honors rust-toolchain.toml)
+        run: rustup show
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: windows-check-cargo-registry-v1-${{ hashFiles('Cargo.lock') }}
+          add-job-id-key: "false"
+          add-rust-environment-hash-key: "false"
+          cache-bin: false
+          cache-targets: false
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: true
+      - name: Check Windows-gated crates
+        run: >-
+          cargo check --target x86_64-pc-windows-msvc
+          -p openwave-core
+          -p openwave-code-execution
+          -p openwave-host-broker
+          -p openwave-server
+          -p openwave-desktop
+          --locked
+
   test:
     name: test
     needs: changes


### PR DESCRIPTION
## Summary

- add a native `windows-latest` cargo-check lane for the crates that contain Windows-gated Rust code
- run it under the existing `full-ci` pull-request gate and automatically after merge, on schedules, and on manual runs
- keep the lane check-only and use the locked dependency graph

## Runner and scope

A native Windows runner is the cheapest workable mechanism for this dependency graph. A local `x86_64-pc-windows-msvc` cross-check from macOS reached `ring`'s C build and failed because the Windows SDK headers were unavailable. The selected server and desktop graph also includes bundled SQLite and other native desktop dependencies, so introducing and maintaining `cargo-xwin` plus an SDK/sysroot solely for this lane would add more tooling and failure modes than one native runner minute.

The lane checks the five crates that currently contain Windows conditionals:

- `openwave-core`
- `openwave-code-execution`
- `openwave-host-broker`
- `openwave-server`
- `openwave-desktop`

The remaining workspace crates are not named directly because they contain no Windows-gated code today. Cargo still checks any of them reached transitively by the selected crates. This leaves an explicit gap for a future crate that adds Windows conditionals without being added to this list; the lane name and command keep that scope visible for review.

The native dependency graph makes this heavier than rustfmt or advisory resolution, so it follows the existing heavy-lane policy: ordinary pull requests report a successful skip, `full-ci` opts into pre-merge coverage, and pushes to `main`, scheduled runs, and manual runs execute it automatically.

## Verification

- `rustup target add x86_64-pc-windows-msvc`
- attempted `cargo check --target x86_64-pc-windows-msvc -p openwave-core -p openwave-code-execution -p openwave-host-broker -p openwave-server -p openwave-desktop --locked` locally; it reached the expected cross-toolchain boundary and failed in `ring` because the macOS host lacked Windows SDK headers
- `node --test scripts/workflow-security.test.mjs`
- `cargo fmt --all --check`

The `full-ci` label is required for the native GitHub runner to prove the Windows check itself passes before merge.

Closes #897
