### PR TITLE
fix(router): translate tool schemas into Gemini's accepted subset

### DIFF
--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -224,7 +224,7 @@ pub use tool::{
     ToolErrorCategory, ToolOutput, ToolScratch, ToolSpec, ToolUiView,
 };
 #[cfg(feature = "tools")]
-pub use tools::{CreateAppTool, ListDir, ReadFile, WriteFile};
+pub use tools::{create_app_tool_spec, CreateAppTool, ListDir, ReadFile, WriteFile};
 pub use user_questions::{
     ask_user_questions_tool_spec, validate_ask_user_questions_arguments, AnswerUserQuestions,
     AnswerUserQuestionsRequest, AskUserQuestionsArgs, PendingUserQuestions, UserQuestion,

--- a/crates/openwave-core/src/tools/mod.rs
+++ b/crates/openwave-core/src/tools/mod.rs
@@ -17,5 +17,11 @@ pub use list_dir::ListDir;
 pub use read_file::ReadFile;
 pub use write_file::WriteFile;
 
+/// Model-facing contract for the built-in local-app publisher.
+#[must_use]
+pub fn create_app_tool_spec() -> crate::ToolSpec {
+    definitions::create_app()
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/openwave-router/Cargo.toml
+++ b/crates/openwave-router/Cargo.toml
@@ -41,4 +41,5 @@ uuid = { workspace = true, optional = true }
 
 [dev-dependencies]
 axum = { workspace = true }
+openwave-core = { path = "../openwave-core", default-features = false, features = ["tools"] }
 tokio = { workspace = true, features = ["net", "rt-multi-thread", "test-util"] }

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -1047,9 +1047,15 @@ fn classify_gemini_error(
 mod tests {
     use super::*;
     use openwave_core::provider::ChatMessage;
-    use openwave_core::tool::ToolSpec;
+    use openwave_core::tool::{Tool, ToolSpec};
     use openwave_core::{
-        request_folder_access_tool_spec, spawn_sandbox_agent_tool_spec, wait_for_agents_tool_spec,
+        ask_user_questions_tool_spec, exit_plan_mode_tool_spec, import_connected_file_tool_spec,
+        list_connected_folders_tool_spec, list_folder_tool_spec, read_connected_file_tool_spec,
+        request_folder_access_tool_spec, sandbox_folder_access_proposal_tool_spec,
+        sandbox_read_delegated_file_tool_spec, sandbox_web_search_tool_spec,
+        spawn_sandbox_agent_tool_spec, wait_for_agents_tool_spec, web_extract_tool_spec,
+        web_search_tool_spec, write_output_to_connected_folder_tool_spec, ListDir, ReadFile,
+        WriteFile,
     };
 
     fn request(messages: Vec<ChatMessage>) -> ChatRequest {
@@ -1097,12 +1103,27 @@ mod tests {
     }
 
     #[test]
-    fn foreground_tool_schemas_use_only_geminis_supported_subset() {
+    fn all_tool_schemas_translate_to_geminis_supported_subset() {
         let mut req = request(vec![ChatMessage::text(Role::User, "hi")]);
         req.tools = vec![
             spawn_sandbox_agent_tool_spec(),
             wait_for_agents_tool_spec(),
+            web_search_tool_spec(),
+            web_extract_tool_spec(),
+            sandbox_web_search_tool_spec(),
+            sandbox_read_delegated_file_tool_spec(),
             request_folder_access_tool_spec(),
+            sandbox_folder_access_proposal_tool_spec(),
+            list_connected_folders_tool_spec(),
+            list_folder_tool_spec(),
+            read_connected_file_tool_spec(),
+            import_connected_file_tool_spec(),
+            write_output_to_connected_folder_tool_spec(),
+            exit_plan_mode_tool_spec(),
+            ask_user_questions_tool_spec(),
+            ReadFile.spec(),
+            ListDir.spec(),
+            WriteFile.spec(),
         ];
 
         let body = build_request_json(&req).unwrap();

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -1049,13 +1049,13 @@ mod tests {
     use openwave_core::provider::ChatMessage;
     use openwave_core::tool::{Tool, ToolSpec};
     use openwave_core::{
-        ask_user_questions_tool_spec, exit_plan_mode_tool_spec, import_connected_file_tool_spec,
-        list_connected_folders_tool_spec, list_folder_tool_spec, read_connected_file_tool_spec,
-        request_folder_access_tool_spec, sandbox_folder_access_proposal_tool_spec,
-        sandbox_read_delegated_file_tool_spec, sandbox_web_search_tool_spec,
-        spawn_sandbox_agent_tool_spec, wait_for_agents_tool_spec, web_extract_tool_spec,
-        web_search_tool_spec, write_output_to_connected_folder_tool_spec, ListDir, ReadFile,
-        WriteFile,
+        ask_user_questions_tool_spec, create_app_tool_spec, exit_plan_mode_tool_spec,
+        import_connected_file_tool_spec, list_connected_folders_tool_spec, list_folder_tool_spec,
+        read_connected_file_tool_spec, request_folder_access_tool_spec,
+        sandbox_folder_access_proposal_tool_spec, sandbox_read_delegated_file_tool_spec,
+        sandbox_web_search_tool_spec, spawn_sandbox_agent_tool_spec, wait_for_agents_tool_spec,
+        web_extract_tool_spec, web_search_tool_spec, write_output_to_connected_folder_tool_spec,
+        ListDir, ReadFile, WriteFile,
     };
 
     fn request(messages: Vec<ChatMessage>) -> ChatRequest {
@@ -1121,6 +1121,7 @@ mod tests {
             write_output_to_connected_folder_tool_spec(),
             exit_plan_mode_tool_spec(),
             ask_user_questions_tool_spec(),
+            create_app_tool_spec(),
             ReadFile.spec(),
             ListDir.spec(),
             WriteFile.spec(),

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -370,13 +370,18 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         body["systemInstruction"] = json!({ "parts": [{ "text": system }] });
     }
     if !req.tools.is_empty() {
-        body["tools"] = json!([{
-            "functionDeclarations": req.tools.iter().map(|tool| json!({
-                "name": tool.name,
-                "description": tool.description,
-                "parameters": tool.input_schema,
-            })).collect::<Vec<_>>(),
-        }]);
+        let declarations = req
+            .tools
+            .iter()
+            .map(|tool| {
+                Ok(json!({
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": gemini_tool_schema(&tool.input_schema)?,
+                }))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        body["tools"] = json!([{ "functionDeclarations": declarations }]);
         body["toolConfig"] = json!({
             "functionCallingConfig": gemini_function_calling_config(req.tool_choice.as_ref())?,
         });
@@ -402,6 +407,123 @@ fn gemini_function_calling_config(choice: Option<&ToolChoice>) -> Result<Value> 
             )))
         }
     })
+}
+
+/// Translate JSON Schema into the subset Gemini accepts for function parameters.
+///
+/// Tool schemas are intentionally lossy at this provider boundary: unsupported
+/// validation keywords are omitted, while the structural shape and constraints
+/// Gemini can express are retained. Building from an allowlist prevents a new
+/// JSON Schema keyword from becoming an unknown protobuf field in every turn.
+fn gemini_tool_schema(schema: &Value) -> Result<Value> {
+    let unsupported = |detail: &str| {
+        AgentError::Provider(format!(
+            "gemini function parameters cannot express {detail}"
+        ))
+    };
+    let object = schema
+        .as_object()
+        .ok_or_else(|| unsupported("a non-object schema"))?;
+    let mut out = serde_json::Map::new();
+
+    for keyword in GEMINI_SCHEMA_KEYWORDS {
+        if let Some(value) = object.get(*keyword) {
+            out.insert((*keyword).to_owned(), value.clone());
+        }
+    }
+    if let Some(format) = object.get("format").and_then(Value::as_str) {
+        if GEMINI_FORMATS.contains(&format) {
+            out.insert("format".to_owned(), json!(format));
+        }
+    }
+    if let Some(default) = object.get("default") {
+        out.insert("default".to_owned(), default.clone());
+    }
+
+    let mut nullable = object
+        .get("nullable")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let mut declared: Option<&str> = None;
+    let mut any_of = None;
+    if let Some(branches) = object.get("anyOf") {
+        let branches = branches
+            .as_array()
+            .ok_or_else(|| unsupported("a non-array `anyOf`"))?;
+        let mut concrete = Vec::new();
+        for branch in branches {
+            if branch.get("type").is_some_and(|value| value == "null") {
+                nullable = true;
+            } else {
+                concrete.push(gemini_tool_schema(branch)?);
+            }
+        }
+        if concrete.len() == 1 && object.get("type").is_none() {
+            out.extend(
+                concrete
+                    .pop()
+                    .and_then(|branch| branch.as_object().cloned())
+                    .ok_or_else(|| unsupported("a non-object `anyOf` branch"))?,
+            );
+        } else if !concrete.is_empty() {
+            any_of = Some(concrete);
+        }
+    }
+    if let Some(value) = object.get("type") {
+        let names: Vec<&str> = match value {
+            Value::String(name) => vec![name.as_str()],
+            Value::Array(names) => names
+                .iter()
+                .map(Value::as_str)
+                .collect::<Option<_>>()
+                .ok_or_else(|| unsupported("a non-string type name"))?,
+            _ => return Err(unsupported("a non-string type")),
+        };
+        for name in names {
+            if name == "null" {
+                nullable = true;
+            } else if declared.replace(name).is_some() {
+                return Err(unsupported("a union of two concrete types"));
+            }
+        }
+    }
+
+    if let Some(name) = declared {
+        let gemini_type =
+            gemini_schema_type(name).ok_or_else(|| unsupported(&format!("the type `{name}`")))?;
+        out.insert("type".to_owned(), json!(gemini_type));
+        if name == "object" {
+            let properties = object
+                .get("properties")
+                .and_then(Value::as_object)
+                .map(|properties| {
+                    properties
+                        .iter()
+                        .map(|(name, property)| Ok((name.clone(), gemini_tool_schema(property)?)))
+                        .collect::<Result<serde_json::Map<_, _>>>()
+                })
+                .transpose()?
+                .unwrap_or_default();
+            out.insert("properties".to_owned(), Value::Object(properties));
+            if let Some(required) = object.get("required") {
+                out.insert("required".to_owned(), required.clone());
+            }
+        }
+        if name == "array" {
+            let items = object
+                .get("items")
+                .ok_or_else(|| unsupported("an array with no item schema"))?;
+            out.insert("items".to_owned(), gemini_tool_schema(items)?);
+        }
+    } else if let Some(branches) = any_of {
+        out.insert("anyOf".to_owned(), Value::Array(branches));
+    } else if !out.contains_key("type") && !out.contains_key("enum") {
+        return Err(unsupported("a schema with no type, enum, or anyOf"));
+    }
+    if nullable {
+        out.insert("nullable".to_owned(), json!(true));
+    }
+    Ok(Value::Object(out))
 }
 
 /// Keywords `responseSchema` understands and that carry over unchanged.
@@ -926,6 +1048,9 @@ mod tests {
     use super::*;
     use openwave_core::provider::ChatMessage;
     use openwave_core::tool::ToolSpec;
+    use openwave_core::{
+        request_folder_access_tool_spec, spawn_sandbox_agent_tool_spec, wait_for_agents_tool_spec,
+    };
 
     fn request(messages: Vec<ChatMessage>) -> ChatRequest {
         ChatRequest {
@@ -969,6 +1094,78 @@ mod tests {
             .get("thinkingBudget")
             .is_none());
         assert!(body["generationConfig"].get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn foreground_tool_schemas_use_only_geminis_supported_subset() {
+        let mut req = request(vec![ChatMessage::text(Role::User, "hi")]);
+        req.tools = vec![
+            spawn_sandbox_agent_tool_spec(),
+            wait_for_agents_tool_spec(),
+            request_folder_access_tool_spec(),
+        ];
+
+        let body = build_request_json(&req).unwrap();
+        let declarations = body["tools"][0]["functionDeclarations"].as_array().unwrap();
+        assert_eq!(declarations.len(), req.tools.len());
+
+        fn assert_supported(schema: &Value) {
+            const SUPPORTED: &[&str] = &[
+                "type",
+                "format",
+                "description",
+                "nullable",
+                "enum",
+                "items",
+                "properties",
+                "required",
+                "minimum",
+                "maximum",
+                "minItems",
+                "maxItems",
+                "minLength",
+                "maxLength",
+                "pattern",
+                "anyOf",
+                "default",
+            ];
+            let object = schema.as_object().expect("Gemini schema must be an object");
+            for (keyword, value) in object {
+                assert!(
+                    SUPPORTED.contains(&keyword.as_str()),
+                    "unsupported Gemini schema keyword `{keyword}` in {schema}"
+                );
+                if keyword == "type" {
+                    assert!(value.is_string(), "Gemini type must be scalar in {schema}");
+                }
+            }
+            if let Some(properties) = object.get("properties").and_then(Value::as_object) {
+                for property in properties.values() {
+                    assert_supported(property);
+                }
+            }
+            if let Some(items) = object.get("items") {
+                assert_supported(items);
+            }
+            if let Some(branches) = object.get("anyOf").and_then(Value::as_array) {
+                for branch in branches {
+                    assert_supported(branch);
+                }
+            }
+        }
+
+        for declaration in declarations {
+            assert_supported(&declaration["parameters"]);
+        }
+        let wait = declarations
+            .iter()
+            .find(|declaration| declaration["name"] == "wait_for_agents")
+            .unwrap();
+        assert!(wait["parameters"]["properties"]["agent_ids"]
+            .get("uniqueItems")
+            .is_none());
+        let nullable = gemini_tool_schema(&json!({ "type": ["string", "null"] })).unwrap();
+        assert_eq!(nullable, json!({ "type": "STRING", "nullable": true }));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1516

## Summary

- translate JSON Schema tool parameters at the Gemini adapter boundary using an allowlist of supported Schema fields
- recursively preserve object, array, enum, range, length, pattern, default, and supported format semantics
- collapse nullable JSON Schema unions to one concrete Gemini type plus `nullable: true`
- drop unsupported constraints such as `uniqueItems`, `additionalProperties`, and JSON Schema metadata without changing the shared tool specs
- fail the turn rather than send a degraded request when a tool schema cannot be translated

## Verification

- `cargo fmt --all`
- `cargo test -p openwave-router --locked`
- `cargo test -p openwave-core --locked`
- `cargo check --workspace --locked`
