### PR TITLE
feat(core): persist assistant reasoning and gate replay on the model route

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -50,8 +50,8 @@ use crate::model::{
 };
 use crate::preview::{ToolActionPreview, ToolResultPreview};
 use crate::provider::{
-    ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, RefusalDetails,
-    RefusalOutcome, StopReason, Usage,
+    ChatMessage, ChatRequest, ContentBlock, MessageReasoning, ModelProvider, ProviderEvent,
+    ReasoningOrigin, RefusalDetails, RefusalOutcome, StopReason, Usage,
 };
 use crate::semantic_checkpoint::{
     ContextCheckpoint, ContextCheckpointPayloadV1, SaveContextCheckpointOutcome,
@@ -1079,6 +1079,9 @@ struct AssistantCandidate {
     message_id: MessageId,
     content: String,
     citations: Vec<AssistantCitationInput>,
+    /// The step's reasoning, bound to the route that produced it. Rides the
+    /// durable message so a later turn can replay it to the same model.
+    reasoning: MessageReasoning,
 }
 
 impl AssistantCandidate {
@@ -1091,6 +1094,7 @@ impl AssistantCandidate {
             turn_id,
             role: Role::Assistant,
             content: self.content.clone(),
+            reasoning: self.reasoning.clone(),
             created_at: Utc::now(),
         }
     }
@@ -1595,6 +1599,12 @@ impl Agent {
                             message_id,
                             content: parsed.content,
                             citations: parsed.citations,
+                            // A cancel can cut the stream between reasoning
+                            // blocks, and a provider that validates replay
+                            // checks the prefix against what it generated. A
+                            // partial set is not that, so this message keeps
+                            // none.
+                            reasoning: MessageReasoning::default(),
                         };
                         let message = candidate.message(message_id, chat.id, turn_id);
                         if publish_terminal {
@@ -1666,6 +1676,10 @@ impl Agent {
                 message_id: candidate_message_id,
                 content: parsed.content,
                 citations: parsed.citations,
+                reasoning: MessageReasoning::captured(
+                    self.reasoning_origin(),
+                    std::mem::take(&mut reasoning),
+                ),
             };
             let text = &candidate.content;
             let refusal = refused.then(|| {
@@ -1762,10 +1776,12 @@ impl Agent {
                     role: Role::Assistant,
                     content: blocks,
                     // The step's reasoning rides its assistant message for the
-                    // rest of the turn. A steer, cancel, or broken stream
-                    // discarded `reasoning` along with the step before here,
-                    // so nothing partial ever reaches the transcript.
-                    reasoning: std::mem::take(&mut reasoning),
+                    // rest of the turn, and rides the durable message the
+                    // candidate writes so a later turn can replay it too. A
+                    // steer, cancel, or broken stream discarded `reasoning`
+                    // along with the step before here, so nothing partial ever
+                    // reaches the transcript.
+                    reasoning: candidate.reasoning.clone(),
                 });
             }
 
@@ -2166,7 +2182,7 @@ impl Agent {
             // next step never sees a request it cannot account for.
             transcript.push(ChatMessage {
                 role: Role::User,
-                reasoning: Vec::new(),
+                reasoning: MessageReasoning::default(),
                 content: calls
                     .iter()
                     .zip(outputs)
@@ -2779,7 +2795,7 @@ impl Agent {
                 content: vec![ContentBlock::Text {
                     text: msg.content.clone(),
                 }],
-                reasoning: Vec::new(),
+                reasoning: MessageReasoning::default(),
             });
             events.send(AgentEvent::UserSteered {
                 message_id,
@@ -2822,7 +2838,7 @@ impl Agent {
                 content: vec![ContentBlock::Text {
                     text: steer.content.clone(),
                 }],
-                reasoning: Vec::new(),
+                reasoning: MessageReasoning::default(),
             });
             events.send_committed(event_ordinal, event)?;
         }
@@ -3516,7 +3532,7 @@ impl Agent {
                         content: output.content,
                         is_error: true,
                     }],
-                    reasoning: Vec::new(),
+                    reasoning: MessageReasoning::default(),
                 });
                 continue;
             }
@@ -3589,7 +3605,7 @@ impl Agent {
             });
             transcript.push(ChatMessage {
                 role: Role::User,
-                reasoning: Vec::new(),
+                reasoning: MessageReasoning::default(),
                 content: tool_result_blocks(
                     call.provider_id,
                     self.tool_result_for_model(&output.content, call.call_id),
@@ -3600,6 +3616,17 @@ impl Agent {
             });
         }
         Ok(())
+    }
+
+    /// The route this agent's turns run on, for attributing reasoning blocks.
+    ///
+    /// Both halves matter: a block is minted by one model on one provider and
+    /// is only valid as input back to that pair.
+    fn reasoning_origin(&self) -> ReasoningOrigin {
+        ReasoningOrigin {
+            provider: self.config.provider.clone(),
+            model: self.config.model.clone(),
+        }
     }
 
     async fn persist(
@@ -3617,6 +3644,7 @@ impl Agent {
                 turn_id,
                 role,
                 content: content.to_string(),
+                reasoning: MessageReasoning::default(),
                 created_at: Utc::now(),
             })
             .await?;
@@ -4135,7 +4163,7 @@ fn rebuild_transcript_with_boundary(
                 push_tool_batch(
                     &mut out,
                     &batches[batch_i],
-                    text,
+                    text.is_some().then_some(*message),
                     max_result_bytes,
                     image_input,
                 );
@@ -4152,8 +4180,14 @@ fn rebuild_transcript_with_boundary(
                     );
                     batch_i += 1;
                 }
