### PR TITLE
feat(core): gate background agent spawns behind one approval

### DIFF
--- a/crates/openwave-core/src/agent.rs
+++ b/crates/openwave-core/src/agent.rs
@@ -763,6 +763,10 @@ pub struct SandboxAgentSpawnRequest {
     pub task: String,
     /// Canonical closed arguments emitted by the provider.
     pub arguments: Value,
+    /// Whether this spawn already parked on the approval gate and carries a
+    /// durable pending tool-call row the checkpoint must finalize rather than
+    /// insert. Set only by [`Agent::gate_sandbox_spawn`].
+    pub approval_gated: bool,
 }
 
 impl SandboxAgentSpawnRequest {
@@ -1053,6 +1057,17 @@ enum CallIsolation {
     SandboxSpawn,
     /// Leaves the loop as an ordered child-wait checkpoint.
     AgentWait,
+}
+
+/// What the approval gate decided about one delegation.
+enum SandboxSpawnGate {
+    /// The spawn may proceed. The request records whether a durable pending
+    /// tool-call row is waiting for the checkpoint to finalize.
+    Admit(SandboxAgentSpawnRequest),
+    /// The spawn will not happen. Its durable row is already terminal and its
+    /// `ToolCallCompleted` event has been published; this is what the model
+    /// reads.
+    Declined(ToolOutput),
 }
 
 /// How one client call's model-facing arguments map onto the canonical durable
@@ -1354,19 +1369,36 @@ impl Agent {
             self.persist(chat.id, turn_id, Role::User, user_input)
                 .await?;
         }
-        if let Some(request) = self.pending_sandbox_spawns.first().cloned() {
+        if !self.pending_sandbox_spawns.is_empty() {
             let Some(steer_revision) = self.pending_sandbox_spawn_steer_revision else {
                 return Err(AgentError::Store(
                     "pending sandbox spawns require a durably claimed turn".into(),
                 ));
             };
-            return Ok(AgentTurnOutcome::SandboxAgentSpawn {
-                request,
-                remaining_requests: self.pending_sandbox_spawns[1..].to_vec(),
-                usage: Usage::default(),
-                steer_revision,
-                model_steps: 0,
-            });
+            // Every spawn from the batch passes the gate, not just the first
+            // one the step yielded: the model can name several delegations in
+            // one step, and a card for one of them is not consent for the rest.
+            // A refused spawn is answered in place and the batch moves on.
+            for index in 0..self.pending_sandbox_spawns.len() {
+                let request = self.pending_sandbox_spawns[index].clone();
+                match self
+                    .gate_sandbox_spawn(chat, turn_id, &request, events)
+                    .await?
+                {
+                    SandboxSpawnGate::Admit(request) => {
+                        return Ok(AgentTurnOutcome::SandboxAgentSpawn {
+                            request,
+                            remaining_requests: self.pending_sandbox_spawns[index + 1..].to_vec(),
+                            usage: Usage::default(),
+                            steer_revision,
+                            model_steps: 0,
+                        });
+                    }
+                    // Answered durably and published; the transcript rebuild
+                    // below picks the refusal up as this call's result.
+                    SandboxSpawnGate::Declined(_) => {}
+                }
+            }
         }
         // The provider transcript for this turn: prior stored text + the blocks
         // we build up as the loop runs.
@@ -2111,29 +2143,64 @@ impl Agent {
                         CallIsolation::SandboxSpawn => {
                             match self.sandbox_checkpoint(call, generation_steer_revision) {
                                 Ok((request, steer_revision)) => {
-                                    let remaining_requests = calls
-                                        .iter()
-                                        .enumerate()
-                                        .skip(index + 1)
-                                        .filter(|(sibling, _)| {
-                                            matches!(
-                                                isolations[*sibling],
-                                                Some(CallIsolation::SandboxSpawn)
-                                            )
-                                        })
-                                        .filter_map(|(_, sibling)| {
-                                            self.sandbox_checkpoint(sibling, Some(steer_revision))
-                                                .ok()
-                                                .map(|(request, _)| request)
-                                        })
-                                        .collect();
-                                    return Ok(AgentTurnOutcome::SandboxAgentSpawn {
-                                        request,
-                                        remaining_requests,
-                                        usage: total_usage,
-                                        steer_revision,
-                                        model_steps: steps_used,
-                                    });
+                                    // Every spawn the step named, in model
+                                    // order. Each one passes the gate on its
+                                    // own: a card about one delegation is not
+                                    // consent for the others, and the first
+                                    // that clears it leaves the loop carrying
+                                    // the rest.
+                                    let mut queued = vec![(index, request)];
+                                    for (sibling, sibling_call) in
+                                        calls.iter().enumerate().skip(index + 1)
+                                    {
+                                        if !matches!(
+                                            isolations[sibling],
+                                            Some(CallIsolation::SandboxSpawn)
+                                        ) {
+                                            continue;
+                                        }
+                                        match self
+                                            .sandbox_checkpoint(sibling_call, Some(steer_revision))
+                                        {
+                                            Ok((request, _)) => queued.push((sibling, request)),
+                                            Err(reason) => {
+                                                outputs[sibling] = Some(self.decline_call(
+                                                    sibling_call,
+                                                    events,
+                                                    reason.into(),
+                                                ));
+                                            }
+                                        }
+                                    }
+                                    let mut admitted = None;
+                                    for (position, (slot, request)) in queued.iter().enumerate() {
+                                        match self
+                                            .gate_sandbox_spawn(chat, turn_id, request, events)
+                                            .await?
+                                        {
+                                            SandboxSpawnGate::Admit(request) => {
+                                                admitted = Some((position, request));
+                                                break;
+                                            }
+                                            // Refused before any child existed,
+                                            // and already answered durably.
+                                            SandboxSpawnGate::Declined(output) => {
+                                                outputs[*slot] = Some(output);
+                                            }
+                                        }
+                                    }
+                                    if let Some((position, request)) = admitted {
+                                        return Ok(AgentTurnOutcome::SandboxAgentSpawn {
+                                            request,
+                                            remaining_requests: queued[position + 1..]
+                                                .iter()
+                                                .map(|(_, request)| request.clone())
+                                                .collect(),
+                                            usage: total_usage,
+                                            steer_revision,
+                                            model_steps: steps_used,
+                                        });
+                                    }
                                 }
                                 Err(reason) => {
                                     outputs[index] =
@@ -2589,6 +2656,7 @@ impl Agent {
                 child_run_id: AgentRunId::sandbox_for_spawn_call(call.call_id),
                 task,
                 arguments,
+                approval_gated: false,
             },
             steer_revision,
         ))
@@ -3402,6 +3470,250 @@ impl Agent {
             content: self.tool_result_for_model(&output.content, call_id),
             ..output.clone()
         }
+    }
+
+    /// Decide whether one delegation may create a child, before it does.
+    ///
+    /// A background run's own tool calls are advanced by the sandbox worker
+    /// under its own lease and never re-enter this chat's gate, so the spawn is
+    /// the only point at which the reader can be asked. It is asked once, for
+    /// the whole run: nobody is watching a background run, and a mid-run card
+    /// would stall it against its own deadline.
+    ///
+    /// A spawn's tool call is normally written already completed, in the same
+    /// transaction that admits the child, which leaves the approval broker
+    /// nothing to park on. A gated spawn therefore first accepts an ordinary
+    /// pending server row and parks on that, exactly like any other Sensitive
+    /// call; [`crate::Store::checkpoint_sandbox_spawn`] finalizes that same row
+    /// when it admits the child, strictly after the decision has committed.
+    ///
+    /// An interrupted decision leaves the row pending, which
+    /// [`Self::resume_pending_server_calls`] abandons on the next attempt. That
+    /// is the fail-closed direction: no child is admitted by a decision nobody
+    /// finished making.
+    async fn gate_sandbox_spawn(
+        &self,
+        chat: &Chat,
+        turn_id: TurnId,
+        request: &SandboxAgentSpawnRequest,
+        events: &EventSink<'_>,
+    ) -> Result<SandboxSpawnGate> {
+        const KIND: ToolApprovalKind = ToolApprovalKind::DelegateMayRunBackgroundAgent;
+        let mode = chat.permission_mode.unwrap_or(PermissionMode::Ask);
+        // `Allow` is the chat saying it will not be asked. A standing grant is
+        // the reader having already answered this exact question here, which is
+        // what keeps repeat delegation in one conversation from re-prompting.
+        // Either way the spawn takes the ordinary ungated path and no durable
+        // pending row is created.
+        if matches!(mode, PermissionMode::Allow)
+            || self.standing_grants.covers(
+                chat.id,
+                chat.project_id,
+                crate::SPAWN_SANDBOX_AGENT_TOOL,
+                KIND,
+                &request.arguments,
+            )
+        {
+            return Ok(SandboxSpawnGate::Admit(request.clone()));
+        }
+        let call = PendingCall {
+            call_id: request.call_id,
+            provider_id: request.provider_id.clone(),
+            name: crate::SPAWN_SANDBOX_AGENT_TOOL.into(),
+            args: serde_json::to_string(&request.arguments)?,
+        };
+        // What the reader is deciding. The task says what the child is told to
+        // do; the network policy says what it can do with what it learns, and
+        // is the part that is actually being consented to — the run's workspace
+        // is keyed by its own id and carries no folder grants, staged host
+        // paths, or chat attachments.
+        let preview = Some(ToolActionPreview::DelegateAgent {
+            task: request.task.clone(),
+            network: chat.network_policy.clone(),
+        });
+        if let Some(committed) = self.accept_server_call(chat.id, turn_id, &call).await? {
+            // An earlier attempt already answered this exact call. Replay what
+            // it committed rather than asking a second time.
+            return Ok(SandboxSpawnGate::Declined(
+                self.settle_gated_spawn(chat.id, turn_id, &call, events, preview, committed)
+                    .await?,
+            ));
+        }
+        macro_rules! refuse {
+            ($output:expr) => {
+                return Ok(SandboxSpawnGate::Declined(
+                    self.settle_gated_spawn(chat.id, turn_id, &call, events, preview, $output)
+                        .await?,
+                ))
+            };
+        }
+        if self.durable_steer_lease.is_some() && events.flush().await.is_err() {
+            refuse!(ToolOutput::error("approval event journal is unavailable"));
+        }
+        let journal = match (self.durable_steer_lease, events.proposed_ordinal()) {
+            (Some(lease_token), Ok(Some(event_ordinal))) => Some(ApprovalJournalIdentity {
+                lease_token,
+                event_ordinal,
+            }),
+            (None, Ok(None)) => None,
+            _ => refuse!(ToolOutput::error(
+                "approval event journal identity is invalid"
+            )),
+        };
+        let registering = self.approvals.register(
+            ApprovalRequest {
+                call_id: request.call_id,
+                chat_id: chat.id,
+                turn_id,
+                tool_name: crate::SPAWN_SANDBOX_AGENT_TOOL.into(),
+                class: ApprovalClass::Sensitive,
+                kind: KIND,
+                preview: preview.clone(),
+                // A judge deciding a whole unattended run is not the same
+                // question as a judge deciding one call, so delegation is never
+                // handed to it.
+                auto_judge: false,
+            },
+            journal,
+        );
+        let registration = match future::select(registering, self.cancel.cancelled()).await {
+            Either::Left((registration, _)) if !self.cancel.is_cancelled() => registration,
+            Either::Left(_) | Either::Right(((), _)) => {
+                refuse!(ToolOutput::failed(
+                    ToolErrorCategory::UserCancelled,
+                    "turn cancelled while registering delegation approval",
+                ));
+            }
+        };
+        let required = AgentEvent::ApprovalRequired {
+            auto_judging: false,
+            call_id: request.call_id,
+            tool_name: crate::SPAWN_SANDBOX_AGENT_TOOL.into(),
+            class: ApprovalClass::Sensitive,
+            kind: KIND,
+            grant_scopes: GrantScope::mintable_ladder_for(
+                KIND,
+                crate::SPAWN_SANDBOX_AGENT_TOOL,
+                &request.arguments,
+            ),
+            preview: preview.clone(),
+        };
+        let authorized_by_standing_grant = matches!(
+            registration.publication,
+            ApprovalRequiredPublication::StandingGrant
+        );
+        match registration.publication {
+            ApprovalRequiredPublication::Ordinary => events.send(required),
+            ApprovalRequiredPublication::Committed {
+                event_ordinal,
+                event,
+            } => {
+                if events
+                    .send_committed_proposed(event_ordinal, event)
+                    .is_err()
+                {
+                    refuse!(ToolOutput::error(
+                        "approval event publication is unavailable"
+                    ));
+                }
+            }
+            ApprovalRequiredPublication::Recovered {
+                event_ordinal,
+                event,
+            } => {
+                if events
+                    .send_recovered_proposed(event_ordinal, event)
+                    .is_err()
+                {
+                    refuse!(ToolOutput::error("approval event recovery is unavailable"));
+                }
+            }
+            ApprovalRequiredPublication::None | ApprovalRequiredPublication::StandingGrant => {}
+        }
+        let decision = match future::select(registration.decision, self.cancel.cancelled()).await {
+            Either::Left((decision, _)) if !self.cancel.is_cancelled() => decision,
+            Either::Left(_) | Either::Right(((), _)) => {
+                if !authorized_by_standing_grant {
+                    events.send(AgentEvent::ApprovalDecided {
+                        call_id: request.call_id,
+                        approved: false,
+                    });
+                }
+                refuse!(ToolOutput::failed(
+                    ToolErrorCategory::UserCancelled,
+                    "turn cancelled while awaiting delegation approval",
+                ));
+            }
+        };
+        let approved = matches!(decision, ApprovalDecision::Approve);
+        if !authorized_by_standing_grant {
+            events.send(AgentEvent::ApprovalDecided {
+                call_id: request.call_id,
+                approved,
+            });
+        }
+        if let ApprovalDecision::Reject { reason } = decision {
+            refuse!(ToolOutput::failed(ToolErrorCategory::UserDeclined, reason));
+        }
+        // A cancel landing concurrently with the approval must not admit a
+        // child that will keep running after the turn has stopped.
+        if self.cancel.is_cancelled() {
+            refuse!(ToolOutput::failed(
+                ToolErrorCategory::UserCancelled,
+                "turn cancelled after delegation approval",
+            ));
+        }
+        Ok(SandboxSpawnGate::Admit(SandboxAgentSpawnRequest {
+            approval_gated: true,
+            ..request.clone()
+        }))
+    }
+
+    /// Close a delegation that will not happen: resolve its durable pending row
+    /// and publish the result the model reads.
+    async fn settle_gated_spawn(
+        &self,
+        chat_id: ChatId,
+        turn_id: TurnId,
+        call: &PendingCall,
+        events: &EventSink<'_>,
+        preview: Option<ToolActionPreview>,
+        output: ToolOutput,
+    ) -> Result<ToolOutput> {
+        let resolution = if output.is_error {
+            ToolCallResolution::Failed {
+                result: output.content.clone(),
+                error_code: output
+                    .error_category
+                    .unwrap_or(ToolErrorCategory::ToolFailed)
+                    .as_str()
+                    .into(),
+                error_detail: None,
+            }
+        } else {
+            ToolCallResolution::Completed {
+                result: output.content.clone(),
+            }
+        };
+        let outcome = self
+            .resolve_server_call_retry(chat_id, turn_id, call.call_id, &resolution, None)
+            .await?;
+        if !matches!(
+            outcome,
+            ResolveToolCallOutcome::Resolved | ResolveToolCallOutcome::Existing
+        ) {
+            return Err(AgentError::Store(format!(
+                "refused delegation {} could not be resolved: {outcome:?}",
+                call.call_id
+            )));
+        }
+        events.send(AgentEvent::ToolCallCompleted {
+            call_id: call.call_id,
+            output: self.tool_output_for_event(&output, call.call_id),
+            action: preview,
+            result: None,
+        });
+        Ok(output)
     }
 
     /// Resume persisted server calls accepted by an earlier attempt before
@@ -5492,7 +5804,10 @@ mod tests {
             title: None,
             model: None,
             reasoning_effort: None,
-            permission_mode: None,
+            // Consent is not what this test is about: the chat has already
+            // said it will not be asked, so the checkpoint shape is what
+            // shows through.
+            permission_mode: Some(PermissionMode::Allow),
             network_policy: Default::default(),
             attachment_revision: 0,
             root_attachments: Vec::new(),
@@ -5651,7 +5966,7 @@ mod tests {
             title: None,
             model: None,
             reasoning_effort: None,
-            permission_mode: None,
+            permission_mode: Some(PermissionMode::Allow),
             network_policy: Default::default(),
             attachment_revision: 0,
             root_attachments: Vec::new(),
@@ -5698,6 +6013,135 @@ mod tests {
         assert_eq!(request.task, "research A");
         assert_eq!(remaining_requests.len(), 1);
         assert_eq!(remaining_requests[0].task, "research B");
+    }
+
+    /// A background run's own calls never come back to this chat's gate, so
+    /// the spawn is the only moment consent can be asked for. A chat that
+    /// would park a foreground call parks the delegation too, and a refusal
+    /// leaves no checkpoint for the worker to admit a child from.
+    #[tokio::test]
+    async fn a_refused_delegation_never_reaches_a_spawn_checkpoint() {
+        let (outcome, events) = drive_gated_delegation(Arc::new(RefuseGate)).await;
+        assert!(
+            !matches!(outcome, AgentTurnOutcome::SandboxAgentSpawn { .. }),
+            "a refused delegation must not yield a spawn checkpoint: {outcome:?}"
+        );
+        // The card names the policy the child would inherit, because egress is
+        // what the reader is deciding.
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                AgentEvent::ApprovalRequired { kind, preview, .. }
+                    if *kind == ToolApprovalKind::DelegateMayRunBackgroundAgent
+                        && matches!(
+                            preview,
+                            Some(ToolActionPreview::DelegateAgent { task, network })
+                                if task == "research A"
+                                    && *network == crate::NetworkPolicy::Open
+                        )
+            )),
+            "{events:?}"
+        );
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                AgentEvent::ToolCallCompleted { output, .. } if output.is_error
+            )),
+            "the model is told the delegation was refused: {events:?}"
+        );
+    }
+
+    /// An approved delegation is admitted through the ordinary spawn
+    /// checkpoint, carrying the flag that tells it to finalize the row the
+    /// approval parked on rather than insert a second one.
+    #[tokio::test]
+    async fn an_approved_delegation_checkpoints_against_its_own_parked_call() {
+        let (outcome, _events) = drive_gated_delegation(Arc::new(crate::AutoApproveGate)).await;
+        let AgentTurnOutcome::SandboxAgentSpawn { request, .. } = outcome else {
+            panic!("an approved delegation should produce a checkpoint: {outcome:?}");
+        };
+        assert_eq!(request.task, "research A");
+        assert!(request.approval_gated);
+    }
+
+    /// Drive one delegation in a chat that asks before it acts, with the
+    /// claimed-turn sink drained concurrently so the gate's journal flush is
+    /// acknowledged the way the worker acknowledges it.
+    async fn drive_gated_delegation(
+        gate: Arc<dyn ApprovalGate>,
+    ) -> (AgentTurnOutcome, Vec<AgentEvent>) {
+        let db = tempfile::tempdir().unwrap();
+        let store: Arc<dyn Store> = Arc::new(
+            DbStore::connect(&format!(
+                "sqlite://{}?mode=rwc",
+                db.path().join("gate.db").display()
+            ))
+            .await
+            .unwrap(),
+        );
+        let chat = Chat {
+            id: ChatId::new(),
+            project_id: None,
+            title: None,
+            model: None,
+            reasoning_effort: None,
+            permission_mode: None,
+            network_policy: crate::NetworkPolicy::Open,
+            attachment_revision: 0,
+            root_attachments: Vec::new(),
+            created_at: Utc::now(),
+        };
+        store.create_chat(&chat).await.unwrap();
+        let turn_id = TurnId::new();
+        store
+            .accept_turn(turn_id, chat.id, "fake", "delegate")
+            .await
+            .unwrap();
+        let lease_token = uuid::Uuid::new_v4();
+        let now = Utc::now();
+        store
+            .claim_turn_run(lease_token, now, now + chrono::Duration::minutes(1))
+            .await
+            .unwrap();
+        let mut registry = ToolRegistry::new();
+        registry.register_foreground_agent_orchestration();
+        let agent = Agent::new(
+            Arc::new(ClientToolProvider {
+                assistant_text: false,
+                sibling_call: false,
+                name: crate::SPAWN_SANDBOX_AGENT_TOOL,
+                arguments: r#"{"task":"research A"}"#,
+            }),
+            Arc::new(registry),
+            store,
+            AgentConfig {
+                model: "fake".into(),
+                max_steps: 1,
+                ..AgentConfig::default()
+            },
+        )
+        .with_durable_steer(lease_token)
+        .with_approvals(gate)
+        .with_foreground_agent_orchestration();
+        let (tx, mut rx) = unbounded();
+        let chat_for_turn = chat.clone();
+        let handle = tokio::spawn(async move {
+            agent
+                .run_claimed_turn(&chat_for_turn, turn_id, MessageId::new(), 1, &tx)
+                .await
+        });
+        let mut events = Vec::new();
+        while let Some(emission) = rx.next().await {
+            match emission {
+                ClaimedAgentEvent::Pending { event, .. } => events.push(event),
+                ClaimedAgentEvent::Committed { event, .. }
+                | ClaimedAgentEvent::Recovered { event, .. } => events.push(event.event),
+                ClaimedAgentEvent::Flush(acknowledge) => {
+                    let _ = acknowledge.send(());
+                }
+            }
+        }
+        (handle.await.unwrap().unwrap(), events)
     }
 
     #[tokio::test]

