### PR TITLE
feat(desktop): surfaced app card in the transcript with an Open action

### DIFF
--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -262,6 +262,8 @@ pub enum ResultEntryKind {
     Link,
     /// An output this conversation published.
     Output,
+    /// A local app this profile published.
+    App,
 }
 
 /// One thing a call surfaced.
@@ -287,14 +289,22 @@ pub struct ResultEntry {
     /// projections predate the field.
     #[serde(default)]
     pub media_type: Option<String>,
-    /// The durable output this row names, when the row is one.
+    /// The durable record this row names, when the renderer can open one.
     ///
     /// Data rather than display text: the renderer routes a click through its
-    /// own panel navigation and never prints the id. Present only on
-    /// [`ResultEntryKind::Output`] rows; `default` because retained
-    /// projections predate the field.
-    #[serde(default)]
-    pub output_id: Option<String>,
+    /// own panel navigation and never prints the id, and [`ResultEntryKind`]
+    /// names where that click goes — an [`Output`] row opens the outputs
+    /// panel, an [`App`] row the apps library. A kind with nowhere to go
+    /// leaves this `None`.
+    ///
+    /// Aliased and `default` because retained projections wrote it as
+    /// `output_id`, when a published output was the only place a row could
+    /// point.
+    ///
+    /// [`Output`]: ResultEntryKind::Output
+    /// [`App`]: ResultEntryKind::App
+    #[serde(default, alias = "output_id")]
+    pub target_id: Option<String>,
 }
 
 impl ResultEntry {
@@ -307,7 +317,7 @@ impl ResultEntry {
             detail: None,
             meta: None,
             media_type: None,
-            output_id: None,
+            target_id: None,
         }
     }
 
@@ -332,10 +342,10 @@ impl ResultEntry {
         self
     }
 
-    /// Name the durable output this row is.
+    /// Name the durable record this row points at, which its kind routes.
     #[must_use]
-    pub fn with_output_id(mut self, output_id: impl Into<String>) -> Self {
-        self.output_id = Some(output_id.into());
+    pub fn with_target_id(mut self, target_id: impl Into<String>) -> Self {
+        self.target_id = Some(target_id.into());
         self
     }
 }
@@ -549,8 +559,9 @@ const ENTRY_TOOLS: &[&str] = &[
     crate::READ_CONNECTED_FILE_TOOL,
     crate::IMPORT_CONNECTED_FILE_TOOL,
     crate::WRITE_OUTPUT_TO_CONNECTED_FOLDER_TOOL,
-    // Lists the one app record the call created or revised: name and ordinal
-    // only, never the bundle or the manifest's bindings.
+    // Lists the one app record the call created or revised: name, ordinal, and
+    // the app id the card opens it by — never the bundle or the manifest's
+    // bindings.
     crate::local_app::CREATE_APP_TOOL,
 ];
 
@@ -732,7 +743,7 @@ fn exec_output_entries(value: Option<&Value>) -> Vec<ResultEntry> {
                 .with_meta(format!("v{version} · {status}"))
                 .with_media_type(media_type);
             if let Some(output_id) = row.get("output_id").and_then(Value::as_str) {
-                entry = entry.with_output_id(output_id);
+                entry = entry.with_target_id(output_id);
             }
             Some(entry)
         })
@@ -747,7 +758,7 @@ fn result_entry(value: &Value) -> Option<ResultEntry> {
         detail: entry_field(value.get("detail")),
         meta: entry_field(value.get("meta")),
         media_type: entry_field(value.get("media_type")),
-        output_id: entry_field(value.get("output_id")),
+        target_id: entry_field(value.get("target_id")),
     })
 }
 