-            } else if let Some(text) = text {
-                out.push(ChatMessage::text(Role::Assistant, text.to_string()));
+            } else if text.is_some() {
+                out.push(ChatMessage {
+                    role: Role::Assistant,
+                    content: vec![ContentBlock::Text {
+                        text: message.content.clone(),
+                    }],
+                    reasoning: message.reasoning.clone(),
+                });
             }
         } else {
             out.push(user_message_with_attachments(
@@ -4290,7 +4324,7 @@ fn user_message_with_attachments(
     ChatMessage {
         role: message.role,
         content,
-        reasoning: Vec::new(),
+        reasoning: MessageReasoning::default(),
     }
 }
 
@@ -4479,12 +4513,15 @@ fn batch_tool_calls(tool_calls: &[ToolCallRecord]) -> Vec<Vec<&ToolCallRecord>> 
 fn push_tool_batch(
     out: &mut Vec<ChatMessage>,
     batch: &[&ToolCallRecord],
-    assistant_text: Option<&str>,
+    assistant: Option<&Message>,
     max_result_bytes: usize,
     image_input: bool,
 ) {
     let mut blocks: Vec<ContentBlock> = Vec::new();
-    if let Some(text) = assistant_text.filter(|t| !t.is_empty()) {
+    if let Some(text) = assistant
+        .map(|message| message.content.as_str())
+        .filter(|text| !text.is_empty())
+    {
         blocks.push(ContentBlock::Text {
             text: text.to_string(),
         });
@@ -4500,9 +4537,14 @@ fn push_tool_batch(
         out.push(ChatMessage {
             role: Role::Assistant,
             content: blocks,
-            // Rebuilt from the store, which holds no reasoning: replaying
-            // nothing is the valid degradation.
-            reasoning: Vec::new(),
+            // The step's reasoning was persisted with its prose preamble, so
+            // it comes back here. A step that wrote no preamble has no message
+            // row to have carried any, and replaying nothing is the valid
+            // degradation. Whether these blocks actually go on the wire is the
+            // adapter's call: they replay only to the route that minted them.
+            reasoning: assistant
+                .map(|message| message.reasoning.clone())
+                .unwrap_or_default(),
         });
     }
     let results: Vec<ContentBlock> = batch
@@ -4530,7 +4572,7 @@ fn push_tool_batch(
         out.push(ChatMessage {
             role: Role::User,
             content: results,
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         });
     }
 }
@@ -4824,7 +4866,7 @@ mod tests {
             self.seen.lock().unwrap().push(
                 req.messages
                     .iter()
-                    .flat_map(|message| message.reasoning.iter().cloned())
+                    .flat_map(|message| message.reasoning.blocks().to_vec())
                     .collect(),
             );
             let events = if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
@@ -4835,6 +4877,9 @@ mod tests {
                             "thinking": "plan: read the note first",
                             "signature": "sig-1",
                         }),
+                    },
+                    ProviderEvent::TextDelta {
+                        text: "checking the note".into(),
                     },
                     ProviderEvent::ToolCallStarted {
                         index: 0,
@@ -6997,10 +7042,11 @@ mod tests {
 
     /// A reasoning block streamed on one step must ride the step's assistant
     /// message — verbatim and whole — into the next step's request, and must
-    /// stay in-memory: nothing about it reaches the durable record, so a turn
-    /// rebuilt from the store degrades to sending no reasoning.
+    /// survive the turn: it is persisted with that message, so a later turn
+    /// rebuilt from the store still carries it. Whether it goes on the wire is
+    /// then the adapter's call — see the router's replay gate.
     #[tokio::test]
-    async fn reasoning_blocks_ride_later_steps_of_the_same_turn() {
+    async fn reasoning_blocks_survive_the_turn_that_produced_them() {
         let workspace = tempfile::tempdir().unwrap();
         std::fs::write(workspace.path().join("note.txt"), "secret").unwrap();
         let db = tempfile::tempdir().unwrap();
@@ -7055,13 +7101,40 @@ mod tests {
             "thinking": "plan: read the note first",
             "signature": "sig-1",
         });
-        let seen = seen.lock().unwrap().clone();
-        assert_eq!(seen.len(), 2, "one tool step, then the answer step");
-        assert!(seen[0].is_empty(), "nothing to replay on the first call");
+        {
+            let seen = seen.lock().unwrap();
+            assert_eq!(seen.len(), 2, "one tool step, then the answer step");
+            assert!(seen[0].is_empty(), "nothing to replay on the first call");
+            assert_eq!(
+                seen[1],
+                vec![block.clone()],
+                "the block reaches the next step exactly as streamed"
+            );
+        }
+
+        // A second turn on a fresh agent over the same store is the reload:
+        // every message comes back off disk.
+        let reloaded = Agent::new(
+            Arc::new(ReasoningRecordingProvider {
+                calls: AtomicUsize::new(1),
+                seen: seen.clone(),
+            }),
+            Arc::new(ToolRegistry::new().with(Box::new(ReadFile))),
+            store.clone(),
+            AgentConfig {
+                model: "fake".into(),
+                tool_scratch: Some(tool_scratch(workspace.path())),
+                ..Default::default()
+            },
+        );
+        let (tx, rx) = unbounded();
+        reloaded.run_turn(&chat, "and again", &tx).await.unwrap();
+        drop(tx);
+        let _: Vec<AgentEvent> = rx.collect().await;
         assert_eq!(
-            seen[1],
+            seen.lock().unwrap()[2],
             vec![block],
-            "the block reaches the next step exactly as streamed"
+            "the persisted block comes back on the rebuilt transcript"
         );
     }
 
@@ -10036,6 +10109,7 @@ mod tests {
                 chat_id,
                 turn_id: TurnId::new(),
                 role: Role::User,
+                reasoning: Default::default(),
                 content: format!(
                     "OLD PREFIX: choose the durable SQLite path. {}",
                     "historical detail ".repeat(1_200)
@@ -10047,6 +10121,7 @@ mod tests {
                 chat_id,
                 turn_id: TurnId::new(),
                 role: Role::Assistant,
+                reasoning: Default::default(),
                 content: "OLD ASSISTANT: SQLite is confirmed; source:decision-doc.".into(),
                 created_at: Utc::now(),
             },
@@ -10055,6 +10130,7 @@ mod tests {
                 chat_id,
                 turn_id: TurnId::new(),
                 role: Role::User,
+                reasoning: Default::default(),
                 content: "RECENT USER: keep this exchange raw.".into(),
                 created_at: Utc::now(),
             },
@@ -10063,6 +10139,7 @@ mod tests {
                 chat_id,
                 turn_id: TurnId::new(),
                 role: Role::Assistant,
+                reasoning: Default::default(),
                 content: "RECENT ASSISTANT: this is the newest completed exchange.".into(),
                 created_at: Utc::now(),
             },
@@ -10424,6 +10501,7 @@ mod tests {
             chat_id: chat.id,
             turn_id: TurnId::new(),
             role: Role::User,
+            reasoning: Default::default(),
             content: "old decision ".repeat(1_000),
             created_at: Utc::now(),
         };
@@ -10548,7 +10626,7 @@ mod tests {
                     name: "read_file".into(),
                     input: serde_json::json!({"path": "decision.md"}),
                 }],
-                reasoning: Vec::new(),
+                reasoning: MessageReasoning::default(),
             },
             ChatMessage {
                 role: Role::User,
@@ -10557,7 +10635,7 @@ mod tests {
                     content: "the durable decision".into(),
                     is_error: false,
                 }],
-                reasoning: Vec::new(),
+                reasoning: MessageReasoning::default(),
             },
             ChatMessage::text(Role::User, "Continue from the decision."),
         ];
@@ -11859,6 +11937,7 @@ mod tests {
                 chat_id: chat,
                 turn_id: turn,
                 role: Role::User,
+                reasoning: Default::default(),
                 content: "compare these".into(),
                 created_at: t0,
             },
@@ -11867,6 +11946,7 @@ mod tests {
                 chat_id: chat,
                 turn_id: turn,
                 role: Role::User,
+                reasoning: Default::default(),
                 content: "and this one?".into(),
                 created_at: t1,
             },
@@ -11943,6 +12023,7 @@ mod tests {
             chat_id: chat,
             turn_id: turn,
             role: Role::User,
+            reasoning: Default::default(),
             content: "summarize this file".into(),
             created_at,
         };
@@ -12056,6 +12137,7 @@ mod tests {
                 chat_id: chat,
                 turn_id: turn,
                 role: Role::User,
+                reasoning: Default::default(),
                 content: "read it".into(),
                 created_at: t0,
             },
@@ -12064,6 +12146,7 @@ mod tests {
                 chat_id: chat,
                 turn_id: turn,
                 role: Role::Assistant,
+                reasoning: Default::default(),
                 content: "looking…".into(),
                 created_at: t1,
             },
@@ -12251,6 +12334,7 @@ mod tests {
                 chat_id: chat,
                 turn_id: turn,
                 role: Role::User,
+                reasoning: Default::default(),
                 content: "go".into(),
                 created_at: t0,
             },
@@ -12259,6 +12343,7 @@ mod tests {
                 chat_id: chat,
                 turn_id: turn,
                 role: Role::Assistant,
+                reasoning: Default::default(),
                 content: "done".into(),
                 created_at: t2,
             },
@@ -12306,6 +12391,7 @@ mod tests {
                 chat_id: chat,
                 turn_id: turn,
                 role: Role::User,
+                reasoning: Default::default(),
                 content: "hi".into(),
                 created_at: DateTime::<Utc>::from_timestamp(1, 0).unwrap(),
             },
@@ -12314,6 +12400,7 @@ mod tests {
                 chat_id: chat,
                 turn_id: turn,
                 role: Role::Tool,
+                reasoning: Default::default(),
                 content: "legacy".into(),
                 created_at: DateTime::<Utc>::from_timestamp(2, 0).unwrap(),
             },
@@ -12322,6 +12409,7 @@ mod tests {
                 chat_id: chat,
                 turn_id: turn,
                 role: Role::Assistant,
+                reasoning: Default::default(),
                 content: "bye".into(),
                 created_at: DateTime::<Utc>::from_timestamp(3, 0).unwrap(),
             },

--- a/crates/openwave-core/src/context.rs
+++ b/crates/openwave-core/src/context.rs
@@ -187,6 +187,7 @@ const fn is_compressible(block: &ContentBlock) -> bool {
 /// estimate runs over their serialized form.
 fn estimate_reasoning_tokens(msg: &ChatMessage) -> usize {
     msg.reasoning
+        .blocks()
         .iter()
         .map(|block| estimate_tokens(&block.to_string()))
         .sum()
@@ -705,6 +706,7 @@ pub fn content_floor_for_level(level: u32) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provider::{MessageReasoning, ReasoningOrigin};
     use serde_json::json;
 
     fn user_msg(text: &str) -> ChatMessage {
@@ -723,7 +725,7 @@ mod tests {
                 name: name.into(),
                 input: json!({ "arg": args }),
             }],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         }
     }
 
@@ -735,7 +737,7 @@ mod tests {
                 content: content.into(),
                 is_error: false,
             }],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         }
     }
 
@@ -760,11 +762,15 @@ mod tests {
             json!({"type": "thinking", "thinking": "p".repeat(300), "signature": "sig"}),
             json!({"type": "redacted_thinking", "data": "blob"}),
         ];
+        let origin = ReasoningOrigin {
+            provider: None,
+            model: "m".into(),
+        };
         let mut thinking_step = assistant_msg(&"calling a tool ".repeat(50));
-        thinking_step.reasoning = reasoning.clone();
+        thinking_step.reasoning = MessageReasoning::captured(origin, reasoning.clone());
 
         let mut silent_step = thinking_step.clone();
-        silent_step.reasoning = Vec::new();
+        silent_step.reasoning = MessageReasoning::default();
         assert!(
             estimate_message_tokens(&thinking_step) > estimate_message_tokens(&silent_step),
             "reasoning tokens must be counted"
@@ -783,7 +789,8 @@ mod tests {
             .find(|message| message.role == Role::Assistant)
             .expect("the step fits under this budget");
         assert_eq!(
-            fitted_step.reasoning, reasoning,
+            fitted_step.reasoning.blocks(),
+            reasoning,
             "truncation never touches the blocks"
         );
         assert!(
@@ -835,7 +842,7 @@ mod tests {
         let msg = ChatMessage {
             role: Role::User,
             content: blocks,
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         };
         // Callers never allocate below the message's irreducible overhead floor
         // (role + each block's fixed envelope); test at and above it.
@@ -863,7 +870,7 @@ mod tests {
                     text: format!("chunk {i} ").repeat(30),
                 })
                 .collect(),
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         };
         let msgs = vec![
             user_msg("kick off the conversation here"),
@@ -1071,7 +1078,7 @@ mod tests {
         ChatMessage {
             role: Role::User,
             content: vec![image_block(width, height)],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         }
     }
 
@@ -1173,7 +1180,7 @@ mod tests {
                 },
                 image_block(400, 300),
             ],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         }];
         messages.extend((0..10).map(|index| assistant_msg(&format!("message {index}"))));
         messages.push(ChatMessage {
@@ -1186,7 +1193,7 @@ mod tests {
                 },
                 image_block(800, 600),
             ],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         });
 
         evict_old_tool_result_images(&mut messages, TOOL_RESULT_IMAGE_MESSAGE_WINDOW);

