### PR TITLE
fix(router): inline schema refs and guarantee typed nodes for Gemini tools

### DIFF
--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -415,7 +415,22 @@ fn gemini_function_calling_config(choice: Option<&ToolChoice>) -> Result<Value> 
 /// validation keywords are omitted, while the structural shape and constraints
 /// Gemini can express are retained. Building from an allowlist prevents a new
 /// JSON Schema keyword from becoming an unknown protobuf field in every turn.
+///
+/// Every node this emits carries an explicit `type` (optionally alongside
+/// `nullable`) or is an `anyOf` whose branches each satisfy the same rule.
+/// Gemini rejects the whole request when any node omits its type, so a schema
+/// that carries its shape some other way — a `$ref` into `$defs`, a bare
+/// `const`, an enum with the type left implicit — has to be resolved here
+/// rather than forwarded.
 fn gemini_tool_schema(schema: &Value) -> Result<Value> {
+    gemini_tool_schema_node(schema, schema, &mut Vec::new())
+}
+
+fn gemini_tool_schema_node(
+    schema: &Value,
+    root: &Value,
+    resolving: &mut Vec<String>,
+) -> Result<Value> {
     let unsupported = |detail: &str| {
         AgentError::Provider(format!(
             "gemini function parameters cannot express {detail}"
@@ -424,12 +439,41 @@ fn gemini_tool_schema(schema: &Value) -> Result<Value> {
     let object = schema
         .as_object()
         .ok_or_else(|| unsupported("a non-object schema"))?;
+
+    // Gemini has no `$defs`, so a reference is inlined before translation.
+    // Sibling keywords on the referring node (a `description`, a `default`)
+    // stay authoritative over the target's own.
+    if let Some(reference) = object.get("$ref").and_then(Value::as_str) {
+        if resolving.iter().any(|seen| seen == reference) {
+            return Err(unsupported(&format!(
+                "the recursive schema reference `{reference}`"
+            )));
+        }
+        let target = resolve_schema_ref(root, reference)
+            .and_then(Value::as_object)
+            .ok_or_else(|| unsupported(&format!("the unresolvable reference `{reference}`")))?;
+        let mut inlined = target.clone();
+        for (keyword, value) in object {
+            if keyword != "$ref" {
+                inlined.insert(keyword.clone(), value.clone());
+            }
+        }
+        resolving.push(reference.to_owned());
+        let translated = gemini_tool_schema_node(&Value::Object(inlined), root, resolving);
+        resolving.pop();
+        return translated;
+    }
+
     let mut out = serde_json::Map::new();
 
     for keyword in GEMINI_SCHEMA_KEYWORDS {
         if let Some(value) = object.get(*keyword) {
             out.insert((*keyword).to_owned(), value.clone());
         }
+    }
+    // Gemini has no `const`; a single-member enum says the same thing.
+    if let Some(value) = object.get("const") {
+        out.insert("enum".to_owned(), json!([value]));
     }
     if let Some(format) = object.get("format").and_then(Value::as_str) {
         if GEMINI_FORMATS.contains(&format) {
@@ -444,6 +488,20 @@ fn gemini_tool_schema(schema: &Value) -> Result<Value> {
         .get("nullable")
         .and_then(Value::as_bool)
         .unwrap_or(false);
+    // A `null` member of an enum is Gemini's `nullable`, not an enum value.
+    let denulled = out
+        .get("enum")
+        .and_then(Value::as_array)
+        .and_then(|values| {
+            values
+                .iter()
+                .any(Value::is_null)
+                .then(|| values.iter().filter(|value| !value.is_null()).cloned())
+        });
+    if let Some(values) = denulled {
+        nullable = true;
+        out.insert("enum".to_owned(), Value::Array(values.collect()));
+    }
     let mut declared: Option<&str> = None;
     let mut any_of = None;
     if let Some(branches) = object.get("anyOf") {
@@ -455,7 +513,7 @@ fn gemini_tool_schema(schema: &Value) -> Result<Value> {
             if branch.get("type").is_some_and(|value| value == "null") {
                 nullable = true;
             } else {
-                concrete.push(gemini_tool_schema(branch)?);
+                concrete.push(gemini_tool_schema_node(branch, root, resolving)?);
             }
         }
         if concrete.len() == 1 && object.get("type").is_none() {
@@ -499,7 +557,12 @@ fn gemini_tool_schema(schema: &Value) -> Result<Value> {
                 .map(|properties| {
                     properties
                         .iter()
-                        .map(|(name, property)| Ok((name.clone(), gemini_tool_schema(property)?)))
+                        .map(|(name, property)| {
+                            Ok((
+                                name.clone(),
+                                gemini_tool_schema_node(property, root, resolving)?,
+                            ))
+                        })
                         .collect::<Result<serde_json::Map<_, _>>>()
                 })
                 .transpose()?
@@ -513,17 +576,66 @@ fn gemini_tool_schema(schema: &Value) -> Result<Value> {
             let items = object
                 .get("items")
                 .ok_or_else(|| unsupported("an array with no item schema"))?;
-            out.insert("items".to_owned(), gemini_tool_schema(items)?);
+            out.insert(
+                "items".to_owned(),
+                gemini_tool_schema_node(items, root, resolving)?,
+            );
         }
     } else if let Some(branches) = any_of {
         out.insert("anyOf".to_owned(), Value::Array(branches));
-    } else if !out.contains_key("type") && !out.contains_key("enum") {
-        return Err(unsupported("a schema with no type, enum, or anyOf"));
+    } else if !out.contains_key("type") && !out.contains_key("anyOf") {
+        // A schema that only lists its permitted values still owes Gemini a
+        // type; JSON Schema leaves it implicit, Gemini rejects the request.
+        let inferred = out
+            .get("enum")
+            .and_then(Value::as_array)
+            .ok_or_else(|| unsupported("a schema with no type, enum, or anyOf"))
+            .and_then(|values| {
+                gemini_enum_type(values)
+                    .ok_or_else(|| unsupported("an enum with no single value type"))
+            })?;
+        out.insert("type".to_owned(), json!(inferred));
     }
     if nullable {
         out.insert("nullable".to_owned(), json!(true));
     }
     Ok(Value::Object(out))
+}
+
+/// Resolve a local `#/...` JSON pointer reference against the root schema.
+///
+/// Only same-document references are supported; this boundary never fetches a
+/// remote schema, and every generator this repository uses emits `$defs`
+/// pointers.
+fn resolve_schema_ref<'a>(root: &'a Value, reference: &str) -> Option<&'a Value> {
+    let pointer = reference.strip_prefix('#')?;
+    if pointer.is_empty() {
+        return Some(root);
+    }
+    root.pointer(pointer)
+}
+
+/// Infer the Gemini type an enum's members share, or `None` when they disagree.
+fn gemini_enum_type(values: &[Value]) -> Option<&'static str> {
+    let mut inferred: Option<&'static str> = None;
+    for value in values {
+        let name = match value {
+            Value::String(_) => "STRING",
+            Value::Bool(_) => "BOOLEAN",
+            Value::Number(number) if number.is_i64() || number.is_u64() => "INTEGER",
+            Value::Number(_) => "NUMBER",
+            _ => return None,
+        };
+        inferred = Some(match inferred {
+            None => name,
+            // Integer literals mixed with fractional ones are still numbers.
+            Some(seen) if seen == name => seen,
+            Some("INTEGER") if name == "NUMBER" => "NUMBER",
+            Some("NUMBER") if name == "INTEGER" => "NUMBER",
+            Some(_) => return None,
+        });
+    }
+    inferred
 }
 
 /// Keywords `responseSchema` understands and that carry over unchanged.
@@ -1152,6 +1264,13 @@ mod tests {
                 "default",
             ];
             let object = schema.as_object().expect("Gemini schema must be an object");
+            // Gemini rejects the whole request when any node omits its type,
+            // so the translator must resolve a shape JSON Schema left implicit
+            // rather than forward it.
+            assert!(
+                object.contains_key("type") || object.contains_key("anyOf"),
+                "Gemini schema node must declare a type or anyOf: {schema}"
+            );
             for (keyword, value) in object {
                 assert!(
                     SUPPORTED.contains(&keyword.as_str()),
@@ -1188,6 +1307,49 @@ mod tests {
             .is_none());
         let nullable = gemini_tool_schema(&json!({ "type": ["string", "null"] })).unwrap();
         assert_eq!(nullable, json!({ "type": "STRING", "nullable": true }));
+    }
+
+    /// Reproduces the shapes a derived tool schema reaches Gemini with that
+    /// carry no type of their own: a `$defs` reference, a bare `const`, and an
+    /// enum whose type is left implicit. Gemini rejects the entire request for
+    /// any one of them.
+    #[test]
+    fn derived_schema_shapes_without_a_type_are_resolved() {
+        let translated = gemini_tool_schema(&json!({
+            "type": "object",
+            "$defs": {
+                "Capability": { "enum": ["read_files", "write_files"] },
+                "Version": { "const": 2 },
+            },
+            "properties": {
+                "capabilities": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/Capability" },
+                    "uniqueItems": true,
+                },
+                "version": { "$ref": "#/$defs/Version", "description": "Wire version." },
+            },
+            "required": ["capabilities"],
+        }))
+        .unwrap();
+        assert_eq!(
+            translated["properties"]["capabilities"]["items"],
+            json!({ "type": "STRING", "enum": ["read_files", "write_files"] })
+        );
+        assert_eq!(
+            translated["properties"]["version"],
+            json!({ "type": "INTEGER", "enum": [2], "description": "Wire version." })
+        );
+
+        let cyclic = gemini_tool_schema(&json!({
+            "$defs": { "Node": { "type": "object", "properties": { "next": { "$ref": "#/$defs/Node" } } } },
+            "$ref": "#/$defs/Node",
+        }))
+        .unwrap_err();
+        assert!(
+            cyclic.to_string().contains("recursive schema reference"),
+            "expected a descriptive cycle error, got {cyclic}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
A live Gemini turn failed with a 400: `Unable to submit request because \`request_folder_access\` functionDeclaration \`parameters.requested_capabilities\` schema didnt specify the schema type field.`

Gemini requires an explicit type on every schema node and names the nearest ancestor property when one is missing, not the offending node. `request_folder_access` derives its capability list from an enum whose wire shape is kept compact and typeless, so the array item schema reaching the translator was a bare `{"enum": ["read_files"]}`. `gemini_tool_schema` had an escape hatch that accepted a node carrying `enum` without `type` and forwarded it unchanged, so the request left the process malformed and every folder-access turn on Gemini failed. `folder_hint` had the same shape one level up.

The invariant is now explicit and enforced: every node this function emits carries a `type` (optionally with `nullable`) or is an `anyOf` whose branches each satisfy the same rule recursively. Three shapes that carry structure some other way are resolved rather than forwarded:

- **`$ref`** — local `#/...` pointers are inlined from `$defs` (or a root `definitions`, since resolution is a plain JSON pointer) before translation, with sibling keywords on the referring node overriding the targets. A visited set scoped to the current resolution path returns a descriptive error on a cycle instead of recursing forever. Previously any `$ref` was a hard failure.
- **`const: X`** → `"enum": [X]`, which is how Gemini spells a fixed value.
- **enum with no type** — the type is inferred from the members (all strings → `STRING`, integers → `INTEGER`, numbers → `NUMBER`, booleans → `BOOLEAN`; a mix of integer and fractional literals is `NUMBER`). Anything genuinely mixed is an error. A `null` member becomes `nullable` rather than an enum value.

Unchanged: the allowlist/drop semantics for keywords Gemini cannot express (`uniqueItems` and friends are still dropped silently), the `anyOf`/`nullable` collapsing, and the hard errors for schemas that are genuinely inexpressible — an unknown type name, a union of two concrete types, an array without items.

## Tests

`all_tool_schemas_translate_to_geminis_supported_subset` already walked every built-in client and agent tool spec, including `request_folder_access` — it just never checked for a type, only that each keyword was on the allowlist. It now asserts the every-node-has-type invariant on each node it visits, which is what would have caught this before it shipped.

One new test, `derived_schema_shapes_without_a_type_are_resolved`, covers the three resolutions above plus the cycle guard against a minimal fixture. It reproduces the live failure class directly: a `$defs` enum behind an array `items` ref is exactly the shape that broke.

`cargo test -p openwave-router` passes (99 tests); rustfmt and clippy are clean on the crate. Not driven against the live API.