--- a/crates/openwave-core/src/approval.rs
+++ b/crates/openwave-core/src/approval.rs
@@ -93,6 +93,17 @@ pub enum ToolApprovalKind {
     /// once but not standing-grantable, because "stop asking about workspace
     /// edits here" is exactly what switching the chat to `Auto` says.
     WorkspaceMayModifyFiles,
+    /// A background agent may run commands in its own workspace and reach the
+    /// network under this chat's policy, without any of its own calls coming
+    /// back for approval.
+    ///
+    /// Consent is given once, for the whole run: nobody is watching a
+    /// background run, so a mid-run card would stall it against its own
+    /// deadline. What the reader is deciding is egress — the run's workspace
+    /// is keyed by its own id and carries no folder grants, staged host paths,
+    /// or chat attachments — so the card names the network policy the child
+    /// inherits.
+    DelegateMayRunBackgroundAgent,
     /// A Sensitive action with no presentable consent semantics: rejectable but
     /// not approvable from the renderer.
     Unsupported,
@@ -112,6 +123,7 @@ impl ToolApprovalKind {
             // alone, so a workspace tool missing here parks as an approvable
             // card the renderer presents and then 409s the approval itself.
             "create_app" => Self::WorkspaceMayModifyFiles,
+            crate::SPAWN_SANDBOX_AGENT_TOOL => Self::DelegateMayRunBackgroundAgent,
             name if name.starts_with("mcp__") => Self::ExternalMcpMayCallServer,
             _ => Self::Unsupported,
         }
@@ -159,6 +171,9 @@ impl ToolApprovalKind {
             // workspace tool the name table does not know recovers as a true
             // `Unsupported` — rejectable-only, never silently approvable.
             Self::WorkspaceMayModifyFiles => "unsupported",
+            // Same closed-constraint fold. `approval_from_model` recovers the
+            // delegation kind from the exact tool name stored beside it.
+            Self::DelegateMayRunBackgroundAgent => "unsupported",
             Self::Unsupported => "unsupported",
         }
     }
