### PR TITLE
feat(desktop): show background child-agent runs in the transcript

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1097,6 +1097,10 @@ impl Store for DbStore {
         ops::agent_run::list_agent_runs(self, chat_id).await
     }
 
+    async fn get_agent_run_result(&self, id: AgentRunId) -> Result<Option<crate::AgentRunResult>> {
+        ops::agent_run::get_agent_run_result(self, id).await
+    }
+
     async fn claim_agent_run(
         &self,
         lease_token: uuid::Uuid,

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -2835,6 +2835,18 @@ pub(in crate::db) async fn list_agent_runs(
         .collect()
 }
 
+pub(in crate::db) async fn get_agent_run_result(
+    store: &DbStore,
+    id: AgentRunId,
+) -> Result<Option<AgentRunResult>> {
+    entities::agent_run_result::Entity::find_by_id(id.0)
+        .one(&store.conn)
+        .await
+        .map_err(store_err)?
+        .map(agent_run_result_from_model)
+        .transpose()
+}
+
 fn validate_request(
     id: AgentRunId,
     parent_id: Option<AgentRunId>,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -2265,6 +2265,11 @@ pub trait Store: Send + Sync {
         agent_run_storage_unavailable()
     }
 
+    /// Fetch the immutable terminal receipt for one agent run, if it exists.
+    async fn get_agent_run_result(&self, _id: AgentRunId) -> Result<Option<AgentRunResult>> {
+        agent_run_storage_unavailable()
+    }
+
     /// Atomically claim the oldest due sandbox run under exact bounded lease
     /// ownership.
     ///

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
@@ -16,11 +16,13 @@ function run(
     tier: "background",
     execution_location: "in_process",
     status,
+    task: `Task for ${id}`,
     started_at: null,
     finished_at: null,
     last_error_code: null,
     activity: null,
     produced_output: status === "completed",
+    terminal_text: status === "completed" ? `Result from ${id}` : null,
     created_at: "2026-07-27T12:00:00Z",
     updated_at: "2026-07-27T12:00:00Z",
   };
@@ -53,8 +55,29 @@ describe("BackgroundAgentList", () => {
     expect(markup).toContain("2 background agents");
     expect(markup).toContain("Working in the background");
     expect(markup).toContain("Finished");
+    expect(markup).toContain("Task for run-running");
+    expect(markup).toContain("Result from run-completed");
     expect(markup).not.toContain("Could not finish");
     expect(markup.indexOf("Running")).toBeLessThan(markup.indexOf("Completed"));
+  });
+
+  it("shows a terminal failure error", () => {
+    const failed = run("run-failed", "call-failed", "failed");
+    failed.terminal_text = "Sandbox task failed (provider_error): request timed out";
+    const markup = renderToStaticMarkup(
+      <BackgroundAgentList
+        spawns={[{ callId: "call-failed", status: "completed" }]}
+        runs={[failed]}
+        loading={false}
+        error={null}
+        onRetry={() => undefined}
+        onCancel={noop}
+        onLoadActivity={noActivity}
+      />,
+    );
+
+    expect(markup).toContain("Error:");
+    expect(markup).toContain("request timed out");
   });
 
   it("shows a skeleton as soon as a spawn is visible but not durable yet", () => {

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
@@ -63,7 +63,7 @@ describe("BackgroundAgentList", () => {
 
   it("shows a terminal failure error", () => {
     const failed = run("run-failed", "call-failed", "failed");
-    failed.terminal_text = "Sandbox task failed (provider_error): request timed out";
+    failed.terminal_text = "Sandbox task failed (provider_error)";
     const markup = renderToStaticMarkup(
       <BackgroundAgentList
         spawns={[{ callId: "call-failed", status: "completed" }]}
@@ -77,7 +77,7 @@ describe("BackgroundAgentList", () => {
     );
 
     expect(markup).toContain("Error:");
-    expect(markup).toContain("request timed out");
+    expect(markup).toContain("Sandbox task failed (provider_error)");
   });
 
   it("shows a skeleton as soon as a spawn is visible but not durable yet", () => {

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
@@ -223,6 +223,7 @@ function BackgroundAgentRow({
   };
 
   const contentId = `background-agent-activity-${run.id}`;
+  const terminalLabel = run.status === "failed" ? "Error" : "Result";
 
   return (
     <div className="px-3 py-2.5">
@@ -254,8 +255,11 @@ function BackgroundAgentRow({
             className={cn("size-2 shrink-0 rounded-full", getAgentRunDotClass(run.status))}
             aria-hidden="true"
           />
-          <span className="min-w-0 flex-1 truncate font-medium text-foreground">
-            {label}
+          <span className="min-w-0 flex-1">
+            <span className="block truncate font-medium text-foreground">{label}</span>
+            {run.task && (
+              <span className="block truncate text-xs text-muted-foreground">{run.task}</span>
+            )}
           </span>
         </button>
         <span className="shrink-0 text-xs text-muted-foreground">
@@ -287,6 +291,12 @@ function BackgroundAgentRow({
           </Button>
         )}
       </div>
+      {run.terminal_text && (
+        <div className="mt-2 rounded-md bg-muted/50 px-2.5 py-2 text-sm text-foreground">
+          <span className="font-medium">{terminalLabel}: </span>
+          <span className="whitespace-pre-wrap break-words">{run.terminal_text}</span>
+        </div>
+      )}
       {expanded && (
         <div id={contentId} className="mt-2 pl-5">
           <AgentActivityTimeline state={activity} />

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -23,11 +23,13 @@ function backgroundRun(
     tier: "background",
     execution_location: "in_process",
     status,
+    task: `Task for ${id}`,
     started_at: null,
     finished_at: null,
     last_error_code: null,
     activity: null,
     produced_output: status === "completed",
+    terminal_text: status === "completed" ? `Result from ${id}` : null,
     created_at: "2026-07-27T12:00:00Z",
     updated_at: "2026-07-27T12:00:00Z",
   };

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -74,10 +74,14 @@ export type AgentRunId = string;
 /**
  * Renderer-safe state for one agent run.
  *
- * Worker lease tokens, delegated inputs, scheduling budgets, and other
- * executor-facing fields intentionally remain inside the server/store boundary.
+ * Worker lease tokens, scheduling budgets, and other executor-facing fields
+ * intentionally remain inside the server/store boundary.
  */
-export type AgentRunSnapshot = { id: AgentRunId, parent_id: AgentRunId | null, tier: AgentRunTier, execution_location: AgentRunExecutionLocation, status: AgentRunStatus, started_at: string | null, finished_at: string | null, 
+export type AgentRunSnapshot = { id: AgentRunId, parent_id: AgentRunId | null, tier: AgentRunTier, execution_location: AgentRunExecutionLocation, status: AgentRunStatus, 
+/**
+ * The exact bounded task delegated by the visible spawn step.
+ */
+task: string | null, started_at: string | null, finished_at: string | null, 
 /**
  * Stable, bounded classification suitable for renderer display.
  */
@@ -98,7 +102,11 @@ activity: AgentActivitySnapshot | null,
  * deliverable never cross this boundary. A renderer uses it to offer a
  * "view output" affordance and link to the outputs surface.
  */
-produced_output: boolean, created_at: string, updated_at: string, spawn_call_id: CallId | null, };
+produced_output: boolean, 
+/**
+ * Bounded terminal display text returned to the parent, if settled.
+ */
+terminal_text: string | null, created_at: string, updated_at: string, spawn_call_id: CallId | null, };
 
 /**
  * Durable lifecycle of an [`AgentRun`].

--- a/crates/openwave-desktop/ui/src/useAgentRuns.test.ts
+++ b/crates/openwave-desktop/ui/src/useAgentRuns.test.ts
@@ -13,11 +13,13 @@ function run(status: AgentRun["status"] = "running"): AgentRun {
     tier: "background",
     execution_location: "in_process",
     status,
+    task: "Task for run-1",
     started_at: null,
     finished_at: null,
     last_error_code: null,
     activity: null,
     produced_output: status === "completed",
+    terminal_text: status === "completed" ? "Result from run-1" : null,
     created_at: "2026-07-27T12:00:00Z",
     updated_at: "2026-07-27T12:00:00Z",
   };

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -2406,13 +2406,16 @@ pub async fn list_agent_runs(
     let now = Utc::now();
     let mut snapshots = Vec::with_capacity(runs.len());
     for run in runs {
-        let terminal_text = if run.status.is_terminal() {
-            store
+        let terminal_text = match run.status {
+            AgentRunStatus::Completed | AgentRunStatus::Cancelled => store
                 .get_agent_run_result(run.id)
                 .await?
-                .map(|result| result.text)
-        } else {
-            None
+                .map(|result| result.text),
+            AgentRunStatus::Failed => run
+                .last_error_code
+                .as_deref()
+                .map(|code| format!("Sandbox task failed ({code})")),
+            _ => None,
         };
         let activity = if run.tier == AgentRunTier::Background {
             let calls = store.list_sandbox_tool_calls_for_agent_run(run.id).await?;

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -2160,8 +2160,8 @@ fn remove_private_chat_scratch(root: &FsPath, id: ChatId) -> std::io::Result<()>
 
 /// Renderer-safe state for one agent run.
 ///
-/// Worker lease tokens, delegated inputs, scheduling budgets, and other
-/// executor-facing fields intentionally remain inside the server/store boundary.
+/// Worker lease tokens, scheduling budgets, and other executor-facing fields
+/// intentionally remain inside the server/store boundary.
 #[derive(Debug, Serialize, ts_rs::TS)]
 pub struct AgentRunSnapshot {
     pub id: openwave_core::AgentRunId,
@@ -2169,6 +2169,8 @@ pub struct AgentRunSnapshot {
     pub tier: AgentRunTier,
     pub execution_location: AgentRunExecutionLocation,
     pub status: AgentRunStatus,
+    /// The exact bounded task delegated by the visible spawn step.
+    pub task: Option<String>,
     pub started_at: Option<chrono::DateTime<Utc>>,
     pub finished_at: Option<chrono::DateTime<Utc>>,
     /// Stable, bounded classification suitable for renderer display.
@@ -2186,6 +2188,8 @@ pub struct AgentRunSnapshot {
     /// deliverable never cross this boundary. A renderer uses it to offer a
     /// "view output" affordance and link to the outputs surface.
     pub produced_output: bool,
+    /// Bounded terminal display text returned to the parent, if settled.
+    pub terminal_text: Option<String>,
     pub created_at: chrono::DateTime<Utc>,
     pub updated_at: chrono::DateTime<Utc>,
     // This is an OpenWave call id, not a provider call identity. It lets a
@@ -2195,7 +2199,11 @@ pub struct AgentRunSnapshot {
 }
 
 impl AgentRunSnapshot {
-    fn from_run(run: AgentRun, activity: Option<AgentActivitySnapshot>) -> Self {
+    fn from_run(
+        run: AgentRun,
+        activity: Option<AgentActivitySnapshot>,
+        terminal_text: Option<String>,
+    ) -> Self {
         // A background child commits its final result receipt in the same
         // transaction as its terminal `Completed` state, so the terminal state
         // is an exact, renderer-safe proxy for output presence.
@@ -2208,11 +2216,13 @@ impl AgentRunSnapshot {
             tier: run.tier,
             execution_location: run.execution_location,
             status: run.status,
+            task: run.input,
             started_at: run.started_at,
             finished_at: run.finished_at,
             last_error_code: run.last_error_code,
             activity,
             produced_output,
+            terminal_text,
             created_at: run.created_at,
             updated_at: run.updated_at,
         }
@@ -2396,6 +2406,14 @@ pub async fn list_agent_runs(
     let now = Utc::now();
     let mut snapshots = Vec::with_capacity(runs.len());
     for run in runs {
+        let terminal_text = if run.status.is_terminal() {
+            store
+                .get_agent_run_result(run.id)
+                .await?
+                .map(|result| result.text)
+        } else {
+            None
+        };
         let activity = if run.tier == AgentRunTier::Background {
             let calls = store.list_sandbox_tool_calls_for_agent_run(run.id).await?;
             sandbox_activity(&calls)
@@ -2404,7 +2422,7 @@ pub async fn list_agent_runs(
         } else {
             None
         };
-        snapshots.push(AgentRunSnapshot::from_run(run, activity));
+        snapshots.push(AgentRunSnapshot::from_run(run, activity, terminal_text));
     }
     Ok(Json(snapshots))
 }

--- a/crates/openwave-server/src/scoped_store.rs
+++ b/crates/openwave-server/src/scoped_store.rs
@@ -26,8 +26,8 @@ use axum::http::request::Parts;
 use axum::http::StatusCode;
 
 use openwave_core::{
-    AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentRun, AgentRunId, CallId, Chat, ChatId,
-    ChatTranscriptSnapshot, DeleteChatOutcome, DeleteProjectOutcome, DocumentId,
+    AcceptTurnOutcome, AcceptTurnSteerOutcome, AgentRun, AgentRunId, AgentRunResult, CallId, Chat,
+    ChatId, ChatTranscriptSnapshot, DeleteChatOutcome, DeleteProjectOutcome, DocumentId,
     DocumentListCursor, DocumentRecord, DocumentScope, DocumentSourceUpsert, DocumentSummaryRecord,
     ImageRef, JournaledTurnOutcome, NetworkPolicy, OwnerId, PermissionMode, Project, ProjectId,
     ReasoningEffort, RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome, Result,
@@ -256,6 +256,11 @@ impl ScopedStore {
     /// [`Store::get_agent_run`].
     pub async fn get_agent_run(&self, id: AgentRunId) -> Result<Option<AgentRun>> {
         self.store.get_agent_run(id).await
+    }
+
+    /// [`Store::get_agent_run_result`].
+    pub async fn get_agent_run_result(&self, id: AgentRunId) -> Result<Option<AgentRunResult>> {
+        self.store.get_agent_run_result(id).await
     }
 
     /// [`Store::request_agent_run_cancellation`].

--- a/crates/openwave-server/src/tests/sandbox.rs
+++ b/crates/openwave-server/src/tests/sandbox.rs
@@ -313,6 +313,11 @@ async fn agent_run_activity_history_is_ordered_renderer_safe_and_flags_a_produce
         snapshot.get("produced_output"),
         Some(&serde_json::json!(true))
     );
+    assert_eq!(snapshot.get("task"), Some(&serde_json::json!("research")));
+    assert_eq!(
+        snapshot.get("terminal_text"),
+        Some(&serde_json::json!("final answer"))
+    );
     assert_eq!(snapshot.get("activity"), Some(&serde_json::json!(null)));
 
     // The activity history is the ordered, terminal-outcome projection.
@@ -1170,28 +1175,33 @@ async fn agent_run_snapshots_omit_persisted_raw_failure_detail() {
     let chat: Chat = json_body(response).await;
 
     let run = admit_sandbox_for_test(&store, chat.id, "research").await;
-    let lease_token = uuid::Uuid::new_v4();
-    assert_eq!(
-        store
-            .claim_agent_run(lease_token, chrono::Duration::minutes(5), 1, 1)
+    let raw_detail = "upstream request failed: Authorization: Bearer private-token";
+    for attempt in 1..=openwave_core::AgentRun::DEFAULT_MAX_ATTEMPTS {
+        let lease_token = uuid::Uuid::new_v4();
+        assert_eq!(
+            store
+                .claim_agent_run(lease_token, chrono::Duration::minutes(5), 1, 1)
+                .await
+                .unwrap()
+                .unwrap()
+                .id,
+            run.id
+        );
+        assert!(store
+            .fail_agent_run(
+                run.id,
+                lease_token,
+                "sandbox_transport_failed",
+                raw_detail,
+                chrono::Duration::microseconds(1),
+            )
             .await
             .unwrap()
-            .unwrap()
-            .id,
-        run.id
-    );
-    let raw_detail = "upstream request failed: Authorization: Bearer private-token";
-    assert!(store
-        .fail_agent_run(
-            run.id,
-            lease_token,
-            "sandbox_transport_failed",
-            raw_detail,
-            chrono::Duration::seconds(1),
-        )
-        .await
-        .unwrap()
-        .is_some());
+            .is_some());
+        if attempt < openwave_core::AgentRun::DEFAULT_MAX_ATTEMPTS {
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+    }
     assert_eq!(
         store
             .get_agent_run(run.id)
@@ -1223,8 +1233,11 @@ async fn agent_run_snapshots_omit_persisted_raw_failure_detail() {
         snapshot.get("last_error_code"),
         Some(&serde_json::json!("sandbox_transport_failed"))
     );
+    assert_eq!(
+        snapshot.get("terminal_text"),
+        Some(&serde_json::json!(format!(
+            "Sandbox task failed (sandbox_transport_failed): {raw_detail}"
+        )))
+    );
     assert!(snapshot.get("last_error_detail").is_none());
-    assert!(!serde_json::to_string(snapshot)
-        .unwrap()
-        .contains(raw_detail));
 }

--- a/crates/openwave-server/src/tests/sandbox.rs
+++ b/crates/openwave-server/src/tests/sandbox.rs
@@ -1235,9 +1235,12 @@ async fn agent_run_snapshots_omit_persisted_raw_failure_detail() {
     );
     assert_eq!(
         snapshot.get("terminal_text"),
-        Some(&serde_json::json!(format!(
-            "Sandbox task failed (sandbox_transport_failed): {raw_detail}"
-        )))
+        Some(&serde_json::json!(
+            "Sandbox task failed (sandbox_transport_failed)"
+        ))
     );
     assert!(snapshot.get("last_error_detail").is_none());
+    assert!(!serde_json::to_string(snapshot)
+        .unwrap()
+        .contains(raw_detail));
 }


### PR DESCRIPTION
## Summary

- show each background child’s delegated task beneath its existing transcript status row
- show the immutable terminal result or failure text when the child settles
- keep the existing live status refresh path and transcript card styling

This is step 3 of #1454: minimum viable child-run status in the transcript. It does not add live sibling/subagent inspection (#954), mid-run steering (#951), or any other steps from the parent issue.

## Verification

- `cargo fmt --all --check`
- `cargo test -p openwave-server --locked`
- `pnpm test`
- `pnpm build`