--- a/crates/openwave-core/src/db/entities.rs
+++ b/crates/openwave-core/src/db/entities.rs
@@ -261,6 +261,7 @@ pub mod message {
         pub seq: i64,
         pub role: String,
         pub content: String,
+        pub reasoning: Option<Json>,
         pub turn_lease_token: Option<Uuid>,
         pub created_at: DateTimeUtc,
     }

--- a/crates/openwave-core/src/db/migration/baseline/chat.rs
+++ b/crates/openwave-core/src/db/migration/baseline/chat.rs
@@ -495,6 +495,7 @@ pub(super) fn message_table() -> TableCreateStatement {
         .col(ColumnDef::new(Message::Seq).big_integer().not_null())
         .col(ColumnDef::new(Message::Role).text().not_null())
         .col(ColumnDef::new(Message::Content).text().not_null())
+        .col(ColumnDef::new(Message::Reasoning).json_binary())
         .col(
             ColumnDef::new(Message::CreatedAt)
                 .timestamp_with_time_zone()

--- a/crates/openwave-core/src/db/migration/idens.rs
+++ b/crates/openwave-core/src/db/migration/idens.rs
@@ -437,6 +437,7 @@ pub(crate) enum Message {
     Seq,
     Role,
     Content,
+    Reasoning,
     TurnLeaseToken,
     CreatedAt,
 }

--- a/crates/openwave-core/src/db/ops/citation.rs
+++ b/crates/openwave-core/src/db/ops/citation.rs
@@ -14,7 +14,8 @@ use crate::storage::{AppendClaimedMessageOutcome, ChatCitationSnapshot, TurnLeas
 
 use super::super::{entities, store_err, DbStore};
 use super::conversation::{
-    next_message_seq_on, reserve_message_identity_on, MESSAGE_IDENTITY_OWNER_MESSAGE,
+    next_message_seq_on, reasoning_to_db, reserve_message_identity_on,
+    MESSAGE_IDENTITY_OWNER_MESSAGE,
 };
 use super::{acquire_chat_write_lock, acquire_turn_write_lock};
 
@@ -58,6 +59,7 @@ pub(in crate::db) async fn append_assistant_message(
         seq: Set(next_message_seq_on(&transaction, message.chat_id).await?),
         role: Set("assistant".into()),
         content: Set(message.content.clone()),
+        reasoning: Set(reasoning_to_db(&message.reasoning)),
         turn_lease_token: Set(None),
         created_at: Set(created_at),
     }
@@ -136,6 +138,7 @@ pub(in crate::db) async fn append_claimed_assistant_message(
         seq: Set(next_message_seq_on(&transaction, message.chat_id).await?),
         role: Set("assistant".into()),
         content: Set(message.content.clone()),
+        reasoning: Set(reasoning_to_db(&message.reasoning)),
         turn_lease_token: Set(Some(lease_token)),
         created_at: Set(created_at),
     }
@@ -177,6 +180,7 @@ where
         || stored.turn_id != message.turn_id.0
         || stored.role != "assistant"
         || stored.content != message.content
+        || stored.reasoning != reasoning_to_db(&message.reasoning)
         || stored.turn_lease_token != turn_lease_token
         || stored.created_at != created_at
     {

--- a/crates/openwave-core/src/db/ops/conversation.rs
+++ b/crates/openwave-core/src/db/ops/conversation.rs
@@ -15,6 +15,7 @@ use crate::model::{
     ChatRootAttachment, Message, OwnerId, PermissionMode, ReasoningEffort, Role,
     RootAttachmentOrigin, ToolCallRecord, TurnRunStatus, MAX_ROOT_ATTACHMENTS,
 };
+use crate::provider::MessageReasoning;
 use crate::storage::{
     ChatTerminalTurnSnapshot, ChatTerminalTurnStatus, ChatToolActivitySnapshot,
     ChatToolActivityStatus, ChatTranscriptSnapshot, DeleteChatOutcome,
@@ -1042,6 +1043,7 @@ pub(in crate::db) async fn append_message(store: &DbStore, message: &Message) ->
         seq: Set(seq),
         role: Set(role_to_db(message.role).to_string()),
         content: Set(message.content.clone()),
+        reasoning: Set(reasoning_to_db(&message.reasoning)),
         turn_lease_token: Set(None),
         created_at: Set(message.created_at),
     };
@@ -1416,8 +1418,29 @@ fn message_from_model(model: entities::message::Model) -> Result<Message> {
         turn_id: TurnId(model.turn_id),
         role: role_from_db(&model.role)?,
         content: model.content,
+        reasoning: reasoning_from_db(model.reasoning),
         created_at: model.created_at,
     })
+}
+
+/// Reasoning as it is stored: absent when there is nothing to replay, so a
+/// message without reasoning writes the same row it always did.
+pub(in crate::db) fn reasoning_to_db(reasoning: &MessageReasoning) -> Option<serde_json::Value> {
+    if reasoning.is_empty() {
+        return None;
+    }
+    serde_json::to_value(reasoning).ok()
+}
+
+/// Reasoning as it is read back.
+///
+/// Replay is an optimization on top of the transcript, so a column this
+/// version cannot parse degrades to no reasoning rather than failing the load
+/// of an otherwise intact conversation.
+pub(in crate::db) fn reasoning_from_db(stored: Option<serde_json::Value>) -> MessageReasoning {
+    stored
+        .and_then(|value| serde_json::from_value(value).ok())
+        .unwrap_or_default()
 }
 
 /// `Role` is persisted as its snake_case name (matching its serde encoding).

--- a/crates/openwave-core/src/db/ops/turn.rs
+++ b/crates/openwave-core/src/db/ops/turn.rs
@@ -180,6 +180,7 @@ pub(in crate::db) async fn accept_turn(
         seq: Set(next_message_seq_on(&transaction, chat_id).await?),
         role: Set("user".into()),
         content: Set(content.into()),
+        reasoning: Set(None),
         turn_lease_token: Set(None),
         created_at: Set(now),
     };

--- a/crates/openwave-core/src/db/ops/turn/resolution.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution.rs
@@ -19,7 +19,7 @@ use super::super::super::{entities, store_err, DbStore};
 use super::super::{
     acquire_chat_write_lock, acquire_turn_write_lock,
     conversation::{
-        append_event_on, next_message_seq_on, reserve_message_identity_on,
+        append_event_on, next_message_seq_on, reasoning_to_db, reserve_message_identity_on,
         MESSAGE_IDENTITY_OWNER_MESSAGE,
     },
 };
@@ -328,6 +328,7 @@ async fn complete_turn_run_inner(
         seq: Set(next_message_seq_on(&transaction, output.chat_id).await?),
         role: Set("assistant".into()),
         content: Set(output.content.clone()),
+        reasoning: Set(reasoning_to_db(&output.reasoning)),
         turn_lease_token: Set(Some(lease_token)),
         created_at: Set(output_created_at),
     };
@@ -1065,6 +1066,7 @@ where
                 && message.turn_id == output.turn_id.0
                 && message.role == "assistant"
                 && message.content == output.content
+                && message.reasoning == reasoning_to_db(&output.reasoning)
                 && message.created_at == created_at
         }))
 }

--- a/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
+++ b/crates/openwave-core/src/db/ops/turn/resolution/cancellation.rs
@@ -498,6 +498,7 @@ async fn finish_turn_cancellation_inner(
                 seq: Set(next_message_seq_on(&transaction, output.chat_id).await?),
                 role: Set("assistant".into()),
                 content: Set(output.content.clone()),
+                reasoning: Set(reasoning_to_db(&output.reasoning)),
                 turn_lease_token: Set(Some(lease_token)),
                 created_at: Set(canonical_db_timestamp(output.created_at)?),
             };

