### PR TITLE
fix(agents): publish a run's files under its conversation and scope submission to its own work

### DIFF
--- a/crates/openwave-core/src/db/ops/agent_run.rs
+++ b/crates/openwave-core/src/db/ops/agent_run.rs
@@ -2412,6 +2412,17 @@ fn validate_agent_run_result_payload(payload: &AgentRunResultPayload) -> Result<
                     "agent-run submission names an invalid filename".into(),
                 ));
             }
+            // One pill per file: a repeated name would present the same output
+            // twice and say nothing extra.
+            let distinct = outputs
+                .iter()
+                .map(|output| output.filename.as_str())
+                .collect::<std::collections::HashSet<_>>();
+            if distinct.len() != outputs.len() {
+                return Err(AgentError::Store(
+                    "agent-run submission repeats a filename".into(),
+                ));
+            }
             Ok(())
         }
         AgentRunResultPayload::FolderAccessProposal { request } if request.is_well_formed() => {

--- a/crates/openwave-core/src/db/tests/output.rs
+++ b/crates/openwave-core/src/db/tests/output.rs
@@ -556,6 +556,7 @@ mod output_scan {
         sync_output_directory(
             store,
             scratch,
+            scratch,
             chat_id,
             call_id,
             RevisionProducer::Turn(TurnId::new()),
@@ -808,6 +809,43 @@ mod output_scan {
         assert!(scan.notes[0].contains("not a private workspace directory"));
         assert!(store.list_outputs(chat.id, 10).await.unwrap().is_empty());
     }
+
+    /// A background run writes in its own workspace but publishes into its
+    /// parent conversation. The bytes have to land under the conversation's
+    /// scratch regardless, because that is the only place a reader looks for a
+    /// revision — publishing them beside the file that produced them would
+    /// leave the catalog listing an output nothing can open.
+    #[tokio::test]
+    async fn publishing_from_another_workspace_writes_bytes_under_the_conversation() {
+        let (_dir, store, chat) = store_with_chat().await;
+        let workspace = tempfile::tempdir().unwrap();
+        let conversation = tempfile::tempdir().unwrap();
+        write_output_file(workspace.path(), "report.md", b"# Report");
+
+        let scan = sync_output_directory(
+            &store,
+            &open_scratch(workspace.path()),
+            &open_scratch(conversation.path()),
+            chat.id,
+            CallId::new(),
+            RevisionProducer::Run(crate::AgentRunId::new()),
+            at(0),
+        )
+        .await
+        .unwrap();
+
+        let output = store
+            .get_output(scan.entries[0].output_id)
+            .await
+            .unwrap()
+            .unwrap();
+        let relative = output_revision_relative_path(output.id, output.current_revision);
+        assert_eq!(
+            std::fs::read(conversation.path().join(&relative)).unwrap(),
+            b"# Report"
+        );
+        assert!(!workspace.path().join(&relative).exists());
+    }
 }
 
 #[cfg(feature = "tools")]
@@ -832,6 +870,7 @@ mod restore {
             std::fs::write(directory.join("report.md"), content).unwrap();
             sync_output_directory(
                 store,
+                &dir,
                 &dir,
                 chat_id,
                 CallId::new(),

--- a/crates/openwave-core/src/output_scan.rs
+++ b/crates/openwave-core/src/output_scan.rs
@@ -79,15 +79,19 @@ struct ScanCandidate {
     content: Vec<u8>,
 }
 
-/// Scan `output/` under one conversation's private scratch and publish its
-/// files as durable outputs.
+/// Scan `output/` under a workspace and publish its files as durable outputs.
 ///
-/// `scratch` is the exact owning conversation's private scratch directory.
-/// Identities derive from the (call, filename) pair, so an exact retry of the
-/// same call republishes idempotently instead of forking records.
+/// `workspace` is the private scratch the files were written into, and
+/// `publication` is the owning conversation's own private scratch, where
+/// revision bytes live because that is the only place a reader looks for them.
+/// For a foreground turn the two are the same directory; a background run
+/// writes in its own per-run workspace and publishes into its parent
+/// conversation. Identities derive from the (call, filename) pair, so an exact
+/// retry of the same call republishes idempotently instead of forking records.
 pub async fn sync_output_directory(
     store: &dyn Store,
-    scratch: &Dir,
+    workspace: &Dir,
+    publication: &Dir,
     chat_id: ChatId,
     call_id: CallId,
     producer: RevisionProducer,
@@ -96,7 +100,7 @@ pub async fn sync_output_directory(
     let mut sync = OutputDirectorySync::default();
 
     // Reading is blocking capability I/O; keep it off the async runtime.
-    let read_scratch = scratch
+    let read_scratch = workspace
         .try_clone()
         .map_err(|error| AgentError::Store(format!("could not open private scratch: {error}")))?;
     let (candidates, mut read_notes) =
@@ -115,7 +119,14 @@ pub async fn sync_output_directory(
 
     for candidate in candidates {
         match record_candidate(
-            store, scratch, chat_id, call_id, producer, now, &existing, &candidate,
+            store,
+            publication,
+            chat_id,
+            call_id,
+            producer,
+            now,
+            &existing,
+            &candidate,
         )
         .await
         {
@@ -133,7 +144,7 @@ pub async fn sync_output_directory(
 #[allow(clippy::too_many_arguments)]
 async fn record_candidate(
     store: &dyn Store,
-    scratch: &Dir,
+    publication: &Dir,
     chat_id: ChatId,
     call_id: CallId,
     producer: RevisionProducer,
@@ -164,7 +175,7 @@ async fn record_candidate(
             });
         }
         let revision_id = OutputRevisionId::for_call_artifact(call_id, &candidate.filename);
-        publish_revision_bytes(scratch, output.id, revision_id, &candidate.content).await?;
+        publish_revision_bytes(publication, output.id, revision_id, &candidate.content).await?;
         let updated = store
             .append_output_revision(
                 output.id,
@@ -189,7 +200,7 @@ async fn record_candidate(
 
     let output_id = OutputId::for_call_artifact(call_id, &candidate.filename);
     let revision_id = OutputRevisionId::for_call_artifact(call_id, &candidate.filename);
-    publish_revision_bytes(scratch, output_id, revision_id, &candidate.content).await?;
+    publish_revision_bytes(publication, output_id, revision_id, &candidate.content).await?;
     let created = store
         .create_output(&CreateOutput {
             id: output_id,

--- a/crates/openwave-server/src/code_execution.rs
+++ b/crates/openwave-server/src/code_execution.rs
@@ -1958,7 +1958,30 @@ impl ConfiguredCodeExecutionProvider {
             .await
     }
 
+    /// Open one private scratch directory under the scratch root, creating it
+    /// if a conversation has not needed one yet — a background run can publish
+    /// into a conversation that has never executed anything itself.
+    async fn open_scratch_directory(
+        &self,
+        name: &str,
+    ) -> std::result::Result<cap_std::fs::Dir, CodeExecutionError> {
+        let path = self.scratch_root.join(name);
+        tokio::task::spawn_blocking(move || {
+            std::fs::create_dir_all(&path)?;
+            cap_std::fs::Dir::open_ambient_dir(&path, cap_std::ambient_authority())
+        })
+        .await
+        .map_err(|_| CodeExecutionError::Sandbox("output scan task failed".into()))?
+        .map_err(|_| CodeExecutionError::Sandbox("the private workspace is unavailable".into()))
+    }
+
     /// Scan one workspace's `output/` and record what changed as revisions.
+    ///
+    /// Files are read out of the workspace the command ran in and their bytes
+    /// are published into the owning conversation's own scratch, which is where
+    /// every reader resolves a revision. For a foreground turn those are the
+    /// same directory; a background run's workspace is its own, so the two
+    /// differ and only the publication side follows the conversation.
     async fn publish_output_directory(
         &self,
         workspace: &ExecutionWorkspaceId,
@@ -1966,17 +1989,19 @@ impl ConfiguredCodeExecutionProvider {
         call_id: CallId,
         producer: RevisionProducer,
     ) -> std::result::Result<OutputArtifactScan, CodeExecutionError> {
-        let scratch_path = self.scratch_root.join(workspace.as_str());
-        let scratch = tokio::task::spawn_blocking(move || {
-            cap_std::fs::Dir::open_ambient_dir(&scratch_path, cap_std::ambient_authority())
-        })
-        .await
-        .map_err(|_| CodeExecutionError::Sandbox("output scan task failed".into()))?
-        .map_err(|_| CodeExecutionError::Sandbox("the private workspace is unavailable".into()))?;
+        let workspace_dir = self.open_scratch_directory(workspace.as_str()).await?;
+        let publication_dir = if workspace.as_str() == chat_id.to_string() {
+            workspace_dir.try_clone().map_err(|_| {
+                CodeExecutionError::Sandbox("the private workspace is unavailable".into())
+            })?
+        } else {
+            self.open_scratch_directory(&chat_id.to_string()).await?
+        };
 
         let sync = openwave_core::sync_output_directory(
             &*self.store,
-            &scratch,
+            &workspace_dir,
+            &publication_dir,
             chat_id,
             call_id,
             producer,

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -708,11 +708,14 @@ impl SandboxAgentRunWorker {
         }
     }
 
-    /// Resolve submitted filenames against the conversation's live outputs.
+    /// Resolve submitted filenames against the outputs this run itself wrote.
     ///
     /// Matching is by filename because that is the identity the run worked with
-    /// and the only one it ever sees. The newest live output wins, which is the
-    /// same rule the output scan applies when it republishes a filename.
+    /// and the only one it ever sees, but a name only resolves when some
+    /// revision of the output it lands on was produced by this run. Without
+    /// that scope a run could hand over any file already in the conversation —
+    /// including one the user's own turn produced — and have it presented as
+    /// its work.
     async fn resolve_submitted_outputs(
         &self,
         run: &AgentRun,
@@ -725,23 +728,45 @@ impl SandboxAgentRunWorker {
             .store
             .list_outputs(run.chat_id, OUTPUT_LOOKUP_LIMIT)
             .await?;
-        filenames
+        let mut resolved = Vec::with_capacity(filenames.len());
+        for filename in filenames {
+            // `list_outputs` orders newest-updated first, so the first match
+            // this run wrote is the record its file landed on.
+            let mut output_id = None;
+            for output in existing
+                .iter()
+                .filter(|output| &output.filename == filename)
+            {
+                if self.run_produced_output(run.id, output.id).await? {
+                    output_id = Some(output.id);
+                    break;
+                }
+            }
+            let Some(output_id) = output_id else {
+                return Err(AgentError::msg(format!(
+                    "sandbox agent submitted {filename}, which it never wrote under output/"
+                )));
+            };
+            resolved.push(AgentRunSubmittedOutput {
+                output_id,
+                filename: filename.clone(),
+            });
+        }
+        Ok(resolved)
+    }
+
+    /// Whether any revision of one output was published for this run.
+    async fn run_produced_output(
+        &self,
+        run_id: openwave_core::AgentRunId,
+        output_id: openwave_core::OutputId,
+    ) -> Result<bool> {
+        Ok(self
+            .store
+            .list_output_revisions(output_id)
+            .await?
             .iter()
-            .map(|filename| {
-                existing
-                    .iter()
-                    .find(|output| &output.filename == filename)
-                    .map(|output| AgentRunSubmittedOutput {
-                        output_id: output.id,
-                        filename: filename.clone(),
-                    })
-                    .ok_or_else(|| {
-                        AgentError::msg(format!(
-                            "sandbox agent submitted {filename}, which it never wrote under output/"
-                        ))
-                    })
-            })
-            .collect()
+            .any(|revision| revision.producing_run_id == Some(run_id)))
     }
 
     async fn submit_folder_access_proposal(
@@ -2221,9 +2246,10 @@ mod tests {
 
     /// A run's deliverables are the files it wrote, so submission has exactly two
     /// jobs: carry the names the model chose through to the parent, and refuse a
-    /// name that never became an output rather than inventing one.
+    /// name the run did not produce — whether nothing in the conversation carries
+    /// it, or something does but another writer put it there.
     #[tokio::test]
-    async fn submitting_files_carries_their_names_and_refuses_a_name_that_was_never_published() {
+    async fn submitting_files_carries_their_names_and_refuses_a_name_this_run_did_not_write() {
         let dir = tempfile::tempdir().unwrap();
         let store: Arc<dyn Store> = Arc::new(
             DbStore::connect(&format!(
@@ -2235,24 +2261,31 @@ mod tests {
         );
         let chat = sandbox_chat();
         store.create_chat(&chat).await.unwrap();
+        let call = CallId::new();
+        let id = openwave_core::AgentRunId::sandbox_for_spawn_call(call);
         let published = openwave_core::OutputId::new();
-        store
-            .create_output(&openwave_core::CreateOutput {
-                id: published,
+        let seed = |output_id, filename: &str, run: Option<openwave_core::AgentRunId>| {
+            let request = openwave_core::CreateOutput {
+                id: output_id,
                 chat_id: chat.id,
-                filename: "Q3 revenue.md".into(),
+                filename: filename.to_owned(),
                 kind: openwave_core::DeliverableKind::Text,
                 revision: openwave_core::NewOutputRevision {
                     id: openwave_core::OutputRevisionId::new(),
                     byte_len: 4,
                     sha256: [0; 32],
                     turn_id: None,
-                    producing_run_id: None,
+                    producing_run_id: run,
                     created_at: chrono::Utc::now(),
                 },
-            })
-            .await
-            .unwrap();
+            };
+            let store = store.clone();
+            async move { store.create_output(&request).await.unwrap() }
+        };
+        // What this run wrote, and what somebody else's writer left in the same
+        // conversation under a name the run might reach for.
+        seed(published, "Q3 revenue.md", Some(id)).await;
+        seed(openwave_core::OutputId::new(), "Q4 revenue.md", None).await;
 
         let done = |filename: &str| {
             Arc::new(EventProvider(vec![
@@ -2290,8 +2323,6 @@ mod tests {
             )
         };
 
-        let call = CallId::new();
-        let id = openwave_core::AgentRunId::sandbox_for_spawn_call(call);
         admit_sandbox(&store, chat.id, call, "Summarize Q3 revenue.").await;
         assert_eq!(
             worker(done("Q3 revenue.md")).run_once().await.unwrap(),

--- a/crates/openwave-server/src/sandbox_exec_worker.rs
+++ b/crates/openwave-server/src/sandbox_exec_worker.rs
@@ -103,11 +103,20 @@ impl SandboxExecRunner for HostSandboxExec {
         {
             Ok(outputs) => outputs,
             // The command ran; a scan that could not record its files says so
-            // in the receipt rather than losing the command's result.
-            Err(error) => OutputArtifactScan {
-                entries: Vec::new(),
-                notes: vec![format!("outputs unavailable: {error}")],
-            },
+            // in the receipt rather than losing the command's result. The host's
+            // own diagnosis stays here — the model gets the coarse fact, which
+            // is all it can act on.
+            Err(error) => {
+                tracing::warn!(%error, "agent-run output scan failed");
+                OutputArtifactScan {
+                    entries: Vec::new(),
+                    notes: vec![
+                        "outputs could not be recorded for this command; files under output/ \
+                         are not published yet"
+                            .to_owned(),
+                    ],
+                }
+            }
         };
         Ok((response, outputs))
     }
@@ -519,9 +528,21 @@ fn exec_resolution(
     ToolCallResolution::Completed { result }
 }
 
-/// Keep the tail of a captured stream: a failing command's diagnosis is
-/// usually at the end, not the beginning.
+/// Keep the tail of a captured stream — a failing command's diagnosis is
+/// usually at the end, not the beginning — within the receipt's budget, and
+/// strip interior NUL bytes.
+///
+/// A receipt carrying a NUL is refused when it is resolved, which would leave
+/// the call parked and re-executed every lease period rather than failing. A
+/// command that prints one (reading a binary it just wrote, say) is ordinary,
+/// so the byte comes out here.
 fn clamp(stream: &str) -> String {
+    let stream = if stream.contains('\0') {
+        std::borrow::Cow::Owned(stream.replace('\0', ""))
+    } else {
+        std::borrow::Cow::Borrowed(stream)
+    };
+    let stream = stream.as_ref();
     if stream.len() <= MAX_RECEIPT_STREAM_BYTES {
         return stream.to_owned();
     }


### PR DESCRIPTION
A review of #1553 after it merged turned up four defects in the path it added. All four are fixed here.

**A submitted output could not be opened.** `sync_output_directory` wrote revision bytes relative to the directory it scanned. For a foreground turn that directory is the conversation's own scratch, so the write path and the read path agreed by coincidence. A background run's workspace is keyed by the run, so its bytes landed at `scratch_root/agent-run-<id>/outputs/…` while every reader resolves `scratch_root/<chat_id>/outputs/…`. The catalog gained a row, the pill rendered, and opening, previewing, downloading, or restoring it failed. The scan now takes the workspace it reads from and the conversation scratch it publishes into as separate arguments; the foreground caller passes one directory for both.

**A run could submit a file it never wrote.** Resolution matched a filename against every live output in the conversation. An agent that produced nothing could call `done(["Q3 revenue.xlsx"], "here's the analysis")`, name a document the user's own turn produced, and have it presented as the agent's deliverable — and the same lookup was a name-existence oracle over the catalog. A name now only resolves to an output some revision of which this run published.

**A NUL byte in command output wedged the run.** The resolver refuses any receipt containing a NUL, so a command that printed one (reading a binary it had just written, say) never got a receipt at all. The call stayed `Claimed`, its executor lease expired, and the same command was re-executed every lease period until the run's deadline. The byte is stripped where the streams are clamped.

**Host error strings reached model context.** A failed output scan put the raw `CodeExecutionError` — built from a store or filesystem error — into the receipt, bypassing the coarse classification every other executor failure goes through. The model now gets the fact that outputs were not recorded; the detail is logged.

Also rejects a submission that repeats a filename at the storage boundary, which the tool boundary already refused.

## Tests

One added: publishing from a workspace that is not the conversation's scratch writes bytes where the reader looks and not beside the file that produced them. That is the defect above, and nothing else in the suite reads back what the scan writes.

The submission test now seeds two outputs — one this run published, one it did not — so the negative case covers the rule that actually matters. It previously asserted the old, wrong behavior: it seeded an output with no producing run and expected `done` to resolve it.

## Verification

`cargo test -p openwave-core -p openwave-server --locked` (1,156 tests), clippy `--all-targets` clean, `cargo fmt`. Nothing UI-facing changed. I did not drive the app; the check worth running is the one #1553 named — delegate a task requiring a document, then open the resulting row in Outputs, which is what was broken.

## Left for follow-ups

- A `done` naming an unresolvable file fails the run, and because `done` is not a checkpoint the retry replays byte-identical context and re-emits the identical call until the attempt budget is gone. A resolution failure should reach the model as something it can correct.
- Each background run creates a scratch tree that is never destroyed, so host scratch now grows with delegation volume rather than with the number of conversations.