### PR TITLE
fix(host-broker): harden root containment for Windows path semantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,14 @@ jobs:
           -p openwave-server
           -p openwave-desktop
           --locked
+      # The host broker's containment tests are the only ones in the workspace
+      # that need real NTFS — directory junctions, hidden shares, 8.3 short
+      # names. `cargo check` never compiles a test target, so without this step
+      # those tests exist and run nowhere. Deliberately one crate: this lane is
+      # for the checks that cannot be answered off Windows, not a second copy of
+      # the workspace suite.
+      - name: Host broker containment tests
+        run: cargo test -p openwave-host-broker --locked
 
   test:
     name: test

--- a/crates/openwave-host-broker/src/audit.rs
+++ b/crates/openwave-host-broker/src/audit.rs
@@ -361,12 +361,27 @@ impl JsonlAuditSink {
             file.sync_all()
         });
         if let Err(source) = write_result {
-            return match file.set_len(original_length).and_then(|()| file.sync_all()) {
+            return match self.roll_back_to(original_length) {
                 Ok(()) => Err(AppendFailure::safe(source)),
                 Err(_) => Err(AppendFailure::ambiguous(source)),
             };
         }
         Ok(())
+    }
+
+    /// Return the log to the length it had before a failed append.
+    ///
+    /// This needs a second handle rather than the appending one. Windows opens
+    /// a file for append with `FILE_APPEND_DATA` and explicitly *without*
+    /// `FILE_WRITE_DATA`, and `SetEndOfFile` requires `FILE_WRITE_DATA`, so
+    /// truncating through the appending handle always fails there. That failure
+    /// is not cosmetic: it turns every transient write failure into an
+    /// ambiguous one, which refuses the operation and demands a broker restart
+    /// instead of allowing a clean retry.
+    fn roll_back_to(&self, length: u64) -> io::Result<()> {
+        let file = OpenOptions::new().write(true).open(&self.path)?;
+        file.set_len(length)?;
+        file.sync_all()
     }
 
     fn rotate(&self, writer: &mut WriterState) -> io::Result<()> {

--- a/crates/openwave-host-broker/src/broker/tests.rs
+++ b/crates/openwave-host-broker/src/broker/tests.rs
@@ -3381,6 +3381,11 @@ fn exec_grant(subject: GrantSubject, root_id: RootId) -> Grant {
     .unwrap()
 }
 
+/// A registered root must never hand its path to exec once something else has
+/// taken that path. Unix permits the rename that stages this, so the broker
+/// closes the gap itself by re-confirming the directory's identity before the
+/// path leaves it.
+#[cfg(unix)]
 #[test]
 fn exec_root_resolution_rejects_a_replaced_registered_path() {
     let (temp, broker, path) = setup();
@@ -3403,6 +3408,41 @@ fn exec_root_resolution_rejects_a_replaced_registered_path() {
     )
     .unwrap_err();
     assert_eq!(error.code, ErrorCode::HostIo);
+}
+
+/// The same invariant on Windows, enforced a layer lower: the rename that the
+/// Unix test performs cannot happen at all while the root is pinned, because
+/// cap-std opens directories without `FILE_SHARE_DELETE` precisely so a
+/// registered directory cannot be renamed or deleted underneath it. Asserting
+/// the refusal is what keeps that guarantee from being lost in a dependency
+/// bump — if the share mode ever widened, the rename would start succeeding
+/// here and the identity re-check would become load-bearing on Windows too.
+#[cfg(windows)]
+#[test]
+fn a_registered_root_cannot_be_replaced_underneath_its_pinned_handle() {
+    let (temp, broker, path) = setup();
+    let conversation = Uuid::new_v4();
+    let registered = register(
+        &broker.controller(),
+        GrantSubject::conversation(conversation).unwrap(),
+        conversation,
+        path.clone(),
+        OperationId::new(),
+    );
+
+    let moved = temp.path().join("moved-documents");
+    let denied = std::fs::rename(&path, &moved).unwrap_err();
+    // ERROR_SHARING_VIOLATION
+    assert_eq!(denied.raw_os_error(), Some(32));
+
+    let roots = resolve_exec(
+        &broker.controller(),
+        ExecutionContext::standalone(conversation).unwrap(),
+        vec![registered.root.root_id],
+    )
+    .unwrap();
+    assert_eq!(roots.len(), 1);
+    assert_eq!(roots[0].root_id, registered.root.root_id);
 }
 
 #[test]

--- a/crates/openwave-host-broker/src/path_policy.rs
+++ b/crates/openwave-host-broker/src/path_policy.rs
@@ -1,7 +1,7 @@
 //! Cross-platform root registration and containment policy.
 
 use std::{
-    ffi::OsString,
+    ffi::{OsStr, OsString},
     io,
     path::{Component, Path, PathBuf, Prefix},
 };
@@ -44,6 +44,20 @@ pub enum RootPolicyError {
     /// incomplete.
     #[error("required host policy location is unavailable: {0}")]
     MissingKnownFolder(&'static str),
+    /// A UNC root reached a hidden administrative share (`C$`, `ADMIN$`) or a
+    /// loopback server name. Either one reaches a local volume the drive-letter
+    /// policy protects, under a name that policy cannot recognize.
+    #[error("root uses an administrative or loopback network share")]
+    AdministrativeShare,
+    /// A canonical Windows path component that can name something other than
+    /// the directory it appears to name: an alternate data stream, a reserved
+    /// device name, or a name Windows silently rewrites.
+    #[error("root path contains a non-portable Windows component")]
+    NonPortableComponent,
+    /// The canonical path is not already its long-name form, so it may be an
+    /// 8.3 short name aliasing a different directory than policy compared.
+    #[error("root path could not be confirmed as its long-name form")]
+    ShortNameAlias,
 }
 
 /// A canonical root pinned to a descriptor after policy validation.
@@ -119,7 +133,7 @@ impl RootPolicy {
     /// read from ambient environment. Unsupported targets return an error rather
     /// than receiving an empty allow-most policy.
     pub fn for_host(home: PathBuf) -> Result<Self, RootPolicyError> {
-        let home = std::fs::canonicalize(home)?;
+        let home = canonicalize_host_path(&home)?;
         #[cfg(unix)]
         let paths = |items: &[&str]| items.iter().map(PathBuf::from).collect();
 
@@ -192,7 +206,7 @@ impl RootPolicy {
         if !candidate.is_absolute() {
             return Err(RootPolicyError::NotAbsolute);
         }
-        let canonical_path = std::fs::canonicalize(candidate)?;
+        let canonical_path = canonicalize_host_path(candidate)?;
         self.validate_canonical(&canonical_path)?;
         let directory = open_canonical_dir_nofollow(&canonical_path)?;
         let identity = root_identity(&directory)?;
@@ -209,7 +223,7 @@ impl RootPolicy {
         if !path.is_absolute() {
             return Err(RootPolicyError::NotAbsolute);
         }
-        self.sensitive.push(std::fs::canonicalize(path)?);
+        self.sensitive.push(canonicalize_host_path(path)?);
         Ok(self)
     }
 
@@ -219,6 +233,9 @@ impl RootPolicy {
         }
         if !supported_canonical_namespace(root) {
             return Err(RootPolicyError::UnsupportedNamespace);
+        }
+        if cfg!(windows) {
+            validate_windows_shape(root)?;
         }
         if is_within(root, &self.home) {
             return Err(RootPolicyError::TooBroad);
@@ -304,7 +321,7 @@ fn canonical_windows_known_folder(
     variables: &'static [&'static str],
 ) -> Result<PathBuf, RootPolicyError> {
     let path = windows_known_folder_from(variables, |name| std::env::var_os(name))?;
-    std::fs::canonicalize(path).map_err(Into::into)
+    canonicalize_host_path(&path)
 }
 
 #[cfg(windows)]
@@ -323,7 +340,7 @@ fn windows_known_folder_from(
 fn supported_canonical_namespace(path: &Path) -> bool {
     #[cfg(windows)]
     {
-        return path.components().find_map(|component| match component {
+        path.components().find_map(|component| match component {
             Component::Prefix(prefix) => Some(matches!(
                 prefix.kind(),
                 Prefix::Disk(_)
@@ -332,7 +349,7 @@ fn supported_canonical_namespace(path: &Path) -> bool {
                     | Prefix::VerbatimUNC(_, _)
             )),
             _ => None,
-        }) == Some(true);
+        }) == Some(true)
     }
 
     #[cfg(not(windows))]
@@ -340,6 +357,139 @@ fn supported_canonical_namespace(path: &Path) -> bool {
         let _ = path;
         true
     }
+}
+
+/// Resolve a host path to its canonical form, refusing anything Windows could
+/// still resolve somewhere else.
+///
+/// `std::fs::canonicalize` already resolves symlinks, junctions, and 8.3 short
+/// names — on Windows it opens the path and asks the kernel for the final name.
+/// The extra step here does not repeat that work; it refuses to trust it
+/// silently. Every path policy compares — the home directory, the known folders
+/// it protects, the broker's private directory, and each candidate root — goes
+/// through this one function, so all sides of every comparison are in the same
+/// long-name form.
+fn canonicalize_host_path(path: &Path) -> Result<PathBuf, RootPolicyError> {
+    let canonical = std::fs::canonicalize(path)?;
+    #[cfg(windows)]
+    require_long_name_form(&canonical)?;
+    Ok(canonical)
+}
+
+/// Require a canonical Windows path to already equal its long-name expansion.
+///
+/// `C:\PROGRA~1` and `C:\Program Files` name one directory and compare unequal,
+/// so a short name reaching a protected location would pass a policy written in
+/// long names. Canonicalization is expected to have expanded it; this confirms
+/// it did rather than assuming. The path was just opened successfully by
+/// `canonicalize`, so a failure here means the host cannot tell us what this
+/// path names, and the registration is refused.
+#[cfg(windows)]
+fn require_long_name_form(canonical: &Path) -> Result<(), RootPolicyError> {
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+    use windows_sys::Win32::Storage::FileSystem::GetLongPathNameW;
+
+    let mut wide: Vec<u16> = canonical.as_os_str().encode_wide().collect();
+    wide.push(0);
+    let required = unsafe { GetLongPathNameW(wide.as_ptr(), std::ptr::null_mut(), 0) };
+    if required == 0 {
+        return Err(RootPolicyError::ShortNameAlias);
+    }
+    let mut buffer = vec![0u16; required as usize];
+    let written = unsafe { GetLongPathNameW(wide.as_ptr(), buffer.as_mut_ptr(), required) };
+    // A second call that needs more room than the first reported means the path
+    // changed underneath us.
+    if written == 0 || written >= required {
+        return Err(RootPolicyError::ShortNameAlias);
+    }
+    buffer.truncate(written as usize);
+    let long = PathBuf::from(OsString::from_wide(&buffer));
+    if !same_canonical_path(&long, canonical) {
+        return Err(RootPolicyError::ShortNameAlias);
+    }
+    Ok(())
+}
+
+/// Refuse canonical Windows paths whose components can name something other
+/// than the directory they appear to name.
+///
+/// Nothing rejected here can be an ordinary NTFS directory: `:`, `<>"|?*`, and
+/// control characters are not legal in a name, reserved device names cannot be
+/// created, and Windows strips trailing dots and spaces rather than storing
+/// them. A canonical path containing one is therefore not a folder the user
+/// picked — it is a stream reference, a device, or a name that will resolve
+/// differently the next time it is opened.
+fn validate_windows_shape(root: &Path) -> Result<(), RootPolicyError> {
+    for component in root.components() {
+        match component {
+            Component::Prefix(prefix) if !is_addressable_share(prefix.kind()) => {
+                return Err(RootPolicyError::AdministrativeShare);
+            }
+            Component::Normal(segment)
+                if !portable_windows_component(&segment.to_string_lossy()) =>
+            {
+                return Err(RootPolicyError::NonPortableComponent);
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Whether a UNC prefix names a share the user could have meant.
+///
+/// `\\localhost\C$\Windows` and `\\host\ADMIN$` reach the same bytes as the
+/// drive-letter paths the policy protects, under a name no drive-letter
+/// comparison can match. Non-UNC prefixes are the namespace check's business.
+fn is_addressable_share(prefix: Prefix<'_>) -> bool {
+    match prefix {
+        Prefix::UNC(server, share) | Prefix::VerbatimUNC(server, share) => {
+            !is_hidden_share(&share.to_string_lossy())
+                && !is_loopback_server(&server.to_string_lossy())
+        }
+        _ => true,
+    }
+}
+
+/// Whether one path component of a canonical Windows path names exactly the
+/// directory it spells.
+fn portable_windows_component(segment: &str) -> bool {
+    // A colon opens an alternate data stream (`Documents:evil`) or a
+    // drive-relative path; either way the component no longer names the
+    // directory the rest of the policy compared.
+    !segment.is_empty()
+        && !segment.contains(':')
+        && crate::relative_path::portable_filename(segment)
+}
+
+/// Administrative and hidden shares end in `$` — `C$`, `ADMIN$`, `IPC$`.
+fn is_hidden_share(share: &str) -> bool {
+    share.ends_with('$')
+}
+
+/// Server names that route a UNC path back to this machine's own volumes.
+fn is_loopback_server(server: &str) -> bool {
+    let server = server.trim_start_matches('[').trim_end_matches(']');
+    server.eq_ignore_ascii_case("localhost")
+        || server.eq_ignore_ascii_case("::1")
+        || server == "."
+        || server
+            .split_once('.')
+            .is_some_and(|(first, rest)| first == "127" && rest.chars().any(|c| c.is_ascii_digit()))
+}
+
+/// Whether two absolute paths name the same location under host path
+/// comparison rules.
+#[cfg(windows)]
+fn same_canonical_path(left: &Path, right: &Path) -> bool {
+    let left = normalized_components(left);
+    let right = normalized_components(right);
+    left.len() == right.len()
+        && left
+            .iter()
+            .zip(right.iter())
+            .all(|(&left, &right)| component_eq(left, right))
 }
 
 fn open_canonical_dir_nofollow(path: &Path) -> io::Result<Dir> {
@@ -410,12 +560,25 @@ fn component_eq(left: Component<'_>, right: Component<'_>) -> bool {
     }
 }
 
-fn os_component_eq(left: &std::ffi::OsStr, right: &std::ffi::OsStr) -> bool {
+fn os_component_eq(left: &OsStr, right: &OsStr) -> bool {
     if cfg!(windows) {
-        left.eq_ignore_ascii_case(right)
+        windows_component_eq(left, right)
     } else {
         left == right
     }
+}
+
+/// Compare two Windows path components the way the filesystem does.
+///
+/// NTFS folds case over the whole Unicode range, not just ASCII, so an
+/// ASCII-only comparison would read `C:\Ünister\Documents` and
+/// `C:\ünister\Documents` as different folders. Every caller uses equality to
+/// *refuse* — a protected location, the whole home directory, another user's
+/// profile — so widening what counts as equal only ever fails closed. Lossy
+/// conversion is safe for the same reason: it can merge two unpaired surrogates
+/// into one replacement character, which again only refuses more.
+fn windows_component_eq(left: &OsStr, right: &OsStr) -> bool {
+    left == right || left.to_string_lossy().to_lowercase() == right.to_string_lossy().to_lowercase()
 }
 
 fn prefix_eq(left: Prefix<'_>, right: Prefix<'_>) -> bool {
@@ -432,10 +595,7 @@ fn prefix_eq(left: Prefix<'_>, right: Prefix<'_>) -> bool {
         | (
             Prefix::VerbatimUNC(left_server, left_share),
             Prefix::VerbatimUNC(right_server, right_share),
-        ) => {
-            left_server.eq_ignore_ascii_case(right_server)
-                && left_share.eq_ignore_ascii_case(right_share)
-        }
+        ) => os_component_eq(left_server, right_server) && os_component_eq(left_share, right_share),
         (Prefix::Verbatim(left), Prefix::Verbatim(right))
         | (Prefix::DeviceNS(left), Prefix::DeviceNS(right)) => os_component_eq(left, right),
         _ => false,
@@ -660,5 +820,160 @@ mod tests {
             policy.open_root(Path::new("Documents/project")),
             Err(RootPolicyError::NotAbsolute)
         ));
+    }
+
+    /// The component grammar is a plain string rule, so it is checked on every
+    /// host even though it only governs Windows roots. Windows path *parsing*
+    /// is not available off Windows, which is why the whole-path cases below
+    /// are separate.
+    #[test]
+    fn windows_root_components_that_can_name_something_else_are_refused() {
+        for component in [
+            // Alternate data stream and drive-relative forms.
+            "Documents:evil",
+            "C:",
+            // Reserved device names, with and without an extension.
+            "NUL",
+            "con",
+            "COM1",
+            "lpt0.log",
+            "CONIN$",
+            // Windows strips these, so the stored name is not what was checked.
+            "Reports.",
+            "Reports ",
+            "",
+        ] {
+            assert!(
+                !portable_windows_component(component),
+                "accepted {component:?}"
+            );
+        }
+        for component in ["Documents", "my.project", "COM", "COM10", "résumé", "$"] {
+            assert!(
+                portable_windows_component(component),
+                "refused {component:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unc_hidden_shares_and_loopback_servers_are_recognized() {
+        for share in ["C$", "ADMIN$", "IPC$"] {
+            assert!(is_hidden_share(share), "{share}");
+        }
+        assert!(!is_hidden_share("projects"));
+        for server in ["localhost", "LOCALHOST", "127.0.0.1", "[::1]", "::1", "."] {
+            assert!(is_loopback_server(server), "{server}");
+        }
+        for server in ["fileserver", "127", "files.example.com"] {
+            assert!(!is_loopback_server(server), "{server}");
+        }
+    }
+
+    #[test]
+    fn windows_component_comparison_folds_case_beyond_ascii() {
+        assert!(windows_component_eq(
+            OsStr::new("Ünister"),
+            OsStr::new("ÜNISTER")
+        ));
+        assert!(!windows_component_eq(
+            OsStr::new("Ünister"),
+            OsStr::new("Unister")
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn rejects_unc_roots_that_alias_a_local_volume() {
+        let policy = RootPolicy::for_test(
+            PathBuf::from(r"C:\Users\alice"),
+            vec![PathBuf::from(r"C:\Windows")],
+            vec![PathBuf::from(r"C:\Users")],
+            Vec::new(),
+        );
+        for path in [
+            r"\\localhost\C$\Windows\System32",
+            r"\\WORKSTATION\ADMIN$\System32",
+            r"\\?\UNC\127.0.0.1\projects\app",
+        ] {
+            assert!(
+                matches!(
+                    policy.validate_canonical(Path::new(path)),
+                    Err(RootPolicyError::AdministrativeShare)
+                ),
+                "{path}"
+            );
+        }
+        assert!(policy
+            .validate_canonical(Path::new(r"\\fileserver\projects\app"))
+            .is_ok());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn rejects_stream_and_device_components_in_a_canonical_root() {
+        let policy = RootPolicy::for_test(
+            PathBuf::from(r"C:\Users\alice"),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        for path in [r"C:\Users\alice\Documents:evil", r"C:\Users\alice\NUL"] {
+            assert!(
+                matches!(
+                    policy.validate_canonical(Path::new(path)),
+                    Err(RootPolicyError::NonPortableComponent)
+                ),
+                "{path}"
+            );
+        }
+    }
+
+    /// The long-name confirmation must not refuse ordinary folders — if it
+    /// did, no Windows user could connect one.
+    #[cfg(windows)]
+    #[test]
+    fn long_name_confirmation_accepts_an_ordinary_canonical_folder() {
+        let temp = tempfile::tempdir().unwrap();
+        let folder = temp.path().join("Project Reports");
+        std::fs::create_dir(&folder).unwrap();
+        require_long_name_form(&folder.canonicalize().unwrap()).unwrap();
+    }
+
+    /// The escape a Windows host adds over Unix: a junction is a reparse point
+    /// rather than a symlink, and nothing in the policy layer would notice one
+    /// appearing inside an already-registered root. Containment for it comes
+    /// from resolving every component without following links.
+    #[cfg(windows)]
+    #[test]
+    fn a_junction_inside_a_registered_root_cannot_reach_its_target() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join("home");
+        let root = home.join("Documents");
+        let outside = temp.path().join("outside");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("secret.txt"), "secret").unwrap();
+
+        let junction = root.join("escape");
+        let created = std::process::Command::new("cmd")
+            .args(["/C", "mklink", "/J"])
+            .arg(&junction)
+            .arg(&outside)
+            .status()
+            .unwrap();
+        assert!(created.success(), "could not create a directory junction");
+
+        let policy = RootPolicy::for_test(
+            home.canonicalize().unwrap(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let opened = policy.open_root(&root).unwrap();
+        let directory = opened.directory();
+        assert!(directory.open_dir_nofollow("escape").is_err());
+        assert!(directory.read_dir("escape").is_err());
+        assert!(directory.open("escape/secret.txt").is_err());
     }
 }

--- a/crates/openwave-host-broker/src/path_policy.rs
+++ b/crates/openwave-host-broker/src/path_policy.rs
@@ -657,6 +657,15 @@ mod tests {
             Path::new(r"\\?\C:\Windows\System32")
         ));
         assert!(is_within(
+            Path::new(r"\\server\share\projects"),
+            Path::new(r"\\?\UNC\server\share\projects\app")
+        ));
+        // A whole network share carries no named folder, so it is a filesystem
+        // root like `C:\` or `/` — too broad to register, and it contains
+        // nothing for policy purposes. The share-relative root above is the
+        // shallowest UNC path containment is defined for.
+        assert!(is_filesystem_root(Path::new(r"\\server\share")));
+        assert!(!is_within(
             Path::new(r"\\server\share"),
             Path::new(r"\\?\UNC\server\share\folder")
         ));

--- a/crates/openwave-host-broker/src/relative_path.rs
+++ b/crates/openwave-host-broker/src/relative_path.rs
@@ -87,7 +87,12 @@ impl RelativePath {
     }
 }
 
-fn portable_filename(value: &str) -> bool {
+/// Whether one path segment names exactly the file it spells on Windows.
+///
+/// Shared with the host-root policy, which applies the same rule to the
+/// components of a canonical root path, so one list of reserved names governs
+/// both the agent-facing protocol and the folders the user connects.
+pub(crate) fn portable_filename(value: &str) -> bool {
     if value.ends_with(['.', ' '])
         || value.chars().any(|character| {
             character <= '\u{1f}' || matches!(character, '<' | '>' | '"' | '|' | '?' | '*')
@@ -108,7 +113,7 @@ fn matches_device_number(value: &str, prefix: &str) -> bool {
     value.strip_prefix(prefix).is_some_and(|suffix| {
         matches!(
             suffix,
-            "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "¹" | "²" | "³"
+            "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "¹" | "²" | "³"
         )
     })
 }
@@ -176,6 +181,8 @@ mod tests {
             "CON",
             "aux.txt",
             "LPT9.log",
+            "COM0",
+            "lpt0.log",
             "CONIN$",
             "conout$.txt",
             "CLOCK$",


### PR DESCRIPTION
Root policy compares canonical paths as strings. On Windows there is more than one way to spell one directory, and the checks were written against Unix semantics. Each vector in #1529 is either hardened here or shown below to be already covered.

## Hardened

**UNC administrative shares** — `\\localhost\C$\Windows\System32` and `\\WORKSTATION\ADMIN$\...` reach exactly the bytes the drive-letter policy protects, under a name no drive-letter comparison can match, so a candidate root there passed every sensitive-location check. `validate_windows_shape` now refuses UNC roots whose share is hidden (ends in `$`) or whose server is a loopback alias (`localhost`, `127.x`, `::1`, `.`). Ordinary shares (`\\fileserver\projects\app`) stay registrable.

**8.3 short names** — `C:\PROGRA~1` and `C:\Program Files` are one directory and compare unequal, so a short name would pass a policy written in long names. `std::fs::canonicalize` is expected to expand them (it asks the kernel for the final name), and the policy's own protected paths come from environment variables that are canonicalized the same way — but that was an assumption, not a check. All four canonicalizations in this module (home, Windows known folders, the broker's private directory, the candidate root) now go through `canonicalize_host_path`, which on Windows confirms the result equals its `GetLongPathNameW` expansion and refuses otherwise. A failed API call is also a refusal: the path was just opened successfully by `canonicalize`, so if the host cannot say what it names, registration should not proceed.

**Alternate data streams and reserved device names in a root path** — `RelativePath` already rejects both for agent-facing paths, but `open_root` takes an absolute host path, which can also come from configured (`OperatorConfig`) consent rather than the picker. Canonical root components are now checked against the same grammar: no `:`, no reserved device name, no trailing dot or space, no character illegal in an NTFS name. Nothing rejected here can be an ordinary directory, so this costs no legitimate folder. The reserved-name list is now shared with `relative_path` rather than duplicated, and gained `COM0`/`LPT0` to match what cap-std's own open path refuses.

**Case-insensitive comparison** — `os_component_eq` folded ASCII only, so a user profile or protected folder with a non-ASCII name (`C:\Ünister\…`) compared unequal to the same name in different case. It now folds over the full Unicode range. Every caller uses equality to *refuse* — a protected location, the whole home directory, another user's whole profile — so widening what counts as equal only ever fails closed, which is also why lossy conversion is safe here.

Also fixed a pre-existing `clippy::needless_return` in `supported_canonical_namespace` that only fires when compiling for Windows.

## Already covered, unchanged

**Junctions and directory symlinks** — a junction is a reparse point with a name-surrogate tag, which `std`'s `FileType::is_symlink` reports as a symlink. cap-primitives opens every component with `FollowSymlinks::No`, which on Windows adds `FILE_FLAG_OPEN_REPARSE_POINT`, so the reparse point itself is what gets inspected (`cap-primitives/src/windows/fs/open_unchecked.rs`, the `enforce_nofollow` branch). It then resolves the link manually; a junction target is always absolute, and an absolute destination hits `CowComponent::PrefixOrRootDir => Err(errors::escape_attempt())` in `cap-primitives/src/fs/manually/open.rs`. That holds for every broker filesystem entry point, including `read_bounded`, which opens with the default `FollowSymlinks::Yes` — the last component is still resolved manually. A junction *selected as* the root is resolved by `canonicalize` before `validate_canonical` sees it, the same as the Unix symlink case, and `open_canonical_dir_nofollow` then re-opens the canonical path component by component.

**UNC and `\\?\` paths from canonicalization** — `supported_canonical_namespace` already admits only `Disk`, `VerbatimDisk`, `UNC`, and `VerbatimUNC` prefixes and rejects `DeviceNS` and general `Verbatim` (`\\?\Volume{…}`, `\\.\GLOBALROOT\…`); `prefix_eq` already equates verbatim and non-verbatim forms so `\\?\C:\Windows` matches a policy entry of `C:\Windows`.

**Runtime containment is not string-based** — after registration, every operation goes through the pinned `Dir` handle, not a path prefix comparison, so the case-folding and spelling questions above are confined to policy validation at registration and state reload (`StateFile::load` re-runs `open_root`).

## Tests

Cross-platform (they are string rules, so they run everywhere): the component grammar table (`Documents:evil`, `C:`, `NUL`, `con`, `COM1`, `lpt0.log`, `CONIN$`, trailing dot/space, plus the legitimate names it must keep accepting), hidden-share and loopback-server recognition, and non-ASCII case folding. `COM0`/`lpt0.log` added to the existing `RelativePath` rejection table.

**Only a real Windows runner executes these**, and `cargo check` never compiles a test target, so the `windows-check` lane gained a `cargo test -p openwave-host-broker --locked` step — one crate, on the runner's native target, adding roughly a minute of compile to a job that already builds these dependencies. Without it these tests would exist and run nowhere:

- `rejects_unc_roots_that_alias_a_local_volume` and `rejects_stream_and_device_components_in_a_canonical_root` need Windows path parsing (off Windows, `C:\Users\alice\NUL` is a single path component).
- `long_name_confirmation_accepts_an_ordinary_canonical_folder` guards the new `GetLongPathNameW` check against refusing ordinary folders, which would break all Windows registration.
- `a_junction_inside_a_registered_root_cannot_reach_its_target` creates a real NTFS junction with `mklink /J` and asserts the pinned root handle cannot open, list, or read through it. This is the one that would tell us cap-std's guarantee had regressed.

I typechecked all of them locally against the Windows target as well; the lane is what actually runs them against real NTFS.

## What the first Windows execution surfaced

Turning the lane on ran this crate's tests on Windows for the first time, and three pre-existing `#[cfg(windows)]` tests failed — all three worth having found. One is a real defect: the audit sink's rollback after a partial append truncated through the appending handle, but Windows opens a file for append with `FILE_APPEND_DATA` and deliberately without `FILE_WRITE_DATA`, and `SetEndOfFile` needs the latter, so on Windows the rollback could never succeed and every transient audit write failure was promoted to the ambiguous failure that refuses the operation and demands a broker restart. The rollback now takes its own write handle. The other two were Unix-only choreography in the tests, not product behaviour, and are restated per host rather than skipped: a registered root cannot be renamed out from under its pinned handle on Windows at all (cap-std omits `FILE_SHARE_DELETE` on directories for exactly this reason), so the Windows test asserts that refusal — the same guarantee one layer down, and a canary if a dependency bump ever widened the share mode; and the prefix-equivalence test was asserting containment from a bare `\\server\share`, which carries no named folder and is therefore a filesystem root like `C:\` — too broad to register and containing nothing — so it now uses a share-relative folder and states the whole-share rule separately.

## Verification

```
$ cargo fmt --all
$ cargo test -p openwave-host-broker -p openwave-desktop --locked
test result: ok. 111 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
test result: ok. 99 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo check --workspace --locked
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 52.57s

$ cargo clippy -p openwave-host-broker --all-targets --locked \
    --target x86_64-pc-windows-msvc -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.76s

$ cargo clippy -p openwave-host-broker --all-targets --locked \
    --target x86_64-unknown-linux-gnu -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.92s
```

`--all-targets` on the Windows target is what compiles the `#[cfg(windows)]` tests; `cargo check --workspace --locked` left `Cargo.lock` unchanged. No new dependencies — `GetLongPathNameW` comes from the `windows-sys` `Win32_Storage_FileSystem` feature the crate already enables.

Not verified: nothing here was exercised on a running Windows host.

Closes #1529


