### PR TITLE
fix(server): apply model policy on the unresolved-model turn path

### DIFF
--- a/crates/openwave-server/src/providers.rs
+++ b/crates/openwave-server/src/providers.rs
@@ -561,6 +561,47 @@ pub fn apply_model_policy(
     Ok(())
 }
 
+/// Resolve a selection against the curated registry alone — no store reads and
+/// no legacy free-form fallback.
+///
+/// A selection key names its provider outright; a bare id resolves only when
+/// exactly one curated row answers to it, so an ambiguous name is left to the
+/// caller rather than routed by guesswork.
+pub fn curated_model_policy(value: &str) -> Option<ResolvedModelPolicy> {
+    if let Some((provider, id)) = model_registry::parse_selection_key(value) {
+        return model_registry::find_for(provider, id).map(ResolvedModelPolicy::curated);
+    }
+    let mut owners = model_registry::models_named(value);
+    let spec = owners.next()?;
+    owners
+        .next()
+        .is_none()
+        .then(|| ResolvedModelPolicy::curated(spec))
+}
+
+/// Configure a turn whose selection did not resolve through the host registry.
+///
+/// Embedders that inject a provider keep their free-form model contract, but a
+/// model the registry already owns still runs under its own policy: without the
+/// provider hint the router may serve it from any OpenAI-compatible route, and
+/// without the policy's reasoning flags a stored effort is shaped into a request
+/// the endpoint never agreed to take. An id nothing in the registry claims keeps
+/// the raw model, and its effort stays off the wire the way it already does —
+/// every adapter sends the parameter only for a config that claims a reasoning
+/// model, which no unregistered selection ever sets on its own.
+pub fn apply_free_form_model(
+    config: &mut AgentConfig,
+    model: String,
+    reasoning_effort: Option<ReasoningEffort>,
+) -> Result<()> {
+    if let Some(policy) = curated_model_policy(&model) {
+        return apply_model_policy(config, &policy, reasoning_effort);
+    }
+    config.model = model;
+    config.reasoning_effort = reasoning_effort;
+    Ok(())
+}
+
 /// Public catalog row plus current provider readiness.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CatalogModel {
@@ -1616,6 +1657,48 @@ mod tests {
                 None
             );
         }
+    }
+
+    /// Repro: a chat pinned to `openai::gpt-5.6-sol` reached the
+    /// OpenAI-compatible `/v1/chat/completions` route with `reasoning_effort`
+    /// attached and the vendor refused the request. The free-form turn path
+    /// assigned the raw model and effort without applying the registry policy,
+    /// so the request carried no provider hint and the router was free to serve
+    /// a model the registry already owns from any OpenAI-compatible route.
+    #[test]
+    fn a_registered_model_keeps_its_policy_on_the_free_form_path() {
+        let mut config = AgentConfig::default();
+        apply_free_form_model(
+            &mut config,
+            "openai::gpt-5.6-sol".into(),
+            Some(ReasoningEffort::Max),
+        )
+        .unwrap();
+        assert_eq!(config.provider, Some(ProviderId::new("openai")));
+        assert_eq!(config.model, "gpt-5.6-sol");
+        assert!(config.reasoning_model);
+        assert_eq!(config.reasoning_effort, Some(ReasoningEffort::Max));
+
+        // A bare curated id resolves the same way, and the effort is clamped to
+        // what that generation actually takes.
+        let mut config = AgentConfig::default();
+        apply_free_form_model(&mut config, "gpt-5.5".into(), Some(ReasoningEffort::Max)).unwrap();
+        assert_eq!(config.provider, Some(ProviderId::new("openai")));
+        assert_eq!(config.reasoning_effort, Some(ReasoningEffort::XHigh));
+
+        // An id the registry does not claim keeps the free-form contract, and
+        // its effort stays off the wire because nothing declared the model a
+        // reasoning model.
+        let mut config = AgentConfig::default();
+        apply_free_form_model(
+            &mut config,
+            "local-model".into(),
+            Some(ReasoningEffort::High),
+        )
+        .unwrap();
+        assert_eq!(config.provider, None);
+        assert_eq!(config.model, "local-model");
+        assert!(!config.reasoning_model);
     }
 
     #[test]

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -529,8 +529,11 @@ impl SandboxAgentRunWorker {
                 chat.reasoning_effort,
             )?;
         } else {
-            agent_config.model = model;
-            agent_config.reasoning_effort = chat.reasoning_effort;
+            crate::providers::apply_free_form_model(
+                &mut agent_config,
+                model,
+                chat.reasoning_effort,
+            )?;
         }
         let request = sandbox_request(
             &agent_config,

--- a/crates/openwave-server/src/sandbox_container_run.rs
+++ b/crates/openwave-server/src/sandbox_container_run.rs
@@ -573,9 +573,9 @@ impl SandboxContainerRunner {
             crate::providers::apply_model_policy(&mut config, &policy, chat.reasoning_effort)?;
         } else {
             // A test or custom embedder that injects one provider keeps its
-            // free-form model contract, as elsewhere in the server.
-            config.model = model;
-            config.reasoning_effort = chat.reasoning_effort;
+            // free-form model contract, as elsewhere in the server — but a
+            // registered model still runs under its own policy.
+            crate::providers::apply_free_form_model(&mut config, model, chat.reasoning_effort)?;
         }
         let network_policy = crate::sandbox_docker::compile_network_policy(&chat.network_policy);
         Ok((config, network_policy))

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -736,8 +736,11 @@ impl TurnWorker {
             if let Some(policy) = model_policy.as_ref() {
                 crate::providers::apply_model_policy(&mut config, policy, chat.reasoning_effort)?;
             } else {
-                config.model = turn.model.clone();
-                config.reasoning_effort = chat.reasoning_effort;
+                crate::providers::apply_free_form_model(
+                    &mut config,
+                    turn.model.clone(),
+                    chat.reasoning_effort,
+                )?;
             }
             config.utility_model = utility_model.clone();
             config.max_steps = remaining_steps;


### PR DESCRIPTION
## Summary

The turn worker resolves the registry policy for a turn's model only when the resolver enforces the model registry. On the other branch it assigned the raw model id and the chat's reasoning effort directly, skipping `apply_model_policy` — so the request carried no provider hint, no `reasoning_model` flag, and an unclamped effort. Without a hint, `Router::select` is free to fall back to any OpenAI-compatible route for a model the registry already owns, which puts a native OpenAI Responses model on `/v1/chat/completions`. The sandbox agent-run worker and the container runner had the same branch.

This routes that branch through a new `providers::apply_free_form_model`: a selection the curated registry owns (by selection key or by an unambiguous bare id) gets its full policy — provider hint, reasoning flags, context/output limits, and effort clamped to the levels the model actually accepts. An id nothing in the registry claims keeps the free-form contract embedders rely on; its effort stays off the wire the way it already does, since every adapter sends `reasoning_effort` only for a config that claims a reasoning model, and an unregistered selection never sets that.

## Tests

One regression test in `providers`, pinning the live failure: `openai::gpt-5.6-sol` on this path keeps the `openai` provider hint and its reasoning contract instead of drifting to an OpenAI-compatible route, a bare curated id resolves the same way with its effort clamped, and an unregistered id still routes free-form.

## Verification

- `cargo check -p openwave-server --locked`
- `cargo test -p openwave-server --locked --lib` (589 passed)
- `cargo clippy -p openwave-server --locked --lib --all-features` (clean)
- `cargo fmt --all -- --check`