### PR TITLE
feat(desktop): unified inbox for pending approvals and questions

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -40,9 +40,22 @@ const listChats = vi.fn(async () => chats);
 const createChat = vi.fn(async () => chats[0]);
 const listPendingUserQuestions = vi.fn(async () => [] as unknown[]);
 const listPendingFolderAccessRequests = vi.fn(async () => [] as unknown[]);
-const listPendingChatPrompts = vi.fn(async () => [] as unknown[]);
+const listInbox = vi.fn(async () => [] as unknown[]);
 const listPendingOutputWritebackRequests = vi.fn(async () => [] as unknown[]);
 const requestUserAttention = vi.fn(async () => {});
+
+/** One waiting question, as the shell's cross-chat read returns it. */
+function parked(chatId: string, callId: string) {
+  return {
+    chatId,
+    chatTitle: null,
+    turnId: "turn-1",
+    callId,
+    kind: "question" as const,
+    action: null,
+    requestedAt: "2026-08-04T00:00:00Z",
+  };
+}
 const postMessage = vi.fn(async () => {});
 // Unmanaged is the shape most of these shell tests model; the managed gate
 // has its own DOM tests, and the one shell test that flips this to managed
@@ -80,7 +93,7 @@ vi.mock("./api", () => ({
     createChat = createChat;
     listPendingUserQuestions = listPendingUserQuestions;
     listPendingFolderAccessRequests = listPendingFolderAccessRequests;
-    listPendingChatPrompts = listPendingChatPrompts;
+    listInbox = listInbox;
     listPendingOutputWritebackRequests = listPendingOutputWritebackRequests;
     postMessage = postMessage;
     openEvents = vi.fn(() => ({ close: vi.fn() }));
@@ -196,8 +209,8 @@ beforeEach(() => {
   listPendingUserQuestions.mockResolvedValue([]);
   listPendingFolderAccessRequests.mockReset();
   listPendingFolderAccessRequests.mockResolvedValue([]);
-  listPendingChatPrompts.mockReset();
-  listPendingChatPrompts.mockResolvedValue([]);
+  listInbox.mockReset();
+  listInbox.mockResolvedValue([]);
   listPendingOutputWritebackRequests.mockReset();
   listPendingOutputWritebackRequests.mockResolvedValue([]);
   requestUserAttention.mockClear();
@@ -238,15 +251,7 @@ describe("app shell", () => {
   });
 
   it("marks a parked conversation other than the one that is open", async () => {
-    listPendingChatPrompts.mockResolvedValue([
-      {
-        chatId: "chat-2",
-        questionCallIds: ["call-parked"],
-        planCallIds: [],
-        folderAccessCallIds: [],
-        outputWritebackCallIds: [],
-      },
-    ]);
+    listInbox.mockResolvedValue([parked("chat-2", "call-parked")]);
     await mountApp({ at: "/c/chat-1" });
 
     // The conversation's own rail carries no chat list, so the way back to the
@@ -460,20 +465,12 @@ describe("app shell", () => {
     // question. The summary watcher belongs to the shell, so it is still
     // running with no conversation open. Prompt detail is not fetched here —
     // settings has no chat, and the one being returned to rehydrates its own.
-    const readsBefore = listPendingChatPrompts.mock.calls.length;
-    listPendingChatPrompts.mockResolvedValue([
-      {
-        chatId: "chat-1",
-        questionCallIds: ["call-1"],
-        planCallIds: [],
-        folderAccessCallIds: [],
-        outputWritebackCallIds: [],
-      },
-    ]);
+    const readsBefore = listInbox.mock.calls.length;
+    listInbox.mockResolvedValue([parked("chat-1", "call-1")]);
     useRefreshSignals.getState().signal("userQuestions");
 
     await waitFor(() =>
-      expect(listPendingChatPrompts.mock.calls.length).toBeGreaterThan(readsBefore),
+      expect(listInbox.mock.calls.length).toBeGreaterThan(readsBefore),
     );
     // And the dock still gets told, which is the whole point.
     await waitFor(() => expect(requestUserAttention).toHaveBeenCalled());
@@ -498,7 +495,7 @@ describe("app shell", () => {
     await user.keyboard("{Meta>}n{/Meta}");
 
     expect(createChat).not.toHaveBeenCalled();
-    expect(listPendingChatPrompts).not.toHaveBeenCalled();
+    expect(listInbox).not.toHaveBeenCalled();
   });
 
   it("returns from settings to the conversation that was open", async () => {

--- a/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.dom.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -9,6 +9,7 @@ import type { ComposerImages } from "./Composer";
 import { useChatSessionStore } from "./ChatSessionStore";
 import { useComposerDrafts } from "./ComposerDrafts";
 import { usePendingPrompts } from "./PendingPrompts";
+import { renderWithRouter } from "./test/router";
 
 vi.mock("./host", () => ({
   hasNativeHost: () => false,
@@ -80,8 +81,8 @@ function DraftingChatView(overrides: Partial<ChatViewProps> = {}) {
   );
 }
 
-function renderChatView(overrides: Partial<ChatViewProps> = {}) {
-  const props: ChatViewProps = {
+function chatViewProps(overrides: Partial<ChatViewProps> = {}): ChatViewProps {
+  return {
     client,
     chat,
     hydrated: true,
@@ -98,7 +99,11 @@ function renderChatView(overrides: Partial<ChatViewProps> = {}) {
     onSend: vi.fn(async () => {}),
     ...overrides,
   };
-  render(<ChatView {...props} />);
+}
+
+async function renderChatView(overrides: Partial<ChatViewProps> = {}) {
+  const props = chatViewProps(overrides);
+  await renderWithRouter(<ChatView {...props} />);
   return props;
 }
 
@@ -110,7 +115,7 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("ChatView", () => {
-  it("renders the live session transcript straight from the store", () => {
+  it("renders the live session transcript straight from the store", async () => {
     useChatSessionStore.getState().update((session) => ({
       ...session,
       messages: [
@@ -118,7 +123,7 @@ describe("ChatView", () => {
         { id: "m2", role: "assistant", text: "hi!", sources: [] },
       ],
     }));
-    renderChatView();
+    await renderChatView();
     expect(screen.getByText("hello there")).toBeInTheDocument();
     expect(screen.getByText("hi!")).toBeInTheDocument();
   });
@@ -148,9 +153,55 @@ describe("ChatView", () => {
       ] as never,
     });
 
-    renderChatView();
+    await renderChatView();
 
     expect(await screen.findByText("Which quarter?")).toBeInTheDocument();
+  });
+
+  it("reveals the card a deep link named, then drops it from the URL", async () => {
+    // What the inbox promises: opening an item lands on the exact card that
+    // parked, not at the bottom of a transcript the reader has to search.
+    usePendingPrompts.setState({
+      chatId: "chat-1",
+      userQuestions: [
+        {
+          callId: "call-q",
+          turnId: "turn-1",
+          askedAt: "2026-07-24T00:00:00.000Z",
+          questions: [
+            {
+              id: "q1",
+              header: "Scope",
+              question: "Which quarter?",
+              options: [],
+              questionType: "single_select",
+              allowFreeForm: true,
+            },
+          ],
+        },
+      ] as never,
+    });
+    const scrollIntoView = vi.spyOn(Element.prototype, "scrollIntoView");
+
+    const { router } = await renderWithRouter(
+      <ChatView {...chatViewProps()} />,
+      { initialUrl: "/c/chat-1?focus=call-q" },
+    );
+
+    // The right card, not merely some scroll: the anchor the deep link named
+    // is the element that gets pointed out.
+    await waitFor(() =>
+      expect(
+        document.querySelector('[data-pending-call-id="call-q"]'),
+      ).toHaveClass("is-deep-linked"),
+    );
+    expect(scrollIntoView).toHaveBeenCalled();
+    // The link is spent once honored: a reload should show the conversation as
+    // it stands, not scroll to a card that may long since have been answered.
+    await waitFor(() =>
+      expect(router.state.location.search).not.toHaveProperty("focus"),
+    );
+    scrollIntoView.mockRestore();
   });
 
   it("sends an approval decision through its own client", async () => {
@@ -167,7 +218,7 @@ describe("ChatView", () => {
         },
       ],
     }));
-    renderChatView();
+    await renderChatView();
 
     await userEvent.click(screen.getAllByRole("option")[0]!);
 
@@ -181,8 +232,8 @@ describe("ChatView", () => {
     );
   });
 
-  it("re-renders as stream events land in the store", () => {
-    renderChatView();
+  it("re-renders as stream events land in the store", async () => {
+    await renderChatView();
     act(() => {
       useChatSessionStore
         .getState()
@@ -206,7 +257,7 @@ describe("ChatView", () => {
       busy: true,
       activeTurnId: "turn-1",
     }));
-    render(<DraftingChatView />);
+    await renderWithRouter(<DraftingChatView />);
 
     const message = screen.getByLabelText("Message");
     await userEvent.type(message, "go left");
@@ -233,7 +284,7 @@ describe("ChatView", () => {
       busy: true,
       activeTurnId: "turn-1",
     }));
-    render(<DraftingChatView />);
+    await renderWithRouter(<DraftingChatView />);
 
     const message = screen.getByLabelText("Message");
     await userEvent.type(message, "go left");

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -23,6 +23,7 @@ import type {
   ComposerReasoning,
 } from "./ComposerToolsMenu";
 import { MessageList, type RetryableTurn } from "./MessageList";
+import { revealPendingCall } from "./TranscriptFocus";
 import { useTranscriptVisible } from "./TranscriptVisibility";
 import { useFolderAccessRequests } from "./useFolderAccessRequests";
 import { useOutputWritebackRequests } from "./useOutputWritebackRequests";
@@ -32,6 +33,7 @@ import { useTurnControls } from "./useTurnControls";
 import { usePlanApprovals } from "./usePlanApprovals";
 import { useUserQuestions } from "./useUserQuestions";
 import { useAgentRuns } from "./useAgentRuns";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { ArrowDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -128,6 +130,9 @@ export function ChatView({
     [messages],
   );
   const agentRuns = useAgentRuns(client, chat.id, backgroundAgentSpawnKeys);
+
+  const navigate = useNavigate();
+  const focusCallId = (useSearch({ strict: false }) as { focus?: string }).focus;
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const followsLatestRef = useRef(true);
@@ -273,6 +278,47 @@ export function ChatView({
     userQuestions.requests,
     scrollToBottom,
   ]);
+
+  // A deep link from the inbox names the parked call it was opened for. The
+  // card it decides is mounted from a separate poll, so the reveal is retried
+  // for a short while rather than given up on at first paint, and the search
+  // param is dropped once honored so a reload does not re-scroll a transcript
+  // the reader has since moved through.
+  useEffect(() => {
+    if (!focusCallId || !transcriptVisible) return;
+    let settled = false;
+    const clear = () => {
+      settled = true;
+      window.clearInterval(timer);
+      window.clearTimeout(deadline);
+      void navigate({
+        to: "/c/$chatId",
+        params: { chatId: chat.id },
+        search: (previous: Record<string, unknown>) => ({
+          ...previous,
+          focus: undefined,
+        }),
+        replace: true,
+      });
+    };
+    const attempt = () => {
+      if (settled) return;
+      if (!revealPendingCall(scrollRef.current, focusCallId)) return;
+      // Arriving at a specific card means the reader is no longer following
+      // the end of the transcript; letting follow stay armed would scroll them
+      // straight back off it.
+      followsLatestRef.current = false;
+      setScrolledAway(true);
+      clear();
+    };
+    const timer = window.setInterval(attempt, 120);
+    const deadline = window.setTimeout(clear, 5_000);
+    attempt();
+    return () => {
+      window.clearInterval(timer);
+      window.clearTimeout(deadline);
+    };
+  }, [focusCallId, transcriptVisible, chat.id, navigate]);
 
   const jumpToLatest = useCallback(() => {
     followsLatestRef.current = true;

--- a/crates/openwave-desktop/ui/src/Inbox.ts
+++ b/crates/openwave-desktop/ui/src/Inbox.ts
@@ -1,0 +1,39 @@
+import { create } from "zustand";
+
+import type { InboxItem } from "./api";
+
+/**
+ * Everything parked on the reader, in one place.
+ *
+ * Shell state, like {@link useChatAttention}: an item waits whether or not the
+ * screen that would show it is mounted, so the watcher that fills this lives in
+ * the shell and every view only reads. The list is the server's read model
+ * verbatim — the inbox stores nothing of its own, and an item leaves it when
+ * the next poll no longer finds its journal row parked.
+ */
+export type InboxStore = {
+  items: InboxItem[];
+  /** Whether a first read has landed, so an empty list can be told from "not yet". */
+  loaded: boolean;
+  setItems: (items: InboxItem[]) => void;
+  clear: () => void;
+};
+
+function sameItems(left: InboxItem[], right: InboxItem[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((item, index) => item.callId === right[index]?.callId)
+  );
+}
+
+export const useInbox = create<InboxStore>()((set) => ({
+  items: [],
+  loaded: false,
+  setItems: (items) =>
+    set((state) =>
+      state.loaded && sameItems(state.items, items)
+        ? state
+        : { items, loaded: true },
+    ),
+  clear: () => set({ items: [], loaded: false }),
+}));

--- a/crates/openwave-desktop/ui/src/InboxView.tsx
+++ b/crates/openwave-desktop/ui/src/InboxView.tsx
@@ -1,0 +1,148 @@
+import { useNavigate } from "@tanstack/react-router";
+import { formatDistanceToNow } from "date-fns";
+import {
+  CircleCheck,
+  FolderOpen,
+  ListChecks,
+  MessageCircleQuestion,
+  Save,
+  ShieldQuestion,
+  type LucideIcon,
+} from "lucide-react";
+
+import type { InboxItem, InboxItemKind } from "./api";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "./components/ui/empty";
+import { useInbox } from "./Inbox";
+
+/** How each kind reads, and what it is answered by. */
+const KIND_PRESENTATION: Record<
+  InboxItemKind,
+  { label: string; description: string; icon: LucideIcon }
+> = {
+  tool_approval: {
+    label: "Approval",
+    description: "An action is waiting for your decision.",
+    icon: ShieldQuestion,
+  },
+  question: {
+    label: "Question",
+    description: "The assistant asked you something before continuing.",
+    icon: MessageCircleQuestion,
+  },
+  plan_review: {
+    label: "Plan review",
+    description: "A plan is waiting for you to accept or send back.",
+    icon: ListChecks,
+  },
+  folder_access: {
+    label: "Folder access",
+    description: "A folder needs connecting before the work can go on.",
+    icon: FolderOpen,
+  },
+  output_writeback: {
+    label: "Save to folder",
+    description: "A file is waiting for you to confirm the write.",
+    icon: Save,
+  },
+};
+
+/**
+ * Everything waiting on the reader, across their conversations.
+ *
+ * Nothing is answered here. An item is a pointer back to the card that owns the
+ * decision, in the conversation it paused: that card is the only place with the
+ * question, the plan, or the action under review, and routing every answer
+ * through it is what keeps one resolution path rather than two. Opening an item
+ * carries the parked call in the URL so the transcript reopens where it stopped.
+ */
+export function InboxView() {
+  const navigate = useNavigate();
+  const items = useInbox((state) => state.items);
+  const loaded = useInbox((state) => state.loaded);
+
+  if (items.length === 0) {
+    return (
+      <Empty className="h-full">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <CircleCheck aria-hidden="true" />
+          </EmptyMedia>
+          <EmptyTitle>{loaded ? "Nothing is waiting" : "Loading…"}</EmptyTitle>
+          {loaded && (
+            <EmptyDescription>
+              Approvals, questions, and plan reviews from every conversation
+              collect here while they wait for you.
+            </EmptyDescription>
+          )}
+        </EmptyHeader>
+      </Empty>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3 overflow-y-auto p-6">
+      <h1 className="text-lg font-medium">Inbox</h1>
+      <ul className="flex flex-col gap-2">
+        {items.map((item) => (
+          <li key={item.callId}>
+            <InboxRow
+              item={item}
+              onOpen={() =>
+                void navigate({
+                  to: "/c/$chatId",
+                  params: { chatId: item.chatId },
+                  search: { focus: item.callId },
+                })
+              }
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function InboxRow({ item, onOpen }: { item: InboxItem; onOpen: () => void }) {
+  const presentation = KIND_PRESENTATION[item.kind];
+  const Icon = presentation.icon;
+  const title = item.chatTitle?.trim() || "New chat";
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      className="hover:bg-muted flex w-full items-center gap-3 rounded-lg border p-3 text-left"
+    >
+      <span className="bg-muted text-foreground flex size-8 shrink-0 items-center justify-center rounded-md">
+        <Icon aria-hidden="true" className="size-4" />
+      </span>
+      <span className="flex min-w-0 flex-col">
+        <span className="flex min-w-0 items-center gap-2">
+          <span className="text-sm font-medium">{presentation.label}</span>
+          <span className="text-muted-foreground truncate text-sm">{title}</span>
+        </span>
+        <span className="text-muted-foreground text-xs">
+          {presentation.description}
+        </span>
+      </span>
+      <time
+        dateTime={item.requestedAt}
+        className="text-muted-foreground ml-auto shrink-0 text-xs"
+      >
+        {waitedFor(item.requestedAt)}
+      </time>
+    </button>
+  );
+}
+
+/** How long this has been waiting, or nothing when the timestamp is unusable. */
+export function waitedFor(requestedAt: string): string {
+  const parsed = new Date(requestedAt);
+  if (Number.isNaN(parsed.getTime())) return "";
+  return `${formatDistanceToNow(parsed)} ago`;
+}

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -375,6 +375,7 @@ export function MessageList({
             }
             onCancel={() => onFolderAccessCancel(request.callId, request.turnId)}
           />,
+          request.callId,
         ),
       )}
       {outputWritebackRequests.map((request) =>
@@ -393,6 +394,7 @@ export function MessageList({
               onOutputWritebackCancel(request.callId, request.turnId)
             }
           />,
+          request.callId,
         ),
       )}
       {userQuestionRequests.map((request) =>
@@ -411,6 +413,7 @@ export function MessageList({
               )
             }
           />,
+          request.callId,
         ),
       )}
       {planApprovalRequests.map((request) =>
@@ -424,6 +427,7 @@ export function MessageList({
             onDecide={(decision) => onPlanDecision(request.callId, decision)}
             onCancel={() => onPlanCancel(request.turnId)}
           />,
+          request.callId,
         ),
       )}
       {shouldShowAssistantWorking(
@@ -691,6 +695,12 @@ function isolatedCard(
   key: string,
   signature: string,
   card: ReactNode,
+  /**
+   * The parked call this card decides, when it decides one. It is written to
+   * the DOM so a deep link from the inbox can find the card it named — the
+   * transcript is otherwise addressable only by scroll position.
+   */
+  pendingCallId?: string,
 ): ReactNode {
   return (
     <ErrorBoundary
@@ -698,7 +708,11 @@ function isolatedCard(
       resetKey={signature}
       fallback={<ToolActivityUnavailable />}
     >
-      {card}
+      {pendingCallId ? (
+        <div data-pending-call-id={pendingCallId}>{card}</div>
+      ) : (
+        card
+      )}
     </ErrorBoundary>
   );
 }
@@ -821,6 +835,7 @@ function surfacedCard(entry: ChatMessage, context: CardContext): ReactNode {
         error={approvalState?.approvalErrors[entry.callId]}
         onDecide={onApproval}
       />,
+      entry.callId,
     );
   }
   if (entry.role !== "tool") return null;

--- a/crates/openwave-desktop/ui/src/TranscriptFocus.ts
+++ b/crates/openwave-desktop/ui/src/TranscriptFocus.ts
@@ -1,0 +1,54 @@
+/**
+ * Returning a deep link to the exact place a conversation paused.
+ *
+ * The transcript has no addressable positions of its own — it is a stream that
+ * follows its own end. What it does have is the parked call each waiting card
+ * decides, which the inbox already names, so a card is found by that id and the
+ * scroll is put on it rather than at the bottom.
+ */
+
+/** How the DOM node of a waiting card is labelled. See `MessageList`. */
+export const PENDING_CALL_ATTRIBUTE = "data-pending-call-id";
+
+/** The class a revealed card wears while it is being pointed out. */
+export const FOCUS_CLASS = "is-deep-linked";
+
+/** How long the reveal highlight stays up. */
+export const FOCUS_HIGHLIGHT_MS = 2_000;
+
+/**
+ * Put the scroll on the card deciding `callId`, if it is on screen yet.
+ *
+ * `false` means the card is not mounted — the conversation is still loading, or
+ * the item was answered elsewhere — and the caller decides whether to wait for
+ * it. Never scrolls to a guess: an absent card leaves the transcript where the
+ * reader left it.
+ */
+export function revealPendingCall(
+  container: Element | null,
+  callId: string,
+): boolean {
+  const card = findPendingCard(container, callId);
+  if (!card) return false;
+  card.scrollIntoView({ block: "center", behavior: "smooth" });
+  card.classList.add(FOCUS_CLASS);
+  setTimeout(() => card.classList.remove(FOCUS_CLASS), FOCUS_HIGHLIGHT_MS);
+  return true;
+}
+
+/**
+ * The card deciding `callId`, or `null`.
+ *
+ * The id is written into a selector, so it is checked against the shape ids
+ * actually take before it gets there. Anything else is treated as no match
+ * rather than escaped, because a value that is not an id cannot name a card.
+ */
+export function findPendingCard(
+  container: Element | null,
+  callId: string,
+): HTMLElement | null {
+  if (!container || !/^[A-Za-z0-9_-]{1,128}$/.test(callId)) return null;
+  return container.querySelector<HTMLElement>(
+    `[${PENDING_CALL_ATTRIBUTE}="${callId}"]`,
+  );
+}

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ApiClient,
   parseFolderAccessRequest,
+  parseInboxItem,
   parsePendingChatPrompt,
   parseOutputWritebackRequest,
   parsePendingUserQuestions,
@@ -99,6 +100,44 @@ describe("parseFolderAccessRequest", () => {
         folder_hint: "desktop",
         claimed: "yes",
       }),
+    ).toBeNull();
+  });
+});
+
+describe("inbox items", () => {
+  const safe = {
+    chat_id: "chat-1",
+    chat_title: "Quarterly review",
+    turn_id: "turn-1",
+    call_id: "call-1",
+    kind: "tool_approval",
+    action: "exec",
+    requested_at: "2026-08-04T00:00:00Z",
+  };
+
+  it("accepts the read model, with its optional fields absent", () => {
+    expect(parseInboxItem(safe)).toEqual({
+      chatId: "chat-1",
+      chatTitle: "Quarterly review",
+      turnId: "turn-1",
+      callId: "call-1",
+      kind: "tool_approval",
+      action: "exec",
+      requestedAt: "2026-08-04T00:00:00Z",
+    });
+    const { chat_title: _title, action: _action, ...untitled } = safe;
+    expect(parseInboxItem({ ...untitled, kind: "question" })).toMatchObject({
+      chatTitle: null,
+      action: null,
+      kind: "question",
+    });
+  });
+
+  it("rejects an unknown kind, an unknown tool, and smuggled detail", () => {
+    expect(parseInboxItem({ ...safe, kind: "everything" })).toBeNull();
+    expect(parseInboxItem({ ...safe, action: "rm_rf" })).toBeNull();
+    expect(
+      parseInboxItem({ ...safe, questions: [{ question: "private" }] }),
     ).toBeNull();
   });
 });

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -42,6 +42,7 @@ import {
   type ConsentStatementSnapshot,
   type GrantLevel,
   type GrantScope,
+  type InboxItemKind,
   type McpServerInfo as WireMcpServerInfo,
   type ManagedPolicy as WireManagedPolicy,
   type ManagedPolicySource as WireManagedPolicySource,
@@ -90,6 +91,7 @@ import {
 export type {
   ApprovalClass,
   ApprovalGrantRung,
+  InboxItemKind,
   GrantLevel,
   GrantScope,
   StandingGrantSnapshot,
@@ -628,6 +630,24 @@ export type PendingOutputWritebackRequest = {
   callId: string;
   turnId: string;
   claimedByDesktop: boolean;
+};
+
+/**
+ * One thing waiting on the reader, wherever it parked.
+ *
+ * Deliberately as opaque as the per-chat attention summary: enough to triage
+ * and to navigate back, never the question, the plan, or the arguments. Those
+ * are read from the conversation the item points at, by the card that owns
+ * them — which is also the only place the item can be answered.
+ */
+export type InboxItem = {
+  chatId: string;
+  chatTitle: string | null;
+  turnId: string;
+  callId: string;
+  kind: InboxItemKind;
+  action: RendererToolName | null;
+  requestedAt: string;
 };
 
 /** Opaque prompt state used to mark another chat as needing attention. */
@@ -1305,6 +1325,31 @@ export class ApiClient {
     return this.json(`/chats/${chatId}`, { headers: this.headers() });
   }
 
+  /**
+   * Everything parked on this reader, across their conversations.
+   *
+   * One server-side read rather than a loop over chats: the shell needs the
+   * whole set to badge the inbox and mark the rail, and asking each chat in
+   * turn would make that cost grow with the profile.
+   */
+  async listInbox(): Promise<InboxItem[]> {
+    const body = await this.json<unknown>("/inbox", { headers: this.headers() });
+    if (!Array.isArray(body)) {
+      throw new Error("inbox response is not an array");
+    }
+    const items: InboxItem[] = [];
+    const seen = new Set<string>();
+    for (const value of body) {
+      const item = parseInboxItem(value);
+      if (!item || seen.has(item.callId)) {
+        throw new Error("inbox response contains invalid data");
+      }
+      seen.add(item.callId);
+      items.push(item);
+    }
+    return items;
+  }
+
   async listPendingChatPrompts(): Promise<PendingChatPrompt[]> {
     const body = await this.json<unknown>("/chats/pending-prompts", {
       headers: this.headers(),
@@ -1892,6 +1937,69 @@ export function parseOutputWritebackRequest(
  * shared shell state. Details belong to the selected chat's recovery route,
  * never to the list indicator.
  */
+const INBOX_ITEM_KINDS = new Set<InboxItemKind>([
+  "tool_approval",
+  "question",
+  "plan_review",
+  "folder_access",
+  "output_writeback",
+]);
+
+export function parseInboxItem(value: unknown): InboxItem | null {
+  if (
+    !isRecord(value) ||
+    !onlyKeys<{
+      chat_id: string;
+      chat_title?: string;
+      turn_id: string;
+      call_id: string;
+      kind: InboxItemKind;
+      action?: RendererToolName;
+      requested_at: string;
+    }>(value, [
+      "chat_id",
+      "chat_title",
+      "turn_id",
+      "call_id",
+      "kind",
+      "action",
+      "requested_at",
+    ]) ||
+    !nonEmptyBounded(value.chat_id, 128) ||
+    !nonEmptyBounded(value.turn_id, 128) ||
+    !nonEmptyBounded(value.call_id, 128) ||
+    !nonEmptyBounded(value.requested_at, 64) ||
+    typeof value.kind !== "string" ||
+    !INBOX_ITEM_KINDS.has(value.kind as InboxItemKind)
+  ) {
+    return null;
+  }
+  // Both are optional on the wire, and neither may arrive as anything but its
+  // own declared shape — an untitled chat omits the key rather than sending an
+  // empty title, and only the closed tool vocabulary may name an action.
+  if (
+    value.chat_title !== undefined &&
+    !nonEmptyBounded(value.chat_title, 256)
+  ) {
+    return null;
+  }
+  if (
+    value.action !== undefined &&
+    !RENDERER_TOOL_NAMES.includes(value.action as RendererToolName)
+  ) {
+    return null;
+  }
+  return {
+    chatId: value.chat_id,
+    chatTitle: (value.chat_title as string | undefined) ?? null,
+    turnId: value.turn_id,
+    callId: value.call_id,
+    kind: value.kind as InboxItemKind,
+    action: (value.action as RendererToolName | undefined) ?? null,
+    requestedAt: value.requested_at,
+  };
+}
+
 export function parsePendingChatPrompt(value: unknown): PendingChatPrompt | null {
   if (
     !isRecord(value) ||

--- a/crates/openwave-desktop/ui/src/router.tsx
+++ b/crates/openwave-desktop/ui/src/router.tsx
@@ -11,6 +11,7 @@ import { AppShell } from "./AppShell";
 import { ChatExplorer } from "./ChatExplorer";
 import { ChatRoute } from "./ChatRoute";
 import { HomeRoute } from "./HomeRoute";
+import { InboxView } from "./InboxView";
 import { useManagedPolicy } from "./managedPolicy";
 import type { PanelSearch } from "./panel/panelUrl";
 import { RouteFrame } from "./RouteFrame";
@@ -19,6 +20,12 @@ import { defaultSettingsPathFor, SETTINGS_SECTIONS } from "./settings/sections";
 import { HomeSidebar } from "./sidebar/HomeSidebar";
 
 const rootRoute = createRootRoute({ component: AppShell });
+
+/**
+ * A conversation's URL carries its layout and, when arrived at from the inbox,
+ * the parked call the transcript should reveal.
+ */
+type ChatSearch = PanelSearch & { focus?: string };
 
 const homeRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -54,13 +61,38 @@ function AllChatsRoute() {
   );
 }
 
+/**
+ * The inbox shares home's rail: what is waiting spans conversations, so it is
+ * not scoped to one either.
+ */
+const inboxRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/inbox",
+  component: InboxRoute,
+});
+
+function InboxRoute() {
+  return (
+    <RouteFrame sidebar={<HomeSidebar />}>
+      <div className="content-container min-h-0 w-full min-w-0 flex-1 overflow-hidden">
+        <InboxView />
+      </div>
+    </RouteFrame>
+  );
+}
+
 const chatRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/c/$chatId",
-  validateSearch: (search: Record<string, unknown>): PanelSearch => ({
+  validateSearch: (search: Record<string, unknown>): ChatSearch => ({
     left: typeof search.left === "string" ? search.left : undefined,
     right: typeof search.right === "string" ? search.right : undefined,
     fullscreen: typeof search.fullscreen === "string" ? search.fullscreen : undefined,
+    // Where a deep link is pointing: the parked call to reveal once the
+    // transcript is up. It rides beside the layout params because it is
+    // addressing state like they are, and it is dropped from the URL as soon
+    // as it has been honored so a reload does not re-scroll.
+    focus: typeof search.focus === "string" ? search.focus : undefined,
   }),
   component: ChatRouteComponent,
 });
@@ -141,6 +173,7 @@ const settingsSectionRoutes = SETTINGS_SECTIONS.map((section) =>
 export const routeTree = rootRoute.addChildren([
   homeRoute,
   allChatsRoute,
+  inboxRoute,
   chatRoute,
   settingsRoute.addChildren([
     settingsIndexRoute,

--- a/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
@@ -14,6 +14,7 @@ import { listDeliverables, type DeliverablesCatalog } from "@/deliverables";
 import type { PanelType } from "@/panel/panelTypes";
 import { usePanelNav } from "@/panel/usePanelNav";
 import { useRefreshSignals } from "@/RefreshSignals";
+import { InboxButton } from "./InboxButton";
 import { RecentChatsSection } from "./RecentChatsSection";
 import { SidebarButton, SidebarSectionTitle } from "./primitives";
 import { SidebarFrame } from "./SidebarFrame";
@@ -67,6 +68,8 @@ export function ChatSidebar({ chat }: { chat: Chat }) {
           </span>
         )}
       </SidebarButton>
+
+      <InboxButton />
 
       <ChatPanelButton
         label="Outputs"

--- a/crates/openwave-desktop/ui/src/sidebar/HomeSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/HomeSidebar.tsx
@@ -3,6 +3,7 @@ import { LayoutGrid, MessagesSquare } from "lucide-react";
 
 import { useApp } from "@/AppContext";
 import { useChatListStore } from "@/ChatListStore";
+import { InboxButton } from "./InboxButton";
 import { NewChatButton } from "./NewChatButton";
 import { RecentChatsSection } from "./RecentChatsSection";
 import { SidebarButton, SidebarSectionTitle } from "./primitives";
@@ -42,6 +43,10 @@ export function HomeSidebar() {
         disabled={creatingChat || deletingChatId !== null}
         creating={creatingChat}
       />
+
+      <div className="mt-2">
+        <InboxButton />
+      </div>
 
       <SidebarSectionTitle className="mt-4">Chats</SidebarSectionTitle>
       <div className="flex flex-col gap-0.5">

--- a/crates/openwave-desktop/ui/src/sidebar/InboxButton.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/InboxButton.tsx
@@ -1,0 +1,42 @@
+import { useNavigate, useRouterState } from "@tanstack/react-router";
+import { Inbox } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { useInbox } from "@/Inbox";
+import { SidebarButton } from "./primitives";
+
+/**
+ * The way to everything that is waiting, from anywhere.
+ *
+ * It sits on both rails because being blocked is not scoped to a conversation:
+ * the reader is most likely to be inside one chat when another one parks. The
+ * count is the number of parked items the shell's own poll last saw, so the
+ * badge and the inbox can never disagree.
+ */
+export function InboxButton() {
+  const navigate = useNavigate();
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const waiting = useInbox((state) => state.items.length);
+  const active = pathname === "/inbox";
+
+  return (
+    <SidebarButton
+      aria-current={active ? "page" : undefined}
+      data-active={active || undefined}
+      className="data-[active]:bg-muted"
+      onClick={() => void navigate({ to: "/inbox" })}
+    >
+      <Inbox />
+      <span>Inbox</span>
+      {waiting > 0 && (
+        <Badge
+          variant="outline"
+          className="-my-0.5 ml-auto"
+          aria-label={`${waiting} waiting on you`}
+        >
+          {waiting}
+        </Badge>
+      )}
+    </SidebarButton>
+  );
+}

--- a/crates/openwave-desktop/ui/src/styles.css
+++ b/crates/openwave-desktop/ui/src/styles.css
@@ -519,6 +519,22 @@ body {
   opacity: 1;
 }
 
+/* Where a deep link landed. A brief ring rather than a lasting state: it says
+   "this one" while the scroll settles, then gets out of the way of the card's
+   own affordances. */
+[data-pending-call-id].is-deep-linked {
+  border-radius: var(--radius);
+  outline: 2px solid var(--ring);
+  outline-offset: 4px;
+  transition: outline-color 400ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-pending-call-id].is-deep-linked {
+    transition: none;
+  }
+}
+
 .message {
   width: 100%;
   overflow-wrap: anywhere;

--- a/crates/openwave-desktop/ui/src/test/router.tsx
+++ b/crates/openwave-desktop/ui/src/test/router.tsx
@@ -24,10 +24,13 @@ export async function renderWithRouter(
   const chatRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/c/$chatId",
-    validateSearch: (search: Record<string, unknown>): PanelSearch => ({
+    validateSearch: (
+      search: Record<string, unknown>,
+    ): PanelSearch & { focus?: string } => ({
       left: typeof search.left === "string" ? search.left : undefined,
       right: typeof search.right === "string" ? search.right : undefined,
       fullscreen: typeof search.fullscreen === "string" ? search.fullscreen : undefined,
+      focus: typeof search.focus === "string" ? search.focus : undefined,
     }),
     component: () => <>{ui}</>,
   });

--- a/crates/openwave-desktop/ui/src/useChatPromptWatcher.test.ts
+++ b/crates/openwave-desktop/ui/src/useChatPromptWatcher.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ApiClient } from "./api";
 import { useChatAttention } from "./ChatAttention";
+import { useInbox } from "./Inbox";
 import { usePendingPrompts } from "./PendingPrompts";
 import { useRefreshSignals } from "./RefreshSignals";
 import { useChatPromptWatcher } from "./useChatPromptWatcher";
@@ -21,30 +22,26 @@ function folderRequest(callId: string) {
   return { callId, turnId: "turn-1", displayPath: "~/Notes" };
 }
 
-function prompt(
+/** One parked item as the cross-chat read returns it. */
+function inboxItem(
   chatId: string,
-  {
-    questions = [],
-    folderAccess = [],
-    outputWritebacks = [],
-  }: {
-    questions?: string[];
-    folderAccess?: string[];
-    outputWritebacks?: string[];
-  } = {},
+  callId: string,
+  kind: "question" | "folder_access" | "tool_approval" = "question",
 ) {
   return {
     chatId,
-    questionCallIds: questions,
-    planCallIds: [],
-    folderAccessCallIds: folderAccess,
-    outputWritebackCallIds: outputWritebacks,
+    chatTitle: null,
+    turnId: "turn-1",
+    callId,
+    kind,
+    action: null,
+    requestedAt: "2026-08-04T00:00:00Z",
   };
 }
 
 function stubClient(overrides: Record<string, unknown> = {}) {
   return {
-    listPendingChatPrompts: vi.fn().mockResolvedValue([]),
+    listInbox: vi.fn().mockResolvedValue([]),
     listPendingUserQuestions: vi.fn().mockResolvedValue([]),
     listPendingFolderAccessRequests: vi.fn().mockResolvedValue([]),
     listPendingOutputWritebackRequests: vi.fn().mockResolvedValue([]),
@@ -61,6 +58,7 @@ beforeEach(() => {
     outputWritebacks: [],
   });
   useChatAttention.getState().clear();
+  useInbox.getState().clear();
 });
 afterEach(cleanup);
 
@@ -85,18 +83,18 @@ describe("useChatPromptWatcher", () => {
     act(() => useRefreshSignals.getState().signal("userQuestions"));
 
     await waitFor(() => expect(client.listPendingUserQuestions).toHaveBeenCalledTimes(2));
-    await waitFor(() => expect(client.listPendingChatPrompts).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(client.listInbox).toHaveBeenCalledTimes(2));
   });
 
   it("asks for attention once per question, not once per read", async () => {
     const client = stubClient({
-      listPendingChatPrompts: vi.fn().mockResolvedValue([prompt("chat-2", { questions: ["call-1"] })]),
+      listInbox: vi.fn().mockResolvedValue([inboxItem("chat-2", "call-1")]),
     });
     renderHook(() => useChatPromptWatcher(client, "chat-1"));
     await waitFor(() => expect(host.requestUserAttention).toHaveBeenCalledTimes(1));
 
     act(() => useRefreshSignals.getState().signal("userQuestions"));
-    await waitFor(() => expect(client.listPendingChatPrompts).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(client.listInbox).toHaveBeenCalledTimes(2));
 
     expect(host.requestUserAttention).toHaveBeenCalledTimes(1);
   });
@@ -104,18 +102,18 @@ describe("useChatPromptWatcher", () => {
   it("forgets a question once it stops being pending", async () => {
     // The announce-set spans the life of the shell, so it has to be pruned or a
     // long session accumulates the id of every question ever asked.
-    const listPendingChatPrompts = vi
+    const listInbox = vi
       .fn()
-      .mockResolvedValueOnce([prompt("chat-1", { questions: ["call-1"] })])
+      .mockResolvedValueOnce([inboxItem("chat-1", "call-1")])
       .mockResolvedValue([]);
-    const client = stubClient({ listPendingChatPrompts });
+    const client = stubClient({ listInbox });
     renderHook(() => useChatPromptWatcher(client, "chat-1"));
     await waitFor(() => expect(host.requestUserAttention).toHaveBeenCalledTimes(1));
 
     act(() => useRefreshSignals.getState().signal("userQuestions"));
     await waitFor(() => expect(usePendingPrompts.getState().userQuestions).toHaveLength(0));
 
-    listPendingChatPrompts.mockResolvedValue([prompt("chat-1", { questions: ["call-2"] })]);
+    listInbox.mockResolvedValue([inboxItem("chat-1", "call-2")]);
     act(() => useRefreshSignals.getState().signal("userQuestions"));
 
     await waitFor(() => expect(host.requestUserAttention).toHaveBeenCalledTimes(2));
@@ -162,9 +160,10 @@ describe("useChatPromptWatcher", () => {
 
   it("marks parked chats even when no conversation is open", async () => {
     const client = stubClient({
-      listPendingChatPrompts: vi.fn().mockResolvedValue([
-        prompt("chat-2", { questions: ["call-question"] }),
-        prompt("chat-3", { folderAccess: ["call-folder"] }),
+      listInbox: vi.fn().mockResolvedValue([
+        inboxItem("chat-2", "call-question"),
+        inboxItem("chat-3", "call-folder", "folder_access"),
+        inboxItem("chat-3", "call-approval", "tool_approval"),
       ]),
     });
     renderHook(() => useChatPromptWatcher(client, null));
@@ -174,6 +173,9 @@ describe("useChatPromptWatcher", () => {
         new Set(["chat-2", "chat-3"]),
       ),
     );
+    // The rail's markers and the inbox come from the same read, so a chat
+    // parked on an approval is marked exactly like one parked on a question.
+    expect(useInbox.getState().items).toHaveLength(3);
     expect(host.requestUserAttention).toHaveBeenCalledTimes(1);
     expect(client.listPendingUserQuestions).not.toHaveBeenCalled();
     expect(usePendingPrompts.getState().userQuestions).toEqual([]);

--- a/crates/openwave-desktop/ui/src/useChatPromptWatcher.ts
+++ b/crates/openwave-desktop/ui/src/useChatPromptWatcher.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react";
 import type { ApiClient } from "./api";
 import { useChatAttention } from "./ChatAttention";
 import { requestUserAttention } from "./host";
+import { useInbox } from "./Inbox";
 import { usePendingPrompts } from "./PendingPrompts";
 import { useRefreshSignals } from "./RefreshSignals";
 
@@ -10,15 +11,18 @@ const POLL_INTERVAL_MS = 10_000;
 
 const promptActions = usePendingPrompts.getState();
 const attentionActions = useChatAttention.getState();
+const inboxActions = useInbox.getState();
 
 /**
- * Watches every conversation for a parked prompt and keeps detailed prompt
- * cards current for the open one.
+ * Watches every conversation for parked work and keeps detailed prompt cards
+ * current for the open one.
  *
- * The summary poll is deliberately one server-side read, rather than a browser
- * loop over chats. Detail still comes from the selected chat's established
- * recovery routes, which keeps prompt content scoped to the conversation that
- * can render it.
+ * The cross-chat poll is deliberately one server-side read, rather than a
+ * browser loop over chats, and it is the read the inbox is built from — the
+ * rail's attention markers and the inbox are two views of one set, so they
+ * cannot disagree about what is waiting. Detail still comes from the selected
+ * chat's established recovery routes, which keeps prompt content scoped to the
+ * conversation that can render it.
  */
 export function useChatPromptWatcher(client: ApiClient | null, chatId: string | null): void {
   // Which questions the shell has already announced. It spans chat switches
@@ -34,6 +38,7 @@ export function useChatPromptWatcher(client: ApiClient | null, chatId: string | 
   useEffect(() => {
     if (!client) {
       attentionActions.clear();
+      inboxActions.clear();
       announcedCallIdsRef.current = new Set();
       refreshRef.current = null;
       return;
@@ -43,6 +48,7 @@ export function useChatPromptWatcher(client: ApiClient | null, chatId: string | 
     // sidebar carrying the previous server's attention state until the first
     // summary response arrives.
     attentionActions.clear();
+    inboxActions.clear();
     announcedCallIdsRef.current = new Set();
     let cancelled = false;
     let summarySeq = 0;
@@ -50,20 +56,14 @@ export function useChatPromptWatcher(client: ApiClient | null, chatId: string | 
     const readSummary = async () => {
       const seq = ++summarySeq;
       try {
-        const pending = await client.listPendingChatPrompts();
+        const pending = await client.listInbox();
         if (cancelled || seq !== summarySeq) return;
 
+        inboxActions.setItems(pending);
         attentionActions.setChatIdsWithPendingPrompts(
-          pending.map((prompt) => prompt.chatId),
+          pending.map((item) => item.chatId),
         );
-        const pendingPromptIds = new Set(
-          pending.flatMap((prompt) => [
-            ...prompt.questionCallIds,
-            ...prompt.planCallIds,
-            ...prompt.folderAccessCallIds,
-            ...prompt.outputWritebackCallIds,
-          ]),
-        );
+        const pendingPromptIds = new Set(pending.map((item) => item.callId));
         const unannounced = [...pendingPromptIds].filter(
           (callId) => !announcedCallIdsRef.current.has(callId),
         );
@@ -77,7 +77,7 @@ export function useChatPromptWatcher(client: ApiClient | null, chatId: string | 
         if (!cancelled && seq === summarySeq) {
           // Keep the last successful state visible. Clearing it on a transient
           // failure would make a waiting chat look resolved.
-          console.error("failed to refresh pending chat prompts", err);
+          console.error("failed to refresh the inbox", err);
         }
       }
     };


### PR DESCRIPTION
Follows #1539, which added the cross-chat read model and `GET /inbox`. This is
the surface: one place that shows everything waiting, and a way back to the
card that is waiting.

- An **Inbox** route listing every parked item — approvals, questions, plan
  reviews, folder access, save-to-folder — with the conversation it belongs to
  and how long it has been waiting.
- An **Inbox entry on both rails**, with a count badge. Being blocked is not
  scoped to a conversation: the reader is usually inside one chat when another
  parks, so the way to the inbox exists on the chat rail too.
- **Deep links.** Opening an item navigates to `/c/{chatId}?focus={callId}` —
  layout and addressing state live in the URL here, so the parked call rides
  beside the panel params. On arrival the transcript looks for the card
  deciding that call, scrolls it into view, and rings it briefly. Waiting cards
  now carry `data-pending-call-id`; that attribute is the only transcript
  position the app can address, and it is exactly the one an inbox item names.
  The param is dropped once honored, so a reload does not re-scroll to a card
  that may have been answered since.
- **One cross-chat poll, not two.** The shell watcher that marked parked chats
  now reads `/inbox` and feeds both the rail's attention markers and the inbox,
  so the badge and the list cannot disagree. A side effect worth naming: a chat
  parked on a tool approval now gets the same attention marker a parked
  question always did — the old summary read never covered approvals.

Nothing is answered from the inbox itself. An item is a pointer back to the
card that owns the decision, which is the only place with the question, the
plan, or the action under review — and keeping every answer on that path is
what keeps one resolution path instead of two.

## Tests

- One behavior test that a deep link reveals the card it named and then clears
  itself from the URL — the promise the inbox makes, end to end.
- Validator coverage for the new wire shape: an unknown kind, a tool outside
  the renderer vocabulary, and smuggled detail are all rejected.
- Existing `ChatView` tests now mount inside the test router, because the view
  reads the URL; the shell and watcher tests follow the read they now make.
  No new tests were added for the rendering of the list itself.

## Verification

```
$ cargo fmt --all --check
(clean; no Rust changed in this slice)

$ pnpm test            # crates/openwave-desktop/ui
Test Files  109 passed (109)
     Tests  725 passed (725)

$ pnpm build           # crates/openwave-desktop/ui
✓ built in 14.58s
```

Not verified by driving the running app: the reveal and the rings were checked
under jsdom, not on screen.

Closes #1510.
