### PR TITLE
fix(core): reserve output/ from write_file

### DIFF
--- a/crates/openwave-core/src/tools/definitions.rs
+++ b/crates/openwave-core/src/tools/definitions.rs
@@ -14,7 +14,8 @@ pub(super) const WRITE_FILE: &str = "write_file";
 pub(super) fn read_file() -> ToolSpec {
     ToolSpec::for_args::<read_file_tool::Arguments>(
         READ_FILE,
-        "Read a UTF-8 text file, relative to the private scratch directory.",
+        "Read a UTF-8 text file, relative to the private scratch directory. Files under \
+         output/ are readable here, but only exec can write them.",
     )
 }
 
@@ -29,7 +30,10 @@ pub(super) fn write_file() -> ToolSpec {
     ToolSpec::for_args::<write_file_tool::Arguments>(
         WRITE_FILE,
         "Write a UTF-8 text file into private scratch, creating parent directories. \
-         Overwrites an existing file.",
+         Overwrites an existing file. Scratch files are intermediate work, not \
+         user-visible outputs: output/ is reserved and a write there is refused, \
+         because a user-visible output is published by saving it into output/ from \
+         an exec command.",
     )
 }
 

--- a/crates/openwave-core/src/tools/private_scratch.rs
+++ b/crates/openwave-core/src/tools/private_scratch.rs
@@ -30,6 +30,21 @@ pub(super) fn relative_path(rel: &str) -> std::result::Result<PathBuf, String> {
     Ok(path.to_path_buf())
 }
 
+/// Whether a scratch-relative path names the published-output directory or
+/// anything inside it.
+///
+/// `output/` is not ordinary scratch: its bytes become durable, versioned
+/// outputs when an exec call's post-command scan publishes them, attributed to
+/// that call and its turn. A write that lands there without publishing anything
+/// leaves bytes for the next unrelated exec scan to publish under its own
+/// identity, so the directory is reserved from the intermediate-write API
+/// rather than allowed to misattribute a revision.
+pub(super) fn is_published_output_path(path: &Path) -> bool {
+    path.components()
+        .find(|component| !matches!(component, Component::CurDir))
+        .is_some_and(|component| component.as_os_str() == crate::EXEC_OUTPUT_DIRECTORY)
+}
+
 /// The last segment of a scratch-relative path, for a card row's name.
 ///
 /// A row leads with the file rather than the path so a column of results stays

--- a/crates/openwave-core/src/tools/tests.rs
+++ b/crates/openwave-core/src/tools/tests.rs
@@ -187,6 +187,28 @@ async fn confinement_rejects_escaping_and_absolute_paths() {
     assert!(absolute.is_error);
 }
 
+/// A direct write to `output/` must be refused rather than silently staged.
+///
+/// The published-output directory is scanned after an exec call, and every
+/// revision it finds is attributed to that call and its turn. Bytes left there
+/// by `write_file` publish nothing of their own and would be credited to the
+/// next unrelated exec call, so the write has to fail at the boundary.
+#[tokio::test]
+async fn write_file_refuses_the_published_output_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let ctx = ctx(dir.path());
+
+    for path in ["output/report.md", "./output/nested/report.md", "output"] {
+        let refused = WriteFile
+            .execute(&ctx, json!({"path": path, "content": "published?"}))
+            .await
+            .unwrap();
+        assert!(refused.is_error, "{path}: {refused:?}");
+        assert!(refused.content.contains("exec"), "{path}: {refused:?}");
+    }
+    assert!(!dir.path().join("output").exists());
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn confinement_rejects_symlink_escape() {

--- a/crates/openwave-core/src/tools/write_file.rs
+++ b/crates/openwave-core/src/tools/write_file.rs
@@ -5,11 +5,11 @@ use serde_json::Value;
 
 use crate::error::Result;
 use crate::preview::{ResultEntry, ResultEntryKind};
-use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolOutput, ToolSpec};
+use crate::tool::{ApprovalClass, Tool, ToolCtx, ToolErrorCategory, ToolOutput, ToolSpec};
 
 use super::arguments;
 use super::definitions;
-use super::private_scratch::{file_name, relative_path, write_utf8_file};
+use super::private_scratch::{file_name, is_published_output_path, relative_path, write_utf8_file};
 
 /// `write_file` — atomically write a UTF-8 text file into private scratch.
 pub struct WriteFile;
@@ -42,6 +42,25 @@ impl Tool for WriteFile {
             Ok(path) => path,
             Err(message) => return Ok(ToolOutput::error(message)),
         };
