### PR TITLE
ci: restore SheetJS tarball integrity

### DIFF
--- a/crates/openwave-desktop/ui/pnpm-lock.yaml
+++ b/crates/openwave-desktop/ui/pnpm-lock.yaml
@@ -3583,7 +3583,7 @@ packages:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
-    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
+    resolution: {integrity: sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==, tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
     version: 0.20.3
     engines: {node: '>=0.8'}
     hasBin: true


### PR DESCRIPTION
## Summary

- restore the SHA-512 integrity value for the externally hosted SheetJS tarball
- repair frozen pnpm installs after the Radix checkbox dependency update rewrote the lockfile without that value
- unblock the desktop UI, macOS cache, and macOS release workflows on `main`

## Verification

- `npx --yes pnpm@10.34.5 install --frozen-lockfile --ignore-scripts` with a clean isolated store
- `npx --yes pnpm@10.34.5 test` (109 test files, 728 tests)
- `npx --yes pnpm@10.34.5 build`
- `git diff --check`