### PR TITLE
feat(agents): background agents produce files and submit them as outputs

### DIFF
--- a/crates/openwave-core/src/agent_tools.rs
+++ b/crates/openwave-core/src/agent_tools.rs
@@ -30,6 +30,14 @@ pub const WEB_EXTRACT_TOOL: &str = "web_extract";
 pub const SANDBOX_WEB_SEARCH_TOOL: &str = WEB_SEARCH_TOOL;
 /// Stable name for the native-executed exact delegated file read.
 pub const SANDBOX_READ_DELEGATED_FILE_TOOL: &str = "read_delegated_file";
+/// Stable name for command execution inside a background run's own workspace.
+///
+/// Deliberately the same name a foreground turn sees: it is the same operation
+/// against the same kind of private workspace, and a model that has learned one
+/// vocabulary should not have to learn a second one when it is delegated work.
+pub const SANDBOX_EXEC_TOOL: &str = "exec";
+/// Stable name for a background run's terminal submission of its own files.
+pub const SANDBOX_DONE_TOOL: &str = "done";
 
 /// Maximum task length in Unicode scalar values advertised to a model.
 ///
@@ -38,6 +46,14 @@ pub const SANDBOX_READ_DELEGATED_FILE_TOOL: &str = "read_delegated_file";
 pub const MAX_SANDBOX_AGENT_TASK_CHARS: usize = 16_000;
 /// Maximum number of depth-one children in one foreground wait request.
 pub const MAX_WAIT_FOR_AGENTS_CHILDREN: usize = TurnAgentRunWaitSet::MAX_CHILDREN;
+/// Maximum host-executed tool checkpoints one sandbox run may accumulate.
+///
+/// A sandbox run's checkpoints form a chain the worker replays in full on every
+/// claim, so the count is bounded rather than open-ended: the whole chain rides
+/// each model request. Real delegated work needs a sequence — search, read,
+/// then several commands to produce a file — so the bound is a working budget,
+/// not the one-call fence it replaced.
+pub const MAX_SANDBOX_TOOL_CALLS: usize = 16;
 /// Maximum web-search query length advertised to a model.
 pub const MAX_WEB_SEARCH_QUERY_CHARS: usize = 400;
 /// Maximum requested web-search result count.
@@ -46,6 +62,26 @@ pub const MAX_WEB_SEARCH_RESULTS: usize = 10;
 pub const MAX_WEB_SEARCH_DOMAINS: usize = 20;
 /// Default result count when a model omits `max_results`.
 pub const DEFAULT_WEB_SEARCH_RESULTS: usize = 5;
+/// Maximum executable length advertised to a sandboxed background agent.
+///
+/// The three sandbox-exec bounds mirror the ones `openwave-code-execution`
+/// enforces at the provider boundary. They are restated here because the schema
+/// a background agent sees is core's to publish, and the executor revalidates
+/// every field before a command runs.
+pub const MAX_SANDBOX_EXEC_COMMAND_BYTES: usize = 1_024;
+/// Maximum argument-vector length advertised to a sandboxed background agent.
+pub const MAX_SANDBOX_EXEC_ARGUMENTS: usize = 128;
+/// Maximum working-directory length advertised to a sandboxed background agent.
+pub const MAX_SANDBOX_EXEC_CWD_BYTES: usize = 1_024;
+/// Maximum number of files one background run may submit through `done`.
+pub const MAX_SANDBOX_DONE_OUTPUTS: usize = 16;
+/// Maximum summary length in Unicode scalar values a submission may carry.
+///
+/// The summary is prose the parent turn reads beside the submitted filenames,
+/// not the deliverable itself. Bounding it well under [`AgentRun::MAX_RESULT_LEN`]
+/// keeps a multi-child wait result inside its own serialized ceiling and keeps
+/// the pressure where it belongs: on the files, not on the description of them.
+pub const MAX_SANDBOX_DONE_SUMMARY_CHARS: usize = 4_000;
 /// Maximum web-extract URL length in bytes advertised to a model.
 ///
 /// `openwave-web-search` holds its fetch-admission URL bound to this value, so