@@ -179,6 +194,7 @@ impl ToolApprovalKind {
             Self::ExecMayRunNetworkedCommand => "exec_may_run_networked_command",
             Self::ExternalMcpMayCallServer => "external_mcp_may_call_server",
             Self::WorkspaceMayModifyFiles => "workspace_may_modify_files",
+            Self::DelegateMayRunBackgroundAgent => "delegate_may_run_background_agent",
             Self::Unsupported => "unsupported",
         }
     }
@@ -193,6 +209,7 @@ impl ToolApprovalKind {
             "exec_may_run_networked_command" => Some(Self::ExecMayRunNetworkedCommand),
             "external_mcp_may_call_server" => Some(Self::ExternalMcpMayCallServer),
             "workspace_may_modify_files" => Some(Self::WorkspaceMayModifyFiles),
+            "delegate_may_run_background_agent" => Some(Self::DelegateMayRunBackgroundAgent),
             "unsupported" => Some(Self::Unsupported),
             _ => None,
         }
@@ -208,6 +225,7 @@ impl ToolApprovalKind {
                 | Self::ExecMayRunNetworkedCommand
                 | Self::ExternalMcpMayCallServer
                 | Self::WorkspaceMayModifyFiles
+                | Self::DelegateMayRunBackgroundAgent
         )
     }
 
