### PR TITLE
ci: list maintenance PRs in a release-notes Maintenance section

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,9 +2,6 @@ name-template: "OpenWave v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 tag-prefix: "v"
 categories:
-  - type: pre-exclude
-    when:
-      label: "semver:none"
   - title: "Breaking Changes"
     exclusive: true
     when:
@@ -29,8 +26,16 @@ categories:
     exclusive: true
     when:
       label: "release-note:revert"
+  # Maintenance changes carry no user-facing feature or fix, but they are not
+  # invisible: a refactor can rebuild the local database or change build
+  # requirements. Every merged PR is accounted for in the notes — nothing is
+  # pre-excluded — with maintenance listed after the user-facing sections.
+  - title: "Maintenance"
+    exclusive: true
+    when:
+      label: "semver:none"
   # Historical PRs merged before managed labels existed remain visible here in
-  # the first draft. Current maintenance PRs are removed by the pre-exclude.
+  # the first draft.
   - title: "Other Changes"
   - type: version-resolver
     semver-increment: minor

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,9 +1,6 @@
 # GitHub's native "Generate release notes" button uses this configuration.
 # Keep these categories aligned with release-drafter.yml.
 changelog:
-  exclude:
-    labels:
-      - "semver:none"
   categories:
     - title: "Breaking Changes"
       labels:
@@ -23,6 +20,12 @@ changelog:
     - title: "Reverted Changes"
       labels:
         - "release-note:revert"
+    # Maintenance changes are listed, not dropped: a refactor can rebuild the
+    # local database or change build requirements, and a reader of the notes
+    # must be able to account for every merged PR.
+    - title: "Maintenance"
+      labels:
+        - "semver:none"
     - title: "Other Changes"
       labels:
         - "*"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -66,9 +66,15 @@ without asking authors to classify a PR twice:
 | `revert`   | Reverted Changes            |
 | Any `!`    | Breaking Changes            |
 
-Documentation and other maintenance-only types remain excluded. In the rendered
+Documentation and other maintenance-only types carry no `release-note:*` label
+and appear in a trailing **Maintenance** section instead — listed, not dropped,
+because a maintenance change can still matter to someone updating (a schema
+baseline rebuild, a toolchain requirement). Every merged PR is accounted for in
+the notes. In the rendered
 notes, the section heading supplies the type, so the draft formatter removes the
-redundant Conventional Commit prefix from each PR title. When a category has
+redundant Conventional Commit prefix from each PR title. Maintenance entries
+keep their full prefixes: that section mixes types, so the prefix is the
+information. When a category has
 multiple user-facing changes with the same scope, the formatter groups them
 under a third-level heading: for example, multiple `feat(desktop)` changes are
 rendered under **New Features**, then **Desktop**. A singleton scope is kept
@@ -96,9 +102,11 @@ The release-draft workflow keeps exactly one draft GitHub Release up to date:
    the next tag. The draft formatter then groups repeated scoped Conventional
    Commit titles beneath scope subheadings and keeps other entries compact at
    the end of their section. Breaking changes are always shown first.
-3. Maintenance-only PRs are omitted. The largest release effect among included
-   PRs chooses the proposed version; the category labels do not independently
-   change the version.
+3. Maintenance-only PRs land in the trailing **Maintenance** section, so every
+   merged PR is accounted for in the notes. The largest release effect among
+   all PRs chooses the proposed version; the category labels do not
+   independently change the version, and a maintenance-only release proposes a
+   patch bump.
 
 The first release has no previous published release to use as a comparison
 baseline, so Release Drafter intentionally leaves that draft as a manual


### PR DESCRIPTION
Refactor, docs, ci, and other `semver:none` PRs were pre-excluded from the drafted release notes entirely (`type: pre-exclude` in `release-drafter.yml`, `exclude` in `release.yml`). A maintenance change can still matter to someone updating — #1542's migration-baseline squash rebuilds the local database on next start — and an omitted PR leaves no trace that anything was left out.

Both generators now list `semver:none` PRs in a trailing **Maintenance** section, after the user-facing sections, so every merged PR is accounted for:

- `.github/release-drafter.yml`: the `pre-exclude` category is replaced by an exclusive `Maintenance` changelog category; `Other Changes` stays last for historical unlabeled PRs.
- `.github/release.yml` (native "Generate release notes"): same section, `exclude` removed.
- `docs/releases.md`: the two passages stating maintenance PRs are omitted now describe the Maintenance section.

The draft formatter needs no change: it only scope-groups and prefix-strips the known user-facing sections, so Maintenance entries pass through with their full `refactor(core):`-style prefixes — which is the right rendering for a section that mixes types.

Version resolution: unchanged whenever a release contains any user-facing PR (highest increment still wins). A maintenance-only release now proposes a patch bump via the existing fallback resolver instead of proposing nothing; pre-exclude was the only mechanism that kept PRs out of resolution, and keeping notes complete is worth that corner case.

Verification: `node --test scripts/format-release-notes.test.mjs` passes (formatter untouched); both YAML files parse. The drafter regenerates the current draft on the next push to main, so #1542 and today's other maintenance merges appear retroactively.