--- a/crates/openwave-core/src/db/ops/turn/steer.rs
+++ b/crates/openwave-core/src/db/ops/turn/steer.rs
@@ -14,7 +14,7 @@ use super::super::super::{entities, store_err, DbStore};
 use super::super::{
     acquire_chat_write_lock, acquire_turn_write_lock,
     conversation::{
-        append_event_on, next_message_seq_on, reserve_message_identity_on,
+        append_event_on, next_message_seq_on, reasoning_to_db, reserve_message_identity_on,
         transfer_steer_message_identity_on, MESSAGE_IDENTITY_OWNER_MESSAGE,
         MESSAGE_IDENTITY_OWNER_STEER,
     },
@@ -430,6 +430,7 @@ pub(in crate::db) async fn apply_turn_steer(
             seq: Set(next_message_seq_on(&transaction, preceding.chat_id).await?),
             role: Set("assistant".into()),
             content: Set(preceding.content.clone()),
+            reasoning: Set(reasoning_to_db(&preceding.reasoning)),
             turn_lease_token: Set(Some(lease_token)),
             created_at: Set(preceding_created_at),
         };
@@ -461,6 +462,7 @@ pub(in crate::db) async fn apply_turn_steer(
         seq: Set(next_message_seq_on(&transaction, ChatId(steer.chat_id)).await?),
         role: Set("user".into()),
         content: Set(steer.content.clone()),
+        reasoning: Set(None),
         turn_lease_token: Set(Some(lease_token)),
         created_at: Set(now),
     };

--- a/crates/openwave-core/src/db/tests.rs
+++ b/crates/openwave-core/src/db/tests.rs
@@ -2133,6 +2133,7 @@ async fn chats_and_messages_roundtrip() {
         chat_id: chat.id,
         turn_id: TurnId::new(),
         role: Role::User,
+        reasoning: Default::default(),
         content: "hi there".into(),
         created_at: DateTime::<Utc>::from_timestamp(1_700_000_001, 0).unwrap(),
     };
@@ -2157,6 +2158,7 @@ async fn make_queued_turn(
         turn_id: Set(turn_id.0),
         seq: Set(seq),
         role: Set("user".into()),
+        reasoning: Default::default(),
         content: Set("turn input".into()),
         turn_lease_token: Set(None),
         created_at: Set(now),
@@ -2237,6 +2239,7 @@ async fn turn_run_schema_enforces_delivery_and_single_writer_invariants() {
         turn_id: Set(first.id),
         seq: Set(first_output_seq),
         role: Set("assistant".into()),
+        reasoning: Default::default(),
         content: Set("done".into()),
         turn_lease_token: Set(None),
         created_at: Set(now),
@@ -3285,6 +3288,7 @@ async fn resuming_turn_claims_a_new_lease_without_consuming_failure_budget() {
         chat_id: chat.id,
         turn_id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "resumed answer".into(),
         created_at: resume_at + chrono::Duration::seconds(1),
     };
@@ -3691,6 +3695,7 @@ async fn client_wait_parks_resolves_and_recovers_exactly() {
         chat_id: chat.id,
         turn_id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "must not commit".into(),
         created_at: resolved_at + chrono::Duration::microseconds(1),
     };
@@ -5092,6 +5097,7 @@ async fn turn_completion_atomically_persists_exact_output_and_recovers_retries()
         chat_id: chat.id,
         turn_id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "final answer".into(),
         created_at: claimed_at + chrono::Duration::nanoseconds(1_234_567),
     };
@@ -5355,6 +5361,7 @@ async fn turn_failure_receipt_recovers_exact_retries_after_the_turn_advances() {
         chat_id: chat.id,
         turn_id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "recovered".into(),
         created_at: canonical_retry_at + chrono::Duration::seconds(1),
     };
@@ -6027,6 +6034,7 @@ async fn running_turn_cancellation_holds_the_chat_until_exact_worker_acknowledge
         chat_id: chat.id,
         turn_id: turn.id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "too late".into(),
         created_at: requested_at + chrono::Duration::seconds(1),
     };
@@ -6494,6 +6502,7 @@ async fn turn_completion_and_cancellation_serialize_to_one_decision() {
         chat_id: chat.id,
         turn_id: turn.id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "race answer".into(),
         created_at: decided_at,
     };
@@ -6572,6 +6581,7 @@ async fn turn_completion_and_failure_serialize_to_one_terminal_decision() {
         chat_id: chat.id,
         turn_id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "race winner".into(),
         created_at: resolved_at,
     };
@@ -6664,6 +6674,7 @@ async fn turn_completion_uses_the_heartbeated_lease_and_fences_operation_time() 
         chat_id: chat.id,
         turn_id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "prepared before retry".into(),
         created_at: heartbeat_at - chrono::Duration::microseconds(1),
     };
@@ -6727,6 +6738,7 @@ async fn turn_completion_rejects_prepared_output_retried_after_expiry() {
         chat_id: chat.id,
         turn_id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "prepared while live".into(),
         created_at: lease_expires_at - chrono::Duration::seconds(1),
     };
@@ -6792,6 +6804,7 @@ async fn stale_turn_attempt_cannot_complete_a_reclaimed_turn() {
         chat_id: chat.id,
         turn_id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "stale answer".into(),
         created_at: first_expiry + chrono::Duration::seconds(1),
     };
@@ -6850,6 +6863,7 @@ async fn concurrent_different_turn_completions_commit_one_output_once() {
         chat_id: chat.id,
         turn_id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "one answer".into(),
         created_at: claimed_at + chrono::Duration::seconds(1),
     };
@@ -6925,6 +6939,7 @@ async fn turn_completion_rolls_back_output_when_state_update_fails() {
         chat_id: chat.id,
         turn_id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "must roll back".into(),
         created_at: claimed_at + chrono::Duration::seconds(1),
     };
@@ -6989,6 +7004,7 @@ async fn turn_completion_rolls_back_state_and_output_when_terminal_event_fails()
         chat_id: chat.id,
         turn_id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "must roll back".into(),
         created_at: claimed_at + chrono::Duration::seconds(1),
     };
@@ -7317,6 +7333,7 @@ async fn list_chats_is_newest_first_and_messages_follow_commit_sequence() {
         chat_id: newer.id,
         turn_id: TurnId::new(),
         role: Role::User,
+        reasoning: Default::default(),
         content: format!("t{ts}"),
         created_at: DateTime::<Utc>::from_timestamp(ts, 0).unwrap(),
     };
@@ -7337,6 +7354,7 @@ async fn delete_chat_erases_quiesced_history_and_fails_closed_for_live_work_or_r
         chat_id: chat.id,
         turn_id: TurnId::new(),
         role: Role::User,
+        reasoning: Default::default(),
         content: "delete this history".into(),
         created_at: Utc::now(),
     };
@@ -7593,6 +7611,7 @@ async fn refused_turn_metadata_hydrates_with_its_exact_durable_output() {
             chat_id: chat.id,
             turn_id,
             role: Role::Assistant,
+            reasoning: Default::default(),
             content: content.into(),
             created_at: accepted.available_at,
         };
@@ -7933,6 +7952,7 @@ async fn all_roles_round_trip() {
                 chat_id: chat.id,
                 turn_id: TurnId::new(),
                 role: *role,
+                reasoning: Default::default(),
                 content: String::new(),
                 created_at: DateTime::<Utc>::from_timestamp(i as i64, 0).unwrap(),
             })
@@ -8208,6 +8228,7 @@ async fn claimed_intermediate_message_is_co_committed_with_the_turn_lease() {
         chat_id: chat.id,
         turn_id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "intermediate".into(),
         created_at: claimed_at,
     };
@@ -9586,6 +9607,7 @@ async fn reasoning_deltas_rebuild_into_the_transcript() {
         chat_id: chat.id,
         turn_id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "the answer".into(),
         created_at: accepted.available_at,
     };
@@ -9875,6 +9897,7 @@ async fn cancellation_with_partial_output_commits_a_durable_message() {
         chat_id: chat.id,
         turn_id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "the answer so far".into(),
         created_at: requested_at,
     };

--- a/crates/openwave-core/src/db/tests/agent_run.rs
+++ b/crates/openwave-core/src/db/tests/agent_run.rs
@@ -1698,6 +1698,7 @@ async fn cancellation_retry_remains_pending_while_parent_completion_is_fenced() 
         chat_id: chat.id,
         turn_id: origin.id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "parent completed independently".into(),
         created_at: completed_at,
     };

--- a/crates/openwave-core/src/db/tests/context_checkpoint.rs
+++ b/crates/openwave-core/src/db/tests/context_checkpoint.rs
@@ -17,6 +17,7 @@ async fn store_with_messages() -> (tempfile::TempDir, DbStore, Chat, Message, Me
         chat_id: chat.id,
         turn_id: TurnId::new(),
         role: Role::User,
+        reasoning: Default::default(),
         content: "Choose SQLite for local development.".into(),
         created_at: at(0),
     };