@@ -223,7 +241,8 @@ impl ToolApprovalKind {
     ///
     /// MCP stays out on the same replaceable-executable grounds as standing
     /// grants: consent given to a namespace is not consent to whatever
-    /// Settings later puts behind it.
+    /// Settings later puts behind it. Delegation stays out because the judge
+    /// would be deciding a whole unattended run rather than one call.
     #[must_use]
     pub const fn is_auto_judgeable(self) -> bool {
         matches!(
@@ -720,6 +739,12 @@ impl GrantScope {
         // whole-workspace rung — that consent already exists as `Auto` mode.
         if let ToolActionPreview::WriteFile { path } = &action {
             return place_ladder(path);
+        }
+        // Delegation is consented to as delegation. A task is model-authored
+        // prose, so an exact-action grant would never match a second time and
+        // would only be a rung that looks narrower than it is.
+        if matches!(action, ToolActionPreview::DelegateAgent { .. }) {
+            return vec![Self::WholeTool];
         }
         vec![Self::ExactAction(action), Self::WholeTool]
     }

--- a/crates/openwave-core/src/db/migration/baseline/tools.rs
+++ b/crates/openwave-core/src/db/migration/baseline/tools.rs
@@ -221,7 +221,34 @@ pub(super) fn tool_call_table() -> TableCreateStatement {
                                 .eq(crate::ToolApprovalStatus::Rejected.as_str())
                                 .and(Expr::col(ToolCall::ApprovalReason).is_not_null())
                                 .and(Expr::col(ToolCall::ApprovalDecidedAt).is_not_null())),
-                    )),
+                    ))
+                // A delegation is the one action whose call changes execution
+                // class after it is decided: it parks as a Sensitive server
+                // call and, once approved, is finalized into the completed
+                // orchestration row that admitted the background run. Keeping
+                // the approval on that row is what makes the consent for an
+                // unattended run readable next to the run it authorized.
+                .or(Expr::col(ToolCall::Execution)
+                    .eq(crate::model::ToolCallExecution::Orchestration.as_str())
+                    .and(
+                        Expr::col(ToolCall::Status)
+                            .eq(crate::model::ToolCallStatus::Completed.as_str()),
+                    )
+                    .and(
+                        Expr::col(ToolCall::ApprovalStatus)
+                            .eq(crate::ToolApprovalStatus::Approved.as_str()),
+                    )
+                    .and(
+                        Expr::col(ToolCall::ApprovalClass)
+                            .eq(crate::ApprovalClass::Sensitive.as_str()),
+                    )
+                    .and(
+                        Expr::col(ToolCall::ApprovalKind)
+                            .eq(crate::ToolApprovalKind::DelegateMayRunBackgroundAgent.as_str()),
+                    )
+                    .and(Expr::col(ToolCall::ApprovalReason).is_null())
+                    .and(Expr::col(ToolCall::ApprovalRequestedAt).is_not_null())
+                    .and(Expr::col(ToolCall::ApprovalDecidedAt).is_not_null())),
         )
         .check(
             Expr::col(ToolCall::ApprovalReason)
@@ -327,6 +354,7 @@ pub(super) fn standing_tool_grant_table() -> TableCreateStatement {
             crate::ToolApprovalKind::ExecMayRunNetworkedCommand.standing_grant_key(),
             crate::ToolApprovalKind::WebExtractMayFetchUrl.standing_grant_key(),
             crate::ToolApprovalKind::WorkspaceMayModifyFiles.standing_grant_key(),
+            crate::ToolApprovalKind::DelegateMayRunBackgroundAgent.standing_grant_key(),
         ]))
         // Exactly one of `chat_id` / `project_id` names the level.
         .check(

--- a/crates/openwave-core/src/db/ops/approval.rs
+++ b/crates/openwave-core/src/db/ops/approval.rs
@@ -940,6 +940,9 @@ fn approval_from_model(model: &entities::tool_call::Model) -> Result<ToolApprova
         // `Unsupported`: rejectable-only, never silently approvable.
         Some("unsupported") => match ToolApprovalKind::for_tool_name(&model.name) {
             ToolApprovalKind::WorkspaceMayModifyFiles => ToolApprovalKind::WorkspaceMayModifyFiles,
+            ToolApprovalKind::DelegateMayRunBackgroundAgent => {
+                ToolApprovalKind::DelegateMayRunBackgroundAgent
+            }
             _ => ToolApprovalKind::Unsupported,
         },
         _ => {

--- a/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
+++ b/crates/openwave-core/src/db/ops/turn/sandbox_spawn.rs
@@ -8,6 +8,7 @@ use crate::agent_tools::{
     parse_canonical_spawn_sandbox_agent_arguments, SpawnSandboxAgentArgs, SpawnSandboxAgentResult,
     SPAWN_SANDBOX_AGENT_TOOL,
 };
+use crate::approval::ToolApprovalStatus;
 use crate::error::{AgentError, Result};
 use crate::event::{AgentEvent, SequencedEvent};
 use crate::model::{
@@ -15,6 +16,7 @@ use crate::model::{
     ToolCallRecord, ToolCallStatus, TurnCheckpointProgress, TurnRunStatus, TurnSteerStatus,
 };
 use crate::storage::{AdmitSandboxAgentRunOutcome, CheckpointSandboxSpawnOutcome};
+use crate::ApprovalClass;
 use crate::{AgentRunId, ChatId, ToolOutput};
 
 use super::super::super::{entities, store_err, DbStore};
@@ -159,13 +161,19 @@ where
     if request.event_ordinal != next_ordinal {
         return Ok(CheckpointSandboxSpawnOutcome::IdentityConflict);
     }
-    if entities::tool_call::Entity::find_by_id(request.call_id.0)
+    // A gated spawn parked on the approval gate first, which left an ordinary
+    // pending server row for this exact call. That row is finalized here, in
+    // the same transaction that admits the child, so admission is strictly
+    // after the decision committed. An ungated spawn must have no row at all.
+    let existing_call = entities::tool_call::Entity::find_by_id(request.call_id.0)
         .one(conn)
         .await
-        .map_err(store_err)?
-        .is_some()
-    {
-        return Ok(CheckpointSandboxSpawnOutcome::IdentityConflict);
+        .map_err(store_err)?;
+    match &existing_call {
+        Some(existing)
+            if request.approval_gated && gated_call_is_admissible(existing, turn, request) => {}
+        None if !request.approval_gated => {}
+        _ => return Ok(CheckpointSandboxSpawnOutcome::IdentityConflict),
     }
 
     let arguments = canonical_arguments(request)?;
@@ -212,42 +220,61 @@ where
 
     let totals = checked_totals(turn, request.progress)?;
     let created_at = now.max(child.created_at);
-    let history_order = next_tool_history_order_on(conn, ChatId(turn.chat_id)).await?;
-    let call_model = entities::tool_call::ActiveModel {
-        id: Set(request.call_id.0),
-        chat_id: Set(turn.chat_id),
-        turn_id: Set(turn.id),
-        provider_id: Set(request.provider_id.clone()),
-        history_order: Set(history_order),
-        name: Set(SPAWN_SANDBOX_AGENT_TOOL.into()),
-        arguments: Set(request.arguments.clone()),
-        raw_arguments: Set(None),
-        execution: Set(ToolCallExecution::Orchestration.as_str().into()),
-        status: Set(ToolCallStatus::Completed.as_str().into()),
-        result: Set(Some(request.result.clone())),
-        result_preview: Set(None),
-        error_code: Set(None),
-        error_detail: Set(None),
-        approval_status: Set(None),
-        approval_class: Set(None),
-        approval_kind: Set(None),
-        approval_reason: Set(None),
-        approval_requested_at: Set(None),
-        approval_decided_at: Set(None),
-        approval_event_seq: Set(None),
-        approval_grant_source_call_id: Set(None),
-        auto_judge_status: Set(None),
-        client_executor_id: Set(None),
-        client_lease_token: Set(None),
-        client_lease_expires_at: Set(None),
-        turn_lease_token: Set(Some(request.lease_token)),
-        resolution_turn_lease_token: Set(Some(request.lease_token)),
-        created_at: Set(created_at),
-        resolved_at: Set(Some(created_at)),
-    }
-    .insert(conn)
-    .await
-    .map_err(store_err)?;
+    let history_order = match &existing_call {
+        // The gated row already took its place in tool history when it was
+        // accepted; moving it now would reorder the transcript around a card
+        // the reader has already answered.
+        Some(existing) => existing.history_order,
+        None => next_tool_history_order_on(conn, ChatId(turn.chat_id)).await?,
+    };
+    let call_model = match existing_call {
+        Some(existing) => {
+            let mut active: entities::tool_call::ActiveModel = existing.into();
+            active.execution = Set(ToolCallExecution::Orchestration.as_str().into());
+            active.status = Set(ToolCallStatus::Completed.as_str().into());
+            active.result = Set(Some(request.result.clone()));
+            active.turn_lease_token = Set(Some(request.lease_token));
+            active.resolution_turn_lease_token = Set(Some(request.lease_token));
+            active.created_at = Set(created_at);
+            active.resolved_at = Set(Some(created_at));
+            active.update(conn).await.map_err(store_err)?
+        }
+        None => entities::tool_call::ActiveModel {
+            id: Set(request.call_id.0),
+            chat_id: Set(turn.chat_id),
+            turn_id: Set(turn.id),
+            provider_id: Set(request.provider_id.clone()),
+            history_order: Set(history_order),
+            name: Set(SPAWN_SANDBOX_AGENT_TOOL.into()),
+            arguments: Set(request.arguments.clone()),
+            raw_arguments: Set(None),
+            execution: Set(ToolCallExecution::Orchestration.as_str().into()),
+            status: Set(ToolCallStatus::Completed.as_str().into()),
+            result: Set(Some(request.result.clone())),
+            result_preview: Set(None),
+            error_code: Set(None),
+            error_detail: Set(None),
+            approval_status: Set(None),
+            approval_class: Set(None),
+            approval_kind: Set(None),
+            approval_reason: Set(None),
+            approval_requested_at: Set(None),
+            approval_decided_at: Set(None),
+            approval_event_seq: Set(None),
+            approval_grant_source_call_id: Set(None),
+            auto_judge_status: Set(None),
+            client_executor_id: Set(None),
+            client_lease_token: Set(None),
+            client_lease_expires_at: Set(None),
+            turn_lease_token: Set(Some(request.lease_token)),
+            resolution_turn_lease_token: Set(Some(request.lease_token)),
+            created_at: Set(created_at),
+            resolved_at: Set(Some(created_at)),
+        }
+        .insert(conn)
+        .await
+        .map_err(store_err)?,
+    };
     let call = tool_call_from_model(call_model)?;
     let payload = AgentEvent::ToolCallCompleted {
         call_id: request.call_id,
@@ -419,15 +446,26 @@ where
     };
     let stored_event: AgentEvent = serde_json::from_value(event.payload)?;
     let arguments = canonical_arguments(request)?;
+    // A gated spawn's row carries the approval that admitted it; an ungated
+    // one must carry no approval at all.
+    let approval_columns_valid = if request.approval_gated {
+        call_model.approval_status.as_deref() == Some(ToolApprovalStatus::Approved.as_str())
+            && call_model.approval_class.as_deref() == Some(ApprovalClass::Sensitive.as_str())
+            && call_model.approval_kind.is_some()
+            && call_model.approval_requested_at.is_some()
+            && call_model.approval_decided_at.is_some()
+    } else {
+        call_model.approval_status.is_none()
+            && call_model.approval_class.is_none()
+            && call_model.approval_kind.is_none()
+            && call_model.approval_reason.is_none()
+            && call_model.approval_requested_at.is_none()
+            && call_model.approval_decided_at.is_none()
+            && call_model.approval_event_seq.is_none()
+    };
     let raw_call_valid = call_model.error_code.is_none()
         && call_model.error_detail.is_none()
-        && call_model.approval_status.is_none()
-        && call_model.approval_class.is_none()
-        && call_model.approval_kind.is_none()
-        && call_model.approval_reason.is_none()
-        && call_model.approval_requested_at.is_none()
-        && call_model.approval_decided_at.is_none()
-        && call_model.approval_event_seq.is_none()
+        && approval_columns_valid
         && call_model.client_executor_id.is_none()
         && call_model.client_lease_token.is_none()
         && call_model.client_lease_expires_at.is_none();
@@ -490,6 +528,37 @@ where
             event: stored_event,
         },
     }))