+        // Publishing an output is an exec-scan responsibility, and the scan
+        // attributes every revision to the call it ran for. Writing here
+        // directly would publish nothing now and hand the bytes to whichever
+        // later exec call happened to run next, which would then be credited
+        // with the revision. Refuse and say where outputs come from.
+        if is_published_output_path(&path) {
+            return Ok(ToolOutput::failed(
+                ToolErrorCategory::InvalidArguments,
+                format!(
+                    "{}/ is reserved for published outputs and cannot be written with write_file: \
+                     {}. Produce user-visible files from an exec command that saves them into {}/ \
+                     — those are published as durable, versioned outputs. Use another scratch path \
+                     for intermediate text.",
+                    crate::EXEC_OUTPUT_DIRECTORY,
+                    arguments.path,
+                    crate::EXEC_OUTPUT_DIRECTORY
+                ),
+            ));
+        }
         let workspace = match ctx.workspace() {
             Ok(workspace) => workspace,
             Err(message) => return Ok(ToolOutput::error(message)),

--- a/crates/openwave-server/src/foreground_prompt.rs
+++ b/crates/openwave-server/src/foreground_prompt.rs
@@ -166,7 +166,7 @@ pub(crate) fn compose_for_surface(
         }
         if has("exec") {
             lines.push(
-                "- When the user needs a file they can preview or save, produce it in `output/` so it becomes a user-visible output instead of leaving it only in scratch.",
+                "- When the user needs a file they can preview or save, produce it in `output/` from an `exec` command so it becomes a user-visible output; `write_file` cannot write there.",
             );
         }
         push_section(&mut prompt, PRIVATE_SCRATCH_HEADING, &lines);
@@ -1066,10 +1066,11 @@ mod tests {
             false,
         );
 
-        // Re-pinned for the Open network default and parallel sibling spawn contract.
+        // Re-pinned for the reserved `output/` directory: outputs are produced
+        // by `exec`, never by `write_file`.
         assert_eq!(
             identity(&prompt),
-            "foreground-v2:sha256:28043f7e84f2ef827100574ba635f534c04ad969f9e8e9b2cf534fd91ff7d664"
+            "foreground-v2:sha256:0a38ffd0ca7c82c4b4079090dfb5bc03d13b3b39da9807332a6ddfb2c6bac853"
         );
     }
 }


### PR DESCRIPTION
Addresses item (1) of #1520 only — misattributed output revisions. Items (2)-(5) stay open.

## The bug

`write_file("output/x")` mutates a scratch file and publishes nothing. Output publication happens in the post-exec scan (`crates/openwave-code-execution/src/tool.rs:156-172`), which attributes every revision it records to the call and turn that owns the exec it just ran (`crates/openwave-server/src/code_execution.rs:1936-1966`). So the bytes sat in `output/` until some later, unrelated `exec` ran, and that call was credited with the revision. Version history showed the wrong action as the producer of the change.

## Resolution: (b), reserve `output/`

I went with reserving the directory rather than having `write_file` invoke the publication path itself.

Publication needs a store handle and the turn that owns the call. `ToolCtx` carries neither — it has `chat_id`, `project_id`, `call_id`, and a capability-confined scratch `Dir` — and `sync_output_directory` is driven from the server's provider wrapper, which has both. Making `write_file` publish means either threading a store into `ToolCtx` for every built-in tool or moving the tool out of `openwave-core`; both are a much larger diff than this one, in service of giving outputs a second producer whose durability, approval class (`Workspace` vs `Sensitive`), and undo behavior differ from the first. One producer is the clearer contract, and it is the one the model is already told to use: scratch is intermediate work, `output/` is what `exec` publishes.

## What changed

- `crates/openwave-core/src/tools/private_scratch.rs` — `is_published_output_path`, which skips leading `.` components so `./output/x` is caught too.
- `crates/openwave-core/src/tools/write_file.rs` — a path naming `output/` or anything under it returns a `ToolErrorCategory::InvalidArguments` failure naming the path and telling the model to save the file from an `exec` command instead. Invalid-arguments rather than the generic tool-failure category because this is the model getting the request wrong, not the product failing, and `is_product_failure()` should stay false for it.
- `crates/openwave-core/src/tools/definitions.rs` — `write_file` states the reservation; `read_file` says `output/` is readable but only `exec` writes it.
- `crates/openwave-server/src/foreground_prompt.rs` — the scratch guidance line already told the model to produce user-visible files in `output/`; it now says to do so from an `exec` command and that `write_file` cannot write there. Golden prompt identity re-pinned accordingly.

`read_file`/`list_dir` are untouched in behavior — reading and listing published outputs stays available, which matters in plan mode where `exec` is never advertised.

## Test

One: `write_file_refuses_the_published_output_directory`, covering `output/report.md`, `./output/nested/report.md`, and bare `output`, asserting the call fails, the message points at `exec`, and nothing was created on disk. No mirror or guard tests added.

## Verification

```
$ cargo fmt --all
$ cargo test -p openwave-core --locked
test result: ok. 578 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 31.44s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (postgres_turn_state)
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (doc-tests)

$ cargo test -p openwave-server --locked
test result: ok. 587 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 78.17s
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.00s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (doc-tests)

$ cargo check --workspace --locked
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 04s
```

No lockfile drift, no new dependencies. Nothing under `crates/openwave-desktop/ui/` changed, so `pnpm test`/`pnpm build` do not apply.

Not verified by driving the app: the end-to-end effect on a real turn's version history. The attribution path itself is unchanged — this removes the only way to reach it without an owning exec call.

Part of #1520.