### PR TITLE
feat(server): structured exec capability reporting and a truthful default

### DIFF
--- a/crates/openwave-code-execution/src/lib.rs
+++ b/crates/openwave-code-execution/src/lib.rs
@@ -63,12 +63,13 @@ pub use skills::{
 pub use tool::{ExecTool, EXEC_TOOL_NAME};
 pub use types::{
     CodeExecutionError, CodeExecutionProvider, CodeExecutionProviderKind, CodeExecutionRequest,
-    CodeExecutionResponse, ExecFolderAccess, ExecFolderGrant, ExecutionId, ExecutionWorkspaceId,
-    OutputArtifactEntry, OutputArtifactScan, OutputArtifactStatus, SandboxPreparation,
-    SandboxPreparationSink, StagedUpload, WorkspaceFileEntry, WorkspaceFilePath,
-    WorkspaceLifecycle, WorkspaceListing, MAX_ARGUMENTS, MAX_ARGUMENT_BYTES, MAX_CAPTURE_BYTES,
-    MAX_COMMAND_BYTES, MAX_CWD_BYTES, MAX_EXEC_FOLDER_GRANTS, MAX_STAGED_PATHS,
-    MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES, MAX_WORKSPACE_PATH_BYTES,
+    CodeExecutionResponse, CodeExecutionUnavailableReason, ExecFolderAccess, ExecFolderGrant,
+    ExecutionId, ExecutionWorkspaceId, OutputArtifactEntry, OutputArtifactScan,
+    OutputArtifactStatus, SandboxPreparation, SandboxPreparationSink, StagedUpload,
+    WorkspaceFileEntry, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, MAX_ARGUMENTS,
+    MAX_ARGUMENT_BYTES, MAX_CAPTURE_BYTES, MAX_COMMAND_BYTES, MAX_CWD_BYTES,
+    MAX_EXEC_FOLDER_GRANTS, MAX_STAGED_PATHS, MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES,
+    MAX_WORKSPACE_PATH_BYTES,
 };
 
 /// Stable workspace-relative location populated by hosts that ship the

--- a/crates/openwave-code-execution/src/local.rs
+++ b/crates/openwave-code-execution/src/local.rs
@@ -31,8 +31,8 @@ use crate::sbpl::SANDBOX_EXEC;
 use crate::CodeExecutionProviderKind;
 use crate::{
     CodeExecutionError, CodeExecutionProvider, CodeExecutionRequest, CodeExecutionResponse,
-    ExecutionWorkspaceId, WorkspaceFileEntry, WorkspaceFilePath, WorkspaceLifecycle,
-    WorkspaceListing, MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES,
+    CodeExecutionUnavailableReason, ExecutionWorkspaceId, WorkspaceFileEntry, WorkspaceFilePath,
+    WorkspaceLifecycle, WorkspaceListing, MAX_WORKSPACE_FILE_BYTES, MAX_WORKSPACE_LIST_ENTRIES,
 };
 #[cfg(target_os = "macos")]
 use crate::{ExecFolderAccess, ExecFolderGrant};
@@ -120,10 +120,19 @@ impl LocalExecutionProvider {
         self
     }
 
-    /// Whether the mandatory native confinement primitive exists on this host.
-    #[must_use]
-    pub fn is_supported() -> bool {
-        cfg!(target_os = "macos") && Path::new(SANDBOX_EXEC).is_file()
+    /// Structured availability of the native local sandbox on this host.
+    ///
+    /// `Ok(())` means the mandatory confinement primitive exists. The error is
+    /// a stable reason code, so a caller can report *why* local execution is
+    /// impossible without re-deriving the platform rules itself.
+    pub fn availability() -> Result<(), CodeExecutionUnavailableReason> {
+        if !cfg!(target_os = "macos") {
+            return Err(CodeExecutionUnavailableReason::UnsupportedPlatform);
+        }
+        if !Path::new(SANDBOX_EXEC).is_file() {
+            return Err(CodeExecutionUnavailableReason::MissingSandboxBinary);
+        }
+        Ok(())
     }
 
     /// Host knowledge about the local adapter's egress enforcement: Seatbelt
@@ -304,10 +313,11 @@ impl CodeExecutionProvider for LocalExecutionProvider {
         request: CodeExecutionRequest,
     ) -> Result<CodeExecutionResponse, CodeExecutionError> {
         request.validate()?;
-        if !Self::is_supported() {
-            return Err(CodeExecutionError::Unavailable(
-                "native local sandboxing is not supported on this host".into(),
-            ));
+        if let Err(reason) = Self::availability() {
+            return Err(CodeExecutionError::Unavailable(format!(
+                "native local sandboxing is not available on this host: {}",
+                reason.message()
+            )));
         }
         let ResolvedExecutionPaths {
             workspace,

--- a/crates/openwave-code-execution/src/types.rs
+++ b/crates/openwave-code-execution/src/types.rs
@@ -58,6 +58,56 @@ impl std::fmt::Display for CodeExecutionProviderKind {
     }
 }
 
+/// Why a provider cannot execute anything on this host right now.
+///
+/// A stable machine-readable code, not a sentence: the reason is decided where
+/// the fact is known (the platform probe, the credential slot) and every
+/// surface renders its own copy from the code. Reasons are what the user can
+/// act on — install a key, switch provider — never an internal failure detail.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ts_rs::TS)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CodeExecutionUnavailableReason {
+    /// The provider's confinement primitive does not exist for this operating
+    /// system at all. Nothing the user installs or pastes changes this.
+    UnsupportedPlatform,
+    /// The platform supports the provider but its sandbox binary is missing
+    /// from the host.
+    MissingSandboxBinary,
+    /// A managed provider whose API key slot is empty.
+    MissingCredential,
+}
+
+impl CodeExecutionUnavailableReason {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::UnsupportedPlatform => "unsupported_platform",
+            Self::MissingSandboxBinary => "missing_sandbox_binary",
+            Self::MissingCredential => "missing_credential",
+        }
+    }
+
+    /// One plain sentence for callers that must put the reason in a message
+    /// rather than render it — the model-facing execution error, mainly.
+    #[must_use]
+    pub const fn message(self) -> &'static str {
+        match self {
+            Self::UnsupportedPlatform => {
+                "this provider has no sandbox implementation for this operating system"
+            }
+            Self::MissingSandboxBinary => "the host's native sandbox binary is missing",
+            Self::MissingCredential => "no API key is saved for this provider",
+        }
+    }
+}
+
+impl std::fmt::Display for CodeExecutionUnavailableReason {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
 /// Stable provider idempotency key for one canonical tool call.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -634,7 +684,10 @@ pub trait CodeExecutionProvider: Send + Sync {
 pub enum CodeExecutionError {
     #[error("invalid code execution request: {0}")]
     InvalidRequest(String),
-    #[error("code execution is not configured")]
+    #[error(
+        "code execution is not configured: no execution provider is available on this host \
+         (configure one under Settings → Code execution)"
+    )]
     NotConfigured,
     #[error("code execution provider is unavailable: {0}")]
     Unavailable(String),

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -497,7 +497,19 @@ export type CitationLocator = { "kind": "document" } | { "kind": "page", page: n
 /**
  * Renderer-safe configuration and readiness.
  */
-export type CodeExecutionConfigInfo = { provider?: CodeExecutionProviderKind, timeout_ms: number, available: boolean, has_credential: boolean, 
+export type CodeExecutionConfigInfo = { provider?: CodeExecutionProviderKind, timeout_ms: number, available: boolean, 
+/**
+ * Why the *selected* provider cannot run, when it cannot. Absent while
+ * execution is available or no provider is selected at all.
+ */
+unavailable_reason?: CodeExecutionUnavailableReason, has_credential: boolean, 
+/**
+ * One row per shipped provider: whether it could run here at all, and the
+ * reason it could not. This is what makes an unusable host legible —
+ * "paste an E2B key" is visible instead of being inferred from a generic
+ * execution failure.
+ */
+providers: Array<CodeExecutionProviderAvailability>, 
 /**
  * The configured egress policy and each managed provider's enforcement
  * status, so the renderer can present the policy and disclose which
@@ -556,9 +568,28 @@ policy: EgressConfig,
 enforcement: Array<CodeExecutionEgressEnforcement>, };
 
 /**
+ * Structured capability report for one execution provider on this host.
+ *
+ * `available` and `unavailable_reason` are two views of one decision, made in
+ * [`provider_availability`], so no surface has to re-derive whether a platform
+ * supports a provider or whether a key is saved.
+ */
+export type CodeExecutionProviderAvailability = { provider: CodeExecutionProviderKind, available: boolean, unavailable_reason?: CodeExecutionUnavailableReason, };
+
+/**
  * A configured code-execution backend.
  */
 export type CodeExecutionProviderKind = "local" | "e2b" | "daytona";
+
+/**
+ * Why a provider cannot execute anything on this host right now.
+ *
+ * A stable machine-readable code, not a sentence: the reason is decided where
+ * the fact is known (the platform probe, the credential slot) and every
+ * surface renders its own copy from the code. Reasons are what the user can
+ * act on — install a key, switch provider — never an internal failure detail.
+ */
+export type CodeExecutionUnavailableReason = "unsupported_platform" | "missing_sandbox_binary" | "missing_credential";
 
 /**
  * Identifies one profile-scoped connected app — an outside integration

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.dom.test.tsx
@@ -70,14 +70,26 @@ const NO_DETACHED: CodeExecutionConfigInfo["detached_admission"] = [
   },
 ];
 
+/** Every provider usable: the macOS shape, where nothing is dark. */
+const ALL_PROVIDERS_AVAILABLE: CodeExecutionConfigInfo["providers"] = [
+  { provider: "local", available: true },
+  { provider: "e2b", available: true },
+  { provider: "daytona", available: true },
+];
+
 function clientFor(
-  config: CodeExecutionConfigInfo,
+  config: Omit<CodeExecutionConfigInfo, "providers"> &
+    Partial<Pick<CodeExecutionConfigInfo, "providers">>,
   credentials: CodeExecutionCredentialReadiness[] = [
     { provider: "e2b", has_credential: false },
     { provider: "daytona", has_credential: false },
   ],
 ) {
-  const putCodeExecutionConfig = vi.fn().mockResolvedValue(config);
+  const resolved: CodeExecutionConfigInfo = {
+    providers: ALL_PROVIDERS_AVAILABLE,
+    ...config,
+  };
+  const putCodeExecutionConfig = vi.fn().mockResolvedValue(resolved);
   const putCodeExecutionCredential = vi
     .fn()
     .mockImplementation((provider: string) =>
@@ -90,7 +102,7 @@ function clientFor(
     );
   return {
     client: {
-      getCodeExecutionConfig: vi.fn().mockResolvedValue(config),
+      getCodeExecutionConfig: vi.fn().mockResolvedValue(resolved),
       listCodeExecutionCredentials: vi.fn().mockResolvedValue({ credentials }),
       putCodeExecutionConfig,
       putCodeExecutionCredential,
@@ -266,5 +278,44 @@ describe("CodeExecutionPanel", () => {
         .length,
     ).toBeGreaterThan(0);
     expect(screen.queryByText(/no_scoped_model_token/)).toBeNull();
+  });
+
+  it("names why each provider is unusable on a host with no execution at all", async () => {
+    const { client } = clientFor({
+      provider: undefined,
+      timeout_ms: 20_000,
+      available: false,
+      has_credential: false,
+      providers: [
+        {
+          provider: "local",
+          available: false,
+          unavailable_reason: "unsupported_platform",
+        },
+        {
+          provider: "e2b",
+          available: false,
+          unavailable_reason: "missing_credential",
+        },
+        {
+          provider: "daytona",
+          available: false,
+          unavailable_reason: "missing_credential",
+        },
+      ],
+      egress: OPEN_EGRESS,
+      detached_admission: NO_DETACHED,
+    });
+
+    render(<CodeExecutionPanel client={client} />);
+
+    // The headline states the host has nothing, and each row says what would
+    // change it — a missing key must be readable here, not archaeological.
+    await screen.findByText(/No execution provider configured/i);
+    expect(
+      screen.getByText(/Not supported on this operating system/i),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(/Add an API key above/i)).toHaveLength(2);
+    expect(screen.queryByText(/missing_credential/)).toBeNull();
   });
 });

--- a/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/CodeExecutionPanel.tsx
@@ -184,17 +184,18 @@ export function CodeExecutionPanel({ client }: { client: ApiClient }) {
             title="Active provider"
             description="Agents execute in this one provider. The others stay configured and idle."
           >
+            <ProviderAvailabilityDisclosure rows={config.providers} />
+
             <ActiveProviderField
               value={provider}
               disabled={working}
               onChange={setProvider}
-              options={[
-                { kind: LOCAL_PROVIDER, label: "Local native sandbox" },
-                ...credentials.map((credential) => ({
-                  kind: credential.provider,
-                  label: `${codeExecutionProviderLabel(credential.provider)} cloud sandbox`,
-                })),
-              ]}
+              options={config.providers.map((row) => ({
+                kind: row.provider,
+                label: row.available
+                  ? PROVIDER_SANDBOX_LABEL[row.provider]
+                  : `${PROVIDER_SANDBOX_LABEL[row.provider]} — unavailable`,
+              }))}
             />
 
             <TimeoutSecondsField
@@ -274,7 +275,7 @@ const DETACHED_DENIAL_SENTENCES: Record<DetachedAdmissionDenialReason, string> =
       "The run would carry third-party credentials without an externally enforced network boundary keeping them from leaving.",
   };
 
-const DETACHED_PROVIDER_LABEL: Record<
+const PROVIDER_SANDBOX_LABEL: Record<
   DetachedAdmissionRow["provider"],
   string
 > = {
@@ -282,6 +283,56 @@ const DETACHED_PROVIDER_LABEL: Record<
   e2b: "E2B cloud sandbox",
   daytona: "Daytona cloud sandbox",
 };
+
+type ProviderAvailabilityRow = CodeExecutionConfigInfo["providers"][number];
+type ProviderUnavailableReason = NonNullable<
+  ProviderAvailabilityRow["unavailable_reason"]
+>;
+
+/**
+ * Each typed unavailability reason as the sentence that tells the user what
+ * would change it. The codes come from the server's single availability
+ * decision, so this list is exactly the set of states execution can be in —
+ * the panel never guesses why a provider is dark.
+ */
+const PROVIDER_UNAVAILABLE_SENTENCES: Record<ProviderUnavailableReason, string> =
+  {
+    unsupported_platform:
+      "Not supported on this operating system. Use a cloud sandbox instead — it runs the same commands with the same staged files.",
+    missing_sandbox_binary:
+      "This host is missing the sandbox binary local execution needs to confine commands.",
+    missing_credential: "Add an API key above to make this provider usable.",
+  };
+
+/**
+ * Per-provider capability, stated plainly: which providers could run here at
+ * all, and for each one that can't, the reason and the fix. Without this a
+ * host with no usable provider looks identical to a misconfigured one.
+ */
+function ProviderAvailabilityDisclosure({
+  rows,
+}: {
+  rows: CodeExecutionConfigInfo["providers"];
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      {rows.map((row) => (
+        <div key={row.provider} className="flex items-start gap-2 text-sm">
+          <Badge variant={row.available ? "success" : "warning"} size="sm">
+            {row.available ? "Available" : "Unavailable"}
+          </Badge>
+          <span className="text-muted-foreground">
+            <span className="font-medium text-foreground">
+              {PROVIDER_SANDBOX_LABEL[row.provider]}
+            </span>
+            {row.unavailable_reason &&
+              ` — ${PROVIDER_UNAVAILABLE_SENTENCES[row.unavailable_reason]}`}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 /**
  * Per-provider detached-admission disclosure: for each execution provider,
@@ -303,7 +354,7 @@ function DetachedAdmissionDisclosure({
               {row.admitted ? "Available" : "Not available"}
             </Badge>
             <span className="font-medium text-foreground">
-              {DETACHED_PROVIDER_LABEL[row.provider]}
+              {PROVIDER_SANDBOX_LABEL[row.provider]}
             </span>
           </div>
           {!row.admitted && (
@@ -401,10 +452,16 @@ function codeExecutionState(config: CodeExecutionConfigInfo | null): {
   description: string;
 } {
   if (!config?.provider) {
+    // With no provider selected, say whether that is a choice or the only
+    // honest state this host has: if nothing here could run, the reasons in
+    // the list below are the whole story.
+    const usable = config?.providers.some((row) => row.available) ?? true;
     return {
       kind: "disabled",
-      label: "Disabled",
-      description: "No code-execution provider is selected.",
+      label: usable ? "Disabled" : "No execution provider configured",
+      description: usable
+        ? "No code-execution provider is selected."
+        : "No execution provider is available on this host. Add a cloud sandbox key below to enable code execution.",
     };
   }
   if (config.available) {
@@ -417,17 +474,14 @@ function codeExecutionState(config: CodeExecutionConfigInfo | null): {
           : "The local native sandbox is available.",
     };
   }
-  if (config.provider !== LOCAL_PROVIDER && !config.has_credential) {
-    return {
-      kind: "not-configured",
-      label: "Not configured",
-      description: `${codeExecutionProviderLabel(config.provider)} is selected but needs an API key.`,
-    };
-  }
   return {
     kind: "not-configured",
     label: "Unavailable",
-    description: "The selected execution provider is unavailable.",
+    description: `${codeExecutionProviderLabel(config.provider)} is selected but cannot run: ${
+      config.unavailable_reason
+        ? PROVIDER_UNAVAILABLE_SENTENCES[config.unavailable_reason]
+        : "the provider reported no reason."
+    }`,
   };
 }
 

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -15,14 +15,15 @@ use async_trait::async_trait;
 use chrono::Utc;
 use openwave_code_execution::{
     resolve_scratch_directory, sync, CodeExecutionError, CodeExecutionProvider,
-    CodeExecutionProviderKind, CodeExecutionRequest, CodeExecutionResponse, DaytonaCredential,
-    DaytonaExecutionProvider, E2BCredential, E2BExecutionProvider, ExecFolderAccess,
-    ExecFolderGrant, ExecutionId, ExecutionWorkspaceId, LocalExecutionProvider,
-    MaterializationPrecondition, MaterializedChangeKind, OutputArtifactEntry, OutputArtifactScan,
-    OutputArtifactStatus, PreviewScan, RejectedChangeReason, RemoteSessionPool, SharedPackageCache,
-    StagedUpload, WorkspaceFilePath, WorkspaceLifecycle, WorkspaceListing, WriteOverlay,
-    WriteSnapshotSink, DAYTONA_CREDENTIAL_KEY, DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES,
-    E2B_CREDENTIAL_KEY, PACKAGE_CACHE_DIR, PACKAGE_MANAGER_DOMAINS,
+    CodeExecutionProviderKind, CodeExecutionRequest, CodeExecutionResponse,
+    CodeExecutionUnavailableReason, DaytonaCredential, DaytonaExecutionProvider, E2BCredential,
+    E2BExecutionProvider, ExecFolderAccess, ExecFolderGrant, ExecutionId, ExecutionWorkspaceId,
+    LocalExecutionProvider, MaterializationPrecondition, MaterializedChangeKind,
+    OutputArtifactEntry, OutputArtifactScan, OutputArtifactStatus, PreviewScan,
+    RejectedChangeReason, RemoteSessionPool, SharedPackageCache, StagedUpload, WorkspaceFilePath,
+    WorkspaceLifecycle, WorkspaceListing, WriteOverlay, WriteSnapshotSink, DAYTONA_CREDENTIAL_KEY,
+    DOCUMENT_SCRIPTS_DIR, DOCUMENT_SCRIPT_FILES, E2B_CREDENTIAL_KEY, PACKAGE_CACHE_DIR,
+    PACKAGE_MANAGER_DOMAINS,
 };
 use openwave_core::{
     exec_attachment_file_name, BlobStore, CallId, Chat, ChatId, ExecFileRejectionReason,
@@ -183,6 +184,16 @@ const CREDENTIAL_PROVIDERS: [CodeExecutionProviderKind; 2] = [
     CodeExecutionProviderKind::Daytona,
 ];
 
+/// Every execution provider this build ships, in the order the settings
+/// surface reports them. Availability is computed per row, so a host with no
+/// usable provider says so with a reason for each rather than presenting a
+/// selection that cannot run.
+const EXECUTION_PROVIDERS: [CodeExecutionProviderKind; 3] = [
+    CodeExecutionProviderKind::Local,
+    CodeExecutionProviderKind::E2b,
+    CodeExecutionProviderKind::Daytona,
+];
+
 /// Host-owned, non-secret egress policy for the managed exec sandboxes.
 ///
 /// The model never sets this (invariant 1): it is host configuration, carries
@@ -239,10 +250,10 @@ impl EgressConfig {
     }
 }
 
-/// Non-secret host selection. Local is usable by default because its mandatory
-/// sandbox confines writes and enforces each chat's network policy outside the
-/// workload. `None` explicitly removes execution from service without changing
-/// the stable tool contract.
+/// Non-secret host selection. Local is the default only where its mandatory
+/// sandbox actually exists; that sandbox confines writes and enforces each
+/// chat's network policy outside the workload. `None` explicitly removes
+/// execution from service without changing the stable tool contract.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CodeExecutionConfig {
     #[serde(default)]
@@ -275,7 +286,15 @@ pub struct CodeExecutionConfig {
 impl Default for CodeExecutionConfig {
     fn default() -> Self {
         Self {
-            provider: Some(CodeExecutionProviderKind::Local),
+            // Local is the default only on hosts where it can actually run.
+            // Selecting it elsewhere would be a dead selection: every exec
+            // would fail and the surface would report a configured provider
+            // that never works. No provider at all is the truthful state, and
+            // the settings surface says which providers are unavailable and
+            // why.
+            provider: LocalExecutionProvider::availability()
+                .is_ok()
+                .then_some(CodeExecutionProviderKind::Local),
             timeout_ms: DEFAULT_TIMEOUT_MS,
             egress: EgressConfig::Open,
             e2b_template: None,
@@ -379,7 +398,17 @@ pub struct CodeExecutionConfigInfo {
     pub provider: Option<CodeExecutionProviderKind>,
     pub timeout_ms: u64,
     pub available: bool,
+    /// Why the *selected* provider cannot run, when it cannot. Absent while
+    /// execution is available or no provider is selected at all.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub unavailable_reason: Option<CodeExecutionUnavailableReason>,
     pub has_credential: bool,
+    /// One row per shipped provider: whether it could run here at all, and the
+    /// reason it could not. This is what makes an unusable host legible —
+    /// "paste an E2B key" is visible instead of being inferred from a generic
+    /// execution failure.
+    pub providers: Vec<CodeExecutionProviderAvailability>,
     /// The configured egress policy and each managed provider's enforcement
     /// status, so the renderer can present the policy and disclose which
     /// providers actually restrict egress today.
@@ -616,6 +645,51 @@ pub struct CodeExecutionCredentialReadiness {
     pub has_credential: bool,
 }
 
+/// Structured capability report for one execution provider on this host.
+///
+/// `available` and `unavailable_reason` are two views of one decision, made in
+/// [`provider_availability`], so no surface has to re-derive whether a platform
+/// supports a provider or whether a key is saved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ts_rs::TS)]
+pub struct CodeExecutionProviderAvailability {
+    pub provider: CodeExecutionProviderKind,
+    pub available: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub unavailable_reason: Option<CodeExecutionUnavailableReason>,
+}
+
+impl CodeExecutionProviderAvailability {
+    fn new(
+        provider: CodeExecutionProviderKind,
+        unavailable_reason: Option<CodeExecutionUnavailableReason>,
+    ) -> Self {
+        Self {
+            provider,
+            available: unavailable_reason.is_none(),
+            unavailable_reason,
+        }
+    }
+}
+
+/// The single place that decides whether a provider can execute here.
+///
+/// Local asks the adapter's own platform probe; the managed providers are
+/// available exactly when their credential slot is filled. Everything else —
+/// the default selection, the settings rows, the selected provider's status —
+/// reads this, so they cannot disagree.
+async fn provider_availability(
+    secrets: &dyn SecretProvider,
+    provider: CodeExecutionProviderKind,
+) -> CodeExecutionProviderAvailability {
+    let reason = match provider {
+        CodeExecutionProviderKind::Local => LocalExecutionProvider::availability().err(),
+        _ => (!has_credential(secrets, provider).await)
+            .then_some(CodeExecutionUnavailableReason::MissingCredential),
+    };
+    CodeExecutionProviderAvailability::new(provider, reason)
+}
+
 /// Credential readiness for every managed provider this host supports, so the
 /// renderer can offer a key field per provider without selecting one first.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -685,17 +759,25 @@ pub async fn config_info(
         Some(provider) => has_credential(secrets, provider).await,
         None => false,
     };
-    let available = match config.provider {
-        Some(CodeExecutionProviderKind::Local) => LocalExecutionProvider::is_supported(),
-        Some(CodeExecutionProviderKind::E2b | CodeExecutionProviderKind::Daytona) => has_credential,
-        None => false,
-        _ => false,
-    };
+    let mut providers = Vec::with_capacity(EXECUTION_PROVIDERS.len());
+    for provider in EXECUTION_PROVIDERS {
+        providers.push(provider_availability(secrets, provider).await);
+    }
+    // The selected provider's status is read out of the same rows, so the
+    // headline and the per-provider list can never contradict each other.
+    let selected = config.provider.and_then(|provider| {
+        providers
+            .iter()
+            .find(|candidate| candidate.provider == provider)
+            .copied()
+    });
     Ok(CodeExecutionConfigInfo {
         provider: config.provider,
         timeout_ms: config.timeout_ms,
-        available,
+        available: selected.is_some_and(|row| row.available),
+        unavailable_reason: selected.and_then(|row| row.unavailable_reason),
         has_credential,
+        providers,
         egress: CodeExecutionEgressInfo::from_config(config.egress),
         detached_admission: detached_admission_info(host_config),
     })
@@ -3018,9 +3100,18 @@ mod tests {
     }
 
     #[test]
-    fn local_is_the_only_bounded_default() {
+    fn the_default_selection_is_never_a_provider_that_cannot_run() {
         let config = CodeExecutionConfig::default();
-        assert_eq!(config.provider, Some(CodeExecutionProviderKind::Local));
+        // Local is the only unattended default, and only where its sandbox
+        // exists: on any other host the honest default is no provider, so the
+        // surface reports "not configured" instead of a selection that fails
+        // every exec.
+        assert_eq!(
+            config.provider,
+            LocalExecutionProvider::availability()
+                .is_ok()
+                .then_some(CodeExecutionProviderKind::Local)
+        );
         assert_eq!(config.timeout_ms, DEFAULT_TIMEOUT_MS);
         assert!(config.validate().is_ok());
         assert!(CodeExecutionConfig {
@@ -3036,7 +3127,11 @@ mod tests {
 
     #[test]
     fn selection_contains_no_endpoint_or_credential_reference() {
-        let json = serde_json::to_value(CodeExecutionConfig::default()).unwrap();
+        let json = serde_json::to_value(CodeExecutionConfig {
+            provider: Some(CodeExecutionProviderKind::Local),
+            ..CodeExecutionConfig::default()
+        })
+        .unwrap();
         assert_eq!(json["provider"], "local");
         assert!(json.get("endpoint").is_none());
         assert!(json.get("credential").is_none());
@@ -3288,6 +3383,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unavailable_providers_report_an_actionable_reason() {
+        let (store, dir) = test_store().await;
+        let host_config = openwave_core::Config::desktop(dir.path());
+        let info = config_info(&host_config, &store, &NoSecrets).await.unwrap();
+        let rows: HashMap<_, _> = info
+            .providers
+            .iter()
+            .map(|row| (row.provider, *row))
+            .collect();
+
+        // No key is saved here, so a managed provider must say exactly that —
+        // "paste a key" has to be readable off the report, not inferred from a
+        // failed execution.
+        for managed in CREDENTIAL_PROVIDERS {
+            let row = rows[&managed];
+            assert!(!row.available);
+            assert_eq!(
+                row.unavailable_reason,
+                Some(CodeExecutionUnavailableReason::MissingCredential)
+            );
+        }
+        let local = rows[&CodeExecutionProviderKind::Local];
+        assert_eq!(
+            local.unavailable_reason,
+            LocalExecutionProvider::availability().err()
+        );
+
+        // The untouched host selects a provider only where one can actually
+        // run: on a host without the local sandbox the report is "nothing
+        // configured" plus the reasons above, never a dead Local selection.
+        assert_eq!(info.provider.is_some(), local.available);
+        assert_eq!(info.available, local.available);
+    }
+
+    #[tokio::test]
     async fn workspace_capability_degrades_to_none_instead_of_failing() {
         let (store, dir) = test_store().await;
         let provider = ConfiguredCodeExecutionProvider::new(
@@ -3295,6 +3425,17 @@ mod tests {
             Arc::new(NoSecrets),
             dir.path().join("scratch"),
         );
+        // Selected explicitly: the default no longer picks Local on hosts
+        // without the native sandbox, and this case is about the workspace
+        // surface, not about what a fresh host defaults to.
+        provider
+            .store
+            .set_setting(
+                CODE_EXECUTION_SETTING,
+                &serde_json::json!({ "provider": "local", "timeout_ms": DEFAULT_TIMEOUT_MS }),
+            )
+            .await
+            .unwrap();
         assert!(provider.workspace().await.unwrap().is_some());
 
         // Disabling execution and selecting a managed provider without a


### PR DESCRIPTION
`LocalExecutionProvider::is_supported()` was a bare bool, and `CodeExecutionConfig::default()` selected `Local` unconditionally. On a host without the native sandbox that produced a selected-but-dead provider: settings said a provider was configured, every exec failed with a generic "unavailable", and nothing said what to do about it.

## What changed

- `CodeExecutionUnavailableReason` (`unsupported_platform`, `missing_sandbox_binary`, `missing_credential`) replaces the bool. `LocalExecutionProvider::availability()` returns `Ok(())` or the reason; the adapter's own execution error now names it.
- `provider_availability()` in the server is the single place the decision is made — the platform probe for Local, the credential slot for the managed providers. The default selection, the per-provider rows, and the selected provider's status all read it, so they cannot disagree.
- `CodeExecutionConfig::default()` selects `Local` only where its sandbox exists. Elsewhere the truthful default is no provider, and exec fails with the typed `NotConfigured` — whose message now says a provider must be configured rather than just "not configured".
- `CodeExecutionConfigInfo` gains `providers: Vec<CodeExecutionProviderAvailability>` and `unavailable_reason` for the selected provider (both additive; the existing `available` and `has_credential` are unchanged in meaning).
- Settings shows a status row per provider with the reason as a sentence, labels unavailable providers in the picker, and reports "No execution provider configured" when nothing on the host can run. The reason codes are rendered by the UI, never printed raw.

No behavior change on macOS with the sandbox present: the default is still Local, every row reads available, and the headline is unchanged.

The exec tool spec stays registered — the config is runtime-mutable, so gating registration at startup would be wrong. The model-facing surface is covered by the typed errors instead: `NotConfigured` when nothing is selected, `Unavailable` carrying the reason when a dead provider is selected explicitly.

## Tests

- `unavailable_providers_report_an_actionable_reason` — the config report names a missing credential per managed provider and mirrors the local probe, and an untouched host selects a provider only when one can run.
- `the_default_selection_is_never_a_provider_that_cannot_run` — the existing default test, now asserting the availability contract instead of an unconditional `Local`.
- One panel test for the no-usable-provider host: the headline, both reason sentences, and no raw enum names.
- `workspace_capability_degrades_to_none_instead_of_failing` now selects Local explicitly; it is about the workspace surface, not what a fresh host defaults to.

## Verification

```
cargo fmt --all
cargo test -p openwave-server -p openwave-code-execution --locked   # 588 + 5 passed, 0 failed
cargo clippy -p openwave-code-execution -p openwave-server --all-targets --locked   # clean
cargo check --workspace --locked   # clean, no lock diff
pnpm test    # 109 files, 722 tests passed
pnpm build   # built
```

Wire bindings regenerated with `UPDATE_WIRE_TYPES=1`.

Ran on macOS, where local execution is available; the unavailable-host paths are covered by the tests above rather than by driving the app on Windows or Linux.

Closes #1528