@@ -25,6 +26,7 @@ async fn store_with_messages() -> (tempfile::TempDir, DbStore, Chat, Message, Me
         chat_id: chat.id,
         turn_id: TurnId::new(),
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "The local database choice is SQLite.".into(),
         created_at: at(1),
     };

--- a/crates/openwave-core/src/db/tests/parent_terminal_guard.rs
+++ b/crates/openwave-core/src/db/tests/parent_terminal_guard.rs
@@ -69,6 +69,7 @@ fn output_for(turn: &crate::TurnRun, chat_id: crate::ChatId) -> Message {
         chat_id,
         turn_id: turn.id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "foreground answer".into(),
         created_at: Utc::now().max(turn.updated_at),
     }

--- a/crates/openwave-core/src/db/tests/turn_steer.rs
+++ b/crates/openwave-core/src/db/tests/turn_steer.rs
@@ -74,6 +74,7 @@ async fn turn_steer_schema_enforces_durable_delivery_identity() {
         turn_id: Set(claimed.id.0),
         seq: Set(2),
         role: Set("user".into()),
+        reasoning: Default::default(),
         content: Set("change course".into()),
         turn_lease_token: Set(None),
         created_at: Set(now),
@@ -119,6 +120,7 @@ async fn turn_steer_schema_enforces_durable_delivery_identity() {
         turn_id: Set(claimed.id.0),
         seq: Set(3),
         role: Set("user".into()),
+        reasoning: Default::default(),
         content: Set("mismatched identity".into()),
         turn_lease_token: Set(None),
         created_at: Set(now),
@@ -229,6 +231,7 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
         chat_id: chat.id,
         turn_id: turn.id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: format!(
             "candidate before steer :cit[candidate]{{doc={} lines=1-1}}",
             document.id
@@ -315,6 +318,7 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
         chat_id: chat.id,
         turn_id: turn.id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "final answer".into(),
         created_at: completed_at,
     };
@@ -394,6 +398,7 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
         chat_id: chat.id,
         turn_id: turn.id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "generated from revision one".into(),
         created_at: stale_after_apply_at,
     };
@@ -416,6 +421,7 @@ async fn durable_turn_steer_applies_exactly_and_preserves_transcript_order() {
         chat_id: chat.id,
         turn_id: turn.id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: format!("fresh final :cit[answer]{{doc={} lines=1-1}}", document.id),
         created_at: fresh_completed_at,
     };
@@ -583,6 +589,7 @@ async fn turn_steer_admission_validates_identity_payload_and_monotonic_time() {
             chat_id: chat.id,
             turn_id: turn.id,
             role: Role::User,
+            reasoning: Default::default(),
             content: "already used".into(),
             created_at: Utc::now(),
         })
@@ -758,6 +765,7 @@ async fn concurrent_apply_and_completion_leave_no_pending_steer() {
         chat_id: chat.id,
         turn_id: turn.id,
         role: Role::Assistant,
+        reasoning: Default::default(),
         content: "stale completion".into(),
         created_at: stale_output_at,
     };
@@ -813,6 +821,7 @@ async fn concurrent_apply_and_completion_leave_no_pending_steer() {
                 chat_id: chat.id,
                 turn_id: turn.id,
                 role: Role::Assistant,
+                reasoning: Default::default(),
                 content: "fresh completion".into(),
                 created_at: completed_at,
             },
@@ -958,6 +967,7 @@ async fn concurrent_message_and_steer_reserve_one_shared_identity() {
                 chat_id: message_chat.id,
                 turn_id: message_turn.id,
                 role: Role::Assistant,
+                reasoning: Default::default(),
                 content: "shared identity".into(),
                 created_at: Utc::now(),
             })
@@ -1274,6 +1284,7 @@ async fn failed_steer_message_insert_rolls_back_the_application_receipt() {
         turn_id: Set(turn.id.0),
         seq: Set(2),
         role: Set("assistant".into()),
+        reasoning: Default::default(),
         content: Set("occupy identity".into()),
         turn_lease_token: Set(None),
         created_at: Set(Utc::now()),

--- a/crates/openwave-core/src/deliverable_acceptance.rs
+++ b/crates/openwave-core/src/deliverable_acceptance.rs
@@ -215,6 +215,7 @@ pub async fn restore_output_to_revision(
             // fresh id is an inert marker rather than a claim on turn state.
             turn_id: crate::id::TurnId::new(),
             role: crate::model::Role::System,
+            reasoning: Default::default(),
             content: format!(
                 "User restored output '{}' to the content of version {} \
                  (now the latest version, v{}). Re-read output/{} before \

--- a/crates/openwave-core/src/lib.rs
+++ b/crates/openwave-core/src/lib.rs
@@ -188,8 +188,9 @@ pub use preview::{
     ToolResultPreview, MAX_RESULT_ENTRIES, MAX_RESULT_ENTRY_CHARS,
 };
 pub use provider::{
-    ChatMessage, ChatRequest, ContentBlock, ModelProvider, ProviderEvent, ProviderId,
-    RefusalDetails, RefusalOutcome, ResponseFormat, StopReason, ToolChoice, Usage,
+    ChatMessage, ChatRequest, ContentBlock, MessageReasoning, ModelProvider, ProviderEvent,
+    ProviderId, ReasoningOrigin, RefusalDetails, RefusalOutcome, ResponseFormat, StopReason,
+    ToolChoice, Usage,
 };
 pub use renderer_tool::RendererToolName;
 pub use secret_cache::CachingSecretProvider;

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -13,7 +13,7 @@ use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::image::ImageRef;
-use crate::provider::Usage;
+use crate::provider::{MessageReasoning, Usage};
 
 use crate::id::{
     AgentRunId, CallId, ChatId, DocumentId, HostRootId, MessageId, ProjectId,
@@ -2349,6 +2349,15 @@ pub struct Message {
     pub role: Role,
     /// The text body.
     pub content: String,
+    /// Reasoning blocks this message's step produced, with the route that
+    /// minted them.
+    ///
+    /// Persisted so an assistant message keeps its reasoning across a reload
+    /// and can be replayed to the same model on a later turn. Empty for every
+    /// user message, and for an assistant step whose reasoning had no message
+    /// row to ride (a tool step with no prose preamble writes no message).
+    #[serde(default, skip_serializing_if = "MessageReasoning::is_empty")]
+    pub reasoning: MessageReasoning,
     /// When it was created.
     pub created_at: DateTime<Utc>,
 }

--- a/crates/openwave-core/src/provider.rs
+++ b/crates/openwave-core/src/provider.rs
@@ -34,6 +34,86 @@ impl std::fmt::Display for ProviderId {
     }
 }
 
+/// The exact model route that produced a set of reasoning blocks.
+///
+/// A reasoning block is minted by one model on one provider and is only valid
+/// as input back to that same route. `provider` mirrors [`ChatRequest::provider`]
+/// — `None` means the host let the router pick, in which case the model name
+/// determines the route and comparing models alone is enough.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReasoningOrigin {
+    /// The explicit provider route, if the host pinned one.
+    pub provider: Option<ProviderId>,
+    /// The model that generated the blocks.
+    pub model: String,
+}
+
+/// A message's opaque reasoning blocks, bound to the route that minted them.
+///
+/// The blocks are provider values kept in emission order and kept whole — a
+/// message replays either all of them or none, because a provider that
+/// validates replay (Anthropic) rejects rearranged, edited, or partially
+/// dropped reasoning. They stay a `Vec`: a provider may emit several in one
+/// step, and flattening them into one block would lose both the count and the
+/// per-block signatures.
+///
+/// The origin travels with the blocks so a consumer can tell whether they are
+/// valid input for the request it is about to send. Blocks and origin are set
+/// together by [`MessageReasoning::captured`] and are private so they cannot
+/// drift apart.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MessageReasoning {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    origin: Option<ReasoningOrigin>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    blocks: Vec<Value>,
+}
+
+impl MessageReasoning {
+    /// Blocks captured from a live stream on `origin`'s route.
+    ///
+    /// An empty block list carries no origin: there is nothing to attribute.
+    pub fn captured(origin: ReasoningOrigin, blocks: Vec<Value>) -> Self {
+        if blocks.is_empty() {
+            return Self::default();
+        }
+        Self {
+            origin: Some(origin),
+            blocks,
+        }
+    }
+
+    /// Whether there is anything to replay.
+    pub fn is_empty(&self) -> bool {
+        self.blocks.is_empty()
+    }
+
+    /// The blocks, whatever route they came from.
+    pub fn blocks(&self) -> &[Value] {
+        &self.blocks
+    }
+
+    /// The route that minted the blocks, if any were captured.
+    pub fn origin(&self) -> Option<&ReasoningOrigin> {
+        self.origin.as_ref()
+    }
+
+    /// The blocks, but only when they are valid input for this exact route.
+    ///
+    /// A block minted by another provider — or by another model on the same
+    /// provider — is foreign input, so a mismatch yields nothing rather than
+    /// failing: switching models mid-conversation is ordinary, and sending no
+    /// reasoning is always a valid request shape.
+    pub fn replayable_for(&self, provider: Option<&ProviderId>, model: &str) -> &[Value] {
+        match &self.origin {
+            Some(origin) if origin.provider.as_ref() == provider && origin.model == model => {
+                &self.blocks
+            }
+            _ => &[],
+        }
+    }
+}
+
 /// One piece of a message. Assistant messages carry text (and, when the model
 /// calls tools, `ToolUse` blocks); tool results come back as `ToolResult`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -83,19 +163,14 @@ pub struct ChatMessage {
     /// The ordered content blocks.
     pub content: Vec<ContentBlock>,
     /// Reasoning blocks the model produced in the step this message came
-    /// from, captured from the live stream for verbatim replay on the later
-    /// steps of the same turn.
+    /// from, for verbatim replay on a later request to the same route.
     ///
-    /// A side channel, not content: serde never reads or writes it, so no
-    /// stored transcript or wire request changes shape. The blocks are opaque
-    /// provider values kept in emission order and kept whole — a message
-    /// replays either all of them or none, because a provider that validates
-    /// replay (Anthropic) rejects rearranged, edited, or partially dropped
-    /// reasoning. Only an assistant message built from a live provider stream
-    /// carries any; a message rebuilt from the store has none and degrades to
-    /// sending no reasoning, which is always a valid shape.
+    /// A side channel, not content: serde never reads or writes it here, so no
+    /// wire request changes shape. Replay is gated on the origin recorded with
+    /// the blocks — see [`MessageReasoning::replayable_for`] — because a block
+    /// from another provider or another model is not valid input.
     #[serde(default, skip)]
-    pub reasoning: Vec<Value>,
+    pub reasoning: MessageReasoning,
 }
 
 impl ChatMessage {
@@ -104,7 +179,7 @@ impl ChatMessage {
         Self {
             role,
             content: vec![ContentBlock::Text { text: text.into() }],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         }
     }
 }

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -15,12 +15,12 @@ use openwave_core::{
     DeleteProjectOutcome, DocumentId, DocumentSourceBlob, DocumentSourceUpsert, DocumentUpsert,
     FinishAgentRunCancellationOutcome, FinishRootAttachmentChangeOutcome,
     FinishTurnCancellationOutcome, HeartbeatClientToolCallOutcome, HostRootId, Message, MessageId,
-    ParkTurnForAgentRunWaitSetOutcome, ParkTurnForClientCallOutcome, Project, ProjectId,
-    RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome, RequestTurnCancellationOutcome,
-    ResolveToolCallOutcome, ResumeTurnForAgentRunWaitSetOutcome, Role, RootAttachmentChangeAction,
-    RootAttachmentChangeId, RootAttachmentChangeTerminal, RootAttachmentOrigin,
-    SandboxSpawnCheckpointRequest, SpawnSandboxAgentResult, StopReason, Store,
-    SubmitAgentRunResultOutcome, ToolCallExecution, ToolCallRecord, ToolCallResolution,
+    MessageReasoning, ParkTurnForAgentRunWaitSetOutcome, ParkTurnForClientCallOutcome, Project,
+    ProjectId, RecordTurnFailureOutcome, RequestAgentRunCancellationOutcome,
+    RequestTurnCancellationOutcome, ResolveToolCallOutcome, ResumeTurnForAgentRunWaitSetOutcome,
+    Role, RootAttachmentChangeAction, RootAttachmentChangeId, RootAttachmentChangeTerminal,
+    RootAttachmentOrigin, SandboxSpawnCheckpointRequest, SpawnSandboxAgentResult, StopReason,
+    Store, SubmitAgentRunResultOutcome, ToolCallExecution, ToolCallRecord, ToolCallResolution,
     ToolCallStatus, TurnCheckpointProgress, TurnFailureRetry, TurnId, TurnRun, TurnRunStatus,
     TurnSteerId, TurnSteerStatus, Usage, UserQuestionAnswer, ASK_USER_QUESTIONS_TOOL,
 };
