### PR TITLE
perf(core): compile tool schema validators at registration

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -119,20 +119,51 @@ pub struct ToolRegistry {
 }
 
 #[derive(Clone)]
+struct RegisteredSpec {
+    spec: ToolSpec,
+    validator: Option<jsonschema::Validator>,
+}
+
+impl RegisteredSpec {
+    fn new(spec: ToolSpec) -> Self {
+        // ToolSpec schemas are draft 2020-12, including schemars-generated
+        // schemas whose compact provider form deliberately omits `$schema`.
+        // Invalid tool-authored schemas fail open: they are registration bugs,
+        // and refusing every call would make an existing tool unusable.
+        let validator = jsonschema::options()
+            .with_draft(jsonschema::Draft::Draft202012)
+            .build(&spec.input_schema)
+            .ok();
+        Self { spec, validator }
+    }
+
+    fn mismatch(&self, arguments: &Value) -> Option<String> {
+        self.validator
+            .as_ref()?
+            .validate(arguments)
+            .err()
+            .map(|error| error.to_string())
+    }
+}
+
+#[derive(Clone)]
 enum RegisteredTool {
-    Server(Arc<dyn Tool>),
+    Server {
+        tool: Arc<dyn Tool>,
+        registered: RegisteredSpec,
+    },
     Client {
-        spec: ToolSpec,
+        registered: RegisteredSpec,
         validate_arguments: Option<fn(&Value) -> bool>,
         class: ApprovalClass,
     },
     ForegroundClient {
-        spec: ToolSpec,
+        registered: RegisteredSpec,
         validate_arguments: fn(&Value) -> bool,
         class: ApprovalClass,
     },
     ForegroundOrchestration {
-        spec: ToolSpec,
+        registered: RegisteredSpec,
         kind: ForegroundOrchestrationKind,
         class: ApprovalClass,
     },
@@ -153,8 +184,14 @@ impl ToolRegistry {
 
     /// Register a tool under its advertised name (replacing any existing one).
     pub fn register(&mut self, tool: Box<dyn Tool>) {
-        self.tools
-            .insert(tool.spec().name, RegisteredTool::Server(Arc::from(tool)));
+        let registered = RegisteredSpec::new(tool.spec());
+        self.tools.insert(
+            registered.spec.name.clone(),
+            RegisteredTool::Server {
+                tool: Arc::from(tool),
+                registered,
+            },
+        );
     }
 
     /// Register a client-owned tool contract with no server-side executor.
@@ -166,7 +203,7 @@ impl ToolRegistry {
         self.tools.insert(
             spec.name.clone(),
             RegisteredTool::Client {
-                spec,
+                registered: RegisteredSpec::new(spec),
                 validate_arguments: None,
                 class,
             },
@@ -183,7 +220,7 @@ impl ToolRegistry {
         self.tools.insert(
             spec.name.clone(),
             RegisteredTool::Client {
-                spec,
+                registered: RegisteredSpec::new(spec),
                 validate_arguments: Some(validate_arguments),
                 class,
             },
@@ -201,7 +238,7 @@ impl ToolRegistry {
         self.tools.insert(
             spec.name.clone(),
             RegisteredTool::ForegroundClient {
-                spec,
+                registered: RegisteredSpec::new(spec),
                 validate_arguments,
                 class,
             },
@@ -240,7 +277,7 @@ impl ToolRegistry {
             self.tools.insert(
                 spec.name.clone(),
                 RegisteredTool::ForegroundOrchestration {
-                    spec,
+                    registered: RegisteredSpec::new(spec),
                     kind,
                     class: ApprovalClass::Sensitive,
                 },
@@ -259,7 +296,7 @@ impl ToolRegistry {
     #[must_use]
     pub fn get(&self, name: &str) -> Option<&dyn Tool> {
         match self.tools.get(name) {
-            Some(RegisteredTool::Server(tool)) => Some(tool.as_ref()),
+            Some(RegisteredTool::Server { tool, .. }) => Some(tool.as_ref()),
             Some(RegisteredTool::Client { .. })
             | Some(RegisteredTool::ForegroundClient { .. })
             | Some(RegisteredTool::ForegroundOrchestration { .. })
@@ -281,7 +318,7 @@ impl ToolRegistry {
     #[must_use]
     pub fn server_tool(&self, name: &str) -> Option<Arc<dyn Tool>> {
         match self.tools.get(name)? {
-            RegisteredTool::Server(tool) => Some(tool.clone()),
+            RegisteredTool::Server { tool, .. } => Some(tool.clone()),
             RegisteredTool::Client { .. }
             | RegisteredTool::ForegroundClient { .. }
             | RegisteredTool::ForegroundOrchestration { .. } => None,
@@ -292,7 +329,7 @@ impl ToolRegistry {
     #[must_use]
     pub fn execution(&self, name: &str) -> Option<ToolCallExecution> {
         Some(match self.tools.get(name)? {
-            RegisteredTool::Server(_) => ToolCallExecution::Server,
+            RegisteredTool::Server { .. } => ToolCallExecution::Server,
             RegisteredTool::Client { .. } | RegisteredTool::ForegroundClient { .. } => {
                 ToolCallExecution::Client
             }
@@ -333,12 +370,12 @@ impl ToolRegistry {
         self.tools
             .values()
             .filter_map(|tool| match tool {
-                RegisteredTool::Server(tool)
+                RegisteredTool::Server { tool, .. }
                     if read_only && tool.approval_class() != ApprovalClass::ReadOnly =>
                 {
                     None
                 }
-                RegisteredTool::Server(tool) => Some(tool.spec()),
+                RegisteredTool::Server { registered, .. } => Some(registered.spec.clone()),
                 RegisteredTool::Client { class, .. }
                 | RegisteredTool::ForegroundClient { class, .. }
                 | RegisteredTool::ForegroundOrchestration { class, .. }
@@ -346,23 +383,25 @@ impl ToolRegistry {
                 {
                     None
                 }
-                RegisteredTool::Client { spec, .. } => Some(spec.clone()),
+                RegisteredTool::Client { registered, .. } => Some(registered.spec.clone()),
                 // The plan continuation exists only where a plan can be
                 // proposed: outside plan mode the tool would park a turn on a
                 // decision whose accept is meaningless.
-                RegisteredTool::ForegroundClient { spec, .. }
-                    if !read_only && spec.name == crate::EXIT_PLAN_MODE_TOOL =>
+                RegisteredTool::ForegroundClient { registered, .. }
+                    if !read_only && registered.spec.name == crate::EXIT_PLAN_MODE_TOOL =>
                 {
                     None
                 }
-                RegisteredTool::ForegroundClient { spec, .. } if allow_agent_orchestration => {
-                    Some(spec.clone())
-                }
-                RegisteredTool::ForegroundClient { .. } => None,
-                RegisteredTool::ForegroundOrchestration { spec, .. }
+                RegisteredTool::ForegroundClient { registered, .. }
                     if allow_agent_orchestration =>
                 {
-                    Some(spec.clone())
+                    Some(registered.spec.clone())
+                }
+                RegisteredTool::ForegroundClient { .. } => None,
+                RegisteredTool::ForegroundOrchestration { registered, .. }
+                    if allow_agent_orchestration =>
+                {
+                    Some(registered.spec.clone())
                 }
                 RegisteredTool::ForegroundOrchestration { .. } => None,
             })
@@ -378,10 +417,39 @@ impl ToolRegistry {
     #[must_use]
     pub fn registered_class(&self, name: &str) -> Option<ApprovalClass> {
         match self.tools.get(name)? {
-            RegisteredTool::Server(tool) => Some(tool.approval_class()),
+            RegisteredTool::Server { tool, .. } => Some(tool.approval_class()),
             RegisteredTool::Client { class, .. }
             | RegisteredTool::ForegroundClient { class, .. }
             | RegisteredTool::ForegroundOrchestration { class, .. } => Some(*class),
+        }
+    }
+
+    /// Validate arguments against the exact schema stored at registration.
+    ///
+    /// A returned string names the first failing instance path and constraint.
+    /// `None` means either that the arguments conform or that the tool supplied
+    /// an invalid schema, which remains a fail-open registration bug.
+    #[must_use]
+    pub fn schema_mismatch(&self, name: &str, arguments: &Value) -> Option<String> {
+        let registered = match self.tools.get(name)? {
+            RegisteredTool::Server { registered, .. }
+            | RegisteredTool::Client { registered, .. }
+            | RegisteredTool::ForegroundClient { registered, .. }
+            | RegisteredTool::ForegroundOrchestration { registered, .. } => registered,
+        };
+        registered.mismatch(arguments)
+    }
+
+    #[cfg(test)]
+    fn schema_is_compiled(&self, name: &str) -> bool {
+        match self.tools.get(name) {
+            Some(RegisteredTool::Server { registered, .. })
+            | Some(RegisteredTool::Client { registered, .. })
+            | Some(RegisteredTool::ForegroundClient { registered, .. })
+            | Some(RegisteredTool::ForegroundOrchestration { registered, .. }) => {
+                registered.validator.is_some()
+            }
+            None => false,
         }
     }
 
@@ -400,7 +468,7 @@ impl ToolRegistry {
             Some(RegisteredTool::ForegroundClient {
                 validate_arguments, ..
             }) => validate_arguments(arguments),
-            Some(RegisteredTool::Server(_))
+            Some(RegisteredTool::Server { .. })
             | Some(RegisteredTool::ForegroundOrchestration { .. })
             | None => false,
         }
@@ -3069,7 +3137,7 @@ impl Agent {
         // server's advertised contract was decorative. Hold every call to the
         // schema the model was shown, at the same refusal point, so the model
         // can re-emit the call instead of debugging a tool it never reached.
-        if let Some(mismatch) = crate::tool::schema_mismatch(&spec.input_schema, &arguments) {
+        if let Some(mismatch) = self.tools.schema_mismatch(&call.name, &arguments) {
             return ToolOutput::failed(
                 ToolErrorCategory::InvalidArguments,
                 format!(
@@ -7141,6 +7209,43 @@ mod tests {
             self.ran.fetch_add(1, Ordering::SeqCst);
             Ok(ToolOutput::text("counted"))
         }
+    }
+
+    #[test]
+    fn registry_compiles_draft_2020_12_schemas_once_for_every_tool_surface() {
+        let spec = ToolSpec {
+            name: "client_schema".into(),
+            description: "a schema-validated client tool".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "labels": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minContains": 1,
+                        "contains": {"const": "required"}
+                    }
+                },
+                "required": ["labels"]
+            }),
+        };
+        let mut registry = ToolRegistry::new().with(Box::new(StrictCountingTool {
+            ran: Arc::new(AtomicUsize::new(0)),
+        }));
+        registry.register_client(spec, ApprovalClass::ReadOnly);
+
+        assert!(registry.schema_is_compiled("strict_counter"));
+        assert!(registry.schema_is_compiled("client_schema"));
+        assert_eq!(
+            registry.schema_mismatch(
+                "client_schema",
+                &serde_json::json!({"labels": ["other", "required"]})
+            ),
+            None
+        );
+        assert!(registry
+            .schema_mismatch("client_schema", &serde_json::json!({"labels": ["other"]}))
+            .is_some());
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -126,10 +126,15 @@ struct RegisteredSpec {
 
 impl RegisteredSpec {
     fn new(spec: ToolSpec) -> Self {
-        // ToolSpec schemas are draft 2020-12, including schemars-generated
-        // schemas whose compact provider form deliberately omits `$schema`.
-        // Invalid tool-authored schemas fail open: they are registration bugs,
-        // and refusing every call would make an existing tool unusable.
+        // OpenWave's schemars-generated ToolSpec schemas target draft 2020-12,
+        // but their compact provider form deliberately omits `$schema`, so pin
+        // the draft instead of relying on auto-detection. External MCP schemas
+        // share this registration path and draft-07 is common in the wild; in
+        // particular, its tuple-form `items` has different 2020-12 semantics.
+        // Such incompatible schemas must fail compilation and therefore remain
+        // unvalidated, rather than being mis-validated under the wrong draft.
+        // Invalid schemas fail open because refusing every call would make one
+        // misconfigured tool permanently unusable.
         let validator = jsonschema::options()
             .with_draft(jsonschema::Draft::Draft202012)
             .build(&spec.input_schema)
@@ -438,19 +443,6 @@ impl ToolRegistry {
             | RegisteredTool::ForegroundOrchestration { registered, .. } => registered,
         };
         registered.mismatch(arguments)
-    }
-
-    #[cfg(test)]
-    fn schema_is_compiled(&self, name: &str) -> bool {
-        match self.tools.get(name) {
-            Some(RegisteredTool::Server { registered, .. })
-            | Some(RegisteredTool::Client { registered, .. })
-            | Some(RegisteredTool::ForegroundClient { registered, .. })
-            | Some(RegisteredTool::ForegroundOrchestration { registered, .. }) => {
-                registered.validator.is_some()
-            }
-            None => false,
-        }
     }
 
     /// Validate canonical arguments against a registered client-owned contract.
@@ -7212,7 +7204,7 @@ mod tests {
     }
 
     #[test]
-    fn registry_compiles_draft_2020_12_schemas_once_for_every_tool_surface() {
+    fn registry_refuses_schema_mismatches_for_server_and_client_tools() {
         let spec = ToolSpec {
             name: "client_schema".into(),
             description: "a schema-validated client tool".into(),
@@ -7234,8 +7226,9 @@ mod tests {
         }));
         registry.register_client(spec, ApprovalClass::ReadOnly);
 
-        assert!(registry.schema_is_compiled("strict_counter"));
-        assert!(registry.schema_is_compiled("client_schema"));
+        assert!(registry
+            .schema_mismatch("strict_counter", &serde_json::json!({"path": 42}))
+            .is_some_and(|mismatch| mismatch.contains("string")));
         assert_eq!(
             registry.schema_mismatch(
                 "client_schema",
@@ -7246,6 +7239,24 @@ mod tests {
         assert!(registry
             .schema_mismatch("client_schema", &serde_json::json!({"labels": ["other"]}))
             .is_some());
+    }
+
+    #[test]
+    fn registry_fails_open_when_a_tool_schema_does_not_compile() {
+        let mut registry = ToolRegistry::new();
+        registry.register_client(
+            ToolSpec {
+                name: "invalid_schema".into(),
+                description: "a tool with a misconfigured schema".into(),
+                input_schema: serde_json::json!({"type": "nonsense"}),
+            },
+            ApprovalClass::ReadOnly,
+        );
+
+        assert_eq!(
+            registry.schema_mismatch("invalid_schema", &serde_json::json!({})),
+            None
+        );
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/tool.rs
+++ b/crates/openwave-core/src/tool.rs
@@ -166,23 +166,6 @@ fn remove_null_schema_defaults(schema: &mut Value) {
     }
 }
 
-/// Check parsed tool-call arguments against the advertised schema, returning
-/// the mismatch to echo back to the model.
-///
-/// `None` means the call may proceed — either because the arguments conform
-/// or because the schema itself does not compile. A schema that is not a
-/// schema is the tool's bug, not the model's: refusing every call against it
-/// would brick the tool, and dispatch never had a contract to enforce there
-/// in the first place.
-#[must_use]
-pub fn schema_mismatch(input_schema: &Value, arguments: &Value) -> Option<String> {
-    let validator = jsonschema::validator_for(input_schema).ok()?;
-    validator
-        .validate(arguments)
-        .err()
-        .map(|error| error.to_string())
-}
-
 /// What to do with a property the schema does not require, when converting to
 /// the strict schema subset providers enforce.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -790,32 +773,6 @@ mod tests {
         // `Option` reliably does. A hand-written tool schema cannot promise
         // that, so the conversion is refused rather than quietly performed.
         assert!(strict_json_schema(&schema, OptionalProperties::Reject).is_none());
-    }
-
-    #[test]
-    fn schema_mismatch_names_the_violation_and_fails_open_on_a_non_schema() {
-        let schema = serde_json::json!({
-            "type": "object",
-            "properties": {"path": {"type": "string"}},
-            "required": ["path"],
-            "additionalProperties": false
-        });
-        assert_eq!(
-            schema_mismatch(&schema, &serde_json::json!({"path": "x"})),
-            None
-        );
-        assert!(schema_mismatch(&schema, &serde_json::json!({"path": 42}))
-            .is_some_and(|mismatch| mismatch.contains("string")),);
-        assert!(schema_mismatch(&schema, &serde_json::json!({})).is_some());
-        // A schema that is not a schema is the tool's bug, not the model's:
-        // there is no contract to hold the call to, so the call proceeds.
-        assert_eq!(
-            schema_mismatch(
-                &serde_json::json!({"type": "nonsense"}),
-                &serde_json::json!({})
-            ),
-            None
-        );
     }
 
     #[test]

--- a/crates/openwave-mcp/src/server.rs
+++ b/crates/openwave-mcp/src/server.rs
@@ -332,10 +332,7 @@ impl McpServer {
                 params.name
             )));
         }
-        let spec = tool.spec();
-        if let Some(mismatch) =
-            openwave_core::tool::schema_mismatch(&spec.input_schema, &params.arguments)
-        {
+        if let Some(mismatch) = self.tools.schema_mismatch(&params.name, &params.arguments) {
             return Err(RpcError::invalid_params(format!(
                 "arguments for {} do not satisfy its schema: {mismatch}",
                 params.name


### PR DESCRIPTION
Closes #1509

## Summary

- compile each tool input-schema validator once when the tool is registered
- expose schema mismatch checks through the shared registry so the existing agent and MCP-server dispatch refusals reuse the compiled validator
- keep invalid or draft-incompatible externally supplied schemas fail-open so a misconfigured tool is not made permanently unusable
- pin Draft 2020-12 for OpenWave's compact schemars-generated schemas and document the compatibility tradeoff for common draft-07 MCP schemas

Issue #1509 overstated the gap: schema validation already existed at both dispatch points. What was missing was compile-once registration and a unified registry accessor; this PR preserves the existing refusal behavior while removing per-call validator compilation.

## Verification

- `cargo fmt --all`
- `cargo test -p openwave-core -p openwave-mcp --locked`
- `cargo check --workspace --locked`
