### PR TITLE
fix(server): make the exec config route test platform-truthful

### DIFF
--- a/crates/openwave-server/src/tests/configuration.rs
+++ b/crates/openwave-server/src/tests/configuration.rs
@@ -582,7 +582,14 @@ async fn code_execution_config_route_is_authenticated_and_preserves_explicit_dis
         .unwrap();
     assert_eq!(initial.status(), StatusCode::OK);
     let initial: serde_json::Value = json_body(initial).await;
-    assert_eq!(initial["provider"], "local");
+    // The untouched default selects Local only where its sandbox exists, so
+    // the truthful initial read differs by host: "local" on a supporting
+    // platform, null elsewhere.
+    if openwave_code_execution::LocalExecutionProvider::availability().is_ok() {
+        assert_eq!(initial["provider"], "local");
+    } else {
+        assert!(initial["provider"].is_null());
+    }
     assert_eq!(
         initial["timeout_ms"],
         crate::code_execution::DEFAULT_TIMEOUT_MS


### PR DESCRIPTION
Main's headless workspace lane has been red since #1533 merged: `code_execution_config_route_is_authenticated_and_preserves_explicit_disable` asserts the untouched default provider is `"local"`, but the default now selects Local only where its sandbox exists — on the Linux runner the truthful read is `null`. Every push run after 68beaa8a fails the same single assertion.

Assert the platform-derived expectation instead, mirroring how `the_default_selection_is_never_a_provider_that_cannot_run` already handles it: `"local"` where `LocalExecutionProvider::availability()` holds, `null` elsewhere. The rest of the test (auth, explicit-disable persistence) is unchanged.

Verification: `cargo fmt --all`; `cargo test -p openwave-server --locked --lib code_execution_config_route_is_authenticated` — 1 passed (macOS takes the `"local"` branch; the `null` branch is what the Linux lane exercises).