+}
+
+/// Whether the row a gated spawn parked on is the one this checkpoint may
+/// finalize.
+///
+/// The approval must read approved, so a child is never admitted alongside a
+/// decision that is still pending or was refused, and the immutable call
+/// identity must be the one the reader was shown — a row whose arguments,
+/// tool, or turn differ describes a different question than the one answered.
+fn gated_call_is_admissible(
+    call: &entities::tool_call::Model,
+    turn: &entities::turn_run::Model,
+    request: &SandboxSpawnCheckpointRequest,
+) -> bool {
+    call.chat_id == turn.chat_id
+        && call.turn_id == turn.id
+        && call.provider_id == request.provider_id
+        && call.name == SPAWN_SANDBOX_AGENT_TOOL
+        && call.arguments == request.arguments
+        && call.raw_arguments.is_none()
+        && call.execution == ToolCallExecution::Server.as_str()
+        && call.status == ToolCallStatus::Pending.as_str()
+        && call.result.is_none()
+        && call.error_code.is_none()
+        && call.error_detail.is_none()
+        && call.approval_status.as_deref() == Some(ToolApprovalStatus::Approved.as_str())
+        && call.approval_class.as_deref() == Some(ApprovalClass::Sensitive.as_str())
+        && call.approval_kind.is_some()
+        && call.client_executor_id.is_none()
+        && call.client_lease_token.is_none()
+        && call.client_lease_expires_at.is_none()
 }
 
 fn validate_request(request: &SandboxSpawnCheckpointRequest) -> Result<()> {

--- a/crates/openwave-core/src/db/tests/delegated_file_read.rs
+++ b/crates/openwave-core/src/db/tests/delegated_file_read.rs
@@ -67,6 +67,7 @@ async fn delegated_sandbox(
             "task": "read the delegated report",
             "resource": resource,
         }),
