### PR TITLE
fix(desktop): drop inert app rows from the tool activity rail

### DIFF
--- a/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/MessageList.dom.test.tsx
@@ -942,6 +942,11 @@ describe("actionable tool results", () => {
     expect(screen.getByText("Sentry triage")).toBeInTheDocument();
     expect(screen.getByText("revision 1")).toBeInTheDocument();
 
+    // Expanding the rail must not repeat the app as an inert row — the card
+    // below is the one copy, and it is the one that can act.
+    await user.click(screen.getByRole("button", { name: "Created an app" }));
+    expect(screen.getAllByText("Sentry triage")).toHaveLength(1);
+
     await user.click(
       screen.getByRole("button", { name: "Open app Sentry triage" }),
     );

--- a/crates/openwave-desktop/ui/src/ToolEntriesList.tsx
+++ b/crates/openwave-desktop/ui/src/ToolEntriesList.tsx
@@ -70,8 +70,16 @@ const LIST_VERBS: Readonly<Partial<Record<string, string>>> = {
  * rail line, and only one of them is a fact about the conversation.
  */
 export function ToolEntriesList({ name, result }: ToolEntriesListProps) {
-  const { entries, failures, elided } = result;
+  const { failures, elided } = result;
+  // App rows are promoted to standing cards under the phase, where the open
+  // action lives. Repeated here they would be inert copies of a card the
+  // reader can already act on — keyed on kind, like the promotion itself, so
+  // any tool that publishes an app is covered.
+  const entries = result.entries.filter((entry) => entry.kind !== "app");
   if (entries.length === 0 && failures.length === 0) {
+    // A result that was all app rows has been shown in full as cards;
+    // "Nothing was found" would be a different and untrue claim.
+    if (result.entries.length > 0) return null;
     return (
       <div className="bg-background max-w-prose rounded-lg border p-3">
         <p className="text-muted-foreground text-xs">Nothing was found.</p>


### PR DESCRIPTION
The `create_app` accordion rendered its published app twice: once as the standing card under the phase (with the **Open app** button), and again inside the expanded activity rail as a bordered row that looks clickable but has no click handler or link.

App entries are already promoted to standing cards by `surfacedAppCards` (keyed on `kind === "app"`), so the rail copy carries no information the card doesn't. This filters app-kind rows out of `ToolEntriesList` — keyed on kind, matching the promotion, so any tool that publishes an app is covered — and renders nothing (rather than "Nothing was found") when the whole result was promoted.

Extends the existing app-card test to expand the rail and assert the app appears exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)