@@ -1062,12 +1073,14 @@ mod tests {
         // makes the transcript card clickable — and the icon's media type is
         // derived from the filename by the output-creation rules. A row
         // without an id (older journal data) still renders, unrouted.
-        assert_eq!(outputs[0].output_id.as_deref(), Some("output-report"));
+        assert_eq!(outputs[0].target_id.as_deref(), Some("output-report"));
         assert_eq!(outputs[0].media_type.as_deref(), Some("text/markdown"));
-        assert_eq!(outputs[1].output_id, None);
+        assert_eq!(outputs[1].target_id, None);
         assert_eq!(outputs[1].media_type.as_deref(), Some("image/png"));
 
-        // A pre-outputs journal row deserializes with the field defaulted.
+        // A pre-outputs journal row deserializes with the field defaulted, and
+        // a row journaled while the target id was still spelled `output_id`
+        // reads back onto the field that replaced it.
         let stored: ToolResultPreview = serde_json::from_value(serde_json::json!({
             "tool": "exec",
             "exit_code": 0,
@@ -1081,6 +1094,15 @@ mod tests {
             panic!("stored exec row");
         };
         assert!(outputs.is_empty());
+        let retained: ResultEntry = serde_json::from_value(serde_json::json!({
+            "kind": "output",
+            "label": "report.md",
+            "detail": null,
+            "meta": "v3 · updated",
+            "output_id": "output-report",
+        }))
+        .unwrap();
+        assert_eq!(retained.target_id.as_deref(), Some("output-report"));
     }
 
     #[test]

--- a/crates/openwave-core/src/renderer_tool.rs
+++ b/crates/openwave-core/src/renderer_tool.rs
@@ -47,6 +47,7 @@ pub enum RendererToolName {
     AskUserQuestions,
     ExitPlanMode,
     Exec,
+    CreateApp,
     /// The fold for anything unrecognized, including a tool that has since been
     /// removed and any name a provider invented.
     Other,
@@ -82,6 +83,7 @@ impl From<&str> for RendererToolName {
             crate::ASK_USER_QUESTIONS_TOOL => Self::AskUserQuestions,
             crate::EXIT_PLAN_MODE_TOOL => Self::ExitPlanMode,
             "exec" => Self::Exec,
+            crate::local_app::CREATE_APP_TOOL => Self::CreateApp,
             _ => Self::Other,
         }
     }
@@ -128,6 +130,7 @@ mod tests {
             crate::ASK_USER_QUESTIONS_TOOL,
             crate::EXIT_PLAN_MODE_TOOL,
             "exec",
+            crate::local_app::CREATE_APP_TOOL,
         ] {
             let folded = RendererToolName::from(name);
             assert_ne!(

--- a/crates/openwave-core/src/tools/create_app.rs
+++ b/crates/openwave-core/src/tools/create_app.rs
@@ -206,10 +206,13 @@ impl CreateAppTool {
             record.name, record.id,
         ))
         .with_entries(vec![ResultEntry::new(
-            ResultEntryKind::Output,
+            ResultEntryKind::App,
             record.name.clone(),
         )
-        .with_meta(format!("revision {ordinal}"))])
+        .with_meta(format!("revision {ordinal}"))
+        // The row's navigation target: the renderer opens the app in the
+        // library panel by this id and never prints it.
+        .with_target_id(record.id.to_string())])
     }
 }
 
