### PR TITLE
fix(desktop): report folder exec and write reach to the model

### DIFF
--- a/crates/openwave-core/src/client_tools.rs
+++ b/crates/openwave-core/src/client_tools.rs
@@ -45,6 +45,23 @@ pub enum RequestedFolderCapability {
     ReadFiles,
 }
 
+/// One folder capability the trusted host reports as currently granted.
+///
+/// This vocabulary is deliberately separate from [`RequestedFolderCapability`]:
+/// the request remains a narrow, untrusted proposal while the result reports
+/// the broker's real authorization decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum GrantedFolderCapability {
+    /// List directories and read files below the selected folder.
+    ReadFiles,
+    /// Create files or replace them after any required approval.
+    WriteFiles,
+    /// Expose the selected folder to model-authored commands.
+    ExecuteCommands,
+}
+
 /// Non-authoritative, well-known starting location for the native picker.
 ///
 /// This is deliberately not a free-form path. The trusted desktop decides how
@@ -113,14 +130,14 @@ pub struct RequestFolderAccessArgs {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
 pub enum RequestFolderAccessResult {
-    /// The user selected a folder and the broker reports live read access.
+    /// The user selected a folder and the broker reports its live capabilities.
     Connected {
         /// Opaque broker-local root identity, never a host path.
         root_id: uuid::Uuid,
         /// Bounded leaf name safe for display.
         display_name: String,
         /// Capabilities the trusted host actually granted.
-        capabilities: Vec<RequestedFolderCapability>,
+        capabilities: Vec<GrantedFolderCapability>,
     },
     /// The user declined or closed the picker; no access was granted.
     Declined,
@@ -416,7 +433,7 @@ pub fn validate_write_output_to_connected_folder_arguments(arguments: &Value) ->
 pub fn list_connected_folders_tool_spec() -> ToolSpec {
     ToolSpec::for_args::<ListConnectedFoldersArgs>(
         LIST_CONNECTED_FOLDERS_TOOL,
-        "List folders already connected to this conversation. Results contain opaque root IDs and display names only; use request_folder_access to ask the user to choose another folder.",
+        "List folders already connected to this conversation. Results contain opaque root IDs, display names, and the capabilities the trusted host currently grants on each folder; use request_folder_access to ask the user to choose another folder.",
     )
 }
 
@@ -563,7 +580,11 @@ mod tests {
         let result = RequestFolderAccessResult::Connected {
             root_id: uuid::Uuid::new_v4(),
             display_name: "Documents".into(),
-            capabilities: vec![RequestedFolderCapability::ReadFiles],
+            capabilities: vec![
+                GrantedFolderCapability::ReadFiles,
+                GrantedFolderCapability::WriteFiles,
+                GrantedFolderCapability::ExecuteCommands,
+            ],
         };
         let encoded = serde_json::to_value(&result).unwrap();
         assert_eq!(encoded["status"], "connected");

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -109,13 +109,13 @@ pub use client_tools::{
     validate_list_connected_folders_arguments, validate_list_folder_arguments,
     validate_read_connected_file_arguments, validate_request_folder_access_arguments,
     validate_write_output_to_connected_folder_arguments,
-    write_output_to_connected_folder_tool_spec, ImportConnectedFileArgs, ImportConnectedFileResult,
-    ListConnectedFoldersArgs, ListFolderArgs, OutputWriteMode, ReadConnectedFileArgs,
-    RequestFolderAccessArgs, RequestFolderAccessResult, RequestedFolderCapability,
-    RequestedFolderHint, WriteOutputToConnectedFolderArgs, WriteOutputToConnectedFolderProposal,
-    IMPORT_CONNECTED_FILE_TOOL, LIST_CONNECTED_FOLDERS_TOOL, LIST_FOLDER_TOOL,
-    MAX_CONNECTED_FOLDER_PATH_BYTES, MAX_FOLDER_ACCESS_REASON_CHARS, READ_CONNECTED_FILE_TOOL,
-    REQUEST_FOLDER_ACCESS_TOOL, WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
+    write_output_to_connected_folder_tool_spec, GrantedFolderCapability, ImportConnectedFileArgs,
+    ImportConnectedFileResult, ListConnectedFoldersArgs, ListFolderArgs, OutputWriteMode,
+    ReadConnectedFileArgs, RequestFolderAccessArgs, RequestFolderAccessResult,
+    RequestedFolderCapability, RequestedFolderHint, WriteOutputToConnectedFolderArgs,
+    WriteOutputToConnectedFolderProposal, IMPORT_CONNECTED_FILE_TOOL, LIST_CONNECTED_FOLDERS_TOOL,
+    LIST_FOLDER_TOOL, MAX_CONNECTED_FOLDER_PATH_BYTES, MAX_FOLDER_ACCESS_REASON_CHARS,
+    READ_CONNECTED_FILE_TOOL, REQUEST_FOLDER_ACCESS_TOOL, WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
 };
 pub use config::{Config, Profile};
 #[cfg(any(feature = "sqlite", feature = "postgres"))]

--- a/crates/openwave-desktop/src/client_execution.rs
+++ b/crates/openwave-desktop/src/client_execution.rs
@@ -8,13 +8,14 @@
 use std::path::PathBuf;
 
 use openwave_core::{
-    validate_request_folder_access_arguments, CallId, ChatId, RequestFolderAccessArgs,
-    RequestFolderAccessResult, RequestedFolderCapability, RequestedFolderHint, ToolCallExecution,
+    validate_request_folder_access_arguments, CallId, ChatId, GrantedFolderCapability,
+    RequestFolderAccessArgs, RequestFolderAccessResult, RequestedFolderHint, ToolCallExecution,
     ToolCallRecord, ToolCallStatus, REQUEST_FOLDER_ACCESS_TOOL,
 };
 use openwave_host_broker::{
-    ConsentMethod, ControlRequest, ControlResult, LookupRegisterRootReceiptRequest,
-    RegisterRootReceipt, RegisterRootRequest, RootSummary,
+    Capability, ConsentMethod, ControlRequest, ControlResult, LookupRegisterRootReceiptRequest,
+    OperationEnvelope, OperationRequest, OperationResult, RegisterRootReceipt, RegisterRootRequest,
+    RootSummary, PROTOCOL_VERSION,
 };
 use serde::Deserialize;
 use tauri::{AppHandle, Manager, State};
@@ -505,13 +506,44 @@ fn picker_start(
     candidate.is_dir().then_some(candidate)
 }
 
-fn connected_resolution(
+async fn connected_resolution(
+    state: &HostAccess,
+    context: AuthoritativeContext,
     root: openwave_host_broker::RootSummary,
 ) -> Result<StoredResolution, String> {
+    let listed = state
+        .broker
+        .operation(OperationEnvelope {
+            protocol_version: PROTOCOL_VERSION,
+            request_id: openwave_host_broker::RequestId::new(),
+            context: context.execution,
+            request: OperationRequest::ListRoots,
+        })
+        .await
+        .map_err(|_| "could not verify the selected folder's capabilities".to_owned())?;
+    let OperationResult::ListRoots { roots } = listed else {
+        return Err("host broker returned an unexpected folder listing".to_owned());
+    };
+    let access = roots
+        .into_iter()
+        .find(|candidate| candidate.root_id == root.root_id)
+        .ok_or_else(|| {
+            "the selected folder is no longer available to this conversation".to_owned()
+        })?;
     let result = RequestFolderAccessResult::Connected {
         root_id: root.root_id.as_uuid(),
         display_name: root.display_name,
-        capabilities: vec![RequestedFolderCapability::ReadFiles],
+        capabilities: access
+            .capabilities
+            .into_iter()
+            .filter_map(|capability| match capability {
+                Capability::ReadFiles => Some(GrantedFolderCapability::ReadFiles),
+                Capability::WriteFiles => Some(GrantedFolderCapability::WriteFiles),
+                Capability::ExecuteCommands => Some(GrantedFolderCapability::ExecuteCommands),
+                Capability::ListRoots => None,
+                _ => None,
+            })
+            .collect(),
     };
     Ok(StoredResolution::Completed {
         result: serde_json::to_string(&result)
@@ -624,17 +656,7 @@ mod tests {
     }
 
     #[test]
-    fn terminal_results_are_typed_and_path_free() {
-        let connected = connected_resolution(openwave_host_broker::RootSummary {
-            root_id: openwave_host_broker::RootId::new(),
-            display_name: "Documents".into(),
-        })
-        .unwrap();
-        let StoredResolution::Completed { result, .. } = connected else {
-            panic!("expected completed result")
-        };
-        assert!(result.contains("connected"));
-        assert!(!result.contains("/Users/"));
+    fn declined_results_are_typed() {
         assert!(matches!(
             declined_resolution().unwrap(),
             StoredResolution::Completed { result, .. } if result.contains("declined")

--- a/crates/openwave-desktop/src/client_execution.rs
+++ b/crates/openwave-desktop/src/client_execution.rs
@@ -8,9 +8,9 @@
 use std::path::PathBuf;
 
 use openwave_core::{
-    validate_request_folder_access_arguments, CallId, ChatId, GrantedFolderCapability,
-    RequestFolderAccessArgs, RequestFolderAccessResult, RequestedFolderHint, ToolCallExecution,
-    ToolCallRecord, ToolCallStatus, REQUEST_FOLDER_ACCESS_TOOL,
+    validate_request_folder_access_arguments, CallId, ChatId, RequestFolderAccessArgs,
+    RequestFolderAccessResult, RequestedFolderHint, ToolCallExecution, ToolCallRecord,
+    ToolCallStatus, REQUEST_FOLDER_ACCESS_TOOL,
 };
 use openwave_host_broker::{
     Capability, ConsentMethod, ControlRequest, ControlResult, LookupRegisterRootReceiptRequest,
@@ -22,6 +22,8 @@ use tauri::{AppHandle, Manager, State};
 use uuid::Uuid;
 
 use crate::host_access::{pick_folder, AuthoritativeContext, HostAccess};
+
+use self::folder_operations::granted_folder_capabilities;
 
 mod control_plane;
 pub(crate) mod delegated_file_read;
@@ -511,7 +513,7 @@ async fn connected_resolution(
     context: AuthoritativeContext,
     root: openwave_host_broker::RootSummary,
 ) -> Result<StoredResolution, String> {
-    let listed = state
+    let capabilities = state
         .broker
         .operation(OperationEnvelope {
             protocol_version: PROTOCOL_VERSION,
@@ -520,30 +522,31 @@ async fn connected_resolution(
             request: OperationRequest::ListRoots,
         })
         .await
-        .map_err(|_| "could not verify the selected folder's capabilities".to_owned())?;
-    let OperationResult::ListRoots { roots } = listed else {
-        return Err("host broker returned an unexpected folder listing".to_owned());
-    };
-    let access = roots
-        .into_iter()
-        .find(|candidate| candidate.root_id == root.root_id)
-        .ok_or_else(|| {
-            "the selected folder is no longer available to this conversation".to_owned()
-        })?;
+        .ok()
+        .and_then(|listed| match listed {
+            OperationResult::ListRoots { roots } => roots
+                .into_iter()
+                .find(|candidate| candidate.root_id == root.root_id)
+                .map(|access| access.capabilities),
+            _ => None,
+        });
+    connected_resolution_from_capabilities(root, capabilities.as_deref())
+}
+
+fn connected_resolution_from_capabilities(
+    root: openwave_host_broker::RootSummary,
+    capabilities: Option<&[Capability]>,
+) -> Result<StoredResolution, String> {
     let result = RequestFolderAccessResult::Connected {
         root_id: root.root_id.as_uuid(),
         display_name: root.display_name,
-        capabilities: access
-            .capabilities
-            .into_iter()
-            .filter_map(|capability| match capability {
-                Capability::ReadFiles => Some(GrantedFolderCapability::ReadFiles),
-                Capability::WriteFiles => Some(GrantedFolderCapability::WriteFiles),
-                Capability::ExecuteCommands => Some(GrantedFolderCapability::ExecuteCommands),
-                Capability::ListRoots => None,
-                _ => None,
-            })
-            .collect(),
+        // A revocation or broker outage can race this post-consent projection.
+        // Consent already succeeded, so return the pathless root identity and
+        // under-report reach rather than turning that race into a user-facing
+        // failure immediately after the picker closes.
+        capabilities: capabilities
+            .map(granted_folder_capabilities)
+            .unwrap_or_default(),
     };
     Ok(StoredResolution::Completed {
         result: serde_json::to_string(&result)
@@ -656,7 +659,24 @@ mod tests {
     }
 
     #[test]
-    fn declined_results_are_typed() {
+    fn terminal_results_are_typed_and_path_free() {
+        let connected = connected_resolution_from_capabilities(
+            openwave_host_broker::RootSummary {
+                root_id: openwave_host_broker::RootId::new(),
+                display_name: "Documents".into(),
+            },
+            Some(&[
+                Capability::ReadFiles,
+                Capability::WriteFiles,
+                Capability::ExecuteCommands,
+            ]),
+        )
+        .unwrap();
+        let StoredResolution::Completed { result, .. } = connected else {
+            panic!("expected completed result")
+        };
+        assert!(result.contains("connected"));
+        assert!(!result.contains("/Users/"));
         assert!(matches!(
             declined_resolution().unwrap(),
             StoredResolution::Completed { result, .. } if result.contains("declined")

--- a/crates/openwave-desktop/src/client_execution/folder_operations.rs
+++ b/crates/openwave-desktop/src/client_execution/folder_operations.rs
@@ -567,7 +567,9 @@ fn serialize_result(call: &ToolCallRecord, result: OperationResult) -> StoredRes
     }
 }
 
-fn granted_folder_capabilities(capabilities: &[Capability]) -> Vec<GrantedFolderCapability> {
+pub(super) fn granted_folder_capabilities(
+    capabilities: &[Capability],
+) -> Vec<GrantedFolderCapability> {
     capabilities
         .iter()
         .filter_map(|capability| match capability {
@@ -575,6 +577,9 @@ fn granted_folder_capabilities(capabilities: &[Capability]) -> Vec<GrantedFolder
             Capability::WriteFiles => Some(GrantedFolderCapability::WriteFiles),
             Capability::ExecuteCommands => Some(GrantedFolderCapability::ExecuteCommands),
             Capability::ListRoots => None,
+            // Capability is non-exhaustive. Unknown future per-folder reach is
+            // intentionally under-reported until this one conversion and the
+            // model-facing vocabulary are extended together.
             _ => None,
         })
         .collect()

--- a/crates/openwave-desktop/src/client_execution/folder_operations.rs
+++ b/crates/openwave-desktop/src/client_execution/folder_operations.rs
@@ -10,14 +10,14 @@ use std::collections::HashSet;
 use openwave_code_execution::host_paths::{resolve_scratch_directory, ScratchEntryKind};
 use openwave_core::{
     validate_import_connected_file_arguments, validate_list_connected_folders_arguments,
-    validate_list_folder_arguments, validate_read_connected_file_arguments, CallId, ListFolderArgs,
-    ReadConnectedFileArgs, ResultEntry, ResultEntryKind, ToolCallExecution, ToolCallRecord,
-    ToolCallStatus, IMPORT_CONNECTED_FILE_TOOL, LIST_CONNECTED_FOLDERS_TOOL, LIST_FOLDER_TOOL,
-    READ_CONNECTED_FILE_TOOL,
+    validate_list_folder_arguments, validate_read_connected_file_arguments, CallId,
+    GrantedFolderCapability, ListFolderArgs, ReadConnectedFileArgs, ResultEntry, ResultEntryKind,
+    ToolCallExecution, ToolCallRecord, ToolCallStatus, IMPORT_CONNECTED_FILE_TOOL,
+    LIST_CONNECTED_FOLDERS_TOOL, LIST_FOLDER_TOOL, READ_CONNECTED_FILE_TOOL,
 };
 use openwave_host_broker::{
-    DirectoryEntry, EntryKind, OperationEnvelope, OperationRequest, OperationResult, PathRequest,
-    ReadFileResult, RelativePath, RootId, PROTOCOL_VERSION,
+    Capability, DirectoryEntry, EntryKind, OperationEnvelope, OperationRequest, OperationResult,
+    PathRequest, ReadFileResult, RelativePath, RootId, PROTOCOL_VERSION,
 };
 use tauri::Manager;
 
@@ -493,6 +493,7 @@ fn serialize_result(call: &ToolCallRecord, result: OperationResult) -> StoredRes
                     "folders": roots.iter().map(|root| serde_json::json!({
                         "root_id": root.root_id,
                         "display_name": root.display_name,
+                        "capabilities": granted_folder_capabilities(&root.capabilities),
                     })).collect::<Vec<_>>(),
                 }),
                 rows,
@@ -564,6 +565,19 @@ fn serialize_result(call: &ToolCallRecord, result: OperationResult) -> StoredRes
             "The connected-folder result was too large to return.",
         ),
     }
+}
+
+fn granted_folder_capabilities(capabilities: &[Capability]) -> Vec<GrantedFolderCapability> {
+    capabilities
+        .iter()
+        .filter_map(|capability| match capability {
+            Capability::ReadFiles => Some(GrantedFolderCapability::ReadFiles),
+            Capability::WriteFiles => Some(GrantedFolderCapability::WriteFiles),
+            Capability::ExecuteCommands => Some(GrantedFolderCapability::ExecuteCommands),
+            Capability::ListRoots => None,
+            _ => None,
+        })
+        .collect()
 }
 
 fn truncate_utf8(value: &str, max_bytes: usize) -> (String, bool) {
@@ -661,6 +675,52 @@ fn read_file_name(path: &str) -> String {
 mod tests {
     use super::*;
     use openwave_core::ChatId;
+
+    #[test]
+    fn broker_capabilities_reach_the_model_facing_folder_listing() {
+        let call = ToolCallRecord {
+            id: CallId::new(),
+            chat_id: ChatId::new(),
+            turn_id: openwave_core::TurnId::new(),
+            provider_id: "tool-1".into(),
+            name: LIST_CONNECTED_FOLDERS_TOOL.into(),
+            arguments: serde_json::json!({}),
+            raw_arguments: None,
+            execution: ToolCallExecution::Client,
+            status: ToolCallStatus::Pending,
+            result: None,
+            result_preview: None,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
+            created_at: chrono::Utc::now(),
+            resolved_at: None,
+        };
+        let root_id = RootId::new();
+        let resolution = serialize_result(
+            &call,
+            OperationResult::ListRoots {
+                roots: vec![openwave_host_broker::RootAccess {
+                    root_id,
+                    display_name: "Documents".into(),
+                    capabilities: vec![
+                        Capability::ReadFiles,
+                        Capability::WriteFiles,
+                        Capability::ExecuteCommands,
+                    ],
+                }],
+            },
+        );
+        let StoredResolution::Completed { result, .. } = resolution else {
+            panic!("expected completed result");
+        };
+        let result: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(
+            result["folders"][0]["capabilities"],
+            serde_json::json!(["read_files", "write_files", "execute_commands"])
+        );
+    }
 
     /// The confusion this exists to prevent: the agent writes a file with
     /// `exec`, calls `list_folder` to confirm it, and is shown a folder that

--- a/crates/openwave-desktop/src/client_execution/product_sync.rs
+++ b/crates/openwave-desktop/src/client_execution/product_sync.rs
@@ -150,7 +150,7 @@ async fn drive_product_attachment(
     match begun.change.phase {
         RootAttachmentChangePhase::Completed => {
             verify_completed_product_attachment(state, &begun.change).await?;
-            return connected_resolution(root);
+            return connected_resolution(state, current_context, root).await;
         }
         RootAttachmentChangePhase::Failed => {
             verify_failed_product_attachment(state, &begun.change).await?;
@@ -168,7 +168,7 @@ async fn drive_product_attachment(
     match finished.change.phase {
         RootAttachmentChangePhase::Completed => {
             verify_completed_product_attachment(state, &finished.change).await?;
-            connected_resolution(root)
+            connected_resolution(state, current_context, root).await
         }
         RootAttachmentChangePhase::Failed => {
             verify_failed_product_attachment(state, &finished.change).await?;


### PR DESCRIPTION
## Summary

- report each connected folder’s broker-authorized read, write, and command capabilities in `list_connected_folders` results
- return the broker’s live capability set after folder consent instead of a hardcoded read-only result
- keep folder access requests limited to the existing read-only proposal vocabulary while using a separate result vocabulary for actual grants

## Tests

- `cargo fmt --all --check`
- `cargo test -p openwave-core --locked`
- `cargo test -p openwave-desktop --locked`
- `cargo test -p openwave-server --locked`
- `UPDATE_WIRE_TYPES=1 cargo test -p openwave-server the_generated_bindings_are_current --locked`
- `cargo check --workspace --locked`

Removed the old connected-result unit assertion because the result now intentionally depends on live broker authorization; the new broker-to-serialization regression test covers that boundary directly.

Closes #1444