### PR TITLE
feat(desktop): Library → Apps entry in the chat sidebar

### DIFF
--- a/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/AppShell.dom.test.tsx
@@ -141,6 +141,10 @@ vi.mock("./FoldersView", () => ({
   FoldersView: () => <div data-testid="folders">folders</div>,
 }));
 
+vi.mock("./apps/AppsPanel", () => ({
+  AppsPanel: () => <div data-testid="apps">apps</div>,
+}));
+
 // The settings rail (Back to app, section links) is the real thing here; only
 // the section body is stubbed. Providers is where a bare /settings lands, so
 // stubbing it is enough to stand in for whichever section the outlet renders.
@@ -349,6 +353,14 @@ describe("app shell", () => {
     expect(screen.getByTestId("transcript")).toBeInTheDocument();
     await waitFor(() =>
       expect(router.state.location.search).toEqual({ left: "folders", right: "chat" }),
+    );
+
+    // The Library entry reaches the app catalog without leaving the chat.
+    await user.click(screen.getByRole("button", { name: "Apps" }));
+
+    expect(await screen.findByTestId("apps")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(router.state.location.search).toEqual({ left: "apps", right: "chat" }),
     );
   });
 

--- a/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
+++ b/crates/openwave-desktop/ui/src/sidebar/ChatSidebar.tsx
@@ -4,6 +4,7 @@ import {
   ChevronLeft,
   CircleAlert,
   FolderOpen,
+  LayoutGrid,
   Shapes,
 } from "lucide-react";
 
@@ -91,6 +92,17 @@ export function ChatSidebar({ chat }: { chat: Chat }) {
       <div className="flex flex-col gap-0.5">
         <RecentChatsSection activeChatId={chat.id} />
       </div>
+
+      {/* Apps outlive every conversation, but reaching one from inside a chat
+          used to mean a trip through home. The library opens beside the
+          conversation like the other navigation panels do. */}
+      <SidebarSectionTitle className="mt-4">Library</SidebarSectionTitle>
+      <ChatPanelButton
+        label="Apps"
+        icon={<LayoutGrid />}
+        active={openPanelTypes.has("apps")}
+        onClick={() => openPanel({ type: "apps" })}
+      />
     </SidebarFrame>
   );
 }


### PR DESCRIPTION
Inside a conversation there was no way to reach a local app: the Apps library was only on home, even though the chat route already renders the apps panel beside the transcript (`case "apps"`).

The chat rail now carries a **Library** section beneath Chats with an **Apps** entry, matching the Home sidebar's Library/Apps entry. It dispatches through the panel nav (`openPanel({ type: "apps" })`) exactly as Outputs and Folders do, so it opens beside the conversation rather than replacing it — library list first, drill-in per app — and marks itself current while either slot holds the panel.

UI only; no Rust, wire types, or dependency changes.

Testing: extended the existing shell panel-arrangement DOM test with one click on the new entry, asserting the apps panel renders and the URL becomes `left=apps&right=chat`. `pnpm exec tsc --noEmit`, `pnpm test` (109 files, 726 tests), and `pnpm build` all pass.

Closes #1544
🤖 Generated with [Claude Code](https://claude.com/claude-code)