@@ -203,6 +239,84 @@ pub struct WebExtractArgs {
 #[derive(Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 struct SandboxReadDelegatedFileArgs {}
+
+/// Canonical arguments for one command inside a background run's own workspace.
+///
+/// This is the sandbox presentation of the foreground `exec` contract, narrowed
+/// to what a background run can legitimately ask for: no staged host paths and
+/// no folder authority, because a background run's workspace holds nothing but
+/// what its own earlier commands wrote.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SandboxExecArgs {
+    /// Executable name or path.
+    #[schemars(
+        length(min = 1, max = MAX_SANDBOX_EXEC_COMMAND_BYTES),
+        description = "Executable name or path."
+    )]
+    pub command: String,
+    /// Arguments passed directly to the executable, with no shell parsing.
+    #[serde(default)]
+    #[schemars(
+        length(max = MAX_SANDBOX_EXEC_ARGUMENTS),
+        description = "Arguments passed directly to the executable."
+    )]
+    pub args: Vec<String>,
+    /// Workspace-relative working directory.
+    #[serde(default = "default_sandbox_exec_cwd")]
+    #[schemars(
+        length(min = 1, max = MAX_SANDBOX_EXEC_CWD_BYTES),
+        description = "Workspace-relative working directory (defaults to '.')."
+    )]
+    pub cwd: String,
+}
+
+fn default_sandbox_exec_cwd() -> String {
+    ".".into()
+}
+
+/// Canonical arguments for a background run's terminal submission.
+///
+/// The model names files, not identities: every entry is the filename of a file
+/// the run already wrote under `output/`, which the host published as an output
+/// under that same name. Nothing here creates an output — submission only marks
+/// which of the run's published files are the deliverables the task asked for.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SandboxDoneArgs {
+    /// Filenames of files written under `output/` that answer the task.
+    #[serde(default)]
+    #[schemars(
+        length(max = MAX_SANDBOX_DONE_OUTPUTS),
+        description = "Filenames of files you wrote under output/ that are the deliverables for this task."
+    )]
+    pub outputs: Vec<String>,
+    /// Short prose describing what was produced.
+    #[schemars(
+        length(min = 1, max = MAX_SANDBOX_DONE_SUMMARY_CHARS),
+        description = "Short summary of what you produced and anything the reader should know. Do not restate the file contents here."
+    )]
+    pub summary: String,
+}
+
+impl SandboxDoneArgs {
+    /// Whether every field is within the advertised bounds.
+    ///
+    /// Filenames are checked against the same portable-filename rule the output
+    /// scan applies, so a submission can only ever name something the scan could
+    /// have published.
+    #[must_use]
+    pub fn is_well_formed(&self) -> bool {
+        self.outputs.len() <= MAX_SANDBOX_DONE_OUTPUTS
+            && self
+                .outputs
+                .iter()
+                .all(|name| crate::validate_portable_filename(name).is_ok())
+            && self.outputs.iter().collect::<HashSet<_>>().len() == self.outputs.len()
+            && !self.summary.trim().is_empty()
+            && self.summary.chars().count() <= MAX_SANDBOX_DONE_SUMMARY_CHARS
+    }
+}
 
 impl WaitForAgentsArgs {
     /// Whether this proposal has a non-empty, bounded, unique list of IDs.
@@ -410,12 +524,12 @@ pub fn web_extract_tool_spec() -> ToolSpec {
 /// Sandbox-specific presentation of the shared web-search contract.
 ///
 /// The checkpoint worker, not the ordinary tool registry, executes this
-/// definition under its own durable lease. The one-call instruction matches
-/// the sandbox state machine's admission bound.
+/// definition under its own durable lease, which is why the sandbox needs its
+/// own wording at all.
 #[must_use]
 pub fn sandbox_web_search_tool_spec() -> ToolSpec {
     let mut spec = web_search_tool_spec();
-    spec.description = "Search the public web for current information. Use at most once, with a focused query, and cite sources with the exact result URLs. Results may be unavailable when the host has not configured web search.".into();
+    spec.description = "Search the public web for current information. Use focused queries and cite sources with the exact result URLs. Results may be unavailable when the host has not configured web search.".into();
     spec
 }
 
@@ -437,6 +551,76 @@ pub fn sandbox_read_delegated_file_tool_spec() -> ToolSpec {
 #[must_use]
 pub fn validate_sandbox_read_delegated_file_arguments(arguments: &Value) -> bool {
     serde_json::from_value::<SandboxReadDelegatedFileArgs>(arguments.clone()).is_ok()
+}
+
+/// Contract for running one command in a background run's private workspace.
+///
+/// The description is where a background agent learns the only way it has to
+/// produce something the user can keep: write the file under `output/`. The
+/// filename becomes the output's name, so the agent names its own deliverables
+/// and the host never invents a title for it.
+#[must_use]
+pub fn sandbox_exec_tool_spec() -> ToolSpec {
+    ToolSpec::for_args::<SandboxExecArgs>(
+        SANDBOX_EXEC_TOOL,
+        "Run one executable with an argument vector in this background task's own private \
+         workspace. No shell parses the arguments unless you invoke a shell explicitly (for \
+         example command '/bin/sh' with args ['-c', '…']). The workspace starts empty and is \
+         yours alone: it holds nothing but what your own earlier commands wrote, and you cannot \
+         reach the conversation, the user's files, or any connected folder from it. Save every \
+         deliverable under output/ — each file you write there is published to the user as a \
+         durable output named by its own filename, and writing the same filename again publishes \
+         a new version of that same output. Name those files the way you want the user to see \
+         them. Every command returns bounded stdout and stderr.",
+    )
+}
+
+/// Whether arguments are a bounded, canonical sandbox exec payload.
+#[must_use]
+pub fn validate_sandbox_exec_arguments(arguments: &Value) -> bool {
+    serde_json::from_value::<SandboxExecArgs>(arguments.clone())
+        .is_ok_and(|arguments| arguments.is_well_formed())
+}
+
+/// Contract by which a background run finishes and submits its own files.
+///
+/// This is the only way a background run says what it produced. There is no
+/// host-side synthesis of a result document: if the run wants the user to keep
+/// something, it writes the file and names it here.
+#[must_use]
+pub fn sandbox_done_tool_spec() -> ToolSpec {
+    ToolSpec::for_args::<SandboxDoneArgs>(
+        SANDBOX_DONE_TOOL,
+        "Finish this background task. List the filenames you wrote under output/ that are the \
+         deliverables the task asked for — those files are what the user receives, named exactly \
+         as you named them — and give a short summary of what you produced. Call this only after \
+         the files exist. If the task genuinely produced no file, submit no filenames and say so \
+         in the summary.",
+    )
+}
+
+/// Whether arguments are a bounded, canonical sandbox submission payload.
+#[must_use]
+pub fn validate_sandbox_done_arguments(arguments: &Value) -> bool {
+    serde_json::from_value::<SandboxDoneArgs>(arguments.clone())
+        .is_ok_and(|arguments| arguments.is_well_formed())
+}
+
+impl SandboxExecArgs {
+    /// Whether every field is within the advertised bounds.
+    ///
+    /// Schema bounds are advisory — a provider may forward anything — so the
+    /// durable checkpoint admission and the executor both check them here. The
+    /// working directory is only bounded in length; the provider owns the
+    /// traversal rules for its own filesystem.
+    #[must_use]
+    pub fn is_well_formed(&self) -> bool {
+        !self.command.is_empty()
+            && self.command.len() <= MAX_SANDBOX_EXEC_COMMAND_BYTES
+            && self.args.len() <= MAX_SANDBOX_EXEC_ARGUMENTS
+            && !self.cwd.is_empty()
+            && self.cwd.len() <= MAX_SANDBOX_EXEC_CWD_BYTES
+    }
 }
 
 #[cfg(test)]
@@ -695,7 +879,7 @@ mod tests {
         );
         assert_eq!(foreground.input_schema["additionalProperties"], false);
         assert!(foreground.description.contains("exact result URLs"));
-        assert!(sandbox.description.contains("at most once"));
+        assert!(sandbox.description.contains("exact result URLs"));
     }
 
     #[test]

--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -1256,6 +1256,16 @@ impl Store for DbStore {
         ops::agent_run::submit_agent_run_result(self, id, lease_token, text).await
     }
 
+    async fn submit_agent_run_submission(
+        &self,
+        id: AgentRunId,
+        lease_token: uuid::Uuid,
+        outputs: &[crate::AgentRunSubmittedOutput],
+        summary: &str,
+    ) -> Result<Option<SubmitAgentRunResultOutcome>> {
+        ops::agent_run::submit_agent_run_submission(self, id, lease_token, outputs, summary).await
+    }
+
     async fn submit_agent_run_folder_access_proposal(
         &self,
         id: AgentRunId,

--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -4,13 +4,15 @@ use sea_orm::{
     NotSet, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Set, Statement, TransactionTrait,
 };
 
-use crate::agent_tools::SandboxAgentFileResource;
+use crate::agent_tools::{
+    SandboxAgentFileResource, MAX_SANDBOX_DONE_OUTPUTS, MAX_SANDBOX_DONE_SUMMARY_CHARS,
+};
 use crate::error::{AgentError, Result};
 use crate::id::{AgentRunId, CallId, ChatId, TurnId};
 use crate::model::{
     AgentRun, AgentRunCancellationReason, AgentRunExecutionLocation, AgentRunInboxEntry,
-    AgentRunInboxStatus, AgentRunResult, AgentRunResultPayload, AgentRunStatus, AgentRunTier,
-    SandboxAgentAdmission, TurnRunStatus, TurnSteerStatus,
+    AgentRunInboxStatus, AgentRunResult, AgentRunResultPayload, AgentRunStatus,
+    AgentRunSubmittedOutput, AgentRunTier, SandboxAgentAdmission, TurnRunStatus, TurnSteerStatus,
 };
 use crate::storage::{
     AcceptAgentRunOutcome, AdmitSandboxAgentRunOutcome, FailAgentRunOutcome,
@@ -1517,6 +1519,26 @@ pub(in crate::db) async fn submit_agent_run_result(
     .await
 }
 
+/// Submit a background run's files as its terminal receipt.
+pub(in crate::db) async fn submit_agent_run_submission(
+    store: &DbStore,
+    id: AgentRunId,
+    lease_token: uuid::Uuid,
+    outputs: &[AgentRunSubmittedOutput],
+    summary: &str,
+) -> Result<Option<SubmitAgentRunResultOutcome>> {
+    submit_agent_run_result_payload(
+        store,
+        id,
+        lease_token,
+        AgentRunResultPayload::Submission {
+            outputs: outputs.to_vec(),
+            summary: summary.to_owned(),
+        },
+    )
+    .await
+}
+
 /// Submit the one typed folder-consent proposal a sandbox may return to its
 /// foreground parent. This is a terminal child result, never a client call.
 pub(in crate::db) async fn submit_agent_run_folder_access_proposal(
@@ -2370,6 +2392,28 @@ fn validate_agent_run_result_payload(payload: &AgentRunResultPayload) -> Result<
             "agent-run result requires 1..={} characters",
             AgentRun::MAX_RESULT_LEN
         ))),
+        AgentRunResultPayload::Submission { outputs, summary } => {
+            if outputs.len() > MAX_SANDBOX_DONE_OUTPUTS {
+                return Err(AgentError::Store(format!(
+                    "agent-run submission carries at most {MAX_SANDBOX_DONE_OUTPUTS} outputs"
+                )));
+            }
+            if summary.trim().is_empty() || summary.chars().count() > MAX_SANDBOX_DONE_SUMMARY_CHARS
+            {
+                return Err(AgentError::Store(format!(
+                    "agent-run submission summary requires 1..={MAX_SANDBOX_DONE_SUMMARY_CHARS} characters"
+                )));
+            }
+            if outputs
+                .iter()
+                .any(|output| crate::validate_portable_filename(&output.filename).is_err())
+            {
+                return Err(AgentError::Store(
+                    "agent-run submission names an invalid filename".into(),
+                ));
+            }
+            Ok(())
+        }
         AgentRunResultPayload::FolderAccessProposal { request } if request.is_well_formed() => {
             Ok(())
         }
@@ -2383,6 +2427,7 @@ fn validate_agent_run_result_payload(payload: &AgentRunResultPayload) -> Result<
 fn agent_run_result_payload_kind(payload: &AgentRunResultPayload) -> &'static str {
     match payload {
         AgentRunResultPayload::FinalText { .. } => "final_text",
+        AgentRunResultPayload::Submission { .. } => "submission",
         AgentRunResultPayload::FolderAccessProposal { .. } => "folder_access_proposal",
         AgentRunResultPayload::Cancelled { .. } => "cancelled",
     }
@@ -2393,6 +2438,12 @@ fn agent_run_result_payload_json(payload: &AgentRunResultPayload) -> Result<Stri
         AgentRunResultPayload::FinalText { text } => serde_json::to_string(&serde_json::json!({
             "text": text,
         })),
+        AgentRunResultPayload::Submission { outputs, summary } => {
+            serde_json::to_string(&serde_json::json!({
+                "outputs": outputs,
+                "summary": summary,
+            }))
+        }
         AgentRunResultPayload::FolderAccessProposal { request } => serde_json::to_string(request),
         AgentRunResultPayload::Cancelled { reason } => serde_json::to_string(&serde_json::json!({
             "reason": reason.as_str(),
@@ -2413,6 +2464,21 @@ fn agent_run_result_payload_from_columns(kind: &str, json: &str) -> Result<Agent
                 AgentError::Store("invalid stored final-text agent-run result payload".into())
             })?;
             AgentRunResultPayload::FinalText { text: payload.text }
+        }
+        "submission" => {
+            #[derive(serde::Deserialize)]
+            #[serde(deny_unknown_fields)]
+            struct SubmissionPayload {
+                outputs: Vec<AgentRunSubmittedOutput>,
+                summary: String,
+            }
+            let payload = serde_json::from_str::<SubmissionPayload>(json).map_err(|_| {
+                AgentError::Store("invalid stored submission agent-run result payload".into())
+            })?;
+            AgentRunResultPayload::Submission {
+                outputs: payload.outputs,
+                summary: payload.summary,
+            }
         }
         "folder_access_proposal" => {
             let request = serde_json::from_str::<RequestFolderAccessArgs>(json).map_err(|_| {
@@ -2447,6 +2513,17 @@ fn agent_run_result_payload_from_columns(kind: &str, json: &str) -> Result<Agent
 fn agent_run_result_display_text(payload: &AgentRunResultPayload) -> String {
     match payload {
         AgentRunResultPayload::FinalText { text } => text.clone(),
+        AgentRunResultPayload::Submission { outputs, summary } => {
+            if outputs.is_empty() {
+                return format!("Produced no files.\n{summary}");
+            }
+            let names = outputs
+                .iter()
+                .map(|output| output.filename.as_str())
+                .collect::<Vec<_>>()
+                .join("\n");
+            format!("Submitted files:\n{names}\n\n{summary}")
+        }
         AgentRunResultPayload::FolderAccessProposal { request } => {
             let hint = match request.folder_hint {
                 Some(RequestedFolderHint::Documents) => "\nPicker hint: Documents",

--- a/crates/openwave-core/src/db/ops/sandbox_tool.rs
+++ b/crates/openwave-core/src/db/ops/sandbox_tool.rs
@@ -1,11 +1,12 @@
 use chrono::Duration;
 use sea_orm::{
-    sea_query::ExprTrait, ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait,
-    PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Set, TransactionTrait,
+    sea_query::ExprTrait, ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter,
+    QueryOrder, QuerySelect, Set, TransactionTrait,
 };
 
 use crate::agent_tools::{
-    validate_sandbox_read_delegated_file_arguments, SandboxAgentFileResource,
+    validate_sandbox_exec_arguments, validate_sandbox_read_delegated_file_arguments,
+    SandboxAgentFileResource, MAX_SANDBOX_TOOL_CALLS, SANDBOX_EXEC_TOOL,
     SANDBOX_READ_DELEGATED_FILE_TOOL,
 };
 use crate::error::{AgentError, Result};
@@ -36,6 +37,10 @@ pub(in crate::db) async fn park_agent_run_for_sandbox_tool_call(
         || call.agent_run_id != agent_run_id
         || (call.name == SANDBOX_READ_DELEGATED_FILE_TOOL
             && !validate_sandbox_read_delegated_file_arguments(&call.arguments))
+        // Exec arguments are checked here as well as in the executor: the
+        // checkpoint is immutable once parked, so an out-of-bounds command must
+        // never become a durable row the lane can only fail on.
+        || (call.name == SANDBOX_EXEC_TOOL && !validate_sandbox_exec_arguments(&call.arguments))
     {
         return Err(AgentError::Store(
             "invalid sandbox tool checkpoint request".into(),
@@ -94,12 +99,22 @@ pub(in crate::db) async fn park_agent_run_for_sandbox_tool_call(
         transaction.commit().await.map_err(store_err)?;
         return Ok(ParkSandboxToolCallOutcome::LeaseLost);
     }
-    let existing_count = entities::sandbox_tool_call::Entity::find()
+    // A run parks checkpoints one at a time: parking releases the lease, and the
+    // worker only regains it once the checkpoint resolves. So an unresolved
+    // sibling means this park came from a worker running on a stale view, and the
+    // chain is bounded because the worker replays all of it on every claim.
+    let siblings = entities::sandbox_tool_call::Entity::find()
         .filter(entities::sandbox_tool_call::Column::AgentRunId.eq(agent_run_id.0))
-        .count(&transaction)
+        .select_only()
+        .column(entities::sandbox_tool_call::Column::Status)
+        .into_tuple::<String>()
+        .all(&transaction)
         .await
         .map_err(store_err)?;
-    if existing_count != 0 {
+    let all_resolved = siblings
+        .iter()
+        .all(|status| status_from_db(status).is_ok_and(SandboxToolCallStatus::is_terminal));
+    if !all_resolved || siblings.len() >= MAX_SANDBOX_TOOL_CALLS {
         transaction.commit().await.map_err(store_err)?;
         return Ok(ParkSandboxToolCallOutcome::IdentityConflict);
     }

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -2186,6 +2186,94 @@ async fn sandbox_tool_checkpoint_is_lease_fenced_and_receipt_idempotent() {
 }
 
 #[tokio::test]
+async fn a_sandbox_run_may_checkpoint_repeatedly_up_to_a_bounded_chain() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let sandbox = accepted_sandbox_for_tool_test(&store, chat.id).await;
+
+    // The whole chain rides every model request, so the count is bounded. Drive
+    // the bound exactly: the run keeps checkpointing until the budget is spent,
+    // then the next park is refused rather than growing the transcript further.
+    for step in 0..crate::MAX_SANDBOX_TOOL_CALLS {
+        let worker_lease = uuid::Uuid::new_v4();
+        assert_eq!(
+            store
+                .claim_agent_run(worker_lease, Duration::minutes(5), 1, 1)
+                .await
+                .unwrap()
+                .unwrap()
+                .id,
+            sandbox.id,
+            "run should be claimable for checkpoint {step}"
+        );
+        let request = SandboxToolCallRequest {
+            id: CallId::new(),
+            agent_run_id: sandbox.id,
+            chat_id: chat.id,
+            provider_id: format!("provider-call-{step}"),
+            name: "web_search".into(),
+            arguments: serde_json::json!({"query": format!("step {step}")}),
+        };
+        assert!(
+            matches!(
+                store
+                    .park_agent_run_for_sandbox_tool_call(sandbox.id, worker_lease, &request)
+                    .await
+                    .unwrap(),
+                ParkSandboxToolCallOutcome::Parked { .. }
+            ),
+            "checkpoint {step} should park"
+        );
+        let executor_lease = uuid::Uuid::new_v4();
+        store
+            .claim_sandbox_tool_call(request.id, executor_lease, Duration::minutes(2))
+            .await
+            .unwrap();
+        store
+            .resolve_sandbox_tool_call(
+                request.id,
+                executor_lease,
+                &ToolCallResolution::Completed {
+                    result: format!("results {step}"),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    let worker_lease = uuid::Uuid::new_v4();
+    store
+        .claim_agent_run(worker_lease, Duration::minutes(5), 1, 1)
+        .await
+        .unwrap()
+        .unwrap();
+    let over_budget = SandboxToolCallRequest {
+        id: CallId::new(),
+        agent_run_id: sandbox.id,
+        chat_id: chat.id,
+        provider_id: "provider-call-over".into(),
+        name: "web_search".into(),
+        arguments: serde_json::json!({"query": "one too many"}),
+    };
+    assert!(matches!(
+        store
+            .park_agent_run_for_sandbox_tool_call(sandbox.id, worker_lease, &over_budget)
+            .await
+            .unwrap(),
+        ParkSandboxToolCallOutcome::IdentityConflict
+    ));
+    assert_eq!(
+        store
+            .list_sandbox_tool_calls_for_agent_run(sandbox.id)
+            .await
+            .unwrap()
+            .len(),
+        crate::MAX_SANDBOX_TOOL_CALLS
+    );
+}
+
+#[tokio::test]
 async fn cancelling_waiting_sandbox_fences_claimed_tool_work() {
     let (_dir, store) = temp_store().await;
     let chat = sample_chat();

--- a/crates/openwave-core/src/db/tests/delegated_file_read.rs
+++ b/crates/openwave-core/src/db/tests/delegated_file_read.rs
@@ -332,14 +332,25 @@ async fn delegated_read_checkpoint_and_claim_are_exact_and_lane_isolated() {
         name: "web_search".into(),
         arguments: serde_json::json!({"query": "second tool"}),
     };
-    assert_eq!(
+    assert!(
+        matches!(
+            store
+                .park_agent_run_for_sandbox_tool_call(run.id, next_worker_lease, &second)
+                .await
+                .unwrap(),
+            ParkSandboxToolCallOutcome::Parked { .. }
+        ),
+        "a resolved read does not end the run's checkpoint chain"
+    );
+    // The chain continues, but each checkpoint stays on its own executor lane:
+    // the delegated-file broker never claims search work.
+    assert!(matches!(
         store
-            .park_agent_run_for_sandbox_tool_call(run.id, next_worker_lease, &second)
+            .claim_delegated_file_read(second.id, uuid::Uuid::new_v4(), Duration::minutes(1))
             .await
             .unwrap(),
-        ParkSandboxToolCallOutcome::IdentityConflict,
-        "one sandbox may checkpoint only one total tool call"
-    );
+        ClaimDelegatedFileReadOutcome::Unavailable
+    ));
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/db/tests/output.rs
+++ b/crates/openwave-core/src/db/tests/output.rs
@@ -496,65 +496,6 @@ async fn a_binary_workspace_artifact_is_accepted_published_and_attributed_to_its
 
 #[cfg(feature = "tools")]
 #[tokio::test]
-async fn a_background_run_result_becomes_a_revertible_text_output() {
-    use crate::deliverable::output_revision_relative_path;
-    use crate::deliverable_acceptance::{merge_agent_run_result, AgentResultOutputMerge};
-    use crate::id::AgentRunId;
-
-    let (_dir, store, chat) = store_with_chat().await;
-    let scratch = tempfile::tempdir().unwrap();
-    let dir = open_scratch(scratch.path());
-
-    let run_id = AgentRunId::new();
-    let merge = AgentResultOutputMerge {
-        run_id,
-        chat_id: chat.id,
-        filename: "Agent result.md".into(),
-        text: "# Findings\n\nThe background agent finished.".into(),
-        created_at: at(0),
-    };
-
-    let record = merge_agent_run_result(&store, &dir, &merge).await.unwrap();
-    assert_eq!(record.chat_id, chat.id);
-    assert_eq!(record.media_type, "text/markdown");
-    assert_eq!(record.revision_count, 1);
-    // Identity is derived from the run, so it is stable and idempotent.
-    assert_eq!(record.id, OutputId::for_run(run_id));
-    assert_eq!(record.current_revision, OutputRevisionId::for_run(run_id));
-
-    // The bytes landed at the write-once revision path the desktop reads.
-    let published = scratch.path().join(output_revision_relative_path(
-        record.id,
-        record.current_revision,
-    ));
-    assert_eq!(std::fs::read(&published).unwrap(), merge.text.as_bytes());
-
-    // The revision is attributed to the producing run, never a turn — this is
-    // what the agent-run surface correlates against.
-    let revision = store
-        .get_output_revision(record.current_revision)
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(revision.producing_run_id, Some(run_id));
-    assert_eq!(revision.turn_id, None);
-
-    // An ambiguous submit retry re-runs the merge without forking a second
-    // output or revision.
-    let retried = merge_agent_run_result(&store, &dir, &merge).await.unwrap();
-    assert_eq!(retried, record);
-    assert_eq!(store.list_outputs(chat.id, 10).await.unwrap().len(), 1);
-
-    // Recording it is safe because it is revertible: retracting it hides the
-    // output while keeping its revision, and restoring brings it back.
-    assert!(store.delete_output(record.id, at(30)).await.unwrap());
-    assert!(store.list_outputs(chat.id, 10).await.unwrap().is_empty());
-    assert!(store.restore_output(record.id, at(60)).await.unwrap());
-    assert_eq!(store.list_outputs(chat.id, 10).await.unwrap().len(), 1);
-}
-
-#[cfg(feature = "tools")]
-#[tokio::test]
 async fn acceptance_enforces_the_binary_cap_and_rejects_empty_artifacts() {
     use crate::deliverable::{RevisionProducer, MAX_BINARY_DELIVERABLE_BYTES};
     use crate::deliverable_acceptance::{accept_workspace_artifact, WorkspaceArtifactProposal};

--- a/crates/openwave-core/src/deliverable_acceptance.rs
+++ b/crates/openwave-core/src/deliverable_acceptance.rs
@@ -21,10 +21,10 @@ use sha2::{Digest, Sha256};
 use crate::deliverable::{
     output_revision_relative_path, revision_byte_ceiling, CreateOutput, DeliverableKind,
     NewOutputRevision, OutputRevision, RevisionProducer, MAX_BINARY_DELIVERABLE_BYTES,
-    MAX_DELIVERABLE_BYTES, OUTPUTS_DIRECTORY,
+    OUTPUTS_DIRECTORY,
 };
 use crate::error::{AgentError, Result};
-use crate::id::{AgentRunId, ChatId, OutputId, OutputRevisionId};
+use crate::id::{ChatId, OutputId, OutputRevisionId};
 use crate::storage::Store;
 use crate::OutputRecord;
 
@@ -122,98 +122,6 @@ pub async fn accept_workspace_artifact(
             })
             .await
     }
-}
-
-/// A completed background agent run's text result, ready to record in the
-/// conversation's output record.
-///
-/// The merge is performed by the host at result-commit time; the model that
-/// produced the text can neither author nor decline it. Its identities are
-/// derived from the producing run ([`OutputId::for_run`],
-/// [`OutputRevisionId::for_run`]) so an ambiguous submit retry lands on the same
-/// output rather than forking a second one.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AgentResultOutputMerge {
-    /// Completed background run whose result is being merged. Fixes the derived
-    /// output and revision identities and is recorded as the revision's producer.
-    pub run_id: AgentRunId,
-    /// Conversation that owns both the run and the merged output.
-    pub chat_id: ChatId,
-    /// Host-derived display filename. Portable ASCII ending in a text extension;
-    /// the model never names it.
-    pub filename: String,
-    /// The run's bounded final text.
-    pub text: String,
-    /// Host-stamped merge time.
-    pub created_at: DateTime<Utc>,
-}
-
-/// Record a completed background run's text result as a conversation output.
-///
-/// The bytes are published once at the derived revision path under the exact
-/// conversation's private scratch, then recorded as a text output whose producer
-/// is the background run. Re-running the same run id is idempotent: the derived
-/// identities and matching content return the original record.
-///
-/// This is host-side by construction — nothing the sandbox model returns can
-/// steer the filename, the media type, or whether the merge happens. Safety
-/// comes from the merge being a durable, revertible output revision, not from a
-/// human accept gate.
-pub async fn merge_agent_run_result(
-    store: &dyn Store,
-    scratch: &Dir,
-    merge: &AgentResultOutputMerge,
-) -> Result<OutputRecord> {
-    if merge.text.is_empty() {
-        return Err(AgentError::Store("agent result is empty".into()));
-    }
-    let content = merge.text.as_bytes();
-    if content.len() > MAX_DELIVERABLE_BYTES {
-        return Err(AgentError::Store(format!(
-            "agent result is too large (maximum {MAX_DELIVERABLE_BYTES} bytes)"
-        )));
-    }
-
-    let output_id = OutputId::for_run(merge.run_id);
-    let revision_id = OutputRevisionId::for_run(merge.run_id);
-    let byte_len = content.len() as u64;
-    let sha256: [u8; 32] = Sha256::digest(content).into();
-    let relative_path = output_revision_relative_path(output_id, revision_id);
-
-    // Publishing is blocking capability I/O; keep it off the async runtime. The
-    // path is write-once, so an interrupted retry re-publishes identical bytes.
-    let scratch = scratch
-        .try_clone()
-        .map_err(|error| AgentError::Store(format!("could not open private scratch: {error}")))?;
-    let content = content.to_vec();
-    tokio::task::spawn_blocking(move || {
-        crate::tools::private_scratch::publish_immutable_file(&scratch, &relative_path, &content)
-    })
-    .await
-    .map_err(|error| AgentError::Store(format!("result publication task failed: {error}")))?
-    .map_err(|error| AgentError::Store(format!("could not publish agent result: {error}")))?;
-
-    let revision = NewOutputRevision {
-        id: revision_id,
-        byte_len,
-        sha256,
-        // Provenance is the background run, never a foreground turn, so the
-        // revision carries no turn-scoped retrieval citations.
-        turn_id: None,
-        producing_run_id: None,
-        created_at: merge.created_at,
-    }
-    .with_producer(RevisionProducer::Run(merge.run_id));
-
-    store
-        .create_output(&CreateOutput {
-            id: output_id,
-            chat_id: merge.chat_id,
-            filename: merge.filename.clone(),
-            kind: DeliverableKind::Text,
-            revision,
-        })
-        .await
 }
 
 /// Restore an output to the content of one of its earlier revisions.

--- a/crates/openwave-core/src/id.rs
+++ b/crates/openwave-core/src/id.rs
@@ -373,17 +373,6 @@ impl OutputId {
         Self(Uuid::new_v5(&Self::NAMESPACE, call_id.as_uuid().as_bytes()))
     }
 
-    /// Derive the retry-stable output identity for one background agent run.
-    ///
-    /// A completed background run records its result as exactly one
-    /// conversation output. Deriving the identity from the run makes the merge
-    /// idempotent: an ambiguous submit retry lands on the same output rather than
-    /// forking a second record.
-    #[must_use]
-    pub fn for_run(run_id: AgentRunId) -> Self {
-        Self(Uuid::new_v5(&Self::NAMESPACE, run_id.as_uuid().as_bytes()))
-    }
-
     /// Derive the retry-stable output identity for one artifact filename
     /// published by one canonical tool call.
     ///
@@ -419,13 +408,6 @@ impl OutputRevisionId {
     #[must_use]
     pub fn for_call(call_id: CallId) -> Self {
         Self(Uuid::new_v5(&Self::NAMESPACE, call_id.as_uuid().as_bytes()))
-    }
-
-    /// Derive the retry-stable first-revision identity for one background agent
-    /// run's submitted output.
-    #[must_use]
-    pub fn for_run(run_id: AgentRunId) -> Self {
-        Self(Uuid::new_v5(&Self::NAMESPACE, run_id.as_uuid().as_bytes()))
     }
 
     /// Derive the retry-stable revision identity for one artifact filename

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -25,10 +25,11 @@ pub const VERSION: &str = match option_env!("OPENWAVE_VERSION") {
 
 /// Upper bound on the filename lookup when matching files to existing
 /// outputs. Far above the catalog's own display cap. Shared between the
-/// output scan and the agent's filename resolution for output write-backs so
-/// both match the same window; it lives here, ungated, because the agent
-/// compiles without the `tools` feature the scan is behind.
-pub(crate) const OUTPUT_LOOKUP_LIMIT: u64 = 1_000;
+/// output scan, the agent's filename resolution for output write-backs, and a
+/// background run's submission so all three match the same window; it lives
+/// here, ungated, because the agent compiles without the `tools` feature the
+/// scan is behind.
+pub const OUTPUT_LOOKUP_LIMIT: u64 = 1_000;
 
 pub mod agent;
 pub mod agent_tools;
@@ -77,16 +78,20 @@ pub use agent::{
     SandboxAgentSpawnRequest, ToolRegistry, UtilityModel,
 };
 pub use agent_tools::{
-    sandbox_read_delegated_file_tool_spec, sandbox_web_search_tool_spec,
-    spawn_sandbox_agent_tool_spec, validate_sandbox_read_delegated_file_arguments,
+    sandbox_done_tool_spec, sandbox_exec_tool_spec, sandbox_read_delegated_file_tool_spec,
+    sandbox_web_search_tool_spec, spawn_sandbox_agent_tool_spec, validate_sandbox_done_arguments,
+    validate_sandbox_exec_arguments, validate_sandbox_read_delegated_file_arguments,
     validate_spawn_sandbox_agent_arguments, validate_wait_for_agents_arguments,
     wait_for_agents_tool_spec, web_extract_tool_spec, web_search_tool_spec,
-    SandboxAgentFileResource, SpawnSandboxAgentArgs, SpawnSandboxAgentResult, WaitForAgentResult,
-    WaitForAgentsArgs, WaitForAgentsResult, WebExtractArgs, WebSearchArgs,
-    DEFAULT_WEB_SEARCH_RESULTS, MAX_SANDBOX_AGENT_TASK_CHARS, MAX_WAIT_FOR_AGENTS_CHILDREN,
-    MAX_WEB_EXTRACT_URL_BYTES, MAX_WEB_SEARCH_DOMAINS, MAX_WEB_SEARCH_QUERY_CHARS,
-    MAX_WEB_SEARCH_RESULTS, SANDBOX_READ_DELEGATED_FILE_TOOL, SANDBOX_WEB_SEARCH_TOOL,
-    SPAWN_SANDBOX_AGENT_TOOL, WAIT_FOR_AGENTS_TOOL, WEB_EXTRACT_TOOL, WEB_SEARCH_TOOL,
+    SandboxAgentFileResource, SandboxDoneArgs, SandboxExecArgs, SpawnSandboxAgentArgs,
+    SpawnSandboxAgentResult, WaitForAgentResult, WaitForAgentsArgs, WaitForAgentsResult,
+    WebExtractArgs, WebSearchArgs, DEFAULT_WEB_SEARCH_RESULTS, MAX_SANDBOX_AGENT_TASK_CHARS,
+    MAX_SANDBOX_DONE_OUTPUTS, MAX_SANDBOX_DONE_SUMMARY_CHARS, MAX_SANDBOX_EXEC_ARGUMENTS,
+    MAX_SANDBOX_EXEC_COMMAND_BYTES, MAX_SANDBOX_EXEC_CWD_BYTES, MAX_SANDBOX_TOOL_CALLS,
+    MAX_WAIT_FOR_AGENTS_CHILDREN, MAX_WEB_EXTRACT_URL_BYTES, MAX_WEB_SEARCH_DOMAINS,
+    MAX_WEB_SEARCH_QUERY_CHARS, MAX_WEB_SEARCH_RESULTS, SANDBOX_DONE_TOOL, SANDBOX_EXEC_TOOL,
+    SANDBOX_READ_DELEGATED_FILE_TOOL, SANDBOX_WEB_SEARCH_TOOL, SPAWN_SANDBOX_AGENT_TOOL,
+    WAIT_FOR_AGENTS_TOOL, WEB_EXTRACT_TOOL, WEB_SEARCH_TOOL,
 };
 pub use approval::{
     ApprovalDecision, ApprovalFuture, ApprovalGate, ApprovalJournalIdentity, ApprovalRegistration,
@@ -131,8 +136,7 @@ pub use deliverable::{
 };
 #[cfg(feature = "tools")]
 pub use deliverable_acceptance::{
-    accept_workspace_artifact, merge_agent_run_result, restore_output_to_revision,
-    AgentResultOutputMerge, WorkspaceArtifactProposal,
+    accept_workspace_artifact, restore_output_to_revision, WorkspaceArtifactProposal,
 };
 pub use error::{AgentError, AgentErrorInfo, ProviderErrorInfo, ProviderFailure, Result};
 pub use event::{AgentEvent, SequencedEvent};
@@ -149,23 +153,24 @@ pub use keychain::KeychainSecretProvider;
 pub use model::{
     exec_attachment_file_name, AgentRun, AgentRunCancellationReason, AgentRunCancellationSignal,
     AgentRunExecutionLocation, AgentRunInboxEntry, AgentRunInboxStatus, AgentRunResult,
-    AgentRunResultPayload, AgentRunStatus, AgentRunTier, AgentRunWaitCondition,
-    AgentRunWaitSetCandidate, AgentRunWaitSetCheckpointRequest, BeginRootAttachmentChange,
-    BlobRetirement, BlobRetirementStatus, Chat, ChatRootAttachment, ClientToolCallRequest,
-    DelegatedFileReadClaim, DocumentListCursor, DocumentRecord, DocumentScope, DocumentSourceBlob,
-    DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert, ExecFileChange, ExecFileRejection,
-    ExecFileRejectionReason, ExecFileRejectionRecord, ExecFileSnapshot, ExecFileSnapshotRecord,
-    ExecUndoState, Message, MessageAttachment, MessageDocumentAttachment, NetworkPolicy, OwnerId,
-    PermissionMode, Project, ReasoningEffort, Role, RootAttachmentChange,
-    RootAttachmentChangeAction, RootAttachmentChangeFailure, RootAttachmentChangePhase,
-    RootAttachmentChangeTerminal, RootAttachmentOrigin, RootAttachmentSubjectKind,
-    SandboxAgentAdmission, SandboxSpawnCheckpoint, SandboxSpawnCheckpointRequest, SandboxToolCall,
-    SandboxToolCallReceipt, SandboxToolCallRequest, SandboxToolCallStatus, SourceReadiness,
-    ToolCallExecution, ToolCallRecord, ToolCallResolution, ToolCallStatus, TurnAgentRunWaitSet,
-    TurnAgentRunWaitStatus, TurnCheckpointProgress, TurnClientWait, TurnClientWaitStatus,
-    TurnFailureReceipt, TurnFailureRetry, TurnRun, TurnRunStatus, TurnSteer, TurnSteerStatus,
-    EXEC_SNAPSHOT_RETAINED_TURNS, MAX_ATTACHMENT_REVISION, MAX_EXEC_SNAPSHOT_BYTES,
-    MAX_EXEC_WORKSPACE_FILE_BYTES, MAX_MESSAGE_ATTACHMENTS, MAX_ROOT_ATTACHMENTS,
+    AgentRunResultPayload, AgentRunStatus, AgentRunSubmittedOutput, AgentRunTier,
+    AgentRunWaitCondition, AgentRunWaitSetCandidate, AgentRunWaitSetCheckpointRequest,
+    BeginRootAttachmentChange, BlobRetirement, BlobRetirementStatus, Chat, ChatRootAttachment,
+    ClientToolCallRequest, DelegatedFileReadClaim, DocumentListCursor, DocumentRecord,
+    DocumentScope, DocumentSourceBlob, DocumentSourceUpsert, DocumentSummaryRecord, DocumentUpsert,
+    ExecFileChange, ExecFileRejection, ExecFileRejectionReason, ExecFileRejectionRecord,
+    ExecFileSnapshot, ExecFileSnapshotRecord, ExecUndoState, Message, MessageAttachment,
+    MessageDocumentAttachment, NetworkPolicy, OwnerId, PermissionMode, Project, ReasoningEffort,
+    Role, RootAttachmentChange, RootAttachmentChangeAction, RootAttachmentChangeFailure,
+    RootAttachmentChangePhase, RootAttachmentChangeTerminal, RootAttachmentOrigin,
+    RootAttachmentSubjectKind, SandboxAgentAdmission, SandboxSpawnCheckpoint,
+    SandboxSpawnCheckpointRequest, SandboxToolCall, SandboxToolCallReceipt, SandboxToolCallRequest,
+    SandboxToolCallStatus, SourceReadiness, ToolCallExecution, ToolCallRecord, ToolCallResolution,
+    ToolCallStatus, TurnAgentRunWaitSet, TurnAgentRunWaitStatus, TurnCheckpointProgress,
+    TurnClientWait, TurnClientWaitStatus, TurnFailureReceipt, TurnFailureRetry, TurnRun,
+    TurnRunStatus, TurnSteer, TurnSteerStatus, EXEC_SNAPSHOT_RETAINED_TURNS,
+    MAX_ATTACHMENT_REVISION, MAX_EXEC_SNAPSHOT_BYTES, MAX_EXEC_WORKSPACE_FILE_BYTES,
+    MAX_MESSAGE_ATTACHMENTS, MAX_ROOT_ATTACHMENTS,
 };
 #[cfg(feature = "tools")]
 pub use output_scan::{

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1484,6 +1484,13 @@ pub struct AgentRunResult {
 pub enum AgentRunResultPayload {
     /// Ordinary final text from the sandbox model.
     FinalText { text: String },
+    /// Files the run wrote and then submitted as its deliverables.
+    Submission {
+        /// Outputs the run named, in the order it named them.
+        outputs: Vec<AgentRunSubmittedOutput>,
+        /// Bounded prose describing what the run produced.
+        summary: String,
+    },
     /// A sandbox request for its foreground parent to consider folder consent.
     FolderAccessProposal {
         /// Non-authoritative, validated request arguments.
@@ -1494,6 +1501,20 @@ pub enum AgentRunResultPayload {
         /// Stable reason recorded by the cancellation state machine.
         reason: AgentRunCancellationReason,
     },
+}
+
+/// One file a background run submitted as a deliverable.
+///
+/// The filename is the identity the model worked with and the name the user
+/// sees; the output id is the host's resolution of that name against the
+/// conversation's own output record, captured at submission time so a later
+/// rename or delete cannot rewrite what the run claimed to have produced.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentRunSubmittedOutput {
+    /// Conversation output the submitted filename resolved to.
+    pub output_id: crate::id::OutputId,
+    /// Filename the run wrote under `output/`, which names the output.
+    pub filename: String,
 }
 
 /// Durable reason a sandbox child was cancelled.

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -2431,6 +2431,21 @@ pub trait Store: Send + Sync {
         agent_run_storage_unavailable()
     }
 
+    /// Atomically submit a background run's own files as its terminal receipt.
+    ///
+    /// The outputs already exist: the run wrote them and the host published
+    /// them by filename. Submission records which of them the run offers as its
+    /// deliverables, so nothing here creates or renames conversation content.
+    async fn submit_agent_run_submission(
+        &self,
+        _id: AgentRunId,
+        _lease_token: uuid::Uuid,
+        _outputs: &[crate::AgentRunSubmittedOutput],
+        _summary: &str,
+    ) -> Result<Option<SubmitAgentRunResultOutcome>> {
+        agent_run_storage_unavailable()
+    }
+
     /// Atomically submit one validated folder-consent proposal as a sandbox's
     /// typed terminal receipt. This only wakes the foreground parent through
     /// its durable inbox; it cannot grant host access or invoke a client tool.

--- a/crates/openwave-desktop/ui/src/AgentRunDisplay.ts
+++ b/crates/openwave-desktop/ui/src/AgentRunDisplay.ts
@@ -56,6 +56,7 @@ export function getAgentRunDotClass(status: AgentRunStatus): string {
 export function agentRunStatusDetail(run: AgentRun): string {
   if (run.activity) {
     const activity = {
+      exec: { running: "Running a command", waiting: "Waiting to run a command" },
       web_search: { running: "Searching the web", waiting: "Waiting to search" },
       read_delegated_file: {
         running: "Reading a delegated file",
@@ -104,6 +105,13 @@ const ACTIVITY_HISTORY_LABELS: Record<
   AgentActivityKind,
   Record<AgentActivityOutcome, string>
 > = {
+  exec: {
+    waiting: "Waiting to run a command",
+    running: "Running a command",
+    completed: "Ran a command",
+    failed: "A command failed",
+    cancelled: "Command stopped",
+  },
   web_search: {
     waiting: "Waiting to search the web",
     running: "Searching the web",

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.test.tsx
@@ -21,7 +21,7 @@ function run(
     finished_at: null,
     last_error_code: null,
     activity: null,
-    produced_output: status === "completed",
+    submitted_outputs: [],
     terminal_text: status === "completed" ? `Result from ${id}` : null,
     created_at: "2026-07-27T12:00:00Z",
     updated_at: "2026-07-27T12:00:00Z",
@@ -81,6 +81,28 @@ describe("BackgroundAgentList", () => {
     expect(markup).toContain("Task for run-failed");
     expect(markup).not.toContain("Sandbox task failed (provider_error)");
     expect(markup).not.toContain("Result from run-done");
+  });
+
+  it("names the files an agent submitted, which are its deliverables", () => {
+    const submitted = run("run-done", "call-done", "completed");
+    submitted.submitted_outputs = [
+      { output_id: "output-1", filename: "Q3 revenue.md" },
+      { output_id: "output-2", filename: "revenue.xlsx" },
+    ];
+    const markup = renderToStaticMarkup(
+      <BackgroundAgentList
+        spawns={[{ callId: "call-done", status: "completed" }]}
+        runs={[submitted]}
+        loading={false}
+        error={null}
+        onRetry={() => undefined}
+        onCancel={noop}
+        onLoadActivity={noActivity}
+      />,
+    );
+
+    expect(markup).toContain("Q3 revenue.md");
+    expect(markup).toContain("revenue.xlsx");
   });
 
   it("shows a skeleton as soon as a spawn is visible but not durable yet", () => {

--- a/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentList.tsx
@@ -9,6 +9,7 @@ import {
   getAgentRunDotClass,
   RUNNING_AGENT_STATUSES,
 } from "./AgentRunDisplay";
+import { SubmittedOutputPills } from "./SubmittedOutputPills";
 import type { ToolCallStatus } from "./ToolCallCard";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -32,6 +33,8 @@ type BackgroundAgentListProps = {
   onLoadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
   /** Open one run's dedicated panel beside the conversation. */
   onOpen?: (runId: string) => void;
+  /** Open one file a run submitted, from its pill on the row. */
+  onOpenOutput?: (outputId: string) => void;
 };
 
 /**
@@ -48,6 +51,7 @@ export function BackgroundAgentList({
   onCancel,
   onLoadActivity,
   onOpen,
+  onOpenOutput,
 }: BackgroundAgentListProps) {
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const sandboxRuns = runs.filter((run) => run.tier === "background");
@@ -139,6 +143,7 @@ export function BackgroundAgentList({
                         onCancel={onCancel}
                         onLoadActivity={onLoadActivity}
                         onOpen={onOpen}
+                        onOpenOutput={onOpenOutput}
                       />
                     ))}
                   </div>
@@ -173,11 +178,13 @@ function BackgroundAgentRow({
   onCancel,
   onLoadActivity,
   onOpen,
+  onOpenOutput,
 }: {
   run: AgentRun;
   onCancel: (runId: string) => Promise<void>;
   onLoadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
   onOpen?: (runId: string) => void;
+  onOpenOutput?: (outputId: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [stopping, setStopping] = useState(false);
@@ -265,6 +272,14 @@ function BackgroundAgentRow({
           </Button>
         )}
       </div>
+      {run.submitted_outputs.length > 0 && (
+        <div className="mt-2 pl-5">
+          <SubmittedOutputPills
+            outputs={run.submitted_outputs}
+            onOpenOutput={onOpenOutput}
+          />
+        </div>
+      )}
       {expanded && (
         <div id={contentId} className="mt-2 pl-5">
           <AgentActivityTimeline state={activity} />

--- a/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
+++ b/crates/openwave-desktop/ui/src/BackgroundAgentPanel.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
-import { Bot, FileOutput, Square } from "lucide-react";
+import { Bot, Square } from "lucide-react";
 
 import { useApp } from "./AppContext";
 import { AgentActivityTimeline, useAgentRunActivity } from "./AgentActivityTimeline";
 import { agentRunStatusDetail, RUNNING_AGENT_STATUSES } from "./AgentRunDisplay";
 import type { AgentRun } from "./api";
+import { SubmittedOutputPills } from "./SubmittedOutputPills";
 import { useAgentRuns } from "./useAgentRuns";
 import { PanelBreadcrumb } from "@/components/PanelHeader";
 import { PanelFrame } from "@/panel/PanelFrame";
@@ -85,9 +86,7 @@ export function BackgroundAgentPanel({
         <BackgroundAgentDetail
           run={run}
           activity={activity}
-          onViewOutput={
-            run.produced_output ? () => openPanel({ type: "outputs" }) : undefined
-          }
+          onOpenOutput={(outputId) => openPanel({ type: "outputs", outputId })}
         />
       ) : agentRuns.error ? (
         <div className="flex items-center justify-between gap-3 p-4 text-sm" role="status">
@@ -118,11 +117,11 @@ export function BackgroundAgentPanel({
 function BackgroundAgentDetail({
   run,
   activity,
-  onViewOutput,
+  onOpenOutput,
 }: {
   run: AgentRun;
   activity: ReturnType<typeof useAgentRunActivity>;
-  onViewOutput?: () => void;
+  onOpenOutput?: (outputId: string) => void;
 }) {
   const live = RUNNING_AGENT_STATUSES.has(run.status);
   const now = useNowWhile(live);
@@ -149,22 +148,11 @@ function BackgroundAgentDetail({
         )}
       </div>
       <div className="mt-3 flex shrink-0 flex-col gap-2 border-b px-4 pb-3 empty:hidden">
-        {onViewOutput && (
-          <div className="flex items-center justify-between gap-2 rounded-md border px-3 py-2">
-            <span className="text-sm text-foreground">
-              This agent produced output.
-            </span>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-7 shrink-0 gap-1 px-2 text-xs"
-              onClick={onViewOutput}
-            >
-              <FileOutput className="size-3.5" aria-hidden="true" />
-              View output
-            </Button>
-          </div>
+        {run.submitted_outputs.length > 0 && (
+          <SubmittedOutputPills
+            outputs={run.submitted_outputs}
+            onOpenOutput={onOpenOutput}
+          />
         )}
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto p-4" aria-live="polite">

--- a/crates/openwave-desktop/ui/src/ChatRoute.tsx
+++ b/crates/openwave-desktop/ui/src/ChatRoute.tsx
@@ -637,6 +637,7 @@ export function ChatRoute({ chatId }: { chatId: string }) {
             onSend={onSend}
             onRetryTurn={retryTurn}
             onOpenAgentPanel={(runId) => openPanel({ type: "agent", runId })}
+            onOpenOutput={(outputId) => openPanel({ type: "outputs", outputId })}
           />
         </TranscriptVisibilityProvider>
       );

--- a/crates/openwave-desktop/ui/src/ChatView.tsx
+++ b/crates/openwave-desktop/ui/src/ChatView.tsx
@@ -62,6 +62,7 @@ export type ChatViewProps = {
   onRetryTurn?: (turn: RetryableTurn) => void;
   /** Open one background run's panel beside the conversation. */
   onOpenAgentPanel?: (runId: string) => void;
+  onOpenOutput?: (outputId: string) => void;
 };
 
 /**
@@ -93,6 +94,7 @@ export function ChatView({
   onSend,
   onRetryTurn,
   onOpenAgentPanel,
+  onOpenOutput,
 }: ChatViewProps) {
   const transcriptVisible = useTranscriptVisible();
   // Subscribed here rather than in the route above: a keystroke should
@@ -363,6 +365,7 @@ export function ChatView({
           onCancelBackgroundAgentRun={agentRuns.cancel}
           onLoadBackgroundAgentActivity={agentRuns.loadActivity}
           onOpenBackgroundAgent={onOpenAgentPanel}
+          onOpenOutput={onOpenOutput}
           busy={busy}
           streamStalled={streamStalled}
           scrollRef={attachScrollRef}

--- a/crates/openwave-desktop/ui/src/MessageList.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.test.tsx
@@ -28,7 +28,7 @@ function backgroundRun(
     finished_at: null,
     last_error_code: null,
     activity: null,
-    produced_output: status === "completed",
+    submitted_outputs: [],
     terminal_text: status === "completed" ? `Result from ${id}` : null,
     created_at: "2026-07-27T12:00:00Z",
     updated_at: "2026-07-27T12:00:00Z",

--- a/crates/openwave-desktop/ui/src/MessageList.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.tsx
@@ -199,6 +199,7 @@ type MessageListProps = {
     runId: string,
   ) => Promise<AgentActivityHistoryEntry[]>;
   onOpenBackgroundAgent?: (runId: string) => void;
+  onOpenOutput?: (outputId: string) => void;
   busy: boolean;
   /** The live turn's stream has gone quiet — see [useStreamStalled]. */
   streamStalled?: boolean;
@@ -268,6 +269,7 @@ export function MessageList({
   onCancelBackgroundAgentRun = async () => undefined,
   onLoadBackgroundAgentActivity = async () => [],
   onOpenBackgroundAgent,
+  onOpenOutput,
   busy,
   streamStalled = false,
   scrollRef,
@@ -319,6 +321,7 @@ export function MessageList({
       cancel: onCancelBackgroundAgentRun,
       loadActivity: onLoadBackgroundAgentActivity,
       open: onOpenBackgroundAgent,
+      openOutput: onOpenOutput,
     },
     retry,
   );
@@ -536,6 +539,7 @@ export function groupMessageItems(
     cancel: (runId: string) => Promise<void>;
     loadActivity: (runId: string) => Promise<AgentActivityHistoryEntry[]>;
     open?: (runId: string) => void;
+    openOutput?: (outputId: string) => void;
   } = {
     runs: [],
     loading: false,
@@ -650,6 +654,7 @@ export function groupMessageItems(
             onCancel={backgroundAgents.cancel}
             onLoadActivity={backgroundAgents.loadActivity}
             onOpen={backgroundAgents.open}
+            onOpenOutput={backgroundAgents.openOutput}
           />,
         ),
       );

--- a/crates/openwave-desktop/ui/src/SubmittedOutputPills.tsx
+++ b/crates/openwave-desktop/ui/src/SubmittedOutputPills.tsx
@@ -1,0 +1,72 @@
+import { FileText } from "lucide-react";
+
+import type { AgentRun } from "./api";
+
+/** Beyond this many, the rest collapse into a count rather than wrapping on. */
+const MAX_VISIBLE_OUTPUTS = 6;
+
+/**
+ * The files a background agent handed over, named by the agent itself.
+ *
+ * A background run's deliverable is not text the host paraphrases: the run
+ * writes files under `output/`, the scan publishes them under their own
+ * filenames, and `done` submits that set. So this is the whole result surface —
+ * one pill per file, each opening the output it names.
+ */
+export function SubmittedOutputPills({
+  outputs,
+  onOpenOutput,
+}: {
+  outputs: AgentRun["submitted_outputs"];
+  /** Open one submitted output; without it the pills are labels, not links. */
+  onOpenOutput?: (outputId: string) => void;
+}) {
+  if (outputs.length === 0) return null;
+  const visible = outputs.slice(0, MAX_VISIBLE_OUTPUTS);
+  const hidden = outputs.length - visible.length;
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5" aria-label="Submitted files">
+      {visible.map((output) => (
+        <SubmittedOutputPill
+          key={output.output_id}
+          filename={output.filename}
+          onOpen={onOpenOutput ? () => onOpenOutput(output.output_id) : undefined}
+        />
+      ))}
+      {hidden > 0 && (
+        <span className="text-muted-foreground text-xs">+{hidden} more</span>
+      )}
+    </div>
+  );
+}
+
+function SubmittedOutputPill({
+  filename,
+  onOpen,
+}: {
+  filename: string;
+  onOpen?: () => void;
+}) {
+  const body = (
+    <>
+      <FileText className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+      <span className="min-w-0 truncate">{filename}</span>
+    </>
+  );
+  const frame =
+    "bg-background inline-flex max-w-56 min-w-0 items-center gap-1.5 rounded-md border px-2 py-1 text-xs";
+  if (!onOpen) {
+    return <span className={frame}>{body}</span>;
+  }
+  return (
+    <button
+      type="button"
+      className={`${frame} hover:bg-muted/40 cursor-pointer transition-colors`}
+      onClick={onOpen}
+      aria-label={`Open output ${filename}`}
+    >
+      {body}
+    </button>
+  );
+}

--- a/crates/openwave-desktop/ui/src/api.ts
+++ b/crates/openwave-desktop/ui/src/api.ts
@@ -2218,6 +2218,7 @@ function nonEmptyBounded(value: unknown, maxChars: number): value is string {
 }
 
 const AGENT_ACTIVITY_KINDS = new Set<AgentActivityKind>([
+  "exec",
   "web_search",
   "read_delegated_file",
   "list_connected_folders",

--- a/crates/openwave-desktop/ui/src/deliverables.test.ts
+++ b/crates/openwave-desktop/ui/src/deliverables.test.ts
@@ -55,7 +55,7 @@ describe("deliverable renderer projections", () => {
       deliverables: [
         {
           outputId,
-          filename: "Agent result ce116263.md",
+          filename: "Q3 revenue.md",
           mediaType: "text/markdown",
           sizeBytes: 42,
           revisionCount: 1,

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -25,7 +25,7 @@ export type AgentActivityHistoryItem = { kind: AgentActivityKind, outcome: Agent
  * Adding a durable tool does not automatically expose it to a renderer: it
  * must be deliberately admitted here with a safe label.
  */
-export type AgentActivityKind = "web_search" | "read_delegated_file" | "list_connected_folders" | "list_folder" | "read_connected_file" | "import_connected_file";
+export type AgentActivityKind = "exec" | "web_search" | "read_delegated_file" | "list_connected_folders" | "list_folder" | "read_connected_file" | "import_connected_file";
 
 /**
  * Coarse, renderer-safe lifecycle for one historical activity entry.
@@ -95,14 +95,13 @@ last_error_code: string | null,
  */
 activity: AgentActivitySnapshot | null, 
 /**
- * Whether a completed background run committed an immutable terminal
- * receipt, which happens atomically with its terminal state.
+ * Files a background run submitted as its deliverables, in its own order.
  *
- * This is presence only: the payload, its display text, and any merged
- * deliverable never cross this boundary. A renderer uses it to offer a
- * "view output" affordance and link to the outputs surface.
+ * A background run produces outputs by writing files and submitting them
+ * by name; nothing here is host-authored, and a run that submitted nothing
+ * carries an empty list.
  */
-produced_output: boolean, 
+submitted_outputs: Array<SubmittedOutputSnapshot>, 
 /**
  * Bounded terminal display text returned to the parent, if settled.
  */
@@ -1290,6 +1289,15 @@ resolved_key: string | null, };
 export type NetworkPolicy = { "mode": "off" } | { "mode": "package_managers" } | { "mode": "allowed_hosts", allowed_hosts: Array<string>, package_managers: boolean, } | { "mode": "open" };
 
 /**
+ * Identifies one conversation-owned output across all of its revisions.
+ *
+ * This is the durable handle a model, renderer, or export names. It is
+ * deliberately opaque: possession of an id is not authority, and it never
+ * encodes a filename or a host path.
+ */
+export type OutputId = string;
+
+/**
  * Closed renderer-safe pending approval projection. Canonical arguments,
  * model-authored summaries, and unknown tool names never cross this boundary;
  * only a tool's own closed preview of the action under review does.
@@ -1723,6 +1731,15 @@ level_title: string | null, action: RendererToolName, approval: ToolApprovalKind
  * picker displays is what creation will actually seed.
  */
 export type StickyChatDefaults = { model: string | null, reasoning_effort: ReasoningEffort | null, permission_mode: PermissionMode | null, network_policy: NetworkPolicy | null, };
+
+/**
+ * One file a background run submitted, as the renderer sees it.
+ */
+export type SubmittedOutputSnapshot = { output_id: OutputId, 
+/**
+ * The name the run gave the file, which is the output's name.
+ */
+filename: string, };
 
 /**
  * The action a call will take, in a form a human can inspect.

--- a/crates/openwave-desktop/ui/src/useAgentRuns.test.ts
+++ b/crates/openwave-desktop/ui/src/useAgentRuns.test.ts
@@ -18,7 +18,7 @@ function run(status: AgentRun["status"] = "running"): AgentRun {
     finished_at: null,
     last_error_code: null,
     activity: null,
-    produced_output: status === "completed",
+    submitted_outputs: [],
     terminal_text: status === "completed" ? "Result from run-1" : null,
     created_at: "2026-07-27T12:00:00Z",
     updated_at: "2026-07-27T12:00:00Z",

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -1788,6 +1788,224 @@ impl ConfiguredCodeExecutionProvider {
         }
         Ok(Some(ConfiguredWorkspace { provider }))
     }
+
+    /// Run one command for a background agent run in its own workspace.
+    ///
+    /// A background run is confined to the workspace named by its own identity:
+    /// no folder authority, no conversation attachments, and no write overlay,
+    /// so the only files it can read are the ones its own earlier commands
+    /// wrote. Delegation already bypasses the conversation's approval gate, so
+    /// this path must never be the one that hands a background agent host
+    /// paths. The parent conversation contributes exactly one thing — its
+    /// network policy — because the user chose that policy for this work.
+    pub async fn execute_for_agent_run(
+        &self,
+        chat_id: ChatId,
+        request: CodeExecutionRequest,
+    ) -> std::result::Result<CodeExecutionResponse, CodeExecutionError> {
+        if !request.folder_grants.is_empty() {
+            return Err(CodeExecutionError::InvalidRequest(
+                "a background run's execution carries no folder authority".into(),
+            ));
+        }
+        let chat = self
+            .store
+            .get_chat(chat_id)
+            .await
+            .map_err(|_| {
+                CodeExecutionError::Unavailable("conversation storage is unavailable".into())
+            })?
+            .ok_or_else(|| {
+                CodeExecutionError::InvalidRequest("execution conversation does not exist".into())
+            })?;
+        let (kind, provider) = self.resolve(Some(&chat.network_policy)).await?;
+        self.execute_prepared(kind, provider, request, None, chat_id)
+            .await
+    }
+
+    /// Prepare the workspace, run one command, and reconcile its files.
+    ///
+    /// Everything above this point differs between a foreground turn and a
+    /// background run — whose authority the request carries, and whose
+    /// attachments belong in the workspace. From here down the two are the same
+    /// operation against a private workspace. `chat` is the conversation whose
+    /// attachments are materialized and whose write overlay this command joins;
+    /// a background run passes `None` for both. `degradation_chat` is only the
+    /// conversation the one-shot sandbox-degradation notice is deduplicated
+    /// against.
+    async fn execute_prepared(
+        &self,
+        kind: CodeExecutionProviderKind,
+        provider: Box<dyn CodeExecutionProvider>,
+        request: CodeExecutionRequest,
+        chat: Option<ChatId>,
+        degradation_chat: ChatId,
+    ) -> std::result::Result<CodeExecutionResponse, CodeExecutionError> {
+        let host_dir = self.scratch_root.join(request.workspace_id.as_str());
+        let skills = self.current_skills();
+        prepare_execution_directories(
+            &host_dir,
+            kind != CodeExecutionProviderKind::Local,
+            self.document_scripts_source.as_deref(),
+            &skills,
+        )
+        .await?;
+        if let (Some(blobs), Some(chat_id)) = (self.blobs.as_deref(), chat) {
+            materialize_chat_attachments(&*self.store, blobs, chat_id, &host_dir).await?;
+        }
+        // A remote sandbox has its own filesystem, but the model is shown one
+        // path vocabulary across the file tools and exec. Stage exactly the
+        // paths the model listed on this call into the workspace before the
+        // command, and pull only output/ and preview/ back out afterwards —
+        // the two directories the host output and preview scans read. The
+        // local provider already runs inside scratch, so nothing is staged
+        // there, but the listed paths are validated identically so a bad path
+        // fails the same way on every provider.
+        let lifecycle = match kind {
+            CodeExecutionProviderKind::Local => None,
+            _ => provider.workspace_lifecycle(),
+        };
+        let Some(lifecycle) = lifecycle else {
+            sync::validate_staged_paths(&host_dir, &request.files).await?;
+            let inspector = chat.and_then(|chat| self.overlay_inspector(chat));
+            let mut response = provider.execute(request).await?;
+            if let Some(inspector) = inspector {
+                response.sync_notes.extend(inspector.notes().await);
+            }
+            // Local exec writes output/ directly into scratch; convert any
+            // office files there so the skill's visual QA loop has a PDF to
+            // render, exactly like the remote pull path below.
+            if response.exit_code == Some(0) && !response.timed_out {
+                response.sync_notes.extend(
+                    openwave_code_execution::render_office_outputs(
+                        self.office_converter.as_deref(),
+                        &host_dir,
+                    )
+                    .await,
+                );
+            }
+            return Ok(response);
+        };
+        // A staging that fails outright fails the execution: a listed path
+        // that does not exist, an over-bound expansion, or an unreachable
+        // workspace would otherwise surface as a baffling not-found inside the
+        // sandbox. Entries a listed directory had to leave behind individually
+        // ride along as notes instead.
+        let mut staged_paths =
+            implicit_staged_paths(self.document_scripts_source.is_some(), !skills.is_empty());
+        staged_paths.extend(request.files.iter().cloned());
+        let mut notes =
+            sync::stage_listed_paths(lifecycle, &request.workspace_id, &host_dir, &staged_paths)
+                .await?
+                .notes;
+        let mut response = provider.execute(request.clone()).await?;
+        // A failed pull keeps the execution's output — the command did run —
+        // and says the host copies are stale instead of failing the call.
+        match sync::pull_result_dirs(lifecycle, &request.workspace_id, &host_dir).await {
+            Ok(pulled) => notes.extend(pulled.notes),
+            Err(error) => notes.push(format!(
+                "output files were not copied back to private scratch: {error}"
+            )),
+        }
+        // The pull just landed any office outputs in host scratch; convert
+        // them there so the model can render page images next call. The
+        // sandbox itself has no LibreOffice — the host is where the converter
+        // lives, for every provider.
+        if response.exit_code == Some(0) && !response.timed_out {
+            notes.extend(
+                openwave_code_execution::render_office_outputs(
+                    self.office_converter.as_deref(),
+                    &host_dir,
+                )
+                .await,
+            );
+        }
+        // A failed command plus an empty or thin staged set usually means the
+        // command's inputs were never listed; one bounded line points there.
+        if response.timed_out || response.exit_code != Some(0) {
+            notes.push(staged_set_note(&request.files));
+        }
+        response.sync_notes.extend(notes);
+        // Degrading is news once. The provider reports it on the execution that
+        // discovered it; a later sandbox rebuild rediscovers the same thing, and
+        // repeating it on every card would be noise rather than information.
+        if response.degraded.is_some()
+            && !self
+                .degradation_reported
+                .lock()
+                .map(|mut reported| reported.insert(degradation_chat))
+                .unwrap_or(false)
+        {
+            response.degraded = None;
+        }
+        Ok(response)
+    }
+
+    /// Publish a background run's `output/` files into its parent conversation.
+    ///
+    /// The run wrote the files and named them; this only records what is there.
+    /// Revisions are attributed to the run rather than to a turn, so a file two
+    /// runs both wrote becomes successive versions of one output, exactly as it
+    /// does when a turn overwrites its own.
+    pub async fn collect_agent_run_outputs(
+        &self,
+        workspace: &ExecutionWorkspaceId,
+        chat_id: ChatId,
+        call_id: CallId,
+        run_id: openwave_core::AgentRunId,
+    ) -> std::result::Result<OutputArtifactScan, CodeExecutionError> {
+        self.publish_output_directory(workspace, chat_id, call_id, RevisionProducer::Run(run_id))
+            .await
+    }
+
+    /// Scan one workspace's `output/` and record what changed as revisions.
+    async fn publish_output_directory(
+        &self,
+        workspace: &ExecutionWorkspaceId,
+        chat_id: ChatId,
+        call_id: CallId,
+        producer: RevisionProducer,
+    ) -> std::result::Result<OutputArtifactScan, CodeExecutionError> {
+        let scratch_path = self.scratch_root.join(workspace.as_str());
+        let scratch = tokio::task::spawn_blocking(move || {
+            cap_std::fs::Dir::open_ambient_dir(&scratch_path, cap_std::ambient_authority())
+        })
+        .await
+        .map_err(|_| CodeExecutionError::Sandbox("output scan task failed".into()))?
+        .map_err(|_| CodeExecutionError::Sandbox("the private workspace is unavailable".into()))?;
+
+        let sync = openwave_core::sync_output_directory(
+            &*self.store,
+            &scratch,
+            chat_id,
+            call_id,
+            producer,
+            Utc::now(),
+        )
+        .await
+        .map_err(|error| {
+            CodeExecutionError::Unavailable(format!("outputs could not be recorded: {error}"))
+        })?;
+        Ok(OutputArtifactScan {
+            entries: sync
+                .entries
+                .into_iter()
+                .map(|entry| OutputArtifactEntry {
+                    filename: entry.filename,
+                    output_id: entry.output_id.to_string(),
+                    ordinal: entry.ordinal,
+                    status: match entry.status {
+                        openwave_core::OutputSyncStatus::Created => OutputArtifactStatus::Created,
+                        openwave_core::OutputSyncStatus::Updated => OutputArtifactStatus::Updated,
+                        openwave_core::OutputSyncStatus::Unchanged => {
+                            OutputArtifactStatus::Unchanged
+                        }
+                    },
+                })
+                .collect(),
+            notes: sync.notes,
+        })
+    }
 }
 
 fn exec_folder_grant_for_turn(
@@ -1874,118 +2092,8 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
                 .collect::<std::result::Result<Vec<_>, _>>()?;
             request = request.with_folder_grants(grants)?;
         }
-        let host_dir = self.scratch_root.join(request.workspace_id.as_str());
-        let skills = self.current_skills();
-        prepare_execution_directories(
-            &host_dir,
-            kind != CodeExecutionProviderKind::Local,
-            self.document_scripts_source.as_deref(),
-            &skills,
-        )
-        .await?;
-        if let Some(blobs) = self.blobs.as_deref() {
-            let chat_id = request
-                .workspace_id
-                .as_str()
-                .parse::<ChatId>()
-                .map_err(|_| {
-                    CodeExecutionError::InvalidRequest(
-                        "execution workspace does not identify a conversation".into(),
-                    )
-                })?;
-            materialize_chat_attachments(&*self.store, blobs, chat_id, &host_dir).await?;
-        }
-        // A remote sandbox has its own filesystem, but the model is shown one
-        // path vocabulary across the file tools and exec. Stage exactly the
-        // paths the model listed on this call into the workspace before the
-        // command, and pull only output/ and preview/ back out afterwards —
-        // the two directories the host output and preview scans read. The
-        // local provider already runs inside scratch, so nothing is staged
-        // there, but the listed paths are validated identically so a bad path
-        // fails the same way on every provider.
-        let lifecycle = match kind {
-            CodeExecutionProviderKind::Local => None,
-            _ => provider.workspace_lifecycle(),
-        };
-        let Some(lifecycle) = lifecycle else {
-            sync::validate_staged_paths(&host_dir, &request.files).await?;
-            let inspector = request
-                .workspace_id
-                .as_str()
-                .parse::<ChatId>()
-                .ok()
-                .and_then(|chat| self.overlay_inspector(chat));
-            let mut response = provider.execute(request).await?;
-            if let Some(inspector) = inspector {
-                response.sync_notes.extend(inspector.notes().await);
-            }
-            // Local exec writes output/ directly into scratch; convert any
-            // office files there so the skill's visual QA loop has a PDF to
-            // render, exactly like the remote pull path below.
-            if response.exit_code == Some(0) && !response.timed_out {
-                response.sync_notes.extend(
-                    openwave_code_execution::render_office_outputs(
-                        self.office_converter.as_deref(),
-                        &host_dir,
-                    )
-                    .await,
-                );
-            }
-            return Ok(response);
-        };
-        // A staging that fails outright fails the execution: a listed path
-        // that does not exist, an over-bound expansion, or an unreachable
-        // workspace would otherwise surface as a baffling not-found inside the
-        // sandbox. Entries a listed directory had to leave behind individually
-        // ride along as notes instead.
-        let mut staged_paths =
-            implicit_staged_paths(self.document_scripts_source.is_some(), !skills.is_empty());
-        staged_paths.extend(request.files.iter().cloned());
-        let mut notes =
-            sync::stage_listed_paths(lifecycle, &request.workspace_id, &host_dir, &staged_paths)
-                .await?
-                .notes;
-        let mut response = provider.execute(request.clone()).await?;
-        // A failed pull keeps the execution's output — the command did run —
-        // and says the host copies are stale instead of failing the call.
-        match sync::pull_result_dirs(lifecycle, &request.workspace_id, &host_dir).await {
-            Ok(pulled) => notes.extend(pulled.notes),
-            Err(error) => notes.push(format!(
-                "output files were not copied back to private scratch: {error}"
-            )),
-        }
-        // The pull just landed any office outputs in host scratch; convert
-        // them there so the model can render page images next call. The
-        // sandbox itself has no LibreOffice — the host is where the converter
-        // lives, for every provider.
-        if response.exit_code == Some(0) && !response.timed_out {
-            notes.extend(
-                openwave_code_execution::render_office_outputs(
-                    self.office_converter.as_deref(),
-                    &host_dir,
-                )
-                .await,
-            );
-        }
-        // A failed command plus an empty or thin staged set usually means the
-        // command's inputs were never listed; one bounded line points there.
-        if response.timed_out || response.exit_code != Some(0) {
-            notes.push(staged_set_note(&request.files));
-        }
-        response.sync_notes.extend(notes);
-        // Degrading is news once. The provider reports it on the execution that
-        // discovered it; a later sandbox rebuild rediscovers the same thing, and
-        // repeating it on every card would be noise rather than information.
-        if response.degraded.is_some()
-            && !self
-                .degradation_reported
-                .lock()
-                .map(|mut reported| reported.insert(chat_id))
-                .unwrap_or(false)
-        {
-            response.degraded = None;
-        }
-        Ok(response)
+        self.execute_prepared(kind, provider, request, Some(chat_id), chat_id)
+            .await
     }
 
     async fn collect_preview_images(
@@ -2029,46 +2137,8 @@ impl CodeExecutionProvider for ConfiguredCodeExecutionProvider {
                     "execution identity is not owned by this conversation".into(),
                 )
             })?;
-
-        let scratch_path = self.scratch_root.join(workspace.as_str());
-        let scratch = tokio::task::spawn_blocking(move || {
-            cap_std::fs::Dir::open_ambient_dir(&scratch_path, cap_std::ambient_authority())
-        })
-        .await
-        .map_err(|_| CodeExecutionError::Sandbox("output scan task failed".into()))?
-        .map_err(|_| CodeExecutionError::Sandbox("the private workspace is unavailable".into()))?;
-
-        let sync = openwave_core::sync_output_directory(
-            &*self.store,
-            &scratch,
-            chat_id,
-            call_id,
-            RevisionProducer::Turn(turn_id),
-            Utc::now(),
-        )
-        .await
-        .map_err(|error| {
-            CodeExecutionError::Unavailable(format!("outputs could not be recorded: {error}"))
-        })?;
-        Ok(OutputArtifactScan {
-            entries: sync
-                .entries
-                .into_iter()
-                .map(|entry| OutputArtifactEntry {
-                    filename: entry.filename,
-                    output_id: entry.output_id.to_string(),
-                    ordinal: entry.ordinal,
-                    status: match entry.status {
-                        openwave_core::OutputSyncStatus::Created => OutputArtifactStatus::Created,
-                        openwave_core::OutputSyncStatus::Updated => OutputArtifactStatus::Updated,
-                        openwave_core::OutputSyncStatus::Unchanged => {
-                            OutputArtifactStatus::Unchanged
-                        }
-                    },
-                })
-                .collect(),
-            notes: sync.notes,
-        })
+        self.publish_output_directory(workspace, chat_id, call_id, RevisionProducer::Turn(turn_id))
+            .await
     }
 
     // `workspace_lifecycle` stays `None` here on purpose: the capability of

--- a/crates/openwave-server/src/lib.rs
+++ b/crates/openwave-server/src/lib.rs
@@ -61,6 +61,7 @@ mod sandbox_container_run_worker;
 /// CLI: container provision, loopback addressing, idempotent teardown, and a
 /// correlation-tag orphan sweep.
 pub mod sandbox_docker;
+mod sandbox_exec_worker;
 mod sandbox_web_search_worker;
 mod scoped_model_token;
 mod scoped_store;
@@ -587,6 +588,7 @@ pub struct Server {
     _sandbox_agent_run_worker: AbortTask,
     _sandbox_container_run_worker: Option<AbortTask>,
     _sandbox_web_search_worker: AbortTask,
+    _sandbox_exec_worker: AbortTask,
     _blob_retirement_worker: AbortTask,
     _blob_orphan_auditor: AbortTask,
     _approval_judge_worker: AbortTask,
@@ -999,6 +1001,13 @@ async fn bind_inner(
             state.sandbox_attempts.clone(),
             sandbox_web_search_worker::SandboxWebSearchWorkerConfig::default(),
         );
+    let sandbox_exec_worker = sandbox_exec_worker::SandboxExecWorker::with_attempts(
+        state.store.clone(),
+        code_execution.clone(),
+        state.agent_run_wake.clone(),
+        state.sandbox_attempts.clone(),
+        sandbox_exec_worker::SandboxExecWorkerConfig::default(),
+    );
     let sandbox_container_run_worker = {
         let enabled = sandbox_container_admission.enabled();
         sandbox_container_run_worker::SandboxContainerRunWorker::new(
@@ -1028,6 +1037,7 @@ async fn bind_inner(
     let sandbox_container_run_worker =
         sandbox_container_run_worker.map(|worker| tokio::spawn(worker.run()));
     let sandbox_web_search_worker = tokio::spawn(sandbox_web_search_worker.run());
+    let sandbox_exec_worker = tokio::spawn(sandbox_exec_worker.run());
     let blob_retirement_worker = tokio::spawn(blob_retirement_worker.run());
     let blob_orphan_auditor = tokio::spawn(blob_orphan_auditor.run());
     let approval_judge_worker = tokio::spawn(approval_judge_worker.run());
@@ -1052,6 +1062,7 @@ async fn bind_inner(
         _sandbox_agent_run_worker: AbortTask(sandbox_agent_run_worker),
         _sandbox_container_run_worker: sandbox_container_run_worker.map(AbortTask),
         _sandbox_web_search_worker: AbortTask(sandbox_web_search_worker),
+        _sandbox_exec_worker: AbortTask(sandbox_exec_worker),
         _blob_retirement_worker: AbortTask(blob_retirement_worker),
         _blob_orphan_auditor: AbortTask(blob_orphan_auditor),
         _approval_judge_worker: AbortTask(approval_judge_worker),

--- a/crates/openwave-server/src/routes.rs
+++ b/crates/openwave-server/src/routes.rs
@@ -2193,13 +2193,12 @@ pub struct AgentRunSnapshot {
     /// arguments, results, provider call identities, executor leases, or raw
     /// executor diagnostics.
     pub activity: Option<AgentActivitySnapshot>,
-    /// Whether a completed background run committed an immutable terminal
-    /// receipt, which happens atomically with its terminal state.
+    /// Files a background run submitted as its deliverables, in its own order.
     ///
-    /// This is presence only: the payload, its display text, and any merged
-    /// deliverable never cross this boundary. A renderer uses it to offer a
-    /// "view output" affordance and link to the outputs surface.
-    pub produced_output: bool,
+    /// A background run produces outputs by writing files and submitting them
+    /// by name; nothing here is host-authored, and a run that submitted nothing
+    /// carries an empty list.
+    pub submitted_outputs: Vec<SubmittedOutputSnapshot>,
     /// Bounded terminal display text returned to the parent, if settled.
     pub terminal_text: Option<String>,
     pub created_at: chrono::DateTime<Utc>,
@@ -2215,12 +2214,8 @@ impl AgentRunSnapshot {
         run: AgentRun,
         activity: Option<AgentActivitySnapshot>,
         terminal_text: Option<String>,
+        submitted_outputs: Vec<SubmittedOutputSnapshot>,
     ) -> Self {
-        // A background child commits its final result receipt in the same
-        // transaction as its terminal `Completed` state, so the terminal state
-        // is an exact, renderer-safe proxy for output presence.
-        let produced_output =
-            run.tier == AgentRunTier::Background && run.status == AgentRunStatus::Completed;
         Self {
             id: run.id,
             parent_id: run.parent_id,
@@ -2233,12 +2228,20 @@ impl AgentRunSnapshot {
             finished_at: run.finished_at,
             last_error_code: run.last_error_code,
             activity,
-            produced_output,
+            submitted_outputs,
             terminal_text,
             created_at: run.created_at,
             updated_at: run.updated_at,
         }
     }
+}
+
+/// One file a background run submitted, as the renderer sees it.
+#[derive(Debug, Clone, Serialize, ts_rs::TS)]
+pub struct SubmittedOutputSnapshot {
+    pub output_id: openwave_core::OutputId,
+    /// The name the run gave the file, which is the output's name.
+    pub filename: String,
 }
 
 /// Fixed, renderer-safe names for supported live work.
@@ -2248,6 +2251,7 @@ impl AgentRunSnapshot {
 #[derive(Debug, Clone, Copy, Serialize, ts_rs::TS)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentActivityKind {
+    Exec,
     WebSearch,
     ReadDelegatedFile,
     ListConnectedFolders,
@@ -2280,6 +2284,7 @@ fn sandbox_activity(calls: &[SandboxToolCall]) -> Option<AgentActivitySnapshot> 
     // lingering in the UI after the run has advanced.
     let call = calls.iter().rev().find(|call| !call.status.is_terminal())?;
     let kind = match call.name.as_str() {
+        openwave_core::SANDBOX_EXEC_TOOL => AgentActivityKind::Exec,
         "web_search" => AgentActivityKind::WebSearch,
         openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL => AgentActivityKind::ReadDelegatedFile,
         // Unknown tool names are executor data, not a renderer API contract.
@@ -2343,6 +2348,7 @@ fn sandbox_activity_history(calls: &[SandboxToolCall]) -> Vec<AgentActivityHisto
 
 fn sandbox_activity_history_item(call: &SandboxToolCall) -> Option<AgentActivityHistoryItem> {
     let kind = match call.name.as_str() {
+        openwave_core::SANDBOX_EXEC_TOOL => AgentActivityKind::Exec,
         "web_search" => AgentActivityKind::WebSearch,
         openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL => AgentActivityKind::ReadDelegatedFile,
         // Unknown tool names are executor data, not a renderer API contract.
@@ -2418,11 +2424,29 @@ pub async fn list_agent_runs(
     let now = Utc::now();
     let mut snapshots = Vec::with_capacity(runs.len());
     for run in runs {
+        let mut submitted_outputs = Vec::new();
         let terminal_text = match run.status {
-            AgentRunStatus::Completed | AgentRunStatus::Cancelled => store
-                .get_agent_run_result(run.id)
-                .await?
-                .map(|result| result.text),
+            AgentRunStatus::Completed | AgentRunStatus::Cancelled => {
+                match store.get_agent_run_result(run.id).await? {
+                    Some(result) => match &result.payload {
+                        // A submission's names belong to the structured field,
+                        // where the reader can open each one. Repeating them in
+                        // the prose block would say the same thing twice, so
+                        // the text here is the run's summary alone.
+                        openwave_core::AgentRunResultPayload::Submission { outputs, summary } => {
+                            submitted_outputs.extend(outputs.iter().map(|output| {
+                                SubmittedOutputSnapshot {
+                                    output_id: output.output_id,
+                                    filename: output.filename.clone(),
+                                }
+                            }));
+                            Some(summary.clone())
+                        }
+                        _ => Some(result.text),
+                    },
+                    None => None,
+                }
+            }
             AgentRunStatus::Failed => run
                 .last_error_code
                 .as_deref()
@@ -2437,7 +2461,12 @@ pub async fn list_agent_runs(
         } else {
             None
         };
-        snapshots.push(AgentRunSnapshot::from_run(run, activity, terminal_text));
+        snapshots.push(AgentRunSnapshot::from_run(
+            run,
+            activity,
+            terminal_text,
+            submitted_outputs,
+        ));
     }
     Ok(Json(snapshots))
 }
@@ -2583,7 +2612,7 @@ async fn signal_sandbox_run_after_commit(state: &AppState, run_id: openwave_core
             }
             if let Ok(Some(receipt)) = state.store.get_sandbox_tool_call_receipt(call.id).await {
                 if receipt.status == SandboxToolCallStatus::Cancelled {
-                    state.sandbox_attempts.cancel_search(
+                    state.sandbox_attempts.cancel_checkpoint(
                         call.id,
                         run_id,
                         receipt.executor_lease_token,

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -1,11 +1,16 @@
 //! Execution for durably claimed sandboxed agent runs.
 //!
 //! A sandbox run intentionally is not a second foreground turn. It receives
-//! only its immutable delegated task, may checkpoint one fixed host-owned web
-//! search call, and returns bounded text through the fenced agent-run result
-//! transition.
-//! That keeps the first execution surface small while preserving the same
-//! claim, heartbeat, cancellation, and replay mechanics as other workers.
+//! only its immutable delegated task and a small fixed tool surface — commands
+//! in its own private workspace, a host-owned web search, the one file
+//! explicitly delegated to it — and returns bounded text through the fenced
+//! agent-run result transition. Every tool call is a durable checkpoint
+//! executed by its own lane, so the run holds no lease while it waits.
+//!
+//! Its real product is files: a command that writes under `output/` publishes
+//! that file to the parent conversation as an output named by its own
+//! filename. The run never names an output identity, and neither does the
+//! host.
 
 use std::path::PathBuf;
 #[cfg(test)]
@@ -15,13 +20,15 @@ use std::time::Duration;
 
 use futures::StreamExt;
 use openwave_core::{
-    sandbox_folder_access_proposal_tool_spec, sandbox_read_delegated_file_tool_spec,
-    sandbox_web_search_tool_spec, validate_sandbox_read_delegated_file_arguments, AgentConfig,
-    AgentError, AgentRun, AgentRunStatus, CallId, ChatMessage, ChatRequest, ContentBlock,
-    FailAgentRunOutcome, ModelProvider, ParkSandboxToolCallOutcome, ProviderEvent,
-    RequestFolderAccessArgs, Result, ResumeTurnForAgentRunWaitSetOutcome, Role, SandboxToolCall,
-    SandboxToolCallRequest, SandboxToolCallStatus, StopReason, Store, SubmitAgentRunResultOutcome,
-    ToolCallRecord,
+    sandbox_done_tool_spec, sandbox_exec_tool_spec, sandbox_folder_access_proposal_tool_spec,
+    sandbox_read_delegated_file_tool_spec, sandbox_web_search_tool_spec,
+    validate_sandbox_exec_arguments, validate_sandbox_read_delegated_file_arguments, AgentConfig,
+    AgentError, AgentRun, AgentRunStatus, AgentRunSubmittedOutput, CallId, ChatMessage,
+    ChatRequest, ContentBlock, FailAgentRunOutcome, ModelProvider, ParkSandboxToolCallOutcome,
+    ProviderEvent, RequestFolderAccessArgs, Result, ResumeTurnForAgentRunWaitSetOutcome, Role,
+    SandboxToolCall, SandboxToolCallRequest, SandboxToolCallStatus, StopReason, Store,
+    SubmitAgentRunResultOutcome, ToolCallRecord, MAX_SANDBOX_TOOL_CALLS, OUTPUT_LOOKUP_LIMIT,
+    SANDBOX_EXEC_TOOL,
 };
 use tokio::sync::Notify;
 
@@ -35,9 +42,8 @@ use crate::state::SandboxAttemptGuard;
 /// Deliberately do not inherit the foreground system prompt: it may describe
 /// interactive tools or conversation-wide responsibilities that are outside a
 /// depth-one child run's authority.
-const SANDBOX_SYSTEM_PROMPT: &str = "You are a sandboxed background agent. Work only on the delegated task below and return a concise, self-contained result for your parent agent. You cannot access the conversation, filesystem, connected folders, or other agents. You may use at most one tool: web_search when current public-web information is necessary, or request_folder_access only to propose that your foreground parent decide whether to ask the user. The proposal grants no access and cannot open a picker. Otherwise finish directly.";
-const SANDBOX_DELEGATED_FILE_SYSTEM_PROMPT: &str = "You are a sandboxed background agent. Work only on the delegated task below and return a concise, self-contained result for your parent agent. You cannot access the conversation, filesystem, connected folders, or other agents except for the one exact file explicitly delegated to this run. You may use at most one tool: read_delegated_file to read that exact file, web_search when current public-web information is necessary, or request_folder_access only to propose that your foreground parent decide whether to ask the user. The proposal grants no access and cannot open a picker. Otherwise finish directly.";
-const SANDBOX_TOOL_LIMIT: usize = 1;
+const SANDBOX_SYSTEM_PROMPT: &str = "You are a sandboxed background agent. Work only on the delegated task below. You cannot access the conversation, the user's files, connected folders, or other agents. You do have your own private workspace: use exec to run commands in it, and write every deliverable the task asks for as a file under output/ — each file you write there is published to the user as a durable output named by its own filename, so name those files the way you want the user to see them. Prefer producing a file over describing what a file would contain. Use web_search when current public-web information is necessary, and request_folder_access only to propose that your foreground parent decide whether to ask the user — the proposal grants no access and cannot open a picker. Take as many tool steps as the task genuinely needs, then finish by calling done with the filenames you wrote under output/ and a short summary of what you produced.";
+const SANDBOX_DELEGATED_FILE_SYSTEM_PROMPT: &str = "You are a sandboxed background agent. Work only on the delegated task below. You cannot access the conversation, the user's files, connected folders, or other agents, except for the one exact file explicitly delegated to this run. You do have your own private workspace: use exec to run commands in it, and write every deliverable the task asks for as a file under output/ — each file you write there is published to the user as a durable output named by its own filename, so name those files the way you want the user to see them. Prefer producing a file over describing what a file would contain. Use read_delegated_file to read that one delegated file, web_search when current public-web information is necessary, and request_folder_access only to propose that your foreground parent decide whether to ask the user — the proposal grants no access and cannot open a picker. Take as many tool steps as the task genuinely needs, then finish by calling done with the filenames you wrote under output/ and a short summary of what you produced.";
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SandboxAgentRunWorkerConfig {
@@ -508,7 +514,32 @@ impl SandboxAgentRunWorker {
                 provider_id,
                 arguments,
             }) => {
-                self.park_web_search(run, lease_token, provider_id, arguments)
+                self.park_sandbox_tool_call(
+                    run,
+                    lease_token,
+                    provider_id,
+                    openwave_core::SANDBOX_WEB_SEARCH_TOOL,
+                    arguments,
+                    "sandbox web-search checkpoint identity conflict",
+                )
+                .await
+            }
+            Ok(SandboxCompletion::Exec {
+                provider_id,
+                arguments,
+            }) => {
+                self.park_sandbox_tool_call(
+                    run,
+                    lease_token,
+                    provider_id,
+                    SANDBOX_EXEC_TOOL,
+                    arguments,
+                    "sandbox exec checkpoint identity conflict",
+                )
+                .await
+            }
+            Ok(SandboxCompletion::Done { outputs, summary }) => {
+                self.submit_submission(&run, lease_token, &outputs, &summary)
                     .await
             }
             Ok(SandboxCompletion::FolderAccessProposal { request }) => {
@@ -519,8 +550,15 @@ impl SandboxAgentRunWorker {
                 provider_id,
                 arguments,
             }) => {
-                self.park_delegated_file_read(run, lease_token, provider_id, arguments)
-                    .await
+                self.park_sandbox_tool_call(
+                    run,
+                    lease_token,
+                    provider_id,
+                    openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL,
+                    arguments,
+                    "sandbox delegated-file checkpoint identity conflict",
+                )
+                .await
             }
             Err(error) => self.record_failure(&run, lease_token, error).await,
         }
@@ -621,14 +659,8 @@ impl SandboxAgentRunWorker {
             .submit_agent_run_result(id, lease_token, &text)
             .await?
         {
-            Some(SubmitAgentRunResultOutcome::Completed(result))
-            | Some(SubmitAgentRunResultOutcome::Existing(result)) => {
-                // The result is durably committed and delivered to the parent
-                // inbox. Now the host — never the model — records it in the
-                // conversation's output record as a revertible version. The
-                // merge runs on the committed text, so the model that produced
-                // it cannot author, decline, or steer it.
-                self.record_result_output(run, &result).await;
+            Some(SubmitAgentRunResultOutcome::Completed(_))
+            | Some(SubmitAgentRunResultOutcome::Existing(_)) => {
                 Ok(SandboxAgentRunWorkerOutcome::Completed(id))
             }
             None => {
@@ -638,49 +670,78 @@ impl SandboxAgentRunWorker {
         }
     }
 
-    /// Record a completed background run's text result in its conversation's
-    /// outputs.
+    /// Submit the run's own files as its terminal result.
     ///
-    /// This is best-effort after the result has already committed: the merge is
-    /// idempotent on the run's derived output identity, so an ambiguous submit
-    /// retry re-runs it harmlessly, and a failure here never fails a run whose
-    /// result is already delivered. Only a `FinalText` result becomes an output;
-    /// a folder-access proposal or cancellation is not conversation content.
-    async fn record_result_output(&self, run: &AgentRun, result: &openwave_core::AgentRunResult) {
-        let openwave_core::AgentRunResultPayload::FinalText { text } = &result.payload else {
-            return;
+    /// The files already exist as conversation outputs — the run wrote them
+    /// under `output/` and the host published them by filename after the command
+    /// that produced them. Submission only resolves those names to the output
+    /// identities they landed on and records which ones the run offers, so no
+    /// host-authored document is invented on the run's behalf.
+    async fn submit_submission(
+        &self,
+        run: &AgentRun,
+        lease_token: uuid::Uuid,
+        filenames: &[String],
+        summary: &str,
+    ) -> Result<SandboxAgentRunWorkerOutcome> {
+        let id = run.id;
+        let outputs = match self.resolve_submitted_outputs(run, filenames).await {
+            Ok(outputs) => outputs,
+            // The model named a file that was never published. That is a model
+            // error, not a host failure: report it the same way as any other
+            // malformed completion so the run's own attempt budget bounds it.
+            Err(error) => return self.record_failure(run, lease_token, error).await,
         };
-        if text.is_empty() {
-            return;
-        }
-        let Some(root) = &self.private_scratch_root else {
-            return;
-        };
-        let scratch = match open_chat_scratch(root, run.chat_id) {
-            Ok(scratch) => scratch,
-            Err(error) => {
-                tracing::warn!(
-                    "could not open scratch to record agent run {} output: {error}",
-                    run.id
-                );
-                return;
-            }
-        };
-        let merge = openwave_core::AgentResultOutputMerge {
-            run_id: run.id,
-            chat_id: run.chat_id,
-            filename: agent_result_filename(run.input.as_deref()),
-            text: text.clone(),
-            created_at: result.submitted_at,
-        };
-        if let Err(error) =
-            openwave_core::merge_agent_run_result(&*self.store, &scratch, &merge).await
+        match self
+            .store
+            .submit_agent_run_submission(id, lease_token, &outputs, summary)
+            .await?
         {
-            tracing::warn!(
-                "could not record agent run {} result in outputs: {error}",
-                run.id
-            );
+            Some(SubmitAgentRunResultOutcome::Completed(_))
+            | Some(SubmitAgentRunResultOutcome::Existing(_)) => {
+                Ok(SandboxAgentRunWorkerOutcome::Completed(id))
+            }
+            None => {
+                self.acknowledge_cancellation_or_lease_loss(id, lease_token)
+                    .await
+            }
         }
+    }
+
+    /// Resolve submitted filenames against the conversation's live outputs.
+    ///
+    /// Matching is by filename because that is the identity the run worked with
+    /// and the only one it ever sees. The newest live output wins, which is the
+    /// same rule the output scan applies when it republishes a filename.
+    async fn resolve_submitted_outputs(
+        &self,
+        run: &AgentRun,
+        filenames: &[String],
+    ) -> Result<Vec<AgentRunSubmittedOutput>> {
+        if filenames.is_empty() {
+            return Ok(vec![]);
+        }
+        let existing = self
+            .store
+            .list_outputs(run.chat_id, OUTPUT_LOOKUP_LIMIT)
+            .await?;
+        filenames
+            .iter()
+            .map(|filename| {
+                existing
+                    .iter()
+                    .find(|output| &output.filename == filename)
+                    .map(|output| AgentRunSubmittedOutput {
+                        output_id: output.id,
+                        filename: filename.clone(),
+                    })
+                    .ok_or_else(|| {
+                        AgentError::msg(format!(
+                            "sandbox agent submitted {filename}, which it never wrote under output/"
+                        ))
+                    })
+            })
+            .collect()
     }
 
     async fn submit_folder_access_proposal(
@@ -705,19 +766,27 @@ impl SandboxAgentRunWorker {
         }
     }
 
-    async fn park_web_search(
+    /// Park one tool call as a durable checkpoint and release the run's lease.
+    ///
+    /// Every sandbox tool that needs an executor parks the same way — only the
+    /// tool name and the conflict message differ — so they share this body
+    /// rather than each carrying its own copy of the crash-recovery reasoning
+    /// below.
+    async fn park_sandbox_tool_call(
         &self,
         run: AgentRun,
         lease_token: uuid::Uuid,
         provider_id: String,
+        name: &str,
         arguments: serde_json::Value,
+        conflict_message: &str,
     ) -> Result<SandboxAgentRunWorkerOutcome> {
         let call = SandboxToolCallRequest {
             id: CallId::new(),
             agent_run_id: run.id,
             chat_id: run.chat_id,
             provider_id,
-            name: openwave_core::SANDBOX_WEB_SEARCH_TOOL.into(),
+            name: name.into(),
             arguments,
         };
         let outcome = match self
@@ -758,81 +827,8 @@ impl SandboxAgentRunWorker {
                 Ok(SandboxAgentRunWorkerOutcome::ToolCheckpointed(call.id))
             }
             ParkSandboxToolCallOutcome::IdentityConflict => {
-                self.record_failure(
-                    &run,
-                    lease_token,
-                    AgentError::msg("sandbox web-search checkpoint identity conflict"),
-                )
-                .await
-            }
-            ParkSandboxToolCallOutcome::DelegatedResourceUnavailable => {
-                self.record_failure(
-                    &run,
-                    lease_token,
-                    AgentError::msg("sandbox delegated resource is unavailable"),
-                )
-                .await
-            }
-            ParkSandboxToolCallOutcome::LeaseLost => {
-                self.acknowledge_cancellation_or_lease_loss(run.id, lease_token)
+                self.record_failure(&run, lease_token, AgentError::msg(conflict_message))
                     .await
-            }
-        }
-    }
-
-    async fn park_delegated_file_read(
-        &self,
-        run: AgentRun,
-        lease_token: uuid::Uuid,
-        provider_id: String,
-        arguments: serde_json::Value,
-    ) -> Result<SandboxAgentRunWorkerOutcome> {
-        let call = SandboxToolCallRequest {
-            id: CallId::new(),
-            agent_run_id: run.id,
-            chat_id: run.chat_id,
-            provider_id,
-            name: openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL.into(),
-            arguments,
-        };
-        let outcome = match self
-            .store
-            .park_agent_run_for_sandbox_tool_call(run.id, lease_token, &call)
-            .await
-        {
-            Ok(outcome) => outcome,
-            Err(error) => {
-                let recovered = self
-                    .store
-                    .list_sandbox_tool_calls_for_agent_run(run.id)
-                    .await?
-                    .into_iter()
-                    .find(|existing| {
-                        existing.park_lease_token == lease_token
-                            && existing.provider_id == call.provider_id
-                            && existing.name == call.name
-                            && existing.arguments == call.arguments
-                    });
-                if let Some(call) = recovered {
-                    self.wake.notify_one();
-                    return Ok(SandboxAgentRunWorkerOutcome::ToolCheckpointed(call.id));
-                }
-                return Err(error);
-            }
-        };
-        match outcome {
-            ParkSandboxToolCallOutcome::Parked { call, .. }
-            | ParkSandboxToolCallOutcome::Existing { call, .. } => {
-                self.wake.notify_one();
-                Ok(SandboxAgentRunWorkerOutcome::ToolCheckpointed(call.id))
-            }
-            ParkSandboxToolCallOutcome::IdentityConflict => {
-                self.record_failure(
-                    &run,
-                    lease_token,
-                    AgentError::msg("sandbox delegated-file checkpoint identity conflict"),
-                )
-                .await
             }
             ParkSandboxToolCallOutcome::DelegatedResourceUnavailable => {
                 self.record_failure(
@@ -897,82 +893,6 @@ impl SandboxAgentRunWorker {
     }
 }
 
-/// Open one conversation's private-scratch directory as a capability root.
-///
-/// This is the same `<scratch root>/<chat id>` directory the desktop reads an
-/// output revision from; the merge writes the revision bytes below it under
-/// `outputs/`. The directory is created and locked to the owner on first use.
-fn open_chat_scratch(
-    root: &std::path::Path,
-    chat_id: openwave_core::ChatId,
-) -> Result<cap_std::fs::Dir> {
-    let path = root.join(chat_id.to_string());
-    std::fs::create_dir_all(&path).map_err(|error| {
-        AgentError::Store(format!(
-            "failed to create chat scratch {}: {error}",
-            path.display()
-        ))
-    })?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).map_err(
-            |error| {
-                AgentError::Store(format!(
-                    "failed to secure chat scratch {}: {error}",
-                    path.display()
-                ))
-            },
-        )?;
-    }
-    cap_std::fs::Dir::open_ambient_dir(&path, cap_std::ambient_authority()).map_err(|error| {
-        AgentError::Store(format!(
-            "failed to open chat scratch {}: {error}",
-            path.display()
-        ))
-    })
-}
-
-/// Host-derived, portable display filename for a submitted agent result.
-///
-/// The model never names the output, but the task it was given is the closest
-/// thing to a title the host has, and it is what the reader recognises in the
-/// outputs catalog. The record's opaque identity remains the authority, so two
-/// runs given the same task are still two outputs that happen to read alike.
-fn agent_result_filename(task: Option<&str>) -> String {
-    const MAX_TITLE_CHARS: usize = 60;
-
-    let title: String = task
-        .unwrap_or_default()
-        .lines()
-        .next()
-        .unwrap_or_default()
-        .chars()
-        // Portable ASCII only: the name reaches a filesystem on export, and a
-        // task is free-form model-facing prose that can hold anything.
-        .map(|character| match character {
-            'a'..='z' | 'A'..='Z' | '0'..='9' | ' ' | '-' | '_' => character,
-            _ => ' ',
-        })
-        .collect::<String>()
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ");
-
-    let title = match title.char_indices().nth(MAX_TITLE_CHARS) {
-        // Cut back to the last whole word so the name ends on something
-        // readable rather than mid-token.
-        Some((cut, _)) => title[..title[..cut].rfind(' ').unwrap_or(cut)].to_string(),
-        None => title,
-    };
-
-    if title.is_empty() {
-        "Agent result.md".to_string()
-    } else {
-        format!("{title}.md")
-    }
-}
-
 fn delegated_file_admission_matches(
     run: &AgentRun,
     admission: &openwave_core::SandboxAgentAdmission,
@@ -997,7 +917,7 @@ async fn sandbox_request(
     store: &dyn Store,
     delegated_file_available: bool,
 ) -> Result<ChatRequest> {
-    if calls.len() > SANDBOX_TOOL_LIMIT {
+    if calls.len() > MAX_SANDBOX_TOOL_CALLS {
         return Err(AgentError::msg("sandbox tool budget exceeded"));
     }
     if config.max_steps == 0 || calls.len().saturating_add(1) > config.max_steps {
@@ -1009,6 +929,7 @@ async fn sandbox_request(
             call.name.as_str(),
             openwave_core::SANDBOX_WEB_SEARCH_TOOL
                 | openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL
+                | SANDBOX_EXEC_TOOL
         ) || !call.status.is_terminal()
         {
             return Err(AgentError::msg("sandbox checkpoint cannot be resumed"));
@@ -1049,23 +970,33 @@ async fn sandbox_request(
             .into(),
         ),
         messages,
-        // Once a receipt exists, omit the tool definition. This makes the
-        // depth-one sandbox's one-call budget visible to the model and turns a
-        // second call into a deterministic worker error rather than new work.
-        // A tool checkpoint consumes one model completion and a resumed final
-        // completion. Never advertise work that the remaining model budget
-        // cannot consume after its durable receipt arrives.
-        tools: if calls.is_empty() && config.max_steps >= 2 {
+        // A checkpoint costs one model completion now and one more to consume its
+        // receipt, so tools are only advertised while the remaining step budget
+        // can pay for both — never advertise work the budget cannot consume. The
+        // checkpoint count is bounded separately: the whole chain is replayed on
+        // every claim, so it is a working budget rather than an open loop.
+        tools: if calls.len() < MAX_SANDBOX_TOOL_CALLS
+            && calls.len().saturating_add(2) <= config.max_steps
+        {
             let mut tools = vec![
+                sandbox_exec_tool_spec(),
                 sandbox_web_search_tool_spec(),
+                sandbox_done_tool_spec(),
                 sandbox_folder_access_proposal_tool_spec(),
             ];
             if delegated_file_available {
                 tools.push(sandbox_read_delegated_file_tool_spec());
             }
             tools
-        } else if calls.is_empty() && config.max_steps >= 1 {
-            vec![sandbox_folder_access_proposal_tool_spec()]
+        } else if calls.len().saturating_add(1) <= config.max_steps {
+            // Both of these terminate the run in place of a final answer, so
+            // they need no follow-up completion and stay available to the last
+            // step. Submission especially: a run that spent its budget writing
+            // files must still be able to hand them over.
+            vec![
+                sandbox_done_tool_spec(),
+                sandbox_folder_access_proposal_tool_spec(),
+            ]
         } else {
             vec![]
         },
@@ -1081,6 +1012,16 @@ async fn sandbox_request(
 
 enum SandboxCompletion {
     Final(String),
+    /// The run's own files, offered as the deliverables for the task.
+    Done {
+        outputs: Vec<String>,
+        summary: String,
+    },
+    /// One command to run in this run's own private workspace.
+    Exec {
+        provider_id: String,
+        arguments: serde_json::Value,
+    },
     WebSearch {
         provider_id: String,
         arguments: serde_json::Value,
@@ -1102,6 +1043,14 @@ async fn complete_sandbox_task(
         .tools
         .iter()
         .any(|tool| tool.name == openwave_core::SANDBOX_WEB_SEARCH_TOOL);
+    let exec_advertised = request
+        .tools
+        .iter()
+        .any(|tool| tool.name == SANDBOX_EXEC_TOOL);
+    let done_advertised = request
+        .tools
+        .iter()
+        .any(|tool| tool.name == openwave_core::SANDBOX_DONE_TOOL);
     let folder_proposal_advertised = request
         .tools
         .iter()
@@ -1176,6 +1125,40 @@ async fn complete_sandbox_task(
                         return Ok(SandboxCompletion::WebSearch {
                             provider_id,
                             arguments,
+                        });
+                    }
+                    if name == SANDBOX_EXEC_TOOL && exec_advertised {
+                        let arguments = serde_json::from_str(&arguments).map_err(|_| {
+                            AgentError::msg("sandbox agent emitted invalid exec arguments")
+                        })?;
+                        if !validate_sandbox_exec_arguments(&arguments) {
+                            return Err(AgentError::msg(
+                                "sandbox agent emitted invalid exec arguments",
+                            ));
+                        }
+                        return Ok(SandboxCompletion::Exec {
+                            provider_id,
+                            arguments,
+                        });
+                    }
+                    if name == openwave_core::SANDBOX_DONE_TOOL && done_advertised {
+                        let arguments = serde_json::from_str::<serde_json::Value>(&arguments)
+                            .map_err(|_| {
+                                AgentError::msg("sandbox agent emitted invalid done arguments")
+                            })?;
+                        if !openwave_core::validate_sandbox_done_arguments(&arguments) {
+                            return Err(AgentError::msg(
+                                "sandbox agent emitted invalid done arguments",
+                            ));
+                        }
+                        let arguments =
+                            serde_json::from_value::<openwave_core::SandboxDoneArgs>(arguments)
+                                .map_err(|_| {
+                                    AgentError::msg("sandbox agent emitted invalid done arguments")
+                                })?;
+                        return Ok(SandboxCompletion::Done {
+                            outputs: arguments.outputs,
+                            summary: arguments.summary,
                         });
                     }
                     if name == openwave_core::REQUEST_FOLDER_ACCESS_TOOL
@@ -1350,6 +1333,53 @@ mod tests {
                 vec![
                     ProviderEvent::TextDelta {
                         text: "search-informed answer".into(),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::EndTurn,
+                    },
+                ]
+            };
+            Ok(stream::iter(events).boxed())
+        }
+    }
+
+    /// Two searches then a final answer, for the multi-checkpoint chain.
+    #[derive(Default)]
+    struct SearchTwiceThenFinalProvider {
+        requests: Mutex<Vec<ChatRequest>>,
+    }
+
+    #[async_trait]
+    impl ModelProvider for SearchTwiceThenFinalProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::new("sandbox-web-search")
+        }
+
+        async fn stream(&self, request: ChatRequest) -> Result<BoxStream<'static, ProviderEvent>> {
+            let call_number = {
+                let mut requests = self.requests.lock().unwrap();
+                requests.push(request);
+                requests.len()
+            };
+            let events = if call_number <= 2 {
+                vec![
+                    ProviderEvent::ToolCallStarted {
+                        index: 0,
+                        id: format!("search_{call_number}"),
+                        name: openwave_core::SANDBOX_WEB_SEARCH_TOOL.into(),
+                    },
+                    ProviderEvent::ToolCallArgsDelta {
+                        index: 0,
+                        fragment: format!(r#"{{"query":"OpenWave {call_number}"}}"#),
+                    },
+                    ProviderEvent::Stop {
+                        reason: StopReason::ToolUse,
+                    },
+                ]
+            } else {
+                vec![
+                    ProviderEvent::TextDelta {
+                        text: "answer from two searches".into(),
                     },
                     ProviderEvent::Stop {
                         reason: StopReason::EndTurn,
@@ -1695,10 +1725,16 @@ mod tests {
         let requests = provider.requests.lock().unwrap();
         assert_eq!(requests.len(), 1);
         assert_eq!(
-            requests[0].tools,
+            requests[0]
+                .tools
+                .iter()
+                .map(|tool| tool.name.as_str())
+                .collect::<Vec<_>>(),
             vec![
-                sandbox_web_search_tool_spec(),
-                sandbox_folder_access_proposal_tool_spec(),
+                SANDBOX_EXEC_TOOL,
+                openwave_core::SANDBOX_WEB_SEARCH_TOOL,
+                openwave_core::SANDBOX_DONE_TOOL,
+                openwave_core::REQUEST_FOLDER_ACCESS_TOOL,
             ]
         );
         assert_eq!(
@@ -1834,12 +1870,106 @@ mod tests {
         );
         let requests = provider.requests.lock().unwrap();
         assert_eq!(requests.len(), 2);
-        assert!(requests[1].tools.is_empty());
+        // The last step cannot pay for another receipt, so the checkpointing
+        // tools are withdrawn; submission and the folder-access proposal
+        // terminate the run in place of a final answer and stay available.
+        assert_eq!(
+            requests[1]
+                .tools
+                .iter()
+                .map(|tool| tool.name.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                openwave_core::SANDBOX_DONE_TOOL,
+                openwave_core::REQUEST_FOLDER_ACCESS_TOOL,
+            ]
+        );
         assert!(
             matches!(&requests[1].messages[1].content[0], ContentBlock::ToolUse { id, name, input } if id == "search_1" && name == openwave_core::SANDBOX_WEB_SEARCH_TOOL && input == &serde_json::json!({"query":"OpenWave"}))
         );
         assert!(
             matches!(&requests[1].messages[2].content[0], ContentBlock::ToolResult { tool_use_id, content, is_error } if tool_use_id == "search_1" && content == "{\"results\":[]}" && !is_error)
+        );
+    }
+
+    /// A run whose task needs more than one lookup: the checkpoint chain has to
+    /// survive a second park and replay both receipts in order, because the
+    /// worker rebuilds the whole transcript from the database on every claim.
+    #[tokio::test]
+    async fn a_run_checkpoints_more_than_once_and_replays_every_receipt_in_order() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = sandbox_chat();
+        store.create_chat(&chat).await.unwrap();
+        let provider = Arc::new(SearchTwiceThenFinalProvider::default());
+        let worker = SandboxAgentRunWorker::new(
+            store.clone(),
+            Arc::new(FixedResolver(provider.clone())),
+            Arc::new(Notify::new()),
+            Arc::new(Notify::new()),
+            Arc::new(EventBus::default()),
+            AgentConfig {
+                model: "sandbox-model".into(),
+                max_steps: 4,
+                ..AgentConfig::default()
+            },
+            None,
+            SandboxAgentRunWorkerConfig::default(),
+        );
+        let spawn = CallId::new();
+        let id = openwave_core::AgentRunId::sandbox_for_spawn_call(spawn);
+        admit_sandbox(&store, chat.id, spawn, "Research this thoroughly.").await;
+
+        for result in ["{\"results\":[\"first\"]}", "{\"results\":[\"second\"]}"] {
+            let call_id = match worker.run_once().await.unwrap() {
+                SandboxAgentRunWorkerOutcome::ToolCheckpointed(call_id) => call_id,
+                outcome => panic!("unexpected outcome: {outcome:?}"),
+            };
+            assert_eq!(
+                store.get_agent_run(id).await.unwrap().unwrap().status,
+                AgentRunStatus::Waiting
+            );
+            let executor_lease = uuid::Uuid::new_v4();
+            store
+                .claim_sandbox_tool_call(call_id, executor_lease, chrono::Duration::minutes(1))
+                .await
+                .unwrap();
+            store
+                .resolve_sandbox_tool_call(
+                    call_id,
+                    executor_lease,
+                    &ToolCallResolution::Completed {
+                        result: result.into(),
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            SandboxAgentRunWorkerOutcome::Completed(id)
+        );
+        let requests = provider.requests.lock().unwrap();
+        assert_eq!(requests.len(), 3);
+        let replayed: Vec<&str> = requests[2]
+            .messages
+            .iter()
+            .filter_map(|message| match message.content.first() {
+                Some(ContentBlock::ToolResult { content, .. }) => Some(content.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            replayed,
+            vec!["{\"results\":[\"first\"]}", "{\"results\":[\"second\"]}"]
         );
     }
 
@@ -1990,11 +2120,13 @@ mod tests {
         store.request_agent_run_cancellation(id).await.unwrap();
         assert_eq!(
             worker
-                .park_web_search(
+                .park_sandbox_tool_call(
                     run,
                     lease,
                     "search_1".into(),
-                    serde_json::json!({"query":"OpenWave"})
+                    openwave_core::SANDBOX_WEB_SEARCH_TOOL,
+                    serde_json::json!({"query":"OpenWave"}),
+                    "sandbox web-search checkpoint identity conflict",
                 )
                 .await
                 .unwrap(),
@@ -2085,6 +2217,110 @@ mod tests {
             worker.fail_wait_set_resume_responses.load(Ordering::SeqCst),
             0
         );
+    }
+
+    /// A run's deliverables are the files it wrote, so submission has exactly two
+    /// jobs: carry the names the model chose through to the parent, and refuse a
+    /// name that never became an output rather than inventing one.
+    #[tokio::test]
+    async fn submitting_files_carries_their_names_and_refuses_a_name_that_was_never_published() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = sandbox_chat();
+        store.create_chat(&chat).await.unwrap();
+        let published = openwave_core::OutputId::new();
+        store
+            .create_output(&openwave_core::CreateOutput {
+                id: published,
+                chat_id: chat.id,
+                filename: "Q3 revenue.md".into(),
+                kind: openwave_core::DeliverableKind::Text,
+                revision: openwave_core::NewOutputRevision {
+                    id: openwave_core::OutputRevisionId::new(),
+                    byte_len: 4,
+                    sha256: [0; 32],
+                    turn_id: None,
+                    producing_run_id: None,
+                    created_at: chrono::Utc::now(),
+                },
+            })
+            .await
+            .unwrap();
+
+        let done = |filename: &str| {
+            Arc::new(EventProvider(vec![
+                ProviderEvent::ToolCallStarted {
+                    index: 0,
+                    id: "done_1".into(),
+                    name: openwave_core::SANDBOX_DONE_TOOL.into(),
+                },
+                ProviderEvent::ToolCallArgsDelta {
+                    index: 0,
+                    fragment: serde_json::json!({
+                        "outputs": [filename],
+                        "summary": "Wrote the revenue summary.",
+                    })
+                    .to_string(),
+                },
+                ProviderEvent::Stop {
+                    reason: StopReason::ToolUse,
+                },
+            ]))
+        };
+        let worker = |provider: Arc<EventProvider>| {
+            SandboxAgentRunWorker::new(
+                store.clone(),
+                Arc::new(FixedResolver(provider)),
+                Arc::new(Notify::new()),
+                Arc::new(Notify::new()),
+                Arc::new(EventBus::default()),
+                AgentConfig {
+                    model: "sandbox-model".into(),
+                    ..AgentConfig::default()
+                },
+                None,
+                SandboxAgentRunWorkerConfig::default(),
+            )
+        };
+
+        let call = CallId::new();
+        let id = openwave_core::AgentRunId::sandbox_for_spawn_call(call);
+        admit_sandbox(&store, chat.id, call, "Summarize Q3 revenue.").await;
+        assert_eq!(
+            worker(done("Q3 revenue.md")).run_once().await.unwrap(),
+            SandboxAgentRunWorkerOutcome::Completed(id)
+        );
+        let result = store.get_agent_run_result(id).await.unwrap().unwrap();
+        assert!(matches!(
+            &result.payload,
+            openwave_core::AgentRunResultPayload::Submission { outputs, summary }
+                if outputs.len() == 1
+                    && outputs[0].output_id == published
+                    && outputs[0].filename == "Q3 revenue.md"
+                    && summary == "Wrote the revenue summary."
+        ));
+        // The parent reads the filenames, because the files are the result.
+        assert!(result.text.contains("Q3 revenue.md"));
+
+        let unwritten = CallId::new();
+        let unwritten_id = openwave_core::AgentRunId::sandbox_for_spawn_call(unwritten);
+        admit_sandbox(&store, chat.id, unwritten, "Summarize Q4 revenue.").await;
+        assert_eq!(
+            worker(done("Q4 revenue.md")).run_once().await.unwrap(),
+            SandboxAgentRunWorkerOutcome::RetryScheduled(unwritten_id)
+        );
+        assert!(store
+            .get_agent_run_result(unwritten_id)
+            .await
+            .unwrap()
+            .is_none());
     }
 
     #[tokio::test]
@@ -2569,16 +2805,18 @@ mod tests {
         .unwrap();
         assert_eq!(request.system.as_deref(), Some(SANDBOX_SYSTEM_PROMPT));
         assert_eq!(
-            request.tools,
+            request
+                .tools
+                .iter()
+                .map(|tool| tool.name.as_str())
+                .collect::<Vec<_>>(),
             vec![
-                sandbox_web_search_tool_spec(),
-                sandbox_folder_access_proposal_tool_spec(),
+                SANDBOX_EXEC_TOOL,
+                openwave_core::SANDBOX_WEB_SEARCH_TOOL,
+                openwave_core::SANDBOX_DONE_TOOL,
+                openwave_core::REQUEST_FOLDER_ACCESS_TOOL,
             ]
         );
-        assert!(request
-            .tools
-            .iter()
-            .all(|tool| tool.name != openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL));
     }
 
     #[tokio::test]
@@ -2604,8 +2842,15 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(
-            request.tools,
-            vec![sandbox_folder_access_proposal_tool_spec()]
+            request
+                .tools
+                .iter()
+                .map(|tool| tool.name.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                openwave_core::SANDBOX_DONE_TOOL,
+                openwave_core::REQUEST_FOLDER_ACCESS_TOOL,
+            ]
         );
         let provider = Arc::new(EventProvider(vec![
             ProviderEvent::ToolCallStarted {
@@ -2865,29 +3110,6 @@ mod tests {
             openwave_core::SANDBOX_READ_DELEGATED_FILE_TOOL
         );
         assert_eq!(calls[0].arguments, serde_json::json!({}));
-    }
-
-    /// The task is free-form model-facing prose and the filename reaches a real
-    /// filesystem on export, so the two things this has to get right are that
-    /// nothing unportable survives and that a long task still ends on a word.
-    #[test]
-    fn a_result_filename_is_a_portable_title_drawn_from_the_task() {
-        assert_eq!(
-            agent_result_filename(Some("Summarize the Q3 revenue report")),
-            "Summarize the Q3 revenue report.md"
-        );
-        assert_eq!(
-            agent_result_filename(Some("Read ../etc/passwd: \"now\"\nthen stop")),
-            "Read etc passwd now.md"
-        );
-        assert_eq!(
-            agent_result_filename(Some(
-                "Compare every competitor pricing page and write up where our own tiers sit"
-            )),
-            "Compare every competitor pricing page and write up where.md"
-        );
-        assert_eq!(agent_result_filename(Some("   ")), "Agent result.md");
-        assert_eq!(agent_result_filename(None), "Agent result.md");
     }
 
     fn sandbox_chat() -> Chat {

--- a/crates/openwave-server/src/sandbox_exec_worker.rs
+++ b/crates/openwave-server/src/sandbox_exec_worker.rs
@@ -1,0 +1,817 @@
+//! Durable execution of a background run's exec checkpoints.
+//!
+//! A background run cannot execute anything itself: it parks the command as a
+//! checkpoint and releases its lease, and this lane runs the command under its
+//! own executor lease against the run's private workspace. The workspace is
+//! named by the run, holds nothing but what the run's own earlier commands
+//! wrote, and carries no folder authority — a delegated run must not reach the
+//! user's files. Files the command leaves in `output/` are published to the
+//! parent conversation as outputs named by their own filenames.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use openwave_code_execution::{
+    CodeExecutionError, CodeExecutionRequest, CodeExecutionResponse, ExecutionId,
+    ExecutionWorkspaceId, OutputArtifactScan, OutputArtifactStatus,
+};
+use openwave_core::{
+    AgentError, AgentRunId, CallId, ChatId, ClaimSandboxToolCallOutcome, Result, SandboxExecArgs,
+    SandboxToolCall, Store, ToolCallResolution, SANDBOX_EXEC_TOOL,
+};
+use tokio::sync::Notify;
+
+use crate::code_execution::ConfiguredCodeExecutionProvider;
+use crate::retry::LaneBackoff;
+use crate::state::SandboxAttemptGuard;
+
+const CANDIDATE_BATCH_SIZE: u64 = 16;
+/// Per-stream budget for a command's captured output inside one receipt.
+///
+/// The whole checkpoint chain is replayed into every model request the run
+/// makes, so a receipt is charged against the run's context on each step, not
+/// once. The provider already caps capture far higher; this is the tighter
+/// bound that keeps a chain of commands affordable.
+const MAX_RECEIPT_STREAM_BYTES: usize = 3_000;
+const TRUNCATION_MARKER: &str = "\n…[truncated]";
+
+/// One command to run for one durably claimed checkpoint.
+#[derive(Debug, Clone)]
+pub(crate) struct SandboxExecJob {
+    pub(crate) call_id: CallId,
+    pub(crate) run_id: AgentRunId,
+    pub(crate) chat_id: ChatId,
+    pub(crate) arguments: SandboxExecArgs,
+}
+
+/// Deliberately coarse host exec failures. A provider or configuration detail
+/// must never become a checkpoint receipt or model context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SandboxExecFailure {
+    /// The request or the host configuration cannot support exec at all;
+    /// retrying is pointless and the receipt is terminal.
+    Rejected { code: &'static str, message: String },
+    /// A backend or storage fault that may not recur.
+    Transient,
+}
+
+#[async_trait]
+pub(crate) trait SandboxExecRunner: Send + Sync {
+    /// Run the command and publish whatever it left in `output/`.
+    ///
+    /// The scan runs whatever the exit code was: a later failing step must not
+    /// hide a file the command already durably wrote.
+    async fn run(
+        &self,
+        job: SandboxExecJob,
+    ) -> std::result::Result<(CodeExecutionResponse, OutputArtifactScan), SandboxExecFailure>;
+}
+
+/// The configured host provider, confined to one background run's workspace.
+struct HostSandboxExec {
+    provider: Arc<ConfiguredCodeExecutionProvider>,
+}
+
+#[async_trait]
+impl SandboxExecRunner for HostSandboxExec {
+    async fn run(
+        &self,
+        job: SandboxExecJob,
+    ) -> std::result::Result<(CodeExecutionResponse, OutputArtifactScan), SandboxExecFailure> {
+        let workspace = agent_run_workspace(job.run_id).map_err(classify)?;
+        let execution = ExecutionId::parse(job.call_id.to_string()).map_err(classify)?;
+        // `files` and `folder_grants` stay empty: the run's workspace is the
+        // only filesystem it has, and nothing outside it may be staged in.
+        let request = CodeExecutionRequest::new(
+            execution,
+            workspace.clone(),
+            job.arguments.command,
+            job.arguments.args,
+            job.arguments.cwd,
+        )
+        .map_err(classify)?;
+        let response = self
+            .provider
+            .execute_for_agent_run(job.chat_id, request)
+            .await
+            .map_err(classify)?;
+        let outputs = match self
+            .provider
+            .collect_agent_run_outputs(&workspace, job.chat_id, job.call_id, job.run_id)
+            .await
+        {
+            Ok(outputs) => outputs,
+            // The command ran; a scan that could not record its files says so
+            // in the receipt rather than losing the command's result.
+            Err(error) => OutputArtifactScan {
+                entries: Vec::new(),
+                notes: vec![format!("outputs unavailable: {error}")],
+            },
+        };
+        Ok((response, outputs))
+    }
+}
+
+/// Workspace identity for one background run.
+///
+/// The run, never its parent conversation: sibling runs delegated in one
+/// message execute concurrently and must not share a filesystem. They do share
+/// the conversation's outputs catalog, so two runs that write `report.md`
+/// produce two versions of one output.
+fn agent_run_workspace(
+    run_id: AgentRunId,
+) -> std::result::Result<ExecutionWorkspaceId, CodeExecutionError> {
+    ExecutionWorkspaceId::parse(format!("agent-run-{run_id}"))
+}
+
+fn classify(error: CodeExecutionError) -> SandboxExecFailure {
+    match error {
+        CodeExecutionError::NotConfigured => SandboxExecFailure::Rejected {
+            code: "exec_not_configured",
+            message: "Code execution is not configured for this host.".into(),
+        },
+        CodeExecutionError::InvalidRequest(_) => SandboxExecFailure::Rejected {
+            code: "invalid_exec_arguments",
+            message: "The command could not be run as requested.".into(),
+        },
+        _ => SandboxExecFailure::Transient,
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SandboxExecWorkerConfig {
+    lease: Duration,
+    heartbeat: Duration,
+    idle_min: Duration,
+    idle_cap: Duration,
+    failure_delay: Duration,
+    failure_delay_cap: Duration,
+    retry_delay: Duration,
+    max_concurrency: usize,
+}
+
+impl Default for SandboxExecWorkerConfig {
+    fn default() -> Self {
+        // A command is capped at two minutes, and a cold managed sandbox can
+        // spend a while being built before it runs. The lease covers that with
+        // room to spare and is renewed while the command runs, so an executor
+        // that dies is still reclaimed promptly rather than at the far end of
+        // the envelope. The database caps the lease at the run's deadline.
+        Self {
+            lease: Duration::from_secs(300),
+            heartbeat: Duration::from_secs(20),
+            idle_min: Duration::from_millis(250),
+            idle_cap: Duration::from_secs(5),
+            failure_delay: Duration::from_secs(1),
+            failure_delay_cap: Duration::from_secs(30),
+            retry_delay: Duration::from_secs(2),
+            max_concurrency: 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SandboxExecWorkerOutcome {
+    Idle,
+    Resolved(CallId),
+    RetryScheduled(CallId),
+    LeaseLost(CallId),
+}
+
+#[derive(Clone)]
+pub(crate) struct SandboxExecWorker {
+    store: Arc<dyn Store>,
+    exec: Arc<dyn SandboxExecRunner>,
+    wake: Arc<Notify>,
+    attempts: Arc<SandboxAttemptGuard>,
+    config: SandboxExecWorkerConfig,
+}
+
+impl SandboxExecWorker {
+    pub(crate) fn with_attempts(
+        store: Arc<dyn Store>,
+        provider: Arc<ConfiguredCodeExecutionProvider>,
+        wake: Arc<Notify>,
+        attempts: Arc<SandboxAttemptGuard>,
+        config: SandboxExecWorkerConfig,
+    ) -> Self {
+        Self::with_runner_and_attempts(
+            store,
+            Arc::new(HostSandboxExec { provider }),
+            wake,
+            attempts,
+            config,
+        )
+    }
+
+    #[cfg(test)]
+    fn with_runner(
+        store: Arc<dyn Store>,
+        exec: Arc<dyn SandboxExecRunner>,
+        wake: Arc<Notify>,
+        config: SandboxExecWorkerConfig,
+    ) -> Self {
+        Self::with_runner_and_attempts(
+            store,
+            exec,
+            wake,
+            Arc::new(SandboxAttemptGuard::default()),
+            config,
+        )
+    }
+
+    fn with_runner_and_attempts(
+        store: Arc<dyn Store>,
+        exec: Arc<dyn SandboxExecRunner>,
+        wake: Arc<Notify>,
+        attempts: Arc<SandboxAttemptGuard>,
+        config: SandboxExecWorkerConfig,
+    ) -> Self {
+        assert!(!config.lease.is_zero());
+        assert!(!config.heartbeat.is_zero());
+        assert!(config.max_concurrency > 0);
+        Self {
+            store,
+            exec,
+            wake,
+            attempts,
+            config,
+        }
+    }
+
+    pub(crate) async fn run(self) {
+        let mut lanes = tokio::task::JoinSet::new();
+        for _ in 0..self.config.max_concurrency {
+            lanes.spawn(self.clone().run_lane());
+        }
+        let mut restart_backoff =
+            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
+        while let Some(result) = lanes.join_next().await {
+            if let Err(error) = result {
+                eprintln!("openwave: sandbox exec worker lane stopped: {error}");
+                tokio::time::sleep(restart_backoff.next_delay()).await;
+            }
+            lanes.spawn(self.clone().run_lane());
+        }
+    }
+
+    async fn run_lane(self) {
+        let mut idle_delay = self.config.idle_min;
+        let mut failure_backoff =
+            LaneBackoff::new(self.config.failure_delay, self.config.failure_delay_cap);
+        loop {
+            match self.run_once().await {
+                Ok(SandboxExecWorkerOutcome::Idle) => {
+                    failure_backoff.reset();
+                    tokio::select! {
+                        _ = tokio::time::sleep(idle_delay) => {}
+                        _ = self.wake.notified() => {}
+                    }
+                    idle_delay = idle_delay.saturating_mul(2).min(self.config.idle_cap);
+                }
+                Ok(_) => {
+                    failure_backoff.reset();
+                    idle_delay = self.config.idle_min;
+                }
+                Err(error) => {
+                    eprintln!("openwave: sandbox exec worker iteration failed: {error}");
+                    let delay = failure_backoff.next_delay();
+                    tokio::select! {
+                        _ = tokio::time::sleep(delay) => {}
+                        _ = self.wake.notified() => {}
+                    }
+                }
+            }
+        }
+    }
+
+    /// Claim and resolve one exact persisted exec checkpoint.
+    pub(crate) async fn run_once(&self) -> Result<SandboxExecWorkerOutcome> {
+        for candidate in self
+            .store
+            .list_sandbox_tool_call_candidates_named(SANDBOX_EXEC_TOOL, CANDIDATE_BATCH_SIZE)
+            .await?
+        {
+            let lease_token = uuid::Uuid::new_v4();
+            let call = match self
+                .store
+                .claim_sandbox_tool_call_named(
+                    candidate.id,
+                    SANDBOX_EXEC_TOOL,
+                    lease_token,
+                    chrono_duration(self.config.lease)?,
+                )
+                .await?
+            {
+                ClaimSandboxToolCallOutcome::Claimed(call)
+                | ClaimSandboxToolCallOutcome::Existing(call) => call,
+                ClaimSandboxToolCallOutcome::Unavailable => continue,
+            };
+            self.wake.notify_one();
+            return self.process(call, lease_token).await;
+        }
+        Ok(SandboxExecWorkerOutcome::Idle)
+    }
+
+    async fn process(
+        &self,
+        call: SandboxToolCall,
+        lease_token: uuid::Uuid,
+    ) -> Result<SandboxExecWorkerOutcome> {
+        let Some(active_attempt) =
+            self.attempts
+                .register_checkpoint(call.id, call.agent_run_id, lease_token)
+        else {
+            return Ok(SandboxExecWorkerOutcome::LeaseLost(call.id));
+        };
+        let cancel = active_attempt.cancel_token();
+        // Close cancel-before-register and prove this exact executor lease
+        // before anything runs.
+        let Some(_) = self
+            .store
+            .heartbeat_sandbox_tool_call(call.id, lease_token, chrono_duration(self.config.lease)?)
+            .await?
+        else {
+            return Ok(SandboxExecWorkerOutcome::LeaseLost(call.id));
+        };
+        let resolution = match parse_exec_job(&call) {
+            Err(resolution) => resolution,
+            Ok(job) => {
+                // The command holds the lease for as long as it runs, so the
+                // lease is renewed underneath it. A renewal the database
+                // refuses means this attempt no longer owns the checkpoint;
+                // abandon it rather than write a receipt for it.
+                let result = {
+                    let mut running = std::pin::pin!(self.exec.run(job));
+                    let mut heartbeat = tokio::time::interval(self.config.heartbeat);
+                    heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                    heartbeat.tick().await;
+                    loop {
+                        tokio::select! {
+                            result = &mut running => break Some(result),
+                            _ = cancel.cancelled() => break None,
+                            _ = heartbeat.tick() => {
+                                if self
+                                    .store
+                                    .heartbeat_sandbox_tool_call(
+                                        call.id,
+                                        lease_token,
+                                        chrono_duration(self.config.lease)?,
+                                    )
+                                    .await?
+                                    .is_some()
+                                {
+                                    continue;
+                                }
+                                break None;
+                            }
+                        }
+                    }
+                };
+                match result {
+                    None => return Ok(SandboxExecWorkerOutcome::LeaseLost(call.id)),
+                    Some(Ok((response, outputs))) => exec_resolution(&response, &outputs),
+                    Some(Err(SandboxExecFailure::Rejected { code, message })) => {
+                        failed_resolution(code, &message)
+                    }
+                    Some(Err(SandboxExecFailure::Transient)) => {
+                        if call.retry_at.is_none() {
+                            return self.schedule_retry(call.id, lease_token).await;
+                        }
+                        failed_resolution(
+                            "exec_failed",
+                            "The command could not be run in this task's workspace.",
+                        )
+                    }
+                }
+            }
+        };
+        match self
+            .store
+            .resolve_sandbox_tool_call(call.id, lease_token, &resolution)
+            .await?
+        {
+            openwave_core::ResolveSandboxToolCallOutcome::Resolved
+            | openwave_core::ResolveSandboxToolCallOutcome::Existing => {
+                self.wake.notify_one();
+                Ok(SandboxExecWorkerOutcome::Resolved(call.id))
+            }
+            openwave_core::ResolveSandboxToolCallOutcome::NotFound
+            | openwave_core::ResolveSandboxToolCallOutcome::AlreadyTerminal
+            | openwave_core::ResolveSandboxToolCallOutcome::LeaseLost => {
+                Ok(SandboxExecWorkerOutcome::LeaseLost(call.id))
+            }
+        }
+    }
+
+    /// Park the call for its single bounded retry instead of writing a terminal
+    /// failure receipt. The durable `retry_at` marker makes the second attempt
+    /// terminal on any failure.
+    async fn schedule_retry(
+        &self,
+        id: CallId,
+        lease_token: uuid::Uuid,
+    ) -> Result<SandboxExecWorkerOutcome> {
+        match self
+            .store
+            .retry_sandbox_tool_call(id, lease_token, chrono_duration(self.config.retry_delay)?)
+            .await?
+        {
+            openwave_core::RetrySandboxToolCallOutcome::Scheduled => {
+                self.wake.notify_one();
+                Ok(SandboxExecWorkerOutcome::RetryScheduled(id))
+            }
+            openwave_core::RetrySandboxToolCallOutcome::LeaseLost => {
+                Ok(SandboxExecWorkerOutcome::LeaseLost(id))
+            }
+        }
+    }
+}
+
+fn parse_exec_job(
+    call: &SandboxToolCall,
+) -> std::result::Result<SandboxExecJob, ToolCallResolution> {
+    if call.name != SANDBOX_EXEC_TOOL {
+        return Err(failed_resolution(
+            "unsupported_sandbox_tool",
+            "This sandbox tool is not available.",
+        ));
+    }
+    let invalid = || {
+        failed_resolution(
+            "invalid_exec_arguments",
+            "The command arguments are invalid.",
+        )
+    };
+    let arguments =
+        serde_json::from_value::<SandboxExecArgs>(call.arguments.clone()).map_err(|_| invalid())?;
+    if !arguments.is_well_formed() {
+        return Err(invalid());
+    }
+    Ok(SandboxExecJob {
+        call_id: call.id,
+        run_id: call.agent_run_id,
+        chat_id: call.chat_id,
+        arguments,
+    })
+}
+
+/// Render one command's result for the model that asked for it.
+///
+/// Published files come first: they are the point of the command, and the run
+/// finishes by naming them. A nonzero exit is not a lane failure — the model
+/// asked for a command and is owed its exit code — but it is marked as an error
+/// receipt so the model does not read a failed build as a success.
+fn exec_resolution(
+    response: &CodeExecutionResponse,
+    outputs: &OutputArtifactScan,
+) -> ToolCallResolution {
+    let exit = response
+        .exit_code
+        .map_or_else(|| "signal".into(), |code| code.to_string());
+    let mut result = format!("exit: {exit}\nduration_ms: {}", response.duration_ms);
+    if response.timed_out {
+        result.push_str(
+            "\ntimed_out: true (the host killed this command at its time limit; its output may be \
+             empty or incomplete — split the work into smaller commands rather than rerunning \
+             this one unchanged)",
+        );
+    }
+    let published: Vec<String> = outputs
+        .entries
+        .iter()
+        .filter_map(|entry| match entry.status {
+            OutputArtifactStatus::Created => Some(format!(
+                "published {} (version {})",
+                entry.filename, entry.ordinal
+            )),
+            OutputArtifactStatus::Updated => Some(format!(
+                "republished {} (version {})",
+                entry.filename, entry.ordinal
+            )),
+            // A file that still matches its published version is not news.
+            OutputArtifactStatus::Unchanged => None,
+        })
+        .collect();
+    if !published.is_empty() || !outputs.notes.is_empty() {
+        result.push_str("\n\noutputs:");
+        for line in published.iter().chain(&outputs.notes) {
+            result.push('\n');
+            result.push_str(line);
+        }
+    }
+    if !response.stdout.is_empty() {
+        result.push_str("\n\nstdout:\n");
+        result.push_str(&clamp(&response.stdout));
+    }
+    if !response.stderr.is_empty() {
+        result.push_str("\n\nstderr:\n");
+        result.push_str(&clamp(&response.stderr));
+    }
+    if response.timed_out || response.exit_code != Some(0) {
+        return ToolCallResolution::Failed {
+            result,
+            error_code: "exec_command_failed".into(),
+            error_detail: None,
+        };
+    }
+    ToolCallResolution::Completed { result }
+}
+
+/// Keep the tail of a captured stream: a failing command's diagnosis is
+/// usually at the end, not the beginning.
+fn clamp(stream: &str) -> String {
+    if stream.len() <= MAX_RECEIPT_STREAM_BYTES {
+        return stream.to_owned();
+    }
+    let start = stream.len() - MAX_RECEIPT_STREAM_BYTES;
+    let start = (start..stream.len())
+        .find(|index| stream.is_char_boundary(*index))
+        .unwrap_or(stream.len());
+    format!("{TRUNCATION_MARKER}\n{}", &stream[start..])
+}
+
+fn failed_resolution(code: &str, result: &str) -> ToolCallResolution {
+    ToolCallResolution::Failed {
+        result: result.into(),
+        error_code: code.into(),
+        error_detail: None,
+    }
+}
+
+fn chrono_duration(duration: Duration) -> Result<chrono::Duration> {
+    chrono::Duration::from_std(duration)
+        .map_err(|error| AgentError::msg(format!("invalid sandbox exec duration: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    use chrono::Utc;
+    use openwave_code_execution::{
+        CodeExecutionProviderKind, OutputArtifactEntry, OutputArtifactStatus,
+    };
+    use openwave_core::{
+        Chat, DbStore, ParkSandboxToolCallOutcome, SandboxToolCallRequest, SandboxToolCallStatus,
+    };
+
+    use super::*;
+
+    /// One scripted result per attempt, so a lane's retry behaviour is observed
+    /// rather than inferred.
+    struct ScriptedExec {
+        attempts: AtomicUsize,
+        results: Mutex<
+            Vec<
+                std::result::Result<
+                    (CodeExecutionResponse, OutputArtifactScan),
+                    SandboxExecFailure,
+                >,
+            >,
+        >,
+    }
+
+    #[async_trait]
+    impl SandboxExecRunner for ScriptedExec {
+        async fn run(
+            &self,
+            _job: SandboxExecJob,
+        ) -> std::result::Result<(CodeExecutionResponse, OutputArtifactScan), SandboxExecFailure>
+        {
+            self.attempts.fetch_add(1, Ordering::SeqCst);
+            self.results.lock().unwrap().remove(0)
+        }
+    }
+
+    fn scripted(
+        results: Vec<
+            std::result::Result<(CodeExecutionResponse, OutputArtifactScan), SandboxExecFailure>,
+        >,
+    ) -> Arc<ScriptedExec> {
+        Arc::new(ScriptedExec {
+            attempts: AtomicUsize::new(0),
+            results: Mutex::new(results),
+        })
+    }
+
+    fn response(stdout: &str) -> CodeExecutionResponse {
+        CodeExecutionResponse {
+            provider: CodeExecutionProviderKind::Local,
+            exit_code: Some(0),
+            stdout: stdout.into(),
+            stderr: String::new(),
+            timed_out: false,
+            output_truncated: false,
+            duration_ms: 12,
+            sync_notes: Vec::new(),
+            degraded: None,
+        }
+    }
+
+    async fn test_store() -> (Arc<DbStore>, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                dir.path().join("test.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        (store, dir)
+    }
+
+    /// Park one exec checkpoint the way a background run's own loop does.
+    async fn checkpoint(store: &Arc<DbStore>, arguments: serde_json::Value) -> CallId {
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: Some("sandbox exec".into()),
+            model: Some("model".into()),
+            reasoning_effort: None,
+            permission_mode: None,
+            network_policy: Default::default(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let turn_id = openwave_core::TurnId::new();
+        store
+            .accept_turn(turn_id, chat.id, "sandbox-test-model", "sandbox exec test")
+            .await
+            .unwrap();
+        let turn_lease = uuid::Uuid::new_v4();
+        let now = Utc::now();
+        let turn = store
+            .claim_turn_run(turn_lease, now, now + chrono::Duration::hours(1))
+            .await
+            .unwrap()
+            .turn
+            .unwrap();
+        let run = match store
+            .admit_sandbox_agent_run(
+                turn.id,
+                CallId::new(),
+                "write a report",
+                turn_lease,
+                turn.steer_revision,
+                1,
+                Utc::now(),
+            )
+            .await
+            .unwrap()
+            .unwrap()
+        {
+            openwave_core::AdmitSandboxAgentRunOutcome::Accepted { child, .. } => child,
+            outcome => panic!("unexpected sandbox admission: {outcome:?}"),
+        };
+        let worker_lease = uuid::Uuid::new_v4();
+        assert_eq!(
+            store
+                .claim_agent_run(worker_lease, chrono::Duration::minutes(5), 1, 1)
+                .await
+                .unwrap()
+                .unwrap()
+                .id,
+            run.id
+        );
+        let request = SandboxToolCallRequest {
+            id: CallId::new(),
+            agent_run_id: run.id,
+            chat_id: chat.id,
+            provider_id: "provider-call".into(),
+            name: SANDBOX_EXEC_TOOL.into(),
+            arguments,
+        };
+        assert!(matches!(
+            store
+                .park_agent_run_for_sandbox_tool_call(run.id, worker_lease, &request)
+                .await
+                .unwrap(),
+            ParkSandboxToolCallOutcome::Parked { .. }
+        ));
+        request.id
+    }
+
+    fn worker(store: Arc<DbStore>, exec: Arc<dyn SandboxExecRunner>) -> SandboxExecWorker {
+        SandboxExecWorker::with_runner(
+            store,
+            exec,
+            Arc::new(Notify::new()),
+            SandboxExecWorkerConfig::default(),
+        )
+    }
+
+    #[tokio::test]
+    async fn a_command_receipt_names_its_published_files_and_keeps_the_output_tail() {
+        let (store, _dir) = test_store().await;
+        let call = checkpoint(
+            &store,
+            serde_json::json!({"command":"python3","args":["report.py"]}),
+        )
+        .await;
+        let stdout = format!("{}TAIL-MARKER", "x".repeat(MAX_RECEIPT_STREAM_BYTES));
+        let exec = scripted(vec![Ok((
+            response(&stdout),
+            OutputArtifactScan {
+                entries: vec![OutputArtifactEntry {
+                    filename: "Quarterly review.md".into(),
+                    output_id: openwave_core::OutputId::new().to_string(),
+                    ordinal: 1,
+                    status: OutputArtifactStatus::Created,
+                }],
+                notes: Vec::new(),
+            },
+        ))]);
+        assert_eq!(
+            worker(store.clone(), exec).run_once().await.unwrap(),
+            SandboxExecWorkerOutcome::Resolved(call)
+        );
+        let receipt = store
+            .get_sandbox_tool_call_receipt(call)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(receipt.status, SandboxToolCallStatus::Completed);
+        // The filename the command chose is what the model is told was
+        // published — no host-invented title anywhere in the receipt.
+        assert!(receipt
+            .result
+            .contains("published Quarterly review.md (version 1)"));
+        assert!(receipt.result.contains("TAIL-MARKER"));
+        assert!(receipt.result.contains(TRUNCATION_MARKER));
+        assert!(receipt.result.len() < 2 * MAX_RECEIPT_STREAM_BYTES);
+    }
+
+    #[tokio::test]
+    async fn a_transient_failure_retries_once_and_then_resolves_terminally() {
+        let (store, _dir) = test_store().await;
+        let call = checkpoint(&store, serde_json::json!({"command":"python3"})).await;
+        let exec = scripted(vec![
+            Err(SandboxExecFailure::Transient),
+            Err(SandboxExecFailure::Transient),
+        ]);
+        let worker = SandboxExecWorker::with_runner(
+            store.clone(),
+            exec.clone(),
+            Arc::new(Notify::new()),
+            SandboxExecWorkerConfig {
+                retry_delay: Duration::from_millis(1),
+                ..SandboxExecWorkerConfig::default()
+            },
+        );
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            SandboxExecWorkerOutcome::RetryScheduled(call)
+        );
+        assert!(store
+            .get_sandbox_tool_call_receipt(call)
+            .await
+            .unwrap()
+            .is_none());
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(
+            worker.run_once().await.unwrap(),
+            SandboxExecWorkerOutcome::Resolved(call)
+        );
+        assert_eq!(exec.attempts.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            store
+                .get_sandbox_tool_call_receipt(call)
+                .await
+                .unwrap()
+                .unwrap()
+                .status,
+            SandboxToolCallStatus::Failed
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unconfigured_host_fails_the_command_without_spending_a_retry() {
+        let (store, _dir) = test_store().await;
+        let call = checkpoint(&store, serde_json::json!({"command":"python3"})).await;
+        let exec = scripted(vec![Err(SandboxExecFailure::Rejected {
+            code: "exec_not_configured",
+            message: "Code execution is not configured for this host.".into(),
+        })]);
+        assert_eq!(
+            worker(store.clone(), exec.clone())
+                .run_once()
+                .await
+                .unwrap(),
+            SandboxExecWorkerOutcome::Resolved(call)
+        );
+        assert_eq!(exec.attempts.load(Ordering::SeqCst), 1);
+        let receipt = store
+            .get_sandbox_tool_call_receipt(call)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(receipt.status, SandboxToolCallStatus::Failed);
+        assert_eq!(receipt.error_code.as_deref(), Some("exec_not_configured"));
+    }
+}

--- a/crates/openwave-server/src/sandbox_web_search_worker.rs
+++ b/crates/openwave-server/src/sandbox_web_search_worker.rs
@@ -245,7 +245,7 @@ impl SandboxWebSearchWorker {
     ) -> Result<SandboxWebSearchWorkerOutcome> {
         let Some(active_attempt) =
             self.attempts
-                .register_search(call.id, call.agent_run_id, lease_token)
+                .register_checkpoint(call.id, call.agent_run_id, lease_token)
         else {
             return Ok(SandboxWebSearchWorkerOutcome::LeaseLost(call.id));
         };
@@ -970,7 +970,11 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert!(attempts.cancel_search(call.id, call.agent_run_id, receipt.executor_lease_token));
+        assert!(attempts.cancel_checkpoint(
+            call.id,
+            call.agent_run_id,
+            receipt.executor_lease_token
+        ));
         assert_eq!(
             execution.await.unwrap().unwrap(),
             SandboxWebSearchWorkerOutcome::LeaseLost(call.id)
@@ -1049,7 +1053,11 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert!(attempts.cancel_search(call.id, call.agent_run_id, receipt.executor_lease_token));
+        assert!(attempts.cancel_checkpoint(
+            call.id,
+            call.agent_run_id,
+            receipt.executor_lease_token
+        ));
         assert_eq!(
             execution.await.unwrap().unwrap(),
             SandboxWebSearchWorkerOutcome::LeaseLost(call.id)

--- a/crates/openwave-server/src/state.rs
+++ b/crates/openwave-server/src/state.rs
@@ -339,15 +339,18 @@ impl AppState {
     }
 }
 
-/// Exact local cancellation handles for sandbox model and web-search attempts.
+/// Exact local cancellation handles for sandbox model and checkpoint attempts.
 ///
-/// Registration is RAII: stale permits cannot remove a newer lease for the
-/// same durable identity. The maps are intentionally process-local and never
-/// participate in admission or terminal decisions.
+/// Every executor lane shares the checkpoint map — search, delegated file read,
+/// command execution — because a cancellation reaches them all the same way:
+/// by the exact durable call, run, and executor lease identity, never by tool
+/// name. Registration is RAII: stale permits cannot remove a newer lease for
+/// the same durable identity. The maps are intentionally process-local and
+/// never participate in admission or terminal decisions.
 #[derive(Default)]
 pub(crate) struct SandboxAttemptGuard {
     models: Mutex<HashMap<(AgentRunId, Uuid), CancelToken>>,
-    searches: Mutex<HashMap<(CallId, AgentRunId, Uuid), CancelToken>>,
+    checkpoints: Mutex<HashMap<(CallId, AgentRunId, Uuid), CancelToken>>,
 }
 
 impl SandboxAttemptGuard {
@@ -371,20 +374,20 @@ impl SandboxAttemptGuard {
         })
     }
 
-    pub(crate) fn register_search(
+    pub(crate) fn register_checkpoint(
         self: &Arc<Self>,
         call_id: CallId,
         agent_run_id: AgentRunId,
         executor_lease_token: Uuid,
-    ) -> Option<ActiveSandboxSearchAttempt> {
-        let mut searches = self.searches.lock().unwrap();
+    ) -> Option<ActiveSandboxCheckpointAttempt> {
+        let mut checkpoints = self.checkpoints.lock().unwrap();
         let identity = (call_id, agent_run_id, executor_lease_token);
-        if searches.contains_key(&identity) {
+        if checkpoints.contains_key(&identity) {
             return None;
         }
         let cancel = CancelToken::new();
-        searches.insert(identity, cancel.clone());
-        Some(ActiveSandboxSearchAttempt {
+        checkpoints.insert(identity, cancel.clone());
+        Some(ActiveSandboxCheckpointAttempt {
             guard: Arc::clone(self),
             call_id,
             agent_run_id,
@@ -408,14 +411,14 @@ impl SandboxAttemptGuard {
     }
 
     /// Signal only the exact sandbox call, run, and executor lease identity.
-    pub(crate) fn cancel_search(
+    pub(crate) fn cancel_checkpoint(
         &self,
         call_id: CallId,
         agent_run_id: AgentRunId,
         executor_lease_token: Uuid,
     ) -> bool {
         if let Some(cancel) =
-            self.searches
+            self.checkpoints
                 .lock()
                 .unwrap()
                 .get(&(call_id, agent_run_id, executor_lease_token))
@@ -450,7 +453,7 @@ impl Drop for ActiveSandboxModelAttempt {
     }
 }
 
-pub(crate) struct ActiveSandboxSearchAttempt {
+pub(crate) struct ActiveSandboxCheckpointAttempt {
     guard: Arc<SandboxAttemptGuard>,
     call_id: CallId,
     agent_run_id: AgentRunId,
@@ -458,15 +461,15 @@ pub(crate) struct ActiveSandboxSearchAttempt {
     cancel: CancelToken,
 }
 
-impl ActiveSandboxSearchAttempt {
+impl ActiveSandboxCheckpointAttempt {
     pub(crate) fn cancel_token(&self) -> CancelToken {
         self.cancel.clone()
     }
 }
 
-impl Drop for ActiveSandboxSearchAttempt {
+impl Drop for ActiveSandboxCheckpointAttempt {
     fn drop(&mut self) {
-        self.guard.searches.lock().unwrap().remove(&(
+        self.guard.checkpoints.lock().unwrap().remove(&(
             self.call_id,
             self.agent_run_id,
             self.executor_lease_token,
@@ -762,18 +765,18 @@ mod tests {
         let run = AgentRunId::sandbox_for_spawn_call(CallId::new());
         let lease = Uuid::new_v4();
         let held = guard
-            .register_search(call, run, lease)
+            .register_checkpoint(call, run, lease)
             .expect("register search");
 
-        assert!(!guard.cancel_search(CallId::new(), run, lease));
-        assert!(!guard.cancel_search(
+        assert!(!guard.cancel_checkpoint(CallId::new(), run, lease));
+        assert!(!guard.cancel_checkpoint(
             call,
             AgentRunId::sandbox_for_spawn_call(CallId::new()),
             lease
         ));
-        assert!(!guard.cancel_search(call, run, Uuid::new_v4()));
+        assert!(!guard.cancel_checkpoint(call, run, Uuid::new_v4()));
         assert!(!held.cancel_token().is_cancelled());
-        assert!(guard.cancel_search(call, run, lease));
+        assert!(guard.cancel_checkpoint(call, run, lease));
         assert!(held.cancel_token().is_cancelled());
     }
 
@@ -798,20 +801,22 @@ mod tests {
         assert!(current_model.cancel_token().is_cancelled());
 
         let call = CallId::new();
-        let old_search_lease = Uuid::new_v4();
+        let old_checkpoint_lease = Uuid::new_v4();
         let stale_search = guard
-            .register_search(call, run, old_search_lease)
+            .register_checkpoint(call, run, old_checkpoint_lease)
             .expect("register old search");
-        let new_search_lease = Uuid::new_v4();
+        let new_checkpoint_lease = Uuid::new_v4();
         let current_search = guard
-            .register_search(call, run, new_search_lease)
+            .register_checkpoint(call, run, new_checkpoint_lease)
             .expect("a distinct search lease may coexist until its heartbeat fences it");
         assert!(!stale_search.cancel_token().is_cancelled());
         assert!(!current_search.cancel_token().is_cancelled());
-        assert!(guard.register_search(call, run, new_search_lease).is_none());
+        assert!(guard
+            .register_checkpoint(call, run, new_checkpoint_lease)
+            .is_none());
         drop(stale_search);
         assert!(!current_search.cancel_token().is_cancelled());
-        assert!(guard.cancel_search(call, run, new_search_lease));
+        assert!(guard.cancel_checkpoint(call, run, new_checkpoint_lease));
         assert!(current_search.cancel_token().is_cancelled());
     }
 }

--- a/crates/openwave-server/src/tests/sandbox.rs
+++ b/crates/openwave-server/src/tests/sandbox.rs
@@ -215,7 +215,7 @@ async fn agent_run_snapshots_expose_only_safe_live_sandbox_activity() {
 }
 
 #[tokio::test]
-async fn agent_run_activity_history_is_ordered_renderer_safe_and_flags_a_produced_result() {
+async fn agent_run_activity_history_is_ordered_renderer_safe_and_names_submitted_files() {
     let (router, token, store, _dir) = test_app().await;
     let bearer = format!("Bearer {token}");
     let chat = make_chat(&router, &bearer).await;
@@ -274,7 +274,7 @@ async fn agent_run_activity_history_is_ordered_renderer_safe_and_flags_a_produce
     ));
 
     // Resolving the checkpoint hands the run back for continuation; take it and
-    // commit its terminal result so the snapshot reports a produced result.
+    // submit a file, which is what a produced result is.
     let continuation_lease = uuid::Uuid::new_v4();
     assert_eq!(
         store
@@ -285,13 +285,39 @@ async fn agent_run_activity_history_is_ordered_renderer_safe_and_flags_a_produce
             .id,
         run.id
     );
+    let submitted = openwave_core::OutputId::new();
     store
-        .submit_agent_run_result(run.id, continuation_lease, "final answer")
+        .create_output(&openwave_core::CreateOutput {
+            id: submitted,
+            chat_id: chat.id,
+            filename: "Q3 revenue.md".into(),
+            kind: openwave_core::DeliverableKind::Text,
+            revision: openwave_core::NewOutputRevision {
+                id: openwave_core::OutputRevisionId::new(),
+                byte_len: 4,
+                sha256: [0; 32],
+                turn_id: None,
+                producing_run_id: Some(run.id),
+                created_at: chrono::Utc::now(),
+            },
+        })
+        .await
+        .unwrap();
+    store
+        .submit_agent_run_submission(
+            run.id,
+            continuation_lease,
+            &[openwave_core::AgentRunSubmittedOutput {
+                output_id: submitted,
+                filename: "Q3 revenue.md".into(),
+            }],
+            "wrote the quarterly revenue summary",
+        )
         .await
         .unwrap()
         .expect("completion commits");
 
-    // The run snapshot flags result presence without carrying any payload.
+    // The run snapshot names the submitted files without carrying their bytes.
     let response = router
         .clone()
         .oneshot(
@@ -310,13 +336,16 @@ async fn agent_run_activity_history_is_ordered_renderer_safe_and_flags_a_produce
         .find(|snapshot| snapshot.get("id") == Some(&serde_json::json!(run.id)))
         .expect("sandbox snapshot is returned");
     assert_eq!(
-        snapshot.get("produced_output"),
-        Some(&serde_json::json!(true))
+        snapshot.get("submitted_outputs"),
+        Some(&serde_json::json!([
+            {"output_id": submitted, "filename": "Q3 revenue.md"}
+        ]))
     );
     assert_eq!(snapshot.get("task"), Some(&serde_json::json!("research")));
+    // The names live in the structured field; the prose is the summary alone.
     assert_eq!(
         snapshot.get("terminal_text"),
-        Some(&serde_json::json!("final answer"))
+        Some(&serde_json::json!("wrote the quarterly revenue summary"))
     );
     assert_eq!(snapshot.get("activity"), Some(&serde_json::json!(null)));
 
@@ -946,11 +975,11 @@ async fn parent_turn_cancellation_signals_its_exact_running_child_search() {
     ));
     let active = state
         .sandbox_attempts
-        .register_search(request.id, run.id, search_lease)
+        .register_checkpoint(request.id, run.id, search_lease)
         .expect("register exact search");
     let stale = state
         .sandbox_attempts
-        .register_search(request.id, run.id, uuid::Uuid::new_v4())
+        .register_checkpoint(request.id, run.id, uuid::Uuid::new_v4())
         .expect("register stale search identity");
 
     let response = post_json(

--- a/docs/agent-runs.md
+++ b/docs/agent-runs.md
@@ -54,7 +54,7 @@ differ:
 | --- | --- |
 | Responds directly in the chat | Works on one delegated task |
 | Final assistant text completes a turn | An explicit result submission completes the run |
-| Uses conversation-facing tools | May make at most one sandbox-safe tool call; has no shared conversation context |
+| Uses conversation-facing tools | Uses a small fixed sandbox tool surface over a bounded checkpoint budget; has no shared conversation context |
 | Usually short-lived work | May park and resume over a longer period |
 | Streams answer content | Publishes bounded progress and a final result |
 
@@ -160,22 +160,38 @@ answer/cancel races cannot produce two results. See
 
 ## Sandbox and host-access boundary
 
-A background agent has private runtime scratch but cannot access that scratch,
-projects, general host folders, the general network, or the parent
-conversation. Its narrow exceptions share one total tool-call budget: a
-checkpointed public web search, a typed folder-access proposal that grants no
-access, or—only in the embedded desktop—one exact file named by its immutable
-admission. The read tool takes no arguments. A native executor revalidates the
-current chat attachment immediately before the host broker performs a bounded
-UTF-8 read, persists private no-replay recovery state, and publishes only
-bounded content or a neutral failure. Headless workers never advertise the
-read. Sandboxes do not receive foreground spawn/wait or broker transport
-contracts, and absolute paths never cross into provider context. See
+A background agent cannot access projects, general host folders, the general
+network, or the parent conversation. Its narrow exceptions share one bounded
+tool-call budget: commands in its own execution workspace, a checkpointed
+public web search, a typed folder-access proposal that grants no access, or—only
+in the embedded desktop—one exact file named by its immutable admission. A run
+may spend that budget over several checkpoints; the worker replays the whole
+resolved chain on every claim, which is why the count is capped. The read tool
+takes no arguments. A native executor revalidates the current chat attachment
+immediately before the host broker performs a bounded UTF-8 read, persists
+private no-replay recovery state, and publishes only bounded content or a
+neutral failure. Headless workers never advertise the read. Sandboxes do not
+receive foreground spawn/wait or broker transport contracts, and absolute paths
+never cross into provider context. See
 [Host access and connected folders](host-access.md).
 
+Execution is how a background run produces anything the user keeps. Its
+workspace is named by the run, not the conversation, so siblings delegated in
+one message never share a filesystem; it starts empty and holds nothing but what
+the run's own earlier commands wrote. The request carries no folder authority
+and stages no host paths — delegation already bypasses the conversation's
+approval gate, so this path must not be the one that hands a delegated agent the
+user's files. The one thing the parent conversation contributes is its network
+policy, because the user chose that policy for this work. After each command the
+host scans the workspace's `output/` and publishes what it finds into the parent
+conversation's outputs, keyed by filename and attributed to the run: a new
+filename becomes a new output, and the same filename written again becomes its
+next version. The agent names its own deliverables that way, and the host never
+invents a title for one. See [Outputs](deliverables.md).
+
 This is intentionally not chat-wide or root-wide access. A sandbox cannot list
-roots or directories, open a picker, request a different file, write, run a
-shell command, or use a general filesystem API. A detach can revoke the exact
+roots or directories, open a picker, request a different file, write outside its
+own workspace, or use a general filesystem API. A detach can revoke the exact
 read before claim, at the final pre-dispatch heartbeat, or at resolution; if
 content arrived after authority was lost, it is discarded rather than returned
 to the model.
@@ -247,7 +263,13 @@ The scheduler's ownership rules are deliberately strict:
   expired worker cannot resume ownership.
 
 Final sandbox output is stored as an immutable typed receipt keyed by the child
-run and the exact lease segment that submitted it. Besides final text, the only
+run and the exact lease segment that submitted it. The ordinary way a run ends is
+a submission: the run calls `done` with the filenames it wrote under `output/`
+and a short summary, and the receipt records the outputs the scan already
+published under those names alongside the summary. Naming a file the run never
+wrote fails the completion like any other malformed one, bounded by the run's own
+attempt budget; a run that genuinely produced nothing submits nothing. Final text
+remains the receipt for a model that simply stops without submitting. The only
 current non-text outcome is a validated folder-consent proposal. It carries no
 host path, root identity, broker grant, or client-call identity; it only tells
 the foreground parent to decide whether the existing foreground consent tool is
@@ -294,7 +316,7 @@ renderer correlation key, not a provider call identity or scheduler control.
 
 When an agent has a live, supported tool checkpoint, the snapshot may also
 contain a small `activity` object. Its values are a deliberately admitted,
-fixed display vocabulary—for example, sandbox `web_search` or foreground
+fixed display vocabulary—for example, sandbox `exec` and `web_search`, or foreground
 `list_connected_folders`, `list_folder`, and `read_connected_file`, each with
 `waiting` or `running` status. It is not a tool trace: queries, tool arguments,
 results, folder/root identities, relative paths, filenames, host paths, grants,

--- a/docs/deliverables.md
+++ b/docs/deliverables.md
@@ -118,33 +118,32 @@ it, and acceptance is a host-side operation the model cannot perform for itself.
 Acceptance changes nothing about export: a person still chooses the destination
 through **Save As…**, and the bytes never leave private app data until then.
 
-## Auto-merging a background agent's result
+## A background agent's own files
 
-A background agent finishes by submitting one immutable text result to its
-foreground parent. That result also becomes conversation output: when the run
-completes, the **host** merges the text into the output record as a durable
-revision. The merge is host-side by construction — it runs on the already
-committed result text, so the sandbox model can neither author, decline, nor
-steer it, and there is no pre-accept prompt. Safety comes from the merge being a
-versioned, revertible output rather than from a human gate.
+A background agent produces nothing by narration. It runs commands in its own
+private workspace, writes deliverables under `output/`, and each file it writes
+there is published to the conversation's output record by the same scan the
+foreground exec path uses — keyed by filename, so writing the same name again
+appends a version rather than forking a second output. The host never authors a
+result document on the run's behalf and never invents a title.
 
-- The merge happens at result-commit time, right after the fenced result
-  transition. Its output and revision identities are derived from the producing
-  run, so an ambiguous submit retry re-runs the merge onto the same record
-  instead of forking a second output. The revision records the background run as
-  its producer, exactly like an accepted binary artifact, so the agent-run
-  surface can correlate a completed run with the output it produced.
-- The merged output is bounded and media-typed like every other deliverable: a
-  text result becomes a `text/markdown` output under the 512 KiB text ceiling,
-  written once at the same revision path a foreground deliverable uses. A folder
-  proposal or a cancellation is not conversation content and is never merged.
-- The merge is best-effort after the result has committed and delivered: a
-  failure to publish never fails a run whose result the parent can already
-  consume.
+- The run finishes by calling `done` with the filenames it wants the reader to
+  receive and a short summary. Submission resolves those names against the
+  conversation's live outputs and records the pair; it creates nothing, so a run
+  cannot submit a file it never wrote.
+- The published revision records the background run as its producer, exactly
+  like an accepted binary artifact, so the agent-run surface can correlate a
+  completed run with the outputs it produced.
+- Submission is bounded: at most 16 filenames and a short summary. The summary
+  is prose beside the files, not a substitute for them.
+- A run that legitimately produced no file submits no filenames; a folder
+  proposal or a cancellation is not conversation content and never becomes an
+  output.
 
 ## Versioning, restore, and delete
 
-Auto-merge and the exec `output/` scan are safe because every published output
+The `output/` scan is safe — for foreground turns and background runs alike —
+because every published output
 is a durable, append-only version history the user can always walk back:
 
 - **Version history.** Each output's detail panel lists its versions once there

--- a/docs/how-openwave-works.md
+++ b/docs/how-openwave-works.md
@@ -253,8 +253,10 @@ The built-in server registry currently contains:
   turn without creating another chat message. See
   [Durable user questions](user-questions.md).
 
-Depth-one sandbox agents have a separate, smaller surface and one total tool
-call. Besides web search or a typed folder-access proposal, an embedded-desktop
+Depth-one sandbox agents have a separate, smaller surface and a bounded
+checkpoint chain rather than one total tool call: every checkpoint is replayed on
+each claim, so the count is capped as a working budget. Besides web search or a
+typed folder-access proposal, an embedded-desktop
 child may receive `read_delegated_file` when its foreground spawn immutably
 named one exact attached root and relative path. The tool accepts no arguments;
 it cannot browse, choose a path, open a picker, write, or run commands. The

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -236,11 +236,22 @@ sequence; reconnecting clients replay the journal, and cursor-based consumers
 can ignore a repeated live publication after commit-response loss.
 
 A background sandbox has no shared conversation, general filesystem, general
-network, or broad host-folder access. It receives one bounded task and has one
-total tool-call budget. Depending on its remaining model-step budget and exact
-admission, it may be offered `web_search`, a sandbox-only
-`request_folder_access` proposal, or the desktop-only
-`read_delegated_file`. The delegated read is available only when the foreground
+network, or broad host-folder access. It receives one bounded task and works
+through a bounded budget of tool-call checkpoints. Depending on its remaining
+model-step budget and exact admission, it may be offered `exec`, `web_search`,
+a sandbox-only `request_folder_access` proposal, or the desktop-only
+`read_delegated_file`.
+
+`exec` runs against a workspace named by the run itself, so concurrently
+delegated siblings never share scratch. It carries no folder authority and
+stages no host paths: delegation already runs outside the conversation's
+approval gate, and the sandbox filesystem is the whole of what a delegated run
+can reach. Files the run leaves under `output/` are published to the parent
+conversation as outputs named by their own filenames — writing the same filename
+again produces the next version of that output rather than a second one. The run
+never names an output identity, and neither does the host.
+
+The delegated read is available only when the foreground
 spawn named one exact `{root_id, relative_path}` that was attached to the chat
 and remains attached. It accepts no model arguments: the sandbox cannot choose
 a root or path, discover neighboring files, or broaden the delegation.


### PR DESCRIPTION
A background run's deliverable used to be host-synthesized text: the worker took whatever final answer the model returned and wrote it into the conversation as an output whose name the host invented (#1550 improved that name; the artifact should not have existed). An agent's output should be the files it wrote, under the names it gave them.

The two halves needed for that already existed and had never been connected. `output_scan.rs` publishes files under `output/` as outputs keyed by filename, with `RevisionProducer::Run(run_id)` already defined for exactly this case — but its only caller was the foreground exec path, because a background run's whole tool surface was `web_search` + `read_delegated_file`, gated to a single checkpoint.

## What changes

- **A real multi-step loop.** Sixteen tool calls, with `exec` parked and resumed through the same durable checkpoint mechanics `web_search` already used, on its own executor lane (`sandbox_exec_worker.rs`). Each run gets a workspace named by the run, so siblings delegated in one message never share scratch.
- **The scan runs for background work.** After each command the host scans that workspace's `output/` and publishes what it finds into the parent conversation's outputs, attributed to the run: new filename → new output, same filename again → next version.
- **A `done` tool ends the run** by submitting the filenames it wrote plus a short summary (16 names, 4,000 chars). Names resolve against the outputs the scan already published, newest live match per name; naming a file the run never wrote fails the completion like any other malformed one, bounded by the run's own attempt budget. A run that genuinely produced nothing submits nothing. `done` is terminal, so it needs no executor lane and stays advertised on the last step — a run that spent its budget writing files can still hand them over.
- **The synthesized artifact and its scaffolding come out:** `record_result_output`, `agent_result_filename`, `merge_agent_run_result`, and `OutputId::for_run` / `OutputRevisionId::for_run`.
- **The snapshot carries the files.** `produced_output` was a tier-and-status guess standing in for a real answer; it is replaced by `submitted_outputs`, and the renderer shows one pill per file that opens the output it names. The panel's prose block is the run's summary alone, since the filenames are already on screen. `exec` joins the activity vocabulary, so the timeline finally shows the work.

## Boundary

A background run's exec is confined to its own workspace: no folder grants, no staged host paths, no chat scratch. Delegation already bypasses the conversation's approval gate, so this path must not be the one that hands a delegated agent the user's files. The only thing the parent conversation contributes is its network policy.

## Notes

- Existing `Agent result *.md` and task-titled rows in a live database stay until deleted by hand; nothing here rewrites history.
- Deleted two tests: the result-filename derivation test and the output-merge test, both covering code this removes.
- Labelled `full-ci` — this touches the exec and turn-state paths.

## Verification

`cargo test -p openwave-core -p openwave-server --locked`, clippy `--all-targets`, `cargo fmt`, and in `crates/openwave-desktop/ui`: `tsc --noEmit`, `pnpm test`, `pnpm build`. Not driven in the running app — the end-to-end check worth doing is delegating a task that requires producing a document and confirming Outputs gains a row named by the file the agent wrote.