+        approval_gated: false,
         result: serde_json::to_string(&SpawnSandboxAgentResult { agent_id: child_id }).unwrap(),
         event_ordinal: 2,
         progress: TurnCheckpointProgress {

--- a/crates/openwave-core/src/db/tests/sandbox_spawn_checkpoint.rs
+++ b/crates/openwave-core/src/db/tests/sandbox_spawn_checkpoint.rs
@@ -63,6 +63,7 @@ fn request(
         call_id,
         provider_id: format!("provider-{call_id}"),
         arguments: serde_json::json!({"task": task}),
+        approval_gated: false,
         result: serde_json::to_string(&SpawnSandboxAgentResult {
             agent_id: AgentRunId::sandbox_for_spawn_call(call_id),
         })
@@ -140,6 +141,134 @@ async fn detach_conversation_root(
         )
         .await
         .unwrap();
+}
+
+/// Park a spawn on the approval gate the way the agent does: an ordinary
+/// pending server row for the exact call, plus a journaled approval request.
+async fn park_spawn_on_approval(
+    store: &crate::DbStore,
+    chat: &crate::Chat,
+    turn: &crate::TurnRun,
+    lease: uuid::Uuid,
+    request: &SandboxSpawnCheckpointRequest,
+) {
+    store
+        .accept_tool_call(&ToolCallRecord {
+            id: request.call_id,
+            chat_id: chat.id,
+            turn_id: turn.id,
+            provider_id: request.provider_id.clone(),
+            name: SPAWN_SANDBOX_AGENT_TOOL.into(),
+            arguments: request.arguments.clone(),
+            raw_arguments: None,
+            execution: ToolCallExecution::Server,
+            status: ToolCallStatus::Pending,
+            result: None,
+            result_preview: None,
+            error_code: None,
+            error_detail: None,
+            client_executor_id: None,
+            client_lease_expires_at: None,
+            created_at: Utc::now(),
+            resolved_at: None,
+        })
+        .await
+        .unwrap();
+    store
+        .request_tool_call_approval_and_append_event(
+            &crate::ApprovalRequest {
+                auto_judge: false,
+                call_id: request.call_id,
+                chat_id: chat.id,
+                turn_id: turn.id,
+                tool_name: SPAWN_SANDBOX_AGENT_TOOL.into(),
+                class: crate::ApprovalClass::Sensitive,
+                kind: crate::ToolApprovalKind::DelegateMayRunBackgroundAgent,
+                preview: None,
+            },
+            lease,
+            2,
+            Utc::now(),
+        )
+        .await
+        .unwrap();
+}
+
+/// A background run is admitted by the decision, not beside it.
+///
+/// The spawn's tool call is written already completed in the transaction that
+/// creates the child, so a gated spawn parks on an ordinary pending server row
+/// first and this checkpoint finalizes that row. An undecided row must not
+/// produce a child: an interrupted decision is abandoned on the next attempt,
+/// and nothing may run on the strength of a question nobody answered.
+#[tokio::test]
+async fn a_gated_spawn_admits_its_child_only_once_the_approval_has_committed() {
+    let (_dir, store) = temp_store().await;
+    let chat = sample_chat();
+    store.create_chat(&chat).await.unwrap();
+    let (turn, lease) = running_turn(&store, chat.id).await;
+    let mut undecided = request(
+        &turn,
+        lease,
+        CallId::new(),
+        "research one fact",
+        3,
+        progress(),
+    );
+    undecided.approval_gated = true;
+    park_spawn_on_approval(&store, &chat, &turn, lease, &undecided).await;
+
+    assert!(matches!(
+        store
+            .checkpoint_sandbox_spawn(&undecided, Utc::now())
+            .await
+            .unwrap(),
+        Some(CheckpointSandboxSpawnOutcome::IdentityConflict)
+    ));
+    // Only the parent run exists: no child was created beside the open card.
+    assert_eq!(store.list_agent_runs(chat.id).await.unwrap().len(), 1);
+    let parked = store.list_tool_calls(chat.id).await.unwrap();
+    assert_eq!(parked.len(), 1);
+    assert_eq!(parked[0].status, ToolCallStatus::Pending);
+    assert_eq!(parked[0].execution, ToolCallExecution::Server);
+
+    store
+        .decide_tool_call_approval(
+            chat.id,
+            undecided.call_id,
+            &crate::ApprovalDecision::Approve,
+            Utc::now(),
+        )
+        .await
+        .unwrap();
+    let approved = store
+        .checkpoint_sandbox_spawn(&undecided, Utc::now())
+        .await
+        .unwrap()
+        .unwrap();
+    let CheckpointSandboxSpawnOutcome::Checkpointed { child, call, .. } = approved else {
+        panic!("an approved spawn should admit its child");
+    };
+    assert_eq!(
+        child.id,
+        AgentRunId::sandbox_for_spawn_call(undecided.call_id)
+    );
+    // The parked row became the spawn's own completed orchestration call
+    // rather than a second row beside it.
+    assert_eq!(call.id, undecided.call_id);
+    assert_eq!(call.execution, ToolCallExecution::Orchestration);
+    assert_eq!(call.status, ToolCallStatus::Completed);
+    assert_eq!(store.list_tool_calls(chat.id).await.unwrap().len(), 1);
+
+    // The same request retried after the commit recovers the one receipt.
+    assert!(matches!(
+        store
+            .checkpoint_sandbox_spawn(&undecided, Utc::now())
+            .await
+            .unwrap(),
+        Some(CheckpointSandboxSpawnOutcome::Existing { .. })
+    ));
+    assert_eq!(store.list_agent_runs(chat.id).await.unwrap().len(), 2);
 }
 
 #[tokio::test]

--- a/crates/openwave-core/src/model.rs
+++ b/crates/openwave-core/src/model.rs
@@ -1448,6 +1448,11 @@ pub struct SandboxSpawnCheckpointRequest {
     /// Host-resolved execution location for the child admitted by this atomic
     /// checkpoint. Existing callers use the in-process default.
     pub execution_location: AgentRunExecutionLocation,
+    /// Whether the spawn parked on the approval gate first, so a pending
+    /// server tool-call row already exists for `call_id` and must be finalized
+    /// rather than inserted. The row's approval must read approved: admission
+    /// happens strictly after the decision commits.
+    pub approval_gated: bool,
 }
 
 /// Immutable final text submitted by one exact sandbox worker lease.

--- a/crates/openwave-core/src/preview.rs
+++ b/crates/openwave-core/src/preview.rs
@@ -99,6 +99,25 @@ pub enum ToolActionPreview {
         /// Workspace-relative destination path, never a host path.
         path: String,
     },
+    /// A delegation to a background agent: an unattended run whose own calls
+    /// never come back for approval.
+    ///
+    /// Two things make up the action, and the second is the one being decided.
+    /// The task is what the child is told to do; the network policy is what it
+    /// can do with what it learns, because that policy is inherited from this
+    /// chat and is the only way anything leaves the box. The run's workspace is
+    /// keyed by its own id and holds no folder grants, staged host paths, or
+    /// chat attachments, so there is no file surface to name here.
+    ///
+    /// Unlike the other variants this one is not derivable from the call's
+    /// arguments alone — the policy is chat state — so it is built where the
+    /// spawn is gated rather than by [`ToolActionPreview::build`].
+    DelegateAgent {
+        /// The child's self-contained task, as the model wrote it.
+        task: String,
+        /// The network policy the child inherits from this chat.
+        network: crate::model::NetworkPolicy,
+    },
 }
 
 impl ToolActionPreview {

--- a/crates/openwave-core/tests/postgres_turn_state.rs
+++ b/crates/openwave-core/tests/postgres_turn_state.rs
@@ -440,6 +440,7 @@ fn postgres_spawn_checkpoint_request(
         },
         max_active_background_agents: AgentRun::DEFAULT_MAX_ACTIVE_BACKGROUND_AGENTS,
         execution_location: openwave_core::AgentRunExecutionLocation::InProcess,
+        approval_gated: false,
     }
 }
 