@@ -106,6 +106,7 @@ async fn postgres_terminal_citations_are_atomic_and_exactly_recoverable() {
         chat_id: chat.id,
         turn_id: TurnId::new(),
         role: Role::Assistant,
+        reasoning: MessageReasoning::default(),
         content: "standalone".into(),
         created_at: nanosecond_created_at,
     };
@@ -151,6 +152,7 @@ async fn postgres_terminal_citations_are_atomic_and_exactly_recoverable() {
         chat_id: chat.id,
         turn_id,
         role: Role::Assistant,
+        reasoning: MessageReasoning::default(),
         content: format!(":cit[answer]{{doc={} lines=1-1}}", document_id.0),
         created_at: completed_at,
     };
@@ -859,6 +861,7 @@ async fn postgres_parent_completion_and_child_admission_form_one_terminal_bounda
         chat_id: chat.id,
         turn_id: turn.id,
         role: Role::Assistant,
+        reasoning: MessageReasoning::default(),
         content: "race-safe terminal answer".into(),
         created_at: utc_now_at_postgres_precision().max(turn.updated_at),
     };
@@ -2366,6 +2369,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         chat_id: next_chat.id,
         turn_id: next.id,
         role: Role::Assistant,
+        reasoning: MessageReasoning::default(),
         content: "postgres completion".into(),
         created_at: delayed_retry_at + Duration::seconds(1),
     };
@@ -2672,6 +2676,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         chat_id: turn_event_chat.id,
         turn_id: turn_event.id,
         role: Role::Assistant,
+        reasoning: MessageReasoning::default(),
         content: "event turn complete".into(),
         created_at: event_claimed_at + Duration::seconds(1),
     };
@@ -2817,6 +2822,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
         chat_id: steer_chat.id,
         turn_id: steer_turn.id,
         role: Role::Assistant,
+        reasoning: MessageReasoning::default(),
         content: "postgres candidate".into(),
         created_at: Utc::now(),
     };
@@ -2883,6 +2889,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
                     chat_id: steer_chat.id,
                     turn_id: steer_turn.id,
                     role: Role::Assistant,
+                    reasoning: MessageReasoning::default(),
                     content: "stale steer completion".into(),
                     created_at: steer_completed_at,
                 },
@@ -2920,6 +2927,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
                 chat_id: steer_chat.id,
                 turn_id: steer_turn.id,
                 role: Role::Assistant,
+                reasoning: MessageReasoning::default(),
                 content: "fresh steer completion".into(),
                 created_at: fresh_completed_at,
             },
@@ -3017,6 +3025,7 @@ async fn postgres_turn_acceptance_claims_and_receipts_are_atomic() {
                 chat_id: registry_message_chat.id,
                 turn_id: registry_message_turn.id,
                 role: Role::Assistant,
+                reasoning: MessageReasoning::default(),
                 content: "shared postgres identity".into(),
                 created_at: Utc::now(),
             })

--- a/crates/openwave-desktop/src/chat_debug.rs
+++ b/crates/openwave-desktop/src/chat_debug.rs
@@ -837,6 +837,7 @@ mod tests {
                 chat_id,
                 turn_id,
                 role: Role::User,
+                reasoning: Default::default(),
                 content: "run git status in ~/code/openwave".to_owned(),
                 created_at: at(0),
             }],

--- a/crates/openwave-router/src/anthropic.rs
+++ b/crates/openwave-router/src/anthropic.rs
@@ -327,22 +327,20 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
         // as a long silent pause before the answer. `summarized` is what makes
         // the reasoning stream the renderer already draws worth drawing.
         //
-        // Reasoning captured from this turn's own stream rides back on the
-        // assistant messages that produced it (see `attach_reasoning_blocks`),
-        // restoring the model's inter-tool plan continuity. Anything rebuilt
-        // from the store — a retry, a resumed turn, an older chat — still
-        // replays no thinking blocks at all. Adaptive mode relaxes turn
-        // validation for exactly that case: no assistant turn has to begin
-        // with a thinking block, and history assembled from mixed sources
-        // needs none reinserted, so sending zero of them is always a valid
-        // shape. The 400 lives in *partial* replay — within the latest
-        // assistant message the consecutive thinking blocks must match what
-        // the model generated verbatim, `redacted_thinking` included, which
-        // is why capture and replay below keep the raw blocks whole rather
-        // than filtering on `type == "thinking"`. Omission also keeps history
-        // portable: blocks are bound to the model that produced them and a
-        // chat can switch models mid-conversation, where a foreign block is
-        // ignored rather than rejected and so only wastes input tokens.
+        // Reasoning rides back on the assistant messages that produced it
+        // (see `attach_reasoning_blocks`), restoring the model's inter-tool
+        // plan continuity — within a turn from its own stream, and across
+        // turns from the durable message the step wrote. A step that never
+        // reached the store, or one whose blocks belong to another route,
+        // replays nothing. Adaptive mode relaxes turn validation for exactly
+        // that case: no assistant turn has to begin with a thinking block,
+        // and history assembled from mixed sources needs none reinserted, so
+        // sending zero of them is always a valid shape. The 400 lives in
+        // *partial* replay — within the latest assistant message the
+        // consecutive thinking blocks must match what the model generated
+        // verbatim, `redacted_thinking` included, which is why capture and
+        // replay below keep the raw blocks whole rather than filtering on
+        // `type == "thinking"`.
         body["thinking"] = json!({ "type": "adaptive", "display": "summarized" });
         if let Some(effort) = req.reasoning_effort {
             body["output_config"] = json!({ "effort": effort.as_str() });
@@ -352,8 +350,8 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
     Ok(body)
 }
 
