### PR TITLE
feat(desktop): slim the MCP App card chrome and let compact views render compactly

### DIFF
--- a/crates/openwave-desktop/ui/src/McpAppBridge.test.ts
+++ b/crates/openwave-desktop/ui/src/McpAppBridge.test.ts
@@ -156,7 +156,7 @@ describe("createMcpAppBridge", () => {
     fromView({ jsonrpc: "2.0", method: "ui/notifications/size-changed", params: { height: 512.4 } });
     expect(onHeight).toHaveBeenLastCalledWith(513);
     fromView({ jsonrpc: "2.0", method: "ui/notifications/size-changed", params: { height: 20 } });
-    expect(onHeight).toHaveBeenLastCalledWith(160);
+    expect(onHeight).toHaveBeenLastCalledWith(40);
     fromView({ jsonrpc: "2.0", method: "ui/notifications/size-changed", params: { height: 99999 } });
     expect(onHeight).toHaveBeenLastCalledWith(800);
     fromView({ jsonrpc: "2.0", method: "ui/notifications/size-changed", params: {} });

--- a/crates/openwave-desktop/ui/src/McpAppBridge.ts
+++ b/crates/openwave-desktop/ui/src/McpAppBridge.ts
@@ -50,7 +50,7 @@ export type AppOperationInvoker = (
   body: unknown,
 ) => Promise<AppRestInvokeResult>;
 
-const MIN_FRAME_HEIGHT = 160;
+const MIN_FRAME_HEIGHT = 40;
 const MAX_FRAME_HEIGHT = 800;
 
 export type McpAppBridge = {

--- a/crates/openwave-desktop/ui/src/McpAppCard.dom.test.tsx
+++ b/crates/openwave-desktop/ui/src/McpAppCard.dom.test.tsx
@@ -46,7 +46,8 @@ describe("McpAppCard", () => {
     );
     expect(frame).toHaveAttribute("sandbox", "allow-scripts");
     expect(frame.getAttribute("sandbox")).not.toContain("allow-same-origin");
-    expect(screen.getByText("Sandboxed")).toBeInTheDocument();
+    // The slim provenance row keeps embedded documents attributable.
+    expect(screen.getByText("gateway")).toBeInTheDocument();
   });
 
   it("degrades to a reconnect hint when no frame can be minted", async () => {

--- a/crates/openwave-desktop/ui/src/McpAppCard.tsx
+++ b/crates/openwave-desktop/ui/src/McpAppCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { AppWindow, ShieldCheck } from "lucide-react";
+import { AppWindow } from "lucide-react";
 import { useApp } from "./AppContext";
 import { createMcpAppBridge, type McpAppBridge } from "./McpAppBridge";
 import { useTheme } from "./theme";
@@ -24,7 +24,7 @@ type ViewState =
   | { kind: "unavailable" }
   | { kind: "ready"; url: string };
 
-const DEFAULT_FRAME_HEIGHT = 384;
+const DEFAULT_FRAME_HEIGHT = 96;
 
 export function McpAppCard({
   server,
@@ -110,15 +110,15 @@ export function McpAppCard({
       className="bg-background max-w-prose overflow-hidden rounded-lg border"
       aria-label={`App view from MCP server ${server}`}
     >
-      <div className="flex w-full items-center justify-between gap-2 px-2.5 py-1.5">
-        <span className="text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs font-medium">
-          <AppWindow className="size-3.5 shrink-0" aria-hidden="true" />
-          <span className="truncate">App view · {server}</span>
-        </span>
-        <span className="text-muted-foreground flex items-center gap-1 text-xs">
-          <ShieldCheck className="size-3.5 shrink-0" aria-hidden="true" />
-          Sandboxed
-        </span>
+      {/* The one host-drawn provenance mark: embedded documents must stay
+          visually attributable to their server, but the label costs one slim
+          row — the sandbox itself is the iframe attribute, not this text. */}
+      <div
+        className="text-muted-foreground flex w-full min-w-0 items-center gap-1.5 px-2.5 py-1 text-xs font-medium"
+        title={`App view from ${server} · sandboxed`}
+      >
+        <AppWindow className="size-3.5 shrink-0" aria-hidden="true" />
+        <span className="truncate">{server}</span>
       </div>
       <div className="border-t">
         {state.kind === "loading" && (


### PR DESCRIPTION
## What

- `McpAppCard`'s header shrinks to one slim provenance row — server icon + server name, with "App view from {server} · sandboxed" as its tooltip. The "App view ·" prefix and the "Sandboxed" badge are gone; the sandbox boundary is the iframe's `sandbox` attribute and is untouched.
- The bridge's height clamp minimum drops 160 → 40 and the pre-report default frame height 384 → 96, so a view that reports a small height (model-gateway's governed receipts, once brightwave-inc/model-gateway#333 lands) renders as a line, not a card.

## Why

Ecosystem hosts render MCP Apps nearly chrome-less (hairline border + app name). Our header restated the same provenance three ways and the 160px floor forced every compact view to a full-card footprint — two governed 200-receipts cost ~900px of transcript.

## Tests

Updated the pinned clamp bounds in `McpAppBridge.test.ts` and swapped the "Sandboxed"-text assertion for the provenance-row one; the sandbox-attribute assertions (the real invariant) are unchanged. `pnpm vitest run` on the four affected suites (49 tests) and `tsc --noEmit` pass locally.

Closes #1566

🤖 Generated with [Claude Code](https://claude.com/claude-code)