@@ -697,7 +700,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn the_projection_carries_the_name_and_ordinal_and_never_the_bundle() {
+    async fn the_projection_carries_the_name_ordinal_and_app_id_and_never_the_bundle() {
         let fixture = fixture().await;
         let (_, ctx) = fixture.recorded_call().await;
         let output = fixture
@@ -709,12 +712,24 @@ mod tests {
 
         let preview = ToolResultPreview::build(crate::local_app::CREATE_APP_TOOL, &output)
             .expect("create_app projects an entries card");
+        let ToolResultPreview::Entries { entries, .. } = &preview else {
+            panic!("create_app projects entries, not {preview:?}");
+        };
+        let [row] = entries.as_slice() else {
+            panic!("one app row per call");
+        };
+        assert_eq!(row.kind, ResultEntryKind::App);
+        assert_eq!(row.label, "Sentry triage");
+        assert_eq!(row.meta.as_deref(), Some("revision 1"));
+        // The app id is the row's navigation target, so the card can open the
+        // app it just made.
+        assert_eq!(
+            row.target_id.as_deref(),
+            Some(AppId::for_call(ctx.call_id.unwrap()).to_string().as_str())
+        );
+        // Renderer-safe: an id and a name, never the bundle or the bindings.
         let json = serde_json::to_string(&preview).unwrap();
-        assert!(json.contains("Sentry triage"));
-        assert!(json.contains("revision 1"));
-        // Renderer-safe: no bundle markup, no manifest bindings, no ids.
         assert!(!json.contains("doctype"));
         assert!(!json.contains("mcp__sentry__list_issues"));
-        assert!(!json.contains(&AppId::for_call(ctx.call_id.unwrap()).to_string()));
     }
 }

--- a/crates/openwave-desktop/ui/src/AppCard.tsx
+++ b/crates/openwave-desktop/ui/src/AppCard.tsx
@@ -1,0 +1,65 @@
+import { LayoutGrid } from "lucide-react";
+
+import type { ResultEntry } from "@/api";
+import { Button } from "@/components/ui/button";
+import { usePanelNav } from "@/panel/usePanelNav";
+
+/**
+ * The cards a phase hangs under itself for the apps it published.
+ *
+ * The sibling of the output cards, and for the same reason: what the reader
+ * came for is the app, and the activity rail it was announced in is collapsed
+ * by default. The app the turn just built must be one click from the message
+ * that built it, not from a library the reader has to go find.
+ */
+export function AppCardList({ apps }: { apps: ResultEntry[] }) {
+  if (apps.length === 0) return null;
+  return (
+    <div className="flex flex-col items-start gap-2" aria-label="Created apps">
+      {apps.map((entry) => (
+        <AppCard key={`${entry.targetId ?? entry.label}`} entry={entry} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * One published app: its name, which revision this call published, and the way
+ * in. The app opens in the library panel beside the conversation, where its
+ * consent sheet already lives — nothing here grants anything.
+ *
+ * The action is present only when the projection carries the app id; a row
+ * rehydrated from a journal written before the id crossed still renders, as
+ * the same card without a destination.
+ */
+function AppCard({ entry }: { entry: ResultEntry }) {
+  const { openPanel } = usePanelNav();
+  const appId = entry.targetId;
+  return (
+    <div className="bg-background flex max-w-full min-w-0 items-center gap-3 rounded-lg border px-4 py-3 text-left shadow-sm">
+      <span className="bg-muted rounded-md p-2" aria-hidden="true">
+        <LayoutGrid className="size-5" />
+      </span>
+      <span className="flex min-w-0 flex-col">
+        <span className="truncate text-sm font-semibold">{entry.label}</span>
+        {entry.meta && (
+          <span className="text-muted-foreground text-xs tabular-nums">
+            {entry.meta}
+          </span>
+        )}
+      </span>
+      {appId !== null && (
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="ml-2 shrink-0"
+          onClick={() => openPanel({ type: "apps", appId })}
+          aria-label={`Open app ${entry.label}`}
+        >
+          Open app
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
+++ b/crates/openwave-desktop/ui/src/ChatSessionReducer.test.ts
@@ -296,7 +296,7 @@ describe("published outputs", () => {
           detail: null,
           meta: "v2 · updated",
           media_type: null,
-          output_id: null,
+          target_id: null,
         },
       ],
     };
@@ -333,7 +333,7 @@ describe("published outputs", () => {
               meta: "v1 · created",
               media_type:
                 "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-              output_id: null,
+              target_id: null,
             },
           ],
         },

--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -690,8 +690,8 @@ describe("mcp app views", () => {
               tool: "entries",
               elided: 3,
               entries: [
-                { kind: "file", label: "notes.md", detail: null, meta: "1.2 KB", mediaType: null, outputId: null },
-                { kind: "folder", label: "reports", detail: null, meta: null, mediaType: null, outputId: null },
+                { kind: "file", label: "notes.md", detail: null, meta: "1.2 KB", mediaType: null, targetId: null },
+                { kind: "folder", label: "reports", detail: null, meta: null, mediaType: null, targetId: null },
               ],
               failures: [],
             },
@@ -747,7 +747,7 @@ describe("mcp app views", () => {
                   detail: "Pages 3, 7",
                   meta: "2 matches",
                   mediaType: "application/pdf",
-                  outputId: null,
+                  targetId: null,
                 },
               ],
               failures: [],
@@ -794,7 +794,7 @@ describe("mcp app views", () => {
               tool: "entries",
               elided: 0,
               entries: [
-                { kind: "file", label: "q3.md", detail: null, meta: null, mediaType: null, outputId: null },
+                { kind: "file", label: "q3.md", detail: null, meta: null, mediaType: null, targetId: null },
               ],
               failures: [
                 { label: "q4.md", error: "file is not valid UTF-8" },
@@ -864,7 +864,7 @@ describe("actionable tool results", () => {
                   meta: "v1 · created",
                   mediaType:
                     "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-                  outputId: "output-1",
+                  targetId: "output-1",
                 },
               ],
             },
@@ -891,6 +891,62 @@ describe("actionable tool results", () => {
       expect(router.state.location.search).toMatchObject({
         right: "outputs.output-1",
       });
+    });
+  });
+
+  it("opens the app the turn just created, from a card outside the accordion", async () => {
+    const user = userEvent.setup();
+    const { router } = await renderWithRouter(
+      <MessageList
+        messages={[
+          {
+            id: "create-app-1",
+            role: "tool",
+            callId: "call-1",
+            name: "create_app",
+            status: "completed",
+            result: {
+              tool: "entries",
+              elided: 0,
+              failures: [],
+              entries: [
+                {
+                  kind: "app",
+                  label: "Sentry triage",
+                  detail: null,
+                  meta: "revision 1",
+                  mediaType: null,
+                  targetId: "app-1",
+                },
+              ],
+            },
+          },
+        ]}
+        folderAccessRequests={[]}
+        nativeHost={false}
+        nativeBusy={false}
+        resolvingFolderCalls={new Set()}
+        folderAccessErrors={{}}
+        decidingApprovalCalls={new Set()}
+        approvalErrors={{}}
+        busy={false}
+        scrollRef={{ current: null }}
+        onScroll={noop}
+        onApproval={noop}
+        onFolderAccessDecision={noop}
+        onFolderAccessCancel={noop}
+      />,
+    );
+
+    // The card stands on its own, with the activity accordion still collapsed.
+    expect(screen.getByText("Sentry triage")).toBeInTheDocument();
+    expect(screen.getByText("revision 1")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Open app Sentry triage" }),
+    );
+    await waitFor(() => {
+      expect(router.state.location.search).toMatchObject({ left: "apps.app-1" });
     });
   });
 

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -17,6 +17,7 @@ import type {
   ModelInfo,
 } from "./api";
 import { ApprovalCard, type GrantScopeName } from "./ApprovalCard";
+import { AppCardList } from "./AppCard";
 import { AssistantWorkingIndicator } from "./AssistantWorkingIndicator";
 import { FolderAccessCard } from "./FolderAccessCard";
 import type {
@@ -778,9 +779,11 @@ function surfacedCards(
   phase.forEach((entry, entryIndex) => {
     let card: ReactNode = null;
     let outputCards: ReactNode = null;
+    let appCards: ReactNode = null;
     try {
       card = surfacedCard(entry, context);
       outputCards = surfacedOutputCards(entry);
+      appCards = surfacedAppCards(entry);
     } catch (error) {
       console.error("tool result card could not be built", error);
       // The entry's own id may be the unreadable part, so the placeholder is
@@ -789,6 +792,7 @@ function surfacedCards(
     }
     if (card !== null) cards.push(card);
     if (outputCards !== null) cards.push(outputCards);
+    if (appCards !== null) cards.push(appCards);
   });
   return cards;
 }
@@ -807,8 +811,27 @@ function surfacedOutputCards(entry: ChatMessage): ReactNode {
   if (outputs.length === 0) return null;
   return isolatedCard(
     `${entry.id}-outputs`,
-    outputs.map((output) => output.outputId ?? output.label).join(" "),
+    outputs.map((output) => output.targetId ?? output.label).join(" "),
     <OutputCardList outputs={outputs} />,
+  );
+}
+
+/**
+ * The app cards a call earns, or `null` when it published none.
+ *
+ * Keyed on the row's kind rather than the tool's name: an app row is the
+ * entries vocabulary saying "this is an app, and here is where it lives", and
+ * a second tool that publishes one should get the same card without being
+ * listed here.
+ */
+function surfacedAppCards(entry: ChatMessage): ReactNode {
+  if (entry.role !== "tool" || entry.result?.tool !== "entries") return null;
+  const apps = entry.result.entries.filter((row) => row.kind === "app");
+  if (apps.length === 0) return null;
+  return isolatedCard(
+    `${entry.id}-apps`,
+    apps.map((app) => app.targetId ?? app.label).join(" "),
+    <AppCardList apps={apps} />,
   );
 }
 

--- a/crates/openwave-desktop/ui/src/OutputCard.tsx
+++ b/crates/openwave-desktop/ui/src/OutputCard.tsx
@@ -17,7 +17,7 @@ export function OutputCardList({ outputs }: { outputs: ResultEntry[] }) {
   return (
     <div className="flex flex-col items-start gap-2" aria-label="Created outputs">
       {outputs.map((entry) => (
-        <OutputCard key={`${entry.outputId ?? entry.label}`} entry={entry} />
+        <OutputCard key={`${entry.targetId ?? entry.label}`} entry={entry} />
       ))}
     </div>
   );
@@ -30,7 +30,7 @@ export function OutputCardList({ outputs }: { outputs: ResultEntry[] }) {
  */
 function OutputCard({ entry }: { entry: ResultEntry }) {
   const { openPanel } = usePanelNav();
-  const outputId = entry.outputId;
+  const outputId = entry.targetId;
   const body = (
     <>
       <span className="bg-muted rounded-md p-2" aria-hidden="true">

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -241,6 +241,12 @@ const TOOL_PRESENTATIONS: Record<
     complete: "Command complete",
     settled: "Ran a command",
   },
+  create_app: {
+    label: "Create an app",
+    active: "Creating an app",
+    complete: "App created",
+    settled: "Created an app",
+  },
 };
 
 const FALLBACK_TOOL: ToolPresentation = {

--- a/crates/openwave-desktop/ui/src/ToolEntriesList.tsx
+++ b/crates/openwave-desktop/ui/src/ToolEntriesList.tsx
@@ -3,6 +3,7 @@ import {
   FileOutput,
   Folder,
   Globe,
+  LayoutGrid,
   Quote,
   BookOpenText as Source,
   X,
@@ -38,6 +39,7 @@ const ENTRY_ICONS: Record<ResultEntryKind, LucideIcon> = {
   passage: Quote,
   link: Globe,
   output: FileOutput,
+  app: LayoutGrid,
 };
 
 /**
@@ -109,24 +111,22 @@ export function ToolEntriesList({ name, result }: ToolEntriesListProps) {
   );
 }
 
+/** The noun a kind counts as, where it is anything more specific than "item". */
+const ENTRY_NOUNS: Readonly<Partial<Record<ResultEntryKind, string>>> = {
+  source: "source",
+  passage: "passage",
+  file: "file",
+  folder: "folder",
+  output: "output",
+  app: "app",
+  link: "result",
+};
+
 /** The noun the count line counts, by what the rows uniformly are. */
 function listNoun(entries: ResultEntry[], total: number): string {
   const kinds = new Set(entries.map((entry) => entry.kind));
   const kind = kinds.size === 1 ? [...kinds][0] : undefined;
-  const noun =
-    kind === "source"
-      ? "source"
-      : kind === "passage"
-        ? "passage"
-        : kind === "file"
-          ? "file"
-          : kind === "folder"
-            ? "folder"
-            : kind === "output"
-              ? "output"
-              : kind === "link"
-                ? "result"
-                : "item";
+  const noun = (kind === undefined ? undefined : ENTRY_NOUNS[kind]) ?? "item";
   return total === 1 ? noun : `${noun}s`;
 }
 

--- a/crates/openwave-desktop/ui/src/ToolIcon.tsx
+++ b/crates/openwave-desktop/ui/src/ToolIcon.tsx
@@ -10,6 +10,7 @@ import {
   FolderPlus,
   FolderTree,
   Globe,
+  LayoutGrid,
   List,
   Newspaper,
   NotebookPen,
@@ -56,6 +57,9 @@ const TOOL_ICONS: Record<RendererToolName, LucideIcon> = {
   spawn_sandbox_agent: Robot,
   wait_for_agents: Clock,
   exec: Terminal,
+  // The same mark the Apps library carries, so the row and the panel it
+  // opens read as one thing.
+  create_app: LayoutGrid,
   // The server folds every unrecognized tool name to `other`, so this is the
   // one entry that is genuinely "some tool ran" rather than a missing icon.
   other: Wrench,

--- a/crates/openwave-desktop/ui/src/api.test.ts
+++ b/crates/openwave-desktop/ui/src/api.test.ts
@@ -989,7 +989,7 @@ describe("parseToolResultPreview closed results", () => {
           detail: "scratch",
           meta: "1.2 KB",
           mediaType: "text/markdown",
-          outputId: null,
+          targetId: null,
         },
         {
           kind: "folder",
@@ -997,7 +997,7 @@ describe("parseToolResultPreview closed results", () => {
           detail: null,
           meta: null,
           mediaType: null,
-          outputId: null,
+          targetId: null,
         },
       ],
       failures: [{ label: "q4.md", error: "unreadable" }],

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -463,8 +463,11 @@ export type ResultEntry = {
   meta: string | null;
   /** The document's media type, when the row is a document with one. */
   mediaType: string | null;
-  /** The durable output this row names, when the row is one. */
-  outputId: string | null;
+  /**
+   * The durable record this row opens, when its kind names somewhere to go —
+   * an output row the outputs panel, an app row the apps library.
+   */
+  targetId: string | null;
 };
 
 /** One thing a listed call could not do. */
@@ -2457,6 +2460,7 @@ const RESULT_ENTRY_KINDS: readonly ResultEntryKind[] = [
   "passage",
   "link",
   "output",
+  "app",
 ];
 
 /**
@@ -2475,7 +2479,7 @@ function parseResultEntry(value: unknown): ResultEntry | null {
   const detail = value.detail ?? null;
   const meta = value.meta ?? null;
   const mediaType = value.media_type ?? null;
-  const outputId = value.output_id ?? null;
+  const targetId = value.target_id ?? null;
   if (
     typeof label !== "string" ||
     label.length === 0 ||
@@ -2483,11 +2487,11 @@ function parseResultEntry(value: unknown): ResultEntry | null {
     !isOptionalString(detail) ||
     !isOptionalString(meta) ||
     !isOptionalString(mediaType) ||
-    !isOptionalString(outputId)
+    !isOptionalString(targetId)
   ) {
     return null;
   }
-  return { kind: kind as ResultEntryKind, label, detail, meta, mediaType, outputId };
+  return { kind: kind as ResultEntryKind, label, detail, meta, mediaType, targetId };
 }
 
 /**

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1523,7 +1523,7 @@ export type RendererSequencedEvent = { seq: number, event: RendererAgentEvent, }
  * are all generated from this enum, so a variant added here cannot leave one of
  * them behind — see `docs/wire-types.md`.
  */
-export type RendererToolName = "search" | "list_sources" | "read_source" | "read_tool_result" | "web_search" | "web_extract" | "read_delegated_file" | "read_file" | "list_dir" | "write_file" | "request_folder_access" | "connect_folder" | "list_connected_folders" | "list_folder" | "read_connected_file" | "import_connected_file" | "write_output_to_connected_folder" | "spawn_sandbox_agent" | "wait_for_agents" | "ask_user_questions" | "exit_plan_mode" | "exec" | "other";
+export type RendererToolName = "search" | "list_sources" | "read_source" | "read_tool_result" | "web_search" | "web_extract" | "read_delegated_file" | "read_file" | "list_dir" | "write_file" | "request_folder_access" | "connect_folder" | "list_connected_folders" | "list_folder" | "read_connected_file" | "import_connected_file" | "write_output_to_connected_folder" | "spawn_sandbox_agent" | "wait_for_agents" | "ask_user_questions" | "exit_plan_mode" | "exec" | "create_app" | "other";
 
 export type RendererToolStatus = "completed" | "failed";
 
@@ -1571,14 +1571,22 @@ meta: string | null,
  */
 media_type: string | null, 
 /**
- * The durable output this row names, when the row is one.
+ * The durable record this row names, when the renderer can open one.
  *
  * Data rather than display text: the renderer routes a click through its
- * own panel navigation and never prints the id. Present only on
- * [`ResultEntryKind::Output`] rows; `default` because retained
- * projections predate the field.
+ * own panel navigation and never prints the id, and [`ResultEntryKind`]
+ * names where that click goes — an [`Output`] row opens the outputs
+ * panel, an [`App`] row the apps library. A kind with nowhere to go
+ * leaves this `None`.
+ *
+ * Aliased and `default` because retained projections wrote it as
+ * `output_id`, when a published output was the only place a row could
+ * point.
+ *
+ * [`Output`]: ResultEntryKind::Output
+ * [`App`]: ResultEntryKind::App
  */
-output_id: string | null, };
+target_id: string | null, };
 
 /**
  * What one row of a listed result is, which is what picks its icon.
@@ -1586,7 +1594,7 @@ output_id: string | null, };
  * A closed vocabulary rather than an icon name: the renderer chooses how to
  * draw a folder, and a tool must not be able to name a glyph.
  */
-export type ResultEntryKind = "file" | "folder" | "source" | "passage" | "link" | "output";
+export type ResultEntryKind = "file" | "folder" | "source" | "passage" | "link" | "output" | "app";
 
 /**
  * One thing a call could not do.
@@ -1995,5 +2003,6 @@ export const RENDERER_TOOL_NAMES = [
   "ask_user_questions",
   "exit_plan_mode",
   "exec",
+  "create_app",
   "other",
 ] as const;


### PR DESCRIPTION
`create_app` had no real presence in the transcript. It was missing from the
renderer's tool vocabulary, so it folded to `other` and read as "Using a tool",
and its result rendered as a generic entries row inside the activity accordion
— invisible while collapsed, with no way to reach the app the turn had just
published.

## What changed

- **Labels.** `create_app` joins `RendererToolName` and the desktop's
  presentation map ("Create an app" / "Creating an app" / "App created" /
  "Created an app"), with the Apps library's own mark as its icon.
- **A surfaced app card.** `AppCardList` renders outside the accordion the way
  the exec output cards do: app name, the revision this call published, and an
  **Open app** action that opens `{ type: "apps", appId }` in the library panel
  beside the conversation, where the app's consent sheet already lives. It is
  keyed on the row's *kind*, not the tool's name, so a second tool that
  publishes an app gets the same card without being listed anywhere.
- **The wire extension.** #1285 recorded the constraint: entries rows carry no
  navigation target, and the fix should be the entries vocabulary learning one
  rather than an apps-specific hack. `ResultEntry.output_id` was already a
  navigation target, named for the only destination there was, so it
  generalizes to `target_id` routed by the row's kind — an `output` row opens
  the outputs panel, the new `app` kind opens the apps library, and a kind with
  nowhere to go leaves it unset. One field rather than two ways of saying the
  same thing. `#[serde(alias = "output_id")]` keeps retained projections
  readable, and stored previews deserialize through the Rust type before they
  are re-serialized to the desktop, so the renderer only ever sees the new
  spelling.

The projection still carries ids and names only: no bundle markup, no manifest
bindings.

## Tests

Two, both behavioural:

- The `create_app` projection test now asserts the row it actually produces —
  an `app`-kind row whose `target_id` is the app id, alongside the existing
  guards that the bundle and the bindings never cross. It previously asserted
  no id crossed at all, which is the thing this change deliberately reverses.
- `MessageList.dom.test.tsx` drives a completed `create_app` and clicks
  **Open app**, asserting the router lands on `apps.<id>` — the affordance
  end to end rather than the component in isolation.
- The retained-shape alias is folded into the exec preview's existing
  "old rows read back" test rather than earning a test of its own.

`ToolEntriesList`'s noun ladder became a lookup table instead of growing an
eighth nested ternary.

## Verification

`cargo test -p openwave-server --locked` (595 passed), `cargo test -p
openwave-core --locked` for `preview::`, `create_app`, `renderer_tool`,
`cargo clippy -p openwave-core -p openwave-server --all-targets` clean,
`cargo check --workspace --locked --all-targets` clean, `cargo fmt`. In
`crates/openwave-desktop/ui`: `tsc --noEmit`, `pnpm test` (727 passed),
`pnpm build` — all green. Not driven in the running app.

Closes #1543
🤖 Generated with [Claude Code](https://claude.com/claude-code)
