### PR TITLE
fix(server): resolve submitted outputs by indexed filename lookup

### DIFF
--- a/crates/openwave-core/src/db/mod.rs
+++ b/crates/openwave-core/src/db/mod.rs
@@ -746,6 +746,14 @@ impl Store for DbStore {
         ops::output::list_outputs(self, chat_id, limit).await
     }
 
+    async fn find_outputs_by_filename(
+        &self,
+        chat_id: ChatId,
+        filename: &str,
+    ) -> Result<Vec<OutputRecord>> {
+        ops::output::find_outputs_by_filename(self, chat_id, filename).await
+    }
+
     async fn list_output_revisions(&self, output_id: OutputId) -> Result<Vec<OutputRevision>> {
         ops::output::list_output_revisions(self, output_id).await
     }

--- a/crates/openwave-core/src/db/ops/output.rs
+++ b/crates/openwave-core/src/db/ops/output.rs
@@ -166,6 +166,25 @@ pub(in crate::db) async fn list_outputs(
         .collect()
 }
 
+pub(in crate::db) async fn find_outputs_by_filename(
+    store: &DbStore,
+    chat_id: ChatId,
+    filename: &str,
+) -> Result<Vec<OutputRecord>> {
+    entities::output::Entity::find()
+        .filter(entities::output::Column::ChatId.eq(chat_id.0))
+        .filter(entities::output::Column::Filename.eq(filename))
+        .filter(entities::output::Column::DeletedAt.is_null())
+        .order_by_desc(entities::output::Column::UpdatedAt)
+        .order_by_desc(entities::output::Column::Id)
+        .all(&store.conn)
+        .await
+        .map_err(store_err)?
+        .into_iter()
+        .map(output_from_model)
+        .collect()
+}
+
 pub(in crate::db) async fn list_output_revisions(
     store: &DbStore,
     output_id: OutputId,

--- a/crates/openwave-core/src/storage.rs
+++ b/crates/openwave-core/src/storage.rs
@@ -1694,6 +1694,21 @@ pub trait Store: Send + Sync {
         output_storage_unavailable()
     }
 
+    /// List a conversation's live outputs carrying one exact filename, most
+    /// recently updated first.
+    ///
+    /// Filename is the identity everything outside the store works with, and a
+    /// conversation can hold more outputs than any bounded listing returns, so
+    /// resolving a name asks for the name rather than paging the catalog and
+    /// hoping it is on the page.
+    async fn find_outputs_by_filename(
+        &self,
+        _chat_id: ChatId,
+        _filename: &str,
+    ) -> Result<Vec<OutputRecord>> {
+        output_storage_unavailable()
+    }
+
     /// List one output's revisions, newest first.
     async fn list_output_revisions(&self, _output_id: OutputId) -> Result<Vec<OutputRevision>> {
         output_storage_unavailable()

--- a/crates/openwave-desktop/src/deliverables.rs
+++ b/crates/openwave-desktop/src/deliverables.rs
@@ -1122,6 +1122,97 @@ mod tests {
         );
     }
 
+    /// A background run executes in its own `agent-run-{id}` workspace, not in
+    /// the conversation's scratch directory. Its published revisions must still
+    /// land where the catalog reader looks, or every file a background run
+    /// produces renders as unavailable. Publisher and reader are driven against
+    /// each other here because that gap is invisible to either alone.
+    #[tokio::test]
+    async fn a_background_runs_published_output_is_readable_from_the_chats_scratch() {
+        use openwave_code_execution::ExecutionWorkspaceId;
+        use openwave_core::{AgentRunId, CallId, Chat, DbStore, SecretProvider, Store};
+        use std::sync::Arc;
+
+        struct NoSecrets;
+
+        #[async_trait::async_trait]
+        impl SecretProvider for NoSecrets {
+            async fn get_secret(&self, _key: &str) -> openwave_core::Result<Option<String>> {
+                Ok(None)
+            }
+            async fn set_secret(&self, _key: &str, _value: &str) -> openwave_core::Result<()> {
+                Ok(())
+            }
+            async fn delete_secret(&self, _key: &str) -> openwave_core::Result<()> {
+                Ok(())
+            }
+        }
+
+        let database = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                database.path().join("t.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            reasoning_effort: None,
+            permission_mode: None,
+            network_policy: Default::default(),
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+
+        // The run wrote a file under `output/` in its own workspace, and the
+        // conversation's scratch does not exist yet.
+        let scratch_root = tempfile::tempdir().unwrap();
+        let run_id = AgentRunId::sandbox_for_spawn_call(CallId::new());
+        let workspace = ExecutionWorkspaceId::parse(format!("agent-run-{run_id}")).unwrap();
+        let output_dir = scratch_root
+            .path()
+            .join(workspace.as_str())
+            .join(openwave_core::EXEC_OUTPUT_DIRECTORY);
+        std::fs::create_dir_all(&output_dir).unwrap();
+        let content = b"# Q3 revenue\n\nUp.";
+        std::fs::write(output_dir.join("summary.md"), content).unwrap();
+
+        let provider = openwave_server::code_execution::ConfiguredCodeExecutionProvider::new(
+            store.clone(),
+            Arc::new(NoSecrets),
+            scratch_root.path(),
+        );
+        let scan = provider
+            .collect_agent_run_outputs(&workspace, chat.id, CallId::new(), run_id)
+            .await
+            .unwrap();
+        assert_eq!(scan.entries.len(), 1, "{:?}", scan.notes);
+
+        let output = store
+            .list_outputs(chat.id, 10)
+            .await
+            .unwrap()
+            .pop()
+            .expect("the run's file should be a conversation output");
+        let revision = store
+            .get_output_revision(output.current_revision)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(revision.producing_run_id, Some(run_id));
+        assert_eq!(
+            read_output_revision_bytes(scratch_root.path(), chat.id, &output, &revision).unwrap(),
+            content
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn private_revision_and_export_destinations_reject_symlinks() {

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -27,8 +27,7 @@ use openwave_core::{
     ChatRequest, ContentBlock, FailAgentRunOutcome, ModelProvider, ParkSandboxToolCallOutcome,
     ProviderEvent, RequestFolderAccessArgs, Result, ResumeTurnForAgentRunWaitSetOutcome, Role,
     SandboxToolCall, SandboxToolCallRequest, SandboxToolCallStatus, StopReason, Store,
-    SubmitAgentRunResultOutcome, ToolCallRecord, MAX_SANDBOX_TOOL_CALLS, OUTPUT_LOOKUP_LIMIT,
-    SANDBOX_EXEC_TOOL,
+    SubmitAgentRunResultOutcome, ToolCallRecord, MAX_SANDBOX_TOOL_CALLS, SANDBOX_EXEC_TOOL,
 };
 use tokio::sync::Notify;
 
@@ -716,26 +715,24 @@ impl SandboxAgentRunWorker {
     /// that scope a run could hand over any file already in the conversation —
     /// including one the user's own turn produced — and have it presented as
     /// its work.
+    ///
+    /// The lookup asks the store for the filename rather than paging the
+    /// catalog, so a conversation holding more outputs than any one page
+    /// returns cannot hide a run's own file from it.
     async fn resolve_submitted_outputs(
         &self,
         run: &AgentRun,
         filenames: &[String],
     ) -> Result<Vec<AgentRunSubmittedOutput>> {
-        if filenames.is_empty() {
-            return Ok(vec![]);
-        }
-        let existing = self
-            .store
-            .list_outputs(run.chat_id, OUTPUT_LOOKUP_LIMIT)
-            .await?;
         let mut resolved = Vec::with_capacity(filenames.len());
         for filename in filenames {
-            // `list_outputs` orders newest-updated first, so the first match
+            // The candidates come back newest-updated first, so the first match
             // this run wrote is the record its file landed on.
             let mut output_id = None;
-            for output in existing
-                .iter()
-                .filter(|output| &output.filename == filename)
+            for output in self
+                .store
+                .find_outputs_by_filename(run.chat_id, filename)
+                .await?
             {
                 if self.run_produced_output(run.id, output.id).await? {
                     output_id = Some(output.id);


### PR DESCRIPTION
Two follow-ups to #1556, which fixed where a background run's output revisions
are published and scoped submission to the run's own work.

Submission resolved a run's filenames against `list_outputs(chat_id,
OUTPUT_LOOKUP_LIMIT)` — the newest 1000 live outputs. The producer check then
filtered that page down to outputs the run itself wrote. In a conversation
holding more than 1000 outputs, a file the run genuinely produced can sit off
the end of the page, and `done` refuses it with "which it never wrote under
output/" — a run that did its work correctly fails, and burns an attempt doing
it. The page was never the right question to ask: submission knows the exact
filename it is resolving, so it now asks the store for that filename directly.
`Store::find_outputs_by_filename` returns the conversation's live outputs
carrying one exact name, newest-updated first, which is the same ordering the
scan applies. The producer check is unchanged; only the candidate set it runs
over stops being capped.

The second change is a test across the publisher/reader boundary that #1556
moved. `a_background_runs_published_output_is_readable_from_the_chats_scratch`
runs the real publication path for an `agent-run-{id}` workspace with a file
actually written under `output/`, then reads the bytes back through
`read_output_revision_bytes` — the same reader the deliverables catalog uses —
and asserts they match. It lives in the desktop crate because that is where the
reader is, and it is the only test that drives both sides against each other:
publisher and reader each look correct in isolation, and the defect lived
exactly in their disagreement about which directory holds the bytes. Reverting
#1556's scan/publication split makes it fail with "Output content is
unavailable", which is the string a user saw on every background-produced file,
so it is guarding the seam it claims to.

No schema change — the new store method is a query over existing columns.
