### PR TITLE
fix(desktop): gate folder exec grants by local support

### DIFF
--- a/crates/openwave-desktop/src/broker.rs
+++ b/crates/openwave-desktop/src/broker.rs
@@ -1,7 +1,7 @@
 //! Native-only lifecycle client for the capability-gated host-broker sidecar.
 
 use std::{
-    ffi::{OsStr, OsString},
+    ffi::OsString,
     path::{Path, PathBuf},
     process::Stdio,
     sync::Mutex as StdMutex,
@@ -60,6 +60,8 @@ impl BrokerClient {
                 app,
                 data_dir,
                 home_dir,
+                execute_commands: openwave_code_execution::LocalExecutionProvider::availability()
+                    .is_ok(),
                 session: None,
             }
             .run(receiver),
@@ -170,6 +172,7 @@ struct BrokerWorker {
     app: AppHandle,
     data_dir: PathBuf,
     home_dir: PathBuf,
+    execute_commands: bool,
     session: Option<Session>,
 }
 
@@ -259,7 +262,15 @@ impl BrokerWorker {
             return Err(BrokerClientError::DispatchExpired);
         }
         if self.session.is_none() {
-            self.session = Some(Session::start(&self.app, &self.data_dir, &self.home_dir).await?);
+            self.session = Some(
+                Session::start(
+                    &self.app,
+                    &self.data_dir,
+                    &self.home_dir,
+                    self.execute_commands,
+                )
+                .await?,
+            );
         }
         if dispatch_deadline.is_some_and(|deadline| Instant::now() >= deadline) {
             return Err(BrokerClientError::DispatchExpired);
@@ -306,17 +317,22 @@ impl Session {
         app: &AppHandle,
         data_dir: &Path,
         home_dir: &Path,
+        execute_commands: bool,
     ) -> Result<Self, BrokerClientError> {
+        let mut args = vec![
+            OsString::from("--data-dir"),
+            data_dir.as_os_str().to_owned(),
+            OsString::from("--home"),
+            home_dir.as_os_str().to_owned(),
+        ];
+        if execute_commands {
+            args.push(OsString::from("--execute-commands"));
+        }
         let mut sidecar = app
             .shell()
             .sidecar(SIDECAR_NAME)
             .map_err(|_| BrokerClientError::Start)?
-            .args([
-                OsStr::new("--data-dir"),
-                data_dir.as_os_str(),
-                OsStr::new("--home"),
-                home_dir.as_os_str(),
-            ])
+            .args(args)
             .env_clear();
         sidecar = sidecar.envs(minimal_environment());
 

--- a/crates/openwave-host-broker/src/bin/openwave-host-broker.rs
+++ b/crates/openwave-host-broker/src/bin/openwave-host-broker.rs
@@ -37,7 +37,8 @@ fn main() -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    let broker = match Broker::open(policy, &data_dir) {
+    let broker = match Broker::open_with_execute_commands(policy, &data_dir, args.execute_commands)
+    {
         Ok(broker) => broker,
         Err(error) => {
             eprintln!("openwave-host-broker: could not open broker state: {error}");
@@ -59,13 +60,22 @@ fn main() -> ExitCode {
 struct Args {
     data_dir: PathBuf,
     home: PathBuf,
+    execute_commands: bool,
 }
 
 impl Args {
     fn parse(mut args: impl Iterator<Item = OsString>) -> Result<Self, &'static str> {
         let mut data_dir = None;
         let mut home = None;
+        let mut execute_commands = false;
         while let Some(argument) = args.next() {
+            if argument == OsStr::new("--execute-commands") {
+                if execute_commands {
+                    return Err("duplicate sidecar argument");
+                }
+                execute_commands = true;
+                continue;
+            }
             let destination = match argument.as_os_str() {
                 value if value == OsStr::new("--data-dir") && data_dir.is_none() => &mut data_dir,
                 value if value == OsStr::new("--home") && home.is_none() => &mut home,
@@ -83,7 +93,11 @@ impl Args {
         if !data_dir.is_absolute() || !home.is_absolute() {
             return Err("sidecar paths must be absolute");
         }
-        Ok(Self { data_dir, home })
+        Ok(Self {
+            data_dir,
+            home,
+            execute_commands,
+        })
     }
 }
 

--- a/crates/openwave-host-broker/src/broker.rs
+++ b/crates/openwave-host-broker/src/broker.rs
@@ -137,6 +137,7 @@ pub struct Operator {
 
 struct Shared {
     policy: RootPolicy,
+    execute_commands: bool,
     state: Mutex<State>,
     state_file: Option<StateFile>,
     audit: Arc<dyn AuditSink>,
@@ -303,7 +304,7 @@ struct PreparedRegistration {
     conversation_id: Uuid,
     root_id: RootId,
     root: RegisteredRoot,
-    grants: [Grant; 4],
+    grants: Vec<Grant>,
     attachment: RootAttachment,
 }
 
@@ -551,9 +552,15 @@ impl OperationAudit {
 impl Broker {
     /// Create an empty broker using the reviewed host-root policy.
     pub fn new(policy: RootPolicy) -> Self {
+        Self::new_with_execute_commands(policy, true)
+    }
+
+    /// Create an empty broker with the host's local command reach declared.
+    pub fn new_with_execute_commands(policy: RootPolicy, execute_commands: bool) -> Self {
         Self {
             shared: Arc::new(Shared {
                 policy,
+                execute_commands,
                 state: Mutex::new(State::default()),
                 state_file: None,
                 audit: Arc::new(MemoryAuditSink::new()),
@@ -567,6 +574,7 @@ impl Broker {
         Self {
             shared: Arc::new(Shared {
                 policy,
+                execute_commands: true,
                 state: Mutex::new(State::default()),
                 state_file: None,
                 audit,
@@ -579,8 +587,17 @@ impl Broker {
     /// Persisted roots are revalidated and descriptor-pinned before this
     /// constructor returns, so stale state is never advertised.
     pub fn open(policy: RootPolicy, data_dir: &Path) -> Result<Self, BrokerError> {
+        Self::open_with_execute_commands(policy, data_dir, true)
+    }
+
+    /// Open durable broker state with the host's local command reach declared.
+    pub fn open_with_execute_commands(
+        policy: RootPolicy,
+        data_dir: &Path,
+        execute_commands: bool,
+    ) -> Result<Self, BrokerError> {
         let state_file = StateFile::open(data_dir)?;
-        let state = state_file.load(&policy)?;
+        let state = state_file.load(&policy, execute_commands)?;
         // A sink that could not be prepared is not replaced by one that discards
         // records: it stays the real sink, refusing until the host can hold the
         // log. Registration and writes fail with a stated reason, reads keep
@@ -594,6 +611,7 @@ impl Broker {
         let broker = Self {
             shared: Arc::new(Shared {
                 policy,
+                execute_commands,
                 state: Mutex::new(state),
                 state_file: Some(state_file),
                 audit,
@@ -767,6 +785,7 @@ impl Controller {
                         prepared.root.owner,
                         root_id,
                         prepared.grants[0].consent().clone(),
+                        self.shared.execute_commands,
                     )
                     .map_err(error_response)?;
                     if !next.attachments.iter().any(|attachment| {
@@ -916,13 +935,16 @@ impl Controller {
         // exec reach is part of that consent rather than a second prompt. The
         // capability exists so it can be named, audited, and revoked on its own
         // afterwards, not to add a step here.
-        let exec_grant = Grant::from_consent(
-            GrantId::new(),
-            request.subject,
-            Capability::ExecuteCommands,
-            Scope::Root { root_id },
-            consent,
-        )?;
+        let mut grants = vec![list_grant, read_grant, write_grant];
+        if self.shared.execute_commands {
+            grants.push(Grant::from_consent(
+                GrantId::new(),
+                request.subject,
+                Capability::ExecuteCommands,
+                Scope::Root { root_id },
+                consent,
+            )?);
+        }
         Ok(PreparedRegistration {
             conversation_id: request.conversation_id,
             root_id,
@@ -931,7 +953,7 @@ impl Controller {
                 display_name,
                 root: Arc::new(validated),
             },
-            grants: [list_grant, read_grant, write_grant, exec_grant],
+            grants,
             attachment: RootAttachment::new(request.conversation_id, root_id)?,
         })
     }
@@ -957,7 +979,8 @@ impl Controller {
             Claim::Start => {}
         }
 
-        let result = apply_root_attachment(&mut next, fingerprint).map_err(error_response);
+        let result = apply_root_attachment(&mut next, fingerprint, self.shared.execute_commands)
+            .map_err(error_response);
         complete_attachment(&mut next, request.operation_id, fingerprint, result.clone())
             .map_err(error_response)?;
         self.commit_state(&mut state, next)
@@ -1124,6 +1147,9 @@ impl Controller {
         if !has_root_attachment(&next, request.conversation_id, request.root_id) {
             return Err(error_response(BrokerError::Denied));
         }
+        if request.capability == Capability::ExecuteCommands && !self.shared.execute_commands {
+            return Err(error_response(BrokerError::Denied));
+        }
         let already_granted = next.grants.iter().any(|grant| {
             grant.subject() == request.subject
                 && grant.capability() == request.capability
@@ -1213,7 +1239,8 @@ impl Operator {
             match envelope.request {
                 OperationRequest::ListRoots => {
                     let state = self.lock_state()?;
-                    let (result, authorized_by) = list_roots(&state, envelope.context)?;
+                    let (result, authorized_by) =
+                        list_roots(&state, envelope.context, self.shared.execute_commands)?;
                     grant_id = authorized_by;
                     Ok(result)
                 }
@@ -2067,6 +2094,7 @@ fn destination_matches(root: &Dir, path: &RelativePath, byte_len: usize, sha256:
 fn apply_root_attachment(
     state: &mut State,
     request: AttachmentFingerprint,
+    execute_commands: bool,
 ) -> Result<RootAttachmentMutationResult, BrokerError> {
     validate_subject_conversation(request.subject, request.conversation_id)?;
     let changed = match request.mutation {
@@ -2084,7 +2112,13 @@ fn apply_root_attachment(
                 return Err(BrokerError::InvalidConsentMethod);
             }
             let consent = ConsentRecord::new(method, Utc::now());
-            ensure_subject_grants(state, request.subject, request.root_id, consent)?;
+            ensure_subject_grants(
+                state,
+                request.subject,
+                request.root_id,
+                consent,
+                execute_commands,
+            )?;
             if has_root_attachment(state, request.conversation_id, request.root_id) {
                 false
             } else {
@@ -2233,6 +2267,7 @@ fn ensure_subject_grants(
     subject: GrantSubject,
     root_id: RootId,
     consent: ConsentRecord,
+    execute_commands: bool,
 ) -> Result<(), BrokerError> {
     if !state.grants.iter().any(|grant| {
         grant.subject() == subject
@@ -2269,11 +2304,13 @@ fn ensure_subject_grants(
             consent.clone(),
         )?);
     }
-    if !state.grants.iter().any(|grant| {
-        grant.subject() == subject
-            && grant.capability() == Capability::ExecuteCommands
-            && matches!(grant.scope(), Scope::Root { root_id: granted } if *granted == root_id)
-    }) {
+    if execute_commands
+        && !state.grants.iter().any(|grant| {
+            grant.subject() == subject
+                && grant.capability() == Capability::ExecuteCommands
+                && matches!(grant.scope(), Scope::Root { root_id: granted } if *granted == root_id)
+        })
+    {
         state.grants.push(Grant::from_consent(
             GrantId::new(),
             subject,
@@ -2453,6 +2490,7 @@ fn list_unavailable_roots(state: &State) -> Result<Vec<UnavailableRootSummary>, 
 fn list_roots(
     state: &State,
     context: ExecutionContext,
+    execute_commands: bool,
 ) -> Result<(OperationResult, Option<GrantId>), BrokerError> {
     if !state
         .attachments
@@ -2477,7 +2515,7 @@ fn list_roots(
         .map(|(root_id, root)| RootAccess {
             root_id: *root_id,
             display_name: root.display_name.clone(),
-            capabilities: root_capabilities(state, context, root_id),
+            capabilities: root_capabilities(state, context, root_id, execute_commands),
         })
         .take(MAX_LIST_ROOTS + 1)
         .collect::<Vec<_>>();
@@ -2561,6 +2599,7 @@ fn root_capabilities(
     state: &State,
     context: ExecutionContext,
     root_id: &RootId,
+    execute_commands: bool,
 ) -> Vec<Capability> {
     let mut capabilities = [Capability::ReadFiles, Capability::WriteFiles]
         .into_iter()
@@ -2568,7 +2607,7 @@ fn root_capabilities(
             authorize(state, context, *capability, Resource::Root(root_id)).is_ok()
         })
         .collect::<Vec<_>>();
-    if authorize_exec_reach(state, context, root_id).is_ok() {
+    if execute_commands && authorize_exec_reach(state, context, root_id).is_ok() {
         capabilities.push(Capability::ExecuteCommands);
     }
     capabilities

--- a/crates/openwave-host-broker/src/broker/state_file.rs
+++ b/crates/openwave-host-broker/src/broker/state_file.rs
@@ -95,7 +95,11 @@ impl StateFile {
         })
     }
 
-    pub(super) fn load(&self, policy: &RootPolicy) -> Result<State, BrokerError> {
+    pub(super) fn load(
+        &self,
+        policy: &RootPolicy,
+        execute_commands: bool,
+    ) -> Result<State, BrokerError> {
         let mut file = match File::open(&self.path) {
             Ok(file) => file,
             Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(State::default()),
@@ -150,8 +154,11 @@ impl StateFile {
         }
 
         let mut grants = persisted.grants;
-        if persisted.version < 4 {
+        if persisted.version < 4 && execute_commands {
             carry_forward_exec_grants(&mut grants)?;
+        }
+        if !execute_commands {
+            grants.retain(|grant| grant.capability() != Capability::ExecuteCommands);
         }
         let mut attachments = persisted.attachments;
         for root in &mut unavailable {

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -48,6 +48,38 @@ fn setup() -> (tempfile::TempDir, Broker, PathBuf) {
     (temp, Broker::new(policy), root)
 }
 
+#[test]
+fn a_no_exec_host_does_not_report_command_reach_for_a_fresh_folder() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("home/Documents");
+    std::fs::create_dir_all(&root).unwrap();
+    let broker = Broker::new_with_execute_commands(test_policy(&temp), false);
+    let conversation = Uuid::new_v4();
+    let registered = register(
+        &broker.controller(),
+        GrantSubject::conversation(conversation).unwrap(),
+        conversation,
+        root,
+        OperationId::new(),
+    );
+
+    assert_eq!(
+        operate(
+            &broker.operator(),
+            ExecutionContext::standalone(conversation).unwrap(),
+            OperationRequest::ListRoots,
+        )
+        .unwrap(),
+        OperationResult::ListRoots {
+            roots: vec![RootAccess {
+                root_id: registered.root.root_id,
+                display_name: registered.root.display_name,
+                capabilities: vec![Capability::ReadFiles, Capability::WriteFiles],
+            }],
+        }
+    );
+}
+
 fn durable_setup() -> (tempfile::TempDir, Broker, PathBuf, PathBuf) {
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path().join("home/Documents");
@@ -1609,7 +1641,11 @@ fn connected_root_results_are_bounded_before_transport_serialization() {
         );
     }
     assert!(matches!(
-        list_roots(&state, ExecutionContext::standalone(conversation).unwrap()),
+        list_roots(
+            &state,
+            ExecutionContext::standalone(conversation).unwrap(),
+            true,
+        ),
         Err(BrokerError::RootListTooLarge)
     ));
 }


### PR DESCRIPTION
## Summary

- pass native local-execution availability from the desktop host into the broker sidecar
- refuse to mint, migrate, widen, or report folder command reach when the host has no local execution provider
- keep read and write folder capabilities available independently

Closes #1530

## Verification

`cargo fmt --all`

```text
completed successfully (no output)
```

`cargo test -p openwave-host-broker -p openwave-desktop --locked`

```text
test result: ok. 112 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.60s;test result: ok. 97 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.02s test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s;test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.54s test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

`cargo check --workspace --locked`

```text
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 15.28s
warning: the following packages contain code that will be rejected by a future version of Rust: proc-macro-error2 v2.0.1
```
