### PR TITLE
fix(desktop): name a background agent's output after its task

### DIFF
--- a/crates/openwave-core/src/db/tests/output.rs
+++ b/crates/openwave-core/src/db/tests/output.rs
@@ -496,7 +496,7 @@ async fn a_binary_workspace_artifact_is_accepted_published_and_attributed_to_its
 
 #[cfg(feature = "tools")]
 #[tokio::test]
-async fn a_background_run_result_auto_merges_into_a_revertible_text_output() {
+async fn a_background_run_result_becomes_a_revertible_text_output() {
     use crate::deliverable::output_revision_relative_path;
     use crate::deliverable_acceptance::{merge_agent_run_result, AgentResultOutputMerge};
     use crate::id::AgentRunId;
@@ -545,7 +545,7 @@ async fn a_background_run_result_auto_merges_into_a_revertible_text_output() {
     assert_eq!(retried, record);
     assert_eq!(store.list_outputs(chat.id, 10).await.unwrap().len(), 1);
 
-    // The auto-merge is safe because it is revertible: retracting it hides the
+    // Recording it is safe because it is revertible: retracting it hides the
     // output while keeping its revision, and restoring brings it back.
     assert!(store.delete_output(record.id, at(30)).await.unwrap());
     assert!(store.list_outputs(chat.id, 10).await.unwrap().is_empty());

--- a/crates/openwave-core/src/deliverable_acceptance.rs
+++ b/crates/openwave-core/src/deliverable_acceptance.rs
@@ -124,7 +124,7 @@ pub async fn accept_workspace_artifact(
     }
 }
 
-/// A completed background agent run's text result, ready to auto-merge into the
+/// A completed background agent run's text result, ready to record in the
 /// conversation's output record.
 ///
 /// The merge is performed by the host at result-commit time; the model that
@@ -148,8 +148,7 @@ pub struct AgentResultOutputMerge {
     pub created_at: DateTime<Utc>,
 }
 
-/// Auto-merge a completed background run's text result into a conversation
-/// output.
+/// Record a completed background run's text result as a conversation output.
 ///
 /// The bytes are published once at the derived revision path under the exact
 /// conversation's private scratch, then recorded as a text output whose producer

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -391,7 +391,7 @@ impl OutputId {
 
     /// Derive the retry-stable output identity for one background agent run.
     ///
-    /// A completed background run auto-merges its result into exactly one
+    /// A completed background run records its result as exactly one
     /// conversation output. Deriving the identity from the run makes the merge
     /// idempotent: an ambiguous submit retry lands on the same output rather than
     /// forking a second record.
@@ -438,7 +438,7 @@ impl OutputRevisionId {
     }
 
     /// Derive the retry-stable first-revision identity for one background agent
-    /// run's auto-merged output.
+    /// run's submitted output.
     #[must_use]
     pub fn for_run(run_id: AgentRunId) -> Self {
         Self(Uuid::new_v5(&Self::NAMESPACE, run_id.as_uuid().as_bytes()))

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1807,7 +1807,7 @@ pub trait Store: Send + Sync {
     }
 
     /// Restore a soft-deleted output, returning it to the catalog. This is the
-    /// exact inverse of [`Store::delete_output`], so retracting an auto-merged
+    /// exact inverse of [`Store::delete_output`], so retracting a submitted
     /// output is reversible. Returns `false` only when the output does not
     /// exist; restoring a live output is the same durable outcome, not a
     /// conflict. Nothing about the revision history changes.

--- a/crates/openwave-desktop/src/deliverables.rs
+++ b/crates/openwave-desktop/src/deliverables.rs
@@ -68,7 +68,7 @@ pub(crate) struct DeliverableSummary {
     revision_count: u32,
     updated_at: String,
     /// Background run that produced the current revision, when the output was
-    /// auto-merged from a background agent rather than a foreground turn. The
+    /// submitted by a background agent rather than a foreground turn. The
     /// renderer uses it to badge the output and correlate it with the agent-run
     /// surface; it is a display key, not authority.
     producing_run_id: Option<Uuid>,

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
@@ -56,18 +56,20 @@ describe("BackgroundAgentList", () => {
     expect(markup).toContain("Working in the background");
     expect(markup).toContain("Finished");
     expect(markup).toContain("Task for run-running");
-    expect(markup).toContain("Result from run-completed");
     expect(markup).not.toContain("Could not finish");
     expect(markup.indexOf("Running")).toBeLessThan(markup.indexOf("Completed"));
   });
 
-  it("shows a terminal failure error", () => {
+  it("keeps result text out of the list, which is a list to scan", () => {
     const failed = run("run-failed", "call-failed", "failed");
     failed.terminal_text = "Sandbox task failed (provider_error)";
     const markup = renderToStaticMarkup(
       <BackgroundAgentList
-        spawns={[{ callId: "call-failed", status: "completed" }]}
-        runs={[failed]}
+        spawns={[
+          { callId: "call-failed", status: "completed" },
+          { callId: "call-done", status: "completed" },
+        ]}
+        runs={[failed, run("run-done", "call-done", "completed")]}
         loading={false}
         error={null}
         onRetry={() => undefined}
@@ -76,8 +78,9 @@ describe("BackgroundAgentList", () => {
       />,
     );
 
-    expect(markup).toContain("Error:");
-    expect(markup).toContain("Sandbox task failed (provider_error)");
+    expect(markup).toContain("Task for run-failed");
+    expect(markup).not.toContain("Sandbox task failed (provider_error)");
+    expect(markup).not.toContain("Result from run-done");
   });
 
   it("shows a skeleton as soon as a spawn is visible but not durable yet", () => {
@@ -112,7 +115,7 @@ describe("BackgroundAgentList", () => {
     expect(markup).toEqual("");
   });
 
-  it("offers Stop on a cancellable run and View output only once it produced a result", () => {
+  it("offers Stop on a cancellable run", () => {
     const markup = renderToStaticMarkup(
       <BackgroundAgentList
         spawns={[
@@ -128,12 +131,10 @@ describe("BackgroundAgentList", () => {
         onRetry={() => undefined}
         onCancel={noop}
         onLoadActivity={noActivity}
-        onViewOutput={() => undefined}
       />,
     );
 
     expect(markup).toContain("Stop");
-    expect(markup).toContain("View output");
   });
 
   it("does not offer Stop on a settled run", () => {

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Bot, ChevronDown, ChevronRight, FileOutput, Square } from "lucide-react";
+import { Bot, ChevronDown, ChevronRight, Square } from "lucide-react";
 
 import type { AgentActivityHistoryEntry, AgentRun } from "./api";
 import { AgentActivityTimeline, useAgentRunActivity } from "./AgentActivityTimeline";
@@ -30,8 +30,6 @@ type BackgroundAgentListProps = {
   onCancel: (runId: string) => Promise<void>;
   /** Fetch a run's ordered, renderer-safe activity history. */
   onLoadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
-  /** Open the outputs surface, when a completed run produced a result. */
-  onViewOutput?: () => void;
   /** Open one run's dedicated panel beside the conversation. */
   onOpen?: (runId: string) => void;
 };
@@ -49,7 +47,6 @@ export function BackgroundAgentList({
   onRetry,
   onCancel,
   onLoadActivity,
-  onViewOutput,
   onOpen,
 }: BackgroundAgentListProps) {
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
@@ -112,7 +109,7 @@ export function BackgroundAgentList({
           </button>
         </div>
       ) : (
-        <div aria-live="polite">
+        <div className="max-h-48 overflow-y-auto" aria-live="polite">
           {AGENT_RUN_STATUS_GROUPS.map((group) => {
             const groupRuns = matchedRuns.filter((run) => group.statuses.includes(run.status));
             if (groupRuns.length === 0) return null;
@@ -135,14 +132,12 @@ export function BackgroundAgentList({
                 </button>
                 {!collapsed && (
                   <div className="divide-y divide-border/60">
-                    {groupRuns.map((run, index) => (
+                    {groupRuns.map((run) => (
                       <BackgroundAgentRow
                         key={run.id}
                         run={run}
-                        label={`Background agent ${index + 1}`}
                         onCancel={onCancel}
                         onLoadActivity={onLoadActivity}
-                        onViewOutput={onViewOutput}
                         onOpen={onOpen}
                       />
                     ))}
@@ -167,25 +162,21 @@ export function BackgroundAgentList({
 }
 
 /**
- * One background run: its live status on a line, expandable into the ordered
- * timeline of what it has done, with a Stop control while it is cancellable and
- * a link to its output once it finishes with one. When the panel navigation is
- * wired, the row itself opens the run's dedicated panel; the chevron keeps the
- * inline timeline for a quick glance without leaving the transcript.
+ * One background run: the task it was given, its live status, and a Stop control
+ * while it is cancellable, expandable into the ordered timeline of what it has
+ * done. The row itself opens the run's dedicated panel, which is where the
+ * result belongs — a finished agent's full text inline would bury every sibling
+ * row under it, and a delegation of any size is a list to scan, not to read.
  */
 function BackgroundAgentRow({
   run,
-  label,
   onCancel,
   onLoadActivity,
-  onViewOutput,
   onOpen,
 }: {
   run: AgentRun;
-  label: string;
   onCancel: (runId: string) => Promise<void>;
   onLoadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
-  onViewOutput?: () => void;
   onOpen?: (runId: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -202,7 +193,6 @@ function BackgroundAgentRow({
   const stoppable =
     RUNNING_AGENT_STATUSES.has(run.status) && run.status !== "cancelling";
   const showStopping = stopping || run.status === "cancelling";
-  const canViewOutput = run.produced_output && onViewOutput !== undefined;
 
   // Drop the optimistic bridge once the durable transition has caught up: any
   // status that is no longer a cancellable running state is confirmation
@@ -223,7 +213,6 @@ function BackgroundAgentRow({
   };
 
   const contentId = `background-agent-activity-${run.id}`;
-  const terminalLabel = run.status === "failed" ? "Error" : "Result";
 
   return (
     <div className="px-3 py-2.5">
@@ -255,28 +244,13 @@ function BackgroundAgentRow({
             className={cn("size-2 shrink-0 rounded-full", getAgentRunDotClass(run.status))}
             aria-hidden="true"
           />
-          <span className="min-w-0 flex-1">
-            <span className="block truncate font-medium text-foreground">{label}</span>
-            {run.task && (
-              <span className="block truncate text-xs text-muted-foreground">{run.task}</span>
-            )}
+          <span className="min-w-0 flex-1 truncate text-sm text-foreground">
+            {run.task ?? "Background agent"}
           </span>
         </button>
         <span className="shrink-0 text-xs text-muted-foreground">
           {showStopping ? "Stopping" : agentRunStatusDetail(run)}
         </span>
-        {canViewOutput && (
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="h-7 shrink-0 gap-1 px-2 text-xs"
-            onClick={onViewOutput}
-          >
-            <FileOutput className="size-3.5" aria-hidden="true" />
-            View output
-          </Button>
-        )}
         {stoppable && (
           <Button
             type="button"
@@ -291,12 +265,6 @@ function BackgroundAgentRow({
           </Button>
         )}
       </div>
-      {run.terminal_text && (
-        <div className="mt-2 rounded-md bg-muted/50 px-2.5 py-2 text-sm text-foreground">
-          <span className="font-medium">{terminalLabel}: </span>
-          <span className="whitespace-pre-wrap break-words">{run.terminal_text}</span>
-        </div>
-      )}
       {expanded && (
         <div id={contentId} className="mt-2 pl-5">
           <AgentActivityTimeline state={activity} />

--- a/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
@@ -134,7 +134,7 @@ function BackgroundAgentDetail({
         <div className="flex items-center gap-2">
           <Bot className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
           <h2 className="min-w-0 flex-1 truncate text-base font-medium">
-            Background agent
+            {run.task ?? "Background agent"}
           </h2>
           <AgentRunStatusBadge status={run.status} />
         </div>
@@ -168,6 +168,16 @@ function BackgroundAgentDetail({
         )}
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto p-4" aria-live="polite">
+        {run.terminal_text && (
+          <div className="mb-4 rounded-md border bg-muted/40 px-3 py-2.5">
+            <p className="text-xs font-medium text-muted-foreground">
+              {run.status === "failed" ? "Error" : "Result"}
+            </p>
+            <p className="mt-1 text-sm break-words whitespace-pre-wrap text-foreground">
+              {run.terminal_text}
+            </p>
+          </div>
+        )}
         <AgentActivityTimeline state={activity} />
       </div>
     </div>

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -636,7 +636,6 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             onSelectPrompt={setComposerDraft}
             onSend={onSend}
             onRetryTurn={retryTurn}
-            onViewOutput={() => openPanel({ type: "outputs" })}
             onOpenAgentPanel={(runId) => openPanel({ type: "agent", runId })}
           />
         </TranscriptVisibilityProvider>

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -58,8 +58,6 @@ export type ChatViewProps = {
   onSend: () => Promise<void>;
   /** Put a failed turn back on the wire, unchanged, as a new turn. */
   onRetryTurn?: (turn: RetryableTurn) => void;
-  /** Open the outputs surface, offered on a completed background run's row. */
-  onViewOutput?: () => void;
   /** Open one background run's panel beside the conversation. */
   onOpenAgentPanel?: (runId: string) => void;
 };
@@ -92,7 +90,6 @@ export function ChatView({
   onSelectPrompt,
   onSend,
   onRetryTurn,
-  onViewOutput,
   onOpenAgentPanel,
 }: ChatViewProps) {
   const transcriptVisible = useTranscriptVisible();
@@ -319,7 +316,6 @@ export function ChatView({
           onRetryBackgroundAgentRuns={agentRuns.refresh}
           onCancelBackgroundAgentRun={agentRuns.cancel}
           onLoadBackgroundAgentActivity={agentRuns.loadActivity}
-          onViewBackgroundAgentOutput={onViewOutput}
           onOpenBackgroundAgent={onOpenAgentPanel}
           busy={busy}
           streamStalled={streamStalled}

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -197,7 +197,6 @@ type MessageListProps = {
   onLoadBackgroundAgentActivity?: (
     runId: string,
   ) => Promise<AgentActivityHistoryEntry[]>;
-  onViewBackgroundAgentOutput?: () => void;
   onOpenBackgroundAgent?: (runId: string) => void;
   busy: boolean;
   /** The live turn's stream has gone quiet — see [useStreamStalled]. */
@@ -267,7 +266,6 @@ export function MessageList({
   onRetryBackgroundAgentRuns = () => undefined,
   onCancelBackgroundAgentRun = async () => undefined,
   onLoadBackgroundAgentActivity = async () => [],
-  onViewBackgroundAgentOutput,
   onOpenBackgroundAgent,
   busy,
   streamStalled = false,
@@ -319,7 +317,6 @@ export function MessageList({
       retry: onRetryBackgroundAgentRuns,
       cancel: onCancelBackgroundAgentRun,
       loadActivity: onLoadBackgroundAgentActivity,
-      viewOutput: onViewBackgroundAgentOutput,
       open: onOpenBackgroundAgent,
     },
     retry,
@@ -533,7 +530,6 @@ export function groupMessageItems(
     retry: () => void;
     cancel: (runId: string) => Promise<void>;
     loadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
-    viewOutput?: () => void;
     open?: (runId: string) => void;
   } = {
     runs: [],
@@ -648,12 +644,24 @@ export function groupMessageItems(
             onRetry={backgroundAgents.retry}
             onCancel={backgroundAgents.cancel}
             onLoadActivity={backgroundAgents.loadActivity}
-            onViewOutput={backgroundAgents.viewOutput}
             onOpen={backgroundAgents.open}
           />,
         ),
       );
     }
+
+    // The agent list below already names the delegation and every agent in it.
+    // Leaving the spawn and wait calls on the rail as well stacks a second
+    // summary of the same thing above it ("Waited for background agents and
+    // delegated N tasks"), so the phase line covers everything except them.
+    const railActivities =
+      spawns.length > 0
+        ? activities.filter(
+            (entry) =>
+              entry.name !== "spawn_sandbox_agent" &&
+              entry.name !== "wait_for_agents",
+          )
+        : activities;
 
     // The rail and every card inside carry their own boundary, so this one is
     // only a backstop for the phase's own frame.
@@ -662,7 +670,7 @@ export function groupMessageItems(
         key={`tool-activity-group-${groupIndex}`}
         fallback={<ToolActivityUnavailable />}
       >
-        <ToolActivityGroup activities={activities} groupIndex={groupIndex}>
+        <ToolActivityGroup activities={railActivities} groupIndex={groupIndex}>
           {children.length > 0 ? children : undefined}
         </ToolActivityGroup>
       </ErrorBoundary>,

--- a/crates/openwave-desktop/ui/src/deliverables.test.ts
+++ b/crates/openwave-desktop/ui/src/deliverables.test.ts
@@ -49,7 +49,7 @@ describe("deliverable renderer projections", () => {
     });
   });
 
-  it("carries an auto-merged output's producing run and rejects a malformed one", () => {
+  it("carries a submitted output's producing run and rejects a malformed one", () => {
     const runId = "ce116263-15b5-5df2-b472-269378e9da58";
     const [summary] = parseDeliverablesCatalog({
       deliverables: [

--- a/crates/openwave-desktop/ui/src/deliverables.ts
+++ b/crates/openwave-desktop/ui/src/deliverables.ts
@@ -8,7 +8,7 @@ export type DeliverableSummary = {
   revisionCount: number;
   updatedAt: string;
   // The background run that produced the current revision, when this output was
-  // auto-merged from a background agent rather than written by a foreground
+  // submitted by a background agent rather than written by a foreground
   // turn. `null` for a foreground deliverable.
   producingRunId: string | null;
 };

--- a/crates/openwave-desktop/ui/src/outputs/OutputsView.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/OutputsView.dom.test.tsx
@@ -95,9 +95,6 @@ describe("OutputsView", () => {
     const user = userEvent.setup();
 
     render(<OutputsView chatId="chat-1" apis={apis} />);
-    // The auto-merged output is badged as coming from a background agent.
-    expect(await screen.findByText("Agent")).toBeVisible();
-
     await user.click(
       await screen.findByRole("button", { name: "More options for Research brief.md" }),
     );

--- a/crates/openwave-desktop/ui/src/outputs/outputCellRenderers.tsx
+++ b/crates/openwave-desktop/ui/src/outputs/outputCellRenderers.tsx
@@ -1,9 +1,8 @@
 import type { CustomCellRendererProps } from "ag-grid-react";
 import { format } from "date-fns";
-import { BotIcon, DownloadIcon, MoreHorizontalIcon, Trash2Icon } from "lucide-react";
+import { DownloadIcon, MoreHorizontalIcon, Trash2Icon } from "lucide-react";
 import { useState } from "react";
 
-import { Badge } from "@/components/ui/badge";
 import { DocumentIcon } from "@/components/document-table/DocumentIcon";
 import { Button } from "@/components/ui/button";
 import {
@@ -58,14 +57,6 @@ export function NameCellRenderer(props: CellProps) {
         </WithTooltip>
         <span className="truncate">{output.filename}</span>
       </button>
-      {output.producingRunId !== null && (
-        <WithTooltip label="Auto-merged from a background agent">
-          <Badge variant="outline" size="sm" className="ml-2 shrink-0 px-1.5 text-2xs font-medium">
-            <BotIcon className="size-3" />
-            Agent
-          </Badge>
-        </WithTooltip>
-      )}
     </div>
   );
 }

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -717,11 +717,11 @@ impl SandboxAgentRunWorker {
             Some(SubmitAgentRunResultOutcome::Completed(result))
             | Some(SubmitAgentRunResultOutcome::Existing(result)) => {
                 // The result is durably committed and delivered to the parent
-                // inbox. Now the host — never the model — merges it into the
+                // inbox. Now the host — never the model — records it in the
                 // conversation's output record as a revertible version. The
                 // merge runs on the committed text, so the model that produced
-                // it cannot author, decline, or steer the merge.
-                self.auto_merge_result_output(run, &result).await;
+                // it cannot author, decline, or steer it.
+                self.record_result_output(run, &result).await;
                 Ok(SandboxAgentRunWorkerOutcome::Completed(id))
             }
             None => {
@@ -731,19 +731,15 @@ impl SandboxAgentRunWorker {
         }
     }
 
-    /// Auto-merge a completed background run's text result into its
-    /// conversation's outputs.
+    /// Record a completed background run's text result in its conversation's
+    /// outputs.
     ///
     /// This is best-effort after the result has already committed: the merge is
     /// idempotent on the run's derived output identity, so an ambiguous submit
     /// retry re-runs it harmlessly, and a failure here never fails a run whose
     /// result is already delivered. Only a `FinalText` result becomes an output;
     /// a folder-access proposal or cancellation is not conversation content.
-    async fn auto_merge_result_output(
-        &self,
-        run: &AgentRun,
-        result: &openwave_core::AgentRunResult,
-    ) {
+    async fn record_result_output(&self, run: &AgentRun, result: &openwave_core::AgentRunResult) {
         let openwave_core::AgentRunResultPayload::FinalText { text } = &result.payload else {
             return;
         };
@@ -757,7 +753,7 @@ impl SandboxAgentRunWorker {
             Ok(scratch) => scratch,
             Err(error) => {
                 tracing::warn!(
-                    "could not open scratch to auto-merge agent run {} output: {error}",
+                    "could not open scratch to record agent run {} output: {error}",
                     run.id
                 );
                 return;
@@ -766,7 +762,7 @@ impl SandboxAgentRunWorker {
         let merge = openwave_core::AgentResultOutputMerge {
             run_id: run.id,
             chat_id: run.chat_id,
-            filename: agent_result_filename(run.id),
+            filename: agent_result_filename(run.input.as_deref()),
             text: text.clone(),
             created_at: result.submitted_at,
         };
@@ -774,7 +770,7 @@ impl SandboxAgentRunWorker {
             openwave_core::merge_agent_run_result(&*self.store, &scratch, &merge).await
         {
             tracing::warn!(
-                "could not auto-merge agent run {} result into outputs: {error}",
+                "could not record agent run {} result in outputs: {error}",
                 run.id
             );
         }
@@ -1030,15 +1026,44 @@ fn open_chat_scratch(
     })
 }
 
-/// Host-derived, portable display filename for an auto-merged agent result.
+/// Host-derived, portable display filename for a submitted agent result.
 ///
-/// The model never names the output. A short, run-derived suffix keeps several
-/// background results in one conversation distinguishable while the record's
-/// opaque identity remains the authority.
-fn agent_result_filename(run_id: openwave_core::AgentRunId) -> String {
-    let id = run_id.to_string();
-    let short = id.get(..8).unwrap_or(id.as_str());
-    format!("Agent result {short}.md")
+/// The model never names the output, but the task it was given is the closest
+/// thing to a title the host has, and it is what the reader recognises in the
+/// outputs catalog. The record's opaque identity remains the authority, so two
+/// runs given the same task are still two outputs that happen to read alike.
+fn agent_result_filename(task: Option<&str>) -> String {
+    const MAX_TITLE_CHARS: usize = 60;
+
+    let title: String = task
+        .unwrap_or_default()
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .chars()
+        // Portable ASCII only: the name reaches a filesystem on export, and a
+        // task is free-form model-facing prose that can hold anything.
+        .map(|character| match character {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | ' ' | '-' | '_' => character,
+            _ => ' ',
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let title = match title.char_indices().nth(MAX_TITLE_CHARS) {
+        // Cut back to the last whole word so the name ends on something
+        // readable rather than mid-token.
+        Some((cut, _)) => title[..title[..cut].rfind(' ').unwrap_or(cut)].to_string(),
+        None => title,
+    };
+
+    if title.is_empty() {
+        "Agent result.md".to_string()
+    } else {
+        format!("{title}.md")
+    }
 }
 
 fn delegated_file_admission_matches(
@@ -3145,6 +3170,29 @@ mod tests {
             openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL
         );
         assert_eq!(calls[0].arguments, serde_json::json!({}));
+    }
+
+    /// The task is free-form model-facing prose and the filename reaches a real
+    /// filesystem on export, so the two things this has to get right are that
+    /// nothing unportable survives and that a long task still ends on a word.
+    #[test]
+    fn a_result_filename_is_a_portable_title_drawn_from_the_task() {
+        assert_eq!(
+            agent_result_filename(Some("Summarize the Q3 revenue report")),
+            "Summarize the Q3 revenue report.md"
+        );
+        assert_eq!(
+            agent_result_filename(Some("Read ../etc/passwd: \"now\"\nthen stop")),
+            "Read etc passwd now.md"
+        );
+        assert_eq!(
+            agent_result_filename(Some(
+                "Compare every competitor pricing page and write up where our own tiers sit"
+            )),
+            "Compare every competitor pricing page and write up where.md"
+        );
+        assert_eq!(agent_result_filename(Some("   ")), "Agent result.md");
+        assert_eq!(agent_result_filename(None), "Agent result.md");
     }
 
     fn sandbox_chat() -> Chat {


### PR DESCRIPTION
A completed background run's result was recorded as `Agent result <hash>.md` and badged "Auto-merged from a background agent" in the outputs catalog. Neither reads as something a person produced: the name is an opaque identifier, and the badge borrows review vocabulary for a step that has no review gate behind it — the host simply records what the agent returned.

- `agent_result_filename` now derives the display name from the run's task: first line, sanitized to portable ASCII, cut back to a whole word at 60 characters, falling back to `Agent result.md`.
- Output identity is unchanged — it comes from `OutputId::for_run`, not the filename — so an ambiguous submit retry still lands on the same output, and two runs given the same task stay two distinct outputs.
- The `Agent` badge and its tooltip are gone from the outputs table. `producing_run_id` and the retract path are untouched; the attribution is still recorded.
- `auto_merge_result_output` → `record_result_output`, and the auto-merge wording in `deliverable_acceptance.rs`, `id.rs`, `storage.rs`, and the desktop deliverable types now says what happens instead. Naming only.

Existing `Agent result <hash>.md` rows in a live database keep their names; there is no migration and only newly recorded results get a title.

Added one test over the filename derivation — sanitization and the word-boundary cut are the parts that are easy to get wrong and reach a real filesystem on export. `cargo test -p openwave-server -p openwave-core`, the full UI suite, clippy, and rustfmt pass locally.