--- a/crates/openwave-desktop/ui/src/ApprovalCard.tsx
+++ b/crates/openwave-desktop/ui/src/ApprovalCard.tsx
@@ -248,6 +248,9 @@ export function approvalAsk(
   if (preview?.tool === "write_file") {
     return { title: "Write this file?", summaryLine: summary };
   }
+  if (preview?.tool === "delegate_agent") {
+    return { title: "Start this background agent?", summaryLine: summary };
+  }
   return { title: summary, summaryLine: null };
 }
 
@@ -411,7 +414,9 @@ function spokenAction(preview: ToolActionPreview): string {
         ? preview.url
         : preview.tool === "write_file"
           ? preview.path
-          : preview.query;
+          : preview.tool === "delegate_agent"
+            ? preview.task
+            : preview.query;
   return bounded(spoken);
 }
 

--- a/crates/openwave-desktop/ui/src/ToolCallCard.tsx
+++ b/crates/openwave-desktop/ui/src/ToolCallCard.tsx
@@ -558,6 +558,16 @@ export function toolApprovalPresentation(
       canRemember: false,
     };
   }
+  if (kind === "delegate_may_run_background_agent") {
+    return {
+      summary:
+        "Allow a background agent to work on this on its own, reaching the network under this chat's policy?",
+      canApprove: true,
+      // Consent is for the whole run, so it is worth remembering: a run's own
+      // calls never come back to be asked about individually.
+      canRemember: true,
+    };
+  }
   return {
     summary: "The exact action cannot be safely described.",
     canApprove: false,

--- a/crates/openwave-desktop/ui/src/ToolPreview.tsx
+++ b/crates/openwave-desktop/ui/src/ToolPreview.tsx
@@ -1,4 +1,5 @@
-import type { ExecResultPreview, ToolActionPreview } from "./api";
+import type { ExecResultPreview, NetworkPolicy, ToolActionPreview } from "./api";
+import { networkPolicyLabel } from "./NetworkPolicyDialog";
 
 /**
  * Presentation of a tool's own preview of the action it is about to take.
@@ -58,6 +59,18 @@ export function toolPreviewPresentation(
       detail: `${headline}\n# fetched from the public web`,
     };
   }
+  if (preview.tool === "delegate_agent") {
+    // The task leads because it is what the run will do, but the network
+    // policy is the part being consented to: the run's workspace is its own,
+    // so what it can reach is the only way anything leaves the box.
+    const headline = preview.task;
+    const detail = [
+      headline,
+      `# network: ${networkPolicyLabel(preview.network)}${networkHosts(preview.network)}`,
+      "# runs unattended in its own workspace; its own calls are not asked about",
+    ].join("\n");
+    return { headline, detail };
+  }
   const headline = [preview.command, ...preview.args]
     .map(quoteArgument)
     .join(" ");
@@ -95,6 +108,16 @@ function publishedWindow(
   if (from) return `# published on or after ${from}`;
   if (to) return `# published on or before ${to}`;
   return null;
+}
+
+/**
+ * The hosts a custom policy names, so the card says which destinations the
+ * delegated run can reach rather than only that the list exists.
+ */
+function networkHosts(policy: NetworkPolicy): string {
+  if (policy.mode !== "allowed_hosts") return "";
+  const hosts = policy.allowed_hosts.join(", ");
+  return hosts.length > 0 ? ` (${hosts})` : "";
 }
 
 /**

--- a/crates/openwave-desktop/ui/src/generated/wire.ts
+++ b/crates/openwave-desktop/ui/src/generated/wire.ts
@@ -1796,7 +1796,15 @@ end_published_at: string | null, } | { "tool": "web_extract", url: string, } | {
 /**
  * Workspace-relative destination path, never a host path.
  */
-path: string, };
+path: string, } | { "tool": "delegate_agent", 
+/**
+ * The child's self-contained task, as the model wrote it.
+ */
+task: string, 
+/**
+ * The network policy the child inherits from this chat.
+ */
+network: NetworkPolicy, };
 
 /**
  * Closed immutable consent semantics stored with each approval request.
@@ -1806,7 +1814,7 @@ path: string, };
  * arguments. `Unsupported` is the fail-closed default: a Sensitive
  * action the server can only reject, never approve.
  */
