### PR TITLE
fix(core): recover create_app's parked approval as the workspace kind

### DIFF
--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -107,6 +107,11 @@ impl ToolApprovalKind {
             "web_extract" => Self::WebExtractMayFetchUrl,
             "exec" => Self::ExecMayRunNetworkedCommand,
             "write_file" => Self::WorkspaceMayModifyFiles,
+            // `create_app` writes app revisions, a `Workspace`-class effect.
+            // Recovery of a parked call re-derives the kind from this table
+            // alone, so a workspace tool missing here parks as an approvable
+            // card the renderer presents and then 409s the approval itself.
+            "create_app" => Self::WorkspaceMayModifyFiles,
             name if name.starts_with("mcp__") => Self::ExternalMcpMayCallServer,
             _ => Self::Unsupported,
         }

--- a/crates/openwave-server/src/approvals.rs
+++ b/crates/openwave-server/src/approvals.rs
@@ -1493,6 +1493,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_parked_create_app_call_can_be_approved() {
+        // `create_app` is `Workspace`-class, so in Ask mode it parks behind
+        // the workspace consent card. The card is presentable and approvable;
+        // resolving re-derives the kind from the stored tool name, so a name
+        // missing from `for_tool_name` made every approval of that card 409
+        // (`NotApprovable`) while the renderer showed an approvable prompt.
+        let (store, request) = setup("create_app").await;
+        assert_eq!(
+            request.kind,
+            openwave_core::ToolApprovalKind::WorkspaceMayModifyFiles
+        );
+        let broker = ApprovalBroker::new(store);
+        let _pending = broker.register(request.clone(), None).await;
+        assert_eq!(
+            broker
+                .resolve(request.chat_id, request.call_id, ApprovalDecision::Approve)
+                .await
+                .unwrap(),
+            ResolveApprovalOutcome::Resolved
+        );
+    }
+
+    #[tokio::test]
     async fn unknown_action_cannot_be_approved_but_can_be_rejected() {
         let (store, request) = setup("third_party_sensitive").await;
         let broker = ApprovalBroker::new(store);


### PR DESCRIPTION
Found smoke-testing local apps end to end: ask chat to build an app, get the workspace consent card ("Allow OpenWave to create or modify files in this chat's workspace?"), click Approve — and the decision fails with `409: this action cannot be approved from the renderer`.

## Cause

Two kind derivations disagree about `create_app`:

- **At park time**, the kind comes from `ToolApprovalKind::for_call`, which folds any `Workspace`-class tool into `WorkspaceMayModifyFiles` — so the renderer presents the approvable workspace card.
- **At decide time**, the broker re-reads the stored call, and recovery re-derives the kind from `for_tool_name` — the name table alone (the DB column stores the legacy fold, not the kind). `create_app` was missing from that table, so the stored call recovered as `Unsupported`, whose `is_approvable()` is false → every Approve of the card 409s while Reject works.

The card was approvable on screen and unapprovable on the wire — worse than fail-closed, because the human's consent was solicited and then discarded.

## Fix

`create_app` joins the name table as `WorkspaceMayModifyFiles`, the kind it already parks and renders under. One arm plus a comment explaining the park/recover asymmetry so the next Workspace-class tool doesn't repeat this.

## Test

`a_parked_create_app_call_can_be_approved` drives the broker over the store-recovered call: the kind assertion pins the table entry, and the resolve leg pins that Approve resolves instead of refusing. Approvals suite (24) and the core approval tests (37) pass.

Note for reviewers: `write_file` was already in the table; `create_app` was the only `Workspace`-class tool missing. The generic degradation for genuinely unknown workspace tools (recover as rejectable-only) is unchanged.