-/// Replay the turn's captured reasoning blocks ahead of the content of the
-/// assistant messages that produced them.
+/// Replay the captured reasoning blocks ahead of the content of the assistant
+/// messages that produced them.
 ///
 /// Anthropic validates the consecutive thinking prefix of an assistant
 /// message against what the model generated, so the blocks go back exactly
@@ -363,18 +361,30 @@ fn build_request_json(req: &ChatRequest) -> Result<Value> {
 /// runs only on a request that actually thinks (see the caller): replaying
 /// reasoning into a request with thinking off buys nothing and risks a
 /// shape the API rejects, while omission is always valid.
+///
+/// A block is only valid input back to the exact route that minted it, so
+/// each message replays only what `replayable_for` clears against this
+/// request's provider and model. A chat may switch between Anthropic, OpenAI
+/// and Gemini models mid-conversation, and even between two Anthropic models;
+/// history rebuilt across such a switch carries foreign blocks whose
+/// signatures this model never produced. Dropping them is the right answer
+/// rather than failing the turn: sending no reasoning is always a valid
+/// shape, and the alternative is a request the API rejects.
 fn attach_reasoning_blocks(body: &mut Value, req: &ChatRequest) {
     let Some(messages) = body.get_mut("messages").and_then(Value::as_array_mut) else {
         return;
     };
     for (message, wire) in req.messages.iter().zip(messages.iter_mut()) {
-        if message.reasoning.is_empty() {
+        let blocks = message
+            .reasoning
+            .replayable_for(req.provider.as_ref(), &req.model);
+        if blocks.is_empty() {
             continue;
         }
         let Some(content) = wire.get_mut("content").and_then(Value::as_array_mut) else {
             continue;
         };
-        let mut combined = message.reasoning.clone();
+        let mut combined = blocks.to_vec();
         combined.append(content);
         *content = combined;
     }
@@ -882,7 +892,7 @@ fn map_stop_reason(reason: &str) -> StopOutcome {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openwave_core::provider::ChatMessage;
+    use openwave_core::provider::{ChatMessage, MessageReasoning, ReasoningOrigin};
     use openwave_core::tool::ToolSpec;
     use openwave_core::ReasoningEffort;
 
@@ -992,7 +1002,7 @@ mod tests {
                     input: json!({"path": format!("f{i}.rs")}),
                 })
                 .collect(),
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         });
         messages.push(ChatMessage {
             role: Role::User,
@@ -1003,7 +1013,7 @@ mod tests {
                     is_error: false,
                 })
                 .collect(),
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         });
         let req = ChatRequest {
             provider: Some(ProviderId::new("anthropic")),
@@ -1432,7 +1442,13 @@ mod tests {
                         input: json!({"path": "a"}),
                     },
                 ],
-                reasoning: reasoning.clone(),
+                reasoning: MessageReasoning::captured(
+                    ReasoningOrigin {
+                        provider: Some(ProviderId::new("anthropic")),
+                        model: "claude-opus-5".into(),
+                    },
+                    reasoning.clone(),
+                ),
             },
             ChatMessage {
                 role: Role::User,
@@ -1441,7 +1457,7 @@ mod tests {
                     content: "ok".into(),
                     is_error: false,
                 }],
-                reasoning: Vec::new(),
+                reasoning: MessageReasoning::default(),
             },
         ];
         let body = build_request_json(&req).unwrap();
@@ -1458,6 +1474,43 @@ mod tests {
             body["messages"][2]["content"][0]["cache_control"],
             ephemeral_cache_control()
         );
+    }
+
+    #[test]
+    fn a_route_switch_replays_no_foreign_reasoning() {
+        // A chat may move between Anthropic, OpenAI and Gemini models — and
+        // between two Anthropic models — mid-conversation. History rebuilt
+        // across such a switch still carries the blocks the earlier model
+        // signed, and this model would reject them. Dropping them is the
+        // answer: sending no reasoning is always a valid shape.
+        let block = json!({"type": "thinking", "thinking": "plan", "signature": "sig-1"});
+        let step = |provider: Option<&str>, model: &str| ChatMessage {
+            role: Role::Assistant,
+            content: vec![ContentBlock::Text {
+                text: "checking".into(),
+            }],
+            reasoning: MessageReasoning::captured(
+                ReasoningOrigin {
+                    provider: provider.map(ProviderId::new),
+                    model: model.into(),
+                },
+                vec![block.clone()],
+            ),
+        };
+        for origin in [
+            // Another Anthropic model: same wire shape, signature this model
+            // never produced.
+            step(Some("anthropic"), "claude-sonnet-5"),
+            // Another provider entirely.
+            step(Some("openai"), "claude-opus-5"),
+        ] {
+            let mut req = reasoning_request("claude-opus-5", None);
+            req.messages = vec![ChatMessage::text(Role::User, "hi"), origin];
+            let body = build_request_json(&req).unwrap();
+            let content = body["messages"][1]["content"].as_array().unwrap();
+            assert_eq!(content.len(), 1, "no block was replayed: {body}");
+            assert_eq!(content[0]["type"], "text");
+        }
     }
 
     #[test]
@@ -1479,7 +1532,13 @@ mod tests {
             content: vec![ContentBlock::Text {
                 text: "checking".into(),
             }],
-            reasoning: vec![json!({"type": "thinking", "thinking": "t", "signature": "s"})],
+            reasoning: MessageReasoning::captured(
+                ReasoningOrigin {
+                    provider: Some(ProviderId::new("anthropic")),
+                    model: "claude-opus-5".into(),
+                },
+                vec![json!({"type": "thinking", "thinking": "t", "signature": "s"})],
+            ),
         });
         req.messages.push(ChatMessage::text(Role::User, "go on"));
         let body = build_request_json(&req).unwrap();
@@ -1604,7 +1663,7 @@ mod tests {
             messages: vec![ChatMessage {
                 role: Role::User,
                 content,
-                reasoning: Vec::new(),
+                reasoning: MessageReasoning::default(),
             }],
             tools: vec![],
             max_tokens: None,

--- a/crates/openwave-router/src/gemini.rs
+++ b/crates/openwave-router/src/gemini.rs
@@ -1174,7 +1174,7 @@ fn classify_gemini_error(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openwave_core::provider::ChatMessage;
+    use openwave_core::provider::{ChatMessage, MessageReasoning};
     use openwave_core::tool::{Tool, ToolSpec};
     use openwave_core::{
         ask_user_questions_tool_spec, create_app_tool_spec, exit_plan_mode_tool_spec,
@@ -1430,7 +1430,7 @@ mod tests {
                         input: json!({"path": "two"}),
                     },
                 ],
-                reasoning: Vec::new(),
+                reasoning: MessageReasoning::default(),
             },
             ChatMessage {
                 role: Role::User,
@@ -1439,7 +1439,7 @@ mod tests {
                     content: "one".into(),
                     is_error: false,
                 }],
-                reasoning: Vec::new(),
+                reasoning: MessageReasoning::default(),
             },
             ChatMessage {
                 role: Role::User,
@@ -1448,7 +1448,7 @@ mod tests {
                     content: "boom".into(),
                     is_error: true,
                 }],
-                reasoning: Vec::new(),
+                reasoning: MessageReasoning::default(),
             },
         ];
         let body = build_request_json(&request(messages)).unwrap();
@@ -1519,7 +1519,7 @@ mod tests {
                 },
                 ContentBlock::Image { image },
             ],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         }]);
         req.images.insert(
             image.blob_id,
@@ -1538,7 +1538,7 @@ mod tests {
         let req = request(vec![ChatMessage {
             role: Role::User,
             content: vec![ContentBlock::Image { image: png_ref(9) }],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         }]);
         let err = build_request_json(&req).unwrap_err();
         assert!(err.to_string().contains("no hydrated bytes"), "{err}");

--- a/crates/openwave-router/src/openai.rs
+++ b/crates/openwave-router/src/openai.rs
@@ -551,7 +551,7 @@ fn usage_event(response: &Value) -> Option<ProviderEvent> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openwave_core::provider::ChatMessage;
+    use openwave_core::provider::{ChatMessage, MessageReasoning};
     use openwave_core::tool::ToolSpec;
     use openwave_core::{ImageData, ImageMediaType, ImageRef, ReasoningEffort};
 
@@ -596,7 +596,7 @@ mod tests {
                 name: "exec".into(),
                 input: json!({"command":"pwd"}),
             }],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         };
         let result = openwave_core::ChatMessage {
             role: Role::User,
@@ -605,7 +605,7 @@ mod tests {
                 content: "ok".into(),
                 is_error: false,
             }],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         };
         let orphan = openwave_core::ChatMessage {
             role: Role::User,
@@ -614,7 +614,7 @@ mod tests {
                 content: "bad".into(),
                 is_error: true,
             }],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         };
         let req = ChatRequest {
             model: "gpt-5.6-sol".into(),
@@ -644,7 +644,7 @@ mod tests {
                         input: json!({"command":"pwd"}),
                     },
                 ],