-export type ToolApprovalKind = "search_may_share_query_and_excerpts" | "web_search_may_share_query" | "web_extract_may_fetch_url" | "exec_may_run_networked_command" | "external_mcp_may_call_server" | "workspace_may_modify_files" | "unsupported";
+export type ToolApprovalKind = "search_may_share_query_and_excerpts" | "web_search_may_share_query" | "web_extract_may_fetch_url" | "exec_may_run_networked_command" | "external_mcp_may_call_server" | "workspace_may_modify_files" | "delegate_may_run_background_agent" | "unsupported";
 
 /**
  * What a call produced, in a form a human can read.

--- a/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
+++ b/crates/openwave-desktop/ui/src/settings/PermissionsPanel.tsx
@@ -23,6 +23,7 @@ const TOOL_LABELS: Partial<Record<RendererToolName, string>> = {
   web_search: "Web search",
   web_extract: "Web pages",
   write_file: "Workspace files",
+  spawn_sandbox_agent: "Background agents",
 };
 
 export function toolGrantLabel(action: RendererToolName): string {
@@ -74,6 +75,12 @@ export function grantScopeLabel(
       if (scope.tool === "write_file") {
         return scope.path;
       }
+      // Delegation is only ever granted for the whole tool — a model-authored
+      // task would never match a second time — so this is named for totality
+      // rather than because a mint stores it.
+      if (scope.tool === "delegate_agent") {
+        return scope.task;
+      }
       return `“${scope.query}”`;
     }
     case "any_args_for":
@@ -92,6 +99,8 @@ export function grantScopeLabel(
           return "Every web search";
         case "web_extract":
           return "Every web page";
+        case "spawn_sandbox_agent":
+          return "Every background agent";
         default:
           return `Every ${toolGrantLabel(action)} call`;
       }

--- a/crates/openwave-server/src/desktop_schema.rs
+++ b/crates/openwave-server/src/desktop_schema.rs
@@ -25,7 +25,7 @@ const VECTOR_DIRECTORY: &str = "vectors";
 const MAX_MARKER_BYTES: u64 = 1_024;
 
 /// Bump this whenever the pre-v1 schema baseline changes incompatibly.
-const DESKTOP_SCHEMA_EPOCH: u32 = 4;
+const DESKTOP_SCHEMA_EPOCH: u32 = 5;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/openwave-server/src/sandbox_agent_run_worker.rs
+++ b/crates/openwave-server/src/sandbox_agent_run_worker.rs
@@ -3073,6 +3073,7 @@ mod tests {
                             "relative_path": "reports/summary.md"
                         }
                     }),
+                    approval_gated: false,
                     result: serde_json::to_string(&openwave_core::SpawnSandboxAgentResult {
                         agent_id: child_id,
                     })

--- a/crates/openwave-server/src/tests/sandbox.rs
+++ b/crates/openwave-server/src/tests/sandbox.rs
@@ -471,6 +471,7 @@ async fn delegated_file_routes_are_native_only_and_expose_only_exact_broker_auth
                     "task": "private delegated task",
                     "resource": resource,
                 }),
+                approval_gated: false,
                 result: serde_json::to_string(&openwave_core::SpawnSandboxAgentResult {
                     agent_id: child_id,
                 })

--- a/crates/openwave-server/src/tests/workers.rs
+++ b/crates/openwave-server/src/tests/workers.rs
@@ -1,5 +1,20 @@
 use super::*;
 
+/// Put a chat in `Allow` so a delegation runs without an approval card.
+async fn allow_delegation(store: &dyn Store, chat: ChatId) {
+    store
+        .update_chat_metadata(
+            chat,
+            None,
+            None,
+            None,
+            Some(Some(openwave_core::PermissionMode::Allow)),
+            None,
+        )
+        .await
+        .unwrap();
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn configured_model_is_used_for_the_turn() {
     let recorder = RecordingProvider::default();
@@ -197,6 +212,9 @@ async fn foreground_spawn_is_nonblocking_and_ordered_wait_resumes_with_child_res
     let router = app(state);
     let bearer = format!("Bearer {token}");
     let chat = make_chat(&router, &bearer).await;
+    // Delegation is a Sensitive action, so anything short of `Allow` would park
+    // this turn on an approval card nobody is here to answer.
+    allow_delegation(store.as_ref(), chat.id).await;
 
     assert_eq!(
         send_message(&router, &bearer, chat.id, "delegate this").await,
@@ -536,6 +554,7 @@ async fn sandbox_container_routing_preserves_in_process_task_and_deadline_shape(
     let router = app(state);
     let bearer = format!("Bearer {token}");
     let chat = make_chat(&router, &bearer).await;
+    allow_delegation(store.as_ref(), chat.id).await;
     assert_eq!(
         send_message(&router, &bearer, chat.id, "delegate this").await,
         StatusCode::ACCEPTED

--- a/crates/openwave-server/src/turn_worker.rs
+++ b/crates/openwave-server/src/turn_worker.rs
@@ -905,6 +905,13 @@ impl TurnWorker {
                     Ok(result) => result,
                     Err(error) => Err(AgentError::msg(format!("agent task stopped: {error}"))),
                 };
+            // The attempt consumed the whole queue: every requeued spawn either
+            // passed the approval gate — and comes back as the outcome's
+            // remaining requests — or was refused and answered durably. Holding
+            // the old list would replay refusals on the next iteration.
+            let had_pending_spawns = !pending_sandbox_spawns.is_empty();
+            pending_sandbox_spawns.clear();
+            pending_sandbox_spawn_steer_revision = None;
             match self.renew_lease(&turn, lease_token).await {
                 LeaseState::Running => {}
                 LeaseState::Cancelling => {
@@ -1466,9 +1473,7 @@ impl TurnWorker {
                     steer_revision,
                     model_steps,
                 }) => {
-                    if (model_steps == 0 && pending_sandbox_spawns.is_empty())
-                        || model_steps > remaining_steps
-                    {
+                    if (model_steps == 0 && !had_pending_spawns) || model_steps > remaining_steps {
                         return Err(AgentError::msg(format!(
                             "turn {} returned an invalid model-step count {model_steps}",
                             turn.id
@@ -1547,6 +1552,7 @@ impl TurnWorker {
                         call_id: request.call_id,
                         provider_id: request.provider_id.clone(),
                         arguments: request.arguments.clone(),
+                        approval_gated: request.approval_gated,
                         result: serde_json::to_string(&openwave_core::SpawnSandboxAgentResult {
                             agent_id: request.child_run_id,
                         })?,
@@ -2843,6 +2849,7 @@ mod committed_event_drain_tests {
             child_run_id: openwave_core::AgentRunId::sandbox_for_spawn_call(call_id),
             task: "Research the error handling options.".into(),
             arguments: serde_json::json!({"task":"Research the error handling options."}),
+            approval_gated: false,
         };
         assert!(sandbox_spawn_checkpoint_is_valid(&tools, &request));
 


### PR DESCRIPTION
Delegating to a background agent used to sidestep the chat's permission mode entirely. The spawn checkpoint writes its tool call already completed, in the same transaction that admits the child, so there was never a pending record for the approval gate to park on — and a chat in Ask could not stop an unattended run from starting.

## What this gates

The spawn, not the child's individual commands. A delegation is Sensitive: in any mode short of `Allow`, the turn now parks on one approval card before the child is admitted.

- **The card names the network policy the child inherits.** That is the decision actually being made. The child's workspace is already isolated — its own run id, no folder grants, no staged host paths, no chat attachments, no write overlay — so egress is what the user is consenting to.
- **Consent is standing-grantable per chat.** Repeat delegations in the same conversation do not re-prompt. Only `WholeTool` is mintable for this action; there is no per-task grant worth keeping.
- **Once admitted, the run executes freely for its lifetime.** No per-command prompts: nobody is watching a background run, and a mid-run card would stall it against its own deadline.
- **Every spawn in a batch is gated on its own**, both mid-step and at the requeue/dequeue site. A card for one delegation is not consent for another.

## The durable shape

The awkward part is that the approval journal requires a pending server tool call to park on, and a spawn has no such record. Rather than inventing a second checkpoint scheme, a gated spawn first accepts an ordinary pending **server** call for `spawn_sandbox_agent`, which satisfies `request_tool_call_approval_and_append_event`'s preconditions unchanged. When the decision commits, `checkpoint_sandbox_spawn` finalizes that same row into the completed orchestration call that admits the child, instead of inserting a fresh one. Admission is therefore strictly after the approval commits.

Recovery falls out of what already exists: an interrupted decision leaves a pending server call, and `resume_pending_server_calls` abandons it rather than replaying — fail-closed, with no child admitted. Exact-retry recovery on the checkpoint keeps its existing behavior, with the approval columns validated per gated/ungated shape.

The checkpoint now verifies the row it is finalizing before touching it: same chat, turn, provider, tool name and arguments; `execution = server`, `status = pending`, no result or error; approval approved, Sensitive, with the delegation kind; no client lease fields. Anything else is an `IdentityConflict`.

## Schema

Two pre-v1 baseline edits, both in place:

- The tool-call approval CHECK gains a third disjunct permitting `execution = orchestration AND status = completed` with an approved Sensitive delegation approval. A delegation is the one action whose call changes execution class after it is decided; keeping the approval on that row is what makes the consent readable next to the run it authorized.
- The standing-grant CHECK learns the new grant key.

`DESKTOP_SCHEMA_EPOCH` goes 4 → 5, which discards existing pre-v1 desktop databases as usual.

## UI

The approval card asks \"Start this background agent?\" and previews the task plus the network policy the child inherits (mode label, allowed hosts where applicable) and the fact that it runs unattended. The tool-call card offers approve and remember; the permissions panel lists the grant as \"Background agents\".

## Tests

Four added, all behavioral:

- a refused delegation never reaches a spawn checkpoint, and the `ApprovalRequired` event carries the task and the inherited network policy;
- an approved delegation checkpoints against its own parked call;
- storage-level: a gated spawn admits its child only once the approval has committed — undecided is an `IdentityConflict` with the row still pending, approval turns the same call id into the completed orchestration row, and retry is `Existing`.

Two existing spawn tests in core and two in the server moved their chats to `Allow`, since they exercise the spawn path rather than the gate.

Verified locally: `cargo test -p openwave-core -p openwave-server --locked`, `cargo clippy -p openwave-core -p openwave-server --all-targets --locked` (clean), `cargo fmt --all`, and `tsc --noEmit` / `pnpm test` / `pnpm build` in the desktop UI. Not verified by driving the app.

Closes #1477