### PR TITLE
fix(desktop): make the background-agent list scannable

### DIFF
--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
@@ -56,18 +56,20 @@ describe("BackgroundAgentList", () => {
     expect(markup).toContain("Working in the background");
     expect(markup).toContain("Finished");
     expect(markup).toContain("Task for run-running");
-    expect(markup).toContain("Result from run-completed");
     expect(markup).not.toContain("Could not finish");
     expect(markup.indexOf("Running")).toBeLessThan(markup.indexOf("Completed"));
   });
 
-  it("shows a terminal failure error", () => {
+  it("keeps result text out of the list, which is a list to scan", () => {
     const failed = run("run-failed", "call-failed", "failed");
     failed.terminal_text = "Sandbox task failed (provider_error)";
     const markup = renderToStaticMarkup(
       <BackgroundAgentList
-        spawns={[{ callId: "call-failed", status: "completed" }]}
-        runs={[failed]}
+        spawns={[
+          { callId: "call-failed", status: "completed" },
+          { callId: "call-done", status: "completed" },
+        ]}
+        runs={[failed, run("run-done", "call-done", "completed")]}
         loading={false}
         error={null}
         onRetry={() => undefined}
@@ -76,8 +78,9 @@ describe("BackgroundAgentList", () => {
       />,
     );
 
-    expect(markup).toContain("Error:");
-    expect(markup).toContain("Sandbox task failed (provider_error)");
+    expect(markup).toContain("Task for run-failed");
+    expect(markup).not.toContain("Sandbox task failed (provider_error)");
+    expect(markup).not.toContain("Result from run-done");
   });
 
   it("shows a skeleton as soon as a spawn is visible but not durable yet", () => {
@@ -112,7 +115,7 @@ describe("BackgroundAgentList", () => {
     expect(markup).toEqual("");
   });
 
-  it("offers Stop on a cancellable run and View output only once it produced a result", () => {
+  it("offers Stop on a cancellable run", () => {
     const markup = renderToStaticMarkup(
       <BackgroundAgentList
         spawns={[
@@ -128,12 +131,10 @@ describe("BackgroundAgentList", () => {
         onRetry={() => undefined}
         onCancel={noop}
         onLoadActivity={noActivity}
-        onViewOutput={() => undefined}
       />,
     );
 
     expect(markup).toContain("Stop");
-    expect(markup).toContain("View output");
   });
 
   it("does not offer Stop on a settled run", () => {

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Bot, ChevronDown, ChevronRight, FileOutput, Square } from "lucide-react";
+import { Bot, ChevronDown, ChevronRight, Square } from "lucide-react";
 
 import type { AgentActivityHistoryEntry, AgentRun } from "./api";
 import { AgentActivityTimeline, useAgentRunActivity } from "./AgentActivityTimeline";
@@ -30,8 +30,6 @@ type BackgroundAgentListProps = {
   onCancel: (runId: string) => Promise<void>;
   /** Fetch a run's ordered, renderer-safe activity history. */
   onLoadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
-  /** Open the outputs surface, when a completed run produced a result. */
-  onViewOutput?: () => void;
   /** Open one run's dedicated panel beside the conversation. */
   onOpen?: (runId: string) => void;
 };
@@ -49,7 +47,6 @@ export function BackgroundAgentList({
   onRetry,
   onCancel,
   onLoadActivity,
-  onViewOutput,
   onOpen,
 }: BackgroundAgentListProps) {
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
@@ -112,7 +109,7 @@ export function BackgroundAgentList({
           </button>
         </div>
       ) : (
-        <div aria-live="polite">
+        <div className="max-h-48 overflow-y-auto" aria-live="polite">
           {AGENT_RUN_STATUS_GROUPS.map((group) => {
             const groupRuns = matchedRuns.filter((run) => group.statuses.includes(run.status));
             if (groupRuns.length === 0) return null;
@@ -135,14 +132,12 @@ export function BackgroundAgentList({
                 </button>
                 {!collapsed && (
                   <div className="divide-y divide-border/60">
-                    {groupRuns.map((run, index) => (
+                    {groupRuns.map((run) => (
                       <BackgroundAgentRow
                         key={run.id}
                         run={run}
-                        label={`Background agent ${index + 1}`}
                         onCancel={onCancel}
                         onLoadActivity={onLoadActivity}
-                        onViewOutput={onViewOutput}
                         onOpen={onOpen}
                       />
                     ))}
@@ -167,25 +162,21 @@ export function BackgroundAgentList({
 }
 
 /**
- * One background run: its live status on a line, expandable into the ordered
- * timeline of what it has done, with a Stop control while it is cancellable and
- * a link to its output once it finishes with one. When the panel navigation is
- * wired, the row itself opens the run's dedicated panel; the chevron keeps the
- * inline timeline for a quick glance without leaving the transcript.
+ * One background run: the task it was given, its live status, and a Stop control
+ * while it is cancellable, expandable into the ordered timeline of what it has
+ * done. The row itself opens the run's dedicated panel, which is where the
+ * result belongs — a finished agent's full text inline would bury every sibling
+ * row under it, and a delegation of any size is a list to scan, not to read.
  */
 function BackgroundAgentRow({
   run,
-  label,
   onCancel,
   onLoadActivity,
-  onViewOutput,
   onOpen,
 }: {
   run: AgentRun;
-  label: string;
   onCancel: (runId: string) => Promise<void>;
   onLoadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
-  onViewOutput?: () => void;
   onOpen?: (runId: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -202,7 +193,6 @@ function BackgroundAgentRow({
   const stoppable =
     RUNNING_AGENT_STATUSES.has(run.status) && run.status !== "cancelling";
   const showStopping = stopping || run.status === "cancelling";
-  const canViewOutput = run.produced_output && onViewOutput !== undefined;
 
   // Drop the optimistic bridge once the durable transition has caught up: any
   // status that is no longer a cancellable running state is confirmation
@@ -223,7 +213,6 @@ function BackgroundAgentRow({
   };
 
   const contentId = `background-agent-activity-${run.id}`;
-  const terminalLabel = run.status === "failed" ? "Error" : "Result";
 
   return (
     <div className="px-3 py-2.5">
@@ -255,28 +244,13 @@ function BackgroundAgentRow({
             className={cn("size-2 shrink-0 rounded-full", getAgentRunDotClass(run.status))}
             aria-hidden="true"
           />
-          <span className="min-w-0 flex-1">
-            <span className="block truncate font-medium text-foreground">{label}</span>
-            {run.task && (
-              <span className="block truncate text-xs text-muted-foreground">{run.task}</span>
-            )}
+          <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+            {run.task ?? "Background agent"}
           </span>
         </button>
         <span className="shrink-0 text-xs text-muted-foreground">
           {showStopping ? "Stopping" : agentRunStatusDetail(run)}
         </span>
-        {canViewOutput && (
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="h-7 shrink-0 gap-1 px-2 text-xs"
-            onClick={onViewOutput}
-          >
-            <FileOutput className="size-3.5" aria-hidden="true" />
-            View output
-          </Button>
-        )}
         {stoppable && (
           <Button
             type="button"
@@ -291,12 +265,6 @@ function BackgroundAgentRow({
           </Button>
         )}
       </div>
-      {run.terminal_text && (
-        <div className="mt-2 rounded-md bg-muted/50 px-2.5 py-2 text-sm text-foreground">
-          <span className="font-medium">{terminalLabel}: </span>
-          <span className="whitespace-pre-wrap break-words">{run.terminal_text}</span>
-        </div>
-      )}
       {expanded && (
         <div id={contentId} className="mt-2 pl-5">
           <AgentActivityTimeline state={activity} />

--- a/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
@@ -134,7 +134,7 @@ function BackgroundAgentDetail({
         <div className="flex items-center gap-2">
           <Bot className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
           <h2 className="min-w-0 flex-1 truncate text-base font-medium">
-            Background agent
+            {run.task ?? "Background agent"}
           </h2>
           <AgentRunStatusBadge status={run.status} />
         </div>
@@ -168,6 +168,16 @@ function BackgroundAgentDetail({
         )}
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto p-4" aria-live="polite">
+        {run.terminal_text && (
+          <div className="mb-4 rounded-md border bg-muted/40 px-3 py-2.5">
+            <p className="text-xs font-medium text-muted-foreground">
+              {run.status === "failed" ? "Error" : "Result"}
+            </p>
+            <p className="mt-1 text-sm break-words whitespace-pre-wrap text-foreground">
+              {run.terminal_text}
+            </p>
+          </div>
+        )}
         <AgentActivityTimeline state={activity} />
       </div>
     </div>

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -636,7 +636,6 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             onSelectPrompt={setComposerDraft}
             onSend={onSend}
             onRetryTurn={retryTurn}
-            onViewOutput={() => openPanel({ type: "outputs" })}
             onOpenAgentPanel={(runId) => openPanel({ type: "agent", runId })}
           />
         </TranscriptVisibilityProvider>

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -58,8 +58,6 @@ export type ChatViewProps = {
   onSend: () => Promise<void>;
   /** Put a failed turn back on the wire, unchanged, as a new turn. */
   onRetryTurn?: (turn: RetryableTurn) => void;
-  /** Open the outputs surface, offered on a completed background run's row. */
-  onViewOutput?: () => void;
   /** Open one background run's panel beside the conversation. */
   onOpenAgentPanel?: (runId: string) => void;
 };
@@ -92,7 +90,6 @@ export function ChatView({
   onSelectPrompt,
   onSend,
   onRetryTurn,
-  onViewOutput,
   onOpenAgentPanel,
 }: ChatViewProps) {
   const transcriptVisible = useTranscriptVisible();
@@ -319,7 +316,6 @@ export function ChatView({
           onRetryBackgroundAgentRuns={agentRuns.refresh}
           onCancelBackgroundAgentRun={agentRuns.cancel}
           onLoadBackgroundAgentActivity={agentRuns.loadActivity}
-          onViewBackgroundAgentOutput={onViewOutput}
           onOpenBackgroundAgent={onOpenAgentPanel}
           busy={busy}
           streamStalled={streamStalled}

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -197,7 +197,6 @@ type MessageListProps = {
   onLoadBackgroundAgentActivity?: (
     runId: string,
   ) => Promise<AgentActivityHistoryEntry[]>;
-  onViewBackgroundAgentOutput?: () => void;
   onOpenBackgroundAgent?: (runId: string) => void;
   busy: boolean;
   /** The live turn's stream has gone quiet — see [useStreamStalled]. */
@@ -267,7 +266,6 @@ export function MessageList({
   onRetryBackgroundAgentRuns = () => undefined,
   onCancelBackgroundAgentRun = async () => undefined,
   onLoadBackgroundAgentActivity = async () => [],
-  onViewBackgroundAgentOutput,
   onOpenBackgroundAgent,
   busy,
   streamStalled = false,
@@ -319,7 +317,6 @@ export function MessageList({
       retry: onRetryBackgroundAgentRuns,
       cancel: onCancelBackgroundAgentRun,
       loadActivity: onLoadBackgroundAgentActivity,
-      viewOutput: onViewBackgroundAgentOutput,
       open: onOpenBackgroundAgent,
     },
     retry,
@@ -533,7 +530,6 @@ export function groupMessageItems(
     retry: () => void;
     cancel: (runId: string) => Promise<void>;
     loadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
-    viewOutput?: () => void;
     open?: (runId: string) => void;
   } = {
     runs: [],
@@ -648,12 +644,24 @@ export function groupMessageItems(
             onRetry={backgroundAgents.retry}
             onCancel={backgroundAgents.cancel}
             onLoadActivity={backgroundAgents.loadActivity}
-            onViewOutput={backgroundAgents.viewOutput}
             onOpen={backgroundAgents.open}
           />,
         ),
       );
     }
+
+    // The agent list below already names the delegation and every agent in it.
+    // Leaving the spawn and wait calls on the rail as well stacks a second
+    // summary of the same thing above it ("Waited for background agents and
+    // delegated N tasks"), so the phase line covers everything except them.
+    const railActivities =
+      spawns.length > 0
+        ? activities.filter(
+            (entry) =>
+              entry.name !== "spawn_sandbox_agent" &&
+              entry.name !== "wait_for_agents",
+          )
+        : activities;
 
     // The rail and every card inside carry their own boundary, so this one is
     // only a backstop for the phase's own frame.
@@ -662,7 +670,7 @@ export function groupMessageItems(
         key={`tool-activity-group-${groupIndex}`}
         fallback={<ToolActivityUnavailable />}
       >
-        <ToolActivityGroup activities={activities} groupIndex={groupIndex}>
+        <ToolActivityGroup activities={railActivities} groupIndex={groupIndex}>
           {children.length > 0 ? children : undefined}
         </ToolActivityGroup>
       </ErrorBoundary>,


### PR DESCRIPTION
The transcript's agent list rendered each run's full result text inline, unbounded, under a row titled `Background agent 1` with the actual task demoted to a subtitle. A delegation of any size became a wall of prose where a list of what was delegated should be, and three stacked headers sat above it: the tool rail's summary line, the `N background agents` header, and the status-group row.

- Rows are titled from the run's task; the redundant subtitle is gone.
- The rows container is a `max-h-48` scroll region, so a large delegation stays compact.
- The spawn and wait calls are dropped from the tool rail when a spawn step renders its own agent list — the list already names both.
- Result text now renders in the run's panel, above the activity timeline. The panel already opened on row click; this is where there's room to read it.
- The per-row `View output` button is removed along with its plumbing through `ChatRoute` → `ChatView` → `MessageList`. The panel keeps an equivalent affordance.

Tests: dropped the assertion that the list contains result text and the `View output` case; added one asserting result text stays *out* of the list. Full UI suite and build pass locally.