-                reasoning: Vec::new(),
+                reasoning: MessageReasoning::default(),
             },
             openwave_core::ChatMessage {
                 role: Role::User,
@@ -653,7 +653,7 @@ mod tests {
                     content: "/tmp".into(),
                     is_error: false,
                 }],
-                reasoning: Vec::new(),
+                reasoning: MessageReasoning::default(),
             },
             ChatMessage::text(Role::User, "thanks"),
         ];
@@ -768,7 +768,7 @@ mod tests {
             messages: vec![openwave_core::ChatMessage {
                 role: Role::User,
                 content: vec![ContentBlock::Image { image }],
-                reasoning: Vec::new(),
+                reasoning: MessageReasoning::default(),
             }],
             images,
             ..Default::default()

--- a/crates/openwave-router/src/openai_compat.rs
+++ b/crates/openwave-router/src/openai_compat.rs
@@ -635,7 +635,7 @@ fn map_stop_reason(reason: &str) -> StopReason {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openwave_core::provider::ChatMessage;
+    use openwave_core::provider::{ChatMessage, MessageReasoning};
     use openwave_core::tool::ToolSpec;
     use openwave_core::ReasoningEffort;
 
@@ -812,7 +812,7 @@ mod tests {
                     input: json!({"path": "a"}),
                 },
             ],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         };
         let mut out = Vec::new();
         extend_openai_messages(&mut out, &msg, &ImageAttachments::new()).unwrap();
@@ -839,7 +839,7 @@ mod tests {
                     is_error: true,
                 },
             ],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         };
         let mut out = Vec::new();
         extend_openai_messages(&mut out, &msg, &ImageAttachments::new()).unwrap();
@@ -1134,7 +1134,7 @@ mod tests {
                 },
                 ContentBlock::Image { image },
             ],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         };
 
         let mut out = Vec::new();
@@ -1155,7 +1155,7 @@ mod tests {
         let msg = ChatMessage {
             role: Role::User,
             content: vec![ContentBlock::Image { image: png_ref(9) }],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         };
         let mut out = Vec::new();
         let err = extend_openai_messages(&mut out, &msg, &ImageAttachments::new()).unwrap_err();
@@ -1180,7 +1180,7 @@ mod tests {
                 },
                 ContentBlock::Image { image },
             ],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         };
 
         let mut out = Vec::new();

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -25,7 +25,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 4;
+const DESKTOP_SCHEMA_EPOCH: u32 = 5;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -24,10 +24,11 @@ use openwave_core::{
     sandbox_read_delegated_file_tool_spec, sandbox_web_search_tool_spec,
     validate_sandbox_exec_arguments, validate_sandbox_read_delegated_file_arguments, AgentConfig,
     AgentError, AgentRun, AgentRunStatus, AgentRunSubmittedOutput, CallId, ChatMessage,
-    ChatRequest, ContentBlock, FailAgentRunOutcome, ModelProvider, ParkSandboxToolCallOutcome,
-    ProviderEvent, RequestFolderAccessArgs, Result, ResumeTurnForAgentRunWaitSetOutcome, Role,
-    SandboxToolCall, SandboxToolCallRequest, SandboxToolCallStatus, StopReason, Store,
-    SubmitAgentRunResultOutcome, ToolCallRecord, MAX_SANDBOX_TOOL_CALLS, SANDBOX_EXEC_TOOL,
+    ChatRequest, ContentBlock, FailAgentRunOutcome, MessageReasoning, ModelProvider,
+    ParkSandboxToolCallOutcome, ProviderEvent, RequestFolderAccessArgs, Result,
+    ResumeTurnForAgentRunWaitSetOutcome, Role, SandboxToolCall, SandboxToolCallRequest,
+    SandboxToolCallStatus, StopReason, Store, SubmitAgentRunResultOutcome, ToolCallRecord,
+    MAX_SANDBOX_TOOL_CALLS, SANDBOX_EXEC_TOOL,
 };
 use tokio::sync::Notify;
 
@@ -967,7 +968,7 @@ async fn sandbox_request(
                 name: call.name.clone(),
                 input: call.arguments.clone(),
             }],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         });
         messages.push(ChatMessage {
             role: Role::User,
@@ -976,7 +977,7 @@ async fn sandbox_request(
                 content: receipt.result,
                 is_error: receipt.status != SandboxToolCallStatus::Completed,
             }],
-            reasoning: Vec::new(),
+            reasoning: MessageReasoning::default(),
         });
     }
     Ok(ChatRequest {

--- a/crates/openwave-server/src/tests/conversations.rs
+++ b/crates/openwave-server/src/tests/conversations.rs
@@ -860,6 +860,7 @@ async fn chat_transcript_replays_only_visible_durable_messages() {
             chat_id: chat.id,
             turn_id: TurnId::new(),
             role: Role::User,
+            reasoning: Default::default(),
             content: "remember this".into(),
             created_at: chrono::Utc::now(),
         })


### PR DESCRIPTION
Reasoning blocks were captured from the live stream and dropped at the end of the turn. They rode the later steps of the turn that produced them and nothing more, so a reload lost them and any request rebuilt from the store replayed none.

## Persisting them

The blocks stay a `Vec` of opaque provider values. A provider may emit several in one step, each with its own signature, and Anthropic validates the consecutive thinking prefix of an assistant message against what the model generated — flattening them into one block would lose both the count and the signatures and turn a valid replay into a 400.

`MessageReasoning` carries the blocks together with the provider and model that minted them. Its fields are private and set together by `captured`, so blocks can never exist without their origin. It sits on both the durable `Message` and the in-flight `ChatMessage`, so a block knows where it came from whether it arrived off the wire or off disk.

Storage is one new nullable `reasoning` column on `message`, holding the serialized value. A message with nothing to replay writes the same row it always did. The two exact-retry comparators (`exact_appended_message_model_on`, `exact_completed_output_on`) learned the column so an idempotent retry is still recognized as exact. The schema is a single pre-v1 baseline rather than a migration chain, so this edits the baseline in place and moves `DESKTOP_SCHEMA_EPOCH` to 5.

Two gaps are deliberate. A step that writes no prose preamble persists no message row, so its reasoning has nowhere to ride and degrades to no replay — inventing an empty assistant message to hold it would be a larger change through transcript projection and message validation. Cancelled steps keep none either: a stream cut between blocks yields a partial prefix, which is exactly what replay validation rejects.

## Gating replay

`attach_reasoning_blocks` now replays only the blocks whose origin matches the request's provider *and* model. Both halves matter — a block is signed by one model on one provider, and another model on the same provider will reject it as readily as another provider will.

A mismatch drops to no replay rather than failing the turn. Moving between Anthropic, OpenAI and Gemini models mid-conversation is supported and ordinary, and history rebuilt across such a switch carries blocks the receiving model never signed. Sending zero reasoning is always a valid request shape; sending a foreign block is a 400.

The other adapters ignore the side channel entirely, so the gate lives where the blocks actually reach a wire body.

## Tests

Two, both behavioral:

- `reasoning_blocks_survive_the_turn_that_produced_them` (extended from `..._ride_later_steps_of_the_same_turn`) drives a real turn, then a second turn on a fresh agent over the same store, and asserts the block comes back on the rebuilt transcript. The fake provider now streams prose beside its tool call so the step has a durable message to persist. It records the raw transcript blocks rather than the gated ones, so it measures persistence and nothing else.
- `a_route_switch_replays_no_foreign_reasoning` builds the actual request body for a model switch — another Anthropic model, then another provider — and asserts neither replays the block. Its sibling `captured_reasoning_is_replayed_verbatim_ahead_of_its_content` already covers the matching route.

## Verification

`cargo test -p openwave-core -p openwave-server -p openwave-router --locked` passes; clippy `--all-targets` is warning-free on those crates plus `openwave-desktop`; `cargo fmt --all` is clean. No renderer wire type changes — reasoning blocks are opaque provider data and stay server-side, so `ChatMessageSnapshot` is untouched and the generated TypeScript needed no regeneration (the staleness check in `openwave-server` passes). The Postgres turn-state lane needs a live server and did not run locally; `full-ci` is on for it.

Closes #1560